### PR TITLE
fix(http): frame-scope the managed-request cleanup paths too (rf2-o8ek)

### DIFF
--- a/examples/core/managed_http_counter/core.cljs
+++ b/examples/core/managed_http_counter/core.cljs
@@ -241,7 +241,13 @@
          ;; :http-counter/start-long. The live fx would deliver it via `:reply-to`,
          ;; so we mirror that: the canonical envelope is the appended last arg.
          :abort-fn (fn [reason]
-                     (rf.http.registry/clear-in-flight! request-id)
+                     ;; The carried frame does the same work on the way OUT as
+                     ;; it does on the way in. `clear-in-flight!`'s one-arg form
+                     ;; is an ANY-FRAME sweep: it would clear this id in EVERY
+                     ;; frame, so mounting this demo twice and cancelling one
+                     ;; copy would silently deregister the other's live request.
+                     ;; Cleanup is frame-scoped for exactly the reason lookup is.
+                     (rf.http.registry/clear-in-flight-in-frame! frame request-id)
                      ;; The canonical abort reply uses `:status :cancelled`
                      ;; with `:cancelled? true`, carries the abort reason
                      ;; under the uniform reply contract's namespaced field

--- a/implementation/http/src/re_frame/http/registry.cljc
+++ b/implementation/http/src/re_frame/http/registry.cljc
@@ -69,6 +69,23 @@
 ;; `[:rf.req frame-id work-id]` per Spec 016 — so at most one frame can match)
 ;; and it is the conservative reading for actor destroy until its callers thread
 ;; a frame. The frame-BEARING arities alongside them are the isolated ones.
+;;
+;; rf2-o8ek audit — the seams are KEPT (no flag day), but the standing law is
+;; now explicit and mechanical: A CLEANUP PATH THAT POSSESSES AN ISSUING FRAME
+;; MUST BE FRAME-EXACT. The audit found two that were not, and both looked
+;; migrated: the `clear-in-flight!` fallback taken when a handle is not yet
+;; published, and a seeded-handle demo whose abort closure kept the 1-arg call
+;; after gaining a `:frame` stamp. Neither was an abort path, which is why the
+;; frame-scoped keys did not cover them — they reintroduced the cross-frame
+;; reach through CLEANUP instead, deleting a sibling frame's live slot and
+;; leaving its request unregistered and unabortable.
+;;
+;; No warning enforces this, deliberately: a registry fn cannot see whether its
+;; caller had a frame to give (there is no ambient ctx down here), so any check
+;; would have to fire on the legitimate resources sweep as readily as on a
+;; mistake. The enforcement is structural instead — every frame-bearing entry
+;; point has a frame-bearing arity, and after this audit NO production path
+;; reaches the 1-arg `clear-in-flight!` sweep at all.
 
 (defn- scoped-key
   "The internal cancellation key: the ISSUING FRAME paired with the caller's
@@ -146,8 +163,43 @@
                    (dissoc actor-index k)))))))
   nil)
 
