### PR TITLE
fix(ssr-node): a render exception crosses as a service-owned refusal (rf2-c38b)

### DIFF
--- a/implementation/ssr-node/README.md
+++ b/implementation/ssr-node/README.md
@@ -479,6 +479,30 @@ can only be discovered after the render, a module that both emitted and
 returned produces a torn response carrying `detail.afterChunks` — the
 bytes really did leave, and the transport must not present them as a page.
 
+And a module that THROWS is refused the same way, which is the other door
+out of a render and the one an author meets by accident rather than on
+purpose. The refusal is always `:rf.ssr-node/render-threw`, with this
+contract's own wording and a `detail` of the entry and `afterChunks`:
+**the exception's `message`, its `detail`, and any `code` it carried do
+not cross the wire**. That is not tidiness. A renderer exception is built
+from the value being processed in the normal case — React names the
+property that was undefined, a validator quotes the input, a template
+interpolates the row — so forwarding it is the response leg carrying
+application data, which is the thing this contract exists not to do. A
+module-set `code` is refused for a second reason: the refusal family is
+this service's, and believing one would let an application bug present
+itself as a caller fault (400), a saturation (503) or a deadline (504),
+sending an operator and a retry policy down the wrong path.
+
+Nothing is lost by it. The full exception, **with its stack**, is written
+to the sidecar's stderr under the usual `[rf.ssr-node]` prefix, which is
+where an operator already reads this service — so a render bug is
+diagnosed in the sidecar's log rather than over a contract published to
+another machine. Two audiences, two channels, and no flag to get wrong.
+There is nothing for a render module to do about any of this: throw
+whatever is natural, and the boundary holds. `test/egress.test.cjs` §4 is
+the witness, with planted sentinels on all three fields.
+
 The CLJS half — the thing behind `MY_APP_SSR.renderToString` — is a
 per-request `gensym` frame made with no initial events,
 `re-frame.ssr.render-state/deserialize` over `state` and `runtime`,
@@ -734,8 +758,20 @@ agreeing; the runaway render is shown still running after 400 ms before a
 200 ms refusal is called a termination; the egress scan is shown finding a
 planted leak — and the leaky fixture shown really returning one, and the
 null-returning fixture shown really returning `null` rather than drifting
-into falling off its end — before its zero is believed; and the absence
-scan is shown finding a planted reference before its zero is believed.
+into falling off its end, and the throwing fixture shown really carrying a
+distinct sentinel on each of `code`, `message` and a nested `detail` —
+before its zero is believed; and the absence scan is shown finding a
+planted reference before its zero is believed.
+
+One of those controls is worth reading twice, because it guards against a
+row going quiet rather than against a row going wrong. The status-spoof
+rows drive a fixture that hard-codes real members of the refusal family as
+its `error.code`, the way an application would — it does not import the
+service's protocol module. Rename a member of `CODE` and those literals
+become codes the service has never heard of, which map to 500 all on their
+own: the rows stay green and stop testing a spoof. So the codes are
+asserted to be live members, and to map to a status other than
+`render-threw`'s, before any of them is trusted reading 500.
 
 ---
 

--- a/implementation/ssr-node/src/isolate.cjs
+++ b/implementation/ssr-node/src/isolate.cjs
@@ -33,7 +33,7 @@
 
 const path = require('node:path');
 const { Worker } = require('node:worker_threads');
-const { CODE, Refusal, chunkFrame } = require('./protocol.cjs');
+const { CODE, Refusal, chunkFrame, isRefusalCode } = require('./protocol.cjs');
 
 const WORKER_PATH = path.join(__dirname, 'worker.cjs');
 
