### PR TITLE
test(template): prove the optimized release boots for every emitted substrate (rf2-eiev)

### DIFF
--- a/tools/template/README.md
+++ b/tools/template/README.md
@@ -142,10 +142,11 @@ clojure -M:test
 ```
 
 The behavioural tier — a real shadow-cljs compile, the focused test
-under Node, the emitted page in Chromium, and the `:advanced` release —
-is opt-in with `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` and needs a primed
-`implementation/node_modules` plus a Playwright Chromium. See
-[Principles §P7](./spec/Principles.md#p7--tested-end-to-end-per-substrate).
+under Node, the emitted page in Chromium, then the `:advanced` release
+and the emitted page in Chromium again over that optimised bundle, for
+every substrate — is opt-in with `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` and
+needs a primed `implementation/node_modules` plus a Playwright Chromium.
+See [Principles §P7](./spec/Principles.md#p7--tested-end-to-end-per-substrate).
 
 ## Spec
 

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -107,7 +107,7 @@ tools/template/
 ├── src/day8/re_frame2_template/
 │   └── hooks.clj                         ; data-fn / template-fn / post-process-fn
 ├── test/day8/re_frame2_template/         ; the suite (see Principles §P7)
-├── test-support/dev-page-boot-proof.cjs  ; the Chromium driver the behavioural tier runs
+├── test-support/page-boot-proof.cjs      ; the Chromium driver the behavioural tier runs (dev + release)
 └── resources/day8/re_frame2_template/
     ├── template.edn                      ; declarative entrypoint
     ├── root/                             ; bulk-copied, default placement

--- a/tools/template/spec/005-Repo-Split.md
+++ b/tools/template/spec/005-Repo-Split.md
@@ -89,7 +89,7 @@ github.com/day8/re-frame2-template/        ; external repo (NEW) — the TEMPLAT
 │   ├── release_gate_test.clj              ; workflow-sanity coverage for template-release.yml
 │   └── repo_split_spec_test.clj           ; executable checks for the §2.1.x deps-new grammar
 ├── test-support/
-│   └── dev-page-boot-proof.cjs            ; Chromium dev-page boot driver (emitted-app tier)
+│   └── page-boot-proof.cjs                ; Chromium page-boot driver, dev + release (emitted-app tier)
 └── .github/workflows/
     └── template-release.yml               ; tag-on-release CI (moved from the monorepo — see §3.2)
 
@@ -322,7 +322,7 @@ off that same root:
 - `release_gate_test.clj` slurps
   `<repo-root>/.github/workflows/template-release.yml`.
 - `emitted_test_run_test.clj` launches
-  `<repo-root>/tools/template/test-support/dev-page-boot-proof.cjs`.
+  `<repo-root>/tools/template/test-support/page-boot-proof.cjs`.
 
 In the monorepo the framework marker and the template body sit under one
 root, so the conflation is invisible. **That is exactly what makes the
@@ -354,7 +354,7 @@ Every current path consumer, and the root it must read from:
 | `test_support` / `template-resource-dir` | `resources/` (deps-new `:src-dirs`) | template |
 | `repo_split_spec_test` | `spec/005-Repo-Split.md` | template |
 | `release_gate_test` | `.github/workflows/template-release.yml` | template |
-| `emitted_test_run_test` (boot proof) | `test-support/dev-page-boot-proof.cjs` | template |
+| `emitted_test_run_test` (boot proof) | `test-support/page-boot-proof.cjs` | template |
 | `version_lockstep_test` (`:rf2-version`) | `VERSION` | framework |
 | `version_lockstep_test` (react / shadow pins) | `implementation/package.json` | framework |
 | `version_lockstep_test` (clojure + substrate pins) | `implementation/core/deps.edn`, `implementation/adapters/reagent/deps.edn`, `implementation/adapters/uix/deps.edn` | framework |
@@ -615,8 +615,10 @@ and the test-architecture setup per §3.2.1):
        `skills/re-frame2-setup/references/first-counter.md`;
      - **behavioural compile / run + browser** (`emitted_test_run_test`)
        — compile the emitted app against `:local/root` framework paths,
-       junction `implementation/node_modules`, and boot the dev page
-       under Chromium via `test-support/dev-page-boot-proof.cjs`;
+       junction `implementation/node_modules`, and boot the page under
+       Chromium via `test-support/page-boot-proof.cjs` twice per
+       substrate: once over the dev bundle, once over the `:advanced`
+       release;
      - **release-workflow sanity** (`release_gate_test`) — read against
        the template repo's own
        `.github/workflows/template-release.yml`;

--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -326,8 +326,10 @@ run and boot the emitted app.
 The behavioural compile+run+boot slice (`emitted_test_run_test.clj`) is
 opt-in via `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` (CI sets this; local
 fast-loop default-off). It is the tier that proves the scaffold a
-newcomer opens actually paints; the manifest equality, the static-parse
-audit and the lockstep guards are the cheap contract underneath it.
+newcomer opens actually paints — and, since rf2-eiev, that the
+`:advanced` bundle they then deploy paints too, for every substrate; the
+manifest equality, the static-parse audit and the lockstep guards are the
+cheap contract underneath it.
 
 ## §8 — Strict substrate coercion (keyword-only)
 

--- a/tools/template/spec/Principles.md
+++ b/tools/template/spec/Principles.md
@@ -173,15 +173,30 @@ is exercised end-to-end across the layers:
    `:app` and `:test` builds, runs the focused test under Node, loads
    the real emitted `index.html` in Chromium and proves it paints the
    counter and moves it 0 → 1 with zero uncaught pageerrors, then
-   breaks the page's mount node and proves that same proof goes red;
-   builds the `:advanced` release. Gated behind
-   `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` (CI sets it; off locally for the
-   fast loop). Its one convenience — junctioning
+   breaks the page's mount node and proves that same proof goes red.
+   Gated behind `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` (CI sets it; off
+   locally for the fast loop). Its one convenience — junctioning
    `implementation/node_modules` into the emitted project instead of
    an `npm install` per variant — is what would let an undeclared npm
    package compile green, so the tier reads the `:browser` build's own
    `manifest.edn` and requires every resolved package to be reachable
    from the emitted `package.json`.
+
+   **The `:advanced` release is proven the same way, for every
+   substrate.** `npm run release` is one of the three commands the
+   emitted README documents, and the scaffold tells its user the
+   resulting `resources/public` is deployable — so the tier finishes
+   each substrate by running `shadow-cljs release app` and loading the
+   emitted page a second time, over that optimised bundle, through the
+   same Chromium driver. A compile that exits 0 is not the claim: under
+   `:advanced` Closure renames un-inferrable property access and drops
+   code behind `goog.DEBUG`, so a non-empty optimised `main.js` can
+   still throw at load or paint nothing. The two verdicts are held
+   apart by construction — the release must change `js/main.js`'s
+   length, and the driver requires the globals it observes (`goog` /
+   `cljs`, objects in the dev bundle and renamed away under
+   `:advanced`) to be the ones that mode's bundle has — so neither
+   bundle can be credited with the other's boot.
 
    The Chromium proof treats an unlaunchable browser asymmetrically,
    and deliberately. Every CI job that enables the tier also installs a

--- a/tools/template/test-support/page-boot-proof.cjs
+++ b/tools/template/test-support/page-boot-proof.cjs
@@ -1,16 +1,23 @@
 #!/usr/bin/env node
 /*
- * Browser proof that the generated scaffold's EMITTED `index.html` boots the
- * DEV bundle — the page a newcomer actually opens after
- * `npx shadow-cljs watch app`.
+ * Browser proof that the generated scaffold's EMITTED `index.html` BOOTS — run
+ * twice per substrate, once over each bundle the scaffold's own commands
+ * produce:
+ *
+ *   * `dev`     — `:optimizations :none`, the page a newcomer opens after
+ *                 `npx shadow-cljs watch app`.
+ *   * `release` — `:advanced`, the page a newcomer DEPLOYS after
+ *                 `npm run release`. Closure renames every un-inferrable
+ *                 property access and eliminates code behind `goog.DEBUG`, so
+ *                 an interop defect that is invisible in dev appears only
+ *                 here.
  *
  * Driven by `emitted_test_run_test.clj` (behind `RF2_TEMPLATE_RUN_EMITTED_TESTS`),
  * which runs it for the Reagent variant, the UIx variant, and the setup
  * skill's shipped leaf scaffold. The JVM half has already generated the
- * scaffold, rewritten its deps to :local/root, linked node_modules, and run
- * `shadow compile app` — so `<proj>/resources/public` holds the emitted
- * `index.html`, `css/app.css`, and the DEV (`:optimizations :none`) bundle at
- * `js/main.js` + `js/cljs-runtime/`.
+ * scaffold, rewritten its deps to :local/root, linked node_modules, and built
+ * the bundle under test into `<proj>/resources/public` beside the emitted
+ * `index.html` and `css/app.css`.
  *
  * WHY THIS EXISTS. Every other gate over the generated app stops at the
  * pure-JVM route: it compiles, so it is presumed to boot. But a scaffold can
@@ -19,7 +26,7 @@
  * fires, a namespace that throws on load. Nothing but loading the REAL emitted
  * page in a REAL browser catches that class, which is what this driver does.
  *
- * The three teeth, in order:
+ * The four teeth, in order:
  *
  *   1. MOUNT — `#app` must paint the scaffold's counter (an `<h1>` with the
  *      project name, a `<button>`, and the counter `<span>`). A bundle that
