### PR TITLE
fix(testbed-support): the open-in-editor guard checks the TCP peer (rf2-mpgs)

### DIFF
--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -63,9 +63,31 @@ npm package through Node.
 Because this endpoint can open a local file, it accepts launches only when all
 of these conditions hold:
 
+- the request arrives from a **loopback TCP peer** — Ring's `:remote-addr`
 - the request method is `POST`
 - the `Host` header names a loopback host
 - when present, `Origin` also names a loopback host
+
+The peer address is the boundary; the rest is defence in depth. `Host`,
+`Origin` and every `X-Forwarded-*` header are strings the client writes, so a
+remote caller can spell them as loopback — the socket the request arrived on is
+the one fact it cannot choose, and forwarding headers are deliberately ignored
+because a `:dev-http` server is a direct listener. Missing or malformed peer
+addresses are refused. A non-loopback peer reaches nothing here, not even the
+`OPTIONS` preflight.
+
+Accepted peers are the whole `127.0.0.0/8` block, IPv6 `::1` — which
+shadow-cljs reports in its expanded `0:0:0:0:0:0:0:1` spelling — and the
+IPv4-mapped `::ffff:127.0.0.1` a dual-stack socket may report. This matters
+because the testbeds listen beyond loopback: `:dev-http` entries that set no
+`:host` bind `0.0.0.0`, so the endpoint is reachable from the network and only
+the peer check turns those callers away.
+
+Running the testbed on another machine or in a container therefore no longer
+works by pointing a browser at it, and widening the check is not the answer. An
+SSH local port-forward is: `ssh -L 8031:localhost:8031 <host>` makes the tunnel
+itself the caller, so the peer the server sees is genuine loopback and nothing
+needs configuring at either end.
 
 CORS reflects only a validated loopback origin; it never emits `*`. Missing
 files return 422 before Node is spawned so the browser client can fall back to