+(defn clear-in-flight-in-frame!
+  "Clear `frame-id`'s handle for `request-id` from both indexes — the
+  FRAME-EXACT cleanup form, and the named sibling of
+  `abort-in-flight-in-frame!` (rf2-o8ek audit).
+
+  Unlike the 2-arg `clear-in-flight!` this is identity-UNCONDITIONAL: it drops
+  whatever this frame currently has under the id, because the caller holds a
+  frame but no handle. Use it exactly there — a cleanup path that knows which
+  frame it is cleaning up for but cannot name the handle:
+
+   - an abort closure built alongside the handle it cancels, so the handle
+     is not in scope (the seeded-handle demos);
+   - the transport's pre-publication window, where `record-in-flight!` has
+     already published the handle to the index but the forward-reference cell
+     the abort-fn reads has not been `reset!` yet.
+
+  Both of those previously fell through to the 1-arg ANY-FRAME sweep, which
+  deletes EVERY frame's slot under the raw id — reintroducing, in the cleanup
+  half, exactly the cross-frame reach the frame-scoped keys removed from the
+  abort/supersede half. Being unconditional is not the same as being
+  unscoped: within one frame it is precisely as safe as the sweep it replaces
+  (a same-frame successor cannot exist in either window), and it simply cannot
+  see a sibling frame.
+
+  A nil `request-id` is a no-op: an anonymous request is indexed only in
+  `actor-in-flight`, where it is reachable only by handle identity — use the
+  2-arg `clear-in-flight!` once the handle is in hand. Returns nil."
+  [frame-id request-id]
+  (when request-id
+    (let [k (scoped-key frame-id request-id)
+          [previous _] (swap-vals! in-flight dissoc k)]
+      (when-let [handle (get previous k)]
+        (remove-from-actor-index! handle))))
+  nil)
+
 (defn clear-in-flight!
-  "Clear a request handle from both indexes. Two arities:
+  "Clear a request handle from both indexes. Three arities:
 
    - 1-arg `[request-id]` — the resolve-by-id, ANY-FRAME form (rf2-o8ek).
      Resolves every frame's handle registered under this raw `request-id`
@@ -163,6 +215,19 @@
      ctx + handle pair, so the cleanup is index-walks by identity and
      does not depend on `request-id` being non-nil. This arity covers
      anonymous-request natural completion from inside spawned actors.
+     A NIL `handle` has no frame to be exact about and falls back to the
+     ANY-FRAME 1-arg sweep — which is why a caller that HOLDS a frame must
+     use the 3-arity below instead, even when its handle may be nil.
+   - 3-arg `[frame-id request-id handle]` — the same natural-completion
+     cleanup, told which frame is doing it (rf2-o8ek audit). Pass everything
+     you know and the registry uses the most precise key available: a non-nil
+     `handle` clears by identity exactly as the 2-arg form does (the frame is
+     read off the handle, so the `frame-id` argument is redundant and
+     ignored), while a nil one clears `frame-id`'s own slot through
+     `clear-in-flight-in-frame!` rather than sweeping every frame's. This is
+     the arity every transport cleanup site uses, because each one holds a
+     ctx carrying `:frame` while its handle cell can still be nil inside the
+     publication window.
 
   Per rf2-plngk this is THE single source of truth for in-flight
   cleanup on per-request termination. The natural-completion sites
@@ -205,9 +270,18 @@
    (if (nil? handle)
      ;; rf2-o8ek — a nil `handle` (an abort that fired before the handle was
      ;; published to `@handle-cell` / `@handle-holder`) carries no `:frame`, so
-     ;; there is no key to be exact about. Fall back to the ANY-FRAME clear
-     ;; above: that pre-publication window precedes any successor, so there is
-     ;; nothing to protect and the slot must still be cleared.
+     ;; THIS arity has no key to be exact about and falls back to the ANY-FRAME
+     ;; clear above.
+     ;;
+     ;; rf2-o8ek audit — that fallback is the reason a frame-bearing caller
+     ;; must not reach this arity with a possibly-nil handle. The original
+     ;; reasoning ("the pre-publication window precedes any successor, so
+     ;; there is nothing to protect") holds only for a SAME-FRAME successor.
+     ;; A SIBLING frame that was already live under the same raw id is not a
+     ;; successor at all, and the sweep deletes its slot — leaving a live
+     ;; request unregistered and unabortable. Every transport site therefore
+     ;; passes `(:frame ctx)` through the 3-arity above; this branch remains
+     ;; only for a caller that genuinely has no frame.
      (clear-in-flight! request-id)
      (do
        (when request-id
@@ -220,6 +294,15 @@
                       (dissoc request-index k)
                       request-index)))))
        (remove-from-actor-index! handle)))
