### PR TITLE
fix(examples): routing schema comment boundary (rf2-51in) and resources-ssr client acquisition coverage (rf2-h3c9)

### DIFF
--- a/examples/capabilities/routing/routing/core.cljs
+++ b/examples/capabilities/routing/routing/core.cljs
@@ -46,12 +46,16 @@
 (rf/reg-route :routing.app/articles
   {:doc  "Articles list."} "/articles")
 
-;; A route may also carry `:params` / `:query` Malli schemas. They are worth
-;; knowing about, but they only *do* anything in an app that loads
-;; `re-frame.schemas` — that require is what wires the validator. This example
-;; stays schemas-free, so it declares none: a schema here would read like a
-;; contract and enforce nothing. `:id` arrives as the string the URL held.
-;; See the schemas guide:
+;; A route may also carry `:params` / `:query` Malli schemas, and they do two
+;; jobs that are worth keeping apart. Coercion always happens: `reg-route`
+;; compiles the schema into a coercion table, so `:params [:map [:id :int]]`
+;; hands the page the number 42 rather than the string "42", schemas artefact
+;; or not. Enforcement is the half that late-binds — a value the schema
+;; rejects is only *refused* in an app that requires `re-frame.schemas`, the
+;; require that wires the validator. Without it a bad value simply passes
+;; through uncoerced and the declared contract goes unchecked. This example
+;; stays schemas-free, so it declares neither schema and `:id` arrives as the
+;; string the URL held. See the schemas guide:
 ;; ../../../../docs/core/how-to/validate-with-schemas.md
 (rf/reg-route :routing.app/article-detail
   {:doc  "Detail page for one article."} "/articles/:id")

--- a/examples/capabilities/ssr/resources_ssr/README.md
+++ b/examples/capabilities/ssr/resources_ssr/README.md
@@ -122,13 +122,20 @@ per-request, and the wire payload stays minimal.
   for you. This page is deliberately route-free — the simplest SSR shape
   there is — so it uses the framework's other answer, the app-minted event
   owner ([Spec 016 §The scoped-cache owner
-  lifecycle](../../../../spec/016-Resources.md)), and owns the matching
-  `:resources-ssr.app/page-closed` release to go with it. Both halves
-  matter. An owner nobody releases pins its entry alive forever; an entry
-  nobody owns is renderable but inert — tag invalidation and
-  focus/reconnect revalidation pass it by, and no GC clock runs. Taking the
-  hold is what makes the hydrated cache a live cache rather than a picture
-  of one.
+  lifecycle](../../../../spec/016-Resources.md)). Taking the hold is what
+  makes the hydrated cache a live cache rather than a picture of one: an
+  entry nobody owns is renderable but inert — tag invalidation and
+  focus/reconnect revalidation pass it by, and no GC clock runs.
+
+  The matching `:resources-ssr.app/page-closed` release is registered here
+  too, and it is worth reading, but nothing in this demo dispatches it —
+  the page is the whole app, so its lifetime is its frame's, and the entry
+  it would release lives in that frame's runtime-db and goes when the frame
+  does. Copy it, though, and the pairing stops being optional the moment
+  the page can be unmounted while the frame lives on: an app-minted owner
+  is never auto-released, so an unreleased one pins its entry for as long
+  as the cache exists. A routed app never writes either half — route leave
+  drops the route owner for you.
 
 - Scope is a wall hydration may never cross. The resource declares
   `:scope :rf.scope/global` — the auditable claim that this article list

