### PR TITLE
fix(epoch,uix): the :depth transition holds the stores it bounds; the UIx imperative recipe follows its frame (rf2-f8wu, rf2-tug6)

### DIFF
--- a/implementation/adapters/uix/README.md
+++ b/implementation/adapters/uix/README.md
@@ -63,7 +63,7 @@ Compose `use-effect` with the standard outer/inner split: the outer `defui` read
           (.addEventListener el "animationend" listener)
           (fn cleanup []
             (.removeEventListener el "animationend" listener))))
-      [tile-id])
+      [tile-id dispatch])   ;; `dispatch` too — it changes when the provider retargets
     ($ :div {:ref ref :class "tile merging"})))
 
 ;; Outer — reads subs, hands props to the inner. Plain UIx defui.
@@ -74,9 +74,9 @@ Compose `use-effect` with the standard outer/inner split: the outer `defui` read
 
 4 things matter:
 
-- The frame api comes from the `use-frame` hook, called at the top of the component body — never a bare `(rf/capture-frame)`. `use-frame` reads the surrounding `frame-provider` / `frame-root` through React context; a no-arg `(rf/capture-frame)` in a plain hooks component reads only the dynamic-var tier and raises `:rf.error/no-frame-context` under a context-provided frame. The `dispatch` you pull off it closes over the resolved frame at render-time, so the effect body — which fires after commit on a frameless stack — still routes to the right frame.
+- The frame api comes from the `use-frame` hook, called at the top of the component body — never a bare `(rf/capture-frame)`. `use-frame` reads the surrounding `frame-provider` / `frame-root` through React context; a no-arg `(rf/capture-frame)` in a plain hooks component reads only the dynamic-var tier and raises `:rf.error/no-frame-context` under a context-provided frame. The `dispatch` you pull off it closes over the resolved frame **at the render that installed the effect**, so the effect body — which fires after commit on a frameless stack — routes to that frame. Keeping it routed to the *surrounding* frame is the deps vector's job, below.
 - The cleanup fn is mandatory. Without it, the listener leaks across re-mounts and across hot-reloads. The cleanup runs on unmount and before each re-run when deps change.
-- The deps vector matters. Include every prop the effect reads so React re-runs the effect when those props change. An empty deps vector means "run once on mount, clean up on unmount."
+- The deps vector matters. Include every **reactive value** the effect reads, not just the props — and that includes the frame-bound callbacks off `use-frame`. `dispatch` is a *different* function once the surrounding provider targets a different frame, so an effect that omits it keeps the listener it installed under the **old** frame: the DOM event then dispatches into a frame the UI has already navigated away from (silently, if that frame is still live — frames are isolated, so nothing errors). The ops map is reference-stable for the same frame incarnation, so naming `dispatch` costs no effect churn within one frame and re-installs the listener exactly when the frame changes. An empty deps vector means "run once on mount, clean up on unmount."
 - Don't call `use-subscribe` inside the effect body. Hooks must be called at the top of the component body, not inside another hook's callback. Subscribe in the outer (or in the inner's top-level `let`) and pass the value as a dep.
 
 ### Cross-references

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs
@@ -42,7 +42,7 @@
   and B never hears it.
 
   The recipe component is compiled here with its real spelling
-  (`uix/use-effect` + `uix-adapter/use-frame` + a UIx `use-ref` on a DOM
+  (`uix/use-effect` + `rf.adapter.uix/use-frame` + a UIx `use-ref` on a DOM
   node), so UIx's own `::missing-deps` analysis guards the dependency list at
   compile time as well.
 
@@ -67,11 +67,11 @@
             [uix.core :as uix :refer-macros [defui $]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter uix-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.adapter.uix/adapter}))
 
 ;; ---- lane gate -------------------------------------------------------------
 ;;
