### PR TITLE
fix(ssr): the request frame's platform, and the presence-attribute class (rf2-323z, rf2-u82a)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/server.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/server.cljs
@@ -220,10 +220,11 @@
       `:frame`, and that frame is a registered `:platform :server` frame.
       Hicasso's cold reads go through pure `compute-sub`, whose
       `:rf.error/sub-exception` is stamped `:frame nil` BY CONSTRUCTION —
-      a pure fn has no frame in scope to stamp — so the second condition
-      already drops it; and `render` does not set `:platform :server` on
-      its per-request frame, so the third would drop it even if the second
-      did not. The buffer stays empty and the host ships a 200.
+      a pure fn has no frame in scope to stamp — so the SECOND condition
+      drops it, and drops it alone: since rf2-323z the request frame IS
+      tagged `:platform :server`, so the third now holds. The buffer still
+      stays empty and the host still ships a 200 — the reason is one
+      condition rather than two, and the verdict below is unchanged.
 
   The verdict is deliberately BOUNDED and deliberately BLUNT: any error
   record inside the window fails the page, including one the application
@@ -321,11 +322,14 @@
                          must be handed the same string, or every
                          `useId` in the tree diverges.
       :app-element-id    :script-src  :title   the document envelope's.
-      :frame-opts        merged UNDER the id and the setup vector, so a
-                         request needing `:images`, `:url-strategy` or
-                         `:fx-overrides` declares them the way any other
-                         frame does. `:id` and `:initial-events` are
-                         this module's and cannot be overridden.
+      :frame-opts        merged UNDER the id, the platform and the setup
+                         vector, so a request needing `:images`,
+                         `:url-strategy` or `:fx-overrides` declares them
+                         the way any other frame does. `:id`, `:platform`
+                         and `:initial-events` are this module's and cannot
+                         be overridden — the renderer OWNS its server
+                         identity rather than asking every caller to
+                         remember it (rf2-323z).
       :version           :schema-digest   passed to `build-payload`.
 
   The first eight are the spellings `18-ssr-and-hydration.md` teaches
