### PR TITLE
fix(xray): pop-out keyboard listener, actor-handle cleanup, and the 017 classifier claim (rf2-61i5, rf2-s4dp, rf2-p0b0)

### DIFF
--- a/tools/xray/README.md
+++ b/tools/xray/README.md
@@ -248,7 +248,12 @@ lives in [`spec/007-UX-IA.md`](spec/007-UX-IA.md) §Global shortcuts):
 open-in-editor hint). Inside the shell, the LIVE-feed spine binds bare
 `Space` / `L` / `j` / `k` / `G`. Pop-out is launched from the chrome's
 `⛶` button or programmatically via `(xray/popout!)` — it is not bound
-to a global chord.
+to a global chord. Once open, the pop-out window has its own listener
+and the same chords work there, with one exception: `Ctrl+Shift+C`
+shows/hides the OPENER's in-app shell, so it stays opener-owned and does
+nothing in the pop-out (see
+[`spec/011-Launch-Modes.md`](spec/011-Launch-Modes.md) §Pop-out to a
+second window).
 
 ### Disable
 

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -355,6 +355,61 @@ via `window.opener`. The pop-out renders into the new window but
 — no `BroadcastChannel`, no `postMessage`, no structured-clone
 serialisation. Same JS realm, no protocol cost.
 
+#### The pop-out has its own keyboard (rf2-61i5)
+
+Runtime state crosses the realm boundary; **DOM key events do not**. A
+keydown made while focus is in the pop-out window is delivered only to
+listeners on the POP-OUT document, so the opener-document listener
+`keybinding/attach!` installs can never see it. A pop-out therefore gets
+**exactly one capture-phase `keydown` listener on its own document**,
+installed by `popout!` and removed by `teardown-popout-state!` — the
+single disposal path that serves an external window close, `teardown!`,
+and reopen alike, so listeners cannot accumulate across open/close
+cycles.
+
+It is the SAME keyboard map, not a second one. `keybinding` exposes one
+canonical handler parameterised by a **surface**; only three answers
+differ between the opener and the pop-out:
+
+| | Opener | Pop-out |
+|---|---|---|
+| "is this surface's shell visible?" | `mount/visible?` (reads `mount-state`) | always — the listener's lifetime *is* the pop-out shell's lifetime |
+| show the shell before opening the palette | `mount/toggle!` | no-op — it is already visible |
+| owns the `Ctrl+Shift+C` shell chord | yes | no |
+
+Three consequences are normative:
+
+- **Spine keys work in the pop-out with no inline shell open.**
+  `mount/visible?` reports on the opener's in-app shell, so reusing it
+  in the pop-out would leave `Space` / `L` / `j` / `k` / `Shift+G` /
+  `,` / `s` dead for exactly the user who moved Xray to a second
+  monitor.
+- **`Cmd/Ctrl+K` opens the palette in the pop-out without mounting,
+  showing, hiding or reparenting the opener's shell.** The palette's
+  open state lives on `:rf/xray`, which both windows render, so it
+  appears wherever a shell is on screen; what must not happen is a
+  change to the OPENER's mount state.
+- **`Ctrl+Shift+C` stays opener-owned.** It shows/hides the opener's
+  in-app shell, a surface that does not exist in the pop-out document.
+  Pressed in the pop-out it is left entirely alone — not dispatched and
+  not `preventDefault`ed — so it falls through to the browser like any
+  unbound key. This is the *operating* chord; the separate decision that
+  **no chord LAUNCHES a pop-out pre-alpha** (above) is untouched.
+
+Every other binding — the mode chord, the settings keys, the
+editor-hint `Esc` path, and the repeat / editable / activatable / modal
+guards — is shared verbatim and dispatches on `:rf/xray` exactly as it
+does from the opener.
+
+Mount reaches this listener through an **injected installer slot**
+rather than a require: `keybinding` already requires `mount` (for
+`visible?` / `toggle!`), so the hook is pushed down at load time
+instead of pulled up, which would be a cycle. An unregistered slot
+degrades to the pre-`rf2-61i5` behaviour — a pop-out with no keyboard —
+and the installer re-reads `:rf.xray/keybinding-enabled?` at install
+time, so an embed host that suppressed Xray's global keyboard gets no
+pop-out listener either.
+
 **Pop-out REFLECTS the opener's already-running instance; it must not
 RESET it (rf2-n4p5it).** `popout!` calls `mount/ensure-xray-frame!`
 with no arg — the SAME default `frame-id` the inline shell already

--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -147,7 +147,9 @@ gates the testbed files themselves, because "nothing compiles this file"
 was filed as a defect (rf2-p0b0) and the answer turned out to be no.
 
 **Every testbed under `tools/xray/testbeds/` that declares a build is
-compiled on every PR that can affect it.** `npm run test:examples-compile`
+compiled by the `examples_compile` sweep — on any PR touching that
+surface's enumerated paths, and unconditionally nightly.**
+`npm run test:examples-compile`
 (`implementation/scripts/check-examples-compile.cjs`) DERIVES its build
 list from `implementation/shadow-cljs.edn` by scanning for `:examples/<name>`
 and `:testbeds/<name>` keys, so a newly-declared testbed build is swept
@@ -161,6 +163,20 @@ The classifier arms that job from **both** relevant directions
 (`.github/scripts/report-changed-surfaces.sh`): `tools/xray/testbeds/*`
 arms it, and so does `implementation/http/*` — i.e. both a change to a
 testbed and a change to a substrate contract a testbed consumes.
+
+**But that surface is an ENUMERATION, not "anything that can affect the
+build", and the gap is deliberate.** `implementation/core/*` is NOT on it:
+its classifier arm sets `implementation_jvm`, `cljs_node_test`,
+`adapter_diagnostic`, `cljs_browser`, `cljs_prod`, `bundle_isolation` and
+`tools_jvm` — but never `examples_compile`. Every testbed build here
+`:require`s `re-frame.core`, so a core-only PR *can* affect these compiles
+with this lane skipped. `.github/workflows/test.yml` states the trade at
+the `cljs-examples-compile` job: core-only changes "keep their focused PR
+gates and rely on the unconditional nightly example compile; they no
+longer queue this perennial long-tail job on every PR" — the sweep is
+~10 minutes and core is the most-touched surface in the repo. So the
+per-PR guarantee is bounded by the enumerated surfaces, and the nightly
+covers the remainder.
 
 Seven of the nine directories here declare a build (`edn_inspector`,
 `machine_epochs`, `managed_http`, `panel_gallery`, `routes_epochs`,

--- a/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
@@ -342,7 +342,62 @@
          (or (= "j" k) (= "KeyJ" code)
              (= "k" k) (= "KeyK" code)))))
 