@@ -28,9 +35,38 @@
  *   2. LIVE — clicking the `+1` button must move the counter 0 -> 1, so the
  *      dataflow (event -> app-db -> subscription -> re-render) is actually
  *      wired, not just static markup.
- *   3. CLEAN — ZERO uncaught `pageerror`s. Console noise stays diagnostic
+ *   3. BUNDLE SHAPE — the page must have run the bundle the caller SAID it
+ *      built. See below; this is what keeps the two verdicts apart.
+ *   4. CLEAN — ZERO uncaught `pageerror`s. Console noise stays diagnostic
  *      (a 404 favicon, a dev-only warn); only `pageerror` is fatal, matching
  *      every adjacent runner's policy in this repo.
+ *
+ * TOOTH 3, AND WHY IT IS NOT DECORATION. Both proofs load the same URL out of
+ * the same directory; the release build simply overwrites `js/main.js` in
+ * place. So without a positive check, a release build that silently failed to
+ * replace the dev bundle would be certified by a browser verdict the DEV
+ * bundle earned — the exact substitution this file's two modes exist to
+ * prevent. The check reads two globals whose presence IS the un-optimised
+ * bundle: `goog` (the Closure runtime namespace) and `cljs` (the
+ * ClojureScript one). `:advanced` renames both away. Measured on a real
+ * emitted UIx scaffold, in both directions:
+ *
+ *     bundle   typeof goog   typeof cljs   js/main.js
+ *     dev      "object"      "object"      6,311,996 bytes
+ *     release  "undefined"   "undefined"      620,222 bytes
+ *
+ * (The byte counts drift by a few between runs — the build bakes in its own
+ * temp path — so it is the ORDER OF MAGNITUDE that is the signal, and the
+ * JVM side asserts only that the two differ, never a figure.)
+ *
+ * Each mode's assertion therefore reads the OPPOSITE way on the other mode's
+ * artefact, which is what makes both non-vacuous without a third fixture.
+ *
+ * NOT a discriminator, and measured so rather than assumed: NETWORK REQUESTS.
+ * The dev `:browser` bundle produced by `shadow-cljs compile` is
+ * self-contained (`CLOSURE_NO_DEPS = true`), so it fetches ZERO
+ * `js/cljs-runtime/` chunks — exactly like the release bundle. Both modes
+ * request precisely `index.html`, `css/app.css` and `js/main.js`.
  *
  * NO CONTENT-SECURITY-POLICY IS IN PLAY, by design on both ends: the emitted
  * `index.html` carries no `<meta http-equiv="Content-Security-Policy">` (both
@@ -39,12 +75,17 @@
  * brings its own policy-bearing fixture and its own diagnostics — this driver
  * deliberately keeps none for a policy no page under it can have.
  *
- * Usage:  node dev-page-boot-proof.cjs <publicRoot> <implRoot> [label]
+ * Usage:  node page-boot-proof.cjs <publicRoot> <implRoot> [label]
  *   publicRoot — <proj>/resources/public (holds index.html + js/ + css/)
  *   implRoot   — <repo>/implementation   (resolves the playwright devDep)
  *   label      — optional variant name, echoed in diagnostics
  *
- * Exit 0 = all three teeth pass. Exit 1 = the proof FAILED. Exit 2 = Chromium
+ * Env:
+ *   RF2_TEMPLATE_BUNDLE_MODE            `dev` (default) or `release`
+ *   RF2_TEMPLATE_EXPECT_H1              pin the exact <h1> text
+ *   RF2_TEMPLATE_BROWSER_PROOF_TIMEOUT_MS
+ *
+ * Exit 0 = all four teeth pass. Exit 1 = the proof FAILED. Exit 2 = Chromium
  * is not launchable here. Exit 2 is a REPORT, not a verdict: the caller
  * decides. Under CI it fails the run (every job enabling this tier provisions
  * a browser, so a missing one is a broken job); locally it is a skip under a
@@ -60,10 +101,33 @@ const path = require('path');
 
 const [, , PUBLIC_ROOT, IMPL_ROOT, LABEL] = process.argv;
 if (!PUBLIC_ROOT || !IMPL_ROOT) {
-  console.error('usage: node dev-page-boot-proof.cjs <publicRoot> <implRoot> [label]');
+  console.error('usage: node page-boot-proof.cjs <publicRoot> <implRoot> [label]');
   process.exit(2);
 }
 const label = LABEL || 'emitted scaffold';
+
+// Which bundle the caller says it built. Defaults to `dev` — the historical
+// behaviour and the only mode a hand invocation is likely to want — but an
+// unrecognised value is a harness error and fails closed rather than silently
+// proving the wrong thing.
+const MODE = (process.env.RF2_TEMPLATE_BUNDLE_MODE || 'dev').trim().toLowerCase();
+
+// typeof for two globals the un-optimised bundle defines and `:advanced`
+// renames away. See "TOOTH 3" above for the measurements.
+const BUNDLE_SHAPES = {
+  dev: { goog: 'object', cljs: 'object' },
+  release: { goog: 'undefined', cljs: 'undefined' },
+};
+const BUNDLE_NOUN = { dev: 'development', release: 'optimized (:advanced) release' };
+
+if (!Object.prototype.hasOwnProperty.call(BUNDLE_SHAPES, MODE)) {
+  console.log(
+    `page boot proof CONFIGURATION ERROR (${label}): RF2_TEMPLATE_BUNDLE_MODE ` +
+      `must be one of ${JSON.stringify(Object.keys(BUNDLE_SHAPES))}, got ` +
+      `${JSON.stringify(MODE)}.`,
+  );
+  process.exit(1);
+}
 
 const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
 
@@ -83,9 +147,9 @@ const MIME = {
 };
 
 // A tiny contained static file server rooted at PUBLIC_ROOT — enough to serve
-// the emitted index.html, the dev bundle, its cljs-runtime chunks and the CSS.
-// Never escapes the root, and sets no security headers of its own: the page
-// under test is served exactly as emitted.
+// the emitted index.html, the bundle under test, any cljs-runtime chunks and
+// the CSS. Never escapes the root, and sets no security headers of its own:
+// the page under test is served exactly as emitted.
 function startStaticServer(root) {
   const canonRoot = path.resolve(root);
   const server = http.createServer((req, res) => {
@@ -120,7 +184,7 @@ function diagnose(lines) {
   const hints = [];
   if (/Failed to load resource.*(main\.js|cljs-runtime)/i.test(blob)) {
     hints.push(
-      'the dev bundle (js/main.js or a js/cljs-runtime chunk) did not load — ' +
+      'the bundle (js/main.js or a js/cljs-runtime chunk) did not load — ' +
         'check the emitted :output-dir / :asset-path against the index.html ' +
         '<script src>.',
     );
@@ -140,6 +204,7 @@ function diagnose(lines) {
   const pageErrors = [];
   let browser;
   let failure = null;
+  let observedShape = null;
 
   // Launch failure is REPORTED, not judged, here: exit 2 means "no launchable
   // browser on this machine" and the caller decides what that is worth. Under
@@ -153,8 +218,8 @@ function diagnose(lines) {
   } catch (launchErr) {
     server.close();
     console.log(
-      `dev-page boot proof SKIPPED (${label}): Chromium is not launchable here ` +
-        `(${launchErr.message.split('\n')[0]}).`,
+      `page boot proof SKIPPED (${label}, ${MODE} bundle): Chromium is not ` +
+        `launchable here (${launchErr.message.split('\n')[0]}).`,
     );
     process.exit(2);
   }
@@ -173,7 +238,7 @@ function diagnose(lines) {
 
     await page.goto(baseUrl + BOOT_PAGE, { waitUntil: 'load', timeout: TIMEOUT_MS });
 
-    // -- Tooth 1: the dev bundle booted and PAINTED the counter into #app ----
+    // -- Tooth 1: the bundle booted and PAINTED the counter into #app --------
     try {
       await page.waitForFunction(
         () => {
@@ -199,17 +264,17 @@ function diagnose(lines) {
         .catch(() => '<unreadable>');
       const hints = diagnose(consoleLines.concat(pageErrors));
       throw new Error(
-        `the emitted dev page did NOT mount: #app never painted the scaffold ` +
-          `counter (BLANK FIRST PAGE). #app innerHTML was ${JSON.stringify(appHtml)}.` +
+        `the emitted ${BUNDLE_NOUN[MODE]} page did NOT mount: #app never painted ` +
+          `the scaffold counter (BLANK FIRST PAGE). #app innerHTML was ` +
+          `${JSON.stringify(appHtml)}.` +
           (hints.length ? `\nLikely cause:\n  - ${hints.join('\n  - ')}` : '') +
           `\n(underlying wait: ${waitErr.message.split('\n')[0]})`,
       );
     }
 
     // -- Tooth 1b (optional): the heading TEXT is the one the caller expects.
-    // Set RF2_TEMPLATE_EXPECT_H1 to pin it — the setup-skill fixture does,
-    // because the heading comes from the shipped views.cljs, so a match is
-    // positive evidence that the source under test is what the browser ran.
+    // Set RF2_TEMPLATE_EXPECT_H1 to pin it — a match is positive evidence that
+    // the source under test is what the browser actually rendered.
     if (EXPECT_H1) {
       const h1 = await page.evaluate(() =>
         (document.querySelector('#app h1').textContent || '').trim(),
@@ -232,6 +297,27 @@ function diagnose(lines) {
       { timeout: TIMEOUT_MS },
     );
 
+    // -- Tooth 3: the page ran the bundle the caller SAID it built -----------
+    observedShape = await page.evaluate(() => ({
+      goog: typeof window.goog,
+      cljs: typeof window.cljs,
+    }));
+    const expectedShape = BUNDLE_SHAPES[MODE];
+    const mismatched = Object.keys(expectedShape).filter(
+      (k) => observedShape[k] !== expectedShape[k],
+    );
+    if (mismatched.length) {
+      const other = MODE === 'dev' ? 'release' : 'dev';
+      throw new Error(
+        `the page booted, but it did NOT run the ${BUNDLE_NOUN[MODE]} bundle: ` +
+          `expected ${JSON.stringify(expectedShape)}, observed ` +
+          `${JSON.stringify(observedShape)} (differs on ${JSON.stringify(mismatched)}). ` +
+          `That shape is the ${BUNDLE_NOUN[other]} one — js/main.js under ` +
+          `${PUBLIC_ROOT} is not the artefact this proof was asked about, so a ` +
+          `PASS here would have credited one bundle with the other's verdict.`,
+      );
+    }
+
     await context.close();
   } catch (err) {
     failure = err;
@@ -240,18 +326,18 @@ function diagnose(lines) {
     server.close();
   }
 
-  // -- Tooth 3: ZERO uncaught pageerrors on the emitted dev page ------------
+  // -- Tooth 4: ZERO uncaught pageerrors on the emitted page ----------------
   if (!failure && pageErrors.length) {
     const hints = diagnose(consoleLines.concat(pageErrors));
     failure = new Error(
-      `the emitted dev page mounted but raised ${pageErrors.length} uncaught ` +
-        `pageerror(s):\n  ${pageErrors.join('\n  ')}` +
+      `the emitted ${BUNDLE_NOUN[MODE]} page mounted but raised ` +
+        `${pageErrors.length} uncaught pageerror(s):\n  ${pageErrors.join('\n  ')}` +
         (hints.length ? `\nLikely cause:\n  - ${hints.join('\n  - ')}` : ''),
     );
   }
 
   if (failure) {
-    console.log(`=== dev-page boot proof (${label}): FAIL ===`);
+    console.log(`=== page boot proof (${label}, ${MODE} bundle): FAIL ===`);
     console.log(failure.message);
     if (consoleLines.length) {
       console.log('--- browser console ---');
@@ -261,8 +347,9 @@ function diagnose(lines) {
   }
 
   console.log(
-    `dev-page boot proof PASS (${label}): the emitted index.html booted the dev ` +
-      'bundle, #app painted the counter, the click moved it 0 -> 1, and Chromium ' +
+    `page boot proof PASS (${label}, ${MODE} bundle): the emitted index.html ` +
+      `booted the ${BUNDLE_NOUN[MODE]} bundle (${JSON.stringify(observedShape)}), ` +
+      '#app painted the counter, the click moved it 0 -> 1, and Chromium ' +
       'reported zero uncaught pageerrors.',
   );
   process.exit(0);

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -9,13 +9,15 @@
    `:local/root` paths into the in-repo source tree, compiles the `:app`
    and `:test` builds, runs `out/node-test.js`, loads the REAL emitted
    `index.html` in Chromium and proves it paints the counter and moves it
-   0 → 1, and (Reagent) builds the `:advanced` release.
+   0 → 1, then builds the `:advanced` release and loads the REAL emitted
+   page a SECOND time over that optimised bundle.
 
-   ## The two consumer-realism teeth
+   ## The three consumer-realism teeth
 
-   A compile-and-run tier that resolves everything from the monorepo is
-   blind in two specific ways, and real defects shipped GREEN through it
-   because of them. Both masks are closed here:
+   A compile-and-run tier that resolves everything from the monorepo, and
+   stops at the bundle the fast loop happens to build, is blind in three
+   specific ways — real defects shipped GREEN through the first two. All
+   three masks are closed here:
 
      * NODE_MODULES JUNCTION. `link-node-modules!` junctions
        `implementation/node_modules` into every emitted project, so the
@@ -25,26 +27,47 @@
        build's own `manifest.edn` and asserts every npm package the build
        resolved is one `npm install` would have produced from the EMITTED
        `package.json`.
-     * NO DEV-PAGE BOOT PROOF. Nothing loaded the emitted `index.html` in
-       a browser. Closed by `run-dev-page-boot-proof!` + its
-       `test-support/dev-page-boot-proof.cjs` driver, which serves the
+     * NO PAGE BOOT PROOF. Nothing loaded the emitted `index.html` in
+       a browser. Closed by `run-page-boot-proof!` + its
+       `test-support/page-boot-proof.cjs` driver, which serves the
        emitted `resources/public`, loads the real page and proves it
        mounts, increments, and raises zero uncaught pageerrors — and by
        `run-broken-boot-witness!`, which breaks the page's mount node and
        requires that same driver to go RED, so a green proof is never the
        inert kind.
+     * NO OPTIMISED-BUNDLE PROOF. `npm run release` is one of the three
+       commands the emitted README documents, and the dev bundle proves
+       nothing about it: under `:advanced` Closure renames every
+       un-inferrable property access and eliminates code behind
+       `goog.DEBUG`, so an interop defect ships green from the dev
+       compile and appears only in the artefact the user deploys. Closed
+       by running the SAME driver a second time over the release build,
+       in `:release` mode — see `run-release-proof!`.
 
-   Both must run BEFORE the optional `:advanced` release build, which
+   The first two must run BEFORE the `:advanced` release build, which
    overwrites the dev bundle and its manifest.
+
+   ## Keeping the two boot verdicts apart
+
+   Both boot proofs load the same URL out of the same directory, so a
+   release build that silently failed to replace the dev bundle could be
+   certified by the verdict the DEV bundle earned. Two independent checks
+   forbid that: this file requires the release `js/main.js` to differ in
+   length from the dev one it recorded before the release ran, and the
+   driver requires the globals it observes in the page to be the ones
+   that mode's bundle has (`goog` / `cljs` are objects in the dev bundle
+   and renamed away under `:advanced`). Each reads the opposite way on
+   the other mode's artefact, so neither is vacuous.
 
    ## Gating
 
    Default off (opt-in via `RF2_TEMPLATE_RUN_EMITTED_TESTS=1`): a cold
-   shadow-cljs compile + Chromium per substrate is ~30–60 s, and the tier
-   needs a populated `implementation/node_modules` (`npm ci` there) plus a
-   Playwright Chromium. CI's `jvm-tools-template` job provides both. When
-   the env var is unset every deftest records a single documented skip
-   assertion and exits.
+   shadow-cljs compile + an `:advanced` release + Chromium per substrate
+   is ~1–2 min, and the tier needs a populated
+   `implementation/node_modules` (`npm ci` there) plus a Playwright
+   Chromium. CI's `jvm-tools-template` job provides both. When the env
+   var is unset every deftest records a single documented skip assertion
+   and exits.
 
    ## The setup skill's default scaffold
 
@@ -70,6 +93,17 @@
 
 (def ^:private emitted-tests-enabled?
   (delay (= "1" (System/getenv "RF2_TEMPLATE_RUN_EMITTED_TESTS"))))
+
+;; --- The scaffolded name ----------------------------------------------------
+
+(def ^:private emitted-project-name
+  "The `:name` every fixture in this tier scaffolds under — and, because the
+  emitted `views.cljs` paints it, the exact `<h1>` text each browser proof
+  pins via `RF2_TEMPLATE_EXPECT_H1`. That coupling is the point: a heading
+  match is positive evidence the browser rendered THIS emission's source and
+  not something left in the output directory. It is also the name the setup
+  skill's shipped leaf is derived for."
+  "acme/my-app")
 
 ;; --- deps.edn local-root rewrite ------------------------------------------
 
@@ -332,48 +366,63 @@
             (println (str "  [" echo-tag "] " (string/trim line)))))
         (is (zero? exit) failure-msg))))
 
-;; --- emitted dev-page boot proof ------------------------------------------
+;; --- emitted page boot proof ----------------------------------------------
 
 (def ^:private boot-proof-driver-rel
-  "tools/template/test-support/dev-page-boot-proof.cjs")
+  "tools/template/test-support/page-boot-proof.cjs")
+
+(def ^:private bundle-mode-blurb
+  "How each mode's page reaches a user — quoted into the failure message so
+  the verdict names the command whose output just broke."
+  {:dev     "the page a newcomer opens after `npx shadow-cljs watch app`"
+   :release (str "the page a newcomer DEPLOYS after `npm run release` — the "
+                 ":advanced bundle, where Closure renames un-inferrable "
+                 "property access and drops code behind `goog.DEBUG`, so a "
+                 "defect invisible in dev surfaces only here")})
 
 (defn- run-boot-proof-driver!
   "Serve the emitted `resources/public` and drive Chromium over the real
-  `index.html` + dev bundle. Returns the driver's {:exit :out}."
-  [^java.io.File root ^java.io.File proj label env-overrides]
+  `index.html` + whichever bundle `mode` (`:dev` / `:release`) says is
+  currently built there. Returns the driver's {:exit :out}."
+  [^java.io.File root ^java.io.File proj label mode env-overrides]
   (let [driver    (.getCanonicalPath (io/file root boot-proof-driver-rel))
         pub-root  (.getCanonicalPath (io/file proj "resources/public"))
         impl-root (.getCanonicalPath (io/file root "implementation"))
         node-path (.getCanonicalPath (io/file root "implementation/node_modules"))]
     (run-process! ["node" driver pub-root impl-root label]
-                  proj (merge {"NODE_PATH" node-path} env-overrides))))
+                  proj (merge {"NODE_PATH"                (str node-path)
+                               "RF2_TEMPLATE_BUNDLE_MODE" (name mode)}
+                              env-overrides))))
 
-(defn- run-dev-page-boot-proof!
-  "The positive proof: the page a newcomer opens after `npx shadow-cljs
-  watch app` mounts the counter, moves it 0 → 1 on click, and raises zero
-  uncaught pageerrors. Assumes `shadow compile app` already built the dev
-  bundle, so it must run BEFORE any `release` build replaces it. Returns
-  the driver's exit code, or nil when `node` is unavailable."
-  [^java.io.File root ^java.io.File proj label]
-  (testing (str label " — Chromium dev-page boot proof (emitted index.html + "
-                "dev bundle mounts, zero pageerror)")
-    (if-not @node-available?
-      (do (announce-browser-skip! (str "dev-page boot proof -- " label)
-                                  "`node` is not on PATH")
-          (is true "`node` unavailable — skipping the emitted dev-page boot proof")
-          nil)
-      (let [{:keys [exit out]} (run-boot-proof-driver! root proj label {})]
-        (check-browser-proof!
-          (str "dev-page boot proof -- " label)
-          "dev-page boot"
-          exit out
-          (str "the emitted dev-page boot proof exited " exit " for " label
-               " — the page a newcomer opens after `npx shadow-cljs watch app` "
-               "did not boot cleanly: either #app never painted (a broken "
-               ":init-fn, a namespace that throws on load, a bundle that did "
-               "not load), the counter did not move 0 -> 1, or Chromium raised "
-               "an uncaught pageerror. Output:\n" out))
-        exit))))
+(defn- run-page-boot-proof!
+  "The positive proof for one bundle: the emitted page mounts the counter,
+  moves it 0 → 1 on click, raises zero uncaught pageerrors, AND is running
+  the bundle `mode` names (the driver's third tooth). Assumes the matching
+  build has just been produced into `resources/public`. Returns the
+  driver's exit code, or nil when `node` is unavailable."
+  [^java.io.File root ^java.io.File proj label mode env-overrides]
+  (let [what (str (name mode) "-bundle boot proof -- " label)]
+    (testing (str label " — Chromium " (name mode) "-bundle boot proof (emitted "
+                  "index.html + " (name mode) " bundle mounts, zero pageerror)")
+      (if-not @node-available?
+        (do (announce-browser-skip! what "`node` is not on PATH")
+            (is true (str "`node` unavailable — skipping the emitted "
+                          (name mode) "-bundle boot proof"))
+            nil)
+        (let [{:keys [exit out]} (run-boot-proof-driver! root proj label mode
+                                                         env-overrides)]
+          (check-browser-proof!
+            what
+            (str (name mode) "-bundle boot")
+            exit out
+            (str "the emitted " (name mode) "-bundle boot proof exited " exit
+                 " for " label " — " (bundle-mode-blurb mode)
+                 " did not boot cleanly: either #app never painted (a broken "
+                 ":init-fn, a namespace that throws on load, a bundle that did "
+                 "not load), the counter did not move 0 -> 1, Chromium raised "
+                 "an uncaught pageerror, or the page was not running the "
+                 (name mode) " bundle at all. Output:\n" out))
+          exit)))))
 
 (defn- run-broken-boot-witness!
   "The red witness for the boot proof: rename the page's mount node so
@@ -392,13 +441,13 @@
       (try
         (spit index broken)
         (let [{:keys [exit out]}
-              (run-boot-proof-driver! root proj (str label " (broken)")
+              (run-boot-proof-driver! root proj (str label " (broken)") :dev
                                       ;; The driver waits this long for #app
                                       ;; to paint before failing; keep the
                                       ;; deliberate failure cheap.
                                       {"RF2_TEMPLATE_BROWSER_PROOF_TIMEOUT_MS" "8000"})]
           (is (= 1 exit)
-              (str "the dev-page boot proof must go RED (exit 1) on a page with "
+              (str "the dev-bundle boot proof must go RED (exit 1) on a page with "
                    "no #app mount node; it exited " exit
                    ". A green here means the proof is inert. Output:\n" out))
           ;; Say so on the green path too: a witness that speaks only when
@@ -412,6 +461,67 @@
       (is (= original (slurp index))
           "index.html is restored byte-for-byte after the witness"))))
 
+;; --- the :advanced release proof -------------------------------------------
+
+(defn- run-release-proof!
+  "`npm run release` is one of the three commands the emitted README
+  documents, and the scaffold tells every substrate's user the resulting
+  `resources/public` is deployable. Prove that: build the `:advanced`
+  release, then load the REAL emitted page over the optimised bundle with
+  the same Chromium driver the dev proof used.
+
+  `dev-bundle-length` is `js/main.js`'s length recorded BEFORE this ran.
+  The release overwrites that file in place, so requiring the length to
+  change is the cheap on-disk half of keeping the two boot verdicts apart;
+  the driver's `:release` mode is the runtime half. A compile that exits 0
+  is NOT the deliverable here — `resources/public/js/main.js` being
+  non-empty was the whole of the old assertion, and a non-empty optimised
+  bundle can still throw at load or paint nothing."
+  [^java.io.File root ^java.io.File proj label env dev-bundle-length]
+  (let [bundle    (io/file proj "resources/public/js/main.js")
+        released?
+        (testing (str label " — clojure -M:shadow release app (:advanced)")
+          (let [{:keys [exit out]}
+                (run-process! ["clojure" "-M:shadow" "-m" "shadow.cljs.devtools.cli"
+                               "release" "app"]
+                              proj env)]
+            (is (zero? exit)
+                (str "`clojure -M:shadow release app` exited " exit " for "
+                     label ". An :advanced-only break (Closure DCE/externs, "
+                     "^:export munging) ships green from the dev compile and "
+                     "surfaces only on a newcomer's `npm run release`. "
+                     "Output:\n" out))
+            (when (zero? exit)
+              (let [emitted? (and (.isFile bundle) (pos? (.length bundle)))
+                    replaced? (and emitted? (not= dev-bundle-length (.length bundle)))]
+                (is emitted?
+                    (str "`shadow release app` must emit a non-empty "
+                         "resources/public/js/main.js for " label ". Bundle: "
+                         (if (.isFile bundle)
+                           (str (.length bundle) " bytes")
+                           "absent")))
+                ;; The release writes over the dev bundle. If it did not, the
+                ;; browser half below would be grading the artefact the dev
+                ;; proof already passed.
+                (is replaced?
+                    (str "the `:advanced` release did not replace the dev bundle for "
+                         label ": resources/public/js/main.js is still "
+                         dev-bundle-length " bytes. Everything after this point "
+                         "would be proving the DEV bundle a second time."))
+                (when replaced?
+                  (println (str "  [release bundle] " label ": dev " dev-bundle-length
+                                " bytes -> :advanced " (.length bundle) " bytes")))
+                replaced?))))]
+    ;; The browser half — the actual "boots" claim, and the deliverable. Only
+    ;; when the release genuinely produced a new bundle: run it over a failed
+    ;; release and every verdict below is about the dev artefact instead, which
+    ;; is the confusion this whole function exists to prevent. Pinning the
+    ;; heading is positive evidence the optimised bundle rendered the emitted
+    ;; `views.cljs` rather than anything left in the output directory.
+    (when released?
+      (run-page-boot-proof! root proj label :release
+                            {"RF2_TEMPLATE_EXPECT_H1" emitted-project-name}))))
+
 ;; --- The orchestration -----------------------------------------------------
 
 (defn- compile-and-run-emitted-test!
@@ -419,19 +529,23 @@
   link node_modules, `clojure -M:shadow compile app test`, prove the
   emitted package.json is complete, boot the real page in Chromium (and,
   when `boot-witness?`, prove that proof bites), run `node
-  out/node-test.js`, and when `release?` build the `:advanced` release.
+  out/node-test.js`, then build the `:advanced` release and boot the real
+  page over THAT.
 
   Every substrate compiles BOTH the `:app` build — the only build that
   pulls its `core.cljs` and views onto the compile classpath — and the
-  `:test` build that runs `events_test.cljs`. No other gate compiles the
-  generated app under `:advanced`, so the Reagent variant runs the release
-  too; the `:app` module + `^:export init` shape is substrate-invariant."
-  [substrate {:keys [release? boot-witness?]}]
+  `:test` build that runs `events_test.cljs`, and every substrate runs the
+  release arm. The release arm was Reagent-only until rf2-eiev, on the
+  rationale that the `:app` module + `^:export init` shape is
+  substrate-invariant; but `deps.edn`, `core.cljs` and `views.cljs` are
+  swapped per substrate and all three are source Closure compiles, so UIx's
+  advertised `npm run release` was never executed by any gate."
+  [substrate {:keys [boot-witness?]}]
   (let [root  (repo-root)
         label (name substrate)
         tmp   (tmp-dir (str "rf2-template-run-" label "-"))]
     (try
-      (let [proj (run-template! tmp "acme/my-app" substrate)]
+      (let [proj (run-template! tmp emitted-project-name substrate)]
         (rewrite-deps-for-local-run! root proj substrate)
         (let [linked?   (link-node-modules! root proj)
               node-path (.getCanonicalPath (io/file root "implementation/node_modules"))
@@ -454,9 +568,10 @@
                   (str "`clojure -M:shadow compile app test` exited " exit
                        " for " label ". Output:\n" out))))
 
-          ;; --- the two teeth, before any release overwrites the dev bundle
+          ;; --- the two teeth, before the release overwrites the dev bundle
           (assert-emitted-package-json-complete! root proj label)
-          (let [proof-exit (run-dev-page-boot-proof! root proj label)]
+          (let [proof-exit (run-page-boot-proof! root proj label :dev
+                                                 {"RF2_TEMPLATE_EXPECT_H1" emitted-project-name})]
             (when (and boot-witness? (= 0 proof-exit))
               (run-broken-boot-witness! root proj label)))
 
@@ -478,26 +593,11 @@
                   (is (re-find #"0 failures, 0 errors" out)
                       (str "expected '0 failures, 0 errors'. Got:\n" out))))))
 
-          ;; --- :advanced release build ---------------------------------------
-          (when release?
-            (testing (str label " — clojure -M:shadow release app (:advanced)")
-              (let [{:keys [exit out]}
-                    (run-process! ["clojure" "-M:shadow" "-m" "shadow.cljs.devtools.cli"
-                                   "release" "app"]
-                                  proj env)]
-                (is (zero? exit)
-                    (str "`clojure -M:shadow release app` exited " exit " for "
-                         label ". An :advanced-only break (Closure DCE/externs, "
-                         "^:export munging) ships green from the dev compile and "
-                         "surfaces only on a newcomer's `npm run release`. "
-                         "Output:\n" out))
-                (let [bundle (io/file proj "resources/public/js/main.js")]
-                  (is (and (.isFile bundle) (pos? (.length bundle)))
-                      (str "`shadow release app` must emit a non-empty "
-                           "resources/public/js/main.js for " label ". Bundle: "
-                           (if (.isFile bundle)
-                             (str (.length bundle) " bytes")
-                             "absent")))))))))
+          ;; --- :advanced release build + its own boot proof -------------------
+          ;; Last, and only here: it overwrites the dev bundle and its
+          ;; manifest, which everything above reads.
+          (run-release-proof! root proj label env
+                              (.length (io/file proj "resources/public/js/main.js")))))
       (finally
         (delete-recursively tmp)))))
 