+   nil)
+  ([frame-id request-id handle]
+   ;; rf2-o8ek audit — the frame-bearing form. A published handle keys itself
+   ;; (its own `:frame` stamp is what `scoped-key` reads), so `frame-id` only
+   ;; does work in the pre-publication window, where it is the difference
+   ;; between clearing this frame's slot and sweeping every frame's.
+   (if (nil? handle)
+     (clear-in-flight-in-frame! frame-id request-id)
+     (clear-in-flight! request-id handle))
    nil))
 
 (defn lookup-in-flight

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -815,7 +815,11 @@
   (if-let [abort-state (aborted-snapshot ctx)]
     (finalise-failure! ctx (aborted-failure ctx abort-state))
     (when-not (already-replied? ctx)
-      (rf.http.registry/clear-in-flight! (:request-id ctx) (:handle ctx))
+      ;; rf2-o8ek audit — frame-bearing clear. `(:handle ctx)` is nil on the
+      ;; synthetic / test-path ctxs this fn documents, and a nil handle in the
+      ;; 2-arg form falls through to the ANY-FRAME sweep. Passing `(:frame ctx)`
+      ;; keeps the fallback inside the completing attempt's own frame.
+      (rf.http.registry/clear-in-flight! (:frame ctx) (:request-id ctx) (:handle ctx))
       ;; rf2-k47b3d — terminal completion: evict this id's issuance counter
       ;; (conditional-atomic; skips when a live re-issue has bumped past it).
       (rf.http.registry/evict-issuance-on-completion! (:frame ctx) (:request-id ctx) (:issuance ctx))
@@ -907,7 +911,9 @@
                                (not= :rf.http/aborted (:kind failure)))
                         (aborted-failure ctx abort-state)
                         failure)]
-      (rf.http.registry/clear-in-flight! (:request-id ctx) (:handle ctx))
+      ;; rf2-o8ek audit — frame-bearing clear, as in `finalise-success!`: a nil
+      ;; `(:handle ctx)` must fall back within this frame, never sweep siblings.
+      (rf.http.registry/clear-in-flight! (:frame ctx) (:request-id ctx) (:handle ctx))
       ;; rf2-k47b3d — terminal completion: evict this id's issuance counter
       ;; (conditional-atomic; skips when a live re-issue has bumped past it, so
       ;; a superseded-then-reclassified attempt does not drop the successor's
@@ -1067,7 +1073,16 @@
                        ;; This mirrors the rf2-lz7se fix at the live-fetch
                        ;; abort-fn in `run-attempt!` and the by-identity
                        ;; clear the timer-fires path below already uses.
-                       (rf.http.registry/clear-in-flight! request-id @handle-cell)
+                       ;;
+                       ;; rf2-o8ek audit — pass the frame too. `@handle-cell`
+                       ;; is nil for as long as the publication window below is
+                       ;; open, and a nil handle in the 2-arg form sweeps EVERY
+                       ;; frame's slot under this raw id. That window precedes
+                       ;; any SAME-FRAME successor, but a sibling frame running
+                       ;; the same reusable app code can already be live under
+                       ;; the same id — and deleting its slot leaves a live
+                       ;; request unregistered and unabortable.
+                       (rf.http.registry/clear-in-flight! (:frame ctx) request-id @handle-cell)
                        ;; rf2-6nczv9 — dispatch guarded by the SHARED once-only
                        ;; reply guard so a prior-phase abort-fn (the just-
                        ;; completed live-fetch handle, resolvable during the
@@ -1792,7 +1807,15 @@
                                   ;; the vector) while closing the gap for
                                   ;; any future trigger that does not
                                   ;; pre-clear.
-                                  (rf.http.registry/clear-in-flight! request-id @handle-holder)
+                                  ;;
+                                  ;; rf2-o8ek audit — pass the frame too. On
+                                  ;; the JVM another thread can fire this
+                                  ;; just-published abort-fn while
+                                  ;; `@handle-holder` is still nil, and a nil
+                                  ;; handle in the 2-arg form sweeps every
+                                  ;; frame's slot under this raw id. The frame
+                                  ;; keeps that fallback inside our own scope.
+                                  (rf.http.registry/clear-in-flight! (:frame ctx) request-id @handle-holder)
                                   ;; The abort closure dispatches a synthesised reply directly
                                   ;; (no finalise-failure! re-entry). The
                                   ;; shared `dispatch-aborted!` reuses the

--- a/implementation/http/test/re_frame/http_frame_scoped_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_frame_scoped_cancellation_test.clj
@@ -413,3 +413,137 @@
           "the any-frame seam still resolves a frame-qualified token")
       (is (= [:resource-superseded] @seen)))
     (rf.http.managed/clear-all-in-flight!)))