@@ -360,6 +364,21 @@
     (try
       (rf/make-frame (assoc frame-opts
                             :id             frame-id
+                            ;; RENDERER-OWNED, exactly as in `render-body`, and
+                            ;; for the same reason: the tag is what gates
+                            ;; client-only fx and cofx out of a render that has
+                            ;; no client. `platform-for-frame-record` reads the
+                            ;; frame's `:config :platform` FIRST and falls back
+                            ;; to the host-wide marker, and that marker is
+                            ;; `:client` on CLJS by default
+                            ;; (`rf.interop/active-platform`) — so an untagged
+                            ;; request frame runs a Node render on the CLIENT
+                            ;; contract, executing browser-only effects in Node
+                            ;; and skipping the server-only ones. Assoc'd OVER
+                            ;; `frame-opts` rather than merged under it: a
+                            ;; caller's `:platform :client` would otherwise
+                            ;; invert the renderer's own identity (rf2-323z).
+                            :platform       :server
                             :initial-events (setup-events snapshot initial-events)))
       (let [;; The hiccup as written, through the same `tree` the hydrating
             ;; door calls: `:adoption` is what it branches on, so this is

--- a/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
@@ -82,7 +82,7 @@
             [re-frame.hicasso.roots-frames-support :as sup]
             [re-frame.hicasso.server :as server]
             [re-frame.hicasso.test.server :as ts]
-            [re-frame.interop :as interop]
+            [re-frame.interop :as rf.interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.constants :as ssr-constants]
             [re-frame.test-support :as test-support]
@@ -483,10 +483,10 @@
   (testing "with the host-wide marker at CLJS's own `:client` default, a
             render's initial event runs the SERVER arm of a platform pair
             and not the client arm"
-    (let [restore (interop/active-platform)]
+    (let [restore (rf.interop/active-platform)]
       (try
         (rf/init-platform :client)
-        (is (= :client (interop/active-platform))
+        (is (= :client (rf.interop/active-platform))
             "PREMISE: the host marker is `:client`, so the frame's own tag is
              the only thing that can select the server arm below — without
              this line a green row could mean the host was `:server` all

--- a/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
@@ -82,6 +82,7 @@
             [re-frame.hicasso.roots-frames-support :as sup]
             [re-frame.hicasso.server :as server]
             [re-frame.hicasso.test.server :as ts]
+            [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.constants :as ssr-constants]
             [re-frame.test-support :as test-support]
@@ -98,6 +99,24 @@
 (rf/reg-sub ::label (fn [db _] (:label db)))
 (rf/reg-sub ::secret (fn [db _] (:secret db)))
 (rf/reg-event ::relabel (fn [{:keys [db]} [_ label]] {:db (assoc db :label label)}))
+
+;; rf2-323z — the platform PAIR. Two effects that differ in exactly one
+;; thing, their `:platforms` metadata, dispatched together from one event,
+;; so which of them runs READS OFF the active platform of whatever frame
+;; drained the event. Nothing else in the pair can decide the answer, which
+;; is what lets the untagged control below be a control.
+(def ^:private platform-spy (atom []))
+
+(rf/reg-fx ::client-only-spy
+  {:platforms #{:client}}
+  (fn [_ _] (swap! platform-spy conj :client)))
+
+(rf/reg-fx ::server-only-spy
+  {:platforms #{:server}}
+  (fn [_ _] (swap! platform-spy conj :server)))
+
+(rf/reg-event ::fire-both-platform-arms
+  (fn [_ _] {:fx [[::client-only-spy {}] [::server-only-spy {}]]}))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -446,6 +465,63 @@
               no-participation shape, not a nil stamped on the wire"
       (let [{:keys [payload]} (server/render (request))]
         (is (not (contains? payload :rf/schema-digest)))))))
+
+(deftest the-request-frame-is-server-platform-and-no-caller-can-invert-it
+  ;; rf2-323z. `render` is the whole-page NODE renderer, and its private
+  ;; request frame was born UNTAGGED. Platform resolution is
+  ;; `(or (-> frame-record :config :platform) (rf.interop/active-platform))`
+  ;; (`fx/platform-for-frame-record`), and the CLJS host marker is `:client`
+  ;; by default (`interop.cljs`) — so an untagged request frame ran a render
+  ;; with no client on the CLIENT contract: a correctly declared
+  ;; `:platforms #{:client}` effect reached from `:initial-events` EXECUTED
+  ;; in Node, and the `#{:server}` one was skipped. Frames are isolated
+  ;; contexts, and a request frame answering to the wrong platform contract
+  ;; is that isolation broken rather than untidiness.
+  ;;
+  ;; The sibling `render-body` has carried `:platform :server` since it
+  ;; landed; this row is what stops the two doors drifting apart again.
+  (testing "with the host-wide marker at CLJS's own `:client` default, a
+            render's initial event runs the SERVER arm of a platform pair
+            and not the client arm"
+    (let [restore (interop/active-platform)]
+      (try
+        (rf/init-platform :client)
+        (is (= :client (interop/active-platform))
+            "PREMISE: the host marker is `:client`, so the frame's own tag is
+             the only thing that can select the server arm below — without
+             this line a green row could mean the host was `:server` all
+             along and the tag did nothing")
+
+        (reset! platform-spy [])
+        (server/render (request :initial-events [[::fire-both-platform-arms]]))
+        (is (= [:server] @platform-spy)
+            "exactly the server-only effect ran inside the request frame")
+
+        (testing "and `:frame-opts` cannot invert it — the renderer OWNS its
+                  server identity, so a caller's contradictory `:platform
+                  :client` is assoc'd OVER rather than merged under, exactly
+                  as `:id` and `:initial-events` are"
+          (reset! platform-spy [])
+          (server/render (request :initial-events [[::fire-both-platform-arms]]
+                                  :frame-opts     {:platform :client}))
+          (is (= [:server] @platform-spy)
+              "the hostile `:platform :client` did not reach the frame"))
+
+        (testing "NON-VACUITY — the same event in an UNTAGGED frame of this
+                  same runtime selects the CLIENT arm. This is the shape
+                  `render` used to build, so it is the defect itself, kept as
+                  the control: were the pair not really platform-gated (both
+                  effects inert, one unregistered, the metadata ignored) this
+                  row would not read `[:client]`, and the two `[:server]`
+                  assertions above would be green about nothing"
+          (reset! platform-spy [])
+          (rf/make-frame {:id             ::untagged-platform-control
+                          :initial-events [[::fire-both-platform-arms]]})
+          (rf/destroy-frame! ::untagged-platform-control)
+          (is (= [:client] @platform-spy)
+              "an untagged frame falls back to the host marker — `:client`"))
+        (finally
+          (rf/init-platform restore))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3b — HOW EVERY ASYNC ROW BELOW ENDS

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -511,6 +511,14 @@
 ;; DIRECTION. Adding a name here without React's evidence reds that test just
 ;; as omitting one does. Two names are deliberate, documented exceptions;
 ;; the test names them and says why.
+;;
+;; THE EVIDENCE CARRIES SIX VALUES PER NAME, NOT TWO (rf2-u82a). `true` and
+;; `false` cannot separate `:presence` from `:overloaded` — the two render
+;; identically for both booleans — so a boolean-only fixture let the classes
+;; be merged with every row green, and `attr-string` serialised a non-boolean
+;; value wrongly for every member of `boolean-attrs`. The four non-booleans
+;; `"yes"`, `""`, `0` and `"0"` are what tell the classes apart and pin the
+;; JS-truthiness collapse the presence class runs on.
 
 (def boolean-attrs
   "HTML boolean attributes: `true` → presence, `false`/absent → omitted.
@@ -546,22 +554,79 @@
   Tracks react-dom 19.2.0."
   #{"download" "capture"})
 
+(defn presence-value-truthy?
+  "Would react-dom treat this value on a `:presence` attribute as present?
+  (rf2-u82a.)
+
+  react-dom's pure-boolean branch is a plain JAVASCRIPT truthiness test —
+  `if (value && …) push(name, '=\"\"')` — so a presence attribute COLLAPSES
+  every truthy value onto the bare name and writes nothing at all for a falsy
+  one. `{:disabled \"yes\"}` renders `disabled` and `{:disabled \"\"}` renders
+  nothing.
+
+  CLOJURE DISAGREES WITH JAVASCRIPT ABOUT EXACTLY TWO OF THE VALUES THAT CAN
+  APPEAR HERE, which is the whole reason this is a named predicate rather than
+  a `when`: `\"\"` and the NUMBER `0` are logically TRUE in Clojure and CLJS
+  and falsy in JS, so `(when v …)` emits a bare attribute where react-dom
+  emits none — a server/client divergence at the DOM level, not merely in
+  bytes, and Spec 011 records that React does not guarantee to patch an
+  attribute-only hydration mismatch. The trap in the other direction is the
+  STRING `\"0\"`, which is a non-empty string and therefore truthy; only the
+  number is not.
+
+  Spelled out rather than reached for through a host truthiness cast, because
+  this is `.cljc`: the JVM has no JS coercion, and the two runtimes must emit
+  the same bytes for the same tree (the render-tree hash compares them).
+  Beyond strings and numbers everything is truthy — keywords, collections,
+  objects — matching JS, where every object is truthy. `NaN` is JS-falsy and
+  is tested as `(not= v v)`, the one NaN check that reads the same on both
+  runtimes.
+
+  TOTAL over every value an attribute map can carry, `nil` and booleans
+  included, rather than documented as undefined for them. `attr-string` does
+  drop `nil` and dispatch booleans before it asks — but `re-frame.ssr.ui-tree`
+  routes both straight here, and a predicate whose contract said \"never
+  called with `nil`\" would have answered `true` for one and emitted an
+  attribute react-dom omits. `null` is falsy in JS, so `nil` is falsy here."
+  [v]
+  (cond
+    (nil? v)     false
+    (boolean? v) v
+    (string? v)  (not= "" v)
+    (number? v)  (not (or (zero? v) (not= v v)))
+    :else        true))
+
 (defn boolean-attr-class
   "Author attribute NAME (a string, no namespace) → the class that decides
-  how a BOOLEAN value for it serialises:
+  how a value for it serialises:
 
     `:stringify`  — `aria-*`, `data-*`, and the booleanish family
                     (`contentEditable` / `draggable` / `spellCheck` plus the
                     four SVG names in `booleanish-attrs`):
-                    `true`/`false` → `\"true\"`/`\"false\"`, NEVER omitted.
+                    `true`/`false` → `\"true\"`/`\"false\"`, NEVER omitted;
+                    any other value stringifies.
     `:presence`   — the true HTML boolean attributes (`disabled`, `checked`,
-                    …) and the overloaded booleans (`download`, `capture`):
-                    `true` → bare name, `false` → omitted. `=\"false\"` is
+                    …): `true` → bare name, `false` → omitted. `=\"false\"` is
                     still TRUTHY to a browser here, so omission is the only
-                    correct rendering of `false`.
+                    correct rendering of `false`. A NON-boolean value is
+                    collapsed the same way, on `presence-value-truthy?`.
+    `:overloaded` — `download` and `capture`: the two booleans exactly as
+                    `:presence`, but a non-boolean value is KEPT
+                    (`download=\"report.pdf\"`).
     `:ordinary`   — everything else: a boolean never reaches markup at all
                     (react-dom drops it rather than inventing a bare
-                    attribute).
+                    attribute); any other value stringifies.
+
+  `:presence` AND `:overloaded` WERE ONE CLASS UNTIL rf2-u82a, and the merge
+  was invisible for as long as only BOOLEAN values consulted this fn — the two
+  rules are identical for `true` and for `false`, and 004B's own tables state
+  them with the same two words. They part on the third case, which is where
+  `download=\"report.pdf\"` has to survive and `disabled=\"yes\"` has to
+  collapse, so a classifier that cannot tell them apart cannot serialise a
+  non-boolean value correctly for either. The split is now derived from
+  react-dom's measured bytes for a non-boolean value, in
+  `re-frame.ssr-boolean-attr-react-parity-test`, exactly as the other three
+  classes are.
 
   TWO NAMES ARE DELIBERATELY NOT WHAT REACT DOES, and both are recorded
   rather than left to be rediscovered (rf2-r9kf, second pass):
@@ -600,7 +665,7 @@
       (str/starts-with? attribute-name "aria-")        :stringify
       (str/starts-with? attribute-name "data-")        :stringify
       (contains? booleanish-attrs collapsed)           :stringify
-      (contains? overloaded-boolean-attrs collapsed)   :presence
+      (contains? overloaded-boolean-attrs collapsed)   :overloaded
       (contains? boolean-attrs collapsed)              :presence
       :else                                            :ordinary)))
 
@@ -706,12 +771,20 @@
   attribute entirely. All non-boolean values stringify and are
   `escape-attr`-escaped.
 
-  A BOOLEAN value is rendered by the attribute's class, not by the value
-  alone (`boolean-attr-class`, rf2-r9kf): `aria-*` / `data-*` / booleanish
-  names stringify BOTH `true` and `false` (`aria-expanded=\"false\"`); true
-  boolean and overloaded-boolean names keep presence semantics (`true` →
-  bare `disabled`, `false` → omitted); a boolean on any other attribute is
-  dropped rather than emitted as a bare name.
+  A value is rendered by the attribute's CLASS, not by the value alone
+  (`boolean-attr-class`, rf2-r9kf / rf2-u82a): `aria-*` / `data-*` /
+  booleanish names stringify BOTH `true` and `false`
+  (`aria-expanded=\"false\"`); true boolean and overloaded-boolean names keep
+  presence semantics for a boolean (`true` → bare `disabled`, `false` →
+  omitted); a boolean on any other attribute is dropped rather than emitted
+  as a bare name.
+
+  A NON-BOOLEAN value asks the class too, and the two presence classes part
+  there: a `:presence` name COLLAPSES it on react-dom's JS truthiness
+  (`{:disabled \"yes\"}` → bare `disabled`, `{:disabled \"\"}` and
+  `{:disabled 0}` → nothing — see `presence-value-truthy?`), while an
+  `:overloaded` name keeps it (`{:download \"report.pdf\"}` →
+  `download=\"report.pdf\"`). Everything else stringifies.
 
   Attribute KEYS are gated through `validate-attr-name!` (HTML5 grammar
   `[A-Za-z][A-Za-z0-9_:-]*`) — a key violating the grammar throws
@@ -744,11 +817,30 @@
                            ;; neighbours.
                            (boolean? v)
                            (case (boolean-attr-class (name k))
-                             :stringify (str (validate-attr-name! k)
-                                             "=\"" (escape-attr v) "\"")
-                             :presence  (when (true? v) (validate-attr-name! k))
-                             :ordinary  nil)
+                             :stringify  (str (validate-attr-name! k)
+                                              "=\"" (escape-attr v) "\"")
+                             (:presence
+                              :overloaded) (when (true? v) (validate-attr-name! k))
+                             :ordinary   nil)
                            (nil? v)   nil
+
+                           ;; rf2-u82a — a PRESENCE attribute collapses a
+                           ;; non-boolean value too, on react-dom's JS
+                           ;; truthiness. Asking the class BEFORE the value is
+                           ;; the whole repair: this branch used to be reached
+                           ;; only after `(boolean? v)` failed, so every
+                           ;; non-boolean fell through to the ordinary
+                           ;; stringify below and emitted `disabled="yes"`
+                           ;; where react-dom emits `disabled=""` — a DOM-level
+                           ;; hydration divergence, and one the structural-tree
+                           ;; serialiser next door already got right.
+                           ;; `:overloaded` deliberately does NOT come here:
+                           ;; keeping the value is what it is for
+                           ;; (`download="report.pdf"`).
+                           (= :presence (boolean-attr-class (name k)))
+                           (when (presence-value-truthy? v)
+                             (validate-attr-name! k))
+
                            :else
                            (let [rendered-val
                                  (cond

--- a/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
+++ b/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
@@ -597,15 +597,19 @@
     (or (keyword? value) (symbol? value))    (name value)
     :else                                    (str value)))
 
-(defn- truthy-attr?
-  "React's boolean-attribute presence test over TREE-SPACE values: `true`
-  -> present; `false` -> absent; a non-empty string is present (`hidden
-  \"until-found\"` renders bare presence on react-dom/server 19.2.0)."
-  [value]
-  (cond
-    (boolean? value) value
-    (string? value)  (not (str/blank? value))
-    :else            (some? value)))
+;; The presence test over TREE-SPACE values is `html/presence-value-truthy?`
+;; — react-dom's own JS truthiness — and it is REACHED rather than restated
+;; (rf2-u82a).
+;;
+;; This ns carried its own near-miss copy until then, and it disagreed with
+;; react-dom on two values in OPPOSITE directions: `(some? value)` made the
+;; NUMBER `0` present where react-dom omits it, and `str/blank?` made a
+;; whitespace string absent where react-dom emits it. Neither was reachable
+;; by any test, because every parity row drove booleans only. Sharing the
+;; rule is the move rf2-r9kf already made for the rosters: the hiccup
+;; emitter and this serialiser answer one input one way, or the two SSR
+;; pipelines drift again — and the drift is silent, because each is
+;; self-consistent.
 
 (defn- serialise-attr
   "One author-space `[k v]` -> `[final-name serialised-value]` or nil
@@ -645,7 +649,7 @@
 
       (contains? boolean-attrs collapsed-name)
       ;; presence/absence; presence serialises as attr="".
-      (when (truthy-attr? attribute-value)
+      (when (html/presence-value-truthy? attribute-value)
         [(dom-attr-name attribute-name) ""])
 
       (boolean? attribute-value)

--- a/implementation/ssr/test/re_frame/ssr_boolean_attr_react_parity_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_boolean_attr_react_parity_test.clj
@@ -33,6 +33,30 @@
   (`value` and `ismap`); they are named below with their reasons, and each is
   pinned so that the premise reding is itself a failure.
 
+  ## The second hole, and it was this file's own shape (rf2-u82a)
+
+  Every row here drove the emitters with `true` and `false` and nothing else,
+  and that was not a gap in coverage so much as a gap the file could not see
+  past. TWO OF THE FOUR CLASSES ARE INDISTINGUISHABLE FOR A BOOLEAN:
+  `:presence` and `:overloaded` both render `name=\"\"` for `true` and
+  nothing for `false`. They part only on a NON-boolean value — a presence
+  name collapses it, an overloaded name keeps it — so a boolean-only probe
+  cannot derive the difference, a boolean-only drive cannot catch a
+  serialiser getting it wrong, and the roster could merge the two classes
+  with every row green. It had: `attr-string` sent every non-boolean value
+  down its ordinary branch and emitted `disabled=\"yes\"` where react-dom
+  emits `disabled=\"\"`, while `re-frame.ssr.ui-tree` next door collapsed —
+  two SSR pipelines answering ONE input two ways, which is precisely the
+  drift the first pass of this file was written to stop.
+
+  The fixture therefore carries FOUR more values per attribute — `\"yes\"`,
+  `\"\"`, `0` and `\"0\"` — and the class is derived four ways instead of
+  three. Those four are not arbitrary: the presence collapse runs on
+  JAVASCRIPT truthiness, and Clojure disagrees about `\"\"` and the number
+  `0` (logically true here, falsy there), while the string `\"0\"` is the
+  trap in the other direction. The evidence is still React's; only the
+  question got wider.
+
   Then it drives every row through the PUBLIC emitters — `emit/
   render-to-string`, `streaming/render-shell`, and `ui-tree/emit-ui-tree` —
   so the roster being right cannot be undone by a serialiser that stops
@@ -91,8 +115,19 @@
 (defn- react-class
   "One evidence row -> the class react-dom applied: `:stringify` (both
   booleans reach markup as `=\"true\"` / `=\"false\"`), `:presence` (`true`
-  reaches markup, `false` does not), or `:ordinary` (neither does)."
-  [{:keys [attribute true-markup false-markup]}]
+  reaches markup as `=\"\"`, `false` does not, and a NON-boolean value is
+  collapsed to `=\"\"` as well), `:overloaded` (the same two booleans, but a
+  non-boolean value is KEPT — `download=\"report.pdf\"`), or `:ordinary`
+  (neither boolean reaches markup).
+
+  THE BOOLEAN PAIR ALONE CANNOT SEPARATE THE MIDDLE TWO (rf2-u82a). Presence
+  and overloaded render identically for `true` and for `false`; they part
+  only on a non-boolean value, which is exactly the case the first version of
+  this file never probed and `attr-string` therefore got wrong for every
+  member of `boolean-attrs`. `:string-markup` — react-dom's own bytes for the
+  value `\"yes\"`, on the same element — is what tells them apart, so the
+  distinction is derived from React here rather than declared by us."
+  [{:keys [attribute true-markup false-markup string-markup]}]
   (let [mentions? #(react-writes? attribute % "=\"")]
     (cond
       (and (react-writes? attribute true-markup "=\"true\"")
@@ -101,7 +136,9 @@
 
       (and (react-writes? attribute true-markup "=\"\"")
            (not (mentions? false-markup)))
-      :presence
+      (if (react-writes? attribute string-markup "=\"yes\"")
+        :overloaded
+        :presence)
 
       (and (not (mentions? true-markup)) (not (mentions? false-markup)))
       :ordinary
@@ -110,7 +147,8 @@
       (throw (ex-info "react-dom markup this test cannot classify"
                       {:attribute attribute
                        :true-markup true-markup
-                       :false-markup false-markup})))))
+                       :false-markup false-markup
+                       :string-markup string-markup})))))
 
 ;; ---------------------------------------------------------------------------
 ;; The two documented divergences.
@@ -154,7 +192,19 @@
      HTML-correct rendering, and the grammar tracks HTML where the two part
      on a genuine HTML boolean attribute. The expected class below is
      therefore unchanged — what changed is that the divergence is now stated
-     in 004B with its reason instead of hiding inside a false provenance."}})
+     in 004B with its reason instead of hiding inside a false provenance.
+
+     rf2-u82a EXTENDS the same divergence to a non-boolean value, and does so
+     deliberately rather than by oversight: `{:ismap \"yes\"}` now renders
+     bare `ismap` here, where react-dom's pass-through default renders
+     `ismap=\"yes\"`. Presence-class is presence-class for every value — 004B
+     says exactly that in its `hidden` row, which calls `hidden` *a pure
+     boolean attr, not an enumerated exception* and records that the draft's
+     `\"until-found\"` string carve-out was FALSIFIED. Re-introducing a
+     value-shaped carve-out for one name is the shape 004B removed, and it
+     would make the class un-statable as a class. The divergence is also
+     strictly smaller than the boolean one already ruled: for `true`,
+     react-dom emits no `ismap` at all while this grammar emits it."}})
 
 (defn- expected-class
   "What `boolean-attr-class` must say for `attribute-name`: React's class,
@@ -176,12 +226,17 @@
         "the fixture records which react-dom produced it")
     (is (<= 30 (count (rows)))
         "react-dom 19 carries three dozen boolean-class attributes")
-    (is (every? (fn [{:keys [attribute true-markup false-markup]}]
-                  (and (string? attribute)
-                       (string? true-markup)
-                       (string? false-markup)))
+    (is (every? (fn [{:keys [attribute true-markup false-markup string-markup
+                             empty-string-markup zero-markup
+                             string-zero-markup]}]
+                  (every? string? [attribute true-markup false-markup
+                                   string-markup empty-string-markup
+                                   zero-markup string-zero-markup]))
                 (rows))
-        "every row carries an attribute name and both markup strings"))
+        "every row carries an attribute name and all SIX markup strings —
+         a row missing the four non-boolean ones would make the presence /
+         overloaded split below derive `:presence` for everything and agree
+         with a classifier that had never learned the difference"))
 
   (testing "rf2-r9kf — NON-VACUITY: the eight names the audit found missing
             are actually IN the evidence, so the agreement asserted below is
@@ -211,6 +266,60 @@
             (str attribute " — react-dom " (:react-dom-version @react-evidence)
                  " renders " (pr-str (:true-markup row)) " / "
                  (pr-str (:false-markup row))))))))
+
+(deftest the-presence-overloaded-split-is-real-in-react-s-own-bytes
+  (testing "rf2-u82a NON-VACUITY — the four-way derivation above is only a
+            check if the evidence actually carries BOTH middle classes. A
+            fixture with no `:overloaded` row would let `boolean-attr-class`
+            call `download` anything at all and still agree"
+    (let [derived (frequencies (map react-class (rows)))]
+      (is (<= 20 (get derived :presence 0))
+          "react-dom 19.2.0 carries a couple of dozen pure boolean attributes")
+      (is (= 2 (get derived :overloaded 0))
+          "and exactly two overloaded ones — `download` and `capture`")
+      (let [overloaded (set (map :attribute (filter #(= :overloaded (react-class %))
+                                                    (rows))))]
+        (is (= #{"download" "capture"} overloaded)
+            "and they are the two 004B names them"))))
+
+  (testing "rf2-u82a — react-dom collapses a presence attribute on JAVASCRIPT
+            truthiness, and this is the premise the emitters are held to
+            below. It matters because CLOJURE disagrees about exactly two of
+            these four values: `\"\"` and the NUMBER 0 are logically TRUE in
+            Clojure and falsy in JS, so the obvious `(when v …)` emits a bare
+            attribute where React emits nothing. `\"0\"` is the trap in the
+            other direction — the STRING is truthy; only the number is not"
+    (doseq [row (rows)
+            :when (= :presence (react-class row))]
+      (let [{:keys [attribute string-markup empty-string-markup
+                    zero-markup string-zero-markup]} row
+            present? #(react-writes? attribute % "=\"\"")
+            absent?  #(not (react-writes? attribute % "=\""))]
+        (is (present? string-markup)
+            (str attribute " — a truthy string COLLAPSES to =\"\", it is not "
+                 "kept as =\"yes\""))
+        (is (absent? empty-string-markup)
+            (str attribute " — the empty string is JS-falsy: no attribute"))
+        (is (absent? zero-markup)
+            (str attribute " — the NUMBER 0 is JS-falsy: no attribute"))
+        (is (present? string-zero-markup)
+            (str attribute " — the STRING \"0\" is truthy: attribute present")))))
+
+  (testing "rf2-u82a — while an OVERLOADED name keeps every non-boolean value
+            it is given, falsy ones included. This is the half the current
+            `:else` branch already gets right, and pinning it is what stops a
+            repair to the presence class taking `download=\"report.pdf\"` with
+            it"
+    (doseq [row (rows)
+            :when (= :overloaded (react-class row))]
+      (let [{:keys [attribute string-markup empty-string-markup
+                    zero-markup]} row]
+        (is (react-writes? attribute string-markup "=\"yes\"")
+            (str attribute " keeps a string value"))
+        (is (react-writes? attribute empty-string-markup "=\"\"")
+            (str attribute " keeps an empty string as an empty value"))
+        (is (react-writes? attribute zero-markup "=\"0\"")
+            (str attribute " keeps the number 0 as \"0\""))))))
 
 (deftest documented-divergences-still-have-their-premise
   (testing "rf2-r9kf — `value` is deliberately NOT booleanish here. The
@@ -266,12 +375,85 @@
 
 (defn- expected-hiccup-markup
   "The `<div>` markup the hiccup emitters must produce for `attribute` set to
-  `value`, given the class."
+  a BOOLEAN `value`, given the class. Presence and overloaded names are one
+  arm here: for a boolean they are indistinguishable, which is precisely why
+  the non-boolean drive below has to exist."
   [klass attribute value]
   (case klass
-    :stringify (str "<div " attribute "=\"" value "\"></div>")
-    :presence  (if value (str "<div " attribute "></div>") "<div></div>")
-    :ordinary  "<div></div>"))
+    :stringify              (str "<div " attribute "=\"" value "\"></div>")
+    (:presence :overloaded) (if value (str "<div " attribute "></div>") "<div></div>")
+    :ordinary               "<div></div>"))
+
+;; ---------------------------------------------------------------------------
+;; The NON-BOOLEAN drive (rf2-u82a).
+;;
+;; Everything above this line hands the emitters `true` and `false` only, and
+;; that is the shape of the hole it left: a presence attribute given a
+;; non-boolean value took `attr-string`'s ordinary `:else` branch and emitted
+;; `disabled="yes"`, where react-dom collapses to `disabled=""` and the
+;; structural-tree serialiser next door already collapsed too. Two SSR
+;; pipelines disagreeing about one input, with every row in this file green,
+;; because no row could reach the input.
+;; ---------------------------------------------------------------------------
+
+(def ^:private non-boolean-probe-values
+  "The four non-boolean values `react_dom_probe/boolean_attr_classes.cjs`
+  measures beside the booleans. Each carries the fixture field holding
+  react-dom's own markup for it, and the string every class EXCEPT
+  `:presence` must serialise it to (`0` is a JVM `Long` here, and
+  `hash/canonical-number` prints it `\"0\"` — the same bytes CLJS produces)."
+  [{:value "yes" :field :string-markup       :serialised "yes"}
+   {:value ""    :field :empty-string-markup :serialised ""}
+   {:value 0     :field :zero-markup         :serialised "0"}
+   {:value "0"   :field :string-zero-markup  :serialised "0"}])
+
+(defn- react-emits?
+  "Did react-dom write `attribute` at all in this markup?"
+  [attribute markup]
+  (react-writes? attribute markup "=\""))
+
+(defn- expected-hiccup-markup-for-value
+  "The `<div>` markup the hiccup emitters must produce for a NON-boolean
+  `value`. For the presence class the expectation is react-dom's OWN verdict
+  on the same value — read off the row rather than restated — re-spelled in
+  this grammar's bare presence form. Every other class keeps the value."
+  [klass attribute {:keys [field serialised]} row]
+  (if (= :presence klass)
+    (if (react-emits? attribute (get row field))
+      (str "<div " attribute "></div>")
+      "<div></div>")
+    (str "<div " attribute "=\"" serialised "\"></div>")))
+
+(deftest render-to-string-follows-react-for-every-non-boolean-probe-value
+  (testing "rf2-u82a — the PUBLIC hiccup render path over the whole evidence
+            and all four non-boolean values. A presence name collapses a
+            truthy value to its bare self and omits a JS-falsy one; an
+            overloaded name keeps every value it is given; a stringifying or
+            ordinary name keeps it too"
+    (doseq [row   (rows)
+            probe non-boolean-probe-values]
+      (let [attribute (:attribute row)
+            klass     (expected-class attribute (react-class row))]
+        (is (= (expected-hiccup-markup-for-value klass attribute probe row)
+               (rf.ssr.emit/render-to-string
+                 [:div {(keyword attribute) (:value probe)}] {}))
+            (str attribute " " (pr-str (:value probe)) " (" klass ") — react-dom "
+                 (:react-dom-version @react-evidence) " renders "
+                 (pr-str (get row (:field probe)))))))))
+
+(deftest render-shell-follows-react-for-every-non-boolean-probe-value
+  (testing "rf2-u82a — and the STREAMING hiccup mode, which re-derives
+            attributes through the same shared helper. A repair landing on
+            one hiccup mode only is the drift this pins"
+    (doseq [row   (rows)
+            probe non-boolean-probe-values]
+      (let [attribute (:attribute row)
+            klass     (expected-class attribute (react-class row))]
+        (is (= (expected-hiccup-markup-for-value klass attribute probe row)
+               (:shell-html
+                 (rf.ssr.streaming/render-shell
+                   [:div {(keyword attribute) (:value probe)}])))
+            (str attribute " " (pr-str (:value probe)) " (" klass ")"))))))
 
 (deftest render-to-string-follows-react-for-every-evidenced-attribute
   (testing "rf2-r9kf — the PUBLIC hiccup render path, table-driven over the
@@ -306,14 +488,19 @@
   structural-tree serialiser renames attributes through the React prop
   vocabulary, so matching on the author's name would misread a rename as an
   omission."
-  [baseline true-html false-html]
+  [baseline true-html false-html string-html]
   (cond
     (and (str/includes? true-html "=\"true\"")
          (str/includes? false-html "=\"false\""))
     :stringify
 
     (and (not= baseline true-html) (= baseline false-html))
-    :presence
+    ;; The two middle classes are one shape for a boolean, so the split is
+    ;; read off a NON-boolean value exactly as react-dom's own is (rf2-u82a):
+    ;; a presence name collapses `"yes"` onto the same output `true` gave, an
+    ;; overloaded name keeps it. Still name-agnostic — this compares the
+    ;; serialiser's outputs with each other, never with the author's spelling.
+    (if (= true-html string-html) :presence :overloaded)
 
     (and (= baseline true-html) (= baseline false-html))
     :ordinary
@@ -321,7 +508,7 @@
     :else
     (throw (ex-info "serialiser output this test cannot classify"
                     {:baseline baseline :true-html true-html
-                     :false-html false-html}))))
+                     :false-html false-html :string-html string-html}))))
 
 (defn- tree-html [attrs]
   (rf.ssr.ui-tree/emit-ui-tree {:rf.ui/tree-version 1 :tag :div :attrs attrs}))
@@ -340,5 +527,35 @@
           (is (= klass
                  (observed-class baseline
                                  (tree-html {key true})
-                                 (tree-html {key false})))
+                                 (tree-html {key false})
+                                 (tree-html {key "yes"})))
               (str attribute " (" klass ") — structural-tree serialiser")))))))
