### PR TITLE
fix(reagent-slim): after-render waits for the React commit, not the forceUpdate call (rf2-cdoo, rf2-vy0a)

### DIFF
--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -211,7 +211,7 @@ Public symbols (the audit-binding fourteen surfaces, per Stage 2 §2.7 — thirt
 | `atom` | `[x]`, `[x & {:keys [meta validator]}]` | Re-export of `reagent2.ratom/atom` (the `RAtom` constructor). |
 | `create-class` | `[spec]` | Form-3 entry point. Validates `spec` against the 7-key cap; throws `:rf.error/create-class-key-unsupported` on miss. Delegates to `reagent2.impl.component/create-class*`. |
 | `current-component` | `[]` | Returns the in-flight component instance via `reagent2.impl.component/*current-component*`. |
-| `after-render` | `[f]` | Schedule `f` to run after the next React commit. Routes through `reagent2.impl.batching/after-render`. The `re-frame.interop/after-render` alias (`interop.cljs:19`) re-exports this. |
+| `after-render` | `[f]` | Schedule `f` to run after the next React commit — `f` observes the COMMITTED DOM (rf2-cdoo, §4.1). Routes through `reagent2.impl.batching/do-after-render`. The `re-frame.interop/after-render` alias (`interop.cljs:19`) re-exports this. |
 | `as-element` | `[form]` | Convert hiccup form to React element. Delegates to `reagent2.impl.template/as-element`. |
 | `props` | `[this]` | Form-3 accessor. Delegates to `reagent2.impl.component/get-props`. |
 | `children` | `[this]` | Form-3 accessor. |
@@ -364,14 +364,17 @@ Vars:
 - `queue-render!` `[component]` — enqueue a component for re-render; schedules a microtask if one is not already scheduled.
 - `schedule` `[]` — arm the microtask without enqueueing.
 - `flush!` `[]` — synchronous drain: `ratom/flush!` first (Reaction recomputes may enqueue further component renders), then the component queue's `forceUpdate` pass, then the after-render queue. The implementation hook for `reagent2.dom.client/flush-views!` and `flush-render!`.
-- `do-after-render` `[f]` — schedule `f` after the next render. The public ABI behind `reagent2.core/after-render`.
+- `do-after-render` `[f]` — schedule `f` after the next React COMMIT. The public ABI behind `reagent2.core/after-render`.
 - `mark-rendered` `[component]` — clear a component's dirty flag.
 - `installed?` — the `defonce` guard for late-bind hook installation.
+- `render-commit` — an atom holding the INJECTED host commit boundary, `(fn [drain] …)`, or nil (rf2-cdoo). `reagent2.dom.client` installs `react-dom/flushSync` into it at ns-load; this ns requires no react-dom of its own, so a Node / SSR consumer that never loads the DOM client keeps the bare drain. The injection direction mirrors `reagent2.ratom/rea-schedule`, which this ns fills in the other direction.
 
-Two properties of the shipped queue are contract, not incidental: a Reaction
+Three properties of the shipped queue are contract, not incidental: a Reaction
 that fires DURING a flush is held for the NEXT turn rather than flattened into
-the current drain, and the after-render pass swallows a per-callback throw so
-one misbehaving callback cannot strand the rest of the queue (rf2-p27yih).
+the current drain; the after-render pass swallows a per-callback throw so
+one misbehaving callback cannot strand the rest of the queue (rf2-p27yih); and
+an after-render callback observes the COMMITTED DOM, not merely a DOM whose
+`forceUpdate` has been REQUESTED (rf2-cdoo — see §4.1).
 
 See §4 for the scheduler's full design.
 
@@ -469,12 +472,31 @@ back to `js/Promise.resolve().then`). The microtask body (`run-queues`):
 
 1. Clears `scheduled?`.
 2. Drains the REACTIVE queue first (`ratom/flush!`) — Reaction recomputes can enqueue further component renders, which step 3 then picks up.
-3. Takes the component queue, replaces it with nil, and for each still-dirty component marks it rendered and calls its React `forceUpdate`.
+3. Takes the component queue, replaces it with nil, and for each still-dirty component marks it rendered and calls its React `forceUpdate`. When step 4 has callbacks waiting AND a host commit boundary is installed (`render-commit`, §2.9), this whole pass runs INSIDE that boundary.
 4. Takes the after-render queue, replaces it with nil, and runs each callback inside a per-callback `try` (rf2-p27yih), so one throw cannot strand the rest.
 
 Each queue is taken-and-nilled before it is walked, which is what makes a
 Reaction that fires DURING the drain land on the NEXT turn rather than being
 flattened into this one — the ordering §4.6 and the Suspense test depend on.