-(defn- handle-keydown [^js event]
+;; ---- surfaces (rf2-61i5) -------------------------------------------------
+;;
+;; Xray can be on screen in TWO documents at once: the opener's in-app shell
+;; and a `mount/popout!` window. DOM key events do not cross realms, so each
+;; live document needs its own listener — but they must not need their own
+;; keyboard MAP. `handle-keydown-on` below is the single canonical handler;
+;; a surface is the small bundle of answers that differ between the two.
+;;
+;;   :shell-visible?  is THIS surface's shell on screen right now?
+;;                    Opener: `mount/visible?`, which reads `mount-state`.
+;;                    Pop-out: always — the listener's lifetime IS the
+;;                    pop-out shell's lifetime (installed by `popout!`,
+;;                    disposed by `teardown-popout-state!`), so there is no
+;;                    window in which it is installed and the shell is not
+;;                    showing. Reading `mount/visible?` here would be the
+;;                    bug: it reports on the OPENER's inline shell, so a
+;;                    pop-out user with no inline shell open would find the
+;;                    spine keys dead.
+;;   :show-shell!     make it visible before opening the palette. The
+;;                    pop-out shell is already visible, so this is a no-op
+;;                    there — and it must stay one, or Cmd/Ctrl+K in the
+;;                    pop-out would mount or reopen the opener's shell.
+;;   :owns-shell-toggle-chord?
+;;                    Ctrl+Shift+C shows/hides the opener's IN-APP shell.
+;;                    That surface does not exist in the pop-out document,
+;;                    and reaching across to toggle the opener's would be
+;;                    an action the user did not ask for in the window they
+;;                    are looking at, so the chord stays opener-owned. In
+;;                    the pop-out the key is left entirely alone — not
+;;                    consumed, not `preventDefault`ed — so it falls
+;;                    through to the browser like any unbound key.
+;;
+;; Everything else — the chord predicates, the spine roster, the repeat /
+;; editable / activatable / modal guards, and the `:rf/xray` frame every
+;; action dispatches on — is shared verbatim. There is no second table.
+
+;; Both entries call THROUGH the var rather than capturing the fn object at
+;; def time. Capturing would freeze whatever `mount/visible?` was bound to
+;; when this ns loaded — breaking `with-redefs` in the existing tests, and
+;; leaving a stale fn behind after a shadow-cljs `:after-load` recompiles
+;; mount. Same reasoning as the `attached-fn` stash, in the other direction.
+(def ^:private opener-surface
+  {:shell-visible?           (fn opener-shell-visible? [] (mount/visible?))
+   :show-shell!              (fn opener-show-shell! [] (mount/toggle!))
+   :owns-shell-toggle-chord? true})
+
+(def ^:private popout-surface
+  {:shell-visible?           (constantly true)
+   :show-shell!              (fn no-op-show-shell! [] nil)
+   :owns-shell-toggle-chord? false})
+
+(defn- handle-keydown-on
+  "The one canonical keydown handler, read against `surface` (see above).
+  Every arm below is shared by both surfaces; only the three destructured
+  answers differ."
+  [{:keys [shell-visible? show-shell! owns-shell-toggle-chord?]} ^js event]
   (cond
     ;; rf2-llecpa — ignore OS key-repeat for every binding EXCEPT the
     ;; j / k step keys. Holding a toggle chord (Ctrl+Shift+C shell,
@@ -355,10 +410,15 @@
     (and (.-repeat event) (not (step-key? event)))
     nil
 
+    ;; rf2-61i5 — opener-owned. In the pop-out this arm matches and then
+    ;; does nothing: no dispatch, and deliberately no `preventDefault`, so
+    ;; the keystroke is left to the browser rather than being swallowed by
+    ;; a surface that has no in-app shell to toggle.
     (xray-toggle-key? event)
-    (do (.preventDefault event)
-        (.stopPropagation event)
-        (mount/toggle!))
+    (when owns-shell-toggle-chord?
+      (.preventDefault event)
+      (.stopPropagation event)
+      (mount/toggle!))
 
     ;; rf2-o5f5f.1 — Cmd-Shift-M flips Dynamic ↔ Static. Always
     ;; wired; the chord owns this keystroke for Xray (per
@@ -401,8 +461,13 @@
         ;; stranded hidden while the palette state flips invisibly).
         ;; The palette-toggle dispatch is routed through Xray's frame so
         ;; the palette open-state lives on :rf/xray.
-        (when-not (mount/visible?)
-          (mount/toggle!))
+        ;;
+        ;; rf2-61i5 — both halves read from the SURFACE. In the pop-out
+        ;; `shell-visible?` is always true, so `show-shell!` is never
+        ;; reached and the opener's mount state is not touched: the palette
+        ;; opens in the window the user is typing in.
+        (when-not (shell-visible?)
+          (show-shell!))
         (rf/with-frame :rf/xray
           (rf/dispatch [:rf.xray/palette-toggle])))
 
@@ -418,7 +483,7 @@
     ;; `target-inside-modal?` which closest-walks the event target
     ;; for `data-rf-xray-mode="settings"|"palette"`.
     :else
-    (when (and (mount/visible?)
+    (when (and (shell-visible?)
                (target-inside-xray? event)
                (not (target-editable? event))
                ;; rf2-d716o9 — yield to a focused activatable control
@@ -431,6 +496,13 @@
         (.stopPropagation event)
         (rf/with-frame :rf/xray
           (rf/dispatch [event-id]))))))
+
+(defn- handle-keydown
+  "The opener document's handler. Kept as its own `defn` because
+  `attach!` / `detach!` stash and compare this exact fn object across
+  shadow-cljs `:after-load` reloads (rf2-t2o6o)."
+  [^js event]
+  (handle-keydown-on opener-surface event))
 
 (defn attach!
   "Install the global Ctrl+Shift+C listener once. No-op on second +
@@ -487,3 +559,44 @@
   currently installed?'. Reads the `attached-state` defonce atom."
   []
   @attached-state)
+
+;; ---- pop-out document listener (rf2-61i5) --------------------------------
+
+(defn install-popout-keydown!
+  "Install ONE capture-phase `keydown` listener on pop-out document `doc`
+  and return a zero-arg disposer that removes exactly that listener.
+  Returns nil — installing nothing — when there is no document, or when
+  the host has cleared `:rf.xray/keybinding-enabled?`.
+
+  Called by `mount/popout!` through the installer slot this namespace
+  registers below; the disposer is stored in `popout-state` and invoked
+  by `teardown-popout-state!`, which is the single disposal path for an
+  external window close, `teardown!`, and reopen alike.
+
+  Deliberately NOT routed through `attach!`'s `defonce` sentinel. That
+  sentinel exists to keep the ONE process-wide opener listener from
+  double-attaching across hot reloads. A pop-out listener is per-document
+  and per-window-lifetime: its handler is a fresh closure over `doc`, held
+  only by the disposer mount stores, so reopening installs one new
+  listener rather than accumulating handlers, and a reload cannot leave a
+  stale one behind that a reference comparison would miss.
+
+  The config slot is read at install time, matching `attach!`'s posture:
+  an embed host that suppressed Xray's global keyboard gets no pop-out
+  listener either."
+  [^js doc]
+  (when (and (some? doc)
+             (config/keybinding-attach-enabled?))
+    (let [f (fn popout-keydown [^js e]
+              (handle-keydown-on popout-surface e))]
+      (.addEventListener doc "keydown" f true)
+      (fn dispose-popout-keydown! []
+        (.removeEventListener doc "keydown" f true)
+        nil))))
+
+;; The injection that closes the mount <-> keybinding cycle. This namespace
+;; already requires mount (for `visible?` / `toggle!`), so the hook is pushed
+;; DOWN rather than pulled up. Registration is inert on its own: nothing
+;; installs until `popout!` calls the installer, and the installer re-reads
+;; the config slot then.
+(mount/register-popout-keydown-installer! install-popout-keydown!)

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -84,8 +84,38 @@
   ;; opener runtime remains the source of truth. The `:overlay-node` slot holds
   ;; the opener-gone overlay element (sibling to the shell root) and
   ;; `:watchdog-id` holds the setInterval token that polls
-  ;; `window.opener.closed`.
+  ;; `window.opener.closed`. `:keydown-dispose` (rf2-61i5) holds the
+  ;; zero-arg disposer for this pop-out document's own keydown listener,
+  ;; or nil when none was installed.
   (atom nil))
+
+(defonce ^:private popout-keydown-installer
+  ;; rf2-61i5 — the seam that gives a pop-out document its keyboard.
+  ;;
+  ;; DOM key events do not cross realms, so the opener-document listener
+  ;; `keybinding/attach!` installs can never see a keypress made in the
+  ;; pop-out window. The pop-out therefore needs its own listener, but the
+  ;; require already runs `keybinding -> mount` (for `toggle!` / `visible?`),
+  ;; so mount cannot reach back for the keyboard map without a cycle.
+  ;;
+  ;; Instead keybinding INJECTS its installer here at load time. The slot
+  ;; holds `(fn [doc] -> disposer-fn-or-nil)`: mount hands over a document
+  ;; and gets back a zero-arg disposer it stores and later calls, without
+  ;; knowing what a chord is. nil when keybinding was never loaded (or the
+  ;; host disabled it), in which case a pop-out simply has no keyboard —
+  ;; exactly the behaviour that shipped before this bead.
+  (atom nil))
+
+(defn register-popout-keydown-installer!
+  "Register the fn that installs a pop-out document's keydown listener
+  (rf2-61i5). Called once by `day8.re-frame2-xray.keybinding` at load
+  time; see `popout-keydown-installer` for why the injection runs this
+  way round. `installer` takes the pop-out `document` and returns either
+  a zero-arg disposer that removes exactly the listener it installed, or
+  nil when it declined to install one."
+  [installer]
+  (reset! popout-keydown-installer installer)
+  nil)
 
 (defonce ^:private diagnostic-state
   (atom {:ok? true :reason nil}))
@@ -1032,10 +1062,20 @@
   swallow-errors guards — this is a last-chance cleanup (test
   fixture, opener-side unload), not a contract-checking call site."
   []
-  (when-let [{:keys [window unmount watchdog-id
+  (when-let [{:keys [window unmount watchdog-id keydown-dispose
                      opener-window opener-pagehide-handler]} @popout-state]
     (when watchdog-id
       (try (js/clearInterval watchdog-id) (catch :default _ nil)))
+    ;; rf2-61i5 — drop the pop-out document's keydown listener. This is the
+    ;; ONE disposal path for it: external close routes here via
+    ;; `register-popout-unload-cleanup!`, `teardown!` calls this directly,
+    ;; and `popout!` returns the existing state rather than re-opening, so
+    ;; listeners cannot accumulate across open/close cycles. The disposer
+    ;; removes the exact fn object that was added — `removeEventListener`
+    ;; compares by reference, and the handler is a fresh per-pop-out closure
+    ;; over that document.
+    (when keydown-dispose
+      (try (keydown-dispose) (catch :default _ nil)))
     ;; rf2-uong — drop the opener-side `pagehide` announcer. Unlike the
     ;; watchdog (a timer owned by this realm) the listener would otherwise
     ;; accumulate across repeated popout open/close cycles in ONE opener
@@ -1081,7 +1121,12 @@
 
   Production sessions never call `teardown!` so the listener-leak
   exposure is test-only — the convention is pinned in
-  `tools/xray/spec/Conventions.md` §Mount conventions."
+  `tools/xray/spec/Conventions.md` §Mount conventions.
+
+  That obligation is about the OPENER-document listener only. The
+  pop-out document's own listener (rf2-61i5) IS disposed from here, via
+  `teardown-popout-state!`, because mount owns its disposer rather than
+  having to reach into keybinding for it."
   []
   ;; Restore the host's inline `display` before clearing the snapshot —
   ;; teardown is the cleanest exit and must leave the host element in
@@ -1527,6 +1572,16 @@
                         ;; see, because the reload destroys the watchdog.
                         announcer    (register-opener-reload-announcer!
                                        js/window win overlay-node)
+                        ;; rf2-61i5 — the pop-out's OWN keydown listener.
+                        ;; Key events do not cross realms, so without this
+                        ;; the documented keyboard workflow (Cmd/Ctrl+K,
+                        ;; Cmd/Ctrl+Shift+M, Space / L / j / k / G, `,`/s)
+                        ;; is inert whenever focus is in this window.
+                        ;; `keydown-dispose` is nil when keybinding is not
+                        ;; loaded or the host disabled it.
+                        keydown-dispose (when-let [install @popout-keydown-installer]
+                                          (try (install doc)
+                                               (catch :default _ nil)))
                         state        {:ok?          true
                                       :window       win
                                       :node         node
@@ -1534,6 +1589,7 @@
                                       :mode         :popout
                                       :overlay-node overlay-node
                                       :watchdog-id  watchdog-id
+                                      :keydown-dispose         keydown-dispose
                                       :opener-window           js/window
                                       :opener-pagehide-handler announcer}]
                     (reset! popout-state state)

--- a/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
@@ -951,3 +951,220 @@
         (handle-keydown event)
         (is (true? @prevented)
             "Space consumed — the spine live-pause binding fired on a plain node")))))
+
+;; ---- (10) the pop-out document's own listener (rf2-61i5) -----------------
+;;
+;; `mount/popout!` renders a live shell into a SECOND document, and DOM key
+;; events do not cross realms — so the opener-document listener could never
+;; see a keypress made in the pop-out window, and the documented keyboard
+;; workflow was inert whenever focus was there.
+;;
+;; Two things are under test, and they fail in different ways:
+;;
+;;   * ROUTING. `handle-keydown-on` is now surface-parameterised. Every
+;;     assertion below pairs the pop-out surface with the OPENER surface on
+;;     the identical event, so a test cannot pass by the handler having
+;;     become inert — the control shares the shape of the target.
+;;   * OWNERSHIP. `install-popout-keydown!` must add exactly one
+;;     capture-phase listener to the document it is handed and return a
+;;     disposer that removes THAT fn object.
+;;
+;; The browser-level counterpart (a real second window, real keypresses)
+;; lives in the feature-matrix scenario added under the same bead.
+
+(defn- handle-keydown-on [surface event]
+  (#'keybinding/handle-keydown-on surface event))
+
+(def ^:private popout-surface @#'keybinding/popout-surface)
+(def ^:private opener-surface @#'keybinding/opener-surface)
+
+(defn- mk-shell-key-event
+  "Synthetic keydown whose `.target` resolves the Xray shell testid via
+  `.closest` — i.e. a key pressed INSIDE a rendered shell, which is what
+  both surfaces see. Modifiers and key are caller-supplied; prevent/stop
+  are spied."
+  [{:keys [key code ctrl? shift? meta? alt?]
+    :or   {ctrl? false shift? false meta? false alt? false}}]
+  (let [prevented  (atom false)
+        stopped    (atom false)
+        shell-node (js-obj "id" "fake-shell")
+        target     (js-obj "tagName"      "DIV"
+                           "getAttribute" (fn [_] nil)
+                           "closest"      (fn [sel]
+                                            (when (re-find #"rf-xray-shell" sel)
+                                              shell-node)))]
+    {:event     (js-obj "key"             key
+                        "code"            code
+                        "target"          target
+                        "ctrlKey"         ctrl?
+                        "shiftKey"        shift?
+                        "metaKey"         meta?
+                        "altKey"          alt?
+                        "repeat"          false
+                        "preventDefault"  (fn [] (reset! prevented true))
+                        "stopPropagation" (fn [] (reset! stopped true)))
+     :prevented prevented
+     :stopped   stopped}))
+
+(deftest popout-spine-keys-fire-with-no-opener-shell-visible
+  (testing "rf2-61i5 — the bug's core. `mount/visible?` reports on the
+            OPENER's in-app shell, so with no inline shell open every bare
+            spine key was refused. In the pop-out the shell IS on screen,
+            so the spine must fire; the opener surface on the SAME event
+            must still refuse. Pairing them is the control: if the handler
+            had merely gone inert, the pop-out half would fail too."
+    (setup-xray-runtime!)
+    (with-redefs [mount/visible? (constantly false)]
+      (doseq [k [{:key " " :code "Space"}
+                 {:key "j" :code "KeyJ"}
+                 {:key "k" :code "KeyK"}
+                 {:key "l" :code "KeyL"}]]
+        (let [{:keys [event prevented]} (mk-shell-key-event k)]
+          (handle-keydown-on popout-surface event)
+          (is (true? @prevented)
+              (str "pop-out spine key " k " must fire with no opener shell")))
+        (let [{:keys [event prevented]} (mk-shell-key-event k)]
+          (handle-keydown-on opener-surface event)
+          (is (false? @prevented)
+              (str "opener spine key " k " must still refuse when its own "
+                   "shell is hidden — the pre-existing contract")))))))
+
+(deftest popout-palette-does-not-touch-the-opener-shell
+  (testing "rf2-61i5 — Cmd/Ctrl+K in the pop-out opens the palette WITHOUT
+            mounting, showing or reopening the opener's inline shell. The
+            opener surface on the identical event still calls `toggle!`
+            when its shell is hidden, which is what makes the pop-out
+            assertion mean something."
+    (setup-xray-runtime!)
+    (let [toggles (atom 0)]
+      (with-redefs [mount/visible? (constantly false)
+                    mount/toggle!  (fn [] (swap! toggles inc) nil)]
+        (doseq [chord [{:key "k" :code "KeyK" :meta? true}
+                       {:key "k" :code "KeyK" :ctrl? true}]]
+          (reset! toggles 0)
+          (let [{:keys [event prevented]} (mk-shell-key-event chord)]
+            (handle-keydown-on popout-surface event)
+            (is (true? @prevented)
+                (str "pop-out " chord " is consumed — the palette opens here"))
+            (is (zero? @toggles)
+                (str "pop-out " chord " must NOT mount or reopen the opener's "
+                     "shell — that is the accident this bead names")))
+          (reset! toggles 0)
+          (let [{:keys [event]} (mk-shell-key-event chord)]
+            (handle-keydown-on opener-surface event)
+            (is (= 1 @toggles)
+                (str "control: the OPENER surface still shows its hidden "
+                     "shell before opening the palette on " chord))))))))
+
+(deftest popout-shell-toggle-chord-stays-opener-owned
+  (testing "rf2-61i5 — Ctrl+Shift+C shows/hides the opener's IN-APP shell,
+            a surface that does not exist in the pop-out document. Pressed
+            in the pop-out it must not reach across and toggle the opener's
+            shell, and must not be swallowed either (no preventDefault), so
+            it falls through to the browser like any unbound key."
+    (setup-xray-runtime!)
+    (let [toggles (atom 0)]
+      (with-redefs [mount/visible? (constantly true)
+                    mount/toggle!  (fn [] (swap! toggles inc) nil)]
+        (let [{:keys [event prevented stopped]}
+              (mk-shell-key-event {:key "C" :code "KeyC" :ctrl? true :shift? true})]
+          (handle-keydown-on popout-surface event)
+          (is (zero? @toggles) "pop-out Ctrl+Shift+C must not toggle the opener")
+          (is (false? @prevented) "and must not consume the key")
+          (is (false? @stopped)   "and must not stop propagation"))
+        (reset! toggles 0)
+        (let [{:keys [event prevented]}
+              (mk-shell-key-event {:key "C" :code "KeyC" :ctrl? true :shift? true})]
+          (handle-keydown-on opener-surface event)
+          (is (= 1 @toggles) "control: the opener surface still owns the chord")
+          (is (true? @prevented) "and still consumes it"))))))
+
+(deftest popout-mode-chord-routes-through-the-shared-map
+  (testing "rf2-61i5 — Cmd/Ctrl+Shift+M and `,` / s are NOT surface-
+            dependent: both surfaces route them identically through the one
+            keyboard map. Proves the pop-out reuses the canonical roster
+            rather than carrying a second table."
+    (setup-xray-runtime!)
+    (with-redefs [mount/visible? (constantly true)]
+      (doseq [chord [{:key "M" :code "KeyM" :ctrl? true :shift? true}
+                     {:key "," :code "Comma"}
+                     {:key "s" :code "KeyS"}]]
+        (let [popout (mk-shell-key-event chord)
+              opener (mk-shell-key-event chord)]
+          (handle-keydown-on popout-surface (:event popout))
+          (handle-keydown-on opener-surface (:event opener))
+          (is (= @(:prevented opener) @(:prevented popout))
+              (str "surfaces must agree on " chord))
+          (is (true? @(:prevented popout))
+              (str chord " is a live binding on both surfaces")))))))
+
+(deftest install-popout-keydown-owns-exactly-one-listener
+  (testing "rf2-61i5 — installing on a pop-out document adds exactly ONE
+            capture-phase keydown listener, and the returned disposer
+            removes that exact fn object (add/removeEventListener compare
+            by reference)."
+    (let [{:keys [doc listeners]} (mk-stub-document)
+          dispose (keybinding/install-popout-keydown! doc)]
+      (is (fn? dispose) "an installer that ran returns its disposer")
+      (is (= 1 (count @listeners)) "exactly one listener installed")
+      (let [{:keys [type use-capture]} (first @listeners)]
+        (is (= "keydown" type))
+        (is (true? use-capture) "capture phase, as on the opener document"))
+      (dispose)
+      (is (zero? (count @listeners))
+          "the disposer removed the exact listener it installed"))))
+
+(deftest popout-listeners-do-not-accumulate-across-windows
+  (testing "rf2-61i5 — each pop-out document gets its own listener and its
+            own disposer; disposing one must not disturb the other. This is
+            the reopen contract: `teardown-popout-state!` disposes, a later
+            `popout!` installs one fresh listener rather than stacking
+            handlers."
+    (let [a (mk-stub-document)
+          b (mk-stub-document)
+          dispose-a (keybinding/install-popout-keydown! (:doc a))
+          dispose-b (keybinding/install-popout-keydown! (:doc b))]
+      (is (= 1 (count @(:listeners a))))
+      (is (= 1 (count @(:listeners b))))
+      (is (not (identical? (:handler (first @(:listeners a)))
+                           (:handler (first @(:listeners b)))))
+          "a fresh closure per document — not one shared process-wide fn")
+      (dispose-a)
+      (is (zero? (count @(:listeners a))) "a disposed")
+      (is (= 1 (count @(:listeners b))) "b untouched by a's disposal")
+      (dispose-b)
+      (is (zero? (count @(:listeners b)))))))
+
+(deftest install-popout-keydown-honours-the-config-slot
+  (testing "rf2-61i5 — an embed host that cleared
+            :rf.xray/keybinding-enabled? gets no pop-out listener either.
+            The slot is read at INSTALL time, matching attach!'s posture."
+    (let [{:keys [doc listeners]} (mk-stub-document)]
+      (try
+        (config/set-keybinding-enabled! false)
+        (is (nil? (keybinding/install-popout-keydown! doc))
+            "declined — nil rather than a disposer")
+        (is (zero? (count @listeners)) "nothing installed")
+        (finally
+          (config/set-keybinding-enabled! true)))
+      ;; Control, sharing the shape: with the slot restored the SAME call on
+      ;; the SAME document installs — so the zero above is a refusal, not an
+      ;; installer that never works.
+      (let [dispose (keybinding/install-popout-keydown! doc)]
+        (is (= 1 (count @listeners)) "installs once the slot is back on")
+        (dispose)))))
+
+(deftest install-popout-keydown-refuses-a-nil-document
+  (testing "rf2-61i5 — a pop-out whose document is unreachable installs
+            nothing and returns nil rather than throwing; `popout!` stores
+            the nil and `teardown-popout-state!` skips disposal."
+    (is (nil? (keybinding/install-popout-keydown! nil)))))
+
+(deftest popout-installer-is-registered-with-mount
+  (testing "rf2-61i5 — the injection that closes the mount <-> keybinding
+            cycle. `mount/popout!` reaches keybinding ONLY through this
+            slot, so an unregistered installer means a keyboard-less
+            pop-out with nothing else failing."
+    (is (identical? keybinding/install-popout-keydown!
+                    @#'mount/popout-keydown-installer)
+        "keybinding registered its installer into mount at load time")))

--- a/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
@@ -1165,6 +1165,8 @@
             cycle. `mount/popout!` reaches keybinding ONLY through this
             slot, so an unregistered installer means a keyboard-less
             pop-out with nothing else failing."
+    ;; Two derefs, not one: the var holds an ATOM, so `@#'` yields the atom
+    ;; and the second `@` reads the installer out of it.
     (is (identical? keybinding/install-popout-keydown!
-                    @#'mount/popout-keydown-installer)
+                    @@#'mount/popout-keydown-installer)
         "keybinding registered its installer into mount at load time")))

--- a/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
@@ -1341,14 +1341,17 @@
   of what `popout!` would install if it had a real browser window
   available. Returns the seeded state map so the test can assert
   against its slots."
-  [{:keys [window unmount-fn]}]
+  [{:keys [window unmount-fn keydown-dispose]}]
   (let [node    (mk-stub-node)
         unmount (or unmount-fn (fn [] nil))
-        state   {:ok? true
-                 :window  window
-                 :node    node
-                 :unmount unmount
-                 :mode    :popout}]
+        state   (cond-> {:ok? true
+                         :window  window
+                         :node    node
+                         :unmount unmount
+                         :mode    :popout}
+                  ;; rf2-61i5 — only seeded when a test asks for it, so the
+                  ;; existing tests keep exercising the nil-disposer path.
+                  keydown-dispose (assoc :keydown-dispose keydown-dispose))]
     (reset! @#'mount/popout-state state)
     state))
 
@@ -1411,6 +1414,80 @@
               "popout-state cleared despite the throw")
           (is (true? @closed?)
               "popout window still closed despite the throw"))))))
