### PR TITLE
fix(realworld-http): correlate every profile settle with the profile it was issued for (rf2-8icg)

### DIFF
--- a/examples/real-apps/realworld_http/profile.cljs
+++ b/examples/real-apps/realworld_http/profile.cljs
@@ -46,6 +46,78 @@
   (get-in runtime-db [:rf.runtime/routing :current :params :username]))
 
 ;; ============================================================================
+;; THE CORRELATION GATE — the profile the page is on owns every settle
+;; ============================================================================
+;;
+;; Walking `/profile/alice` → `/profile/bob` puts up to four requests in flight
+;; and cancels none of them. The per-username `:request-id`s
+;; (`[:profile/load "alice"]` vs `[:profile/load "bob"]`) are deliberately
+;; DISTINCT, so managed HTTP's same-id supersede never fires between them and
+;; alice's replies are delivered in full, however late.
+;;
+;; That is the framework doing exactly what it promises rather than falling
+;; short of it. Supersede retires a re-issue of the SAME read — a route
+;; re-match, a `?page=` step; both DO reuse the id here, so both are handled
+;; for you, and a suppressed reply cannot clobber fresh data no matter how late
+;; it arrives. Correlating a reply with the SCREEN is the app's correctness
+;; boundary (Spec 014: navigation staleness for a plain managed request is the
+;; app's, not the fx's). See ../../../docs/async/http.md#cancellation-supersession-and-abort.
+;;
+;; And no id scheme closes the gap, which is worth knowing before reaching for
+;; one. Collapse the reads onto a page-slot id (`:request-id :profile/load`)
+;; and bob's issuance would indeed supersede alice's — but the two FOLLOW
+;; settles below are superseded by nothing, because arriving at bob issues no
+;; new follow. `:profile/followed` re-seeds the WHOLE banner map from its
+;; reply, so a late alice success would put alice's name, bio and avatar under
+;; bob's URL. One law wants one mechanism, so every settle in this file carries
+;; the username it was issued for and asks the question below before writing.
+;;
+;; Each slice records WHICH profile it is loading (`[:profile :username]`,
+;; `[:profile.articles :username]`, `[:profile.favorites :username]`, stamped
+;; by the load handler in the same write that starts the load). The nine
+;; settles that follow — three successes, three failures, the two follow
+;; settles and the follow rollback — carry that username and gate on it. A late
+;; alice settle while the slice targets bob is dropped whole: no data, no
+;; status, no error, no timestamp, no machine broadcast.
+;;
+;; The MACHINE is why "no broadcast" is in that list. `:profile/load-failed`
+;; sends `:fetch-failed`, which puts the `:data` region in `:error` — a state
+;; with no `fetch-succeeded` edge — so an ungated late alice failure could
+;; strand a perfectly good bob banner in an error presentation for as long as
+;; the reader stayed on it. Gated, no cross-identity broadcast reaches the
+;; machine at all, and every path to `:loaded` for the identity the page IS on
+;; passes through `:fetch-started` first. The missing edge is unreachable
+;; rather than merely unused, so it stays missing.
+;;
+;; Retention follows the same law: a SAME-username re-entry is a refresh that
+;; keeps the loaded data up while `:fetching` (never blank a page to reload
+;; it), while a username CHANGE is a new identity that resets the slice, so
+;; alice is never renderable under `/profile/bob`. The two list subs ask once
+;; more at READ time — a list belongs to the page only while its username
+;; matches the banner's — because the tabs load on separate routes, so
+;; `/profile/alice` → `/profile/bob/favorites` reloads the banner and the
+;; favorited list and leaves the AUTHORED list still holding alice's.
+;;
+;; comments.cljs spells the identical law against `:slug`, with the two-owners
+;; refinement this page does not need: every settle here writes a slice, none
+;; navigates, so the slice's own identity is the only question to ask.
+;;
+;; The `realworld_resources/` twin needs none of this, and the contrast is the
+;; real lesson. Its state is keyed by resource identity — `[scope
+;; :realworld/profile {:username …}]`, and its follow/unfollow mutations
+;; `:populates` and `:invalidates` that same keyed entry — so alice and bob are
+;; simply different cache entries and a late reply has nowhere wrong to land.
+;; Here the page owns one shared slice per region, and a shared slice has to
+;; carry its identity by hand.
+(defn reply-for-current-profile?
+  "Does a reply REQUESTED for `username` still belong to the slice at
+   `slice-key` (`:profile` / `:profile.articles` / `:profile.favorites`)? True
+   exactly when the username the reply carries equals the one the slice
+   currently targets."
+  [db slice-key username]
+  (= username (get-in db [slice-key :username])))
+
+;; ============================================================================
 ;; THE MACHINE — :ui/profile  (one machine, two regions)
 ;; ============================================================================
 ;;