+
+(deftest structural-tree-serialiser-collapses-on-react-s-truthiness
+  (testing "rf2-u82a — the structural-tree serialiser's presence collapse held
+            its OWN truthiness predicate, and it disagreed with react-dom on
+            two of these four values: it read the number `0` as present (only
+            `nil` was absent) and a whitespace string as absent (`str/blank?`).
+            Both rules are now the one shared helper the hiccup emitter uses,
+            so the two pipelines cannot answer one input two ways again.
+            Name-agnostic: the serialiser renames attributes through the React
+            prop vocabulary, so every comparison is between its OWN outputs"
+    (let [baseline (tree-html {})]
+      (doseq [row   (rows)
+              probe non-boolean-probe-values
+              :let  [attribute (:attribute row)
+                     klass     (expected-class attribute (react-class row))
+                     key       (keyword attribute)]
+              :when (contains? #{:presence :overloaded} klass)]
+        (let [observed (tree-html {key (:value probe)})
+              why      (str attribute " " (pr-str (:value probe)) " (" klass
+                            ") — react-dom renders "
+                            (pr-str (get row (:field probe))))]
+          (if (= :presence klass)
+            (if (react-emits? attribute (get row (:field probe)))
+              (is (= (tree-html {key true}) observed)
+                  (str why "; a truthy value collapses onto what `true` gives"))
+              (is (= baseline observed)
+                  (str why "; a JS-falsy value writes no attribute at all")))
+            (is (str/includes? observed (str "=\"" (:serialised probe) "\""))
+                (str why "; an overloaded name keeps the value"))))))))

--- a/implementation/ssr/test/react_dom_probe/boolean_attr_classes.cjs
+++ b/implementation/ssr/test/react_dom_probe/boolean_attr_classes.cjs
@@ -38,6 +38,25 @@
 //      `multiple` a `<select>`, `muted` a `<video>`; everything else lands on
 //      a `<div>`). Where two elements disagree about the class, the generator
 //      ABORTS rather than picking one.
+//   4. The same element's markup for FOUR NON-BOOLEAN values as well —
+//      `"yes"`, `""`, `0` and `"0"` (rf2-u82a). Two things need them, and
+//      neither is reachable from the boolean pair alone.
+//
+//      FIRST, `:presence` and `:overloaded` are INDISTINGUISHABLE for a
+//      boolean: both render `name=""` for `true` and nothing for `false`.
+//      They part only on a non-boolean value — a presence name collapses it
+//      to `name=""`, an overloaded name keeps it as `name="value"` — which is
+//      why `download="report.pdf"` survives and `disabled="yes"` does not.
+//      Recording `"yes"` lets the class be derived four ways instead of
+//      three, from React's bytes exactly as the other three are.
+//
+//      SECOND, the presence collapse runs on JAVASCRIPT truthiness, and
+//      ClojureScript disagrees with JS about two values that matter: `""` and
+//      the number `0` are logically TRUE in CLJS and FALSY in JS, so the
+//      obvious `(when v …)` emits a bare attribute where React emits none.
+//      `""` and `0` measure that, and `"0"` pins the asymmetry that invites
+//      the over-correction — the STRING `"0"` is truthy; only the NUMBER 0 is
+//      not.
 //
 // The EDN carries React's bytes and nothing else — no class label, no
 // restatement of our own rules. `re_frame/ssr_boolean_attr_react_parity_test`
@@ -238,12 +257,34 @@ function probe(name) {
   return chosen;
 }
 
+// The non-boolean values, measured on the SAME element the boolean pair was
+// measured on so the six strings in a row are comparable. Keyed by the EDN
+// field each becomes; the value is what is handed to `createElement`.
+const nonBooleanProbes = [
+  ['stringMarkup', 'yes'],       // truthy in JS and in CLJS
+  ['emptyStringMarkup', ''],     // FALSY in JS, logically true in CLJS
+  ['zeroMarkup', 0],             // FALSY in JS, logically true in CLJS
+  ['stringZeroMarkup', '0'],     // truthy — the string, not the number
+];
+
 const rows = [];
 for (const name of [...candidates, ...prefixProbes]) {
   if (!acceptsBoolean(name)) continue;
   const { element, trueMarkup, falseMarkup } = probe(name);
   if (trueMarkup === null || falseMarkup === null) continue;
-  rows.push({ name, element, trueMarkup, falseMarkup });
+  const row = { name, element, trueMarkup, falseMarkup };
+  let incomplete = false;
+  for (const [field, value] of nonBooleanProbes) {
+    const html = markup(element, name, value);
+    // A null here means react-dom THREW on this element for this value. It
+    // cannot be recorded as "the attribute was omitted" — that is a real
+    // verdict this row would then be asserting falsely — so the whole row is
+    // dropped and the fixture's own floor below catches a mass loss.
+    if (html === null) { incomplete = true; break; }
+    row[field] = html;
+  }
+  if (incomplete) continue;
+  rows.push(row);
 }
 rows.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 
@@ -268,7 +309,10 @@ const out = [];
 out.push(';; GENERATED FILE — do not hand-edit.');
 out.push(';;');
 out.push(';; react-dom boolean attribute-value evidence for rf2-r9kf. Every string');
-out.push(';; below is react-dom\'s own output, measured by');
+out.push(';; below is react-dom\'s own output — six values per attribute: `true`,');
+out.push(';; `false`, and the four non-booleans `"yes"`, `""`, `0`, `"0"` that');
+out.push(';; separate the presence class from the overloaded one and pin the');
+out.push(';; JS-truthiness collapse (rf2-u82a). Measured by');
 out.push(';; `react_dom_probe/boolean_attr_classes.cjs` against the installed');
 out.push(';; package; nothing here restates a re-frame rule. The class is DERIVED');
 out.push(';; from these bytes in `re_frame/ssr_boolean_attr_react_parity_test.clj`.');
@@ -284,8 +328,12 @@ out.push(' [');
 for (const row of rows) {
   out.push('  {:attribute ' + ednString(row.name) +
            ' :element ' + ednString(row.element));
-  out.push('   :true-markup  ' + ednString(row.trueMarkup));
-  out.push('   :false-markup ' + ednString(row.falseMarkup) + '}');
+  out.push('   :true-markup         ' + ednString(row.trueMarkup));
+  out.push('   :false-markup        ' + ednString(row.falseMarkup));
+  out.push('   :string-markup       ' + ednString(row.stringMarkup));
+  out.push('   :empty-string-markup ' + ednString(row.emptyStringMarkup));
+  out.push('   :zero-markup         ' + ednString(row.zeroMarkup));
+  out.push('   :string-zero-markup  ' + ednString(row.stringZeroMarkup) + '}');
 }
 out.push(' ]}');
 process.stdout.write(out.join('\n') + '\n');

--- a/implementation/ssr/test/react_dom_probe/boolean_attr_classes.edn
+++ b/implementation/ssr/test/react_dom_probe/boolean_attr_classes.edn
@@ -1,7 +1,10 @@
 ;; GENERATED FILE — do not hand-edit.
 ;;
 ;; react-dom boolean attribute-value evidence for rf2-r9kf. Every string
-;; below is react-dom's own output, measured by
+;; below is react-dom's own output — six values per attribute: `true`,
+;; `false`, and the four non-booleans `"yes"`, `""`, `0`, `"0"` that
+;; separate the presence class from the overloaded one and pin the
+;; JS-truthiness collapse (rf2-u82a). Measured by
 ;; `react_dom_probe/boolean_attr_classes.cjs` against the installed
 ;; package; nothing here restates a re-frame rule. The class is DERIVED
 ;; from these bytes in `re_frame/ssr_boolean_attr_react_parity_test.clj`.
@@ -15,147 +18,339 @@
  :rows
  [
   {:attribute "allowFullScreen" :element "div"
-   :true-markup  "<div allowFullScreen=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div allowFullScreen=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div allowFullScreen=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div allowFullScreen=\"\"></div>"}
   {:attribute "aria-expanded" :element "div"
-   :true-markup  "<div aria-expanded=\"true\"></div>"
-   :false-markup "<div aria-expanded=\"false\"></div>"}
+   :true-markup         "<div aria-expanded=\"true\"></div>"
+   :false-markup        "<div aria-expanded=\"false\"></div>"
+   :string-markup       "<div aria-expanded=\"yes\"></div>"
+   :empty-string-markup "<div aria-expanded=\"\"></div>"
+   :zero-markup         "<div aria-expanded=\"0\"></div>"
+   :string-zero-markup  "<div aria-expanded=\"0\"></div>"}
   {:attribute "aria-hidden" :element "div"
-   :true-markup  "<div aria-hidden=\"true\"></div>"
-   :false-markup "<div aria-hidden=\"false\"></div>"}
+   :true-markup         "<div aria-hidden=\"true\"></div>"
+   :false-markup        "<div aria-hidden=\"false\"></div>"
+   :string-markup       "<div aria-hidden=\"yes\"></div>"
+   :empty-string-markup "<div aria-hidden=\"\"></div>"
+   :zero-markup         "<div aria-hidden=\"0\"></div>"
+   :string-zero-markup  "<div aria-hidden=\"0\"></div>"}
   {:attribute "async" :element "div"
-   :true-markup  "<div async=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div async=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div async=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div async=\"\"></div>"}
   {:attribute "autoFocus" :element "div"
-   :true-markup  "<div autofocus=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div autofocus=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div autofocus=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div autofocus=\"\"></div>"}
   {:attribute "autoPlay" :element "div"
-   :true-markup  "<div autoPlay=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div autoPlay=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div autoPlay=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div autoPlay=\"\"></div>"}
   {:attribute "autoReverse" :element "div"
-   :true-markup  "<div autoReverse=\"true\"></div>"
-   :false-markup "<div autoReverse=\"false\"></div>"}
+   :true-markup         "<div autoReverse=\"true\"></div>"
+   :false-markup        "<div autoReverse=\"false\"></div>"
+   :string-markup       "<div autoReverse=\"yes\"></div>"
+   :empty-string-markup "<div autoReverse=\"\"></div>"
+   :zero-markup         "<div autoReverse=\"0\"></div>"
+   :string-zero-markup  "<div autoReverse=\"0\"></div>"}
   {:attribute "capture" :element "div"
-   :true-markup  "<div capture=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div capture=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div capture=\"yes\"></div>"
+   :empty-string-markup "<div capture=\"\"></div>"
+   :zero-markup         "<div capture=\"0\"></div>"
+   :string-zero-markup  "<div capture=\"0\"></div>"}
   {:attribute "checked" :element "input"
-   :true-markup  "<input checked=\"\"/>"
-   :false-markup "<input/>"}
+   :true-markup         "<input checked=\"\"/>"
+   :false-markup        "<input/>"
+   :string-markup       "<input checked=\"\"/>"
+   :empty-string-markup "<input/>"
+   :zero-markup         "<input/>"
+   :string-zero-markup  "<input checked=\"\"/>"}
   {:attribute "children" :element "div"
-   :true-markup  "<div></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div>yes</div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div>0</div>"
+   :string-zero-markup  "<div>0</div>"}
   {:attribute "contentEditable" :element "div"
-   :true-markup  "<div contentEditable=\"true\"></div>"
-   :false-markup "<div contentEditable=\"false\"></div>"}
+   :true-markup         "<div contentEditable=\"true\"></div>"
+   :false-markup        "<div contentEditable=\"false\"></div>"
+   :string-markup       "<div contentEditable=\"yes\"></div>"
+   :empty-string-markup "<div contentEditable=\"\"></div>"
+   :zero-markup         "<div contentEditable=\"0\"></div>"
+   :string-zero-markup  "<div contentEditable=\"0\"></div>"}
   {:attribute "controls" :element "div"
-   :true-markup  "<div controls=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div controls=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div controls=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div controls=\"\"></div>"}
   {:attribute "data-open" :element "div"
-   :true-markup  "<div data-open=\"true\"></div>"
-   :false-markup "<div data-open=\"false\"></div>"}
+   :true-markup         "<div data-open=\"true\"></div>"
+   :false-markup        "<div data-open=\"false\"></div>"
+   :string-markup       "<div data-open=\"yes\"></div>"
+   :empty-string-markup "<div data-open=\"\"></div>"
+   :zero-markup         "<div data-open=\"0\"></div>"
+   :string-zero-markup  "<div data-open=\"0\"></div>"}
   {:attribute "default" :element "div"
-   :true-markup  "<div default=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div default=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div default=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div default=\"\"></div>"}
   {:attribute "defaultChecked" :element "div"
-   :true-markup  "<div></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div></div>"}
   {:attribute "defaultValue" :element "div"
-   :true-markup  "<div></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div></div>"}
   {:attribute "defer" :element "div"
-   :true-markup  "<div defer=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div defer=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div defer=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div defer=\"\"></div>"}
   {:attribute "disablePictureInPicture" :element "div"
-   :true-markup  "<div disablePictureInPicture=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div disablePictureInPicture=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div disablePictureInPicture=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div disablePictureInPicture=\"\"></div>"}
   {:attribute "disableRemotePlayback" :element "div"
-   :true-markup  "<div disableRemotePlayback=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div disableRemotePlayback=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div disableRemotePlayback=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div disableRemotePlayback=\"\"></div>"}
   {:attribute "disabled" :element "div"
-   :true-markup  "<div disabled=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div disabled=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div disabled=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div disabled=\"\"></div>"}
   {:attribute "download" :element "div"
-   :true-markup  "<div download=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div download=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div download=\"yes\"></div>"
+   :empty-string-markup "<div download=\"\"></div>"
+   :zero-markup         "<div download=\"0\"></div>"
+   :string-zero-markup  "<div download=\"0\"></div>"}
   {:attribute "draggable" :element "div"
-   :true-markup  "<div draggable=\"true\"></div>"
-   :false-markup "<div draggable=\"false\"></div>"}
+   :true-markup         "<div draggable=\"true\"></div>"
+   :false-markup        "<div draggable=\"false\"></div>"
+   :string-markup       "<div draggable=\"yes\"></div>"
+   :empty-string-markup "<div draggable=\"\"></div>"
+   :zero-markup         "<div draggable=\"0\"></div>"
+   :string-zero-markup  "<div draggable=\"0\"></div>"}
   {:attribute "externalResourcesRequired" :element "div"
-   :true-markup  "<div externalResourcesRequired=\"true\"></div>"
-   :false-markup "<div externalResourcesRequired=\"false\"></div>"}
+   :true-markup         "<div externalResourcesRequired=\"true\"></div>"
+   :false-markup        "<div externalResourcesRequired=\"false\"></div>"
+   :string-markup       "<div externalResourcesRequired=\"yes\"></div>"
+   :empty-string-markup "<div externalResourcesRequired=\"\"></div>"
+   :zero-markup         "<div externalResourcesRequired=\"0\"></div>"
+   :string-zero-markup  "<div externalResourcesRequired=\"0\"></div>"}
   {:attribute "focusable" :element "div"
-   :true-markup  "<div focusable=\"true\"></div>"
-   :false-markup "<div focusable=\"false\"></div>"}
+   :true-markup         "<div focusable=\"true\"></div>"
+   :false-markup        "<div focusable=\"false\"></div>"
+   :string-markup       "<div focusable=\"yes\"></div>"
+   :empty-string-markup "<div focusable=\"\"></div>"
+   :zero-markup         "<div focusable=\"0\"></div>"
+   :string-zero-markup  "<div focusable=\"0\"></div>"}
   {:attribute "formNoValidate" :element "div"
-   :true-markup  "<div formNoValidate=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div formNoValidate=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div formNoValidate=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div formNoValidate=\"\"></div>"}
   {:attribute "hidden" :element "div"
-   :true-markup  "<div hidden=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div hidden=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div hidden=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div hidden=\"\"></div>"}
   {:attribute "inert" :element "div"
-   :true-markup  "<div inert=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div inert=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div inert=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div inert=\"\"></div>"}
   {:attribute "innerHTML" :element "div"
-   :true-markup  "<div></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div></div>"}
   {:attribute "is" :element "div"
-   :true-markup  "<div></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div is=\"yes\"></div>"
+   :empty-string-markup "<div is=\"\"></div>"
+   :zero-markup         "<div is=\"0\"></div>"
+   :string-zero-markup  "<div is=\"0\"></div>"}
   {:attribute "itemScope" :element "div"
-   :true-markup  "<div itemScope=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div itemScope=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div itemScope=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div itemScope=\"\"></div>"}
   {:attribute "loop" :element "div"
-   :true-markup  "<div loop=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div loop=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div loop=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div loop=\"\"></div>"}
   {:attribute "multiple" :element "div"
-   :true-markup  "<div multiple=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div multiple=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div multiple=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div multiple=\"\"></div>"}
   {:attribute "muted" :element "div"
-   :true-markup  "<div muted=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div muted=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div muted=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div muted=\"\"></div>"}
   {:attribute "noModule" :element "div"
-   :true-markup  "<div noModule=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div noModule=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div noModule=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div noModule=\"\"></div>"}
   {:attribute "noValidate" :element "div"
-   :true-markup  "<div noValidate=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div noValidate=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div noValidate=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div noValidate=\"\"></div>"}
   {:attribute "open" :element "div"
-   :true-markup  "<div open=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div open=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div open=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div open=\"\"></div>"}
   {:attribute "playsInline" :element "div"
-   :true-markup  "<div playsInline=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div playsInline=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div playsInline=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div playsInline=\"\"></div>"}
   {:attribute "preserveAlpha" :element "div"
-   :true-markup  "<div preserveAlpha=\"true\"></div>"
-   :false-markup "<div preserveAlpha=\"false\"></div>"}
+   :true-markup         "<div preserveAlpha=\"true\"></div>"
+   :false-markup        "<div preserveAlpha=\"false\"></div>"
+   :string-markup       "<div preserveAlpha=\"yes\"></div>"
+   :empty-string-markup "<div preserveAlpha=\"\"></div>"
+   :zero-markup         "<div preserveAlpha=\"0\"></div>"
+   :string-zero-markup  "<div preserveAlpha=\"0\"></div>"}
   {:attribute "readOnly" :element "div"
-   :true-markup  "<div readOnly=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div readOnly=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div readOnly=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div readOnly=\"\"></div>"}
   {:attribute "required" :element "div"
-   :true-markup  "<div required=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div required=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div required=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div required=\"\"></div>"}
   {:attribute "reversed" :element "div"
-   :true-markup  "<div reversed=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div reversed=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div reversed=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div reversed=\"\"></div>"}
   {:attribute "scoped" :element "div"
-   :true-markup  "<div scoped=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div scoped=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div scoped=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div scoped=\"\"></div>"}
   {:attribute "seamless" :element "div"
-   :true-markup  "<div seamless=\"\"></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div seamless=\"\"></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div seamless=\"\"></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div seamless=\"\"></div>"}
   {:attribute "selected" :element "option"
-   :true-markup  "<option selected=\"\"></option>"
-   :false-markup "<option></option>"}
+   :true-markup         "<option selected=\"\"></option>"
+   :false-markup        "<option></option>"
+   :string-markup       "<option selected=\"\"></option>"
+   :empty-string-markup "<option></option>"
+   :zero-markup         "<option></option>"
+   :string-zero-markup  "<option selected=\"\"></option>"}
   {:attribute "spellCheck" :element "div"
-   :true-markup  "<div spellCheck=\"true\"></div>"
-   :false-markup "<div spellCheck=\"false\"></div>"}
+   :true-markup         "<div spellCheck=\"true\"></div>"
+   :false-markup        "<div spellCheck=\"false\"></div>"
+   :string-markup       "<div spellCheck=\"yes\"></div>"
+   :empty-string-markup "<div spellCheck=\"\"></div>"
+   :zero-markup         "<div spellCheck=\"0\"></div>"
+   :string-zero-markup  "<div spellCheck=\"0\"></div>"}
   {:attribute "suppressContentEditableWarning" :element "div"
-   :true-markup  "<div></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div></div>"}
   {:attribute "suppressHydrationWarning" :element "div"
-   :true-markup  "<div></div>"
-   :false-markup "<div></div>"}
+   :true-markup         "<div></div>"
+   :false-markup        "<div></div>"
+   :string-markup       "<div></div>"
+   :empty-string-markup "<div></div>"
+   :zero-markup         "<div></div>"
+   :string-zero-markup  "<div></div>"}
   {:attribute "value" :element "div"
-   :true-markup  "<div value=\"true\"></div>"
-   :false-markup "<div value=\"false\"></div>"}
+   :true-markup         "<div value=\"true\"></div>"
+   :false-markup        "<div value=\"false\"></div>"
+   :string-markup       "<div value=\"yes\"></div>"
+   :empty-string-markup "<div value=\"\"></div>"
+   :zero-markup         "<div value=\"0\"></div>"
+   :string-zero-markup  "<div value=\"0\"></div>"}
  ]}