+
+;; ---- pop-out keydown listener lifecycle (rf2-61i5) -----------------------
+;;
+;; `popout!` renders a shell into a second document, and DOM key events do
+;; not cross realms — so the pop-out gets its OWN listener, installed
+;; through the slot `keybinding` injects and disposed by
+;; `teardown-popout-state!`. That one disposal path serves every exit:
+;; `teardown!`, and an external window close via the pagehide/unload
+;; handler. These pin the mount half; the routing half is in
+;; keybinding_cljs_test.cljs.
+
+(deftest teardown!-disposes-the-popout-keydown-listener
+  (testing "rf2-61i5 — teardown! must run the pop-out document's keydown
+            disposer, so a torn-down pop-out leaves no live handler."
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [window]} (mk-stub-popout-window)
+              disposals (atom 0)]
+          (seed-popout-state! {:window          window
+                               :keydown-dispose (fn []
+                                                  (swap! disposals inc)
+                                                  nil)})
+          (mount/teardown!)
+          (is (= 1 @disposals)
+              "the pop-out keydown disposer ran exactly once")
+          (is (nil? @@#'mount/popout-state)
+              "and the singleton still cleared"))))))
+
+;; (The external-close half of this contract needs
+;; `register-popout-cleanup!`, defined further down with the other
+;; pagehide/unload tests, so it lives beside them rather than here.)
+
+(deftest teardown!-swallows-a-throwing-keydown-disposer
+  (testing "rf2-61i5 — teardown is last-chance cleanup: a throwing disposer
+            must not strand the substrate unmount, the window close, or the
+            singleton. Same posture as the unmount guard above."
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [window closed?]} (mk-stub-popout-window)
+              unmount-calls (atom 0)]
+          (seed-popout-state!
+            {:window          window
+             :unmount-fn      (fn [] (swap! unmount-calls inc) nil)
+             :keydown-dispose (fn [] (throw (ex-info "disposer blew up"
+                                                     {:reason :test})))})
+          (is (nil? (mount/teardown!))
+              "teardown returns nil even when the disposer throws")
+          (is (nil? @@#'mount/popout-state) "singleton cleared despite the throw")
+          (is (= 1 @unmount-calls) "substrate unmount still ran")
+          (is (true? @closed?) "window still closed"))))))
+
+(deftest teardown!-tolerates-a-popout-with-no-keydown-disposer
+  (testing "rf2-61i5 — `install-popout-keydown!` returns nil when the host
+            disabled Xray's keyboard, so `:keydown-dispose` is legitimately
+            absent. Teardown must skip it rather than calling nil."
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [window closed?]} (mk-stub-popout-window)]
+          (seed-popout-state! {:window window})
+          (is (nil? (:keydown-dispose @@#'mount/popout-state))
+              "precondition: no disposer on this pop-out")
+          (is (nil? (mount/teardown!)))
+          (is (nil? @@#'mount/popout-state))
+          (is (true? @closed?)))))))
+
+(deftest popout-keydown-installer-slot-is-registered
+  (testing "rf2-61i5 — mount reaches the keyboard map only through this
+            injected slot (requiring keybinding from here would be a
+            cycle). An empty slot means a keyboard-less pop-out with
+            nothing else failing, so pin that it is populated."
+    (is (some? @#'mount/popout-keydown-installer)
+        "an installer is registered")
+    (is (fn? @@#'mount/popout-keydown-installer)
+        "and it is callable")))
 
 (deftest teardown!-clears-both-singletons-in-one-call
   (testing "rf2-yudol + rf2-sbfb7: a single teardown! call clears
@@ -1521,6 +1598,27 @@
               "popout-state cleared by the pagehide handler")
           (is (= 1 @unmount-calls)
               "substrate unmount fn invoked by the pagehide handler"))))))