@@ -128,7 +150,8 @@ clojure -M:test
 ```
 
 The JVM suite covers file resolution, query parsing, launch argument handling,
-JSON responses, and the method/loopback/origin guard. It also witnesses a real
+JSON responses, and the peer/method/host/origin guard — including a remote peer
+sending a forged loopback `Host`, which must never launch. It also witnesses a real
 relative Story coordinate and a real relative Xray coordinate resolving to
 their on-disk files through the handler, with `launch!` stubbed.
 

--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -2,13 +2,14 @@
   "Dev-only Ring endpoint for opening source coordinates in an editor.
 
   The JVM handler resolves classpath-relative files at request time and invokes
-  the Node `launch-editor` package. Launches require POST, a loopback Host, and
-  a loopback Origin when one is present. This `.clj` namespace runs only in the
+  the Node `launch-editor` package. Reaching the endpoint at all requires a
+  loopback TCP peer; launches additionally require POST, a loopback Host, and a
+  loopback Origin when one is present. This `.clj` namespace runs only in the
   shadow-cljs server and is never part of a browser bundle."
   (:require [clojure.string :as str]
             [re-frame.source-coords :as rf.source-coords]
             [re-frame.source-coords.editor-uri :as rf.source-coords.editor-uri])
-  (:import [java.net URI]
+  (:import [java.net InetAddress URI]
            [java.io File InputStream InputStreamReader]
            [java.util.concurrent TimeUnit]))
 
@@ -350,8 +351,9 @@
   (when (and (string? s) (re-matches #"\d+" s))
     (try (Long/parseLong s) (catch Throwable _ nil))))
 
-;; Launches must be addressed to loopback and, when supplied, originate there.
-;; The handler separately enforces POST and reflects only validated origins.
+;; Callers must ARRIVE from loopback; launches must additionally be addressed to
+;; loopback and, when supplied, originate there. The handler separately enforces
+;; POST and reflects only validated origins.
 
 (defn ^:private loopback-host?
   "Recognize localhost, 127.0.0.0/8, and IPv6 loopback host values."
@@ -376,6 +378,49 @@
                  ;; a bare IPv4 in 127.0.0.0/8
                  (re-matches #"127\.\d{1,3}\.\d{1,3}\.\d{1,3}" bare)))))))
 
+(defn ^:private loopback-peer?
+  "Is `remote-addr` — Ring's TCP peer for this request — a loopback address?
+
+  The peer is the one caller fact a client cannot choose. `Host`, `Origin` and
+  every `X-Forwarded-*` header are strings the client writes, so a request from
+  anywhere can spell them as loopback; the socket it arrived on cannot lie.
+  This is therefore the authoritative check, and `local-request?` below is
+  defence in depth on top of it. Forwarding headers are deliberately ignored:
+  a shadow-cljs `:dev-http` server is a direct listener, so honouring one would
+  hand the decision straight back to the client.
+
+  shadow-cljs fills `:remote-addr` from `InetAddress.getHostAddress`, so values
+  arriving here are bare numeric literals — never names, never `addr:port`.
+
+  Accepted, and why each belongs in the set:
+
+  - the whole `127.0.0.0/8` block, not merely `127.0.0.1`: a client may connect
+    to any address in it (`127.0.0.53` is the systemd-resolved local stub) and
+    the kernel never routes that block off the machine;
+  - `::1`, IPv6 loopback, and its expanded spelling `0:0:0:0:0:0:0:1` — which
+    is the form `getHostAddress` actually emits, so a check for the short
+    spelling alone would refuse every genuine IPv6 caller;
+  - `::ffff:127.0.0.1`, the IPv4-mapped form a dual-stack socket may report for
+    an IPv4 loopback client.
+
+  Everything else fails closed, missing and malformed values included. Parsing
+  happens only once the string already looks like a numeric literal, so nothing
+  can reach name resolution: `getByName` would resolve `localhost` — or any
+  attacker-chosen name pointing at 127.0.0.1 — to a loopback address."
+  [remote-addr]
+  (boolean
+    (when (and (string? remote-addr) (not (str/blank? remote-addr)))
+      ;; A scope id (`::1%lo0`) names an interface, not a different address.
+      (let [s (first (str/split (str/trim remote-addr) #"%"))]
+        (when (and (string? s)
+                   ;; Numeric literals only — see the docstring's last note.
+                   (re-matches #"[0-9A-Fa-f:.]+" s)
+                   (or (str/includes? s ":")
+                       (re-matches #"\d{1,3}(?:\.\d{1,3}){3}" s)))
+          (try
+            (.isLoopbackAddress (InetAddress/getByName s))
+            (catch Throwable _ false)))))))
+
 (defn ^:private origin-host
   "Extract an Origin host, rejecting blank, malformed, and opaque origins."
   [origin]
@@ -397,7 +442,11 @@
               headers))))
 
 (defn ^:private local-request?
-  "Require a loopback Host and, when present, a loopback Origin."
+  "Require a loopback Host and, when present, a loopback Origin.
+
+  Both values are client-supplied, so this is defence in depth — it narrows a
+  loopback peer's browser to same-machine pages and closes DNS rebinding. It is
+  NOT the boundary: `loopback-peer?` is, and `handle` applies that first."
   [{:keys [headers]}]
   (let [host   (get-header headers "host")
         origin (get-header headers "origin")]
@@ -454,9 +503,9 @@
 (defn handle
   "Handle the open-in-editor path or return nil for another path.
 
-  Query keys are `file` (required), `line`, `column`, and `editor`. Only a
-  local POST reaches `launch!`. Invalid input produces JSON 400/403/405
-  responses; missing files and launch failures produce 422, as does a
+  Query keys are `file` (required), `line`, `column`, and `editor`. Only a POST
+  from a loopback TCP peer reaches `launch!`. Invalid input produces JSON
+  400/403/405 responses; missing files and launch failures produce 422, as does a
   coordinate-bearing request whose editor cannot carry the position — either
   because this endpoint named a position-blind command
   (`position-would-be-dropped?`, answered here without spawning Node) or
@@ -464,10 +513,16 @@
   one (`launch-shim`'s probe, answered at launch time). Every one of those
   non-2xx answers hands the launch to the client's `editor://` URI fallback,
   which does carry the coordinate."
