### PR TITLE
fix(examples): the Nine States load lane is newest-intent-wins (rf2-t9va)

### DIFF
--- a/examples/patterns/nine_states/README.md
+++ b/examples/patterns/nine_states/README.md
@@ -128,8 +128,14 @@ beats which, you edit one table, not 10 views.
   ([the uniform reply](../../../docs/core/glossary.md#the-uniform-reply)),
   which the demo events forward into the machine as `:fetch-succeeded` /
   `:fetch-failed`. No promise-threading glue between the network and the
-  state graph. See
-  [`spec/Pattern-RemoteData.md`](../../../spec/Pattern-RemoteData.md).
+  state graph. Both load events also name the page's one data-load slot
+  with a shared `:request-id`, so a newer load supersedes an older one
+  still in flight instead of racing it — newest intent wins, and the
+  arbitration stays in the managed-HTTP boundary rather than in a
+  hand-written ownership check. See
+  [`spec/Pattern-RemoteData.md`](../../../spec/Pattern-RemoteData.md)
+  and [cancellation and
+  supersession](../../../docs/async/http.md#cancellation-supersession-and-abort).
 - A form, the data-oriented way. The `{:draft :errors :touched}`
   slice in app-db holds the form's working state; a pure validator decides
   correct-vs-incorrect; the form region tracks the lifecycle. See

--- a/examples/patterns/nine_states/core.cljs
+++ b/examples/patterns/nine_states/core.cljs
@@ -109,6 +109,38 @@
    :errors   {}
    :touched  #{}})
 
+(def data-load-request-id
+  "The page has exactly one data-load slot, and this is its name. Every
+   request that fills that slot — `:nine-states.demo/load` and
+   `:nine-states.demo/load-with-failure` alike — issues
+   `:rf.http/managed` under this one `:request-id`, and that is what
+   makes the page *newest-intent-wins*: issuing a request under an id
+   that is already in flight supersedes the earlier attempt, and the
+   superseded attempt's reply is suppressed before it can reach a
+   handler.
+
+   That matters here because nothing else in the page stops two loads
+   from racing. The control panel stays live while the `:data` region is
+   `:loading`, so a second click starts a second load; `:loading` then
+   has no `:fetch-started` of its own to notice, and accepts whichever
+   `:fetch-succeeded` / `:fetch-failed` lands *first* and leaves for a
+   bucket that has no completion handler at all — so without the shared
+   id, a nearly-finished old load would choose the visible bucket and the
+   newer one's result would be dropped on the floor. One field, and the
+   arbitration lives in the managed-HTTP boundary instead of in a
+   hand-rolled ownership check.
+
+   So read it as ownership, not as tracing metadata. It is deliberately
+   the same id for the succeeding and the failing load, because they
+   compete for the same slot — an old failure must not be able to park
+   the page at `:error` while a newer success is still in flight. And it
+   is safe to keep it a plain, reusable constant: supersession is scoped
+   to the issuing frame, so two frames running this example (the Story
+   shell mounts one per variant) never supersede each other's requests.
+   See [cancellation and supersession]
+   (../../../docs/async/http.md#cancellation-supersession-and-abort)."
+  :nine-states.data/load)
+
 ;; ============================================================================
 ;; SCHEMAS
 ;; ============================================================================
@@ -200,6 +232,16 @@
 ;; framework's canned-success / canned-failure fxs. That's what lets the
 ;; control panel conjure Empty / One / Some / Too Many on demand, no
 ;; backend required. See [managed HTTP](../../../docs/async/http.md).
+;;
+;; Worth knowing while you read the load events below: an `:fx-overrides`
+;; entry REPLACES `:rf.http/managed` outright, so under this stub the
+;; framework's in-flight registry — and with it the `:request-id`
+;; supersession the load events rely on — never runs, and the canned
+;; replies land synchronously anyway, one at a time. The requests are
+;; still written the way a real one must be, because swapping this
+;; override out for the real transport is the moment the id starts
+;; earning its keep and is exactly the copy-and-adapt step this example
+;; exists to guide.
 
 (defn- generate-todos [todo-count]
   (vec (for [index (range todo-count)]
@@ -342,6 +384,16 @@
       ;; fetch: the region drops to :nothing and :reset-domain wipes :data.
       ;; A late reply from the abandoned load is then inert — :nothing has no
       ;; :fetch-succeeded handler, so it can't resurrect the reset state.
+      ;;
+      ;; Note :loading deliberately has no :fetch-started of its own — a
+      ;; second load while one is in flight is not a state change, so
+      ;; there is nothing here to arbitrate the two replies. That job
+      ;; belongs to the request itself, and `data-load-request-id` does
+      ;; it: the second request supersedes the first and the first's
+      ;; reply is suppressed before it can arrive. The same one id also
+      ;; closes the reset-then-reload window, where :reset alone would
+      ;; leave the abandoned request live and :loading would accept its
+      ;; reply once the reload put the region back here.
       {:tags #{:data/loading :data/transient}
        :on   {:fetch-succeeded {:target :resolving
                                 :action :set-items}
@@ -465,7 +517,11 @@
          folds back through :nine-states.demo/loaded into the machine's
          :fetch-succeeded event, and from there the :data region's
          :always-cascade reads the count and picks the cardinality bucket.
-         Ask for n items, get the matching state."}
+         Ask for n items, get the matching state.
+
+         The request rides the page's one `data-load-request-id`, so
+         clicking a second load while the first is still in flight
+         supersedes it rather than racing it — see that def."}
   (fn handler-demo-load [_ [_ {:keys [n]}]]
     {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
           [:rf.http/managed
@@ -473,17 +529,21 @@
                          :url    "/api/todos"
                          :query  {:n (or n 0)}}
             :decode     :json
+            :request-id data-load-request-id
             :on-success [:nine-states.demo/loaded]
             :on-failure [:nine-states.demo/load-failed]}]]}))
 
 (rf/reg-event :nine-states.demo/load-with-failure
   {:doc "Same idea, but the fetch is rigged to fail — the :data region
-         lands in :error."}
+         lands in :error. Same `data-load-request-id` as the succeeding
+         load, deliberately: both fill the one data-load slot, so either
+         kind of newer intent supersedes either kind of older attempt."}
   (fn handler-demo-load-with-failure [_ _]
     {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
           [:rf.http/managed
            {:request    {:method :get :url "/api/todos/fail"}
             :decode     :json
+            :request-id data-load-request-id
             :on-success [:nine-states.demo/loaded]
             :on-failure [:nine-states.demo/load-failed]}]]}))
 

--- a/examples/patterns/nine_states/stories.cljs
+++ b/examples/patterns/nine_states/stories.cljs
@@ -127,6 +127,16 @@
            {:request    {:method :get :url "/api/todos" :query {:n (or n 0)}}
             :value      (generate-todos (or n 0))
             :decode     :json
+            ;; The twin carries the live example's ownership field too, so
+            ;; the envelope a reader inspects in Xray is the real one. It
+            ;; reaches for `nine-states.core`'s constant rather than
+            ;; copying the keyword — a story that drifted onto its own id
+            ;; would be teaching the exact mistake the id exists to
+            ;; prevent. (`generate-todos` above is copied because it is
+            ;; private; this is public, and shared on purpose.) Story runs
+            ;; each variant in its own frame and supersession is
+            ;; frame-scoped, so one shared id costs the variants nothing.
+            :request-id nine-states.core/data-load-request-id
             :on-success [:nine-states.demo/loaded]
             :on-failure [:nine-states.demo/load-failed]}]]}))
 
