### PR TITLE
fix(examples/linearlite): commit each write at the granularity it wrote at (rf2-9man)

### DIFF
--- a/examples/capabilities/resources/linearlite/README.md
+++ b/examples/capabilities/resources/linearlite/README.md
@@ -56,13 +56,12 @@ The whole point fits in 4 facts, all in one small app.
   to get subtly wrong.
 
 - The reply settles the same way every time — no clock-watching. A success
-  reply commits: the mutation's `:populates` re-seeds the board with the
-  server's authoritative value, so a card's temporary id is replaced by the
-  server's and the optimistic marker clears. A failure reply rolls back: the
-  recorded before is restored exactly, and the change visibly reverts. No
-  wall-clock race decides which wins. The verdict keys off recorded facts — which
-  write this is, and each entry's revision when the patch applied — not "whichever
-  reply landed last."
+  reply commits: the mutation's `:patches` folds in the value the server saved
+  for that write, so a card's temporary id is replaced by the server's and the
+  optimistic marker clears. A failure reply rolls back: the recorded before is
+  restored exactly, and the change visibly reverts. Which of the two happens
+  keys off recorded facts — which write this is, and each entry's revision when
+  the patch applied — not "whichever reply landed last."
 
 - Rollback is the thing you actually watch — the headline. A **"Fail the next
   write"** toggle tells the demo backend to answer the next write with a `503`.
@@ -93,6 +92,31 @@ with stale data. So instead the runtime refetches the authoritative value and le
 the read path heal the cache. (This is the deliberate difference from TanStack/SWR,
 which restore captured context unconditionally — fine until two writes overlap.)
 
+Overlapping writes commit at the granularity they wrote at. Nothing stops you
+adding a card while a retitle is still saving, or moving one card while another
+is in flight — the controls stay live, and each write runs under its own
+mutation instance (`[:create tmp-id]`, `[:edit id]`, `[:status id]`). So the
+success consequences have to be disjoint, or one write's commit would undo
+another's. That is why each mutation declares
+[`:patches`](../../../../docs/resources/glossary.md#mutation) and not
+`:populates`: `edit-title` sets the title the server saved, `change-status` sets
+the status, `create-issue` swaps its temporary card for the server's row, and
+none of them re-seeds the whole board from its own reply. A whole-board reply is
+a snapshot of the server as it stood when *that* write landed — it knows nothing
+about the write that started a moment later — so seeding the cache from it would
+drop the other change, and the board would settle on whichever reply arrived
+last. The demo backend answers a write with just the row it changed, to match.
+
+Be precise about what is ordered for you. The commit-or-roll-back verdict for a
+write is decided from recorded facts, and a stale reply for a write that has
+since re-executed is suppressed. Both of those are *per-instance* guarantees.
+Two **independent** instances writing the same entry are not ordered for you,
+and nothing on the client could order them. Keeping their consequences disjoint
+is the application's job — and it is a small one: patch what you wrote. (If your
+API only hands back coarse snapshots, the honest alternatives are to invalidate
+and refetch, or to serialise the writes deliberately. Not to treat the snapshots
+as though they commute.)
+
 Scope is a fail-closed leak boundary, even on a write. The board is one public
 board, so the resource carries the explicit, auditable `:scope :rf.scope/global`
 claim — there's no implicit default to fall back on. A per-team board would carry a
