### PR TITLE
examples(resources-ssr): the client boot acquires the route-free resource (rf2-h3c9)

### DIFF
--- a/examples/capabilities/ssr/resources_ssr/README.md
+++ b/examples/capabilities/ssr/resources_ssr/README.md
@@ -103,11 +103,32 @@ per-request, and the wire payload stays minimal.
   the cleanup the wire couldn't carry: it orphans the now-defunct SSR
   owner, recomputes the reverse indexes from `:entries`, and settles any
   wire-stripped in-flight entry to a stable
-  [status](../../../../docs/resources/glossary.md#resource-status). The
-  result is the whole point: a fresh hydrated entry renders its data
-  immediately and does not re-fetch it. (A stale, redacted, or
-  omitted entry does refetch — because for those the client genuinely
-  has no usable data in hand.)
+  [status](../../../../docs/resources/glossary.md#resource-status).
+  Reconciling is all it does. It classifies what arrived; it never causes
+  work — and neither does a passive subscription. So the client issues one
+  command of its own: `run` dispatches `:resources-ssr.app/page-opened`,
+  which `ensure`s the same resource under the app's own
+  [owner](../../../../docs/resources/glossary.md#owner--cause) before the
+  first render. That is where the payoff actually lands. For the fresh
+  hydrated entry the `ensure` is a cache hit — it takes the hold, arms the
+  entry's timers, and issues nothing — so the server's data renders on the
+  first paint and no second request goes out. A cold or stale entry gets
+  exactly the one load it needs, and no more.
+
+- Acquisition is the app's job here, because there is no route. A routed
+  page would not write that event at all: `reg-route`'s `:resources` plan
+  `ensure`s under a `[:route route-id nav-token]` owner on route entry and
+  releases it on route leave, so the framework mints and retires the hold
+  for you. This page is deliberately route-free — the simplest SSR shape
+  there is — so it uses the framework's other answer, the app-minted event
+  owner ([Spec 016 §The scoped-cache owner
+  lifecycle](../../../../spec/016-Resources.md)), and owns the matching
+  `:resources-ssr.app/page-closed` release to go with it. Both halves
+  matter. An owner nobody releases pins its entry alive forever; an entry
+  nobody owns is renderable but inert — tag invalidation and
+  focus/reconnect revalidation pass it by, and no GC clock runs. Taking the
+  hold is what makes the hydrated cache a live cache rather than a picture
+  of one.
 
 - Scope is a wall hydration may never cross. The resource declares
   `:scope :rf.scope/global` — the auditable claim that this article list
@@ -121,8 +142,15 @@ per-request, and the wire payload stays minimal.
 
 The SSR-resource runtime is real: `handle-request` drives the actual
 server path, not a skeleton stand-in. The blocking poll, the per-entry
-projection (redaction / omission / scoped-key privacy / index omission),
-and the client hydration reconcile + refetch plan all run end-to-end.
+payload projection, the client hydration reconcile, and the client
+acquisition all run end-to-end. Two limits on that worth stating plainly.
+`:articles/list` declares neither `:sensitive?` nor `:large?`, so the
+projection's redaction and omission branches are available to it but are
+never taken on this page. And hydration's refetch plan *classifies* what
+arrived without issuing anything — the request this page does or doesn't
+make is decided by the client `ensure` above, not by the plan. The generic
+contract for both is [Spec 016 §SSR and
+hydration](../../../../spec/016-Resources.md).
 
 The `index.html` next to this file carries a pre-baked hydration
 payload — a `:loaded` `:articles/list` entry — so the browser-side `run`
@@ -135,9 +163,11 @@ not under the scoped-key vector as a map key. It's an illustrative
 stand-in for what `handle-request` emits behind a real server, not a
 byte-exact capture. Because `:articles/list` declares no time-based
 staleness policy, the baked entry carries `:stale-at nil` and stays
-deterministically fresh — no rotting absolute deadline — so on hydration
-it renders immediately and the client does not refetch. One visible
-difference is the frame-id. This hand-written
+deterministically fresh — no rotting absolute deadline. So the client's
+`:resources-ssr.app/page-opened` `ensure` takes the fresh-skip path: it
+attaches the page owner and arms the entry's timers without issuing a
+request, which is what lets this fixture run with no server behind it.
+One visible difference is the frame-id. This hand-written
 payload pins `:rf/frame-id :rf/default` — present and equal to the
 client's fixed target, a valid no-conflict shape a static file can
 hand-pick. `handle-request` instead drops `:rf/frame-id`, because its

--- a/examples/capabilities/ssr/resources_ssr/core.cljc
+++ b/examples/capabilities/ssr/resources_ssr/core.cljc
@@ -25,9 +25,12 @@
      `:rf/runtime-db`). Fetch handles and the tag/owner indexes stay home;
      the indexes recompute from `:entries` the moment the client installs them.
    - On the client the framework's `:rf/hydrate` event drops those entries
-     into the frame's `:rf.runtime/resources` slice. A fresh entry renders
-     immediately and serves from cache. Stale, redacted, or omitted entries
-     refetch — because for those the client has nothing usable in hand.
+     into the frame's `:rf.runtime/resources` slice — and that is all it
+     does. Hydration reconciles and classifies; it never causes work, and
+     neither does reading. The `[:ssr …]` owner is dropped with the request
+     that minted it, so what lands is a renderable entry that nothing holds.
+     Acquiring it on the client is the app's job, and on a page with no route
+     the app has to do it by hand — see CLIENT-SIDE ACQUISITION below.
 
    This drives the real server path, not a stand-in. It blocks on the
    preloaded page resource before rendering (`await-resource-loaded!`,
@@ -148,17 +151,94 @@
                        :cause    :ssr-preload}]]]}))
 
 ;; ============================================================================
