### PR TITLE
test/fix(adapters): per-arm linearlite overlap coverage (rf2-chl2) + reagent-slim presence truthiness (rf2-owml)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -155,9 +155,10 @@
   "PRESENCE class: `true` emits the bare (lowercased) name, `false`
   omits it, and any other JAVASCRIPT-truthy value also emits the bare
   name (react-dom collapses `{:disabled \"yes\"}` to `disabled=\"\"`).
-  JS-falsey non-booleans — `\"\"` and `0`, both of which are logically
-  TRUE in ClojureScript — are omitted, as react-dom omits them; see
-  `presence-value-truthy?` (rf2-owml).
+  A JS-FALSEY non-boolean is omitted, as react-dom omits it, even though
+  every such value is logically TRUE in ClojureScript; the rule is
+  JavaScript's own coercion rather than a roster of the values it
+  accepts — see `presence-value-truthy?` (rf2-owml).
 
   Keyed on the LOWERCASE name so all three hiccup spellings of a
   camelCase attribute reach the same row — `:read-only`, `:readOnly`
@@ -706,21 +707,28 @@
   value as present (rf2-owml).
 
   react-dom collapses a presence attribute on JavaScript truthiness, so
-  `{:disabled \"\"}` and `{:disabled 0}` render NOTHING while
-  `{:disabled \"yes\"}` renders `disabled=\"\"`. ClojureScript disagrees:
-  `\"\"` and `0` are logically TRUE in CLJS, so the obvious `(when v ...)`
-  emits a bare `disabled` here where React emits no attribute at all.
+  `{:disabled \"\"}`, `{:disabled 0}` and `{:disabled (js/BigInt 0)}`
+  render NOTHING while `{:disabled \"yes\"}` renders `disabled=\"\"`.
+  ClojureScript disagrees: every one of those values is logically TRUE
+  in CLJS, so the obvious `(when v ...)` emits a bare `disabled` here
+  where React emits no attribute at all.
 
-  Only strings and numbers can be JS-falsey once `nil`, `false` and
-  `js/undefined` have been handled upstream — keywords, collections and
-  objects are all truthy — so the two cases are spelled out rather than
-  reaching for a `js*` truthiness cast. Note that the STRING `\"0\"` is
-  truthy (it is a non-empty string); only the NUMBER `0` is not."
+  ASK JAVASCRIPT rather than enumerate the values it calls falsey.
+  `js/Boolean` IS the coercion react-dom performs, so this states the
+  rule; a roster of the values that satisfy it does not, and cannot be
+  read to see whether it is complete. The earlier spelling here tested
+  `string?` and `number?` explicitly and returned `true` for everything
+  else — right for keywords, collections and JS objects, and silently
+  wrong for the one remaining JS primitive that can be falsey. A
+  `BigInt` zero is missed by `cljs.core/number?`, which compiles to
+  `typeof x === \"number\"`, so `{:disabled (js/BigInt 0)}` emitted a
+  bare `disabled` where react-dom 19.2 emits nothing (rf2-owml).
+
+  Note that the STRING `\"0\"` is truthy (a non-empty string) where the
+  NUMBER `0` is not, and that `nil`, `js/undefined` and `false` never
+  reach here — `emit-attribute` handles them first."
   [v]
-  (cond
-    (string? v) (not= "" v)
-    (number? v) (not (or (zero? v) (js/isNaN v)))
-    :else       true))
+  (js/Boolean v))
 
 (defn- emit-boolean-attribute
   "Emit one attribute whose VALUE is a boolean, per react-dom's three

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
@@ -216,31 +216,48 @@
     (let [[a b] (=parity [:input {:disabled false}])]
       (is (= a b)))))
 