-  [{:keys [uri request-method query-string] :as req}]
+  [{:keys [uri request-method query-string remote-addr] :as req}]
   (when (= uri endpoint-path)
     (let [ao (allow-origin req)]
       (cond
+        ;; The transport boundary, applied before anything a client can write.
+        ;; A remote caller reaches nothing here — not the launch path, not the
+        ;; preflight — however it spells Host, Origin or X-Forwarded-For.
+        (not (loopback-peer? remote-addr))
+        (json-resp 403 ao {:ok false :error "forbidden"})
+
         ;; Cross-port local testbeds require an OPTIONS response.
         (= request-method :options)
         {:status 204
@@ -476,7 +531,7 @@
                    "access-control-allow-headers" "content-type"
                    "vary"                          "origin"}}
 
-        ;; Apply the network boundary before resolving a path.
+        ;; Defence in depth, still before any path is resolved.
         (not (local-request? req))
         (json-resp 403 ao {:ok false :error "forbidden"})
 

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -66,15 +66,21 @@
 ;; Launch is stubbed while the method, Host, Origin, and CORS guards are tested.
 
 (defn ^:private req
-  "Build a minimal endpoint request; nil host/origin values omit the header."
-  [{:keys [method host origin file]
-    :or   {method :post host "localhost:8031"}}]
-  {:uri            rf.testbed.open-in-editor-server/endpoint-path
-   :request-method method
-   :query-string   (when file (str "file=" file "&line=10"))
-   :headers        (cond-> {}
-                     host   (assoc "host" host)
-                     origin (assoc "origin" origin))})
+  "Build a minimal endpoint request; nil host/origin values omit the header.
+
+  `:remote-addr` carries the TCP peer the way shadow-cljs's Ring adapter does
+  — a bare numeric address from `InetAddress.getHostAddress` — and defaults to
+  loopback because every honest testbed caller is one. Pass `:peer` to model a
+  remote caller; pass `:peer :absent` to model an adapter that supplied none."
+  [{:keys [method host origin file peer]
+    :or   {method :post host "localhost:8031" peer "127.0.0.1"}}]
+  (cond-> {:uri            rf.testbed.open-in-editor-server/endpoint-path
+           :request-method method
+           :query-string   (when file (str "file=" file "&line=10"))
+           :headers        (cond-> {}
+                             host   (assoc "host" host)
+                             origin (assoc "origin" origin))}
+    (not= :absent peer) (assoc :remote-addr peer)))
 
 (defmacro ^:private with-launch-spy
   "Record launch calls without opening an editor."
@@ -147,6 +153,134 @@
                            :file "/etc/passwd"}))]
           (is (= 403 (:status resp)))
           (is (zero? (count @calls))))))))
