### PR TITLE
fix(xray): retract the dead universal value-copy affordance and correct the egress inventory (rf2-6r9j.24)

### DIFF
--- a/tools/xray/README.md
+++ b/tools/xray/README.md
@@ -261,9 +261,12 @@ force-disable in dev.
 Xray exposes no agent seam. An agent driving a running re-frame2 app
 uses `re-frame2-pair.runtime` + `tools/re-frame2-pair-mcp/` — the
 second snippet under [Enable](#enable). Xray's only value-egress
-surfaces are the two human copy affordances (the `Snapshot app-db`
-palette verb and the `⎘` copy button), both fail-closed with no
-raw-value opt-in; see [`spec/API.md`](./spec/API.md) §Off-box egress.
+surface is the one human copy affordance — the `Snapshot app-db`
+palette verb — fail-closed with no raw-value opt-in. Static Machines'
+`Copy Mermaid` also writes to the clipboard, but it emits value-free
+topology (state / event / guard / action names from the registered
+definition, never `:data` values), so it is not a value-egress site.
+See [`spec/API.md`](./spec/API.md) §Off-box egress.
 
 ## Spec
 

--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -660,8 +660,15 @@ The user can:
 
 - Click a breadcrumb segment → opens the segment-inspector popup
   (rf2-e9tb0)
-- Click the Copy value / Copy path / Show me when this changed
-  affordance buttons in the section header
+
+That is the whole list. The section-header affordance buttons this
+bullet list once also named were dropped when the panel became a
+current-state inspector (rf2-okvit, recorded in the
+`panels/app_db_diff.cljs` namespace docstring); the universal
+value-copy gesture on the renderer itself was retired separately under
+rf2-6r9j.24, honouring the
+[`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §10.5
+B.9 lock rather than reopening it.
 
 Not present:
 

--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -413,8 +413,6 @@ epoch-history; the body shows the focused epoch's `:db-after`
 |---|---|---|
 | `:rf.xray/focus-slice-path` | `[_ path]` | Sets the "Show me when this changed" focused path. |
 | `:rf.xray/clear-slice-focus` | `[_]` | Drops the focus. |
-| `:rf.xray/copy-value-to-clipboard` | `[_ value]` | `event-fx` — routes `value` through `egress/egress-value` **before** the clipboard write, then emits `{:fx [[:rf.xray.fx/copy-to-clipboard {:text (pr-str <elided>)}]]}`. The clipboard is an off-box sink, so sensitive ⇒ `:rf/redacted`, large ⇒ `:rf.size/large-elided`, fail-closed (rf2-uo0rc.2; same class as the palette snapshot rf2-mxzgg). No raw opt-in. The observed frame (`[:focus :frame]` ⇒ `:target-frame`) is passed as the `:frame` opt **unconditionally**, including when it is absent or names a destroyed frame — that is what makes the no-target / stale-target cases redact the whole value instead of resolving the ambient `:rf/xray` chrome frame and shipping it raw (rf2-7htk7). |
-| `:rf.xray/copy-path-to-clipboard` | `[_ path]` | `event-fx` — emits `{:fx [[:rf.xray.fx/copy-to-clipboard {:text (pr-str path)}]]}`. The path vector carries only key names (no values), so it is not a value-egress site and is not elided. |
 | `:rf.xray/open-segment-inspector` | `[_ path]` | rf2-e9tb0 — opens the segment-inspector popup at `path` (vector). |
 | `:rf.xray/close-segment-inspector` | `[_]` | rf2-e9tb0 — closes the popup. |
 
@@ -423,6 +421,20 @@ epoch-history; the body shows the focused epoch's `:db-after`
 > and the `:rf.xray/pinned-slices-store` + `:rf.xray/pinned-slices`
 > subs were dropped when the pinned-watches strip was superseded by
 > the segment-inspector popup. Catalogued here for the audit trail.
+
+> **rf2-6r9j.24 (2026-09-04) — the two clipboard copy events removed.**
+> `:rf.xray/copy-value-to-clipboard` (`[_ value]`, which routed the
+> value through `egress/egress-value` before the clipboard write) and
+> `:rf.xray/copy-path-to-clipboard` (`[_ path]`, value-free and never
+> elided) were dropped with the universal EDN-widget `⎘` affordance
+> that was their only intended dispatcher. Neither had a dispatcher
+> anywhere in `tools/xray/src`: the affordance's only call site went in
+> the rf2-oqa60 phase-1 rebuild and was never re-wired, and the design
+> lock at [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md)
+> §10.5 (super-prompt B.9) puts copy-value and copy-path explicitly OUT
+> on that renderer. The `:rf.xray.fx/copy-to-clipboard` fx below
+> SURVIVES — Static Machines' `Copy Mermaid` is its reachable consumer.
+> Catalogued here for the audit trail.
 
 ### Effects
 

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -681,19 +681,30 @@ Xray is the human surface, AI belongs in the separate Pair tool — and
 [`018-Event-Spine.md`](./018-Event-Spine.md) with it, which has the
 agent read raw instrumentation rather than an Xray-curated facade.
 
-## Off-box egress — the two panel copy paths
+## Off-box egress — the one panel copy path
 
-Xray's own value-egress surface is small and closed. Two HUMAN
-affordances put a value the developer is looking at onto an off-box
+Xray's own value-egress surface is small and closed. ONE HUMAN
+affordance puts a value the developer is looking at onto an off-box
 sink (Tool-Pair §Privacy egress,
 [`Security.md`](../../../spec/Security.md) §Off-box egress):
 
 | Affordance | Sink | Source |
 |---|---|---|
 | The `Snapshot app-db` command-palette verb | JS console + system clipboard | `palette/events.cljs` |
-| The `⎘` copy button riding every value inspector (`:rf.xray/copy-value-to-clipboard`) | System clipboard | `panels/app_db_diff_events.cljs` |
 
-Both route the value through Xray's single named panel-local safe-egress
+> **rf2-6r9j.24 (2026-09-04) — the universal `⎘` copy button is
+> retired.** A second row here once claimed a copy button riding every
+> value inspector. It had been unreachable since the rf2-oqa60 phase-1
+> rebuild dropped its only call site, and it was out of contract under
+> the [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md)
+> §10.1 / §10.5 B.9 lock, which puts copy-value and copy-path
+> explicitly OUT on that renderer. The inventory is corrected rather
+> than the button restored: an enumeration of where values can leave
+> Xray is worse wrong than short. A future FOCUSED copy affordance must
+> reopen B.9 with the mayor first, and must carry provenance — see the
+> `:path` paragraph below.
+
+It routes the value through Xray's single named panel-local safe-egress
 fn — `day8.re-frame2-xray.egress/egress-value` — BEFORE it reaches the
 sink. That fn is a thin wrapper over the framework's normative
 wire-elision walker (`re-frame.core/elide-wire-value`) with the off-box
@@ -702,17 +713,25 @@ defaults BAKED IN, so the shortest call is the safe one (rf2-rcogp):
 frame-declared sensitive slot egresses as `:rf/redacted`, and a large
 slot as the `:rf.size/large-elided` marker.
 
-**Neither affordance exposes a raw-value opt-in.** Xray's copy paths are
+Static Machines' `Copy Mermaid` action also writes to the system
+clipboard, and is deliberately NOT in the table above: `mermaid/emit`
+is value-free by contract — state / event / guard / action NAMES from
+the registered definition, never runtime or definition `:data` values —
+so it is not a value-egress site and rides
+`:rf.xray.fx/copy-to-clipboard` directly.
+
+**The affordance exposes no raw-value opt-in.** Xray's copy path is
 ALWAYS the redacted, size-elided projection — there is no
-`{:include-sensitive? true}` gesture reachable from the UI.
+`{:include-sensitive? true}` gesture reachable from the UI, and any
+future affordance inherits that.
 
 The egress is pinned to the frame being INSPECTED, not the frame the
 affordance dispatches in. The palette resolves and validates the focused
 frame before it reads the db, then wraps the snapshot in
-`(rf/with-frame tf …)` (rf2-mxzgg); the copy event NAMES the observed
-frame (`[:focus :frame]`, falling back to `:target-frame` — rf2-uo0rc.2)
-as `egress-value`'s `:frame` opt. That frame's own `:sensitive` /
-`:large` declarations then govern the redaction rather than the (empty)
+`(rf/with-frame tf …)` (rf2-mxzgg). A panel affordance that has NOT
+already established the frame that way MUST instead name it as
+`egress-value`'s `:frame` opt, so that frame's own `:sensitive` /
+`:large` declarations govern the redaction rather than the (empty)
 Xray-chrome frame's.
 
 **A value with no resolvable frame fails closed, and NAMING the frame is
@@ -720,11 +739,12 @@ what delivers that** (rf2-7htk7). The walker resolves the ambient frame
 when no `:frame` is supplied, and for a panel affordance the ambient
 frame is the LIVE `:rf/xray` chrome frame — which resolves, so its
 normally-empty declaration registry applies and the value egresses RAW.
-The copy event therefore forwards `:frame` even when the picker has
-selected nothing: `elide-wire-value` validates the id against the live
-registry, so an unselected picker and a host frame destroyed between
-render and click both take the walker's frameless arm and egress the
-whole-value `:rf/redacted` sentinel. `egress-value` substitutes a
+Such an affordance must therefore forward `:frame` even when the picker
+has selected nothing: `elide-wire-value` validates the id against the
+live registry, so an unselected picker and a host frame destroyed
+between render and click both take the walker's frameless arm and
+egress the whole-value `:rf/redacted` sentinel. `egress-value`
+substitutes a
 private identity value for an explicitly-passed `nil` to make that so —
 an identity, not a keyword: the registry is keyed by whatever `:id`
 `make-frame` is handed, so any keyword, however it is namespaced, is a
@@ -742,13 +762,20 @@ isolation must tell the walker where it lives or the declaration will
 not match (rf2-a96xq). The whole-db snapshot passes no `:path` — the
 value IS the walked root.
 
-The sibling `:rf.xray/copy-path-to-clipboard` copies only the path
-vector (key names, no values), so it is not a value-egress site and is
-not elided.
+That `:path` requirement is why the retired copy button could not simply
+be rewired, and it binds any replacement. The canonical value inspector
+is handed SLICES at a path, raw managed-fx request / response values
+that [`Security.md`](../../../spec/Security.md) says are not rooted at
+app-db at all, raw before / after trace values, and registry values. An
+affordance that walked whatever a shared renderer was handed, as if it
+were an app-db root, would be fail-OPEN on most of its consumers. A
+focused copy design therefore starts from the data owner outward, with
+a per-call-site projection that can state the value's provenance.
 
 `day8.re-frame2-xray.egress` is **internal**: no api-manifest row, not
 part of Xray's published surface, and not a seam for out-of-process
-callers. It exists because the two affordances above need it.
+callers. It exists because the affordance above needs it, and it stays
+the prescribed fail-closed gesture for any future one.
 
 Panel-local RENDER elision is a separate, weaker concern with its own
 knob — the `:rf.xray/egress-profile` config key (see

--- a/tools/xray/src/day8/re_frame2_xray/egress.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/egress.cljs
@@ -2,16 +2,22 @@
   "Xray's panel-local off-box safe-egress projection.
 
   INTERNAL to Xray. This namespace is not part of Xray's published API and
-  carries no api-manifest row: it exists because two PANEL affordances put a
-  value the developer is looking at onto an off-box sink, and both need the
+  carries no api-manifest row: it exists because a PANEL affordance puts a
+  value the developer is looking at onto an off-box sink, and needs the
   framework's wire-elision walker with the off-box defaults already applied.
 
-  The two sinks (Security.md §Off-box egress):
+  ONE human value-egress affordance today (Security.md §Off-box egress): the
+  command-palette `Snapshot app-db` verb — JS console + system clipboard
+  (`palette/events.cljs`).
 
-  - the command-palette `Snapshot app-db` verb — JS console + system
-    clipboard (`palette/events.cljs`);
-  - the universal `⎘` copy-value affordance that rides every value
-    inspector — system clipboard (`panels/app_db_diff_events.cljs`).
+  The universal `⎘` copy-value affordance that once rode every value
+  inspector was RETIRED on 2026-09-04 (rf2-6r9j.24) — unreachable since the
+  rf2-oqa60 rebuild, and out of contract under the `spec/021` §10.5 B.9 lock.
+  This namespace stays the MUST-use gesture any FUTURE affordance inherits,
+  so its fail-closed arms are kept and pinned by tests rather than deleted
+  with it. Static Machines' `Copy Mermaid` also writes to the clipboard but
+  is NOT a value-egress site — `mermaid/emit` is value-free by contract, so
+  that text rides `:rf.xray.fx/copy-to-clipboard` directly.
 
   Programmer/AI inspection of a running app is NOT this namespace's job and
   never was: that seam is `re-frame2-pair.runtime` plus
@@ -47,8 +53,8 @@
   Off-box defaults: `:include-sensitive?` and `:include-large?` are both
   `false`, so a frame-declared sensitive slot egresses as `:rf/redacted` and
   a large slot as the `:rf.size/large-elided` marker. Xray's panel
-  affordances expose no opt-in argument — the copy and snapshot paths are
-  ALWAYS the redacted, size-elided projection.
+  affordances expose no opt-in argument — the snapshot path is ALWAYS the
+  redacted, size-elided projection, and any future affordance inherits that.
 
   Optional `:path` — the ABSOLUTE app-db path the value sits at. The
   framework's `:sensitive` / `:large` declarations (EP-0025 commit-plane
@@ -64,7 +70,8 @@
   its (normally empty) declaration registry and ships the value RAW. Passing
   the inspected frame — even when it is `nil` or has since been destroyed —
   routes the nil/dead case to the walker's frameless arm, which redacts the
-  whole value to `:rf/redacted` (rf2-7htk7):
+  whole value to `:rf/redacted` (rf2-7htk7). The contract — no live caller
+  today, and the shape any future panel affordance MUST take:
 
       (egress/egress-value v {:frame observed})   ; nil / dead ⇒ :rf/redacted
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
@@ -7,9 +7,22 @@
   `:rf.xray/reorder-pinned-slices` events were removed when the
   pinned-watches strip was superseded by the path-segment inspector
   popup (Mike 2026-05-19 Q13). The matching `pin-path` / `unpin-path`
-  / `reorder-paths` helpers were pulled in lockstep."
-  (:require [re-frame.core :as rf]
-            [day8.re-frame2-xray.egress :as egress]))
+  / `reorder-paths` helpers were pulled in lockstep.
+
+  ## rf2-6r9j.24 — the two copy EVENTS dropped; the fx stays
+
+  `:rf.xray/copy-value-to-clipboard` and `:rf.xray/copy-path-to-clipboard`
+  were retired on 2026-09-04 with the universal EDN-widget `⎘` affordance
+  that was their only intended dispatcher — neither had a dispatcher
+  anywhere in `tools/xray/src`. The `:rf.xray.fx/copy-to-clipboard` fx
+  below SURVIVES: Static Machines' reachable `Copy Mermaid` gesture
+  rides it (`static/machines/panel.cljs`), and that text is value-free
+  static topology rather than a value egress.
+
+  The fail-closed egress proofs those events carried (rf2-7htk7) now sit
+  directly on `egress/egress-value` in
+  `test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs`."
+  (:require [re-frame.core :as rf]))
 
 (defn install!
   "Install the App-DB Diff events and effects."
@@ -59,47 +72,16 @@
             (notify! on-failure))
           (catch :default _ (notify! on-failure))))))
 
-  ;; ---- universal copy-to-clipboard — OFF-BOX EGRESS (rf2-uo0rc.2) ----------
+  ;; ---- no value-copy EVENT here (rf2-6r9j.24) ------------------------------
   ;;
-  ;; The system clipboard is an OFF-BOX SINK (Security.md §Off-box egress,
-  ;; palette/events.cljs §Off-box egress): whatever lands there can be
-  ;; pasted into a teammate's chat or scraped. So the COPIED VALUE must
-  ;; cross it through Xray's single named fail-closed panel-local
-  ;; safe-egress fn `egress/egress-value` — the SAME projection the
-  ;; palette snapshot uses (rf2-mxzgg). On the
-  ;; bare call the off-box defaults are baked in: `:sensitive?` slots ⇒
-  ;; `:rf/redacted`, large slots ⇒ `:rf.size/large-elided`. The earlier
-  ;; copy fx wrote the RAW `(pr-str value)` — a `[:auth :token]
-  ;; {:sensitive? true}` slot or a large blob leaked verbatim.
-  ;;
-  ;; The egress is pinned to the OBSERVED frame (the frame Xray is
-  ;; inspecting — `[:focus :frame]`, falling back to the legacy
-  ;; `:target-frame` slot) by naming it as `egress-value`'s `:frame` opt,
-  ;; so THAT frame's own schema declarations govern the redaction —
-  ;; mirroring the palette's `snapshot-app-db!`, which pins to the focused
-  ;; frame for the same reason (the displayed value's `:sensitive?` / size
-  ;; declarations live on the inspected frame, not the Xray chrome frame
-  ;; the affordance dispatches from).
-  ;;
-  ;; rf2-7htk7 — NAMING the frame is what makes the no-target and
-  ;; stale-target cases fail closed, and the earlier `(rf/with-frame …)`
-  ;; form could not: this handler runs UNDER the live `:rf/xray` frame, so
-  ;; a bare `(egress/egress-value value)` fallback resolved that ambient
-  ;; frame, applied Xray's (empty) declaration registry, and shipped the
-  ;; value RAW to the clipboard. `:frame` is forwarded even when
-  ;; `observed` is nil, and `elide-wire-value` validates it against the
-  ;; live registry — so an unselected picker AND a host frame destroyed
-  ;; between render and click both take the walker's frameless arm and
-  ;; egress `:rf/redacted`. No liveness branch here: the walker owns that
-  ;; test, and duplicating it is how the hole opened.
-  (rf/reg-event :rf.xray/copy-value-to-clipboard
-    (fn [{:keys [db]} [_ value]]
-      (let [observed (or (get-in db [:focus :frame]) (get db :target-frame))
-            elided   (egress/egress-value value {:frame observed})]
-        {:fx [[:rf.xray.fx/copy-to-clipboard {:text (pr-str elided)}]]})))
-
-  ;; The path-copy variant copies ONLY the path vector (key names, no
-  ;; values) so there is nothing to elide — it is not a value-egress site.
-  (rf/reg-event :rf.xray/copy-path-to-clipboard
-    (fn [_ctx [_ path]]
-      {:fx [[:rf.xray.fx/copy-to-clipboard {:text (pr-str path)}]]})))
+  ;; Anything that puts a VALUE on this fx must first cross Xray's single
+  ;; named fail-closed projection `egress/egress-value`, NAMING the observed
+  ;; frame so the no-target and stale-target cases redact whole rather than
+  ;; resolving the ambient `:rf/xray` chrome frame and shipping raw
+  ;; (rf2-7htk7). It must also carry the value's absolute app-db `:path`,
+  ;; because the framework keys `:sensitive` / `:large` declarations by
+  ;; absolute path and a slice egress'd without one matches nothing
+  ;; (rf2-a96xq). The retired value-copy event (see the ns docstring)
+  ;; satisfied the first requirement and not the second — it received only
+  ;; `[_ value]` — which is why it could not simply be rewired.
+  )

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -37,10 +37,10 @@
   former browse/diff modes into the single path). The legacy
   `edn-inspector.render` engine is gone.
 
-  The widget has NO ⎘ copy affordance (deferred to follow-on beads —
-  the popup phase, D6=a). The old EDN widget's copy gesture is
-  unaffected on surfaces still wired to it (Trace, segment-inspector,
-  Static panels) until subsequent phases migrate them.
+  The renderer carries NO copy affordance (`spec/021-Dynamic-Panel-
+  Designs.md` §10.5, the B.9 lock). The universal EDN-widget copy
+  gesture that once rode the other surfaces was retired under
+  rf2-6r9j.24.
 
   ## Inspector-card layout (rf2-63ie5 + rf2-okq7p, post-rf2-jcdvo)
 

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
@@ -258,11 +258,11 @@
   ;; event / guard / action NAMES from the registered definition, never
   ;; runtime or definition `:data` values (`mermaid/emit` is value-free
   ;; by contract; its invalid-definition diagnostic is value-free too,
-  ;; rf2-8nzxib). Like `:rf.xray/copy-path-to-clipboard`, this is NOT a
-  ;; value-egress site, so the text rides the fx directly rather than
-  ;; through `egress/egress-value` — routing it there would `pr-str` the
-  ;; block (breaking the exact-emit contract) without ever finding a
-  ;; value to elide.
+  ;; rf2-8nzxib). This is therefore NOT a value-egress site, so the text
+  ;; rides the fx directly rather than through `egress/egress-value` —
+  ;; routing it there would `pr-str` the block (breaking the exact-emit
+  ;; contract) without ever finding a value to elide. Since rf2-6r9j.24
+  ;; this is the only gesture in Xray that reaches the clipboard fx.
   ;;
   ;; `emit` throws on a definition it cannot project. The header already
   ;; gates the control on `grammar/valid-definition?` (whose truth means

--- a/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
@@ -680,22 +680,11 @@
     "[data-rf-force-colors=\"active\"] [data-testid=\"rf-xray-static-shell\"] a {\n"
     "  color: LinkText !important;\n"
     "}\n"
-    ;; rf2-f026h — universal EDN-widget copy affordance hover-reveal. The
-    ;; `⎘` copy button (widget/copy-affordance) rides on every browse /
-    ;; inspect render's `position:relative` root. It paints recessed
-    ;; (low opacity) at rest so it doesn't clutter the dense value tree,
-    ;; and lifts to full opacity when the operator hovers the value
-    ;; container or tabs into the button (`:focus-within` covers the
-    ;; keyboard path). Like re-frame-10x, the copy gesture is present on
-    ;; every value but stays out of the way until reached for.
-    "[data-testid^=\"rf-xray-edn-widget-browse-\"] .rf-xray-edn-widget-copy {\n"
-    "  opacity: 0.18;\n"
-    "  transition: opacity 120ms ease-out;\n"
-    "}\n"
-    "[data-testid^=\"rf-xray-edn-widget-browse-\"]:hover .rf-xray-edn-widget-copy,\n"
-    "[data-testid^=\"rf-xray-edn-widget-browse-\"]:focus-within .rf-xray-edn-widget-copy {\n"
-    "  opacity: 1;\n"
-    "}\n"
+    ;; rf2-6r9j.24 — the rf2-f026h hover-reveal rules for the universal
+    ;; EDN-widget `⎘` copy button are DELETED with the affordance itself.
+    ;; They had been unmatchable as well as unused: their selector prefix
+    ;; `rf-xray-edn-widget-browse-` named a render container the rf2-oqa60
+    ;; rebuild replaced with `rf-xray-edn-inspector-…`.
     ;; rf2-8l03l — view-row hover-highlight (supersedes the flat grey
     ;; :bg-3 inline tint). When the operator hovers a view-row in the
     ;; Views / Reactive panel, `apply-highlight!` toggles this class on

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
@@ -32,7 +32,6 @@
   Pre-alpha · NO back-compat shims · dev-only · bundle-isolated.
   zprint stays for `code-block` source-text rendering."
   (:require [clojure.string :as str]
-            [re-frame.core :as rf]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack]]
             ;; The first-class edn-inspector widget owns the WHOLE
@@ -47,69 +46,25 @@
 ;; `:rf.xray.edn-inspector/expansion` slot + toggle/reset events; this
 ;; facade simply delegates to it.
 
-;; ---- universal copy-to-clipboard affordance -----------------------------
+;; ---- no value-copy affordance on this renderer (rf2-6r9j.24) -------------
 ;;
-;; re-frame-10x makes every value copyable. Rather than thread a copy
-;; button into each panel, the affordance rides on the WIDGET ROOT so
-;; it lands on every `browse` (and therefore `inspect`) call — Trace's
-;; `edn/browse`, the segment-inspector + Static panels' `edn/inspect`,
-;; all at once.
+;; The universal `⎘` copy button this facade once carried was RETIRED
+;; on 2026-09-04 (rf2-6r9j.24). It had been unreachable since the
+;; rf2-oqa60 phase-1 rebuild removed its only call site, and the
+;; canonical renderer's own design lock — `spec/021-Dynamic-Panel-
+;; Designs.md` §10.1 / §10.5, the polished super-prompt B.9 — says
+;; copy-value and copy-path are explicitly OUT here. The retraction
+;; honours that lock rather than reopening it, so spec, published
+;; skill, and runtime agree again: no copy-value on this renderer.
 ;;
-;; The `:rf.xray/copy-value-to-clipboard` event + the
-;; `:rf.xray.fx/copy-to-clipboard` fx are registered process-globally
-;; by `app-db-diff-events/install!` (always called from
-;; `registry.cljs`), so the dispatch resolves on every surface.
-;;
-;; The affordance captures the SURROUNDING frame at render time via
-;; `(rf/current-frame-id)` and dispatches into it on click. The
-;; click-handler fires after React pops the frame context, so the
-;; render-time capture is what keeps the dispatch on the right instance
-;; frame (N parallel shells stay isolated). The widget root threads
-;; everywhere through plain fns, so a render-time `current-frame-id`
-;; capture is cleaner than plumbing a `dispatch-fn` through the whole
-;; inspect/browse/diff/mini tree.
-
-(defn copy-affordance
-  "A hover-revealed `⎘` copy button that copies `value` to the
-  clipboard via `:rf.xray/copy-value-to-clipboard`. Pure hiccup —
-  positioned `absolute` top-right of a `position:relative` parent. The
-  `testid` is derived from the widget's render container id so tests can
-  target the per-render affordance. The `⎘` glyph is the same
-  click-to-copy mark spec 007:668 uses for the namespace-fade keyword
-  copy."
-  [value testid]
-  ;; Capture the surrounding instance frame at RENDER time so the
-  ;; deferred copy click dispatches back to it (not a `:rf/xray`
-  ;; literal). The widget renders inside the panels' `reg-view`s, so
-  ;; `current-frame-id` resolves through the React-context tier here.
-  (let [frame (rf/current-frame-id)]
-   [:button {:data-testid testid
-            :aria-label  "Copy value to clipboard"
-            :title       "Copy value"
-            :on-click    (fn [^js e]
-                           (.stopPropagation e)
-                           (rf/dispatch [:rf.xray/copy-value-to-clipboard value]
-                                        {:frame frame}))
-            :class       "rf-xray-edn-widget-copy"
-            :style       {:position      "absolute"
-                          :top           "2px"
-                          :right         "2px"
-                          :z-index       1
-                          :background    (:bg-3 tokens)
-                          :color         (:text-secondary tokens)
-                          :border        (str "1px solid " (:border-subtle tokens))
-                          :border-radius "3px"
-                          :cursor        "pointer"
-                          :font-family   mono-stack
-                          :font-size     "11px"
-                          :line-height   1
-                          :padding       "2px 5px"
-                          ;; Recede until the parent is hovered. The
-                          ;; in-bundle stylesheet (theme/css) reveals it
-                          ;; on `:hover` / `:focus-within`; tests assert
-                          ;; on presence + dispatch, not the CSS reveal.
-                          :opacity       0.55}}
-    "⎘"]))
+;; A FOCUSED copy affordance remains possible as a NEW design, but it
+;; must reopen B.9 with the mayor first, and it has to carry
+;; provenance: `egress/egress-value` keys the framework's `:sensitive`
+;; / `:large` declarations by ABSOLUTE app-db path, and this facade's
+;; call sites hand it slices, raw fx request/response values, and
+;; registry values that are not rooted at app-db at all. A default-on
+;; root button walking whatever it was handed as if it were an app-db
+;; root would be fail-OPEN on most of them.
 
 ;; ---- panel-facing facade — inspect / inspect-inline ----------------------
 ;;
@@ -127,16 +82,13 @@
   including the spec/015 sentinels (`:rf/redacted` and
   `:rf.size/large-elided`) as first-class chip chrome.
 
-  Single-arg form picks a default panel-id; two-arg / three-arg forms
-  accept a node-key string (passed through as a stable per-mount
-  qualifier) and an opts map. The `:copy?` key is accepted but ignored
-  — copy chrome rides on the widget root instead.
+  Single-arg form picks a default panel-id; the two-arg form accepts a
+  node-key string, passed through as a stable per-mount qualifier.
 
   Diff rendering also routes through the widget (an opt-in `:before`
   mode on `ei/edn-inspector`)."
-  ([v] (inspect v "root" nil))
-  ([v node-key] (inspect v node-key nil))
-  ([v node-key _opts]
+  ([v] (inspect v "root"))
+  ([v node-key]
    [ei/edn-inspector v
     {:panel-id (keyword (str "rf.xray.inspect/" node-key))
      :default-expanded-depth 3}]))

--- a/tools/xray/test/day8/re_frame2_xray/frame_singleton_guard_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/frame_singleton_guard_test.clj
@@ -35,8 +35,10 @@
   then migrated EVERY remaining surface — filters, palette, the static
   shell + machines + routes surfaces, the machine / cancellation /
   trace / issues / app-db-segment panels, the epoch pipeline, the share
-  + settings + spine-filter modals, the edn-widget copy affordance, and
-  the resize handles. The `pending-migration` allowlist below is now
+  + settings + spine-filter modals, and the resize handles. (The
+  edn-widget copy affordance was also migrated by that sweep; it has
+  since been retired outright under rf2-6r9j.24.) The
+  `pending-migration` allowlist below is now
   EMPTY: every file is LOCKED clean by this guard, as is any NEW file.
   Re-introducing a bare `{:frame :rf/xray}` literal or a global
   `rf/dispatch` in an `:on-*` handler trips the guard immediately.

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -49,6 +49,7 @@
             [re-frame.elision :as rf.elision]
             [re-frame.frame :as rf.frame]
             [re-frame.registrar :as rf.registrar]
+            [day8.re-frame2-xray.egress :as egress]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.panels.app-db-diff :as app-db-diff]
@@ -231,12 +232,11 @@
   (testing "register-xray-handlers! installs the Phase 5 events.
             Pin / unpin / reorder events were removed under rf2-e9tb0;
             the segment-inspector open / close events landed in their
-            place."
+            place. The two dispatcher-less clipboard copy events retired
+            under rf2-6r9j.24 — the fx they rode survives, pinned below."
     (registry/register-xray-handlers!)
     (is (some? (rf.registrar/handler :event :rf.xray/focus-slice-path)))
     (is (some? (rf.registrar/handler :event :rf.xray/clear-slice-focus)))
-    (is (some? (rf.registrar/handler :event :rf.xray/copy-value-to-clipboard)))
-    (is (some? (rf.registrar/handler :event :rf.xray/copy-path-to-clipboard)))
     ;; rf2-e9tb0 — segment-inspector events registered.
     (is (some? (rf.registrar/handler :event :rf.xray/open-segment-inspector)))
     (is (some? (rf.registrar/handler :event :rf.xray/close-segment-inspector)))
@@ -368,42 +368,26 @@
   (rf/with-frame :rf/xray
     (is (= [] @(rf/subscribe [:rf.xray/show-me-when-this-changed-result])))))
 
-;; ---- (7) clipboard fx is wired (fires without crashing) -----------------
-
-(deftest copy-events-fire-clipboard-fx
-  (testing ":rf.xray/copy-value-to-clipboard + :rf.xray/copy-path-to-
-            clipboard route through :rf.xray.fx/copy-to-clipboard; the
-            fx is best-effort (no-op on non-browser targets).
-
-            rf2-7htk7 — the value copy needs a LIVE observed frame to
-            round-trip a value at all: with none selected the egress
-            fails closed (see copy-value-with-no-observed-frame-*
-            below), so this wiring test selects :rf/default."
-    (registry/register-xray-handlers!)
-    (rf/make-frame {:id :rf/default})
-    (let [captured (atom [])]
-      ;; rf2-h1vqa4: capture via the frame's :fx-overrides seam (fn-value
-      ;; form) instead of re-registering the xray-owned fx id — a cross-ns
-      ;; re-registration fails the frame's default-image assembly loud.
-      (rf/make-frame {:id :rf/xray
-                      :fx-overrides {:rf.xray.fx/copy-to-clipboard
-                                     (fn [_ctx args] (swap! captured conj args))}})
-      (rf/with-frame :rf/xray
-        (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])
-        (rf/dispatch-sync [:rf.xray/copy-value-to-clipboard {:a 1}])
-        (rf/dispatch-sync [:rf.xray/copy-path-to-clipboard [:cart :items]]))
-      (is (= 2 (count @captured)))
-      (is (= "{:a 1}" (:text (first @captured))))
-      (is (= "[:cart :items]" (:text (second @captured)))))))
-
-;; ---- (7b) clipboard copy is an OFF-BOX EGRESS site (rf2-uo0rc.2) ---------
+;; ---- (7) the off-box safe-egress projection (rf2-uo0rc.2 + rf2-7htk7) ----
 ;;
-;; The system clipboard is an off-box sink. The copy fx wrote the RAW
-;; (pr-str value) — a `{:sensitive? true}` slot or a large blob leaked
-;; verbatim. The value-copy event now routes through egress/egress-value
-;; (fail-closed: sensitive ⇒ :rf/redacted, large ⇒ :rf.size/large-elided),
-;; pinned to the observed frame so that frame's schema declarations govern
-;; — the same fix class as the palette snapshot (rf2-mxzgg).
+;; These are the fail-closed proofs for `egress/egress-value`, Xray's single
+;; named panel-local off-box projection. They used to reach it THROUGH the
+;; value-copy event that rode the universal `⎘` affordance; rf2-6r9j.24
+;; retired both, so they now call `egress-value` directly and assert on its
+;; RETURN VALUE rather than on a captured fx.
+;;
+;; Re-pointing rather than deleting is deliberate. The projection SURVIVES
+;; the retraction — `egress.cljs` prescribes it as the MUST-use gesture any
+;; future panel affordance inherits, and the palette's `Snapshot app-db`
+;; verb uses it today — so its invariants still need pins. A green suite
+;; that lost them is exactly the fail-open this bead was filed about.
+;;
+;; The invariants, in the same order the copy-event tests proved them:
+;; sensitive slot ⇒ :rf/redacted · large slot ⇒ :rf.size/large-elided ·
+;; undeclared value passes through · nil :frame ⇒ whole value redacted ·
+;; destroyed frame id ⇒ redacted · a LIVE frame registered under the
+;; keyword the second pass used as its explicit-nil substitute ⇒ still
+;; redacted (the third-pass collision regression).
 ;;
 
 (defn- seed-sensitive-schema! []
@@ -421,194 +405,114 @@
   (rf.frame/swap-runtime-db! :rf/default
     (fn [rt] (rf.elision/apply-classification-effects rt {:large [[:blob :payload]]}))))
 
-(defn- capture-copy!
-  "rf2-h1vqa4: the capture rides the `:rf/xray` frame's `:fx-overrides`
-  (fn-value form) — call AFTER the frame exists; re-`make-frame` is a
-  surgical config update on the live frame."
-  []
-  (let [captured (atom [])]
-    (rf/make-frame {:id :rf/xray
-                    :fx-overrides {:rf.xray.fx/copy-to-clipboard
-                                   (fn [_ctx args] (swap! captured conj args))}})
-    captured))
-
-(deftest copy-value-redacts-sensitive-slot
-  (testing "rf2-uo0rc.2 — a copied value carrying a frame-declared
-            sensitive slot is REDACTED before it reaches the clipboard fx;
-            the raw secret never crosses the off-box boundary"
-    (registry/register-xray-handlers!)
+(deftest egress-value-redacts-sensitive-slot
+  (testing "rf2-uo0rc.2 — a value carrying a frame-declared sensitive slot
+            is REDACTED by the projection; the raw secret never reaches an
+            off-box sink"
     (rf/make-frame {:id :rf/default})
-    (rf/make-frame {:id :rf/xray})
     ;; Declare the sensitive path on the OBSERVED frame (:rf/default) so the
-    ;; egress, pinned to the observed frame, matches the declaration.
+    ;; egress, pinned to that frame by name, matches the declaration.
     (rf/with-frame :rf/default (seed-sensitive-schema!))
-    (let [captured (capture-copy!)]
-      ;; Pin the spine focus at the observed frame so the event resolves it.
-      (rf/with-frame :rf/xray
-        (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])
-        (rf/dispatch-sync
-          [:rf.xray/copy-value-to-clipboard
-           {:auth {:username "ada" :password "shh"}}]))
-      (is (= 1 (count @captured)))
-      (let [text (:text (first @captured))]
-        (is (re-find #":rf/redacted" text)
-            (str "the sensitive slot must be redacted on the clipboard text. "
-                 "text: " (pr-str text)))
-        (is (not (re-find #"shh" text))
-            (str "the RAW secret leaked to the clipboard — off-box egress "
-                 "fail-open (rf2-uo0rc.2). text: " (pr-str text)))
-        (is (re-find #"ada" text)
-            "non-sensitive sibling survives the copy")))))
+    (let [out (egress/egress-value {:auth {:username "ada" :password "shh"}}
+                                   {:frame :rf/default})
+          text (pr-str out)]
+      (is (re-find #":rf/redacted" text)
+          (str "the sensitive slot must be redacted. text: " (pr-str text)))
+      (is (not (re-find #"shh" text))
+          (str "the RAW secret survived the projection — off-box egress "
+               "fail-open (rf2-uo0rc.2). text: " (pr-str text)))
+      (is (re-find #"ada" text)
+          "non-sensitive sibling survives the projection"))))
 
-(deftest copy-value-size-elides-large-slot
-  (testing "rf2-uo0rc.2 — a copied value carrying a frame-declared
-            :large slot is size-elided before it reaches the clipboard fx"
-    (registry/register-xray-handlers!)
+(deftest egress-value-size-elides-large-slot
+  (testing "rf2-uo0rc.2 — a value carrying a frame-declared :large slot is
+            size-elided by the projection"
     (rf/make-frame {:id :rf/default})
-    (rf/make-frame {:id :rf/xray})
     (rf/with-frame :rf/default (seed-large-schema!))
-    (let [captured (capture-copy!)]
-      (rf/with-frame :rf/xray
-        (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])
-        (rf/dispatch-sync
-          [:rf.xray/copy-value-to-clipboard
-           {:blob {:payload {:big "value"}}}]))
-      (is (= 1 (count @captured)))
-      (let [text (:text (first @captured))]
-        (is (re-find #":rf.size/large-elided" text)
-            (str "the large slot must be size-elided on the clipboard text. "
-                 "text: " (pr-str text)))
-        (is (not (re-find #"\"value\"" text))
-            (str "the RAW large value leaked to the clipboard. text: "
-                 (pr-str text)))))))
+    (let [out  (egress/egress-value {:blob {:payload {:big "value"}}}
+                                    {:frame :rf/default})
+          text (pr-str out)]
+      (is (re-find #":rf.size/large-elided" text)
+          (str "the large slot must be size-elided. text: " (pr-str text)))
+      (is (not (re-find #"\"value\"" text))
+          (str "the RAW large value survived the projection. text: "
+               (pr-str text))))))
 
-(deftest copy-value-non-sensitive-passes-through
-  (testing "rf2-uo0rc.2 — egress is a no-op for a value with no
-            sensitive/large declarations: the copy still round-trips the
-            full value (fail-closed only bites declared slots)"
-    (registry/register-xray-handlers!)
+(deftest egress-value-non-sensitive-passes-through
+  (testing "rf2-uo0rc.2 — the projection is a no-op for a value with no
+            sensitive/large declarations: the full value round-trips
+            (fail-closed only bites declared slots)"
     (rf/make-frame {:id :rf/default})
-    (rf/make-frame {:id :rf/xray})
-    (let [captured (capture-copy!)]
-      (rf/with-frame :rf/xray
-        (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])
-        (rf/dispatch-sync [:rf.xray/copy-value-to-clipboard {:a 1 :b [2 3]}]))
-      (is (= "{:a 1, :b [2 3]}" (:text (first @captured)))
-          "an undeclared value copies verbatim"))))
+    (is (= "{:a 1, :b [2 3]}"
+           (pr-str (egress/egress-value {:a 1 :b [2 3]} {:frame :rf/default})))
+        "an undeclared value projects verbatim")))
 
-;; ---- (7c) no-target / stale-target copy FAILS CLOSED (rf2-7htk7) ---------
+;; ---- (7b) no-target / stale-target egress FAILS CLOSED (rf2-7htk7) -------
 ;;
-;; The copy handler runs UNDER the live `:rf/xray` chrome frame. The
-;; pre-fix fallback — a bare `(egress/egress-value value)` whenever the
-;; observed frame was nil or no longer live — therefore resolved
-;; `:rf/xray`, applied its normally-EMPTY declaration registry, and shipped
-;; the value RAW to the clipboard. The comment on that branch claimed it was
-;; "still fail-closed"; it was not. `elide-wire-value`'s frameless arm can
-;; only be reached by NAMING a frame that does not resolve, which is what
-;; the handler now does by forwarding `:frame observed` unconditionally.
+;; A panel affordance runs UNDER the live `:rf/xray` chrome frame. A bare
+;; `(egress/egress-value value)` whenever the observed frame is nil or no
+;; longer live therefore resolves `:rf/xray`, applies its normally-EMPTY
+;; declaration registry, and passes the value through RAW. An earlier
+;; comment on that branch claimed it was "still fail-closed"; it was not.
+;; `elide-wire-value`'s frameless arm can only be reached by NAMING a frame
+;; that does not resolve — which is why `egress.cljs` requires a caller to
+;; forward `:frame` unconditionally, including when it is nil.
 
-(deftest copy-value-with-no-observed-frame-fails-closed
-  (testing "rf2-7htk7 — with NO frame selected in the picker, the copied
-            value is redacted whole rather than shipped under the Xray
-            chrome frame's empty policy"
-    (registry/register-xray-handlers!)
-    (let [captured (atom [])]
-      (rf/make-frame {:id :rf/xray
-                      :fx-overrides {:rf.xray.fx/copy-to-clipboard
-                                     (fn [_ctx args] (swap! captured conj args))}})
-      ;; No :rf.xray/set-target-frame — `[:focus :frame]` and
-      ;; `:target-frame` are both absent, which is the unselected picker.
-      (rf/with-frame :rf/xray
-        (rf/dispatch-sync
-          [:rf.xray/copy-value-to-clipboard {:auth {:token "shh"}}]))
-      (is (= 1 (count @captured)))
-      (let [text (:text (first @captured))]
-        (is (= ":rf/redacted" text)
-            (str "no resolvable observed frame must egress the whole-value "
-                 "redaction sentinel. text: " (pr-str text)))
-        (is (not (re-find #"shh" text))
-            (str "the RAW value leaked to the clipboard with no frame policy "
-                 "in force (rf2-7htk7). text: " (pr-str text)))))))
+(deftest egress-value-with-nil-frame-fails-closed
+  (testing "rf2-7htk7 — an explicitly-nil :frame (the unselected picker)
+            redacts the value whole rather than projecting it under the
+            Xray chrome frame's empty policy"
+    (let [out (egress/egress-value {:auth {:token "shh"}} {:frame nil})]
+      (is (= :rf/redacted out)
+          (str "no resolvable frame must egress the whole-value redaction "
+               "sentinel. got: " (pr-str out)))
+      (is (not (re-find #"shh" (pr-str out)))
+          (str "the RAW value survived with no frame policy in force "
+               "(rf2-7htk7). got: " (pr-str out))))))
 
-(deftest copy-value-with-destroyed-observed-frame-fails-closed
-  (testing "rf2-7htk7 — a host frame destroyed between render and click
-            leaves a STALE observed id; a frame-id that no longer
-            resolves fails closed exactly like the frameless case"
-    (registry/register-xray-handlers!)
+(deftest egress-value-with-destroyed-frame-fails-closed
+  (testing "rf2-7htk7 — a host frame destroyed between render and use
+            leaves a STALE observed id; a frame-id that no longer resolves
+            fails closed exactly like the nil case"
     (rf/make-frame {:id :rf/default})
-    (let [captured (atom [])]
-      (rf/make-frame {:id :rf/xray
-                      :fx-overrides {:rf.xray.fx/copy-to-clipboard
-                                     (fn [_ctx args] (swap! captured conj args))}})
-      (rf/with-frame :rf/xray
-        (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default]))
-      ;; The inspected frame goes away while the picker still names it.
-      (rf/destroy-frame! :rf/default)
-      (rf/with-frame :rf/xray
-        (rf/dispatch-sync
-          [:rf.xray/copy-value-to-clipboard {:auth {:token "shh"}}]))
-      (is (= 1 (count @captured)))
-      (let [text (:text (first @captured))]
-        (is (= ":rf/redacted" text)
-            (str "a stale observed frame must egress the whole-value "
-                 "redaction sentinel. text: " (pr-str text)))
-        (is (not (re-find #"shh" text))
-            (str "the RAW value leaked to the clipboard under a destroyed "
-                 "frame (rf2-7htk7). text: " (pr-str text)))))))
+    ;; The inspected frame goes away while the caller still names it.
+    (rf/destroy-frame! :rf/default)
+    (let [out (egress/egress-value {:auth {:token "shh"}} {:frame :rf/default})]
+      (is (= :rf/redacted out)
+          (str "a stale frame id must egress the whole-value redaction "
+               "sentinel. got: " (pr-str out)))
+      (is (not (re-find #"shh" (pr-str out)))
+          (str "the RAW value survived under a destroyed frame (rf2-7htk7). "
+               "got: " (pr-str out))))))
 
-(deftest copy-value-with-no-observed-frame-fails-closed-under-id-collision
+(deftest egress-value-with-nil-frame-fails-closed-under-id-collision
   (testing "rf2-7htk7 (third pass) — an app registers a LIVE frame under the
             public keyword the earlier explicit-nil substitute expanded to,
-            :day8.re-frame2-xray.egress/no-frame. With the picker unselected
-            the copy must still redact whole: a substitute that is itself a
+            :day8.re-frame2-xray.egress/no-frame. An explicitly-nil :frame
+            must STILL redact whole: a substitute that is itself a
             registrable frame id resolved to that live frame, took the
             walker's live-frame branch, and its empty declaration registry
-            shipped the value RAW"
-    (registry/register-xray-handlers!)
+            passed the value through RAW"
     ;; The app's own frame holds the secret and declares it sensitive — but
-    ;; the picker never selects it, so its policy is not what governs here.
+    ;; it is not the frame named here, so its policy is not what governs.
     (rf/make-frame {:id :rf/default})
     (rf/with-frame :rf/default (seed-sensitive-schema!))
     ;; The colliding frame: an ordinary public keyword any app can spell.
     (rf/make-frame {:id :day8.re-frame2-xray.egress/no-frame})
     (try
-      (let [captured (atom [])]
-        (rf/make-frame {:id :rf/xray
-                        :fx-overrides {:rf.xray.fx/copy-to-clipboard
-                                       (fn [_ctx args] (swap! captured conj args))}})
-        ;; No :rf.xray/set-target-frame — the unselected picker.
-        (rf/with-frame :rf/xray
-          (rf/dispatch-sync
-            [:rf.xray/copy-value-to-clipboard
-             {:auth {:username "ada" :password "shh"}}]))
-        (is (= 1 (count @captured)))
-        (let [text (:text (first @captured))]
-          (is (= ":rf/redacted" text)
-              (str "no observed frame must egress the whole-value redaction "
-                   "sentinel even with a live frame registered under the "
-                   "explicit-nil substitute's id. text: " (pr-str text)))
-          (is (not (re-find #"shh" text))
-              (str "the RAW secret leaked to the clipboard through a live "
-                   "frame colliding with the explicit-nil substitute "
-                   "(rf2-7htk7). text: " (pr-str text)))))
+      (let [out (egress/egress-value {:auth {:username "ada" :password "shh"}}
+                                     {:frame nil})]
+        (is (= :rf/redacted out)
+            (str "an explicitly-nil frame must egress the whole-value "
+                 "redaction sentinel even with a live frame registered under "
+                 "the substitute's id. got: " (pr-str out)))
+        (is (not (re-find #"shh" (pr-str out)))
+            (str "the RAW secret survived through a live frame colliding "
+                 "with the explicit-nil substitute (rf2-7htk7). got: "
+                 (pr-str out))))
       (finally
         ;; Never leave the colliding id live for a sibling test.
         (rf/destroy-frame! :day8.re-frame2-xray.egress/no-frame)))))
-
-(deftest copy-path-is-not-a-value-egress
-  (testing "rf2-uo0rc.2 — the path-copy variant copies only the path
-            vector (key names, no values); it is not a value-egress site
-            and must NOT redact path segments"
-    (registry/register-xray-handlers!)
-    (rf/make-frame {:id :rf/default})
-    (rf/make-frame {:id :rf/xray})
-    (rf/with-frame :rf/default (seed-sensitive-schema!))
-    (let [captured (capture-copy!)]
-      (rf/with-frame :rf/xray
-        (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])
-        (rf/dispatch-sync [:rf.xray/copy-path-to-clipboard [:auth :password]]))
-      (is (= "[:auth :password]" (:text (first @captured)))
-          "the path vector copies verbatim — it carries no values to elide"))))
 
 ;; ---- (8) view renders — current-state inspector (rf2-okvit) -------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -187,14 +187,12 @@
         (is (nil? (find-by-testid tree "rf-xray-app-db-state-area-:rf/route"))
             "absent route → no placeholder card")))))
 
-;; ---- affordance strip (rf2-kbxgj + rf2-ilubp) ---------------------------
+;; ---- affordance strip (rf2-kbxgj) ---------------------------------------
 ;;
 ;; rf2-kbxgj removed the dead per-section "⤴ subs" downstream-subs hover
-;; trigger; rf2-ilubp opted the app-db inspect renders out of the EDN
-;; widget's universal ⎘ copy gesture (`:copy? false`). The current-state
-;; inspector is now a clean sectioned view with no per-block affordances.
-;; These tests pin the negative: neither affordance appears anywhere in
-;; the rendered tree.
+;; trigger. The current-state inspector is a clean sectioned view with no
+;; per-block affordances. This test pins the negative: the trigger appears
+;; nowhere in the rendered tree.
 
 (defn- all-testids
   "Every `:data-testid` in the rendered tree (no fn-component expansion
@@ -217,17 +215,13 @@
                     ids)
           "no path-keyed downstream-subs trigger on any section"))))
 
-(deftest no-copy-button-on-app-db-blocks
-  (testing "rf2-ilubp — the app-db inspect renders opt out of the EDN
-            widget's universal ⎘ copy button (`:copy? false`); no
-            `…-copy` testid appears on any value block"
-    (let [model (sections {:counter 5 :user {:name "ada"}}
-                          {:rf/route    {:id :home}
-                           :rf/machines {:title/flow {:state :playing}}})
-          tree  (state/state-body model)
-          ids   (all-testids tree)]
-      (is (not-any? #(.endsWith % "-copy") ids)
-          "no copy affordance on any app-db section value block"))))
+;; rf2-6r9j.24 — the rf2-ilubp negative (`no-copy-button-on-app-db-blocks`)
+;; is DELETED. It asserted that no testid ended in `-copy`, which held
+;; because the app-db renders opted out of the EDN widget's universal
+;; affordance; that affordance is now retired everywhere, so nothing in the
+;; tool can produce such a testid and the assertion was vacuously green
+;; forever. rf2-ilubp's App-DB outcome survives — App-DB carries no copy
+;; control — and is now enforced by construction rather than by this test.
 
 ;; ---- section-shell chrome (rf2-jcdvo) ------------------------------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
@@ -284,8 +284,10 @@
 ;; takes its LIVE-frame branch, and that frame's (empty) declaration registry
 ;; ships the value RAW: the fail-CLOSED stamp becomes fail-OPEN.
 ;;
-;; Modelled on `copy-value-with-no-observed-frame-fails-closed-under-id-collision`
-;; in `app_db_diff_cljs_test.cljs`.
+;; Modelled on `egress-value-with-nil-frame-fails-closed-under-id-collision`
+;; in `app_db_diff_cljs_test.cljs` (renamed under rf2-6r9j.24 when that proof
+;; was re-pointed from the retired copy event onto `egress/egress-value`
+;; directly; the sentinel it models is unchanged).
 ;; ---------------------------------------------------------------------------
 
 (def ^:private colliding-sentinel-id

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -545,8 +545,9 @@
    :rf.xray/clear-trace-expand
    :rf.xray/close-edit-popup
    :rf.xray/close-shell
-   :rf.xray/copy-path-to-clipboard
-   :rf.xray/copy-value-to-clipboard
+   ;; rf2-6r9j.24 — the two dispatcher-less clipboard copy events were
+   ;; retired with the universal EDN-widget affordance that was their only
+   ;; intended caller. The fx they rode survives (see the reg-fx section).
    ;; First-class edn-inspector widget events (sticky-expansion +
    ;; reset). Per `tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.4.
    ;; The pre-rf2-q3dzw flat-shape sibling events
@@ -2083,65 +2084,34 @@
 
 ;; ---- (6) reg-fx contracts -----------------------------------------------
 ;;
-;; The three :rf.xray.fx/* handlers each follow re-frame v2's
-;; `(fn [ctx args] ...)` signature. We replace each registered fx with
-;; a capture stub (same pattern as time_travel_cljs_test.cljs) and
-;; dispatch the corresponding event-fx so the captured args round-trip.
-
-(defonce ^:private captured-fx (atom []))
-
-(defn- install-capture-fx!
-  "rf2-h1vqa4: the capture rides the `:rf/xray` frame's `:fx-overrides`
-  (fn-value form); re-`make-frame` is a surgical config update on the
-  live frame the fixture created."
-  []
-  (reset! captured-fx [])
-  (rf/make-frame {:id :rf/xray
-                  :fx-overrides {:rf.xray.fx/copy-to-clipboard
-                                 (fn [_ctx args]
-                                   (swap! captured-fx conj
-                                          [:rf.xray.fx/copy-to-clipboard args]))}}))
-
-(deftest fx-copy-value-to-clipboard-fires-with-pr-str
-  (testing ":rf.xray/copy-value-to-clipboard routes through the clipboard fx"
-    (setup-xray-frame!)
-    ;; rf2-7htk7 — a LIVE observed frame is what lets a value round-trip at
-    ;; all: with none selected the egress fails closed and the fx receives
-    ;; `:rf/redacted` (pinned in app_db_diff_cljs_test §7c). This test is
-    ;; about the fx wiring, so it selects one.
-    (rf/make-frame {:id :rf/default})
-    (install-capture-fx!)
-    (rf/with-frame :rf/xray
-      (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default])
-      (rf/dispatch-sync [:rf.xray/copy-value-to-clipboard {:a 1}]))
-    (is (= 1 (count @captured-fx)))
-    (let [[fx-id args] (first @captured-fx)]
-      (is (= :rf.xray.fx/copy-to-clipboard fx-id))
-      (is (= "{:a 1}" (:text args))
-          "the value is pr-str'd before reaching the fx"))))
-
-(deftest fx-copy-path-to-clipboard-fires-with-pr-str
-  (testing ":rf.xray/copy-path-to-clipboard routes through the clipboard fx"
-    (setup-xray-frame!)
-    (install-capture-fx!)
-    (rf/with-frame :rf/xray
-      (rf/dispatch-sync [:rf.xray/copy-path-to-clipboard [:users :count]]))
-    (is (= 1 (count @captured-fx)))
-    (let [[fx-id args] (first @captured-fx)]
-      (is (= :rf.xray.fx/copy-to-clipboard fx-id))
-      (is (= "[:users :count]" (:text args))))))
+;; The :rf.xray.fx/* handlers each follow re-frame v2's `(fn [ctx args] ...)`
+;; signature.
+;;
+;; rf2-6r9j.24 — the two event-level clipboard round-trip tests went with
+;; the dispatcher-less events they drove, and the `:fx-overrides` capture
+;; stub they shared went with them. The fx itself keeps its pins: its
+;; node-target contract directly below, and its full reachable gesture (the
+;; Static Machines `Copy Mermaid` action, including the REAL registered fx
+;; on this node target) in `static/machines/copy_mermaid_cljs_test.cljs`.
 
 (deftest fx-copy-to-clipboard-handles-non-browser-target
   (testing ":rf.xray.fx/copy-to-clipboard does not throw on a node-test
-            target (no js/navigator.clipboard); contract is best-effort"
+            target (no js/navigator.clipboard); contract is best-effort.
+
+            rf2-6r9j.24 — driven by invoking the REGISTERED fx handler
+            directly rather than through a retired event, so the contract
+            keeps its pin without depending on any particular caller."
     (setup-xray-frame!)
     ;; Re-register the LIVE handler (the registry's, not our capture).
     (registry/reset-for-test!)
     (registry/register-xray-handlers!)
-    (rf/with-frame :rf/xray
-      ;; Should not throw — the registry's reg-fx wraps the navigator
-      ;; access in a try / catch :default _ nil.
-      (is (nil? (rf/dispatch-sync [:rf.xray/copy-value-to-clipboard :hi]))))))
+    (let [handler (rf.registrar/handler :fx :rf.xray.fx/copy-to-clipboard)]
+      (is (some? handler) "the fx stays registered")
+      (rf/with-frame :rf/xray
+        ;; Should not throw — the reg-fx wraps the navigator access in a
+        ;; try / catch :default, and with no `:on-failure` there is nothing
+        ;; to dispatch on the unavailable-clipboard branch.
+        (is (nil? (handler {:frame :rf/xray} {:text ":hi"})))))))
 
 ;; ---- (7) override-aware reader semantics --------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
@@ -427,15 +427,14 @@
             (on-key (mk-ev "a" prevented))
             (is (false? @prevented))))))))
 
-;; ---- (11) expand-surface EDN renders via the shared widget (2kwhw+f026h) --
+;; ---- (11) expand-surface EDN renders via the shared widget (rf2-2kwhw) ----
 
-(deftest expand-meta-renders-through-edn-widget-with-copy
+(deftest expand-meta-renders-through-edn-widget
   (testing "rf2-2kwhw + rf2-oqa60 — the registrar-meta block routes
-            through the shared EDN widget; phase 1 delegates to the
-            first-class edn-inspector widget. The copy affordance is
-            deferred to the popup phase (D6=a) — phase 1 has no copy
-            chrome on the new widget, so this test now smokes the
-            widget wiring only."
+            through the shared EDN widget, which delegates to the
+            first-class edn-inspector widget. This test smokes that
+            wiring. The renderer carries no copy chrome (rf2-6r9j.24
+            retired the universal affordance; spec/021 §10.5, B.9)."
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test cart-routes]

--- a/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
@@ -253,15 +253,15 @@
             "every row carries role=listitem")))))
 
 ;; -------------------------------------------------------------------------
-;; (5) schema EDN renders through the shared widget (rf2-2kwhw + rf2-f026h)
+;; (5) schema EDN renders through the shared widget (rf2-2kwhw)
 ;; -------------------------------------------------------------------------
 
-(deftest schema-edn-renders-through-widget-with-copy
+(deftest schema-edn-renders-through-widget
   (testing "rf2-2kwhw + rf2-oqa60 — the Malli schema renders via the
-            shared EDN widget; phase 1 delegates to the first-class
-            edn-inspector widget. The copy affordance is deferred to
-            the popup phase (D6=a) — phase 1 has no copy chrome on
-            the new widget."
+            shared EDN widget, which delegates to the first-class
+            edn-inspector widget. The renderer carries no copy chrome
+            (rf2-6r9j.24 retired the universal affordance; spec/021
+            §10.5, B.9)."
     (setup-xray!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync


### PR DESCRIPTION
Implements the rf2-6r9j.24 ruling: **RETRACT** the dead universal value-copy affordance, delete its dispatcher-less copy events, and correct the off-box egress inventory. **The B.9 lock is honoured, not reopened.**

## Why retract rather than restore

The affordance was documented on every value inspector but unreachable: the rf2-oqa60 phase-1 rebuild removed its only call site and nothing re-wired it. The component, its CSS, an accepted-but-ignored `:copy?` option and two events all survived, and the published egress inventory counted the button as one of exactly **two** off-box value sinks — an enumeration wrong in the direction that matters.

The decisive reason restore was rejected: **the surviving event was origin-blind.** It received only `[_ value]` and passed no `:path`, while the framework keys `:sensitive` / `:large` declarations by absolute app-db path. The shared renderer is handed slices at a path, raw managed-fx request/response values (which `spec/Security.md` says are not rooted at app-db at all), raw trace before/after values, and registry values. A default-on root button walking whatever it was handed, as if it were an app-db root, would be fail-**OPEN** on most of its consumers — converting an unreachable overclaim into a reachable one.

## Retracted

- `views.edn-widget/copy-affordance` and its comment block; the now-unused `re-frame.core` require; the `:copy?` accepted-but-ignored story and the discarded 3-arity of `inspect` (verified: no call site passes an opts map — every one of the tracked `edn/inspect` call sites is 1- or 2-arg).
- The hover/focus CSS in `theme/global-styles`. It was dead twice over: its selector prefix `rf-xray-edn-widget-browse-` named a render container that no longer exists anywhere in the repo.
- Both dispatcher-less events, `:rf.xray/copy-value-to-clipboard` and `:rf.xray/copy-path-to-clipboard` (zero dispatchers in `tools/xray/src`).

## Deliberately kept

- **The `:rf.xray.fx/copy-to-clipboard` fx.** Static Machines' reachable `Copy Mermaid` uses it with real success/failure callbacks. Its node-target no-throw contract keeps a pin, now driven by invoking the registered handler directly instead of through a retired event.
- **`egress/egress-value` entire**, including the explicit-`:frame` arm and the `no-frame` identity sentinel. It is the prescribed fail-closed gesture any future affordance inherits, and it is one of three carriers of a security class cited by name from `panels/local_render.cljc`, `local_render_cljs_test.cljc` and `implementation/core/.../derivation/egress.cljc` — all three left untouched and still true.
- **The six rf2-7htk7 fail-closed proofs, RE-POINTED** at `egress/egress-value` directly and landing in the same commit that deletes the events. Deleting them with the event would have been the exact fail-open this bead was filed about.

## B.9 lock — honoured

`spec/021-Dynamic-Panel-Designs.md` sections 10.1 / 10.5 and `skills/re-frame2-xray/references/shared-components.md` are **UNCHANGED**. The lock says copy-value and copy-path are explicitly OUT on this renderer and that a re-proposal must reopen B.9 with the mayor first; this change declines to reopen it, so spec, published skill and runtime say the same thing again. `spec/018-Event-Spine.md` (rf2-mv9e) and `spec/007-UX-IA.md`'s long-keyword glyph (a different design) are likewise untouched.

## Spec files that moved, and why

Per the standing rule that any PR touching `tools/xray/` updates `tools/xray/spec/*`:

| File | Change |
|---|---|
| `spec/API.md` | Off-box egress section retitled to one panel copy path; the copy-button row deleted; dated retirement blockquote added; the `:frame` and copy-path paragraphs rewritten as the contract a future affordance inherits; the `:path` paragraph extended to record why restore was not wiring |
| `spec/014-Registry-Catalogue.md` | both event rows deleted; dated retirement blockquote added in the rf2-e9tb0 style, naming both ids for the audit trail. The fx row stays |
| `spec/004-App-DB-Diff.md` | the stale Copy value / Copy path / "Show me when this changed" header-button bullet corrected — those were dropped under rf2-okvit |
| `tools/xray/README.md` | one value-egress surface, not two; `Copy Mermaid` named separately as value-free |

## Two-way census

Exact tracked-file searches (`git grep -n -F`, excluding `.beads`).

**Retired — zero live sites:**

| Token | Hits | Disposition |
|---|---|---|
| `rf-xray-edn-widget-copy` | 0 | gone |
| `:copy?` (under `tools/xray`) | 0 | gone — controlled against `:card?`, which returns hits |
| `copy-affordance` | 1 | pre-existing record in `edn_widget_cljs_test.cljs` that the copy tests were deleted |
| `rf-xray-edn-widget-browse` | 1 | retirement note recording that the prefix is extinct |
| `copy-value-to-clipboard` | 2 | both in dated retirement records (014 blockquote + events ns docstring) |
| `copy-path-to-clipboard` | 2 | same two records |

**Deviation, stated plainly:** the ruling's census asks these last two to return *nothing*, while the same ruling directs a retirement blockquote "naming both event ids ... for the audit trail". Those two instructions conflict. I followed the blockquote directive, because it is the more specific one and it matches the rf2-e9tb0 precedent sitting immediately above it in both files, which names its removed ids the same way. **Zero live sites; four occurrences, all inside dated retirement records.**

**Kept — all still resolve:** `rf.xray.fx/copy-to-clipboard` 20 · `egress/egress-value` 24 · `egress/no-frame` 6 · `snapshot-app-db` 26 · `copy-mermaid` 49.

Census run across several token axes, not just the hyphenated ids: symbol/id form, underscore file form, CSS class form, the U+2398 glyph itself, and spaced/title-case prose (`copy button`, `copy affordance`, `copy gesture`, `copy chrome`, `copy control`, `value-copy`, `Copy path`, `two human copy`). The prose axis is what found the `004` bullet and one stale cross-reference the id axes missed.

## Gates — captured exits, before and after

| Gate | Path | Before | After |
|---|---|---|---|
| `clojure -M:test` | from `tools/xray/` | exit **0** · 1270 tests / 6100 assertions | exit **0** · 1270 / 6100 |
| `npm run test:cljs` (split: compile, then run) | from `implementation/` | exit **0** · 11176 tests / 55753 assertions | exit **0** · **11171 / 55734** |
| `clojure -M:test` (api-manifest — runs `xray_spec_check.clj`, which reads `spec/API.md`) | `implementation/scripts/api-manifest/` | — | exit **0** · 95 / 185 |
| `python scripts/check_doc_slugs.py` | repo root | — | exit **0** |
| `python scripts/check_readme_links.py --ci` | repo root | — | exit **0** |

All exits are the runner's own, captured to a file on one command line and quoted from it; no gate was piped through a filter. Every log's first line names the worktree it ran in; each log carries exactly one summary line and zero NUL bytes. Re-run in full on the final rebased base.

**The −5 test delta is exactly the five tests deleted** — the two event-level clipboard round-trips in `registry_cljs_test`, the two copy-event tests in `app_db_diff_cljs_test`, and the vacuous rf2-ilubp `no-copy-button-on-app-db-blocks` negative (it asserted no testid ends in `-copy`; nothing can produce one now, so it was green forever regardless). rf2-ilubp's App-DB outcome survives, enforced by construction. **No proof was lost:** all six fail-closed proofs are present and renamed.

**Sabotage-verified.** Breaking `egress-value`'s explicit-nil substitution turned the suite **red** (exit 1, 3 failures) naming exactly `egress-value-with-nil-frame-fails-closed` and `...-under-id-collision` — so the re-pointed proofs genuinely execute and the gate reads this worktree. Reverted and confirmed by blob hash against the committed object. The destroyed-frame proof correctly stayed green under that particular sabotage: it is protected by the walker's own id validation, not by the sentinel.

Both doc gates were controlled the same way — a planted broken target and anchor in `tools/xray/spec/API.md` turned `check_doc_slugs.py` red, and a planted broken target in `tools/xray/README.md` turned `check_readme_links.py --ci` red, confirming each gate covers the files this PR changes. Both plants reverted and hash-verified.

**Hand-checks the gates cannot do:** no changed line in any of the four documents falls inside a fenced code block (checked programmatically; detector controlled against a file with known fences), so neither link gate's fence blind-spot applies here. Table column counts verified by hand in `spec/API.md` and `014` — both tables are 3-column throughout after the row deletions. `mkdocs build --strict` is **not** nominated: `tools/` is outside `docs_dir` and is not staged by the hook.

## Out of fence — needs a follow-up

`spec/api-manifest-metadata.edn` carries the same stale claim, calling `egress` "the panel-local fail-closed projection the **two human copy affordances** use". It is a fifth claim site the ruling did not name, and it sits in top-level `spec/**`, outside this PR's fence, so it is deliberately untouched here. Recorded on the bead.
