### PR TITLE
fix(examples-machines): :error-shown clears its error on exit (rf2-283u)

### DIFF
--- a/examples/capabilities/machines/state_machine_walkthrough/README.md
+++ b/examples/capabilities/machines/state_machine_walkthrough/README.md
@@ -57,6 +57,14 @@ at it, poke here.
   rejected attempts, then a third that the retry guard rejects, parking the
   machine in `:locked-out`.
 
+- Entry and exit as a matched pair. `:submitting` declares
+  `:entry :issue-request`, so every path *into* it issues the request;
+  `:error-shown` declares `:exit :clear-error`, so every path *out of* it drops
+  the message. Dismiss and a direct retry are both covered without either
+  transition restating it — which is why the view renders the error row from
+  `:data` alone. A non-nil error is always a live one, never a leftover from the
+  attempt before.
+
 - The same flow tested as pure function calls. Feed a starting
   [snapshot](../../../../docs/machines/glossary.md#snapshot) and an event into
   `machine-transition`, then assert against the snapshot that comes back. For

--- a/examples/capabilities/machines/state_machine_walkthrough/core.cljc
+++ b/examples/capabilities/machines/state_machine_walkthrough/core.cljc
@@ -70,6 +70,9 @@
 
    :actions
    {:clear-error
+    ;; Named once here, then used from two different slots below: as a
+    ;; transition :action leaving :idle, and as :error-shown's :exit. Keyword
+    ;; refs resolve machine-locally against this map, so one action serves both.
     (fn [_] {:data {:error nil}})
 
     :issue-request
@@ -104,6 +107,11 @@
 
    :states
    {:idle
+    ;; :error-shown's :exit (below) already guarantees a nil error on every path
+    ;; that reaches :idle, so for any snapshot the table itself produced this
+    ;; :action is redundant. It earns its keep on the ones a test hand-builds —
+    ;; this example's whole point being that a pure call may start from any
+    ;; :data you care to hand it.
     {:on {:walkthrough.login/submit {:target :submitting
                               :action :clear-error}}}
 
@@ -124,8 +132,23 @@
                                    :action :record-error}]}}
 
     :error-shown
-    {:on {:walkthrough.login/dismiss {:target :idle}
-          :walkthrough.login/submit  {:target :submitting}}}
+    ;; The error belongs to THIS state, so this is where it gets cleaned up.
+    ;; :exit runs on the way out — on every way out — and it is the other half
+    ;; of the pair :submitting shows above: "Use `:entry` for work that should
+    ;; happen whenever the state is entered ... Use `:exit` for cleanup"
+    ;; (docs/machines/concepts.md). Saying it once here covers both exits,
+    ;; Dismiss and a direct retry. Hanging :clear-error off each transition
+    ;; instead restates one invariant per edge, and that lasts precisely until
+    ;; someone adds a third edge and forgets.
+    ;;
+    ;; Slot order is :exit -> transition :action -> target :entry, so on a
+    ;; direct retry the stale message is gone BEFORE :submitting's
+    ;; :issue-request fires — a fresh request never rides alongside the previous
+    ;; failure. And {:data {:error nil}} MERGES, so :attempts survives untouched
+    ;; and the retry guard goes on counting.
+    {:exit :clear-error
+     :on   {:walkthrough.login/dismiss {:target :idle}
+            :walkthrough.login/submit  {:target :submitting}}}
 
     :authed
     ;; Journey's end, happy path. The :auth/authenticated tag rides along once

--- a/examples/capabilities/machines/state_machine_walkthrough/views.cljs
+++ b/examples/capabilities/machines/state_machine_walkthrough/views.cljs
@@ -66,6 +66,10 @@
                :data-testid "login-submit"
                :disabled (or busy? locked?)}
       (if busy? "Signing in…" "Sign in")]