+
+**Why step 3 needs a commit boundary at all (rf2-cdoo).** "After the next
+React commit" is what `after-render` promises, and calling `forceUpdate` is
+not committing. Under React 19 `createRoot` an update originating outside
+React's batching context — which a microtask drain is — is SCHEDULED, and the
+DOM still holds the old value when the call returns. This is the same fact
+`flush-render!` (§2.4) documents for the explicit synchronous path; on the
+ordinary microtask path it meant a callback promised the new DOM read the old
+one. Measured on the real-DOM ordinary path before the repair: a dispatch to
+`n=2` handed the callback `n=1`
+(`test/re_frame/adapter/reagent_slim_after_render_dom_cljs_test.cljs`).
+
+The boundary is **injected, not required**, so `reagent2.impl.batching` stays
+host-neutral, and it is **gated on there being a callback to keep the promise
+to**: a turn with an empty after-render queue takes the bare drain and keeps
+React 19's concurrent scheduling rather than being promoted to discrete
+priority because the scheduler happened to run. Stock Reagent reaches the same
+place by the same shape — `reagent.impl.batching/run-queue` brackets its dirty
+pass in an injected react-flush that `reagent.dom.client` installs.
 
 The microtask boundary is universal across React 19's host platforms (browser, server-component runtimes, React Native via Hermes). No `requestAnimationFrame` fallback is required; React 19 itself does not target environments without microtask support.
 
@@ -1126,7 +1148,7 @@ Per the bead description and Stage 2 §5 risk register R-001..R-007.
 | `reagent2.dom.server` | `dom/server_cljs_test.cljs` + `dom/parity_cljs_test.cljs` + `dom/server_subscribe_ssr_cljs_test.cljs` | render-to-static-markup output for representative corpus; parity against `react-dom/server` per §8.7; the SSR non-reactive deref branch. |
 | `reagent2.impl.template` | `impl/template_cljs_test.cljs` (+ the reserved-head and keyword-prop-warn-once siblings) | hiccup → React-element shapes; narrowed convert-prop-value (R-001); kebab-camel cache; tag parsing; sequence-children handling; `:>` / `:<>` / `:r>` / `:f>` interop. |
 | `reagent2.impl.component` | `impl/component_cljs_test.cljs` (runtime) + `impl/component_test.clj` (the compile-time classifiers, §5.2) | create-class 7-key cap (R-002); throw-on-unsupported-key per banned key; lifecycle method mapping per §6.4; `:component-did-catch` error-boundary integration per §6.5; `:get-snapshot-before-update` pairing per §6.6; and, on the CLJ side, `classify-form-body` / `tag-form-meta` — including that there is no separate `defview` macro. |
-| `reagent2.impl.batching` | `impl/batching_cljs_test.cljs` | microtask scheduling; dirty-flag dedup; flush! synchronous drain; after-render queue; React 19 transition cooperation (R-005). |
+| `reagent2.impl.batching` | `impl/batching_cljs_test.cljs` (+ `re_frame/adapter/reagent_slim_after_render_dom_cljs_test.cljs` for the real-DOM half) | microtask scheduling; dirty-flag dedup; flush! synchronous drain; after-render queue; React 19 transition cooperation (R-005). The focused file drives fake components whose `forceUpdate` body is synchronous, so it can pin call ORDER but not commit timing; the `-dom-` sibling reads `textContent` from INSIDE the callback on a real React 19 root and is what pins the post-COMMIT promise (rf2-cdoo). |
 | `reagent2.impl.diag` | `impl/diag_cljs_test.cljs` | the EP-0015-safe value summary (§2.10) — shape only, never the value. |
 | `re-frame.adapter.reagent-slim` | `re_frame/adapter/*_cljs_test.cljs` | the adapter-Var surface: slot parity, client roots, dispose drains, flush-render!/flush-views!, source-coord stamping, StrictMode. |
 

--- a/implementation/adapters/reagent-slim/src/reagent2/core.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/core.cljs
@@ -154,8 +154,12 @@
 ;; ---------------------------------------------------------------------------
 
 (defn after-render
-  "Schedule `f` to run after the next React commit. Routes through
-  `reagent2.impl.batching/do-after-render`."
+  "Schedule `f` to run after the next React commit — `f` observes the
+  COMMITTED DOM, not a DOM whose re-render has merely been REQUESTED
+  (rf2-cdoo). Routes through `reagent2.impl.batching/do-after-render`.
+
+  Never synchronous: `f` runs on the scheduler's own turn even when no
+  component is dirty."
   [f]
   (batching/do-after-render f))
 

--- a/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
@@ -67,6 +67,37 @@
             ["react-dom/client" :as react-dom-client]))
 
 ;; ---------------------------------------------------------------------------
