### PR TITLE
fix(http): frame-scope managed request cancellation and supersession (rf2-o8ek)

### DIFF
--- a/examples/core/managed_http_counter/core.cljs
+++ b/examples/core/managed_http_counter/core.cljs
@@ -224,6 +224,14 @@
       (rf.http.registry/record-in-flight!
         request-id nil
         {:url      long-pending-url
+         ;; The same carried frame, stamped onto the handle — which is what the
+         ;; live transport does on every request it registers. It is not
+         ;; decoration: a `:request-id` is frame-LOCAL, so the registry keys
+         ;; cancellation on (frame, request-id) and `:rf.http/managed-abort`
+         ;; resolves only its own frame's handle (Spec 014 §Frame scope — a
+         ;; `:request-id` is frame-local). A handle seeded without `:frame`
+         ;; would sit in a scope no dispatch can reach.
+         :frame    frame
          ;; The :abort-fn is the request's cancellation hook — the thing that
          ;; actually runs when someone pulls the plug. The live
          ;; :rf.http/managed-abort handler looks this handle up by request-id

--- a/implementation/http/src/re_frame/http/handlers.cljc
+++ b/implementation/http/src/re_frame/http/handlers.cljc
@@ -387,7 +387,11 @@
         ;; attempt has one work id (EP-0007 / Managed-Effects §Work-id
         ;; correlation §184). An anonymous request (nil request-id) never
         ;; supersedes and stays at issuance 1.
-        issuance     (rf.http.registry/next-issuance! request-id)
+        ;;
+        ;; rf2-o8ek — the counter is keyed by (issuing frame, request-id): a
+        ;; sibling frame reusing the same raw id runs its own sequence, so
+        ;; this frame's first issuance is 1 whatever the sibling has done.
+        issuance     (rf.http.registry/next-issuance! frame-id request-id)
         normalised   (assoc normalised0 :issuance issuance)]
     ;; rf2-azcmd3 — supersession emits the SUPERSEDED attempt's canonical
     ;; `:status :stale` / `:rf.reply/work-status :suppressed` reply-envelope trace
@@ -399,8 +403,14 @@
     ;; (`:reason :request-id-superseded`) — that suppresses its app reply; this
     ;; ADDS the canonical stale reply-envelope row the old `:rf.http/aborted`
     ;; trace alone did not record.