+
+;; The TCP peer is the only caller fact the client cannot forge. Host, Origin
+;; and every forwarding header are client-supplied, so the guard treats them as
+;; defence in depth on top of the transport check — never as the discriminator.
+
+(deftest guard-rejects-spoofed-loopback-host-from-remote-peer
+  (testing "a POST from a NON-loopback peer that spoofs `Host: localhost` and
+            sends no Origin — the shape a direct HTTP client can produce
+            against a testbed bound to 0.0.0.0 — is 403 before path resolution
+            and never launches"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (rf.testbed.open-in-editor-server/handle
+                     (req {:method :post
+                           :host   "localhost:8031"
+                           :origin nil
+                           :peer   "203.0.113.7"
+                           :file   "/etc/passwd"}))]
+          (is (= 403 (:status resp))
+              "a forged loopback Host does not admit a remote peer")
+          (is (re-find #"\"error\":\"forbidden\"" (:body resp)))
+          (is (zero? (count @calls)) "launch! was not called")))))
+  (testing "spoofing a loopback ORIGIN as well does not help — the peer still
+            decides"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (rf.testbed.open-in-editor-server/handle
+                     (req {:method :post
+                           :host   "127.0.0.1:8031"
+                           :origin "http://localhost:8042"
+                           :peer   "10.0.0.5"
+                           :file   "/etc/passwd"}))]
+          (is (= 403 (:status resp)))
+          (is (zero? (count @calls)))))))
+  (testing "an IPv6 remote peer is refused on the same footing"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (rf.testbed.open-in-editor-server/handle
+                     (req {:method :post
+                           :host   "localhost:8031"
+                           :peer   "2001:db8::5"
+                           :file   "/etc/passwd"}))]
+          (is (= 403 (:status resp)))
+          (is (zero? (count @calls))))))))
+
+(deftest guard-fails-closed-on-unknown-peer
+  (testing "an absent :remote-addr is refused — a missing transport fact is
+            never read as permission"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (rf.testbed.open-in-editor-server/handle
+                     (req {:method :post :host "localhost:8031"
+                           :peer :absent :file "/etc/passwd"}))]
+          (is (= 403 (:status resp)))
+          (is (zero? (count @calls)))))))
+  (testing "blank and malformed peer values are refused too"
+    (doseq [bad ["" "   " "not-an-address" "127.0.0.1.evil.example"
+                 "127.0.0.1, 10.0.0.5" "localhost"]]
+      (let [calls (atom [])]
+        (with-launch-spy calls
+          (let [resp (rf.testbed.open-in-editor-server/handle
+                       (req {:method :post :host "localhost:8031"
+                             :peer bad :file "/etc/passwd"}))]
+            (is (= 403 (:status resp)) (str "refused peer value: " (pr-str bad)))
+            (is (zero? (count @calls)))))))))
+
+(deftest guard-ignores-forwarding-headers
+  (testing "X-Forwarded-For cannot launder a remote peer into a loopback one —
+            these dev servers are direct listeners, so a forwarding header is
+            just another client-supplied string"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (rf.testbed.open-in-editor-server/handle
+                     (-> (req {:method :post :host "localhost:8031"
+                               :peer "203.0.113.7" :file "/etc/passwd"})
+                         (assoc-in [:headers "x-forwarded-for"] "127.0.0.1")
+                         (assoc-in [:headers "x-real-ip"] "127.0.0.1")))]
+          (is (= 403 (:status resp)))
+          (is (zero? (count @calls))))))))
+
+(deftest guard-rejects-remote-peer-before-method-and-preflight
+  (testing "the transport check is the OUTERMOST gate: a remote peer gets 403
+            for a GET (not 405) and for an OPTIONS preflight (not 204)"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (is (= 403 (:status (rf.testbed.open-in-editor-server/handle
+                              (req {:method :get :host "localhost:8031"
+                                    :peer "203.0.113.7" :file "/etc/passwd"})))))
+        (is (= 403 (:status (rf.testbed.open-in-editor-server/handle
+                              (req {:method :options :host "localhost:8031"
+                                    :origin "http://localhost:8042"
+                                    :peer "203.0.113.7"})))))
+        (is (zero? (count @calls)) "launch! was not called")))))
+
+(deftest guard-allows-every-loopback-peer-representation
+  (testing "each address a Ring adapter can put in :remote-addr for a genuine
+            loopback caller still reaches launch!"
+    ;; shadow-cljs's adapter emits `InetAddress.getHostAddress`, so IPv6
+    ;; loopback arrives EXPANDED as 0:0:0:0:0:0:0:1 — never the `::1` spelling.
+    (doseq [peer ["127.0.0.1" "127.0.0.53" "0:0:0:0:0:0:0:1" "::1"
+                  "::ffff:127.0.0.1" "::1%1"]]
+      (let [calls (atom [])]
+        (with-launch-spy calls
+          (let [resp (rf.testbed.open-in-editor-server/handle
+                       (req {:method :post :host "localhost:8031"
+                             :peer peer :file "fake_ns/core.cljs"}))]
+            (is (= 200 (:status resp)) (str "accepted peer: " peer))
+            (is (= 1 (count @calls)) (str "launch! ran for peer: " peer))))))))
+
+(deftest loopback-peer?-classifies-correctly
+  (testing "the IPv4 loopback block, both IPv6 loopback spellings, and the
+            IPv4-mapped form are accepted"
+    (doseq [addr ["127.0.0.1" "127.0.0.53" "127.255.255.254"
+                  "::1" "0:0:0:0:0:0:0:1"
+                  "0000:0000:0000:0000:0000:0000:0000:0001"
+                  "::ffff:127.0.0.1" "0:0:0:0:0:ffff:7f00:1"
+                  "::1%1"]]
+      (is (#'rf.testbed.open-in-editor-server/loopback-peer? addr)
+          (str "loopback peer: " addr))))
+  (testing "everything else is refused, including values that merely LOOK
+            loopback and anything that would need name resolution"
+    (doseq [addr [nil "" "   " "0.0.0.0" "10.0.0.5" "192.168.1.5"
+                  "203.0.113.7" "2001:db8::1" "::" "0:0:0:0:0:0:0:2"
+                  "128.0.0.1" "27.0.0.1" "1127.0.0.1" "127.0.0.1.evil.example"
+                  "127malicious.example" "localhost" "127.0.0.999"
+                  "127.0.0.1, 10.0.0.5" "127.0.0.1:52344" 12345]]
+      (is (not (#'rf.testbed.open-in-editor-server/loopback-peer? addr))
+          (str "refused peer: " (pr-str addr))))))
 
 (deftest guard-rejects-non-post-drive-by
   (testing "a simple GET drive-by (the `<img>`/`<form>`/`no-cors` class) is
@@ -241,6 +375,7 @@
                      {:uri            rf.testbed.open-in-editor-server/endpoint-path
                       :request-method :post
                       :query-string   "file=%"
+                      :remote-addr    "127.0.0.1"
                       :headers        {"host" "localhost:8031"}})]
           (is (= 400 (:status resp)) "malformed query is a clean 400, not a throw")
           (is (re-find #"\"ok\":false" (:body resp)))
@@ -254,6 +389,7 @@
                      {:uri            rf.testbed.open-in-editor-server/endpoint-path
                       :request-method :post
                       :query-string   "file=abc%zz"
+                      :remote-addr    "127.0.0.1"
                       :headers        {"host" "localhost:8031"}})]
           (is (= 400 (:status resp)))
           (is (re-find #"\"error\":\"malformed-query\"" (:body resp)))
@@ -286,6 +422,7 @@
                      {:uri            rf.testbed.open-in-editor-server/endpoint-path
                       :request-method :post
                       :query-string   "file=deep/re-frame2+wip/core.cljs&line=7"
+                      :remote-addr    "127.0.0.1"
                       :headers        {"host" "localhost:8031"}})]
           (is (= 200 (:status resp)) "the launch path is reached")
           (is (= 1 (count @calls)) "launch! invoked once")
@@ -427,6 +564,7 @@
                      {:uri            rf.testbed.open-in-editor-server/endpoint-path
                       :request-method :post
                       :query-string   "file=fake_ns/core.cljs&column=7"
+                      :remote-addr    "127.0.0.1"
                       :headers        {"host" "localhost:8031"}})]
           (is (= 200 (:status resp)))
           (is (= 1 (count @calls)))
@@ -635,6 +773,7 @@
                     {:uri            rf.testbed.open-in-editor-server/endpoint-path
                      :request-method :post
                      :query-string   (str "file=" missing "&line=10&column=3")
+                     :remote-addr    "127.0.0.1"
                      :headers        {"host" "localhost:8031"}})]
       (is (= 422 (:status resp)) "missing file is a non-2xx, not a false 200")
       (is (re-find #"\"ok\":false" (:body resp)))
@@ -652,6 +791,7 @@
                        {:uri            rf.testbed.open-in-editor-server/endpoint-path
                         :request-method :post
                         :query-string   "line=10&column=3"
+                        :remote-addr    "127.0.0.1"
                         :headers        {"host" "localhost:8031"}})]
             (is (= 400 (:status resp)))
             (is (re-find #"\"ok\":false" (:body resp)))
@@ -661,6 +801,7 @@
                        {:uri            rf.testbed.open-in-editor-server/endpoint-path
                         :request-method :post
                         :query-string   "file=&line=10"
+                        :remote-addr    "127.0.0.1"
                         :headers        {"host" "localhost:8031"}})]
             (is (= 400 (:status resp)))
             (is (re-find #"\"error\":\"missing-file\"" (:body resp)))))
@@ -669,6 +810,7 @@
                        {:uri            rf.testbed.open-in-editor-server/endpoint-path
                         :request-method :post
                         :query-string   nil
+                        :remote-addr    "127.0.0.1"
                         :headers        {"host" "localhost:8031"}})]
             (is (= 400 (:status resp)))
             (is (re-find #"\"error\":\"missing-file\"" (:body resp)))))
@@ -715,6 +857,7 @@
                      {:uri            rf.testbed.open-in-editor-server/endpoint-path
                       :request-method :post
                       :query-string   "file=fake_ns/core.cljs&line=3&editor=vscode"
+                      :remote-addr    "127.0.0.1"
                       :headers        {"host" "localhost:8031"}})]
           (is (= 200 (:status resp)))
           (is (= 1 (count @calls)))