+     ;; A straight read of the machine's :data — no state check, no second
+     ;; predicate. It can be, because the machine drops the error as it leaves
+     ;; :error-shown, so a non-nil error is always a live one. Data that tells
+     ;; the truth is what lets a view stay this small.
      (when (and err (not locked?))
        [:div.error-row
         [:p.error err]


### PR DESCRIPTION
Closes rf2-283u.

## The defect, and when it bites

`:error-shown` records a failed login into the machine's `:data :error`, but
neither transition out of it cleared the error, while `views.cljs` renders the
error row from `:data` alone — `(when (and err (not locked?)) ...)`, with no
state condition.

**The staleness window opens the instant the machine leaves `:error-shown`** and
closes only at the next `:idle -> :submitting` submit, whose `:action
:clear-error` finally nils it. Three things a reader could see inside it:

- **Dismiss did not dismiss.** Click the button labelled **Dismiss**: the banner
  flips `error-shown` -> `idle`, and the error text and the Dismiss button stay
  on screen unchanged. Clicking again does nothing at all — `:idle` has no
  `dismiss` handler, so the control is inert. The window stays open indefinitely.
- **A fresh request wearing the last one's failure.** Submitting straight from
  `:error-shown` moves to `:submitting`: inputs dim, the button reads
  "Signing in…", and the *previous* attempt's message sits underneath a request
  that has not failed yet.
- **An error beside a success.** Fail, retry directly, succeed: the flow lands
  `:authed`, which carries no `:auth/locked` tag, so `root-view` still renders
  the form — with the stale failure showing.

## The fix: the machine layer already owns this

`:exit` is a per-state hook in the machine grammar (`spec/005-StateMachines.md`
§state-node grammar), resolved through the same machine-local `:actions` map as
any other action ref. The chapter this example is pinned to says it in one line:

> Use `:entry` for work that should happen whenever the state is entered —
> issuing the request, so every path into `:submitting` fires it. Use `:exit`
> for cleanup.
> — `docs/machines/concepts.md`

The example already showed the `:entry` half on `:submitting`. This adds the
`:exit` half it was missing, reusing the `:clear-error` action defined a few
lines above:

```clojure
:error-shown
{:exit :clear-error
 :on   {:walkthrough.login/dismiss {:target :idle}
        :walkthrough.login/submit  {:target :submitting}}}
```

Nothing new is introduced — no runtime, API or spec change, no new tag,
subscription, schema, or state-specific render branch.

**Why the state hook rather than an action on each edge.** The error belongs to
`:error-shown`, so the invariant is stated once, on the state that owns it, and
every path out is covered — including the third edge somebody adds later. Both
current exits target other states, so `:exit` fires on both (a targetless
transition is the only no-cascade geometry). Slot order is `:exit` ->
`:action` -> `:entry`, so on a direct retry the message is gone *before*
`:submitting`'s `:issue-request` fires. `{:data {:error nil}}` merges, so
`:attempts` survives untouched and the retry guard goes on counting.

The `:idle` edge keeps its `:action :clear-error`: it is redundant for any
snapshot the table itself produces, but this example's whole point is that a
pure call may start from any `:data` you hand it, and its headless scenarios
build snapshots by hand. A comment now says exactly that, so the pair does not
read as an accident.

## The sibling was checked, and is not the same

`examples/core/login` shares the machine's shape but **does not have this
defect in a reachable form**, and is left alone (the item lists broad cleanup
there as a non-goal):

- Its `:error-shown` submit edge already carries `:action :clear-error`, with a
  comment reasoning explicitly about the stale message.
- Its dismiss edge has no clear — but **no view in that example renders a
  Dismiss control**. `:auth.login/dismiss` appears only in `stories.cljs`, as a
  harmless nudge to seed the machine snapshot. The window exists in the table
  and is unreachable from the UI.

## Verification

Examples are test-free (rf2-8cevm) and `implementation/**` was out of scope for
this change, so **no test file was added anywhere**. Verified instead by
compiling the build and by driving the real table on the JVM through
`machine-transition`, with a liveness control: the same table with `:exit`
stripped back off must still show the stale error, and it does
(`dismiss -> :idle` / error `"bad creds"`; `retry -> :submitting` / error
`"bad creds"`). That control is what makes the green meaningful rather than
vacuous. The driver was a scratch script, not a committed file.

Measured against the item's acceptance criteria, from
`{:state :error-shown :data {:attempts 1 :error "bad creds"}}`:

| Check | Result |
| --- | --- |
| Dismiss | `:idle`, error `nil`, attempts `1` |
| Direct submit | `:submitting`, error `nil`, attempts `1`, exactly one `:rf.http/managed` fx |
| Lockout unchanged | third failure -> `:locked-out`, attempts `3`, terminal message retained |
| First failures retryable | `:submitting` -> `:error-shown`, attempts `1` |

Gates run locally, each exit code captured to a file rather than read off the
harness:

| Gate | Exit | Detail |
| --- | --- | --- |
| `check-examples-compile.cjs --list` | 0 | 58 derived builds; `examples/state-machine-walkthrough` and `examples/login` both present |
| `check-examples-compile.cjs` | 0 | 58/58 built, **0 warnings**; the changed build 209 files / 0 warnings |
| `clojure -M:test -n re-frame.examples-test` | 0 | 15 tests, **96 assertions**, 0 failures, 0 errors |
| `check_readme_links.py --ci` | 0 | proven live: a planted broken link in this README made it exit 1 naming the file and line; restored byte-identically |

`mkdocs build --strict` and `check_doc_slugs.py` do **not** cover `examples/`,
so neither is cited here — a green from either would have inspected nothing in
this diff.