@@ -160,15 +232,25 @@
   {:doc "Fetch the public profile banner — username, bio, image, following.
          Public endpoint, so the house data-fetch retry applies. Broadcasts
          `:fetch-started` into the `:ui/profile` machine, nudging the `:data`
-         region to `:loading` (or `:refreshing`, if a banner's already up)."
+         region to `:loading` (or `:refreshing`, if a banner's already up).
+
+         Stamps the username the slice is loading and CARRIES it on both reply
+         targets, so a settle for a profile the reader has left writes nothing
+         — see THE CORRELATION GATE above. A same-username re-entry is a
+         refresh (keep the banner up, `:fetching`); a different username is a
+         new identity, so the slice resets and alice's banner is never
+         renderable under `/profile/bob`."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
-    (let [username (username-from-db rt)]
-      {:db (-> db
-               (assoc-in [:profile :status]
-                         (if (get-in db [:profile :data]) :fetching :loading))
-               (assoc-in [:profile :error] nil)
-               (update-in [:profile :attempt] (fnil inc 0)))
+    (let [username (username-from-db rt)
+          refresh? (reply-for-current-profile? db :profile username)
+          slice    (if refresh? (:profile db) (request-slice))]
+      {:db (assoc db :profile
+                  (-> slice
+                      (assoc :username username
+                             :status   (if (and refresh? (:data slice)) :fetching :loading)
+                             :error    nil)
+                      (update :attempt (fnil inc 0))))
        :fx [[:dispatch [:ui/profile [:fetch-started]]]
             [:rf.http/managed
              (rh/request {:method     :get
@@ -176,42 +258,63 @@
                           :decode     schema/ProfileResponse
                           :retry      rh/data-fetch-retry
                           :request-id [:profile/load username]
-                          :on-success [:profile/loaded]
-                          :on-failure [:profile/load-failed]})]]})))
+                          :on-success [:profile/loaded username]
+                          :on-failure [:profile/load-failed username]})]]})))
 
 (rf/reg-event :profile/loaded
-  {:rf.cofx/requires [:rf/time-ms]}
-  (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
-    {:db (-> db
-             (assoc-in [:profile :status] :loaded)
-             (assoc-in [:profile :data] (:profile value))
-             (assoc-in [:profile :error] nil)
-             (assoc-in [:profile :loaded-at] time-ms))
-     :fx [[:dispatch [:ui/profile [:fetch-succeeded]]]]}))
+  {:doc "The banner GET's `:on-success`, carrying the username it was requested
+         for. Correlation-gated: a late reply for a profile the slice no longer
+         targets writes nothing — not data, not status, not the timestamp — and
+         broadcasts nothing into the machine."
+   :rf.cofx/requires [:rf/time-ms]}
+  (fn [{:keys [db rf/time-ms]} [_ username {:keys [value]}]]
+    (when (reply-for-current-profile? db :profile username)
+      {:db (-> db
+               (assoc-in [:profile :status] :loaded)
+               (assoc-in [:profile :data] (:profile value))
+               (assoc-in [:profile :error] nil)
+               (assoc-in [:profile :loaded-at] time-ms))
+       :fx [[:dispatch [:ui/profile [:fetch-succeeded]]]]})))
 
 (rf/reg-event :profile/load-failed
-  (fn [{:keys [db]} [_ {:keys [error]}]]
-    (let [message (rh/failure->message error)]
-      {:db (-> db
-               (assoc-in [:profile :status] :error)
-               (assoc-in [:profile :error] message))
-       :fx [[:dispatch [:ui/profile [:fetch-failed {:failure message}]]]]})))
+  {:doc "The banner GET's `:on-failure`, correlated exactly as `:profile/loaded`
+         is — and this is the gate that keeps the MACHINE honest. An ungated
+         late failure sends the `:data` region to `:error`, which has no
+         `fetch-succeeded` edge, so it would strand the current profile's page
+         in an error presentation even after that profile's own load succeeded."}
+  (fn [{:keys [db]} [_ username {:keys [error]}]]
+    (when (reply-for-current-profile? db :profile username)
+      (let [message (rh/failure->message error)]
+        {:db (-> db
+                 (assoc-in [:profile :status] :error)
+                 (assoc-in [:profile :error] message))
+         :fx [[:dispatch [:ui/profile [:fetch-failed {:failure message}]]]]}))))
 
 (rf/reg-event :profile.articles/load
   {:doc "Fetch the articles this user wrote. Public; house retry. Also
          broadcasts `:show-articles` so the `:ui/profile` :tab region knows
          which tab is live. `?page=` paginates via `rh/paginate-path` (the
          official RealWorld limit/offset shape), which also URL-encodes the
-         `:author` filter."
+         `:author` filter.
+
+         Same correlation law as the banner: the slice records the username it
+         is loading, both reply targets carry it, and a username change resets
+         the list. The `?page=` step does NOT — it reuses `:request-id`, so
+         managed HTTP supersedes the previous page's reply for you, and the
+         rows stay up while `:fetching`."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [username (username-from-db rt)
           page     (or (get-in rt [:rf.runtime/routing :current :query :page]) 1)
-          path     (rh/paginate-path "/articles" {:author username} page)]
-      {:db (-> db
-               (assoc-in [:profile.articles :status] :loading)
-               (assoc-in [:profile.articles :error] nil)
-               (update-in [:profile.articles :attempt] (fnil inc 0)))
+          path     (rh/paginate-path "/articles" {:author username} page)
+          refresh? (reply-for-current-profile? db :profile.articles username)
+          slice    (if refresh? (:profile.articles db) (assoc (request-slice) :data []))]
+      {:db (assoc db :profile.articles
+                  (-> slice
+                      (assoc :username username
+                             :status   (if (and refresh? (seq (:data slice))) :fetching :loading)
+                             :error    nil)
+                      (update :attempt (fnil inc 0))))
        :fx [[:dispatch [:ui/profile [:show-articles]]]
             [:rf.http/managed
              (rh/request {:method     :get
@@ -219,40 +322,56 @@
                           :decode     schema/ArticlesResponse
                           :retry      rh/data-fetch-retry
                           :request-id [:profile.articles/load username]
-                          :on-success [:profile.articles/loaded]
-                          :on-failure [:profile.articles/load-failed]})]]})))
+                          :on-success [:profile.articles/loaded username]
+                          :on-failure [:profile.articles/load-failed username]})]]})))
 
 (rf/reg-event :profile.articles/loaded
-  {:rf.cofx/requires [:rf/time-ms]}
-  (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
-    {:db (-> db
-             (assoc-in [:profile.articles :status] :loaded)
-             (assoc-in [:profile.articles :data] (vec (:articles value)))
-             (assoc-in [:profile.articles :articles-count]
-                       (or (:articlesCount value) (count (:articles value))))
-             (assoc-in [:profile.articles :loaded-at] time-ms))}))
+  {:doc "The authored-list GET's `:on-success`, carrying the username it was
+         requested for and gated on it — see THE CORRELATION GATE above."
+   :rf.cofx/requires [:rf/time-ms]}
+  (fn [{:keys [db rf/time-ms]} [_ username {:keys [value]}]]
+    (when (reply-for-current-profile? db :profile.articles username)
+      {:db (-> db
+               (assoc-in [:profile.articles :status] :loaded)
+               (assoc-in [:profile.articles :data] (vec (:articles value)))
+               (assoc-in [:profile.articles :articles-count]
+                         (or (:articlesCount value) (count (:articles value))))
+               (assoc-in [:profile.articles :loaded-at] time-ms))})))
 
 (rf/reg-event :profile.articles/load-failed
-  (fn [{:keys [db]} [_ {:keys [error]}]]
-    {:db (-> db
-        (assoc-in [:profile.articles :status] :error)
-        (assoc-in [:profile.articles :error] (rh/failure->message error)))}))
+  {:doc "The authored-list GET's `:on-failure`, correlated exactly as
+         `:profile.articles/loaded` is — a late failure for the previous
+         profile must not mark the current one's list errored."}
+  (fn [{:keys [db]} [_ username {:keys [error]}]]
+    (when (reply-for-current-profile? db :profile.articles username)
+      {:db (-> db
+          (assoc-in [:profile.articles :status] :error)
+          (assoc-in [:profile.articles :error] (rh/failure->message error)))})))
 
 (rf/reg-event :profile.favorites/load
   {:doc "Fetch the articles this user favorited. Public; house retry. Also
          broadcasts `:show-favorites` so the `:ui/profile` :tab region knows
          which tab is live. `?page=` paginates via `rh/paginate-path` (the
          official RealWorld limit/offset shape), which also URL-encodes the
-         `:favorited` filter."
+         `:favorited` filter.
+
+         Correlated exactly as the authored list is — the slice records the
+         username it is loading, both reply targets carry it, a username change
+         resets the list, and a `?page=` step is left to managed HTTP's same-id
+         supersede."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [username (username-from-db rt)
           page     (or (get-in rt [:rf.runtime/routing :current :query :page]) 1)
-          path     (rh/paginate-path "/articles" {:favorited username} page)]
-      {:db (-> db
-               (assoc-in [:profile.favorites :status] :loading)
-               (assoc-in [:profile.favorites :error] nil)
-               (update-in [:profile.favorites :attempt] (fnil inc 0)))
+          path     (rh/paginate-path "/articles" {:favorited username} page)
+          refresh? (reply-for-current-profile? db :profile.favorites username)
+          slice    (if refresh? (:profile.favorites db) (assoc (request-slice) :data []))]
+      {:db (assoc db :profile.favorites
+                  (-> slice
+                      (assoc :username username
+                             :status   (if (and refresh? (seq (:data slice))) :fetching :loading)
+                             :error    nil)
+                      (update :attempt (fnil inc 0))))
        :fx [[:dispatch [:ui/profile [:show-favorites]]]
             [:rf.http/managed
              (rh/request {:method     :get
@@ -260,28 +379,55 @@
                           :decode     schema/ArticlesResponse
                           :retry      rh/data-fetch-retry
                           :request-id [:profile.favorites/load username]
-                          :on-success [:profile.favorites/loaded]
-                          :on-failure [:profile.favorites/load-failed]})]]})))
+                          :on-success [:profile.favorites/loaded username]
+                          :on-failure [:profile.favorites/load-failed username]})]]})))
 
 (rf/reg-event :profile.favorites/loaded
-  {:rf.cofx/requires [:rf/time-ms]}
-  (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
-    {:db (-> db
-             (assoc-in [:profile.favorites :status] :loaded)
-             (assoc-in [:profile.favorites :data] (vec (:articles value)))
-             (assoc-in [:profile.favorites :articles-count]
-                       (or (:articlesCount value) (count (:articles value))))
-             (assoc-in [:profile.favorites :loaded-at] time-ms))}))
+  {:doc "The favorited-list GET's `:on-success`, carrying the username it was
+         requested for and gated on it — see THE CORRELATION GATE above."
+   :rf.cofx/requires [:rf/time-ms]}
+  (fn [{:keys [db rf/time-ms]} [_ username {:keys [value]}]]
+    (when (reply-for-current-profile? db :profile.favorites username)
+      {:db (-> db
+               (assoc-in [:profile.favorites :status] :loaded)
+               (assoc-in [:profile.favorites :data] (vec (:articles value)))
+               (assoc-in [:profile.favorites :articles-count]
+                         (or (:articlesCount value) (count (:articles value))))
+               (assoc-in [:profile.favorites :loaded-at] time-ms))})))
 
 (rf/reg-event :profile.favorites/load-failed
-  (fn [{:keys [db]} [_ {:keys [error]}]]
-    {:db (-> db
-        (assoc-in [:profile.favorites :status] :error)
-        (assoc-in [:profile.favorites :error] (rh/failure->message error)))}))
+  {:doc "The favorited-list GET's `:on-failure`, correlated exactly as
+         `:profile.favorites/loaded` is."}
+  (fn [{:keys [db]} [_ username {:keys [error]}]]
+    (when (reply-for-current-profile? db :profile.favorites username)
+      {:db (-> db
+          (assoc-in [:profile.favorites :status] :error)
+          (assoc-in [:profile.favorites :error] (rh/failure->message error)))})))
 
 ;; ============================================================================
 ;; FOLLOW / UNFOLLOW
 ;; ============================================================================