--- a/examples/capabilities/ssr/resources_ssr/core.cljc
+++ b/examples/capabilities/ssr/resources_ssr/core.cljc
@@ -214,12 +214,17 @@
                        :cause    [:event :resources-ssr.app/page-opened]}]]]}))
 
 (rf/reg-event :resources-ssr.app/page-closed
-  {:doc       "The matching release, and it is not optional: whatever mints an
-               owner must also drop it, or the entry is pinned alive forever and
-               the cache never GCs. This demo is a single page whose lifetime is
-               its frame's, so nothing here dispatches it — a page that can be
-               unmounted dispatches it on the way out, and a routed app gets the
-               equivalent for free when route-leave releases the route owner."
+  {:doc       "The matching release. NOTHING IN THIS DEMO DISPATCHES IT, and the
+               reason is the boundary rather than an oversight: this page is the
+               whole app, so its lifetime is its frame's, and the entry it would
+               release lives in that frame's runtime-db — destroy the frame and
+               the cache goes with it, leaving no longer-lived cache for an
+               unreleased owner to pin. Read it as the half you WILL need. The
+               framework never auto-releases an app-minted owner, so the moment a
+               page can be unmounted while its frame lives on, the pairing stops
+               being optional: dispatch this on the way out or the entry is
+               pinned alive and never GCs. A routed app writes neither half —
+               route leave drops the route owner for you."
    :platforms #{:client}}
   (fn [_ _]
     {:fx [[:dispatch [:rf.resource/release-owner {:owner page-owner}]]]}))

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -847,6 +847,252 @@
                 "the client cache keys the installed entry on the byte key-id")))))))
 
 ;; ============================================================================