+
+(deftest popout-external-close-disposes-the-keydown-listener
+  (testing "rf2-61i5 — the user closing the pop-out window is the common
+            exit, and it routes through the same disposal path as
+            teardown!. Without this the keydown handler outlives its own
+            document."
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [window listeners]} (mk-stub-popout-window)
+              disposals (atom 0)]
+          (seed-popout-state! {:window          window
+                               :keydown-dispose (fn []
+                                                  (swap! disposals inc)
+                                                  nil)})
+          (register-popout-cleanup! window)
+          (let [pagehide-handler (first (get @listeners "pagehide"))]
+            (pagehide-handler (js-obj "type" "pagehide")))
+          (is (= 1 @disposals)
+              "pagehide disposed the pop-out keydown listener")
+          (is (nil? @@#'mount/popout-state)
+              "and cleared the singleton, as before"))))))
 
 (deftest popout-unload-handler-also-clears-popout-state
   (testing "rf2-yudol: the unload event is the older companion to

--- a/tools/xray/test/day8/re_frame2_xray/testbed_managed_http_frame_scope_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/testbed_managed_http_frame_scope_test.clj
@@ -51,7 +51,15 @@
        any-frame seams (`clear-in-flight!` 1-arg, `abort-on-actor-destroy`
        1-arg), and a deferred `rf/dispatch` from inside an `:abort-fn` must
        carry `{:frame frame}` — by then there is no ambient frame, and in
-       re-frame2 frame identity is carried, not found."
+       re-frame2 frame identity is carried, not found.
+    3. Every recorded handle's `:abort-fn` must actually retire its OWN
+       request-id from the issuing frame. `abort-on-actor-destroy` clears
+       the ACTOR slot eagerly and then delegates the request-index half to
+       each handle's closure (registry.cljc: \"the per-handle request-id
+       cleanup is owned by `clear-in-flight!` ... called inside the
+       `abort-fn` closure\"), so a no-op closure leaves a GHOST — an
+       actor-destroy that empties the actor index while the request index
+       keeps entries for an actor that no longer exists."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
             [clojure.string :as str]))
