### PR TITLE
fix(story): Start refuses a CAPTURED prepare failure, not only a thrown one (rf2-k6y2)

### DIFF
--- a/tools/story/spec/009-Test-Mode.md
+++ b/tools/story/spec/009-Test-Mode.md
@@ -508,7 +508,44 @@ A preparation failure — an unknown variant, a `:db-seed` that violates a
 registered schema, a throwing loader or `:setup` handler — REJECTS the
 promise `prepare-variant` returns, and `begin!` leaves the section in its
 inactive state rather than offering step controls over a frame that never
-reached `:ready`.
+reached the state the variant's `:setup` describes.
+
+Those failures reach `prepare-variant` by two routes, and **only one of them
+is a throw** — which is why the rejection is a decision the seam makes
+rather than one it inherits:
+
+| Route     | Cause                                                        | How it arrives                                                        |
+|-----------|--------------------------------------------------------------|-----------------------------------------------------------------------|
+| Thrown    | unknown variant; a `:db-seed` schema violation               | escapes phases 0-2; the promise rejects on it                          |
+| Captured  | a throwing `:loaders` / `:setup` handler                     | recorded onto `[:rf.story/assertions]`; **the phase returns normally** |
+
+The captured route is `run-variant`'s gather-the-full-picture contract
+(`002-Runtime.md` §Error projection — a run reports every failure it saw
+rather than aborting at the first) and it STAYS. But it means the absence of
+a throw is NOT evidence of a successful preparation: phases 0-2 complete over
+a frame whose `:setup` never ran. `prepare-variant` therefore inspects the
+frame's freshly-reset assertions accumulator after phases 0-2 and rejects
+with `:rf.error/story-prepare-failed` (carrying the records under
+`:failures`) when it holds a captured `:rf.error/exception`. Reading the
+accumulator is sound because phase 0's fresh-frame boundary clears it, so
+every record present belongs to THIS preparation.
+
+That was the rf2-k6y2 post-merge audit's finding: the first fix moved Start
+onto `prepare-variant` and had `begin!` branch on rejection alone, so a
+captured `:setup` failure resolved `nil` and published an active cursor-0
+stepper over a failed preparation — the same class of lie as the original
+defect, one lifecycle half further in.
+
+`:rf.error/loader-incomplete` is deliberately NOT a prepare failure. A
+`:loaders-complete-when` that reports not-ready is a contract-pending signal
+rather than an exception, and the ordinary shell plays such a variant anyway
+(`resume-run!`'s `:force-play?`). Refusing to step-debug a variant the shell
+itself runs would withdraw the debugger exactly where it is most wanted; the
+recorded assertion still tells the operator the loaders never settled.
+
+`run-variant` and `prepare-run!` are unchanged by this: they keep RESOLVING a
+result that reports every failure they saw. The refusal is Start's alone,
+because Start is the only caller that must decide whether to present controls.
 
 ### Controls
 

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -1732,6 +1732,39 @@
 
 ;; ---- prepare-variant -----------------------------------------------------
 
+(defn- captured-prepare-failures
+  "The pipeline exceptions phases 0-2 CAPTURED onto `variant-id`'s frame,
+  as a (possibly empty) vector of the `:rf.error/exception` records.
+
+  `run-loaders!` / `run-events!` deliberately do not rethrow a failing
+  `:loaders` / `:setup` handler: `capture-phase-errors` collects the
+  pipeline-exception trace events and `record-error!` projects each onto
+  `[:rf.story/assertions]`, then the phase RETURNS. That is
+  `run-variant`'s gather-the-full-picture contract, and it stays — a run
+  result is meant to report every failure it saw, not abort at the first.
+  The consequence is that `prepare-ctx!` can complete WITHOUT THROWING over
+  a frame whose `:setup` never ran, which is why a caller that needs a
+  yes/no on the preparation cannot read the absence of a throw as success.
+
+  Reading the accumulator is sound BECAUSE phase 0's `ensure-fresh-frame!`
+  resets the frame's app-db — `[:rf.story/assertions]` included — so every
+  record present when phases 0-2 return belongs to THIS preparation. There
+  is no prior run's residue to mistake for a fresh failure.
+
+  `:rf.error/loader-incomplete` is deliberately NOT in this set. A
+  `:loaders-complete-when` that reports not-ready is a contract-pending
+  signal rather than a failure, and the shell plays such a variant anyway
+  (`resume-run!`'s `:force-play?` — the
+  `:story.counter-matrix/loader-never-completes` case). Refusing to
+  step-debug a variant the ordinary shell runs would take away the debugger
+  exactly where it is most wanted; the recorded assertion still tells the
+  operator the loaders never settled."
+  [variant-id]
+  (filterv (fn [{:keys [assertion passed?]}]
+             (and (= :rf.error/exception assertion)
+                  (not passed?)))
+           (read-assertions variant-id)))
+
 (defn prepare-variant
   "Re-run the PREPARE half of the four-phase lifecycle for `variant-id` —
   phases 0-2 (fresh-frame boundary, allocation, `:db-seed`, `:loaders`,
@@ -1763,7 +1796,26 @@
   `:setup` handler. Rejecting (rather than resolving an error result, as
   `run-variant` does) is what lets the caller return its UI to an honest
   inactive state instead of presenting controls over a frame that never
-  reached `:ready`.
+  reached the state the variant's `:setup` describes.
+
+  Those failures reach here by TWO routes, and only one of them is a throw:
+
+  - THROWN — an unknown variant (the plan compiler refuses with
+    `:rf.error/story-unknown-variant`) and a `:db-seed` schema violation
+    escape `prepare-ctx!`, so `rf.story.async/promise` rejects on them.
+  - CAPTURED — a throwing `:loaders` / `:setup` handler does NOT escape.
+    `run-loaders!` / `run-events!` project it onto `[:rf.story/assertions]`
+    and return normally (`run-variant`'s gather-the-full-picture contract),
+    so `prepare-ctx!` completes over a frame whose `:setup` never ran.
+
+  Reading the absence of a throw as success therefore published an active
+  cursor-0 stepper over a failed preparation — the residual the rf2-k6y2
+  post-merge audit found in the fix for rf2-k6y2 itself. So this checks
+  `captured-prepare-failures` explicitly and rejects on a non-empty set,
+  carrying the records under the thrown error's `:failures` so the caller
+  can say WHAT failed rather than only THAT it did. `run-variant` and
+  `prepare-run!` are untouched: they keep resolving a result that reports
+  every failure they saw.
 
   `opts` is the standard `run-variant` opts (`:active-modes` /
   `:cell-overrides` / `:substrate`)."
@@ -1774,12 +1826,25 @@
      (rf.story.async/promise
        (fn [resolve]
          ;; `rf.story.async/promise` rejects when this body throws, which is
-         ;; the honest settle for every prepare-half failure — including an
-         ;; unknown variant, which `prepare-context`'s plan compile already
-         ;; refuses with `:rf.error/story-unknown-variant`. Phases 0-2 are
+         ;; the honest settle for every prepare-half failure. Phases 0-2 are
          ;; synchronous, so the promise has settled by the time this returns.
          (reset-run-owner! variant-id)
          (prepare-ctx! variant-id (rf.story.frames/variant-body variant-id) opts)
+         (when-let [failures (seq (captured-prepare-failures variant-id))]
+           (rf.error/throw-error!
+             :rf.error/story-prepare-failed
+             'rf.story/prepare-variant
+             (str "re-frame2-story: variant " variant-id
+                  " — preparation (phases 0-2) recorded "
+                  (count failures)
+                  " captured pipeline exception(s) from :loaders / :setup, so "
+                  "the frame never reached the state the variant's :setup "
+                  "describes. The records are on the frame's "
+                  ":rf.story/assertions and under :failures here; fix the "
+                  "failing handler and prepare again.")
+             {:recovery :fix-the-failing-loader-or-setup-handler
+              :extra    {:variant/id variant-id
+                         :failures   (vec failures)}}))
          (resolve nil))))))
 
 ;; ---- watch-variant -------------------------------------------------------

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
@@ -157,7 +157,19 @@
                 ;; `:db-seed`, a throwing loader / `:setup` handler) rejects.
                 ;; Leave the slot cleared so the section returns to its
                 ;; honest inactive state rather than offering step controls