### PR DESCRIPTION
Two SSR-adjacent defects, one commit each (plus a one-line ratchet fix). Both
bead premises were checked at source before any edit; both held, with one
correction noted below.

## rf2-323z — `server/render` left its Node request frame on the client platform (P2)

`re-frame.hicasso.server/render` minted its per-request frame **untagged**.
Platform resolution is `(or (-> frame-record :config :platform) (rf.interop/active-platform))`
(`fx/platform-for-frame-record`, verified at source) and the CLJS host marker
defaults to `:client` (`interop.cljs:207`), so a whole-page Node render ran on
the **client** contract: a correctly declared `:platforms #{:client}` effect or
coeffect reached from `:initial-events` executed in Node — DOM or storage
access, host calls, duplicate external work — while the `#{:server}` one was
skipped.

Frames are isolated contexts, so this is an isolation break rather than
untidiness, and a silent one: no platform error is raised, the request just
settles from the wrong state. The sibling `render-body` has carried
`:platform :server` since it landed; this brings the older door level with it.

The tag is assoc'd **over** `:frame-opts`, beside `:id` and `:initial-events`,
so a caller's contradictory `:platform :client` cannot hijack the renderer's
identity. `:preset :ssr-server` would have been the wrong lever — presets let
user-supplied keys win on conflict (`frame.cljc`, `expand-preset`), which is
exactly the inversion the bead asks to close.