@@ -513,10 +613,18 @@
 
 ;; --- Tests -----------------------------------------------------------------
 
+;; One deftest per substrate the generator can emit. That set is DERIVED —
+;; `hooks.clj`'s `substrate-registry` is the single roster, `valid-substrates`
+;; is `(set (keys …))` of it, and `template-fn`'s `case` names each entry's
+;; `_<substrate>/` tree — so a third substrate lands here as a third deftest.
+;; `template_test.clj` holds the roster itself to the registry; these two are
+;; the behavioural arms of it. (Hicasso and reagent-slim are reserved, not
+;; emitted — see spec/001-Substrate-Variants.md §Future substrates.)
+
 (deftest reagent-emitted-tests-run-test
   (testing "the emitted Reagent app compiles, its focused test runs green, the
             real page boots and moves 0 -> 1 (and the proof bites), and the
-            :advanced release build is clean"
+            :advanced release build boots the same way"
     (if-not @emitted-tests-enabled?
       (skip-if-disabled! :reagent)
       (do (is @clojure-cli-available?
@@ -524,11 +632,12 @@
           (is @node-available?
               "`node` must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
           (when (and @clojure-cli-available? @node-available?)
-            (compile-and-run-emitted-test! :reagent {:release? true :boot-witness? true}))))))
+            (compile-and-run-emitted-test! :reagent {:boot-witness? true}))))))
 
 (deftest uix-emitted-tests-run-test
-  (testing "the emitted UIx app compiles, its focused test runs green, and the
-            real page boots and moves 0 -> 1"
+  (testing "the emitted UIx app compiles, its focused test runs green, the real
+            page boots and moves 0 -> 1, and the :advanced release build boots
+            the same way"
     (if-not @emitted-tests-enabled?
       (skip-if-disabled! :uix)
       (do (is @clojure-cli-available?
@@ -617,7 +726,7 @@
   [substrate]
   (let [tmp (tmp-dir (str "rf2-setup-emit-" (name substrate) "-"))]
     (try
-      (project-files (run-template! tmp "acme/my-app" substrate))
+      (project-files (run-template! tmp emitted-project-name substrate))
       (finally (delete-recursively tmp)))))
 
 (defn- assert-leaf-equals-emission! [leaf files expected]
@@ -702,10 +811,10 @@
                    "event id is a runtime miss, not a compile error; exited " exit
                    ". Output:\n" out)))
         (let [{:keys [exit out]}
-              (run-boot-proof-driver! root proj (str label " (broken click)")
+              (run-boot-proof-driver! root proj (str label " (broken click)") :dev
                                       {"RF2_TEMPLATE_BROWSER_PROOF_TIMEOUT_MS" "8000"})]
           (is (= 1 exit)
-              (str "the dev-page boot proof must go RED (exit 1) when the +1 button "
+              (str "the dev-bundle boot proof must go RED (exit 1) when the +1 button "
                    "dispatches an unregistered event; it exited " exit
                    ". A green here means the click tooth is inert. Output:\n" out))
           (when (= 1 exit)
@@ -785,16 +894,16 @@
           ;; evidence that the leaf's source — not a stale bundle — is what
           ;; the browser rendered.
           (let [proof-exit
-                (testing (str label " — Chromium dev-page boot proof (heading acme/my-app "
+                (testing (str label " — Chromium dev-bundle boot proof (heading acme/my-app "
                               "painted, counter 0 -> 1, zero pageerror)")
                   (let [{:keys [exit out]}
-                        (run-boot-proof-driver! root proj label
-                                                {"RF2_TEMPLATE_EXPECT_H1" "acme/my-app"})]
+                        (run-boot-proof-driver! root proj label :dev
+                                                {"RF2_TEMPLATE_EXPECT_H1" emitted-project-name})]
                     (check-browser-proof!
-                      (str "dev-page boot proof -- " label)
-                      "dev-page boot"
+                      (str "dev-bundle boot proof -- " label)
+                      "dev-bundle boot"
                       exit out
-                      (str "the shipped scaffold's dev-page boot proof exited " exit
+                      (str "the shipped scaffold's dev-bundle boot proof exited " exit
                            " — the page an author opens after `npx shadow-cljs watch app` "
                            "did not paint the heading `acme/my-app` with the counter at 0, "
                            "or the click did not move it to 1, or Chromium raised an "


### PR DESCRIPTION
Closes rf2-eiev.

## The gap

The emitted `README.md` tells every scaffold's user to run `npm run release`
and serve `resources/public`, and `_shared/package.json` maps that script to
`shadow-cljs release app` for both substrates. `spec/Principles.md` §P7 said
each substrate is exercised end-to-end and that the behavioural layer builds
the advanced release. The tier did not enforce it:

- it booted only the **development** bundle;
- it ran `shadow release app` for **Reagent only** — UIx passed an empty
  option map, so its advertised release command was never executed by any
  gate;
- it graded the optimised output on **process exit plus a non-empty
  `main.js`**, and neither optimised bundle was ever loaded in a browser.

A dev build proves nothing about `:advanced`. Closure renames every
un-inferrable property access and eliminates code behind `goog.DEBUG`, so an
interop defect ships green from the dev compile and surfaces only in the
artefact the user deploys. `adf2f47322` already recorded that compile success
is not a boot proof: an emitted page compiled cleanly and booted blank.

## What this does

Every substrate now runs `shadow-cljs release app` and then loads the real
emitted `index.html` a **second** time, over that optimised bundle, through
the **same** Chromium driver — heading paints, counter reads `0`, click moves
it to `1`, zero uncaught pageerrors. No second browser harness, no new
option, no new build mode.

**The two boot verdicts cannot be swapped for one another.** The release
overwrites `js/main.js` in place, so a release that silently failed to
replace the dev bundle could otherwise be certified by the verdict the dev
bundle already earned. Two independent checks forbid it:

- **on disk** — the release `js/main.js` must differ in length from the dev
  one recorded before the release ran;
- **at runtime** — the driver requires the globals it observes in the page to
  be the ones that mode's bundle has. `goog` and `cljs` are objects in the
  un-optimised bundle and renamed away under `:advanced`.

Each reads the *opposite* way on the other mode's artefact, so neither is
vacuous, and the run output prints both readings.

The obvious discriminator does **not** work, and was measured rather than
assumed: the dev `:browser` bundle produced by `shadow-cljs compile` is
self-contained (`CLOSURE_NO_DEPS = true`) and fetches **zero**
`js/cljs-runtime/` chunks, exactly like the release bundle. Both modes
request precisely `index.html`, `css/app.css` and `js/main.js`. That is
recorded in the driver's header so the next reader does not re-derive it.

The driver is renamed `dev-page-boot-proof.cjs` -> `page-boot-proof.cjs`: it
now proves both pages, and its old name would have been a lie about half its
work. Package completeness and the dev-page proof still run *before* the
release overwrites the dev bundle and its manifest; the broken-mount and
broken-click witnesses are unchanged and still go red.

## Evidence

`tools/template`, `RF2_TEMPLATE_RUN_EMITTED_TESTS=1 CI=1 clojure -M:test`
(`CI=1` so an unlaunchable Chromium would fail rather than skip):

```
[dev-bundle boot]     PASS (reagent, dev bundle)      {"goog":"object","cljs":"object"}
[broken-boot witness] reagent: RED (exit 1), as required
[release bundle]      reagent: dev 6371929 bytes -> :advanced 634135 bytes
[release-bundle boot] PASS (reagent, release bundle)  {"goog":"undefined","cljs":"undefined"}
[dev-bundle boot]     PASS (uix, dev bundle)          {"goog":"object","cljs":"object"}
[release bundle]      uix: dev 6311689 bytes -> :advanced 620069 bytes
[release-bundle boot] PASS (uix, release bundle)      {"goog":"undefined","cljs":"undefined"}
[dev-bundle boot]     PASS (setup-skill leaf, dev bundle)
[broken-boot witness] / [broken-click witness] setup-skill leaf: RED (exit 1), as required
```

Captured exit **0**, 379 s wall, **39 tests / 354 assertions, 0 failures 0
errors**. Both witnesses still restore their input byte-for-byte. The gate-off
run is unchanged in shape at 39 tests / 296 assertions — the tier contributes
the 58-assertion difference. The driver's new fail-closed path was exercised
directly: an unrecognised `RF2_TEMPLATE_BUNDLE_MODE` exits 1 with a
configuration message rather than proving the wrong bundle.

**Both doc gates were proven live on the files this PR edits**, since a green
that inspected nothing is the failure mode worth guarding: a planted broken
anchor in `spec/Principles.md` made `scripts/check_doc_slugs.py` exit 1 naming
file, line and anchor; a planted broken target in `README.md` made
`scripts/check_readme_links.py --ci` exit 1 naming file, line and target. Both
files were restored byte-for-byte (`cmp` identical, CRLF preserved) and both
gates return exit 0 on the tree as submitted. Tree-diagram column alignment in
`002-Generated-Shape.md` and `005-Repo-Split.md` was checked by hand — no gate
inspects it.

## Scope and cost

**The substrate set is counted from the generator, not from a name search.**
`hooks.clj`'s `substrate-registry` is the single roster, `valid-substrates` is
derived from it, and `template-fn`'s `case` names each entry's `_<substrate>/`
tree. Asking the generator returns exactly two — `:reagent` and `:uix` — and
every other keyword (`:hicasso`, `:reagent-slim`, `:helix`) is refused with
`:rf.error/template-substrate-must-be-one-of`. Hicasso and reagent-slim are
**reserved and gated** in `spec/001-Substrate-Variants.md` §Future substrates,
not missing: Hicasso is owned by rf2-8urba (deferred, gated on the
repository's first `v*` tag) and reagent-slim on its first published artefact.
Nothing here touches either.

**No CI change, so no check-count band movement.** The tier already runs
per-PR (`test.yml` `jvm-tools-template`, guarded on the `template_expensive`
surface, `timeout-minutes: 35`), nightly (`expensive-tests.yml`) and at tag
time (`template-release.yml`). The marginal cost of this PR is **one extra
`:advanced` compile** (UIx) plus two extra Chromium page loads; a warm UIx
advanced release measured 25.55 s of compile (~36 s wall). That is small
against the existing budget, so it stays where it is. If the job ever crowds
its timeout, the cheapest lever is to move the release arm alone to the
nightly — the split point already exists in the code as `run-release-proof!`.

## What this does not establish

- **Not** that the emitted `:mvn/version` coords resolve for a real consumer —
  the tier rewrites both framework coords to `:local/root` (pre-existing,
  rf2-8n4s71 #1).
- **Not** that `npm install` from the emitted `package.json` produces a working
  tree — the tier junctions `implementation/node_modules`. Mitigated, not
  removed, by the existing manifest-completeness check.
- **Nothing about deployment conditions**: no CSP, no sub-path `:asset-path`,
  no CDN, no host other than the driver's local static server.
- The setup-skill leaf fixture still proves the **dev** bundle only. It is a
  Reagent emission whose release path the Reagent arm covers; a third advanced
  compile buys no new coverage.
- There is no separate red-witness for `:release` mode. The driver's
  mount/click/pageerror teeth are witnessed in dev mode on the same code path,
  and the mode tooth is witnessed by the two artefacts reading opposite ways
  in the same run.

## Note for `skills/re-frame2-setup`

**No skill follow-up is needed, and that is a checked claim, not an
assumption.** This PR changes no generated file — the emitted twelve-file
manifest is byte-identical, which the ungated
`setup-skill-leaves-are-the-template-emission-test` re-asserts against a real
deps-new emission on every run, and it passes. `hooks.clj` is untouched, so
the CI-wired `skills/re-frame2-setup/tests/*_test.clj` parity test that
`load-file`s it is unaffected. The renamed driver is test-support and is
referenced only from `tools/template/**`.
