### PR TITLE
fix(spine): the driver-root unmount failure is a teardown step, not a swallow (rf2-ss8x)

### DIFF
--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1636,33 +1636,53 @@
   set-tick slot) AFTER calling this; the ratom family's dispose IS exactly
   this subset (no warn-cache, no driver-root).
 
-  THIS IS THE REthrow CHOKEPOINT (rf2-ss8x). Returns nil on a clean drain;
-  on failure it rethrows the FIRST captured cleanup failure — unchanged, and
-  only once every Reaction and every root has been attempted and ownership
-  finalized. That ordering is the whole point, and it is what
-  `rf.substrate.adapter/dispose-adapter!` was always built to receive: it
-  invokes this inside a try/finally, so the process-owned lifecycle still
-  reaches its terminal state (`adapter-disposed?` true, install slot cleared,
-  public delegation answering `:rf.error/adapter-disposed`) and the failure
-  then propagates to the `rf/destroy-adapter!` caller. Before rf2-ss8x both
-  per-step catches discarded their throw, so that tested mechanism could
-  never see a failure and a broken teardown reported success.
+  Rethrow. Returns nil on a clean drain; on failure the FIRST captured
+  cleanup failure is rethrown — unchanged, and only once every Reaction and
+  every root has been attempted and ownership finalized. That ordering is the
+  whole point, and it is what `rf.substrate.adapter/dispose-adapter!` was
+  always built to receive: it invokes the adapter disposer inside a
+  try/finally, so the process-owned lifecycle still reaches its terminal state
+  (`adapter-disposed?` true, install slot cleared, public delegation answering
+  `:rf.error/adapter-disposed`) and the failure then propagates to the
+  `rf/destroy-adapter!` caller. Before rf2-ss8x both per-step catches
+  discarded their throw, so that tested mechanism could never see a failure
+  and a broken teardown reported success.
 
   Later failures ride the rethrown primary as secondary diagnostic evidence —
   see `rethrow-teardown-failure!`. Ownership finalization sits in a `finally`
   per MUST (3), so a caches/claims clear happens even if the drain collapses
