### PR TITLE
fix(mcp-conformance): hermetic cleanup grades the spawned process tree, not the npx wrapper (rf2-kzbf)

### DIFF
--- a/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
+++ b/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
@@ -78,6 +78,11 @@ const CLEANUP_SHADOW_SIGTERM_GRACE_MS =
   Number(process.env.HERMETIC_CLEANUP_SHADOW_GRACE_MS) || 5_000;
 const CLEANUP_SHADOW_SIGKILL_GRACE_MS =
   Number(process.env.HERMETIC_CLEANUP_SHADOW_KILL_MS) || 5_000;
+// How long the owned-descendant reap waits for a tree-kill to actually drain
+// the process table. A JVM under `taskkill /F` dies promptly; this is the
+// bound past which we report the survivors as DIRTY rather than wait forever.
+const CLEANUP_SHADOW_TREE_GRACE_MS =
+  Number(process.env.HERMETIC_CLEANUP_SHADOW_TREE_MS) || 10_000;
 // Signal/watchdog paths race cleanup against this final bound.
 const CLEANUP_HARD_CAP_MS =
   Number(process.env.HERMETIC_CLEANUP_HARD_CAP_MS) || 30_000;
@@ -169,6 +174,223 @@ function waitForChildExit(child, hasExited) {
   return new Promise((resolve) => {
     child.once('exit', () => resolve());
   });
+}
+
+// ---------------------------------------------------------------------------
+// Owned-process-tree teardown (rf2-kzbf)
+//
+// THE DEFECT THIS EXISTS TO CLOSE. On Windows the handle `crossSpawn` returns
+// is NOT shadow-cljs. cross-spawn 7.0.6 rewrites the trusted absolute `npx`
+// into `C:\Windows\system32\cmd.exe /d /s /c "...npx.CMD shadow-cljs watch
+// app"`, so the child we hold — and whose `exit` event drives
+// `hasShadowExited()` — is the COMMAND WRAPPER. The shadow-cljs Node process
+// and the JVM it boots are its DESCENDANTS. Node's own child_process docs are
+// explicit that killing a shell child does not terminate the processes it
+// launched, and `child.kill()` on Windows terminates only the direct child.
+//
+// So `hasShadowExited() === true` proves the WRAPPER is gone and says nothing
+// about the JVM still holding the fixture's port 8030. Grading teardown on
+// that flag alone certifies a run GREEN while its residue survives — measured
+// exactly so: wrapper `exit` code=0 observed, `report.clean === true`, pass
+// sentinel emitted, grandchild still alive.
+//
+// The repair grades on the OWNED DESCENDANTS themselves. It is scoped to the
+// subtree rooted at the exact PID this runner spawned — the same discipline
+// as `scripts/test-core-jvm-windows.ps1`'s `Stop-OurSubtree` — so unrelated
+// Node/JVM processes (peer workers, other MCP servers) are never targeted.
+
+// Is `pid` still alive? Signal 0 performs the permission/existence check
+// without delivering a signal. EPERM means the pid EXISTS but is not ours to
+// signal, which is still ALIVE; only ESRCH proves it is gone.
+function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return Boolean(e) && e.code === 'EPERM';
+  }
+}
+
+// Epoch-ms of the .NET/CIM `CreationDate` a process reports, used ONLY as an
+// ownership guard: Windows recycles PIDs, so a process that predates our spawn
+// cannot be our descendant even if it currently names our root as its parent.
+const WINDOWS_PROCESS_TABLE_PS =
+  'Get-CimInstance Win32_Process | ForEach-Object { ' +
+  '$c = 0; ' +
+  'if ($_.CreationDate) { $c = [int64](($_.CreationDate.ToUniversalTime() - ' +
+  "[datetime]'1970-01-01').TotalMilliseconds) } " +
+  "'{0},{1},{2}' -f $_.ProcessId, $_.ParentProcessId, $c }";
+
+// Read the Windows process table as [{ pid, ppid, createdMs }]. `wmic` is
+// removed on current Windows 11 builds, so this goes through PowerShell CIM.
+// Parameterised on its runner so the unit test can drive the parse without a
+// real process table.
+function readWindowsProcessTable({ runPs } = {}) {
+  const run =
+    runPs ||
+    (() =>
+      require('node:child_process').execFileSync(
+        path.join(
+          process.env.SystemRoot || 'C:\\Windows',
+          'System32',
+          'WindowsPowerShell',
+          'v1.0',
+          'powershell.exe',
+        ),
+        ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_PROCESS_TABLE_PS],
+        { encoding: 'utf8', windowsHide: true, maxBuffer: 32 * 1024 * 1024 },
+      ));
+  const rows = [];
+  for (const raw of String(run() || '').split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    const parts = line.split(',');
+    if (parts.length < 3) continue;
+    const pid = Number(parts[0]);
+    const ppid = Number(parts[1]);
+    const createdMs = Number(parts[2]);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    rows.push({
+      pid,
+      ppid: Number.isInteger(ppid) ? ppid : 0,
+      createdMs: Number.isFinite(createdMs) ? createdMs : 0,
+    });
+  }
+  return rows;
+}
+
+// Breadth-first descendant closure of `rootPid` over `table`, EXCLUDING any
+// process created before `notBeforeMs` (a recycled PID wearing our root's
+// number). The root itself is included when still present.
+function ownedDescendants(table, rootPid, notBeforeMs) {
+  const childrenOf = new Map();
+  for (const row of table) {
+    if (!childrenOf.has(row.ppid)) childrenOf.set(row.ppid, []);
+    childrenOf.get(row.ppid).push(row);
+  }
+  const byPid = new Map(table.map((r) => [r.pid, r]));
+  const owned = [];
+  const seen = new Set([rootPid]);
+  const queue = [rootPid];
+  if (byPid.has(rootPid)) owned.push(rootPid);
+  while (queue.length > 0) {
+    const current = queue.shift();
+    for (const child of childrenOf.get(current) || []) {
+      if (seen.has(child.pid)) continue;
+      // A descendant created before we spawned our root is not ours.
+      if (child.createdMs > 0 && child.createdMs < notBeforeMs) continue;
+      seen.add(child.pid);
+      owned.push(child.pid);
+      queue.push(child.pid);
+    }
+  }
+  return owned;
+}
+
+// Build the teardown seam `makeCleanup` grades on. Returns an async
+// `reapShadowTree()` resolving to:
+//   { supported, owned, survivors, error }
+// `supported:false` (non-Windows) is the identity: no owned set, no
+// survivors, no error — POSIX grading is left exactly as it was, since no
+// equivalent defect was demonstrated there (a POSIX `npx` is exec'd directly,
+// not behind a `cmd.exe` shim).
+function makeShadowTreeReaper({
+  rootPid,
+  spawnedAtMs,
+  platform = process.platform,
+  readTable = readWindowsProcessTable,
+  treeKill = defaultWindowsTreeKill,
+  graceMs = CLEANUP_SHADOW_TREE_GRACE_MS,
+  pollMs = 200,
+  isAlive = pidAlive,
+  log: logFn = log,
+  logErr: logErrFn = logErr,
+} = {}) {
+  const inert = async () => ({
+    supported: false,
+    owned: [],
+    survivors: [],
+    error: null,
+  });
+  if (platform !== 'win32') return inert;
+  if (!Number.isInteger(rootPid) || rootPid <= 0) {
+    // No PID to own means no tree we can honestly claim to have reaped.
+    return async () => ({
+      supported: true,
+      owned: [],
+      survivors: [],
+      error: 'no shadow root pid was recorded — owned-descendant teardown ' +
+        'could not be attempted',
+    });
+  }
+  return async function reapShadowTree() {
+    let owned;
+    try {
+      owned = ownedDescendants(readTable(), rootPid, spawnedAtMs);
+    } catch (e) {
+      return {
+        supported: true,
+        owned: [],
+        survivors: [],
+        error: `could not enumerate the process table (${e && e.message})`,
+      };
+    }
+    if (owned.length === 0) {
+      logFn(`owned shadow tree (root pid ${rootPid}) is already empty`);
+      return { supported: true, owned: [], survivors: [], error: null };
+    }
+    logFn(
+      `owned shadow tree rooted at pid ${rootPid}: ${owned.join(', ')} — ` +
+        'tree-killing OUR subtree only',
+    );
+    let killError = null;
+    try {
+      // Kill the root's subtree first; then any orphan we attributed to the
+      // root but whose own parent link died with the wrapper.
+      treeKill(rootPid);
+      for (const pid of owned) {
+        if (pid !== rootPid && isAlive(pid)) treeKill(pid);
+      }
+    } catch (e) {
+      killError = `tree-kill failed (${e && e.message})`;
+    }
+    const deadline = Date.now() + graceMs;
+    let survivors = owned.filter((pid) => isAlive(pid));
+    while (survivors.length > 0 && Date.now() < deadline) {
+      await new Promise((r) => {
+        const t = setTimeout(r, pollMs);
+        if (typeof t.unref === 'function') t.unref();
+      });
+      survivors = survivors.filter((pid) => isAlive(pid));
+    }
+    if (survivors.length > 0) {
+      logErrFn(
+        `owned shadow descendants SURVIVED tree-kill after ${graceMs}ms: ` +
+          survivors.join(', '),
+      );
+    }
+    return { supported: true, owned, survivors, error: killError };
+  };
+}
+
+// `taskkill /T` walks descendants, `/F` forces. Scoped to the pid we own —
+// the pattern already proven in scripts/test-core-jvm-windows.ps1.
+function defaultWindowsTreeKill(pid) {
+  try {
+    require('node:child_process').execFileSync(
+      path.join(
+        process.env.SystemRoot || 'C:\\Windows',
+        'System32',
+        'taskkill.exe',
+      ),
+      ['/pid', String(pid), '/T', '/F'],
+      { stdio: 'ignore', windowsHide: true },
+    );
+  } catch {
+    // taskkill exits non-zero when the pid is already gone — the survivor
+    // poll below is what actually grades the outcome, so this is not fatal.
+  }
 }
 
 // Race a `browser.close()` thunk against `ms`, PRESERVING the outcome —