+;; Host commit boundary for the ORDINARY scheduled queue (rf2-cdoo)
+;; ---------------------------------------------------------------------------
+;;
+;; `reagent2.core/after-render` promises to run its callback after the next
+;; React commit, and the slim adapter publishes it at `:adapter/after-render`,
+;; so `re-frame.interop/after-render` lands on that queue. But
+;; `reagent2.impl.batching`'s microtask drain called each dirty component's
+;; bare `forceUpdate` and then ran the callbacks immediately — and under React
+;; 19 `createRoot` a bare `forceUpdate` from outside React's batching context
+;; is SCHEDULED, not committed (the same fact `flush-render!` below documents
+;; and relies on). The callback therefore read the OLD DOM. Measured on the
+;; real-DOM ordinary path: the callback saw `n=1` after a dispatch to `n=2`.
+;;
+;; The repair is the seam stock Reagent already uses — the queue asks the HOST
+;; to bracket its dirty-component pass — with the direction of the dependency
+;; kept as it was: `batching` requires nothing of react-dom, and this ns, which
+;; is the DOM host by definition, installs the boundary into it at ns-load.
+;; A consumer that never loads this ns (Node, SSR through
+;; `reagent2.dom.server`) keeps the bare drain and pulls no react-dom.
+;;
+;; `batching` applies it only on turns with a pending after-render callback, so
+;; an ordinary reactive re-render keeps React 19's concurrent scheduling and is
+;; not silently promoted to discrete priority.
+
+(defonce ^:private render-commit-installed?
+  (do
+    (reset! batching/render-commit
+            (fn commit-render [drain] (react-dom/flushSync drain)))
+    true))
+
+;; ---------------------------------------------------------------------------
 ;; flush-views! — test-flush primitive (Stage 4-B)
 ;; ---------------------------------------------------------------------------
 ;;

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/batching.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/batching.cljs
@@ -12,7 +12,8 @@
     After (flush!) returns:
       - All currently-dirty components have re-rendered.
       - All Reactions whose dependencies changed have recomputed.
-      - All :after-render callbacks queued before flush! fired.
+      - All :after-render callbacks queued before flush! fired, each
+        having observed the COMMITTED DOM (rf2-cdoo).
 
   The user-facing `(reagent2.dom.client/flush-views!)` test primitive
   composes this synchronous drain with `react/act` (per §4.2). The