-                ;; over a frame that never reached `:ready`.
+                ;; over a frame whose `:setup` never ran.
+                ;;
+                ;; This branch is the ONLY thing standing between a failed
+                ;; preparation and an active cursor-0 stepper over it, and
+                ;; only HALF the failures arrive as a throw: a failing
+                ;; `:loaders` / `:setup` handler is CAPTURED onto
+                ;; `[:rf.story/assertions]` by `run-loaders!` / `run-events!`,
+                ;; which then return normally. `prepare-variant` inspects the
+                ;; accumulator and rejects explicitly for that class — do not
+                ;; "simplify" that check away on the reading that a
+                ;; preparation which did not throw succeeded (rf2-k6y2
+                ;; post-merge audit). The records stay on the frame either
+                ;; way, so the pane can still say what failed.
                 (swap! results-atom dissoc variant-id)
                 nil))))
 

--- a/tools/story/test/re_frame/story/stepper_start_test.cljc
+++ b/tools/story/test/re_frame/story/stepper_start_test.cljc
@@ -201,6 +201,50 @@
       (is (= 3 @ext-effect-count) "exactly once"))))
 
 ;; ---- (5) a prepare failure settles honestly ------------------------------
+;;
+;; `begin!` has ONE branch for a failed preparation: the promise's rejection
+;; path, whose `.catch` drops the slot so the section returns to its inactive
+;; state. So `prepare-variant` REJECTING is not a stylistic choice about how
+;; an error travels — it is the whole of what stops the debugger presenting
+;; step controls over a frame that never reached the `:setup` state.
+;;
+;; The failure classes split by HOW the failure travels, and the split is
+;; invisible from the call site:
+;;
+;;   • THROWN — an unknown variant (the plan compiler refuses), a `:db-seed`
+;;     that violates a registered schema. The throw escapes `prepare-ctx!`
+;;     and `rf.story.async/promise` rejects on it.
+;;
+;;   • CAPTURED — a throwing `:loaders` or `:setup` handler. `run-loaders!` /
+;;     `run-events!` deliberately do NOT rethrow: `capture-phase-errors`
+;;     collects the pipeline-exception trace events and `record-error!`
+;;     projects each onto the frame's `[:rf.story/assertions]`, then the
+;;     phase RETURNS normally. That is `run-variant`'s gather-the-full-picture
+;;     contract and it stays. But it means `prepare-ctx!` completes without
+;;     throwing over a frame whose `:setup` never ran (rf2-k6y2 post-merge
+;;     audit) — so the captured class needs its OWN check, and these tests
+;;     are it.
+
+#?(:clj
+   (defn- begin-outcome
+     "Drive the exact composition `stepper-state/begin!` performs — the
+     runtime seam, then `play/begin-stepper!` ONLY on the resolve path — and
+     report which branch ran (`:then` / `:catch`).
+
+     `begin!`'s CLJS body is `(-> (prepare-variant v) (.then …) (.catch …))`;
+     `rf.story.async/then` + `catch*` are the portable spelling of that same
+     pair, so this drives the control flow the Start button drives rather
+     than a re-description of it."
+     [vid]
+     (let [branch (atom nil)]
+       (-> (rf.story.runtime/prepare-variant vid)
+           (rf.story.async/then   (fn [_]
+                                    (rf.story.play/begin-stepper! vid)
+                                    (reset! branch :then)
+                                    nil))
+           (rf.story.async/catch* (fn [_] (reset! branch :catch) nil))
+           (rf.story.async/deref-blocking 2000))
+       @branch)))
 
 #?(:clj
    (deftest prepare-variant-rejects-on-a-failed-preparation
@@ -211,3 +255,82 @@
        (let [p (rf.story.runtime/prepare-variant :story.stepper/never-registered)]
          (is (thrown? java.util.concurrent.ExecutionException
                       (rf.story.async/deref-blocking p 2000)))))))