@@ -119,7 +143,8 @@ There's no server here. So the example overrides the
 [`:rf.http/managed`](../../../../docs/resources/glossary.md#managed-http) effect — the
 one transport every read and write lowers onto — with a small canned stub. The
 stub holds the canonical board in a closure (it is the demo server) and builds
-the authoritative reply for each read and write, delegating to the
+the authoritative reply for each read and write — a read answers with the whole
+board, a write with just the row it changed — delegating to the
 framework-shipped `:rf.http/managed-canned-success` / `-failure`
 ([Spec 014 §Testing](../../../../spec/014-HTTPRequests.md#testing)). It delays each reply by a
 small `:after-ms`, so the optimistic value is visibly painted before the reply

--- a/examples/capabilities/resources/linearlite/core.cljs
+++ b/examples/capabilities/resources/linearlite/core.cljs
@@ -31,11 +31,16 @@
      to get subtly wrong.
 
    - The reply settles the same way every time. A success (`:ok`) commits:
-     `:populates` overwrites the optimistic guess with the server's authoritative
-     board. A failure (`:error`) rolls back: the recorded value returns and the
-     optimistic change visibly reverts. The verdict reads recorded facts — the
-     generation-acceptance verdict (which write this is) plus each entry's
-     revision when the patch applied — so no wall-clock race decides who wins.
+     `:patches` folds in the value the server saved for THAT write, replacing the
+     optimistic guess. A failure (`:error`) rolls back: the recorded value returns
+     and the optimistic change visibly reverts. Which of the two happens reads
+     recorded facts — the generation-acceptance verdict (which write this is)
+     plus each entry's revision when the patch applied — so no wall-clock race
+     decides it. And because each commit touches only what its own write changed
+     (its title, its status, its own new card), two writes in flight at once can
+     settle in either order without one undoing the other. Re-seeding the whole
+     board from a single write's reply is what would break that, and it's why
+     these mutations use `:patches` rather than `:populates`.
 
    - Rollback is the thing you actually watch. A 'Fail the next write' toggle
      arms the demo backend to answer the next mutation with a 503. The optimistic
@@ -106,7 +111,7 @@
 ;; The entire issue board is a single resource entry: `{:issues [...]}`. The
 ;; route ensures it on entry; the view reads it passively. Every optimistic
 ;; write patches this one entry's `:data` in place, and the success reply
-;; re-seeds it with the server's authoritative board via `:populates`. The
+;; patches it again with the value the server saved for that write. The
 ;; runtime owns the board's value, its freshness, and the recorded inverse that
 ;; makes rollback honest. It lives in the resource cache — state you don't own,
 ;; kept where state you don't own belongs, never in app-db.
@@ -115,7 +120,7 @@
   {:doc            "The whole issue board — `{:issues [...]}` — as one managed
                     server-state read. Optimistic writes patch this entry in
                     place before their request is sent; the success reply
-                    re-seeds it with the server's authoritative board."
+                    patches it again with the value the server saved."
 
    ;; One public board in the demo, so the identity params are empty. A real app
    ;; would scope this per-team or per-user and key the team into :params.
@@ -132,8 +137,8 @@
 
    ;; A tag on the board, so something external (a server push, say) can
    ;; invalidate the whole thing by tag. The optimistic writes below patch the
-   ;; entry directly and re-seed via `:populates` on commit, so they never need
-   ;; this coarser hammer. Guide:
+   ;; entry directly and patch it again on commit, so they never need this
+   ;; coarser hammer. Guide:
    ;; ../../../../docs/resources/glossary.md#cache-tag
    :tags           (fn [_params _data] #{[:board]})}
   (fn [_params _ctx]
@@ -146,7 +151,7 @@
 
 (def ^:private board-key
   "Where the board lives in the cache: a `{:resource :scope :params}` map. We
-   reuse it as both the `:optimistic` patch key and the `:populates` commit key,
+   reuse it as both the `:optimistic` patch key and the `:patches` commit key,
    so every write aims at exactly the same entry. Empty `:params` means the one
    public board."
   {:resource :linearlite/board :scope :rf.scope/global :params {}})
@@ -159,10 +164,10 @@
 
 ;; A counter for client-minted ids. The moment an optimistic card appears it
 ;; needs a stable React key, but the server hasn't named the issue yet — so we
-;; hand it a `tmp-N` id to tide it over. On commit the success reply re-seeds the
-;; whole board with the server's value (real id and all), so the temporary id
-;; never outlives the round trip; a rollback just removes the card that never
-;; landed.
+;; hand it a `tmp-N` id to tide it over. On commit the success reply carries the
+;; row the server created (real id and all) and the commit patch swaps it in for
+;; the temporary card, so the temporary id never outlives the round trip; a
+;; rollback just removes the card that never landed.
 (defonce ^:private optimistic-id-seq (atom 0))
 
 (defn- next-issue-id
@@ -181,25 +186,59 @@
 
 (defn- patch-issue
   "Build a board-`:data` patch that applies `f` to the issue with `id` and
-   leaves everything else alone. Forward only: the runtime records the inverse,
-   so this never has to describe how to undo itself."
+   leaves every other card alone. Forward only: the runtime records the inverse,
+   so this never has to describe how to undo itself.
+
+   Variadic because one shape serves both hooks: an `:optimistic` patch fn is
+   handed the data, a success-time `:patches` fn is handed the data and the
+   reply. `f` closes over whatever it needs either way."
   [id f]
-  (fn [data]
+  (fn [data & _]
     (update data :issues
             (fn [issues]
               (mapv (fn [issue] (if (= id (:id issue)) (f issue) issue))
                     (or issues []))))))
+
+(defn- replied-issue
+  "The row a write's reply is about. A write answers with the issue it changed,
+   in the board's own `{:issues [...]}` envelope, so pick out the one this write
+   named. `nil` when the reply doesn't carry it — and then the commit leaves the
+   card exactly as it is rather than inventing a value for it."
+  [result id]
+  (some #(when (= id (:id %)) %) (:issues result)))
 
 ;; ============================================================================
 ;; THE MUTATIONS — create / edit-title / change-status, all optimistic
 ;; ============================================================================
 ;;
 ;; Each write reads the same three keys. `:optimistic` is the forward patch over
-;; the board entry, applied before the request goes out. `:populates` is the
-;; commit — on `:ok`, re-seed the board with the server's authoritative value.
-;; `:on-conflict :invalidate` is the (default) conflict policy. The runtime fills
-;; in the rest itself: it records the inverse and each entry's revision, and the
-;; reply settles deterministically.
+;; the board entry, applied before the request goes out. `:patches` is the
+;; commit — on `:ok`, fold the server's saved value for THIS write into the
+;; board. `:on-conflict :invalidate` is the (default) conflict policy. The
+;; runtime fills in the rest itself: it records the inverse and each entry's
+;; revision, and the reply settles deterministically.
+;;
+;; WHY `:patches` AND NOT `:populates`. `:populates` seeds the entry with the
+;; reply outright, and it's the right tool when the reply IS the whole of what
+;; the entry holds. It's the wrong tool here, because these three writes are
+;; INDEPENDENT: they run under separate mutation instances (`[:create tmp-id]`,
+;; `[:edit id]`, `[:status id]`), the controls stay live while a write is in
+;; flight, so two of them are routinely outstanding over the one board at once.
+;; A whole-board reply is a snapshot of the server as it stood when THAT write
+;; landed — it knows nothing of the write that started a moment later — so
+;; seeding the entry from it would throw the other write's change away, and the
+;; board would settle on whichever reply arrived last. The runtime's stale-reply
+;; suppression does not cover this: it's scoped to one instance's re-execute,
+;; which is a different question from ordering two instances that write the same
+;; entry. Nothing on the client can order those; keeping their consequences
+;; disjoint is the part you own, and it's a small part — patch what you wrote.
+;;
+;; So each write commits at the granularity it wrote at: `edit-title` sets the
+;; title the server saved, `change-status` sets the status, `create-issue` swaps
+;; its temporary card for the server's row. Nothing else on the board is
+;; touched, so the three commits COMMUTE — they can land in any order and every
+;; accepted change survives. The demo backend answers a write with just the row
+;; it changed, to match.
 ;;
 ;; Writes don't retry — reads do, writes don't. A 503 surfaces as `:error` and
 ;; rolls the optimistic change back, which is exactly the arc the demo's 'fail
@@ -222,10 +261,19 @@
                                  (upsert-issue issues
                                                {:id id :title title :status :backlog
                                                 :optimistic? true}))))})
-   ;; Commit: the `:ok` reply is the server's whole authoritative board. Re-seed
-   ;; the entry with it — the placeholder id gives way to the server's, and the
-   ;; optimistic flag clears. Same `{:issues …}` envelope the resource stores.
-   :populates     (fn [_params result] {board-key result})
+   ;; Commit: the `:ok` reply carries the row the server created, with its real
+   ;; id. Drop the temporary card and merge that row in — this write's own card
+   ;; and nothing else, so a write still in flight over another card keeps its
+   ;; optimistic value. The placeholder id gives way to the server's and the
+   ;; optimistic flag clears, because the server's row carries neither.
+   :patches       (fn [{:keys [id]} result]
+                    {board-key
+                     (fn [data & _]
+                       (update data :issues
+                               (fn [issues]
+                                 (reduce upsert-issue
+                                         (filterv #(not= id (:id %)) issues)
+                                         (:issues result)))))})
    ;; On conflict (the default): if a rollback is contested, refetch rather than
    ;; restore a now-stale inverse. See the conflict-policy note at the top.
    :on-conflict   :invalidate}
@@ -242,7 +290,17 @@
    :scope         :rf.scope/global
    :optimistic    (fn [{:keys [id title]}]
                     {board-key (patch-issue id #(assoc % :title title :optimistic? true))})
-   :populates     (fn [_params result] {board-key result})
+   ;; Commit: take the TITLE off the row the server saved — the one field this
+   ;; write asked for — and leave the rest of the card, and every other card,
+   ;; alone. A status move still in flight over the same issue survives.
+   :patches       (fn [{:keys [id]} result]
+                    (let [saved (replied-issue result id)]
+                      {board-key (patch-issue id (fn [issue]
+                                                   (if saved
+                                                     (-> issue
+                                                         (assoc :title (:title saved))
+                                                         (dissoc :optimistic?))
+                                                     issue)))}))
    :on-conflict   :invalidate}
   (fn [{:keys [id title]} _ctx]
     {:request {:method :put :url (str "/api/issues/" id)
@@ -257,7 +315,17 @@
    :scope         :rf.scope/global
    :optimistic    (fn [{:keys [id status]}]
                     {board-key (patch-issue id #(assoc % :status status :optimistic? true))})
-   :populates     (fn [_params result] {board-key result})
+   ;; Commit: the STATUS off the saved row, and nothing else — the twin of the
+   ;; retitle above. Retitle and move can be in flight over the same card at
+   ;; once, and settling either leaves the other's optimistic value standing.
+   :patches       (fn [{:keys [id]} result]
+                    (let [saved (replied-issue result id)]
+                      {board-key (patch-issue id (fn [issue]
+                                                   (if saved
+                                                     (-> issue
+                                                         (assoc :status (:status saved))
+                                                         (dissoc :optimistic?))
+                                                     issue)))}))
    :on-conflict   :invalidate}
   (fn [{:keys [id status]} _ctx]
     {:request {:method :put :url (str "/api/issues/" id)
@@ -308,37 +376,46 @@
   (str "srv-" (inc (count (:issues board)))))
 
 (defn- apply-write!
-  "Apply a successful write to the canonical demo board and return the new
-   authoritative board — the value that becomes the `:populates` payload. Routed
-   the way a real server would route it, by method + URL: POST mints a fresh
-   server id for the new issue; PUT patches title and/or status by id from the
-   request body."
+  "Apply a successful write to the canonical demo board and return THE ROW IT
+   CHANGED, in the board's own `{:issues [...]}` envelope — the value that
+   becomes the `:patches` payload. Routed the way a real server would route it,
+   by method + URL: POST mints a fresh server id for the new issue; PUT patches
+   title and/or status by id from the request body.
+
+   A write's reply speaks only for the row that write touched. That's the
+   deliberate bit: a whole-board reply would also carry a stale copy of every
+   OTHER card — including one a concurrent write had just changed — and folding
+   that into the cache would silently undo the other write."
   [method url body]
-  (swap! demo-board
-         (fn [board]
-           (cond
-             ;; POST /api/issues — a create. Mint a server id for the new issue.
-             (and (= method :post) (str/ends-with? url "/api/issues"))
-             (update board :issues
-                     (fn [issues]
-                       (conj (vec issues)
-                             {:id (next-server-id board) :title (:title body) :status :backlog})))
+  (let [create? (and (= method :post) (str/ends-with? url "/api/issues"))
+        put-id  (when (= method :put) (second (re-find #"/api/issues/([^/?]+)$" url)))
+        ;; The id this write is about, minted up front for a create so the reply
+        ;; can name the row it produced.
+        id      (if create? (next-server-id @demo-board) put-id)
+        board'  (swap! demo-board
+                       (fn [board]
+                         (cond
+                           ;; POST /api/issues — a create, under the id above.
+                           create?
+                           (update board :issues
+                                   (fn [issues]
+                                     (conj (vec issues)
+                                           {:id id :title (:title body) :status :backlog})))
 
-             ;; PUT /api/issues/:id — edit title and/or move status.
-             (and (= method :put) (re-find #"/api/issues/([^/?]+)$" url))
-             (let [id (second (re-find #"/api/issues/([^/?]+)$" url))]
-               (update board :issues
-                       (fn [issues]
-                         (mapv (fn [issue]
-                                 (if (= id (:id issue))
-                                   (cond-> issue
-                                     (contains? body :title)  (assoc :title (:title body))
-                                     (contains? body :status) (assoc :status (:status body)))
-                                   issue))
-                               issues))))
+                           ;; PUT /api/issues/:id — edit title and/or move status.
+                           put-id
+                           (update board :issues
+                                   (fn [issues]
+                                     (mapv (fn [issue]
+                                             (if (= id (:id issue))
+                                               (cond-> issue
+                                                 (contains? body :title)  (assoc :title (:title body))
+                                                 (contains? body :status) (assoc :status (:status body)))
+                                               issue))
+                                           issues)))
 
-             :else board)))
-  (strip-optimistic @demo-board))
+                           :else board)))]
+    (strip-optimistic {:issues (filterv #(= id (:id %)) (:issues board'))})))
 
 (rf/reg-fx :linearlite.demo/http-stub
   {:doc       "Demo stand-in for `:rf.http/managed`. Holds the canonical board in
@@ -378,8 +455,8 @@
                                  :kind     :rf.http/http-5xx
                                  :tags     {:status  503
                                             :message "Simulated server failure (the demo's rollback seam)."})))
-        ;; Otherwise, success: a read returns the current board; a write mutates
-        ;; the canonical board and returns the new authoritative one.
+        ;; Otherwise, success: a read returns the whole current board; a write
+        ;; mutates the canonical board and returns just the row it changed.
         (let [payload (if write?
                         (apply-write! method url body)
                         (strip-optimistic @demo-board))


### PR DESCRIPTION
Closes rf2-9man.

## The defect, reproduced

The board's three writes — create, retitle, change-status — each run under their
own mutation instance (`[:create tmp-id]`, `[:edit id]`, `[:status id]`), and the
controls stay live while a write is in flight, so two of them are routinely
outstanding over the one board resource at once. Each committed with
`:populates`, seeding that one entry from its own **whole-board** reply. A reply
built before a concurrent write landed does not contain that write — so seeding
the cache from it dropped the other change, and the final cache state was
whichever reply arrived last.

That contradicted what the example promised. `README.md` said success settles
from recorded facts and "not whichever reply landed last"; the ns docstring said
the same. Both sentences are true of the **verdict** (commit vs roll back) and of
same-instance stale-reply suppression, and neither covers ordering two
independent instances that write the same entry — which nothing on the client
can do.

**Reproduced before repairing**, with two temporary tests planted in
`implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs`
driving the example's own registrations (see *Witness* below). Both were red on
the unmodified example and green after the change, with identical inputs:

| | before | after |
|---|---|---|
| settling write A must not erase write B's still-pending optimistic move | `:done` vs `:in-progress` — **failed** | passed |
| A's older snapshot landing **last** must not revert B's already-accepted move | `:done` vs `:in-progress` — **failed** | passed |

The second is the permanent loss: both successes accepted, and the older
aggregate snapshot silently erased an already-committed change.

## Owner: the example, not the framework

`implementation/` is untouched. `:populates` is documented as an *authoritative
load* that seeds an entry from the reply, and `populate-entry` does exactly that.
The framework already ships the right tool for this shape — `:patches`,
`(fn [params result] -> {target patch-fn})` — and the example's own README
already called `:optimistic` "the exact-target twin of a mutation's success-time
`:patches`". The bug was the example choosing the aggregate consequence for
fine-grained, independent writes.

## The fix

Each mutation now commits at the granularity it wrote at, so the three
consequences are disjoint and commute:

- `edit-title` sets the title the server saved, on its own card only.
- `change-status` sets the status the server saved, on its own card only.
- `create-issue` drops its temporary card and merges in the server's row.

The demo backend answers a write with just the row it changed, in the board's own
`{:issues [...]}` envelope, to match; a read still answers with the whole board.
`patch-issue` is now variadic so one shape serves both hooks (`:optimistic` is
handed the data, `:patches` the data and the reply).

Two writes can now settle in either order — same card or different cards, title
and status at once — and every accepted change survives.

## Docs

README and the source comments now state the bounded guarantee instead of
implying a stronger one: the commit-or-roll-back verdict and same-instance stale-
reply suppression are per-instance; independent instances writing one entry are
not ordered for you, and keeping their consequences disjoint is the application's
job. The README also names the honest alternatives when an API only returns
coarse snapshots (invalidate/refetch, or deliberate serialisation) rather than
pretending such snapshots commute.

## Witness — where it is, and where it is not

Examples are test-free by ruling (rf2-8cevm), so the witness could not live under
`examples/`. Its natural home is the adapter test tree, which is out of this
worker's fence (concurrent work). So the two tests above were planted there,
**run**, and removed; the file is byte-identical to its committed blob
(`f7c581dd8e8ec8d703b4456b6e58e5f13af1285a`, verified by content hash, not by
reading a diff). A follow-up bead carries the exact test source so the durable
regression can be landed by whoever owns that tree next; it also notes two stale
`:populates` references left behind — the passing-but-misnamed
`successful-write-commits-the-server-board-via-populates`, and the frozen pilot
baseline under `docs/design/hicasso/product/pilots/baseline/linearlite/`.

## Gates (captured exits, run on the final rebased base)

| gate | captured exit | result |
|---|---|---|
| `npm run test:cljs` | 0 | 11176 tests / 55753 assertions / 0 failures |
| `npm run test:examples-compile` | 0 | 58 builds, zero warnings (`[:examples/linearlite]` among them) |
| `python scripts/check_readme_links.py --ci` | 0 | silent |

The README-link gate was checked for discrimination rather than trusted: a
planted broken anchor in this README returned exit 1 naming the file and line,
and the restored file returned exit 0 again.

Anchors and table column counts in the README were checked by hand. The example
was not driven in a browser; the behavioural claim rests on the red→green
witness above, which exercises the example's real registrations.