@@ -729,6 +872,7 @@
           {:uri            rf.testbed.open-in-editor-server/endpoint-path
            :request-method :post
            :query-string   "file=fake_ns/core.cljs&editor=emacs"
+           :remote-addr    "127.0.0.1"
            :headers        {"host" "localhost:8031"}})
         (is (nil? (nth (first @calls) 3))
             "unknown editor → nil hint"))))
@@ -739,6 +883,7 @@
           {:uri            rf.testbed.open-in-editor-server/endpoint-path
            :request-method :post
            :query-string   "file=fake_ns/core.cljs"
+           :remote-addr    "127.0.0.1"
            :headers        {"host" "localhost:8031"}})
         (is (nil? (nth (first @calls) 3))
             "no editor param → nil hint")))))
@@ -799,6 +944,7 @@
                      {:uri            rf.testbed.open-in-editor-server/endpoint-path
                       :request-method :post
                       :query-string   "file=fake_ns/core.cljs&line=27&column=9&editor=windsurf"
+                      :remote-addr    "127.0.0.1"
                       :headers        {"host" "localhost:8031"}})]
           (is (= 422 (:status resp))
               "a 200 here would be a false claim that 27:9 reached the editor")
@@ -819,6 +965,7 @@
                      {:uri            rf.testbed.open-in-editor-server/endpoint-path
                       :request-method :post
                       :query-string   "file=fake_ns/core.cljs&editor=windsurf"
+                      :remote-addr    "127.0.0.1"
                       :headers        {"host" "localhost:8031"}})]
           (is (= 200 (:status resp)))
           (is (= 1 (count @calls)))