`docs/core/hicasso/18-ssr-and-hydration.md` needed **no** amendment: it already
teaches `(rf/init! ssr/adapter)` and nothing else, and tells authors to put
browser work behind `:platforms #{:client}`. That promise was false before this
commit and is true after it. Two prose claims *inside* `server.cljs` did move —
including `refuse-recovered-render-error!`'s three-condition account, which
said the request frame was untagged. Its verdict is unchanged (the buffer still
stays empty and the host still ships a 200) but now rests on one condition
rather than two.

The test is a **platform pair** — two effects differing in exactly their
`:platforms` metadata, dispatched from one initial event — so which one runs
reads off the frame's active platform and nothing else. It carries the
adversarial arm and a **non-vacuity control** that builds the untagged frame
`render` used to build and shows it selecting the client arm. Without that
control both `[:server]` assertions could be green about an inert pair.

## rf2-u82a — a presence attribute collapses a non-boolean value (P3)

`{:disabled "yes"}` rendered `disabled="yes"`. react-dom 19.2.0 renders
`disabled=""`, and `re-frame.ssr.ui-tree` — the structural-tree serialiser
sharing this artefact's rosters — already collapsed. **Two SSR pipelines
answering one input two ways**, each self-consistent.

**Which contract.** The bead deliberately left this open, since a deliberate
004B divergence would have made the current behaviour correct. It is not one.
004B §Booleans and their neighbours already rules the case in its `hidden` row
— *a **pure boolean** attr, not an enumerated exception: `true` /
`"until-found"` / **any truthy** → bare presence* — and records the draft's
string-value carve-out as **falsified by probe**. Spec and react-dom agree; the
implementation contradicted both.