-  in a way the per-step catches do not cover."
-  [dispose-reaction! unmount-op active-roots-cell emitter-cell]
-  (let [failures (make-teardown-failures)]
-    (try
-      (dispose-frame-sub-caches! dispose-reaction! failures)
-      (doseq [root @active-roots-cell]
-        (try (unmount-op root)
-             (catch :default e (record-teardown-failure! failures e))))
-      (finally
-        (reset! active-roots-cell #{})
-        (when emitter-cell (reset! emitter-cell nil))))
-    (rethrow-teardown-failure! failures)))
+  in a way the per-step catches do not cover.
+
+  Arities. The FOUR-arg form is the whole teardown for a spine that layers
+  nothing on top of this subset — the ratom family — so it owns the
+  accumulator and rethrows the primary itself. The FIVE-arg form takes the
+  CALLER's accumulator, records into it and returns nil WITHOUT rethrowing,
+  so a spine that layers further teardown (the React-hook spine's warn-cache,
+  singleton driver root and set-tick slot) runs that layer inside ONE teardown
+  transaction and rethrows once, at the end (rf2-ss8x).
+
+  Why threading the accumulator rather than nesting two. Two accumulators do
+  not compose: the inner rethrow attaches ITS secondaries to the primary, and
+  an outer accumulator that then caught that primary would overwrite the same
+  `rfAdapterTeardownSecondaryErrors` expando with only its own later failures
+  — silently dropping the shared drain's evidence. One accumulator across both
+  layers keeps every failure in one traversal-ordered list, and keeps the
+  first-failure rule meaning the same thing at both layers."
+  ([dispose-reaction! unmount-op active-roots-cell emitter-cell]
+   (let [failures (make-teardown-failures)]
+     (dispose-active-roots-and-caches! dispose-reaction! unmount-op
+                                       active-roots-cell emitter-cell failures)
+     (rethrow-teardown-failure! failures)))
+  ([dispose-reaction! unmount-op active-roots-cell emitter-cell failures]
+   (try
+     (dispose-frame-sub-caches! dispose-reaction! failures)
+     (doseq [root @active-roots-cell]
+       (try (unmount-op root)
+            (catch :default e (record-teardown-failure! failures e))))
+     (finally
+       (reset! active-roots-cell #{})
+       (when emitter-cell (reset! emitter-cell nil))))
+   nil))
 
 (defn make-dispose-adapter!
   "Build a `dispose-adapter!` fn satisfying Spec 006 §Adapter disposal
@@ -1685,14 +1705,16 @@
   Best-effort drains. React's `.unmount` is idempotent / no-op on
   already-unmounted roots; a per-root unmount throw is captured rather
   than propagated so one misbehaving root does not strand the rest of the
-  drain, and the FIRST captured failure is rethrown by the shared drain
-  once everything has been attempted (rf2-ss8x). The sub-cache walk has
+  drain, and the FIRST captured failure is rethrown by this fn once
+  everything has been attempted (rf2-ss8x). The sub-cache walk has
   its own per-entry try/catch (see `dispose-frame-sub-caches!`).
 
   rf2-t0x90: also unmounts the singleton after-render DRIVER ROOT (if
   one was lazily armed) and clears its `set-tick` slot, so a torn-down
   adapter releases it and a subsequent `init!` re-arms a fresh one
-  against the new adapter rather than bumping a stale setter."
+  against the new adapter rather than bumping a stale setter. That unmount
+  is a teardown STEP under the same accumulator as the shared drain, not a
+  swallowed side-errand — see the primacy note in the body."
   [{:keys [active-roots-cell warn-cache emitter-cell
            after-render-driver-root-cell after-render-set-tick-ref]}]
   (fn dispose-adapter! []
@@ -1700,26 +1722,52 @@
     ;; drain-with-capture + emitter clear) is the shared core; the React-hook
     ;; spine layers warn-cache + driver-root + set-tick teardown on top.
     ;;
-    ;; rf2-ss8x: the shared core now RETHROWS the first cleanup failure, so
-    ;; this spine's extra teardown must sit in a `finally` — otherwise a
-    ;; throwing Reaction or root would strand the singleton driver root and
-    ;; the warn-once cache, trading MUST (2)'s leak for MUST (2)'s report and
-    ;; leaving the next `init!` bumping a stale setter. Every step below is
-    ;; already throw-guarded or a plain `reset!`, so the `finally` cannot
-    ;; displace the primary failure travelling through it.
-    (try
-      (dispose-active-roots-and-caches! rf.disposable/-dispose
-                                        (fn [r] (.unmount r))
-                                        active-roots-cell emitter-cell)
-      (finally
-        (when warn-cache (reset! warn-cache #{}))
-        (when after-render-driver-root-cell
-          (when-let [root @after-render-driver-root-cell]
-            (try (.unmount root) (catch :default _ nil)))
-          (reset! after-render-driver-root-cell nil))
-        (when after-render-set-tick-ref
-          (reset! after-render-set-tick-ref nil))))
-    nil))
+    ;; rf2-ss8x: ONE teardown transaction spans both layers. The accumulator
+    ;; is owned HERE and handed to the shared core's five-arg arity, which
+    ;; records into it instead of rethrowing its own — so the layered teardown
+    ;; below runs inside the same drain and the single rethrow happens after
+    ;; every step and every ownership reset.
+    ;;
+    ;; PRIMACY, and why the asymmetry is the substance. The singleton driver
+    ;; root is a host-specific resource this spine owns alone (Spec 006 MUST
+    ;; (2)), and its unmount is a teardown step like any other, so it obeys
+    ;; the same first-failure rule as every step before it:
+    ;;
+    ;;   * Nothing earlier threw  -> the driver-root failure IS the primary
+    ;;     and must surface. `destroy-adapter!` returning a clean nil over a
+    ;;     driver root that never released is exactly the silent hole MUST (2)
+    ;;     forbids: the fixture, hot-reload cycle or programmer cannot tell a
+    ;;     clean shutdown from a leaked React root, and the next `init!`
+    ;;     re-arms against a host resource the last generation still holds.
+    ;;   * The shared drain already failed -> it is a SECONDARY on the
+    ;;     primary's `rfAdapterTeardownSecondaryErrors`. The earlier failure
+    ;;     names the real fault and reaches the caller with identity and stack
+    ;;     intact; attachment never wraps or replaces it.
+    ;;
+    ;; The pre-rf2-ss8x `(catch :default _ nil)` here got the second case
+    ;; right by accident — a discarded secondary loses only evidence — and the
+    ;; first case wrong every single time, which is the whole defect.
+    ;;
+    ;; The layered teardown stays in a `finally` so a collapse the per-step
+    ;; catches do not cover still clears the caches (MUST (3)); every step in
+    ;; it is throw-guarded or a plain `reset!`, so the `finally` cannot
+    ;; displace a failure travelling through it.
+    (let [failures (make-teardown-failures)]
+      (try
+        (dispose-active-roots-and-caches! rf.disposable/-dispose
+                                          (fn [r] (.unmount r))
+                                          active-roots-cell emitter-cell
+                                          failures)
+        (finally
+          (when warn-cache (reset! warn-cache #{}))
+          (when after-render-driver-root-cell
+            (when-let [root @after-render-driver-root-cell]
+              (try (.unmount root)
+                   (catch :default e (record-teardown-failure! failures e))))
+            (reset! after-render-driver-root-cell nil))
+          (when after-render-set-tick-ref
+            (reset! after-render-set-tick-ref nil))))
+      (rethrow-teardown-failure! failures))))
 
 (defn make-hiccup-emitter-cell
   "Return a fresh `(atom nil)` cell that will hold the substrate's

--- a/implementation/core/test/re_frame/substrate/spine_dispose_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_dispose_cljs_test.cljs
@@ -97,6 +97,159 @@
         (is (nil? @set-tick-ref)
             "the after-render set-tick slot still cleared past the rethrow")))))
 
