### PR TITLE
docs(examples): the routing example stops advertising an inert route schema (rf2-51in)

### DIFF
--- a/examples/capabilities/routing/routing/README.md
+++ b/examples/capabilities/routing/routing/README.md
@@ -23,7 +23,7 @@ This is the smallest app that puts all 3 to work — just a
 
 - The route table is data (`reg-route`) — 4 rows, one per page:
   `:routing.app/home`, `:routing.app/articles`, `:routing.app/article-detail`
-  (whose `:id` path param carries a Malli `:params` schema), and the
+  (whose `/articles/:id` pattern captures `:id` as a string), and the
   reserved `:rf.route/not-found`. You register rows, the same way you
   register an event handler. No router object is built.
 - The root view branches on the route — `root-view` is a `case`
@@ -63,6 +63,13 @@ table, navigation as an event, the route as a subscription, and a
 root-view switch. This app has each one once, in its plainest form, with
 nothing extra to distract. Read it and you have a complete pattern to
 copy when scaffolding a routed app.
+
+One thing it deliberately leaves out: a route may declare `:params` /
+`:query` Malli schemas, but those validate only in an app that requires
+`re-frame.schemas` — that require is what wires the validator. Declared
+without it, a route schema reads like a contract and enforces nothing, so
+this app declares none and `:id` stays the string the URL held. See the
+[schemas guide](../../../../docs/core/how-to/validate-with-schemas.md).
 
 Two small details are worth copying too:
 

--- a/examples/capabilities/routing/routing/core.cljs
+++ b/examples/capabilities/routing/routing/core.cljs
@@ -46,9 +46,15 @@
 (rf/reg-route :routing.app/articles
   {:doc  "Articles list."} "/articles")
 
+;; A route may also carry `:params` / `:query` Malli schemas. They are worth
+;; knowing about, but they only *do* anything in an app that loads
+;; `re-frame.schemas` — that require is what wires the validator. This example
+;; stays schemas-free, so it declares none: a schema here would read like a
+;; contract and enforce nothing. `:id` arrives as the string the URL held.
+;; See the schemas guide:
+;; ../../../../docs/core/how-to/validate-with-schemas.md
 (rf/reg-route :routing.app/article-detail
-  {:doc    "Detail page for one article."
-   :params [:map [:id :string]]} "/articles/:id")
+  {:doc  "Detail page for one article."} "/articles/:id")
 
 ;; When a URL matches nothing, the runtime routes to :rf.route/not-found for
 ;; you. Register it like any other route and you decide what that page says.


### PR DESCRIPTION
Closes rf2-51in.

## The defect

`examples/capabilities/routing/routing/core.cljs` declared

```clojure
(rf/reg-route :routing.app/article-detail
  {:doc    "Detail page for one article."
   :params [:map [:id :string]]} "/articles/:id")
```

and the README called that out as a demonstrated Malli feature ("whose
`:id` path param carries a Malli `:params` schema"). Neither was true of
this app. The namespace requires only `re-frame.routing` and the Reagent
adapter, and `:examples/routing` declares no preload.

Route validation is late-bound. `validate-route-shape` returns
`[false nil]` when no validator hook is registered, and the hook
`:schemas/validate-with-registered-fn` is published only when
`re-frame.schemas` loads. Spec 012 §Param validation at the call site says
the same thing from the other side — the check "is gated on the schemas
artefact". Nothing here loads it, so the declaration validated nothing.

The instance hid unusually well: path captures are already strings and
`:string` is a deliberate coercion passthrough, so the declaration also
changed no value. A reader copying the shape and swapping `:string` for
`:int`, an enum or a closed map would get working coercion (routing derives
that without schemas) beside a boundary that still rejects nothing — a
contract in appearance only. That is what makes it a teaching defect rather
than dead code.

## The fix, and why this direction

Withdrawn rather than made real. Making it real means requiring
`re-frame.schemas`, which Spec 010 prices at **+39.9 KB gzip** on a matched
A/B — and an honest schema demo also needs a visible invalid-input path,
which is a different example than "the smallest app that exercises Spec 012
end to end". Neither belongs in this one.

Deliberately **not** hand-rolled: the framework's validation is real and
complete, it simply is not loaded here. An example that grew its own guard
would teach a worse pattern than the one being fixed.

In its place, both files now say what is actually true — route schemas
exist, and the `re-frame.schemas` require is what makes them fire — with a
pointer to `docs/core/how-to/validate-with-schemas.md`.

## Behaviour

Unchanged. Path captures come from the compiled pattern, not from `:params`
metadata, and `coerce-path` returns params unchanged when no `:params`
schema is present (or an all-string one). `/articles/:id` supplies the same
string `:id` to `article-detail-page` as before. No runtime, package,
coercion or other-example behaviour moves.

## Verification

Examples are test-free (rf2-8cevm) — no `*.spec.cjs` may live under
`examples/` — and a substrate contract test would be the wrong home for a
two-line prose-and-metadata correction that changes no runtime behaviour.
So this is verified by compile plus the source evidence above, not by a new
test, and that is stated plainly rather than papered over.

- `node implementation/scripts/check-examples-compile.cjs` — **exit 0**,
  all 58 derived builds, zero warnings, including
  `[:examples/routing] Build completed. (178 files, 177 compiled, 0 warnings)`.
- `python scripts/check_readme_links.py --ci` — **exit 0**, empty output.
  A green here is otherwise indistinguishable from a dead gate, so it was
  controlled: planting a broken target in the new paragraph's link produced
  **exit 1** naming the file and line 72; restoring from a byte-copy and
  re-running returned exit 0 with CRLF line endings intact.
- Both re-run on the final rebased base.

Not cited, because they cover nothing here: `mkdocs build --strict`
(`docs_dir` is `docs`, and the hook stages only `spec/` and `migration/`,
so `examples/` is invisible to it) and `scripts/check_doc_slugs.py`
(`DEFAULT_ROOTS` is docs / spec / skills / migration, plus `tools/*/spec`).
Anchors and prose in the README were checked by hand.