**Named as a class, not patched per attribute.** `boolean-attr-class` mapped
`boolean-attrs` and `overloaded-boolean-attrs` onto one `:presence` class. That
merge is invisible while only *boolean* values consult the classifier — the two
rules are identical for `true` and for `false` — and wrong the moment a
non-boolean value does, because that is the only case where they differ.
`download="report.pdf"` must survive the same change that collapses
`disabled="yes"`. `:overloaded` is now its own class, and `attr-string` asks
the class **before** the value.

The collapse runs on **JavaScript** truthiness, and Clojure disagrees about two
values that reach it: `""` and the *number* `0` are logically true here and
falsy there; the *string* `"0"` is the trap in the other direction.
`presence-value-truthy?` states that rule once, total over `nil` and booleans,
spelled out rather than reached for through a host truthiness cast — this is
`.cljc`, and both runtimes must emit the same bytes, since the render-tree hash
compares them. `ui-tree` now reaches it instead of carrying its own near-miss
copy, which read `0` as present and a whitespace string as absent.

**The existing control could not reach the defect, so it was replaced rather
than patched.** Every row of the react-dom parity suite drove the emitters with
`true` and `false` only — and that is not thin coverage so much as a hole the
file could not see past: the boolean pair *cannot* distinguish `:presence` from
`:overloaded`, so a boolean-only probe cannot derive the split and a
boolean-only drive cannot catch a serialiser getting it wrong. The evidence
fixture now carries four more values per attribute (`"yes"`, `""`, `0`, `"0"`),
measured from the installed react-dom by the same generator, and the class is
derived four ways instead of three. The prior 144 evidence strings are
**byte-identical** — the regeneration is purely additive, checked line by line.

