### PR TITLE
fix(ci): three gates that reported success where they should have refused (rf2-i7q4, rf2-z65e, rf2-7mcp)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -2408,6 +2408,28 @@ else
       skills/re-frame2-pair/*|skills/shared/*)
         skills_structural=true
         ;;
+      skills/re-frame2-improver/*)
+        # rf2-z65e — the same silent hole rf2-g1m2q found in two other trees:
+        # this one armed NOTHING AT ALL. The main case has no default arm, so a
+        # diff confined to the improver tree classified to zero outputs, and
+        # `skills/re-frame2-improver/tests/storage_materializer_test.clj` (added
+        # by PR #9232 with `.github/workflows/**` fenced out, so local-only) had
+        # nothing scheduling it. The step that loops it lives in the
+        # `skills-structural` job, gated on this output.
+        #
+        # THE NEAR-MISS PREFIX HERE IS `implementor`, NOT `pair-retro`. Both
+        # `skills/re-frame2-improver/` and `skills/re-frame2-implementor/` begin
+        # `skills/re-frame2-imp`, and the implementor tree carries no tests and
+        # no arm — so a pattern loosened to `skills/re-frame2-imp*` would arm
+        # this tier for a tree with nothing to run. The literal name is the
+        # whole guard.
+        #
+        # ONE output, structural only. The tree is prose plus a Babashka
+        # fixture that loads no re-frame2 runtime, drives no live Pair op and
+        # compiles into no example build, so the expensive lanes the
+        # `skills/re-frame2-pair/*` neighbour arms have nothing to do here.
+        skills_structural=true
+        ;;
       skills/re-frame2-setup/*)
         # rf2-agi57x — the re-frame2-setup skill carries a structural drift
         # guard (tests/setup_drift_test.clj) gated under skills-structural.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5969,6 +5969,44 @@ jobs:
             bb "$test_file"
           done
 
+      # re-frame2-improver structural fixture (rf2-z65e).
+      # `tests/storage_materializer_test.clj` pins the canonical storage
+      # materializer in `references/schemaless-events.md` — it discriminates in
+      # both directions (restoring the direct `.getItem js/globalThis.localStorage`
+      # form fails it with 2 assertions, removing the decode catch fails it with
+      # 1). PR #9232 added it with `.github/workflows/**` fenced out, so it was
+      # local-only: the third skill test in a row to be written, proven, and then
+      # not run by anything. Loop every *_test.clj, as the two steps above do, so
+      # a future improver test is gated without another wiring PR.
+      #
+      # `skills/re-frame2-improver/*` arms `skills_structural` in
+      # `.github/scripts/report-changed-surfaces.sh` (rf2-z65e), so a diff
+      # confined to this tree schedules this step; the arm is pinned from both
+      # sides in `implementation/scripts/_changed-surfaces.test.cjs`
+      # (SKILLS_STRUCTURAL_ONLY_FILES), including the `implementor` / `improver`
+      # prefix boundary that is why the tree needs an arm of its own.
+      #
+      # A FOURTH NAMED STEP RATHER THAN A DERIVED LOOP, and the reason is
+      # measured rather than stylistic. The obvious generalisation — loop every
+      # package under skills/ that HAS a tests/ directory — is silently wrong
+      # for two of the four packages that have one: re-frame2-pair keeps its
+      # tests one level deeper (tests/prompts/, tests/runtime/), so a
+      # `tests/*_test.clj` glob matches NOTHING there, and reagent-migration's
+      # tests/ is a shadow-cljs fixture built by a different job entirely
+      # (reagent-migration-fixture-cold-start), not a bb suite. A derived loop
+      # would therefore report success having run nothing for the package with
+      # the most tests in it — the same fail-open shape this bead exists to
+      # close. The explicit list cannot do that: a package with no step visibly
+      # has no step.
+      - name: Run re-frame2-improver structural tests
+        working-directory: skills/re-frame2-improver
+        run: |
+          set -euo pipefail
+          for test_file in tests/*_test.clj; do
+            echo "== $test_file =="
+            bb "$test_file"
+          done
+
   # ---------------------------------------------------------------------------
   # re-frame2-pair SHIPPED-preload pure-core node-test (rf2-etsj8p / rf2-pxxbjk).
   #

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2438,6 +2438,12 @@ test('NON-preload re-frame2-pair skill file does NOT arm cljs_browser / mcp_live
 // `/` straight after `pair`, and `skills/re-frame2-pair-retro/...` has a `-`
 // there, so it never matches. The negative assertions pin that boundary from
 // the other side — retro paths must not arm the PAIR tree's expensive gates.
+//
+// rf2-z65e — `skills/re-frame2-improver/**` joins the roster, the THIRD tree
+// found arming nothing at all, and its near-miss is a different one:
+// `skills/re-frame2-implementor/` shares the prefix `skills/re-frame2-imp`,
+// carries no tests and has no arm, so the improver arm must name the tree in
+// full. The negative assertion for that boundary is below the loop.
 const SKILLS_STRUCTURAL_ONLY_FILES = pinnedRoster('SKILLS_STRUCTURAL_ONLY_FILES', [
   'skills/re-frame2-pair-retro/SKILL.md',
   'skills/re-frame2-pair-retro/tests/duplicate_search_test.clj',
@@ -2446,6 +2452,9 @@ const SKILLS_STRUCTURAL_ONLY_FILES = pinnedRoster('SKILLS_STRUCTURAL_ONLY_FILES'
   'skills/reagent-migration/references/procedure.md',
   'skills/reagent-migration/tests/fixture/test/reagent_migration/mig23_cold_start_test.cljs',
   'skills/reagent-migration/tests/fixture/shadow-cljs.edn',
+  'skills/re-frame2-improver/SKILL.md',
+  'skills/re-frame2-improver/tests/storage_materializer_test.clj',
+  'skills/re-frame2-improver/references/schemaless-events.md',
 ]);
 for (const file of SKILLS_STRUCTURAL_ONLY_FILES) {
   test(`${file} arms skills_structural (rf2-g1m2q)`, () => {
@@ -2472,6 +2481,29 @@ for (const file of SKILLS_STRUCTURAL_ONLY_FILES) {
     }
   });
 }
+
+// rf2-z65e — the improver arm's boundary, pinned from the other side. This
+// tree has no arm and no tests, and it is one `-` away from `improver` in a
+// shared `skills/re-frame2-imp` prefix — the pair / pair-retro trap wearing
+// different names. A pattern loosened to `skills/re-frame2-imp*` would pass
+// every assertion above and start scheduling a job with nothing to run; this
+// is the assertion that would catch it.
+//
+// It pins the CURRENT behaviour, which is that this tree still classifies to
+// nothing at all. That is a gap of its own — but an empty one: the package
+// carries no test file for any job to run, so wiring it would arm a tier over
+// prose. Should it gain a `tests/` directory, it needs an arm of its own and
+// this assertion is where the choice gets made rather than inherited.
+test('skills/re-frame2-implementor/ does not inherit the improver arm (rf2-z65e)', () => {
+  const result = classify('skills/re-frame2-implementor/SKILL.md');
+  assert.equal(
+    result.skills_structural,
+    'false',
+    'the implementor tree shares the prefix `skills/re-frame2-imp` with the ' +
+      'improver tree but carries no tests; an arm matching it would schedule ' +
+      'the skills-structural job for a tree with nothing to run.',
+  );
+});
 
 // rf2-bbe91 (audit reopen of PR #8868) — the REVERSE edge into the MIG-23 SSR
 // cold-start fixture. rf2-g1m2q above armed `skills_structural` from the SKILL
@@ -6423,7 +6455,16 @@ const DECLARED_NO_SURFACE_OUTPUT = {
   skills: SKILLS_ALWAYS_ON,
   'skills/re-frame-migration': SKILLS_ALWAYS_ON,
   'skills/re-frame2-implementor': SKILLS_ALWAYS_ON,
-  'skills/re-frame2-improver': SKILLS_ALWAYS_ON,
+  // rf2-z65e — `skills/re-frame2-improver` is DELIBERATELY ABSENT for the same
+  // reason as the two trees named below, and it is the reason this bead could
+  // not be split: the tree gained an executable half
+  // (tests/storage_materializer_test.clj, looped by the improver step in the
+  // `skills-structural` job) and an arm to schedule it, so the declaration went
+  // stale in the same commit that armed it. Its neighbour one line up,
+  // `skills/re-frame2-implementor`, STAYS — that tree really does arm nothing,
+  // and the two names differ by four characters after a shared
+  // `skills/re-frame2-imp` prefix.
+  //
   // rf2-g1m2q — `skills/re-frame2-pair-retro` and `skills/reagent-migration`
   // are DELIBERATELY ABSENT from this table now. Both used to sit here as
   // SKILLS_ALWAYS_ON, which was true of them as pure prose trees; rf2-qad4l and

--- a/implementation/scripts/_compile-node-test-signal.test.cjs
+++ b/implementation/scripts/_compile-node-test-signal.test.cjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/*
+ * rf2-i7q4 — a signal-killed compile must not report success.
+ *
+ * THE DEFECT. Node's `close` event reports a signal death as
+ * `(code=null, signal='SIGTERM')`. `compile-node-test.cjs` kept only the first
+ * argument, and its abnormal-exit branch returned that `null` straight to
+ * `process.exit()` — which reads a non-number as SUCCESS. The wrapper printed
+ * `did not complete (exit null)` on stderr and handed its caller exit 0 in the
+ * same breath. An OOM kill, a cancelled CI job, or an administrative taskkill
+ * of the shadow-cljs JVM all land there, and every one of them recorded a
+ * green compile.
+ *
+ * WHY THIS RUNS A REAL PROCESS. The defect lives at the process boundary: it
+ * is about what Node reports when a child is killed, and what
+ * `process.exit(null)` then does. A unit test over a hand-made result object
+ * would assert the fix's own arithmetic back at itself and could not see
+ * either half. So this suite kills a REAL child with a REAL signal and reads
+ * the REAL exit status of the REAL CLI:
+ *
+ *   - the wrapper runs unmodified, as its own process, through its own
+ *     `require.main === module` CLI path and its own `process.exit(code)`;
+ *   - `runCapturing` does its own `spawn`, and the child that dies is an
+ *     ordinary OS process killed with `child.kill('SIGTERM')` by the wrapper's
+ *     own process;
+ *   - the verdict read here is the exit status the OS reports for the wrapper,
+ *     the same number an npm lane or a CI step would branch on.
+ *
+ * WHAT IS SUBSTITUTED, and it is one thing: WHICH PROGRAM the child runs. A
+ * `--require` preload points shadow-cljs's entry-point resolution at a stub
+ * whose behaviour each arm chooses, because the alternative is a multi-minute
+ * ClojureScript compile that would have to be killed mid-flight to prove
+ * anything. Nothing in the wrapper is patched, and the signal is not simulated.
+ *
+ * THE CONTROL ARM IS THE POINT. `a compile that is NOT signalled still
+ * succeeds` runs the identical stub through the identical preload with the
+ * kill deleted and nothing else changed. It must be GREEN. If it ever reds,
+ * the signal arm's red is an artefact of the harness rather than evidence
+ * about signals, and neither number means anything.
+ *
+ * EXPECTED EXIT CODES, stated per arm, because refusing IS this wrapper's job:
+ * the signal arm expects 1 (and expected 0 before the fix — that is the bug),
+ * the control arm expects 0, the numeric-status arm expects the child's own 3,
+ * and the missing-output arm expects 1.
+ *
+ * Discovered by `npm run test:scripts`.
+ */
+
+const assert = require('assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { createPolicyTestSuite } = require('./_policy-test-util.cjs');
+const { makeScratchDir, cleanupScratchDirs } = require('./lib/scratch-fixtures.cjs');
+
+const SCRIPTS_DIR = __dirname;
+const IMPL_DIR = path.resolve(SCRIPTS_DIR, '..');
+const REPO_ROOT = path.resolve(IMPL_DIR, '..');
+const WRAPPER = path.join(SCRIPTS_DIR, 'compile-node-test.cjs');
+
+const { test, run } = createPolicyTestSuite('compile-node-test-signal');
+
+// The lane holds the two fixture programs and the wrapper's `:output-to`
+// target. Per-process and torn down by the shared helper, so a concurrent
+// sibling suite in the same checkout is never touched (rf2-2i1ay).
+const lane = makeScratchDir(REPO_ROOT, 'rf2-i7q4-signal');
+
+// A stand-in for shadow-cljs. The wrapper spawns whatever
+// `require.resolve('shadow-cljs/cli/runner.js')` yields under `process.execPath`
+// with `compile <build-id>` appended, so this only has to be a Node script; the
+// arm picks its behaviour through the environment.
+const VICTIM = path.join(lane, 'shadow-cljs-stand-in.cjs');
+fs.writeFileSync(
+  VICTIM,
+  [
+    "'use strict';",
+    "const fs = require('node:fs');",
+    'const mode = process.env.RF2_PROOF_MODE;',
+    'const out = process.env.RF2_PROOF_OUTPUT;',
+    // A real shadow-cljs tally, so the arms that reach the tally reader are
+    // reading the shape it actually parses rather than a green it invented.
+    "const TALLY = '[:signal-proof] Build completed. (2 files, 2 compiled, 0 warnings, 0.42s)\\n';",
+    "if (mode === 'signal') {",
+    // Announce, then hold. The first byte of output is the parent's cue to
+    // kill, which makes the arm deterministic rather than timing-dependent.
+    "  process.stdout.write('[:signal-proof] Compiling ...\\n');",
+    '  setInterval(() => {}, 1000);',
+    // If the kill never lands, do not hang the suite: exit cleanly and let the
+    // stderr assertion say what actually happened.
+    '  setTimeout(() => process.exit(0), 15000);',
+    '} else {',
+    "  if (mode !== 'no-output') fs.writeFileSync(out, '// compiled\\n');",
+    '  process.stdout.write(TALLY);',
+    "  process.exit(mode === 'code3' ? 3 : 0);",
+    '}',
+    '',
+  ].join('\n'),
+);
+
+// Preload. Two seams, both minimal: point the entry-point resolution at the
+// stand-in, and — in the signal arm only — kill the child the wrapper spawned.
+// The kill is issued by the wrapper's own process against its own child, which
+// is what makes `close` report (null, 'SIGTERM') rather than a synthesised
+// shape.
+const PRELOAD = path.join(lane, 'preload.cjs');
+fs.writeFileSync(
+  PRELOAD,
+  [
+    "'use strict';",
+    "const Module = require('node:module');",
+    "const cp = require('node:child_process');",
+    'const victim = process.env.RF2_PROOF_VICTIM;',
+    'const origResolve = Module._resolveFilename;',
+    'Module._resolveFilename = function (request, ...rest) {',
+    "  if (request === 'shadow-cljs/cli/runner.js') return victim;",
+    '  return origResolve.call(this, request, ...rest);',
+    '};',
+    'const origSpawn = cp.spawn;',
+    'cp.spawn = function (...args) {',
+    '  const child = origSpawn.apply(this, args);',
+    "  if (process.env.RF2_PROOF_MODE === 'signal') {",
+    "    child.stdout.once('data', () => child.kill('SIGTERM'));",
+    '  }',
+    '  return child;',
+    '};',
+    '',
+  ].join('\n'),
+);
+
+const OUTPUT_ABS = path.join(lane, 'signal-proof-out.js');
+// The wrapper resolves `:output-to` against the implementation root.
+const OUTPUT_REL = path.relative(IMPL_DIR, OUTPUT_ABS);
+
+// Run the wrapper's real CLI and return the OS-reported status plus its stderr.
+function runWrapper(mode) {
+  const result = spawnSync(
+    process.execPath,
+    ['--require', PRELOAD, WRAPPER, 'signal-proof', OUTPUT_REL],
+    {
+      cwd: IMPL_DIR,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        RF2_PROOF_MODE: mode,
+        RF2_PROOF_VICTIM: VICTIM,
+        RF2_PROOF_OUTPUT: OUTPUT_ABS,
+      },
+    },
+  );
+  assert.equal(result.error, undefined, `could not launch the wrapper: ${result.error}`);
+  // A wrapper killed in its own right would report a signal here; every arm
+  // expects the wrapper itself to exit under its own control.
+  assert.equal(
+    result.signal,
+    null,
+    `the wrapper process itself was signalled (${result.signal}); this suite ` +
+      'kills the CHILD, never the wrapper.',
+  );
+  return result;
+}
+
+// ── The defect ───────────────────────────────────────────────────────────
+
+// EXPECTED EXIT: 1. Before the fix this arm read 0 — the whole bug.
+test('a signal-killed child makes the CLI exit 1 and names the signal (rf2-i7q4)', () => {
+  // A stale bundle from a previous, successful compile. The wrapper deletes
+  // `:output-to` before every attempt, and a signal must not resurrect that
+  // guarantee's failure mode: an aborted compile leaves NO bundle.
+  fs.writeFileSync(OUTPUT_ABS, '// stale bundle from an earlier compile\n');
+
+  const result = runWrapper('signal');
+
+  assert.equal(
+    result.status,
+    1,
+    'a compile whose child was killed by SIGTERM reported exit ' +
+      `${result.status}. Node reports a signal death as (null, 'SIGTERM'), and ` +
+      'process.exit(null) exits 0 — so an unnormalised null status hands ' +
+      'automation a green for a compile that never finished.',
+  );
+  assert.match(
+    result.stderr,
+    /terminated by signal SIGTERM/,
+    `the diagnostic must name the signal; stderr was:\n${result.stderr}`,
+  );
+  // Nothing in the diagnostic may still describe the death as an exit status:
+  // "exit null" is the sentence that used to sit beside the false green.
+  assert.doesNotMatch(result.stderr, /exit null/, 'stderr still calls a signal death an exit status');
+  assert.equal(
+    fs.existsSync(OUTPUT_ABS),
+    false,
+    'the stale bundle survived a signalled compile — output pre-deletion regressed',
+  );
+});
+
+// ── The control: same fault, signal deleted ──────────────────────────────
+
+// EXPECTED EXIT: 0. This arm is what makes the arm above evidence. It runs the
+// identical preload and the identical stand-in with only the kill removed; a
+// red here means the harness reds for reasons that have nothing to do with
+// signals, and the signal arm proves nothing.
+test('the same stand-in WITHOUT the kill still compiles green (control)', () => {
+  const result = runWrapper('clean');
+  assert.equal(
+    result.status,
+    0,
+    `the control arm exited ${result.status}; stderr was:\n${result.stderr}`,
+  );
+  assert.equal(fs.existsSync(OUTPUT_ABS), true, 'the control arm wrote no bundle');
+});
+
+// ── The mapping either side of the seam ──────────────────────────────────
+
+// EXPECTED EXIT: 3 — the child's own status, passed through rather than
+// normalised. Collapsing every abnormal outcome to 1 would lose real codes.
+test("a numeric child status is the child's own, not a normalised 1", () => {
+  const result = runWrapper('code3');
+  assert.equal(result.status, 3, `expected the child's exit 3, got ${result.status}`);
+  assert.match(result.stderr, /did not complete \(exit 3\)/, result.stderr);
+});
+
+// EXPECTED EXIT: 1. Preserved from before this change: a child that exits 0
+// without writing the bundle is still fatal.
+test('a clean exit that writes no bundle is still refused', () => {
+  fs.rmSync(OUTPUT_ABS, { force: true });
+  const result = runWrapper('no-output');
+  assert.equal(result.status, 1, `expected 1, got ${result.status}`);
+  assert.match(result.stderr, /is missing — treating as fatal/, result.stderr);
+});
+
+try {
+  run();
+} finally {
+  cleanupScratchDirs();
+}

