### PR TITLE
fix(mcp-conformance): fence the ppid link, not only the root row (rf2-kzbf)

### DIFF
--- a/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
+++ b/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
@@ -302,13 +302,108 @@ function readWindowsProcessTable({ runPs } = {}) {
 //                  either (the caller grades it dirty).
 //   'ours'       — a row wears it, we have not seen our child exit, and it
 //                  was created at or after the instant we spawned.
-function classifyRootRow(table, rootPid, notBeforeMs, { rootExited = false } = {}) {
+function classifyRootRow(table, rootPid, notBeforeMs, opts = {}) {
+  const { rootExited = false, rootExitedAtMs = 0 } = opts;
   const row = table.find((r) => r.pid === rootPid);
   if (!row) return 'absent';
-  if (rootExited) return 'stranger';
+  // An observed exit INSTANT is the same evidence as the boolean, carrying
+  // more of it — accept either, so a caller cannot supply the instant and
+  // still be classified as though the handle were live.
+  if (rootExited || rootExitedAtMs > 0) return 'stranger';
   if (!Number.isFinite(row.createdMs) || row.createdMs <= 0) return 'unprovable';
   if (row.createdMs < notBeforeMs) return 'stranger';
   return 'ours';
+}
+
+// The evidence the KILL DECISION turns on — for the root row AND for the rows
+// that merely NAME its number as their parent (rf2-kzbf audit of PR #9247).
+//
+// Fencing the root row answered "may we kill the row wearing our number?".
+// It left the other half unanswered: the walk started at `rootPid` and swept
+// up its ppid claimants regardless of what the root had just been classified
+// as. Two holes of exactly the shape the first fix closed, one level down:
+//
+//   * an UNPROVABLE root still handed us its children, and the reaper
+//     tree-killed them before returning its dirty error. If the undated row
+//     is a stranger, that was the stranger's child; reporting dirty AFTER
+//     the kill is not fail-closed.
+//   * an ABSENT root left NO ceiling at all (`strangerCeilingMs` is Infinity
+//     when no row wears the number), so a stranger that took the number,
+//     forked, and exited before we enumerated left a child wearing our
+//     number as PPID, above our spawn floor and below no ceiling.
+//
+// A boolean "our wrapper exited" cannot separate that child from our own
+// orphan. The INSTANT it exited can: a DIRECT child of our wrapper had to be
+// created before the wrapper died, so the observed exit time is a genuine
+// upper bound on ownership. Where neither that instant nor a dated stranger
+// row is available there is no positive evidence at all, and the answer is to
+// kill nothing and grade dirty — never to guess.
+//
+// Returns `{ rootClass, killRoot, strangerCeilingMs, exitCeilingMs, error }`.
+// A non-null `error` with `refuse` set means the walk must not run.
+function rootOwnershipEvidence(table, rootPid, notBeforeMs, opts = {}) {
+  const rootClass = classifyRootRow(table, rootPid, notBeforeMs, opts);
+  const rootRow = table.find((r) => r.pid === rootPid) || null;
+  const exitedAtMs = Number(opts.rootExitedAtMs);
+  // Our own direct child predates our wrapper's death, so anything parented
+  // by that number afterwards is somebody else's.
+  const exitCeilingMs =
+    Number.isFinite(exitedAtMs) && exitedAtMs > 0 ? exitedAtMs : Infinity;
+  // A stranger that inherited the number was created after our wrapper died,
+  // so its own creation instant bounds ownership too.
+  const strangerCeilingMs =
+    rootClass === 'stranger' && rootRow && rootRow.createdMs > 0
+      ? rootRow.createdMs
+      : Infinity;
+  const base = { rootClass, killRoot: false, strangerCeilingMs, exitCeilingMs };
+
+  if (rootClass === 'ours') {
+    // The row IS our live wrapper, so its ppid link is trustworthy and no
+    // ceiling applies: anything below it is ours by construction.
+    return { ...base, killRoot: true, refuse: false, error: null };
+  }
+  if (rootClass === 'unprovable') {
+    return {
+      ...base,
+      refuse: true,
+      error:
+        'the process table reported no usable creation time for the row ' +
+        `wearing root pid ${rootPid} — refusing to tree-kill a PID that ` +
+        'cannot be proven ours, or anything parented by it',
+    };
+  }
+  // 'absent' / 'stranger': the wrapper is gone, so the ppid link is the only
+  // claim a direct child has on us. It needs a ceiling to be worth anything.
+  const claimants = table.filter((r) => r.ppid === rootPid && r.pid !== rootPid);
+  if (
+    claimants.length > 0 &&
+    !Number.isFinite(exitCeilingMs) &&
+    !Number.isFinite(strangerCeilingMs)
+  ) {
+    return {
+      ...base,
+      refuse: true,
+      error:
+        `${claimants.length} process(es) name the vacated root pid ${rootPid} ` +
+        'as their parent, but neither an observed wrapper-exit instant nor a ' +
+        'dated row wearing that number is available — ownership could not be ' +
+        'bounded, so nothing was killed',
+    };
+  }
+  // An undated claimant cannot be held against either ceiling. It is left
+  // alone (it may be a stranger's) and named, so the run is not certified on
+  // a tree we could not fully account for.
+  const undated = claimants.filter((r) => !(r.createdMs > 0)).map((r) => r.pid);
+  return {
+    ...base,
+    refuse: false,
+    error:
+      undated.length > 0
+        ? `pid(s) ${undated.join(', ')} name the vacated root pid ${rootPid} ` +
+          'as their parent but report no usable creation time — they cannot ' +
+          'be proven ours, so they were left alone'
+        : null,
+  };
 }
 
 // Breadth-first descendant closure of `rootPid` over `table`, EXCLUDING any
@@ -319,41 +414,36 @@ function classifyRootRow(table, rootPid, notBeforeMs, { rootExited = false } = {
 // in its children's `ParentProcessId`, so the walk always starts from
 // `rootPid` even when no row of ours wears it any more.
 //
-// One extra bound applies in the 'stranger' case: the stranger's own children
-// must not be swept up with our orphans. A process of ours orphaned by our
-// dead wrapper necessarily PREDATES the stranger that inherited the number,
-// so a direct child of `rootPid` created at or after the stranger's own
-// creation is the STRANGER'S child, not ours.
+// The ceilings from `rootOwnershipEvidence` bound that discovery, and they
+// apply to the ROOT'S DIRECT CHILDREN only: a grandchild our own JVM forked
+// later reaches us through a parent we have already proven ours, so its ppid
+// link is trustworthy and no ceiling applies to it.
 function ownedDescendants(table, rootPid, notBeforeMs, opts = {}) {
+  const ev = rootOwnershipEvidence(table, rootPid, notBeforeMs, opts);
+  if (ev.refuse) return [];
   const childrenOf = new Map();
   for (const row of table) {
     if (!childrenOf.has(row.ppid)) childrenOf.set(row.ppid, []);
     childrenOf.get(row.ppid).push(row);
   }
-  const byPid = new Map(table.map((r) => [r.pid, r]));
-  const rootClass = classifyRootRow(table, rootPid, notBeforeMs, opts);
-  const rootRow = byPid.get(rootPid) || null;
-  const strangerCeilingMs =
-    rootClass === 'stranger' && rootRow && rootRow.createdMs > 0
-      ? rootRow.createdMs
-      : Infinity;
   const owned = [];
   const seen = new Set([rootPid]);
   const queue = [rootPid];
-  if (rootClass === 'ours') owned.push(rootPid);
+  if (ev.killRoot) owned.push(rootPid);
   while (queue.length > 0) {
     const current = queue.shift();
     for (const child of childrenOf.get(current) || []) {
       if (seen.has(child.pid)) continue;
       // A descendant created before we spawned our root is not ours.
       if (child.createdMs > 0 && child.createdMs < notBeforeMs) continue;
-      // Nor is a direct child the STRANGER fathered after taking the number.
-      if (
-        current === rootPid &&
-        child.createdMs > 0 &&
-        child.createdMs >= strangerCeilingMs
-      ) {
-        continue;
+      if (current === rootPid && ev.rootClass !== 'ours') {
+        // A direct claimant on a VACATED number needs a date to be held
+        // against the ceilings at all; without one it is not provably ours.
+        if (!(child.createdMs > 0)) continue;
+        // Nor is a direct child the STRANGER fathered after taking the number.
+        if (child.createdMs >= ev.strangerCeilingMs) continue;
+        // Nor one created after our own wrapper had already died.
+        if (child.createdMs > ev.exitCeilingMs) continue;
       }
       seen.add(child.pid);
       owned.push(child.pid);
@@ -377,6 +467,11 @@ function makeShadowTreeReaper({
   // number is free, so any row still wearing it belongs to somebody else.
   // Read as a thunk because it flips while cleanup is running.
   rootExited = () => false,
+  // WHEN it emitted `exit`, as epoch ms (0 until it has). The boolean above
+  // withdraws the authority to kill the NUMBER; this is what bounds the
+  // orphans discovered THROUGH it, since a direct child of our wrapper had
+  // to be created before the wrapper died (rf2-kzbf audit of PR #9247).
+  rootExitedAtMs = () => 0,
   platform = process.platform,
   readTable = readWindowsProcessTable,
   treeKill = defaultWindowsTreeKill,
@@ -405,11 +500,17 @@ function makeShadowTreeReaper({
   }
   return async function reapShadowTree() {
     let owned;
-    let rootClass;
+    let evidence;
     try {
       const table = readTable();
-      const opts = { rootExited: Boolean(rootExited()) };
-      rootClass = classifyRootRow(table, rootPid, spawnedAtMs, opts);
+      const exitedAt = Number(rootExitedAtMs());
+      const opts = {
+        rootExited: Boolean(rootExited()),
+        rootExitedAtMs: Number.isFinite(exitedAt) && exitedAt > 0 ? exitedAt : 0,
+      };
+      // ONE evidence read drives both the kill decision and the grade, so the
+      // two can never disagree about what we were entitled to touch.
+      evidence = rootOwnershipEvidence(table, rootPid, spawnedAtMs, opts);
       owned = ownedDescendants(table, rootPid, spawnedAtMs, opts);
     } catch (e) {
       return {
@@ -419,14 +520,11 @@ function makeShadowTreeReaper({
         error: `could not enumerate the process table (${e && e.message})`,
       };
     }
-    // FAIL CLOSED on a root row we cannot date: it is not ours to kill, and
-    // "we could not tell" is not a proven teardown either (AC3).
-    const rootError =
-      rootClass === 'unprovable'
-        ? 'the process table reported no usable creation time for the row ' +
-          `wearing root pid ${rootPid} — refusing to tree-kill a PID that ` +
-          'cannot be proven ours'
-        : null;
+    // FAIL CLOSED wherever ownership could not be established: nothing of the
+    // sort is ours to kill, and "we could not tell" is not a proven teardown
+    // either (AC3).
+    const rootClass = evidence.rootClass;
+    const rootError = evidence.error;
     if (rootClass === 'stranger') {
       logFn(
         `the row wearing root pid ${rootPid} is NOT the process we spawned ` +
@@ -449,7 +547,7 @@ function makeShadowTreeReaper({
       // number is provably the process we spawned. Then any orphan we
       // attributed to the root but whose own parent link died with the
       // wrapper.
-      if (rootClass === 'ours') treeKill(rootPid);
+      if (evidence.killRoot) treeKill(rootPid);
       for (const pid of owned) {
         if (pid !== rootPid && isAlive(pid)) treeKill(pid);
       }
@@ -1400,8 +1498,13 @@ async function main() {
   // own, and the ONLY subtree teardown is allowed to touch (rf2-kzbf).
   const shadowRootPid = shadow.pid;
   let shadowExited = false;
+  // WHEN the wrapper died, not merely THAT it did: our own direct children
+  // all predate this instant, so it is the upper bound that keeps a
+  // stranger's later child out of the kill set (rf2-kzbf audit of PR #9247).
+  let shadowExitedAtMs = 0;
   shadow.on('exit', (code, sig) => {
     shadowExited = true;
+    shadowExitedAtMs = Date.now();
     log(`shadow-cljs exited code=${code} sig=${sig}`);
   });
   shadow.stdout.on('data', (d) => {
@@ -1434,6 +1537,7 @@ async function main() {
       rootPid: shadowRootPid,
       spawnedAtMs: shadowSpawnedAtMs,
       rootExited: () => shadowExited,
+      rootExitedAtMs: () => shadowExitedAtMs,
     }),
   });
   // Expose the teardown to the module-scope hard watchdog
@@ -1847,5 +1951,6 @@ module.exports = {
   makeShadowTreeReaper,
   ownedDescendants,
   classifyRootRow,
+  rootOwnershipEvidence,
   pidAlive,
 };

--- a/tools/mcp-conformance/test/runner-cleanup.test.cjs
+++ b/tools/mcp-conformance/test/runner-cleanup.test.cjs
@@ -964,7 +964,8 @@ test('a REAL cmd wrapper that exits with a live grandchild is graded DIRTY, then
   });
   const rootPid = shadow.pid;
   let shadowExited = false;
-  shadow.on('exit', () => { shadowExited = true; });
+  let shadowExitedAtMs = 0;
+  shadow.on('exit', () => { shadowExited = true; shadowExitedAtMs = Date.now(); });
 
   // Wait for the wrapper to exit AND the grandchild to announce itself.
   const deadline = Date.now() + 20_000;
@@ -1013,6 +1014,7 @@ test('a REAL cmd wrapper that exits with a live grandchild is graded DIRTY, then
       hasShadowExited: () => shadowExited,
       reapShadowTree: makeShadowTreeReaper({
         rootPid, spawnedAtMs, rootExited: () => shadowExited,
+        rootExitedAtMs: () => shadowExitedAtMs,
         treeKill: () => {}, graceMs: 300, pollMs: 50,
         log: () => {}, logErr: () => {},
       }),
@@ -1039,6 +1041,7 @@ test('a REAL cmd wrapper that exits with a live grandchild is graded DIRTY, then
       // through the dead parent link instead (rf2-kzbf audit).
       reapShadowTree: makeShadowTreeReaper({
         rootPid, spawnedAtMs, rootExited: () => shadowExited,
+        rootExitedAtMs: () => shadowExitedAtMs,
         log: () => {}, logErr: () => {},
       }),
       log: () => {}, logErr: () => {},

--- a/tools/mcp-conformance/test/runner-cleanup.test.cjs
+++ b/tools/mcp-conformance/test/runner-cleanup.test.cjs
@@ -676,6 +676,159 @@ test('an UNDATED root row fails CLOSED: not killed, and not graded clean (rf2-kz
   assert.equal(sentinel, null, 'and emit no pass sentinel');
 });
 
+// ---- and the PPID LINK is fenced too (rf2-kzbf audit of PR #9247) ---------
+//
+// Fencing the root ROW answered "may we kill the row wearing our number?".
+// It left the other half unanswered — "may we kill the rows that NAME our
+// number as their parent?" — and the walk ran regardless, so a root we had
+// just declared unkillable still handed us its children to kill. These pin
+// the second half to the same standard: no positive ownership evidence, no
+// kill, and no clean grade either.
+
+test('an UNPROVABLE root does not hand us its CHILDREN either (rf2-kzbf audit of PR #9247, AC2)', () => {
+  // The audit's deterministic probe. Pre-fix `owned` was [200] — the child of
+  // a row we had just refused to kill because we could not prove it ours.
+  const table = [
+    { pid: 100, ppid: 1, createdMs: 0 },      // wears our number; undatable
+    { pid: 200, ppid: 100, createdMs: 6000 }, // its child — but whose child?
+  ];
+  assert.deepEqual(
+    ownedDescendants(table, 100, 5000),
+    [],
+    'if the root row may be a stranger, that is the stranger\'s child',
+  );
+});
+
+test('makeShadowTreeReaper kills NOTHING through an unprovable root (rf2-kzbf audit of PR #9247, AC2/AC3)', async () => {
+  // Pre-fix: `treeKill(200)` ran, and only THEN did the dirty error come back.
+  // Reporting dirty after the kill is not fail-closed.
+  const killed = [];
+  const reap = makeShadowTreeReaper({
+    rootPid: 100,
+    spawnedAtMs: 5000,
+    platform: 'win32',
+    readTable: () => [
+      { pid: 100, ppid: 1, createdMs: 0 },
+      { pid: 200, ppid: 100, createdMs: 6000 },
+    ],
+    treeKill: (pid) => killed.push(pid),
+    isAlive: () => true,
+    graceMs: 20,
+    pollMs: 5,
+    log: () => {},
+    logErr: () => {},
+  });
+  const out = await reap();
+  assert.deepEqual(killed, [], 'nothing may be killed through a root we cannot prove ours');
+  assert.deepEqual(out.owned, []);
+  assert.match(out.error, /cannot be proven ours/);
+
+  const report = await makeCleanup({
+    getBrowser: () => null,
+    getShadow: () => null,
+    hasShadowExited: () => true,
+    reapShadowTree: reap,
+    log: () => {},
+    logErr: () => {},
+  })();
+  assert.equal(report.clean, false);
+  let sentinel = null;
+  assert.equal(
+    finalizeConformance(report, {
+      emitPass: (l) => { sentinel = l; }, log: () => {}, logErr: () => {}, flush: () => {}, count: 0,
+    }),
+    2,
+  );
+  assert.equal(sentinel, null);
+});
+
+test('a stranger that took our number, forked and EXITED does not lend us its child (rf2-kzbf audit of PR #9247, AC2)', () => {
+  // Nothing wears our number now, so there is no stranger ROW whose creation
+  // instant could bound the walk — the case where `strangerCeilingMs` was
+  // Infinity and every ppid claimant above the spawn floor was swept up.
+  // The bound that remains is the instant OUR wrapper exited: a DIRECT child
+  // of that wrapper had to exist before the wrapper died.
+  const table = [
+    { pid: 200, ppid: 100, createdMs: 5500 }, // our orphan — before the exit
+    { pid: 300, ppid: 100, createdMs: 7000 }, // the stranger's child — after it
+    { pid: 400, ppid: 200, createdMs: 7500 }, // our orphan's OWN later child
+  ];
+  const owned = ownedDescendants(table, 100, 5000, {
+    rootExited: true,
+    rootExitedAtMs: 6000,
+  });
+  assert.ok(
+    !owned.includes(300),
+    'a process parented by our number AFTER our wrapper died is not ours: ' + JSON.stringify(owned),
+  );
+  assert.deepEqual(
+    owned.sort((a, b) => a - b),
+    [200, 400],
+    'while our orphan is still found, and the bound applies only to the ROOT\'s direct ' +
+      'children — a grandchild our own JVM forked later is still ours',
+  );
+});
+
+test('no dated stranger and no observed exit instant means orphan discovery is UNBOUNDED — refuse (rf2-kzbf audit of PR #9247, AC2/AC3)', async () => {
+  // A boolean "our wrapper exited" cannot separate our orphan from a
+  // stranger's. Without the instant there is no positive evidence at all, so
+  // the answer is to kill nothing and grade dirty — never to guess.
+  const killed = [];
+  const reap = makeShadowTreeReaper({
+    rootPid: 100,
+    spawnedAtMs: 5000,
+    platform: 'win32',
+    rootExited: () => true,
+    readTable: () => [{ pid: 200, ppid: 100, createdMs: 6000 }],
+    treeKill: (pid) => killed.push(pid),
+    isAlive: () => true,
+    graceMs: 20,
+    pollMs: 5,
+    log: () => {},
+    logErr: () => {},
+  });
+  const out = await reap();
+  assert.deepEqual(killed, []);
+  assert.deepEqual(out.owned, []);
+  assert.match(out.error, /could not be bounded/);
+});
+
+test('an UNDATED direct child of a dead root is not swept up on the ppid link alone (rf2-kzbf audit of PR #9247, AC2)', () => {
+  // Same hole one row down: once the root row is gone, the ppid link is the
+  // only claim a direct child has on us, and an undatable row cannot be held
+  // against the ceiling at all.
+  const table = [
+    { pid: 200, ppid: 100, createdMs: 0 },    // undatable — ours, or not?
+    { pid: 201, ppid: 100, createdMs: 5500 }, // provably ours
+  ];
+  assert.deepEqual(
+    ownedDescendants(table, 100, 5000, { rootExited: true, rootExitedAtMs: 6000 }),
+    [201],
+    'the provable orphan is still reaped; the unprovable row is left alone',
+  );
+});
+
+test('an already-empty tree stays CLEAN whether or not an exit instant was recorded (rf2-kzbf audit of PR #9247 — no false RED)', async () => {
+  for (const extra of [{}, { rootExited: () => true, rootExitedAtMs: () => 6000 }]) {
+    const reap = makeShadowTreeReaper({
+      rootPid: 100,
+      spawnedAtMs: 5000,
+      platform: 'win32',
+      readTable: () => [{ pid: 999, ppid: 1, createdMs: 7000 }],
+      treeKill: () => { throw new Error('nothing to kill'); },
+      isAlive: () => false,
+      graceMs: 20,
+      pollMs: 5,
+      log: () => {},
+      logErr: () => {},
+      ...extra,
+    });
+    const out = await reap();
+    assert.deepEqual(out.owned, []);
+    assert.equal(out.error, null, 'an empty tree is a reaped tree, not an unproven one');
+  }
+});
+
 // ---- the reaper's own outcome grading -------------------------------------
 
 test('makeShadowTreeReaper reports SURVIVORS when the kill removes nothing (rf2-kzbf)', async () => {


### PR DESCRIPTION
Closes the two residuals the rf2-kzbf audit of PR #9247 recorded. Both were
reproduced deterministically against the merged implementation before any
fix went in.

## The defect

PR #9213 fenced the ROOT ROW — "may we kill the row wearing our number?" —
and left the other half unasked. `ownedDescendants` started its walk at the
root PID and swept up every ppid claimant regardless of what the root had
just been classified as:

1. **An unprovable root still handed us its children.** With root
   `{pid:100, createdMs:0}` and child `{pid:200, ppid:100, createdMs:6000}`
   at `spawnedAtMs=5000`, `owned` was `[200]` and the reaper ran
   `treeKill(200)` *before* returning its dirty error. If the undated row is
   a stranger, that was the stranger's child — reporting dirty after the
   kill is not fail-closed.
2. **An absent root left the walk with no ceiling at all.** When our wrapper
   has exited and a stranger reuses the number, forks, and itself exits
   before we enumerate, `rootClass` is `absent` and `strangerCeilingMs` is
   `Infinity`. The stranger's surviving child keeps the recycled number as
   its PPID, clears the spawn floor, and is killed as ours.

## The repair

A boolean "our wrapper exited" cannot separate that child from our own
orphan. The **instant** it exited can: a direct child of our wrapper had to
be created before the wrapper died, so the observed exit time is a genuine
upper bound on ownership.

- `rootOwnershipEvidence` derives both ceilings (the dated stranger row, the
  observed wrapper-exit instant) plus the kill decision from **one** read of
  the table, and the reaper drives the kill and the grade from that same
  object — the two cannot disagree about what we were entitled to touch.
- An **unprovable root kills nothing**: the walk is refused outright, not
  performed and then regretted.
- **No ceiling, no walk.** Where neither an exit instant nor a dated row is
  available and rows do claim the vacated number, nothing is killed and the
  reap grades dirty (AC3).
- An **undated direct claimant** on a vacated number is left alone for the
  same reason and named in the dirty report, so the run is not certified on
  a tree we could not fully account for.
- The ceilings bind the root's **direct children only** — a grandchild our
  own JVM forked after the wrapper died reaches us through a parent already
  proven ours.
- The runner records `shadowExitedAtMs` alongside `shadowExited` and passes
  it in; POSIX is untouched (the reaper is still the inert identity there).

## Red-then-green

Six table-model regressions landed first, in their own commit, red against
the merged implementation (`node --test test/runner-cleanup.test.cjs` →
**exit 1, 5 failed / 32 passed of 37**):

- an unprovable root does not hand us its children (the audit's own probe);
- the reaper kills nothing through an unprovable root, and grades exit 2
  with no pass sentinel;
- a stranger that took our number, forked and exited does not lend us its
  child — while our orphan *and its own later grandchild* are still found;
- no dated stranger and no exit instant means discovery is unbounded, so
  refuse;
- an undated direct child of a dead root is not swept up on the ppid link;
- and the other direction — an already-empty tree stays CLEAN, so the repair
  cannot buy safety with a false RED (this one passed before and after).

After the fix: **exit 0, 37/37**. The real-process Windows witness (a
cross-spawn'd `.cmd` wrapper that exits leaving a live grandchild) ran
unskipped on Windows and still discovers, reaps and proves-dead its orphan
through the new bound.

## Quality gates

| Gate | Result |
| --- | --- |
| `node --test test/runner-cleanup.test.cjs` (before fix) | **exit 1** — 5 fail / 32 pass of 37 (the control) |
| `node --test test/runner-cleanup.test.cjs` (after fix) | **exit 0** — 37 pass / 0 fail / 0 skipped |
| `npm run test:unit` (the package's own Node unit cluster) | **exit 0** — 149 tests, 140 pass, 0 fail, 9 skipped |

Run on Windows 11, so the Windows-only real-process witness executed rather
than skipping — the platform the defect lives on.

**Skipped, with reasons:**

- `npm test` / the full live hermetic suite and `scripts/test-fast-pr.sh` —
  not run locally: sibling workers were live and a gate that heavy wedges
  rather than fails under concurrency. CI owns the full spine; the changed
  surface is `tools/mcp-conformance/**` only, covered by
  `mcp-conformance-re-frame2-pair` and the nightly `mcp-live` job.
- **AC4 (two consecutive Windows hermetic-suite runs, port-8030 checks) is
  NOT satisfied by this PR and cannot be satisfied by CI as it stands.**
  Both suite jobs run on `ubuntu-latest` (`test.yml` line 5508,
  `expensive-tests.yml` line 349), where `makeShadowTreeReaper` returns the
  inert identity and none of this code executes. Closing that needs a
  Windows runner in a hot-zone workflow file, which is out of this change's
  fence. Filed separately.

## Notes

`cross-spawn@7.0.6`'s parser was re-checked read-only on this machine and
confirms the premise the whole bead rests on: a bare `npx` becomes
`C:\Windows\system32\cmd.exe /d /s /c ...` targeting `npx.CMD`, so the
handle we hold is the shim, not the JVM.

---