@@ -22,10 +23,11 @@
   Public surface (consumed by other ns'es in the artefact):
 
     queue-render!   ;; component → enqueue + schedule microtask
-    do-after-render ;; fn → run after the next render
+    do-after-render ;; fn → run after the next React COMMIT
     schedule        ;; force a microtask schedule (no-op if already scheduled)
     flush!          ;; synchronous drain (test primitive's worker)
     mark-rendered   ;; clear a component's dirty flag (called by render)
+    render-commit   ;; injected host commit boundary (rf2-cdoo, see below)
 
   Stage 4-A wired `reagent2.ratom/rea-schedule` as a `clojure.core/atom`
   hook. This ns installs a scheduler fn into that atom at load time so
@@ -69,6 +71,32 @@
   the React commit so the next dependency change re-enqueues."
   [^js c]
   (set! (.-cljsIsDirty c) false))
+
+;; ---------------------------------------------------------------------------
+;; Host commit boundary (rf2-cdoo)
+;;
+;; This ns must stay host-neutral: it is required by `reagent2.core` and by
+;; the component layer, and a Node / SSR consumer that never loads
+;; `reagent2.dom.client` must not be made to pull `react-dom` in. So the
+;; commit boundary is INJECTED rather than required, exactly as
+;; `reagent2.ratom/rea-schedule` injects the scheduler in the other
+;; direction — `reagent2.dom.client` installs `react-dom/flushSync` here at
+;; ns-load, and with nothing installed the queue keeps its bare drain.
+;;
+;; Why a boundary is needed at all: under React 19 `createRoot`, a bare
+;; `forceUpdate` issued from outside React's batching context is SCHEDULED,
+;; not committed — the DOM still holds the old value when the call returns.
+;; `flush-render!` already documents and relies on this; `flush-queues` below
+;; is where the ordinary microtask path needs it, so that a callback
+;; promised "after the next React commit" actually gets one.
+;; ---------------------------------------------------------------------------
+
+(defonce ^{:doc "Injected commit boundary: `(fn [drain] ...)` that runs
+  `drain` and guarantees React has COMMITTED the resulting work before it
+  returns. `reagent2.dom.client` installs `react-dom/flushSync`; nil (the
+  default, on a host with no DOM client loaded) means the bare drain."}
+  render-commit
+  (atom nil))
 
 ;; ---------------------------------------------------------------------------
 ;; The render queue
@@ -142,7 +170,23 @@
     ;; further component renders into component-queue, which we then
     ;; pick up in flush-render below.
     (ratom/flush!)
-    (.flush-render this)
+    ;; rf2-cdoo — POST-COMMIT, not merely post-forceUpdate. `after-render`
+    ;; promises "after the next React commit", and a bare `forceUpdate`
+    ;; issued from this microtask is only SCHEDULED by React 19 (the same
+    ;; automatic-batching fact `reagent2.dom.client/flush-render!` already
+    ;; documents), so draining the callbacks straight after `flush-render`
+    ;; handed them the OLD DOM. When callbacks are waiting, the dirty pass
+    ;; therefore runs inside the host's commit boundary — supplied by
+    ;; `reagent2.dom.client` through `render-commit` so this ns stays
+    ;; host-neutral (no react-dom require; a Node/SSR consumer that never
+    ;; loads the DOM client keeps the bare drain).
+    ;;
+    ;; The gate is deliberate: a turn with NO pending callback keeps the
+    ;; ordinary concurrent path, so an ordinary reactive re-render is not
+    ;; forced to discrete priority just because the scheduler ran.
+    (if-some [commit (when (some? after-render-queue) @render-commit)]
+      (commit (fn [] (.flush-render this)))
+      (.flush-render this))
     (.flush-after-render this)))
 
 (defonce ^:private render-queue
@@ -170,11 +214,13 @@
 
 (defn do-after-render
   "Register `f` to run at the end of the next flush turn — i.e. after
-  every dirty component has re-rendered. The public ABI for
+  every dirty component has re-rendered AND React has COMMITTED that
+  render, so `f` observes the new DOM (rf2-cdoo). The public ABI for
   `reagent2.core/after-render`.
 
   Schedules a microtask drain so `f` fires even if no component is
-  dirty (matches stock Reagent semantics)."
+  dirty (matches stock Reagent semantics). With no component dirty there
+  is nothing to commit and `f` fires on the bare turn."
   [f]
   (.add-after-render render-queue f)
   (.schedule render-queue))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_after_render_dom_cljs_test.cljs
@@ -1,0 +1,177 @@
+(ns re-frame.adapter.reagent-slim-after-render-dom-cljs-test
+  "rf2-cdoo — the reagent-slim ORDINARY-PATH proof that an `after-render`
+  callback observes the COMMITTED DOM.
+
+  WHAT IT PROVES. `reagent2.core/after-render` promises to run `f` \"after the
+  next React commit\", and the slim adapter publishes it at
+  `:adapter/after-render`, so `rf.interop/after-render` reaches this exact
+  queue. This file pins that promise on the path production actually takes:
+  the microtask the render scheduler queues by itself, with no test primitive
+  driving it.
+
+  WHY A DOM READ AND NOT A COUNTER. The pre-existing slim coverage
+  (`reagent2.impl.batching`'s focused tests, and the shared React suite's
+  `assert-after-render-runs-after-commit`) asserts that the callback FIRED —
+  a counter, or a `[:render :after]` call-order vector over fake components
+  whose `forceUpdate` body runs synchronously. A callback invoked while
+  React has only SCHEDULED the class update passes every one of those and
+  still reads stale DOM. So the witness here reads
+  `(.-textContent mount-node)` INSIDE the callback and asserts the new value
+  is already there.
+
+  THE FORBIDDEN SHORTCUTS, and why each would make this vacuous:
+
+    - `reagent2.dom.client/flush-views!` and the adapter's `flush-render!`
+      both impose a commit boundary of their own (`react/act` /
+      `react-dom/flushSync`), which is the very thing under test;
+    - a manual `react-dom/flushSync` around the state change or the drain
+      does the same by hand;
+    - an extra `requestAnimationFrame` (or any await) BEFORE the DOM read
+      lets React's scheduler commit first, so the callback would observe
+      the new DOM no matter when it ran.
+
+  None of those appears between the state change and the callback's read.
+  The `flushSync` that DOES appear wraps only the INITIAL MOUNT — React 19's
+  `root.render` first pass is otherwise asynchronous, and without it there
+  is no committed baseline to have been stale about. The `js/setTimeout`
+  that follows is likewise not a shortcut: the callback has ALREADY recorded
+  what it saw by then, so deferring the ASSERTION cannot change the
+  OBSERVATION. It only gives the test a point at which the scheduler turn is
+  certainly over.
+
+  THE PRE-CHANGE ASSERTION IS LOAD-BEARING. Between `dispatch-sync` and the
+  callback the test asserts the DOM still reads the OLD value. Without it a
+  substrate that committed synchronously on dispatch would satisfy the
+  post-condition trivially, and the test would pin nothing.
+
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` build
+  discovers it for the real-DOM assertion; the `:node-test` runner also
+  loads it, where the body gates on `(browser?)` and no-ops cleanly."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [reagent2.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.interop :as rf.interop]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.views]))
+
+;; Map-form (`:async? true`) fixture: a fn-form fixture tears down
+;; synchronously and would restore the registrar while an `(async done)` body
+;; is still in flight. `:ambient-frame nil` (EP-0002, rf2-9o48ih) opts out of
+;; the default ambient `*current-frame*` :rf/default scope — the mount runs
+;; inside the test body's dynamic extent, where an ambient :rf/default scope
+;; would shadow the React-context tier and the probe's `subscribe` would read
+;; :rf/default's empty app-db instead of the provider's seeded frame.
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter
+     :async? true
+     :ambient-frame nil}))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (when (browser?)
+    (.createElement js/document "div")))
+
+(deftest after-render-callback-observes-the-committed-dom
+  (testing "reagent-slim — an ordinary-path after-render callback sees the
+  COMMITTED DOM, not the pre-commit DOM (rf2-cdoo)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (async done
+        (let [frame-kw :rf.reagent-slim-after-render/probe-frame]
+          (rf/make-frame {:id frame-kw :doc "after-render post-commit probe frame"})
+          (rf/reg-event ::seed (fn [_ _] {:db {:n 1}}))
+          (rf/reg-event ::inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
+          (rf/dispatch-sync [::seed] {:frame frame-kw})
+          (rf/reg-sub ::n (fn [db _] (:n db)))
+          (rf/reg-view* :rf.reagent-slim-after-render/probe
+                        (fn probe []
+                          [:div "n=" @(rf/subscribe [::n])]))
+          (let [mount-node (make-mount-node!)
+                root       (rdc/create-root mount-node)
+                ;; What the callback saw, recorded from INSIDE it. An `is`
+                ;; here would be swallowed by the queue's per-callback throw
+                ;; isolation (rf2-p27yih), so the callback records and the
+                ;; assertions run outside it.
+                seen       (atom [])]
+            ;; Initial mount inside flushSync so React 19's otherwise-async
+            ;; first pass is committed before we go on — this is the baseline
+            ;; the callback could be stale about, not a drain of the queue
+            ;; under test.
+            (react-dom/flushSync
+              (fn []
+                (rdc/render root [rf/frame-provider {:frame frame-kw}
+                                  [(rf/view :rf.reagent-slim-after-render/probe)]])))
+            (is (= "n=1" (.-textContent mount-node))
+                "baseline: the committed DOM shows the seeded value n=1")
+
+            ;; The state change. Under the rewrite this only ENQUEUES the
+            ;; dependent component for the next microtask turn, so nothing has
+            ;; committed yet...
+            (rf/dispatch-sync [::inc] {:frame frame-kw})
+            ;; ...which this asserts, so a substrate that committed
+            ;; synchronously here could not satisfy the post-condition below
+            ;; vacuously.
+            (is (= "n=1" (.-textContent mount-node))
+                "precondition: dispatch alone has NOT committed — the DOM still
+                 reads n=1, so the callback below has something to be stale about")
+
+            ;; THE PROOF. Queue an ordinary after-render callback into the same
+            ;; scheduler turn and let the turn run on its own. No flush-views!,
+            ;; no flush-render!, no act, no flushSync, no rAF between here and
+            ;; the callback's read.
+            (rf.interop/after-render
+              (fn after-render-probe []
+                (swap! seen conj (.-textContent mount-node))))
+
+            (js/setTimeout
+              (fn []
+                (is (= 1 (count @seen))
+                    (str "the after-render callback fired exactly once — saw "
+                         (pr-str @seen)))
+                (is (= "n=2" (first @seen))
+                    (str "the after-render callback observed the COMMITTED new
+                          DOM; it read " (pr-str (first @seen))
+                         " — reading \"n=1\" means the callback ran while React
+                          had only SCHEDULED the class update (rf2-cdoo)"))
+                (is (= "n=2" (.-textContent mount-node))
+                    "the update did commit — the callback's read is the only
+                     thing in question, not whether the render happened")
+                (try (.unmount root) (catch :default _ nil))
+                (done))
+              50)))))))
+
+(deftest after-render-with-no-dirty-component-still-fires
+  (testing "reagent-slim — a callback queued with no dirty component still
+  fires asynchronously, and the commit-aware path does not strand it (rf2-cdoo)"
+    (async done
+      (let [fired (atom 0)]
+        (rf.interop/after-render (fn [] (swap! fired inc)))
+        (is (= 0 @fired) "not yet — after-render is never synchronous")
+        (js/setTimeout
+          (fn []
+            (is (= 1 @fired)
+                "the callback fired on its own scheduler turn with nothing dirty")
+            (done))
+          50)))))
+
+(deftest after-render-preserves-fifo-and-throw-isolation
+  (testing "reagent-slim — callbacks keep FIFO order and one throwing callback
+  does not strand the rest (rf2-cdoo preserves rf2-p27yih)"
+    (async done
+      (let [order (atom [])]
+        (rf.interop/after-render (fn [] (swap! order conj :first)))
+        (rf.interop/after-render (fn [] (swap! order conj :boom)
+                                        (throw (js/Error. "after-render probe"))))
+        (rf.interop/after-render (fn [] (swap! order conj :third)))
+        (js/setTimeout
+          (fn []
+            (is (= [:first :boom :third] @order)
+                "FIFO order preserved and the throw did not abort the drain")
+            (done))
+          50)))))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_sub_cache_walk_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_sub_cache_walk_cljs_test.cljs
@@ -139,12 +139,48 @@
             (str "post-dispose: frame " (pr-str fid)
                  "'s sub-cache atom is empty"))))))
 
-(deftest dispose-adapter-walk-is-best-effort
-  (testing "rf2-sx77q G3: a throwing per-entry dispose does NOT abort the
-  rest of the walk. The best-effort tolerance is spine-shared but was
-  previously pinned ONLY on the Reagent adapter; this slim sibling closes
-  the gap so a future spine refactor that drops the per-entry try/catch
-  is caught at the slim surface too (slim claims drop-in Reagent parity)."
+;; ---- the poison entry has to be one the disposer actually CALLS ------------
+;;
+;; rf2-vy0a. Until this bead the poison entry here was a bare
+;; `(js-obj "not" "a reaction")`, and it never threw. The ratom family's
+;; claimed-generation disposer (`spine/make-ratom-dispose-dispatch`)
+;; dispatches `re-frame.disposable/IDisposable` → the substrate's
+;; `IDisposable` → `:else nil`; a bare `js-obj` satisfies NEITHER protocol,
+;; so the entry was SKIPPED in silence. Every assertion in the test passed
+;; and the per-entry failure path it was written for was never reached — the
+;; test proved visit-and-clear and nothing else.
+;;
+;; `throwing-cached-reaction` reifies reagent2's own `IDisposable` — whose
+;; methods are `dispose!` / `add-on-dispose!`, NOT `-dispose`, and that
+;; naming detail is the whole reason the bare object fell through — so the
+;; real disposal route lands in a body that throws a sentinel this test
+;; allocated. A sentinel rather than a message because "the FIRST failure
+;; specifically" is unprovable against an error the runtime minted.
+;;
+;; Mirrors `re-frame.dispose-adapter-sub-cache-walk-cljs-test`'s
+;; `throwing-cached-reaction`, which rf2-ss8x built for the stock-Reagent
+;; surface after finding the same vacuity there.
+
+(defn- throwing-cached-reaction
+  "A sub-cache-shaped `:reaction` whose disposal throws `sentinel` and
+  records the attempt in `attempts`. Implements reagent2's `IDisposable`
+  so the adapter's claimed-generation disposer dispatches into it exactly
+  as it would into a real Reaction."
+  [sentinel attempts]
+  (reify ratom/IDisposable
+    (dispose! [_]
+      (swap! attempts inc)
+      (throw sentinel))
+    (add-on-dispose! [_ _f] nil)))
+
+(deftest dispose-adapter-walk-drains-past-a-throwing-entry-then-rethrows
+  (testing "rf2-sx77q G3 + rf2-ss8x, made load-bearing by rf2-vy0a: a throwing
+  per-entry dispose does NOT abort the rest of the walk, and the failure is
+  rethrown to the caller once the drain is complete. The tolerance and the
+  rethrow are both spine-shared but were pinned ONLY on the Reagent adapter;
+  this slim sibling closes the gap so a future spine refactor that drops
+  either is caught at the slim surface too (slim claims drop-in Reagent
+  parity)."
     (rf/make-frame {:id :walk/a})
     (rf/make-frame {:id :walk/b})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
@@ -159,38 +195,43 @@
       (is (= 1 @r-b))
 
       ;; Inject a sentinel reaction into walk/a's sub-cache whose dispose
-      ;; path throws — mirrors a misbehaving downstream (e.g. an
-      ;; on-dispose hook raising). The walk must still drain the rest of
-      ;; walk/a's cache AND walk/b's cache.
-      (let [cache-a      (:sub-cache (frame/frame :walk/a))
-            poison-entry {:reaction (js-obj "not" "a reaction")}]
-        (swap! cache-a assoc [:poison] poison-entry)
+      ;; path throws — mirrors a misbehaving downstream (e.g. a user
+      ;; `:on-dispose` hook raising). The walk must still drain the rest of
+      ;; walk/a's cache AND walk/b's cache, and then surface this exact value.
+      (let [sentinel (ex-info "poison entry disposal" {::poison true})
+            attempts (atom 0)
+            cache-a  (:sub-cache (frame/frame :walk/a))]
+        (swap! cache-a assoc [:poison]
+               {:reaction (throwing-cached-reaction sentinel attempts)})
 
         (let [reactions-before [r-a r-b]
               disposed         (atom #{})]
           (doseq [r reactions-before]
             (ratom/add-on-dispose! r (fn [& _] (swap! disposed conj r))))
 
-          ;; NOTE (rf2-ss8x): this `poison-entry` does not in fact throw. The
-          ;; ratom family's claimed-generation disposer dispatches
-          ;; `re-frame.disposable/IDisposable` → the substrate's `IDisposable`
-          ;; → `:else nil`, and a bare `js-obj` satisfies neither protocol, so
-          ;; it is SKIPPED rather than raising. What survives here is the
-          ;; visit-and-clear half; the per-entry failure path is pinned on the
-          ;; stock-Reagent surface (`re-frame.dispose-adapter-sub-cache-walk-
-          ;; cljs-test`) with a reaction that really does throw, and on this
-          ;; adapter by the throwing-root proof in
-          ;; `reagent-slim-dispose-drain-roots-cljs-test`.
-          (adapter/dispose-adapter!)
+          (let [thrown (try (adapter/dispose-adapter!)
+                            ::returned-normally
+                            (catch :default e e))]
+            ;; (1) THE POISON ACTUALLY FIRED. Without this the rest of the
+            ;; test is satisfied by an entry that was silently skipped —
+            ;; which is exactly what it was before rf2-vy0a.
+            (is (= 1 @attempts)
+                "the poison entry's disposer was CALLED, exactly once — not
+                 skipped by the dispatch's :else branch, and not retried")
 
-          (doseq [r reactions-before]
-            (is (contains? @disposed r)
-                "the walk reached and disposed the real Reaction past the poison entry"))
+            ;; (2) DRAIN EVERYTHING past it, in the same frame and a later one.
+            (doseq [r reactions-before]
+              (is (contains? @disposed r)
+                  "the walk reached and disposed the real Reaction past the poison entry"))
+            (is (= {} @(:sub-cache (frame/frame :walk/a)))
+                "walk/a's cache was still cleared despite the throw")
+            (is (= {} @(:sub-cache (frame/frame :walk/b)))
+                "walk/b's cache was still cleared after the throwing walk/a entry")
 
-          (is (= {} @(:sub-cache (frame/frame :walk/a)))
-              "walk/a's cache was still cleared despite the throw")
-          (is (= {} @(:sub-cache (frame/frame :walk/b)))
-              "walk/b's cache was still cleared after the throwing walk/a entry"))))))
+            ;; (3) RETHROW, and the IDENTICAL value rather than a wrapper.
+            (is (identical? sentinel thrown)
+                "rf/destroy-adapter! rethrew the poison entry's own error
+                 object, unwrapped, after the drain finished")))))))
 
 (deftest dispose-adapter-walk-tolerates-an-empty-frames-registry
   (testing "dispose-adapter! on an installed slim adapter with no live

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_flush_render_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_flush_render_dom_cljs_test.cljs
@@ -24,15 +24,22 @@
   `:flush-render!` actually services — is exercised here directly, exactly as
   the Reagent-bridge twin does for stock `reagent.dom.client`.
 
-  THE PREMISE THIS VERIFIES (rf2-0bz5ah). reagent-slim's adapter `:flush-render!`
-  is `(f)` then `reagent2.impl.batching/flush!` — a synchronous drain that
-  class-`forceUpdate`s every dirty component, with NO `react-dom/flushSync`
-  boundary. Under React 19 `createRoot`, an update originating OUTSIDE React's
-  batching (a bare `forceUpdate` from the flush! drain) commits synchronously
-  by default — so the contract HOLDS without an explicit `flushSync`. This test
-  is the empirical proof of that guarantee: if the bare `forceUpdate` did NOT
-  commit synchronously, the post-`flush-render!` assertion would read the OLD
-  value and fail, surfacing the need for a `flushSync` boundary.
+  THE PREMISE THIS VERIFIES (rf2-0bz5ah). reagent-slim's adapter
+  `:flush-render!` is `(f)` then `reagent2.impl.batching/flush!`, and it wraps
+  BOTH in a `react-dom/flushSync` boundary. That boundary is load-bearing:
+  under React 19 `createRoot` a bare `forceUpdate` issued from outside React's
+  batching context is SCHEDULED rather than committed, so without it the DOM
+  still holds the OLD value when `flush!` returns. (This docstring previously
+  claimed the opposite — that the bare `forceUpdate` commits synchronously and
+  the boundary is redundant. It does not: `3d89c29c61` added the boundary after
+  a browser run read the old value, and rf2-cdoo measured the same fact again
+  on the ordinary microtask path, where a callback promised the new DOM was
+  handed `n=1` after a dispatch to `n=2`. The prose is corrected here rather
+  than left contradicting its own source.)
+
+  So this test is the empirical proof that the boundary does its job: if the
+  drain did NOT commit before returning, the post-`flush-render!` assertion
+  would read the OLD value and fail.
 
   HOW THE PROOF IS RIGOROUS. After the initial mount commits (wrapped in
   `react-dom/flushSync` so React 19's otherwise-async `root.render` first pass
@@ -110,11 +117,11 @@
             (rf/dispatch-sync [::inc] {:frame frame-kw})
             ;; THE PROOF: flush-render! commits the enqueued re-render
             ;; synchronously. The DOM must reflect n=2 on the next line — no
-            ;; microtask wait, no manual flush-views!. (The bare class
-            ;; forceUpdate the batching drain issues commits synchronously
-            ;; under React 19's default-flush-for-non-batched-updates rule;
-            ;; if it did not, this assertion would read n=1 and fail —
-            ;; surfacing the need for a flushSync boundary.)
+            ;; microtask wait, no manual flush-views!. (What makes that so is
+            ;; flush-render!'s own react-dom/flushSync boundary; the bare
+            ;; class forceUpdate the batching drain issues is only SCHEDULED
+            ;; by React 19, so without the boundary this assertion would read
+            ;; n=1 and fail.)
             (flush!)
             (is (= "n=2" (.-textContent mount-node))
                 "DOM reflects the dispatched change SYNCHRONOUSLY after


### PR DESCRIPTION
Two reagent-slim beads, one artefact.

## rf2-cdoo (P1) — after-render could precede the React 19 DOM commit

**The premise holds, and it is measured rather than reasoned.** `reagent2.core/after-render` promises "after the next React commit", and the slim adapter publishes it at `:adapter/after-render`, so `re-frame.interop/after-render` lands on this queue. `RenderQueue.flush-queues` called `ratom/flush!`, then each dirty component's bare `.forceUpdate`, then the callbacks — with no commit boundary anywhere. Under React 19 `createRoot` an update issued from outside React's batching context (a microtask is outside it) is **scheduled**, not committed, so the callback read the old DOM.

Measured on a real React 19 root, ordinary microtask path, no test primitive driving it: after a dispatch taking `n=1` to `n=2`, the callback was handed **`n=1`**. The browser lane reported `expected: (= "n=2" (first @seen)) / actual: (not (= "n=2" "n=1"))`, one failure in 792 tests. After the repair the same lane is 792/4280 with zero failures — same totals, that one assertion flipped.

**The repair** brackets the dirty-component pass in a host commit boundary. The boundary is *injected*, not required: `reagent2.dom.client` installs `react-dom/flushSync` into `reagent2.impl.batching/render-commit` at ns-load, the same direction `reagent2.ratom/rea-schedule` is filled from `batching`. So `batching` still requires nothing of react-dom and a Node/SSR consumer that never loads the DOM client keeps the bare drain. It is applied **only on turns that actually have a callback waiting**, so an ordinary reactive re-render keeps React 19's concurrent scheduling instead of being promoted to discrete priority because the scheduler happened to run. Stock Reagent reaches the same place by the same shape (`run-queue`'s injected react-flush).

Callback FIFO order, the once-only drain, per-callback throw isolation, the fires-with-nothing-dirty case and the next-turn cascade rule are all unchanged and now pinned at the adapter tier as well as the focused tier.

**The witness reads the DOM, not a proxy.** The pre-existing coverage — the focused `batching_cljs_test` `[:render :after]` vector over fake components whose `forceUpdate` body is synchronous, and the shared React suite's fire-counter — passes just as happily when the callback runs pre-commit. The new test reads `textContent` from *inside* the callback, and asserts the **old** DOM between the dispatch and the callback so a substrate that committed synchronously could not satisfy it vacuously. It uses no `flush-views!`, no `flush-render!`, no `act`, no manual `flushSync` around the update or drain, and no `requestAnimationFrame` before the read. The `flushSync` present wraps only the initial mount (React 19's `root.render` first pass is otherwise async, so without it there is no committed baseline to be stale about); the `setTimeout` that follows only defers the *assertion* — the callback has already recorded what it saw, so it cannot change the observation.

**No pair-MCP change was needed.** `tools/re-frame2-pair-mcp/.../dispatch.cljs` already documents the adapter hook as post-commit/pre-paint for `:await-render`. That prose was describing a guarantee the slim substrate did not keep; it keeps it now, so the file is correct as written and is untouched. `spec/002-Frames.md` is likewise untouched: it names after-render effects as the "show this, then run the heavy block" replacement for queue-pausing, which is the contract this repair makes true rather than a statement needing revision.

## rf2-vy0a (P3) — the sub-cache poison proof was vacuous

**Confirmed, and reproduced.** `dispose-adapter-walk-is-best-effort` injected `{:reaction (js-obj "not" "a reaction")}` and claimed to pin a throwing per-entry dispose. The ratom family's claimed-generation disposer dispatches `re-frame.disposable/IDisposable` → the substrate's `IDisposable` → `:else nil`; a bare `js-obj` satisfies neither, so the entry was **skipped in silence**. The test proved visit-and-clear and nothing else, and the per-entry failure path it was written for was never reached.

*What it was pinning*: that a throwing entry does not abort the walk. *What it actually exercised*: that the walk visits an unrecognised entry and clears the cache anyway.

The witness now reifies reagent2's own `IDisposable` — methods `dispose!` / `add-on-dispose!`, **not** `-dispose`, which is precisely why the bare object fell through — following the stock-Reagent fix already on main rather than inventing a second approach. It asserts the disposer was called exactly once, that siblings past it in the same frame and in a later frame were still drained, and the drain-then-rethrow contract (`identical?` on a test-allocated sentinel).

**Making it honest revealed no live defect**: the now-real test passes against current source. Negative control — reverting the witness to the original bare `js-obj` — fails with `attempts` reading **0** (the disposer was never called) and `thrown` reading `::returned-normally`, which is the vacuity reproduced exactly.

## Verification

| Gate | Result |
|---|---|
| `npm run test:cljs` | exit 0 — 11,185 tests / 55,876 assertions, 0 failures |
| browser lane (`compile browser-test` + runner) | exit 0 — 792 tests / 4,280 assertions, 0 failures |
| browser lane, pre-fix | exit 1 — 1 failure, `(not (= "n=2" "n=1"))` |
| `npm run test:reagent-slim:bundle-isolation` (`:advanced` release) | exit 0 — 0 warnings both builds, 6 contracts, 25 sentinel checks |
| `npm run test:reagent-slim:smoke` | exit 0 — 1 client-runtime smoke, 0 failures |
| `npm run test:adapter-smokes` | exit 0 — 2 specs, 0 failures |
| `scripts/check_require_alias_dialect.py` | exit 0 — surface holds at floor 337 |
| `scripts/check_readme_links.py --ci` | exit 0 |

Both silent-on-success gates were proven live with a planted fault and restored to match HEAD: the alias ratchet read 338 against floor 337 naming the exact planted line, and the link gate named the planted broken target in `IMPL-SPEC.md`.

`test:adapter-smokes` runs `shadow-cljs compile`, not `release`, and covers only the Reagent and UIx testbeds — the `:advanced` coverage for this surface is the bundle-isolation gate and the slim runtime smoke is its own script, so all three are listed above.

## Gates that do not apply

`mkdocs build --strict` and `scripts/check_doc_slugs.py` inspect nothing in this diff: no path under `docs/`, `spec/`, `skills/`, `migration/` or `tools/*/spec` is touched. `IMPL-SPEC.md` is markdown beside source, which is `check_readme_links.py --ci`'s roster, and that is the gate reported above.