@@ -136,6 +144,15 @@
 ;; seeding fx inherit the guard instead of escaping it.
 (defn- records-handle? [form] (str/includes? form "record-in-flight!"))
 
+(defn- abort-fn-form
+  "The text of the closure a form hands `record-in-flight!` under
+  `:abort-fn` — the substring from the first `(` after the key to its
+  matching `)`. Returns nil when the key is absent or unbalanced."
+  [form]
+  (when-let [k (str/index-of form ":abort-fn")]
+    (when-let [open (str/index-of form "(" k)]
+      (balanced-form form open))))
+
 ;; ---- the extractor itself is under test ---------------------------------
 ;;
 ;; A source-text guard whose scanner silently returned nil would pass every
@@ -149,6 +166,15 @@
     (is (= "(a ; )\nb)"       (balanced-form "(a ; )\nb)" 0)))
     (is (= "(a \\) b)"        (balanced-form "(a \\) b)" 0)))
     (is (nil? (balanced-form "(a b" 0)) "unbalanced input returns nil")))
+
+(deftest abort-fn-extractor-works
+  (testing "the closure is lifted out of the handle map, not the whole map"
+    (is (= "(fn [r] (clear! r))"
+           (abort-fn-form "{:url u :abort-fn (fn [r] (clear! r)) :frame f}")))
+    (is (= "(fn [_reason] nil)"
+           (abort-fn-form "{:abort-fn (fn [_reason] nil) :frame frame}"))))
+  (testing "and a handle with no :abort-fn reports nil rather than passing"
+    (is (nil? (abort-fn-form "{:url u :frame f}")))))
 
 (deftest testbed-source-is-readable
   (testing "the testbed source is present and non-trivial"
@@ -206,3 +232,31 @@
     ;; banning every unscoped registry call.
     (is (str/includes? (fx-form ":managed-http/clear-registry")
                        "clear-all-in-flight!"))))