@@ -155,6 +165,9 @@
             :kind       :rf.http/transport
             :tags       {:message "Network unreachable."}
             :decode     :json
+            ;; Same slot, same id as the succeeding twin — see the live
+            ;; example's `data-load-request-id`.
+            :request-id nine-states.core/data-load-request-id
             :on-success [:nine-states.demo/loaded]
             :on-failure [:nine-states.demo/load-failed]}]]}))
 


### PR DESCRIPTION
## What and why

The Nine States example issued both of its data loads with `:rf.http/managed` and **no `:request-id`**. An anonymous managed request never supersedes — `implementation/http/src/re_frame/http/registry.cljc` says so in as many words — so the page settled **first-reply-wins** rather than newest-intent-wins.

The three things that compose into the defect, each read at source:

- The control panel disables its load buttons only on `:mode/read-only`, not on `:data/loading`, so a second click while a load is in flight is a supported interaction.
- `:loading` has no `:fetch-started` transition, so a second load is not a state change and the region cannot notice it.
- `:loading` leaves for a bucket on whichever `:fetch-succeeded` / `:fetch-failed` arrives **first**, and the buckets consume no completion at all — so the newer load's result is then dropped on the floor. The failure crosses kinds too: an old failing load could park the page at `:error` while a newer success was still in flight.