@@ -842,6 +989,7 @@
                          {:uri            rf.testbed.open-in-editor-server/endpoint-path
                           :request-method :post
                           :query-string   (str "file=fake_ns/core.cljs&line=27&column=9&editor=" editor)
+                          :remote-addr    "127.0.0.1"
                           :headers        {"host" "localhost:8031"}})]
               (is (<= 200 (:status resp) 299)
                   "the endpoint is still preferred for this editor")
@@ -1000,6 +1148,7 @@
                            {:uri            rf.testbed.open-in-editor-server/endpoint-path
                             :request-method :post
                             :query-string   (str "file=" file "&line=12&column=3")
+                            :remote-addr    "127.0.0.1"
                             :headers        {"host" "localhost:8042"}})]
                 (is (= 200 (:status resp))
                     (str tool " relative coordinate was accepted"))
@@ -1264,6 +1413,7 @@
                    {:uri            rf.testbed.open-in-editor-server/endpoint-path
                     :request-method :post
                     :query-string   "file=fake_ns/core.cljs&line=27&column=9"
+                    :remote-addr    "127.0.0.1"
                     :headers        {"host" "localhost:8031"}})]
         (is (= 422 (:status resp))
             "a 200 here would claim 27:9 reached an editor that never got it")
@@ -1288,6 +1438,7 @@
                    {:uri            rf.testbed.open-in-editor-server/endpoint-path
                     :request-method :post
                     :query-string   "file=fake_ns/core.cljs&column=7"
+                    :remote-addr    "127.0.0.1"
                     :headers        {"host" "localhost:8031"}})]
         (is (= 422 (:status resp))
             "a 200 here would claim 1:7 reached an editor that never got it")