-(deftest parity-presence-attr-js-falsey-values
-  (testing "rf2-owml: a presence attribute collapses on JS TRUTHINESS, so the
-            JS-falsey non-booleans are omitted like react-dom omits them.
-            `\"\"` and `0` are falsey in JavaScript and TRUTHY in ClojureScript,
-            so a `(when v ...)` written in CLJS emits a bare `disabled` where
-            react-dom emits nothing. Neither value is a boolean, so the
-            boolean-class probe in
-            `reagent2.dom.boolean-attr-react-parity-cljs-test` cannot see this
-            — it is pinned here, against the live react-dom reference."
-    (doseq [v ["" 0]]
+(def ^:private presence-value-corpus
+  "Non-boolean `:disabled` values, each labelled and paired with the bytes this
+  serializer must produce. The corpus spans the JS PRIMITIVE TYPES that can be
+  falsey rather than a list of remembered values, because that is the axis the
+  defect lives on: string, number and bigint each contribute a falsey member and
+  a truthy neighbour, and every falsey member here is logically TRUE in
+  ClojureScript — which is precisely why a `(when v ...)` written in CLJS
+  diverges from react-dom.
+
+  A bigint is the row worth stating plainly: `cljs.core/number?` compiles to
+  `typeof x === \"number\"`, so a partial falsey roster written in CLJS terms
+  cannot see `0n` at all (rf2-owml). None of these values is a boolean, so the
+  class probe in `reagent2.dom.boolean-attr-react-parity-cljs-test` cannot see
+  any of them either."
+  [["the empty string"      ""              "<button>x</button>"]
+   ["the number zero"       0               "<button>x</button>"]
+   ["a bigint zero"         (js/BigInt 0)   "<button>x</button>"]
+   ["a non-empty string"    "yes"           "<button disabled>x</button>"]
+   ;; falsey as a NUMBER, truthy as a STRING — the pair that catches a coercion
+   ;; applied to the wrong type.
+   ["the string \"0\""      "0"             "<button disabled>x</button>"]
+   ["a non-zero number"     1               "<button disabled>x</button>"]
+   ["a non-zero bigint"     (js/BigInt 1)   "<button disabled>x</button>"]])
+
+(deftest parity-presence-attr-collapses-on-js-truthiness
+  (testing "rf2-owml: a presence attribute collapses on JS TRUTHINESS, against
+            the live react-dom reference"
+    (doseq [[label v _] presence-value-corpus]
       (let [[a b] (=parity [:button {:disabled v} "x"])]
         (is (= a b)
-            (str "react-dom omits a presence attribute whose value is the "
-                 "JS-falsey " (pr-str v)))))
-    ;; The reference bytes, stated independently of react-dom so the intent
-    ;; survives a react-dom bump.
-    (is (= "<button>x</button>" (via-rewrite [:button {:disabled ""} "x"])))
-    (is (= "<button>x</button>" (via-rewrite [:button {:disabled 0} "x"]))))
-  (testing "the truthy neighbours must NOT move — including the string \"0\",
-            which is falsey as a number and truthy as a string"
-    (doseq [v ["yes" "0" 1]]
-      (let [[a b] (=parity [:button {:disabled v} "x"])]
-        (is (= a b) (str "react-dom collapses the truthy " (pr-str v)))))
-    (is (= "<button disabled>x</button>" (via-rewrite [:button {:disabled "0"} "x"])))
-    (is (= "<button disabled>x</button>" (via-rewrite [:button {:disabled "yes"} "x"])))))
+            (str "react-dom and this serializer must agree about " label)))))
+  (testing "…and the reference bytes, stated independently of react-dom so the
+            intent survives a react-dom bump"
+    (doseq [[label v expected] presence-value-corpus]
+      (is (= expected (via-rewrite [:button {:disabled v} "x"]))
+          (str "the emitted bytes for " label))))
+  (testing "NaN is JS-falsey too. It is asserted on this serializer's bytes
+            ALONE and deliberately kept out of the `=parity` loop above: React
+            logs a 'Received NaN for the disabled attribute' warning for it, and
+            a suite should not manufacture one to make a point the raw bytes
+            already make."
+    (is (= "<button>x</button>" (via-rewrite [:button {:disabled js/NaN} "x"])))))
 
 (deftest empty-value-on-an-ordinary-attribute-keeps-its-quotes
   (testing "rf2-owml: the canonicalisation above collapses `k=\"\"` to bare `k`

--- a/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
@@ -877,10 +877,25 @@
    when A's older reply lands: `:peer-optimistic` leaves B in flight, so the
    reply can only erase an OPTIMISTIC value (the visible regression);
    `:peer-accepted` settles B first, so it can only revert a COMMITTED one (the
-   permanent last-reply-wins cache state). Both were rf2-9man's symptoms."
+   permanent last-reply-wins cache state). Both were rf2-9man's symptoms.
+
+   EVERY ROW STARTS FROM A FRESH RUNTIME, and the reset belongs HERE rather
+   than in the fixture: `use-fixtures :each` runs once per `deftest`, so the
+   three rows of one `doseq` would otherwise share a single board, and each
+   row's `:final` is written against the canned two-card board. `load-board!`
+   cannot stand in for the reset — re-entering a route already entered plans no
+   second read, so its `reply-success!` finds no board request in
+   `last-managed-args` and reseeds nothing. The leak is not only arithmetic on
+   `:final`: `dispatch-b!` identifies a created card BY TITLE, so a Gamma left
+   committed by an earlier row is the card it returns, and the row then watches
+   an instance that settled before it began. `frames`-reset-then-`init!` is
+   section 0's pairing, and calling the example's own `init!` keeps the
+   registrar refilled before the url-bound frame is made (rf2-k4oe)."
   [{:keys [writer peer dispatch-a! reply-a dispatch-b! reply-b
            peer-desc peer-holds? writer-desc writer-committed? final]}
    order]
+  (reset! frame/frames {})
+  (init!)
   (load-board!)
   (let [inst-a (dispatch-a!)
         args-a @last-managed-args]

--- a/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
@@ -209,6 +209,14 @@
 
 (defn- issue-by-id [id] (some #(when (= id (:id %)) %) (issues)))
 
+(defn- issue-by-title
+  "The card carrying `title`. A newly created card is found by title rather
+   than by id, because its id changes underneath it — the client-minted `tmp-N`
+   placeholder gives way to the server's on commit — while the title is the one
+   thing that survives the round trip unchanged."
+  [title]
+  (some #(when (= title (:title %)) %) (issues)))
+
 (defn- mutation-state
   "The passive `[:rf/mutation {:instance …}]` view-model the example's
    card view reads (`{:pending? :success? :error? :settled? :optimistic? …}`)."
@@ -763,3 +771,169 @@
             "A's older snapshot landing last must not revert B's ACCEPTED move —
              pre-fix this was permanent last-reply-wins in the client cache")
         (is (= "Alpha!" (:title (issue-by-id "srv-1"))) "A's accepted title survives")))))
+
+
+;; ============================================================================
+;; 7. EVERY ARM TAKES ITS TURN AS THE OLDER WRITE (rf2-chl2)
+;; ============================================================================
+;;
+;; Section 6 pins the defect through ONE pairing: `edit-title` is always the
+;; older write and `change-status` always the newer one, and only the older
+;; one's reply ever lands behind a change it does not know about. That leaves
+;; two of the three commit arms without a tooth, in two different ways:
+;;
+;;   * Restore `change-status` ALONE to `:populates` and section 6 stays GREEN.
+;;     Its reply is the snapshot taken AFTER the retitle, so seeding the whole
+;;     entry from it happens to reinstate the very change that seeding would
+;;     otherwise clobber. An arm can be reverted with nothing on screen.
+;;   * `create-issue` is never one of the two writes at all, and its commit is
+;;     not the same shape as the other two — it reconciles a temporary row
+;;     against the server's, rather than lifting one field off it. Nothing in
+;;     section 6 reaches that code.
+;;
+;; So here each arm takes its turn as A, the OLDER write, against a DIFFERENT
+;; instance's later change B on a different card. One table, one driver, run in
+;; both settle orders: B still merely optimistic when A's older reply lands, and
+;; B already ACCEPTED when it lands. Reverting any single arm to `:populates`
+;; reds the row that names it.
+;;
+;; THE REPLY SHAPE IS THE EXAMPLE'S OWN, and deliberately not section 6's.
+;; `apply-write!` answers a write with just the row it changed, in the board's
+;; `{:issues [...]}` envelope, so that is what each row here replays. Section 6's
+;; coarse whole-board envelopes are the sharper probe for `edit-title` and
+;; `change-status`, whose commits pick their own row out of whatever they are
+;; handed — and they are the WRONG probe for `create-issue`, whose commit upserts
+;; every row the reply carries and is contracted to receive only the one it
+;; created. Feeding it a whole board would test the test's envelope rather than
+;; the example. Under `:patches` a single-row reply says nothing about any other
+;; card and every arm leaves the rest of the board alone; under `:populates` that
+;; same reply BECOMES the whole board and the other card vanishes outright.
+
+(def ^:private stale-writer-cases
+  "One row per commit arm. `A` is the arm under test — the older write, whose
+   reply is built before `B` is dispatched and speaks only for A's own row. `B`
+   is a different mutation on a different card, so a row stays red for exactly
+   the arm it names when that arm alone is reverted.
+
+   `dispatch-a!` / `dispatch-b!` dispatch their write and RETURN its mutation
+   instance, because a create's instance carries the temporary id it minted."
+  [{:writer            "create-issue"
+    :peer              "change-status"
+    :dispatch-a!       (fn []
+                         (rf/dispatch-sync [:linearlite/create-issue "Gamma"])
+                         [:create (:id (issue-by-title "Gamma"))])
+    :reply-a           {:issues [{:id "srv-3" :title "Gamma" :status :backlog}]}
+    :dispatch-b!       (fn []
+                         (rf/dispatch-sync [:linearlite/change-status "srv-2" :done])
+                         [:status "srv-2"])
+    :reply-b           {:issues [{:id "srv-2" :title "Beta" :status :done}]}
+    :peer-desc         "srv-2's move to :done"
+    :peer-holds?       (fn [] (= :done (:status (issue-by-id "srv-2"))))
+    :writer-desc       "the server's row replaces the temporary card"
+    :writer-committed? (fn [] (= {:id "srv-3" :title "Gamma" :status :backlog}
+                                 (issue-by-id "srv-3")))
+    :final             #{{:id "srv-1" :title "Alpha" :status :backlog}
+                         {:id "srv-2" :title "Beta"  :status :done}
+                         {:id "srv-3" :title "Gamma" :status :backlog}}}
+
+   {:writer            "edit-title"
+    :peer              "create-issue"
+    :dispatch-a!       (fn []
+                         (rf/dispatch-sync [:linearlite/commit-edit "srv-1" "Alpha!"])
+                         [:edit "srv-1"])
+    :reply-a           {:issues [{:id "srv-1" :title "Alpha!" :status :backlog}]}
+    :dispatch-b!       (fn []
+                         (rf/dispatch-sync [:linearlite/create-issue "Gamma"])
+                         [:create (:id (issue-by-title "Gamma"))])
+    :reply-b           {:issues [{:id "srv-3" :title "Gamma" :status :backlog}]}
+    ;; the created card is watched by TITLE: its id changes on commit.
+    :peer-desc         "the newly created Gamma card"
+    :peer-holds?       (fn [] (some? (issue-by-title "Gamma")))
+    :writer-desc       "srv-1's accepted title"
+    :writer-committed? (fn [] (= "Alpha!" (:title (issue-by-id "srv-1"))))
+    :final             #{{:id "srv-1" :title "Alpha!" :status :backlog}
+                         {:id "srv-2" :title "Beta"   :status :in-progress}
+                         {:id "srv-3" :title "Gamma"  :status :backlog}}}
+
+   {:writer            "change-status"
+    :peer              "edit-title"
+    :dispatch-a!       (fn []
+                         (rf/dispatch-sync [:linearlite/change-status "srv-2" :done])
+                         [:status "srv-2"])
+    :reply-a           {:issues [{:id "srv-2" :title "Beta" :status :done}]}
+    :dispatch-b!       (fn []
+                         (rf/dispatch-sync [:linearlite/commit-edit "srv-1" "Alpha!"])
+                         [:edit "srv-1"])
+    :reply-b           {:issues [{:id "srv-1" :title "Alpha!" :status :backlog}]}
+    :peer-desc         "srv-1's retitle to \"Alpha!\""
+    :peer-holds?       (fn [] (= "Alpha!" (:title (issue-by-id "srv-1"))))
+    :writer-desc       "srv-2's accepted move"
+    :writer-committed? (fn [] (= :done (:status (issue-by-id "srv-2"))))
+    :final             #{{:id "srv-1" :title "Alpha!" :status :backlog}
+                         {:id "srv-2" :title "Beta"   :status :done}}}])
+
+(defn- run-stale-writer-case!
+  "Drive one row of `stale-writer-cases`. `order` picks what B's change is worth
+   when A's older reply lands: `:peer-optimistic` leaves B in flight, so the
+   reply can only erase an OPTIMISTIC value (the visible regression);
+   `:peer-accepted` settles B first, so it can only revert a COMMITTED one (the
+   permanent last-reply-wins cache state). Both were rf2-9man's symptoms."
+  [{:keys [writer peer dispatch-a! reply-a dispatch-b! reply-b
+           peer-desc peer-holds? writer-desc writer-committed? final]}
+   order]
+  (load-board!)
+  (let [inst-a (dispatch-a!)
+        args-a @last-managed-args]
+    (reset! last-managed-args nil)
+    (let [inst-b (dispatch-b!)
+          args-b @last-managed-args]
+      (is (some? args-a) (str writer " (A, the older write) lowered a request"))
+      (is (some? args-b) (str peer " (B) lowered a request"))
+      ;; POSITIVE CONTROLS: the overlap is REAL — two instances in flight over
+      ;; the one board entry, each with its optimistic value showing. Without
+      ;; these the row would still pass if a refactor made a write settle at
+      ;; dispatch, and would then be pinning nothing.
+      (is (true? (:optimistic? (mutation-state inst-a)))
+          (str "CONTROL: " writer " (A) is still in flight"))
+      (is (true? (:optimistic? (mutation-state inst-b)))
+          (str "CONTROL: " peer " (B) is still in flight"))
+      (is (peer-holds?)
+          (str "CONTROL: " peer-desc " is on the board before A settles"))
+      (when (= :peer-accepted order)
+        (reply-success! args-b reply-b)
+        (is (true? (:success? (mutation-state inst-b)))
+            (str "CONTROL: " peer " has SETTLED :success"))
+        (is (false? (:optimistic? (mutation-state inst-b)))
+            (str "CONTROL: " peer-desc " is ACCEPTED — what follows can only "
+                 "revert a committed change, never a merely-optimistic one")))
+      ;; A's reply lands. It was built before B was dispatched and speaks only
+      ;; for the row A wrote.
+      (reply-success! args-a reply-a)
+      (is (peer-holds?)
+          (str "settling " writer " must not erase " peer-desc
+               " — A's reply predates B and says nothing about B's card"))
+      (is (writer-committed?)
+          (str "…while A's own accepted change commits: " writer-desc))
+      (when (= :peer-optimistic order)
+        (reply-success! args-b reply-b))
+      (is (peer-holds?) (str peer-desc " survives once both writes have settled"))
+      (is (writer-committed?) (str writer-desc " survives once both writes have settled"))
+      (is (= final (set (issues)))
+          "the board is exactly both accepted changes and nothing else — no card
+           lost, no stale value reinstated, no optimistic marker left behind"))))
+
+(deftest each-arm-in-turn-settles-behind-a-still-optimistic-peer
+  (doseq [{:keys [writer peer] :as row} stale-writer-cases]
+    (testing (str "examples/capabilities/resources/linearlite — " writer
+                  " is the OLDER write and its reply lands while " peer
+                  " is still optimistic over another card. Committing it must "
+                  "not erase what the other write has on screen (rf2-chl2)")
+      (run-stale-writer-case! row :peer-optimistic))))
+
+(deftest each-arm-in-turn-settles-behind-an-already-accepted-peer
+  (doseq [{:keys [writer peer] :as row} stale-writer-cases]
+    (testing (str "examples/capabilities/resources/linearlite — the same pairing "
+                  "with the replies REORDERED: " peer " settles and is ACCEPTED "
+                  "first, then " writer "'s older reply lands last. It must not "
+                  "permanently revert a change already committed (rf2-chl2)")
+      (run-stale-writer-case! row :peer-accepted))))


### PR DESCRIPTION
Two adapter beads, two commits, no file overlap.

## rf2-chl2 — every linearlite commit arm takes its turn as the older write

The bead's original task (land the two overlapping-write tests) is already on
main as `614437e64a`. The live instruction is the post-merge audit note added
when the bead was reopened: both landed tests use the same pairing, so two of
the three commit arms have no overlapping-write tooth.

Confirmed at source before editing, by modelling the three `:patches` arms from
the example against the pre-fix `:populates` arm (`(fn [_params result]
{board-key result})`, from `28900a4052^`) and replaying section 6's two tests:

| arm reverted to `:populates` | section 6 test 1 | section 6 test 2 |
| --- | --- | --- |
| none (tip) | GREEN | GREEN |
| `create-issue` | GREEN | GREEN |
| `edit-title` | RED | RED |
| `change-status` | GREEN | GREEN |

So `change-status` and `create-issue` can each be reverted with nothing on
screen — `change-status` because its reply is the snapshot taken *after* the
retitle, so seeding the entry from it reinstates the very change seeding would
otherwise clobber; `create-issue` because it never appears in either test.

Added a three-row table (one row per arm) plus one driver, run in both settle
orders — B still optimistic when A's older reply lands, and B already accepted
when it lands. Each row replays the single-row reply envelope the example's own
`apply-write!` sends, which is the in-contract shape for `create-issue` (its
commit upserts *every* row the reply carries) as well as for the other two.
Every row asserts the whole final board as a set, so a lost card, a reinstated
stale value or a leftover optimistic marker all red.

Discrimination, same model, six scenarios (3 rows × 2 orders):

| arm reverted | rows red | rows green |
| --- | --- | --- |
| none (tip) | — | all 6 |
| `create-issue` | the 2 `A=create` rows, plus the 2 `A=edit` rows (whose B is a create) | the 2 `A=status` rows |
| `edit-title` | the 2 `A=edit` rows, plus the 2 `A=status` rows (whose B is an edit) | the 2 `A=create` rows |
| `change-status` | the 2 `A=status` rows, plus the 2 `A=create` rows (whose B is a status) | the 2 `A=edit` rows |

Each arm reverted alone now reds, and the first assertion to fail in each case
is the one on the row that names that arm ("settling A must not erase B").

Not done, deliberately: the bead's second stale-`:populates` reference,
`docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs`.
The bead itself says that frozen baseline is the hicasso pilots' call, and the
tree is outside this fence. The first one (a test name describing `:populates`)
was already fixed in `614437e64a`.

## rf2-owml — a presence attribute asks JavaScript, not a falsey roster

Census re-run at tip first, because the bead's headline is a count. The bead
says `parity_cljs_test.cljs` carries its own 22-name canonicalisation set, six
short of production. **At tip that set does not exist: 22 → 0.** Commit
`e21b733d53` removed it and replaced it with a class rule — an empty attribute
value collapses to the bare name, whatever the name — which is the outcome the
bead asked for first ("the hand-maintained set disappears rather than being
corrected"). Production rosters at tip: `presence-attributes` 28,
`stringifying-attributes` 8, `overloaded-boolean-attributes` 2. A repo-wide
search for a set-literal roster under `reagent-slim/test/` returns zero, and the
same pattern returns six hits under `reagent-slim/src/`, so the zero is real.
The bead's finding (a) (`{:disabled ""}` / `{:disabled 0}`) was fixed by that
same commit.

What remains live is the newest note on the bead: `presence-value-truthy?`
enumerated the JS-falsey values (`""`, `0`, `NaN`) and returned `true` for
everything else. `cljs.core/number?` compiles to `typeof x === "number"`, so a
bigint zero reached the fallthrough and emitted a bare `disabled` where
react-dom 19.2.0 emits nothing.

Fixed by calling `js/Boolean` — the coercion react-dom itself performs. The
rule can be read to see that it is complete; a roster cannot, and it drifts
again the next time JavaScript grows a primitive. The parity corpus becomes a
labelled table spanning the falsey-capable primitive *types* (string, number,
bigint), each with a falsey member and a truthy neighbour, checked against the
live react-dom reference and pinned again on this serializer's raw bytes. NaN
is asserted on the bytes alone, because React logs a warning for it.

Measured against the installed react-dom 19.2.0 as the oracle, with the old and
new predicates transcribed to JS: the old one is RED on `a bigint zero` and
green on the other six rows; the new one is GREEN on all seven. Only that one
row moves, so the rest of the corpus is a genuine control against an over-broad
coercion.

## Quality gates

Run from `implementation/`, `implementation/adapters/reagent-slim` and
`implementation/adapters/reagent`; exit codes are the runner's own, captured on
the same command line as the run.

| gate | command | exit | result |
| --- | --- | --- | --- |
| CLJS node-test (the check that was red) | `node out/node-test.js` | 0 | 11232 tests / 56893 assertions, 0 failures, 0 errors |
| reagent-slim JVM suite | `clojure -M:test` | 0 | 10 tests / 10 assertions, 0 failures, 0 errors |
| reagent adapter classpath probe | `clojure -M:test` | 0 | 0 tests / 0 assertions — the artefact's `:test` alias is `--probe`, and its own `deps.edn` records that zero is the correct outcome (the adapter ns is CLJS-only) |
| clj-kondo, changed files | `clj-kondo --fail-level error --lint <changed files>` | 0 | errors 0, warnings 1 (a pre-existing `clojure.string` unresolved-namespace on an untouched line) |

**The CLJS lane is now run rather than deferred, and running it found a real
defect.** This PR's first revision deferred `npm run test:cljs` to CI because
sibling workers made a concurrent shadow-cljs compile unsafe. CI then went red
on `CLJS (shadow-cljs :node-test)` with 7 failures, all in
`re-frame.linearlite-example-cljs-test`: the new `stale-writer-cases` table
shared ONE runtime across its three rows, since `use-fixtures :each` resets
once per `deftest` and not once per row. Row 1 left `srv-2` moved to `:done`
and a committed `Gamma` card on the board, so rows 2 and 3 measured `:final`
against a board that was not the canned two-card one they are written against,
and `dispatch-b!` — which finds a created card by TITLE — returned the previous
row's already-settled `Gamma`. `load-board!` could not stand in for the reset:
re-entering a route already entered plans no second read, so its
`reply-success!` had no board request waiting and reseeded nothing.

A dedicated `npm ci` was installed inside this worktree — a real directory, not
a junction or a link into any sibling's tree — and the gate was then run in the
CI step's own two commands:

    npx shadow-cljs compile node-test   # exit 0 in every run, before and after
    node out/node-test.js               # exit 1 before the fix, exit 0 after

The verdict is the SECOND command's. `shadow-cljs compile` exits 0 with failing
tests — `:autorun` prints the red summary while the compile itself succeeds —
so the compile's exit code says nothing about the suite. Before the fix: 7
failures, 0 errors, at the same seven line numbers CI reported. After: 0
failures, 0 errors.

The fix is one reset at the top of the driver (`frames`-reset then the example's
own `init!`, section 0's pairing, ahead of `load-board!`). **No assertion
changed**: the assertion count is identical either side of it (56893), so
nothing was removed or weakened, and each row's positive controls — "A is still
in flight", "B is still in flight", "the peer's change is on the board before A
settles" — pass, so every row still exercises a real two-writes-in-flight
overlap.

The reagent-slim parity work was not implicated. `reagent2.dom.parity-cljs-test`
is in the node-test roster and every one of its assertions passed in both the
red and the green run, so `presence-value-truthy?`'s move to `js/Boolean` and
the rebuilt falsey-capable table are confirmed by execution, not only by reading.

Both JVM gates were shown to read this checkout rather than a sibling's: a
planted failing `deftest` in `reagent2/impl/component_test.clj` took the
reagent-slim gate to exit 1 with 11 tests / 1 failure, and the restore was
verified by SHA-256 (`d8f6e4bd…` before and after), not by reading a diff;
clj-kondo named a planted symbol at the exact line in this worktree's copy, and
that restore was hashed too (`1a648d6e…`).

Nothing outside the two adapter trees is touched. No `spec/`, no
`shadow-cljs.edn`, no workflow, no `examples/` (the example's own source is
already fixed on main and is another worker's fence — the two temporary
single-arm reverts used for the model were made in a scratch copy of the patch
functions, never in the tree).