@@ -114,7 +114,7 @@
   "The README's canonical imperative-lifecycle recipe, compiled."
   [{:keys [tile-id]}]
   (let [ref                     (uix/use-ref)
-        {:keys [dispatch-sync]} (uix-adapter/use-frame)]
+        {:keys [dispatch-sync]} (rf.adapter.uix/use-frame)]
     (uix/use-effect
       (fn []
         (let [el       (.-current ref)
@@ -133,7 +133,7 @@
   the subject here, not a mistake for UIx's linter to report."
   [{:keys [tile-id]}]
   (let [ref                     (uix/use-ref)
-        {:keys [dispatch-sync]} (uix-adapter/use-frame)]
+        {:keys [dispatch-sync]} (rf.adapter.uix/use-frame)]
     (uix/use-effect
       (fn []
         (let [el       (.-current ref)
@@ -175,7 +175,7 @@
          root       (react-dom-client/createRoot mount-node)
          render!    (fn [frame-kw]
                       (act-fn (fn []
-                                (.render root ($ uix-adapter/frame-provider
+                                (.render root ($ rf.adapter.uix/frame-provider
                                                  {:frame frame-kw}
                                                  ($ component {:tile-id 7}))))))
          element    #(.querySelector mount-node ".tile")

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs
@@ -1,0 +1,251 @@
+(ns re-frame.adapter.uix-effect-frame-deps-dom-cljs-test
+  "rf2-tug6 — an imperative `use-effect` listener follows the frame its
+  component is rendered under, across a PROVIDER SWAP.
+
+  ## The defect
+
+  The canonical outer/inner recipe in `implementation/adapters/uix/README.md`
+  installs a DOM listener from `use-effect` and dispatches from it through the
+  ops map `use-frame` returns. The effect closed over TWO reactive values —
+  the domain prop and `dispatch` — and named only the prop in its deps vector.
+
+  `use-frame`'s bundle is reference-stable for one resolved frame INCARNATION
+  and a NEW map once the surrounding `frame-provider` retargets
+  (`re-frame.adapter.use-frame/use-frame`'s render-phase memo is keyed on the
+  frame AND its incarnation token). So a provider swap re-renders the mounted
+  component with a B-locked `dispatch` in hand — and React, told only that the
+  prop is unchanged, does NOT re-run the effect. The listener installed under
+  A stays installed, and the next DOM event dispatches into A.
+
+  That is an isolation break, not staleness: frames are isolated contexts, so
+  a write into still-live A raises nothing at all. It just lands in the frame
+  the UI has navigated away from. (Had A been destroyed instead, the capture
+  fence would have dropped it and emitted the destroyed-frame error — the
+  louder half, and the less serious one.)
+
+  ## What is pinned, and why in this shape
+
+  Both deftests drive the REAL swap path: one mount, one component instance,
+  the provider's `:frame` prop changed and the tree re-rendered in place. That
+  is the trap this suite exists to avoid — a test that remounts, or that
+  renders a second instance, exercises nothing, because a fresh mount runs its
+  effect afresh and passes with or without the dependency. Each therefore
+  asserts the DOM element is `identical?` across the swap before drawing any
+  conclusion from what the listener did.
+
+  The negative control is a second component carrying the ORIGINAL deps
+  vector, marked `^:lint/disable` so UIx's exhaustive-deps linter reads the
+  omission as deliberate rather than warning on it. It is the control this
+  suite would otherwise be missing: without it, a green here could equally
+  mean the fix works or that the swap never reached the component. It fails
+  in the specific way the bead describes — the second event lands in A again,
+  and B never hears it.
+
+  The recipe component is compiled here with its real spelling
+  (`uix/use-effect` + `uix-adapter/use-frame` + a UIx `use-ref` on a DOM
+  node), so UIx's own `::missing-deps` analysis guards the dependency list at
+  compile time as well.
+
+  WHY `dispatch-sync` AND NOT `dispatch`. The two come off the same ops map
+  and are re-created together, so the closure capture and the deps obligation
+  are identical; `dispatch-sync` lets the assertion read the frame's app-db
+  immediately after the event instead of waiting out a router macrotask
+  (`re-frame.interop/next-tick` is deliberately NOT a microtask, so `act()`
+  does not drain it). The README teaches `dispatch`; nothing about the
+  dependency differs.
+
+  TOOTH: put the recipe component's deps back to `[tile-id]` and
+  `imperative-effect-follows-the-frame-across-a-provider-swap` fails exactly
+  where the negative control below already fails.
+
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` (ns-regexp
+  `-dom-cljs-test$`) discovers it; `:node-test`'s `cljs-test$` regex also
+  matches, where both deftests self-gate on `(browser?)` and no-op cleanly."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react" :as React]
+            ["react-dom/client" :as react-dom-client]
+            [uix.core :as uix :refer-macros [defui $]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter uix-adapter/adapter}))
+
+;; ---- lane gate -------------------------------------------------------------
+;;
+;; Local rather than borrowed: the shared React suite's equivalents are
+;; private, and this file forwards nothing to it.
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- with-browser-act
+  "Skip under `:node-test` (no DOM) and when `act()` is unreachable;
+  otherwise opt the runner into React's act environment and call `(f act-fn)`."
+  [f]
+  (if-not (browser?)
+    (is true ":node-test: no DOM — the :browser-test runner exercises the assertions")
+    (if-let [act-fn (and (exists? (.-act React)) (.-act React))]
+      (do (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+          (f act-fn))
+      (is true "act() not reachable from this runner; skipping"))))
+
+;; ---- the two frames and the one event --------------------------------------
+
+(def ^:private frame-a :rf.uix-effect-frame-deps/frame-a)
+(def ^:private frame-b :rf.uix-effect-frame-deps/frame-b)
+
+(defn- hits
+  "Every tile-id the named frame has been told finished, in order."
+  [frame-kw]
+  (:hits (rf/app-db-value frame-kw)))
+
+;; ---- probes ----------------------------------------------------------------
+;;
+;; `effect-log` records the effect's setup/cleanup calls so the balance
+;; assertion reads what React actually did rather than inferring it.
+
+(def ^:private effect-log (atom []))
+
+(defui tile-inner
+  "The README's canonical imperative-lifecycle recipe, compiled."
+  [{:keys [tile-id]}]
+  (let [ref                     (uix/use-ref)
+        {:keys [dispatch-sync]} (uix-adapter/use-frame)]
+    (uix/use-effect
+      (fn []
+        (let [el       (.-current ref)
+              listener (fn [_evt] (dispatch-sync [::finished tile-id]))]
+          (swap! effect-log conj :setup)
+          (.addEventListener el "animationend" listener)
+          (fn cleanup []
+            (swap! effect-log conj :cleanup)
+            (.removeEventListener el "animationend" listener))))
+      [tile-id dispatch-sync])
+    ($ :div {:ref ref :class "tile"})))
+
+(defui stale-tile-inner
+  "The recipe as it read before rf2-tug6 — identical but for the deps vector,
+  which names the domain prop alone. `^:lint/disable` because the omission is
+  the subject here, not a mistake for UIx's linter to report."
+  [{:keys [tile-id]}]
+  (let [ref                     (uix/use-ref)
+        {:keys [dispatch-sync]} (uix-adapter/use-frame)]
+    (uix/use-effect
+      (fn []
+        (let [el       (.-current ref)
+              listener (fn [_evt] (dispatch-sync [::finished tile-id]))]
+          (swap! effect-log conj :setup)
+          (.addEventListener el "animationend" listener)
+          (fn cleanup []
+            (swap! effect-log conj :cleanup)
+            (.removeEventListener el "animationend" listener))))
+      ^:lint/disable [tile-id])
+    ($ :div {:ref ref :class "tile"})))
+
+;; ---- the shared drive ------------------------------------------------------
+
+(defn- run-provider-swap!
+  "Mount `component` (one instance, prop `{:tile-id 7}`) under a provider
+  targeting `frame-a`, fire the event, retarget the SAME tree at `frame-b`,
+  fire it again. Returns the observations; asserts the in-place update itself,
+  because every later conclusion depends on it.
+
+  The two frames and the `::finished` handler are created here so each deftest
+  gets them fresh from the reset fixture.
+
+  The ambient `:rf/default` dynamic scope the fixture installs is cleared for
+  the duration: `use-frame` resolves the dynamic-var tier BEFORE the provider
+  tier, so leaving it bound masks the provider outright and both renders
+  resolve the same frame — the suite would then pass while proving nothing
+  (the rf2-4mi2zj masking note, and the same `binding` the shared React
+  suite's provider rows take)."
+  [act-fn component]
+  (reset! effect-log [])
+  (rf/reg-event ::finished
+                (fn [{:keys [db]} [_ tile-id]]
+                  {:db (update db :hits (fnil conj []) tile-id)}))
+  (rf/make-frame {:id frame-a :doc "rf2-tug6 — provider target A"})
+  (rf/make-frame {:id frame-b :doc "rf2-tug6 — provider target B"})
+  (binding [rf.frame/*current-frame* nil]
+   (let [mount-node (.createElement js/document "div")
+         root       (react-dom-client/createRoot mount-node)
+         render!    (fn [frame-kw]
+                      (act-fn (fn []
+                                (.render root ($ uix-adapter/frame-provider
+                                                 {:frame frame-kw}
+                                                 ($ component {:tile-id 7}))))))
+         element    #(.querySelector mount-node ".tile")
+         fire!      (fn [el] (act-fn (fn [] (.dispatchEvent el (js/Event. "animationend")))))]
+     (try
+       (render! frame-a)
+       (let [el-under-a (element)]
+         ;; Control: the listener is installed and routes to the mounting
+         ;; frame. Without this row a suite where the listener never attached
+         ;; would pass the isolation assertions vacuously.
+         (fire! el-under-a)
+         (let [after-mount {:log @effect-log :a (hits frame-a) :b (hits frame-b)}]
+
+           ;; THE SWAP. Same component type, same position, same key, same
+           ;; domain prop — only the provider's target changes.
+           (render! frame-b)
+           (let [el-under-b (element)]
+             (is (identical? el-under-a el-under-b)
+                 (str "the provider swap UPDATED the mounted instance in place. "
+                      "A remount here would run the effect afresh and make every "
+                      "assertion below vacuous"))
+             (fire! el-under-b)
+             {:after-mount after-mount
+              :log         @effect-log
+              :a           (hits frame-a)
+              :b           (hits frame-b)})))
+       (finally
+         (try (.unmount root) (catch :default _ nil)))))))
+
+;; ---- the pin ---------------------------------------------------------------
+
+(deftest imperative-effect-follows-the-frame-across-a-provider-swap
+  (testing "naming `dispatch` in the deps vector re-installs the listener on
+            the frame the component is now rendered under — the post-swap
+            event reaches B alone, exactly once"
+    (with-browser-act
+      (fn [act-fn]
+        (let [{:keys [after-mount log a b]} (run-provider-swap! act-fn tile-inner)]
+          (is (= [7] (:a after-mount))
+              "control: before the swap the listener routes to the mounting frame")
+          (is (nil? (:b after-mount))
+              "control: and B has heard nothing yet")
+
+          (is (= [7] b)
+              "after the swap the event reaches B")
+          (is (= [7] a)
+              (str "and A is untouched by it — still holding only the control "
+                   "hit. A second entry here is the isolation break: a write "
+                   "into the frame the UI has navigated away from"))
+          (is (= [:setup :cleanup :setup] log)
+              (str "the effect re-ran ONCE and its cleanup was balanced — the "
+                   "old listener was removed, so one event produces one "
+                   "dispatch rather than two")))))))
+
+(deftest omitting-the-frame-dep-keeps-dispatching-into-the-previous-frame
+  (testing "the negative control: with the domain prop alone in the deps
+            vector the effect never re-runs, and the listener installed under
+            A keeps writing into A after the provider has moved to B"
+    (with-browser-act
+      (fn [act-fn]
+        (let [{:keys [after-mount log a b]} (run-provider-swap! act-fn stale-tile-inner)]
+          (is (= [7] (:a after-mount))
+              "control: the listener starts out routed to the mounting frame")
+
+          (is (= [:setup] log)
+              "the effect did NOT re-run across the swap — React was told only
+               that the unchanged prop was unchanged")
+          (is (= [7 7] a)
+              "so the post-swap event landed in A a second time")
+          (is (nil? b)
+              (str "and B — the frame the component is now rendered under — "
+                   "never heard it. This is what the recipe's deps vector "
+                   "prevents (rf2-tug6)")))))))

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -52,6 +52,55 @@
   [x]
   (and (integer? x) (not (neg? x))))
 
+;; ---- retention serialization ----------------------------------------------
+;;
+;; `:depth` is a RULE about two stores — the per-frame rings, and the
+;; last-settled anchors that name records inside them — and both the rule and
+;; the stores are written in more than one step:
+;;
+;;   record!                  reads the depth, THEN swaps `histories`
+;;   set-last-settled-epoch!  reads the depth, THEN swaps `last-settled-epoch`
+;;   merge-config!            swaps `config`, THEN prunes every ring, THEN
+;;                            reconciles the anchors against the pruned map
+;;
+;; Left unserialized those sequences interleave, and the interleavings are not
+;; benign. A writer that captured the PREVIOUS depth can commit its append
+;; after `configure!` has already returned, which republishes the exact defect
+;; the boundary prune exists to close: the excess record is queryable through
+;; `epoch-history` / `projected-history`, and it is a live `restore-epoch!` /
+;; `replay-epoch!` target. Swapping the config before the prune makes that
+;; escape self-repairing for a POSITIVE depth — the next append re-caps the
+;; ring — but PERMANENT at depth 0, where `record!` never appends again. And
+;; "a later append repairs it" was never the promise: the promise is about the
+;; state at `configure!`'s RETURN. Symmetrically, an anchor published at the
+;; seam between the prune and the reconciliation is judged against a snapshot
+;; taken before its record existed, so a CORRECT anchor is discarded as
+;; unretained.
+;;
+;; One monitor closes both: it is held across each whole sequence, so
+;; `configure!` cannot return while a writer still holds a stale depth, and no
+;; anchor decision is taken against a stale ring.
+;;
+;; DEADLOCK-FREE BY CONSTRUCTION, and that is why it needs no place in the
+;; ledger lock order documented further down (nor in the `:drain-lock`
+;; argument beside it). This is a LEAF: every section it guards is atom swaps
+;; over the epoch stores and nothing else — no other lock is acquired
+;; underneath it and no foreign code runs there (`:redact-fn` is STORED here,
+;; never invoked). A lock that acquires nothing cannot supply the second edge
+;; of a cycle. `commit-frame-owner-record!` reaches it from INSIDE the
+;; frame-owner serialization, which fixes the only nesting that exists as
+;; frame-owner → retention; the JVM monitor is reentrant, so the two writers
+;; it calls take it without re-blocking.
+;;
+;; CLJS is single-threaded and keeps the simple path: the helper is a bare call.
+
+#?(:clj
+   (defonce ^:private retention-lock (Object.)))
+
+(defn- with-retention-lock [f]
+  #?(:clj  (locking retention-lock (f))
+     :cljs (f)))
+
 (declare enforce-depth!)
 
 (defn merge-config!
@@ -67,7 +116,11 @@
   knobs deliberately differ here: `:depth` is a bound on what the ring
   HOLDS, so it is applied at this boundary, whereas `:trace-events-keep`
   bounds how far back raw traces survive and stays an append-time rule (no
-  retained record has its payload rewritten by a config change)."
+  retained record has its payload rewritten by a config change).
+
+  The config swap and that enforcement are ONE step under the retention lock,
+  so no writer holding the previous depth can commit between them — see the
+  retention-serialization section above."
   [opts]
   (when (map? opts)
     (let [numeric-options (select-keys opts [:depth :trace-events-keep])
@@ -88,12 +141,16 @@
                                     {:redact-fn redact-fn-value})))
           valid-options (merge valid-numeric-options valid-redact-option)]
       (when (seq valid-options)
-        (swap! config merge valid-options)
-        ;; Config FIRST, then the rings: any `record!` that begins after
-        ;; the swap already reads the new depth, so the prune below cannot
-        ;; be undone by an append it raced.
-        (when (contains? valid-options :depth)
-          (enforce-depth! (:depth valid-options))))))
+        (with-retention-lock
+          (fn []
+            (swap! config merge valid-options)
+            ;; Config first, then the rings — but the ordering is no longer
+            ;; what carries the invariant. Both are inside the retention
+            ;; lock, which is what makes the prune un-undoable: a `record!`
+            ;; that read the previous depth cannot be mid-flight here, and
+            ;; one that starts after this section reads the new depth.
+            (when (contains? valid-options :depth)
+              (enforce-depth! (:depth valid-options))))))))
   nil)
 
 (defn current-config
@@ -207,14 +264,23 @@
   "Append a record into the frame's history. The depth cap and the
   `:trace-events-keep` cap are read from the config atom on each
   append so runtime `(rf/configure! {:epoch-history ...})` takes effect
-  immediately."
+  immediately.
+
+  The depth READ and the ring write are one step under the retention lock.
+  Split, they are a hole in `configure!`'s post-return invariant: an append
+  that captured the previous depth commits after the boundary prune has run,
+  and at depth 0 nothing later re-caps the ring (this function appends
+  nothing at depth 0, so the escaped record is permanent). See the
+  retention-serialization section at the top of this namespace."
   [record]
-  (let [history-depth       (depth)
-        trace-events-to-keep (trace-events-keep)]
-    (when (pos? history-depth)
-      (let [frame-id (:frame record)]
-        (swap! histories update frame-id append-record record
-               history-depth trace-events-to-keep)))))
+  (with-retention-lock
+    (fn []
+      (let [history-depth        (depth)
+            trace-events-to-keep (trace-events-keep)]
+        (when (pos? history-depth)
+          (let [frame-id (:frame record)]
+            (swap! histories update frame-id append-record record
+                   history-depth trace-events-to-keep)))))))
 
 (defn history-for
   "Return the frame's history vector (oldest-first) or `[]`."
@@ -277,10 +343,18 @@
   (`commit-record!`, the synthetic-replace recorder, and `perform-restore!`'s
   re-anchor): no anchor without a ring record to anchor to. The readers all
   `when-let` off `last-settled-epoch-id`, so a nil anchor degrades cleanly to
-  no back-fill — correct under depth 0."
+  no back-fill — correct under depth 0.
+
+  That gate is a depth read followed by a store write, which is the shape
+  `record!` has, so it takes the same retention lock for the same reason: an
+  anchor must not be published against a depth `configure!` has already
+  replaced, and `enforce-depth!`'s reconciliation must not be judging an
+  anchor against a ring snapshot taken before it existed."
   [frame-id epoch-id]
-  (when (and frame-id epoch-id (pos? (depth)))
-    (swap! last-settled-epoch assoc frame-id epoch-id))
+  (with-retention-lock
+    (fn []
+      (when (and frame-id epoch-id (pos? (depth)))
+        (swap! last-settled-epoch assoc frame-id epoch-id))))
   nil)
 
 (defn last-settled-epoch-id
@@ -924,12 +998,15 @@
   `drop-render-key-mount-attribution!`. `reset-histories!` below clears
   these same two anchors in lockstep, for the same reason.
 
-  Ordering against a concurrent JVM append: `merge-config!` swaps the
-  config BEFORE calling here, so any `record!` beginning afterwards already
-  reads the new depth. An append that had read the previous depth and lands
-  after this prune can leave one frame transiently one record over the cap;
-  `record!` re-reads the depth on every append, so the next append re-caps
-  it. Returns nil."
+  Against a concurrent JVM append: the CALLER holds the retention lock across
+  its config swap and this call, and `record!` / `set-last-settled-epoch!`
+  take that same lock across their own depth-read-then-write. So there is no
+  in-flight writer holding the previous depth to land after this prune, and
+  the retained-id set below cannot be stale with respect to a concurrently
+  committed record. An earlier revision left that gap open and called the
+  excess transient, which it is for a positive depth and is NOT at depth 0 —
+  `record!` appends nothing there, so no later append ever re-caps the ring
+  (rf2-f8wu post-merge audit). Returns nil."
   [depth]
   (let [pruned-histories (swap! histories
                                 (fn [histories-map]

--- a/implementation/epoch/test/re_frame/epoch_depth_transition_race_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_depth_transition_race_test.clj
@@ -1,0 +1,200 @@
+(ns re-frame.epoch-depth-transition-race-test
+  "rf2-f8wu (post-merge audit) — the `:depth` transition is ONE atomic step
+  against the stores it bounds.
+
+  ## The invariant
+
+  `(rf/configure! {:epoch-history {:depth N}})` promises that *once
+  `configure!` returns, every ring respects the accepted depth* (Tool-Pair
+  §Time-travel \"Bounded history\", and its depth-0 bullet: `epoch-history`
+  returns `[]`). The single-threaded half of that promise is pinned in
+  `re-frame.epoch-test`. This namespace pins the half a single thread cannot
+  reach.
+
+  ## The defect these tests close
+
+  The depth reduction and the ring append were two independent sequences over
+  three atoms:
+
+      record!         reads `(depth)`, THEN swaps `histories`
+      merge-config!   swaps `config`, THEN prunes `histories`,
+                      THEN reconciles the anchors
+
+  Nothing held the stores still between those steps, so a writer that had
+  already captured the PREVIOUS depth could commit its append after
+  `configure!` had returned. The excess record was then queryable through
+  `epoch-history` / `projected-history` and — for a full runtime record —
+  a live `restore-epoch!` / `replay-epoch!` target: exactly the two failures
+  the original bead named, re-entered through a door the boundary fix left
+  open.
+
+  Config-swap-before-prune made the escape TRANSIENT for a positive depth (the
+  next append re-caps the ring) but PERMANENT at depth 0, because `record!`
+  skips `append-record` entirely at depth 0 — no later append ever arrives to
+  repair it. \"Transient\" is also the wrong bar for a positive reduction: the
+  promise is about the state at `configure!`'s return, not about some later
+  event.
+
+  The anchors have the same shape. `enforce-depth!` computed its retained-id
+  set from the pruned snapshot and reconciled `last-settled-epoch` in a
+  SEPARATE swap, so a record committed at that seam could have its own,
+  correct anchor discarded as unretained.
+
+  ## How these tests establish it deterministically
+
+  A concurrency defect proved by racing threads is a defect proved sometimes.
+  Each test below PLACES the interleaving rather than hoping for it: a writer
+  thread is parked inside `record!` at the exact point the depth has been
+  captured and the ring not yet touched, and the configuring thread runs
+  against that held position.
+
+  The seam is `re-frame.epoch.state/trace-events-keep`, which `record!` calls
+  exactly once — on the line after it captures the depth and before its
+  `swap!`. It is the only call between the two, which is what makes it an
+  exact seam rather than an approximate one.
+
+  TOOTH: drop the retention serialization from `record!` or from
+  `merge-config!` and both deftests below fail — the parked writer's append
+  lands after `configure!` has already published its result."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; Side-effect require: publishes the `:epoch/*` late-bind hooks
+            ;; the core facade's epoch surface resolves through.
+            [re-frame.epoch]
+            [re-frame.epoch.state :as epoch-state]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(def ^:private join-ms
+  "Generous upper bound for joining a helper thread. Nothing here waits on it
+  in the passing case; it exists so a regression HANGS the one deftest rather
+  than the whole suite."
+  10000)
+
+(defn- park-writer-inside-record!
+  "Dispatch `event` into `frame-id` on a background thread and park that
+  thread INSIDE `record!` — after it has read the depth, before it swaps the
+  ring.
+
+  Returns `{:writer <future> :release! <fn>}`. The caller drives the
+  transition it wants to test against the parked position, then calls
+  `release!` and joins `:writer`.
+
+  The park is installed with `with-redefs`, which is process-global rather
+  than thread-local — deliberate, since the point is to hold the ONE writer
+  the test starts. No other thread in these deftests records, so nothing else
+  can reach the redefinition."
+  [frame-id event]
+  (let [reached   (promise)
+        release   (promise)
+        real-keep epoch-state/trace-events-keep
+        writer    (future
+                    (with-redefs [epoch-state/trace-events-keep
+                                  (fn []
+                                    (deliver reached true)
+                                    (deref release join-ms :timeout)
+                                    (real-keep))]
+                      (rf/dispatch-sync event {:frame frame-id})
+                      :committed))]
+    (assert (true? (deref reached join-ms :timeout))
+            "writer never reached the depth seam inside record!")
+    {:writer   writer
+     :release! (fn [] (deliver release true))}))
+
+(defn- configure-depth-on-another-thread!
+  "Run `(rf/configure! {:epoch-history {:depth depth}})` on its own thread and
+  return its future, having first waited for it to reach a settled position:
+  either it PUBLISHED its result, or it is waiting on the parked writer.
+
+  The wait is a determinism device for the UNFIXED code, not an assertion.
+  Without it the configure could still be ahead of its config swap when the
+  test releases the writer, and the interleaving under test would simply not
+  have happened — a green that proved nothing. With the retention
+  serialization in place the configure is blocked instead, so the loop runs
+  out its budget and the test proceeds to release the writer."
+  [frame-id depth]
+  (let [configurer (future (rf/configure! {:epoch-history {:depth depth}})
+                           :configured)
+        published? (fn []
+                     (and (= depth (epoch-state/depth))
+                          (<= (count (rf/epoch-history frame-id)) depth)))]
+    (loop [remaining 60]
+      (when (and (pos? remaining) (not (published?)))
+        (Thread/sleep 5)
+        (recur (dec remaining))))
+    configurer))
+
+(defn- epoch-ids [frame-id]
+  (mapv :epoch-id (rf/epoch-history frame-id)))
+
+;; ---- depth 0: the permanent escape ----------------------------------------
+
+(deftest an-in-flight-append-cannot-escape-a-depth-zero-transition
+  (testing "a record! that captured the previous depth cannot land after
+            configure! returned — at depth 0 nothing later re-prunes, so an
+            escape is PERMANENT, queryable and time-travellable"
+    (rf/configure! {:epoch-history {:depth 5}})
+    (rf/make-frame {:id :test/main})
+    (rf/reg-event :seed (fn [_ _] {:db {:n 1}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (is (= 1 (count (rf/epoch-history :test/main))) "precondition: one record")
+
+    (let [{:keys [writer release!]} (park-writer-inside-record!
+                                      :test/main [:inc])
+          configurer                (configure-depth-on-another-thread!
+                                      :test/main 0)]
+      (release!)
+      (is (= :committed  (deref writer join-ms :timeout))  "the writer finished")
+      (is (= :configured (deref configurer join-ms :timeout)) "configure! finished")
+
+      (is (= [] (rf/epoch-history :test/main))
+          "the parked append did not escape the transition")
+      (is (= [] (rf/projected-history :test/main))
+          "and it is not reachable through the off-box projection either")
+      (is (nil? (epoch-state/last-settled-epoch-id :test/main))
+          "no back-fill anchor survives naming a record the ring does not hold")
+      (is (= {:n 2} (rf/app-db-value :test/main))
+          "the frame itself still settled the event — only its RETENTION was
+           refused"))))
+
+;; ---- positive reduction: the accepted cap, and anchor coherence -----------
+
+(deftest an-in-flight-append-cannot-overshoot-a-positive-reduction
+  (testing "the ring respects the ACCEPTED depth once configure! returns, even
+            when a writer holding the previous depth commits across the
+            transition — and the surviving anchor names a retained record"
+    (rf/configure! {:epoch-history {:depth 10}})
+    (rf/make-frame {:id :test/main})
+    (rf/reg-event :seed (fn [_ _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:inc] {:frame :test/main})
+    (rf/dispatch-sync [:inc] {:frame :test/main})
+    (is (= 3 (count (rf/epoch-history :test/main))) "precondition: three records")
+
+    (let [{:keys [writer release!]} (park-writer-inside-record!
+                                      :test/main [:inc])
+          configurer                (configure-depth-on-another-thread!
+                                      :test/main 1)]
+      (release!)
+      (is (= :committed  (deref writer join-ms :timeout))  "the writer finished")
+      (is (= :configured (deref configurer join-ms :timeout)) "configure! finished")
+
+      (let [ids    (epoch-ids :test/main)
+            anchor (epoch-state/last-settled-epoch-id :test/main)]
+        (is (= 1 (count ids))
+            "the ring holds the accepted depth, not the one the writer captured")
+        (is (= {:n 3} (:db-after (last (rf/epoch-history :test/main))))
+            "and what it holds is the NEWEST record — the one that raced in")
+        (is (some? anchor)
+            "the concurrent record's own anchor was not discarded as unretained")
+        (is (= (last ids) anchor)
+            "the anchor names a record the ring still holds")))))

--- a/implementation/epoch/test/re_frame/epoch_depth_transition_race_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_depth_transition_race_test.clj
@@ -61,12 +61,12 @@
             ;; Side-effect require: publishes the `:epoch/*` late-bind hooks
             ;; the core facade's epoch surface resolves through.
             [re-frame.epoch]
-            [re-frame.epoch.state :as epoch-state]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -92,9 +92,9 @@
   [frame-id event]
   (let [reached   (promise)
         release   (promise)
-        real-keep epoch-state/trace-events-keep
+        real-keep rf.epoch.state/trace-events-keep
         writer    (future
-                    (with-redefs [epoch-state/trace-events-keep
+                    (with-redefs [rf.epoch.state/trace-events-keep
                                   (fn []
                                     (deliver reached true)
                                     (deref release join-ms :timeout)
@@ -121,7 +121,7 @@
   (let [configurer (future (rf/configure! {:epoch-history {:depth depth}})
                            :configured)
         published? (fn []
-                     (and (= depth (epoch-state/depth))
+                     (and (= depth (rf.epoch.state/depth))
                           (<= (count (rf/epoch-history frame-id)) depth)))]
     (loop [remaining 60]
       (when (and (pos? remaining) (not (published?)))
@@ -158,7 +158,7 @@
           "the parked append did not escape the transition")
       (is (= [] (rf/projected-history :test/main))
           "and it is not reachable through the off-box projection either")
-      (is (nil? (epoch-state/last-settled-epoch-id :test/main))
+      (is (nil? (rf.epoch.state/last-settled-epoch-id :test/main))
           "no back-fill anchor survives naming a record the ring does not hold")
       (is (= {:n 2} (rf/app-db-value :test/main))
           "the frame itself still settled the event — only its RETENTION was
@@ -189,7 +189,7 @@
       (is (= :configured (deref configurer join-ms :timeout)) "configure! finished")
 
       (let [ids    (epoch-ids :test/main)
-            anchor (epoch-state/last-settled-epoch-id :test/main)]
+            anchor (rf.epoch.state/last-settled-epoch-id :test/main)]
         (is (= 1 (count ids))
             "the ring holds the accepted depth, not the one the writer captured")
         (is (= {:n 3} (:db-after (last (rf/epoch-history :test/main))))

--- a/scripts/test-epoch-prod-gate.sh
+++ b/scripts/test-epoch-prod-gate.sh
@@ -139,7 +139,11 @@ test_root="$artefact/test"
 # the VACUOUS-PASS class rf2-o5dbf kept finding in routing, and for this artefact
 # it lives among the greens, not among the reds.
 known_red=(
-  # ── CLASS A · SUBJECT ELIDED (15).  These suites obtain their subject by
+  # ── CLASS A · SUBJECT ELIDED (17.  The 2026-08-15 triage below counted 15
+  #    and the number was not kept up as entries landed; it is recounted here
+  #    rather than restated.  `excluded` on the run's own summary line is the
+  #    authority either way — it counts the array.)  These suites obtain
+  #    their subject by
   #    dispatching and reading the ring back — recording, restore, replay,
   #    capture-buffer and projection-of-a-recorded-record.  Under the gate the
   #    ring never fills, so there is no subject to assert about; see the header
@@ -148,6 +152,12 @@ known_red=(
   #    designed not to have in production.  DISPOSITION: correct as-is.
   re-frame.actor-revertibility-restore-test              #  21 /   44
   re-frame.epoch-attribution-test                        # 107 /  208
+  #    rf2-f8wu post-merge audit — the `:depth` transition serialization.
+  #    Its subject is a writer PARKED INSIDE `record!`: under the gate
+  #    `record!` is never reached, so the park never arms and the suite has
+  #    nothing to observe.  Class A, and dev-only by construction rather
+  #    than by choice.
+  re-frame.epoch-depth-transition-race-test              #   2 /   14
   re-frame.epoch-drain-serialization-test                #  13 /   26
   re-frame.epoch-egress-redaction-cljs-test              #  62 /  117
   re-frame.epoch-egress-resource-trace-test              # 145 /  581


### PR DESCRIPTION
Two unrelated artefacts, no file overlap. Two commits, smaller first.

## rf2-f8wu — the `:depth` transition holds the stores it bounds

**The bead's live instruction is its post-merge audit note, not its description.** PR #9205 landed the boundary prune and closed the single-threaded defect; the audit reopened the bead one level down, and that is what this commit answers.

`record!` read the depth and THEN swapped the ring; `merge-config!` swapped the config and THEN pruned. Nothing held the stores still between those steps, so a writer that had already captured the PREVIOUS depth could commit its append after `configure!` had returned — and that record is queryable through `epoch-history` / `projected-history` and a live `restore-epoch!` / `replay-epoch!` target, which are exactly the two routes the fix exists to close. Config-swap-before-prune made the escape self-repairing for a positive depth and **permanent at depth 0**, where `record!` appends nothing and no later append ever re-caps the ring. The old `enforce-depth!` docstring conceded the window and called the excess transient; at zero it is not, and "a later append repairs it" was never the promise anyway — the promise is about the state at `configure!`'s return.

`set-last-settled-epoch!` has the same shape (a depth read, then a store write), and the anchor reconciliation had a second seam: it judged anchors against a retained-id set snapshotted from the pruned map, so a record committed at that seam could have its own, correct anchor discarded as unretained.

One monitor now spans each whole sequence. It is a **leaf** — the sections it guards are atom swaps over the epoch stores and nothing else, no other lock is taken underneath it and no foreign code runs there (`:redact-fn` is stored, never invoked) — so it cannot supply the second edge of a cycle and needs no place in the ledger lock order or the `:drain-lock` argument documented further down in the same file. The only nesting that exists is frame-owner -> retention, from `commit-frame-owner-record!`, and the JVM monitor is reentrant. CLJS is single-threaded and keeps the bare call.

Two new deftests **place** the interleaving rather than racing for it: a writer parked inside `record!` at the exact point between the depth capture and the ring swap, with the configuring thread run against that held position. Both are red against the previous code.

Spec unchanged — Tool-Pair §Time-travel already promises the excess is gone once `configure!` returns. This makes that true under concurrency.

The new namespace joins the epoch production-gate lane by default and is Class A (subject elided): under `-Dre-frame.debug=false` `record!` is never reached, so the park never arms. Added to that roster with its classification, per the procedure the script's own header sets out. Its Class A heading count was already stale by one and is recounted rather than restated.

## rf2-tug6 — the UIx imperative effect recipe follows its frame

The canonical outer/inner recipe installed a DOM listener from `use-effect`, dispatched from it through the ops map `use-frame` returns, and named only the domain prop in its deps vector — two lines above a bullet telling readers to name everything the effect reads.

That omission routes events. `use-frame`'s bundle is reference-stable for one resolved frame incarnation and a NEW map once the surrounding `frame-provider` retargets, so a provider swap re-renders the mounted component with a B-locked `dispatch` in hand — and React, told only that the prop is unchanged, does not re-run the effect. The listener installed under A stays installed, and the next DOM event dispatches into A. Frames are isolated contexts, so a write into still-live A raises nothing: a tenant/tab/provider switch silently mutates the frame the UI has navigated away from while showing the new one.

The fix is the dependency, `[tile-id dispatch]` — which is what the hook's reference-stability guarantee exists to make cheap: no effect churn within one frame, a re-install exactly when the frame changes. The deps bullet now says reactive VALUE rather than prop and names the frame-bound callbacks explicitly.

The browser regression drives the **real** swap path — one mount, one instance, the provider's `:frame` prop changed and the tree re-rendered in place — and asserts the DOM element is `identical?` across the swap before drawing any conclusion, because a remount would run the effect afresh and pass either way. It carries its own **negative control**: a second component with the original deps vector (`^:lint/disable`, since the omission is the subject) that fails in the bead's exact shape — the post-swap event lands in A a second time and B never hears it. It also clears the fixture's ambient `:rf/default` dynamic scope, because `use-frame` resolves the dynamic-var tier before the provider tier and leaving it bound masks the provider outright.

No public API and no adapter machinery added.

## Quality gates

Every row below was captured on the FINAL tree (rebased onto `origin/main`, alias fix included) unless the row says otherwise. Each runner was redirected to a log and its own exit code echoed on one command line — no gate was piped through a filter.

| gate | command | captured exit | result |
| --- | --- | --- | --- |
| **require-alias dialect ratchet** — the gate that was red | `python scripts/check_require_alias_dialect.py --verbose` | **1 before the fix**, **0 after** | before: `implementation/adapters` 339 v. floor 337 and `implementation/epoch` 199 v. floor 196; after: `require-alias dialect clean: 2793 file(s), 10850 re-frame require edge(s), 2446 non-canonical, every surface at or under its floor` |
| ratchet fixture witness (CI runs it as the step before) | `python scripts/check_require_alias_dialect.py --self-test` | 0 | 79 passed, 0 failed |
| ratchet per-surface census | `python scripts/check_require_alias_dialect.py --report` | 0 | `implementation/adapters` **337, floor 337**; `implementation/epoch` **196, floor 196** — both exactly AT floor, neither raised |
| clj-kondo over the two renamed files | `clj-kondo --lint <the two files> --fail-level error` | 0 | errors: 0, warnings: 0 — the static control that no qualified use site was left behind |
| epoch JVM suite | `clojure -M:test` in `implementation/epoch` | 0 | 558 tests / 7273 assertions, 0 failures, 0 errors |
| epoch production gate | `sh scripts/test-epoch-prod-gate.sh` | 0 | 25 tests / 76 assertions, 0 failures (5 of 29 namespaces) |
| UIx adapter JVM lane | `clojure -M:test` in `implementation/adapters/uix` | 0 | 4 tests / 34 assertions, 0 failures |
| new epoch race suite — **the behavioural control**, captured on the pre-rebase tree | `clojure -M:test -n re-frame.epoch-depth-transition-race-test` in `implementation/epoch` | **1 before the fix**, 0 after | 3 failures red (escaped record present in `epoch-history` AND `projected-history`; ring one over the accepted cap), then 2 tests / 14 assertions green. Its 2 tests / 14 assertions are inside the 558 / 7273 re-run above. |
| README/source link gate, captured when the README landed | `python scripts/check_readme_links.py --ci` | 0 | clean; no README changed since |

**On the alias fix specifically.** The ratchet is a per-surface FLOOR, and the two test namespaces this branch adds pushed two surfaces over theirs at once — adapters by 2, epoch by 3, each excess wholly attributable to the new file on that surface. The repair spells the new files canonically per `spec/Conventions.md §Require-alias dialect` (`uix-adapter` → `rf.adapter.uix`, `epoch-state` → `rf.epoch.state`, `plain-atom` → `rf.substrate.plain-atom`, `test-support` → `rf.test-support`), moving every qualified use site with the alias including the one quoted in the UIx ns docstring. **No baseline or floor file was touched** — `scripts/require-alias-baseline.edn` is unchanged; raising a ratchet to admit new debt inverts what it is for, and walking the existing 337/196 down is its own bead. Pre-existing violations inside each floor are untouched, `implementation/epoch/src/re_frame/epoch/state.cljc`'s `[re-frame.privacy :as privacy]` among them: it is on `main` already, this branch changes no require line in that file, and both surfaces reach floor without it. Neither file carries an auto-resolved `::alias/key` keyword for a renamed alias, so nothing beyond the qualified symbols travelled.

**"Lint required" was not a second defect.** It is `lint.yml`'s `lint-required` aggregator, whose `needs:` are `detect, clj-kondo, splint, eslint, api-manifest, require-alias-dialect`; its log read `needs results: success, success, success, skipped, success, failure` — the single `failure` in position six being the ratchet. Fixing the ratchet is the whole of its repair.

**Skipped, with reason.** The UIx `:browser-test` lane is the only lane covering `uix_effect_frame_deps_dom_cljs_test.cljs`, and it is a shadow-cljs build. This dispatch ran alongside live sibling workers and forbade starting one, because two builds that heavy wedge rather than fail. **CI owns that lane and this PR relies on it** — likewise `scripts/test-fast-pr.sh` and `npm run test:cljs`, not run for the same reason. What was done instead: the file was read-validated against the CLJS reader, the UIx 1.4.4 linter sources were read directly to confirm the deps analysis is locals-only (so the test atoms are not flagged) and that `use-ref` is in `stable-hooks` (so `ref` is not demanded as a dep, matching the README), and every API it touches was checked against a compiled sibling in the same test tree. For the alias rename on top of that, `clj-kondo` over the file reports zero errors — it resolves every qualified symbol against the new alias — and a boundary-anchored search for the four old aliases returns zero hits on the new file against a control of 6 hits on the pre-rename revision.