+;; ---- layered React-hook teardown: the singleton driver root (rf2-ss8x) ----
+;;
+;; `make-dispose-adapter!` layers warn-cache + singleton after-render DRIVER
+;; ROOT + set-tick teardown on top of the shared drain. The driver root is a
+;; host-specific resource this spine owns ALONE — it lives outside
+;; `active-roots-cell` — and its unmount used to sit under a bare
+;; `(catch :default _ nil)`, so a failure there was discarded outright.
+;;
+;; The fix threads ONE accumulator across both layers, which makes the primacy
+;; rule ASYMMETRIC, and the asymmetry is the substance:
+;;
+;;   * driver-root failure is the ONLY failure  -> it is the PRIMARY and must
+;;     surface, or `destroy-adapter!` reports a clean nil over a React root
+;;     that never released.
+;;   * something earlier already failed         -> it is a SECONDARY on the
+;;     primary's `rfAdapterTeardownSecondaryErrors`, because the earlier
+;;     failure names the real fault and attachment never replaces it.
+;;
+;; The old catch got the second case right by accident and the first wrong
+;; every time. The two tests below pin the two cases, and within each one the
+;; DRAIN assertions and the RETHROW assertions are separated deliberately: a
+;; swallow regression fails only the RETHROW group, a throw-early regression
+;; fails only the DRAIN group, so neither test can pass a defect the other
+;; would catch.
+;;
+;; Node-runtime, no DOM: the spine only ever invokes `.unmount` on whatever
+;; occupies the cell, so a plain JS object with an `unmount` slot exercises
+;; the exact path a real `react-dom-client` root takes.
+
+(deftest dispose-surfaces-a-driver-root-only-unmount-failure-as-the-primary
+  (testing "when the singleton after-render driver root's unmount is the ONLY
+  teardown failure it becomes the PRIMARY and reaches the caller, after every
+  other layer has been attempted and finalized (rf2-ss8x; Spec 006 §Adapter
+  disposal lifecycle MUST 2 + the first-failure rule)"
+    (let [active-roots-cell (rf.substrate.spine/make-active-roots-cell)
+          warn-cache        (rf.substrate.spine/make-warn-once-cache)
+          emitter-cell      (rf.substrate.spine/make-hiccup-emitter-cell)
+          sentinel          (js/Error. "driver root unmount failed")
+          driver-root-cell  (atom #js {:unmount #(throw sentinel)})
+          set-tick-ref      (atom :stale-setter)
+          dispose-fn        (rf.substrate.spine/make-dispose-adapter!
+                              {:active-roots-cell             active-roots-cell
+                               :warn-cache                    warn-cache
+                               :emitter-cell                  emitter-cell
+                               :after-render-driver-root-cell driver-root-cell
+                               :after-render-set-tick-ref     set-tick-ref})
+          healthy           (fake-root)]
+      (swap! active-roots-cell conj (:root healthy))
+      (reset! warn-cache #{:some-stale-warn-key})
+      (reset! emitter-cell (fn fake-emit [_ _] "<html/>"))
+      (let [thrown (try (dispose-fn)
+                        ::returned-normally
+                        (catch :default e e))]
+        ;; ---- DRAIN half. Stays green under a swallow regression; fails only
+        ;; if the driver-root throw is allowed to abandon a later step.
+        (is (= 1 @(:unmount-count healthy))
+            "the healthy app root was unmounted by the shared drain")
+        (is (empty? @active-roots-cell)
+            "active-roots cell drained to empty")
+        (is (nil? @emitter-cell)
+            "hiccup-emitter cell cleared")
+        (is (empty? @warn-cache)
+            "warn-once cache cleared past the driver-root throw")
+        (is (nil? @driver-root-cell)
+            "driver-root cell released even though its unmount threw — a
+            retained root would leak the very host resource being reported")
+        (is (nil? @set-tick-ref)
+            "after-render set-tick slot cleared so a fresh init! re-arms
+            against the new adapter rather than bumping a stale setter")
+        ;; ---- RETHROW half. The ONLY half a swallow regression fails, and the
+        ;; half the pre-fix `(catch :default _ nil)` failed every time.
+        (is (identical? sentinel thrown)
+            "the identical driver-root unmount failure reached the caller as
+            the primary; ::returned-normally here is the silent success over a
+            failed teardown that rf2-ss8x exists to close")))))
+
+(deftest dispose-attaches-a-driver-root-failure-behind-an-earlier-primary
+  (testing "when the shared drain ALREADY failed, the later driver-root
+  unmount failure rides the rethrown primary as secondary evidence instead of
+  displacing it or being discarded — one accumulator spanning the shared drain
+  and the layered React-hook teardown (rf2-ss8x)"
+    (let [active-roots-cell (rf.substrate.spine/make-active-roots-cell)
+          warn-cache        (rf.substrate.spine/make-warn-once-cache)
+          emitter-cell      (rf.substrate.spine/make-hiccup-emitter-cell)
+          root-boom         (js/Error. "app root unmount failed")
+          driver-boom       (js/Error. "driver root unmount failed")
+          driver-root-cell  (atom #js {:unmount #(throw driver-boom)})
+          set-tick-ref      (atom :stale-setter)
+          dispose-fn        (rf.substrate.spine/make-dispose-adapter!
+                              {:active-roots-cell             active-roots-cell
+                               :warn-cache                    warn-cache
+                               :emitter-cell                  emitter-cell
+                               :after-render-driver-root-cell driver-root-cell
+                               :after-render-set-tick-ref     set-tick-ref})
+          healthy           (fake-root)]
+      ;; Exactly one app root throws, so the shared drain's failure is the
+      ;; first recorded regardless of the set's traversal order, and the
+      ;; driver root's is unambiguously the later one.
+      (swap! active-roots-cell conj (:root healthy) #js {:unmount #(throw root-boom)})
+      (let [thrown (try (dispose-fn)
+                        ::returned-normally
+                        (catch :default e e))]
+        ;; ---- DRAIN half.
+        (is (= 1 @(:unmount-count healthy))
+            "the healthy app root was still unmounted despite two failures")
+        (is (empty? @active-roots-cell)
+            "active-roots cell drained to empty")
+        (is (nil? @driver-root-cell)
+            "driver-root cell released")
+        (is (nil? @set-tick-ref)
+            "after-render set-tick slot cleared")
+        ;; ---- RETHROW half: primacy, then attachment.
+        (is (identical? root-boom thrown)
+            "the EARLIER shared-drain failure stayed the primary — a later
+            driver-root failure must never displace the error that names the
+            real fault, and the primary keeps its identity and stack")
+        (let [secondary (when (instance? js/Object thrown)
+                          (aget thrown "rfAdapterTeardownSecondaryErrors"))]
+          (is (some? secondary)
+              "secondary evidence was attached to the rethrown primary")
+          (is (= 1 (if secondary (alength secondary) 0))
+              "exactly one secondary — the driver-root failure")
+          (is (identical? driver-boom (when secondary (aget secondary 0)))
+              "the driver-root failure rides the primary as secondary evidence
+              rather than being discarded, which is what threading one
+              accumulator through the layered teardown buys"))))))
+
+(deftest dispose-captures-a-falsey-driver-root-throw-by-presence
+  (testing "a driver root that throws `false` still surfaces: the layered
+  teardown records by PRESENCE against `capture-none`, never by truthiness, so
+  the legal-but-falsey CLJS throw is not re-swallowed by the fix's own
+  accumulator (rf2-ss8x)"
+    (let [active-roots-cell (rf.substrate.spine/make-active-roots-cell)
+          warn-cache        (rf.substrate.spine/make-warn-once-cache)
+          emitter-cell      (rf.substrate.spine/make-hiccup-emitter-cell)
+          driver-root-cell  (atom #js {:unmount #(throw false)})
+          set-tick-ref      (atom :stale-setter)
+          dispose-fn        (rf.substrate.spine/make-dispose-adapter!
+                              {:active-roots-cell             active-roots-cell
+                               :warn-cache                    warn-cache
+                               :emitter-cell                  emitter-cell
+                               :after-render-driver-root-cell driver-root-cell
+                               :after-render-set-tick-ref     set-tick-ref})
+          thrown            (try (dispose-fn)
+                                 ::returned-normally
+                                 (catch :default e e))]
+      (is (nil? @driver-root-cell)
+          "driver-root cell still released after a falsey throw")
+      (is (false? thrown)
+          "the falsey driver-root throw reached the caller instead of being
+          read as 'nothing failed' — a truthiness accumulator here would
+          rebuild the exact silent hole the bare catch had"))))
+
 (deftest dispose-clears-warn-cache-and-emitter
   (testing "dispose-adapter! also empties the warn-once cache and the hiccup-emitter cell"
     (let [active-roots-cell (rf.substrate.spine/make-active-roots-cell)


### PR DESCRIPTION
Closes the remnant that reopened **rf2-ss8x**. PR #9201 was the Reagent half; this is the UIx half.

## What was still swallowed

`make-dispose-adapter!` builds the **React-hook spine's** `dispose-adapter!` — the one `make-react-spine` hands to the **UIx adapter** and to **Hicasso's substrate**. It layers warn-cache + the singleton after-render **driver root** + the set-tick slot on top of the shared drain.

That driver root is a host-specific resource this spine owns *alone*: it lives outside `active-roots-cell`, so the shared drain never sees it. Its unmount sat under a bare `(catch :default _ nil)`. PR #9201 landed drain-then-rethrow on the shared drain (`make-teardown-failures` / `record-teardown-failure!` / `rethrow-teardown-failure!`, presence-keyed on `capture-none`, secondaries attached via the `rfAdapterTeardownSecondaryErrors` string expando) — but this step still discarded its failure outright. A driver root that never released reported a clean `nil` out of `rf/destroy-adapter!`.

The reopen note read this as a Reagent defect. It is not: stock Reagent and reagent-slim use `make-ratom-spine`, whose entire `dispose-adapter!` *is* the shared drain — no warn-cache, no driver root. **Nothing on the ratom path is touched by this PR.**

## The fix: one accumulator across both layers

`dispose-active-roots-and-caches!` gains a **five-arg arity** that records into the *caller's* accumulator and returns `nil` without rethrowing. The four-arg arity is unchanged in behaviour — it now delegates to the five-arg form and rethrows itself — so the ratom family keeps exactly what it had.

`make-dispose-adapter!` owns the accumulator, hands it to the five-arg form, records the driver-root failure into that same accumulator, and rethrows once, after the `finally` has finished every ownership reset.

**Why threading one accumulator rather than nesting two.** Two would not compose. The inner rethrow attaches *its* secondaries to the primary; an outer accumulator that then caught that primary would overwrite the same `rfAdapterTeardownSecondaryErrors` expando with only its own later failures, silently dropping the shared drain's evidence. One list, one traversal order, one meaning of "first".

## The primacy rule, and why it is asymmetric

This is the substance of the fix, so it is stated in the code as well as here:

* **Driver-root failure is the ONLY failure → it is the PRIMARY and must surface.** A `destroy-adapter!` returning a clean `nil` over a React root that never released is exactly the silent hole Spec 006 MUST (2) forbids: a fixture, a hot-reload cycle or a programmer cannot tell a clean shutdown from a leaked host resource, and the next `init!` re-arms against something the last generation still holds.
* **Something earlier already failed → it is a SECONDARY** on the primary's `rfAdapterTeardownSecondaryErrors`. The earlier failure is the one that names the real fault, and it reaches the caller with identity and stack intact; attachment never wraps or replaces.

The old `(catch :default _ nil)` got the second case right *by accident* — a discarded secondary loses only evidence — and the first case wrong every single time.

The layered teardown stays in a `finally` so MUST (3)'s cache clear still happens even on a collapse the per-step catches do not cover; every step inside it is throw-guarded or a plain `reset!`, so the `finally` cannot displace a failure travelling through it.

**No spec change.** Spec 006's "attempt every step under its own boundary, keep the first thrown value by PRESENCE, finalize ownership, and only then rethrow" (lines 338–356) already mandates this; the driver-root unmount is a teardown step like any other. The code was behind the spec, not the other way round.

## Witnesses, and proof they are live

Three new tests in `implementation/core/test/re_frame/substrate/spine_dispose_cljs_test.cljs`, beside the seam they pin:

1. `dispose-surfaces-a-driver-root-only-unmount-failure-as-the-primary`
2. `dispose-attaches-a-driver-root-failure-behind-an-earlier-primary`
3. `dispose-captures-a-falsey-driver-root-throw-by-presence` (a thrown `false` — the case a truthiness accumulator would re-swallow)

Each separates its **DRAIN** assertions from its **RETHROW** assertions deliberately, and **two complementary regression plants prove the halves fail for different reasons**:

| | plant A — restore the bare `(catch :default _ nil)` | plant B — remove the guard so the throw escapes the `finally` |
|---|---|---|
| suite result | exit 1, **5 failures, 0 errors** | exit 1, **9 failures, 0 errors** |
| test 1 DRAIN | **all green** | **fails** (driver-root cell + set-tick never reset) |
| test 1 RETHROW | **fails** (`::returned-normally` for the sentinel) | **green** |
| test 2 primacy | green (shared-drain primary survives) | **fails** (driver-boom displaces root-boom) |
| test 2 attachment | **fails** (no secondary) | **fails** |

So a swallow regression fails only the rethrow half and a throw-early regression fails only the drain half — neither test can pass a defect the other would catch. Both plants were applied byte-safely to a CRLF file and the tree restored and verified `cmp`-identical afterwards.

## Gates

* `npm run test:cljs` — **exit 0**, **11223 tests / 56725 assertions, 0 failures, 0 errors**. Exactly +3 tests and +17 assertions over the recorded 11220 / 56708 baseline, matching the three new deftests' 7 + 8 + 2 `is` forms.
* `npm run build:hicasso-release` — **exit 0**, `[:hicasso-release] Build completed. (162 files, 107 compiled, 0 warnings)`. This is the `:advanced` / `:infer-externs :auto` gate for the touched interop (`.unmount`): `shadow-cljs.edn` records that it is "the ONLY Closure-optimised compile these namespaces get", and its comment names core's `spine.cljs` specifically for externs inference. Zero `:infer-warning`s.
* `npm run test:hicasso-compile` — **exit 0**, "11 namespaces compiled with zero warnings". The warnings-fatal `:infer-externs :auto` compile.
* Gates re-run on the final rebased base.

**Lane note, stated plainly:** `npm run test:browser` does **not** cover these tests. `:browser-test` binds `:ns-regexp ".*-dom-cljs-test$"` (shadow-cljs.edn line 974) and this namespace ends `-cljs-test`, so it runs under `:node-test` (`cljs-test$`) only. No real React root is needed and none is used: the spine only ever invokes `.unmount` on whatever occupies the cell, so a plain JS object with an `unmount` slot exercises the identical path a `react-dom-client` root takes — which is the same technique the file's existing `fake-root` helper and the pre-existing driver-root test already use.

## Scope

Two files, both in `implementation/core`. The Reagent and reagent-slim adapters, `spec/`, `examples/`, `tools/` and the workflows are untouched.