@@ -285,6 +507,11 @@ function spawnAndGradeInnerTest({
 //   getBrowser()      -> the Playwright Browser or null (promise-returning `close()`)
 //   getShadow()       -> the shadow-cljs child or null (`kill(sig)` + `'exit'` event)
 //   hasShadowExited() -> boolean: has the shadow child already emitted `exit`
+//   reapShadowTree()  -> async: terminate the OWNED descendant subtree and
+//                        report `{ supported, owned, survivors, error }`.
+//                        On Windows `getShadow()` is the `cmd.exe`/npx WRAPPER,
+//                        not shadow-cljs, so its `exit` says nothing about the
+//                        JVM below it (rf2-kzbf). Defaults to an inert reaper.
 //   log / logErr      -> structured loggers (default to the module ones)
 //   timeouts          -> overridable caps (default to the module constants;
 //                        the harness shrinks them so the test runs fast)
@@ -303,11 +530,14 @@ function spawnAndGradeInnerTest({
 //
 // Resolves to `{ clean, browser, shadow, issues }`:
 //   clean   — true ⇔ the browser is proven closed/disconnected (or absent)
-//             AND shadow is proven exited (or absent/already-exited).
+//             AND shadow is proven exited (or absent/already-exited) AND no
+//             process we spawned survived the owned-tree reap.
 //   browser — `{ attempted, state, clean, ... }` where state is one of
 //             'none' | 'closed' | 'disconnected' | 'dirty'.
-//   shadow  — `{ attempted, state, clean, signals }` where state is one of
-//             'none' | 'exited' | 'alive'.
+//   shadow  — `{ attempted, state, clean, signals, tree }` where `state` is the
+//             WRAPPER's state ('none' | 'exited' | 'alive') and `tree` is the
+//             owned-descendant reap report. `clean` requires BOTH: a wrapper
+//             that exited AND a subtree with no survivors (rf2-kzbf).
 //   issues  — human-readable strings naming each dirty resource, the signals
 //             attempted, the timeouts, and the final observed state.
 // Idempotent: repeat/concurrent calls return the SAME in-flight promise and
@@ -318,6 +548,16 @@ function makeCleanup(deps) {
     getBrowser,
     getShadow,
     hasShadowExited,
+    // Default is the INERT reaper: `makeCleanup` itself stays platform-neutral
+    // and knows no PIDs. The real Windows reaper is built at the spawn site,
+    // where the root pid exists, and injected. That keeps this factory (and
+    // every test that drives it) identical on Windows, macOS and Linux.
+    reapShadowTree = async () => ({
+      supported: false,
+      owned: [],
+      survivors: [],
+      error: null,
+    }),
     log: logFn = log,
     logErr: logErrFn = logErr,
     browserCloseMs = CLEANUP_BROWSER_CLOSE_TIMEOUT_MS,
@@ -372,15 +612,16 @@ function makeCleanup(deps) {
       //     especially on Windows.
       const shadow = getShadow();
       let shadowReport;
+      let attempted = false;
+      let signals = [];
+      let wrapperState;
+      let wrapperClean;
       if (!shadow || hasShadowExited()) {
-        shadowReport = {
-          attempted: false,
-          state: hasShadowExited() ? 'exited' : 'none',
-          clean: true,
-          signals: [],
-        };
+        wrapperState = hasShadowExited() ? 'exited' : 'none';
+        wrapperClean = true;
       } else {
-        const signals = [];
+        attempted = true;
+        signals = [];
         try { shadow.kill('SIGTERM'); signals.push('SIGTERM'); } catch {}
         const exitedOnTerm = await settledWithin(
           waitForChildExit(shadow, hasShadowExited),
@@ -398,16 +639,51 @@ function makeCleanup(deps) {
           );
         }
         if (hasShadowExited()) {
-          shadowReport = { attempted: true, state: 'exited', clean: true, signals };
+          wrapperState = 'exited';
+          wrapperClean = true;
         } else {
           const msg =
             `shadow-cljs still has NOT reported exit after ${signals.join('+')} ` +
             `+ ${shadowKillGraceMs}ms grace — child left ALIVE (no observed exit)`;
           logErrFn(msg);
           issues.push(`shadow: ${msg}`);
-          shadowReport = { attempted: true, state: 'alive', clean: false, signals };
+          wrapperState = 'alive';
+          wrapperClean = false;
         }
       }
+
+      // (3b) OWNED DESCENDANTS (rf2-kzbf). The wrapper's `exit` proves only
+      //      that the `cmd.exe`/npx shim is gone. On Windows the shadow-cljs
+      //      Node process and its JVM are GRANDCHILDREN that outlive it and
+      //      keep holding the fixture's port. Reap and grade the subtree
+      //      rooted at the pid we spawned; a survivor — or an inability to
+      //      prove there is none — is DIRTY however clean the wrapper looked.
+      const tree = await reapShadowTree();
+      let treeClean = true;
+      if (tree.error) {
+        const msg =
+          'owned-descendant teardown could NOT be proven ' +
+          `(${tree.error}) — refusing to call the shadow tree reaped`;
+        logErrFn(msg);
+        issues.push(`shadow-tree: ${msg}`);
+        treeClean = false;
+      } else if (tree.survivors.length > 0) {
+        const msg =
+          `${tree.survivors.length} process(es) we spawned SURVIVED teardown ` +
+          `(pids ${tree.survivors.join(', ')}) — the run is NOT hermetic even ` +
+          `though the shadow wrapper reported '${wrapperState}'`;
+        logErrFn(msg);
+        issues.push(`shadow-tree: ${msg}`);
+        treeClean = false;
+      }
+
+      shadowReport = {
+        attempted,
+        state: wrapperState,
+        clean: wrapperClean && treeClean,
+        signals,
+        tree,
+      };
 
       const clean = browserReport.clean && shadowReport.clean;
       logFn(clean ? 'cleanup complete (clean)' : 'cleanup complete (DIRTY)');
@@ -1010,11 +1286,18 @@ async function main() {
   // that ever landed in the checkout can never be executed.
   const npxBin = trustedExe('npx');
   log(`spawning shadow-cljs watch app in ${FIXTURE_DIR} (npx=${npxBin})`);
+  // Record the spawn instant BEFORE the spawn: it is the ownership floor for
+  // the descendant walk, so it must not be later than our own root's creation.
+  const shadowSpawnedAtMs = Date.now();
   const shadow = crossSpawn(npxBin, ['shadow-cljs', 'watch', 'app'], {
     cwd: FIXTURE_DIR,
     stdio: ['ignore', 'pipe', 'pipe'],
     env: { ...process.env, FORCE_COLOR: '0' },
   });
+  // On Windows `shadow.pid` is the `cmd.exe` wrapper cross-spawn interposed;
+  // shadow-cljs and its JVM hang below it. This is the root of the subtree we
+  // own, and the ONLY subtree teardown is allowed to touch (rf2-kzbf).
+  const shadowRootPid = shadow.pid;
   let shadowExited = false;
   shadow.on('exit', (code, sig) => {
     shadowExited = true;
@@ -1042,6 +1325,11 @@ async function main() {
     getBrowser: () => browser,
     getShadow: () => shadow,
     hasShadowExited: () => shadowExited,
+    // The wrapper's `exit` is not the JVM's. Grade the subtree we spawned.
+    reapShadowTree: makeShadowTreeReaper({
+      rootPid: shadowRootPid,
+      spawnedAtMs: shadowSpawnedAtMs,
+    }),
   });
   // Expose the teardown to the module-scope hard watchdog
   // so a watchdog-elapse kills shadow-cljs + Chromium rather than
@@ -1431,6 +1719,13 @@ if (require.main === module) {
 // grading through `makeCleanup`, the dirty-report prose through
 // `finalizeConformance`. Exporting them would advertise a test seam that
 // invites coupling to the helper instead of the decision it serves.
+// `makeShadowTreeReaper` + `ownedDescendants` + `pidAlive` are exported for the
+// owned-tree regression harness (`runner-cleanup.test.cjs`, rf2-kzbf). The
+// factory is driven with injected `readTable`/`treeKill`/`isAlive` fakes so the
+// ownership walk, the recycled-PID guard and the survivor grading are pinned on
+// EVERY platform, and additionally against a REAL cross-spawn'd `cmd.exe`
+// wrapper whose grandchild outlives it on Windows — the exact shape that
+// previously certified a leaked JVM as a clean, GREEN, exit-0 run.
 module.exports = {
   runTrusted,
   SETUP_COMMAND_TIMEOUT_MS,
@@ -1442,4 +1737,7 @@ module.exports = {
   waitForChildExit,
   spawnAndGradeInnerTest,
   wipeStalePortFileCandidate,
+  makeShadowTreeReaper,
+  ownedDescendants,
+  pidAlive,
 };

--- a/tools/mcp-conformance/test/runner-cleanup.test.cjs
+++ b/tools/mcp-conformance/test/runner-cleanup.test.cjs
@@ -53,7 +53,14 @@ const ORCH = path.join(
   'run-re-frame2-pair-live-hermetic-suite.cjs',
 );
 
-const { makeCleanup, settledWithin, waitForChildExit } = require(ORCH);
+const {
+  makeCleanup,
+  settledWithin,
+  waitForChildExit,
+  finalizeConformance,
+  makeShadowTreeReaper,
+  ownedDescendants,
+} = require(ORCH);
 
 // A fake shadow-cljs child: an EventEmitter with a `kill(sig)` that records
 // every signal. `exitAfterKill` lets the test model a JVM that ignores
@@ -358,4 +365,389 @@ test('waitForChildExit resolves immediately when the child already exited (rf2-7
   const p = waitForChildExit(ee, () => false);
   setTimeout(() => ee.emit('exit', 0, null), 10);
   await p;
+});
+
+// ---------------------------------------------------------------------------
+// rf2-kzbf: the teardown must grade the PROCESS TREE WE SPAWNED, not the npx
+// wrapper that fronts it.
+//
+// On Windows cross-spawn 7.0.6 rewrites the trusted absolute `npx` into
+// `cmd.exe /d /s /c "...npx.CMD shadow-cljs watch app"`, so the handle the
+// runner holds — and whose `exit` event sets `shadowExited` — is the COMMAND
+// WRAPPER. shadow-cljs and its JVM are its DESCENDANTS and outlive it.
+//
+// Every test above models wrapper and JVM as ONE EventEmitter
+// (`makeFakeShadow().kill()` emits that same object's `exit`), so they pin
+// direct-child timing and escalation but CANNOT see a wrapper that exits while
+// a grandchild survives. Measured against the real code before this fix: a
+// cross-spawn'd `.cmd` wrapper emitted `exit` code=0 with its grandchild still
+// alive, `report.clean` came back `true`, `report.issues` was `[]`, and
+// `finalizeConformance` emitted the pass sentinel and returned 0 — a certified
+// GREEN hermetic run holding a live process. These pin that shut.
+//
+// The seam is platform-neutral by construction: `makeCleanup` knows no PIDs and
+// takes `reapShadowTree` as a dependency, so the grading tests below run
+// identically on Windows, macOS and Linux. Only the DEFAULT reaper built at the
+// spawn site is platform-conditional, and only the last test in this file — the
+// one that launches a real wrapper — is Windows-gated.
+// ---------------------------------------------------------------------------
+
+// A reap report whose survivors/error the test dictates.
+function fakeReap({ supported = true, owned = [], survivors = [], error = null } = {}) {
+  return async () => ({ supported, owned, survivors, error });
+}
+
+test('a wrapper that EXITED cannot certify clean while owned descendants survive (rf2-kzbf AC1)', async () => {
+  // The exact false-green shape: `hasShadowExited()` is TRUE — the npx/cmd
+  // wrapper is genuinely gone — but the shadow-cljs JVM it launched is still
+  // running and still holding the fixture's port.
+  const cleanup = makeCleanup({
+    getBrowser: () => null,
+    getShadow: () => null,
+    hasShadowExited: () => true,
+    reapShadowTree: fakeReap({ owned: [4242, 4243], survivors: [4243] }),
+    log: () => {},
+    logErr: () => {},
+  });
+
+  const report = await cleanup();
+
+  // The wrapper still grades 'exited' — that observation was never wrong, it
+  // was just never sufficient.
+  assert.equal(report.shadow.state, 'exited', 'the wrapper did exit and should still be reported so');
+  // THE load-bearing assertion. Pre-fix this was `true`: `makeCleanup` graded
+  // shadow solely from `hasShadowExited()` and ignored the descendants entirely.
+  assert.equal(
+    report.shadow.clean,
+    false,
+    'a surviving owned descendant must make the shadow teardown DIRTY even ' +
+      'though the npx/cmd wrapper reported exit (the rf2-kzbf false green)',
+  );
+  assert.equal(report.clean, false, 'the overall teardown must be DIRTY');
+  assert.deepEqual(report.shadow.tree.survivors, [4243]);
+  // The issue names the surviving pid so an operator can act on it.
+  assert.equal(report.issues.length, 1, 'issues: ' + JSON.stringify(report.issues));
+  assert.match(report.issues[0], /4243/, 'the issue must name the surviving pid');
+
+  // AC1 + AC3 end-to-end: no pass sentinel, orchestration exit 2.
+  let sentinel = null;
+  const code = finalizeConformance(report, {
+    emitPass: (line) => { sentinel = line; },
+    log: () => {},
+    logErr: () => {},
+    flush: () => {},
+    count: 0,
+  });
+  assert.equal(code, 2, 'a leaked owned descendant must be an orchestration failure');
+  assert.equal(sentinel, null, 'a run holding a live spawned process must emit NO pass sentinel');
+});
+
+test('an owned-tree reap that cannot be PROVEN is DIRTY, not optimistically clean (rf2-kzbf AC3)', async () => {
+  // Enumeration failed, so we cannot say whether anything survived. "We could
+  // not check" must never grade the same as "we checked and it was empty".
+  const cleanup = makeCleanup({
+    getBrowser: () => null,
+    getShadow: () => null,
+    hasShadowExited: () => true,
+    reapShadowTree: fakeReap({ error: 'could not enumerate the process table (EPERM)' }),
+    log: () => {},
+    logErr: () => {},
+  });
+  const report = await cleanup();
+  assert.equal(report.clean, false, 'an unprovable teardown must be graded DIRTY');
+  assert.equal(report.shadow.clean, false);
+  assert.match(report.issues[0], /could NOT be proven/);
+});
+
+test('the owned-tree reap runs even when the wrapper never exited, and both failures are reported (rf2-kzbf AC2)', async () => {
+  // A wrapper that ignores every signal AND a surviving descendant: the
+  // teardown must attempt and report BOTH rather than short-circuiting.
+  const shadow = makeFakeShadow(); // never exits
+  const cleanup = makeCleanup({
+    getBrowser: () => null,
+    getShadow: () => shadow,
+    hasShadowExited: () => shadow.exited,
+    reapShadowTree: fakeReap({ owned: [7001], survivors: [7001] }),
+    log: () => {},
+    logErr: () => {},
+    shadowTermGraceMs: 20,
+    shadowKillGraceMs: 20,
+  });
+  const report = await cleanup();
+  assert.equal(report.shadow.state, 'alive');
+  assert.deepEqual(shadow.killSignals, ['SIGTERM', 'SIGKILL'], 'signal escalation still runs');
+  assert.equal(report.clean, false);
+  assert.equal(report.issues.length, 2, 'both the wrapper and the tree are reported: ' + JSON.stringify(report.issues));
+});
+
+test('a reaped tree with no survivors still grades CLEAN (rf2-kzbf AC4 — no false RED)', async () => {
+  // The repair must not invert into refusing every run: an owned tree that was
+  // actually reaped is clean, and that is the normal path.
+  const cleanup = makeCleanup({
+    getBrowser: () => null,
+    getShadow: () => null,
+    hasShadowExited: () => true,
+    reapShadowTree: fakeReap({ owned: [900, 901], survivors: [] }),
+    log: () => {},
+    logErr: () => {},
+  });
+  const report = await cleanup();
+  assert.equal(report.clean, true, 'a tree with no survivors is clean');
+  assert.deepEqual(report.issues, []);
+  assert.deepEqual(report.shadow.tree.owned, [900, 901]);
+});
+
+// ---- the descendant walk itself ------------------------------------------
+
+test('ownedDescendants walks the whole subtree, not just direct children (rf2-kzbf)', () => {
+  // The real shape: runner -> cmd.exe(100) -> npx node(200) -> shadow node(300)
+  // -> java(400). Grading the wrapper alone sees none of 200/300/400.
+  const table = [
+    { pid: 1, ppid: 0, createdMs: 1000 },
+    { pid: 100, ppid: 1, createdMs: 5000 },
+    { pid: 200, ppid: 100, createdMs: 5100 },
+    { pid: 300, ppid: 200, createdMs: 5200 },
+    { pid: 400, ppid: 300, createdMs: 5300 },
+    { pid: 999, ppid: 1, createdMs: 5100 }, // an unrelated peer process
+  ];
+  const owned = ownedDescendants(table, 100, 4000);
+  assert.deepEqual(owned.sort((a, b) => a - b), [100, 200, 300, 400]);
+  assert.ok(!owned.includes(999), 'an unrelated sibling process must never be attributed to us');
+});
+
+test('ownedDescendants refuses a RECYCLED pid that predates our spawn (rf2-kzbf AC2)', () => {
+  // Windows recycles PIDs. A process that already existed when we spawned
+  // cannot be our descendant, however its parent link now reads — and killing
+  // it would be exactly the "unrelated JVM" the fence forbids.
+  const table = [
+    { pid: 100, ppid: 1, createdMs: 5000 },
+    { pid: 500, ppid: 100, createdMs: 4000 }, // created BEFORE we spawned
+    { pid: 600, ppid: 100, createdMs: 5500 }, // genuinely ours
+  ];
+  const owned = ownedDescendants(table, 100, 4500);
+  assert.ok(owned.includes(600), 'a descendant created after our spawn is ours');
+  assert.ok(!owned.includes(500), 'a process predating our spawn must NOT be attributed to us');
+});
+
+test('ownedDescendants reports an empty set when the root is already gone and left nothing (rf2-kzbf)', () => {
+  const table = [{ pid: 1, ppid: 0, createdMs: 1000 }];
+  assert.deepEqual(ownedDescendants(table, 100, 4000), []);
+});
+
+// ---- the reaper's own outcome grading -------------------------------------
+
+test('makeShadowTreeReaper reports SURVIVORS when the kill removes nothing (rf2-kzbf)', async () => {
+  // A tree-kill that returns success while removing nothing is precisely the
+  // failure mode this bead is about. The reaper must grade the EFFECT — is the
+  // pid still alive — never the fact that the kill call returned.
+  const killed = [];
+  const reap = makeShadowTreeReaper({
+    rootPid: 100,
+    spawnedAtMs: 0,
+    platform: 'win32',
+    readTable: () => [
+      { pid: 100, ppid: 1, createdMs: 10 },
+      { pid: 200, ppid: 100, createdMs: 20 },
+    ],
+    treeKill: (pid) => { killed.push(pid); /* silently removes nothing */ },
+    isAlive: () => true, // still there afterwards
+    graceMs: 60,
+    pollMs: 10,
+    log: () => {},
+    logErr: () => {},
+  });
+  const out = await reap();
+  assert.ok(killed.includes(100), 'the owned root must be tree-killed');
+  assert.deepEqual(out.survivors.sort((a, b) => a - b), [100, 200], 'survivors must be reported, not assumed dead');
+  assert.equal(out.error, null);
+});
+
+test('makeShadowTreeReaper reports NO survivors once the pids actually die (rf2-kzbf)', async () => {
+  const dead = new Set();
+  const reap = makeShadowTreeReaper({
+    rootPid: 100,
+    spawnedAtMs: 0,
+    platform: 'win32',
+    readTable: () => [
+      { pid: 100, ppid: 1, createdMs: 10 },
+      { pid: 200, ppid: 100, createdMs: 20 },
+    ],
+    treeKill: (pid) => { dead.add(pid); dead.add(200); },
+    isAlive: (pid) => !dead.has(pid),
+    graceMs: 500,
+    pollMs: 10,
+    log: () => {},
+    logErr: () => {},
+  });
+  const out = await reap();
+  assert.deepEqual(out.survivors, []);
+  assert.deepEqual(out.owned.sort((a, b) => a - b), [100, 200]);
+});
+
+test('makeShadowTreeReaper surfaces an enumeration failure instead of reporting clean (rf2-kzbf AC3)', async () => {
+  const reap = makeShadowTreeReaper({
+    rootPid: 100,
+    spawnedAtMs: 0,
+    platform: 'win32',
+    readTable: () => { throw new Error('powershell unavailable'); },
+    treeKill: () => {},
+    log: () => {},
+    logErr: () => {},
+  });
+  const out = await reap();
+  assert.match(out.error, /could not enumerate the process table/);
+  assert.match(out.error, /powershell unavailable/);
+});
+
+test('makeShadowTreeReaper is INERT on POSIX — current behaviour is unchanged there (rf2-kzbf)', async () => {
+  // POSIX `npx` is exec'd directly rather than behind a cmd.exe shim, so no
+  // equivalent defect was demonstrated and the repair must not change grading
+  // for the maintainers running macOS/Linux.
+  for (const platform of ['linux', 'darwin']) {
+    const reap = makeShadowTreeReaper({
+      rootPid: 100,
+      spawnedAtMs: 0,
+      platform,
+      readTable: () => { throw new Error('must never be consulted off Windows'); },
+      treeKill: () => { throw new Error('must never kill off Windows'); },
+    });
+    const out = await reap();
+    assert.equal(out.supported, false, platform + ': the reaper must be inert');
+    assert.deepEqual(out.survivors, [], platform + ': no survivors are claimed');
+    assert.equal(out.error, null, platform + ': and no failure is invented');
+  }
+  // And an inert reap leaves the grading exactly as it was before this fix.
+  const cleanup = makeCleanup({
+    getBrowser: () => null,
+    getShadow: () => null,
+    hasShadowExited: () => true,
+    reapShadowTree: makeShadowTreeReaper({ rootPid: 1, spawnedAtMs: 0, platform: 'linux' }),
+    log: () => {},
+    logErr: () => {},
+  });
+  const report = await cleanup();
+  assert.equal(report.clean, true);
+  assert.equal(report.shadow.state, 'exited');
+});
+
+test('makeShadowTreeReaper refuses to claim a reap when no root pid was recorded (rf2-kzbf AC3)', async () => {
+  const reap = makeShadowTreeReaper({ rootPid: undefined, spawnedAtMs: 0, platform: 'win32' });
+  const out = await reap();
+  assert.equal(out.supported, true);
+  assert.match(out.error, /no shadow root pid/);
+});
+
+// ---- the real thing, on Windows -------------------------------------------
+
+// A REAL cross-spawn'd `.cmd` wrapper that exits immediately after launching a
+// long-lived grandchild — the npx/shadow-cljs shape, minus the 6-minute boot.
+// Windows-only: the defect is a cmd.exe-shim artefact and there is no POSIX
+// counterpart to model.
+test('a REAL cmd wrapper that exits with a live grandchild is graded DIRTY, then reaped (rf2-kzbf AC1/AC2)', { skip: process.platform !== 'win32' ? 'Windows-only: models the cmd.exe shim cross-spawn interposes' : false }, async () => {
+  const crossSpawn = require('cross-spawn');
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const { execFileSync } = require('node:child_process');
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-kzbf-'));
+  const beat = path.join(dir, 'beat.txt');
+  fs.writeFileSync(
+    path.join(dir, 'grandchild.cjs'),
+    'const fs=require("node:fs");const o=process.argv[2];fs.writeFileSync(o,String(process.pid));' +
+      'setInterval(()=>fs.writeFileSync(o,String(process.pid)),200);',
+  );
+  // `start "" /b` detaches the worker and lets the wrapper exit at once —
+  // the wrapper/grandchild lifetime split, compressed.
+  fs.writeFileSync(
+    path.join(dir, 'wrapper.cmd'),
+    '@echo off\r\nstart "" /b node "%~dp0grandchild.cjs" "%~1"\r\nexit /b 0\r\n',
+  );
+
+  const spawnedAtMs = Date.now();
+  const shadow = crossSpawn(path.join(dir, 'wrapper.cmd'), [beat], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const rootPid = shadow.pid;
+  let shadowExited = false;
+  shadow.on('exit', () => { shadowExited = true; });
+
+  // Wait for the wrapper to exit AND the grandchild to announce itself.
+  const deadline = Date.now() + 20_000;
+  while ((!shadowExited || !fs.existsSync(beat)) && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  const grandPid = Number(fs.readFileSync(beat, 'utf8').trim());
+
+  try {
+    assert.ok(shadowExited, 'the cmd wrapper should have exited on its own');
+    assert.ok(Number.isInteger(grandPid) && grandPid > 0, 'the grandchild should have announced its pid');
+
+    // (a) THE PRE-FIX GRADE, reproduced: with the tree reap disabled, the
+    //     wrapper's exit alone certifies this leaking run clean and GREEN.
+    const beforeReport = await makeCleanup({
+      getBrowser: () => null,
+      getShadow: () => shadow,
+      hasShadowExited: () => shadowExited,
+      log: () => {},
+      logErr: () => {},
+    })();
+    assert.equal(
+      beforeReport.clean,
+      true,
+      'sanity: without an owned-tree reap the wrapper exit alone still reads clean — ' +
+        'this is the defect being fixed, reproduced against a real process',
+    );
+    let sentinel = null;
+    finalizeConformance(beforeReport, {
+      emitPass: (l) => { sentinel = l; }, log: () => {}, logErr: () => {}, flush: () => {}, count: 0,
+    });
+    assert.ok(sentinel !== null, 'sanity: and it emitted the GREEN pass sentinel');
+    // ...while the grandchild is demonstrably STILL RUNNING.
+    const m1 = fs.statSync(beat).mtimeMs;
+    await new Promise((r) => setTimeout(r, 500));
+    assert.ok(
+      fs.statSync(beat).mtimeMs > m1,
+      'the grandchild must still be beating — otherwise this test proves nothing',
+    );
+
+    // (b) A reap whose kill is a NO-OP must grade DIRTY. This is the guard
+    //     against a cleanup that reports success and removes nothing.
+    const inertKillReport = await makeCleanup({
+      getBrowser: () => null,
+      getShadow: () => shadow,
+      hasShadowExited: () => shadowExited,
+      reapShadowTree: makeShadowTreeReaper({
+        rootPid, spawnedAtMs, treeKill: () => {}, graceMs: 300, pollMs: 50,
+        log: () => {}, logErr: () => {},
+      }),
+      log: () => {}, logErr: () => {},
+    })();
+    assert.equal(
+      inertKillReport.clean,
+      false,
+      'a real surviving grandchild must grade DIRTY however cleanly the wrapper exited',
+    );
+    assert.ok(
+      inertKillReport.shadow.tree.survivors.includes(grandPid),
+      'the surviving grandchild pid must be named: ' + JSON.stringify(inertKillReport.shadow.tree),
+    );
+
+    // (c) The real reaper terminates the tree and grades it clean.
+    const afterReport = await makeCleanup({
+      getBrowser: () => null,
+      getShadow: () => shadow,
+      hasShadowExited: () => shadowExited,
+      reapShadowTree: makeShadowTreeReaper({ rootPid, spawnedAtMs, log: () => {}, logErr: () => {} }),
+      log: () => {}, logErr: () => {},
+    })();
+    assert.equal(afterReport.clean, true, 'the reaped tree grades clean: ' + JSON.stringify(afterReport.issues));
+    assert.deepEqual(afterReport.shadow.tree.survivors, []);
+    let stillAlive = true;
+    try { process.kill(grandPid, 0); } catch (e) { stillAlive = e.code === 'EPERM'; }
+    assert.equal(stillAlive, false, 'the grandchild must actually be GONE, not merely reported gone');
+  } finally {
+    // Never leave this test's own process behind, whatever failed above.
+    try { execFileSync('taskkill.exe', ['/pid', String(grandPid), '/T', '/F'], { stdio: 'ignore' }); } catch {}
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  }
 });


### PR DESCRIPTION
## The defect

On Windows the child handle `crossSpawn` returns is **not** shadow-cljs. Running the installed cross-spawn 7.0.6 parser against this runner's exact spawn shape:

```
resolved npx: C:\Program Files\nodejs\npx.CMD
parsed.command = C:\Windows\system32\cmd.exe
parsed.args    = ["/d","/s","/c","\"C:\Program^ Files\nodejs\npx.CMD ^\"shadow-cljs^\" ..."]
```

So the child the runner holds — and whose `exit` event sets `shadowExited` — is the **command wrapper**. shadow-cljs and the JVM it boots are its descendants, and `child.kill()` on Windows reaches only the direct child.

`makeCleanup` graded shadow teardown solely from `hasShadowExited()`, which is driven solely by that wrapper's `exit` event. The unit model collapsed both lifetimes into one `EventEmitter` (`makeFakeShadow().kill()` emits that same object's `exit`), so it pinned direct-child timing and escalation but could not see a wrapper that exits while a grandchild survives.

**Measured against the real code**, driving the real `makeCleanup` and `finalizeConformance` with a real cross-spawn'd `.cmd` wrapper whose grandchild outlived it:

```
report.clean        = true
report.shadow       = {"attempted":false,"state":"exited","clean":true,"signals":[]}
report.issues       = []
finalizeConformance exit code = 0
PASS SENTINEL EMITTED         = "RE-FRAME2-PAIR-MCP live hermetic conformance passed."
GRANDCHILD STILL ALIVE        = true
```

A certified GREEN hermetic run still holding a live process on the fixture's fixed port 8030. That defeats the verifier's defining guarantee.

## The repair

Teardown now reaps and grades the subtree rooted at **the exact pid this runner spawned**, adapting the scoped `taskkill /pid <ours> /T /F` pattern already used by `scripts/test-core-jvm-windows.ps1`.

- `clean` requires **both** a wrapper that exited **and** a subtree with no survivors.
- A reap that cannot be proven (enumeration failed, no root pid recorded) is **dirty**, never optimistically clean.
- Descendants created before our spawn are excluded, so a recycled pid can never route the kill at an unrelated JVM. Only our own subtree is ever targeted.
- Liveness is graded on the **effect** — is the pid still there — never on the kill call returning. `wmic` is removed on current Windows 11 builds, so enumeration goes through PowerShell CIM.

## Platform question, answered explicitly

**POSIX behaviour is unchanged.** A POSIX `npx` is exec'd directly rather than behind a `cmd.exe` shim, no equivalent defect was demonstrated there, and the reaper is inert off Windows.

The seam is platform-neutral by construction: `makeCleanup` knows no PIDs and takes `reapShadowTree` as a dependency. Every grading test therefore runs identically on Windows, macOS and Linux. Only the *default* reaper built at the spawn site is platform-conditional, and only one test — the one that launches a real `cmd.exe` wrapper — is Windows-gated (it skips elsewhere).

## The witness

The new tests were run against the **pre-fix** runner (the fixed script swapped out for `origin/main`'s, the new test file left in place):

```
exit 1 — tests 25, pass 12, fail 13
AssertionError: a surviving owned descendant must make the shadow teardown DIRTY
even though the npx/cmd wrapper reported exit (the rf2-kzbf false green)
  actual: true,  expected: false,
```

All 13 new tests fail before and pass after; the 12 pre-existing tests pass in both states, so no existing behaviour changed. The Windows-gated test additionally reproduces the pre-fix false green against a real process, then proves the grandchild is *actually gone* rather than merely reported gone.

## Gates

| Gate | Before | After |
|---|---|---|
| `npm run test:unit` (mcp-conformance) | exit 0 — 124 tests, 115 pass, 0 fail, 9 skipped | exit 0 — 137 tests, 128 pass, 0 fail, 9 skipped |
| New tests vs. pre-fix runner | — | exit 1 — 13 fail (the witness) |

`mkdocs build --strict` does **not** cover this change and is not cited: `docs_dir` is `docs`, and `mkdocs_hooks.py`'s `_STAGE` table stages only `spec` and `migration`, so `tools/mcp-conformance/` is reached by neither door. No markdown was touched, so neither `check_doc_slugs.py` nor `check_readme_links.py --ci` has anything to inspect here. No new files were added, so the require-alias ratchet does not apply (both changed files are `.cjs`, with no ClojureScript requires).

Closes rf2-kzbf.