+
+#?(:clj
+   (deftest start-takes-the-resolve-branch-for-a-healthy-variant
+     (testing "the positive control for the two tests below: a variant that
+               prepares cleanly resolves, so Start reaches `begin-stepper!`
+               and publishes a slot. Without this the `:catch` assertions
+               below would pass on a seam that rejected everything"
+       (let [vid :story.stepper/mutating]
+         (reg-mutating! vid)
+         (is (= :then (begin-outcome vid))
+             "a clean preparation takes the resolve branch")
+         (is (some? (slot vid))
+             "and Start primed the stepper substrate")
+         (is (= 0 (count-of vid))
+             "over the :setup state, with the script still pending")))))
+
+#?(:clj
+   (deftest start-refuses-a-captured-setup-failure
+     (testing "a `:setup` handler that THROWS is captured onto
+               `[:rf.story/assertions]` rather than propagated, so phases 0-2
+               return normally — but the frame never reached the state the
+               variant's `:setup` describes. Start must take the rejection
+               branch and publish NO stepper, exactly as it does for an
+               unknown variant (acceptance 3)"
+       (let [vid :story.stepper/setup-throws]
+         (rf/reg-event :probe/setup-throws
+           (fn [_ _] (throw (ex-info "setup handler blew up" {:probe true}))))
+         (rf.story/reg-variant vid
+           {:setup  [[:probe/setup-throws]]
+            :script [[:dispatch-sync [:probe/inc-and-effect]]]})
+         (is (= :catch (begin-outcome vid))
+             "the failed preparation rejects rather than resolving nil")
+         (is (nil? (slot vid))
+             "so Start never primed the substrate")
+         (is (zero? @ext-effect-count)
+             "and issued no script effect")
+         (is (seq (filter (comp false? :passed?)
+                          (rf.story.runtime/read-assertions vid)))
+             "while the captured failure REMAINS on the frame — the
+              rejection reports the failure, it does not erase it")))))
+
+#?(:clj
+   (deftest start-refuses-a-captured-loader-failure
+     (testing "the same for a throwing `:loaders` handler: `run-loaders!`
+               captures it into the assertions accumulator and returns, so
+               Start must branch on the recorded failure rather than on a
+               throw that never arrives"
+       (let [vid :story.stepper/loader-throws]
+         (rf/reg-event :probe/loader-throws
+           (fn [_ _] (throw (ex-info "loader blew up" {:probe true}))))
+         (rf.story/reg-variant vid
+           {:loaders [[:probe/loader-throws]]
+            :setup   [[:counter/initialise 0]]
+            :script  [[:dispatch-sync [:probe/inc-and-effect]]]})
+         (is (= :catch (begin-outcome vid))
+             "the failed preparation rejects rather than resolving nil")
+         (is (nil? (slot vid))
+             "so Start never primed the substrate")
+         (is (zero? @ext-effect-count)
+             "and issued no script effect")))))
+
+#?(:clj
+   (deftest the-full-run-path-still-gathers-the-whole-picture
+     (testing "`run-variant` is UNCHANGED by the refusal above: a captured
+               `:setup` failure still RESOLVES a result carrying the failed
+               assertion rather than rejecting. The narrowing is Start's
+               alone — the runner keeps reporting everything it saw"
+       (let [vid :story.stepper/setup-throws-full-run]
+         (rf/reg-event :probe/setup-throws
+           (fn [_ _] (throw (ex-info "setup handler blew up" {:probe true}))))
+         (rf.story/reg-variant vid
+           {:setup  [[:probe/setup-throws]]
+            :script [[:dispatch-sync [:probe/inc-and-effect]]]})
+         (let [result (rf.story.async/deref-blocking
+                        (rf.story.runtime/run-variant vid) 2000)]
+           (is (map? result)
+               "the full run resolved a result rather than rejecting")
+           (is (seq (filter (comp false? :passed?) (:assertions result)))
+               "carrying the captured failure"))))))


### PR DESCRIPTION
## What the newest note said

rf2-k6y2 was closed and reopened by a post-merge audit of PR #9214. The
audit note — written while the bead was closed, and the specification here
— names a **residual of that fix**, not the original ordering defect.

The original defect (Start reached its position through `reset-variant`, a
full run, so the whole script executed before cursor 0 was published) is
fixed and stays fixed. Its regression net (`stepper_start_test.cljc` tests
1-4) is green throughout.

The residual: `stepper-state/begin!` branches on the promise
`prepare-variant` returns — `.then` publishes the cursor-0 slot, `.catch`
drops it — and that rejection is the **only** thing standing between a
failed preparation and an active stepper over it. Only half the failures
arrive as a throw.

| Route | Cause | How it arrives |
|---|---|---|
| Thrown | unknown variant; a `:db-seed` schema violation | escapes phases 0-2; the promise rejects |
| Captured | a throwing `:loaders` / `:setup` handler | recorded onto `[:rf.story/assertions]`; **the phase returns normally** |

`run-loaders!` / `run-events!` deliberately do not rethrow: `capture-phase-errors`
collects the pipeline-exception trace events, `record-error!` projects each
onto the frame, and the phase returns. That is `run-variant`'s
gather-the-full-picture contract and it stays. The consequence is that
`prepare-ctx!` completed without throwing over a frame whose `:setup` never
ran, `prepare-variant` resolved `nil`, and Start published "ready · N steps"
at cursor 0 over a failed preparation — the same class of lie as the
original defect, one lifecycle half further in.

## The seam

**`runtime/prepare-variant`, after `prepare-ctx!` returns and before it
resolves.** It now inspects the frame's assertions accumulator and rejects
with `:rf.error/story-prepare-failed` (records carried under `:failures`)
when a captured `:rf.error/exception` is present. `begin!`'s existing
`.catch` needed no change — the branch was already there; nothing was
reaching it.

Reading the accumulator is sound because phase 0's `ensure-fresh-frame!`
clears the frame's app-db, so every record present belongs to *this*
preparation. There is no prior run's residue to mistake for a fresh failure.

### What is deliberately NOT a prepare failure

`:rf.error/loader-incomplete`. A `:loaders-complete-when` reporting
not-ready is a contract-pending signal rather than an exception, and
`resume-run!`'s `:force-play?` means the ordinary shell plays such a
variant (`:story.counter-matrix/loader-never-completes`). Refusing to
step-debug a variant the shell itself runs would withdraw the debugger
exactly where it is most wanted; the recorded assertion still tells the
operator the loaders never settled. Stated in the spec so the line reads
as drawn rather than missed.

### Unchanged

`run-variant` and `prepare-run!` keep resolving a result that reports every
failure they saw. The refusal is Start's alone, because Start is the only
caller that must decide whether to present controls. `prepare-variant` has
exactly one production caller repo-wide (the Start button), so the blast
radius is Start.

## The witness

Four tests in `tools/story/test/re_frame/story/stepper_start_test.cljc`
driving the same `prepare-variant -> begin-stepper!` composition `begin!`
performs (`rf.story.async/then` + `catch*` are the portable spelling of
`begin!`'s `.then` / `.catch`), asserting **which branch ran and whether a
slot exists at the moment Start returns** — not that the script eventually
completes, which passes on the defect.

- Before: **exit 1, 10 tests / 31 assertions, 4 failures, 0 errors.** Both
  captured classes took `:then` and published
  `{:remaining [[:dispatch-sync [:probe/inc-and-effect]]], :ran [], :results []}`.
- After: **exit 0, 10 tests / 31 assertions, 0 failures, 0 errors.**

Same assertion count either side — the fix flipped the four failures, it did
not remove assertions. A positive control pins the resolve branch for a
healthy variant (so the `:catch` assertions cannot pass on a seam that
rejects everything), and a negative control pins that `run-variant` still
resolves the full picture for the same throwing `:setup`.

## Sibling transport controls — censused, and already correct

`stepper_state.cljs` defines 13 `defn` forms, 8 of them public transport
mutators: `begin!` / `step!` / `step-back!` / `rewind!` / `pause!` /
`resume!` / `toggle-breakpoint!` / `end!`, wired to 14 call sites in
`stepper_view.cljs` (8 button `:on-click`, 5 keyboard shortcuts, 1 unmount
teardown). **`begin!` is the only one that reaches an asynchronous runtime
seam** — every other control is synchronous and operates on an
already-published slot, so none can publish over a failed preparation. The
failure-branching axis is single-site; no sibling shares the boundary. On
the *ordering* axis, `step-back!`'s epoch indexing was fixed separately by
rf2-4e545l and its peek-then-pop order is pinned by existing tests.

## Gates

- **`tools/story` `clojure -M:test` — captured exit `0`, 1899 tests /
  6990 assertions, 0 failures, 0 errors**, re-run on the final rebased base.
  Discriminator: tip measured 1895 / 6978; this adds 4 deftests carrying 12
  assertions, so 1899 / 6990 is the exact expected arithmetic — the run saw
  this tree.
- **`scripts/check_doc_slugs.py` — captured exit `0`, empty log.** That gate
  passes silently, so it was **proven live** against this PR's own spec edit:
  a planted broken anchor produced captured exit `1` naming
  `tools/story/spec/009-Test-Mode.md:546` and the exact anchor. Restored
  byte-identically (`cmp` clean; CRLF 685/685; 37204 bytes; zero plant
  residue against a control search returning 3).
- `mkdocs build --strict` **does not cover this change** and is not
  nominated: `docs_dir` is `docs`, and `mkdocs_hooks.py`'s `_STAGE` maps only
  top-level `spec` and `migration` — `tools/story/spec/` is neither.
- `scripts/check_readme_links.py` is not this diff's gate either: no README
  and no markdown beside source was touched.
- **No gate inspects prose, tables or rendering.** Hand-checked: the new
  two-route table has 3 columns across header, separator and both rows;
  every cross-reference in the new prose is plain text or an existing
  in-file section name.

## Not done, and why

No new CLJS test was added to `stepper_state_cljs_test.cljs`. `begin!`'s
control flow is unchanged by this PR — only the seam behind it moved — and
that file's existing `begin!` test already pins the seam it calls. The CLJS
browser lane was not run here (it is outside this task's gate set), so
adding a test that could not be executed would have been the riskier move.

Closes rf2-k6y2.
