### PR TITLE
fix(http): publication across the two in-flight indexes reconciles with cleanup (rf2-o8ek)

### DIFF
--- a/implementation/http/src/re_frame/http/registry.cljc
+++ b/implementation/http/src/re_frame/http/registry.cljc
@@ -123,6 +123,23 @@
   ;; keep independent slots.
   (atom {}))
 
+(defn- remove-from-actor-index!
+  "Drop `handle` from its own actor-index slot BY IDENTITY. Both halves of the
+  slot key — the frame and the actor-id — are read off the handle itself, so
+  the caller never has to carry them (rf2-o8ek)."
+  [handle]
+  (when-let [actor-id (:actor-id handle)]
+    (let [k (scoped-key (:frame handle) actor-id)]
+      (swap! actor-in-flight
+             (fn [actor-index]
+               (let [actor-handles     (get actor-index k [])
+                     remaining-handles (vec (remove #(identical? % handle)
+                                                    actor-handles))]
+                 (if (seq remaining-handles)
+                   (assoc actor-index k remaining-handles)
+                   (dissoc actor-index k)))))))
+  nil)
+
 (defn record-in-flight!
   "Record a request handle. `handle` is the abort-handle map (carries
   `:abort-fn`, `:url`, plus the framework stamps `:request-id` and
@@ -140,7 +157,37 @@
   sleeping-backoff handle) and becomes part of the index key, so no signature
   change was needed here. A handle with no `:frame` keys under `nil`, which is
   a coherent scope of its own: unstamped handles share one namespace exactly as
-  they did before frames entered the key."
+  they did before frames entered the key.
+
+  PUBLICATION IS TWO SWAPS OVER TWO ATOMS, and the trailing reconcile is what
+  makes them behave as one (rf2-o8ek audit). An actor-originated request
+  carrying BOTH ids is published to `in-flight` first and `actor-in-flight`
+  second, so there is a MIDPOINT at which the handle is already resolvable by
+  request-id but has no actor-index slot yet. A cleanup reaching it there —
+  on the JVM, another thread firing the just-published `:abort-fn`, which is
+  exactly the pre-publication window the transport's `@handle-cell` /
+  `@handle-holder` forward references exist for — drops the request slot and
+  then tries to drop an actor slot THAT DOES NOT EXIST YET. Publication then
+  resumes and conj's the already-aborted handle into `actor-in-flight`: a
+  GHOST, surviving in the actor index (and in `in-flight-by-actor`
+  introspection) until a later actor or frame teardown sweeps it.
+
+  Cleanup cannot fix this from its side — it cannot remove a slot the future
+  has not written. So publication observes it instead, using the same
+  IDENTITY law every other path here is built on: once both swaps are done,
+  if this handle is no longer the one `in-flight` holds under its key, a
+  cleanup (or a supersession) overtook publication, and the handle is retracted
+  from the actor index by identity. Idempotent — `remove-from-actor-index!`
+  no-ops on a slot that never gained the handle — and it cannot touch a
+  successor, because both the request-index check and the actor-index removal
+  match on `identical?` against THIS handle.
+
+  Residual, deliberately not closed here (rf2-ni74): the other door is blind
+  at that same midpoint — an `abort-on-actor-destroy` arriving between the two
+  swaps finds no actor slot and fires nothing, so the handle survives its
+  actor's destroy. That is a MISSED abort rather than an incoherent index, it
+  is swept by the later frame-destroy/epoch paths, and closing it needs
+  genuine cross-atom atomicity rather than a reconcile."
   [request-id actor-id handle]
   (let [frame-id       (:frame handle)
         stamped-handle (cond-> handle
@@ -151,24 +198,13 @@
     (when actor-id
       (swap! actor-in-flight update (scoped-key frame-id actor-id)
              (fnil conj []) stamped-handle))
+    ;; Only a handle carrying BOTH ids spans two swaps, so only it has a
+    ;; midpoint to reconcile.
+    (when (and request-id actor-id)
+      (when-not (identical? (get @in-flight (scoped-key frame-id request-id))
+                            stamped-handle)
+        (remove-from-actor-index! stamped-handle)))
     stamped-handle))
-
-(defn- remove-from-actor-index!
-  "Drop `handle` from its own actor-index slot BY IDENTITY. Both halves of the
-  slot key — the frame and the actor-id — are read off the handle itself, so
-  the caller never has to carry them (rf2-o8ek)."
-  [handle]
-  (when-let [actor-id (:actor-id handle)]
-    (let [k (scoped-key (:frame handle) actor-id)]
-      (swap! actor-in-flight
-             (fn [actor-index]
-               (let [actor-handles     (get actor-index k [])
-                     remaining-handles (vec (remove #(identical? % handle)
-                                                    actor-handles))]
-                 (if (seq remaining-handles)
-                   (assoc actor-index k remaining-handles)
-                   (dissoc actor-index k)))))))
-  nil)
 
 (defn clear-in-flight-in-frame!
   "Clear `frame-id`'s handle for `request-id` from both indexes — the

--- a/implementation/http/test/re_frame/http_frame_scoped_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_frame_scoped_cancellation_test.clj
@@ -691,3 +691,155 @@
       (is (actor-live? :frame/b actor-address)
           "frame B's identically-addressed actor keeps its in-flight request"))
     (rf.http.managed/clear-all-in-flight!)))
