### PR TITLE
fix(examples): dev:example waits for the first watch build before advertising the SPA (rf2-qwy3)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ One command, from `implementation/` — the build-id is in each row below:
 npm run dev:example -- <build-id>
 ```
 
-It cleans that build's output directory, stages the example's own `index.html` and the shared `_shared/` assets beside the compiled bundle, starts a watch so your edits recompile live, serves the result on a free loopback port, and prints the URL to open. Add `--no-watch` for a one-shot compile-and-serve, or `--list` to see every runnable build-id.
+It cleans that build's output directory, stages the example's own `index.html` and the shared `_shared/` assets beside the compiled bundle, starts a watch so your edits recompile live, serves the result on a free loopback port, and prints the URL to open. The URL appears only once that first compile has produced the bundle the page loads — a cold first build can take a minute or more, so until then the runner says it is waiting instead of advertising a page that would come up blank. Add `--no-watch` for a one-shot compile-and-serve, or `--list` to see every runnable build-id.
 
 > **Advanced — the compiler on its own.** `shadow-cljs watch <build-id>` compiles the bundle to `implementation/out/examples/<name>/` and does nothing else: it stages no host page, copies no `_shared/` assets, and starts no server, so there is no URL to open and the example's own `index.html` cannot find its `main.js`. Reach for it when you want the compiler alone; use `npm run dev:example` when you want the running app.
 

--- a/examples/scripts/serve-example.cjs
+++ b/examples/scripts/serve-example.cjs
@@ -30,6 +30,11 @@
  *      the output dir over http-server on 127.0.0.1.
  *   4. Spawns `shadow-cljs watch <build>` so edits recompile live. A
  *      `--no-watch` flag runs a one-shot `compile` instead (CI-shaped).
+ *   5. In watch mode, WAITS for that first compile to actually publish the
+ *      bundle before printing the live URL (rf2-qwy3) — the freshly cleaned
+ *      output dir has no `main.js` until it lands, so announcing the page any
+ *      earlier advertises one that comes up blank. It says it is waiting
+ *      meanwhile, so a slow cold compile never looks like a hung tool.
  *
  * The shared staging + harness helpers do the hardened work (cross-platform
  * shell-free spawning, process-tree teardown, port pre-flight); this script
@@ -65,6 +70,13 @@ const {
   createHarnessCleanup,
   spawnHarnessProcess,
   startLocalHttpServer,
+  // The harness's generic "GET this path; resolve the 200 body, else null"
+  // primitive. It is NAMED for its first caller (the ownership-token fetch),
+  // but it is that one plain request and nothing more — so the first-build
+  // probe below reuses it verbatim rather than hand-rolling a second HTTP
+  // client inside the dev runner.
+  fetchToken: fetchServedBody,
+  sleep,
 } = require('../../implementation/scripts/lib/local-browser-harness.cjs');
 
 // __dirname is <repo>/examples/scripts. REPO_ROOT is <repo>; IMPL_ROOT is
@@ -112,6 +124,63 @@ function decideRunnerExit({ server = null, watch = null, interrupted = false } =
     return false; // code null + no signal => clean exit
   };
   return childFailed(server) || childFailed(watch) ? 1 : 0;
+}
+
+// The compiled entrypoint every example host page loads. Hardcoding the name is
+// safe rather than lucky: `check-examples-assets.cjs` MAKES a live
+// `<script src="main.js">` mandatory on every example page (all 34 standalone
+// hosts carry one), so "this run's build has produced something runnable" and
+// "main.js is being served" are the same fact.
+const BUILD_ENTRYPOINT = 'main.js';
+
+// Wait for the first watch build to actually land (rf2-qwy3).
+//
+// THE FACT THE BANNER CLAIMS. The clean-stage boundary above deletes the
+// previous bundle, and `shadow-cljs watch` is asynchronous, so between
+// http-server readiness and the first successful compile the staged root serves
+// its host page and `_shared/` assets while the `main.js` that page requires is
+// still ABSENT. Opening the URL in that window fetches a missing script and
+// leaves a blank, non-booted app — and because no bundle loaded, no shadow
+// client is present to turn the later compile into a live reload, so the
+// programmer must notice the compiler finished and reload by hand. Server
+// ownership and application-build readiness are DIFFERENT facts; the runner is
+// the layer that composes them.
+//
+// WHY AN HTTP POLL OF THE SERVER WE ALREADY OWN, and not a shadow-cljs signal:
+// shadow-cljs's `:browser` target does emit a per-build artefact of its own —
+// `manifest.edn`, written into `:output-dir` on a successful flush — but its
+// name is build-config-settable (`:build-options :manifest-name`), which the
+// runner does not read, and its presence proves a compile FLUSHED rather than
+// that the artefact the page requests is REACHABLE. Fetching the entrypoint
+// back over the loopback server we already own proves the advertised fact
+// directly, needs no shadow-cljs protocol and no parsing of its human log
+// output, and keeps first-build readiness composed HERE rather than generalised
+// into the shared harness (whose ownership-token handshake stays the authority
+// for "this server serves this run's root", and cannot prove build artefacts by
+// design).
+//
+// THE WAIT IS UNBOUNDED BY DESIGN. A cold JVM plus a first compile can take a
+// long while, and a compile error is fixable in place — shadow-cljs keeps
+// watching, its inherited stdio shows the error, and the URL goes live as soon
+// as a fixed source produces output — so the runner must never give up on a
+// HEALTHY watcher. The loop ends only when the entrypoint is served or
+// `isAborted()` goes true (the watch or the server died), which the caller
+// turns into a non-zero exit. Ctrl+C still tears the process tree down via the
+// installed signal handlers.
+//
+// Injectable (`fetchBody`, `isAborted`, `sleep`) so the delayed-artifact,
+// empty-artifact and watch-died-first cases are testable without shadow-cljs.
+async function waitForFirstBuild({ fetchBody, isAborted, sleep: sleepFn, pollMs = 250 }) {
+  for (;;) {
+    if (isAborted()) return { ok: false, reason: 'child-exited' };
+    const body = await fetchBody();
+    // A zero-length body is NOT readiness: a truncated or placeholder
+    // entrypoint boots nothing, and announcing it would restate the very lie
+    // this wait exists to remove.
+    if (typeof body === 'string' && body.length > 0) return { ok: true };
+    if (isAborted()) return { ok: false, reason: 'child-exited' };
+    await sleepFn(pollMs);
+  }
 }
 
 function parseArgs(argv) {
@@ -285,6 +354,39 @@ async function main() {
   });
   if (!ready) return 1;
 
+  // The server now provably owns the staged root — but in watch mode that root
+  // was cleaned moments ago and holds no `main.js` until this run's first
+  // compile lands. Say exactly that, and withhold the live/openable banner
+  // until the entrypoint is really being served (rf2-qwy3). `--no-watch`
+  // already compiled synchronously above, so its output is complete before the
+  // server ever started and it skips this wait unchanged.
+  if (watch) {
+    console.log(
+      `\nserve-example: ${entry.build} — server ready on http://127.0.0.1:${PORT}/,` +
+        ' waiting for the first shadow-cljs build.' +
+        `\n  Not openable yet: the page needs ${BUILD_ENTRYPOINT}, which the first` +
+        ' compile produces. The shadow-cljs output shows progress and any' +
+        ' compile error — fix the source and the URL goes live.\n',
+    );
+    const first = await waitForFirstBuild({
+      fetchBody: () =>
+        fetchServedBody(PORT, { host: '127.0.0.1', path: `/${BUILD_ENTRYPOINT}` }),
+      // The watch dying, or the server going down, ends the wait — never a
+      // timeout on a healthy-but-slow compile.
+      isAborted: () => watchDied || isDown(),
+      sleep,
+    });
+    if (!first.ok) {
+      console.error(
+        `\nserve-example: ${entry.build} — the first build never produced a served ` +
+          `${BUILD_ENTRYPOINT}, so the example was never runnable. No URL was ` +
+          'advertised. See the shadow-cljs output above for the compile error.',
+      );
+      await cleanup.cleanup().catch(() => {});
+      return 1;
+    }
+  }
+
   console.log(
     `\nserve-example: ${entry.build} is live at http://127.0.0.1:${PORT}/` +
       (watch ? '  (shadow-cljs watch running — edits recompile live)' : '  (one-shot compile)') +
@@ -331,4 +433,4 @@ async function cleanupAndExit(code) {
   process.exit(code == null ? 1 : code);
 }
 
-module.exports = { decideRunnerExit, parseArgs };
+module.exports = { decideRunnerExit, parseArgs, waitForFirstBuild, BUILD_ENTRYPOINT };

--- a/implementation/scripts/_examples-staging.test.cjs
+++ b/implementation/scripts/_examples-staging.test.cjs
@@ -82,6 +82,16 @@ function it(label, f) {
   }
 }
 