+;;
+;; Button-driven rather than route-driven, but they write the ROUTE-OWNED
+;; `[:profile ...]` slice, so their settles carry the username they were issued
+;; on and gate on it exactly as the loads do. This pair is why the gate is the
+;; mechanism and a request-id scheme is not: arriving at bob issues no new
+;; follow, so nothing supersedes an alice follow still in flight, and
+;; `:profile/followed` re-seeds the WHOLE banner map from its reply. See THE
+;; CORRELATION GATE above.
+;;
+;; The issuing username comes from `[:profile :username]` — the identity the
+;; slice recorded and the settle will be gated against — rather than from the
+;; route, so the URL written, the flag flipped and the question asked on the
+;; way back are all one fact. It is the same move comments.cljs's
+;; `:article/toggle-follow-author` makes with `[:article :slug]`.
+;;
+;; No `:request-id` here, deliberately, and the same for every other mutation
+;; in this app. It WOULD make a rapid Follow→Unfollow supersede its
+;; predecessor, but supersede aborts the request as well as suppressing the
+;; reply, and abort-mid-write is a decision a POST deserves to have made about
+;; it on purpose. The gate below already covers the race this file is about,
+;; and the last click's own settle is authoritative regardless.
 
 (rf/reg-event :profile/follow
   {:doc "Mark the profile followed right away, then reconcile when the reply
@@ -290,45 +436,58 @@
          so a logged-out click heads to login instead of flipping `:following`
          optimistically only to walk it back after the backend 401s."
    :rf.http/decode-schemas [schema/ProfileResponse]}
-  (fn [{:keys [db] rt :rf.db/runtime} _]
+  (fn [{:keys [db]} _]
     (if (nil? (get-in db [:auth :user]))
       {:fx [[:dispatch [:rf.route/navigate {:to :realworld.auth/login}]]]}
-      (let [username (username-from-db rt)]
+      (let [username (get-in db [:profile :username])]
         {:db (assoc-in db [:profile :data :following] true)
          :fx [[:rf.http/managed
                (rh/request {:method     :post
                             :path       (str "/profiles/" username "/follow")
                             :decode     schema/ProfileResponse
-                            :on-success [:profile/followed]
-                            :on-failure [:profile/follow-rollback false]})]]}))))
+                            :on-success [:profile/followed username]
+                            :on-failure [:profile/follow-rollback username false]})]]}))))
 
 (rf/reg-event :profile/followed
-  (fn [{:keys [db]} [_ {:keys [value]}]]
-    {:db (assoc-in db [:profile :data] (:profile value))}))
+  {:doc "The follow POST's `:on-success`, carrying the username the flip was
+         issued on. This is the write that most needs the gate: it re-seeds the
+         whole banner map, so a late reply for a profile the reader has left
+         would put that profile's name, bio and avatar under the current URL."}
+  (fn [{:keys [db]} [_ username {:keys [value]}]]
+    (when (reply-for-current-profile? db :profile username)
+      {:db (assoc-in db [:profile :data] (:profile value))})))
 
 (rf/reg-event :profile/unfollow
   {:doc "Clear the followed flag right away, then reconcile on the reply.
          Auth-gated, same as `:profile/follow` above."
    :rf.http/decode-schemas [schema/ProfileResponse]}
-  (fn [{:keys [db] rt :rf.db/runtime} _]
+  (fn [{:keys [db]} _]
     (if (nil? (get-in db [:auth :user]))
       {:fx [[:dispatch [:rf.route/navigate {:to :realworld.auth/login}]]]}
-      (let [username (username-from-db rt)]
+      (let [username (get-in db [:profile :username])]
         {:db (assoc-in db [:profile :data :following] false)
          :fx [[:rf.http/managed
                (rh/request {:method     :delete
                             :path       (str "/profiles/" username "/follow")
                             :decode     schema/ProfileResponse
-                            :on-success [:profile/unfollowed]
-                            :on-failure [:profile/follow-rollback true]})]]}))))
+                            :on-success [:profile/unfollowed username]
+                            :on-failure [:profile/follow-rollback username true]})]]}))))
 
 (rf/reg-event :profile/unfollowed
-  (fn [{:keys [db]} [_ {:keys [value]}]]
-    {:db (assoc-in db [:profile :data] (:profile value))}))
+  {:doc "The unfollow DELETE's `:on-success`, correlated exactly as
+         `:profile/followed` is."}
+  (fn [{:keys [db]} [_ username {:keys [value]}]]
+    (when (reply-for-current-profile? db :profile username)
+      {:db (assoc-in db [:profile :data] (:profile value))})))
 
 (rf/reg-event :profile/follow-rollback
-  (fn [{:keys [db]} [_ previous-value _failure-payload]]
-    {:db (assoc-in db [:profile :data :following] previous-value)}))
+  {:doc "The shared `:on-failure` for both, correlated the same way. Refusing a
+         stale rollback strands nothing: the optimistic flip it would undo went
+         with the slice when `:profile/load` reset it for the new username, and
+         returning to that profile re-reads the true flag from the server."}
+  (fn [{:keys [db]} [_ username previous-value _failure-payload]]
+    (when (reply-for-current-profile? db :profile username)
+      {:db (assoc-in db [:profile :data :following] previous-value)})))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS
@@ -338,11 +497,32 @@
 (rf/reg-sub :profile/data    :<- [:profile/slice] (fn [s _] (:data s)))
 (rf/reg-sub :profile/error   :<- [:profile/slice] (fn [s _] (:error s)))
 
