### PR TITLE
fix(xray): frame-stamp the managed-HTTP testbed's seeded handles (rf2-s4dp)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/testbed_managed_http_frame_scope_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/testbed_managed_http_frame_scope_test.clj
@@ -1,0 +1,208 @@
+(ns day8.re-frame2-xray.testbed-managed-http-frame-scope-test
+  "Guard the FRAME SCOPE of the MANAGED-HTTP testbed's registry seams
+  (rf2-s4dp, parent rf2-o8ek).
+
+  ## The problem
+
+  PR #9195 made managed-HTTP cancellation frame-scoped: the in-flight and
+  actor-in-flight indexes key on `(frame-id, id)` rather than the raw id,
+  read off the `:frame` stamp the live transport puts on every handle it
+  records. To avoid a flag day it deliberately KEPT the frame-less arities
+  as documented ANY-FRAME seams.
+
+  That combination has a sharp edge: a call site that was correct BEFORE
+  #9195 is silently wrong after it. A handle recorded without a `:frame`
+  keys under `nil` — a scope no frame-scoped abort can reach — and nothing
+  errors. `tools/xray/testbeds/managed_http/core.cljs` seeds its handles by
+  hand (a real Fetch against a dev-http static server resolves instantly,
+  leaving nothing observably in-flight), so it is exactly such a site, and
+  its step 5 dispatches the live `:rf.http/managed-abort` fx at the handle
+  step 1 seeded. Measured on the pre-fix source with a JVM registry probe:
+
+      {:keyed-under ([nil :xray/in-flight]),
+       :any-frame-finds? true,
+       :real-frame-finds? false,
+       :managed-abort-hits? false}
+
+  — the abort step resolved NOTHING, and did so silently. An any-frame
+  sweep still \"works\" in a single-frame testbed, which is why no existing
+  gate caught it.
+
+  ## Why this guard is source-text rather than a live registry probe
+
+  `day8/re-frame2-http` is NOT on `tools/xray`'s classpath (not even under
+  the `:test` alias), so this suite cannot drive the real registry, and the
+  testbed is a `.cljs` file compiled only by its shadow-cljs browser build,
+  which carries no spec.cjs for this path. Slurping the committed source
+  and asserting the frame-scoping laws is therefore the reachable witness —
+  the same posture as `coverage_matrix_metadata_test.clj` and the other
+  source-text guards in this directory.
+
+  ## What this guard enforces
+
+  Two specific laws, stated over EVERY `record-in-flight!` call in the
+  testbed rather than over three hand-named functions, so a NEW seeding fx
+  inherits them:
+
+    1. An fx that records a registry handle must not discard its fx
+       context (`_frame-ctx`), and every `record-in-flight!` call must
+       stamp `:frame`.
+    2. Cleanup and actor-destroy must use the FRAME-EXACT forms, never the
+       any-frame seams (`clear-in-flight!` 1-arg, `abort-on-actor-destroy`
+       1-arg), and a deferred `rf/dispatch` from inside an `:abort-fn` must
+       carry `{:frame frame}` — by then there is no ambient frame, and in
+       re-frame2 frame identity is carried, not found."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+;; ---- file resolution ----------------------------------------------------
+
+(def ^:private testbed-rel
+  ["tools" "xray" "testbeds" "managed_http" "core.cljs"])
+
+(defn- find-repo-root
+  "Walk up from `user.dir` until the testbed source resolves — robust
+  whether the `:test` alias runs from `tools/xray` or the repo root.
+  Mirrors `coverage_matrix_metadata_test.clj`."
+  []
+  (loop [dir (io/file (System/getProperty "user.dir"))]
+    (when (nil? dir)
+      (throw (ex-info (str "testbed-managed-http-frame-scope: could not locate "
+                           (str/join "/" testbed-rel)
+                           " walking up from " (System/getProperty "user.dir"))
+                      {})))
+    (if (.exists (apply io/file dir testbed-rel))
+      dir
+      (recur (.getParentFile dir)))))
+
+(def ^:private source
+  (delay (slurp (apply io/file (find-repo-root) testbed-rel))))
+
+;; ---- balanced-form extraction -------------------------------------------
+;;
+;; Text scanning, not `read-string`: the source is CLJS carrying
+;; auto-resolved keywords and hiccup metadata, and we only need each fx
+;; form's own text. The scanner tracks strings, escapes and line comments
+;; so a paren inside any of them cannot unbalance the form.
+
+(defn- balanced-form
+  "The substring of `s` starting at `start` (which must index a `(`) up to
+  and including its matching `)`. Returns nil when unbalanced."
+  [^String s ^long start]
+  (loop [i     start
+         depth 0
+         in-str? false
+         in-cmt? false]
+    (if (>= i (.length s))
+      nil
+      (let [c (.charAt s i)]
+        (cond
+          in-cmt? (recur (inc i) depth in-str? (not= c \newline))
+          in-str? (cond
+                    (= c \\) (recur (+ i 2) depth true false)
+                    (= c \") (recur (inc i) depth false false)
+                    :else    (recur (inc i) depth true false))
+          (= c \\) (recur (+ i 2) depth false false)   ; char literal, e.g. \(
+          (= c \") (recur (inc i) depth true false)
+          (= c \;) (recur (inc i) depth false true)
+          (= c \() (recur (inc i) (inc depth) false false)
+          (= c \)) (if (= depth 1)
+                     (subs s start (inc i))
+                     (recur (inc i) (dec depth) false false))
+          :else    (recur (inc i) depth false false))))))
+
+(defn- fx-form
+  "The full text of the `(rf/reg-fx <fx-id> ...)` form registering `fx-id`."
+  [fx-id]
+  (let [s     @source
+        needle (str "(rf/reg-fx " fx-id)
+        idx   (str/index-of s needle)]
+    (when idx (balanced-form s idx))))
+
+(defn- fx-forms
+  "Every `(rf/reg-fx ...)` form in the testbed, as text."
+  []
+  (let [s @source]
+    (loop [from 0 acc []]
+      (if-let [idx (str/index-of s "(rf/reg-fx " from)]
+        (if-let [form (balanced-form s idx)]
+          (recur (+ idx (count form)) (conj acc form))
+          (recur (+ idx 11) acc))
+        acc))))
+
+;; A `record-in-flight!` call site is the thing these laws bind. Matching on
+;; the CALL rather than on a function name is what makes a newly added
+;; seeding fx inherit the guard instead of escaping it.
+(defn- records-handle? [form] (str/includes? form "record-in-flight!"))
+
+;; ---- the extractor itself is under test ---------------------------------
+;;
+;; A source-text guard whose scanner silently returned nil would pass every
+;; assertion below by vacuity, so pin the scanner before trusting it.
+
+(deftest balanced-form-scanner-works
+  (testing "matching paren, ignoring parens in strings, comments and char literals"
+    (is (= "(a b)"            (balanced-form "(a b) trailing" 0)))
+    (is (= "(a (b c) d)"      (balanced-form "(a (b c) d)" 0)))
+    (is (= "(a \")\" b)"      (balanced-form "(a \")\" b)" 0)))
+    (is (= "(a ; )\nb)"       (balanced-form "(a ; )\nb)" 0)))
+    (is (= "(a \\) b)"        (balanced-form "(a \\) b)" 0)))
+    (is (nil? (balanced-form "(a b" 0)) "unbalanced input returns nil")))
+
+(deftest testbed-source-is-readable
+  (testing "the testbed source is present and non-trivial"
+    (is (str/includes? @source "managed-http.core"))
+    (is (> (count @source) 5000)
+        "a truncated or empty read would make every law below vacuous"))
+  (testing "the fx forms the laws bind are actually found"
+    (is (seq (fx-forms)))
+    (is (some? (fx-form ":managed-http/seed-in-flight")))
+    (is (some? (fx-form ":managed-http/issue-as-actor")))
+    (is (some? (fx-form ":managed-http/destroy-actor")))
+    (is (>= (count (filter records-handle? (fx-forms))) 2)
+        "both seeding fxs record a registry handle")))
+
+;; ---- law 1: every recorded handle carries its issuing frame -------------
+
+(deftest recorded-handles-are-frame-stamped
+  (doseq [form (filter records-handle? (fx-forms))]
+    (testing "an fx that records a registry handle keeps its fx context"
+      (is (not (str/includes? form "_frame-ctx"))
+          (str "a `record-in-flight!` fx discards its frame context; the "
+               "issuing frame is available on it and MUST be stamped on the "
+               "handle. Offending form:\n" form)))
+    (testing "and stamps :frame on the handle it records"
+      (is (re-find #":frame\s+frame" form)
+          (str "handle recorded without a `:frame` stamp keys under nil — a "
+               "scope no frame-scoped abort can reach. Offending form:\n"
+               form)))))
+
+;; ---- law 2: cleanup and destroy use the frame-exact forms ---------------
+
+(deftest cleanup-paths-are-frame-exact
+  (testing "the seeded handle's abort-fn clears frame-exactly"
+    (let [form (fx-form ":managed-http/seed-in-flight")]
+      (is (str/includes? form "clear-in-flight-in-frame!"))
+      (is (not (re-find #"clear-in-flight!\s+request-id" form))
+          "the one-arg `clear-in-flight!` is an ANY-FRAME sweep: it would
+           deregister a sibling frame's live slot under the same id")
+      (testing "and its deferred dispatch carries the frame"
+        ;; The abort-fn runs later, with no ambient frame around it; a bare
+        ;; `rf/dispatch` in there raises :rf.error/no-frame-context.
+        (is (re-find #"\{:frame\s+frame\}" form)))))
+
+  (testing "actor destroy uses the frame-scoped 2-arity"
+    (let [form (fx-form ":managed-http/destroy-actor")]
+      (is (re-find #"abort-on-actor-destroy\s+\(:frame\s+frame-ctx\)\s+actor-id"
+                   form)
+          "the 1-arity is the documented ANY-FRAME seam; it sweeps the
+           actor-id in EVERY frame, which is the reach the frame-scoped
+           keys removed from the abort half")))
+
+  (testing "the reset fx may still clear globally — that is its job"
+    ;; `clear-all-in-flight!` is global BY INTENT (the deck's reset button
+    ;; drops every registry slot). Pinned so the law above is not misread as
+    ;; banning every unscoped registry call.
+    (is (str/includes? (fx-form ":managed-http/clear-registry")
+                       "clear-all-in-flight!"))))

--- a/tools/xray/testbeds/managed_http/core.cljs
+++ b/tools/xray/testbeds/managed_http/core.cljs
@@ -213,19 +213,37 @@
                :rf.http/aborted reply + clears the slot — so the LIVE
                :rf.http/managed-abort fx resolves it end-to-end."
    :platforms #{:client}}
-  (fn fx-seed-in-flight [_frame-ctx {:keys [request-id]}]
-    (rf.http.registry/record-in-flight!
-      request-id nil
-      {:url      pending-url
-       :abort-fn (fn [reason]
-                   (rf.http.registry/clear-in-flight! request-id)
-                   ;; rf2-ibksxg — the canonical abort reply: :status :cancelled
-                   ;; with the :rf.http/aborted map under :error.
-                   (rf/dispatch [::reply {:status        :cancelled
-                                          :cancelled?    true
-                                          :cancel/reason reason
-                                          :error         {:kind   :rf.http/aborted
-                                                          :reason reason}}]))})
+  (fn fx-seed-in-flight [frame-ctx {:keys [request-id]}]
+    ;; The ISSUING FRAME, read off this fx's context. A `:request-id` is
+    ;; frame-LOCAL (Spec 014 §Frame scope), so the registry keys cancellation
+    ;; on (frame, request-id) and the live :rf.http/managed-abort fx resolves
+    ;; only its OWN frame's handle. The frame is also what the deferred
+    ;; abort-fn dispatches under: by the time it runs there is no ambient
+    ;; frame, and in re-frame2 frame identity is CARRIED, not found.
+    (let [frame (:frame frame-ctx)]
+      (rf.http.registry/record-in-flight!
+        request-id nil
+        {:url      pending-url
+         ;; Stamped exactly as the live transport stamps every handle it
+         ;; records. Not decoration: an UNSTAMPED handle keys under `nil`,
+         ;; a scope no frame-scoped abort can reach, which would leave the
+         ;; abort step (5) below silently resolving nothing (rf2-s4dp).
+         :frame    frame
+         :abort-fn (fn [reason]
+                     ;; Frame-EXACT cleanup, for the same reason lookup is
+                     ;; frame-scoped. `clear-in-flight!`'s one-arg form is an
+                     ;; ANY-FRAME sweep — it would clear this id in EVERY
+                     ;; frame, so a sibling mount's live slot would be
+                     ;; deregistered along with this one.
+                     (rf.http.registry/clear-in-flight-in-frame! frame request-id)
+                     ;; rf2-ibksxg — the canonical abort reply: :status :cancelled
+                     ;; with the :rf.http/aborted map under :error.
+                     (rf/dispatch [::reply {:status        :cancelled
+                                            :cancelled?    true
+                                            :cancel/reason reason
+                                            :error         {:kind   :rf.http/aborted
+                                                            :reason reason}}]
+                                  {:frame frame}))}))
     nil))
 
 (rf/reg-event ::fire-in-flight
@@ -301,11 +319,18 @@
                populated, exercising the per-actor in-flight surface
                without spawning a real machine actor."
    :platforms #{:client}}
-  (fn fx-issue-as-actor [_frame-ctx {:keys [actor-id request-id]}]
-    (rf.http.registry/record-in-flight!
-      request-id actor-id
-      {:abort-fn (fn [_reason] nil)
-       :url      pending-url})
+  (fn fx-issue-as-actor [frame-ctx {:keys [actor-id request-id]}]
+    ;; Same carried frame as the seed fx above, and for the same reason: the
+    ;; ACTOR index is keyed (frame, actor-id) too, so an unstamped handle
+    ;; lands in the `nil` scope while every other slot in this testbed sits
+    ;; under the host frame. Actor addresses are frame-LOCAL, exactly as
+    ;; request-ids are (rf2-s4dp).
+    (let [frame (:frame frame-ctx)]
+      (rf.http.registry/record-in-flight!
+        request-id actor-id
+        {:abort-fn (fn [_reason] nil)
+         :frame    frame
+         :url      pending-url}))
     nil))
 
 (rf/reg-event ::concurrent-by-actor
@@ -322,12 +347,19 @@
 ;; path a :rf.machine/destroy cascade / frame teardown drives.
 (rf/reg-fx :managed-http/destroy-actor
   {:doc       "Testbed-only fx: drive the framework abort-on-actor-destroy
-               for the supplied actor-id — the SAME path a state-machine
-               actor destroy / frame teardown takes (Spec 014 §Abort on
-               actor destroy)."
+               for the supplied actor-id, FRAME-SCOPED — the isolated form
+               a state-machine actor destroy / frame teardown takes (Spec
+               014 §Abort on actor destroy)."
    :platforms #{:client}}
-  (fn fx-destroy-actor [_frame-ctx {:keys [actor-id]}]
-    (rf.http.managed/abort-on-actor-destroy actor-id)
+  (fn fx-destroy-actor [frame-ctx {:keys [actor-id]}]
+    ;; The 2-arity is the FRAME-SCOPED form: it aborts only this frame's
+    ;; actor, leaving a same-named actor in a sibling frame untouched. The
+    ;; 1-arity is the documented ANY-FRAME seam, which sweeps the actor-id in
+    ;; EVERY frame — the very reach the frame-scoped keys removed from the
+    ;; abort half, so a testbed demonstrating the contract should not model
+    ;; it (rf2-s4dp). Actor addresses are frame-local, so this pairs with the
+    ;; :frame stamp `issue-as-actor` puts on the handles it records.
+    (rf.http.managed/abort-on-actor-destroy (:frame frame-ctx) actor-id)
     nil))
 
 (rf/reg-event ::actor-teardown


### PR DESCRIPTION
## Verdict

**PREMISE HOLDS**, reproduced at tip before any edit. The bead was filed before #9202 and #9210 merged; neither touched this file, and the defect was still live on `bb03f6291c`.

`tools/xray/testbeds/managed_http/core.cljs` step 5 dispatches the live `:rf.http/managed-abort` fx at the handle step 1 seeds. Since #9195 that fx is frame-scoped — `managed-abort-handler` calls `require-frame-stamp!` then `abort-in-flight-in-frame!` with the real frame-id — but the seed fx bound `_frame-ctx` and recorded a handle with no `:frame`, so the handle keyed under `nil`. **The abort step resolved nothing, and did so silently.**

This is the #9195 trap: the frame-less arities were deliberately kept as documented ANY-FRAME seams so there would be no flag day, and the consequence is that a call site correct *before* that change is silently wrong after it. An any-frame sweep still "works" in a single-frame testbed, which is why nothing caught it.

## Reproduction

Against the real registry from `implementation/http` (read-only, exit 0), the pre-fix seed shape reproduces the bead's measurement byte-for-byte:

```
:BEFORE {:keyed-under ([nil :xray/in-flight]), :any-frame-finds? true,
         :real-frame-finds? false, :managed-abort-hits? false}
:AFTER  {:keyed-under ([:rf/default :xray/in-flight]), :any-frame-finds? true,
         :real-frame-finds? true, :managed-abort-hits? true}
```

## Fix

Mirrors the merged rf2-o8ek audit fix in `examples/core/managed_http_counter/core.cljs` — the audited precedent for this exact shape, followed rather than re-invented:

- **`seed-in-flight`** — binds `(:frame frame-ctx)`, stamps `:frame` on the handle, cleans up through `clear-in-flight-in-frame!` instead of the one-arg any-frame sweep, and carries `{:frame frame}` on the deferred dispatch (the `:abort-fn` runs with no ambient frame; frame identity is *carried, not found*).
- **`issue-as-actor`** — a SECOND site the bead did not name, found by the census: it recorded actor handles unstamped too, keying them under `[nil actor-id]`. Now stamped.
- **`destroy-actor`** — now calls the frame-scoped 2-arity of `abort-on-actor-destroy` rather than the any-frame seam, so step 7 exercises the isolated form the contract describes. A testbed is a test surface: the step should genuinely exercise the frame-scoped path, not merely stop erroring.

`clear-registry` deliberately still calls `clear-all-in-flight!` — global by intent (the deck's reset button), and pinned by the guard so the law is not misread as banning every unscoped registry call.

## Census

Over `tools/xray/testbeds/**`, on two token axes (symbol names `record-in-flight!` / `clear-in-flight!` / `abort-on-actor-destroy` / `supersede!` / `abort-in-flight*`, and the `_frame-ctx` discard idiom). **Every registry call site in the tree is in this one file** — four `_frame-ctx` bindings, of which two were defects (both fixed), one is the reset fx (correct), one is `destroy-actor` (now frame-scoped).

Checked and clean beyond the fence, reported not edited: `testbeds/tenant_switcher/core.cljs` (its matches are a comment naming the late-bind hook, plus a `::fake-http` stub that never touches the registry and dispatches synchronously), and `tools/xray/test/.../managed_fx_helpers_cljs_test.cljc` (already stamps `:frame :rf/default` throughout).

## Witness

`tools/xray/test/day8/re_frame2_xray/testbed_managed_http_frame_scope_test.clj` — a JVM guard asserting the frame-scoping laws over **every `record-in-flight!` call** in the testbed rather than three hand-named functions, so a newly added seeding fx inherits them.

It is source-text rather than a live registry probe for a measured reason: `day8/re-frame2-http` is **not on `tools/xray`'s classpath even under `:test`** (verified via `clojure -Spath -A:test`), and the testbed compiles only in a `:browser` build carrying no `spec.cjs`. That is the same posture as `coverage_matrix_metadata_test.clj` and the other source-text guards in that directory. The balanced-paren scanner is itself under test, and the source-readability assertions are pinned, so the laws cannot pass by vacuity.

**Negative control** (testbed reverted to HEAD, guard kept): exit 1, **8 failures, 0 errors** — semantic failures, not read errors. Both laws fired, across both seeding fxs and all four cleanup assertions. Restored and verified byte-identical on both `git hash-object` and `--no-filters`.

## Gates (captured exits, never read through a filter)

- `tools/xray` `clojure -M:test` **BEFORE**: exit 0, 1270 tests / 6100 assertions
- `tools/xray` `clojure -M:test` **AFTER**, on the final rebased base `8875545d4f`: exit 0, **1274 / 6122** (+4 deftests, +22 assertions — the delta confirms the run saw this tree)
- `scripts/check_require_alias_dialect.py`: exit 0 (the new file adds no re-frame require edges; `tools` floor untouched)
- CLJS reader check of the modified testbed under `:features #{:cljs}`: exit 0, 35 forms — no compiler reaches this file locally, so this is what stands in for it. All four call arities were additionally verified against their definitions (`clear-in-flight-in-frame!` `[frame-id request-id]`; `abort-on-actor-destroy` `[frame-id actor-id]`; `dispatch` `([event-vec] [event-vec opts])`; `record-in-flight!` unchanged).

**`npm run test:cljs` declined, and it is not coverage I am implying:** the `:node-test` build is `:ns-regexp "cljs-test$"`, which matches neither `managed-http.core` nor this `.clj` guard, so that suite cannot reach either changed file. **No CI workflow builds `:examples/managed-http`**, and this worktree has no `implementation/node_modules`; I did not create a junction into the mayor's.

`mkdocs build --strict` and `check_doc_slugs.py` are **not** the gates here — neither covers `tools/xray/`, and no markdown changed.

## Spec

**Spec unchanged because `tools/xray/spec/*` does not describe this testbed** — searching that tree for `managed_http` / `managed-http` / `abort-on-actor-destroy` / `managed-abort` returns zero, with a control search (`feature_matrix` / `Coverage matrix`: 10 occurrences across 4 files) proving the instrument executes over it. No coverage-matrix row references this testbed and the repair changes no Xray contract.

## Fence

Confined to `tools/xray/testbeds/**` plus the one new guard under `tools/xray/test/**`. Nothing under `implementation/http/**`, `implementation/machines/**`, `implementation/core/**` or `spec/014-HTTPRequests.md` was touched — PR #9212 (rf2-wjfm) holds those and is still open; `examples/core/managed_http_counter/core.cljs` was read as the precedent, not edited.

One interaction worth flagging for the merge order: rf2-wjfm records that after #9212 **no in-repo destroy path calls the any-frame 1-arity**. Moving `destroy-actor` to the frame-scoped 2-arity is correct on this base and stays correct after #9212 lands, so the two do not conflict.

Closes rf2-s4dp.