`ismap` keeps its documented 004B divergence and now extends it to non-boolean
values; the parity test's `divergences` entry says so, and why a value-shaped
carve-out for one name is the shape 004B removed from `hidden`.

The reagent-slim serializer landed this same rule under rf2-owml / #9244. Its
copy is private (`defn- boolean-attr-class`) and was not touched; the two
artefacts now agree, rather than one being made to imitate the other.

## Quality gates

| Gate | Command (from the named dir) | Captured exit | Result |
|---|---|---|---|
| SSR artefact, JVM | `clojure -M:test` in `implementation/ssr` | **0** | 639 tests, 4181 assertions, 0 failures, 0 errors |
| SSR artefact — RED control, pre-fix | same command, before the source change | **1** | 254 failures, 0 errors, every one in the new/extended rows |
| ssr-ring (downstream consumer), JVM | `clojure -M:test` in `implementation/ssr-ring` | **0** | 231 tests, 1164 assertions, 0 failures |
| hicasso JVM arm | `clojure -M:test` in `implementation/hicasso` | **0** | 3 tests, 92 assertions, 0 failures |
| Require-alias dialect ratchet | `python scripts/check_require_alias_dialect.py --verbose` | **0** | clean; every surface at or under its floor |
| clj-kondo, changed files | `clojure -M:clj-kondo --lint ../core/src ../ssr/src src <test file>` | 2 | 218 pre-existing baseline warnings across core/ssr; **0 findings name any file this branch changes**. The run is without the project's exported config, so exit 2 is the baseline rather than a verdict on this diff |