@@ -198,9 +198,18 @@ class Isolate {
       return;
     }
     if (message.t === 'error') {
+      // THE SECOND READING, and the same discipline the `complete` branch
+      // above states: this is the boundary that BUILDS the public
+      // `Refusal`, so the closed family is checked here as well as at the
+      // worker that posts it. The worker is the enforcement — it is what
+      // stops a module's own `code` being believed at all — and this is
+      // the reading that stops any code the family does not contain from
+      // reaching `http.cjs`'s `statusFor` and choosing a status of its
+      // own. Two independent readings of one property, which is what makes
+      // it a boundary rather than a habit.
       this._settlePendingRender(message.id, () =>
         pendingRender.reject(
-          new Refusal(message.code ?? CODE.RENDER_THREW, message.message, {
+          new Refusal(isRefusalCode(message.code) ? message.code : CODE.RENDER_THREW, message.message, {
             ...(message.detail ?? {}),
             // A caller that already saw chunks has a TORN response. It is
             // named rather than smoothed over: the transport must not

--- a/implementation/ssr-node/src/protocol.cjs
+++ b/implementation/ssr-node/src/protocol.cjs
@@ -215,6 +215,60 @@ const MODULE_RETURN_REFUSAL =
   'an absence. Render what the module has to say, and return nothing.';
 
 /**
+ * What a caller is told when the render module threw.
+ *
+ * ONE WORDING FOR EVERY RENDER EXCEPTION, and the wording is this
+ * contract's rather than the module's — which is the whole of the fix, so
+ * it is worth saying why a fixed string beats the obvious alternative.
+ *
+ * A thrown `Error` is the OTHER way out of a render, and it was carrying
+ * what the returned value is refused for. `message` is built from the
+ * value being processed in every renderer worth the name — React names the
+ * property that was undefined, a validator quotes the input, a template
+ * interpolates the row — so this is not a leak that needs a module doing
+ * something strange; it is a leak that needs a module having a bug.
+ * `detail` is worse: nothing bounds what an application hangs on it. Both
+ * crossed into the public `Refusal` and into the HTTP JSON body.
+ *
+ * `code` is the same untrusted property and a distinct failure. It is a
+ * bare field on an ordinary `Error`, and `http.cjs`'s `statusFor` maps it
+ * to a status — so a module could describe its own bug in this service's
+ * closed vocabulary and present a render fault as a 400 the caller blames
+ * itself for, a 503 a retry policy sleeps on, or a 504. The refusal
+ * taxonomy is a fact about THIS SERVICE'S crossing; the application is not
+ * one of its authors.
+ *
+ * WHY NOT A REDACTED OR TRUNCATED MESSAGE. Because there is no rule that
+ * separates the safe part of an application's exception from the rest, and
+ * a rule that only usually holds is the shape this file already refuses on
+ * the request leg. The diagnosis is not lost — the worker writes the real
+ * exception, stack and all, to the sidecar's stderr, which is where an
+ * operator already reads this package (`bin/serve.cjs` writes there under
+ * the same prefix). Two audiences, two channels: the caller across the
+ * wire gets an honest, closed refusal; the operator inside the process
+ * gets everything.
+ */
+const RENDER_THREW_REFUSAL =
+  'the render module threw. Its exception belongs to the application, not to this contract: ' +
+  'the message, the `detail` and any `code` it carried are the module\'s own and do not cross ' +
+  'this boundary — a diagnostic that echoed them would be application data leaving through ' +
+  'the error channel, which is the same egress the response leg refuses wearing a different ' +
+  'frame type, and a module-chosen `code` would let a render fault present itself as a ' +
+  'caller fault, a saturation or a deadline. The full exception, with its stack, is on the ' +
+  'sidecar\'s stderr for the operator.';
+
+/**
+ * Is this one of the refusal codes this service publishes?
+ *
+ * The family is closed — `CODE` is the whole of it — and this is the test
+ * that says so at the boundary that BUILDS a public `Refusal`, so that a
+ * code arriving from anywhere else cannot reach `statusFor` and be given a
+ * status of its own choosing.
+ */
+const REFUSAL_CODES = Object.freeze(new Set(Object.values(CODE)));
+const isRefusalCode = (code) => REFUSAL_CODES.has(code);
+
+/**
  * A top-level partition key, as its EDN text. Keywords in re-frame2 are
  * what top-level app-db and runtime-db keys are (Spec 011 §`:rf/app-db`
  * projection; Conventions §Reserved runtime-db keys), so the wire spelling
@@ -550,6 +604,8 @@ module.exports = {
   REFUSED_FIELDS,
   COMPLETE_FIELDS,
   MODULE_RETURN_REFUSAL,
+  RENDER_THREW_REFUSAL,
+  isRefusalCode,
   Refusal,
   validateModule,
   validateRequest,

--- a/implementation/ssr-node/src/worker.cjs
+++ b/implementation/ssr-node/src/worker.cjs
@@ -63,9 +63,40 @@
 // it. A channel that refuses is a channel that stays closed.
 
 const { parentPort, workerData } = require('node:worker_threads');
-const { CODE, validateModule, MODULE_RETURN_REFUSAL } = require('./protocol.cjs');
+const {
+  CODE,
+  validateModule,
+  MODULE_RETURN_REFUSAL,
+  RENDER_THREW_REFUSAL,
+} = require('./protocol.cjs');
 
 const postMessage = (message) => parentPort.postMessage(message);
+
+/**
+ * The operator's copy of a render exception — everything the refusal
+ * deliberately does not carry.
+ *
+ * TWO AUDIENCES, TWO CHANNELS, and the distinction is the reason closing
+ * the refusal costs nothing. The caller across the wire is a different
+ * process on a different machine holding a contract; the operator is
+ * inside this one, already reading its output. So the exception goes where
+ * an operator already looks and stops going where a contract is published.
+ *
+ * NOT A NEW SUBSYSTEM. `bin/serve.cjs` already writes `[rf.ssr-node] …` to
+ * stderr, and this is that stream under that prefix — a worker thread's
+ * stderr is piped to the parent process's, so a line written here lands in
+ * the sidecar's log beside the rest. There is no flag: a diagnostic that
+ * can be switched off is one that is off on the day it is wanted, and this
+ * is the only remaining copy of the exception.
+ *
+ * The stack, not the message alone. It opens with the error's own name and
+ * message, so nothing is dropped by preferring it, and it adds the frames
+ * — which is the half a refusal could never have carried anyway.
+ */
+function reportRenderException(entry, err) {
+  const trace = err && err.stack ? err.stack : String(err);
+  process.stderr.write(`[rf.ssr-node] render threw in entry ${entry}: ${trace}\n`);
+}
 
 let renderModule = null;
 let busy = false;
@@ -216,12 +247,44 @@ async function handleRender(renderId, request) {
       renderMs,
     });
   } catch (err) {
+    // THE EXCEPTION DOOR, and it is the same door as the egress door
+    // above — a render module leaves this isolate by returning or by
+    // throwing, and for a while only one of the two was watched.
+    //
+    // What used to be here was `code: err.code ?? …, message: err.message
+    // ?? …, detail: err.detail ?? {}`: three application-authored fields
+    // copied straight onto the protocol, and from there into the public
+    // `Refusal` and the HTTP JSON body. That reads as diagnostic
+    // generosity and it is the very leak the return door refuses, arriving
+    // through the other one. It is also the LIKELIER of the two, which is
+    // the part worth internalising: returning a payload takes a module
+    // doing something unusual, whereas an exception built from the value
+    // being processed is what every renderer already produces — React
+    // names the undefined property, a validator quotes the input, a
+    // template interpolates the row.
+    //
+    // `code` is a second, distinct failure. `http.cjs` maps the refusal
+    // code to a status, so a module that set `err.code` to a member of
+    // this service's own closed family could present its own bug as a 400
+    // the caller blames itself for, a 503 a retry policy sleeps on, or a
+    // 504 — the refusal taxonomy describes THIS SERVICE'S crossing, and
+    // the application is not one of its authors.
+    //
+    // So: one code, one wording, and a `detail` this file builds. The
+    // `entry` is the caller's own identifier handed back — the same
+    // reasoning `requestId` gets on the `complete` frame — and
+    // `afterChunks` is counted here. Neither originates in the module.
+    //
+    // NOTHING IS LOST BY IT, because a refusal was never where an operator
+    // read a stack anyway. The real exception goes to stderr below, in
+    // full; see `reportRenderException`.
+    reportRenderException(request.entry, err);
     postMessage({
       t: 'error',
       id: renderId,
-      code: err.code ?? CODE.RENDER_THREW,
-      message: err.message ?? String(err),
-      detail: err.detail ?? {},
+      code: CODE.RENDER_THREW,
+      message: RENDER_THREW_REFUSAL,
+      detail: { entry: request.entry },
       // NO `stack`, for the reason the boot path gives: the render
       // receiver reads `code`, `message`, `detail` and `afterChunks`, so a
       // stack posted here crossed the boundary only to be dropped — a
@@ -245,7 +308,20 @@ parentPort.on('message', (message) => {
     // unhandled rejection here would be a second failure channel with no
     // request id on it.
     handleRender(message.id, message.request).catch((err) => {
-      postMessage({ t: 'error', id: message.id, code: CODE.RENDER_THREW, message: String(err) });
+      // Service-owned here too. `handleRender` catches the module's own
+      // throw, so anything reaching this last-resort arm is a fault in
+      // THIS file rather than in the render — but `String(err)` was still
+      // an unbounded string on the response protocol, and a law with one
+      // arm that states it differently is a law with a way around it. The
+      // operator gets the real one, as everywhere else on this path.
+      reportRenderException(message.request?.entry, err);
+      postMessage({
+        t: 'error',
+        id: message.id,
+        code: CODE.RENDER_THREW,
+        message: RENDER_THREW_REFUSAL,
+        detail: {},
+      });
     });
   }
 });

--- a/implementation/ssr-node/test/egress.test.cjs
+++ b/implementation/ssr-node/test/egress.test.cjs
@@ -44,6 +44,30 @@
 // except, so the null rows below are ordinary members of this section
 // rather than an appendix to it.
 //
+// ## THERE ARE TWO DOORS OUT OF A RENDER, AND THIS FILE ONCE WATCHED ONE
+//
+// A render module leaves the isolate by RETURNING or by THROWING, and for
+// a commit the sections above were the whole of this file — every one of
+// them driving a module that returns. The row that read "the refusal does
+// not carry the payload out through the error channel" was the closest
+// thing to a guard on the second door and it drove the LEAKY fixture,
+// which returns; so the error channel it checked was the one the return
+// door opens, and a module that threw was never on the table. A control
+// shaped so that it cannot reach the case it is named for is worse than an
+// absent one, because its green is spent.
+//
+// Section 4 is that door. It matters more than the return door rather than
+// less, for a reason worth stating plainly: RETURNING a payload is a
+// module doing something unusual, while THROWING an Error built from the
+// value being processed is what every renderer already does — React names
+// the property that was undefined, a validation error quotes the input, a
+// template error interpolates the row. So the leak on this side does not
+// need a module that reaches for a second channel; it needs a module that
+// has an ordinary bug. And `error.code` is the second half: it is a bare
+// property on an ordinary `Error`, `statusFor` maps it to an HTTP status,
+// so an application render fault could present itself as a 400 the caller
+// blames itself for, a 503 a retry policy sleeps on, or a 504.
+//
 // ## EVERY ROW HAS A CONTROL, AND THE CONTROLS ARE ORDINARY ROWS
 //
 // The suite-wide discipline (see the package README) applies here with
@@ -60,10 +84,16 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const { withService, collect, refusalOf, post } = require('./_support.cjs');
-const { CODE, COMPLETE_FIELDS, MODULE_RETURN_REFUSAL } = require('../src/protocol.cjs');
-const { serve } = require('../src/http.cjs');
+const {
+  CODE,
+  COMPLETE_FIELDS,
+  MODULE_RETURN_REFUSAL,
+  RENDER_THREW_REFUSAL,
+} = require('../src/protocol.cjs');
+const { serve, statusFor } = require('../src/http.cjs');
 const LEAKY = require('./fixtures/leaky.cjs');
 const NULL_RETURN = require('./fixtures/null-return.cjs');
+const THROWS_DATA = require('./fixtures/throws-data.cjs');
 
 // ---------------------------------------------------------------------------
 // The two checkers. Both are ordinary functions so a control can feed them
@@ -308,10 +338,17 @@ test('a render module that returns a value is REFUSED, not silently dropped', as
   });
 });
 
-test('the refusal does not carry the payload out through the error channel', async () => {
+test('the RETURN refusal does not carry the payload out through the error channel', async () => {
   // The subtle re-run of the same leak: a diagnostic that echoed what the
   // module tried to return would be the identical egress wearing a
   // different frame type, and it would look like helpfulness.
+  //
+  // SCOPE, because this row's name used to overstate it. The fixture is
+  // `leaky`, which RETURNS — so what is checked here is the error channel
+  // as the RETURN door opens it, and a thrown Error's `code`, `message`
+  // and `detail` are a different path through the same channel that no row
+  // in this file reached. Section 4 is that path; this row is now half of
+  // a pair rather than the whole claim it was written as.
   await withService('leaky', { isolates: 1 }, async (service) => {
     const err = await refusalOf(() =>
       collect(service, { protocol: 1, entry: 'app/root', state: { ':todos': '"secret-state-3ab1"' } }),
@@ -370,5 +407,220 @@ test('a well-behaved module returns nothing, and the service is fine with that',
     const { chunks, complete } = await collect(service, req());
     assert.strictEqual(chunks.length, 1);
     assert.strictEqual(complete.type, 'complete');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The OTHER door — a render module that THROWS
+//
+// See the header. Everything above drives a module that returns; these
+// rows drive one that throws, which is the ordinary way a renderer fails
+// and was the open half of the response law.
+// ---------------------------------------------------------------------------
+
+// One sentinel per live field of the thrown Error, each arriving as a
+// separate allowlisted state key so a green scan cannot be one field's
+// accident. Distinctive on purpose, for the reason `SENTINELS` gives.
+const THROW_STATE = {
+  ':for-code': '"rf2-c38b-code-1e4a77"',
+  ':for-message': '"rf2-c38b-message-8b30d2"',
+  ':for-detail': '"rf2-c38b-detail-c519f0"',
+};
+const THROW_SENTINELS = [
+  'rf2-c38b-code-1e4a77',
+  'rf2-c38b-message-8b30d2',
+  'rf2-c38b-detail-c519f0',
+];
+
+const throwReq = (entry) => ({ protocol: 1, entry, state: THROW_STATE });
+
+/**
+ * Everything a caller of the in-process API can read off a refusal, as one
+ * scannable frame plus the stack separately.
+ *
+ * `toFrame` is the wire shape, so scanning it is scanning what a transport
+ * would serialise; it is fed to `scanForEgress` rather than to a second
+ * hand-rolled scanner, so the control at the top of section 2 covers this
+ * section too. `stack` is checked alongside because it is a string a
+ * caller can reach on the `Error` even though no frame carries it — and a
+ * service-owned message is what keeps it clean, since `Error`'s stack
+ * opens with the message.
+ */
+const refusalLeaks = (err) => [
+  ...scanForEgress([err.toFrame('corr-throw')], THROW_SENTINELS),
+  ...THROW_SENTINELS.filter((s) => (err.stack ?? '').includes(s)).map((s) => ({
+    type: 'stack',
+    sentinel: s,
+    in: err.stack,
+  })),
+];
+
+test('CONTROL — the throwing fixture really does put all three sentinels on the Error', () => {
+  // In-process, with no service in the way, and for exactly the reason the
+  // leaky control exists: three absence checks below are only measurements
+  // if the three values were genuinely on the Error to begin with. A
+  // fixture that had drifted into throwing a bare `new Error('boom')` would
+  // satisfy every assertion in this section and prove nothing at all.
+  let thrown = null;
+  try {
+    THROWS_DATA.render({ entry: 'app/plain', state: THROW_STATE }, () => {});
+  } catch (err) {
+    thrown = err;
+  }
+  assert.ok(thrown, 'the fixture must actually throw');
+  assert.ok(thrown.message.includes(THROW_SENTINELS[1]), 'message carries its sentinel');
+  assert.ok(String(thrown.code).includes(THROW_SENTINELS[0]), 'code carries its sentinel');
+  assert.ok(thrown.detail.echoed.includes(THROW_SENTINELS[2]), 'detail carries its sentinel');
+  assert.ok(
+    thrown.detail.nested.deeper.includes(THROW_SENTINELS[2]),
+    'and it is NESTED, so a shallow scan would miss it',
+  );
+
+  // The three really are distinct, or one leak could pass for another.
+  assert.strictEqual(new Set(THROW_SENTINELS).size, 3);
+});
+
+test('CONTROL — the spoofed codes really are members of the refusal family', () => {
+  // Without this row the status-spoof row below could go vacuous in the
+  // quietest possible way: rename a member of `CODE`, and the fixture's
+  // hard-coded strings become codes the service has never heard of, which
+  // `statusFor` maps to 500 all on its own. The row would still be green
+  // and would no longer be testing a spoof.
+  const members = new Set(Object.values(CODE));
+  for (const [entry, code] of Object.entries(THROWS_DATA.SPOOFED_CODE)) {
+    assert.ok(members.has(code), `${entry} spoofs ${code}, which is no longer a real code`);
+    assert.notStrictEqual(
+      statusFor(code),
+      statusFor(CODE.RENDER_THREW),
+      `${code} must map to a DIFFERENT status than render-threw, or there is nothing to spoof`,
+    );
+  }
+  assert.strictEqual(Object.keys(THROWS_DATA.SPOOFED_CODE).length, 3, '400, 503 and 504');
+});
+
+test('a render that THROWS is refused with service-owned wording, carrying nothing it authored', async () => {
+  await withService('throws-data', { isolates: 1 }, async (service) => {
+    const err = await refusalOf(() => collect(service, throwReq('app/plain')));
+    assert.ok(err, 'a throw must refuse');
+
+    assert.strictEqual(err.code, CODE.RENDER_THREW, 'the documented code, not the module’s');
+    assert.strictEqual(err.message, RENDER_THREW_REFUSAL, 'the contract owns the wording');
+    assert.deepStrictEqual(
+      Object.keys(err.detail).sort(),
+      ['afterChunks', 'entry'],
+      'the detail is service-owned: the entry the caller named, and the tear count',
+    );
+    assert.strictEqual(err.detail.entry, 'app/plain');
+    assert.strictEqual(err.detail.afterChunks, 0, 'nothing was written, so nothing is torn');
+
+    assert.deepStrictEqual(
+      refusalLeaks(err),
+      [],
+      'the module’s exception reached the public refusal',
+    );
+  });
+});
+
+test('a THROW after emitting is still a torn response, and still carries nothing', async () => {
+  // The pre-emit row above is the clean refusal; this is the other half,
+  // and closing the leak must not have cost the tear. A `detail` rebuilt
+  // by the service is exactly where `afterChunks` could quietly go missing.
+  await withService('throws-data', { isolates: 1 }, async (service) => {
+    const chunks = [];
+    const err = await refusalOf(async () => {
+      for await (const frame of service.renderFrames(throwReq('app/torn'))) {
+        if (frame.type === 'chunk') chunks.push(frame.html);
+      }
+    });
+    assert.deepStrictEqual(chunks, ['<p>first</p>'], 'the bytes really did leave');
+    assert.strictEqual(err.code, CODE.RENDER_THREW);
+    assert.strictEqual(err.message, RENDER_THREW_REFUSAL);
+    assert.strictEqual(err.detail.afterChunks, 1, 'the tear is still named, with its count');
+    assert.deepStrictEqual(refusalLeaks(err), []);
+  });
+});
+
+test('a thrown `code` cannot choose the refusal code, in-process', async () => {
+  // The taxonomy is closed and it is the SERVICE's. A module that types
+  // `err.code = ':rf.ssr-node/service-saturated'` is describing its own
+  // failure in this service's vocabulary; believing it turns an
+  // application bug into a lie about whose fault the failure was.
+  await withService('throws-data', { isolates: 1 }, async (service) => {
+    for (const entry of Object.keys(THROWS_DATA.SPOOFED_CODE)) {
+      const err = await refusalOf(() => collect(service, throwReq(entry)));
+      assert.strictEqual(err.code, CODE.RENDER_THREW, `${entry} spoofed the refusal code`);
+      assert.strictEqual(err.message, RENDER_THREW_REFUSAL);
+      assert.deepStrictEqual(refusalLeaks(err), [], `${entry} leaked`);
+    }
+    // …and the invented-code entry, which is the same fault with no
+    // plausible deniability: a code that is not in the family at all.
+    const invented = await refusalOf(() => collect(service, throwReq('app/plain')));
+    assert.strictEqual(invented.code, CODE.RENDER_THREW);
+  });
+});
+
+test('and it cannot choose the HTTP status either — every throw is a 500', async () => {
+  // The corollary over the transport, and the arm with the operational
+  // teeth: `statusFor` reads the refusal code, so a spoofed 400 tells a
+  // JVM host "your request was bad" about a fault that was entirely ours,
+  // a 503 puts a retry policy to sleep, and a 504 blames a deadline.
+  await withService('throws-data', { isolates: 1 }, async (service) => {
+    const http = await serve({ service, port: 0 });
+    try {
+      const entries = ['app/plain', ...Object.keys(THROWS_DATA.SPOOFED_CODE)];
+      for (const entry of entries) {
+        const res = await post(`http://127.0.0.1:${http.port}/render`, throwReq(entry));
+        assert.strictEqual(res.status, 500, `${entry} chose its own HTTP status`);
+        assert.strictEqual(
+          res.headers.get('x-rf-ssr-refusal'),
+          CODE.RENDER_THREW,
+          `${entry} chose its own refusal header`,
+        );
+
+        const headers = JSON.stringify(Object.fromEntries(res.headers.entries()));
+        for (const s of THROW_SENTINELS) {
+          assert.ok(!res.text.includes(s), `${entry} leaked ${s} into the JSON body`);
+          assert.ok(!headers.includes(s), `${entry} leaked ${s} into a header`);
+        }
+        assert.ok(
+          JSON.parse(res.text).message === RENDER_THREW_REFUSAL,
+          'the body carries the contract’s wording',
+        );
+      }
+    } finally {
+      await http.close();
+    }
+  });
+});
+
+test('a streaming response torn by a throw is DESTROYED, not completed', async () => {
+  // The post-emit arm over the transport. Headers are already sent, so
+  // there is no status left to send and `sendRefusal` destroys the socket:
+  // the caller must see a broken transfer rather than a well-formed
+  // shorter page it would cache and serve. `fetch` surfaces that as a
+  // rejected body read, which is the observation this row makes.
+  await withService('throws-data', { isolates: 1 }, async (service) => {
+    const http = await serve({ service, port: 0 });
+    try {
+      const res = await fetch(`http://127.0.0.1:${http.port}/render?stream=1`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(throwReq('app/torn')),
+      });
+      // The first chunk really did go out under a 200 — that is what makes
+      // the tear a tear rather than a refusal.
+      assert.strictEqual(res.status, 200);
+      const read = await res.text().then(
+        (text) => ({ ok: true, text }),
+        (err) => ({ ok: false, err }),
+      );
+      assert.strictEqual(read.ok, false, 'a torn stream must not read as a complete body');
+      assert.ok(
+        !String(read.err).includes(THROW_SENTINELS[1]),
+        'not even the transport error may carry the module’s wording',
+      );
+    } finally {
+      await http.close();
+    }
   });
 });

--- a/implementation/ssr-node/test/fixtures/throws-data.cjs
+++ b/implementation/ssr-node/test/fixtures/throws-data.cjs
@@ -1,0 +1,68 @@
+'use strict';
+// A render that throws an Error BUILT FROM THE DATA IT WAS HANDED, which
+// is the ordinary shape of a renderer exception rather than an exotic one.
+//
+// `throws.cjs` is the well-behaved thrower: its messages are constants, so
+// it can witness that a throw refuses and that a post-emit throw tears,
+// but it cannot witness what a refusal CARRIES. Every real renderer
+// exception is the other shape — `Cannot read properties of undefined`
+// names the property, a validation error quotes the value, a template
+// error interpolates the row it was rendering. So the interesting question
+// is not whether a module CAN put request state on an Error; it is that
+// doing so is the normal case, and the boundary has to hold anyway.
+//
+// Three sentinels, one per live field, each sourced from a DIFFERENT
+// allowlisted state key, so a green scan cannot be one field's accident:
+//
+//   `:for-code`     → `error.code`     — the field that selects the HTTP status
+//   `:for-message`  → `error.message`  — the field a diagnostic reaches for first
+//   `:for-detail`   → `error.detail`   — nested, because a shallow scan is not one
+//
+// The `app/as-*` entries do the second half: instead of an invented code
+// they set a code that is a REAL member of this service's closed refusal
+// family, which is the arm where nothing looks wrong at all — the refusal
+// is well-formed, the status is a plausible one, and it is a lie about
+// whose fault the failure was. The literals are spelled out here rather
+// than required from `../../src/protocol.cjs` on purpose: an application
+// bundle does not import the service's protocol module, and a spoof
+// written the way an application would write it is the one worth testing.
+// `egress.test.cjs` asserts they really are members, so the row cannot go
+// vacuous if the family is renamed.
+
+const SPOOFED_CODE = Object.freeze({
+  'app/as-caller-fault': ':rf.ssr-node/unknown-entry', // 400 — "the caller asked for a bad entry"
+  'app/as-saturated': ':rf.ssr-node/service-saturated', // 503 — "retry, we are busy"
+  'app/as-deadline': ':rf.ssr-node/render-timeout', // 504 — "it ran too long"
+});
+
+const ENTRY = {
+  stateAllowlist: [':for-code', ':for-message', ':for-detail'],
+  runtimeAllowlist: [],
+};
+
+module.exports = {
+  protocol: 1,
+  buildId: 'throws-data-build-1',
+  entries: {
+    'app/plain': ENTRY, // throws before emitting; invented code
+    'app/torn': ENTRY, // emits, THEN throws — the torn response
+    'app/as-caller-fault': ENTRY,
+    'app/as-saturated': ENTRY,
+    'app/as-deadline': ENTRY,
+  },
+
+  SPOOFED_CODE,
+
+  render({ entry, state }, emit) {
+    if (entry === 'app/torn') emit('<p>first</p>');
+    const err = new Error(`render failed while handling ${state[':for-message']}`);
+    // `code` is a bare property on an ordinary `Error` — nothing stops a
+    // module setting it, and a module that has its own error taxonomy will.
+    err.code = SPOOFED_CODE[entry] ?? state[':for-code'];
+    err.detail = {
+      echoed: state[':for-detail'],
+      nested: { deeper: state[':for-detail'] },
+    };
+    throw err;
+  },
+};

--- a/implementation/ssr-node/test/timeout.test.cjs
+++ b/implementation/ssr-node/test/timeout.test.cjs
@@ -19,7 +19,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const { withService, collect, observed, refusalOf } = require('./_support.cjs');
-const { CODE } = require('../src/protocol.cjs');
+const { CODE, RENDER_THREW_REFUSAL } = require('../src/protocol.cjs');
 
 const hang = (extra = {}) => ({ protocol: 1, entry: 'app/root', state: {}, ...extra });
 const quick = () => ({ protocol: 1, entry: 'app/quick', state: {} });
@@ -93,7 +93,18 @@ test('a render that throws BEFORE emitting is a clean refusal', async () => {
       collect(service, { protocol: 1, entry: 'app/before', state: {} }),
     );
     assert.strictEqual(err.code, CODE.RENDER_THREW);
-    assert.match(err.message, /fell over immediately/);
+    // The wording is the CONTRACT'S, not the module's. This row asserted
+    // `/fell over immediately/` — the exact string authored at
+    // `fixtures/throws.cjs:20` — which made it a standing witness that the
+    // module's own message crossed into the public refusal. That was the
+    // leak rather than a feature of it: an exception's message is built
+    // from the value being processed in any real renderer, so the string
+    // this row was pinning is the shape request state travels in. The
+    // operator still gets the original, with its stack, on the sidecar's
+    // stderr; `egress.test.cjs` §4 is where the absence is measured with
+    // planted sentinels.
+    assert.strictEqual(err.message, RENDER_THREW_REFUSAL);
+    assert.ok(!err.message.includes('fell over immediately'), 'the authored string must not cross');
     assert.strictEqual(err.detail.afterChunks, 0, 'nothing was written, so nothing is torn');
   });
 });


### PR DESCRIPTION
Closes rf2-c38b.

A render module leaves the isolate by **returning** or by **throwing**. The response law — *Node returns body markup and nothing else* — was enforced on the first door only. The catch beside the egress door copied `err.code`, `err.message` and `err.detail` straight onto the protocol; `isolate.cjs` preserved the code/message and spread the detail into the public `Refusal`; `http.cjs` serialised that to JSON with `statusFor` reading the copied code.

Reproduced before editing, with a render module whose `Error` was built from allowlisted request state:

```
in-process Refusal: {"code":":rf.ssr-node/render-threw",
  "message":"message:\"state-secret-7b2\"",
  "detail":{"echo":"\"state-secret-7b2\"","nested":{"deep":"detail:\"state-secret-7b2\""},"afterChunks":0}}

HTTP app/plain: 500  x-rf-ssr-refusal=:rf.ssr-node/render-threw   leaks=true
HTTP app/spoof: 400  x-rf-ssr-refusal=:rf.ssr-node/unknown-entry  leaks=true   ← status spoofed
```

The checked-in `test/fixtures/throws.cjs` supplied the same thing with no synthetic file: `POST app/before` returned HTTP 500 carrying `"fell over immediately"`, the exact authored string.

## What changed

**The exception door now obeys the same law as the return door.** `worker.cjs`'s render catch posts one code (`:rf.ssr-node/render-threw`), the contract's own wording, and a `detail` the file builds — `entry` (the caller's own identifier, on the same reasoning `requestId` gets on the `complete` frame) plus the counted `afterChunks`. No application-authored property crosses.

**A second, independent reading where the public `Refusal` is built.** `isolate.cjs`'s `complete` branch already states the discipline — *"two independent readings of the same property, which is what makes it a boundary rather than a habit"* — and its `error` branch had one. It now refuses any code the closed family does not contain, so nothing but a published member can reach `statusFor`. The two readings are genuinely complementary rather than belt-and-braces, and the negative controls below show it: the worker's fix is what catches a spoof of a **real** member, and the isolate's membership check is what catches an **invented** code string.

**Diagnosis is preserved, not traded away.** The full exception, with its stack, goes to the sidecar's stderr under the `[rf.ssr-node]` prefix `bin/serve.cjs` already writes — a worker thread's stderr is piped to the parent's. Two audiences, two channels, no new subsystem and no flag. The gate log carries 15 such lines, so the channel is demonstrably live.

**The control that could not reach its own case is replaced.** The egress row named *"the refusal does not carry the payload out through the error channel"* drove the `leaky` fixture, which **returns** — so the error channel it checked was the one the return door opens, and a throwing module was never on the table. It is renamed to its real scope (`the RETURN refusal…`) and a new §4 drives a module that throws.

Boot-error handling is deliberately untouched (`worker.cjs:120` still reads `err.code ?? CODE.MALFORMED_MODULE`): the bead's non-goals fence it off, since boot fails before the service listens and has different operator-diagnostic needs.

## Red, then green

The new rows were written first and run against the unfixed implementation — 20 rows, **16 pass / 4 fail**, with the two new CONTROL rows among the passes (so the sentinels were provably on the Error and the spoofed codes provably real members before any absence was believed):

```
✖ a render that THROWS is refused with service-owned wording…   actual: '"rf2-c38b-code-1e4a77"'
✖ a THROW after emitting is still a torn response…              actual: '"rf2-c38b-code-1e4a77"'
✖ a thrown `code` cannot choose the refusal code, in-process     actual: ':rf.ssr-node/unknown-entry'
✖ and it cannot choose the HTTP status either — every throw is a 500
```

**Negative controls after the fix.** Each pass-through was restored in turn and the suite re-run; every restore was verified by hashing the file's bytes back to its baseline (`3a3d9ff127f1`), not by reading a diff.

| restored | egress exit | rows reddened |
|---|---|---|
| `code: err.code ?? …` | 1 | the two status/code rows |
| `message: err.message ?? …` | 1 | all four |
| `detail: {…, ...(err.detail ?? {})}` | 1 | all four |

## Quality gates

| gate | command | exit | result |
|---|---|---|---|
| ssr-node package suite | `node implementation/ssr-node/test/run.cjs` | **0** | **115 rows / 9 suites, all green** (baseline before this change: 108 / 9) |
| README/source-adjacent links | `python scripts/check_readme_links.py --ci` | **0** | green — the gate whose surface covers `implementation/**/README.md` |

The runner prints its own root, and it printed this branch's worktree on every run.

**Skipped, with reason:** the whole-repo spine (`scripts/test-fast-pr.sh`) and every other repo-wide gate — five sibling workers were live in parallel worktrees, and a gate heavy enough that two cannot coexist wedges rather than fails. **CI owns the full spine for this PR.** No CLJS/JVM artefact is touched: the change is confined to a dependency-free CommonJS package, so nothing outside `implementation/ssr-node/**` is in the diff.

`mkdocs build --strict` is not nominated: `docs_dir` is `docs`, so `implementation/**` was never a candidate for it.

## Fence

`implementation/ssr-node/**` only — seven files, all inside it. No hot-zone file is touched (`spec/Conventions.md`, `spec/API.md`, `implementation/shadow-cljs.edn`, `.github/workflows/*` are all untouched), and no change was needed on the JVM side: the `ssr-ring` host's projection is downstream defence and this repairs the Node service's own in-process and HTTP contracts, which is exactly the split rf2-c38b and rf2-9guv were fenced along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
