### PR TITLE
fix(http): actor destroy at the publication midpoint; pin both :error-shown exits (rf2-ni74, rf2-hcj0)

### DIFF
--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -1137,6 +1137,47 @@
         (is (= 3 (get-in s [:data :attempts])) "the third failure records count 3")
         (is (= "bad creds" (get-in s [:data :error])) "the terminal error is retained")))
 
+    (testing "pure :error-shown exits — BOTH ways out clear the stale error and keep the retry count (rf2-hcj0)"
+      ;; rf2-283u gave :error-shown an `:exit :clear-error` so the message a
+      ;; failure left behind cannot outlive the state that owns it. `:exit`
+      ;; runs on EVERY way out, so the invariant is one line in the table but
+      ;; TWO edges in behaviour — and only the behaviour is pinned here, never
+      ;; the table shape: an `:action` hung off each edge would satisfy these
+      ;; assertions too, and should.
+      ;;
+      ;; Each edge is asserted on its own, from the same hand-built failed
+      ;; snapshot, so neither can stand in for the other: dropping the clear
+      ;; from one edge alone leaves that edge's `:error` at "bad creds" while
+      ;; the other stays green.
+      (let [failed {:state :error-shown :data {:attempts 1 :error "bad creds"}}]
+
+        (testing "Dismiss → :idle"
+          (let [{s :snapshot} (rf.machines/machine-transition
+                                login-flow failed [:walkthrough.login/dismiss])]
+            (is (= :idle (:state s)) "Dismiss returns to :idle")
+            (is (nil? (get-in s [:data :error]))
+                "the stale failure is cleared on the way out, so the view's error row goes false")
+            ;; {:data {:error nil}} MERGES, so the retry counter survives —
+            ;; a Dismiss must not hand the user a fresh three attempts.
+            (is (= 1 (get-in s [:data :attempts]))
+                ":attempts is preserved across the clear")))
+
+        (testing "Submit → :submitting (direct retry, no Dismiss in between)"
+          (let [{s :snapshot fx :fx} (rf.machines/machine-transition
+                                       login-flow failed
+                                       [:walkthrough.login/submit
+                                        {:email "a@b.com" :password "secret"}])]
+            (is (= :submitting (:state s)) "a direct retry re-enters :submitting")
+            ;; Slot order is :exit → transition :action → target :entry, so the
+            ;; stale message is gone BEFORE :issue-request fires: a fresh
+            ;; request never rides alongside the previous failure.
+            (is (nil? (get-in s [:data :error]))
+                "the retry clears the stale failure rather than displaying it beside the new request")
+            (is (= 1 (get-in s [:data :attempts]))
+                ":attempts is preserved, so the lockout guard goes on counting")
+            (is (= [:rf.http/managed] (mapv first fx))
+                "entering :submitting still issues exactly one :rf.http/managed request")))))
+
     (testing "drain happy path — full drain lands the app-db at :authed via the canned-success stub"
       ;; Full drain: registers the machine, dispatches into it, asserts the
       ;; app-db landed at :authed. Uses the `:fx-overrides` seam to swap

--- a/implementation/http/src/re_frame/http/registry.cljc
+++ b/implementation/http/src/re_frame/http/registry.cljc
@@ -182,12 +182,14 @@
   successor, because both the request-index check and the actor-index removal
   match on `identical?` against THIS handle.
 
-  Residual, deliberately not closed here (rf2-ni74): the other door is blind
-  at that same midpoint — an `abort-on-actor-destroy` arriving between the two
-  swaps finds no actor slot and fires nothing, so the handle survives its
-  actor's destroy. That is a MISSED abort rather than an incoherent index, it
-  is swept by the later frame-destroy/epoch paths, and closing it needs
-  genuine cross-atom atomicity rather than a reconcile."
+  The OTHER door into the same midpoint is closed on the destroy side rather
+  than here (rf2-ni74). An `abort-on-actor-destroy` arriving between the two
+  swaps used to find no actor slot and fire nothing; it now also reads the
+  request index, where the handle already sits carrying its own `:frame` and
+  `:actor-id` stamps. That could not be a reconcile: a missed abort leaves
+  publication nothing to observe. The two halves compose — aborting a midpoint
+  handle drops its request slot, so the reconcile below then retracts the actor
+  slot publication is about to write, and the destroy leaves no ghost either."
   [request-id actor-id handle]
   (let [frame-id       (:frame handle)
         stamped-handle (cond-> handle
@@ -685,6 +687,36 @@
 ;; without aborting any HTTP (apps that don't issue managed-HTTP pay
 ;; nothing).
 
+(defn- midpoint-actor-handles
+  "The handles `frame-id`'s actor `actor-id` owns that the REQUEST index can
+  see but the actor-index slot cannot — the publication midpoint made reachable
+  (rf2-ni74). `indexed` is that slot's own contents, passed in so the identity
+  dedup costs no second read.
+
+  `record-in-flight!` stamps `:frame` and `:actor-id` onto the handle BEFORE
+  its first swap, so the copy sitting in `in-flight` between the two
+  publications already names its actor. The destroy simply had to look there as
+  well: cross-atom atomicity is not required to see a handle that is already
+  published, only the willingness to read both indexes.
+
+  FRAME-EXACT BY THE `:frame` FILTER, and that is load-bearing rather than
+  tidy. `in-flight` is keyed by request-id and holds EVERY frame's work, so a
+  sweep of it by actor address alone would abort a sibling frame's
+  identically-addressed actor — reintroducing, through this repair, exactly the
+  cross-frame reach rf2-o8ek's compound keys removed. Actor addresses are
+  frame-LOCAL and collide across frames by construction (identical spec,
+  per-frame spawn counter), so the filter is the whole of the isolation.
+
+  Eager, never lazy: the caller fires abort-fns that mutate `in-flight`, so a
+  lazy scan would observe the index it is already changing."
+  [frame-id actor-id indexed]
+  (into []
+        (filter (fn [handle]
+                  (and (= actor-id (:actor-id handle))
+                       (= frame-id (:frame handle))
+                       (not-any? #(identical? % handle) indexed))))
+        (vals @in-flight)))
+
 (defn abort-on-actor-destroy
   "Per Spec 014 §Abort on actor destroy (rf2-wvkn). Abort every in-flight
   `:rf.http/managed` request that was issued from inside spawned actor
@@ -696,6 +728,38 @@
   no-op. Tolerant of repeated invocations against the same actor —
   the actor-side slot is cleared atomically first so a re-entry sees
   an empty registry.
+
+  BOTH INDEXES ARE READ (rf2-ni74). The actor-index slot is this operation's
+  natural selector, but it is not the whole of the actor's in-flight work for
+  the duration of `record-in-flight!`: publication writes the request index
+  first and the actor index second, so between the two swaps an actor-owned
+  handle is fully published and abortable while owning no actor slot at all. A
+  destroy arriving there selected nothing and fired nothing, and publication
+  then completed and left the request live under a destroyed actor — measured
+  `{:case :actor-destroy-at-midpoint, :abort-fired? false,
+  :request-slot-present? true, :actor-slot-count 1}`.
+
+  That is a MISSED abort rather than an incoherent index, which is why
+  publication's trailing reconcile does not cover it: publication cannot retract
+  a handle nobody told it to retract, and the destroy leaves no trace for it to
+  observe. The fix belongs on THIS side — `midpoint-actor-handles` above reads
+  the request index for handles this frame's actor owns, which the handle's own
+  `:frame` / `:actor-id` stamps make exact. No lock, no tombstone, no
+  cross-atom atomicity: the handle was never invisible, only unlooked-for.
+
+  Reversing the publication order was the tempting alternative and is worse — it
+  would blind `:rf.http/managed-abort` by request-id, the primary app-facing
+  cancellation verb, at the same midpoint.
+
+  The two halves compose. Aborting a midpoint handle drops its request slot, so
+  when publication resumes and conj's it into the actor index, the reconcile
+  finds the slot no longer holding this handle and retracts it: the destroy
+  leaves no ghost either.
+
+  The slot is read AND cleared in ONE `swap-vals!`. The earlier shape read with
+  `get` and cleared with a separate `swap!`, so a handle published between the
+  two was dissoc'd from the index without ever being aborted — the same lost
+  abort as above, through a narrower door.
 
   Per rf2-plngk the per-handle request-id cleanup is owned by
   `clear-in-flight!` (called inside the abort-fn closure via
@@ -725,18 +789,30 @@
    (when actor-id
      ;; Snapshot the matching frames BEFORE aborting: each per-frame call
      ;; mutates `actor-in-flight`, and an abort-fn may mutate it re-entrantly.
-     (doseq [frame-id (->> @actor-in-flight
-                           keys
-                           (filter #(= actor-id (second %)))
-                           (mapv first))]
+     ;; Both indexes name frames, for the same reason the 2-arity reads both: a
+     ;; handle at the publication midpoint has a frame but no actor slot yet, so
+     ;; an actor-index-only scan would not even reach the arity that could abort
+     ;; it (rf2-ni74).
+     (doseq [frame-id (distinct
+                        (into (->> @actor-in-flight
+                                   keys
+                                   (filterv #(= actor-id (second %)))
+                                   (mapv first))
+                              (comp (filter #(= actor-id (:actor-id %)))
+                                    (map :frame))
+                              (vals @in-flight)))]
        (abort-on-actor-destroy frame-id actor-id)))
    nil)
   ([frame-id actor-id]
   (when actor-id
-    (let [k       (scoped-key frame-id actor-id)
-          handles (get @actor-in-flight k)]
-      ;; Atomically clear the slot first so a re-entry sees no handles.
-      (swap! actor-in-flight dissoc k)
+    (let [k        (scoped-key frame-id actor-id)
+          ;; Read AND clear in one step, so a handle publishing alongside this
+          ;; destroy cannot be dropped from the index unaborted. A re-entry
+          ;; still sees an empty slot, which is the idempotency guarantee.
+          [previous _] (swap-vals! actor-in-flight dissoc k)
+          indexed  (get previous k [])
+          handles  (into (vec indexed)
+                         (midpoint-actor-handles frame-id actor-id indexed))]
       (doseq [handle handles]
         (when rf.interop/debug-enabled?
           ;; rf2-bma05 — the handle carries the originating request's

--- a/implementation/http/test/re_frame/http_frame_scoped_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_frame_scoped_cancellation_test.clj
@@ -843,3 +843,76 @@
     (is (= 1 (actor-slot-count :frame/a))
         "and so does the actor index — publication completed untouched")
     (rf.http.managed/clear-all-in-flight!)))
+
+;; ---- the OTHER door into the same window (rf2-ni74) ------------------------
+;;
+;; The two cases above enter the publication window through the REQUEST index —
+;; an abort or a supersession resolving the just-published request slot. The
+;; actor-destroy cascade enters through the ACTOR index, which at the midpoint
+;; is the one that does not exist yet, so it selected nothing and fired nothing:
+;; measured `{:case :actor-destroy-at-midpoint, :abort-fired? false,
+;; :request-slot-present? true, :actor-slot-count 1}` — publication then
+;; completed and left the handle fully live in BOTH indexes despite its actor
+;; having been destroyed.
+;;
+;; A missed abort rather than an incoherent index, which is why rf2-o8ek's
+;; reconcile did not cover it: publication cannot retract a handle nobody told
+;; it to retract. The destroy side is what had to change.
+
+(defn- seed-named-actor-handle!
+  "A NAMED (request-id-bearing) actor-owned handle in `frame-id` — the shape
+  that occupies BOTH indexes once published, and so the shape a sibling-frame
+  control must use here. `seed-actor-handle!` above is anonymous and therefore
+  invisible to the request index, which would make a cross-frame control
+  vacuous against a defect reached through that index."
+  [seen frame-id]
+  (rf.http.registry/record-in-flight!
+    shared-id publication-actor
+    {:frame    frame-id
+     :url      "http://127.0.0.1/sibling-actor"
+     :abort-fn (fn [reason] (swap! seen conj [frame-id reason]))}))
+
+(deftest actor-destroy-inside-the-publication-window-still-aborts
+  (testing "rf2-ni74 — an actor destroy landing between the two publications
+            aborts the handle it was published to abort. Before the fix the
+            actor-index lookup was the whole of the destroy's reach, so at the
+            midpoint it selected nothing, fired nothing, and publication went
+            on to leave the request live under a destroyed actor"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen (atom [])]
+      (record-actor-handle-with-midpoint!
+        :frame/a seen
+        #(rf.http.registry/abort-on-actor-destroy :frame/a publication-actor))
+      (is (= [[:frame/a :actor-destroyed]] @seen)
+          "the destroy fired the handle's abort-fn with the actor-destroy reason.
+           This is the assertion the bead is about; empty here is the defect")
+      (is (nil? (get (rf.http.registry/in-flight-snapshot :frame/a) shared-id))
+          "the request index is clear — the abort-fn's own cleanup ran")
+      (is (zero? (actor-slot-count :frame/a))
+          "and the actor index gained no slot: publication's reconcile retracts
+           the handle it finished publishing into an index the abort had already
+           passed, so the destroy leaves no ghost either"))
+    (rf.http.managed/clear-all-in-flight!)))
+
+(deftest actor-destroy-inside-the-publication-window-is-frame-exact
+  (testing "rf2-ni74 — reaching the midpoint handle means reading the REQUEST
+            index, which is keyed by request-id and holds every frame's work.
+            A destroy that swept it by actor address alone would abort a sibling
+            frame's identically-addressed actor — reintroducing, through the
+            repair, exactly the cross-frame reach rf2-o8ek removed. So the
+            sibling here is NAMED, and therefore visible in the index the
+            destroy now consults"
+    (rf.http.managed/clear-all-in-flight!)
+    (let [seen (atom [])]
+      ;; Frame B goes live first, same raw request-id AND same actor address.
+      (seed-named-actor-handle! seen :frame/b)
+      (record-actor-handle-with-midpoint!
+        :frame/a seen
+        #(rf.http.registry/abort-on-actor-destroy :frame/a publication-actor))
+      (is (= [[:frame/a :actor-destroyed]] @seen)
+          "frame A's handle aborted, and ONLY frame A's")
+      (is (some? (get (rf.http.registry/in-flight-snapshot :frame/b) shared-id))
+          "frame B's request slot survives A's actor destroy")
+      (is (= 1 (actor-slot-count :frame/b))
+          "and so does B's actor slot, so B's request is still abortable"))
+    (rf.http.managed/clear-all-in-flight!)))


### PR DESCRIPTION
Two independent items, one commit each, no file overlap.

## rf2-ni74 — http: an actor destroy inside the two-swap publication window fires nothing

`record-in-flight!` publishes an actor-originated request to the request index
first and the actor index second. Between the two swaps the handle is fully
published and abortable yet owns no actor slot, so `abort-on-actor-destroy` —
whose whole reach was that slot — selected nothing and fired nothing.
Publication then completed and left the request live in **both** indexes under a
destroyed actor. Reproduced deterministically (an atom watch runs on the
swapping thread before `swap!` returns, so the interleaving is decided rather
than raced), matching the filed measurement exactly:

```
{:case :actor-destroy-at-midpoint, :abort-fired? false,
 :request-slot-present? true, :actor-slot-count 1}
```

**The item's premise did not hold, and that is the substance of this change.**
It reasoned that a real fix "needs publication to be observable as ONE step
across both atoms (cross-atom atomicity)", and warned against reaching for
coordination machinery. None is needed. `record-in-flight!` stamps `:frame` and
`:actor-id` onto the handle *before* its first swap, so the copy sitting in the
request index at the midpoint already names its own actor. The handle was never
invisible — only unlooked-for. The destroy now reads both indexes. Both atoms,
both keys and every existing index are untouched.

Frame-exactness is load-bearing rather than tidy: `in-flight` is keyed by
request-id and holds every frame's work, so the scan filters on the handle's
`:frame` stamp. Without it a destroy in frame A also aborts a sibling frame's
identically-addressed actor, reintroducing through the repair exactly the
cross-frame reach rf2-o8ek removed.

The two halves compose: aborting a midpoint handle drops its request slot, so
when publication resumes and conj's the handle into the actor index, rf2-o8ek's
trailing reconcile retracts it. The destroy leaves no ghost either — asserted,
not assumed.

Also closed, same class through a narrower door: the actor slot was read with
`get` and cleared with a separate `swap!`, so a handle published between the two
was dissoc'd from the index without ever being aborted — while the comment
beside it claimed the clear was atomic. One `swap-vals!` now does both (the
idiom `clear-in-flight!` already uses here), and the comment is true.

Reversing the publication order stays rejected, for the reason the item gives:
it would blind `:rf.http/managed-abort` by request-id at the same midpoint.

No spec change: Spec 014 §Abort on actor destroy already promises every request
the actor issued is aborted, and documents no window. This makes the promise
true rather than restating it.

## rf2-hcj0 — pin both `:error-shown` exits

rf2-283u gave the walkthrough's `:error-shown` node an `:exit :clear-error`;
nothing pinned it. The test dispatched Dismiss twice and asserted only the
eventual `:locked-out` state, never reading the error after a Dismiss and never
driving a direct retry at all — dropping the `:exit` again would have been green.

`:exit` runs on every way out, so one table line is two edges in behaviour, and
a pin exercising one of them is half a pin. Both edges are now asserted
separately from the same hand-built failed snapshot. Behaviour only: a pin that
grepped the table for `:exit` would fix the mechanism, and an `:action` per edge
is a table the example is entitled to become.

The example itself is unchanged — correct as merged by PR #9243. Nothing under
`examples/` is touched by this PR.

## Quality gates

Run from the worker worktree, all on the final rebased base. Exit codes captured
on the runner's own command line, never through a filter.

| Gate | Command | Exit | Result |
| --- | --- | --- | --- |
| http artefact (rf2-ni74) | `implementation/http $ clojure -M:test` | **0** | 527 tests / 3975 assertions, 0 failures, 0 errors |
| core artefact (rf2-hcj0) | `implementation/core $ clojure -M:test` | **0** | 2187 tests / 11320 assertions, 0 failures, 0 errors |
| resources artefact (downstream http consumer) | `implementation/resources $ clojure -M:test` | **0** | 829 tests / 7537 assertions, 0 failures, 0 errors |
| view-lifetime vocabulary ratchet | `python scripts/check_view_lifetime_residue.py --verbose` | **0** | zero residue in tracked content or paths |

The http figure is +2 tests / +6 assertions over the 525 / 3969 rf2-o8ek
recorded — exactly the two deftests added here. The http suite drives the real
machines destroy cascade (machines is a test-only dep of that artefact), so the
production caller of the changed hook is exercised.

The vocabulary ratchet initially fired on **one word in one explanatory comment**
in this PR — a sentence listing mechanisms the fix does *not* need, which named
the retired reservation term among them. Reworded; no behaviour change, and the
sentence keeps its point. The whole diff was re-scanned with the guard's own
pattern rather than only the reported line: that was the sole occurrence, in
source and in commit messages alike.

### Red-before-green, and controls against the controls

Every control was verified by *reddening*, and every planted fault restored
byte-exact (sha256 compared before and after, `git status` clean on the planted
path afterwards).

| Plant | Expected | Measured |
| --- | --- | --- |
| rf2-ni74 fix absent (pre-fix tip) | both new deftests red | exit 1, 4 failures — abort never fired, request slot present, actor-slot-count 1 |
| drop the `:frame` filter from the midpoint scan | *only* the frame-exactness deftest red | exit 1, 1 failure: `[[:frame/b :actor-destroyed] [:frame/a :actor-destroyed]]` |
| remove `:exit :clear-error` from the example | both new assertions red | exit 1, 2 failures, both `:error` still `"bad creds"` |
| move the clear onto the Dismiss edge alone as an `:action` | *only* the Submit assertion red | exit 1, 1 failure |
| re-insert the retired term in the comment | vocabulary ratchet red | exit 1, naming `registry.cljc:747` |

Rows two and four prove each assertion discriminates the case it names rather
than passing for either. Rows two and five also prove the gates read this
worktree.

### Skipped, and why

- `scripts/test-fast-pr.sh`, `npm run test:cljs` and any shadow-cljs build were
  **not** run: eight sibling workers are live on this host and a gate that heavy
  wedges rather than fails. CI owns the spine, including the CLJS half of the
  `.cljc` registry change. `swap-vals!` and the transducer forms used are core on
  both runtimes, and `swap-vals!` was already in use in this namespace.
- `mkdocs build --strict` and the two link gates are not nominated: no markdown,
  `docs/`, `spec/`, `migration/` or repo-root path is touched.
- `check-examples-compile.cjs` is not nominated: `examples/` is unmodified.
