### PR TITLE
fix(hicasso): the author's annotation value wins at the canonical slot, not at the key (rf2-c5w1)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -893,6 +893,41 @@
                               view-id (error/source-of view-name))
      :data-rf-view          (adapter-context/format-view-id view-id)}))
 
+(defn- author-owns-slot?
+  "Does `authored` already write the React prop slot `slot`, in ANY of the
+  spellings that land there? `codec/canonical-slot` is the resolver — the
+  same one every deny, dissoc and check in the codec asks, and the one the
+  emitter itself uses — so this cannot answer differently from what
+  `convert-props` will do with the map."
+  [authored slot]
+  (reduce-kv (fn [_ k _] (if (= slot (codec/canonical-slot k)) (reduced true) false))
+             false
+             authored))
+
+(defn- without-authored-slots
+  "`attrs` minus every entry whose canonical React slot `authored` already
+  claims — `attrs` itself, by identity, when it claims neither.
+
+  This is what makes the author's ownership a real one. A hiccup attribute
+  key is written in five spellings (`re-frame.hicasso.impl.slot`), and
+  every one of them emits under a single React name, so `merge` — which
+  resolves a collision only between keys that are `=` — keeps BOTH a
+  body's `\"data-rf-view\"` and the framework's `:data-rf-view`, and
+  `convert-props` then writes them into one slot with the map's ITERATION
+  ORDER picking the winner. Removing the framework's entry at the slot
+  makes the collision a real key collision, and there is no second entry
+  left for an order to choose between.
+
+  Two entries against the root's attribute count, dev-mode only, on a map
+  the codec was about to walk anyway."
+  [attrs authored]
+  (reduce-kv (fn [acc k _]
+               (if (author-owns-slot? authored (codec/canonical-slot k))
+                 (dissoc acc k)
+                 acc))
+             attrs
+             attrs))
+
 (defn annotate-root
   "Merge a declared view's Spec 006 annotations into the root of the
   hiccup its body just returned, and answer the hiccup to encode.
@@ -917,16 +952,24 @@
   that is not a vector at all — nil from a conditional body, a string, a
   seq — is left alone for the same reason.
 
-  The author's attrs WIN the merge, matching the Reagent walk
+  The author's attrs WIN, matching the Reagent walk
   (`re-frame.views.source-coord-annotation/inject-source-coord-attr`): a
-  body that wrote either attribute itself keeps the value it wrote."
+  body that wrote either attribute itself keeps the value it wrote. That
+  win is held AT THE CANONICAL SLOT and not at the key
+  (`without-authored-slots`), because this codec accepts five spellings of
+  one attribute and `merge` is keyed by `=` — so a body writing the string
+  `\"data-rf-view\"` beside the framework's keyword left both in the map
+  and let iteration order pick, which is the guarantee failing
+  nondeterministically rather than failing (rf2-c5w1, audit of PR #9191).
+  Ownership is per slot: the annotation a body did NOT write is still
+  stamped beside the one it did."
   [hiccup attrs]
   (if (and (vector? hiccup)
            (pos? (count hiccup))
            (= :tag (codec/head-kind (nth hiccup 0))))
     (let [maybe-attrs (nth hiccup 1 nil)]
       (if (map? maybe-attrs)
-        (assoc hiccup 1 (merge attrs maybe-attrs))
+        (assoc hiccup 1 (merge (without-authored-slots attrs maybe-attrs) maybe-attrs))
         (into [(nth hiccup 0) attrs] (rest hiccup))))
     hiccup))
 

--- a/implementation/hicasso/test/re_frame/hicasso/view_annotation_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/view_annotation_dom_cljs_test.cljs
@@ -77,6 +77,24 @@
   [_]
   [:p {:class "wins" :data-rf-view "author-set"} "wins"])
 
