### PR TITLE
fix(mcp-base, pair-mcp): sorted-collection dedup crash; trace-window/watch-epochs frame ambiguity (rf2-7wwp, rf2-yo4s)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
@@ -348,18 +348,41 @@
   #?(:cljs (satisfies? IRecord form)
      :clj  (instance? clojure.lang.IRecord form)))
 
+(defn ^:private rebuild-into
+  "The empty collection `side-walk` rebuilds `form` into.
+
+  `(empty form)` for everything EXCEPT a sorted map or sorted set,
+  which lower to their unsorted counterparts. Substitution replaces a
+  repeated subtree with a `de-dupe.cache/cache-N` SYMBOL, so rebuilding
+  a sorted collection through its own comparator hands that placeholder
+  to a comparator chosen for the data: a default sorted-map of vector
+  keys throws the moment one key is pooled and another beside it is not
+  (`Symbol cannot be cast to IPersistentVector`). Dedup is default-on,
+  so that turned ordinary persistent app-db state — an index keyed by
+  path vectors, say — into a boundary failure instead of a read.
+
+  Lowering here costs nothing the codec ever kept: the cache travels as
+  EDN/JSON, where a sorted map reads back unsorted regardless, and
+  Clojure equality across the round trip is exact either way. Metadata
+  rides along as `empty` would have carried it."
+  [form]
+  (if (sorted? form)
+    (with-meta (if (map? form) {} #{}) (meta form))
+    (empty form)))
+
 (defn ^:private side-walk
   "Like `clojure.walk/walk`, but `outer` receives BOTH the original form
   and the rebuilt one — which is what lets the encoder read the
   `:cache-id` metadata `inner` attached before the rebuild dropped it.
-  Recognises every Clojure collection; consumes seqs as with `doall`."
+  Recognises every Clojure collection; consumes seqs as with `doall`.
+  Sorted maps/sets rebuild unsorted — see `rebuild-into`."
   [inner outer form]
   (cond
     (list? form)       (outer form (apply list (doall (map inner form))))
     (map-entry?* form) (outer form (vec (doall (map inner form))))
     (seq? form)        (outer form (doall (map inner form)))
     (record?* form)    (outer form (reduce (fn [r x] (conj r (inner x))) form form))
-    (coll? form)       (outer form (into (empty form) (doall (map inner form))))
+    (coll? form)       (outer form (into (rebuild-into form) (doall (map inner form))))
     :else              (outer form form)))
 
 (defn ^:private side-prewalk

--- a/tools/mcp-base/test/re_frame/mcp_base/dedup_test.cljc
+++ b/tools/mcp-base/test/re_frame/mcp_base/dedup_test.cljc
@@ -425,12 +425,71 @@
 (deftest expand-round-trips-every-collection-kind
   ;; The codec's structure-preserving guarantee, now ours to keep: lists,
   ;; seqs, sets, nested maps and map entries all rebuild as themselves.
+  ;; The name says EVERY kind, so the sorted pair rides along — they are
+  ;; the two core collections the walk cannot rebuild as themselves (see
+  ;; `sorted-map-with-a-pooled-key-…` below), and a suite that named them
+  ;; and then skipped them is how this class stayed unseen.
   (let [shared {:s #{:a :b} :v [1 2 3]}
-        v      {:list  (list shared shared)
-                :seq   (map identity [shared shared])
-                :set   #{[:x shared]}
-                :nest  {:deep {:deeper [shared shared]}}}
+        v      {:list   (list shared shared)
+                :seq    (map identity [shared shared])
+                :set    #{[:x shared]}
+                :nest   {:deep {:deeper [shared shared]}}
+                :sorted (sorted-map :b shared :a shared)
+                :s-set  (sorted-set :one :two)}
         out    (rf.mcp-base.dedup/expand (rf.mcp-base.dedup/de-dupe-eq v))]
     (is (= v out))
     (is (list? (:list out)) "a list rebuilds as a list")
-    (is (set? (:set out))   "a set rebuilds as a set")))
+    (is (set? (:set out))   "a set rebuilds as a set")
+    ;; Sortedness is DELIBERATELY not carried: the cache is EDN/JSON, where
+    ;; a sorted map reads back unsorted anyway, and holding the comparator
+    ;; is what made a pooled key throw. Clojure equality is exact either way.
+    (is (and (map? (:sorted out)) (not (sorted? (:sorted out))))
+        "a sorted map rebuilds as an unsorted map")
+    (is (and (set? (:s-set out)) (not (sorted? (:s-set out))))
+        "a sorted set rebuilds as an unsorted set")))
+
+;; ---- Sorted collections: comparator positions and pooled placeholders ------
+;;
+;; Substitution replaces a repeated cacheable subtree with a
+;; `de-dupe.cache/cache-N` SYMBOL. Rebuild a sorted collection through its
+;; own comparator and that symbol is handed to a comparator chosen for the
+;; data — `compare` on a Symbol and an IPersistentVector throws. Dedup is
+;; DEFAULT-ON, so this turned ordinary persistent app-db state into a
+;; boundary failure rather than a read.
+
+(deftest sorted-map-with-a-pooled-key-beside-an-unpooled-one-round-trips
+  (let [shared  [1 2 3]
+        unique  [4 5 6]
+        payload {:index (sorted-map shared :old unique :new)
+                 :again shared}
+        out     (rf.mcp-base.dedup/dedup-value payload true)
+        cache   (get out rf.mcp-base.vocab/dedup-table-key)]
+    (is (contains? out rf.mcp-base.vocab/dedup-table-key)
+        "non-vacuity: a real wrap, not the no-substitutions passthrough")
+    (is (< 1 (count cache))
+        "the repeated key really was pooled — a substitution beyond cache-0")
+    (is (= payload (rf.mcp-base.dedup/expand cache))
+        "expand is equal to the input")
+    (testing "the unordered control takes the same shape"
+      (let [control (assoc payload :index {shared :old unique :new})
+            c-out   (rf.mcp-base.dedup/dedup-value control true)
+            c-cache (get c-out rf.mcp-base.vocab/dedup-table-key)]
+        (is (< 1 (count c-cache)))
+        (is (= control (rf.mcp-base.dedup/expand c-cache)))))
+    (testing "opting out stays a strict passthrough"
+      (is (identical? payload (rf.mcp-base.dedup/dedup-value payload false))))))
+
+(deftest sorted-set-with-a-pooled-element-beside-an-unpooled-one-round-trips
+  ;; The same root cause reached through the other comparator-bearing core
+  ;; collection: here the placeholder lands in ELEMENT position.
+  (let [shared  [1 2 3]
+        payload {:index (sorted-set shared [4 5 6])
+                 :again shared}
+        out     (rf.mcp-base.dedup/dedup-value payload true)
+        cache   (get out rf.mcp-base.vocab/dedup-table-key)]
+    (is (contains? out rf.mcp-base.vocab/dedup-table-key)
+        "non-vacuity: a real wrap")
+    (is (< 1 (count cache))
+        "the repeated element really was pooled")
+    (is (= payload (rf.mcp-base.dedup/expand cache))
+        "expand is equal to the input")))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors_data.cljs
@@ -766,7 +766,8 @@
    :outputSchema envelope-or-marker
    :inputSchema {:type "object"
                  :properties {:ms    {:type "integer" :description "Window size in milliseconds (default 1000). Sticky across pagination — encoded into the cursor on the first call."}
-                              :frame {:type "string"}
+                              :frame {:type "string"
+                                      :description "Frame-id (e.g. \":rf/default\"). Defaults to the operating frame; a multi-frame session with no selection returns :ambiguous-frame rather than an empty window."}
                               :limit knobs/limit-property
                               :cursor knobs/cursor-property
                               :epochs-mode {:type "string"
@@ -813,7 +814,8 @@
    :inputSchema {:type "object"
                  :properties {:since-id {:type "string" :description "The last epoch id you've seen (omit to start fresh). Supplanted by :cursor when both are passed."}
                               :pred     {:type "object" :description "Filter map"}
-                              :frame    {:type "string"}
+                              :frame    {:type "string"
+                                         :description "Frame-id (e.g. \":rf/default\"). Defaults to the operating frame; a multi-frame session with no selection returns :ambiguous-frame rather than an empty poll with :id-aged-out? true."}
                               :limit    knobs/limit-property
                               :cursor   knobs/cursor-property
                               :epochs-mode {:type "string"

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/frame_resolve.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/frame_resolve.cljs
@@ -1,0 +1,98 @@
+(ns re-frame2-pair-mcp.tools.frame-resolve
+  "Browser-side operating-frame resolution for an emitted eval form —
+  the one place a frame-targeted tool turns tier-4 ambiguity into a
+  refusal rather than a confident answer about the wrong frame.
+
+  ## The contract this enforces
+
+  re-frame2 is multi-frame, so every frame-targeted op resolves an
+  operating frame: explicit per-call `frame` (tier 1) -> session pin
+  (tier 2) -> the sole registered app frame (tier 3) -> nil (tier 4,
+  ambiguous). 003-Tool-Catalogue §\"Why these ship\" makes tier 4 a
+  REFUSAL — `{:ok? false :reason :ambiguous-frame}` — rather than a
+  guess.
+
+  ## Why the guard has to be IN the emitted form
+
+  The MCP server cannot resolve the frame: the registry lives in the
+  browser. So a tool that omits `frame` emits an implicit-frame call
+  and the runtime resolves it — and every runtime read fn is
+  nil-TOLERANT. `(epoch-history nil)` bottoms out in a per-frame
+  lookup that answers `[]` for an unknown frame; `(snapshot)` is
+  `(rf/app-db-value nil)` = nil. Neither errors. The tool therefore
+  reports an EMPTY result in the same voice it reports a genuinely
+  empty one, and the agent is told \"nothing happened\" when the truth
+  is \"I could not tell which frame you meant\" (rf2-q17a for
+  `get-path`; rf2-yo4s for `trace-window` / `watch-epochs`, where the
+  empty ring also makes a live cursor look aged out).
+
+  Resolving ONCE, before any read, is what makes that impossible: the
+  wrong branch is never taken, so there is no wrong answer to dress up
+  afterwards. A tool that resolved separately for the read and for a
+  sibling concern (an elision handle, a history count) could also have
+  the two disagree; binding one id and using it everywhere removes
+  that by construction.
+
+  ## No new vocabulary
+
+  The refusal is the runtime's OWN `ambiguous-frame-error` envelope,
+  the same one `read-sub`, `sub-cache-info` and `describe-image`
+  already return: `:reason :ambiguous-frame` plus `:available-frames`,
+  the current `:selected-frame`, and a `:hint` naming the two
+  recoveries that already ship (pass `frame`, or pin one with
+  `set-operating-frame`). It rides out through each tool's existing
+  `:ok? false` -> `wire/err-text` path as an `isError` envelope."
+  (:require [re-frame2-pair-mcp.tools.eval-form :as ef]))
+
+(def resolved-frame-sym
+  "Name of the let-binding [[with-resolved-frame]] puts the resolved
+  operating-frame id in. A tool's inner form reads through this name —
+  for the app-db/history read AND for anything else that must describe
+  the same frame — so one resolution is one truth."
+  "fid")
+
+(defn with-resolved-frame
+  "Wrap `inner-src` — an emitted eval form, as a source string — in the
+  operating-frame resolution and the tier-4 refusal.
+
+  `operation` is the refusing op's keyword (`:get-path`,
+  `:trace-window`, …); it names the op in the envelope and in its
+  hint. `frame` is the caller's explicit target (or nil), passed as
+  the tier-1 override so a tool's own stickier notion of the frame —
+  a paginated tool's cursor-carried `:frame`, say — is honoured ahead
+  of the session pin simply by being handed in here.
+
+  `inner-src` is evaluated only on the resolved branch, and reads the
+  id by the name [[resolved-frame-sym]] binds."
+  [operation frame inner-src]
+  (ef/emit
+    (ef/rt-let
+      [(symbol resolved-frame-sym)
+       (if frame
+         (ef/rt-call 'current-frame frame)
+         (ef/rt-call 'current-frame))]
+      (ef/rt-raw
+        (str "(if (nil? " resolved-frame-sym ") "
+             (ef/emit (ef/rt-call 'ambiguous-frame-error operation))
+             " "
+             inner-src
+             ")")))))
+
+(defn frame-sym-call
+  "`(rt-call sym ... )` with the resolved-frame binding as the trailing
+  frame argument — the shape a runtime fn's explicit-frame arity takes.
+  Sugar for the `(ef/rt-raw resolved-frame-sym)` every call-site would
+  otherwise repeat."
+  [sym & args]
+  (apply ef/rt-call sym (concat args [(ef/rt-raw resolved-frame-sym)])))
+
+(defn refusal?
+  "True when a runtime eval result is a structured refusal rather than
+  the payload the tool asked for — `{:ok? false ...}`, which under
+  [[with-resolved-frame]] is the `:ambiguous-frame` envelope.
+
+  `(false? ...)` deliberately, not `(not ...)`: a blank eval result
+  (nil, from a dead runtime) has `(:ok? nil)` = nil and is NOT a
+  refusal — it is each tool's own blank-result case."
+  [v]
+  (and (map? v) (false? (:ok? v))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
@@ -39,6 +39,7 @@
   `:scalar-value` arm of `run-wire-pipeline` just counts the
   resulting `:rf.size/large-elided` markers."
   (:require [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.frame-resolve :as fr]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.wire-pipeline :as wp]
             [re-frame2-pair-mcp.tools.probe :as probe]
@@ -60,52 +61,17 @@
          "         " elision-opts "))")
     value-sym))
 
-(def ^:private resolved-frame-sym
-  "Name of the let-binding `with-resolved-frame` puts the resolved
-  operating-frame id in. Both eval forms read app-db through it AND
-  hand it to the walker, so the value read and the elision handle
-  describe the same frame by construction."
-  "fid")
+;; The resolve-once-then-refuse wrapper this tool introduced (rf2-q17a)
+;; now lives in `re-frame2-pair-mcp.tools.frame-resolve`, shared with
+;; `trace-window` and `watch-epochs`, which had the same defect through
+;; the epoch ring rather than app-db (rf2-yo4s). Both eval forms here
+;; read app-db through the id it binds AND hand that same id to the
+;; walker, so the value read and the elision handle describe the same
+;; frame by construction.
+(def ^:private resolved-frame-sym fr/resolved-frame-sym)
 
-(defn- with-resolved-frame
-  "Wrap `inner-src` — a get-path eval form — in the operating-frame
-  resolution every frame-targeted call owes the Tool-Pair contract:
-  explicit override -> session pin -> sole app frame -> nil.
-
-  The resolve runs browser-side, ONCE, before any app-db read. `nil`
-  means two-plus app frames are registered with no pin, so the tool
-  cannot know which frame the caller meant, and a tier-4 read must
-  REFUSE rather than read some other frame.
-
-  Refusing is the whole of this wrapper's point. Without it the form
-  called `(snapshot)` — `(rf/app-db-value (current-frame))`, i.e.
-  `(rf/app-db-value nil)`, i.e. nil — and `get-in` over nil answers
-  `:path-not-found` (singular) or `{:exists? false}` for every path
-  (batch). That is a confident falsehood about application state in
-  the one session shape where frame identity matters most: the agent
-  believes the slot is absent and goes off to ADD a path that was
-  already there (rf2-q17a).
-
-  `ambiguous-frame-error` is the SAME refusal envelope `read-sub` and
-  `sub-cache-info` already return — `:reason :ambiguous-frame` plus
-  `:available-frames` and a `:hint` naming the two recoveries that
-  already ship (pass `frame`, or pin one with `set-operating-frame`).
-  No new vocabulary and no new helper layer: the refusal rides the
-  existing `run-eval` `:ok? false` -> `wire/err-text` path out as an
-  `isError` envelope."
-  [frame inner-src]
-  (ef/emit
-    (ef/rt-let
-      [(symbol resolved-frame-sym)
-       (if frame
-         (ef/rt-call 'current-frame frame)
-         (ef/rt-call 'current-frame))]
-      (ef/rt-raw
-        (str "(if (nil? " resolved-frame-sym ") "
-             (ef/emit (ef/rt-call 'ambiguous-frame-error :get-path))
-             " "
-             inner-src
-             ")")))))
+(defn- with-resolved-frame [frame inner-src]
+  (fr/with-resolved-frame :get-path frame inner-src))
 
 (defn- single-path-form
   "Eval form for the singular `:path` read. Calls `snapshot` (full db for

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
@@ -21,9 +21,23 @@
   tell these apart and may misread \"empty window\" as
   \"the MCP isn't capturing my events\". The advisory names the
   history count and points to `snapshot` as the historical-inspection
-  surface."
+  surface.
+
+  ## Operating frame
+
+  The read is frame-targeted, so it resolves the operating frame —
+  the cursor's sticky `:frame` or the caller's `frame` as the tier-1
+  override, then session pin, then sole app frame — BEFORE it touches
+  the ring, and REFUSES at nil with `:ambiguous-frame` (see
+  `re-frame2-pair-mcp.tools.frame-resolve`). It does not read frame nil
+  and report the empty ring that comes back as `:count 0`, which says
+  \"nothing happened\" in the same voice as a genuinely quiet window.
+  The empty-result advisory above could not catch that: it read the
+  SAME implicit-frame history, so both sides came back empty together
+  (rf2-yo4s)."
   (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.frame-resolve :as fr]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.wire-pipeline :as wp]
             [re-frame2-pair-mcp.tools.probe :as probe]
@@ -81,9 +95,15 @@
             ;; Server-side slice: pull the history, drop up-to-cursor,
             ;; filter to the window, take `limit`. The runtime ships
             ;; only what the page needs — not the whole history.
-            history-call (if sticky-frame
-                           (ef/rt-call 'epoch-history sticky-frame)
-                           (ef/rt-call 'epoch-history))
+            ;;
+            ;; Against the RESOLVED frame id, never an implicit read:
+            ;; `(epoch-history)` defaults to `(current-frame)`, which is
+            ;; nil under two-plus app frames with no pin, and
+            ;; `rf/epoch-history` answers `[]` for an unknown frame
+            ;; without erroring — an ambiguity delivered as an empty
+            ;; ring (rf2-yo4s). `with-resolved-frame` below refuses
+            ;; before this call is ever reached.
+            history-call (fr/frame-sym-call 'epoch-history)
             ;; The egress slice (`page`) is the ONLY vector
             ;; that crosses the wire, so projection happens HERE, after
             ;; the cursor `:limit` cap, before the records ship. Each
@@ -93,7 +113,7 @@
             ;; `{:include-sensitive? true}` INTO the projection (app-db
             ;; sensitive axis only); it does NOT disable projection.
             page-src       (str "(vec (take " limit " filtered))")
-            form (ef/emit
+            slice-src (ef/emit
                    (ef/rt-let
                      ['hist      (ef/rt-raw (str "(vec " (ef/emit history-call) ")"))
                       'after-id  after-id
@@ -125,68 +145,87 @@
                             " :head-id (some-> hist peek :epoch-id)"
                             " :next-id next-id"
                             " :history-count (count hist)"
-                            " :remaining (max 0 (- (count filtered) (count page)))}"))))]
+                            " :remaining (max 0 (- (count filtered) (count page)))}"))))
+            ;; Resolve once, refuse at nil, THEN slice. The sticky frame
+            ;; is the tier-1 override, so a cursor's frame outranks the
+            ;; session pin exactly as page 1 did.
+            form (fr/with-resolved-frame :trace-window sticky-frame slice-src)]
         (probe/eval-after-runtime!
           conn build-id form :trace-failed
           (fn [v]
-            (let [v          (if (map? v) v {})
-                  aged-out?  (:id-aged-out? v)
-                  raw-epochs (vec (:epochs v))]
-              (if aged-out?
-                (cursor/cursor-stale-result "trace-window"
-                                            {:requested-id (:requested-id v)
-                                             :head-id      (:head-id v)})
-                (let [{:keys [value indicators]}
-                      (wp/run-wire-pipeline raw-epochs
-                                            {:kind   :epoch-vector
-                                             :incl?  incl?
-                                             :mode   mode
-                                             :dedup? dedup?})
-                      {:keys [dropped elided count]} indicators
-                      next-id     (:next-id v)
-                      next-cursor (cursor/encode-cursor
-                                    (when next-id
-                                      {:v        1
-                                       :after-id next-id
-                                       :ms       window-ms
-                                       :until-ms until-ms
-                                       :frame    sticky-frame}))
-                      has-more?     (some? next-cursor)
-                      remaining     (or (:remaining v) 0)
-                      history-count (or (:history-count v) 0)
-                      ;; Advisory fires only when the window
-                      ;; surfaced ZERO epochs but the per-frame
-                      ;; history holds events that just fell
-                      ;; outside the time slice. Two ratchets:
-                      ;;   - count = 0 (the slot operators read
-                      ;;     to decide \"nothing happened\")
-                      ;;   - history-count > 0 (the underlying
-                      ;;     ring isn't empty — events exist).
-                      advisory      (when (and (zero? count)
-                                               (pos? history-count))
-                                      {:reason            :window-excludes-history
-                                       :frame             sticky-frame
-                                       :epochs-in-history history-count
-                                       :window-ms         window-ms
-                                       :hint              (str history-count
-                                                               " epochs exist in the per-frame "
-                                                               "history but none fell inside the "
-                                                               "last " window-ms "ms window. "
-                                                               "Widen :ms (e.g. 60000), or use "
-                                                               "`snapshot :include [:epochs]` to "
-                                                               "inspect the full history.")})
-                      envelope      (cond-> {:ok?                 true
-                                             :window-ms           window-ms
-                                             :until-ms            until-ms
-                                             :count               count
-                                             :limit               limit
-                                             :epochs-mode         mode
-                                             :dedup               dedup?
-                                             :epochs              value
-                                             :has-more?           has-more?
-                                             :estimated-remaining remaining
-                                             :next-cursor         next-cursor}
-                                      advisory (assoc :advisory advisory))]
-                  (wire/ok-text (wire/with-indicators
-                                  envelope
-                                  {:dropped dropped :elided elided})))))))))))
+            (if (fr/refusal? v)
+              ;; An unanswerable read is an isError envelope carrying the
+              ;; candidate frames and the recovery — never `:count 0`,
+              ;; and never a `:next-cursor`, which would hand the agent a
+              ;; continuation for a page that was never read.
+              (wire/err-text v)
+              (let [v          (if (map? v) v {})
+                    aged-out?  (:id-aged-out? v)
+                    raw-epochs (vec (:epochs v))]
+                (if aged-out?
+                  (cursor/cursor-stale-result "trace-window"
+                                              {:requested-id (:requested-id v)
+                                               :head-id      (:head-id v)})
+                  (let [{:keys [value indicators]}
+                        (wp/run-wire-pipeline raw-epochs
+                                              {:kind   :epoch-vector
+                                               :incl?  incl?
+                                               :mode   mode
+                                               :dedup? dedup?})
+                        {:keys [dropped elided count]} indicators
+                        next-id     (:next-id v)
+                        next-cursor (cursor/encode-cursor
+                                      (when next-id
+                                        {:v        1
+                                         :after-id next-id
+                                         :ms       window-ms
+                                         :until-ms until-ms
+                                         :frame    sticky-frame}))
+                        has-more?     (some? next-cursor)
+                        remaining     (or (:remaining v) 0)
+                        history-count (or (:history-count v) 0)
+                        ;; Advisory fires only when the window
+                        ;; surfaced ZERO epochs but the per-frame
+                        ;; history holds events that just fell
+                        ;; outside the time slice. Two ratchets:
+                        ;;   - count = 0 (the slot operators read
+                        ;;     to decide \"nothing happened\")
+                        ;;   - history-count > 0 (the underlying
+                        ;;     ring isn't empty — events exist).
+                        ;;
+                        ;; Both ratchets read the SAME frame's history,
+                        ;; which is why this could never catch the
+                        ;; ambiguous-frame case: a nil frame emptied
+                        ;; both sides together, so the advisory stayed
+                        ;; silent on the one reading that most needed
+                        ;; explaining (rf2-yo4s). The refusal above is
+                        ;; what covers it; this advisory keeps its own
+                        ;; narrower job.
+                        advisory      (when (and (zero? count)
+                                                 (pos? history-count))
+                                        {:reason            :window-excludes-history
+                                         :frame             sticky-frame
+                                         :epochs-in-history history-count
+                                         :window-ms         window-ms
+                                         :hint              (str history-count
+                                                                 " epochs exist in the per-frame "
+                                                                 "history but none fell inside the "
+                                                                 "last " window-ms "ms window. "
+                                                                 "Widen :ms (e.g. 60000), or use "
+                                                                 "`snapshot :include [:epochs]` to "
+                                                                 "inspect the full history.")})
+                        envelope      (cond-> {:ok?                 true
+                                               :window-ms           window-ms
+                                               :until-ms            until-ms
+                                               :count               count
+                                               :limit               limit
+                                               :epochs-mode         mode
+                                               :dedup               dedup?
+                                               :epochs              value
+                                               :has-more?           has-more?
+                                               :estimated-remaining remaining
+                                               :next-cursor         next-cursor}
+                                        advisory (assoc :advisory advisory))]
+                    (wire/ok-text (wire/with-indicators
+                                    envelope
+                                    {:dropped dropped :elided elided}))))))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
@@ -26,9 +26,23 @@
     - `:no-events-since-id` — caller passed `:since-id` and no new
       epochs landed after it. Calmly says \"nothing new\".
     - `:pred-excludes-history` — the predicate filtered every epoch
-      out. Says the history exists; the pred is the gate."
+      out. Says the history exists; the pred is the gate.
+
+  ## Operating frame
+
+  The poll is frame-targeted, so it resolves the operating frame — the
+  cursor's sticky `:frame` or the caller's `frame` as the tier-1
+  override, then session pin, then sole app frame — BEFORE it touches
+  the ring, and REFUSES at nil with `:ambiguous-frame` (see
+  `re-frame2-pair-mcp.tools.frame-resolve`). It does not read frame nil
+  and relay the empty ring that comes back, which told the agent TWO
+  falsehoods at once: `:count 0` (\"nothing matched\") and, because a
+  cursor id cannot be found in an empty history, `:id-aged-out? true`
+  (\"your cursor fell out of the ring\") — a live cursor declared dead
+  (rf2-yo4s)."
   (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.frame-resolve :as fr]
             [re-frame2-pair-mcp.tools.wire :as wire]
             [re-frame2-pair-mcp.tools.wire-pipeline :as wp]
             [re-frame2-pair-mcp.tools.probe :as probe]
@@ -88,17 +102,22 @@
             ;; envelope identical to a correctly-filtered page so the
             ;; agent couldn't detect the drop.
             sticky-pred     (or (:pred cursor-in) pred-arg)
-            epochs-since-call (if sticky-frame
-                                (ef/rt-call 'epochs-since effective-after sticky-frame)
-                                (ef/rt-call 'epochs-since effective-after))
+            ;; Both ring reads go against the RESOLVED frame id, never
+            ;; an implicit one: `(epochs-since id)` and
+            ;; `(epoch-history)` each default to `(current-frame)`,
+            ;; which is nil under two-plus app frames with no pin, and
+            ;; `rf/epoch-history` answers `[]` for an unknown frame
+            ;; without erroring. `epochs-since` then cannot find the
+            ;; caller's id in that empty history and reports
+            ;; `:id-aged-out? true` — so the ambiguity arrived as a
+            ;; quiet poll AND a dead cursor (rf2-yo4s).
+            epochs-since-call (fr/frame-sym-call 'epochs-since effective-after)
             matches-form (str "(filterv #"
                               (ef/emit (ef/rt-call 'epoch-matches?
                                                    (or sticky-pred {})
                                                    (ef/rt-raw "%")))
                               " (:epochs r))")
-            history-call (if sticky-frame
-                           (ef/rt-call 'epoch-history sticky-frame)
-                           (ef/rt-call 'epoch-history))
+            history-call (fr/frame-sym-call 'epoch-history)
             ;; The `:pred` filter runs on the RAW records
             ;; server-side (never egressed); the capped `:page` is the
             ;; egress slice, ALWAYS projected via `projected-record` for
@@ -106,7 +125,7 @@
             ;; `{:include-sensitive? true}` INTO the projection (app-db
             ;; sensitive axis only), it does NOT disable projection.
             page-src       (str "(vec (take " limit " matches))")
-            form (ef/emit
+            poll-src (ef/emit
                    (ef/rt-let
                      ['r             epochs-since-call
                       'matches       (ef/rt-raw matches-form)
@@ -128,93 +147,106 @@
                             " :next-id next-id"
                             " :history-count history-count"
                             " :since-count since-count"
-                            " :remaining (max 0 (- (count matches) (count page)))}"))))]
+                            " :remaining (max 0 (- (count matches) (count page)))}"))))
+            ;; Resolve once, refuse at nil, THEN poll. The sticky frame
+            ;; is the tier-1 override, so a cursor's frame outranks the
+            ;; session pin exactly as page 1 did.
+            form (fr/with-resolved-frame :watch-epochs sticky-frame poll-src)]
         (probe/eval-after-runtime!
           conn build-id form :watch-failed
           (fn [v]
-            (let [v          (if (map? v) v {})
-                  aged-out?  (:id-aged-out? v)]
-              (if (and aged-out? (some? effective-after))
-                (cursor/cursor-stale-result "watch-epochs"
-                                            {:requested-id (or (:requested-id v) effective-after)
-                                             :head-id      (:head-id v)})
-                (let [matches (vec (:matches v))
-                      {:keys [value indicators]}
-                      (wp/run-wire-pipeline matches
-                                            {:kind   :epoch-vector
-                                             :incl?  incl?
-                                             :mode   mode
-                                             :dedup? dedup?})
-                      {:keys [dropped elided count]} indicators
-                      next-id       (:next-id v)
-                      next-cursor   (cursor/encode-cursor
-                                      (when next-id
-                                        {:v        1
-                                         :after-id next-id
-                                         :ms       nil
-                                         :until-ms nil
-                                         :frame    sticky-frame
-                                         ;; Carry the sticky
-                                         ;; predicate so page 2+ keeps
-                                         ;; filtering. nil when no pred was
-                                         ;; supplied (round-trips losslessly
-                                         ;; through the base64-of-EDN codec).
-                                         :pred     sticky-pred}))
-                      remaining     (or (:remaining v) 0)
-                      history-count (or (:history-count v) 0)
-                      since-count   (or (:since-count v) 0)
-                      ;; Two distinct empty-result
-                      ;; explainers, picked by the runtime data:
-                      ;;
-                      ;;   - since-count = 0 + history-count > 0
-                      ;;     → caller's :since-id is at (or past)
-                      ;;     the head; calmly say \"nothing new
-                      ;;     yet\".
-                      ;;
-                      ;;   - since-count > 0 + count = 0
-                      ;;     → events landed since the id but the
-                      ;;     :pred filtered them all out — point
-                      ;;     at the predicate, not the buffer.
-                      advisory
-                      (cond
-                        (and (zero? count)
-                             (zero? since-count)
-                             (pos? history-count))
-                        {:reason            :no-events-since-id
-                         :frame             sticky-frame
-                         :epochs-in-history history-count
-                         :requested-id      effective-after
-                         :hint              (str "Per-frame history holds "
-                                                 history-count
-                                                 " epochs but none have landed since the "
-                                                 "supplied :since-id. Dispatch an event "
-                                                 "to advance the head, or omit :since-id "
-                                                 "to see the full ring.")}
+            (if (fr/refusal? v)
+              ;; An unanswerable poll is an isError envelope carrying the
+              ;; candidate frames and the recovery. Ahead of the
+              ;; cursor-stale branch on purpose: an ambiguous frame reads
+              ;; an empty ring, in which the caller's live cursor id is
+              ;; simply not found, so the poll would otherwise report the
+              ;; cursor DEAD and send the agent back to page 1 of the
+              ;; wrong frame.
+              (wire/err-text v)
+              (let [v          (if (map? v) v {})
+                    aged-out?  (:id-aged-out? v)]
+                (if (and aged-out? (some? effective-after))
+                  (cursor/cursor-stale-result "watch-epochs"
+                                              {:requested-id (or (:requested-id v) effective-after)
+                                               :head-id      (:head-id v)})
+                  (let [matches (vec (:matches v))
+                        {:keys [value indicators]}
+                        (wp/run-wire-pipeline matches
+                                              {:kind   :epoch-vector
+                                               :incl?  incl?
+                                               :mode   mode
+                                               :dedup? dedup?})
+                        {:keys [dropped elided count]} indicators
+                        next-id       (:next-id v)
+                        next-cursor   (cursor/encode-cursor
+                                        (when next-id
+                                          {:v        1
+                                           :after-id next-id
+                                           :ms       nil
+                                           :until-ms nil
+                                           :frame    sticky-frame
+                                           ;; Carry the sticky
+                                           ;; predicate so page 2+ keeps
+                                           ;; filtering. nil when no pred was
+                                           ;; supplied (round-trips losslessly
+                                           ;; through the base64-of-EDN codec).
+                                           :pred     sticky-pred}))
+                        remaining     (or (:remaining v) 0)
+                        history-count (or (:history-count v) 0)
+                        since-count   (or (:since-count v) 0)
+                        ;; Two distinct empty-result
+                        ;; explainers, picked by the runtime data:
+                        ;;
+                        ;;   - since-count = 0 + history-count > 0
+                        ;;     → caller's :since-id is at (or past)
+                        ;;     the head; calmly say \"nothing new
+                        ;;     yet\".
+                        ;;
+                        ;;   - since-count > 0 + count = 0
+                        ;;     → events landed since the id but the
+                        ;;     :pred filtered them all out — point
+                        ;;     at the predicate, not the buffer.
+                        advisory
+                        (cond
+                          (and (zero? count)
+                               (zero? since-count)
+                               (pos? history-count))
+                          {:reason            :no-events-since-id
+                           :frame             sticky-frame
+                           :epochs-in-history history-count
+                           :requested-id      effective-after
+                           :hint              (str "Per-frame history holds "
+                                                   history-count
+                                                   " epochs but none have landed since the "
+                                                   "supplied :since-id. Dispatch an event "
+                                                   "to advance the head, or omit :since-id "
+                                                   "to see the full ring.")}
 
-                        (and (zero? count)
-                             (pos? since-count))
-                        {:reason            :pred-excludes-history
-                         :frame             sticky-frame
-                         :epochs-in-history history-count
-                         :epochs-since-id   since-count
-                         :hint              (str since-count
-                                                 " epochs landed since the requested id but "
-                                                 "the :pred filter excluded all of them. "
-                                                 "Drop / widen :pred, or use trace-window for "
-                                                 "an unfiltered view.")})
-                      base          (cond-> {:ok?          true
-                                             :head-id      (:head-id v)
-                                             :id-aged-out? (boolean aged-out?)}
-                                      (:requested-id v) (assoc :requested-id (:requested-id v))
-                                      advisory          (assoc :advisory advisory))]
-                  (wire/ok-text (wire/with-indicators
-                                  (assoc base
-                                         :matches             value
-                                         :limit               limit
-                                         :count               count
-                                         :epochs-mode         mode
-                                         :dedup               dedup?
-                                         :has-more?           (some? next-cursor)
-                                         :estimated-remaining remaining
-                                         :next-cursor         next-cursor)
-                                  {:dropped dropped :elided elided})))))))))))
+                          (and (zero? count)
+                               (pos? since-count))
+                          {:reason            :pred-excludes-history
+                           :frame             sticky-frame
+                           :epochs-in-history history-count
+                           :epochs-since-id   since-count
+                           :hint              (str since-count
+                                                   " epochs landed since the requested id but "
+                                                   "the :pred filter excluded all of them. "
+                                                   "Drop / widen :pred, or use trace-window for "
+                                                   "an unfiltered view.")})
+                        base          (cond-> {:ok?          true
+                                               :head-id      (:head-id v)
+                                               :id-aged-out? (boolean aged-out?)}
+                                        (:requested-id v) (assoc :requested-id (:requested-id v))
+                                        advisory          (assoc :advisory advisory))]
+                    (wire/ok-text (wire/with-indicators
+                                    (assoc base
+                                           :matches             value
+                                           :limit               limit
+                                           :count               count
+                                           :epochs-mode         mode
+                                           :dedup               dedup?
+                                           :has-more?           (some? next-cursor)
+                                           :estimated-remaining remaining
+                                           :next-cursor         next-cursor)
+                                    {:dropped dropped :elided elided}))))))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/epoch_frame_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/epoch_frame_test.cljs
@@ -1,0 +1,405 @@
+(ns re-frame2-pair-mcp.epoch-frame-test
+  "Operating-frame resolution for the two epoch-ring tools —
+  `trace-window` and `watch-epochs` (rf2-yo4s).
+
+  ## What this pins
+
+  Both are frame-targeted, so the Tool-Pair contract makes them
+  resolve explicit override -> session pin -> sole app frame -> nil,
+  and REFUSE at nil rather than read some other frame. Neither did.
+  Each emitted an implicit-frame call — `(epoch-history)` /
+  `(epochs-since id)` — whose runtime arity defaults to
+  `(current-frame)`, nil under two-plus app frames with no pin. And
+  `rf/epoch-history` answers `[]` for an unknown frame WITHOUT
+  erroring, so the ambiguity arrived as an empty ring.
+
+  That empty ring is two different falsehoods depending on the tool:
+
+    - `trace-window` reports `:count 0` — \"nothing happened\" — in the
+      same voice as a genuinely quiet window. Its `:count 0` advisory
+      cannot catch it, because the advisory reads the SAME
+      implicit-frame history, so both sides come back empty together.
+    - `watch-epochs` reports `:count 0` AND `:id-aged-out? true`: the
+      caller's cursor id cannot be found in an empty history, so a
+      LIVE cursor is declared dead and the agent is sent back to page
+      one of a frame it never chose.
+
+  ## Why the stub reads the form
+
+  A test that canned an `:ambiguous-frame` response would pass on the
+  DEFECT — the tools faithfully relay whatever the runtime hands them,
+  and the relay was never the bug. So `runtime-answer` plays a live
+  runtime: it derives the operating frame FROM THE EMITTED FORM the
+  way `pure/resolve-operating-frame` would, and then answers with that
+  frame's ring, reproducing `epochs-since`'s real not-found semantics.
+  On the pre-fix form the frame is nil, the ring is `[]`, and the
+  falsehoods appear on their own — which is what makes these witnesses
+  fail on the pre-fix tree rather than merely assert the fixed shape."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [clojure.string :as str]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.raw-state :as raw-state]
+            [re-frame2-pair-mcp.tools.cursor :as cursor]
+            [re-frame2-pair-mcp.tools.trace-window :as tw]
+            [re-frame2-pair-mcp.tools.watch-epochs :as we]))
+
+(def ^:private pristine-eval nrepl/cljs-eval-value)
+
+(use-fixtures :each
+  {:after (fn []
+            (set! nrepl/cljs-eval-value pristine-eval)
+            (raw-state/set-allow-raw-state! false))})
+
+(def ^:private read-edn tu/extract-edn)
+(def ^:private err? tu/error?)
+
+;; Two app frames, no pin — the session shape the resolver calls
+;; ambiguous and the one where guessing is unrecoverable.
+(def ^:private two-frames [:rf/default :stories])
+
+(defn- epoch
+  "A ring record shaped enough for both tools: an id and a
+  `:committed-at` inside any plausible window."
+  [id]
+  {:epoch-id id :committed-at (js/Date.now) :trigger-event [:noop id]})
+
+;; ---------------------------------------------------------------------------
+;; The runtime simulator — answers are DERIVED from the emitted form.
+;; ---------------------------------------------------------------------------
+
+(defn- guards-ambiguity?
+  "True when `form` detects the ambiguity WHERE IT ARISES: it binds the
+  resolved id, branches to `ambiguous-frame-error` on nil, and only
+  then reads the ring. The ORDERING is the assertion — a form that
+  merely mentions the refusal after reading would still have taken the
+  wrong branch."
+  [form operation]
+  (let [resolve-at (str/index-of form "(let [fid (re-frame2-pair.runtime/current-frame")
+        refuse-at  (str/index-of form
+                                 (str "(if (nil? fid) "
+                                      "(re-frame2-pair.runtime/ambiguous-frame-error "
+                                      operation ")"))
+        read-at    (or (str/index-of form "(re-frame2-pair.runtime/epochs-since ")
+                       (str/index-of form "(re-frame2-pair.runtime/epoch-history fid)"))]
+    (boolean (and resolve-at refuse-at read-at
+                  (< resolve-at refuse-at read-at)))))
+
+(defn- resolved-id
+  "The id the browser-side resolver would return for `form` in a session
+  holding `app-frames` with `pin` selected. Mirrors
+  `pure/resolve-operating-frame`: override -> pin -> sole app frame ->
+  nil. The override is read off the form because that is where the
+  tool puts it — from the resolve call once the fix routes it there,
+  and from the ring calls on the pre-fix shape, so this models BOTH
+  trees faithfully and the explicit-frame tiers stay real controls
+  rather than artefacts of the simulator."
+  [form app-frames pin]
+  (if-let [override (second (or (re-find #"current-frame\s+(:[^\s)]+)\)" form)
+                                (re-find #"epoch-history\s+(:[^\s)]+)\)" form)
+                                (re-find #"epochs-since\s+\S+\s+(:[^\s)]+)\)" form)))]
+    (keyword (subs override 1))
+    (or pin
+        (when (= 1 (count app-frames)) (first app-frames)))))
+
+(defn- ambiguous-envelope
+  "The envelope `re-frame2-pair.runtime/ambiguous-frame-error` builds —
+  reproduced here because the preload is not on this test's classpath.
+  Shape per `pure/ambiguous-frame-envelope`."
+  [operation app-frames pin]
+  {:ok?              false
+   :reason           :ambiguous-frame
+   :operation        operation
+   :available-frames app-frames
+   :selected-frame   pin
+   :hint             (str "multiple app frames are registered and no frame is "
+                          "selected, so " (name operation) " cannot pick a target. "
+                          "Pass `frame` (one of " (pr-str app-frames) ") or pin one with "
+                          "`select-frame!` / set-operating-frame, then retry.")})
+
+(defn- since-id-of
+  "The `:since-id` / cursor `:after-id` the form asked `epochs-since`
+  for, as it appears in the emitted source (`nil` when absent)."
+  [form]
+  (when-let [tok (second (re-find #"epochs-since\s+(\"[^\"]*\"|\S+?)[\s)]" form))]
+    (cond
+      (= "nil" tok)              nil
+      (str/starts-with? tok "\"") (subs tok 1 (dec (count tok)))
+      :else                      (js/parseInt tok 10))))
+
+(defn- epochs-since*
+  "`re-frame2-pair.runtime/epochs-since` semantics, reproduced: nil id ->
+  the whole ring; a known id -> the records strictly after it; an
+  UNKNOWN id -> `[]` with `:id-aged-out? true`. That last arm is the
+  one that matters — on an ambiguous frame the ring is empty, so ANY
+  live cursor id is unknown and the poll declares it dead."
+  [history epoch-id]
+  (let [head-id (some-> (peek history) :epoch-id)]
+    (cond
+      (nil? epoch-id)
+      {:epochs history :id-aged-out? false :head-id head-id}
+
+      (some #(= epoch-id (:epoch-id %)) history)
+      {:epochs       (vec (rest (drop-while #(not= epoch-id (:epoch-id %)) history)))
+       :id-aged-out? false
+       :head-id      head-id}
+
+      :else
+      {:epochs [] :id-aged-out? true :head-id head-id :requested-id epoch-id})))
+
+(defn- runtime-answer
+  "Answer `form` as a live runtime would, given the session described by
+  `app-frames` / `pin` / `rings` (a frame-id -> ring vector map). The
+  FRAME is whatever the form resolves, which is the whole point."
+  [form {:keys [operation app-frames pin rings]}]
+  (let [fid (resolved-id form app-frames pin)]
+    (if (and (nil? fid) (guards-ambiguity? form operation))
+      (ambiguous-envelope operation app-frames pin)
+      ;; No guard (or an unambiguous session): the read proceeds. For a
+      ;; nil frame the per-frame lookup misses and the ring is EMPTY —
+      ;; reproducing the pre-fix falsehoods exactly.
+      (let [history (vec (get rings fid))]
+        (if (= :trace-window operation)
+          {:epochs        history
+           :id-aged-out?  false
+           :requested-id  nil
+           :head-id       (some-> (peek history) :epoch-id)
+           :next-id       nil
+           :history-count (count history)
+           :remaining     0}
+          (let [{:keys [epochs id-aged-out? head-id requested-id]}
+                (epochs-since* history (since-id-of form))]
+            {:matches       epochs
+             :id-aged-out?  id-aged-out?
+             :requested-id  requested-id
+             :head-id       head-id
+             :next-id       nil
+             :history-count (count history)
+             :since-count   (count epochs)
+             :remaining     0}))))))
+
+(defn- stub-runtime!
+  "Install the simulator. The preload sentinel is answered directly; the
+  tool's own form is captured into `captured*` and answered by
+  `runtime-answer`."
+  [captured* session]
+  (let [respond
+        (fn [form]
+          (cond
+            (and (string? form) (re-find #"__re_frame2_pair_runtime" form))
+            (js/Promise.resolve true)
+
+            (and (string? form) (re-find #"configure-raw-state!" form))
+            (js/Promise.resolve nil)
+
+            :else
+            (do (when (and captured* (string? form))
+                  (reset! captured* form))
+                (js/Promise.resolve
+                  (if (string? form) (runtime-answer form session) nil)))))]
+    (set! nrepl/cljs-eval-value
+          (fn
+            ([_c _b form] (respond form))
+            ([_c _b form _o] (respond form))))))
+
+;; ---------------------------------------------------------------------------
+;; The witnesses — these fail on the pre-fix tree.
+;; ---------------------------------------------------------------------------
+
+(deftest trace-window-ambiguous-frame-refuses-rather-than-reporting-an-empty-window
+  ;; Both frames HAVE epochs. Reporting `:count 0` is therefore a
+  ;; falsehood about the app, not a thin answer about a quiet one.
+  (async done
+    (stub-runtime! nil {:operation  :trace-window
+                        :app-frames two-frames
+                        :pin        nil
+                        :rings      {:rf/default [(epoch 1) (epoch 2)]
+                                     :stories    [(epoch 7)]}})
+    (-> (tw/trace-window-tool nil (tu/args->js {:ms 60000}))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (err? r) "an unanswerable read is an isError envelope")
+                   (is (= false (:ok? edn)))
+                   (is (= :ambiguous-frame (:reason edn))
+                       "the refusal names the ambiguity, not an empty window")
+                   (is (= :trace-window (:operation edn)))
+                   (is (not= 0 (:count edn))
+                       "REGRESSION: epochs exist in BOTH frames — :count 0 is a falsehood")
+                   (is (not (contains? edn :epochs))
+                       "a refusal carries no :epochs — an empty vector reads as 'nothing there'")
+                   (is (nil? (:next-cursor edn))
+                       "no continuation token for a page that was never read")
+                   (is (= two-frames (:available-frames edn))
+                       "the candidate frames are named so the agent can choose")
+                   (is (nil? (:selected-frame edn))))
+                 (done))))))
+
+(deftest watch-epochs-ambiguous-frame-refuses-rather-than-aging-out-a-live-cursor
+  ;; The second falsehood, and the more damaging one: on an empty ring
+  ;; the caller's live `:since-id` is simply not found, so the poll
+  ;; reports the cursor DEAD.
+  (async done
+    (stub-runtime! nil {:operation  :watch-epochs
+                        :app-frames two-frames
+                        :pin        nil
+                        :rings      {:rf/default [(epoch 1) (epoch 2) (epoch 3)]
+                                     :stories    [(epoch 7)]}})
+    (-> (we/watch-epochs-tool nil (tu/args->js {:since-id 2}))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (err? r))
+                   (is (= false (:ok? edn)))
+                   (is (= :ambiguous-frame (:reason edn))
+                       "the refusal names the ambiguity")
+                   (is (= :watch-epochs (:operation edn)))
+                   (is (not= :rf.mcp/cursor-stale (:reason edn))
+                       "REGRESSION: epoch 2 is alive in :rf/default — declaring the cursor aged out is a falsehood")
+                   (is (not (true? (:id-aged-out? edn)))
+                       "REGRESSION: a live cursor must not be reported dead")
+                   (is (not (contains? edn :matches)))
+                   (is (nil? (:next-cursor edn)))
+                   (is (= two-frames (:available-frames edn))))
+                 (done))))))
+
+(deftest epoch-tool-refusals-name-the-next-action
+  ;; An ambiguity error that merely says "ambiguous" is not good
+  ;; ergonomics. The hint must name what to DO.
+  (async done
+    (stub-runtime! nil {:operation  :trace-window
+                        :app-frames two-frames
+                        :pin        nil
+                        :rings      {}})
+    (-> (tw/trace-window-tool nil (tu/args->js {}))
+        (.then (fn [r]
+                 (let [hint (:hint (read-edn r))]
+                   (is (string? hint))
+                   (is (str/includes? hint "frame") "names the `frame` arg")
+                   (is (str/includes? hint "set-operating-frame")
+                       "names the pin tool the agent already has")
+                   (is (str/includes? hint ":stories")
+                       "names the candidates inline, so choosing needs no second call"))
+                 (done))))))
+
+;; ---------------------------------------------------------------------------
+;; Where the detection sits — the branch, not the message.
+;; ---------------------------------------------------------------------------
+
+(deftest the-emitted-forms-resolve-before-they-read
+  ;; Patching only the message would leave the wrong branch taken. Both
+  ;; forms must bind the resolved id, refuse on nil, and only then touch
+  ;; the ring.
+  (async done
+    (let [captured (atom nil)]
+      (stub-runtime! captured {:operation  :trace-window
+                               :app-frames [:rf/default]
+                               :pin        nil
+                               :rings      {:rf/default [(epoch 1)]}})
+      (-> (tw/trace-window-tool nil (tu/args->js {}))
+          (.then (fn [_]
+                   (is (guards-ambiguity? @captured :trace-window)
+                       "trace-window resolves, refuses on nil, THEN reads the ring")
+                   (is (str/includes? @captured "(re-frame2-pair.runtime/epoch-history fid)")
+                       "the history read goes against the resolved id, never implicitly")))
+          (.then (fn [_]
+                   (let [captured2 (atom nil)]
+                     (stub-runtime! captured2 {:operation  :watch-epochs
+                                               :app-frames [:rf/default]
+                                               :pin        nil
+                                               :rings      {:rf/default [(epoch 1)]}})
+                     (-> (we/watch-epochs-tool nil (tu/args->js {}))
+                         (.then (fn [_]
+                                  (is (guards-ambiguity? @captured2 :watch-epochs)
+                                      "watch-epochs resolves, refuses on nil, THEN polls")
+                                  (is (str/includes? @captured2
+                                                     "(re-frame2-pair.runtime/epochs-since nil fid)")
+                                      "the poll goes against the resolved id")
+                                  (is (str/includes? @captured2
+                                                     "(re-frame2-pair.runtime/epoch-history fid)")
+                                      "so does the advisory's history count — one resolution, one truth")
+                                  (done)))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Controls — the tiers that must keep working, and the genuine empties
+;; the refusal must NOT swallow.
+;; ---------------------------------------------------------------------------
+
+(deftest tier-1-explicit-frame-reads-that-frame
+  (async done
+    (stub-runtime! nil {:operation  :trace-window
+                        :app-frames two-frames
+                        :pin        nil
+                        :rings      {:rf/default [(epoch 1) (epoch 2)]
+                                     :stories    [(epoch 7)]}})
+    (-> (tw/trace-window-tool nil (tu/args->js {:ms 60000 :frame ":stories"}))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (not (err? r)) "an explicit frame is answerable")
+                   (is (true? (:ok? edn)))
+                   (is (= 1 (:count edn)) "reads the NAMED frame's ring"))
+                 (done))))))
+
+(deftest tier-2-session-pin-reads-the-pinned-frame
+  (async done
+    (stub-runtime! nil {:operation  :watch-epochs
+                        :app-frames two-frames
+                        :pin        :stories
+                        :rings      {:rf/default [(epoch 1) (epoch 2)]
+                                     :stories    [(epoch 7)]}})
+    (-> (we/watch-epochs-tool nil (tu/args->js {}))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (not (err? r)) "a pinned session is answerable")
+                   (is (true? (:ok? edn)))
+                   (is (= 1 (:count edn)) "reads the PINNED frame's ring"))
+                 (done))))))
+
+(deftest tier-3-sole-app-frame-reads-it-without-a-pin
+  (async done
+    (stub-runtime! nil {:operation  :trace-window
+                        :app-frames [:rf/default]
+                        :pin        nil
+                        :rings      {:rf/default [(epoch 1) (epoch 2)]}})
+    (-> (tw/trace-window-tool nil (tu/args->js {:ms 60000}))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (not (err? r)) "a sole app frame is answerable with no pin")
+                   (is (= 2 (:count edn))))
+                 (done))))))
+
+(deftest a-cursors-sticky-frame-outranks-the-session-pin
+  ;; The care these two need that get-path did not: the frame a paginated
+  ;; call is ALREADY iterating rides in the cursor, and page 2 must stay
+  ;; on it even when the session was pinned elsewhere in between.
+  (async done
+    (let [c (cursor/encode-cursor {:v 1 :after-id 1 :ms 60000
+                                   :until-ms (+ (js/Date.now) 1000)
+                                   :frame :stories})]
+      (stub-runtime! nil {:operation  :trace-window
+                          :app-frames two-frames
+                          :pin        :rf/default
+                          :rings      {:rf/default [(epoch 1) (epoch 2)]
+                                       :stories    [(epoch 7)]}})
+      (-> (tw/trace-window-tool nil (tu/args->js {:cursor c}))
+          (.then (fn [r]
+                   (let [edn (read-edn r)]
+                     (is (not (err? r)))
+                     (is (= 1 (:count edn))
+                         "page 2 stayed on the cursor's frame, not the session pin"))
+                   (done)))))))
+
+(deftest a-genuinely-empty-ring-in-a-resolvable-frame-still-answers
+  ;; The complement, and the reason the refusal is scoped to tier 4: an
+  ;; honestly quiet frame must still get its honest `:count 0`, not a
+  ;; refusal. Over-firing here would trade one falsehood for another.
+  (async done
+    (stub-runtime! nil {:operation  :trace-window
+                        :app-frames [:rf/default]
+                        :pin        nil
+                        :rings      {:rf/default []}})
+    (-> (tw/trace-window-tool nil (tu/args->js {:ms 60000}))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (not (err? r)) "a resolvable but quiet frame is not a refusal")
+                   (is (true? (:ok? edn)))
+                   (is (= 0 (:count edn)) "and it still says zero, honestly"))
+                 (done))))))

--- a/tools/story-mcp/test/re_frame/story_mcp/tools/dedup_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools/dedup_test.clj
@@ -127,6 +127,28 @@
       (is (= text (rf.story-mcp.tools.result/pr-edn sc))
           "the text slot is re-stringified from the deduped structured payload — both slots ride the same wire shape"))))
 
+(deftest apply-dedup-accepts-sorted-structured-content
+  ;; The wire boundary has to READ ordinary persistent app-db state, not
+  ;; fail on it. A sorted index keyed by path vectors used to throw
+  ;; `ClassCastException` out of the default-on dedup step the moment one
+  ;; key was pooled and another beside it was not — the placeholder symbol
+  ;; reached the tree comparator. The repair is in the shared walk
+  ;; (`re-frame.mcp-base.dedup`); this is the consumer-side pin that the
+  ;; envelope survives it with both slots consistent. No story-mcp
+  ;; production logic is involved.
+  (let [shared  [1 2 3]
+        payload {:index (sorted-map shared :old [4 5 6] :new)
+                 :again shared}
+        result  (rf.story-mcp.tools.result/text-result (rf.story-mcp.tools.result/pr-edn payload) payload)
+        out     (rf.story-mcp.tools.wire-pipeline/apply-dedup result true)
+        sc      (:structuredContent out)]
+    (is (contains? sc :rf.mcp/dedup-table)
+        "non-vacuity: the sorted payload still deduped rather than riding through raw")
+    (is (= payload (rf.story-mcp.test-support/dedup-expand sc))
+        "round-trip restores the original payload")
+    (is (= (-> out :content first :text) (rf.story-mcp.tools.result/pr-edn sc))
+        "text and structuredContent stay consistent")))
+
 (deftest apply-dedup-preserves-sibling-slots
   ;; Anything the handler set on the envelope (e.g. `:isError`) must
   ;; survive the dedup rewrite. The wire-boundary transform is


### PR DESCRIPTION
Two MCP-surface bugs, one package each, one commit each.

## rf2-7wwp — sorted collections crash default-on structural dedup

`re-frame.mcp-base.dedup`'s generic side-walk branch rebuilt every collection with
`(into (empty form) ...)`. The substitution pass replaces a repeated subtree with a
`de-dupe.cache/cache-N` symbol, so a sorted map/set was rebuilt through its own
comparator with that placeholder in key/element position. A default sorted map of
vector keys — an ordinary SPA index keyed by paths — threw the moment one key was
pooled and another beside it was not. Dedup is default-on, so this was a crash on an
ordinary read path, not an opt-in one.

Fix: sorted maps and sets lower to their unsorted counterparts before the rebuild.
The cache travels as EDN/JSON, where a sorted map reads back unsorted regardless, so
nothing the codec ever preserved is lost and Clojure equality across the round trip
stays exact. Wire format, reference grammar, envelope, default-on posture and tool
APIs unchanged.

**Both hosts were affected** — the bead had left CLJS open as unproven. CLJS reports
`Error: Cannot compare [4 5 6] to de-dupe.cache/cache-1` where the JVM reports
`ClassCastException: clojure.lang.Symbol cannot be cast to clojure.lang.IPersistentVector`.

Coverage: two focused cross-host regressions (pooled key beside an unpooled one; the
same in sorted-set element position), each with its unordered control and opt-out
passthrough. `expand-round-trips-every-collection-kind` now covers the two kinds its
name always claimed — it said "every collection kind" and tested five, which is how
this class stayed unseen; its new arms also pin the lowering, so a future "restore
sortedness" change cannot silently reopen the comparator door. One consumer-side pin
in story-mcp's `apply-dedup` shows the wire-boundary envelope surviving with both
slots consistent — test only, no consumer production logic.

## rf2-yo4s — trace-window and watch-epochs turned frame ambiguity into a false empty ring

Both tools are frame-targeted, so the Tool-Pair contract makes them resolve explicit
override to session pin to sole app frame to nil, and REFUSE at nil. Neither did. Each
emitted an implicit-frame call — `(epoch-history)` / `(epochs-since id)` — whose
runtime arity defaults to `(current-frame)`, nil under two-plus app frames with no
pin, and `rf/epoch-history` answers `[]` for an unknown frame without erroring.

An empty ring is not a neutral answer:

- `trace-window` reported `:count 0` — "nothing happened" — in the same voice as a
  genuinely quiet window. Its own `:count 0` advisory could never catch this: the
  advisory reads the SAME implicit-frame history, so both sides came back empty
  together.
- `watch-epochs` added a second falsehood: the caller's live `:since-id` cannot be
  found in an empty history, so the poll reported `:id-aged-out? true` and sent the
  agent back to page one of a frame it never chose.

Both now resolve once, browser-side, before touching the ring, and branch to the
runtime's existing `ambiguous-frame-error`. No new vocabulary. The sticky frame (the
cursor's, else the caller's arg) is handed in as the tier-1 override, so a paginated
call stays on the frame it was already iterating even when the session was pinned
elsewhere in between; the refusal returns no `:next-cursor`, so no continuation is
minted for a page that was never read; and watch-epochs checks the refusal AHEAD of
its cursor-stale branch, which is the ordering the second falsehood needed.

The resolve-then-refuse wrapper get-path introduced under rf2-q17a is now shared
rather than copied a third time. The emitted source is byte-identical for get-path,
so its existing witnesses stay the pin on that tool — and the red control below shows
they go red together with the new ones, which is the evidence the shared helper is
load-bearing for all three.

The two `frame` args, which carried no description at all, now name the refusal and
the escape as get-path's already did. `003-Tool-Catalogue` already requires this of
"every frame-targeted op", so this is a conformance gap, not a spec gap: **no spec
change**.

## Quality gates

Every exit code below is the runner's own, captured to a file on the same command
line as the run, and quoted from that file. Each gate's log names this worktree as
its config/working root.

| Gate | Command | Exit | Result |
| --- | --- | --- | --- |
| mcp-base JVM | `clojure -M:test` in `tools/mcp-base` | 0 | 286 tests, 1001 assertions, 0 failures |
| mcp-base CLJS | `clojure -M:cljs-test -m shadow.cljs.devtools.cli compile cljs-test && node out/cljs-test.js` | 0 | 50 tests, 298 assertions, 0 failures |
| story-mcp JVM | `clojure -M:test` in `tools/story-mcp` | 0 | 289 tests, 1600 assertions, 0 failures |
| pair-mcp | `npx shadow-cljs compile server-test && node out/server-test.js` | 0 | 1140 tests, 4158 assertions, 0 failures |
| pair-mcp descriptors | `npm run check:descriptors` | 0 | `tool-descriptors.edn` in sync (30 tools) |
| lint | `clj-kondo --fail-level error --lint tools/mcp-base --lint tools/re-frame2-pair-mcp --lint tools/story-mcp` | 0 | errors 0 (22 pre-existing warnings, all in story-mcp) |

### Red controls

Each fix was reverted in place, the gate re-run, and the revert then undone and
verified by SHA-256 of the file bytes rather than by reading a diff.

| Control | Exit | Result |
| --- | --- | --- |
| rf2-7wwp, mcp-base JVM focused | 1 | 2 failures, 2 errors (`ClassCastException`) |
| rf2-7wwp, mcp-base CLJS (node step) | 1 | 2 failures, 2 errors (`Cannot compare ... to de-dupe.cache/cache-1`) |
| rf2-7wwp, story-mcp focused dedup | 1 | 1 error (`ClassCastException`) |
| rf2-yo4s, pair-mcp | 1 | 28 failures, 6 errors — including `:count 0` on trace-window and `:rf.mcp/cursor-stale` on a live cursor for watch-epochs, plus the four pre-existing get-path witnesses |

The rf2-7wwp restore hashed identical. The rf2-yo4s restore was done with
`git checkout HEAD --`, whose raw hash differed: the content matched the committed
blob exactly (`git show HEAD:<path>` and the CR-stripped working file both hash to
the pre-mutation value, and `git status` is clean), and the byte difference was git's
own CRLF checkout normalisation on Windows. The gate was re-run green afterwards on
the restored tree.

### One note for anyone running the mcp-base CLJS gate locally

`shadow-cljs compile cljs-test` alone exits **0 even with failing tests** —
`:autorun` prints the red summary and the compile still succeeds. The verdict is the
separate `node out/cljs-test.js` step, which is what `npm run test:cljs` and CI gate
on; measured here, the red control's compile exited 0 while its node step exited 1.
This is the same hazard `tools/re-frame2-pair-mcp/deps.edn` already documents under
rf2-7r9w for that package's build.

### Skipped

`scripts/test-fast-pr.sh` and the live hermetic conformance suite were not run:
several sibling workers are live and that gate wedges rather than fails when two
coexist. CI owns the spine. `tools/mcp-conformance` is untouched — the wire grammar,
the `de-dupe.cache/cache-0` root its Node decoder pins, and every tool name and
argument are unchanged.

### Dependencies

`tools/mcp-base` has no `node_modules` in any checkout; its CLJS build runs from the
`:cljs-test` deps alias through the Clojure CLI, so no install was needed. For
`tools/re-frame2-pair-mcp` the compile does need the npm tree: the gitignored
`package-lock.json` was **copied** into this worktree and `npm ci` run there, giving
this worktree its own real `node_modules` directory (verified a plain directory, not
a junction or symlink, on both sides). No link was created and no shared tree was
written through.