+
+;; ---- law 3: every handle's abort-fn retires its own request-id ----------
+;;
+;; `abort-on-actor-destroy` dissocs the ACTOR slot eagerly and then walks the
+;; handles calling `(:abort-fn handle)`. The request-index half of the
+;; cleanup is owned by that closure and by nothing else, so a handle whose
+;; abort-fn does nothing survives its own actor's destruction: the actor
+;; index empties, the request index does not, and the deck's registry strip
+;; shows request-ids belonging to an actor that is gone.
+;;
+;; Stated over EVERY recording form for the same reason laws 1 and 2 are: a
+;; new seeding fx must inherit the obligation rather than escape it.
+
+(deftest recorded-handles-retire-their-own-request-id
+  (doseq [form (filter records-handle? (fx-forms))]
+    (let [abort (abort-fn-form form)]
+      (testing "every recorded handle carries an :abort-fn closure"
+        (is (some? abort)
+            (str "a handle recorded with no `:abort-fn` can never be retired "
+                 "from the request index. Offending form:\n" form)))
+      (testing "and that closure clears its own request-id, frame-exactly"
+        (is (and (some? abort)
+                 (str/includes? abort "clear-in-flight-in-frame!"))
+            (str "`abort-on-actor-destroy` clears the ACTOR slot itself and "
+                 "delegates the REQUEST-id half to this closure, so a no-op "
+                 "abort-fn leaves a ghost handle in the request index after "
+                 "its actor is destroyed (rf2-s4dp). Offending closure:\n"
+                 (pr-str abort)))))))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -581,6 +581,90 @@ async function assertDefaultInlineLaunchModes(page, state) {
     }
   });
 
+  // rf2-61i5 — the pop-out document's OWN keyboard.
+  //
+  // DOM key events do not cross realms, so a keydown made in the pop-out
+  // window can only be seen by a listener installed on the POP-OUT
+  // document. Dispatching into that document is therefore the one probe
+  // that distinguishes "Xray has a keyboard here" from "Xray has a
+  // keyboard in the opener" — the boundary the pre-existing pop-out
+  // coverage (root/shell presence, shared cascade rendering) never
+  // crossed, because it sent no key at all.
+  //
+  // The two assertions match the acceptance the bead names: a spine step
+  // key moves focus on the shared :rf/xray frame, and Cmd/Ctrl+K opens the
+  // palette in the pop-out WITHOUT disturbing the opener's inline shell.
+  const popoutKeyboard = await page.evaluate(() => {
+    const win = window.open('', 'rf-xray-popout');
+    const doc = win && win.document;
+    if (!doc) return { ok: false, reason: 'pop-out document unreachable' };
+
+    const shell = doc.querySelector('[data-testid="rf-xray-shell"]');
+    if (!shell) return { ok: false, reason: 'pop-out shell not rendered' };
+
+    // The opener's inline shell, whose mount state must not move.
+    const openerRootMode = () => {
+      const root = document.getElementById('rf-xray-root');
+      return root ? root.getAttribute('data-rf-xray-mode') : null;
+    };
+    const openerShellCount = () =>
+      document.querySelectorAll('[data-testid="rf-xray-shell"]').length;
+
+    const before = { rootMode: openerRootMode(), shells: openerShellCount() };
+
+    // KeyboardEvent must be constructed from the POP-OUT realm, or the
+    // capture listener there receives a foreign-realm object.
+    const send = (init) => {
+      const Ctor = win.KeyboardEvent || window.KeyboardEvent;
+      const ev = new Ctor('keydown', Object.assign(
+        { bubbles: true, cancelable: true, composed: true }, init));
+      shell.dispatchEvent(ev);
+      return ev.defaultPrevented;
+    };
+
+    // (a) a spine STEP key — j / k walk the event feed.
+    const stepPrevented = send({ key: 'j', code: 'KeyJ' });
+
+    // (b) the palette chord.
+    const palettePrevented = send({ key: 'k', code: 'KeyK', ctrlKey: true });
+
+    const after = { rootMode: openerRootMode(), shells: openerShellCount() };
+
+    return {
+      ok: true,
+      stepPrevented,
+      palettePrevented,
+      paletteInPopout: Boolean(doc.querySelector('[data-testid="rf-xray-palette-dialog"]')),
+      openerBefore: before,
+      openerAfter: after,
+    };
+  });
+
+  if (!popoutKeyboard.ok) {
+    failWithDetails('Pop-out keyboard probe could not run', { observed: popoutKeyboard });
+  }
+  if (!popoutKeyboard.stepPrevented) {
+    failWithDetails(
+      'Pop-out document has no Xray keydown listener: a spine step key was not consumed there (rf2-61i5)',
+      { observed: popoutKeyboard });
+  }
+  if (!popoutKeyboard.palettePrevented) {
+    failWithDetails(
+      'Cmd/Ctrl+K was not consumed in the pop-out document (rf2-61i5)',
+      { observed: popoutKeyboard });
+  }
+  if (!popoutKeyboard.paletteInPopout) {
+    failWithDetails(
+      'Cmd/Ctrl+K in the pop-out did not open the palette in that window (rf2-61i5)',
+      { observed: popoutKeyboard });
+  }
+  if (popoutKeyboard.openerBefore.rootMode !== popoutKeyboard.openerAfter.rootMode
+      || popoutKeyboard.openerBefore.shells !== popoutKeyboard.openerAfter.shells) {
+    failWithDetails(
+      "Keys pressed in the pop-out moved the OPENER's shell mount state (rf2-61i5)",
+      { observed: popoutKeyboard });
+  }
+
   state.launchModes = {
     inlineDefault: {
       rootMode: defaultInline.rootMode,
@@ -591,6 +675,7 @@ async function assertDefaultInlineLaunchModes(page, state) {
       normalFlowHost: true,
     },
     popout,
+    popoutKeyboard,
   };
   for (const [mode, record] of Object.entries({ popout })) {
     if (!record.implemented) {

--- a/tools/xray/testbeds/managed_http/core.cljs
+++ b/tools/xray/testbeds/managed_http/core.cljs
@@ -328,7 +328,21 @@
     (let [frame (:frame frame-ctx)]
       (rf.http.registry/record-in-flight!
         request-id actor-id
-        {:abort-fn (fn [_reason] nil)
+        {;; NOT a no-op. `abort-on-actor-destroy` dissocs the ACTOR slot
+         ;; itself and then delegates the REQUEST-id half of the cleanup to
+         ;; each handle's own closure — registry.cljc states the ownership:
+         ;; "the per-handle request-id cleanup is owned by `clear-in-flight!`
+         ;; (called inside the abort-fn closure)". So a closure that returns
+         ;; nil leaves this id live in the request index after step 7
+         ;; destroys its actor: the actor index empties while the request
+         ;; index keeps ghosts for an actor that no longer exists, and the
+         ;; registry strip below shows them (rf2-s4dp).
+         ;;
+         ;; Frame-EXACT for the same reason the seed fx's closure is: the
+         ;; one-arg `clear-in-flight!` is an ANY-FRAME sweep that would drop
+         ;; a sibling mount's live slot under the same id.
+         :abort-fn (fn [_reason]
+                     (rf.http.registry/clear-in-flight-in-frame! frame request-id))
          :frame    frame
          :url      pending-url}))
     nil))
@@ -432,7 +446,7 @@
     :watch "Actor-in-flight strip: actor-a now carries TWO pending entries, actor-b ONE (Spec 014 §Abort on actor destroy). Epoch: the fan-out cascade of three issue fxs."}
    {:label "Request outlives a frame teardown"
     :event [::actor-teardown]
-    :watch "Trace: two :rf.http/aborted-on-actor-destroy rows for actor-a's outliving requests. Actor-in-flight strip: actor-a's slot is GONE; actor-b's pending entry remains."}])
+    :watch "Trace: two :rf.http/aborted-on-actor-destroy rows for actor-a's outliving requests. Actor-in-flight strip: actor-a's slot is GONE; actor-b's pending entry remains. Request-id strip: BOTH actor-a ids are gone too and ::actor-b-1 remains — the actor slot is dropped by abort-on-actor-destroy itself, the request-ids by each handle's own abort-fn, so watch both strips to see the whole teardown (rf2-s4dp)."}])
 
 ;; ============================================================================
 ;; RUNNER WIRING — register the deck's run-step event