## The call: adopt the framework's supersession, do not hand-roll a guard

The framework already owns this. A second `:rf.http/managed` under an id already in flight **in the same frame** supersedes the first and suppresses its app reply before any handler sees it (`registry/supersede!`, `:reason :request-id-superseded`), and `spec/014-HTTPRequests.md` names exactly that as the app-level mechanism for requests dispatched directly from an event handler — which get no actor-destroy cascade. So this is one existing field, not new machinery.

The `:spawn` / machine-wrapper route was considered and rejected on the merits as well as by the finding's non-goals: binding the request to `:loading` occupancy would not fire here anyway, because `:loading` has no self-transition on `:fetch-started`, so a second load causes no region exit and therefore no actor destroy. Reaching that route would mean reshaping the machine, which is out of scope.

## The change

- `data-load-request-id` — one named constant for the page's single replaceable data-load slot — on both live request shapes (`:nine-states.demo/load`, `:nine-states.demo/load-with-failure`) and both Story twins.
- One id for the succeeding **and** the failing load is deliberate: they compete for the same slot.
- The Story twins reference the constant rather than copying the keyword; a story drifted onto its own id would teach the mistake the id exists to prevent. Supersession is frame-scoped, so Story's per-variant frames cost nothing.
- Reader-facing prose explains the id as *ownership*, not tracing metadata, and records honestly that the demo `:fx-overrides` stub **replaces** `:rf.http/managed` outright — so the in-flight registry, and supersession with it, only run once a reader swaps in the real transport. That swap is the copy-and-adapt moment this canonical example exists to guide.
- The `:loading` state comment now says why arbitration belongs to the request rather than the region, and notes that the same one id also closes the reset-then-reload window (`:reset` does not abort the in-flight request; the reload's supersession is what protects it).

## What a reader sees differently

Under the real transport: issue a 25-row load, then a 1-row load before the first settles, and the page lands on `:one`. Before this change it landed on `:too-many` and the requested `:one` never appeared.

## Verification — stated plainly

- `node implementation/scripts/check-examples-compile.cjs` — **exit 0**, captured from the runner's own exit file. 58/58 swept builds, zero warnings. `examples/nine-states` (229 files) and `examples/nine-states-with-stories` (695 files) both clean; the latter is what proves the cross-namespace constant reference resolves.
- `scripts/check_readme_links.py --ci` — **exit 0**. Because an empty log on exit 0 proves nothing, this was controlled with two plants in the edited README region: a broken target file returned exit 1 naming `README.md:139`, and a broken anchor returned exit 1 naming `README.md:138`. Both restored from a byte copy and verified with `cmp`.
- `mkdocs build --strict` and `check_doc_slugs.py` **do not cover `examples/`** — citing either here would be a vacuous green, so neither is claimed.
- **No behavioural test accompanies this change, and that is a real gap, not an omission I am papering over.** `examples/` is test-free (rf2-8cevm) and the deterministic overlap regression needs a controlled transport under `implementation/`, which was outside this change's scope. Filed as **rf2-5bmi** with the full shape the finding asked for: hold A open, issue B through the shipped event, prove A's reply reaches no app target, settle B and prove only B's result chooses the state, a cross-kind row, and a negative control that removes the shared id. Verified here by compile plus contract reading only.

Closes rf2-t9va.