+;; The read-time half of THE CORRELATION GATE. The gate on the settles keeps a
+;; stale reply from LANDING in a slice; this keeps an already-landed list from
+;; being RENDERED under the wrong profile — a different question, because the
+;; two tabs load on separate routes. `/profile/alice` → `/profile/bob/favorites`
+;; reloads the banner and the favorited list, and never touches the authored
+;; one, which goes on holding alice's articles quite legitimately. What it must
+;; not do is show them, or count them, under bob's URL.
+;;
+;; Asking here rather than leaning on the `:tab` region is deliberate: the tab
+;; broadcast (`:show-articles` / `:show-favorites`) rides in the load handler's
+;; `:fx`, so it lands a beat after the route does, and an invariant this plain
+;; should not depend on which of two dispatches wins.
+(defn list-for-current-profile
+  "The list slice at `slice-key`, but only while it belongs to the profile the
+   BANNER is on. `nil` when the identities disagree, which every caller reads
+   as empty."
+  [db slice-key]
+  (when (= (get-in db [slice-key :username])
+           (get-in db [:profile :username]))
+    (get db slice-key)))
+
 (rf/reg-sub :profile.articles/data
-  (fn [db _] (get-in db [:profile.articles :data])))
+  (fn [db _] (:data (list-for-current-profile db :profile.articles))))
 
 (rf/reg-sub :profile.favorites/data
-  (fn [db _] (get-in db [:profile.favorites :data])))
+  (fn [db _] (:data (list-for-current-profile db :profile.favorites))))
 
 (rf/reg-sub :profile/own-profile?
   (fn [db _]
@@ -391,10 +571,10 @@
 ;; ---- pagination (official RealWorld limit/offset) ----
 
 (rf/reg-sub :profile.articles/count
-  (fn [db _] (get-in db [:profile.articles :articles-count] 0)))
+  (fn [db _] (:articles-count (list-for-current-profile db :profile.articles) 0)))
 
 (rf/reg-sub :profile.favorites/count
-  (fn [db _] (get-in db [:profile.favorites :articles-count] 0)))
+  (fn [db _] (:articles-count (list-for-current-profile db :profile.favorites) 0)))
 
 (rf/reg-sub :profile/current-count
   {:doc "Grand article count for the active profile tab — drives the page

--- a/examples/real-apps/realworld_http/schema.cljs
+++ b/examples/real-apps/realworld_http/schema.cljs
@@ -46,7 +46,14 @@
    outcome is a NAVIGATION asks the route instead — `article-route-for-slug?`,
    same file: THIS slug outlives a walk to a non-article page, the route's
    does not.) Optional because only the `/article/:slug`-driven slices
-   (`:article`, `:comments`) carry it."
+   (`:article`, `:comments`) carry it.
+
+   `:username` is the same fact for the `/profile/:username`-driven slices
+   (`:profile`, `:profile.articles`, `:profile.favorites`) — the correlation
+   identity `reply-for-current-profile?` (profile.cljs) gates every banner,
+   list and follow settle against, so a late reply for a profile the reader has
+   left can't overwrite the current one's data, status, error, timestamp or
+   machine presentation. Same law as `:slug`, different route param."
   [:map
    [:status         [:enum :idle :loading :fetching :loaded :error]]
    [:data           {:default nil} :any]
@@ -55,6 +62,7 @@
    [:attempt        {:default 0}   :int]
    [:articles-count {:optional true} :int]
    [:slug           {:optional true} [:maybe :string]]
+   [:username       {:optional true} [:maybe :string]]
    [:stale-after-ms {:optional true} [:maybe :int]]])
 
 (def AuthSlice

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -2893,7 +2893,10 @@
     (is (false? (:following (rf/compute-sub [:profile/data] (rf/frame-state-value f))))
         ":profile/unfollowed re-seeds :following false")
     ;; Rollback handler (driven directly): restores the captured prior flag.
-    (rf/dispatch-sync [:profile/follow-rollback true {:kind :rf.http/http-4xx}] {:frame f})
+    ;; The username is the identity the flip was issued on, and the handler is
+    ;; gated on it (rf2-8icg) — the cross-username refusal is pinned by
+    ;; `realworld-profile-page-cross-username` below.
+    (rf/dispatch-sync [:profile/follow-rollback "eve" true {:kind :rf.http/http-4xx}] {:frame f})
     (is (true? (:following (rf/compute-sub [:profile/data] (rf/frame-state-value f))))
         ":profile/follow-rollback restores the captured prior following flag")))
 