### PR DESCRIPTION
Three Xray-surface beads. Each bead's LIVE instruction was taken from the tracker
history rather than its description — two of the three had accreted a newer note
that supersedes the headline, and acting on the description alone would have
re-fixed work already on main.

## rf2-61i5 — the pop-out had no keyboard

`popout!` renders a live shell into a second document, but the only
document-level keydown listener in `tools/xray/src` is `keybinding.cljs`'s, on
the opener's `js/document`. DOM key events do not cross realms, so the
documented keyboard-first workflow was inert whenever focus was in the pop-out:
Cmd/Ctrl+K, Cmd/Ctrl+Shift+M, the Space / L / j / k / G spine, `,` / s and the
contextual Esc all went unseen. Mouse controls and live data kept working, which
made it read as intermittent shortcut breakage rather than an unsupported mode.

Each live pop-out now gets exactly one capture-phase listener on its own
document, installed by `popout!` and disposed by `teardown-popout-state!` — the
single path already serving external close, `teardown!` and reopen, so handlers
cannot accumulate.

**It is the same keyboard map, not a second one.** `handle-keydown-on` is the
canonical handler read against a SURFACE; only three answers differ:

| | Opener | Pop-out |
|---|---|---|
| "is this surface's shell visible?" | `mount/visible?` (reads `mount-state`) | always — the listener's lifetime *is* the pop-out shell's lifetime |
| show the shell before opening the palette | `mount/toggle!` | no-op — already visible |
| owns the `Ctrl+Shift+C` shell chord | yes | no |

Reusing `mount/visible?` in the pop-out was the bug's second half: it reports on
the OPENER's inline shell, so a user with no inline shell open would have found
every bare spine key dead. `Ctrl+Shift+C` stays opener-owned and in the pop-out
is left entirely alone — not even `preventDefault`ed — so it falls through to
the browser. The separate 011 decision that **no chord LAUNCHES a pop-out
pre-alpha** is untouched.

Two details worth flagging for review:

- Both surface entries call **through** the mount vars rather than capturing the
  fn objects at `def` time. Capturing would have frozen whatever `mount/visible?`
  was bound to at load, silently breaking the existing `with-redefs` tests and
  leaving a stale fn after an `:after-load`.
- `mount` and `keybinding` are resolved by **injection, not a require**:
  keybinding already requires mount, so it pushes its installer down into a slot
  at load time. An empty slot degrades to the old keyboard-less pop-out, and the
  installer re-reads `:rf.xray/keybinding-enabled?` at install time, so an embed
  host that suppressed Xray's keyboard gets no pop-out listener either.

## rf2-s4dp — the description's defect was already fixed; the reopen note's was not

The description (unstamped `:frame` on the seeded handle) landed in PR #9216 and
is correct at tip. The bead was then REOPENED with a note recording a second site
the same audit found, and that is what this PR fixes: `:managed-http/issue-as-actor`
recorded every synthetic actor handle with `:abort-fn (fn [_reason] nil)`.

`abort-on-actor-destroy` dissocs the ACTOR slot itself and delegates the
request-index half of the cleanup to each handle's own closure — `registry.cljc`
states the ownership: *"the per-handle request-id cleanup is owned by
`clear-in-flight!` (called inside the abort-fn closure)"*. So step 7 destroyed
actor-a, both `:rf.http/aborted-on-actor-destroy` traces fired, the actor index
emptied — and the request index kept `::actor-a-1` and `::actor-a-2` as ghosts
for an actor that no longer exists, visible on the deck's own registry strip.

