### PR TITLE
fix(pair-mcp): get-path refuses an ambiguous frame instead of reporting a missing path (rf2-q17a)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
@@ -10,6 +10,14 @@
 
   Path vocabulary mirrors `get-in`: a vector of keys / indices.
 
+  ## Operating frame
+
+  Every read here is frame-targeted, so it resolves the operating frame
+  before it touches app-db — see `with-resolved-frame`. With two-plus
+  app frames and no pin the resolve yields nil and the tool REFUSES
+  with `:ambiguous-frame`; it does not read frame nil and report the
+  resulting blank as a missing path (rf2-q17a).
+
   ## Batch read — the plural `paths` arg
 
   The `paths` arg (a vector of path vectors) reads N app-db paths in
@@ -51,6 +59,53 @@
          "  (merge {:path " path-src " :frame " frame-edn "}"
          "         " elision-opts "))")
     value-sym))
+
+(def ^:private resolved-frame-sym
+  "Name of the let-binding `with-resolved-frame` puts the resolved
+  operating-frame id in. Both eval forms read app-db through it AND
+  hand it to the walker, so the value read and the elision handle
+  describe the same frame by construction."
+  "fid")
+
+(defn- with-resolved-frame
+  "Wrap `inner-src` — a get-path eval form — in the operating-frame
+  resolution every frame-targeted call owes the Tool-Pair contract:
+  explicit override -> session pin -> sole app frame -> nil.
+
+  The resolve runs browser-side, ONCE, before any app-db read. `nil`
+  means two-plus app frames are registered with no pin, so the tool
+  cannot know which frame the caller meant, and a tier-4 read must
+  REFUSE rather than read some other frame.
+
+  Refusing is the whole of this wrapper's point. Without it the form
+  called `(snapshot)` — `(rf/app-db-value (current-frame))`, i.e.
+  `(rf/app-db-value nil)`, i.e. nil — and `get-in` over nil answers
+  `:path-not-found` (singular) or `{:exists? false}` for every path
+  (batch). That is a confident falsehood about application state in
+  the one session shape where frame identity matters most: the agent
+  believes the slot is absent and goes off to ADD a path that was
+  already there (rf2-q17a).
+
+  `ambiguous-frame-error` is the SAME refusal envelope `read-sub` and
+  `sub-cache-info` already return — `:reason :ambiguous-frame` plus
+  `:available-frames` and a `:hint` naming the two recoveries that
+  already ship (pass `frame`, or pin one with `set-operating-frame`).
+  No new vocabulary and no new helper layer: the refusal rides the
+  existing `run-eval` `:ok? false` -> `wire/err-text` path out as an
+  `isError` envelope."
+  [frame inner-src]
+  (ef/emit
+    (ef/rt-let
+      [(symbol resolved-frame-sym)
+       (if frame
+         (ef/rt-call 'current-frame frame)
+         (ef/rt-call 'current-frame))]
+      (ef/rt-raw
+        (str "(if (nil? " resolved-frame-sym ") "
+             (ef/emit (ef/rt-call 'ambiguous-frame-error :get-path))
+             " "
+             inner-src
+             ")")))))
 
 (defn- single-path-form
   "Eval form for the singular `:path` read. Calls `snapshot` (full db for
@@ -167,12 +222,13 @@
         ;; The `:elision` echo below still reports the caller's
         ;; large-slot intent.
         walk?         (elision/walk-required? (not elision?) incl?)
-        snapshot-call (if frame
-                        (ef/rt-call 'snapshot frame)
-                        (ef/rt-call 'snapshot))
-        frame-edn     (if frame
-                        (pr-str frame)
-                        (ef/emit (ef/rt-call 'current-frame)))
+        ;; ONE resolution, one truth: both forms read app-db through
+        ;; the frame id `with-resolved-frame` binds, and hand that same
+        ;; id to the walker. The former pair — `(snapshot)` for the read
+        ;; and a SECOND, independent `(current-frame)` call for the
+        ;; walker — could disagree, and neither refused (rf2-q17a).
+        snapshot-call (ef/rt-call 'snapshot (ef/rt-raw resolved-frame-sym))
+        frame-edn     resolved-frame-sym
         run-eval
         ;; Shared eval-then-shrink tail: both branches run a server-side
         ;; form, strip the literal value(s) through the wire-pipeline
@@ -248,11 +304,19 @@
           (wire/err-text {:ok? false :reason :empty-paths
                           :hint "usage: get-path {paths '[[:cart :items] [:user :id]]' [frame :rf/default]}"}))
         (run-eval
-          (batch-paths-form snapshot-call paths walk? frame-edn elision-opts)
+          (with-resolved-frame
+            frame
+            (batch-paths-form snapshot-call paths walk? frame-edn elision-opts))
           :results
+          ;; Mirror the singular arm and attach `:results` / `:elision`
+          ;; only on a hit. An `:ambiguous-frame` refusal dressed with
+          ;; `:results nil` would read as "nothing there" — the exact
+          ;; false-absence this tool must stop telling.
           (fn [envelope' results]
-            (cond-> (assoc envelope' :results results :elision elision?)
-              frame (assoc :frame frame)))))
+            (let [ok? (:ok? envelope')]
+              (cond-> envelope'
+                ok?   (assoc :results results :elision elision?)
+                frame (assoc :frame frame))))))
 
       (nil? path)
       (js/Promise.resolve
@@ -265,7 +329,9 @@
       ;; `:value` slot is only re-attached on a hit.
       :else
       (run-eval
-        (single-path-form snapshot-call path walk? frame-edn elision-opts)
+        (with-resolved-frame
+          frame
+          (single-path-form snapshot-call path walk? frame-edn elision-opts))
         (fn [envelope] (when (:ok? envelope) (:value envelope)))
         (fn [envelope' value]
           (let [ok? (:ok? envelope')]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/elision_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/elision_test.cljs
@@ -362,10 +362,15 @@
   ([path frame elision?] (build-get-path-form path frame elision? false))
   ([path frame elision? include-sensitive?]
    (let [path-edn      (pr-str path)
-         snapshot-call (if frame
-                         (str "(re-frame2-pair.runtime/snapshot " (pr-str frame) ")")
-                         "(re-frame2-pair.runtime/snapshot)")
-         frame-edn     (if frame (pr-str frame) "(re-frame2-pair.runtime/current-frame)")
+         ;; Since rf2-q17a the frame is resolved ONCE into `fid` by the
+         ;; wrapper below; the read and the walker both address it, so
+         ;; there is no longer a `(current-frame)` call in the walker
+         ;; opts and no no-arg `(snapshot)` call at all.
+         snapshot-call "(re-frame2-pair.runtime/snapshot fid)"
+         frame-edn     "fid"
+         resolve-call  (if frame
+                         (str "(re-frame2-pair.runtime/current-frame " (pr-str frame) ")")
+                         "(re-frame2-pair.runtime/current-frame)")
          ;; Helper takes walker-aligned `include-large?`;
          ;; flip from the MCP-arg `elision?` polarity here, mirroring
          ;; the production call site in `tools/get_path.cljs`.
@@ -383,7 +388,10 @@
                          (str "(count (filter #(and (map? %) (contains? % :rf.size/large-elided))"
                               "               (tree-seq coll? seq elided-v)))")
                          "0")]
-     (str "(let [db " snapshot-call
+     (str "(let [fid " resolve-call "]"
+          "  (if (nil? fid)"
+          "    (re-frame2-pair.runtime/ambiguous-frame-error :get-path)"
+          "    (let [db " snapshot-call
           "      path " path-edn
           "      missing #js {}"
           "      v (get-in db path missing)"
@@ -402,7 +410,7 @@
           "              (<= 0 (first rem) (dec (count cur))))"
           "         (recur (conj acc (first rem)) (nth (vec cur) (first rem)) (rest rem))"
           "         :else acc))}"
-          "    {:ok? true :exists? true :path path :value elided-v :elided-count n}))"))))
+          "      {:ok? true :exists? true :path path :value elided-v :elided-count n}))))"))))
 
 (deftest get-path-form-full-raw-opt-in-bypasses-walker
   ;; The raw value rides the wire ONLY on the full-raw
@@ -437,17 +445,24 @@
     ;; The walker's `:path` opt is the supplied path so the marker's
     ;; handle carries `[:rf.elision/at <path>]`.
     (is (re-find #":path path" form))
-    ;; Frame is explicit when supplied.
-    (is (re-find #":frame :rf/default" form))
+    ;; The walker addresses the RESOLVED id. An explicit frame reaches
+    ;; it through tier 1 of the one resolve (rf2-q17a), rather than
+    ;; being spliced in a second time as a literal.
+    (is (re-find #":frame fid" form))
+    (is (re-find #"current-frame :rf/default" form))
     ;; Markers actually fire (include-large? is false).
     (is (re-find #":rf\.size/include-large\? false" form))))
 
 (deftest get-path-form-defaults-to-current-frame
-  ;; No `:frame` arg = the walker uses
-  ;; `(re-frame2-pair.runtime/current-frame)` so the registry lookup
-  ;; hits the operating frame.
+  ;; No `:frame` arg = the form resolves the operating frame ONCE into
+  ;; `fid` and the walker addresses THAT, so the registry lookup and
+  ;; the value read can never name different frames (rf2-q17a). The
+  ;; walker no longer issues a `(current-frame)` call of its own.
   (let [form (build-get-path-form [:cart :items] nil true)]
-    (is (re-find #":frame \(re-frame2-pair\.runtime/current-frame\)" form))))
+    (is (re-find #"let \[fid \(re-frame2-pair\.runtime/current-frame\)\]" form))
+    (is (re-find #":frame fid" form))
+    (is (not (re-find #":frame \(re-frame2-pair\.runtime/current-frame\)" form))
+        "the walker addresses the resolved id, not a second resolve")))
 
 (deftest get-path-form-path-edn-quotes-correctly
   ;; The path is pr-str'd into the form. Mixed key types (keywords,

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/get_path_frame_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/get_path_frame_test.cljs
@@ -1,0 +1,396 @@
+(ns re-frame2-pair-mcp.get-path-frame-test
+  "Operating-frame resolution for the `get-path` tool (rf2-q17a).
+
+  ## What this pins
+
+  `get-path` is frame-targeted, so the Tool-Pair contract makes it
+  resolve explicit override -> session pin -> sole app frame -> nil,
+  and REFUSE at nil rather than read some other frame. Before
+  rf2-q17a it did neither: the emitted form called `(snapshot)` with
+  no frame and no guard, which resolves to `(rf/app-db-value nil)` =
+  nil, and `get-in` over nil answers `:path-not-found` (singular) or
+  `{:exists? false}` for every path (batch). The tool told the agent
+  \"that path does not exist\" when the truth was \"I could not tell
+  which frame you meant\" — and an agent that believes it goes off and
+  adds a path that was already there.
+
+  ## Why the stub reads the form
+
+  A test that canned an `:ambiguous-frame` response would pass on the
+  DEFECT, because the tool faithfully relays whatever the runtime
+  hands it — the bug was never in the relay. So `runtime-answer`
+  below does not take a canned envelope. It plays a live runtime with
+  a given set of app frames and a given pin, DERIVES the operating
+  frame from the emitted form exactly as `pure/resolve-operating-frame`
+  would, and answers accordingly:
+
+    - resolved id is nil AND the form guards on it -> the refusal;
+    - resolved id is nil and the form does NOT guard -> the read runs
+      against `(get db nil)` = nil, and reports the miss — the very
+      falsehood this bead is about;
+    - resolved id is non-nil -> the read runs against that frame's db.
+
+  So the same test body distinguishes the fix from the defect, and
+  the singular/batch refusal tests fail on the pre-fix tree.
+
+  Note `elision_test/build-get-path-form` is a hand-written MIRROR of
+  the form composition and asserts against itself, so it can go green
+  while production drifts. The tests here drive `get-path-tool`
+  itself."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [clojure.string :as str]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.get-path :as get-path]))
+
+(def ^:private pristine-eval nrepl/cljs-eval-value)
+
+(use-fixtures :each
+  {:after (fn [] (set! nrepl/cljs-eval-value pristine-eval))})
+
+(defn- fresh-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{:app})
+    conn))
+
+(def ^:private read-edn tu/extract-edn)
+(def ^:private err? tu/error?)
+
+;; Two app frames, no pin — the session shape the resolver calls
+;; ambiguous and the one where a wrong guess is unrecoverable.
+(def ^:private two-frames [:rf/default :stories])
+
+;; ---------------------------------------------------------------------------
+;; The runtime simulator — answers are DERIVED from the emitted form.
+;; ---------------------------------------------------------------------------
+
+(defn- guards-ambiguity?
+  "True when `form` detects the ambiguity WHERE IT ARISES: it binds the
+  resolved id, branches to `ambiguous-frame-error` on nil, and only
+  then reads app-db. The ordering is the assertion — a form that
+  merely mentions the refusal after reading would still have taken
+  the wrong branch."
+  [form]
+  (let [resolve-at (str/index-of form "(let [fid (re-frame2-pair.runtime/current-frame")
+        refuse-at  (str/index-of form
+                                 (str "(if (nil? fid) "
+                                      "(re-frame2-pair.runtime/ambiguous-frame-error :get-path)"))
+        read-at    (str/index-of form "(re-frame2-pair.runtime/snapshot fid)")]
+    (boolean (and resolve-at refuse-at read-at
+                  (< resolve-at refuse-at read-at)))))
+
+(defn- resolved-id
+  "The id the browser-side resolver would return for `form` in a session
+  holding `app-frames` with `pin` selected. Mirrors
+  `pure/resolve-operating-frame`: override -> pin -> sole app frame ->
+  nil. The override is read off the form because that is where the
+  tool puts it — from the resolve call once the fix routes it there,
+  and from the `snapshot` call on the pre-fix shape, so this models
+  BOTH trees faithfully and tier 1 stays a real control rather than
+  an artefact of the simulator."
+  [form app-frames pin]
+  (if-let [override (second (or (re-find #"current-frame\s+(:[^\s)]+)\)" form)
+                                (re-find #"snapshot\s+(:[^\s)]+)\)" form)))]
+    (keyword (subs override 1))
+    (or pin
+        (when (= 1 (count app-frames)) (first app-frames)))))
+
+(defn- ambiguous-envelope
+  "The envelope `re-frame2-pair.runtime/ambiguous-frame-error` builds —
+  reproduced here because the preload is not on this test's classpath.
+  Shape per `pure/ambiguous-frame-envelope`."
+  [app-frames pin]
+  {:ok?              false
+   :reason           :ambiguous-frame
+   :operation        :get-path
+   :available-frames app-frames
+   :selected-frame   pin
+   :hint             (str "multiple app frames are registered and no frame is "
+                          "selected, so get-path cannot pick a target. "
+                          "Pass `frame` (one of " (pr-str app-frames) ") or pin one with "
+                          "`select-frame!` / set-operating-frame, then retry.")})
+
+(defn- runtime-answer
+  "Answer `form` as a live runtime would, given the session described by
+  `app-frames` / `pin` / `db` (a frame-id -> app-db map). `path` /
+  `paths` are the caller's request; the FRAME is whatever the form
+  resolves, which is the whole point."
+  [form {:keys [app-frames pin db path paths]}]
+  (let [fid (resolved-id form app-frames pin)]
+    (if (and (nil? fid) (guards-ambiguity? form))
+      (ambiguous-envelope app-frames pin)
+      ;; No guard (or an unambiguous session): the read proceeds. For a
+      ;; nil frame `(get db nil)` is nil and every lookup misses —
+      ;; reproducing the pre-fix falsehood exactly.
+      (let [frame-db (get db fid)
+            missing  (js-obj)]
+        (if paths
+          {:ok?     true
+           :results (into {}
+                          (map (fn [p]
+                                 (let [v (get-in frame-db p missing)]
+                                   [p (if (identical? v missing)
+                                        {:exists? false :value nil}
+                                        {:exists? true :value v})])))
+                          paths)
+           :elided-count 0}
+          (let [v (get-in frame-db path missing)]
+            (if (identical? v missing)
+              {:ok? false :reason :path-not-found :path path :deepest-valid-prefix []}
+              {:ok? true :exists? true :path path :value v :elided-count 0})))))))
+
+(defn- stub-runtime!
+  "Install the simulator. Prelude evals (the preload sentinel and the
+  raw-state signal) are answered directly; the get-path form is
+  captured into `captured*` and answered by `runtime-answer`."
+  [captured* session]
+  (let [respond
+        (fn [form]
+          (cond
+            (and (string? form) (re-find #"__re_frame2_pair_runtime" form))
+            (js/Promise.resolve true)
+
+            (and (string? form) (re-find #"configure-raw-state!" form))
+            (js/Promise.resolve nil)
+
+            :else
+            (do (when (and captured* (string? form))
+                  (reset! captured* form))
+                (js/Promise.resolve
+                  (if (string? form)
+                    (runtime-answer form session)
+                    nil)))))]
+    (set! nrepl/cljs-eval-value
+          (fn
+            ([_c _b form] (respond form))
+            ([_c _b form _o] (respond form))))))
+
+;; ---------------------------------------------------------------------------
+;; The witnesses — these fail on the pre-fix tree.
+;; ---------------------------------------------------------------------------
+
+(deftest singular-ambiguous-frame-refuses-rather-than-reporting-path-not-found
+  ;; Acceptance 1: two app frames, no pin, no `frame` arg.
+  (async done
+    (let [captured (atom nil)]
+      (stub-runtime! captured {:app-frames two-frames
+                               :pin        nil
+                               :db         {:rf/default {:cart {:items [1 2]}}
+                                            :stories    {:cart {:items []}}}
+                               :path       [:cart :items]})
+      (-> (get-path/get-path-tool (fresh-conn) (tu/args->js {:path "[:cart :items]"}))
+          (.then (fn [r]
+                   (let [edn (read-edn r)]
+                     (is (err? r) "an unanswerable read is an isError envelope")
+                     (is (= false (:ok? edn)))
+                     (is (= :ambiguous-frame (:reason edn))
+                         "the refusal names the ambiguity, not a missing path")
+                     (is (not= :path-not-found (:reason edn))
+                         "REGRESSION: the path exists in BOTH frames — reporting it absent is a falsehood")
+                     (is (= :get-path (:operation edn)))
+                     (is (= two-frames (:available-frames edn))
+                         "the candidate frames are named so the agent can choose")
+                     (is (nil? (:selected-frame edn)))
+                     (is (not (contains? edn :deepest-valid-prefix))
+                         "no path-discovery breadcrumbs on a question that was never asked"))
+                   (done)))))))
+
+(deftest batch-ambiguous-frame-refuses-rather-than-reporting-every-path-absent
+  ;; Acceptance 2: the batch shape must not answer `:ok? true` with an
+  ;; all-missing results map — the more damaging of the two, since it
+  ;; presents as a SUCCESS.
+  (async done
+    (let [captured (atom nil)]
+      (stub-runtime! captured {:app-frames two-frames
+                               :pin        nil
+                               :db         {:rf/default {:cart {:items [1 2]} :user {:id 7}}
+                                            :stories    {:cart {:items []} :user {:id 9}}}
+                               :paths      [[:cart :items] [:user :id]]})
+      (-> (get-path/get-path-tool (fresh-conn)
+                                  (tu/args->js {:paths "[[:cart :items] [:user :id]]"}))
+          (.then (fn [r]
+                   (let [edn (read-edn r)]
+                     (is (err? r))
+                     (is (= false (:ok? edn))
+                         "REGRESSION: an all-missing batch presented as :ok? true reads as success")
+                     (is (= :ambiguous-frame (:reason edn)))
+                     (is (= :get-path (:operation edn)))
+                     (is (= two-frames (:available-frames edn)))
+                     (is (not (contains? edn :results))
+                         "a refusal carries no :results — `:results nil` reads as 'nothing there'"))
+                   (done)))))))
+
+(deftest refusal-names-the-next-action
+  ;; The stance: an ambiguity error that merely says "ambiguous" is not
+  ;; good ergonomics. The hint must name what to DO.
+  (async done
+    (stub-runtime! nil {:app-frames two-frames :pin nil :db {} :path [:a]})
+    (-> (get-path/get-path-tool (fresh-conn) (tu/args->js {:path "[:a]"}))
+        (.then (fn [r]
+                 (let [hint (:hint (read-edn r))]
+                   (is (string? hint))
+                   (is (str/includes? hint "frame") "names the `frame` arg")
+                   (is (str/includes? hint "set-operating-frame")
+                       "names the pin tool the agent already has")
+                   (is (str/includes? hint ":stories")
+                       "names the candidates inline, so choosing needs no second call"))
+                 (done))))))
+
+;; ---------------------------------------------------------------------------
+;; Where the detection sits — the branch, not the message.
+;; ---------------------------------------------------------------------------
+
+(deftest ambiguity-is-detected-before-app-db-is-read
+  ;; Patching the message alone would leave the wrong branch taken.
+  ;; Both emitted shapes must resolve, guard, THEN read.
+  (async done
+    (let [captured (atom nil)]
+      (stub-runtime! captured {:app-frames two-frames :pin nil :db {} :path [:a]})
+      (-> (get-path/get-path-tool (fresh-conn) (tu/args->js {:path "[:a]"}))
+          (.then (fn [_]
+                   (let [form @captured]
+                     (is (string? form))
+                     (is (guards-ambiguity? form)
+                         "singular: resolve -> refuse-on-nil -> read, in that order"))
+                   (let [captured2 (atom nil)]
+                     (stub-runtime! captured2 {:app-frames two-frames :pin nil
+                                               :db {} :paths [[:a]]})
+                     (-> (get-path/get-path-tool (fresh-conn)
+                                                 (tu/args->js {:paths "[[:a]]"}))
+                         (.then (fn [_]
+                                  (is (guards-ambiguity? @captured2)
+                                      "batch: same ordering")
+                                  (done)))))))))))
+
+(deftest one-resolution-serves-both-the-read-and-the-walker
+  ;; The read and the elision handle must describe the same frame. The
+  ;; walker used to issue a SECOND, independent `(current-frame)` call.
+  (async done
+    (let [captured (atom nil)]
+      (stub-runtime! captured {:app-frames [:rf/default] :pin nil
+                               :db {:rf/default {:a 1}} :path [:a]})
+      (-> (get-path/get-path-tool (fresh-conn) (tu/args->js {:path "[:a]"}))
+          (.then (fn [_]
+                   (let [form @captured]
+                     (is (re-find #":frame fid" form)
+                         "the walker addresses the resolved id")
+                     (is (= 1 (count (re-seq #"re-frame2-pair\.runtime/current-frame" form)))
+                         "exactly ONE resolve per form — two could disagree"))
+                   (done)))))))
+
+(deftest emitted-form-is-well-formed
+  ;; Liveness: the wrapper splices raw source, so a stray paren would
+  ;; ship a form the runtime cannot read. Delimiters must balance.
+  (async done
+    (let [captured (atom nil)
+          balanced?
+          (fn [s]
+            (let [tally (fn [o c] (- (count (re-seq (re-pattern (str "\\" o)) s))
+                                     (count (re-seq (re-pattern (str "\\" c)) s))))]
+              (and (zero? (tally "(" ")"))
+                   (zero? (tally "[" "]"))
+                   (zero? (tally "{" "}")))))]
+      (stub-runtime! captured {:app-frames [:rf/default] :pin nil
+                               :db {:rf/default {:a 1}} :path [:a]})
+      (-> (get-path/get-path-tool (fresh-conn) (tu/args->js {:path "[:a]"}))
+          (.then (fn [_]
+                   (is (balanced? @captured) "singular form balances")
+                   (let [captured2 (atom nil)]
+                     (stub-runtime! captured2 {:app-frames [:rf/default] :pin nil
+                                               :db {:rf/default {:a 1}} :paths [[:a]]})
+                     (-> (get-path/get-path-tool (fresh-conn)
+                                                 (tu/args->js {:paths "[[:a]]"}))
+                         (.then (fn [_]
+                                  (is (balanced? @captured2) "batch form balances")
+                                  (done)))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Acceptance 3 — the resolvable sessions keep their existing shapes.
+;; ---------------------------------------------------------------------------
+
+(deftest explicit-frame-still-reads-that-frame
+  ;; An explicit override wins tier 1 even with two frames registered,
+  ;; and the value returned is that frame's — not the other's.
+  (async done
+    (stub-runtime! nil {:app-frames two-frames
+                        :pin        nil
+                        :db         {:rf/default {:cart {:items [1 2]}}
+                                     :stories    {:cart {:items [:only-here]}}}
+                        :path       [:cart :items]})
+    (-> (get-path/get-path-tool (fresh-conn)
+                                (tu/args->js {:path "[:cart :items]" :frame ":stories"}))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (not (err? r)))
+                   (is (true? (:ok? edn)))
+                   (is (true? (:exists? edn)))
+                   (is (= [:only-here] (:value edn)) "read the frame the caller named")
+                   (is (= :stories (:frame edn))))
+                 (done))))))
+
+(deftest session-pin-still-reads-the-pinned-frame
+  ;; Tier 2. No `frame` arg, two frames registered, but a pin is in
+  ;; effect — a hit, not a refusal.
+  (async done
+    (stub-runtime! nil {:app-frames two-frames
+                        :pin        :stories
+                        :db         {:rf/default {:cart {:items [1 2]}}
+                                     :stories    {:cart {:items [:pinned]}}}
+                        :path       [:cart :items]})
+    (-> (get-path/get-path-tool (fresh-conn) (tu/args->js {:path "[:cart :items]"}))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (not (err? r)))
+                   (is (true? (:ok? edn)))
+                   (is (= [:pinned] (:value edn))))
+                 (done))))))
+
+(deftest sole-app-frame-still-auto-resolves
+  ;; Tier 3. One app frame, no pin, no arg — auto-resolves, no refusal.
+  (async done
+    (stub-runtime! nil {:app-frames [:rf/default]
+                        :pin        nil
+                        :db         {:rf/default {:counter 42}}
+                        :path       [:counter]})
+    (-> (get-path/get-path-tool (fresh-conn) (tu/args->js {:path "[:counter]"}))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (not (err? r)))
+                   (is (true? (:ok? edn)))
+                   (is (= 42 (:value edn))))
+                 (done))))))
+
+(deftest genuine-miss-in-a-resolved-frame-is-still-path-not-found
+  ;; The refusal must not swallow the honest answer: in a session that
+  ;; DOES resolve, an absent path is still `:path-not-found`.
+  (async done
+    (stub-runtime! nil {:app-frames [:rf/default]
+                        :pin        nil
+                        :db         {:rf/default {:counter 42}}
+                        :path       [:no-such :key]})
+    (-> (get-path/get-path-tool (fresh-conn) (tu/args->js {:path "[:no-such :key]"}))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (err? r))
+                   (is (= :path-not-found (:reason edn))
+                       "a resolved frame that genuinely lacks the path still says so"))
+                 (done))))))
+
+(deftest batch-in-a-resolved-frame-still-returns-results
+  (async done
+    (stub-runtime! nil {:app-frames [:rf/default]
+                        :pin        nil
+                        :db         {:rf/default {:cart {:items [1 2]} :user {:id 7}}}
+                        :paths      [[:cart :items] [:user :id] [:nope]]})
+    (-> (get-path/get-path-tool
+          (fresh-conn)
+          (tu/args->js {:paths "[[:cart :items] [:user :id] [:nope]]"}))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (not (err? r)))
+                   (is (true? (:ok? edn)))
+                   (is (= {:exists? true :value [1 2]} (get-in edn [:results [:cart :items]])))
+                   (is (= {:exists? true :value 7} (get-in edn [:results [:user :id]])))
+                   (is (= {:exists? false :value nil} (get-in edn [:results [:nope]]))
+                       "a real per-path miss inside a resolved frame is still reported"))
+                 (done))))))


### PR DESCRIPTION
Closes rf2-q17a.

## The defect

`get-path` is frame-targeted, so the Tool-Pair contract makes it resolve
`explicit override -> session pin -> sole app frame -> nil` and **refuse** at
nil rather than read some other frame. It did neither.

The emitted form called `(snapshot)` with no frame and no guard. That resolves
to `(rf/app-db-value (current-frame))`, and `current-frame` is nil under
two-plus app frames with no pin, and `app-db-value` returns nil for an
unregistered frame. `get-in` over nil then finds nothing, so:

- the **singular** read answered `{:ok? false :reason :path-not-found}`;
- the **batch** read answered `{:ok? true :results {<every path> {:exists? false}}}`
  — presenting as a *success*.

In the one session shape where frame identity matters most, the tool told the
agent *"that path does not exist"* when the truth was *"I could not tell which
frame you meant"*. An agent that believes it goes and changes the app to add a
path that was already there. The recovery that already ships — `available-frames`
plus `set-operating-frame` — was withheld.

`frame-edn` compounded it: the walker issued a **second, independent**
`(current-frame)` call, so the value read and the elision handle could name
different frames.

## The spec already required this

`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md` names `get-path`
explicitly in *"Every frame-targeted op ... REFUSES with `{:ok? false :reason
:ambiguous-frame}` rather than guess"*, and again in the get-path section. So
this was a **code/spec conformance gap, not a spec gap** — the spec is
unchanged, because it already specifies the fixed behaviour.

## The fix

Both forms now resolve the frame **once**, browser-side, **before any app-db
read**, and branch to the runtime's existing `ambiguous-frame-error` when
resolution yields nil:

```clojure
(let [fid (re-frame2-pair.runtime/current-frame)]
  (if (nil? fid)
    (re-frame2-pair.runtime/ambiguous-frame-error :get-path)
    (let [db (re-frame2-pair.runtime/snapshot fid) ...] ...)))
```

Detection sits where the ambiguity **arises**, not where the verdict is printed
— patching the message alone would have left the wrong branch taken. The
refusal rides the existing `run-eval` `:ok? false` -> `wire/err-text` path out
as an `isError` envelope carrying `:reason :ambiguous-frame`, `:operation
:get-path`, `:available-frames` and a hint naming both recoveries, so the error
says what to do next. No new vocabulary, no new helper layer, no policy — the
same envelope `read-sub` and `sub-cache-info` already return.

The resolved id is also what the walker receives, so the read and the elision
handle describe the same frame by construction (one `current-frame` call per
form, down from two). Batch results gain the singular arm's `ok?` guard, so a
refusal is not dressed with `:results nil` — which would read as "nothing
there", the very falsehood at issue.

Tier 1 behaviour is unchanged: `resolve-operating-frame` returns an explicit
override verbatim even when unregistered (pinned by `pure_test`), so an
explicit `frame` still reads that frame and an unregistered one still yields
`:path-not-found`.

## Witness

`test/re_frame2_pair_mcp/get_path_frame_test.cljs` drives `get-path-tool`
itself against a runtime simulator that **derives** its answer from the emitted
form rather than canning one — a canned `:ambiguous-frame` response would pass
on the defect, because the relay was never the bug. The simulator plays a
session with a given frame set and pin, resolves the frame the way
`pure/resolve-operating-frame` does, and returns the refusal only if the form
actually guards; otherwise it reads `(get db nil)` and reports the miss,
reproducing the defect exactly.

Measured both ways on this branch:

| tree | assertions | result |
|---|---|---|
| pre-fix production, same tests | 4115 | 22 failures — exit `1` |
| with the fix | 4116 | **0 failures, 0 errors** — exit `0` |

Controls in the same file: tier 1 (explicit frame), tier 2 (session pin),
tier 3 (sole app frame), a genuine `:path-not-found` inside a resolved frame,
and a real per-path miss inside a resolved batch — all must stay green, so the
refusal cannot swallow honest answers.

`elision_test/build-get-path-form` is a **hand-written mirror** of the form
composition that asserts against itself, so it cannot witness a production
change — it would have gone green through this whole bug. Updated to stay in
lockstep as its own docstring requires, and the new test drives production
directly.

## Sibling census

Censused every `rt-call` the pair-mcp tools emit against the runtime fns that
call `ambiguous-frame-error`. Control: `read-sub!`, `sub-cache-info`,
`describe-image`, `start-recording!`, `sample-signals` all report the refusal,
so the instrument detects the pattern.

**Two siblings share the shape** — `trace-window` and `watch-epochs` emit
implicit `(epoch-history)` / `(epochs-since ...)`, and `state/history-for` returns
`[]` for an unknown frame, so an ambiguous session reports `:count 0` ("nothing
happened"); `watch-epochs` adds `:id-aged-out? true` on top. `trace-window`'s
count-0 advisory cannot catch it, because the advisory reads the same implicit
call. **Filed as rf2-yo4s rather than fixed here**: this bead scopes to
`get-path` and its non-goals forbid widening, and both siblings are cursor-paged
with sticky frame state that needs its own care. Splitting deliberately.

Checked and **not** defects: `precheck` (emits only for an `:explicit` frame),
`replace-app-db` (nil frame fails loudly with `:no-such-frame`), `restore-epoch`
(nil frame returns `false`), `probe`/`health` (reports the operating frame
honestly), `snapshot` (deliberately a broad multi-frame mega-op — an explicit
non-goal of the bead). Ten tools already refuse via the runtime.

## Gates

`npm --prefix tools/re-frame2-pair-mcp test` — the artefact's only verdict
(`deps.edn` documents that `clojure -M:test` deliberately refuses, and a bare
`shadow-cljs compile server-test` exits 0 over failures, rf2-7r9w).

Re-run on the final rebased base: **1131 tests, 4116 assertions, 0 failures,
0 errors**, captured exit `0`.

Verified at the **unit level**; the suite compiles `server-test` from source,
so it ran against this change rather than a stale binary. No live MCP client was
driven and no `npm run build` binary rebuild was performed.

No README beside source was touched, so `check_readme_links.py` is not in scope;
`check_doc_slugs.py` covers `tools/*/spec`, which is unchanged.

**Spec unchanged because** `003-Tool-Catalogue.md` already specifies the
refusal for `get-path` — the code was non-conformant with it.