+
+;; ---- the two-index publication window (rf2-o8ek audit) ---------------------
+;;
+;; The frame-scoped keys above settle WHO a cancellation may reach. These cases
+;; settle WHEN a handle is reachable at all, which those keys did not touch.
+;;
+;; `record-in-flight!` publishes an actor-originated request to the request
+;; index and the actor index in TWO separate `swap!`s over two atoms, so
+;; between them the handle is already resolvable by `:request-id` while owning
+;; no actor-index slot. A cleanup arriving there — on the JVM, another thread
+;; firing the just-published `:abort-fn`; the same pre-publication window the
+;; transport's `@handle-cell` / `@handle-holder` forward references exist for —
+;; drops the request slot and then tries to drop an actor slot THAT DOES NOT
+;; EXIST YET. Publication then resumed and conj'd the already-aborted handle
+;; into the actor index: a GHOST that outlived its own abort and stayed visible
+;; in `actor-in-flight-snapshot` until a later actor or frame teardown.
+;;
+;; Determinism without threads: an atom's watches run on the swapping thread
+;; BEFORE `swap!` returns, so a watch that fires the abort the instant the
+;; request slot appears executes strictly between the two publications. The
+;; interleaving is decided rather than raced — and the landed cases above
+;; cannot see this gap at all, because every one of them calls cleanup only
+;; after `record-in-flight!` has already returned.
+
+(def ^:private publication-actor
+  ;; The actor address the window cases issue from. Both raw ids are ordinary
+  ;; and stable, exactly as reusable app code writes them.
+  :worker/publication)
+
+(defn- actor-slot-count
+  "How many handles `frame-id` currently has indexed under `publication-actor`
+  — read through the same snapshot helper app-facing tooling reads."
+  [frame-id]
+  (count (get (rf.http.registry/actor-in-flight-snapshot frame-id)
+              publication-actor)))
+
+(defn- record-actor-handle-with-midpoint!
+  "Publish an actor-originated handle in `frame-id` under `shared-id` and
+  `publication-actor`, running `at-midpoint!` at the exact instant the request
+  slot appears — after `record-in-flight!`'s first swap and before its second.
+  Aborts land in `seen`.
+
+  The `:abort-fn` performs the cleanup both production sites perform, with the
+  nil handle they necessarily hold inside the window: `@handle-cell` is filled
+  only once `record-in-flight!` RETURNS, so an abort landing here cannot name
+  its own handle and reaches the frame-exact 3-arity."
+  [frame-id seen at-midpoint!]
+  (let [slot [frame-id shared-id]]
+    (add-watch rf.http.registry/in-flight ::publication-midpoint
+               (fn [_ _ before after]
+                 (when (and (nil? (get before slot)) (some? (get after slot)))
+                   ;; Once only: the abort's own cleanup swaps this atom again.
+                   (remove-watch rf.http.registry/in-flight ::publication-midpoint)
+                   (at-midpoint!))))
+    (try
+      (rf.http.registry/record-in-flight!
+        shared-id publication-actor
+        {:frame    frame-id
+         :url      "http://127.0.0.1/publication"
+         :abort-fn (fn [reason]
+                     (swap! seen conj [frame-id reason])
+                     (rf.http.registry/clear-in-flight! frame-id shared-id nil))})
+      (finally
+        (remove-watch rf.http.registry/in-flight ::publication-midpoint)))))
+
+(deftest abort-inside-the-publication-window-leaves-no-ghost-in-the-actor-index
+  (testing "rf2-o8ek audit — an abort reaching the handle between its two
+            publications aborts it, and BOTH indexes are empty afterwards.
+            Before the publication reconcile the request slot went while the
+            actor slot arrived AFTER the abort had already passed, so the app
+            had been told this request was cancelled while
+            `actor-in-flight-snapshot` still reported one in flight for the
+            actor: measured `{:abort-fired? true, :request-slot nil,
+            :actor-slot-count 1}`"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen (atom [])]
+      (record-actor-handle-with-midpoint!
+        :frame/a seen
+        #(rf.http.registry/abort-in-flight-in-frame! :frame/a shared-id :user))
+      (is (= [[:frame/a :user]] @seen)
+          "precondition: the abort really did fire INSIDE the window. If this is
+           empty the interleaving never happened and the rest proves nothing")
+      (is (nil? (get (rf.http.registry/in-flight-snapshot :frame/a) shared-id))
+          "the request index is empty — it already was before the fix")
+      (is (zero? (actor-slot-count :frame/a))
+          "and so is the actor index: nothing may still report an aborted
+           request as in flight"))
+    (rf.http.managed/clear-all-in-flight!)))
+
+(deftest supersede-inside-the-publication-window-leaves-no-ghost-either
+  (testing "rf2-o8ek audit — the same window reached through the OTHER
+            request-index door. `supersede!` clears by identity and THEN fires
+            the abort-fn, so its own actor-index removal finds no slot at the
+            midpoint just as the abort cascade's does. Publication owning the
+            reconcile is what makes this hold for both callers rather than for
+            whichever one a test happened to drive"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen (atom [])]
+      (record-actor-handle-with-midpoint!
+        :frame/a seen
+        #(rf.http.registry/supersede! :frame/a shared-id))
+      (is (= [[:frame/a :request-id-superseded]] @seen)
+          "precondition: the supersession really did land inside the window")
+      (is (zero? (actor-slot-count :frame/a))
+          "the superseded handle left no actor-index slot behind"))
+    (rf.http.managed/clear-all-in-flight!)))
+
+(deftest the-publication-window-reconcile-is-frame-exact
+  (testing "rf2-o8ek — the retraction matches on handle IDENTITY, so a sibling
+            frame already live under the SAME raw request-id AND the same actor
+            address keeps both of its slots and stays abortable. A reconcile
+            that swept by raw id would reintroduce, inside publication, exactly
+            the cross-frame reach the compound keys removed"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen (atom [])]
+      ;; Frame B goes live FIRST, under both of the same ordinary raw ids.
+      (rf.http.registry/record-in-flight!
+        shared-id publication-actor
+        {:frame    :frame/b
+         :url      "http://127.0.0.1/sibling"
+         :abort-fn (fn [reason] (swap! seen conj [:frame/b reason]))})
+      (record-actor-handle-with-midpoint!
+        :frame/a seen
+        #(rf.http.registry/abort-in-flight-in-frame! :frame/a shared-id :user))
+      (is (= [[:frame/a :user]] @seen)
+          "only frame A's handle was aborted")
+      (is (some? (get (rf.http.registry/in-flight-snapshot :frame/b) shared-id))
+          "frame B's request slot survives A's publication-window abort")
+      (is (= 1 (actor-slot-count :frame/b))
+          "and so does frame B's actor slot, so B's request is still abortable")
+      (is (zero? (actor-slot-count :frame/a))
+          "while frame A leaves nothing behind"))
+    (rf.http.managed/clear-all-in-flight!)))
+
+(deftest an-undisturbed-publication-is-never-retracted
+  (testing "rf2-o8ek audit — the reconcile is CONDITIONAL on the handle having
+            lost its request slot. With no interleaving at all an
+            actor-originated request must end up registered in both indexes.
+            Without this control a reconcile that retracted unconditionally
+            would pass every case above while silently unregistering every
+            actor-owned request in the library"
+    (rf.http.managed/clear-all-in-flight!)
+    (rf.http.registry/record-in-flight!
+      shared-id publication-actor
+      {:frame    :frame/a
+       :url      "http://127.0.0.1/quiet"
+       :abort-fn (fn [_reason] nil)})
+    (is (some? (get (rf.http.registry/in-flight-snapshot :frame/a) shared-id))
+        "the request index holds it")
+    (is (= 1 (actor-slot-count :frame/a))
+        "and so does the actor index — publication completed untouched")
+    (rf.http.managed/clear-all-in-flight!)))


### PR DESCRIPTION
Closes the finding the merged-PR audit of #9202 reopened rf2-o8ek for.

## The finding, reproduced at tip before any edit

`registry/record-in-flight!` publishes an actor-originated request to the request index and the actor index in **two separate `swap!`s over two atoms**. Between them the handle is already resolvable by `:request-id` while owning no actor-index slot. A cleanup arriving there — on the JVM, another thread firing the just-published `:abort-fn`, which is exactly the pre-publication window the transport's `@handle-cell` / `@handle-holder` forward references exist for — drops the request slot and then tries to drop an actor slot **that does not exist yet**. Publication then resumes and conj's the already-aborted handle into the actor index.

The result is a ghost: a handle that outlived its own abort and stays visible in `actor-in-flight-snapshot` until a later actor or frame teardown. The app has been told the request was cancelled while introspection still reports it in flight.

A deterministic same-thread watch interleaving on tip printed exactly what the audit recorded:

```
{:abort-fired? true, :request-slot nil, :actor-slot-count 1}
```

Measured alongside it, and worth recording because it bounds the severity: the ghost is confined to the issuing frame. A sibling frame live under the same raw request-id and actor address keeps both of its slots (`{:aborts [[:frame/a :user]], :b-request true, :b-actor-count 1}`), so #9202's frame-scoped keys hold — this is an incoherence *within* one frame, not a cross-frame reach.

## The repair

Cleanup cannot fix this from its side; it cannot remove a slot the future has not written. So publication observes it instead, using the identity law the rest of the registry is already built on: once both swaps are done, if this handle is no longer the one `in-flight` holds under its key, a cleanup or a supersession overtook publication, and the handle is retracted from the actor index by identity.

- Only a handle carrying **both** ids spans two swaps, so only it is reconciled.
- The retraction matches on `identical?` on both sides — the request-index check and the actor-index removal — so it can touch neither a same-id successor nor a sibling frame.
- Idempotent: `remove-from-actor-index!` no-ops on a slot that never gained the handle.
- `remove-from-actor-index!` moves above `record-in-flight!` so the reconcile can call it. That is the whole of the 72-line diff in `registry.cljc`; the rest is the docstring stating the law.

After the fix the same probe prints `{:abort-fired? true, :request-slot nil, :actor-slot-count 0}`.

**No public change.** The `:rf.http/managed` args map, the `:rf.http/managed-abort` effect shape, and the caller's raw `:request-id` as the correlation value echoed in replies and traces are all untouched. No new namespace, registry, lease object, token or config switch. Spec 014 already states the frame-scoped cancellation law (#9195); nothing in it describes publication ordering, so no spec change is warranted here.

## Witness

Four deftests appended to the rf2-o8ek frame-scoped cancellation test. An atom's watches run on the swapping thread **before `swap!` returns**, so a watch that fires the abort the instant the request slot appears interleaves strictly between the two publications — decided, not raced. The landed tests could not see this gap at all, because every one of them calls cleanup only after `record-in-flight!` has already returned.

| deftest | asserts |
| --- | --- |
| `abort-inside-the-publication-window-leaves-no-ghost-in-the-actor-index` | the audit's case, driven through the production `abort-in-flight-in-frame!` door: both indexes empty afterwards |
| `supersede-inside-the-publication-window-leaves-no-ghost-either` | the same window through the *other* request-index door, so the law belongs to publication rather than to one caller |
| `the-publication-window-reconcile-is-frame-exact` | a sibling frame live under the same raw request-id **and** the same actor address keeps both slots and stays abortable |
| `an-undisturbed-publication-is-never-retracted` | the control against an over-broad fix: with no interleaving, an actor-originated request ends up registered in **both** indexes |

Each assertion carries a precondition check first (`the abort really did fire INSIDE the window`), so a case whose interleaving silently stopped happening fails rather than passing vacuously.

**Negative control run.** Removing the reconcile and nothing else takes the suite to captured exit **1** with **3 failures**, all three of the ghost assertions, in exactly the three cases above. The fourth stays green, which is correct — it is the control against an unconditional retraction, so it must pass on both sides. The file was byte-copied before the control and restored with `cmp` verifying byte-identity afterwards.

## Residual, filed rather than closed — rf2-ni74

The other door is blind at the same midpoint: an `abort-on-actor-destroy` arriving between the two swaps finds no actor slot and fires nothing, so the handle survives its actor's destroy. Measured: `{:case :actor-destroy-at-midpoint, :abort-fired? false, :request-slot-present? true, :actor-slot-count 1}`.

That is a **missed abort rather than an incoherent index** — a different class from the ghost this PR closes, still swept by the later frame-destroy / epoch-restore paths, and reachable only in the microseconds between two `swap!`s on the JVM (CLJS is single-threaded). Reversing the publication order does not fix it, it only moves the blind door onto `:rf.http/managed-abort` by request-id, which is the primary app-facing cancellation verb and currently *works* in this window. Closing it properly needs publication to be observable as one step across both atoms — genuine cross-atom atomicity — which is machinery that should be weighed against the width of the window before it is built. Filed P3, `discovered-from` rf2-o8ek, with both the probe and that reasoning recorded.

rf2-wjfm remains the owner of the deferred actor-hook call sites; this PR does not touch them.

## The example was checked and needs no change

`examples/core/managed_http_counter/core.cljs` demonstrates the machinery **correctly** at tip: it stamps `:frame` on its seeded handle and its `:abort-fn` calls the frame-exact `clear-in-flight-in-frame!` — the repair #9202 landed for the previous audit round. It also seeds with `actor-id` `nil`, so it publishes into one index only, has no midpoint, and cannot reach this round's finding at all. Unmodified, so `check-examples-compile.cjs` is not a gate for this diff.

## Gates — captured exit codes, never read through a filter

Re-run on the final rebased base (the base moved during review onto `tools/re-frame2-pair-mcp/**` and beads checkpoints only):

| gate | captured exit | result |
| --- | --- | --- |
| `implementation/http` `clojure -M:test` | 0 | 525 tests, 3969 assertions, 0 failures / 0 errors |
| `npm run test:cljs` | 0 | 11,220 tests, 56,708 assertions, 0 failures / 0 errors |
| negative control (reconcile removed) | 1 | 3 failures, exactly the three ghost assertions |

`npm ci` was run from the lockfile in this worktree rather than linking; `node_modules` verified populated (103 entries) rather than trusting the reported exit.