+// `it` above calls f() WITHOUT awaiting, so an async body's rejection escapes
+// its try/catch and the test prints PASS regardless — a false green. Async
+// cases (the first-build readiness wait, which polls) are therefore queued here
+// and drained by the awaiting runner at the bottom of this file, which owns the
+// summary + exit code for both kinds.
+const asyncTests = [];
+function itAsync(label, f) {
+  asyncTests.push([label, f]);
+}
+
 console.log('examples-staging tests (rf2-pdo5mx)');
 
 // ---- parser: synthetic fixture, both brace placements --------------------
@@ -721,8 +731,200 @@ function noopIo() {
   };
 }
 
-if (failed > 0) {
-  console.error(`\nexamples-staging tests: ${failed} FAILED.`);
-  process.exit(1);
-}
-console.log('\nexamples-staging tests: all passed.');
+// ---- serve-example first-build readiness (rf2-qwy3) ----------------------
+//
+// The dev runner used to print `<build> is live at <url>` the moment
+// http-server proved it owned the staged root. In WATCH mode that root has just
+// been cleaned (rf2-rg2tze) and `shadow-cljs watch` is asynchronous, so the
+// advertised page served its host HTML + _shared assets while the `main.js` it
+// requires was still absent: a blank, non-booted app, with no bundle loaded and
+// therefore no shadow client to turn the later compile into a live reload.
+// Server ownership and application-build readiness are different facts;
+// serve-example composes them via waitForFirstBuild.
+//
+// These pin BOTH halves: the predicate's behaviour (delayed artifact, empty
+// artifact, watch died before first output) and the call-site ordering (the
+// wait precedes the live banner), so a refactor that re-opens the window fails
+// here.
+
+const {
+  waitForFirstBuild,
+  BUILD_ENTRYPOINT,
+} = require('../../examples/scripts/serve-example.cjs');
+
+const SERVE_EXAMPLE_SRC = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'examples', 'scripts', 'serve-example.cjs'),
+  'utf8',
+);
+
+it('the entrypoint serve-example waits for is the one every example host loads', () => {
+  // check-examples-assets.cjs makes `<script src="main.js">` mandatory on every
+  // example page, which is what licenses the runner to key its readiness on a
+  // fixed name rather than parsing each host page.
+  assert.strictEqual(BUILD_ENTRYPOINT, 'main.js');
+});
+
+itAsync('waitForFirstBuild waits through a DELAYED artifact, then reports ready (rf2-qwy3)', async () => {
+  // A fake producer that publishes only on the 4th probe — the cold-compile
+  // case, where the server is ready long before the bundle exists.
+  let probes = 0;
+  const result = await waitForFirstBuild({
+    fetchBody: async () => {
+      probes++;
+      return probes < 4 ? null : 'console.log("booted");';
+    },
+    isAborted: () => false,
+    sleep: async () => {},
+  });
+  assert.deepStrictEqual(result, { ok: true });
+  assert.strictEqual(probes, 4, 'must keep polling until the artifact is actually served');
+});
+
+itAsync('TEETH: waitForFirstBuild does NOT report ready on a zero-length artifact (rf2-qwy3)', async () => {
+  // An empty main.js boots nothing. Announcing it would restate the exact lie
+  // this wait removes, so an empty body must keep the runner waiting.
+  let probes = 0;
+  const result = await waitForFirstBuild({
+    fetchBody: async () => {
+      probes++;
+      // Empty for the first three probes (the acceptance criterion's
+      // "zero-length" case), then real content.
+      return probes < 4 ? '' : 'console.log("booted");';
+    },
+    isAborted: () => false,
+    sleep: async () => {},
+  });
+  assert.deepStrictEqual(result, { ok: true });
+  assert.strictEqual(probes, 4, 'a zero-length entrypoint must not satisfy readiness');
+});
+
+itAsync('TEETH: waitForFirstBuild aborts (never reports ready) when the watch dies first (rf2-qwy3)', async () => {
+  // The watch child crashed before its first compile landed. The runner must
+  // NOT announce the app as live; the caller turns this into a non-zero exit.
+  let watchDied = false;
+  let probes = 0;
+  const result = await waitForFirstBuild({
+    fetchBody: async () => {
+      probes++;
+      watchDied = true; // the watch's exit handler fires between polls
+      return null; // the entrypoint never appears
+    },
+    isAborted: () => watchDied,
+    sleep: async () => {},
+  });
+  assert.deepStrictEqual(result, { ok: false, reason: 'child-exited' });
+  assert.ok(probes >= 1, 'the wait must have actually probed before aborting');
+});
+
+itAsync('waitForFirstBuild reports ready off a REAL http server once a delayed producer writes the entrypoint (rf2-qwy3)', async () => {
+  // End-to-end over the real HTTP path serve-example uses, with a fake
+  // "watch child" (a timer) writing main.js into an initially clean staged
+  // root — no shadow-cljs required. Proves the runner stays silent while the
+  // directory holds only the host page, and flips once the bundle lands.
+  const http = require('http');
+  const { fetchToken: fetchServedBody } = require('./lib/local-browser-harness.cjs');
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-firstbuild-'));
+  // The freshly cleaned staged root: host page + assets present, NO main.js.
+  fs.writeFileSync(path.join(tmpRoot, 'index.html'), '<!doctype html><script src="main.js"></script>');
+
+  const server = http.createServer((req, res) => {
+    const rel = decodeURIComponent(req.url.split('?')[0]).replace(/^\/+/, '');
+    const target = path.join(tmpRoot, rel);
+    if (!fs.existsSync(target) || !fs.statSync(target).isFile()) {
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+    res.statusCode = 200;
+    res.end(fs.readFileSync(target));
+  });
+  try {
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = server.address().port;
+
+    // Before any build: the entrypoint is genuinely unserved — the window the
+    // old code advertised as live.
+    assert.strictEqual(
+      await fetchServedBody(port, { host: '127.0.0.1', path: `/${BUILD_ENTRYPOINT}` }),
+      null,
+      'the cleaned staged root must not serve an entrypoint before the first compile',
+    );
+
+    // The fake watch child publishes the bundle a few polls in.
+    const timer = setTimeout(() => {
+      fs.writeFileSync(path.join(tmpRoot, BUILD_ENTRYPOINT), 'console.log("booted");');
+    }, 120);
+    timer.unref?.();
+
+    const result = await waitForFirstBuild({
+      fetchBody: () => fetchServedBody(port, { host: '127.0.0.1', path: `/${BUILD_ENTRYPOINT}` }),
+      isAborted: () => false,
+      sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+      pollMs: 25,
+    });
+    clearTimeout(timer);
+    assert.deepStrictEqual(result, { ok: true });
+    assert.ok(
+      fs.existsSync(path.join(tmpRoot, BUILD_ENTRYPOINT)),
+      'readiness must not be reported before the producer wrote the entrypoint',
+    );
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+it('TEETH: serve-example awaits the first build BEFORE printing the live URL (rf2-qwy3)', () => {
+  // The call-site pin. On the pre-fix ordering there is no wait at all between
+  // startLocalHttpServer's ready result and the `is live` banner, so this test
+  // fails against it — which is the whole point.
+  const waitAt = SERVE_EXAMPLE_SRC.indexOf('await waitForFirstBuild(');
+  const liveAt = SERVE_EXAMPLE_SRC.indexOf('is live at http://127.0.0.1:');
+  assert.ok(waitAt !== -1, 'serve-example must await the first-build readiness wait');
+  assert.ok(liveAt !== -1, 'serve-example must still print the live URL');
+  assert.ok(
+    waitAt < liveAt,
+    'the first-build wait must precede the live/openable banner, or the runner ' +
+      'advertises a page whose main.js is still absent',
+  );
+});
+
+it('serve-example keeps the wait on the WATCH path only, and tears down on first-build failure (rf2-qwy3)', () => {
+  // --no-watch already compiles synchronously before the server starts, so its
+  // output is complete on the first byte served; it must not grow a wait.
+  assert.ok(
+    /if\s*\(watch\)\s*\{[\s\S]{0,1200}?await waitForFirstBuild\(/.test(SERVE_EXAMPLE_SRC),
+    'the first-build wait must be guarded by the watch branch (--no-watch stays synchronous)',
+  );
+  // A watch that dies before first output must not leave the server up.
+  const failBlock = SERVE_EXAMPLE_SRC.slice(SERVE_EXAMPLE_SRC.indexOf('if (!first.ok)'));
+  assert.ok(
+    /cleanup\.cleanup\(\)/.test(failBlock.slice(0, 600)),
+    'a first-build failure must tear the server down',
+  );
+  assert.ok(
+    /return 1;/.test(failBlock.slice(0, 600)),
+    'a first-build failure must exit non-zero',
+  );
+});
+
+// Drain the queued async cases, then own the summary + exit code for the whole
+// file (both the synchronous `it` results already counted in `failed` and these).
+(async () => {
+  for (const [label, f] of asyncTests) {
+    try {
+      await f();
+      console.log(`  PASS  ${label}`);
+    } catch (err) {
+      failed++;
+      console.error(`  FAIL  ${label}`);
+      console.error(`        ${err.message || err}`);
+    }
+  }
+  if (failed > 0) {
+    console.error(`\nexamples-staging tests: ${failed} FAILED.`);
+    process.exit(1);
+  }
+  console.log('\nexamples-staging tests: all passed.');
+})();


### PR DESCRIPTION
Closes rf2-qwy3.

## The defect, measured

`npm run dev:example -- <build-id>` printed `<build> is live at <url>` as soon as
http-server proved it owned the staged root. In the default **watch** path that root
has just been cleaned (rf2-rg2tze) and `shadow-cljs watch` is asynchronous, so the
advertised page served its host HTML and `_shared/` assets while the `main.js` it
requires was still absent. Opening the URL in that window fetched a missing script and
left a blank, non-booted app — and because no bundle loaded, no shadow client was
present to turn the later compile into a live reload, so the programmer had to notice
the compiler finished and reload by hand.

The item derived this from process ordering and noted no runtime measurement had been
taken. It has now been taken, on a cold cache:

| | |
|---|---|
| server ready, banner printed (pre-fix behaviour) | 07:46:35 |
| `Build completed. (209 files, 208 compiled, 0 warnings, 29.70s)` | 07:48:01 |
| **window in which the strongest status line was false** | **86 seconds** |

The staged directory's own timestamps record the same thing: `.rf-harness-token` and
`_shared` at 07:46, `main.js` / `cljs-runtime/` / `manifest.edn` at 07:48.

## The fix

Server ownership and application-build readiness are different facts. The
ownership-token handshake stays the authority for "this server serves this run's root";
`serve-example` now composes first-build readiness on top of it rather than generalising
it into every local-browser harness consumer.

In watch mode the runner prints that the server is ready and that it is **waiting for
the first build** — naming what is missing and where compile errors appear — then polls
the server it already owns until `/main.js` returns a non-empty body, then prints the
existing live banner unchanged. Withholding the URL silently would make a slow cold
compile look like a hung tool; saying plainly what it is waiting for does not.

The wait is **unbounded by design**. A cold JVM plus a first compile takes a while, and
a compile error is fixable in place (shadow-cljs keeps watching, its inherited stdio
shows the error, and the URL goes live once fixed source produces output), so the runner
must never give up on a healthy watcher. It ends only when the entrypoint is served, or
when the watch or server dies — which tears the tree down and exits non-zero with a
direct initial-build diagnostic. Ctrl+C teardown is unchanged.

`--no-watch` already compiled synchronously before the server started; it skips the wait
and is untouched. Build selection, staging, port choice, caching and teardown are
unchanged.

## Asking the build tool first

shadow-cljs does emit a signal of its own: the `:browser` target writes `manifest.edn`
into `:output-dir` on a successful flush (confirmed present in the watch-mode output dir
alongside `main.js` and `cljs-runtime/`). It was **considered and declined** — its name
is build-config-settable via `:build-options :manifest-name`, which the runner does not
read, and its presence proves a compile *flushed* rather than that the artefact the page
requests is *reachable*, which is what the banner claims. Fetching the entrypoint back
over the already-owned server proves the advertised fact directly, needs no shadow-cljs
protocol and no parsing of its human log output, and adds no config coupling. This is
also what the item bounds the fix to.

Keying readiness on the fixed name `main.js` is licensed rather than lucky:
`check-examples-assets.cjs` makes a live `<script src="main.js">` mandatory on every
example page, and all 34 standalone hosts carry one.

## The harness was checked for the same assumption

There are **six** production `startLocalHttpServer` call sites, not two. The other five —
`serve-and-run-story-feature-load-tests.cjs`, `serve-and-run-story-play-scripts.cjs`,
`serve-and-run-adapter-smokes.cjs`, `run-hicasso-native-ime-witness.cjs`,
`serve-and-run-hicasso-controlled-testbed.cjs` — each compile synchronously via
`spawnSync(..., 'compile', ...)` and throw on a non-zero status *before* the server
starts, so their output is complete on the first byte served. The watch path was the only
asynchronous producer, and the harness itself is correct as designed. No harness change.

## Gates

Behavioural, so the witness fails before and passes after.

- **`implementation/scripts/_examples-staging.test.cjs`** (primary witness) — against the
  pre-fix `serve-example.cjs`: **exit 1, 28 pass / 7 fail**, all seven the new rf2-qwy3
  cases. After: **exit 0, 35 pass / 0 fail**. The six new cases cover a delayed artifact,
  a zero-length artifact, the watch dying before first output, an end-to-end run over a
  real HTTP server with a fake delayed producer (no shadow-cljs), and two call-site pins
  (the wait precedes the banner; `--no-watch` stays synchronous and a first-build failure
  tears down and exits non-zero).
- **`npm run test:scripts`** — captured exit **0**, **tests 122, pass 122, fail 0**.
  Covers `_script-spawn-policy`, `_orchestrator-teardown-policy`,
  `_orchestrator-teardown-integration`, `_local-browser-harness`, `_serve-and-run-cli`,
  `check-examples-assets` and `check-examples-compile`, all of which read this runner.
- **`scripts/check_readme_links.py --ci`** — captured exit **0**. This is the gate that
  covers `examples/README.md`; `check_doc_slugs.py` does not (its roots are
  `docs`/`spec`/`skills`/`migration` plus `tools/*/spec`, verified at source). Proven live
  by planting a broken link: exit **1** naming file and line; restored byte-identical.
- **`node implementation/scripts/check-examples-compile.cjs --list`** — exit **0**, **58
  builds**, unchanged (the roster derives from `shadow-cljs.edn`, which this PR does not
  touch).
- **`mkdocs build --strict` does not cover `examples/`** — it is outside `docs_dir: docs`
  entirely, so it is not a candidate for `exclude_docs` and citing it here would be a
  vacuous green.
- **`npm run test:cljs` was not run**: this diff contains no CLJS, CLJC or EDN, so it
  inspects nothing changed here.
- Runner exercised end-to-end by hand on a cold cache (the measurement above); its
  process tree was terminated and verified gone.

Gates re-run on the final rebased base.