@@ -2924,6 +2927,303 @@
     (profile-follow-test))
   (testing "home-context flattens the two home routes into {:tag :feed :page} (rf2-rq65wv)"
     (home-context-test)))
+
+;; ============================================================================
+;; profile page — cross-username replies stay owned by the route (rf2-8icg)
+;; ============================================================================
+;;
+;; The profile page repeats the article page's navigation-staleness law
+;; (`realworld-article-page-cross-slug` above) over its own THREE shared
+;; slices. `/profile/:username`'s on-match dispatches :profile/load and
+;; :profile.articles/load; `/profile/:username/favorites` dispatches
+;; :profile/load and :profile.favorites/load; the Follow button writes the same
+;; route-owned `[:profile …]` slice from a POST nobody's navigation
+;; supersedes. The reads are keyed per username ([:profile/load "alice"] vs
+;; [:profile/load "bob"]) — DISTINCT ids across a navigation, so managed
+;; HTTP's same-id supersede never fires between them and all of them stay
+;; independently deliverable. Correlation is therefore the app's own boundary,
+;; and it has two halves, both witnessed below:
+;;
+;;   WRITE-TIME — the requested username rides every reply target, each slice
+;;     records the username it is loading, and every terminal handler refuses a
+;;     settle whose username the slice no longer targets. Nothing gets through:
+;;     not data, not status, not the error, not the timestamp, not the machine
+;;     broadcast. `pf-slice*` compares the slice WHOLE for exactly that reason.
+;;
+;;   READ-TIME — the two list subs ask the question again when the view reads
+;;     them, because the tabs load on SEPARATE routes. /profile/alice →
+;;     /profile/bob/favorites reloads the banner and the favorited list and
+;;     never touches the AUTHORED one, which goes on holding alice's articles
+;;     quite legitimately. What it must not do is show them under bob's URL.
+;;
+;; The MACHINE matters here in a way it did not on the article page. An ungated
+;; late alice failure broadcasts :fetch-failed, which puts the :data region in
+;; :error — a state with no fetch-succeeded edge — so bob's own later success
+;; would write app-db and leave the page rendering an error over the top of it.
+;; The failure test below is that strand, refused.
+
+(defn- full-profile [username following?]
+  {:username username :bio (str "Bio of " username) :image nil :following following?})
+
+(defn- pf-slice*
+  "A profile-page slice read straight off the `:rf.db/app` partition, WHOLE —
+   status, data, error, loaded-at, attempt and username together — because the
+   bug is never the one leaf you looked at."
+  [f k]
+  (get-in (rf/frame-state-value f) [:rf.db/app k]))
+
+(defn- pf-has-tag? [f tag]
+  (rf/compute-sub [:rf.machine/has-tag? :ui/profile tag] (rf/frame-state-value f)))
+
+(defn- pf-render* [f]
+  (rf/compute-sub [:profile/render] (rf/frame-state-value f)))
+
+(defn- pf-sub* [f query]
+  (rf/compute-sub query (rf/frame-state-value f)))
+
+(defn- with-held-profile-fx
+  "Run `body-fn` against a frame whose `:rf.http/managed` is a capturing stub:
+   every request is recorded and NONE settles by itself, so each reply can be
+   delivered by hand in the order a slow network would pick. The session is a
+   third party (`zed`) so no assertion below can be satisfied by accident from
+   the logged-in user's own name."
+  [fx-id body-fn]
+  (let [lowered (atom [])]
+    (rf/reg-fx fx-id
+      {:platforms #{:client :server}}
+      (fn [_frame-ctx args] (swap! lowered conj args) nil))
+    (with-new-frame [f (frame/make-anon-frame-record!
+                         {:initial-events [[:app/initialise]]
+                          :fx-overrides {:rf.http/managed fx-id}})]
+      (rf/dispatch-sync [:auth/store-session {:username "zed" :email "z@b.c"
+                                              :token "jwt" :bio nil :image nil}]
+                        {:frame f})
+      (body-fn f lowered))))
+
+(defn- profile-cross-username-late-success-is-refused-test []
+  (with-held-profile-fx :realworld.test/profile-cross-username
+    (fn [f lowered]
+      ;; Enter /profile/alice — its banner + authored GETs go out and stay out.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/profile/alice"] {:frame f})
+      ;; …and follow a link to /profile/bob before either settles.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/profile/bob"] {:frame f})
+      (is (= 4 (count @lowered))
+          "both entries lowered a banner AND an authored-list GET — four requests")
+      (is (= 4 (count (distinct (map :request-id @lowered))))
+          "the four carry DISTINCT per-username request-ids, so same-id
+           supersede never fires between them — every one is independently
+           deliverable, and correlating each reply is the app's job")
+      (let [a-ban (req-by-id @lowered [:profile/load "alice"])
+            a-art (req-by-id @lowered [:profile.articles/load "alice"])
+            b-ban (req-by-id @lowered [:profile/load "bob"])
+            b-art (req-by-id @lowered [:profile.articles/load "bob"])]
+        (is (= [:profile/loaded "alice"] (:on-success a-ban))
+            "the banner's success target carries the username it was requested for")
+        (is (= [:profile/load-failed "alice"] (:on-failure a-ban))
+            "…and so does its failure target")
+        (is (= [:profile.articles/loaded "alice"] (:on-success a-art))
+            "…as do both of the authored list's targets")
+        (is (= [:profile.articles/load-failed "alice"] (:on-failure a-art)))
+        ;; Bob settles normally first — the ordinary path is untouched.
+        (settle-ok! f (:on-success b-ban) {:profile (full-profile "bob" false)})
+        (settle-ok! f (:on-success b-art) {:articles [(full-article "b1" "Bob one")]
+                                           :articlesCount 1})
+        (is (= "bob" (:username (pf-sub* f [:profile/data])))
+            "bob's own banner reply is accepted through the public sub")
+        (is (= ["Bob one"] (mapv :title (pf-sub* f [:profile.articles/data])))
+            "bob's own authored reply is accepted through the public sub")
+        ;; THE LATE ARRIVALS.
+        (let [ban-before (pf-slice* f :profile)
+              art-before (pf-slice* f :profile.articles)]
+          (settle-ok! f (:on-success a-ban) {:profile (full-profile "alice" true)})
+          (settle-ok! f (:on-success a-art) {:articles [(full-article "a1" "Alice one")]
+                                             :articlesCount 9})
+          (is (= {:username "bob"} (route-params* f))
+              "the route still says bob")
+          (is (= ban-before (pf-slice* f :profile))
+              "a late alice banner success changes NOTHING on the profile slice
+               — data, status, error, loaded-at, attempt and username all stand")
+          (is (= art-before (pf-slice* f :profile.articles))
+              "…and the late alice authored success changes nothing on the
+               authored-list slice")
+          (is (= 1 (pf-sub* f [:profile.articles/count]))
+              "…so bob's grand count is not replaced by alice's nine"))))))
+
+(defn- profile-cross-username-late-failure-is-refused-test []
+  (with-held-profile-fx :realworld.test/profile-cross-username-fail
+    (fn [f lowered]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/profile/alice"] {:frame f})
+      (rf/dispatch-sync [:rf.route/handle-url-change "/profile/bob"] {:frame f})
+      (let [a-ban (req-by-id @lowered [:profile/load "alice"])
+            a-art (req-by-id @lowered [:profile.articles/load "alice"])
+            b-ban (req-by-id @lowered [:profile/load "bob"])
+            b-art (req-by-id @lowered [:profile.articles/load "bob"])]
+        (is (true? (pf-has-tag? f :data/loading))
+            "bob's banner fetch is still out — the :data region sits at :loading")
+        (is (= :loading (:status (pf-slice* f :profile.articles)))
+            "…and so is his authored list")
+        ;; ALICE FAILS WHILE BOB IS STILL LOADING. This is the strand the fix
+        ;; is about: :error has no fetch-succeeded edge, so an accepted alice
+        ;; failure here would outlive bob's own success.
+        (settle-fail! f (:on-failure a-ban))
+        (settle-fail! f (:on-failure a-art))
+        (is (true? (pf-has-tag? f :data/loading))
+            "a late alice failure never reaches the machine — the :data region
+             is still :loading, not :error")
+        (is (false? (pf-has-tag? f :data/error))
+            "…so the page-level error presentation stays shut")
+        (is (nil? (pf-sub* f [:profile/error]))
+            "…and no error banner is raised over bob")
+        (is (nil? (:error (pf-slice* f :profile.articles)))
+            "…nor over bob's authored list")
+        ;; Bob's own replies land and render — the strand refused.
+        (settle-ok! f (:on-success b-ban) {:profile (full-profile "bob" false)})
+        (settle-ok! f (:on-success b-art) {:articles [(full-article "b1" "Bob one")]
+                                           :articlesCount 1})
+        (is (= "bob" (:username (pf-sub* f [:profile/data])))
+            "bob's own banner success is accepted")
+        (is (= :loaded (pf-render* f))
+            "…and carries the machine to :loaded, so the page is NOT stranded
+             in an error presentation an earlier profile's failure caused"))
+      ;; NON-VACUITY for the failure gate: a CURRENT username's own failure is
+      ;; still accepted. The gate correlates; it does not swallow failures.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/profile/carol"] {:frame f})
+      (let [c-ban (req-by-id @lowered [:profile/load "carol"])
+            c-art (req-by-id @lowered [:profile.articles/load "carol"])]
+        (settle-fail! f (:on-failure c-ban))
+        (settle-fail! f (:on-failure c-art))
+        (is (= :error (:status (pf-slice* f :profile)))
+            "carol's OWN banner failure is accepted")
+        (is (some? (pf-sub* f [:profile/error]))
+            "…with its message surfaced")
+        (is (= :error (pf-render* f))
+            "…and the machine does reach the error presentation for its own failure")
+        (is (= :error (:status (pf-slice* f :profile.articles)))
+            "carol's OWN authored failure is accepted too")))))
+
+(defn- profile-username-change-resets-and-cross-tab-read-guard-test []
+  (with-held-profile-fx :realworld.test/profile-transition
+    (fn [f lowered]
+      ;; Load alice's banner + authored list fully.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/profile/alice"] {:frame f})
+      (settle-ok! f (:on-success (req-by-id @lowered [:profile/load "alice"]))
+                  {:profile (full-profile "alice" false)})
+      (settle-ok! f (:on-success (req-by-id @lowered [:profile.articles/load "alice"]))
+                  {:articles [(full-article "a1" "Alice one")] :articlesCount 1})
+      (is (= ["Alice one"] (mapv :title (pf-sub* f [:profile.articles/data]))))
+      ;; SAME-username refresh control: re-firing the route's loads for the
+      ;; profile already on screen keeps the loaded data up while they are out.
+      (reset! lowered [])
+      (rf/dispatch-sync [:profile/load] {:frame f})
+      (rf/dispatch-sync [:profile.articles/load] {:frame f})
+      (is (= :fetching (:status (pf-slice* f :profile)))
+          "a same-username re-load is a REFRESH — :fetching, not :loading")
+      (is (= "alice" (:username (pf-sub* f [:profile/data])))
+          "…and alice's banner stays renderable while it is out")
+      (is (= ["Alice one"] (mapv :title (pf-sub* f [:profile.articles/data])))
+          "…as do her authored rows")
+      (settle-ok! f (:on-success (req-by-id @lowered [:profile/load "alice"]))
+                  {:profile (full-profile "alice" false)})
+      (settle-ok! f (:on-success (req-by-id @lowered [:profile.articles/load "alice"]))
+                  {:articles [(full-article "a1" "Alice one")] :articlesCount 1})
+      ;; Now NAVIGATE across BOTH user and tab: /profile/alice →
+      ;; /profile/bob/favorites reloads the banner and the FAVORITED list, and
+      ;; never touches the authored one.
+      (reset! lowered [])
+      (rf/dispatch-sync [:rf.route/handle-url-change "/profile/bob/favorites"] {:frame f})
+      (is (= 2 (count @lowered))
+          "the favorites route reloads exactly two things: the banner and the
+           favorited list")
+      (is (some? (req-by-id @lowered [:profile.favorites/load "bob"]))
+          "…the favorited list being one of them")
+      (is (nil? (req-by-id @lowered [:profile.articles/load "bob"]))
+          "…and NO authored-list request for bob is issued at all")
+      (is (= :loading (:status (pf-slice* f :profile)))
+          "a username CHANGE is not a refresh — the banner slice starts over")
+      (is (nil? (pf-sub* f [:profile/data]))
+          "…so alice's banner is not exposed under bob's URL while bob loads")
+      ;; THE READ-TIME HALF. The authored slice still holds alice's rows, quite
+      ;; legitimately — nothing reloaded it. It must not SHOW them under bob.
+      (is (= "alice" (:username (pf-slice* f :profile.articles)))
+          "the authored slice still targets alice — this route never reloaded it")
+      (is (= 1 (count (:data (pf-slice* f :profile.articles))))
+          "…and alice's rows are still sitting in it")
+      (is (nil? (pf-sub* f [:profile.articles/data]))
+          "…but the read-time guard refuses to expose them under bob's URL")
+      (is (zero? (pf-sub* f [:profile.articles/count]))
+          "…and refuses to count them either")
+      (is (= [] (pf-sub* f [:profile/current-articles]))
+          "…so the tab the view is rendering reads empty while bob's own
+           favorited list is still in flight"))))
+
+(defn- profile-cross-username-follow-settles-are-refused-test []
+  (with-held-profile-fx :realworld.test/profile-cross-username-follow
+    (fn [f lowered]
+      ;; Land on alice and let her banner settle, so Follow has a profile to act on.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/profile/alice"] {:frame f})
+      (settle-ok! f (:on-success (req-by-id @lowered [:profile/load "alice"]))
+                  {:profile (full-profile "alice" false)})
+      (rf/dispatch-sync [:profile/follow] {:frame f})
+      (is (true? (:following (pf-sub* f [:profile/data])))
+          "the optimistic flip lands on alice right away")
+      (let [a-follow (req-by-method+url @lowered :post "/profiles/alice/follow")]
+        (is (= [:profile/followed "alice"] (:on-success a-follow))
+            "the follow POST's success target carries the username the flip was
+             issued on — the follow POST has no :request-id, deliberately, so
+             this target is the only identity the reply carries back")
+        (is (= [:profile/follow-rollback "alice" false] (:on-failure a-follow))
+            "…and its failure target carries that username AND the flag to restore")
+        ;; The reader gives up waiting and opens bob's profile.
+        (rf/dispatch-sync [:rf.route/handle-url-change "/profile/bob"] {:frame f})
+        (settle-ok! f (:on-success (req-by-id @lowered [:profile/load "bob"]))
+                    {:profile (full-profile "bob" false)})
+        (let [before (pf-slice* f :profile)]
+          ;; Alice's follow SUCCEEDS, late. :profile/followed re-seeds the WHOLE
+          ;; banner map from its reply, so ungated this would put alice's name,
+          ;; bio and avatar under bob's URL — not merely flip a flag.
+          (settle-ok! f (:on-success a-follow) {:profile (full-profile "alice" true)})
+          (is (= before (pf-slice* f :profile))
+              "a late alice follow success changes NOTHING on bob's banner slice")
+          (is (= "bob" (:username (pf-sub* f [:profile/data])))
+              "…so bob's name is still the one on screen")
+          ;; The same held request's ROLLBACK branch: either branch is a reply
+          ;; the transport could have picked, and both must be refused.
+          (settle-fail! f (:on-failure a-follow))
+          (is (= before (pf-slice* f :profile))
+              "a late alice rollback changes nothing either — bob's :following
+               flag is not flipped by a failure that was never his")))
+      ;; NON-VACUITY for BOTH branches: bob's own follow settles are accepted.
+      (rf/dispatch-sync [:profile/follow] {:frame f})
+      (settle-ok! f (:on-success (req-by-method+url @lowered :post "/profiles/bob/follow"))
+                  {:profile (full-profile "bob" true)})
+      (is (true? (:following (pf-sub* f [:profile/data])))
+          "bob's OWN follow success is accepted and re-seeds :following true")
+      (rf/dispatch-sync [:profile/unfollow] {:frame f})
+      (is (false? (:following (pf-sub* f [:profile/data])))
+          "the optimistic unfollow flip lands")
+      (settle-fail! f (:on-failure (req-by-method+url @lowered :delete "/profiles/bob/follow")))
+      (is (true? (:following (pf-sub* f [:profile/data])))
+          "bob's OWN rollback is accepted — it restores the captured prior flag,
+           so the gate correlates rather than swallowing rollbacks"))))
+
+(deftest realworld-profile-page-cross-username
+  (testing "cross-username banner/authored requests are independently
+            deliverable; usernames ride both reply targets; a LATE alice
+            success cannot overwrite the active bob page (rf2-8icg)"
+    (profile-cross-username-late-success-is-refused-test))
+  (testing "a LATE alice failure cannot strand bob's machine in :error, and
+            bob's own success still renders :loaded; a CURRENT username's own
+            failure IS accepted (the failure gate's non-vacuity control)
+            (rf2-8icg)"
+    (profile-cross-username-late-failure-is-refused-test))
+  (testing "a username change resets the banner while a same-username re-load
+            retains it as a refresh; the cross-TAB read guard keeps alice's
+            still-loaded authored rows off bob's URL (rf2-8icg)"
+    (profile-username-change-resets-and-cross-tab-read-guard-test))
+  (testing "a held alice follow settles — success or rollback — cannot mutate
+            bob's banner, while bob's own follow success and rollback are both
+            accepted (rf2-8icg)"
+    (profile-cross-username-follow-settles-are-refused-test)))
 
 ;; ============================================================================
 ;; http — failure->message + pure pagination/query helpers


### PR DESCRIPTION
Closes rf2-8icg.

## The race, established at source

`/profile/:username` and `/profile/:username/favorites` both run `[:profile/load]`
plus a list load on every match (`routing.cljs:110-126`). Walking alice -> bob
therefore leaves up to four alice requests in flight, under **distinct**
per-username `:request-id`s (`[:profile/load "alice"]` vs `[:profile/load "bob"]`).
Managed HTTP supersedes only when a *new* request **reuses the same id**, so
nothing suppressed alice's replies and every one of them was delivered in full.

Every reply target omitted the username, and every terminal handler wrote the one
shared `:profile` / `:profile.articles` / `:profile.favorites` slice
unconditionally. A late alice settle could replace bob's data, status, error,
timestamp or `:following` flag. A late alice *failure* was worse than a flash: it
sent the `:ui/profile` `:data` region to `:error`, a state with **no
`fetch-succeeded` edge**, stranding bob's page in an error presentation even after
bob's own load succeeded.

## Framework machinery vs a local gate — and why the gate

The framework half is real and is **kept**: the per-username `:request-id`s stay,
so a route re-match or a `?page=` step still supersedes its own predecessor
*before delivery*. That is supersession doing exactly what it is for — retiring a
re-issue of the same read.

Collapsing the reads onto a page-slot id (`:request-id :profile/load`) so bob
supersedes alice was considered and rejected, because it does not close the hole:

- **Arriving at bob issues no new follow.** An in-flight alice follow is
  superseded by nothing, and `:profile/followed` re-seeds the *whole* banner map
  from its reply — so alice's name, bio and avatar land under bob's URL. Only a
  correlation gate refuses that, so a gate is needed regardless; one law is better
  served by one mechanism than two.
- `comments.cljs` already rules this way in prose, citing Spec 014 (navigation
  staleness for a plain managed request is the app's, not the fx's), and
  `article_editor.cljs` and the resources twin spell the same law. A fourth file
  solving the identical race a fourth way is itself the teaching defect.

So this adopts the law the app already has, against `:username` instead of `:slug`.

## The fix

- Each slice records the username it is loading, stamped in the same write that
  starts the load.
- All **nine** settles carry that username and write nothing when it is no longer
  the slice's: three successes, three failures, `:profile/followed`,
  `:profile/unfollowed`, `:profile/follow-rollback`. "Nothing" includes the
  machine broadcast, which is what un-strands the `:error` presentation.
- A username **change** resets the slice; a same-username re-entry stays a
  `:fetching` refresh, so a reload never blanks a loaded page.
- The two list subs ask once more at **read** time. The tabs load on separate
  routes, so alice -> bob/favorites reloads the banner and the favorited list and
  leaves the **authored** list still holding alice's articles; this stops them
  being rendered, or counted, under bob's URL. Asking here rather than leaning on
  the `:tab` region is deliberate — the tab broadcast rides in the load handler's
  `:fx`, and an invariant this plain should not depend on which dispatch wins.
- `schema.cljs` gains the optional `:username` slice key, the profile-route twin
  of the existing `:slug`.

No `:request-id` was added to the follow/unfollow mutations. It would make a rapid
Follow->Unfollow supersede its predecessor, but supersession aborts the request as
well as suppressing the reply, and abort-mid-write is a decision a POST deserves
to have made about it on purpose. Every other mutation in this app carries no id
either. The bead offers this as optional ("may additionally"); declining keeps the
change consistent with its siblings.

## The third file

`realworld_resources/` was checked and is **immune, mutations included** — not
just the reads the bead cited. Cache identity is
`[scope resource-id canonical-params]` with the username in `:params`, and
`:realworld/follow` / `:realworld/unfollow` key their `:populates` and
`:invalidates` to `{:username username}`. A late alice reply lands in alice's
cache entry, which is correct. It is the model, and the contrast is now written
into the fix's own prose: identity-keyed state needs no gate; one shared slice per
page has to carry its identity by hand. No change made there.

## Verification, and one blocker

Examples are test-free (rf2-8cevm), so no test was added beside the example. The
regression witness the bead's acceptance criteria describe belongs in
`implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`, which is
**fenced for this dispatch** (a peer is live in that tree), so it was not written.
Stating that plainly rather than smuggling a test into a locked tree.

**This PR is not mergeable on its own.** One existing assertion in that fenced
file pins the pre-fix shape:

```clojure
;; line 2896, in profile-follow-test
(rf/dispatch-sync [:profile/follow-rollback true {:kind :rf.http/http-4xx}] {:frame f})
```

It needs the issuing username inserted:

```clojure
(rf/dispatch-sync [:profile/follow-rollback "eve" true {:kind :rf.http/http-4xx}] {:frame f})
```

This is **not** a mechanical arity bump that a different fix could dodge. The
test's premise is a rollback that is a pure function of its args with **no
identity** — which is precisely the defect. Any correct correlation of that
handler changes that dispatch, so the line must move in whatever lands.

Everything else in that suite was checked against the change and is unaffected:
`profile-load-test` and the rest of `profile-follow-test` drive through
`:rf.route/handle-url-change`, so the slices are stamped from the route and the
canned settles correlate. A whole-repo search (with a control) found no other
reference to any changed event id.

Gates: `check-examples-compile.cjs` covers this example — its build list is
derived from `shadow-cljs.edn`, and `:examples/realworld` (`init-fn
realworld-http.core/run`) is in the 58. `mkdocs build --strict` and
`check_doc_slugs.py` do **not** cover `examples/`, so neither is cited here; the
one docs link added (`docs/async/http.md#cancellation-supersession-and-abort`) was
verified by hand against the heading, and the identical anchor is already used
from `docs/async/tutorial.md` and `coming-from-promises.md`, where the docs gate
does validate it.


## Measured gate results

- **`node scripts/check-examples-compile.cjs`** — exit **0**. All 58 swept builds
  compiled with zero warnings. `:examples/realworld` specifically:
  `Build completed. (333 files, 332 compiled, 0 warnings, 10.64s)`.
- **`npm run test:cljs`** — exit **1**. `Ran 11208 tests containing 56567
  assertions. 1 failures, 0 errors.` The single failure is the fenced line
  described above, and it is the fix working:

  ```
  FAIL in (realworld-favorites-follow-feed) (re_frame/realworld_cljs_test.cljs:2897:9)
  :profile/follow-rollback restores the captured prior following flag
  expected: (true? (:following (rf/compute-sub [:profile/data] ...)))
    actual: (not (true? false))
  ```

  The test dispatches the rollback with no username, so `username` binds to
  `true`, does not match the slice's `"eve"`, and the gate correctly refuses the
  write — leaving `:following` `false`. Inserting `"eve"` as the leading argument
  is the whole companion change.

Nothing else in the suite moved: 1 failure, 0 errors, against the same
11208/56567 the tree reports at tip.