+    ;;
+    ;; rf2-o8ek — supersession is scoped to the ISSUING FRAME. Reusable app
+    ;; code writes one ordinary stable id (`:request-id :articles/load`) and
+    ;; two isolated frames running it must not suppress each other's live
+    ;; request; the frame the runtime already holds supplies that isolation
+    ;; without the caller qualifying the id by hand.
     (when request-id
-      (when-let [superseded (rf.http.registry/supersede! request-id)]
+      (when-let [superseded (rf.http.registry/supersede! frame-id request-id)]
         (rf.http.transport/emit-superseded-stale-trace!
           superseded
           (rf.http.reply/work-id {:request-id   request-id
@@ -419,10 +429,27 @@
   `swap!` traffic per abort. Now the single source of truth lives at
   the failure-finalise site; this handler only fires the abort-fn.
 
-  rf2-rak684 — routes through the shared `registry/abort-in-flight!`
-  abort-by-request-id seam (the SAME seam the resources out-of-cascade
-  teardown reaches through the `:http/abort-in-flight!` late-bind hook),
-  so the fx and the teardown hook fire identical abort semantics."
-  [_frame-ctx request-id]
-  (rf.http.registry/abort-in-flight! request-id :user)
+  rf2-rak684 / rf2-o8ek — routes through `registry/abort-in-flight-in-frame!`,
+  the FRAME-SCOPED sibling of the `registry/abort-in-flight!` seam the
+  resources out-of-cascade teardown reaches through the
+  `:http/abort-in-flight!` late-bind hook. Both fire identical abort semantics
+  and differ only in scope, and the difference is forced by what each caller
+  holds: resources carries a token that is already frame-qualified
+  (`[:rf.req frame-id work-id]`, Spec 016), whereas this fx receives the
+  caller's RAW `:request-id` — a frame-LOCAL name that reusable app code
+  reuses across frames by design. Aborting by that raw id process-globally let
+  a `[:rf.http/managed-abort :articles/load]` dispatched in one frame cancel a
+  sibling frame's live request; scoping to the issuing frame is what makes the
+  effect obey the frame-isolation contract (Spec 014 §`:request-id`).
+
+  The frame comes from the fx context's `:frame` — the EP-0002 carried
+  invariant, the same stamp `managed-handler` requires. A nil stamp is an
+  invariant failure (`:rf.error/no-frame-context`), never a synthesised
+  `:rf/default`."
+  [frame-ctx request-id]
+  (let [frame-id (rf.frame/require-frame-stamp!
+                   (:frame frame-ctx) :rf.http/managed-abort
+                   {:where 'rf.http/managed-abort
+                    :event-id (first (:event frame-ctx))})]
+    (rf.http.registry/abort-in-flight-in-frame! frame-id request-id :user))
   nil)

--- a/implementation/http/src/re_frame/http/registry.cljc
+++ b/implementation/http/src/re_frame/http/registry.cljc
@@ -3,18 +3,22 @@
 
   Two indexes coexist:
 
-   - `in-flight`        — request-id → request-handle. Per Spec 014
-                         §Aborts: a `:rf.http/managed-abort` resolves
-                         the abort-fn through this index, and a fresh
-                         request with the same `:request-id` supersedes
-                         the previous one.
-   - `actor-in-flight`  — actor-id → [request-handle ...]. Per Spec 014
-                         §Abort on actor destroy, requests
+   - `in-flight`        — `[frame-id request-id]` → request-handle. Per
+                         Spec 014 §Aborts: a `:rf.http/managed-abort`
+                         resolves the abort-fn through this index, and a
+                         fresh request with the same `:request-id` in the
+                         SAME frame supersedes the previous one.
+   - `actor-in-flight`  — `[frame-id actor-id]` → [request-handle ...]. Per
+                         Spec 014 §Abort on actor destroy, requests
                          whose originating event-id is a spawned state-
                          machine actor's address are ALSO indexed by
                          that actor-id so a `:rf.machine/destroy`
                          cascade can abort every in-flight request the
                          actor had issued.
+
+  Both maps are PROCESS-GLOBAL storage with FRAME-SCOPED KEYS (rf2-o8ek).
+  See §Frame-scoped cancellation identity below for why the frame is part of
+  the key and not merely a stamp on the value.
 
   Handles carry `:abort-fn` (the fn the runtime calls with an abort reason),
   `:url`, plus the framework-stamped `:request-id` and
@@ -31,24 +35,68 @@
             [re-frame.late-bind    :as rf.late-bind]
             [re-frame.trace        :as rf.trace]))
 
+;; ---- frame-scoped cancellation identity (rf2-o8ek) -------------------------
+;;
+;; Per Spec 014 §`:request-id` (internal) and §Abort on actor destroy, managed-
+;; HTTP cancellation is FRAME-SCOPED: a supersession, a `:rf.http/managed-abort`,
+;; or an actor destroy reaches only work issued by the SAME frame.
+;;
+;; The two indexes below are process-global atoms, but their KEY is the pair
+;; `[frame-id id]` — never the caller's raw id alone. The frame was already
+;; stamped on every handle (`:frame`, from the fx context's envelope frame); it
+;; is the KEY that had to change, because a stamp on the value cannot stop a
+;; lookup keyed on the raw id from resolving a sibling frame's handle.
+;;
+;; Why this is a correctness law and not tidiness: frames are ISOLATED CONTEXTS
+;; (Spec 002; `docs/core/frames.md`), and Spec 014 §Frame awareness promises
+;; multi-frame apps "work without extra ceremony". Reusable app code naturally
+;; reuses an ordinary stable id — `:request-id :articles/load` — so with raw-id
+;; keying two frames running the SAME code cross-cancel: frame B's issuance
+;; supersedes frame A's live request, and a `:rf.http/managed-abort` dispatched
+;; in B aborts A's. Making the frame part of the internal key gives that
+;; isolation from information the runtime already holds, with no change to the
+;; public `:rf.http/managed` args map or the `:rf.http/managed-abort` effect
+;; shape — the caller's raw `:request-id` remains the correlation value echoed
+;; in replies and traces.
+;;
+;; ANY-FRAME seams. Three entry points are reached from artefacts that hold a
+;; token but not a frame — resources' out-of-cascade teardown through the
+;; `:http/abort-in-flight!` late-bind hook, and the machines / core actor-
+;; destroy cascade through `:http/abort-on-actor-destroy`. Their frame-less
+;; arities are preserved and documented as ANY-FRAME: they match on the raw id
+;; across every frame, which is exactly the pre-rf2-o8ek behaviour. That is
+;; correct for resources (its token is already frame-qualified —
+;; `[:rf.req frame-id work-id]` per Spec 016 — so at most one frame can match)
+;; and it is the conservative reading for actor destroy until its callers thread
+;; a frame. The frame-BEARING arities alongside them are the isolated ones.
+
+(defn- scoped-key
+  "The internal cancellation key: the ISSUING FRAME paired with the caller's
+  raw id (a `:request-id`, or a spawned actor's address). A 2-vector, so a
+  caller whose raw id is itself a vector can never collide with a compound key
+  — the frame always sits at position 0 and the WHOLE raw id at position 1."
+  [frame-id id]
+  [frame-id id])
+
 ;; ---- in-flight request registry -------------------------------------------
 
 (defonce in-flight
-  ;; request-id → request-handle map. The handle is implementation-specific
-  ;; (CLJS: AbortController; JVM: CompletableFuture). The :abort-fn value
-  ;; is the no-arg fn the runtime calls to cancel.
+  ;; [frame-id request-id] → request-handle map. The handle is implementation-
+  ;; specific (CLJS: AbortController; JVM: CompletableFuture). The :abort-fn
+  ;; value is the no-arg fn the runtime calls to cancel.
   (atom {}))
 
 (defonce actor-in-flight
-  ;; actor-id → vector of {:abort-fn :request-id :url}.
+  ;; [frame-id actor-id] → vector of {:abort-fn :request-id :url :frame}.
   ;;
-  ;; Index by actor-id — populated when a managed request's originating
+  ;; Index by (frame, actor-id) — populated when a managed request's originating
   ;; event-id is a spawned actor's address (per Spec 014 §Abort on actor
   ;; destroy). Each entry carries the same :abort-fn the
   ;; request-id index would carry; the actor-destroy hook walks the
   ;; vector, fires each :abort-fn, and clears the index slot. Multiple
   ;; in-flight requests from the same actor accumulate as separate
-  ;; entries; sibling actors keep independent slots.
+  ;; entries; sibling actors — and same-named actors in SIBLING FRAMES —
+  ;; keep independent slots.
   (atom {}))
 
 (defn record-in-flight!
@@ -61,37 +109,55 @@
   sites can hold a reference for the 2-arg `clear-in-flight!` cleanup
   path. `request-id` and `actor-id` are both optional (pass nil). When
   both are nil the handle is unindexed and only reachable via natural
-  completion."
+  completion.
+
+  rf2-o8ek — the ISSUING FRAME is read off the handle's own `:frame` stamp
+  (the transport stamps it from the fx context on both the live-fetch and the
+  sleeping-backoff handle) and becomes part of the index key, so no signature
+  change was needed here. A handle with no `:frame` keys under `nil`, which is
+  a coherent scope of its own: unstamped handles share one namespace exactly as
+  they did before frames entered the key."
   [request-id actor-id handle]
-  (let [stamped-handle (cond-> handle
+  (let [frame-id       (:frame handle)
+        stamped-handle (cond-> handle
                          request-id (assoc :request-id request-id)
                          actor-id   (assoc :actor-id actor-id))]
     (when request-id
-      (swap! in-flight assoc request-id stamped-handle))
+      (swap! in-flight assoc (scoped-key frame-id request-id) stamped-handle))
     (when actor-id
-      (swap! actor-in-flight update actor-id (fnil conj []) stamped-handle))
+      (swap! actor-in-flight update (scoped-key frame-id actor-id)
+             (fnil conj []) stamped-handle))
     stamped-handle))
 
-(defn- remove-from-actor-index! [actor-id handle]
-  (when actor-id
-    (swap! actor-in-flight
-           (fn [actor-index]
-             (let [actor-handles     (get actor-index actor-id [])
-                   remaining-handles (vec (remove #(identical? % handle)
-                                                  actor-handles))]
-               (if (seq remaining-handles)
-                 (assoc actor-index actor-id remaining-handles)
-                 (dissoc actor-index actor-id))))))
+(defn- remove-from-actor-index!
+  "Drop `handle` from its own actor-index slot BY IDENTITY. Both halves of the
+  slot key — the frame and the actor-id — are read off the handle itself, so
+  the caller never has to carry them (rf2-o8ek)."
+  [handle]
+  (when-let [actor-id (:actor-id handle)]
+    (let [k (scoped-key (:frame handle) actor-id)]
+      (swap! actor-in-flight
+             (fn [actor-index]
+               (let [actor-handles     (get actor-index k [])
+                     remaining-handles (vec (remove #(identical? % handle)
+                                                    actor-handles))]
+                 (if (seq remaining-handles)
+                   (assoc actor-index k remaining-handles)
+                   (dissoc actor-index k)))))))
   nil)
 
 (defn clear-in-flight!
   "Clear a request handle from both indexes. Two arities:
 
-   - 1-arg `[request-id]` — the resolve-by-id form. Resolves the handle
-     from the request-id index and walks both indexes (the handle stores
-     `:actor-id` so the actor-index slot can be located by identity).
-     No-op when `request-id` is nil — anonymous requests use the 2-arg
-     form below.
+   - 1-arg `[request-id]` — the resolve-by-id, ANY-FRAME form (rf2-o8ek).
+     Resolves every frame's handle registered under this raw `request-id`
+     and walks both indexes (the handle stores `:frame` and `:actor-id` so
+     the actor-index slot can be located by identity). It carries no frame,
+     so it cannot be frame-scoped; it is the seam for callers holding an
+     already-frame-qualified token (resources' `[:rf.req frame-id work-id]`,
+     per Spec 016), for which at most one frame can ever match. Prefer the
+     2-arg form, which IS frame-exact. No-op when `request-id` is nil —
+     anonymous requests use the 2-arg form below.
    - 2-arg `[request-id handle]` — the natural-completion form used by
      the per-host attempt loops. Both args are taken from the captured
      ctx + handle pair, so the cleanup is index-walks by identity and
@@ -120,63 +186,115 @@
   dissoc runs exactly as before."
   ([request-id]
    (when request-id
-     (let [handle (get @in-flight request-id)]
-       (swap! in-flight dissoc request-id)
-       (when handle
-         (remove-from-actor-index! (:actor-id handle) handle))))
+     ;; `swap-vals!` (core on both runtimes) yields the pre-swap snapshot from
+     ;; the winning CAS attempt, so the handles we then walk out of the actor
+     ;; index are exactly the ones this call removed.
+     (let [[previous _] (swap-vals!
+                          in-flight
+                          (fn [request-index]
+                            (reduce-kv (fn [index k _]
+                                         (if (= request-id (second k))
+                                           (dissoc index k)
+                                           index))
+                                       request-index request-index)))]
+       (doseq [[k handle] previous
+               :when (= request-id (second k))]
+         (remove-from-actor-index! handle))))
    nil)
   ([request-id handle]
-   (when request-id
-     (swap! in-flight
-            (fn [request-index]
-              ;; rf2-ous9e5 — drop the slot ONLY while it still holds THIS
-              ;; handle, so a same-id successor is never evicted. A nil `handle`
-              ;; (an abort that fired before the handle was published to
-              ;; `@handle-cell` / `@handle-holder`) falls back to the
-              ;; unconditional dissoc — that pre-publication window precedes any
-              ;; successor, so there is nothing to protect and the slot must
-              ;; still be cleared.
-              (if (or (nil? handle)
-                      (identical? (get request-index request-id) handle))
-                (dissoc request-index request-id)
-                request-index))))
-   (when handle
-     (remove-from-actor-index! (:actor-id handle) handle))
+   (if (nil? handle)
+     ;; rf2-o8ek — a nil `handle` (an abort that fired before the handle was
+     ;; published to `@handle-cell` / `@handle-holder`) carries no `:frame`, so
+     ;; there is no key to be exact about. Fall back to the ANY-FRAME clear
+     ;; above: that pre-publication window precedes any successor, so there is
+     ;; nothing to protect and the slot must still be cleared.
+     (clear-in-flight! request-id)
+     (do
+       (when request-id
+         (let [k (scoped-key (:frame handle) request-id)]
+           (swap! in-flight
+                  (fn [request-index]
+                    ;; rf2-ous9e5 — drop the slot ONLY while it still holds THIS
+                    ;; handle, so a same-id successor is never evicted.
+                    (if (identical? (get request-index k) handle)
+                      (dissoc request-index k)
+                      request-index)))))
+       (remove-from-actor-index! handle)))
    nil))
 
 (defn lookup-in-flight
-  "Return the request-handle currently registered under `request-id`, or
-  nil (when absent, or when `request-id` is nil). The handle carries the
-  `:abort-fn` the abort / supersede paths fire. Read-only — does not
-  mutate either index."
-  [request-id]
-  (when request-id
-    (get @in-flight request-id)))
+  "Return a request-handle, or nil (when absent, or when `request-id` is nil).
+  The handle carries the `:abort-fn` the abort / supersede paths fire.
+  Read-only — does not mutate either index.
+
+   - 2-arg `[frame-id request-id]` — the FRAME-SCOPED form (rf2-o8ek), and the
+     one the managed-HTTP lifetime paths use. Resolves the handle issued by
+     THIS frame under this raw `request-id`; a sibling frame's identical id is
+     invisible.
+   - 1-arg `[request-id]` — the ANY-FRAME form: the first handle registered
+     under this raw id in ANY frame. Retained for callers holding a token that
+     is already frame-qualified (resources' `[:rf.req frame-id work-id]`), for
+     which at most one frame can match. Do not reach for it from a call site
+     that HAS a frame — it is precisely the reach-through this bead removed."
+  ([request-id]
+   (when request-id
+     (some (fn [[k handle]]
+             (when (= request-id (second k)) handle))
+           @in-flight)))
+  ([frame-id request-id]
+   (when request-id
+     (get @in-flight (scoped-key frame-id request-id)))))
+
+(defn- fire-abort!
+  "Fire `handle`'s `:abort-fn` with `reason`, defensively. Returns true iff a
+  handle was present and its abort-fn ran without throwing.
+
+  Per rf2-plngk the in-flight registry cleanup is owned by `finalise-failure!`
+  (the abort-fn closure calls into it), so this never touches an index."
+  [handle reason]
+  (boolean
+    (when handle
+      (try ((:abort-fn handle) reason) true
+           (catch #?(:clj Throwable :cljs :default) _ false)))))
 
 (defn abort-in-flight!
   "Best-effort abort the in-flight managed request registered under
-  `request-id`, firing its `:abort-fn` with `reason` (default `:user`).
-  No-op when nothing is registered under `request-id` (the reply already
-  landed, or the id is unknown / nil) — cancellation is opportunistic.
+  `request-id` in ANY frame, firing its `:abort-fn` with `reason` (default
+  `:user`). No-op when nothing is registered under `request-id` (the reply
+  already landed, or the id is unknown / nil) — cancellation is opportunistic.
+  Never throws (a throwing abort-fn is swallowed). Returns true iff a handle
+  was found and its abort-fn fired, false otherwise.
 
-  Per rf2-plngk the in-flight registry cleanup is owned by
-  `finalise-failure!` (the abort-fn closure calls into it), so this fn
-  only fires the abort-fn and never touches the index directly. Never
-  throws (a throwing abort-fn is swallowed). Returns true iff a handle was
-  found and its abort-fn fired, false otherwise.
-
-  This is the shared abort-by-request-id seam: the `:rf.http/managed-abort`
-  fx handler routes through it (`managed-abort-handler`), AND the resources
+  This is the ANY-FRAME abort-by-request-id seam (rf2-o8ek): the resources
   out-of-cascade teardown paths (clear-resource / frame destroy) reach it
   through the published `:http/abort-in-flight!` late-bind hook so they can
   abort a managed request by its frame-qualified request-id without the
-  resources artefact statically `:require`ing the http transport (rf2-rak684)."
+  resources artefact statically `:require`ing the http transport (rf2-rak684).
+  Because that token already carries the frame (`[:rf.req frame-id work-id]`,
+  Spec 016), at most one frame can match and the any-frame scan is exact.
+
+  The `:rf.http/managed-abort` fx does NOT route here — a raw app-authored
+  `:request-id` is frame-LOCAL, so it uses `abort-in-flight-in-frame!` below.
+  Both fire identical abort semantics; they differ only in what they can see."
   ([request-id] (abort-in-flight! request-id :user))
   ([request-id reason]
-   (boolean
-     (when-let [handle (lookup-in-flight request-id)]
-       (try ((:abort-fn handle) reason) true
-            (catch #?(:clj Throwable :cljs :default) _ false))))))
+   (fire-abort! (lookup-in-flight request-id) reason)))
+
+(defn abort-in-flight-in-frame!
+  "Best-effort abort the in-flight managed request `frame-id` issued under
+  `request-id`, firing its `:abort-fn` with `reason` (default `:user`). The
+  FRAME-SCOPED counterpart of `abort-in-flight!` and the seam the
+  `:rf.http/managed-abort` fx routes through (rf2-o8ek).
+
+  A sibling frame that happens to have used the same raw `:request-id` is
+  invisible here — which is the whole point: reusable app code writes
+  `:request-id :articles/load` once, and two isolated frames running that code
+  must not cancel each other. No-op when this frame has nothing registered
+  under the id. Never throws; returns true iff a handle was found and its
+  abort-fn fired."
+  ([frame-id request-id] (abort-in-flight-in-frame! frame-id request-id :user))
+  ([frame-id request-id reason]
+   (fire-abort! (lookup-in-flight frame-id request-id) reason)))
 
 ;; ---- per-request-id issuance generation (rf2-azcmd3) -----------------------
 ;;
@@ -199,8 +317,17 @@
 ;; it stays at issuance 1.
 
 (defonce ^:private issuance-counters
-  ;; request-id → highest issuance number allocated so far. Monotonic per
-  ;; request-id WHILE THE ID IS LIVE: `next-issuance!` only ever advances it,
+  ;; [frame-id request-id] → highest issuance number allocated so far.
+  ;;
+  ;; rf2-o8ek — keyed by the same frame-scoped identity as `in-flight`, because
+  ;; the counter exists to discriminate a supersession, and supersession is
+  ;; frame-scoped. Under raw-id keying a request in frame B took its FIRST
+  ;; issuance number from frame A's counter (measured: frame B's first
+  ;; issuance read 2), perturbing B's `:work/id` for a supersession that never
+  ;; happened to it.
+  ;;
+  ;; Monotonic per (frame, request-id) WHILE THE ID IS LIVE: `next-issuance!`
+  ;; only ever advances it,
   ;; so a superseded attempt (issuance N) and its superseder (N+1) carry
   ;; distinct `:work/id`s, and a late completion of an old attempt cannot reuse
   ;; a live issuance. rf2-k47b3d — the entry is EVICTED (not decremented) when
@@ -215,15 +342,18 @@
 
 (defn next-issuance!
   "Allocate and return the next monotonic issuance number for `request-id`
-  (rf2-azcmd3). The FIRST issuance under a request-id is 1; each subsequent
-  re-issuance (the caller bumps this before `supersede!`) returns the next
+  AS ISSUED BY `frame-id` (rf2-azcmd3; frame-scoped per rf2-o8ek). The FIRST
+  issuance under a (frame, request-id) pair is 1; each subsequent re-issuance
+  in THAT frame (the caller bumps this before `supersede!`) returns the next
   integer, so the superseded and superseding attempts carry distinct
-  `:work/id`s. Returns 1 for a nil `request-id` (an anonymous request never
+  `:work/id`s. A sibling frame reusing the same raw id keeps its own sequence
+  and starts at 1. Returns 1 for a nil `request-id` (an anonymous request never
   supersedes — there is nothing to discriminate)."
-  [request-id]
+  [frame-id request-id]
   (if (nil? request-id)
     1
-    (get (swap! issuance-counters update request-id (fnil inc 0)) request-id)))
+    (let [k (scoped-key frame-id request-id)]
+      (get (swap! issuance-counters update k (fnil inc 0)) k))))
 
 (defn evict-issuance-on-completion!
   "Evict `request-id`'s issuance counter when the attempt that carried
@@ -245,14 +375,19 @@
   Called ONLY at the terminal-completion sites (`finalise-success!`,
   `finalise-failure!`, `dispatch-aborted!`), NEVER on the retry-clear or
   supersede-clear `clear-in-flight!` paths — those are not terminal (the
-  attempt continues under the same issuance, or a live successor owns the id)."
-  [request-id issuance]
+  attempt continues under the same issuance, or a live successor owns the id).
+
+  rf2-o8ek — `frame-id` is the ISSUING frame (the completing attempt's own
+  `:frame`), so an eviction can only ever drop the counter this attempt was
+  allocated from and never a sibling frame's live one."
+  [frame-id request-id issuance]
   (when (and (some? request-id) (some? issuance))
-    (swap! issuance-counters
-           (fn [counters]
-             (if (= issuance (get counters request-id))
-               (dissoc counters request-id)
-               counters))))
+    (let [k (scoped-key frame-id request-id)]
+      (swap! issuance-counters
+             (fn [counters]
+               (if (= issuance (get counters k))
+                 (dissoc counters k)
+                 counters)))))
   nil)
 
 (defn reset-issuance-counters-for-test!
@@ -271,8 +406,15 @@
   (count @issuance-counters))
 
 (defn supersede!
-  "If a request is already in flight under `request-id`, abort it with
-  `:reason :request-id-superseded`. Per Spec 014 §`:request-id` (internal).
+  "If a request `frame-id` issued is already in flight under `request-id`,
+  abort it with `:reason :request-id-superseded`. Per Spec 014 §`:request-id`
+  (internal).
+
+  rf2-o8ek — supersession is FRAME-SCOPED. Only the issuing frame's own prior
+  attempt is superseded; a sibling frame that reused the same raw
+  `:request-id` — the ordinary consequence of running the same reusable app
+  code in two isolated frames — is left untouched, and neither frame can
+  suppress the other's live request.
 
   rf2-azcmd3 — returns the superseded handle (or nil when nothing was in
   flight) so the caller can emit the canonical `:status :stale` /
@@ -280,9 +422,12 @@
   (Managed-Effects §Stale suppression). The handle carries the old attempt's
   identity facts (`:work/id`, `:request-id`, `:origin-event`, `:attempt`,
   `:frame`) the stale-reply trace needs."
-  [request-id]
-  (when-let [superseded-handle (lookup-in-flight request-id)]
-    (clear-in-flight! request-id)
+  [frame-id request-id]
+  (when-let [superseded-handle (lookup-in-flight frame-id request-id)]
+    ;; The identity-conditional 2-arg clear: the slot was just read and holds
+    ;; exactly this handle, so the dissoc runs — and it keys off the handle's
+    ;; own `:frame`, so it can only ever touch this frame's slot.
+    (clear-in-flight! request-id superseded-handle)
     (try
       ((:abort-fn superseded-handle) :request-id-superseded)
       (catch #?(:clj Throwable :cljs :default) _ nil))
@@ -338,18 +483,44 @@
   nil)
 
 (defn in-flight-snapshot
-  "Test-time helper: read the current value of the request-id-keyed
-  in-flight map. Inspecting state in tests; not part of the user-facing
-  API."
-  []
-  @in-flight)
+  "Test-time helper: read the in-flight request index, keyed by the CALLER'S
+  RAW `:request-id` (not the internal `[frame-id request-id]` key). Inspecting
+  state in tests; not part of the user-facing API.
+
+   - 0-arg — every frame, flattened onto the raw id. rf2-o8ek made the internal
+     key frame-scoped; this projection keeps the ergonomic single-frame read
+     (`(contains? (in-flight-snapshot) :articles/load)`) working unchanged. It
+     is LOSSY across frames by construction: two frames holding the same raw id
+     collapse to one entry. A multi-frame assertion MUST use the 1-arg form.
+   - 1-arg `[frame-id]` — only the handles that frame issued, still keyed by
+     raw id. This is the frame-precise read."
+  ([]
+   (into {} (map (fn [[k handle]] [(second k) handle])) @in-flight))
+  ([frame-id]
+   (into {}
+         (comp (filter (fn [[k _]] (= frame-id (first k))))
+               (map (fn [[k handle]] [(second k) handle])))
+         @in-flight)))
 
 (defn actor-in-flight-snapshot
-  "Test-time helper: read the current value of the actor-id-keyed
-  in-flight map. Inspecting state in tests; not part
-  of the user-facing API."
-  []
-  @actor-in-flight)
+  "Test-time helper: read the actor-owned in-flight index, keyed by the raw
+  actor-id (not the internal `[frame-id actor-id]` key). Inspecting state in
+  tests; not part of the user-facing API.
+
+   - 0-arg — every frame. Same-named actors in sibling frames have their handle
+     vectors CONCATENATED under the one actor-id, matching the pre-rf2-o8ek
+     shape; use the 1-arg form to tell them apart.
+   - 1-arg `[frame-id]` — only that frame's actors."
+  ([]
+   (reduce-kv (fn [by-actor k handles]
+                (update by-actor (second k) (fnil into []) handles))
+              {} @actor-in-flight))
+  ([frame-id]
+   (reduce-kv (fn [by-actor k handles]
+                (if (= frame-id (first k))
+                  (assoc by-actor (second k) handles)
+                  by-actor))
+              {} @actor-in-flight)))
 
 (defn seed-in-flight-for-test!
   "Register a fabricated in-flight handle for tests
@@ -406,12 +577,38 @@
   index here AND cleared inside `finalise-failure!`, doubling the
   `swap!` traffic per actor destroy. The actor-side eager dissoc
   remains: it pins the idempotency guarantee against re-entry, and
-  it's a single `swap!` regardless of handle count."
-  [actor-id]
+  it's a single `swap!` regardless of handle count.
+
+  Two arities (rf2-o8ek):
+
+   - 2-arg `[frame-id actor-id]` — FRAME-SCOPED. Aborts only the HTTP the
+     named frame's actor issued. A same-named actor in a sibling frame is
+     untouched, exactly as §Sibling actors are not affected already promises
+     for siblings within one frame. This is the isolated form.
+   - 1-arg `[actor-id]` — ANY-FRAME: sweeps that actor-id in EVERY frame. It
+     is the arity the machines / core destroy cascade currently calls through
+     the `:http/abort-on-actor-destroy` late-bind hook, which passes an
+     actor address and no frame, so it preserves the pre-rf2-o8ek behaviour
+     byte-for-byte rather than silently narrowing a teardown. Actor addresses
+     are frame-LOCAL, so this arity can still reach a sibling frame's work;
+     closing that needs the hook's callers to thread the frame they already
+     hold, which is a change in the machines and core artefacts."
+  ([actor-id]
+   (when actor-id
+     ;; Snapshot the matching frames BEFORE aborting: each per-frame call
+     ;; mutates `actor-in-flight`, and an abort-fn may mutate it re-entrantly.
+     (doseq [frame-id (->> @actor-in-flight
+                           keys
+                           (filter #(= actor-id (second %)))
+                           (mapv first))]
+       (abort-on-actor-destroy frame-id actor-id)))
+   nil)
+  ([frame-id actor-id]
   (when actor-id
-    (let [handles (get @actor-in-flight actor-id)]
+    (let [k       (scoped-key frame-id actor-id)
+          handles (get @actor-in-flight k)]
       ;; Atomically clear the slot first so a re-entry sees no handles.
-      (swap! actor-in-flight dissoc actor-id)
+      (swap! actor-in-flight dissoc k)
       (doseq [handle handles]
         (when rf.interop/debug-enabled?
           ;; rf2-bma05 — the handle carries the originating request's
@@ -426,7 +623,7 @@
         (try
           ((:abort-fn handle) :actor-destroyed)
           (catch #?(:clj Throwable :cljs :default) _ nil)))))
-  nil)
+   nil))
 
 ;; ---- abort-in-flight-for-frame! (rf2-u5kmf8) ------------------------------
 ;;

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -630,7 +630,7 @@
     ;; supersede has ALREADY bumped the counter past this (superseded) attempt's
     ;; issuance, so the evict skips and the live successor keeps the id; only a
     ;; genuinely-quiescent id is dropped.
-    (rf.http.registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
+    (rf.http.registry/evict-issuance-on-completion! (:frame ctx) (:request-id ctx) (:issuance ctx))
     ;; rf2-3fc89f.9 — terminal for this request: detach the external
     ;; `:abort-signal` listener so a shared / parent controller retains no
     ;; completed-request listener. Fires for every abort reason (this is the
@@ -818,7 +818,7 @@
       (rf.http.registry/clear-in-flight! (:request-id ctx) (:handle ctx))
       ;; rf2-k47b3d — terminal completion: evict this id's issuance counter
       ;; (conditional-atomic; skips when a live re-issue has bumped past it).
-      (rf.http.registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
+      (rf.http.registry/evict-issuance-on-completion! (:frame ctx) (:request-id ctx) (:issuance ctx))
       ;; rf2-3fc89f.9 — terminal: detach the external abort-signal listener
       ;; (covers the success, accept-failure, and sample-(2) abort branches
       ;; below; idempotent with the abort-path detach in `dispatch-aborted!`).
@@ -912,7 +912,7 @@
       ;; (conditional-atomic; skips when a live re-issue has bumped past it, so
       ;; a superseded-then-reclassified attempt does not drop the successor's
       ;; live counter).
-      (rf.http.registry/evict-issuance-on-completion! (:request-id ctx) (:issuance ctx))
+      (rf.http.registry/evict-issuance-on-completion! (:frame ctx) (:request-id ctx) (:issuance ctx))
       ;; rf2-3fc89f.9 — terminal: detach the external abort-signal listener
       ;; (natural terminal failure + the abort-precedence reclassification;
       ;; idempotent with the abort-path detach in `dispatch-aborted!`).

--- a/implementation/http/test/re_frame/flows_http_integration_test.clj
+++ b/implementation/http/test/re_frame/flows_http_integration_test.clj
@@ -115,11 +115,19 @@
   actor-id indexes stay consistent (rather than a raw `swap!` of the
   `in-flight` atom that bypasses those invariants). The provided
   `abort-fn` is the recording closure the test uses to observe whether
-  `:rf.http/managed-abort` fired."
+  `:rf.http/managed-abort` fired.
+
+  rf2-o8ek — the seed carries `:frame`, exactly as production does: both
+  `record-in-flight!` sites in `http-transport` stamp `:frame (:frame ctx)`,
+  and that ctx value came from `require-frame-stamp!`, so a real in-flight
+  handle can never lack one. The frame is now part of the registry key, and
+  this test's cancel dispatches from the default frame, so the seed must name
+  it — otherwise the handle is registered in a scope no dispatch can reach."
   [request-id abort-fn]
   (rf.http.registry/seed-in-flight-for-test!
     {:request-id request-id
      :actor-id   nil
+     :frame      :rf/default
      :url        (str "/api/" (name request-id))
      :abort-fn   abort-fn}))
 

--- a/implementation/http/test/re_frame/http_frame_scoped_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_frame_scoped_cancellation_test.clj
@@ -1,0 +1,415 @@
+(ns re-frame.http-frame-scoped-cancellation-test
+  "rf2-o8ek — managed-request cancellation and supersession are FRAME-SCOPED.
+
+  Frames are isolated contexts (Spec 002; `docs/core/frames.md`), and Spec 014
+  §Frame awareness promises multi-frame apps \"work without extra ceremony\".
+  But the in-flight registry keyed both of its cancellation indexes on the RAW
+  caller-supplied id — `request-id -> handle` and `actor-id -> handles` — while
+  the frame rode along only as a stamp on the VALUE. Reusable app code
+  naturally reuses an ordinary stable id (`:request-id :articles/load`), so two
+  isolated frames running the same code cross-cancelled at the lifetime
+  boundary:
+
+   - frame B's issuance SUPERSEDED frame A's live request and suppressed its
+     reply;
+   - `[:rf.http/managed-abort :articles/load]` dispatched in B aborted A's
+     request even when B owned none;
+   - frame B's FIRST issuance number was allocated from frame A's counter,
+     perturbing B's `:work/id` for a supersession that never happened to it;
+   - destroying an actor in one frame walked the same actor-id slot holding a
+     sibling frame's handles.
+
+  The repair makes the ISSUING FRAME part of the internal key (`[frame-id id]`)
+  while the caller's raw `:request-id` stays the public correlation value
+  echoed in replies and traces. The public `:rf.http/managed` args map and the
+  `:rf.http/managed-abort` effect shape are unchanged.
+
+  Determinism: the end-to-end cases hold every request open with a latched
+  localhost `HttpServer`, so \"still live\" and \"aborted\" are decided by the
+  registry rather than by a race with the network. Every positive signal is
+  polled; the one non-event (no reply delivered into the wrong frame) uses the
+  bounded-window idiom the sibling frame-destroy test established."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.http.handlers :as rf.http.handlers]
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
+  (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
+           [java.net InetSocketAddress]
+           [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
+
+;; The one raw id BOTH frames use — the whole point of the bead is that an app
+;; may write this once in reusable code and mount it in N isolated frames.
+(def ^:private shared-id :articles/load)
+
+;; ---- harness ---------------------------------------------------------------
+
+(defn- start-blocking-server!
+  "A localhost server that holds every request open until `latch` counts down,
+  then answers 200 with a JSON body. Holding the request open is what makes
+  \"still in flight\" a decided fact rather than a timing guess."
+  [^CountDownLatch latch body]
+  (let [server (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)]
+    (.createContext server "/"
+                    (reify HttpHandler
+                      (handle [_ ex]
+                        (let [^HttpExchange ex ex]
+                          (.await latch 30 TimeUnit/SECONDS)
+                          (let [bs (.getBytes (str body) "UTF-8")]
+                            (-> ex .getResponseHeaders (.set "Content-Type" "application/json"))
+                            (try
+                              (.sendResponseHeaders ex 200 (long (count bs)))
+                              (with-open [os (.getResponseBody ex)]
+                                (.write os bs))
+                              (catch Throwable _ nil)))
+                          nil))))
+    (.setExecutor server nil)
+    (.start server)
+    {:server server :port (.getPort (.getAddress server))}))
+
+(defn- stop-server! [{:keys [^HttpServer server]}]
+  (.stop server 0))
+
+(defn- await-condition!
+  ([pred] (await-condition! pred 5000))
+  ([pred timeout-ms]
+   (rf.test-support/poll-until pred {:timeout-ms  timeout-ms
+                                  :interval-ms 10
+                                  :label       "http-frame-scoped-cancellation condition"})
+   true))
+
+(defn- register-two-frame-app!
+  "Register ONE set of handlers and mount it in two isolated frames — the exact
+  shape the bead names (documented per-request SSR frames, Story/test variants,
+  side-by-side mounts). `replies` collects every reply envelope; each carries
+  `:rf.frame/id`, so one shared recorder never loses which frame it landed in."
+  [port replies]
+  (rf/make-frame {:id :frame/a :doc "isolated frame A"})
+  (rf/make-frame {:id :frame/b :doc "isolated frame B"})
+  (rf/reg-event :reply/recorder
+    (fn [_ [_ payload]] (swap! replies conj payload) {}))
+  (rf/reg-event :articles/fetch
+    (fn [_ _]
+      {:fx [[:rf.http/managed
+             {:request    {:url (str "http://127.0.0.1:" port "/articles") :method :get}
+              :decode     :json
+              ;; ONE ordinary stable id, written once, reused in both frames.
+              :request-id shared-id
+              :on-success [:reply/recorder]
+              :on-failure [:reply/recorder]}]]}))
+  (rf/reg-event :articles/cancel
+    (fn [_ _] {:fx [[:rf.http/managed-abort shared-id]]})))
+
+(defn- live-in? [frame-id]
+  (some? (rf.http.registry/lookup-in-flight frame-id shared-id)))
+
+(defn- stale-rows [traces]
+  (filter #(= :rf.http/stale-suppressed (:operation %)) traces))
+
+;; ---- AC 1 — two frames, one raw id, both stay live -------------------------
+
+(deftest same-request-id-in-two-frames-does-not-cross-supersede
+  (testing "rf2-o8ek — two isolated frames issuing overlapping requests under
+            the SAME raw :request-id both remain live; neither is superseded
+            merely because the sibling reused the id, no stale-suppressed row
+            fires, and each eventually completes into ITS OWN frame echoing the
+            caller's original raw :request-id (never an internal compound key)"
+    (let [latch   (CountDownLatch. 1)
+          {:keys [port] :as srv} (start-blocking-server! latch "{\"ok\":true}")
+          replies (atom [])
+          traces  (atom [])]
+      (try
+        (rf.trace/register-listener! ::cross (fn [ev] (swap! traces conj ev)))
+        (register-two-frame-app! port replies)
+        (rf/dispatch-sync [:articles/fetch] {:frame :frame/a})
+        (await-condition! #(live-in? :frame/a))
+        (rf/dispatch-sync [:articles/fetch] {:frame :frame/b})
+        (await-condition! #(live-in? :frame/b))
+        ;; THE regression: pre-fix, frame B's issuance superseded frame A's
+        ;; handle out of the one raw-id slot, so this read was nil.
+        (is (live-in? :frame/a)
+            "frame A's request is STILL live after frame B issued the same raw id")
+        (is (live-in? :frame/b)
+            "frame B's request is live")
+        (is (contains? (rf.http.managed/in-flight-snapshot :frame/a) shared-id)
+            "the frame-precise snapshot shows the id under frame A")
+        (is (contains? (rf.http.managed/in-flight-snapshot :frame/b) shared-id)
+            "and independently under frame B")
+        (is (empty? (stale-rows @traces))
+            "NO stale-suppressed row fired — nothing was superseded")
+        (is (empty? @replies)
+            "neither frame's reply has been suppressed or delivered early")
+        ;; Release both requests: each completes into its own frame.
+        (.countDown latch)
+        (await-condition! #(= 2 (count @replies)))
+        (is (= #{:frame/a :frame/b} (set (map :rf.frame/id @replies)))
+            "each reply landed in the frame that issued it")
+        (is (every? #(= :ok (:status %)) @replies)
+            "both requests completed successfully — neither was cancelled")
+        (is (= #{shared-id} (set (map #(get-in % [:correlation :request-id]) @replies)))
+            "each reply echoes the CALLER'S raw :request-id, not a compound key")
+        (finally
+          (rf.trace/unregister-listener! ::cross)
+          (.countDown latch)
+          (stop-server! srv)
+          (rf.http.managed/clear-all-in-flight!))))))
+
+;; ---- AC 2 — reissue supersedes exactly the issuing frame's prior attempt ---
+
+(deftest reissue-supersedes-only-the-issuing-frames-prior-attempt
+  (testing "rf2-o8ek — reissuing the id inside frame A still supersedes exactly
+            A's prior attempt and emits ONE stale-suppressed row for A carrying
+            distinct carried/current work-ids, while frame B's handle — holding
+            the identical raw id — is untouched and completes normally"
+    (let [latch   (CountDownLatch. 1)
+          {:keys [port] :as srv} (start-blocking-server! latch "{\"ok\":true}")
+          replies (atom [])
+          traces  (atom [])]
+      (try
+        (register-two-frame-app! port replies)
+        (rf/dispatch-sync [:articles/fetch] {:frame :frame/a})
+        (await-condition! #(live-in? :frame/a))
+        (rf/dispatch-sync [:articles/fetch] {:frame :frame/b})
+        (await-condition! #(live-in? :frame/b))
+        (let [b-handle (rf.http.registry/lookup-in-flight :frame/b shared-id)]
+          ;; Listen only from here, so the rows we count belong to the reissue.
+          (rf.trace/register-listener! ::reissue (fn [ev] (swap! traces conj ev)))
+          (rf/dispatch-sync [:articles/fetch] {:frame :frame/a})
+          (await-condition! #(seq (stale-rows @traces)))
+          (let [rows (stale-rows @traces)
+                row  (first rows)
+                tags (:tags row)]
+            (is (= 1 (count rows))
+                "exactly ONE stale-suppressed row — frame B's sibling was not superseded")
+            (is (= :frame/a (:frame tags))
+                "the suppressed attempt belongs to frame A, the reissuing frame")
+            (is (= :stale (:rf.reply/status tags)))
+            (is (= :suppressed (:rf.reply/work-status tags)))
+            (is (not= (:rf.reply/carried tags) (:rf.reply/current tags))
+                "carried (superseded) and current (superseding) work-ids stay =-distinct"))
+          (is (identical? b-handle (rf.http.registry/lookup-in-flight :frame/b shared-id))
+              "frame B still holds the SAME handle — byte-for-byte untouched")
+          (is (live-in? :frame/a)
+              "frame A's fresh attempt now owns A's slot"))
+        (.countDown latch)
+        ;; Two live requests remain (A's successor and B's original); the
+        ;; superseded attempt delivers nothing.
+        (await-condition! #(= 2 (count @replies)))
+        (Thread/sleep 150)
+        (is (= 2 (count @replies))
+            "the superseded attempt delivered NO app reply (supersession suppresses)")
+        (is (= #{:frame/a :frame/b} (set (map :rf.frame/id @replies)))
+            "one reply per frame")
+        (finally
+          (rf.trace/unregister-listener! ::reissue)
+          (.countDown latch)
+          (stop-server! srv)
+          (rf.http.managed/clear-all-in-flight!))))))
+
+;; ---- AC 3 — :rf.http/managed-abort is frame-scoped -------------------------
+
+(deftest managed-abort-aborts-only-the-dispatching-frames-request
+  (testing "rf2-o8ek — [:rf.http/managed-abort id] dispatched in frame A aborts
+            ONLY A's request; the identical id in frame B stays live and
+            completes into B. Pre-fix the abort resolved the raw id globally, so
+            a frame owning no request could cancel its sibling's"
+    (let [latch   (CountDownLatch. 1)
+          {:keys [port] :as srv} (start-blocking-server! latch "{\"ok\":true}")
+          replies (atom [])]
+      (try
+        (register-two-frame-app! port replies)
+        (rf/dispatch-sync [:articles/fetch] {:frame :frame/a})
+        (await-condition! #(live-in? :frame/a))
+        (rf/dispatch-sync [:articles/fetch] {:frame :frame/b})
+        (await-condition! #(live-in? :frame/b))
+        (rf/dispatch-sync [:articles/cancel] {:frame :frame/a})
+        (await-condition! #(not (live-in? :frame/a)))
+        (is (not (live-in? :frame/a))
+            "frame A's request was aborted by its own frame's managed-abort")
+        (is (live-in? :frame/b)
+            "frame B's identically-named request is UNTOUCHED and still live")
+        (await-condition! #(= 1 (count @replies)))
+        (let [cancelled (first @replies)]
+          (is (= :cancelled (:status cancelled)) "A received the cancellation reply")
+          (is (= :frame/a (:rf.frame/id cancelled)) "…in frame A"))
+        (.countDown latch)
+        (await-condition! #(= 2 (count @replies)))
+        (let [completed (first (filter #(= :ok (:status %)) @replies))]
+          (is (some? completed) "frame B's request completed normally")
+          (is (= :frame/b (:rf.frame/id completed)) "…into frame B"))
+        (finally
+          (.countDown latch)
+          (stop-server! srv)
+          (rf.http.managed/clear-all-in-flight!))))))
+
+(deftest managed-abort-frame-scoping-is-symmetric
+  (testing "rf2-o8ek — the symmetric case: aborting in frame B leaves frame A's
+            identically-named request live"
+    (let [latch   (CountDownLatch. 1)
+          {:keys [port] :as srv} (start-blocking-server! latch "{\"ok\":true}")
+          replies (atom [])]
+      (try
+        (register-two-frame-app! port replies)
+        (rf/dispatch-sync [:articles/fetch] {:frame :frame/a})
+        (await-condition! #(live-in? :frame/a))
+        (rf/dispatch-sync [:articles/fetch] {:frame :frame/b})
+        (await-condition! #(live-in? :frame/b))
+        (rf/dispatch-sync [:articles/cancel] {:frame :frame/b})
+        (await-condition! #(not (live-in? :frame/b)))
+        (is (live-in? :frame/a) "frame A remains live")
+        (is (not (live-in? :frame/b)) "frame B aborted its own request")
+        (finally
+          (.countDown latch)
+          (stop-server! srv)
+          (rf.http.managed/clear-all-in-flight!))))))
+
+;; ---- AC 7 — the bead's two reproduction probes, at their production seams --
+
+(deftest reproduction-probes-no-longer-reach-across-frames
+  (testing "rf2-o8ek — the two probes the bead recorded (a frame-B supersede
+            selector, and managed-abort-handler carrying frame B's context) no
+            longer resolve or abort frame A's registered handle, while the
+            SAME-frame selector still does. This is the registry/handler-level
+            statement of the end-to-end cases above"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen (atom [])]
+      (rf.http.registry/record-in-flight!
+        :shared nil {:frame    :frame/a
+                     :abort-fn #(swap! seen conj [:frame/a %])})
+      ;; probe 1 — supersede! driven by frame B
+      (is (nil? (rf.http.registry/supersede! :frame/b :shared))
+          "a frame-B supersede finds NOTHING under frame A's handle")
+      (is (empty? @seen) "…and fired no abort")
+      (is (some? (rf.http.registry/lookup-in-flight :frame/a :shared))
+          "frame A's handle survives a sibling frame's supersede")
+      ;; probe 2 — the real managed-abort fx body carrying frame B's ctx
+      (rf.http.handlers/managed-abort-handler {:frame :frame/b :event [:cancel]} :shared)
+      (is (empty? @seen) "a frame-B managed-abort does NOT abort frame A's request")
+      (is (some? (rf.http.registry/lookup-in-flight :frame/a :shared))
+          "frame A's handle is still registered")
+      ;; the same selectors, correctly scoped, still work
+      (rf.http.handlers/managed-abort-handler {:frame :frame/a :event [:cancel]} :shared)
+      (is (= [[:frame/a :user]] @seen)
+          "frame A's OWN managed-abort aborts frame A's request with :reason :user"))
+    (rf.http.managed/clear-all-in-flight!)))
+
+;; ---- AC 4 — actor-destroy cancellation -------------------------------------
+
+(deftest actor-destroy-is-frame-scoped-when-the-frame-is-known
+  (testing "rf2-o8ek — the same generated/fixed actor-id in two frames keeps
+            INDEPENDENT registry slots, and the frame-bearing arity of
+            abort-on-actor-destroy aborts only the named frame's HTTP. This is
+            structural (the frame is part of the key) rather than dependent on
+            an actor-naming convention"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen (atom [])
+          mk   (fn [frame-id]
+                 (rf.http.registry/record-in-flight!
+                   nil :worker/proc#1
+                   {:frame    frame-id
+                    :url      "http://x/y"
+                    :abort-fn #(swap! seen conj [frame-id %])}))]
+      (mk :frame/a)
+      (mk :frame/b)
+      (is (= 1 (count (get (rf.http.managed/actor-in-flight-snapshot :frame/a) :worker/proc#1)))
+          "frame A's actor slot holds exactly its own handle")
+      (is (= 1 (count (get (rf.http.managed/actor-in-flight-snapshot :frame/b) :worker/proc#1)))
+          "frame B's same-named actor keeps an INDEPENDENT slot")
+      (rf.http.registry/abort-on-actor-destroy :frame/a :worker/proc#1)
+      (is (= [[:frame/a :actor-destroyed]] @seen)
+          "destroying frame A's actor aborted ONLY A-owned HTTP")
+      (is (= 1 (count (get (rf.http.managed/actor-in-flight-snapshot :frame/b) :worker/proc#1)))
+          "frame B's actor request is still live"))
+    (rf.http.managed/clear-all-in-flight!)))
+
+(deftest actor-destroy-any-frame-arity-preserves-the-hook-contract
+  (testing "rf2-o8ek — the 1-arg arity is the ANY-FRAME sweep the machines/core
+            destroy cascade calls through the :http/abort-on-actor-destroy hook,
+            which passes an actor address and no frame. It keeps the
+            pre-rf2-o8ek behaviour byte-for-byte rather than silently narrowing
+            a teardown; frame-scoping it needs those callers to thread the frame
+            they already hold"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen (atom [])
+          mk   (fn [frame-id]
+                 (rf.http.registry/record-in-flight!
+                   nil :worker/proc#1
+                   {:frame frame-id :abort-fn #(swap! seen conj [frame-id %])}))]
+      (mk :frame/a)
+      (mk :frame/b)
+      (rf.http.registry/abort-on-actor-destroy :worker/proc#1)
+      (is (= #{[:frame/a :actor-destroyed] [:frame/b :actor-destroyed]} (set @seen))
+          "the any-frame arity sweeps every frame's slot for that actor-id")
+      (is (empty? (rf.http.managed/actor-in-flight-snapshot))
+          "and clears both slots"))
+    (rf.http.managed/clear-all-in-flight!)))
+
+;; ---- AC 5 — frame-lifecycle sweeps still reap every handle they own --------
+
+(deftest frame-lifecycle-sweeps-reap-siblings-that-reused-one-id
+  (testing "rf2-o8ek — frame destroy and epoch restore still abort EVERY handle
+            owned by the selected frame, including two sibling frames that
+            reused a request id. The sweeps filter on the handle's :frame stamp,
+            so frame-scoped keying neither hides a handle from them nor lets one
+            sweep reach a sibling"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen (atom [])
+          ;; Production abort-fns clear their OWN slot through the 2-arg,
+          ;; identity-conditional `clear-in-flight!`, reading the handle back
+          ;; out of a cell published just after registration (the transport's
+          ;; `@handle-cell` / `@handle-holder` idiom). Model that exactly: the
+          ;; 1-arg clear is the ANY-FRAME seam and would take the sibling
+          ;; frame's slot with it, which is the very reach-through under test.
+          mk   (fn [frame-id request-id]
+                 (let [cell   (atom nil)
+                       handle (rf.http.registry/seed-in-flight-for-test!
+                                request-id nil
+                                {:abort-fn   (fn [reason]
+                                               (swap! seen conj [frame-id request-id reason])
+                                               (rf.http.registry/clear-in-flight! request-id @cell))
+                                 :request-id request-id
+                                 :url        "http://x/y"
+                                 :frame      frame-id})]
+                   (reset! cell handle)
+                   handle))]
+      ;; Both frames use the SAME raw id, plus one extra in A.
+      (mk :frame/a shared-id)
+      (mk :frame/a :articles/detail)
+      (mk :frame/b shared-id)
+      (rf.http.registry/abort-in-flight-on-frame-destroyed! :frame/a)
+      (is (= #{[:frame/a shared-id :frame-destroyed]
+               [:frame/a :articles/detail :frame-destroyed]}
+             (set @seen))
+          "BOTH of frame A's handles fired — including the one whose id frame B shares")
+      (is (some? (rf.http.registry/lookup-in-flight :frame/b shared-id))
+          "frame B's identically-named request survives A's destroy")
+      (reset! seen [])
+      (rf.http.registry/abort-in-flight-for-frame! :frame/b)
+      (is (= [[:frame/b shared-id :epoch-restored]] @seen)
+          "the epoch-restore sweep then reaps frame B's own handle")
+      (is (nil? (rf.http.registry/lookup-in-flight :frame/b shared-id))))
+    (rf.http.managed/clear-all-in-flight!)))
+
+;; ---- the any-frame seam resources reaches through is unchanged -------------
+
+(deftest resources-abort-by-frame-qualified-token-still-works
+  (testing "rf2-o8ek — resources aborts a managed request through the
+            :http/abort-in-flight! late-bind hook using its already-frame-
+            qualified token ([:rf.req frame-id work-id], Spec 016). That seam
+            carries no frame argument, so it stays ANY-FRAME — and because the
+            token embeds the frame, at most one frame can ever match"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen  (atom [])
+          token [:rf.req :frame/a :work-1]]
+      (rf.http.registry/record-in-flight!
+        token nil {:frame :frame/a :abort-fn #(swap! seen conj %)})
+      (is (true? (rf.http.registry/abort-in-flight! token :resource-superseded))
+          "the any-frame seam still resolves a frame-qualified token")
+      (is (= [:resource-superseded] @seen)))
+    (rf.http.managed/clear-all-in-flight!)))

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -2523,11 +2523,11 @@
     ;; conditional-atomic evict on completion keeps it at zero.
     (doseq [i (range 500)]
       (let [rid      [:fetch-doc i]
-            issuance (rf.http.registry/next-issuance! rid)]
+            issuance (rf.http.registry/next-issuance! :frame/counters rid)]
         (is (= 1 issuance) "a fresh distinct id starts at issuance 1")
         (is (= 1 (rf.http.registry/issuance-counter-count))
             "exactly one live counter while the request is in flight")
-        (rf.http.registry/evict-issuance-on-completion! rid issuance)
+        (rf.http.registry/evict-issuance-on-completion! :frame/counters rid issuance)
         (is (zero? (rf.http.registry/issuance-counter-count))
             "the counter is evicted the moment the request completes")))
     (is (zero? (rf.http.registry/issuance-counter-count))
@@ -2541,24 +2541,34 @@
   bumped it past the superseded attempt's issuance BEFORE the supersede."
     (rf.http.registry/reset-issuance-counters-for-test!)
     (let [rid [:search-box :q]
-          n1  (rf.http.registry/next-issuance! rid)   ; attempt A: issuance 1
-          n2  (rf.http.registry/next-issuance! rid)]  ; supersede → attempt B: issuance 2
+          n1  (rf.http.registry/next-issuance! :frame/counters rid)   ; attempt A: issuance 1
+          n2  (rf.http.registry/next-issuance! :frame/counters rid)]  ; supersede → attempt B: issuance 2
       (is (= 1 n1))
       (is (= 2 n2) "the superseding attempt gets a distinct, higher issuance")
       ;; Attempt A (the SUPERSEDED one) terminates. Its evict keys on issuance 1,
       ;; but the counter is already at 2 → the atomic compare-and-drop SKIPS.
-      (rf.http.registry/evict-issuance-on-completion! rid n1)
+      (rf.http.registry/evict-issuance-on-completion! :frame/counters rid n1)
       (is (= 1 (rf.http.registry/issuance-counter-count))
           "the superseded attempt's eviction does NOT drop the live counter")
-      (is (= 3 (rf.http.registry/next-issuance! rid))
+      (is (= 3 (rf.http.registry/next-issuance! :frame/counters rid))
           "the counter survived at 2, so the next issuance is 3 — no work-id collision")
       ;; The final live attempt terminates with the counter at its own issuance.
-      (rf.http.registry/evict-issuance-on-completion! rid 3)
+      (rf.http.registry/evict-issuance-on-completion! :frame/counters rid 3)
       (is (zero? (rf.http.registry/issuance-counter-count))
           "the id's final attempt evicts cleanly, bounding the map")))
   ;; A nil request-id never had a counter (anonymous requests stay at issuance 1
   ;; without touching the map) — eviction is a no-op.
   (rf.http.registry/reset-issuance-counters-for-test!)
-  (rf.http.registry/evict-issuance-on-completion! nil 1)
+  (rf.http.registry/evict-issuance-on-completion! :frame/counters nil 1)
   (is (zero? (rf.http.registry/issuance-counter-count))
-      "evicting a nil request-id is a no-op"))
+      "evicting a nil request-id is a no-op")
+  ;; rf2-o8ek — the counter is FRAME-SCOPED: a sibling frame reusing the same
+  ;; raw id runs its own sequence and starts at 1, rather than inheriting the
+  ;; other frame's count (measured pre-fix: frame B's FIRST issuance read 2).
+  (rf.http.registry/reset-issuance-counters-for-test!)
+  (is (= 1 (rf.http.registry/next-issuance! :frame/a :shared)))
+  (is (= 1 (rf.http.registry/next-issuance! :frame/b :shared))
+      "a sibling frame's first issuance under the same raw id is 1, not 2")
+  (is (= 2 (rf.http.registry/next-issuance! :frame/a :shared))
+      "each frame advances its own counter independently")
+  (rf.http.registry/reset-issuance-counters-for-test!))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -674,7 +674,31 @@ A subsequent `:rf.http/managed-abort` fx with the same id (compared by `=`) canc
 {:fx [[:rf.http/managed-abort [:articles :load "hello"]]]}
 ```
 
-When a fresh request supersedes a prior one with the same `:request-id`, the prior request's `:on-failure` reply is **not dispatched** — semantically the new request *replaces* the old one (the debounce-search mental model). The supersession records the superseded attempt the [uniform reply-envelope way](Managed-Effects.md#stale-suppression): a canonical `:rf.http/stale-suppressed` trace row carrying `:rf.reply/status :stale` / `:rf.reply/work-status :suppressed` (`:rf.reply/stale-reason :rf.http/request-id-superseded`) and the **carried** (the superseded attempt's `:work/id`) and **current** (the superseding attempt's `:work/id`) correlation — the two being `=`-distinct because the per-`request-id` issuance counter bumped. The legacy `:rf.http/aborted` trace (with `:reason :request-id-superseded`) still emits for abort-telemetry consumers; consumers wanting either subscribe via `register-listener!`. No app target runs for the superseded attempt. A manual `:rf.http/managed-abort` aborts whichever request currently holds the id and DOES dispatch `:on-failure` with `:reason :user`.
+When a fresh request supersedes a prior one with the same `:request-id` **in the same frame**, the prior request's `:on-failure` reply is **not dispatched** — semantically the new request *replaces* the old one (the debounce-search mental model). The supersession records the superseded attempt the [uniform reply-envelope way](Managed-Effects.md#stale-suppression): a canonical `:rf.http/stale-suppressed` trace row carrying `:rf.reply/status :stale` / `:rf.reply/work-status :suppressed` (`:rf.reply/stale-reason :rf.http/request-id-superseded`) and the **carried** (the superseded attempt's `:work/id`) and **current** (the superseding attempt's `:work/id`) correlation — the two being `=`-distinct because the per-`request-id` issuance counter bumped. The legacy `:rf.http/aborted` trace (with `:reason :request-id-superseded`) still emits for abort-telemetry consumers; consumers wanting either subscribe via `register-listener!`. No app target runs for the superseded attempt. A manual `:rf.http/managed-abort` aborts whichever request currently holds the id **in the frame the abort was dispatched from**, and DOES dispatch `:on-failure` with `:reason :user`.
+
+#### Frame scope — a `:request-id` is frame-local
+
+**A `:request-id` names a request within its issuing frame, never across frames.** Supersession, `:rf.http/managed-abort`, and the per-`:request-id` issuance counter are all scoped to the frame that issued the request:
+
+1. a fresh request supersedes only a **prior request from the same frame**; a sibling frame holding the same `:request-id` keeps its request live and its reply undisturbed;
+2. `[:rf.http/managed-abort id]` aborts only the **dispatching frame's** request under that id;
+3. the issuance counter that discriminates a superseded attempt from its superseder runs **per frame**, so a frame's first issuance under an id is `1` however many times a sibling has re-issued.
+
+This is the [frame-isolation contract](002-Frames.md#routing-the-dispatch-envelope) applied to request *lifetime*, matching what [§Frame awareness](#frame-awareness) already promises for reply *routing* and what [§Chain order and frame scope](#chain-order-and-frame-scope) already states for the interceptor chain: "an interceptor registered against frame A does NOT fire for a request dispatched from frame B". Cancellation is the third such surface, and it is scoped the same way.
+
+The point is ergonomic as much as it is correct. The frame is information the runtime already carries on every request, so an app writes one ordinary stable id in reusable code —
+
+```clojure
+:request-id :articles/load
+```
+
+— and mounts that code in as many isolated frames as it likes (per-request SSR frames, Story variants, side-by-side mounts) without the ids colliding. Callers are **not** asked to hand-qualify an id with a frame; doing so would leak a runtime implementation detail into every call site and make otherwise-reusable event code unsafe in exactly the multi-frame modes the framework advertises.
+
+The caller's raw `:request-id` remains the **public correlation value** — it is what rides in the reply envelope's `:correlation` and in trace rows, unchanged. The frame qualification is internal to the runtime's cancellation index and is never surfaced to the app.
+
+There is deliberately **no** cross-frame cancellation through this effect. A frame cannot reach another frame's in-flight request by naming its id; if such orchestration is ever wanted it deserves an explicit surface rather than an accidental reach-through.
+
+> **Framework-internal identities are qualified separately.** [Spec 016](016-Resources.md#ledger-row-retention-and-identity)'s resource / mutation transport ids are already frame-qualified (`[:rf.req frame-id work-id]`) because they are process-global transport correlation values. That qualification is orthogonal to — and unaffected by — the frame scoping described here.
 
 ### `:abort-signal` (external)
 
@@ -747,6 +771,12 @@ A spawned actor may issue multiple `:rf.http/managed` requests in its lifetime. 
 
 When actor A is destroyed, only A's in-flight requests are aborted. Actor B's in-flight requests — a sibling under the same `:spawn-all` that has not yet been told to stop — are unaffected until B itself is torn down.
 
+#### Frame scope
+
+A spawned actor's address is **frame-local**, exactly as a `:request-id` is (see [§Frame scope — a `:request-id` is frame-local](#frame-scope--a-request-id-is-frame-local)): two isolated frames running the same application code spawn actors under the same address. The in-flight index therefore keys actor-owned work on the **(frame, actor-id)** pair, so a frame's actor slot is independent of a same-named actor's slot in a sibling frame, and the isolation is structural rather than dependent on an actor-naming convention.
+
+Whether a given destroy narrows to one frame is decided by what the destroying caller supplies. The runtime's abort entry point accepts the destroyed actor's address **with** its owning frame — the frame-scoped form, which aborts only that frame's actor-owned HTTP — and, for a caller that holds only an address, an any-frame form that sweeps the address in every frame. The `:http/abort-on-actor-destroy` hook as currently invoked by the state-machine destroy cascade passes an address alone and so takes the any-frame form; threading the frame the cascade already holds is what makes an actor destroy frame-exact, and it is a change on the *calling* side of the hook.
+
 `:spawn-all` sibling cancellation on join resolution (per [Spec 005 §Cancel-on-decision](005-StateMachines.md#cancel-on-decision-default-true)) emits one `:rf.machine/destroy` per surviving sibling, so each sibling's HTTP cascade independently fires the `:http/abort-on-actor-destroy` hook against its own actor-id.
 
 #### Direct dispatches from event handlers — NOT covered
@@ -788,6 +818,8 @@ The sweep is idempotent and a no-op for a frame with no in-flight managed HTTP �
 ## Frame awareness
 
 The reply dispatch lands in the **same frame** the request was issued from. The fx reads the issuing frame's stamp from the dispatch **envelope's** `:frame` key — one of the **sanctioned** sites the bare `:frame` spelling survives at (the binary fx-handler ctx and the dispatch envelope; there is no bare `:frame` *coeffect* — the event-context spelling is `:rf.frame/id`, per [002 §One carrier, one name — the frame stamp](002-Frames.md#one-carrier-one-name--the-frame-stamp)) — and threads it through to the reply dispatch's `{:frame ...}` opt. Multi-frame apps work without extra ceremony.
+
+Frame awareness covers a request's **lifetime**, not only where its reply lands. The same issuing-frame stamp scopes cancellation: supersession, `:rf.http/managed-abort`, and the issuance counter are all frame-local (see [§Frame scope — a `:request-id` is frame-local](#frame-scope--a-request-id-is-frame-local)), and actor-owned work is indexed per frame (see [§Frame scope](#frame-scope)). Without that, "without extra ceremony" would be false in the multi-frame case it is written for: two frames running the same code would cancel each other through their shared ids, and callers would have to hand-qualify every `:request-id` to get the isolation back.
 
 ## Middleware
 
@@ -1179,8 +1211,8 @@ For test suites that need to inspect or reset the in-flight request registry dir
 | Helper | Signature | Purpose |
 |---|---|---|
 | `clear-all-in-flight!` | `(clear-all-in-flight!)` → nil | Drops both the request-id-keyed and actor-id-keyed in-flight maps. Consumed by `re-frame.test-support/make-reset-runtime-fixture` to restore a clean registry between tests; the `:http/clear-all-in-flight!` hook is published via the late-bind table so `test-support` can call it without statically requiring the http artefact. |
-| `in-flight-snapshot` | `(in-flight-snapshot)` → map | Reads the current value of the request-id-keyed in-flight map. For tests that need to assert "this request-id is in flight" without poking the atom directly. |
-| `actor-in-flight-snapshot` | `(actor-in-flight-snapshot)` → map | Reads the current value of the actor-id-keyed in-flight map (per [§Abort on actor destroy](#abort-on-actor-destroy) and). For tests that need to assert the actor → request-id reverse index. |
+| `in-flight-snapshot` | `(in-flight-snapshot)` / `(in-flight-snapshot frame-id)` → map | Reads the in-flight request index keyed by the **caller's raw `:request-id`**, never the internal frame-scoped key. For tests that need to assert "this request-id is in flight" without poking the atom directly. The 0-arity flattens every frame onto the raw id and is therefore lossy when two frames hold the same id — a multi-frame assertion uses the 1-arity, which reads one frame's requests. |
+| `actor-in-flight-snapshot` | `(actor-in-flight-snapshot)` / `(actor-in-flight-snapshot frame-id)` → map | Reads the actor-owned in-flight index keyed by the raw actor-id (per [§Abort on actor destroy](#abort-on-actor-destroy)). For tests that need to assert the actor → request-id reverse index. The 0-arity concatenates same-named actors across frames; the 1-arity reads one frame's actors. |
 | `seed-in-flight-for-test!` | `(seed-in-flight-for-test! handle)` / `(seed-in-flight-for-test! request-id actor-id handle)` → handle | Registers a fabricated in-flight handle through the SAME `record-in-flight!` path production uses, so BOTH indexes stay consistent. For fixtures that need an in-flight slot present without issuing a real request. The 1-arity reads `:request-id` / `:actor-id` off the handle. The raw in-flight atoms are NOT exported — a fixture must seed through this helper rather than `swap!`-ing an atom directly. |
 
 These are **test-only** surfaces — not part of the user-facing API for production code paths. Application code SHOULD route through `:rf.http/managed` and the dispatch-shape replies; the helpers exist so test fixtures can observe, seed, and reset registry state without reaching into the namespace's atoms. The underlying `in-flight` / `actor-in-flight` storage atoms are **not** re-exported from `re-frame.http.managed` — exposing mutable internal storage as API would let callers bypass `record-in-flight!` / `clear-in-flight!` and the actor-index cleanup invariants. The per-frame HTTP-interceptor chain has the symmetric pair: `interceptors-snapshot` (`(interceptors-snapshot)` → `frame-id → [slot …]`, or `(interceptors-snapshot frame-id)` → `[slot …]`) reads the chain for assertions; registration / clearing route through `reg-http-interceptor` / `clear-http-interceptor`, never a raw atom `swap!`.


### PR DESCRIPTION
## The defect

The HTTP in-flight registry is process-global, and both of its cancellation indexes keyed on the **raw caller-supplied id** — `request-id -> handle` and `actor-id -> handles` — while the issuing frame rode along only as a stamp on the *value*. A stamp on the value cannot stop a lookup keyed on the raw id from resolving a sibling frame's handle.

Frames are isolated contexts, and Spec 014 §Frame awareness promises multi-frame apps "work without extra ceremony". But reusable app code reuses an ordinary stable id — `:request-id :articles/load` — so two isolated frames running the same code cross-cancelled at the lifetime boundary. Reproduced at tip before the fix, and each case now has a witness:

| | before | after |
|---|---|---|
| frame B issues the shared id | supersedes and suppresses frame A's live request | A stays live |
| `[:rf.http/managed-abort id]` in frame B | aborts frame A's request even though B owns none | A stays live |
| frame B's **first** issuance under the shared id | `2` — taken off frame A's counter, perturbing B's `:work/id` | `1` |
| destroying frame A's actor `:worker/proc#1` | also aborts frame B's same-named actor's HTTP | only A's (via the frame-bearing arity) |

This is the frame-isolation invariant rather than tidiness: the exposure is exactly the multi-frame modes the library advertises — per-request SSR frames, Story/test variants, side-by-side mounts.

## The contract — Spec 014 was silent, so this settles it

014 said neither "frame-scoped" nor "process-global" for cancellation. It was decided in favour of frame-scoping because the alternative contradicts things 014 already says:

- §Frame awareness — "multi-frame apps work without extra ceremony". Process-global cancellation makes that false unless every caller hand-qualifies its ids.
- §Chain order and frame scope — "an interceptor registered against frame A does NOT fire for a request dispatched from frame B". The interceptor chain, the sibling HTTP surface, is already per-frame. Cancellation is the third such surface and is now scoped the same way.
- §Sibling actors are not affected already asserts isolation between actors; a same-named actor in a sibling frame is the same claim one level out.

Spec changes: a new §Frame scope — a `:request-id` is frame-local (the three-clause law, the "no cross-frame cancellation through this effect" non-goal, and the note that the caller's raw id stays the public correlation value); a §Frame scope note under Abort on actor destroy; §Frame awareness extended from reply *routing* to request *lifetime*; and the two snapshot helpers' new arities in §In-flight registry test helpers.

## The fix

Make the **issuing frame part of the internal key** — `[frame-id id]` — for both indexes and for the issuance counters, deriving it from the `:frame` stamp the transport already puts on every handle. No new namespace, registry, lease object, user-facing token or configuration switch.

Unchanged: the public `:rf.http/managed` args map, the `:rf.http/managed-abort` effect shape, and the caller's raw `:request-id` as the correlation value echoed in replies and traces. Callers are never asked to hand-qualify an id.

`managed-abort-handler` now takes the frame from its fx context (the EP-0002 carried invariant it previously named `_frame-ctx` and discarded); `supersede!` / `next-issuance!` / `evict-issuance-on-completion!` take the issuing frame; `record-in-flight!` and the 2-arg `clear-in-flight!` needed no signature change at all, since the handle already carries `:frame`.

### The any-frame seams, and what is deliberately left

Three entry points are reached from artefacts holding a token but no frame. Their frame-less arities are kept, documented as ANY-FRAME, with their pre-existing behaviour:

- resources' `:http/abort-in-flight!` hook — correct as-is, because its token is already frame-qualified (`[:rf.req frame-id work-id]`, Spec 016), so at most one frame can match;
- the machines/core `:http/abort-on-actor-destroy` hook — passes an address alone, so it keeps the any-frame sweep rather than silently narrowing a teardown.

`abort-on-actor-destroy` gains a frame-bearing arity alongside, and the registry half of the actor case is done. Making an actor destroy frame-exact needs those two callers to thread the frame they already hold — one line each in `implementation/machines/` and `implementation/core/`, both outside this PR's fence. Filed as **rf2-wjfm** with the call sites named.

## Witness

`implementation/http/test/re_frame/http_frame_scoped_cancellation_test.clj` — 9 deftests. The end-to-end cases hold each request open with a latched localhost `HttpServer`, so "still live" and "aborted" are decided by the registry rather than by a race with the network; every positive signal is polled and the one non-event uses the bounded-window idiom the sibling frame-destroy test established. **No timing-sensitive assertion.**

**Negative control (the red).** Restoring raw global keying — `scoped-key` returning `[(when false frame-id) id]` — takes the suite to **exit 1, 21 failures / 3 errors**, with **7 of the 9 new deftests red**: `same-request-id-in-two-frames-does-not-cross-supersede`, `reissue-supersedes-only-the-issuing-frames-prior-attempt`, `managed-abort-aborts-only-the-dispatching-frames-request`, `managed-abort-frame-scoping-is-symmetric`, `reproduction-probes-no-longer-reach-across-frames`, `actor-destroy-is-frame-scoped-when-the-frame-is-known`, `frame-lifecycle-sweeps-reap-siblings-that-reused-one-id`. The two that stay green are exactly the two pinning the ANY-FRAME seams the control does not alter. The plant was then reverted and the revert verified by comparing the file's blob hash against the committed object.

## Two test seeds needed the frame, and neither is a production regression

Both production `record-in-flight!` sites stamp `:frame (:frame ctx)`, and that ctx value came through `require-frame-stamp!`, which throws on nil — so a real in-flight handle can never lack a frame. Two hand-built seeds did:

- `flows_http_integration_test.clj`'s `prime-in-flight!` — now stamps `:frame`, as production does;
- the `managed_http_counter` example's demo-only seed fx, which already *bound* the carried frame for its deferred dispatch but did not put it on the handle. One key. Its driving test in `implementation/core/test/` needed no change.

## Gates

All exits captured by redirecting to a log and echoing the runner's own status on one command line — never through a filter.

| gate | exit | result |
|---|---|---|
| `implementation/http` `clojure -M:test` — **before** | 0 | 506 tests / 3882 assertions, 0 failures/errors |
| `implementation/http` `clojure -M:test` — **after, on the final rebased base** | 0 | 515 tests / 3929 assertions, 0 failures/errors |
| `implementation/http` `clojure -M:test` — **negative control** | 1 | 21 failures / 3 errors (7 of 9 new deftests red) |
| `npm run test:cljs` | 0 | 11,170 tests / 55,743 assertions, 0 failures/errors |
| `python -m mkdocs build --strict` | 0 | `spec/` staged and built by the `on_pre_build` hook |
| `scripts/check_doc_slugs.py` | 0 | — |

The +9 deftests / +47 assertions over the http baseline, and the 55,743 assertions on the CLJS gate, discriminate that each run saw this tree. The doc gate was additionally proven live rather than vacuously green: a broken anchor planted in `spec/014-HTTPRequests.md` took it to **exit 1 naming the file, the line, and the planted anchor**; the plant was reverted and the revert verified by blob hash.

### Hand-checks the gates cannot make

Neither doc gate validates prose, tables or rendering, and neither reads inside a fenced code block:

- **Anchors** — all five link targets added or referenced (`#frame-awareness`, `#chain-order-and-frame-scope`, `#abort-on-actor-destroy`, `#frame-scope--a-request-id-is-frame-local`, `#frame-scope`) resolve; the two new `####` headings produce distinct slugs with no duplicate needing an `_N` suffix.
- **Tables** — the edited §In-flight registry test helpers table is uniform at 3 columns across its header, separator and all four body rows.
- **Fenced blocks** — the one fence added (`:request-id :articles/load`) contains no links, so nothing there is invisible to the gates.

## Fence

Confined to `implementation/http/**`, `spec/014-HTTPRequests.md`, and the one-key example fix a nominated gate demanded. Nothing under `implementation/core/`, `implementation/resources/`, `implementation/machines/`, `implementation/hicasso/`, `implementation/ssr/`, `tools/`, or any other spec file.

Closes rf2-o8ek.