--- a/implementation/scripts/compile-node-test.cjs
+++ b/implementation/scripts/compile-node-test.cjs
@@ -199,7 +199,11 @@ function runCapturing(command, args, options) {
       });
     }
     child.on('error', (error) => resolve({ error, captured }));
-    child.on('close', (status) => resolve({ status, captured }));
+    // BOTH arguments. `close` reports a signal death as (null, 'SIGTERM') —
+    // the status is NULL, and the signal name is the only place the cause is
+    // written down. Dropping the second argument threw that away and left the
+    // caller a status it cannot tell apart from "no idea" (rf2-i7q4).
+    child.on('close', (status, signal) => resolve({ status, signal, captured }));
   });
 }
 
@@ -260,12 +264,31 @@ async function main(argv) {
     return 1;
   }
 
+  // rf2-i7q4 — A SIGNAL-KILLED CHILD IS NOT A PASSING BUILD, and Node's own
+  // convention is what made it read as one. `close` reports a signal death as
+  // (null, 'SIGTERM'): the status is NULL rather than a number, `null !== 0`
+  // so this branch was entered and printed "did not complete (exit null)" —
+  // and then returned that null to `process.exit()`, which reads a non-number
+  // as SUCCESS. The wrapper said the compile had failed and told automation it
+  // had passed, in the same breath. An OOM kill, a CI job cancellation, or an
+  // administrative taskkill of the shadow-cljs JVM all land here.
+  //
+  // So the seam is: a NUMERIC status is the child's own verdict and passes
+  // through untouched (0 continues into the output/tally checks below; 1, 3,
+  // anything else is returned as-is). Any NON-numeric completion is abnormal
+  // by construction and normalises to a stable 1.
   if (result.status !== 0) {
+    const numeric = typeof result.status === 'number';
+    const cause = numeric
+      ? `did not complete (exit ${result.status})`
+      : result.signal
+        ? `was terminated by signal ${result.signal} before it could complete`
+        : 'did not complete and reported no exit status';
     console.error(
-      `compile-node-test: shadow-cljs compile ${buildId} did not complete (exit ${result.status}); ` +
+      `compile-node-test: shadow-cljs compile ${buildId} ${cause}; ` +
         `${outputTo} was cleared before the attempt, not left stale.`
     );
-    return result.status;
+    return numeric ? result.status : 1;
   }
 
   if (!fs.existsSync(outputPath)) {


### PR DESCRIPTION
Three controls that fail OPEN, taken together because they share one shape: each reports success in the case it exists to catch. One is fixed, one is wired, and the third turns out not to hold — with the measurement to say so.

## rf2-i7q4 — a signal-killed compile exited 0

`implementation/scripts/compile-node-test.cjs` dropped the second argument of Node's `close` event. A signal death arrives as `(code=null, signal='SIGTERM')`: `null !== 0`, so the abnormal branch was entered and printed `did not complete (exit null)` — and then returned that `null` to `process.exit()`, which reads a non-number as SUCCESS. The wrapper called the compile failed and told automation it had passed, in the same breath. An OOM kill, a cancelled CI job, or an administrative taskkill of the shadow-cljs JVM all landed there.

**The seam.** A NUMERIC child status is the child's own verdict and passes through untouched — `0` continues into the output/tally checks, `3` stays `3`. Any non-numeric completion is abnormal by construction, normalises to a stable `1`, and the diagnostic names the signal. Output pre-deletion, config-merge cache cleanup, streaming, missing-output rejection and warning-tally rejection are unchanged, and no new option or export was added.

**The test kills a real child with a real signal.** `_compile-node-test-signal.test.cjs` runs the real CLI as its own process, through its own `require.main` path and its own `process.exit`; `runCapturing` does its own `spawn`; the child that dies is an ordinary OS process killed with `child.kill('SIGTERM')`. The only substitution is *which program* the child runs — a `--require` preload points shadow-cljs's entry-point resolution at a stand-in, because the alternative is a multi-minute compile killed mid-flight. The signal is not simulated.

| arm | expected exit | why |
|---|---|---|
| child killed by SIGTERM | **1** | the fix. Read **0** against the pre-fix file — the bug. |
| same stand-in, kill deleted | **0** | the control: proves the harness reaches the real success path |
| child exits 3 | **3** | real numeric codes are not collapsed to 1 |
| child exits 0, writes no bundle | **1** | pre-existing missing-output refusal, preserved |

Red-then-green, measured by reverting only `compile-node-test.cjs` to `HEAD` and re-running: **exit 1, and only the signal arm failed** — the other three stayed green, so the redness comes from the signal and not from the harness. Restoring the fix was verified by SHA-256, not by eye. The signal arm also plants a stale bundle first and asserts it is gone, so output pre-deletion is pinned on the abnormal path too.

## rf2-z65e — a skill test nothing ran

`skills/re-frame2-improver/tests/storage_materializer_test.clj` arrived in PR #9232 with `.github/workflows/**` fenced out. The tree had no arm in `report-changed-surfaces.sh` — a diff confined to it classified to **zero of 29 outputs**, the main `case` having no default arm — and the `skills-structural` job had no step for it.

Three coupled halves in **one commit**, because the mirror test pins what the classifier outputs. The coupling proved itself in both directions: arming the tree without deleting its `DECLARED_NO_SURFACE_OUTPUT` entry reds the suite (it did, on the first run), and keeping the pins without the arm reds it four ways.

**A fourth named step, not a derived loop** — on measurement, not taste. Of the four skill packages with a `tests/` directory, a `tests/*_test.clj` glob matches **nothing** for `re-frame2-pair` (its tests live in `tests/prompts/` and `tests/runtime/`), and `reagent-migration`'s `tests/` is a shadow-cljs fixture built by a different job. A derived loop would report success having run nothing for the package with the most tests in it — the very fail-open shape this bead is about. An explicit list cannot: a package with no step visibly has no step.

The near-miss prefix here is `skills/re-frame2-implementor`, four characters from `skills/re-frame2-improver` after a shared `skills/re-frame2-imp`. It carries no tests, keeps its no-output declaration, and a new assertion pins that boundary from the other side.

**This adds a STEP to an existing job, not a job — the check-count band does not move.** The two-leading-spaces job-key discriminator reads `0` on this diff and `1` on the `366e4fca79` control.

## rf2-7mcp — the premise does not hold; no gate was built

Measured rather than assumed, and the bead itself asked for this judgement before anything was built.

1. **The mechanical half is already gated**, by a script written after the bead was filed: `scripts/check_skill_package_refs.py` (rf2-deo2zp, hardened by rf2-kgw8z and rf2-pp72) enforces that every intra-package link from a shipped doc resolves to a file the `files` allow-list ships. It is armed in `test.yml` *and* the fast-PR spine, and it discriminates — 14 self-test fixtures of which three must produce findings and do.
2. **The half this bead asks for is a deliberate exclusion**, pinned by a fixture named `ok_parent_escape_out_of_scope`. Over all 9 packaged skills and 137 shipped docs: **428 markdown links resolve outside their package**, every one existing in the repo, and **743 path-shaped citations** name an out-of-package tree. A gate there fires on the entire corpus — it is the house convention, not a defect population.
3. **The distinguishing feature is prose.** PR #9230 did not remove the `spec/Tool-Pair.md` citation from pair-retro's SKILL.md; the citation is still there. It added a *declaration* that the package ships no copy of it. The reference is unchanged; its required-ness moved. The citations are backticked prose, not links, so no link gate could have seen them.
4. **The design-level rule the bead nominates as the better enforcement point is already live**, carried three times unprompted in `skills/re-frame2-improver/SKILL.md` ("supporting references, not required reads"; "not shipped in the package — this filter decides without it").

Per the project stance, a gate firing 428 times that cannot tell a required read from an optional one — or a 428-entry allow-list to silence it — costs more than the class it guards. Recorded on the bead with the measurement and a recommendation to close as won't-build. **No new gate script; neither link-checker was touched.**

## Quality gates

Run locally, each redirected to its own log with the runner's own exit code captured on one command line. Every number below is that captured code.

| gate | exit | result |
|---|---|---|
| `node implementation/scripts/_compile-node-test-signal.test.cjs` | 0 | 4 passed (new) |
| `node implementation/scripts/_compile-node-test-warnings.test.cjs` | 0 | 6 passed |
| `node implementation/scripts/_changed-surfaces.test.cjs` | 0 | 366 passed (was 362; +4) |
| `node implementation/scripts/_script-spawn-policy.test.cjs` | 0 | 141 passed |
| `node implementation/scripts/_scratch-fixture-isolation.test.cjs` | 0 | 5 passed |
| `node implementation/scripts/_reagent-slim-smoke-policy.test.cjs` | 0 | all passed |
| `node implementation/scripts/_docs-workflow-policy.test.cjs` | 0 | 5 passed |
| `node implementation/scripts/_lint-workflow-policy.test.cjs` | 0 | 4 passed |
| `bb tests/*_test.clj` in `skills/re-frame2-improver` (the new step's exact command) | 0 | 6 tests, 14 assertions |
| `python scripts/check_skill_package_refs.py --self-test` | 0 | 14 fixtures |
| `python scripts/check_skill_package_refs.py --verbose --ci` | 0 | clean over the live corpus |
| `bash -n .github/scripts/report-changed-surfaces.sh` | 0 | parses |
| `test.yml` YAML parse + step/job census | 0 | 71 jobs (unchanged), skills-structural 5 to 6 steps |

**Deliberate red, quoted because a refusing gate's normal case is non-zero:** `_compile-node-test-signal` exits **1** against the pre-fix `compile-node-test.cjs` (signal arm only), and `_changed-surfaces` exits **1** with the classifier arm removed (4 failures). Both are the red-then-green evidence above, not outstanding failures.

**Skipped, with reasons:** `scripts/test-fast-pr.sh` and `npm run test:cljs` — several sibling workers are live and these are heavy enough that concurrent runs wedge rather than fail; CI owns them. `shellcheck` — not installed on this machine; `bash -n` stands in locally and `lint.yml` owns it in CI. No plant was made under `skills/**` to re-demonstrate the improver test's discrimination: that tree belongs to another worker this wave, and the bead already records the measurement.