+(rf.hicasso/defview author-wins-in-another-spelling
+  "A body that writes the STRING spelling of `data-rf-view`, in a map big
+  enough to be a PersistentHashMap.
+
+  `merge` cannot collapse two spellings of one React slot, so before
+  rf2-c5w1's audit repair both keys survived and `convert-props` let the
+  map's iteration order pick the emitted value — which an array map hid by
+  iterating in insertion order. The eleven fillers are what make the shape
+  a hash map; nothing else about them matters."
+  [_]
+  [:p {:class          "wins-string"
+       "data-rf-view"  "author-string"
+       :data-filler-0  "0" :data-filler-1 "1" :data-filler-2  "2"
+       :data-filler-3  "3" :data-filler-4 "4" :data-filler-5  "5"
+       :data-filler-6  "6" :data-filler-7 "7" :data-filler-8  "8"
+       :data-filler-9  "9" :data-filler-10 "10"}
+   "wins"])
+
 (rf.hicasso/defview inner-view
   "The inner half of a boundary-rooted pair — it tags its OWN root."
   [_]
@@ -101,6 +119,7 @@
    [plain-root {}]
    [attrs-root {}]
    [author-wins {}]
+   [author-wins-in-another-spelling {}]
    [boundary-root {}]
    [fragment-root {}]])
 
@@ -171,6 +190,24 @@
         (is (str/starts-with? (coord-attr handle ".wins")
                               (str view-ns ":author-wins:"))
             "and the attribute it did NOT write is still stamped")