The closure now clears its own request-id via `clear-in-flight-in-frame!`
(frame-exact; the one-arg form is an ANY-FRAME sweep that would drop a sibling
mount's live slot under the same id). actor-b is untouched. Re-entrancy is safe:
the actor slot is already gone when the closure runs, and
`remove-from-actor-index!` is a no-op against an absent slot. Step 7's operator
commentary now names both strips.

## rf2-p0b0 — premise refuted; the residue is one overstated sentence

**The headline ("no CI workflow builds the managed_http testbed") is false**, and
was already refuted by PR #9221. Re-verified here rather than taken on trust:
`node implementation/scripts/check-examples-compile.cjs --list` returns 58 builds
and `examples/managed-http` is one. The roster is DERIVED from
`implementation/shadow-cljs.edn`, so no build id appears in any workflow file and
a name-grep returns an honest-looking zero.

The live instruction is the post-merge audit appended after the bead closed:
PR #9221's new headline in `017-Test-Coverage-Matrix.md` claims every declared
Xray testbed build is "compiled on every PR that can affect it", and the
classifier contradicts the universal half. Verified at source:

- `.github/scripts/report-changed-surfaces.sh` arms `examples_compile` from four
  case arms (`examples/*` plus the feature artefacts incl. `implementation/http/*`;
  `testbeds/*.cljs|.cljc`; the Story/Xray/machines-viz closure; the re-frame2-pair
  preload). `implementation/core/*` is on none of them — its own arm sets
  `implementation_jvm`, `cljs_node_test`, `adapter_diagnostic`, `cljs_browser`,
  `cljs_prod`, `bundle_isolation` and `tools_jvm`, and never `examples_compile`.
- `.github/workflows/test.yml` states the trade at `cljs-examples-compile`:
  core-only changes "keep their focused PR gates and rely on the unconditional
  nightly example compile".
- Every testbed build here requires `re-frame.core`, so a core-only PR *can*
  affect these compiles with the lane skipped.

017 now states the classifier contract and records why the core carve-out is a
considered trade. **No gate added, no classifier change, no workflow file
touched, check-count band unchanged.**

## Xray spec

**Updated in this PR**, per the standing rule for any dispatch touching
`tools/xray/`:

- `tools/xray/spec/011-Launch-Modes.md` §Pop-out gains a normative subsection for
  the pop-out's own listener, the surface table, and the three consequences
  (spine keys live with no inline shell; Cmd/Ctrl+K must not move the opener's
  mount state; Ctrl+Shift+C stays opener-owned).
- `tools/xray/spec/017-Test-Coverage-Matrix.md` carries the rf2-p0b0 correction.

For the **rf2-s4dp** change specifically, **spec is unchanged because** the fix is
confined to a testbed driving surface's cleanup closure: it changes no Xray panel,
projection, trace or contract. The `:rf.http/aborted-on-actor-destroy` traces that
`003-Machine-Inspector.md` and `019-Cross-Cutting-Insight.md` describe are emitted
by the registry *before* each abort-fn is invoked, so they are unaffected.

For the **CLJS-lane fix commit** specifically, **spec is unchanged because**
it edits one assertion's deref idiom in a test file. The behaviour 011
describes — the pop-out's own listener, the surface table, and the three
consequences — is exactly what the corrected assertion pins, and 017's
rf2-p0b0 correction is untouched. Both spec updates above stay in step.

## Quality gates

Exit codes are the runner's own, captured to an `.exit` file on the same command
line and quoted from there. No gate was piped through a filter.

| Gate | Result |
|---|---|
| `clojure -M:test -n ...testbed-managed-http-frame-scope-test` — **RED control, pre-fix** | **exit 1**, 6 tests / 29 assertions, 1 failure, naming the offending closure `(fn [_reason] nil)` |
| same command, post-fix | **exit 0**, 6 tests / 29 assertions, 0 failures 0 errors |
| `clojure -M:test` (full Xray JVM suite, from `tools/xray`) | **exit 0**, **1276 tests / 6129 assertions**, 0 failures 0 errors (baseline before this PR: 1274 / 6122) |
| `clj-kondo --parallel --fail-level error --lint tools/xray` (CI's own invocation) | **exit 0**, **0 errors, 141 warnings** — identical to the pre-change baseline, and zero findings in any file this PR touches |
| `npx shadow-cljs compile node-test && node out/node-test.js` (CI's own two-step invocation, from `implementation/`) — **RED control** | **exit 1** on CI run 33941927346, 11244 tests / 56876 assertions, **1 failure**: `popout-installer-is-registered-with-mount` |
| same command, post-fix, run locally in this worktree | **exit 0**, **11244 tests / 56876 assertions**, 0 failures 0 errors |
| `python scripts/check_doc_slugs.py` | **exit 0** |
| `python scripts/check_readme_links.py --ci` | **exit 0** |
| `node --check tools/xray/testbeds/feature_matrix/scenarios.cjs` | **exit 0** |

### Every gate above was proven live, not assumed

Each planted fault was restored and the restore verified by **sha256, not by
reading a diff**; each gate was then re-run green.

- `check_doc_slugs.py`: a planted broken link + broken anchor in the edited 017
  section produced **exit 1** naming file, **line 179**, and both targets.
- `check_readme_links.py --ci`: a planted broken target in the edited README
  section produced **exit 1** naming `tools/xray/README.md:255`.
- `clj-kondo`: a planted wrong-arity call plus an unresolved `mount/` var
  produced **exit 3**, with the error naming the arity mismatch.
- `clj-kondo` cross-namespace resolution: renaming `install-popout-keydown!` in
  the source made kondo flag **the TEST's** reference to it — so the clean run
  above is evidence the new tests reference real vars, not evidence that kondo
  ignores test files. **Caveat stated honestly: an unresolved var is
  WARNING-level, so that class alone would not fail the gate; only arity
  mismatches are errors.**
- `node --check`: rejected a deliberately malformed file with **exit 1**.
- The paren/delimiter scanner used on the Clojure edits reported **BAD / exit 1**
  on a deliberately unbalanced file.

### Not run, and why

- **The CLJS lane WAS run, on a second pass.** The first push deliberately
  did not run any shadow-cljs build — five sibling workers were live and a
  gate that heavy wedges rather than fails when two coexist — and that PR body
  said so plainly instead of implying coverage it did not have. CI then went
  red on exactly the predicted lane. This pass installed an isolated
  `implementation/node_modules` **inside this worktree** (`npm ci`, exit 0 —
  no link or junction to any other checkout) and ran the lane to completion.
  So rf2-61i5 now has the red/green control it lacked: **CI red, then local
  green on the same two-step command**, both in the table above.
- **`npm run test:examples-compile` and `scripts/test-fast-pr.sh` were still
  not run.** The `examples_compile` surface IS armed by this diff
  (`tools/xray/testbeds/*` and `tools/xray/src/*` are both on the classifier's
  third arm), so `cljs-examples-compile` covers it in CI. The feature-matrix
  browser scenario likewise remains CI-owned.
- **The failure was in the TEST's reading idiom, not in the pop-out
  keyboard.** `mount/popout-keydown-installer` is a `defonce` var holding an
  ATOM, so `@#'` yields the atom and a second `@` is needed for the installer.
  The new pin used one deref and so compared the fn against the atom wrapping
  it; CI's own `actual:` line showed the atom's `:val` was the very same fn
  object, i.e. the registration under test was correct all along. The sibling
  pin in `mount_cljs_test.cljs` already read the slot as `@@#'`, which is the
  idiom used at 85 sites in that file. No production code moved.
- **`mkdocs build --strict` is NOT the gate for `tools/xray/spec/`** — `docs_dir`
  is `docs`, and `mkdocs_hooks.py`'s `_STAGE` table stages only top-level `spec/`
  and `migration/`. Not cited.
- **Markdown prose, tables and rendering are ungated by either link gate**, so
  they were checked by hand and the checks are stated rather than implied: the new
  011 table is 3 cells on every row including header and separator (verified by
  counting delimiters per row); 017's bold-delimiter count went 108 to 110, a
  delta of exactly the one new bold span, even in both; no existing table row was
  touched.
- **The one CLJS edit in rf2-s4dp has no local compiler**, so it was verified by
  hand: `clear-in-flight-in-frame!` is `[frame-id request-id]` (2-arity, matching
  the call), the `rf.http.registry` alias is already bound in the testbed ns, and
  the identical call already exists at another site in the same file.