+;; resources-ssr — THE CLIENT BOOT SEAM (rf2-h3c9)
+;; ============================================================================
+;;
+;; The two tests above stop at `rf.ssr/hydrate!`. Hydration is a state install
+;; and a classification: it reconciles the payload, DROPS the completed
+;; request's `[:ssr …]` owner, and issues nothing. Everything the example
+;; claims about liveness therefore rests on the beat that follows it — the
+;; `:resources-ssr.app/page-opened` acquisition `run` dispatch-syncs after the
+;; hydrate and before the first render. That beat had no test at all, so its
+;; four load-bearing claims (owner attachment, request counts, first-paint
+;; state, and the release that ends the hold) were asserted in prose only.
+;;
+;; The example's `run` is `:cljs`-only, so these tests drive the same seam a
+;; beat lower: the example's OWN registered events against the example's OWN
+;; `app-frame`, in `run`'s order. Everything under test is the example's
+;; production source — the example tree stays test-free (rf2-8cevm).
+;;
+;; The discriminator throughout is Spec 016 §Invalidation's owner rule:
+;; invalidation refetches a matched entry that has ACTIVE OWNERS and leaves a
+;; matched OWNERLESS entry merely stale. So "the client owner is live" is not
+;; asserted by reading a set — it is proved by the request the cache does or
+;; does not make, in both directions.
+
+(def ^:private resources-ssr-articles
+  [{:slug "welcome"   :title "Welcome to re-frame2"}
+   {:slug "resources" :title "Server-state as resources"}])
+
+(def ^:private resources-ssr-key
+  "The example's one scoped resource key — `:articles/list` at global scope,
+  no params. Spec 016 §Resource identity."
+  [:rf.scope/global :articles/list {}])
+
+(defn- resources-ssr-entry
+  "The example's ONE cache entry, read out of `frame`'s runtime-db."
+  [frame]
+  (get-in (:rf.db/runtime (rf/frame-state-value frame))
+          (rf.resources.state/entry-path resources-ssr-key)))
+
+(defn- resources-ssr-owners
+  "The entry's active-owner set (empty when the entry is absent)."
+  [frame]
+  (set (:active-owners (resources-ssr-entry frame))))
+
+(defn- resources-ssr-html
+  "Render the example's own root view through `frame` — the first client paint."
+  [frame]
+  (rf/with-frame frame (rf/render-to-string ((rf/view :app/root)) {})))
+
+(defn- reg-counting-transport!
+  "Register a managed-HTTP stand-in under `fx-id` that COUNTS every request the
+  resource runtime lowers, and — when `reply?` — settles it with the canned
+  articles through the framework's own canned-success stub. Returns the counter
+  atom. A counter is the only honest way to assert `ensure`'s fresh-skip: the
+  refetch PLAN being empty says what hydration classified, not what the
+  acquisition afterwards did or didn't send."
+  [fx-id {:keys [reply?]}]
+  (let [calls (atom 0)]
+    (rf/reg-fx fx-id
+      {:platforms #{:server :client}}
+      (fn [frame-ctx args-map]
+        (swap! calls inc)
+        (when reply?
+          (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-success)]
+            (stub frame-ctx (assoc args-map :value resources-ssr-articles))))))
+    calls))
+
+(defn- resources-ssr-client-frame!
+  "The example's own client app-frame, with `:rf.http/managed` redirected at the
+  counting stand-in. `:platform :client` is what makes this the browser seam
+  rather than a second server render."
+  [fx-id]
+  (let [fid @(resolve 'resources-ssr.core/app-frame)]
+    (rf/make-frame {:id           fid
+                    :doc          "resources-ssr client boot seam"
+                    :platform     :client
+                    :fx-overrides {:rf.http/managed fx-id}})
+    fid))
+
+(defn- resources-ssr-static-payload
+  "The `__rf_payload` EDN baked into the SHIPPED `index.html` — the same
+  forever-fresh entry a reader opening the file offline hydrates from."
+  []
+  (some-> (io/resource "resources_ssr/index.html")
+          slurp
+          (->> (re-find #"(?s)id=\"__rf_payload\" type=\"application/edn\">(.*?)</script>"))
+          second
+          edn/read-string))
+
+(deftest resources-ssr-example-cold-client-boot-acquires-and-first-paints-loading
+  (testing "examples/capabilities/ssr/resources_ssr — a plain client-only load
+            with NO `__rf_payload` (nothing to hydrate). The
+            `:resources-ssr.app/page-opened` acquisition issues EXACTLY ONE
+            managed-HTTP request under the page's app-minted owner, and the
+            first paint is the `:loading` skeleton — NOT the empty `<ul>` an
+            absent entry projects as `:idle`, which reads as a successful answer
+            of zero articles. rf2-h3c9."
+    (require 'resources-ssr.core :reload)
+    (rf/init! rf.ssr/adapter)
+    (let [calls (reg-counting-transport! :resources-ssr-test/pending {:reply? false})
+          fid   (resources-ssr-client-frame! :resources-ssr-test/pending)
+          owner @(resolve 'resources-ssr.core/page-owner)]
+      ;; BEFORE — nothing hydrated, so there is no entry and nothing has fetched.
+      (is (nil? (resources-ssr-entry fid))
+          "a cold client boot starts with no cache entry at all")
+      (is (zero? @calls) "and with no request issued")
+      (is (clojure.string/includes? (resources-ssr-html fid) "articles-list")
+          "the absent entry projects :idle — an EMPTY <ul>, the false empty-success
+           first paint this acquisition exists to prevent")
+      ;; ACQUIRE — `run`'s second beat, dispatch-sync so the ensure drains.
+      (rf/dispatch-sync [:resources-ssr.app/page-opened] {:frame fid})
+      (is (= 1 @calls)
+          "the acquisition issued EXACTLY ONE managed-HTTP request (not zero, not two)")
+      (is (contains? (resources-ssr-owners fid) owner)
+          "the entry is held by the page's app-minted owner [:resources-ssr.app/page-opened]")
+      (is (= :loading (:status (rf/resource-state {:resource :articles/list
+                                                   :scope    :rf.scope/global
+                                                   :params   {}
+                                                   :frame    fid})))
+          "the public read projects :loading while that one request is in flight")
+      ;; AFTER — the first paint the reader actually sees.
+      (let [html (resources-ssr-html fid)]
+        (is (clojure.string/includes? html "articles-skeleton")
+            "first paint is the loading skeleton")
+        (is (not (clojure.string/includes? html "articles-list"))
+            "and NOT an empty <ul> that looks like a successful empty answer")))))
+
+(deftest resources-ssr-example-fresh-hydrated-boot-takes-the-hold-without-refetching
+  (testing "examples/capabilities/ssr/resources_ssr — the ACTUAL checked-in
+            forever-fresh `index.html` payload. Hydration leaves a renderable
+            but OWNERLESS entry (the `[:ssr …]` owner belonged to the finished
+            server request); the acquisition then takes `ensure`'s fresh-skip
+            cache-hit path — it attaches the page owner and issues ZERO
+            requests, and the server's markup still paints. rf2-h3c9."
+    (require 'resources-ssr.core :reload)
+    (rf/init! rf.ssr/adapter)
+    (let [calls   (reg-counting-transport! :resources-ssr-test/canned {:reply? true})
+          fid     (resources-ssr-client-frame! :resources-ssr-test/canned)
+          owner   @(resolve 'resources-ssr.core/page-owner)
+          payload (resources-ssr-static-payload)]
+      (is (some? payload) "the checked-in index.html payload parsed")
+      (rf.ssr/hydrate! {:frame fid :payload payload})
+      ;; BEFORE — the gap this example exists to close: loaded, and held by nothing.
+      (is (= :loaded (:status (resources-ssr-entry fid)))
+          "hydration installed the server's entry :loaded")
+      (is (empty? (resources-ssr-owners fid))
+          "and OWNERLESS — the reconcile dropped the completed request's [:ssr …] owner")
+      (is (zero? @calls) "hydration itself issued nothing")
+      ;; ACQUIRE — the fresh-skip cache hit.
+      (rf/dispatch-sync [:resources-ssr.app/page-opened] {:frame fid})
+      (is (zero? @calls)
+          "a FRESH hydrated entry fresh-skips: the acquisition sent NO request
+           (this is the whole payoff of preloading — no double-fetch)")
+      (is (contains? (resources-ssr-owners fid) owner)
+          "and the page owner is now attached, so the entry is a live consumer")
+      (is (= :loaded (:status (resources-ssr-entry fid)))
+          "the entry stayed :loaded — nothing was disturbed")
+      ;; AFTER — first paint still adopts the server's data.
+      (let [html (resources-ssr-html fid)]
+        (is (clojure.string/includes? html "Welcome to re-frame2"))
+        (is (clojure.string/includes? html "Server-state as resources")
+            "the acquisition did not disturb the markup the server rendered")))))
+
+(deftest resources-ssr-example-stale-hydrated-boot-keeps-data-and-issues-one-request
+  (testing "examples/capabilities/ssr/resources_ssr — a STALE hydrated entry.
+            Invalidating the `[:article-list]` tag BEFORE the acquisition stales
+            the entry while it is still ownerless, which issues nothing (Spec 016
+            §Invalidation leaves a matched OWNERLESS entry stale rather than
+            refetching it — the counterfactual that makes the owner assertions
+            elsewhere mean something). The acquisition then issues EXACTLY ONE
+            background request while the last-known-good data stays visible.
+            rf2-h3c9."
+    (require 'resources-ssr.core :reload)
+    (rf/init! rf.ssr/adapter)
+    (let [calls   (reg-counting-transport! :resources-ssr-test/canned {:reply? true})
+          fid     (resources-ssr-client-frame! :resources-ssr-test/canned)
+          owner   @(resolve 'resources-ssr.core/page-owner)
+          payload (resources-ssr-static-payload)]
+      (rf.ssr/hydrate! {:frame fid :payload payload})
+      ;; STALE IT — and prove an ownerless entry refetches nothing.
+      (rf/dispatch-sync [:rf.resource/invalidate-tags
+                         {:scope :rf.scope/global
+                          :tags  #{[:article-list]}
+                          :cause [:test :resources-ssr/stale-fixture]}]
+                        {:frame fid})
+      (is (zero? @calls)
+          "an OWNERLESS stale entry issues NOTHING — hydration alone never
+           re-establishes liveness, which is exactly the defect rf2-h3c9 names")
+      (is (empty? (resources-ssr-owners fid))
+          "still held by nothing")
+      (is (clojure.string/includes? (resources-ssr-html fid) "Welcome to re-frame2")
+          "stale data stays renderable — last-known-good, not blanked")
+      ;; ACQUIRE — one background request, data still on screen.
+      (rf/dispatch-sync [:resources-ssr.app/page-opened] {:frame fid})
+      (is (= 1 @calls)
+          "the acquisition on a STALE entry issues EXACTLY ONE request")
+      (is (contains? (resources-ssr-owners fid) owner)
+          "under the page's app-minted owner")
+      (let [html (resources-ssr-html fid)]
+        (is (not (clojure.string/includes? html "articles-skeleton"))
+            "a stale refresh shows no skeleton — the entry had data all along")
+        (is (clojure.string/includes? html "Welcome to re-frame2")
+            "and the last-known-good articles stayed on screen throughout")))))
+
+(deftest resources-ssr-example-page-closed-releases-the-hold-the-acquisition-took
+  (testing "examples/capabilities/ssr/resources_ssr — the release half.
+            `:resources-ssr.app/page-closed` is the matching drop for the owner
+            `:resources-ssr.app/page-opened` mints; the framework never
+            auto-releases an app-minted owner. Liveness is proved by request
+            behaviour in BOTH directions: while the owner is attached an
+            invalidation refetches exactly once, and after the release the same
+            invalidation issues nothing and leaves the entry GC-eligible.
+            rf2-h3c9."
+    (require 'resources-ssr.core :reload)
+    (rf/init! rf.ssr/adapter)
+    (let [calls      (reg-counting-transport! :resources-ssr-test/canned {:reply? true})
+          fid        (resources-ssr-client-frame! :resources-ssr-test/canned)
+          owner      @(resolve 'resources-ssr.core/page-owner)
+          payload    (resources-ssr-static-payload)
+          invalidate #(rf/dispatch-sync [:rf.resource/invalidate-tags
+                                         {:scope :rf.scope/global
+                                          :tags  #{[:article-list]}
+                                          :cause [:test :resources-ssr/liveness-probe]}]
+                                        {:frame fid})]
+      (rf.ssr/hydrate! {:frame fid :payload payload})
+      (rf/dispatch-sync [:resources-ssr.app/page-opened] {:frame fid})
+      (is (contains? (resources-ssr-owners fid) owner) "the page owner holds the entry")
+      (is (zero? @calls) "the fresh-skip acquisition issued nothing")
+      ;; HELD — invalidation refetches, because a live owner needs fresh data now.
+      (invalidate)
+      (is (= 1 @calls)
+          "invalidating [:article-list] refetched EXACTLY ONCE — the client owner
+           is semantically live, not merely present in a set")
+      ;; RELEASED — the hold is dropped.
+      (rf/dispatch-sync [:resources-ssr.app/page-closed] {:frame fid})
+      (is (not (contains? (resources-ssr-owners fid) owner))
+          "page-closed released the app-minted owner")
+      (is (empty? (resources-ssr-owners fid))
+          "leaving the entry pinned by nothing — eligible for the ordinary GC lifecycle")
+      ;; AND LIVENESS WENT WITH IT — the same probe now issues nothing.
+      (invalidate)
+      (is (= 1 @calls)
+          "after the release the SAME invalidation refetches nothing (still 1 in
+           total) — the release genuinely ended the hold rather than only
+           emptying a set"))))
+
+;; ============================================================================
 ;; state-machine-walkthrough — chapter §Headless testing. Two flavours:
 ;; pure machine-transition (no rf.frame/app-db) and drain-level (frame +
 ;; :fx-overrides canned stub). JVM-runnable. Formerly the


### PR DESCRIPTION
Two examples that advertised a capability the app never wired. One commit each, no file overlap.

Both beads carry an audit note newer than their description, and in both cases the note — not the description — is the live instruction. Verified by walking `bd history --json` newest-first for the first change to a text-bearing field: on rf2-51in the notes field went from empty to the audit residual and nothing text-bearing has changed since; on rf2-h3c9 the same, preceded by the close/reopen pair from PR #9252's merge audit. Everything after is checkpoint snapshots.

## rf2-51in — the route-schema comment overstated the boundary

PR #9241 already removed the inert `:params [:map [:id :string]]` and the README's Malli claim. What it left is a source comment saying `:params` / `:query` Malli schemas "only *do* anything in an app that loads `re-frame.schemas`". Re-verified at source, that is wrong on the coercion half:

- `reg-route` calls `compile-schema-coercions` on both schemas **unconditionally** and stores `:rf.route/params-coerce` / `:rf.route/query-coerce`. `compile-schema-coercions` contains no late-bind lookup.
- `match-url` applies `coerce-path` and `coerce-query` on every successful match, *before* validation — so `:params [:map [:id :int]]` yields the number `42` with no schemas artefact present. `routing_registry_test.clj`'s `path-param-coercion-against-params-schema` pins exactly that for `:int` and `:uuid`.
- Only `validate-route-shape` is gated: it returns `[false nil]` when `:schemas/validate-with-registered-fn` is unregistered, and that hook is published only by `re-frame.schemas`.

The comment now separates the two halves — coercion always happens, enforcement late-binds. The example stays schemas-free; no runtime, dependency, packaging or coercion behaviour changes. The README's existing "validate only" wording was already accurate and is untouched.

No test, per the bead's acceptance criterion 4 ("No bespoke runtime suite or scanner is introduced for this two-line teaching correction").

## rf2-h3c9 — the client boot seam had no test, and the release read as a live lifecycle

PR #9252 landed the acquisition itself. The audit that reopened the bead found the beat untested: owner attachment, request counts, first-paint state, invalidation refetch and release were asserted in prose only, and both existing tests stop at `hydrate!`.

**Coverage.** Four JVM regressions in `re-frame.examples-test`, driving the example's own registered events against its own `app-frame` in `run`'s order. `run` is `:cljs`-only, so this is the seam a beat lower — the "minimally extracted equivalent" the audit permits. Acceptance criterion 1's browser recipe itself remains covered by the shipped `run`.

| Test | Pins |
|---|---|
| `…cold-client-boot-acquires-and-first-paints-loading` | no payload: **exactly one** request under the page owner; first paint is the loading skeleton, not the empty `<ul>` an absent entry projects as `:idle` |
| `…fresh-hydrated-boot-takes-the-hold-without-refetching` | hydration leaves the entry `:loaded` and **ownerless**; the acquisition fresh-skips — owner attached, **zero** requests, server markup still painted |
| `…stale-hydrated-boot-keeps-data-and-issues-one-request` | **exactly one** background request, last-known-good data visible throughout; carries the counterfactual — invalidating while still ownerless issues nothing |
| `…page-closed-releases-the-hold-the-acquisition-took` | while held, invalidating `[:article-list]` refetches **exactly once**; after `page-closed` the same probe issues nothing |

Liveness is proved by the request the cache does or does not make, in both directions, rather than by reading an owner set — Spec 016 §Invalidation refetches a matched entry with active owners and leaves a matched ownerless one merely stale.

**Prose.** Took the audit's second option — make the boundary explicit and narrow the claim, rather than wiring `page-closed` to a synthetic teardown. The README said the page "owns the matching `:resources-ssr.app/page-closed` release … Both halves matter", which reads as a live lifecycle for an event nothing dispatches. README and the event's own docstring now say plainly that the demo never fires it and why the boundary permits that — the page is the whole app, so the entry lives in a frame that outlives nothing — while keeping it as the half a reader needs the moment a page can be unmounted while its frame lives on. No runtime behaviour changes.

**Examples stay test-free** (rf2-8cevm): the fixtures and assertions live in the framework test tree, in the same file and under the same fixture as the two existing resources-ssr hydration regressions.

## Quality gates

| Gate | Command | Captured exit | Result |
|---|---|---|---|
| Focused JVM suite (final) | `clojure -M:test -n re-frame.examples-test` from `implementation/core` | **0** | Ran 19 tests, 126 assertions, 0 failures, 0 errors |
| Same suite, fault injected | as above, with `:owner page-owner` removed from the example's `page-opened` ensure | **1** | 6 failures across all four new tests |
| Repo README/source-adjacent link gate | `python scripts/check_readme_links.py --ci` | **0** | clean |
| Same gate, fault injected | as above, with a broken target appended to the example README | **1** | named `examples\capabilities\ssr\resources_ssr\README.md:223` |

Both fault-injection runs exist because a green gate proves nothing about a file it never read. The example source was restored byte-for-byte after each (`git diff` on `core.cljc` shows only the intended docstring hunk).

**Not run, and why.** `scripts/test-fast-pr.sh`, `npm run test:cljs` and the examples-compile sweep were deliberately skipped: several sibling workers are live and those gates are heavy enough that concurrent runs wedge rather than fail. CI owns the spine, and this PR relies on it for them.

**No automated gate covers the rf2-51in change.** It is a comment inside a `.cljs` file: `check_doc_slugs.py`'s roots do not reach `examples/`, `check_readme_links.py` reads markdown only, and neither gate looks inside source comments at all. Verified by hand instead: every added line begins with `;;` (proved mechanically — a diff filter for added non-`;;` lines returns nothing, against 10 added lines total), so the change cannot alter compilation, and the guide link target `docs/core/how-to/validate-with-schemas.md` is present on disk.

The four new tests are JVM `.clj`; nothing here touches a CLJS build, `shadow-cljs.edn`, or any hot-zone file.
