### PR TITLE
fix(mcp-conformance): fence the shadow tree's ROOT pid, not just its descendants (rf2-kzbf)

### DIFF
--- a/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
+++ b/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
@@ -198,6 +198,31 @@ function waitForChildExit(child, hasExited) {
 // subtree rooted at the exact PID this runner spawned — the same discipline
 // as `scripts/test-core-jvm-windows.ps1`'s `Stop-OurSubtree` — so unrelated
 // Node/JVM processes (peer workers, other MCP servers) are never targeted.
+//
+// AND THE SAME MISTAKE ONE LEVEL DOWN (the rf2-kzbf audit of PR #9213). "The
+// subtree rooted at the exact PID we spawned" is only as good as the claim
+// that the row wearing that number IS still ours. The first fix fenced the
+// DESCENDANTS on creation time but let the ROOT in on the number alone
+// (`if (byPid.has(rootPid)) owned.push(rootPid)`), then handed that number to
+// `taskkill /T /F`. The wrapper above is short-lived by construction — it
+// exits the moment it has launched the JVM — so its PID is exactly the kind
+// Windows recycles soonest, and cleanup would then tree-kill a STRANGER and
+// everything below it. That is the wrapper/resource confusion again, wearing
+// a PID instead of a handle: an identity check that inspects a name.
+//
+// So the root row is now classified rather than assumed (`classifyRootRow`),
+// on two pieces of evidence that catch the two ways the number can lie:
+//   * we OBSERVED our own child's `exit` — the handle was reaped, the number
+//     is free, and whatever wears it now is not ours (this is the case the
+//     creation floor alone cannot see, because a PID recycled AFTER our spawn
+//     is younger than our spawn floor); and
+//   * the row's creation time predates our spawn instant — it cannot be a
+//     process we started (this is the case the creation floor does see).
+// A row we cannot date at all is FAIL-CLOSED: not killed, and not graded
+// clean either. Orphan discovery is unaffected — Windows leaves the dead
+// wrapper's number in its children's `ParentProcessId`, so the walk still
+// starts at `rootPid` and still finds the JVM this whole mechanism exists
+// for; only the authority to KILL that number is withdrawn.
 
 // Is `pid` still alive? Signal 0 performs the permission/existence check
 // without delivering a signal. EPERM means the pid EXISTS but is not ours to
@@ -260,26 +285,76 @@ function readWindowsProcessTable({ runPs } = {}) {
   return rows;
 }
 
+// Classify the row (if any) currently wearing our root's PID. A PID is a
+// NUMBER, and a number is exactly what recycling forges — so the row is ours
+// only when independent evidence says so, and "we could not tell" is never
+// read as "ours" (that would tree-kill a stranger, which is the one thing
+// teardown must never do):
+//
+//   'absent'     — nothing wears that number now. Our wrapper is gone.
+//   'stranger'   — a row wears it that CANNOT be the process we spawned:
+//                  either we OBSERVED our own child's `exit` (the handle was
+//                  reaped, so whatever holds the number now is somebody
+//                  else's), or the row predates our spawn floor.
+//   'unprovable' — a row wears it but the OS reported no usable creation
+//                  time, so ownership cannot be established either way.
+//                  FAIL CLOSED: not ours to kill, and not a clean teardown
+//                  either (the caller grades it dirty).
+//   'ours'       — a row wears it, we have not seen our child exit, and it
+//                  was created at or after the instant we spawned.
+function classifyRootRow(table, rootPid, notBeforeMs, { rootExited = false } = {}) {
+  const row = table.find((r) => r.pid === rootPid);
+  if (!row) return 'absent';
+  if (rootExited) return 'stranger';
+  if (!Number.isFinite(row.createdMs) || row.createdMs <= 0) return 'unprovable';
+  if (row.createdMs < notBeforeMs) return 'stranger';
+  return 'ours';
+}
+
 // Breadth-first descendant closure of `rootPid` over `table`, EXCLUDING any
 // process created before `notBeforeMs` (a recycled PID wearing our root's
-// number). The root itself is included when still present.
-function ownedDescendants(table, rootPid, notBeforeMs) {
+// number). The ROOT ROW IS SUBJECT TO THE SAME FENCE (rf2-kzbf audit): it is
+// included only when `classifyRootRow` says 'ours'. Discovery of our own
+// ORPHANS is retained regardless — Windows leaves the dead wrapper's number
+// in its children's `ParentProcessId`, so the walk always starts from
+// `rootPid` even when no row of ours wears it any more.
+//
+// One extra bound applies in the 'stranger' case: the stranger's own children
+// must not be swept up with our orphans. A process of ours orphaned by our
+// dead wrapper necessarily PREDATES the stranger that inherited the number,
+// so a direct child of `rootPid` created at or after the stranger's own
+// creation is the STRANGER'S child, not ours.
+function ownedDescendants(table, rootPid, notBeforeMs, opts = {}) {
   const childrenOf = new Map();
   for (const row of table) {
     if (!childrenOf.has(row.ppid)) childrenOf.set(row.ppid, []);
     childrenOf.get(row.ppid).push(row);
   }
   const byPid = new Map(table.map((r) => [r.pid, r]));
+  const rootClass = classifyRootRow(table, rootPid, notBeforeMs, opts);
+  const rootRow = byPid.get(rootPid) || null;
+  const strangerCeilingMs =
+    rootClass === 'stranger' && rootRow && rootRow.createdMs > 0
+      ? rootRow.createdMs
+      : Infinity;
   const owned = [];
   const seen = new Set([rootPid]);
   const queue = [rootPid];
-  if (byPid.has(rootPid)) owned.push(rootPid);
+  if (rootClass === 'ours') owned.push(rootPid);
   while (queue.length > 0) {
     const current = queue.shift();
     for (const child of childrenOf.get(current) || []) {
       if (seen.has(child.pid)) continue;
       // A descendant created before we spawned our root is not ours.
       if (child.createdMs > 0 && child.createdMs < notBeforeMs) continue;
+      // Nor is a direct child the STRANGER fathered after taking the number.
+      if (
+        current === rootPid &&
+        child.createdMs > 0 &&
+        child.createdMs >= strangerCeilingMs
+      ) {
+        continue;
+      }
       seen.add(child.pid);
       owned.push(child.pid);
       queue.push(child.pid);
@@ -298,6 +373,10 @@ function ownedDescendants(table, rootPid, notBeforeMs) {
 function makeShadowTreeReaper({
   rootPid,
   spawnedAtMs,
+  // Has OUR child handle already emitted `exit`? A reaped handle means the
+  // number is free, so any row still wearing it belongs to somebody else.
+  // Read as a thunk because it flips while cleanup is running.
+  rootExited = () => false,
   platform = process.platform,
   readTable = readWindowsProcessTable,
   treeKill = defaultWindowsTreeKill,
@@ -326,8 +405,12 @@ function makeShadowTreeReaper({
   }
   return async function reapShadowTree() {
     let owned;
+    let rootClass;
     try {
-      owned = ownedDescendants(readTable(), rootPid, spawnedAtMs);
+      const table = readTable();
+      const opts = { rootExited: Boolean(rootExited()) };
+      rootClass = classifyRootRow(table, rootPid, spawnedAtMs, opts);
+      owned = ownedDescendants(table, rootPid, spawnedAtMs, opts);
     } catch (e) {
       return {
         supported: true,
@@ -336,19 +419,37 @@ function makeShadowTreeReaper({
         error: `could not enumerate the process table (${e && e.message})`,
       };
     }
+    // FAIL CLOSED on a root row we cannot date: it is not ours to kill, and
+    // "we could not tell" is not a proven teardown either (AC3).
+    const rootError =
+      rootClass === 'unprovable'
+        ? 'the process table reported no usable creation time for the row ' +
+          `wearing root pid ${rootPid} — refusing to tree-kill a PID that ` +
+          'cannot be proven ours'
+        : null;
+    if (rootClass === 'stranger') {
+      logFn(
+        `the row wearing root pid ${rootPid} is NOT the process we spawned ` +
+          '(recycled PID) — it will not be touched',
+      );
+    }
     if (owned.length === 0) {
-      logFn(`owned shadow tree (root pid ${rootPid}) is already empty`);
-      return { supported: true, owned: [], survivors: [], error: null };
+      if (!rootError) {
+        logFn(`owned shadow tree (root pid ${rootPid}) is already empty`);
+      }
+      return { supported: true, owned: [], survivors: [], error: rootError };
     }
     logFn(
       `owned shadow tree rooted at pid ${rootPid}: ${owned.join(', ')} — ` +
         'tree-killing OUR subtree only',
     );
-    let killError = null;
+    let killError = rootError;
     try {
-      // Kill the root's subtree first; then any orphan we attributed to the
-      // root but whose own parent link died with the wrapper.
-      treeKill(rootPid);
+      // Kill the root's subtree first — but ONLY when the row wearing that
+      // number is provably the process we spawned. Then any orphan we
+      // attributed to the root but whose own parent link died with the
+      // wrapper.
+      if (rootClass === 'ours') treeKill(rootPid);
       for (const pid of owned) {
         if (pid !== rootPid && isAlive(pid)) treeKill(pid);
       }
@@ -1326,9 +1427,13 @@ async function main() {
     getShadow: () => shadow,
     hasShadowExited: () => shadowExited,
     // The wrapper's `exit` is not the JVM's. Grade the subtree we spawned.
+    // `rootExited` is what keeps a RECYCLED root pid out of the kill set:
+    // once our own handle has been reaped, the number is free and whatever
+    // wears it now is somebody else's process (rf2-kzbf audit).
     reapShadowTree: makeShadowTreeReaper({
       rootPid: shadowRootPid,
       spawnedAtMs: shadowSpawnedAtMs,
+      rootExited: () => shadowExited,
     }),
   });
   // Expose the teardown to the module-scope hard watchdog
@@ -1719,13 +1824,15 @@ if (require.main === module) {
 // grading through `makeCleanup`, the dirty-report prose through
 // `finalizeConformance`. Exporting them would advertise a test seam that
 // invites coupling to the helper instead of the decision it serves.
-// `makeShadowTreeReaper` + `ownedDescendants` + `pidAlive` are exported for the
-// owned-tree regression harness (`runner-cleanup.test.cjs`, rf2-kzbf). The
-// factory is driven with injected `readTable`/`treeKill`/`isAlive` fakes so the
-// ownership walk, the recycled-PID guard and the survivor grading are pinned on
-// EVERY platform, and additionally against a REAL cross-spawn'd `cmd.exe`
-// wrapper whose grandchild outlives it on Windows — the exact shape that
-// previously certified a leaked JVM as a clean, GREEN, exit-0 run.
+// `makeShadowTreeReaper` + `ownedDescendants` + `classifyRootRow` + `pidAlive`
+// are exported for the owned-tree regression harness
+// (`runner-cleanup.test.cjs`, rf2-kzbf). The factory is driven with injected
+// `readTable`/`treeKill`/`isAlive` fakes so the ownership walk, the
+// recycled-PID guard (on the ROOT row as well as on descendants) and the
+// survivor grading are pinned on EVERY platform, and additionally against a
+// REAL cross-spawn'd `cmd.exe` wrapper whose grandchild outlives it on
+// Windows — the exact shape that previously certified a leaked JVM as a
+// clean, GREEN, exit-0 run.
 module.exports = {
   runTrusted,
   SETUP_COMMAND_TIMEOUT_MS,
@@ -1739,5 +1846,6 @@ module.exports = {
   wipeStalePortFileCandidate,
   makeShadowTreeReaper,
   ownedDescendants,
+  classifyRootRow,
   pidAlive,
 };

--- a/tools/mcp-conformance/test/runner-cleanup.test.cjs
+++ b/tools/mcp-conformance/test/runner-cleanup.test.cjs
@@ -60,6 +60,7 @@ const {
   finalizeConformance,
   makeShadowTreeReaper,
   ownedDescendants,
+  classifyRootRow,
 } = require(ORCH);
 
 // A fake shadow-cljs child: an EventEmitter with a `kill(sig)` that records
@@ -534,6 +535,147 @@ test('ownedDescendants reports an empty set when the root is already gone and le
   assert.deepEqual(ownedDescendants(table, 100, 4000), []);
 });
 
+// ---- the ROOT row is fenced too (rf2-kzbf audit of PR #9213) --------------
+//
+// The first fix fenced the DESCENDANTS on creation time and let the ROOT in on
+// its number alone, then handed that number to `taskkill /T /F`. The wrapper is
+// short-lived by construction, so its PID is exactly the kind Windows recycles
+// soonest: cleanup could tree-kill a stranger and everything below it. These
+// pin the root row to the same standard as every other row.
+
+test('ownedDescendants never claims a root row that PREDATES our spawn (rf2-kzbf audit, AC2)', () => {
+  // The audit's own deterministic probe. Pre-fix this returned [100, 200].
+  const table = [
+    { pid: 100, ppid: 1, createdMs: 1000 }, // wears our number, older than us
+    { pid: 200, ppid: 100, createdMs: 6000 },
+  ];
+  const owned = ownedDescendants(table, 100, 5000);
+  assert.ok(!owned.includes(100), 'a root row older than our spawn is NOT ours: ' + JSON.stringify(owned));
+  assert.ok(
+    !owned.includes(200),
+    'and its children are ITS children — sweeping them up is the same violation one level down',
+  );
+});
+
+test('ownedDescendants disowns the root once OUR handle has been reaped (rf2-kzbf audit, AC2)', () => {
+  // The scenario the audit narrates, which a creation FLOOR alone cannot see:
+  // the wrapper exits, Windows recycles the number to a process created AFTER
+  // our spawn, and our own JVM is orphaned under the old number.
+  const table = [
+    { pid: 100, ppid: 1, createdMs: 7000 },   // the stranger that took the number
+    { pid: 200, ppid: 100, createdMs: 5500 }, // OUR orphaned JVM, older than the stranger
+    { pid: 300, ppid: 100, createdMs: 7500 }, // the stranger's own child
+    { pid: 400, ppid: 200, createdMs: 5600 }, // and our JVM's own child
+  ];
+  const owned = ownedDescendants(table, 100, 5000, { rootExited: true });
+  assert.ok(!owned.includes(100), 'a reaped handle means the number is free — never ours to kill');
+  assert.ok(!owned.includes(300), "the stranger's own child must not be attributed to us");
+  assert.deepEqual(
+    owned.sort((a, b) => a - b),
+    [200, 400],
+    'while our orphan and ITS subtree are still discovered through the dead parent link',
+  );
+});
+
+test('classifyRootRow separates the four cases the kill decision turns on (rf2-kzbf audit)', () => {
+  const at = (createdMs) => [{ pid: 100, ppid: 1, createdMs }];
+  assert.equal(classifyRootRow([], 100, 5000), 'absent');
+  assert.equal(classifyRootRow(at(5000), 100, 5000), 'ours');
+  assert.equal(classifyRootRow(at(4999), 100, 5000), 'stranger');
+  assert.equal(classifyRootRow(at(9000), 100, 5000, { rootExited: true }), 'stranger');
+  // FAIL CLOSED: an undated row cannot be proven ours, so it is not ours.
+  assert.equal(classifyRootRow(at(0), 100, 5000), 'unprovable');
+  assert.equal(classifyRootRow([{ pid: 100, ppid: 1, createdMs: NaN }], 100, 5000), 'unprovable');
+});
+
+test('makeShadowTreeReaper never tree-kills a RECYCLED root pid (rf2-kzbf audit, AC2)', async () => {
+  // The end of the chain the audit measured: `owned` included the recycled
+  // root, so `treeKill(rootPid)` ran `taskkill /pid <stranger> /T /F`.
+  const killed = [];
+  const reap = makeShadowTreeReaper({
+    rootPid: 100,
+    spawnedAtMs: 5000,
+    platform: 'win32',
+    readTable: () => [
+      { pid: 100, ppid: 1, createdMs: 1000 },
+      { pid: 200, ppid: 100, createdMs: 6000 },
+    ],
+    treeKill: (pid) => killed.push(pid),
+    isAlive: () => false,
+    graceMs: 20,
+    pollMs: 5,
+    log: () => {},
+    logErr: () => {},
+  });
+  const out = await reap();
+  assert.deepEqual(killed, [], 'nothing may be killed through a number we cannot prove is ours');
+  assert.deepEqual(out.owned, []);
+  assert.equal(out.error, null, 'and a stranger wearing our number is not itself a teardown failure');
+});
+
+test('makeShadowTreeReaper still reaps OUR orphan after the wrapper exits (rf2-kzbf audit, AC1)', async () => {
+  // The fence must withdraw the authority to kill the NUMBER without losing
+  // the JVM the whole mechanism exists for.
+  const killed = [];
+  const dead = new Set();
+  const reap = makeShadowTreeReaper({
+    rootPid: 100,
+    spawnedAtMs: 5000,
+    rootExited: () => true,
+    platform: 'win32',
+    readTable: () => [
+      { pid: 100, ppid: 1, createdMs: 7000 },   // stranger
+      { pid: 200, ppid: 100, createdMs: 5500 }, // our orphaned JVM
+    ],
+    treeKill: (pid) => { killed.push(pid); dead.add(pid); },
+    isAlive: (pid) => !dead.has(pid),
+    graceMs: 200,
+    pollMs: 5,
+    log: () => {},
+    logErr: () => {},
+  });
+  const out = await reap();
+  assert.deepEqual(killed, [200], 'our orphan is reaped; the stranger holding our old number is not');
+  assert.deepEqual(out.owned, [200]);
+  assert.deepEqual(out.survivors, []);
+});
+
+test('an UNDATED root row fails CLOSED: not killed, and not graded clean (rf2-kzbf audit, AC3)', async () => {
+  const killed = [];
+  const reap = makeShadowTreeReaper({
+    rootPid: 100,
+    spawnedAtMs: 5000,
+    platform: 'win32',
+    readTable: () => [{ pid: 100, ppid: 1, createdMs: 0 }],
+    treeKill: (pid) => killed.push(pid),
+    isAlive: () => true,
+    graceMs: 20,
+    pollMs: 5,
+    log: () => {},
+    logErr: () => {},
+  });
+  const out = await reap();
+  assert.deepEqual(killed, [], 'a row we cannot date is not ours to kill');
+  assert.match(out.error, /cannot be proven ours/);
+
+  // ...and "we could not tell" must not certify the run.
+  const report = await makeCleanup({
+    getBrowser: () => null,
+    getShadow: () => null,
+    hasShadowExited: () => true,
+    reapShadowTree: reap,
+    log: () => {},
+    logErr: () => {},
+  })();
+  assert.equal(report.clean, false, 'an unprovable root must grade DIRTY');
+  let sentinel = null;
+  const code = finalizeConformance(report, {
+    emitPass: (l) => { sentinel = l; }, log: () => {}, logErr: () => {}, flush: () => {}, count: 0,
+  });
+  assert.equal(code, 2);
+  assert.equal(sentinel, null, 'and emit no pass sentinel');
+});
+
 // ---- the reaper's own outcome grading -------------------------------------
 
 test('makeShadowTreeReaper reports SURVIVORS when the kill removes nothing (rf2-kzbf)', async () => {
@@ -717,7 +859,8 @@ test('a REAL cmd wrapper that exits with a live grandchild is graded DIRTY, then
       getShadow: () => shadow,
       hasShadowExited: () => shadowExited,
       reapShadowTree: makeShadowTreeReaper({
-        rootPid, spawnedAtMs, treeKill: () => {}, graceMs: 300, pollMs: 50,
+        rootPid, spawnedAtMs, rootExited: () => shadowExited,
+        treeKill: () => {}, graceMs: 300, pollMs: 50,
         log: () => {}, logErr: () => {},
       }),
       log: () => {}, logErr: () => {},
@@ -737,10 +880,22 @@ test('a REAL cmd wrapper that exits with a live grandchild is graded DIRTY, then
       getBrowser: () => null,
       getShadow: () => shadow,
       hasShadowExited: () => shadowExited,
-      reapShadowTree: makeShadowTreeReaper({ rootPid, spawnedAtMs, log: () => {}, logErr: () => {} }),
+      // Wired exactly as `main()` wires it, so this real-process witness also
+      // exercises the recycled-root fence: the wrapper HAS exited here, so the
+      // reaper may not kill through its number and must reach the grandchild
+      // through the dead parent link instead (rf2-kzbf audit).
+      reapShadowTree: makeShadowTreeReaper({
+        rootPid, spawnedAtMs, rootExited: () => shadowExited,
+        log: () => {}, logErr: () => {},
+      }),
       log: () => {}, logErr: () => {},
     })();
     assert.equal(afterReport.clean, true, 'the reaped tree grades clean: ' + JSON.stringify(afterReport.issues));
+    assert.ok(
+      afterReport.shadow.tree.owned.includes(grandPid),
+      'the orphaned grandchild must still be DISCOVERED through the exited wrapper: ' +
+        JSON.stringify(afterReport.shadow.tree),
+    );
     assert.deepEqual(afterReport.shadow.tree.survivors, []);
     let stillAlive = true;
     try { process.kill(grandPid, 0); } catch (e) { stillAlive = e.code === 'EPERM'; }


### PR DESCRIPTION
## rf2-kzbf — the audit's residual: the ownership fence was not applied to the root PID

The post-merge audit of PR #9213 reopened this bead. The original defect (grading
Windows hermetic cleanup on the `npx`/`cmd.exe` wrapper's `exit` rather than on the
shadow-cljs JVM underneath it) is fixed and stays fixed. What the audit found is the
*same mistake one level down*:

```js
if (byPid.has(rootPid)) owned.push(rootPid);   // root admitted on its NUMBER alone
...
treeKill(rootPid);                              // taskkill /pid <root> /T /F
```

Descendants were fenced on creation time; the root row was not. The wrapper whose PID
that is exits the moment it has launched the JVM, so it is exactly the kind of PID
Windows recycles soonest — after which cleanup could tree-kill an unrelated process
and everything below it.

**The audit's deterministic probe, reproduced at source before any edit** (root
`{pid:100, createdMs:1000}`, child `{pid:200, createdMs:6000}`, `spawnedAtMs=5000`):

```
PROBE owned = [100,200]
PROBE treeKill calls = [100]
```

## The repair

The root row is now **classified** rather than assumed (`classifyRootRow`), on the two
pieces of evidence that catch the two ways a PID can lie:

* **we OBSERVED our own child handle's `exit`** — the handle was reaped, the number is
  free, and whatever wears it now is somebody else's process. This is the case a
  creation *floor* alone cannot see, because a PID recycled **after** our spawn is
  younger than the floor — and it is the case the finding narrates ("once the
  short-lived cmd/npx wrapper exits and Windows recycles its PID"). Wired in `main()`
  as `rootExited: () => shadowExited`, the same flag the wrapper grading already reads.
* **the row's creation time predates our spawn instant** — it cannot be a process we
  started. This is the case the finding's probe exercises.

A row the OS gives **no usable creation time** for fails **closed**: not killed, and not
graded clean either — it becomes a `tree.error`, so `makeCleanup` reports dirty,
`finalizeConformance` returns exit 2 and emits no pass sentinel (AC3).

**Orphan discovery is retained in full.** Windows leaves a dead wrapper's number in its
children's `ParentProcessId`, so the walk still starts at the root PID and still finds
the JVM this whole mechanism exists for. Only the authority to *kill* that number is
withdrawn. One extra bound keeps the same violation from recurring a level further down:
an orphan of ours necessarily **predates** the stranger that inherited the number, so a
direct child created at or after the stranger's own creation is the stranger's child,
not ours.

After the fix, the same four probes:

```
AUDIT-PROBE:           owned=[]         treeKill=[]     error=null
RECYCLED-AFTER-SPAWN:  owned=[200]      treeKill=[]     error=null        (our orphan, not the stranger)
UNDATED-ROOT:          owned=[]         treeKill=[]     error="…refusing to tree-kill a PID that cannot be proven ours"
NORMAL-LIVE-TREE:      owned=[100,200,300] treeKill=[100] error=null      (unchanged normal path)
```

## Proof the new checks have teeth

The five new regressions were run against a **planted regression** — the two pre-fix
lines restored verbatim (`if (byPid.has(rootPid)) owned.push(rootPid)` and the
unconditional `treeKill(rootPid)`), the runner byte-restored from a copy afterwards and
`cmp`-verified identical:

```
CAPTURED_EXIT=1
ℹ tests 31   ℹ pass 26   ℹ fail 5
✖ ownedDescendants never claims a root row that PREDATES our spawn (rf2-kzbf audit, AC2)
✖ ownedDescendants disowns the root once OUR handle has been reaped (rf2-kzbf audit, AC2)
✖ makeShadowTreeReaper never tree-kills a RECYCLED root pid (rf2-kzbf audit, AC2)
✖ makeShadowTreeReaper still reaps OUR orphan after the wrapper exits (rf2-kzbf audit, AC1)
✖ an UNDATED root row fails CLOSED: not killed, and not graded clean (rf2-kzbf audit, AC3)

  AssertionError: nothing may be killed through a number we cannot prove is ours
  + actual: [ 100 ]      - expected: []
```

The 26 pre-existing tests all passed under that plant — which is the audit's own point:
the previously added recycled-PID test covered a stale *child*, never the root.

The **real-process witness** (`a REAL cmd wrapper that exits with a live grandchild`) is
now constructed with `rootExited` exactly as `main()` constructs it, and asserts the
orphaned grandchild is still *discovered* through the exited wrapper. So the same test
that stages a genuine leak — real `cross-spawn`'d `.cmd` wrapper, real detached Node
grandchild still writing its heartbeat, pre-fix grading shown clean + GREEN sentinel,
inert kill shown DIRTY naming the surviving pid, real reap shown clean with the
grandchild actually gone — now also proves the new fence does not lose the orphan it
must still reap. It ran on Windows in this branch (5.9 s / 13.4 s across runs).

## Gates

* `npm run test:runner-cleanup` (`tools/mcp-conformance`) — captured exit **0**,
  **tests 31, pass 31, fail 0, skipped 0**.
* `npm run test:unit` (the whole mcp-conformance Node unit cluster, re-run on the final
  rebased base) — captured exit **0**, **tests 143, pass 134, fail 0, skipped 9**
  (the 9 skips are the pre-existing symlink-privilege ones, unrelated), ending
  `MCP-CONFORMANCE NODE UNIT CLUSTER GREEN`.
* Not run locally: the live hermetic suite itself (`test:re-frame2-pair-live-hermetic-suite`)
  — it boots the fixture and a shadow-cljs JVM for several minutes. AC4's two consecutive
  full runs are left to CI/nightly.
* No README or docs under a link-gate root was touched (the diff is two `.cjs` files), so
  neither `check_readme_links.py` nor `check_doc_slugs.py` has a surface here.
* `eslint` was not run locally (no repo-root `node_modules` in this worktree); the change
  adds no new syntax and no unused bindings, and `lint.yml` covers it.

## Platform

Windows-specific behaviour, verified on Windows 11 by running the suite (including the
real `cmd.exe`-wrapper test) on this machine. The POSIX path is unchanged and still
inert — `makeShadowTreeReaper` returns the identity reaper off `win32`, pinned by the
existing `is INERT on POSIX` test, which passes on every platform. The new
`classifyRootRow` / `ownedDescendants` regressions are pure-function table models and so
run identically on macOS and Linux; what remains unverified off Windows is only the real
process-spawning test, which skips there by design (there is no `cmd.exe` shim to model).

Fence respected: the diff touches `tools/mcp-conformance/**` only — nothing under
`tools/mcp-base/**`, `tools/re-frame2-pair-mcp/**`, `implementation/**`, `spec/**` or
`.github/workflows/**`. No new CI job, so the check-count band does not move.
