### PR TITLE
docs(hicasso): naming-packet.md's witness column names three retirements it predates (rf2-pvmy)

### DIFF
--- a/docs/design/hicasso/product/naming-packet.md
+++ b/docs/design/hicasso/product/naming-packet.md
@@ -22,6 +22,57 @@ is a complete instruction, and the mayor records it.
 (§2) and are not up for re-decision. Everything else in §3 is this packet's judgement and
 is overturnable at no cost beyond the diff sweep.
 
+> **[Currency, 2026-09-05, `rf2-pvmy`. Three post-publication retirements reached this page's
+> Witness column. Every row below is left standing and none is re-scored.]** This packet was
+> written before the `rf2-6c12m` dead-weight sweep and reads throughout as though the surfaces
+> and instruments it cites still stand. Three separate events — none of them a naming decision
+> — are what a reader has to carry:
+>
+> - **The native tier, 2026-08-29 — `aa01f0e8a6` (`rf2-6c12m.31`, wave 2 of ruling
+>   `rf2-6c12m.3` Option A).** `re-frame.hicasso.native` was shrunk to 82 lines publishing
+>   `use-sub` and `use-frame` alone, and the eight `native_*` suites were deleted with it. That
+>   reaches **all of §3.2 Bucket B except row 10**: `n/$` (7), `n/props` (8), `n/defcomponent`
+>   (9), `n/memo`/`n/lazy` (29), `n/component` (43), `n/marker`/`n/tier-sentinel` (44),
+>   `n/el`/`n/props*`/`n/declared-server` (45 and C3-2) and `n/prop-slots` (46) name nothing at
+>   tip, and the four suites their Witness column cites —
+>   `native_surface_cljs_test.cljs` (5 citations), `native_grammar_cljs_test.cljs` (2),
+>   `native_abi_cljs_test.cljs` (1) and `native_hooks_cljs_test.cljs` (1) — resolve to no file.
+>   **Two of those rows cite a suite that still exists and is no longer their witness**, which
+>   a file-existence check would pass: `three_way_parity_cljs_test.cljs` (row 7) reads only
+>   `n/use-sub` today, and `lazy_boundary_dom_cljs_test.cljs` (rows 29 and 43) drives a raw
+>   `react/lazy` through `h/defhost` and names neither `n/memo` nor `n/lazy`. A live file is not
+>   a live witness. **Row 10 is the one row whose subject and witness both survive**: `n/use-sub`
+>   and `n/use-frame` are driven at tip by `hooks_island_cljs_test.cljs` and
+>   `hooks_island_dom_cljs_test.cljs`, and [`correction-ledger.md`](correction-ledger.md) names
+>   the second of those as the suite that took other native subjects ahead of the deletion.
+>
+> - **Facade and gate hygiene, 2026-08-29/30 — `rf2-6c12m.15` (PR #8779) and `bb3a92cd73`
+>   (`rf2-6c12m.8`, PR #8775).** The first removed `h/use-subs` from the door and from
+>   `impl.collector`, struck HS-41, and demoted `::h/navigate` to the implementation keyword
+>   `:re-frame.hicasso.impl.intent/navigate`, off the public marker table — so **rows 48 and 35
+>   describe surfaces that are gone**, each amended on its own row below. The second deleted
+>   `check_facade_inventory.py` alongside `check_naming_census.py`, so the gate this page cites
+>   six times — rows 6 and 47, §4.1, §4.2 twice and §7 — no longer exists. §7 already records
+>   that commit for the census gate; this note extends it to the inventory gate, which the §7
+>   amendment does not name.
+>
+> - **The census suites, 2026-08-29 — `1f98f63a58` (`rf2-6c12m.22`).** A *different* cut from
+>   the native one, earlier the same day and on its own reasoning: suites that measured the
+>   programme rather than the product were retired, their measurements kept on the pages that
+>   publish them. `readset_group_census_cljs_test.cljs` — row 48's witness, and the one retired
+>   citation on this page the native retirement does **not** explain — went in that commit, and
+>   its three measurements are preserved at
+>   [`readset-group-census.md`](readset-group-census.md).
+>
+> **What this note does and does not do.** It corrects the evidence a pending decision rests on,
+> not the decision. No row is deleted, no recommendation is re-scored, no disposition is
+> withdrawn and no replacement witness is invented where none exists: a recommendation that was
+> sound about a surface stays sound about that surface. The sitting `rf2-hic-065` has not been
+> held, so whether a keep-row whose subject no longer ships should be struck, and whether a
+> claim whose witness is retired may stand on argument, are rulings for that sitting and for
+> `rf2-2tt2`. Neither is taken here, and §1's counts below are the packet's own publication
+> reading, left as such.
+
 ## 1. Standing at publication
 
 | Measure | Count |
@@ -108,6 +159,12 @@ namespace, so its publicity bought nothing. The count is now pinned mechanically
 10 SURFACE + 4 INTERNAL by `native_surface_cljs_test.cljs`, and §4's independent
 source-side census agrees at 14.
 
+**[Amended 2026-09-05, `rf2-pvmy`.]** All three figures are historical and the pin is gone.
+`native_surface_cljs_test.cljs` was deleted with the tier on 2026-08-29 by `aa01f0e8a6`, so
+nothing is pinned mechanically at tip, and `re-frame.hicasso.native` publishes **two** names —
+`use-sub` and `use-frame` — not fourteen. The reconciliation is kept as the record of why 14
+and 15 were each right when written; it is not a reading of the tree today.
+
 ### 3.3 Bucket C — root lifecycle, error region, `as-element`
 
 | # | Current name | Candidate(s) | Recommendation — applied as default | Why (one line) | Witness | Override |
@@ -139,7 +196,7 @@ source-side census agrees at 14.
 | 32 | `forms/buffered-field` + its five props | keep | **keep as taught** | Reset unifies on `::h/revision`, which the controlled-input law already owns, so the field adds no second reset vocabulary | `forms_dom_cljs_test.cljs`; D016 | |
 | 33 | `:demand true` in `[:rf/resource …]` | keep | **keep as taught** | `:keep-previous?` is struck from the mint list — it is attested core-resources vocabulary, not a Hicasso mint | `typeahead/demand_dom_cljs_test.cljs` | |
 | 34 | owned-wins merge — no symbol minted | mint nothing; or a named helper | **mint nothing** | Verified across all 22 chapters that no page invents a symbol; this recipe is what stands in for the `:&` grammar row 2 removes | corpus sweep, ch02 and ch04 | |
-| 35 | `::h/navigate` reserved head | keep | **keep, and add it to the reserved-data list** | The brief's list omits it, so what this row owes is a reserved-vocabulary entry rather than a rename | `route_link_cljs_test.cljs` | |
+| 35 | `::h/navigate` reserved head | keep | **keep, and add it to the reserved-data list** | The brief's list omits it, so what this row owes is a reserved-vocabulary entry rather than a rename | `route_link_cljs_test.cljs` · **[Amended 2026-09-05, `rf2-pvmy`: the citation resolves two ways, and the head it names is demoted.]** Two tracked files carry that basename — `implementation/hicasso/test/re_frame/hicasso/route_link_cljs_test.cljs` and `implementation/routing/test/re_frame/route_link_cljs_test.cljs` — and this row means the **first**: it is Hicasso's route-link grammar suite and names the navigate head on four lines, where routing's is about `:route/link`'s click interception and names it on none. The head is no longer spelled `::h/navigate`: `rf2-6c12m.15` (PR #8779) demoted it to the implementation keyword `:re-frame.hicasso.impl.intent/navigate` and took it off the public marker table, and the suite now reads it through `intent/navigate-head?`. `::h/navigate` has zero occurrences under `implementation/` against a control of 30 files for `::h/revision`, so the zero is an absence and not a failed probe. **The recommendation is not re-scored** — whether a demoted head still owes a reserved-vocabulary entry is `rf2-hic-065`'s. | |
 | 36 | `:prefetch :intent` on `route-link` | keep | **keep as taught** | Routing's own `:rf.route/prefetch` event and its `:intent` value are attested, so only the link-side acceptance is new | the retired decline id stays tombstoned, never reused (`rf2-hic-021` law) | |
 | 37 | Xray evidence-envelope keyword spellings | keep | **keep as taught** | spec §10 pins this vocabulary in prose but not the keyword forms, and these are what a Tool-Pair consumer types against | `evidence_schema_cljs_test.cljs` | |
 | 38 | hydration-mismatch report `{:id :root :where :error}` | keep | **keep as taught** | `:rf.ssr/hydration-mismatch` is attested in re-frame.ssr; only the report-map keys are the mint | `identifier_prefix_ssr_dom_cljs_test.cljs` | |
@@ -205,6 +262,14 @@ two independent walks of the same door. `native_surface_cljs_test.cljs` pins
 expansion; this census reads the **source** and also reports 14. Neither agreement was
 arranged: the gate and the test were written before this census existed.
 
+**[Amended 2026-09-05, `rf2-pvmy`.]** Neither instrument survives, so this paragraph records a
+measurement rather than a standing check. `check_facade_inventory.py` was deleted on 2026-08-30
+by `bb3a92cd73` (`rf2-6c12m.8`, PR #8775), together with `check_naming_census.py` — the same
+commit §7's own amendment records for the census gate without naming this one — and
+`native_surface_cljs_test.cljs` on 2026-08-29 by `aa01f0e8a6`. **The agreement was real when
+taken and nothing here disturbs it**; what is gone is the ability to re-run either walk, which
+is what §7 preserves the method for.
+
 **What the census caught that no gate does.** `check_facade_inventory.py` reads one door by
 design, and says so — *"adding a second door here is a data change; deciding what its public
 roster IS is not, and is filed rather than guessed"*. So the 58 unrostered names outside
@@ -243,7 +308,7 @@ member is named verbatim below**, so grouping costs no completeness.
 | New row | Surface — every member named | Recommendation — applied as default | Why (one line) | Witness |
 |---|---|---|---|---|
 | 47 | `h/defview` — the primary authoring macro | **keep** | The one name every reader types first, and the ledger never carried it; there is no candidate because the whole corpus, the guide and HS-01 spell it this way | HS-01; `check_facade_inventory.py` attributes it BY NAME |
-| 48 | `h/use-subs` — the grouped read | **keep, classified SURFACE** | One fixed site takes the whole read-set, which is the control the ordinary path is measured against; it reached the door with no row anywhere until `rf2-2l8pw` minted HS-41 | HS-41; `readset_group_census_cljs_test.cljs` |
+| 48 | `h/use-subs` — the grouped read | **keep, classified SURFACE** | One fixed site takes the whole read-set, which is the control the ordinary path is measured against; it reached the door with no row anywhere until `rf2-2l8pw` minted HS-41 | HS-41; `readset_group_census_cljs_test.cljs` · **[Amended 2026-09-05, `rf2-pvmy`: the witness and the door are both gone, and for different reasons.]** The witness went on 2026-08-29 in `1f98f63a58` (`rf2-6c12m.22`), which retired the suites that measured the programme rather than the product — **not** the native retirement that reaches §3.2, and the distinction matters because that cut preserved what it measured: the three readings are at [`readset-group-census.md`](readset-group-census.md). The door went separately, under `rf2-6c12m.15` (PR #8779), which removed `h/use-subs` from the facade and from `impl.collector` and struck HS-41 — recorded in `facade_roster_ssr_dom_cljs_test.cljs`'s own docstring, and named in the slice example's `views.cljs` as the reason its two grouped-read bodies now read through `h/sub` like the rest. So this row's subject no longer exists. **It is left standing and unscored for `rf2-hic-065`**, which is the sitting that owns whether a row about a removed door is struck or kept as history. |
 | 49 | `re-frame.hicasso.forms` ids — `forms/drafts`, `forms/edit-id`, `forms/commit-id`, `forms/cancel-id` | **keep all four as shipped**, and record that they are ids rather than doors | Each is public *as an id and not as a door* — written into the field's own intents, so it is already visible in the rendered tree, in Xray and in a captured intent; a test that could not name it would be asserting on a literal | `forms.cljs` docstrings; `forms_cljs_test.cljs` |
 | 50 | `re-frame.hicasso.server` — `server/document`, `server/fresh-frame-id`, `server/payload-script`, `server/setup-events`, `server/render-twice` (`server/render` is row 22) | ~~keep all five as shipped~~ — **OVERRIDDEN (operator, 2026-08-15, `rf2-sc1dt`): keep `server/document`, `server/payload-script` and `server/render-twice`; `server/fresh-frame-id` and `server/setup-events` go PRIVATE.** Public surface is four names | The default kept all five as "the request pipeline `server/render` composes". The sitting split them on evidence instead: each survivor does something for an external host that `server/render`'s returns alone cannot — re-wrap a mutated payload against the pinned script id and the EDN-aware escaper, rebuild the envelope without re-spelling `escape-html`/`escape-attr`, run a determinism check whose `:differs-at` diagnoses a red run and which cannot move to a test kit without `react-dom/server`. The two going private have no such story, and `fresh-frame-id` structurally cannot: `server/render` mints its own id and forbids overriding it, so no public path consumes the return value. Zero test churn; the `hicasso.ssr` bundle sentinel is untouched. Implemented by `rf2-34sdz`; full ruling on ledger row 50 | `server_render_ssr_dom_cljs_test.cljs`; `ssr/entry.cljs` |
 | 51 | `re-frame.hicasso.tool` — `tool/read-mounted-boundaries`, `tool/read-read-attribution`, `tool/read-intents`, `tool/explain-render` | **keep all four as shipped** | They are the tool-tier reader door in full — *the four reads Xray and the AI pair consume, and the only door either of them has* — and the `read-*` prefix is what marks them as projections of state the runtime already retains rather than an accumulator | `tool.cljs` namespace docstring; `tool_reads_cljs_test.cljs` |


### PR DESCRIPTION
Closes `rf2-pvmy`.

`docs/design/hicasso/product/naming-packet.md` is a **sitting packet** — it proposes dispositions to `rf2-hic-065`, which has not ruled. So this PR corrects **the evidence a pending decision rests on, not the decision**. No row is deleted, no recommendation is re-scored, no disposition is withdrawn, and no replacement witness is invented where none exists.

Form follows `0523bd9214`, which did this operation on three sibling pages under the same tree, and the page's own in-cell `**[Amended <date>, \`bead\`: …]**` shape (row 18, `rf2-87iu`).

## What the census found

Every `*_test.clj(s|c)` cited on the page, resolved with `git ls-files`: **31 citations, 24 distinct basenames — 18 resolve to exactly one tracked file, 5 to none, 1 to two.** The bead named four of the five missing; the other two findings are the interesting part.

**1. A fifth missing suite the native retirement does not explain.** `readset_group_census_cljs_test.cljs` (row 48's witness) was deleted by **`1f98f63a58` (`rf2-6c12m.22`)** at 15:00 on 2026-08-29 — a *different* cut from `aa01f0e8a6` (`rf2-6c12m.31`) at 20:51 the same day, and on different reasoning. That cut retired suites *"that measured the programme rather than the product"* and **preserved what they measured**, so the correct repair points the reader at `readset-group-census.md`, which carries the three readings — not at "the surface is retired". Its door went separately again: `rf2-6c12m.15` (PR #8779) removed `h/use-subs` from the facade and `impl.collector` and struck HS-41, recorded in `facade_roster_ssr_dom_cljs_test.cljs`'s docstring and named in the slice example's `views.cljs`.

**2. The ambiguous citation resolves, and its subject is demoted.** `route_link_cljs_test.cljs` (row 35) matches two tracked files. The row means the **hicasso** one: it names the navigate head on four lines where `implementation/routing/`'s names it on none. The row is now qualified with both paths and the reason. The head itself is no longer `::h/navigate` — the same `rf2-6c12m.15` demoted it to `:re-frame.hicasso.impl.intent/navigate`, off the public marker table. `::h/navigate` reads **zero** occurrences under `implementation/` against a control of **30 files** for `::h/revision`, so the zero is an absence and not a failed probe.

**3. A live file is not a live witness.** Two Bucket B rows cite suites that still *exist* and no longer witness their subjects — a file-existence check passes them. `three_way_parity_cljs_test.cljs` (row 7) reads only `n/use-sub` today; `lazy_boundary_dom_cljs_test.cljs` (rows 29 and 43) drives a raw `react/lazy` through `h/defhost` and names neither `n/memo` nor `n/lazy`. **Row 10 is the one Bucket B row whose subject and witness both survive** — `hooks_island_cljs_test.cljs` and `hooks_island_dom_cljs_test.cljs`.

**4. A third stale instrument, same family.** `check_facade_inventory.py` is cited **six times** (rows 6 and 47, §4.1, §4.2 twice, §7) and was deleted by `bb3a92cd73` (`rf2-6c12m.8`, PR #8775) alongside `check_naming_census.py`. §7's existing amendment records that commit for the census gate only. This is beyond the bead's stated axis but sits inside the §4.2 paragraph that had to be amended anyway, so leaving it would have made the new note itself half-true.

## What changed

- **A currency banner at the head** (the bead's own first-named option), recording the three events and naming every affected row and citation with counts.
- **Row 35** and **row 48** — in-cell amendments, the two cases a banner cannot disambiguate.
- **The Bucket B reconciliation paragraph** — `native_surface_cljs_test.cljs` pins nothing at tip and `re-frame.hicasso.native` publishes two names, not fourteen.
- **The §4.2 agreement paragraph** — neither instrument survives; the agreement was real when taken and is not a standing check.

## Left for `rf2-hic-065` and `rf2-2tt2`

Whether a keep-row whose subject no longer ships should be struck; whether a claim whose witness is retired may stand on argument; whether a demoted head still owes a reserved-vocabulary entry. §1's counts are left as the packet's own publication reading.

## Gates

- `scripts/check_doc_slugs.py` — **exit 0**, empty log. Proved live on this exact file by a planted broken anchor: **exit 1**, naming file, line and anchor. Restored from a byte copy and verified with `cmp` (exit 0), not with a grep.
- `scripts/check_provenance_pins.py --changed-since origin/main` — **exit 0**: *1 page inspected, 4 cited pins — 4 landed, 0 stranded, 0 unresolvable, 0 foreign; 0 findings*. Proved non-vacuous by substituting one fabricated sha: *4 cited pins — 3 landed, 1 unresolvable*. Both re-run on the final rebased base.
- `mkdocs build --strict` is **not** nominated. `mkdocs.yml`'s `exclude_docs` lists `design/hicasso/`, verified at source, so the strict build never sees this page; citing it would be a green that inspected nothing.
- **No code changed, so no test suite applies.** This is a documentation-accuracy repair on a design-corpus page.
- **Hand-checked:** all 10 markdown table blocks for column-count consistency — 0 mismatched. The two new relative links (`correction-ledger.md`, `readset-group-census.md`) both resolve to tracked files in the same directory. No new anchors introduced. CRLF line endings preserved: 478 lines / 478 CRs, 0 NULs.