### PR DESCRIPTION
## The defect

`re-frame.testbed.open-in-editor-server/local-request?` authenticated a caller
from its `Host` header and, when present, its `Origin`. Both are strings the
**client** writes, so any reachable peer could send `Host: localhost:8031` with
no Origin and pass the guard. Past it the endpoint resolves the caller's `file`
— `resolve-file` passes absolute paths straight through — and spawns an editor,
so the spoof bought arbitrary local file access driven by a network request.

The testbeds really are reachable: every handler-wired `:dev-http` entry in
`implementation/shadow-cljs.edn` omits `:host`, and shadow-cljs binds `0.0.0.0`
when it is absent.

## The witness, red before the fix

`guard-rejects-spoofed-loopback-host-from-remote-peer` — a POST from
`203.0.113.7` carrying `Host: localhost:8031`, no Origin, and
`file=/etc/passwd`. Against the pre-fix code it answered:

```
expected: (= 403 (:status resp))
  actual: (not (= 403 200))
  actual: (not (re-find #"\"error\":\"forbidden\"" "{\"ok\":true,\"file\":\"/etc/passwd\"}"))
```

The launch spy had fired. 25 assertions across the new tests were red before
this change; 0 after.

## The fix

`loopback-peer?` gates the whole endpoint on Ring's `:remote-addr`, ahead of
the method branch and the preflight. The Host/Origin check stays as **defence
in depth** — it still narrows a loopback peer's browser to same-machine pages
and closes DNS rebinding — but it is no longer the boundary.

The transport peer is the one caller fact a client cannot choose, and Ring
already carries it: the pinned adapter fills `:remote-addr` from
`InetAddress.getHostAddress` (verified in the installed
`thheller/shadow-undertow` source, identical in 0.3.1 and 0.3.4).

### Accepted peers, and why each is in the set

| Accepted | Reason |
| --- | --- |
| the whole `127.0.0.0/8` block | a client may connect to any address in it — `127.0.0.53` is the systemd-resolved local stub — and the kernel never routes that block off the machine |
| `::1` **and** `0:0:0:0:0:0:0:1` | IPv6 loopback. The expanded spelling is what `getHostAddress` actually emits, so matching only `::1` would refuse every genuine IPv6 caller |
| `::ffff:127.0.0.1` | the IPv4-mapped form a dual-stack socket may report for an IPv4 loopback client |

Everything else fails closed, **missing and malformed values included** — an
absent `:remote-addr` is never read as permission. `X-Forwarded-*` is
deliberately ignored: a `:dev-http` server is a direct listener, so honouring a
forwarding header would hand the decision straight back to the client.

Parsing runs only once the string already looks like a numeric literal, so no
value can reach name resolution — measured, `InetAddress/getByName "localhost"`
returns a loopback address in 3ms and `"abcd"` spends 2.7s in DNS, so an
unguarded parse would have been a second way in.

## The workflow this closes, and its seam

Running a testbed off-box no longer works by pointing a browser at it — that
was the hole. Widening the default is not the answer; an SSH local port-forward
is (`ssh -L 8031:localhost:8031 <host>`), because the tunnel itself becomes the
caller and the server sees a genuine loopback peer with nothing configured at
either end. The README says so.

## Gates

| Gate | Before | After |
| --- | --- | --- |
| `clojure -M:test` from `tools/testbed-support/` | exit 0 — 41 tests, 228 assertions | exit 0 — 47 tests, 295 assertions |
| `scripts/check_readme_links.py --ci` | — | exit 0 (control: a planted broken target returned exit 1 naming the line) |

`npm run test:testbed-support` was **not** run: this worktree has no
`implementation/node_modules`. That lane's `:ns-regexp`
(`^re-frame\.testbed\..+-cljs-test$`) selects only the `.cljs` suites, and this
diff touches no `.cljs` file — the server namespace is `.clj` and never enters a
browser or Node bundle. CI runs it on this PR.

Fixes rf2-mpgs.