The red-then-green pair is the deliverable: the new rows fail **254**
assertions against the old source and **0** against the new, with no other row
in the artefact moving. The gate was separately shown to read this worktree by
planting an unresolved symbol (exit 2, naming the file) and restoring it with a
verified sha256 match.

**Skipped, and why.** The **Hicasso Node lane** (`:node-test-hicasso`), where
the rf2-323z test actually runs, was **not** run locally: this worktree has no
`node_modules`, and the dispatcher forbade starting a shadow-cljs build with
seven sibling workers live — a build heavy enough that two wedge rather than
fail. `scripts/test-fast-pr.sh` and `npm run test:cljs` are out for the same
reason. **CI owns the spine, and that test in particular.** The changed CLJS was
instead put through clj-kondo with `core` and `ssr` sources on the lint path so
cross-namespace vars resolve for real.

The fixture regeneration ran `node` read-only against the mayor checkout's
installed react-dom 19.2.0 via `NODE_PATH`. **No junction into shared
dependencies was created**; the mayor checkout is clean and its `node_modules`
is intact.

### CI confirmation on this head

The lane that owns the rf2-323z test — **`CLJS (shadow-cljs :node-test)`**,
which compiles and runs `:node-test-hicasso` — is **green**, so the test that
could not be run in this worktree is confirmed in CI, non-vacuity control and
adversarial arm included. Also green: `JVM ssr`, `JVM ssr` under the production
gate (`-Dre-frame.debug=false`), `JVM ssr-ring`, `JVM core`, `JVM core` under
the production gate, `JVM hicasso`, `Require-alias dialect ratchet` and
`Lint required`. No check is failing.
