### PR TITLE
fix(story): the step debugger's Start prepares the variant, it never plays it (rf2-k6y2)

### DIFF
--- a/tools/story/spec/009-Test-Mode.md
+++ b/tools/story/spec/009-Test-Mode.md
@@ -459,7 +459,9 @@ clicking **Start** brings up the full controls + step list.
   ;   read from the per-step result record (or :event for not-yet-run)
 
 ;; CLJS local state — re-frame.story.ui.test-mode.stepper-state:
-(begin!              variant-id)       ; re-allocate the frame + prime the substrate
+(begin!              variant-id)       ; re-allocate the frame through the PRE-PLAY
+                                       ;   lifecycle (phases 0-2, no script) + prime
+                                       ;   the substrate — see §Start semantics
 (step!               variant-id)       ; run the next play STEP (any step type)
 (step-back!          variant-id)       ; restore the prior epoch + decrement cursor
 (rewind!             variant-id)       ; restore the pre-play epoch + reset cursor
@@ -468,6 +470,45 @@ clicking **Start** brings up the full controls + step list.
 (toggle-breakpoint!  variant-id index) ; toggle breakpoint at step index
 (end!                variant-id)       ; tear down (clear interval + substrate state)
 ```
+
+### Start semantics
+
+**Start prepares; it never plays.** Clicking Start runs the variant's
+PRE-PLAY lifecycle only — phases 0-2 (fresh-frame boundary, allocation,
+`:db-seed`, `:loaders`, `:setup`) through
+[`runtime/prepare-variant`](../src/re_frame/story/runtime.cljc) — and
+leaves EVERY script step pending. Cursor and app-db therefore agree at
+every position:
+
+| Cursor | Frame app-db                      | `play/stepper-state`                          |
+|--------|-----------------------------------|-----------------------------------------------|
+| 0      | the `:setup` state (pre-play)     | `:remaining` = the full script, `:ran` = `[]`  |
+| N      | the state after script steps 1..N | `:ran` = those N steps, in order               |
+
+Start MUST NOT run `run-variant` / `reset-variant`. Those compose the
+prepare half with phase 4, and a bare `:script` is auto-runnable by
+default (`play.runner/default-auto-run?`), so the whole script — and every
+effect it issues — executes BEFORE cursor 0 is published: the header reads
+"ready · N steps" over a POST-script app-db, the first Step re-runs step 1,
+and the epoch `begin!` seeds the stack with is the post-script one, so
+Rewind restores that instead of the specified initial state. That was
+rf2-k6y2, and it was deterministic rather than racy — `reset-variant`'s
+promise settles only once phase 4 has drained, so the loss was the WHOLE
+script every time, not a variable prefix.
+
+`reset-variant` keeps its full-run meaning for the `:test` pane's Re-run
+button, and the ordinary shell auto-run keeps owning phase 4 through
+`runtime/resume-run!` (see
+[`003-Render-Shell.md`](003-Render-Shell.md) §One run owner). Start
+additionally drops the one-run-owner attempt for the variant, so a
+generation that was prepared but not yet resumed cannot later run the
+script over the frame being stepped.
+
+A preparation failure — an unknown variant, a `:db-seed` that violates a
+registered schema, a throwing loader or `:setup` handler — REJECTS the
+promise `prepare-variant` returns, and `begin!` leaves the section in its
+inactive state rather than offering step controls over a frame that never
+reached `:ready`.
 
 ### Controls
 
@@ -495,8 +536,10 @@ threads the variant frame's epoch history (per
 `:epoch-id` (the head of `epoch-history`) and pushes it onto an
 `:epoch-stack`. Step-back POPS the stack and `epoch/restore-epoch!`s
 against the new head, then decrements the cursor. Rewind restores
-against the bottom-of-stack epoch (the pre-play state) and resets
-the cursor to 0. That epoch-restore alone rewinds the frame's
+against the bottom-of-stack epoch and resets the cursor to 0 — that
+bottom entry is the epoch Start's prepare-only lifecycle left behind,
+which is the pre-play state precisely BECAUSE Start ran no script step
+(§Start semantics above). That epoch-restore alone rewinds the frame's
 `[:rf.story/assertions]` slot (rf2-luzky — the assertions live in the
 frame's app-db, so a fresh forward run starts clean without a separate
 accumulator reset).

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -7,6 +7,9 @@
   - `run-variant`     — allocate frame; run four-phase lifecycle;
                         return a promise/future of the result map.
   - `reset-variant`   — tear down and re-run.
+  - `prepare-variant` — re-run phases 0-2 ONLY (loaders + setup, no
+                        script), for a caller that owns the script itself
+                        — the `:test` pane's step-debugger.
   - `watch-variant`   — subscribe to lifecycle transitions.
   - `snapshot-identity` — re-export of `re-frame.story.identity/snapshot-identity`.
 
@@ -1726,6 +1729,58 @@
      (reset-run-owner! variant-id)
      (rf.story.frames/destroy! variant-id))
    (run-variant variant-id opts)))
+
+;; ---- prepare-variant -----------------------------------------------------
+
+(defn prepare-variant
+  "Re-run the PREPARE half of the four-phase lifecycle for `variant-id` —
+  phases 0-2 (fresh-frame boundary, allocation, `:db-seed`, `:loaders`,
+  `:setup`) — and STOP. The play script (phase 4) is left ENTIRELY pending.
+
+  `reset-variant`'s pre-play counterpart. Where `reset-variant` composes
+  both halves (the `:test` pane's Re-run button wants exactly that), this
+  one hands back a frame parked at the variant's documented initial state
+  with every script step still to run — the position a step-debugger's
+  Start must present (`009-Test-Mode.md` §Start semantics). Reaching that
+  position through `reset-variant` ran the whole script first, so the
+  debugger showed cursor 0 over a POST-script app-db and re-ran every step
+  and every effect it had already issued (rf2-k6y2).
+
+  Reuses `prepare-ctx!`, the SAME prepare half `run-variant` and
+  `prepare-run!` already drive, so there is no second lifecycle here. The
+  frame is reset IN PLACE by phase 0's `ensure-fresh-frame!` rather than
+  destroyed, so a canvas already mounted over this variant keeps its live
+  reactions while its app-db returns to the initial state.
+
+  Drops the one-run-owner attempt for `variant-id` (as `reset-variant`
+  does, and for the same reason): a generation that was prepared but not
+  yet resumed would otherwise let a later `resume-run!` run the whole
+  script over the frame the caller is about to step through.
+
+  Returns a promise/future that resolves to `nil` once phases 0-2 have
+  settled, and REJECTS when preparation fails — an unknown variant, a
+  `:db-seed` that violates a registered schema, a throwing loader or
+  `:setup` handler. Rejecting (rather than resolving an error result, as
+  `run-variant` does) is what lets the caller return its UI to an honest
+  inactive state instead of presenting controls over a frame that never
+  reached `:ready`.
+
+  `opts` is the standard `run-variant` opts (`:active-modes` /
+  `:cell-overrides` / `:substrate`)."
+  ([variant-id] (prepare-variant variant-id nil))
+  ([variant-id opts]
+   (if-not rf.story.config/enabled?
+     (rf.story.async/resolved nil)
+     (rf.story.async/promise
+       (fn [resolve]
+         ;; `rf.story.async/promise` rejects when this body throws, which is
+         ;; the honest settle for every prepare-half failure — including an
+         ;; unknown variant, which `prepare-context`'s plan compile already
+         ;; refuses with `:rf.error/story-unknown-variant`. Phases 0-2 are
+         ;; synchronous, so the promise has settled by the time this returns.
+         (reset-run-owner! variant-id)
+         (prepare-ctx! variant-id (rf.story.frames/variant-body variant-id) opts)
+         (resolve nil))))))
 
 ;; ---- watch-variant -------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
@@ -103,8 +103,20 @@
 
 (defn begin!
   "Initialise a step-by-step run for `variant-id`. Tears down any prior
-  stepper state, then re-allocates the variant frame (so the run starts
-  fresh) and primes the substrate via `rf.story.play/begin-stepper!`.
+  stepper state, re-allocates the variant frame through the PRE-PLAY
+  lifecycle only, and primes the substrate via
+  `rf.story.play/begin-stepper!`.
+
+  Pre-play is the whole point (spec/009 §Start semantics). `begin!` used
+  to reach its start position through `rf.story.runtime/reset-variant`,
+  which is a FULL run — phases 0-2 AND phase 4 — so a bare `:script`
+  (`:auto-run?` defaults to true) executed end to end before cursor 0 was
+  ever published: the section read \"ready · N steps\" over a POST-script
+  app-db, the first Step re-ran step 1, and Rewind's bottom-of-stack epoch
+  captured the post-script state rather than the specified initial one
+  (rf2-k6y2). `rf.story.runtime/prepare-variant` runs phases 0-2 and
+  stops, so the frame the user is shown at cursor 0 is the one the
+  variant's `:setup` describes and every step is still to run.
 
   Asynchronous: the caller may await the returned promise to drive a
   follow-up auto-resume, but the UI does not need to — the slot's
@@ -115,8 +127,8 @@
     (swap! results-atom update variant-id clear-interval!))
   (rf.story.play/end-stepper! variant-id)
   ;; Re-allocate the variant frame so the stepper starts from the
-  ;; documented initial state.
-  (-> (rf.story.runtime/reset-variant variant-id)
+  ;; documented initial state — WITHOUT running the script.
+  (-> (rf.story.runtime/prepare-variant variant-id)
       (.then  (fn [_]
                 ;; The stepper walks the FULL coerced :script
                 ;; (every step type), not just the dispatch-bearing
@@ -141,8 +153,11 @@
                   (swap! results-atom update variant-id recompute-statuses)
                   nil)))
       (.catch (fn [_]
-                ;; If reset-variant rejects we still leave the slot
-                ;; cleared so the UI returns to the inactive state.
+                ;; A preparation failure (unknown variant, an invalid
+                ;; `:db-seed`, a throwing loader / `:setup` handler) rejects.
+                ;; Leave the slot cleared so the section returns to its
+                ;; honest inactive state rather than offering step controls
+                ;; over a frame that never reached `:ready`.
                 (swap! results-atom dissoc variant-id)
                 nil))))
 

--- a/tools/story/test/re_frame/story/stepper_start_test.cljc
+++ b/tools/story/test/re_frame/story/stepper_start_test.cljc
@@ -1,0 +1,213 @@
+(ns re-frame.story.stepper-start-test
+  "Regression net for the step-debugger's START ordering (rf2-k6y2).
+
+  The `:test` pane's step-debugger promises that cursor 0 IS the pre-play
+  state: `009-Test-Mode.md` §Play step-debugger rows Start as
+  \"re-allocate the frame + prime the substrate\", labels that position
+  \"ready · N steps\", and specifies Rewind as a restore to \"the pre-play
+  epoch\". `stepper-state/begin!` used to reach that position through
+  `runtime/reset-variant`, which is a FULL run — phases 0-2 AND phase 4 —
+  so a bare `:script` (`:auto-run?` defaults to true) executed end to end
+  BEFORE cursor 0 was published. The user pressed Start, watched the whole
+  script run, and was then shown \"ready\" over a post-script app-db; the
+  first Step ran step 1 a SECOND time, and Rewind restored the post-script
+  epoch rather than the specified initial state.
+
+  The defect was deterministic, not a race: `reset-variant`'s promise
+  settles only after phase 4 has drained, so EVERY script step ran before
+  Start's continuation, every time — not a variable prefix.
+
+  These tests drive the same composition `begin!` performs — the runtime
+  seam, then `play/begin-stepper!`, then `play/step-once!` — against the
+  real plain-atom adapter + lifecycle machine + plan compiler + runner, and
+  assert the SEQUENCE the debugger observes rather than the run's end
+  state. An end-state assertion is green either way: the script produces
+  `:count` 3 whether the debugger watched it or not.
+
+  Runs on BOTH runtimes: phases 0-2 are synchronous and the script steps
+  are pure `:dispatch-sync`, so the frame's app-db and the external-effect
+  counter are settled the instant each call returns — no awaiting needed."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.play :as rf.story.play]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.story.runtime :as rf.story.runtime]
+            #?@(:clj [[re-frame.story.async :as rf.story.async]
+                      [re-frame.story.config :as rf.story.config]])))
+
+;; ---- external-effect counter (an irreversible effect proxy) --------------
+;;
+;; app-db resets hide a re-run, but an external effect cannot be un-sent —
+;; so this counter is the honest witness of whether Start executed script
+;; work behind the user's back (acceptance 3).
+
+(def ^:private ext-effect-count (atom 0))
+
+(defn- reset-all! [test-fn]
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  ;; Requiring `re-frame.epoch` installs the epoch artefact's late-bind
+  ;; hooks, so `rf/epoch-history` records a real tape and `rf/restore-epoch!`
+  ;; can travel back to the pre-play epoch the way the CLJS `rewind!` does.
+  ;; Clear the per-frame ring + listeners between tests so each run reads
+  ;; only its own epochs.
+  (rf.epoch/clear-history!)
+  (rf.epoch/clear-epoch-listeners!)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  #?(:clj (require 're-frame.machines :reload))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  #?(:clj (rf.story.config/set-global-args! {}))
+  (reset! rf.story.play/stepper-state {})
+  (reset! rf.story.play.runner-events/run-state {})
+  (reset! rf.story.play.runner-events/step-boundaries {})
+  (rf.story.runtime/reset-run-owner!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (reset! ext-effect-count 0)
+  (rf/reg-fx :probe/external-effect (fn [_ _] (swap! ext-effect-count inc)))
+  (rf/reg-event :probe/inc-and-effect
+    (fn [{:keys [db]} _]
+      {:db (update db :count (fnil inc 0))
+       :fx [[:probe/external-effect nil]]}))
+  (rf/reg-event :counter/initialise
+    (fn [{:keys [db]} [_ n]] {:db (assoc db :count (or n 0))}))
+  (test-fn))
+
+(use-fixtures :each reset-all!)
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- reg-mutating!
+  "Register a MUTATING default-auto-run variant: `:setup` seeds `:count` 0
+  and a bare three-step `:script` increments it (each increment also issues
+  the external effect). A bare `:script` omits `:auto-run?`, so
+  `runner/default-auto-run?` makes it auto-runnable — the exact shape the
+  defect needed."
+  [vid]
+  (rf.story/reg-variant vid
+    {:setup  [[:counter/initialise 0]]
+     :script [[:dispatch-sync [:probe/inc-and-effect]]
+              [:dispatch-sync [:probe/inc-and-effect]]
+              [:dispatch-sync [:probe/inc-and-effect]]]}))
+
+(defn- start!
+  "The runtime half of `stepper-state/begin!`: prepare the variant through
+  the PRE-PLAY lifecycle, then prime the stepper substrate. The CLJS
+  mutator wraps exactly this pair in its promise continuation and adds the
+  ratom slot."
+  [vid]
+  (rf.story.runtime/prepare-variant vid)
+  (rf.story.play/begin-stepper! vid))
+
+(defn- count-of [vid] (:count (rf/app-db-value vid)))
+
+(defn- slot [vid] (get @rf.story.play/stepper-state vid))
+
+;; ---- (1) Start leaves the whole script pending ---------------------------
+
+(deftest start-parks-at-the-pre-play-state
+  (testing "Start prepares phases 0-2 and runs NO script step: the frame
+            carries the :setup state, no script effect has been issued, and
+            every step is still pending"
+    (let [vid :story.stepper/mutating]
+      (reg-mutating! vid)
+      (start! vid)
+      (is (= 0 (count-of vid))
+          "cursor 0 shows the :setup state, not the post-script state")
+      (is (zero? @ext-effect-count)
+          "Start issued no script effect — nothing ran behind the user")
+      (is (= 3 (count (:remaining (slot vid))))
+          "all three steps are pending")
+      (is (= [] (:ran (slot vid)))
+          "the debugger has observed no step yet")
+      (is (= [] (:results (slot vid)))
+          "and recorded no step outcome yet"))))
+
+;; ---- (2) the observed sequence IS the performed sequence ------------------
+
+(deftest the-debugger-observes-every-step-exactly-once
+  (testing "the app-db trajectory the debugger walks is the trajectory the
+            script performs — 1:1 with the cursor, no lost prefix and no
+            repeat"
+    (let [vid :story.stepper/mutating]
+      (reg-mutating! vid)
+      (start! vid)
+      (let [trajectory (into [(count-of vid)]
+                             (mapv (fn [_]
+                                     (rf.story.play/step-once! vid)
+                                     (count-of vid))
+                                   (range 3)))]
+        (is (= [0 1 2 3] trajectory)
+            "step N moves :count from N-1 to N")
+        (is (= 3 @ext-effect-count)
+            "each script effect was issued exactly once across the run")
+        (is (= (rf.story.play/variant-play-steps vid) (:ran (slot vid)))
+            "the steps the debugger recorded are the script's steps, in order")
+        (is (= [] (:remaining (slot vid)))
+            "and the run is parked at the end")))))
+
+;; ---- (3) the pre-play epoch is the one Rewind restores -------------------
+
+(deftest rewind-restores-the-setup-state
+  (testing "the epoch Start leaves at the bottom of the stepper's epoch
+            stack is the :setup state — restoring it returns :count to 0,
+            not to the post-script 3"
+    (let [vid :story.stepper/mutating]
+      (reg-mutating! vid)
+      (start! vid)
+      (let [pre-play (-> (rf/epoch-history vid) last :epoch-id)]
+        (is (some? pre-play) "the pre-play epoch is recorded")
+        (dotimes [_ 3] (rf.story.play/step-once! vid))
+        (is (= 3 (count-of vid)) "the stepped run reached the script's end")
+        (rf/restore-epoch! vid pre-play)
+        (rf.story.play/stepper-rewind! vid)
+        (is (= 0 (count-of vid))
+            "Rewind returns the frame to the specified initial state")
+        (is (= 3 (count (:remaining (slot vid))))
+            "and every step is pending again")))))
+
+;; ---- (4) the full-run entry points are UNCHANGED -------------------------
+
+(deftest reset-variant-still-runs-the-whole-script
+  (testing "`reset-variant` keeps its full-run meaning (the Re-run button) —
+            the fix narrows what START uses, not what a re-run does"
+    (let [vid :story.stepper/mutating]
+      (reg-mutating! vid)
+      (rf.story.runtime/reset-variant vid)
+      (is (= 3 (count-of vid))
+          "reset-variant ran the script end to end, as before")
+      (is (= 3 @ext-effect-count)
+          "and issued every script effect"))))
+
+(deftest prepare-run-and-resume-run-still-split-the-lifecycle
+  (testing "the one run owner's PREPARE / RESUME split is untouched: prepare
+            alone runs no script, resume runs it exactly once"
+    (let [vid :story.stepper/mutating]
+      (reg-mutating! vid)
+      (rf.story.runtime/prepare-run! vid {:run-key {:variant-id vid}})
+      (is (= 0 (count-of vid)) "prepare ran no script step")
+      (rf.story.runtime/resume-run! vid)
+      (is (= 3 (count-of vid)) "resume ran the script")
+      (is (= 3 @ext-effect-count) "exactly once"))))
+
+;; ---- (5) a prepare failure settles honestly ------------------------------
+
+#?(:clj
+   (deftest prepare-variant-rejects-on-a-failed-preparation
+     (testing "an unregistered variant REJECTS the promise rather than
+               resolving, so the caller returns its section to the inactive
+               state instead of presenting a stepper over a frame that never
+               reached :ready"
+       (let [p (rf.story.runtime/prepare-variant :story.stepper/never-registered)]
+         (is (thrown? java.util.concurrent.ExecutionException
+                      (rf.story.async/deref-blocking p 2000)))))))

--- a/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
@@ -319,16 +319,36 @@
           prepared (atom [])
           reset    (atom [])
           ended    (atom [])]
+      ;; Each stub carries EVERY arity of the fn it stands in for.
+      ;; `prepare-variant` and `reset-variant` are both `([variant-id]
+      ;; [variant-id opts])`, so ClojureScript compiles `begin!`'s call site
+      ;; to the arity-specialised entry point
+      ;; `…prepare_variant.cljs$core$IFn$_invoke$arity$1`, and `with-redefs`
+      ;; assigns the stub straight over that fn object. A single-arity stub
+      ;; carries no such property, so the seam dies with `… is not a
+      ;; function` instead of being exercised. Clojure hides this — it
+      ;; dispatches through the var on argument count at run time — so a
+      ;; double must mirror the SHAPE of the fn it replaces, not merely the
+      ;; arity its caller happens to use.
       (with-redefs [rf.story.runtime/prepare-variant
-                    (fn [v]
-                      (swap! prepared conj v)
-                      ;; A promise that never settles: the assertions below
-                      ;; are about what `begin!` CALLS, and a pending
-                      ;; promise keeps the continuation out of the way.
-                      (js/Promise. (fn [_ _] nil)))
+                    (fn stub-prepare
+                      ([v] (stub-prepare v nil))
+                      ([v _opts]
+                       (swap! prepared conj v)
+                       ;; A promise that never settles: the assertions below
+                       ;; are about what `begin!` CALLS, and a pending
+                       ;; promise keeps the continuation out of the way.
+                       (js/Promise. (fn [_ _] nil))))
 
+                    ;; Never called — that is what `@reset` asserts. Giving it
+                    ;; the real shape anyway is what makes that negative
+                    ;; control REPORT: a regression that reached for the full
+                    ;; run would fail the assertion honestly rather than
+                    ;; erroring out before it.
                     rf.story.runtime/reset-variant
-                    (fn [v] (swap! reset conj v) (js/Promise.resolve nil))
+                    (fn stub-reset
+                      ([v] (stub-reset v nil))
+                      ([v _opts] (swap! reset conj v) (js/Promise.resolve nil)))
 
                     rf.story.play/end-stepper!
                     (fn [v] (swap! ended conj v))]

--- a/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
@@ -298,3 +298,44 @@
         (is (= [77] @cleared))
         (is (nil? (get @rf.story.ui.test-mode.stepper-state/results-atom vid))
             "the slot is removed from the local atom")))))
+
+;; ---- begin! ---------------------------------------------------------------
+
+(deftest begin-reaches-its-start-position-through-the-pre-play-lifecycle
+  (testing "begin! prepares the variant through
+            `rf.story.runtime/prepare-variant` — phases 0-2, script left
+            pending — and NEVER through `reset-variant`, whose promise
+            settles only once phase 4 has run the whole script, so the
+            section would show cursor 0 over a post-script app-db (rf2-k6y2).
+
+            Synchronous by construction: `begin!` calls the seam before it
+            returns its promise, and the redefined seam never settles, so
+            the continuation cannot run outside the redef scope. The
+            behaviour behind the seam — Start parks at the `:setup` state,
+            each Step is 1:1 with the cursor, Rewind restores the pre-play
+            epoch — is pinned on both runtimes by
+            `re-frame.story.stepper-start-test`."
+    (let [vid      :story.unit/begin-seam
+          prepared (atom [])
+          reset    (atom [])
+          ended    (atom [])]
+      (with-redefs [rf.story.runtime/prepare-variant
+                    (fn [v]
+                      (swap! prepared conj v)
+                      ;; A promise that never settles: the assertions below
+                      ;; are about what `begin!` CALLS, and a pending
+                      ;; promise keeps the continuation out of the way.
+                      (js/Promise. (fn [_ _] nil)))
+
+                    rf.story.runtime/reset-variant
+                    (fn [v] (swap! reset conj v) (js/Promise.resolve nil))
+
+                    rf.story.play/end-stepper!
+                    (fn [v] (swap! ended conj v))]
+        (rf.story.ui.test-mode.stepper-state/begin! vid)
+        (is (= [vid] @prepared)
+            "Start prepares the variant through the pre-play lifecycle")
+        (is (= [] @reset)
+            "Start never runs the full reset/run path")
+        (is (= [vid] @ended)
+            "any prior stepper session is torn down first")))))


### PR DESCRIPTION
## The defect

`stepper-state/begin!` reached its start position through
`runtime/reset-variant`, which is a **full** run — phases 0-2 **and**
phase 4 — and awaited its promise before publishing cursor 0. A bare
`:script` is auto-runnable by default (`play.runner/default-auto-run?`),
so the whole script executed end to end **before** the user was shown
step 0.

**Deterministic, not racy.** `reset-variant`'s promise settles only once
phase 4 has drained, so the loss was the WHOLE script every time, not a
variable prefix. That matters for what a witness has to assert, and it is
now stated in the spec.

Measured on a mutating three-step variant (`:setup` seeds `:count` 0,
three `[:dispatch-sync [:probe/inc-and-effect]]` steps), driving the same
composition `begin!` performs:

| | expected | pre-fix actual |
|---|---|---|
| app-db at cursor 0 | `0` | `3` |
| external effects issued by Start alone | `0` | `3` |
| app-db trajectory across Start + 3 Steps | `[0 1 2 3]` | `[3 4 5 6]` |
| external effects over the whole stepped run | `3` | `6` |
| app-db after Rewind | `0` | `3` |

So every script step and every effect it issues ran **twice**, and Rewind
restored the post-script epoch `begin!` had captured.

## The contract

`tools/story/spec/009-Test-Mode.md` already **mandated** the correct
outcome and was contradicted by the code — it rows `begin!` as
"re-allocate the frame + prime the substrate", labels cursor 0 "ready ·
N steps", and specifies Rewind as a restore to "the pre-play epoch"/"the
pre-play state". What it did not say was the *mechanism*, which is what
let the wrong one in. A new **§Start semantics** states it: Start runs the
pre-play lifecycle only, cursor and app-db agree at every position, and
Start MUST NOT run `run-variant` / `reset-variant`.

## The fix

`runtime/prepare-variant` — `reset-variant`'s pre-play counterpart:

- reuses `prepare-ctx!`, the **same** prepare half `run-variant` and
  `prepare-run!` already drive, so there is no second lifecycle;
- resets the frame **in place** via phase 0's `ensure-fresh-frame!` rather
  than destroying it, so a mounted canvas keeps its live reactions;
- drops the one-run-owner attempt, so a generation that was prepared but
  not yet resumed cannot later run the script over the frame being
  stepped;
- **rejects** on a prepare failure (unknown variant, invalid `:db-seed`, a
  throwing loader / `:setup` handler), which is what lets `begin!`'s
  existing `.catch` return the section to an honest inactive state.

`run-variant` / `reset-variant` / `prepare-run!` / `resume-run!` and the
`:auto-run?` default are untouched — the Re-run button and the ordinary
shell auto-run behave exactly as before, and two tests pin that.

## Witness

`tools/story/test/re_frame/story/stepper_start_test.cljc` — a `.cljc`
regression net that asserts the **sequence the debugger observes**, not
the run's end state (an end-state assertion is green either way: the
script produces `:count` 3 whether the debugger watched it or not).

Six tests: Start parks at the `:setup` state with every step pending and
no effect issued; the app-db trajectory is `[0 1 2 3]` and the recorded
`:ran` steps equal the script's steps in order; Rewind's pre-play epoch
restores `:count` to 0; `reset-variant` still runs the whole script;
`prepare-run!`/`resume-run!` still split the lifecycle; a failed
preparation rejects.

**Fails before, passes after — same file, same instrument**, the only
difference being which seam the test's `start!` helper names (the pre-fix
tree's `begin!` named `reset-variant`):

```
before:  Ran 6 tests containing 19 assertions.  6 failures, 0 errors.   exit 1
after:   Ran 6 tests containing 19 assertions.  0 failures, 0 errors.   exit 0
```

`stepper_state_cljs_test.cljs` gains one CLJS test pinning `begin!`'s own
seam (it calls `prepare-variant`, never `reset-variant`) in that file's
established redef idiom, synchronous by construction — the redefined seam
returns a promise that never settles, so the continuation cannot escape
the redef scope.

## Gates

All exit codes below are from the runner's own `$?`, captured to a file.

| Gate | Result |
|---|---|
| `tools/story` `clojure -M:test` — **before**, untouched base | 1889 tests / 6959 assertions, 0 failures, 0 errors, **exit 0** |
| `tools/story` `clojure -M:test` — **after**, on the rebased base | 1895 tests / 6978 assertions, 0 failures, 0 errors, **exit 0** |
| witness alone, pre-fix composition | 6 failures, **exit 1** |
| witness alone, post-fix | 0 failures, **exit 0** |
| `scripts/check_doc_slugs.py` | **exit 0** |
| `scripts/check_readme_links.py --ci` | **exit 0** |
| `scripts/check_require_alias_dialect.py --verbose` | **exit 0** — 2779 files, 10806 edges, every surface at or under its floor |
| `re-frame.api-manifest.gen --check` | **exit 0** — in sync, 527 public vars |
| `re-frame.api-manifest.story-spec-check` | **exit 0** — 68 var references in sync |

The +6 tests / +19 assertions delta is exactly the new namespace.

**The slug gate was proven live rather than trusted**: a planted broken
target and broken anchor in the edited `009-Test-Mode.md` (CRLF-anchored,
match count asserted) turned it **exit 1** naming both at line 476 of that
file; removing the plant returned it to exit 0.

## Coverage notes

- `python -m mkdocs build --strict` does **not** cover `tools/story/spec/`
  (outside `docs_dir`), so it is not cited here.
- Neither doc gate reads inside a fenced code block, so the `(begin! …)`
  surface-block edit was **hand-checked**. Anchors and table column counts
  in the new §Start semantics were hand-checked too (the new table is 3
  columns across header, separator and both rows); the one cross-file
  reference is a plain file link with no anchor.
- The CLJS/browser lane was not run locally (this worktree has no
  `node_modules`, and the brief forbade linking into the shared one). CI's
  `test:cljs` carries `../tools/story/test` on its source paths.
- `tools/story/README.md` is unchanged: the claim it makes at lines 28-34
  ("the canvas re-rendering against each step's app-db") is precisely the
  one this fix restores.
- No `tools/story` public **export** is added, removed or renamed —
  `prepare-variant` is a `re-frame.story.runtime` sub-namespace fn like
  `prepare-run!` / `resume-run!`, not a `re-frame.story` facade export, and
  `gen --check` confirms the manifest is unchanged. `tools/story/spec/API.md`
  is untouched.

Closes rf2-k6y2.
