### PR TITLE
fix(ssr-ring): a Node 200 that names no build is refused, not accepted (rf2-9guv)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/node.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/node.clj
@@ -88,11 +88,16 @@
   opaque value: the sidecar's code vocabulary is the sidecar's, spelled
   nowhere on the JVM — which is also what its own absence witness holds.
     :rf.error/ssr-node-build-skew   a 200 whose `x-rf-ssr-build` is not the
-                                    `:build-id` this renderer was built with.
-                                    The sidecar already refuses a mismatched
-                                    REQUEST; this is the defensive check on
-                                    the ANSWER (S7). ex-data `:expected`,
-                                    `:serving`.
+                                    `:build-id` this renderer was built with
+                                    — INCLUDING an absent header, since an
+                                    answer that names no build is not a
+                                    verifiable match and `:render-hash` is
+                                    nil here, so nothing downstream would
+                                    catch it. The sidecar already refuses a
+                                    mismatched REQUEST; this is the defensive
+                                    check on the ANSWER (S7). ex-data
+                                    `:expected`, `:serving` (nil when the
+                                    answer named no build).
 
   `:on-error` keeps its meaning — the net for when the projector cannot
   run — and nothing here reaches it. A malformed construction opt throws
@@ -306,12 +311,23 @@
                 :message message
                 :detail  detail}}))
 