+;; CLIENT-SIDE ACQUISITION — the app-minted page owner
+;; ============================================================================
+;;
+;; Hydration is not acquisition, and this is the section that says so out loud.
+;; `:rf/hydrate` installs the server's entries, and the resource reconcile then
+;; DROPS the `[:ssr request-id nav-token]` owner — that hold belonged to a
+;; server request which has already finished. What arrives on the client is a
+;; `:loaded` entry with no live owner: renderable, but held by nothing. An
+;; ownerless entry is not a consumer. Tag invalidation passes it by, focus and
+;; reconnect revalidation skip it, and no GC clock is armed for it. Reading it
+;; through a subscription changes none of that — reads are passive by contract.
+;; So without an explicit client command the page would render the server's data
+;; once and then quietly stop being a cache.
+;;
+;; A ROUTED page never writes this section. `reg-route`'s `:resources` plan
+;; ensures under a `[:route route-id nav-token]` owner on route entry and
+;; releases it on route leave; the framework mints and retires the hold for you.
+;; This page is deliberately route-free — the simplest SSR shape there is — so
+;; there is no route entry to hang that off, and the app owns the lifecycle.
+;;
+;; The framework's answer for exactly that case is the APP-MINTED EVENT OWNER
+;; (Spec 016 §The scoped-cache owner lifecycle, the App/event owner row): an
+;; event that opens a view mints an owner named after itself, and a matching
+;; event releases it. The framework does not auto-release an app-minted owner —
+;; that pairing is the app's, and Xray lints an app owner it never sees dropped.
+;;
+;; `:resources-ssr.app/page-opened` is this page's one acquisition, and it is
+;; the SAME `ensure` the server ran, under a client owner. What it costs is not
+;; decided here — the resource runtime decides it from what hydration left:
+;;
+;;   - hydrated fresh (what the checked-in payload bakes) — `ensure` takes its
+;;     fresh-skip cache-hit path: attaches the owner, arms the entry's timers,
+;;     issues ZERO requests. The first paint still adopts the server's markup.
+;;   - hydrated stale — the entry keeps rendering its last-known-good data while
+;;     exactly one background refetch goes out.
+;;   - nothing hydrated (a plain client-only load with no `__rf_payload`) — one
+;;     first-load request, and the view shows its `:loading` skeleton until that
+;;     settles, rather than an empty list that looks like a successful answer.
+;;
+;; One event, three outcomes, none of them branched on here. That is the whole
+;; argument for a managed resource over a hand-rolled fetch.
+;; See docs/resources/glossary.md#owner--cause.
+
+(def ^:private page-owner
+  "This page's app-minted liveness owner, named after the event that mints it
+   (Spec 016's App/event owner row). The owner value IS an event id, so an Xray
+   owner row or a trace points straight back at the code holding the entry."
+  [:resources-ssr.app/page-opened])
+
+(rf/reg-event :resources-ssr.app/page-opened
+  {:doc       "The page's one client-side acquisition — take a live hold on
+               :articles/list under this page's app-minted owner. `run`
+               dispatches it AFTER hydrate! and BEFORE the first render, so the
+               entry the first render reads is already the one this owner holds."
+   :platforms #{:client}}
+  (fn [_ _]
+    {:fx [[:dispatch [:rf.resource/ensure
+                      {:resource :articles/list
+                       :params   {}
+                       :owner    page-owner
+                       :cause    [:event :resources-ssr.app/page-opened]}]]]}))
+
+(rf/reg-event :resources-ssr.app/page-closed
+  {:doc       "The matching release, and it is not optional: whatever mints an
+               owner must also drop it, or the entry is pinned alive forever and
+               the cache never GCs. This demo is a single page whose lifetime is
+               its frame's, so nothing here dispatches it — a page that can be
+               unmounted dispatches it on the way out, and a routed app gets the
+               equivalent for free when route-leave releases the route owner."
+   :platforms #{:client}}
+  (fn [_ _]
+    {:fx [[:dispatch [:rf.resource/release-owner {:owner page-owner}]]]}))
+
+;; ============================================================================
 ;; VIEWS — passive reads, server and client alike
 ;; ============================================================================
 ;;
 ;; The view does the simplest possible thing: it reads the resource through a
 ;; subscription and renders whatever's there. Reading never kicks off a fetch —
-;; the preload (server) and the hydration (client) already warmed the cache, so
-;; the data is just sitting there waiting. `:rf/resource` is the
-;; runtime's own subscription; it turns a cache entry into a tidy view-model —
-;; a status flag and the data. Either side, the data is present by first render,
-;; so there's no skeleton to flash. The same view code runs on both — the "one
-;; app, runs twice" promise, now over a managed resource.
+;; that is the contract, not an accident of this page. What warmed the cache is
+;; a command on each side: the server's `:rf/server-init` preload, and the
+;; client's `:resources-ssr.app/page-opened` acquisition below. `:rf/resource`
+;; is the runtime's own subscription; it turns a cache entry into a tidy
+;; view-model — a status flag and the data. On the documented run the data is
+;; present by first render on both sides, so there's no skeleton to flash; the
+;; `:loading` branch is what a cold client-only load shows while its one request
+;; is in flight. The same view code runs on both — the "one app, runs twice"
+;; promise, now over a managed resource.
 ;; See docs/ssr/glossary.md#render-to-string.
 
 (rf/reg-view ^{:rf/id :pages/articles} articles-page []
@@ -355,13 +435,19 @@
 ;; CLIENT ENTRY POINT
 ;; ============================================================================
 ;;
-;; The browser's side of the handoff. `rf.ssr/hydrate!` reads the payload,
-;; dispatch-syncs `[:rf/hydrate payload]` to install the resource projection
-;; into the frame's `:rf.runtime/resources` slice, then verifies the render
-;; hash to confirm client and server agree on what the page should look like.
-;; A fresh hydrated entry renders its data on the first paint and serves it
-;; straight from cache — no second fetch, which is exactly what preloading was
-;; for. A stale entry quietly refetches in the background, per its policy.
+;; The browser's side of the handoff, in three beats: HYDRATE, ACQUIRE, RENDER.
+;;
+;; `rf.ssr/hydrate!` reads the payload, dispatch-syncs `[:rf/hydrate payload]`
+;; to install the resource projection into the frame's `:rf.runtime/resources`
+;; slice, then verifies the render hash to confirm client and server agree on
+;; what the page should look like. That is a state install and a check: it
+;; issues nothing and leaves no owner behind.
+;;
+;; `:resources-ssr.app/page-opened` is the beat that does cause something. For
+;; the fresh hydrated entry it causes a cache hit — the owner attaches, the
+;; timers arm, and no request leaves the browser, which is exactly what
+;; preloading was for. For a cold or stale entry it causes the one load the page
+;; actually needs. Then the adapter renders, once.
 ;; See docs/ssr/concepts.md#the-client-side-hydrate-then-verify.
 
 #?(:cljs (defonce app-root (rf.adapter.reagent/client-root)))
@@ -401,13 +487,26 @@
      (let [el      (and (exists? js/document) (js/document.getElementById "app"))
            payload (rf.ssr/hydrate! {:frame          app-frame
                                   :render-tree-fn (fn [] ((rf/view :app/root)))})
+           ;; ACQUIRE — after the hydrate, before the first render, and the
+           ;; order is load-bearing in both directions. Ahead of `hydrate!` this
+           ;; would fetch a list the payload is about to hand us; after the
+           ;; first render it would paint an idle empty list and then correct
+           ;; itself. It is `dispatch-sync` because the first render must read a
+           ;; settled entry: a sync dispatch drains the `ensure` it enqueues to
+           ;; fixed point before returning, so a cold load's first paint is the
+           ;; `:loading` skeleton rather than an empty `<ul>`.
+           _       (rf/dispatch-sync [:resources-ssr.app/page-opened]
+                                     {:frame app-frame})
            tree    [rf/frame-provider {:frame app-frame} [(rf/view :app/root)]]]
        (when el
          ;; The whole adopt-vs-fresh decision is one option. With a payload the
          ;; server painted the page, so the first render HYDRATES: React
          ;; reconciles against the server markup — same nodes, listeners
-         ;; attached, no re-paint. Without one it is a plain first load and the
-         ;; adapter mounts a fresh root; a fresh entry serves from cache, a
-         ;; stale or absent one refetches per its policy. Either way the root
-         ;; is created exactly once, here, and `render!` above reuses it.
+         ;; attached, no re-paint. The acquisition above cannot disturb that:
+         ;; on a fresh hydrated entry `ensure` fresh-skips, so the tree the
+         ;; adapter adopts is the one the server rendered. Without a payload it
+         ;; is a plain first load and the adapter mounts a fresh root against
+         ;; the loading state that same acquisition just established. Either way
+         ;; the root is created exactly once, here, and `render!` above reuses
+         ;; it.
          (rf.adapter.reagent/render! app-root tree el {:hydrate? (some? payload)})))))

--- a/examples/capabilities/ssr/resources_ssr/index.html
+++ b/examples/capabilities/ssr/resources_ssr/index.html
@@ -38,15 +38,20 @@
     part 5), `:current-work` is stripped on the wire, and host handles never
     serialize. On hydration the framework `:rf/hydrate` installs this projection
     into the client frame's runtime partition; the reconcile orphans the
-    `[:ssr …]` SSR owner + recomputes the indexes; a fresh entry renders
-    immediately and does NOT immediately re-fetch.
+    `[:ssr …]` SSR owner + recomputes the indexes. That leaves the entry
+    renderable but held by nothing, so `run` then dispatches
+    `:resources-ssr.app/page-opened` to take the client's own hold — which
+    for this fresh entry is a cache hit: the owner attaches, the timers arm,
+    and no request is issued.
 
     Freshness: this article list declares NO time-based staleness policy
     (`:articles/list` omits `:stale-after-ms`), so its entry never ages out on
     a timer and the baked `:stale-at` is nil. That keeps this offline fixture
     deterministically fresh indefinitely — no rebased clock, no rotting
     absolute deadline — with explicit invalidation as the real freshness
-    authority. So the hydrated entry is fresh, and the client does NOT refetch.
+    authority. So the hydrated entry is fresh, the client's page-opened
+    `ensure` fresh-skips, and no request leaves the browser — which is what
+    lets this static fixture run with no server behind it.
 
     The `#app` subtree is the dev-build output of `rf/render-to-string` — the
     same string `handle-request` inlines, minus the `data-rf-render-hash`


### PR DESCRIPTION
Closes rf2-h3c9.

## The defect, established at source

`examples/capabilities/ssr/resources_ssr/` never caused its resource on the
browser side. The only `:rf.resource/ensure` was the server-only
`:rf/server-init` preload; `run` made the client frame, called
`rf.ssr/hydrate!`, and rendered a view whose `[:rf/resource ...]` read is
passive by contract.

Hydration could not supply the missing liveness. The resource reconcile
deliberately drops the baked `[:ssr request-id nav-token]` owner, because that
hold belonged to a server request that has finished, and it computes a
hydration refetch plan **without issuing it** — the contract leaves issuance to
a still-live route or consumer. This page has neither.

What a reader would actually see:

- **With the checked-in payload** (the documented `npm run dev:example` path)
  the articles render correctly and then the entry sits **owner-free**. An
  ownerless entry is not an active consumer: tag invalidation passes it by,
  focus/reconnect revalidation skips it, and no GC clock is armed. The page
  looks right and has quietly stopped being a cache.
- **With no `__rf_payload`** — a plain client-only load — `hydrate!` returns nil
  without seeding, the passive read projects `:idle`, and `articles-page` falls
  through to an **empty `<ul>` that nothing will ever fill**.

**This is an absence, not a divergence.** No hydration mismatch was involved
before this change and none is introduced by it — worth stating explicitly given
the boolean-roster (#9207) and reagent-slim parity (#9224) work turning on
mismatches React does not guarantee to patch. Here the server and client agree;
the client simply stops caring.

The prose asserted otherwise: `README.md` claimed stale/redacted/omitted entries
refetch and that "the client hydration reconcile + refetch plan run end to end",
and `run`'s own comment claimed "a stale or absent one refetches per its policy".

## The repair — the framework's seam, not a route and not a timer

Route-free is the operative qualifier. A routed page never writes any of this:
`reg-route`'s `:resources` plan ensures under a `[:route route-id nav-token]`
owner on route entry and releases it on route leave, so the framework mints and
retires the hold. Spec 016's owner table names the answer for a page that has no
route — the **App / event owner kind**: an event that opens a view mints an owner
named after itself, and a matching event releases it, with the app authoritative
for the pairing (§The scoped-cache owner lifecycle; §Polling names the same shape
for a resource with "no natural route / machine owner").

So the example now registers, beside the existing server preload:

- `:resources-ssr.app/page-opened` — ensures `:articles/list` under
  `[:resources-ssr.app/page-opened]` with cause `[:event ...]`;
- `:resources-ssr.app/page-closed` — the symmetric
  `:rf.resource/release-owner`.

`run` dispatch-syncs the open **after `hydrate!` and before the first render**.
Both halves of that are load-bearing:

- *After hydrate*: ahead of it, the ensure would fetch a list the payload is
  about to hand over, and the cold `:loading` state would then be overwritten.
- *Sync*: `dispatch-sync` drains the enqueued ensure to fixed point before
  returning, so a cold load's first paint is the `:loading` skeleton rather than
  an empty `<ul>` that reads as a successful empty answer.

One event, three outcomes, none of them branched on in the example — the resource
runtime decides from what hydration left:

| hydration left | what the ensure costs |
| --- | --- |
| a fresh entry (the checked-in payload) | fresh-skip cache hit: owner attaches, timers arm, **zero** requests |
| a stale entry | last-known-good stays on screen, one background refetch |
| nothing | one first-load request, `:loading` until it settles |

The fresh-skip branch is the one the documented run takes, so **nothing about
that run changes**: the first paint still adopts the server's markup and the
static fixture still runs with no server behind it. It is also where the GC clock
finally starts — Spec 016 says a hydrated entry's GC timer "arms the first time
the client's ensure/fresh-skip path re-establishes ownership", and
`ensure-load`'s `was-owner-free?` arming is exactly that.

Views stay passive. No route was added, no subscription-driven fetching, no
`setTimeout`. Prose in `README.md`, the ns docstring, the section comments and
`index.html` now separate *hydration reconciles and classifies* from *the live
client acquisition causes the work*, and the redacted/omitted refetch claim is
dropped — `:articles/list` declares neither `:sensitive?` nor `:large?`, so those
branches are never taken here; the normative contract is linked instead.

## Verification

`examples/` is test-free (locked, rf2-8cevm), so **no regression witness was
added** — the natural home would be a substrate contract test under
`implementation/`, which is outside this PR's fence. Stated plainly: the
behaviour below is verified by compiling the changed example, by running the
existing JVM lane that loads it, and by reading the implementation at tip; there
is no new automated test proving the client owner attaches.

| gate | result |
| --- | --- |
| `node implementation/scripts/check-examples-compile.cjs` | exit 0 — 58/58 swept builds, 0 warnings |
| `clojure -M:test -n re-frame.examples-test` (in `implementation/core`) | exit 0 — 15 tests, 96 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | exit 0 — 11,217 tests, 56,650 assertions, 0 failures, 0 errors |
| `scripts/check_readme_links.py --ci` | exit 0 |

The compile gate derives its build list from `implementation/shadow-cljs.edn` and
names no build, so grepping its source for this example proves nothing; `--list`
was run and confirms `examples/resources-ssr` is among the 58 derived builds.

**The SSR half has a server-side lane and it is the JVM one.** The compile gate
renders nothing; `implementation/core/test/re_frame/examples_test.clj` does — it
requires `resources-ssr.core`, drives `handle-request` against a canned
managed-HTTP fx, and hydrates the *actual checked-in* `index.html` payload into a
live client frame, asserting the baked entry reads `:loaded`, that both titles
render on the first client render, and that `hydrate-refetch-plan` stays empty
(no double-fetch). All still green, which is the "existing regressions remain
green" acceptance criterion.

**Liveness was planted, not assumed.** A deliberate bad form in `core.cljc` made
the compile gate exit 1 naming the file and line; a deliberate broken link in the
README made `check_readme_links.py --ci` exit 1 naming the file and line (it
otherwise exits 0 with an empty log, which is not by itself evidence of
coverage). Both files were restored from byte copies and verified with `cmp`; all
three files are CRLF and stayed CRLF.

**`mkdocs build --strict` and `scripts/check_doc_slugs.py` do not cover
`examples/`** — `docs_dir` is `docs`, and `examples/` is neither staged into it
nor among the slug gate's roots — so neither is cited here. The README's link
gate is `check_readme_links.py`. The README edits added no tables and no anchor
links (the two new `spec/016-Resources.md` references carry no `#fragment`), and
every anchor reused was already live in the file.

## Where this differs from the item

Four of the seven acceptance criteria are written as test obligations (assert one
request on a cold boot, assert zero on the fresh path, drive a stale payload,
exercise the release). Those cannot be met inside a test-free tree, and the
natural home is fenced. The mechanism they describe is implemented and reasoned
through above; the assertions are not.

The release is registered as `:resources-ssr.app/page-closed` but nothing in the
example dispatches it: this demo is a single page whose lifetime *is* its
frame's, so an unload-time release would be a no-op dressed as a lifecycle — the
same class of decorative claim this PR removes. The comment says so, and names
the two real close points (a page that can be unmounted; route-leave in a routed
app).