+        (finally (rf.hicasso.impl.mount/release! handle))))))
+
+(deftest the-author-wins-a-collision-in-any-spelling-of-the-slot
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (skip! ":node-test has no DOM")
+    (let [handle (mounted!)]
+      (try
+        (is (= "author-string" (view-attr handle ".wins-string"))
+            "a body that wrote the STRING `\"data-rf-view\"` keeps its value
+             too — the framework's entry is dropped at the CANONICAL SLOT,
+             not at the keyword, so nothing is left for the map's iteration
+             order to choose between (rf2-c5w1, audit of PR #9191)")
+        (is (str/starts-with? (coord-attr handle ".wins-string")
+                              (str view-ns ":author-wins-in-another-spelling:"))
+            "and the annotation it did not write is still stamped — ownership
+             is per slot, not a blanket refusal to annotate")
+        (is (= "5" (attr handle ".wins-string" "data-filler-5"))
+            "the author's ordinary attributes are untouched")
         (finally (rf.hicasso.impl.mount/release! handle))))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/view_annotation_slot_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/view_annotation_slot_cljs_test.cljs
@@ -2,7 +2,7 @@
   "SPEC 006'S TWO ANNOTATIONS AND THE AUTHOR'S OWN VALUE, OWNED AT THE
   CANONICAL SLOT RATHER THAN AT THE KEYWORD (rf2-c5w1).
 
-  `collector/annotate-root` merges the framework's two attributes UNDER
+  `rf.hicasso.impl.collector/annotate-root` merges the framework's two attributes UNDER
   the body's own attrs, and Spec 006 §Cross-host records the consequence
   as a guarantee: a body that wrote either attribute itself keeps the
   value it wrote.
@@ -10,7 +10,7 @@
   `merge` resolves a collision only between keys that are `=`, and this
   codec accepts FIVE spellings of one attribute — keyword, namespaced
   keyword, symbol, namespaced symbol and string — every one of which
-  `codec/canonical-slot` folds onto the SAME React prop name. Two
+  `rf.hicasso.impl.codec/canonical-slot` folds onto the SAME React prop name. Two
   surviving keys therefore reach `convert-props`, which writes both into
   one slot, and the map's ITERATION ORDER picks the winner.
 
@@ -32,8 +32,8 @@
   implementations so the second is not silently the first."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [goog.object :as gobj]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]))
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]))
 
 (def ^:private annotations
   "The framework's pre-built attrs map, ASKED of the collector rather than
@@ -41,12 +41,12 @@
   passing beside them. The name was never declared through the macros, so
   `error/source-of` answers nil and the coordinate degrades to `?` — which
   is irrelevant to every claim below, all of which are about the KEY."
-  (collector/view-annotations "re-frame.hicasso.view-annotation-slot-cljs-test/probe"))
+  (rf.hicasso.impl.collector/view-annotations "re-frame.hicasso.view-annotation-slot-cljs-test/probe"))
 
 (def ^:private author-value "author-wrote-this")
 
 (defn- spellings
-  "Every prop-key spelling of `k`'s name — the four `codec/canonical-slot`
+  "Every prop-key spelling of `k`'s name — the four `rf.hicasso.impl.codec/canonical-slot`
   reads through `name`, plus the string the slot rule takes verbatim."
   [k]
   (let [n (name k)]
@@ -77,30 +77,30 @@
 (defn- claimants
   "The keys of `attrs` whose canonical React slot is `slot`."
   [attrs slot]
-  (into #{} (filter #(= slot (codec/canonical-slot %))) (keys attrs)))
+  (into #{} (filter #(= slot (rf.hicasso.impl.codec/canonical-slot %))) (keys attrs)))
 
 (defn- emitted
   "The value `convert-props` writes into `slot` — the emission step, on a
   plain `:p` so the tag shorthand folds nothing."
   [attrs slot]
-  (gobj/get (codec/convert-props attrs (codec/cached-parse :p)) slot))
+  (gobj/get (rf.hicasso.impl.codec/convert-props attrs (rf.hicasso.impl.codec/cached-parse :p)) slot))
 
 (defn- annotated
   "The attrs map `annotate-root` leaves on the root it is handed."
   [authored]
-  (nth (collector/annotate-root [:p authored] annotations) 1))
+  (nth (rf.hicasso.impl.collector/annotate-root [:p authored] annotations) 1))
 
 ;; ---------------------------------------------------------------------------
 ;; The premise, established at source
 ;; ---------------------------------------------------------------------------
 
 (deftest every-spelling-of-an-annotation-names-one-slot
-  (testing "the accepted spelling set is what `codec/canonical-slot` folds
+  (testing "the accepted spelling set is what `rf.hicasso.impl.codec/canonical-slot` folds
             together, and for both annotations it is a single slot — the
             fact that makes a key-keyed merge the wrong instrument"
     (doseq [[k _] annotations]
-      (is (= #{(codec/canonical-slot k)}
-             (into #{} (map codec/canonical-slot) (spellings k)))
+      (is (= #{(rf.hicasso.impl.codec/canonical-slot k)}
+             (into #{} (map rf.hicasso.impl.codec/canonical-slot) (spellings k)))
           (str (pr-str k) ": every spelling emits into one React prop name")))))
 
 (deftest the-two-map-shapes-are-genuinely-different-implementations
@@ -117,7 +117,7 @@
 
 (deftest the-author-owns-the-slot-however-the-annotation-is-spelled
   (doseq [[k framework-value] annotations
-           :let               [slot  (codec/canonical-slot k)
+           :let               [slot  (rf.hicasso.impl.codec/canonical-slot k)
                                other (first (remove #(= k %) (keys annotations)))]
           spelling            (spellings k)
           [shape authored]    [["array map" (small-attrs spelling)]
@@ -132,7 +132,7 @@
             "and the value the codec emits into the slot is the author's")
         (is (not= framework-value (emitted merged slot))
             "never the framework's")
-        (is (= (get annotations other) (emitted merged (codec/canonical-slot other)))
+        (is (= (get annotations other) (emitted merged (rf.hicasso.impl.codec/canonical-slot other)))
             "while the annotation the author did NOT write is still stamped —
              ownership is per slot, not a blanket refusal to annotate")))))
 
@@ -141,6 +141,6 @@
             by slot-keyed ownership"
     (let [merged (annotated {:class "plain" :id "keep-me"})]
       (doseq [[k v] annotations]
-        (is (= v (emitted merged (codec/canonical-slot k)))
+        (is (= v (emitted merged (rf.hicasso.impl.codec/canonical-slot k)))
             (str (pr-str k) " is stamped")))
       (is (= "keep-me" (emitted merged "id")) "and the author's attrs stand"))))

--- a/implementation/hicasso/test/re_frame/hicasso/view_annotation_slot_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/view_annotation_slot_cljs_test.cljs
@@ -1,0 +1,146 @@
+(ns re-frame.hicasso.view-annotation-slot-cljs-test
+  "SPEC 006'S TWO ANNOTATIONS AND THE AUTHOR'S OWN VALUE, OWNED AT THE
+  CANONICAL SLOT RATHER THAN AT THE KEYWORD (rf2-c5w1).
+
+  `collector/annotate-root` merges the framework's two attributes UNDER
+  the body's own attrs, and Spec 006 §Cross-host records the consequence
+  as a guarantee: a body that wrote either attribute itself keeps the
+  value it wrote.
+
+  `merge` resolves a collision only between keys that are `=`, and this
+  codec accepts FIVE spellings of one attribute — keyword, namespaced
+  keyword, symbol, namespaced symbol and string — every one of which
+  `codec/canonical-slot` folds onto the SAME React prop name. Two
+  surviving keys therefore reach `convert-props`, which writes both into
+  one slot, and the map's ITERATION ORDER picks the winner.
+
+  ## Why these rows and not the DOM witness beside them
+
+  The DOM rows in `view-annotation-dom-cljs-test` assert the guarantee
+  through a body that writes the keyword — the one spelling `merge`
+  collapses — so they pass whether ownership is held at the key or at the
+  slot. A small array map iterates in insertion order and happens to pass
+  too, which is why a bigger map is what exposed this.
+
+  So the property is pinned TWICE here. Once STRUCTURALLY: after the merge
+  exactly one key in the map canonicalises to each annotation slot. That
+  claim cannot depend on iteration order at all — there is no second entry
+  for an order to choose between — which is what makes it a witness rather
+  than a lucky run. And once through `convert-props`, the emission step
+  the DOM actually shows. Both are taken over an array map AND over a
+  PersistentHashMap, and one row asserts those two are genuinely different
+  implementations so the second is not silently the first."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [goog.object :as gobj]
+            [re-frame.hicasso.impl.codec :as codec]
+            [re-frame.hicasso.impl.collector :as collector]))
+
+(def ^:private annotations
+  "The framework's pre-built attrs map, ASKED of the collector rather than
+  spelled here, so a rename of either key reddens these rows instead of
+  passing beside them. The name was never declared through the macros, so
+  `error/source-of` answers nil and the coordinate degrades to `?` — which
+  is irrelevant to every claim below, all of which are about the KEY."
+  (collector/view-annotations "re-frame.hicasso.view-annotation-slot-cljs-test/probe"))
+
+(def ^:private author-value "author-wrote-this")
+
+(defn- spellings
+  "Every prop-key spelling of `k`'s name — the four `codec/canonical-slot`
+  reads through `name`, plus the string the slot rule takes verbatim."
+  [k]
+  (let [n (name k)]
+    [(keyword n)
+     (keyword "probe" n)
+     (symbol n)
+     (symbol "probe" n)
+     n]))
+
+(defn- small-attrs
+  "The author's attrs as a two-entry map: a PersistentArrayMap, which
+  iterates in insertion order."
+  [k]
+  {k author-value :class "small"})
+
+(defn- hashed-attrs
+  "The author's attrs as a PersistentHashMap carrying eleven ordinary
+  filler attributes beside the authored one — the shape the audit of
+  PR #9191 reproduced against, and one whose iteration order is not
+  insertion order. `apply hash-map` rather than a map literal so the
+  implementation is chosen by construction and not by counting entries."
+  [k]
+  (apply hash-map
+         (into [k author-value]
+               (mapcat (fn [i] [(keyword (str "data-filler-" i)) (str i)]))
+               (range 11))))
+
+(defn- claimants
+  "The keys of `attrs` whose canonical React slot is `slot`."
+  [attrs slot]
+  (into #{} (filter #(= slot (codec/canonical-slot %))) (keys attrs)))
+
+(defn- emitted
+  "The value `convert-props` writes into `slot` — the emission step, on a
+  plain `:p` so the tag shorthand folds nothing."
+  [attrs slot]
+  (gobj/get (codec/convert-props attrs (codec/cached-parse :p)) slot))
+
+(defn- annotated
+  "The attrs map `annotate-root` leaves on the root it is handed."
+  [authored]
+  (nth (collector/annotate-root [:p authored] annotations) 1))
+
+;; ---------------------------------------------------------------------------
+;; The premise, established at source
+;; ---------------------------------------------------------------------------
+
+(deftest every-spelling-of-an-annotation-names-one-slot
+  (testing "the accepted spelling set is what `codec/canonical-slot` folds
+            together, and for both annotations it is a single slot — the
+            fact that makes a key-keyed merge the wrong instrument"
+    (doseq [[k _] annotations]
+      (is (= #{(codec/canonical-slot k)}
+             (into #{} (map codec/canonical-slot) (spellings k)))
+          (str (pr-str k) ": every spelling emits into one React prop name")))))
+
+(deftest the-two-map-shapes-are-genuinely-different-implementations
+  (let [k (first (keys annotations))]
+    (is (not= (type (small-attrs k)) (type (hashed-attrs k)))
+        "the array-map row and the hash-map row below exercise two different
+         map implementations — without this the second row would be the
+         first wearing a different name, and the order-dependence would go
+         unmeasured")))
+
+;; ---------------------------------------------------------------------------
+;; The guarantee, at the slot
+;; ---------------------------------------------------------------------------
+
+(deftest the-author-owns-the-slot-however-the-annotation-is-spelled
+  (doseq [[k framework-value] annotations
+           :let               [slot  (codec/canonical-slot k)
+                               other (first (remove #(= k %) (keys annotations)))]
+          spelling            (spellings k)
+          [shape authored]    [["array map" (small-attrs spelling)]
+                               ["hash map"  (hashed-attrs spelling)]]]
+    (testing (str (pr-str k) " written as " (pr-str spelling) " in an " shape)
+      (let [merged (annotated authored)]
+        (is (= #{spelling} (claimants merged slot))
+            "exactly ONE key survives the merge into that slot — the author's.
+             A second one leaves the winner to the map's iteration order,
+             which is the defect this row exists to catch")
+        (is (= author-value (emitted merged slot))
+            "and the value the codec emits into the slot is the author's")
+        (is (not= framework-value (emitted merged slot))
+            "never the framework's")
+        (is (= (get annotations other) (emitted merged (codec/canonical-slot other)))
+            "while the annotation the author did NOT write is still stamped —
+             ownership is per slot, not a blanket refusal to annotate")))))
+
+(deftest an-untouched-root-still-carries-both-annotations
+  (testing "the ordinary body — no collision in any spelling — is unchanged
+            by slot-keyed ownership"
+    (let [merged (annotated {:class "plain" :id "keep-me"})]
+      (doseq [[k v] annotations]
+        (is (= v (emitted merged (codec/canonical-slot k)))
+            (str (pr-str k) " is stamped")))
+      (is (= "keep-me" (emitted merged "id")) "and the author's attrs stand"))))


### PR DESCRIPTION
Second carrier on rf2-c5w1. PR #9191 landed Spec 006's two dev-mode DOM annotations on Hicasso boundaries; the post-merge audit reopened the bead against one clause of that deliverable — the guarantee that an author's own value wins a collision with the injected key.

## What the audit found, verified at source

`annotate-root` merged with `(merge attrs maybe-attrs)`. `merge` resolves a collision only between keys that are `=`. This codec accepts **five spellings of one attribute** — keyword, namespaced keyword, symbol, namespaced symbol and string — and `codec/canonical-slot` (which *is* `slot/prop-name`, the shared `.cljc` rule the migration codemod holds `identical?` to) folds every one of them onto a single React prop name. The slot rule reads a key through `name`, so the namespace is discarded; a string is taken verbatim.

So a body writing the string `"data-rf-view"` left **both** its key and the framework's `:data-rf-view` in the map. `convert-props` then wrote both into the one slot, and the attribute map's **iteration order** picked the emitted value.

That is worse than an ordinary bug: the guarantee did not fail, it failed *nondeterministically*. A small `PersistentArrayMap` iterates in insertion order and happens to pass, which is exactly why the keyword-only witness that landed with #9191 missed it.

## The fix

`without-authored-slots` drops the framework's entry for any canonical slot the body already claims — in any spelling — **before** the merge. The collision becomes a real key collision, and there is no second entry left for an order to choose between. The resolver is `codec/canonical-slot`, the codec's own shared rule and the one the emitter itself uses, so the deny cannot answer differently from what `convert-props` will do with the map; no new resolver was forked, and the codec's general duplicate-slot policy is untouched.

Ownership is **per slot**: the annotation a body did not write is still stamped beside the one it did.

## The witness is order-proof, not order-lucky

`view_annotation_slot_cljs_test.cljs` pins the property twice:

* **structurally** — after the merge exactly one key in the map canonicalises to each annotation slot. That claim cannot depend on iteration order at all, because there is no second entry for an order to choose between;
* **through `convert-props`** — the emission step the DOM shows.

Both are taken over all five spellings of both attributes, over a `PersistentArrayMap` **and** a `PersistentHashMap`, with one row asserting those two shapes are genuinely different implementations so the second is not silently the first. A further row pins the accepted spelling set itself (every spelling resolves to one slot), and another pins that an uncollided root still carries both annotations.

The DOM lane gains one row: a `defview` writing the string spelling in a twelve-entry (hash-map) attrs map, asserted at the rendered node.

**Red before, green after.** With the tests in place and the fix absent: **exit 1, 4 tests / 86 assertions, 28 failures**, the hash-map rows emitting the framework's value where the author's was expected (`actual: (not (= "author-wrote-this" ":…/probe"))`). With the fix: 0 failures.

## Deliberately unchanged

* The **three production-erasure sentinels** #9191 added are untouched. The new helpers carry no attribute literal of their own — the slots they compare are derived from the injected map at runtime — so nothing new can survive into a release bundle. Measured, not assumed: the erasure gate reports 8 sentinels absent, 3 positive controls present.
* The **34 repaired test-kit assertions** and the annotation normalisers are untouched.
* The **declined one-shot warning** for a non-DOM root stays declined, with its recorded reason.
* `spec/006-ReactiveSubstrate.md` is **not touched here** — a peer holds that hot-zone file this wave. §Cross-host's sentence "the author's own value wins a collision" is true again with this change, and the exact prose sharpening it to say *at the canonical slot* has been handed to the mayor to sequence after the peer's PR merges.

## Gates

| Gate | Result |
| --- | --- |
| `:node-test-hicasso` (compile + run, post-rebase) | exit 0 — **1188 tests / 4489 assertions**, 0 failures (baseline 1183 / 4402, plus 4 node tests + 1 skipped DOM row) |
| `npm run test:browser` | exit 0 — **789 / 4272**, 0 failures (baseline 788 / 4269, plus the one DOM row) |
| `npm run build:hicasso-release` | exit 0 — 8 sentinels absent, 3 positive controls present; bundle isolation 6 absent / 4 controls present |

Every exit code above was captured with `echo $?` on the runner's own command line, not read off a wrapper. The base moved once during the work, by a single `chore(beads): checkpoint` commit whose diff names `.beads/issues.jsonl` alone; the node lane was recompiled and re-run on the final base after the rebase.