-(defn- throw-build-skew! [{:keys [build-id endpoint]} serving]
+(defn- throw-build-skew!
+  "The answer-side build refusal, for both ways a 200 fails to prove it came
+  from `:build-id`: `serving` names a DIFFERENT build, or it is nil because
+  the answer named none. The two causes read differently to an operator, so
+  the sentence names which one it is; the id and the ex-data slots are one."
+  [{:keys [build-id endpoint]} serving]
   (error/throw-error!
     :rf.error/ssr-node-build-skew error-origin
-    (str "the Node render sidecar at " endpoint " answered from build "
-         (pr-str serving) " where this renderer was built against "
-         (pr-str build-id) ". Redeploy the bundle that matches the JVM host.")
+    (str "the Node render sidecar at " endpoint " answered 200 "
+         (if serving
+           (str "from build " (pr-str serving) " where this renderer was built "
+                "against " (pr-str build-id)
+                ". Redeploy the bundle that matches the JVM host.")
+           (str "with no x-rf-ssr-build header, so its bytes cannot be shown "
+                "to come from " (pr-str build-id)
+                ". Find what stripped the header, or what is answering in "
+                "the sidecar's place.")))
     {:recovery :redeploy-the-matching-bundle
      :extra    {:expected build-id
                 :serving  serving}}))
@@ -351,7 +367,13 @@
         body   (.body http-response)]
     (if (= 200 status)
       (let [serving (response-header http-response "x-rf-ssr-build")]
-        (when (and serving (not= serving build-id))
+        ;; An EQUALITY, not a mismatch test: absence is not a verifiable
+        ;; match. A 200 that names no build reads the same whether a proxy
+        ;; stripped the header, the service is malformed, or something that
+        ;; is not the sidecar answered — and `:render-hash` is nil for a
+        ;; native root, so nothing downstream can catch it either. The bytes
+        ;; are refused rather than wrapped in the JVM-owned document.
+        (when-not (= serving build-id)
           (throw-build-skew! opts serving))
         {:body-html (str body) :render-hash nil})
       (let [error-payload (try

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/node_crossing_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/node_crossing_test.clj
@@ -394,8 +394,9 @@
 
 (defn- with-stub-sidecar
   "Run `f` with the URL of a JDK HttpServer answering every request with
-  `status`, `headers` and `body` — a sidecar impostor for the one answer
-  the real one can never give (a 200 from the wrong build)."
+  `status`, `headers` and `body` — a sidecar impostor for the answers the
+  real one can never give (a 200 from the wrong build, and a 200 that names
+  no build at all)."
   [status headers ^String body f]
   (let [server (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)
         bytes  (.getBytes body "UTF-8")]
@@ -424,6 +425,32 @@
         (is (= [:rf.error/ssr-node-build-skew] (render-failure-ids @seen)))
         (is (= {:expected "crossing-build-1" :serving "drifted-build-9"}
                (select-keys (render-failure-data @seen) [:expected :serving])))
+        (rf/unregister-listener! :errors ::crossing-recorder)))))
+
+(deftest ^:crossing build-skew-arm-a-200-that-names-no-build-is-refused-on-the-jvm
+  ;; The companion to the row above, and the one absence needs a row of its
+  ;; own for: the skew row sends a header, so it can never exercise the arm
+  ;; where there is none. A 200 carrying no `x-rf-ssr-build` is not a
+  ;; verifiable match — a proxy that strips the header, a malformed service,
+  ;; an impostor answering in the sidecar's place all present identically —
+  ;; and this adapter returns `:render-hash nil` for a native root, so the
+  ;; structural hydration-hash channel offers no second check. Unverified
+  ;; bytes must not reach the JVM-owned document.
+  (register-app!)
+  (with-stub-sidecar 200 {} "<main>impostor</main>"
+    (fn [url]
+      (let [seen          (capture-errors!)
+            frames-before (set (rf/frame-ids))
+            response      ((handler (node-renderer url)) request)]
+        (assert-projected-5xx! response frames-before)
+        (is (not (str/includes? (:body response) "impostor"))
+            "the unverified body never ships")
+        (is (= [:rf.error/ssr-node-build-skew] (render-failure-ids @seen))
+            "the same refusal the wrong build gets — no new error category")
+        (let [data (render-failure-data @seen)]
+          (is (= "crossing-build-1" (:expected data)) "the configured expectation")
+          (is (contains? data :serving) "…and an honest missing-serving slot")
+          (is (nil? (:serving data)) "…carrying nil, because the answer named none"))
         (rf/unregister-listener! :errors ::crossing-recorder)))))
 
 ;; ===========================================================================


### PR DESCRIPTION
## What and why

`re-frame.ssr.ring.node/renderer` requires a `:build-id`, sends it to the sidecar, and promises an answer-side build check before Node-rendered bytes enter the JVM-owned document. The 200 arm of `interpret-response!` tested `(and serving (not= serving build-id))`, so an **absent** `x-rf-ssr-build` skipped the check and the body was accepted as `{:body-html ... :render-hash nil}`.

Absence is not a verifiable match. A proxy stripping the header, a malformed service and an impostor answering in the sidecar's place all present identically, and this adapter returns `:render-hash nil` for a native root — so the structural hydration-hash channel provides no second check. Unverified bytes were being wrapped with the JVM hydration payload and shipped as a successful SPA document.

## The change

- `interpret-response!` now tests **equality** (`(when-not (= serving build-id))`), so absence routes through the same `:rf.error/ssr-node-build-skew` refusal and projected 5xx the wrong-build case already takes. No new error category, no new status, no handshake, no retries, no health preflight, no broader response-header validation, and no constraint on the documented non-loopback endpoint.
- `throw-build-skew!` branches its sentence so an operator reads which of the two causes it is. The id, the `:recovery` disposition and the `:expected` / `:serving` ex-data slots are unchanged; `:serving` is nil when the answer named no build (the "retain `:serving` nil, avoid surface growth" option the bead preferred).
- The namespace contract prose for `:rf.error/ssr-node-build-skew` now says absence is included and that `:serving` may be nil.

## Test: red before green

New row `build-skew-arm-a-200-that-names-no-build-is-refused-on-the-jvm`, beside the existing `build-skew-arm-a-200-from-the-wrong-build-is-refused-on-the-jvm`, reusing the same `with-stub-sidecar` / `node-renderer` / `handler` fixtures with `{}` response headers.

The existing skew row **sends** a header, so it can never exercise absence — that blind spot is why the new row exists rather than an extra assertion on the old one.

Against the previous condition the new row failed **8 assertions**: status `200` (not the projected 500), and the response body carried both `<main>impostor</main>` and `__rf_payload`, with zero error records emitted. That is the reported defect reproduced at tip. After the fix the same row is green, and the two discriminators either side of it stayed green throughout the cycle:

- present-but-different build → still refused (unchanged row),
- present exact match → still successful (`one-complete-crossing-a-b-c-e-f`, against the real Node sidecar, which sets `x-rf-ssr-build` on its buffered 200 in `implementation/ssr-node/src/http.cjs`).

So all three 200-answer cases are named and the guard is shown to discriminate rather than to reject wholesale.

## Quality gates

Run from `implementation/ssr-ring`, each redirected to a log with the runner's own exit code captured on the same command line (never through a filter).

| Gate | Command | Result | Exit |
| --- | --- | --- | --- |
| Crossing lane, baseline (pre-change) | `clojure -M:crossing-test` | 9 tests, 95 assertions, 0 failures, 0 errors | `0` |
| Crossing lane, new row vs unfixed code | `clojure -M:crossing-test` | 10 tests, 107 assertions, **8 failures**, 0 errors — all 8 in the new row | `1` |
| Crossing lane, after the fix | `clojure -M:crossing-test` | 10 tests, 107 assertions, 0 failures, 0 errors | `0` |
| Ordinary ssr-ring JVM lane | `clojure -M:test` | 231 tests, 1164 assertions, 0 failures, 0 errors | `0` |

Both lanes the bead names are green. `jvm-node-crossing` in `test.yml` arms on `implementation_jvm`, so CI re-proves the crossing lane on this PR.

**Skipped, with reasons:** no whole-repo gate (`scripts/test-fast-pr.sh` and friends) was run — several workers are live concurrently and a repo-wide gate wedges rather than fails under that load; CI owns the full spine. No CLJS/browser lane: the change is JVM-only, in one Clojure namespace and its JVM test.

## Not done, deliberately

Reconciliation beyond `node.clj` was checked and found unnecessary rather than skipped. `spec/009-Instrumentation.md`, `spec/011-SSR.md`, `docs/ssr/concepts.md`, `examples/substrates/hicasso/login/host.clj` and `implementation/ssr/test/re_frame/ssr_doc_example_node_build_id_test.clj` all describe the refusal as "a 200 whose `x-rf-ssr-build` is not the `:build-id`" — which an absent header already satisfies. The prose was correct; the code under-implemented it. Nothing there is falsified by this change, so no hot-zone spec file is touched.

Fixes rf2-9guv.