+
+;; ---- rf2-o8ek AUDIT — the CLEANUP half of the same isolation ---------------
+;;
+;; The merged repair frame-scoped the registry KEYS, which isolated the abort
+;; and supersede paths. The post-merge audit found two CLEANUP paths that still
+;; escaped that scope, and both looked migrated:
+;;
+;;  1. a seeded-handle demo that gained a `:frame` stamp but kept the ANY-FRAME
+;;     one-arg `clear-in-flight!` in its abort closure;
+;;  2. `clear-in-flight!`'s nil-handle fallback, taken inside the publication
+;;     window between `record-in-flight!` and the `reset!` of the cell the
+;;     abort-fn reads. Both live-fetch hosts acknowledge that window; on the JVM
+;;     another thread can fire the just-published abort-fn while it is open.
+;;
+;; Neither is an abort path, which is why frame-scoped keys did not cover them.
+;; The standing law they now witness: A CLEANUP PATH THAT POSSESSES AN ISSUING
+;; FRAME MUST BE FRAME-EXACT. Cleaning a sibling's slot is not a lesser fault
+;; than aborting it — it leaves a LIVE request unregistered, so nothing can
+;; abort it afterwards and its UI can sit loading forever.
+
+(defn- seed-two-frames-under-one-id!
+  "Register a handle in frame A and frame B under the SAME raw `shared-id`,
+  each recording its own aborts. Returns the aborts atom. Neither closure
+  cleans up — these tests are about which SLOTS a cleanup call reaches, so the
+  cleanup under test is always made explicitly by the test body."
+  []
+  (let [seen (atom [])]
+    (doseq [frame-id [:frame/a :frame/b]]
+      (rf.http.registry/record-in-flight!
+        shared-id nil
+        {:frame    frame-id
+         :url      "http://x/articles"
+         :abort-fn (fn [reason] (swap! seen conj [frame-id reason]))}))
+    seen))
+
+(deftest seeded-demo-abort-closure-clears-only-its-own-frames-slot
+  (testing "rf2-o8ek audit (1) — a seeded-handle demo's abort closure holds the
+            frame it carried in, but not the handle (the closure is built as
+            part of the map `record-in-flight!` is still consuming). It must
+            clean through `clear-in-flight-in-frame!`. The one-arg form it
+            reads as a shorthand for is an ANY-FRAME sweep: with the demo
+            mounted in two frames under one stable id, cancelling A deletes
+            BOTH slots and B's live request becomes unregistered/unabortable"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen (atom [])
+          ;; The example's exact shape: `frame` and `request-id` are lexical,
+          ;; the handle is not.
+          mk   (fn [frame-id]
+                 (rf.http.registry/record-in-flight!
+                   shared-id nil
+                   {:frame    frame-id
+                    :url      "api/long"
+                    :abort-fn (fn [reason]
+                                (rf.http.registry/clear-in-flight-in-frame! frame-id shared-id)
+                                (swap! seen conj [frame-id reason]))}))]
+      (mk :frame/a)
+      (mk :frame/b)
+      ;; Cancel in frame A through the production frame-scoped abort seam —
+      ;; what `[:rf.http/managed-abort id]` dispatched in A resolves to.
+      (is (true? (rf.http.registry/abort-in-flight-in-frame! :frame/a shared-id :user))
+          "frame A's own handle is found and fired")
+      (is (= [[:frame/a :user]] @seen)
+          "only frame A's closure ran")
+      (is (nil? (rf.http.registry/lookup-in-flight :frame/a shared-id))
+          "frame A's slot is cleaned up by its own closure")
+      (is (some? (rf.http.registry/lookup-in-flight :frame/b shared-id))
+          "frame B's identically-named LIVE request is still registered — the audit's failure was here, and it is silent: no abort fires in B, its slot simply vanishes and nothing can cancel it afterwards")
+      (is (true? (rf.http.registry/abort-in-flight-in-frame! :frame/b shared-id :user))
+          "and B remains abortable, which is the consequence that was lost")
+      (is (= [[:frame/a :user] [:frame/b :user]] @seen)))
+    (rf.http.managed/clear-all-in-flight!)))
+
+(deftest pre-publication-clear-cannot-reach-a-sibling-frame
+  (testing "rf2-o8ek audit (2) — the transport's cleanup runs with a nil handle
+            for as long as the publication window is open. The two-arg form has
+            no frame to be exact about and falls back to the ANY-FRAME sweep, so
+            every transport site passes the ctx frame through the three-arity.
+            A nil handle from frame A must clear frame A's own slot and leave an
+            already-live sibling's alone. The original reasoning — that the
+            window precedes any successor — covers same-frame succession only"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen (seed-two-frames-under-one-id!)]
+      ;; Frame A's abort-fn fires while its cell is still nil.
+      (rf.http.registry/clear-in-flight! :frame/a shared-id nil)
+      (is (nil? (rf.http.registry/lookup-in-flight :frame/a shared-id))
+          "frame A's own slot IS cleared — the window still must not leak a slot")
+      (is (some? (rf.http.registry/lookup-in-flight :frame/b shared-id))
+          "frame B's already-live request under the same raw id survives")
+      (is (= [] @seen)
+          "and no abort-fn fired in either frame — a clear is not an abort"))
+    (rf.http.managed/clear-all-in-flight!))
+
+  (testing "the same call with a PUBLISHED handle is unchanged: identity-conditional, so a same-id successor within the frame is not evicted"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [old (rf.http.registry/record-in-flight!
+                shared-id nil {:frame :frame/a :abort-fn (fn [_] nil) :url "old"})
+          new (rf.http.registry/record-in-flight!
+                shared-id nil {:frame :frame/a :abort-fn (fn [_] nil) :url "new"})]
+      (rf.http.registry/clear-in-flight! :frame/a shared-id old)
+      (is (identical? new (rf.http.registry/lookup-in-flight :frame/a shared-id))
+          "the old attempt's clear no-ops against the successor that took the slot"))
+    (rf.http.managed/clear-all-in-flight!)))
+
+(deftest frame-exact-clear-walks-the-actor-index-too
+  (testing "rf2-o8ek audit — `clear-in-flight-in-frame!` is a full cleanup, not
+            a request-index-only one: it recovers the handle it just removed and
+            drops it from that frame's actor slot by identity, leaving a
+            same-named actor in a sibling frame untouched. A half-cleanup here
+            would strand an actor-index entry, which is the leak class
+            rf2-lz7se / rf2-meq28 closed on the handle-bearing paths"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [actor-id :worker/proc]
+      (doseq [frame-id [:frame/a :frame/b]]
+        (rf.http.registry/record-in-flight!
+          shared-id actor-id
+          {:frame frame-id :abort-fn (fn [_] nil) :url "http://x/y"}))
+      (is (= 1 (count (get (rf.http.registry/actor-in-flight-snapshot :frame/a) actor-id))))
+      (rf.http.registry/clear-in-flight-in-frame! :frame/a shared-id)
+      (is (nil? (get (rf.http.registry/actor-in-flight-snapshot :frame/a) actor-id))
+          "frame A's actor slot is emptied, not stranded")
+      (is (= 1 (count (get (rf.http.registry/actor-in-flight-snapshot :frame/b) actor-id)))
+          "the same-named actor in frame B keeps its handle"))
+    (rf.http.managed/clear-all-in-flight!))
+
+  (testing "a nil request-id is a documented no-op — an anonymous request is indexed only in actor-in-flight, reachable only by handle identity"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [handle (rf.http.registry/record-in-flight!
+                   nil :worker/anon {:frame :frame/a :abort-fn (fn [_] nil) :url "u"})]
+      (rf.http.registry/clear-in-flight-in-frame! :frame/a nil)
+      (is (= 1 (count (get (rf.http.registry/actor-in-flight-snapshot :frame/a) :worker/anon)))
+          "the anonymous handle is untouched — the two-arg handle form owns it")
+      (rf.http.registry/clear-in-flight! nil handle)
+      (is (nil? (get (rf.http.registry/actor-in-flight-snapshot :frame/a) :worker/anon))))
+    (rf.http.managed/clear-all-in-flight!)))

--- a/implementation/http/test/re_frame/http_managed_demo_frame_isolation_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_managed_demo_frame_isolation_cljs_test.cljs
@@ -1,0 +1,95 @@
+(ns re-frame.http-managed-demo-frame-isolation-cljs-test
+  "rf2-o8ek audit — the managed-HTTP counter demo, mounted TWICE, must not
+  cross-cancel.
+
+  This is the end-to-end half of the audit's first escaping path. The demo at
+  `examples/core/managed_http_counter/` seeds a request-id-keyed handle by hand
+  so `:rf.http/managed-abort` has something real to resolve, and it writes its
+  stable id (`:http-counter/long`) once — exactly the reusable-app-code shape
+  Spec 014 §Frame scope exists for. rf2-o8ek made the registry keys frame-
+  scoped, and the demo was updated to stamp `:frame` on its seeded handle, so
+  it LOOKED migrated. Its abort closure still called the one-arg
+  `clear-in-flight!`, which rf2-o8ek redefined as an ANY-FRAME sweep.
+
+  Mounted in two frames, cancelling the first therefore invoked only the first
+  frame's closure — correctly — and then deleted BOTH registry slots. The
+  second frame's request stayed `:loading` with nothing left in the registry to
+  abort it: a silent failure, because no abort fires in the second frame and no
+  error is raised anywhere.
+
+  The sibling JVM suite (`re-frame.http-frame-scoped-cancellation-test`) pins
+  the registry contract this rests on. This test pins the DEMO, through its own
+  events and the live `:rf.http/managed-abort` fx, because the defect was that
+  a call site can be half-migrated while every registry-level test stays green.
+
+  It belongs in the framework test tree, NOT under `examples/` (examples stay
+  test-free per rf2-8cevm). It `:require`s `managed-http-counter.core` — an
+  entry ns whose ns-load registers the demo's events / subs / fx — which
+  resolves under the consolidated `:node-test` CLJS build, whose source paths
+  carry both `http/test` and `../examples/core`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
+            [managed-http-counter.core :as mhc]))
+
+;; `:ambient-frame nil` — every dispatch below names its frame explicitly.
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil}))
+
+(defn- mount-and-start!
+  "Boot a fresh anon frame and drive the demo's opening move, which seeds the
+  request-id-keyed handle. Returns the frame ID — which is what the registry
+  keys on and what `require-frame-stamp!` hands the abort seam, so it is also
+  the value these assertions look slots up by."
+  [doc]
+  (let [f (rf.frame/make-anon-frame-record! {:doc doc})]
+    (rf/dispatch-sync [:http-counter/start-long] {:frame f})
+    f))
+
+(deftest cancelling-one-mount-leaves-the-other-mounts-request-live
+  (testing "rf2-o8ek audit — two mounts of the demo share one stable
+            :request-id. Cancelling the first must abort the first and leave
+            the second live, registered, and still abortable"
+    (let [a (mount-and-start! "managed-http-counter mount A")
+          b (mount-and-start! "managed-http-counter mount B")]
+      (is (some? (rf.http.registry/lookup-in-flight a mhc/long-request-id))
+          "mount A seeded its own frame-scoped slot")
+      (is (some? (rf.http.registry/lookup-in-flight b mhc/long-request-id))
+          "so did mount B, under the same raw id")
+      (is (= :loading (:http-counter/status (rf/app-db-value a))))
+      (is (= :loading (:http-counter/status (rf/app-db-value b))))
+
+      ;; Cancel in A only, through the live :rf.http/managed-abort fx.
+      (rf/dispatch-sync [:http-counter/cancel] {:frame a})
+
+      (testing "mount A resolves normally"
+        (is (nil? (rf.http.registry/lookup-in-flight a mhc/long-request-id))
+            "A's slot is cleared by its own abort closure")
+        (is (= :idle (:http-counter/status (rf/app-db-value a)))
+            "A's UI eases back to idle")
+        (is (= :rf.http/aborted (get-in (rf/app-db-value a) [:http-counter/error :kind]))
+            "A records the classified abort"))
+
+      (testing "mount B is untouched — the audit's silent failure"
+        (is (some? (rf.http.registry/lookup-in-flight b mhc/long-request-id))
+            "B's registry slot survives A's cancel; the one-arg ANY-FRAME clear deleted it")
+        (is (= :loading (:http-counter/status (rf/app-db-value b)))
+            "B is still loading, as it should be — nobody cancelled it")
+        (is (nil? (:http-counter/error (rf/app-db-value b)))
+            "and B recorded no abort, because none reached it"))
+
+      (testing "B stays CANCELLABLE, which is what a swept slot silently costs"
+        (rf/dispatch-sync [:http-counter/cancel] {:frame b})
+        (is (nil? (rf.http.registry/lookup-in-flight b mhc/long-request-id)))
+        (is (= :idle (:http-counter/status (rf/app-db-value b)))
+            "B's own cancel resolves it — impossible once its slot has been swept away")
+        (is (= :rf.http/aborted (get-in (rf/app-db-value b) [:http-counter/error :kind]))))
+
+      (testing "each mount's reply was routed to its OWN frame"
+        (is (= :idle (:http-counter/status (rf/app-db-value a)))
+            "A did not receive a second reply from B's cancel")))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -682,7 +682,10 @@ When a fresh request supersedes a prior one with the same `:request-id` **in the
 
 1. a fresh request supersedes only a **prior request from the same frame**; a sibling frame holding the same `:request-id` keeps its request live and its reply undisturbed;
 2. `[:rf.http/managed-abort id]` aborts only the **dispatching frame's** request under that id;
-3. the issuance counter that discriminates a superseded attempt from its superseder runs **per frame**, so a frame's first issuance under an id is `1` however many times a sibling has re-issued.
+3. the issuance counter that discriminates a superseded attempt from its superseder runs **per frame**, so a frame's first issuance under an id is `1` however many times a sibling has re-issued;
+4. **registry cleanup is scoped the same way.** Releasing a request's registry slot — on natural completion, on abort, or inside the window before a freshly-issued handle is published — releases only the *issuing* frame's slot. A sibling frame's identically-named request stays registered, and therefore stays cancellable.
+
+Clause 4 is not a restatement of the first three: cleanup is not an abort, and it fails **silently**. Sweeping a sibling's slot fires none of its callbacks and raises nothing; the sibling's request simply becomes unregistered, so no later `[:rf.http/managed-abort id]`, actor destroy, or frame teardown can reach it and its UI can sit loading indefinitely. A cleanup path that knows which frame it is cleaning up for must therefore use that frame, even where it cannot name the handle.
 
 This is the [frame-isolation contract](002-Frames.md#routing-the-dispatch-envelope) applied to request *lifetime*, matching what [§Frame awareness](#frame-awareness) already promises for reply *routing* and what [§Chain order and frame scope](#chain-order-and-frame-scope) already states for the interceptor chain: "an interceptor registered against frame A does NOT fire for a request dispatched from frame B". Cancellation is the third such surface, and it is scoped the same way.
 


### PR DESCRIPTION
Second carrier for rf2-o8ek. PR #9195 made the in-flight registry keys frame-scoped, which isolated the abort and supersede paths. A post-merge audit reopened the bead: **two cleanup paths still escaped that scope**, and both looked migrated.

## Both audit premises reproduced at tip before any edit (exit 0)

```
PATH1 {:aborts [[:frame/a :user]], :a-live? false, :b-live? false}
PATH2 {:b-live? false}
```

1. **The managed-HTTP counter example.** #9195 gave its seeded handle a `:frame` stamp but left the one-arg `clear-in-flight!` in its abort closure — the arity #9195 redefined as an ANY-FRAME sweep. Mounted in two frames under its stable `:http-counter/long` id, cancelling one mount fired only that mount's closure (correctly) and then deleted **both** registry slots.
2. **`clear-in-flight!`'s nil-handle fallback**, which takes the same sweep. That branch is reached inside the publication window between `record-in-flight!` and the `reset!` of the cell the abort-fn reads; on the JVM another thread can fire the just-published abort-fn while it is open. Its standing justification — "the pre-publication window precedes any successor" — covers *same-frame* succession only, not a sibling frame that was already live.

Neither is an abort path, which is why frame-scoped keys did not cover them. **Both fail silently**: sweeping a sibling's slot fires no callback and raises nothing. The request simply becomes unregistered, so nothing can cancel it afterwards and its UI sits loading.

## Census, not two edits

Three token axes (function names; the effect/hook keywords; the `:abort-fn` closure shape) over the whole tracked tree. Every caller of a frame-less arity, classified:

| Call site | Verdict |
| --- | --- |
| `transport.cljc` ×2 finalise sites (`(:handle ctx)` — nil on the synthetic ctxs the fn documents) | **unmigrated → fixed** |
| `transport.cljc` ×2 publication-window sites (`@handle-cell` / `@handle-holder`) | **unmigrated → fixed** (audit path 2) |
| `examples/core/managed_http_counter/core.cljs` `:abort-fn` | **unmigrated → fixed** (audit path 1) |
| `transport.cljc` ×4 remaining 2-arg sites | already exact — two `when`-guarded, two lexical from `record-in-flight!`; never take the nil branch |
| `work_ledger.cljc` → `:http/abort-in-flight!` hook | **genuinely any-frame**; its token is already frame-qualified (`[:rf.req frame-id work-id]`, Spec 016), so at most one frame matches |
| `machines/` + `core/` → `:http/abort-on-actor-destroy` | out of fence, already owned by **rf2-wjfm**, left open |
| `tools/xray/testbeds/managed_http/core.cljs` | **separate defect, out of fence → filed rf2-s4dp** (see below) |

After this change **no production path reaches the one-arg sweep at all**.

## The seam question, answered explicitly

Kept the seam and migrated the call sites (option 1), strengthened structurally.

* **Rejected a dev-gate warning.** It is the nag-diagnostic the project stance rejects, and it is also mechanically impossible here: a registry fn has no ambient ctx, so it cannot tell whether its caller *had* a frame to give. Any check would fire on the legitimate resources sweep exactly as loudly as on a mistake.
* **Rejected the rename.** Its churn lands in `tools/` and `implementation/resources/test/` — both out of this fence — to rename a path that, after this change, no production code takes.
* **Took the structural half instead**: every frame-bearing entry point now has a frame-bearing arity, so the correct call is the natural one to write.

New `registry/clear-in-flight-in-frame!` — the named sibling of the existing `abort-in-flight-in-frame!` — plus a three-arity `clear-in-flight!` that takes the frame alongside a possibly-nil handle and uses the most precise key available.

## Witnesses that fail before and pass after

Negative controls restore the pre-audit behaviour at the single point both paths funnel through, so the failures are **semantic, not arity errors**.

* JVM (3 new deftests): control → **exit 1, 5 failures**, all three red.
* CLJS (1 new deftest, the demo driven end-to-end through its own events and the live `:rf.http/managed-abort` fx): control → **exit 1, 3 failures**, with mount B stuck at `:loading` — the audit's predicted symptom exactly.

The pre-existing single-frame `managed-http-counter` test stayed **green** under that same plant, which is precisely why this escaped review.

## Gates (captured exits, never read through a filter)

| Gate | Result |
| --- | --- |
| `implementation/http` `clojure -M:test` before | exit 0 — 515 tests / 3929 assertions |
| same, after, on the final rebased base | exit 0 — **518 / 3944** |
| `npm run test:cljs` on the final base | exit 0 — **11,177 / 55,767** |
| `python -m mkdocs build --strict` | exit 0 |
| `scripts/check_doc_slugs.py` | exit 0, **proven live** — a planted broken anchor took it to exit 1 naming file, line 688 and the anchor |
| `scripts/check_readme_links.py --ci` | exit 0 |

`node_modules` was installed from the lockfile in the worker worktree (`npm ci`, exit 0) rather than linked; no junction was created.

## Spec

Spec 014 §Frame scope gains clause 4 — registry cleanup is frame-scoped for the same reason lookup is — with a paragraph on why it is not a restatement of the first three clauses: cleanup is not an abort, and it fails silently.

## Deliberately not done

* **rf2-wjfm** stays open and untouched: AC 4's structural actor case needs the `:http/abort-on-actor-destroy` hook's callers in `machines/` and `core/` to thread a frame, both outside this fence.
* **rf2-s4dp (new, P2)**: `tools/xray/testbeds/managed_http/core.cljs` seeds its handle with **no** `:frame` at all, so it keys under `[nil id]` and the frame-scoped `:rf.http/managed-abort` cannot resolve it — that testbed's abort step is unreachable at tip. Measured with a JVM registry probe (`:managed-abort-hits? false`). Out of fence (`tools/`), so filed with the repair named rather than fixed.
* The resources any-frame seam is unchanged and correct as-is.
