### PR TITLE
fix(story): Start reads readiness from evidence the privacy filter cannot erase (rf2-k6y2)

### DIFF
--- a/tools/story/spec/009-Test-Mode.md
+++ b/tools/story/spec/009-Test-Mode.md
@@ -510,7 +510,7 @@ promise `prepare-variant` returns, and `begin!` leaves the section in its
 inactive state rather than offering step controls over a frame that never
 reached the state the variant's `:setup` describes.
 
-Those failures reach `prepare-variant` by two routes, and **only one of them
+Those failures reach `prepare-variant` by three routes, and **only one of them
 is a throw** — which is why the rejection is a decision the seam makes
 rather than one it inherits:
 
@@ -518,6 +518,7 @@ rather than one it inherits:
 |-----------|--------------------------------------------------------------|-----------------------------------------------------------------------|
 | Thrown    | unknown variant; a `:db-seed` schema violation               | escapes phases 0-2; the promise rejects on it                          |
 | Captured  | a throwing `:loaders` / `:setup` handler                     | recorded onto `[:rf.story/assertions]`; **the phase returns normally** |
+| Redacted  | the same, CLASSIFIED SENSITIVE                               | dropped at the privacy egress gate; **no assertion is recorded at all** |
 
 The captured route is `run-variant`'s gather-the-full-picture contract
 (`002-Runtime.md` §Error projection — a run reports every failure it saw
@@ -535,6 +536,37 @@ onto `prepare-variant` and had `begin!` branch on rejection alone, so a
 captured `:setup` failure resolved `nil` and published an active cursor-0
 stepper over a failed preparation — the same class of lie as the original
 defect, one lifecycle half further in.
+
+**The redacted route is that same lie once more, and reading the assertions
+accumulator does not reach it.** Those records are the DISPLAY path, and the
+display path runs through the privacy egress gate: per Spec 009 §Privacy +
+EP-0015 a pipeline-exception trace event flagged `:sensitive?` is dropped
+before it is ever projected onto `[:rf.story/assertions]`, under the default
+`:rf.egress/local-redacted` profile. So a `:setup` handler whose failure is
+classified sensitive — the variant declares `:sensitive {:app-db [...]}` and
+the handler's chain focuses an overlapping path — left the accumulator EMPTY,
+and a check reading it saw nothing to refuse on. The frame did not look
+merely healthy; it looked uneventful.
+
+The repair is **not** to redact less. Readiness instead rests on a fact the
+filter cannot erase: the capture boundary that drops the event additionally
+records its framework `:operation` — one member of the closed
+`:rf.error/handler-exception` / `:rf.error/coeffect-exception` /
+`:rf.error/interceptor-exception` enum, carrying no message, no `ex-data`, no
+failing event, no `:failing-id`. `prepare-variant` rejects when EITHER set is
+non-empty, reporting the visible records under `:failures` and the hidden
+ones' operation keywords under `:redacted-failure-ops`, so the operator
+learns what CLASS of thing failed without the filter yielding an inch. Like
+the assertions accumulator, the record is cleared at phase 0's fresh-frame
+boundary, so every entry belongs to THIS preparation.
+
+**Suppression is not itself a failure.** A privacy-classified variant whose
+preparation is healthy suppresses plenty of events and MUST still be
+step-debuggable — refusing every such variant would withdraw the debugger
+exactly where privacy makes it hardest to reason without one. Only a
+suppressed pipeline EXCEPTION refuses, which is why the record keys on the
+operation rather than on the suppressed-event counter the `[● REDACTED]`
+hint reads.
 
 `:rf.error/loader-incomplete` is deliberately NOT a prepare failure. A
 `:loaders-complete-when` that reports not-ready is a contract-pending signal

--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -20,6 +20,7 @@
   register via `reg-tag` *before* use; an unregistered tag on a
   variant's `:tags` set raises `:rf.error/unknown-tag`."
   (:require [re-frame.story.assertions   :as rf.story.assertions]
+            [re-frame.story.config       :as rf.story.config]
             [re-frame.story.frames       :as rf.story.frames]
             [re-frame.story.fx-stubs     :as rf.story.fx-stubs]
             [re-frame.story.late-bind    :as rf.story.late-bind]
@@ -64,9 +65,15 @@
   ;; listener closures inspecting every future trace event.
   ;; `remove-trace-listener!` is idempotent, so destroying a frame that never
   ;; installed a listener (or a double-destroy) is harmless.
+  ;; `redacted-failures` is the privacy-safe half of the same phases 0-2
+  ;; failure picture (`runtime/capture-phase-errors` → `prepare-variant`),
+  ;; so it is evicted here for the same reason and at the same moment as
+  ;; `pending-exceptions`: both are per-frame accumulators, and a destroyed
+  ;; frame that kept one would leak it for the life of the session.
   (rf.story.late-bind/set-fn! :drop-assertion-accumulators
     (fn [frame-id]
       (rf.story.play/drop-pending-exceptions! frame-id)
+      (rf.story.config/reset-redacted-failures! frame-id)
       (rf.story.play/remove-trace-listener! frame-id)))
   ;; The play-runner's per-frame run-state (`run-state` / `runs-by-play` /
   ;; `active-play` / `step-boundaries`) is evicted on frame teardown via

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -760,6 +760,74 @@
    (swap! suppressed-counters dissoc (or variant-id :global))
    nil))
 
+;; ---- *redacted-failures* (readiness the egress filter cannot erase) -----
+;;
+;; The counter above answers "how many sensitive events did you not show
+;; me?" — a DISPLAY hint, and deliberately blind to what those events were.
+;; That blindness is what made a caller reading the display path unable to
+;; tell a clean preparation from a redacted catastrophe: a `:setup` handler
+;; whose failure is classified sensitive emits a pipeline exception that the
+;; egress gate drops BEFORE `record-error!`, so `[:rf.story/assertions]`
+;; stays empty and `prepare-variant` resolved over a frame whose `:setup`
+;; never ran (rf2-k6y2, post-merge audit of PR #9252).
+;;
+;; So the capture boundaries record one additional PRIVACY-SAFE fact when
+;; the event they are dropping is a pipeline exception: its `:operation`.
+;; That is a member of the closed framework enum
+;; `rf.story.error/pipeline-exception-operations` — one of three
+;; `:rf.error/*` keywords — and carries no author data at all: no message,
+;; no `ex-data`, no failing event, no `:failing-id`. Nothing here weakens
+;; the redaction; it records only THAT a failure was hidden, and of which
+;; framework class.
+;;
+;; A SET rather than a count, for two reasons. Both Story listeners (the
+;; runtime's `capture-phase-errors` and the play-runner's per-frame
+;; listener) observe the same trace event, so a count would double-report a
+;; single failure; and presence is the whole of what a readiness check
+;; needs. Callers ask "is this empty?", never "how many?".
+
+(defonce
+  ^{:doc "Atom: `{variant-id → #{:rf.error/* operation …}}`. The framework
+         operation keyword of every SUPPRESSED pipeline exception, recorded
+         by the Story listener that dropped it. Read by
+         `re-frame.story.runtime/prepare-variant` so a step-debugger Start
+         refuses a preparation whose failure the privacy filter hid.
+         Per-variant and cleared at the phase-0 fresh-frame boundary, so
+         every entry present when phases 0-2 return belongs to THIS
+         preparation."}
+  redacted-failures
+  (atom {}))
+
+(defn note-redacted-failure!
+  "Record that a pipeline exception carrying `operation` was SUPPRESSED for
+  `variant-id` by the privacy egress gate. Called from a capture-boundary
+  listener's suppress branch, alongside `note-suppressed!` — the counter
+  keeps answering the display question, this answers the readiness one.
+
+  Only the operation keyword is stored. A `nil` `variant-id` is a no-op:
+  readiness is asked per-variant, and a frameless event belongs to no
+  preparation."
+  [variant-id operation]
+  (when (and (some? variant-id) (some? operation))
+    (swap! redacted-failures update variant-id (fnil conj #{}) operation))
+  nil)
+
+(defn redacted-failure-ops
+  "The (possibly empty) SET of framework operation keywords whose pipeline
+  exceptions were suppressed for `variant-id`. Non-empty means a failure
+  occurred that the egress filter erased from the display path."
+  [variant-id]
+  (get @redacted-failures variant-id #{}))
+
+(defn reset-redacted-failures!
+  "Clear the redacted-failure record. With no arg, clears all; with a
+  `variant-id`, just that variant. Called at the phase-0 fresh-frame
+  boundary and on variant teardown."
+  ([] (reset! redacted-failures {}) nil)
+  ([variant-id]
+   (swap! redacted-failures dissoc variant-id)
+   nil))
+
 ;; ---- *reset-all!* (config-leak test-isolation) -------------------------
 ;;
 ;; Every leakable process-global config atom above is a `defonce` that
@@ -806,6 +874,7 @@
                                               reset directly, no toggle-off fire)
   - `session-egress-profile`      → `:rf.egress/local-redacted`
   - `suppressed-counters`         → `{}`
+  - `redacted-failures`           → `{}`
 
   Deliberately leaves `toggle-off-callbacks` intact — those are
   load-time module registrations, not per-test state."
@@ -818,4 +887,5 @@
   (reset! frame-egress-profiles {})
   (reset! session-egress-profile default-egress-profile)
   (reset! suppressed-counters {})
+  (reset! redacted-failures {})
   nil)

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -124,7 +124,21 @@
   events whose `:sensitive?` flag is true are dropped from the capture
   set when Story's local-render egress profile redacts
   (`:rf.egress/local-redacted` — the default). A counter bump is recorded
-  so the UI's redaction hint can surface 'N sensitive events suppressed'."
+  so the UI's redaction hint can surface 'N sensitive events suppressed'.
+
+  The suppress branch ALSO records the dropped event's framework
+  `:operation` via `note-redacted-failure!` when the event is a pipeline
+  exception for THIS variant. That is not a second capture path and it
+  reveals nothing further: the assertion records stay exactly as redacted
+  as before, and what is kept is one member of the closed
+  `pipeline-exception-operations` enum — no message, no `ex-data`, no
+  failing event. It exists because the assertion accumulator is the
+  DISPLAY path, so a caller that must answer 'did phases 0-2 succeed?'
+  cannot read it: under the default profile a sensitive `:setup` failure
+  left the accumulator empty, and `prepare-variant` published a
+  step-debugger over a frame whose `:setup` never ran (rf2-k6y2,
+  post-merge audit of PR #9252). Readiness therefore rests on a fact the
+  egress filter cannot erase, rather than on redaction being weakened."
   [variant-id phase body-fn]
   (let [collected (atom [])
         listener  (fn [ev]
@@ -132,7 +146,16 @@
                       ;; Resolve the suppress decision against the event's
                       ;; own frame (per-(tool,frame) visibility).
                       (rf.story.config/suppress-sensitive? ev)
-                      (rf.story.config/note-suppressed! (rf.trace/trace-event-frame ev))
+                      (do
+                        (rf.story.config/note-suppressed!
+                          (rf.trace/trace-event-frame ev))
+                        ;; `pipeline-exception-event?` also checks the event
+                        ;; targets THIS variant's frame, so a sibling
+                        ;; frame's suppressed failure never marks this
+                        ;; preparation unready.
+                        (when (rf.story.error/pipeline-exception-event? variant-id ev)
+                          (rf.story.config/note-redacted-failure!
+                            variant-id (:operation ev))))
 
                       (rf.story.error/pipeline-exception-event? variant-id ev)
                       (swap! collected conj ev)))]
@@ -824,7 +847,13 @@
   BEFORE phase-1 loaders fire so the privacy gate suppresses sensitive
   loader-phase events and loader-phase handler-exceptions are captured.
   We clear the per-frame `pending-exceptions` slot so the listener has a
-  clean slot; `execute-play!` clears it again at play start.
+  clean slot; `execute-play!` clears it again at play start. The
+  `redacted-failures` record is cleared in the same breath and for the
+  same reason: it is the privacy-safe half of the phases 0-2 failure
+  picture (`capture-phase-errors`), and `prepare-variant` reads it as a
+  yes/no on THIS preparation. Clearing it here — at the same fresh-frame
+  boundary that resets `[:rf.story/assertions]` — is what makes both
+  halves describe one run rather than an accumulation.
 
   The `:loaders-complete-when` vector form reads the epoch
   tape (`rf.story.assertions/dispatched-events`, the SSOT) rather than a side-table
@@ -844,6 +873,7 @@
   (rf.story.frames/allocate! variant-id decorator-stack
                      (select-keys (:world plan) [:sensitive :large]))
   (swap! rf.story.play/pending-exceptions assoc variant-id [])
+  (rf.story.config/reset-redacted-failures! variant-id)
   (rf.story.play/install-trace-listener! variant-id)
   (assoc ctx :epoch-baseline (rf.story.play.runner-events/last-epoch-id variant-id)))
 
@@ -1765,6 +1795,37 @@
                   (not passed?)))
            (read-assertions variant-id)))
 
+(defn- redacted-prepare-failures
+  "The framework operation keywords of the phases 0-2 pipeline exceptions
+  the PRIVACY EGRESS FILTER suppressed for `variant-id` — a (possibly
+  empty) set.
+
+  `captured-prepare-failures` above reads `[:rf.story/assertions]`, and
+  those records are produced AFTER the egress gate. `capture-phase-errors`'
+  first `cond` branch drops a `:sensitive?` trace event before
+  `record-error!` ever runs, so under the default
+  `:rf.egress/local-redacted` profile a `:setup` / `:loaders` handler whose
+  failure is classified sensitive leaves NO assertion — and the predicate
+  above then has nothing to refuse on. That is the shape rf2-k6y2's
+  post-merge audit of PR #9252 found: an instrument answering 'nothing
+  here' in the same voice whether nothing was wrong or the question could
+  not be asked, so Start published a cursor-0 stepper over failed setup.
+
+  The redaction is CORRECT and is untouched. The repair is to stop reading
+  the ABSENCE of an assertion as evidence of success: the capture boundary
+  additionally records the suppressed event's `:operation`, one member of
+  the closed `pipeline-exception-operations` enum, and this reads that.
+  Nothing author-owned crosses — no message, no `ex-data`, no failing
+  event, no `:failing-id`.
+
+  Distinct from `rf.story.config/suppressed-count`, which counts EVERY
+  suppressed sensitive event. A privacy-classified variant whose
+  preparation is healthy suppresses plenty of events and must still be
+  step-debuggable, so suppression alone is never a refusal — only a
+  suppressed pipeline EXCEPTION is."
+  [variant-id]
+  (rf.story.config/redacted-failure-ops variant-id))
+
 (defn prepare-variant
   "Re-run the PREPARE half of the four-phase lifecycle for `variant-id` —
   phases 0-2 (fresh-frame boundary, allocation, `:db-seed`, `:loaders`,
@@ -1798,7 +1859,8 @@
   inactive state instead of presenting controls over a frame that never
   reached the state the variant's `:setup` describes.
 
-  Those failures reach here by TWO routes, and only one of them is a throw:
+  Those failures reach here by THREE routes, and only one of them is a
+  throw:
 
   - THROWN — an unknown variant (the plan compiler refuses with
     `:rf.error/story-unknown-variant`) and a `:db-seed` schema violation
@@ -1807,15 +1869,29 @@
     `run-loaders!` / `run-events!` project it onto `[:rf.story/assertions]`
     and return normally (`run-variant`'s gather-the-full-picture contract),
     so `prepare-ctx!` completes over a frame whose `:setup` never ran.
+  - REDACTED — the same captured failure, but CLASSIFIED SENSITIVE. The
+    privacy egress gate drops the trace event before `record-error!`, so
+    it leaves no assertion either: the frame looks not merely healthy but
+    UNEVENTFUL.
 
   Reading the absence of a throw as success therefore published an active
   cursor-0 stepper over a failed preparation — the residual the rf2-k6y2
-  post-merge audit found in the fix for rf2-k6y2 itself. So this checks
-  `captured-prepare-failures` explicitly and rejects on a non-empty set,
-  carrying the records under the thrown error's `:failures` so the caller
-  can say WHAT failed rather than only THAT it did. `run-variant` and
-  `prepare-run!` are untouched: they keep resolving a result that reports
-  every failure they saw.
+  post-merge audit found in the fix for rf2-k6y2 itself. Reading the
+  absence of an ASSERTION as success published the same stepper over the
+  sensitive-classified case, which the audit of PR #9252 then found. So
+  this checks `captured-prepare-failures` AND `redacted-prepare-failures`
+  and rejects on either, carrying the visible records under the thrown
+  error's `:failures` and the redacted ones' framework operation keywords
+  under `:redacted-failure-ops`, so the caller can say WHAT failed — or,
+  when the filter hid it, what CLASS of thing failed — rather than only
+  THAT it did.
+
+  The two sets answer the same question through independent channels, and
+  that is the point: the display path is redactable by design, so
+  readiness cannot rest on it alone. Neither check weakens the redaction —
+  the second reads a closed framework enum, never author data — and
+  `run-variant` / `prepare-run!` are untouched: they keep resolving a
+  result that reports every failure they saw.
 
   `opts` is the standard `run-variant` opts (`:active-modes` /
   `:cell-overrides` / `:substrate`)."
@@ -1830,21 +1906,30 @@
          ;; synchronous, so the promise has settled by the time this returns.
          (reset-run-owner! variant-id)
          (prepare-ctx! variant-id (rf.story.frames/variant-body variant-id) opts)
-         (when-let [failures (seq (captured-prepare-failures variant-id))]
-           (rf.error/throw-error!
-             :rf.error/story-prepare-failed
-             'rf.story/prepare-variant
-             (str "re-frame2-story: variant " variant-id
-                  " — preparation (phases 0-2) recorded "
-                  (count failures)
-                  " captured pipeline exception(s) from :loaders / :setup, so "
-                  "the frame never reached the state the variant's :setup "
-                  "describes. The records are on the frame's "
-                  ":rf.story/assertions and under :failures here; fix the "
-                  "failing handler and prepare again.")
-             {:recovery :fix-the-failing-loader-or-setup-handler
-              :extra    {:variant/id variant-id
-                         :failures   (vec failures)}}))
+         (let [failures (vec (captured-prepare-failures variant-id))
+               redacted (vec (sort (redacted-prepare-failures variant-id)))]
+           (when (or (seq failures) (seq redacted))
+             (rf.error/throw-error!
+               :rf.error/story-prepare-failed
+               'rf.story/prepare-variant
+               (str "re-frame2-story: variant " variant-id
+                    " — preparation (phases 0-2) recorded "
+                    (count failures)
+                    " captured pipeline exception(s) from :loaders / :setup"
+                    (when (seq redacted)
+                      (str " and " (count redacted)
+                           " more whose details the privacy egress filter "
+                           "suppressed (operations " (pr-str redacted)
+                           "; reveal this frame with :rf.egress/local-raw to "
+                           "see them)"))
+                    ", so the frame never reached the state the variant's "
+                    ":setup describes. The visible records are on the frame's "
+                    ":rf.story/assertions and under :failures here; fix the "
+                    "failing handler and prepare again.")
+               {:recovery :fix-the-failing-loader-or-setup-handler
+                :extra    {:variant/id           variant-id
+                           :failures             failures
+                           :redacted-failure-ops redacted}})))
          (resolve nil))))))
 
 ;; ---- watch-variant -------------------------------------------------------

--- a/tools/story/test/re_frame/story/stepper_start_test.cljc
+++ b/tools/story/test/re_frame/story/stepper_start_test.cljc
@@ -334,3 +334,160 @@
                "the full run resolved a result rather than rejecting")
            (is (seq (filter (comp false? :passed?) (:assertions result)))
                "carrying the captured failure"))))))
+
+;; ---- (6) a REDACTED prepare failure settles honestly ---------------------
+;;
+;; Section (5) branches on the assertion records `capture-phase-errors`
+;; projects onto `[:rf.story/assertions]`. Those records are the DISPLAY
+;; path, and the display path runs THROUGH the privacy egress filter: the
+;; capture listener's first `cond` branch drops a `:sensitive?` trace event
+;; and only bumps the suppressed counter (Spec 009 §Privacy + EP-0015,
+;; `:rf.egress/local-redacted` is the default profile).
+;;
+;; So a setup/loader handler whose failure is CLASSIFIED SENSITIVE produced
+;; no assertion at all, and a readiness check reading assertions saw an
+;; empty accumulator — indistinguishable from a clean preparation. Start
+;; resolved and published a cursor-0 stepper over a frame whose `:setup`
+;; never ran (the rf2-k6y2 post-merge audit of PR #9252).
+;;
+;; The redaction is CORRECT and stays. What was wrong is reading the
+;; ABSENCE of an assertion as evidence of success, so readiness now rests on
+;; a privacy-safe fact the egress filter cannot erase — the operation
+;; keyword of a suppressed pipeline exception, recorded at the same capture
+;; boundary that drops the event.
+;;
+;; The classification is REAL, not injected: the variant declares
+;; `:sensitive {:app-db [[:auth :password]]}`, the throwing handler is
+;; path-scoped at `[:auth]`, and the router's own overlap calculation
+;; (`re-frame.privacy/collect-redaction-paths` → `:schema-sensitive?` →
+;; the handler scope's `:sensitive?` stamp) marks every trace event the
+;; handler emits. No synthetic trace event is fed to a listener.
+
+(def ^:private sensitive-path [:auth :password])
+
+#?(:clj
+   (defn- reg-sensitive-thrower!
+     "Register an event whose interceptor chain focuses app-db at `[:auth]`
+     — a PREFIX of the variant's declared sensitive path — and throws. The
+     path overlap is what makes the router stamp the handler scope
+     `:sensitive?`, so the pipeline-exception trace event the throw emits is
+     the one Story's egress filter drops."
+     [event-id]
+     (rf/reg-event event-id
+       {:interceptors [[:rf.interceptor/path [:auth]]]}
+       (fn [_ _] (throw (ex-info "sensitive handler blew up"
+                                 {:password "hunter2"}))))))
+
+#?(:clj
+   (defn- failure-records [vid]
+     (filterv (comp false? :passed?) (rf.story.runtime/read-assertions vid))))
+
+#?(:clj
+   (deftest start-refuses-a-redacted-setup-failure
+     (testing "a `:setup` handler that throws under a SENSITIVE path
+               classification emits a pipeline exception the privacy egress
+               filter suppresses, so NO assertion is recorded — yet the
+               preparation still failed. Start must take the rejection
+               branch on evidence the filter cannot erase (rf2-k6y2 audit
+               of PR #9252)"
+       (let [vid :story.stepper/sensitive-setup-throws]
+         (reg-sensitive-thrower! :probe/sensitive-setup-throws)
+         (rf.story/reg-variant vid
+           {:sensitive {:app-db [sensitive-path]}
+            :setup     [[:probe/sensitive-setup-throws]]
+            :script    [[:dispatch-sync [:probe/inc-and-effect]]]})
+         (let [branch (begin-outcome vid)]
+           (is (empty? (failure-records vid))
+               "PRECONDITION — the display path really is empty: the
+                sensitive exception was redacted away, so a readiness check
+                reading assertions has nothing to refuse on. Without this
+                the test would be re-running section (5)'s ordinary case")
+           (is (pos? (rf.story.config/suppressed-count vid))
+               "PRECONDITION — and the egress filter is the reason it is
+                empty, not a handler that failed to throw")
+           (is (= :catch branch)
+               "the redacted preparation failure rejects rather than
+                resolving nil")
+           (is (nil? (slot vid))
+               "so Start never primed the substrate")
+           (is (zero? @ext-effect-count)
+               "and issued no script effect"))))))
+
+#?(:clj
+   (deftest start-refuses-a-redacted-loader-failure
+     (testing "the same for a throwing `:loaders` handler under a sensitive
+               classification — phase 1 drops the event at the same gate"
+       (let [vid :story.stepper/sensitive-loader-throws]
+         (reg-sensitive-thrower! :probe/sensitive-loader-throws)
+         (rf.story/reg-variant vid
+           {:sensitive {:app-db [sensitive-path]}
+            :loaders   [[:probe/sensitive-loader-throws]]
+            :setup     [[:counter/initialise 0]]
+            :script    [[:dispatch-sync [:probe/inc-and-effect]]]})
+         (let [branch (begin-outcome vid)]
+           (is (empty? (failure-records vid))
+               "PRECONDITION — no assertion survived the egress filter")
+           (is (= :catch branch)
+               "the redacted loader failure rejects")
+           (is (nil? (slot vid))
+               "so Start never primed the substrate")
+           (is (zero? @ext-effect-count)
+               "and issued no script effect"))))))
+
+#?(:clj
+   (deftest start-runs-a-healthy-sensitive-variant
+     (testing "THE CONTROL THAT KEEPS THE REFUSAL HONEST. A variant that
+               declares a sensitive path and emits suppressed sensitive
+               events but whose preparation SUCCEEDS must still reach
+               `begin-stepper!`. Readiness keys on a suppressed PIPELINE
+               EXCEPTION, never on suppression itself — a debugger that
+               refused every privacy-classified variant would take the tool
+               away exactly where it is most wanted"
+       (let [vid :story.stepper/sensitive-healthy]
+         (rf/reg-event :probe/sensitive-seed
+           {:interceptors [[:rf.interceptor/path [:auth]]]}
+           (fn [_ _] {:db {:password "hunter2"}}))
+         (rf.story/reg-variant vid
+           {:sensitive {:app-db [sensitive-path]}
+            :setup     [[:probe/sensitive-seed]
+                        [:counter/initialise 0]]
+            :script    [[:dispatch-sync [:probe/inc-and-effect]]]})
+         (let [branch (begin-outcome vid)]
+           (is (pos? (rf.story.config/suppressed-count vid))
+               "PRECONDITION — this variant DID have sensitive events
+                suppressed, so it exercises the same gate as the two
+                refusals above")
+           (is (= :then branch)
+               "a healthy sensitive preparation still resolves")
+           (is (some? (slot vid))
+               "and Start primed the stepper")
+           (is (= 0 (count-of vid))
+               "over the :setup state, with the script still pending"))))))
+
+#?(:clj
+   (deftest a-redacted-refusal-reveals-nothing
+     (testing "the refusal carries the FACT of the failure and no more: the
+               rejection's data names the suppressed operation (a framework
+               keyword) and never the exception message, its `ex-data`, or
+               the failing event. Redaction is not weakened to make the
+               debugger honest"
+       (let [vid :story.stepper/sensitive-setup-throws-payload]
+         (reg-sensitive-thrower! :probe/sensitive-setup-throws)
+         (rf.story/reg-variant vid
+           {:sensitive {:app-db [sensitive-path]}
+            :setup     [[:probe/sensitive-setup-throws]]
+            :script    [[:dispatch-sync [:probe/inc-and-effect]]]})
+         (let [err (atom nil)]
+           (-> (rf.story.runtime/prepare-variant vid)
+               (rf.story.async/catch* (fn [e] (reset! err e) nil))
+               (rf.story.async/deref-blocking 2000))
+           (is (some? @err) "the preparation rejected")
+           (let [payload (pr-str (ex-data @err))]
+             (is (not (re-find #"hunter2" payload))
+                 "the sensitive `ex-data` value is absent from the rejection")
+             (is (not (re-find #"sensitive handler blew up" payload))
+                 "so is the exception message")
+             (is (re-find #"rf\.error/handler-exception" payload)
+                 "while the framework operation keyword — which carries no
+                  author data — IS reported, so the operator learns WHAT
+                  class of failure the filter hid")))))))


### PR DESCRIPTION
## The defect

`prepare-variant` refused a captured `:setup` / `:loaders` failure by reading the frame's `[:rf.story/assertions]`. Those records are the **display** path, and the display path runs *through* the privacy egress gate — `capture-phase-errors`' first `cond` branch drops a `:sensitive?` pipeline-exception trace event before `record-error!` ever runs (Spec 009 §Privacy + EP-0015).

So under the **default** `:rf.egress/local-redacted` profile, a setup handler whose failure is classified sensitive left the accumulator empty. The frame did not look merely healthy — it looked *uneventful*. Start resolved and published an active cursor-0 stepper over a preparation that had failed.

An instrument that answers "nothing here" in the same voice whether nothing is wrong or the question could not be asked. This is the residual the post-merge audit of #9252 found; rf2-k6y2 was reopened for it rather than a new bead filed, because it is the same acceptance-3 gap one layer in.

## The fix

**The redaction is correct and is untouched — nothing here reduces what the privacy filter hides.** What changes is that readiness stops resting on the *absence* of an assertion.

The same capture boundary that drops the event additionally records its framework `:operation`: one member of the closed `pipeline-exception-operations` enum (`:rf.error/handler-exception` / `:rf.error/coeffect-exception` / `:rf.error/interceptor-exception`). No message, no `ex-data`, no failing event, no `:failing-id`.

`prepare-variant` now rejects when **either** set is non-empty, reporting the visible records under `:failures` and the hidden ones' operation keywords under `:redacted-failure-ops` — so the operator learns what *class* of thing failed without the filter yielding an inch.

**Suppression alone is never a refusal.** A privacy-classified variant whose preparation is healthy suppresses plenty of events and must still be step-debuggable, so the record keys on a suppressed pipeline *exception*, never on the `suppressed-count` the `[● REDACTED]` hint reads.

Lifecycle, matching the assertions accumulator it complements: per-variant, cleared at phase 0's fresh-frame boundary so every entry belongs to *this* preparation, evicted on frame teardown beside `pending-exceptions`. `run-variant` / `prepare-run!` keep gather-the-full-picture semantics unchanged.

## Files

- `tools/story/src/re_frame/story/config.cljc` — the privacy-safe `redacted-failures` record + its three accessors, cleared by `reset-all!`
- `tools/story/src/re_frame/story/runtime.cljc` — `capture-phase-errors` records the operation in its suppress branch; `run-phase-0!` clears the record; `redacted-prepare-failures` reads it; `prepare-variant` rejects on either set
- `tools/story/src/re_frame/story/canonical.cljc` — frame-teardown eviction beside `drop-pending-exceptions!`
- `tools/story/spec/009-Test-Mode.md` — §Start semantics: the failure-route table gains the third (Redacted) row, with why reading the assertions accumulator cannot reach it and why suppression is not itself a failure
- `tools/story/test/re_frame/story/stepper_start_test.cljc` — section (6), four witnesses

## Red then green, under the DEFAULT egress posture

The classification is produced by the router's own sensitive-path overlap — the variant declares `:sensitive {:app-db [[:auth :password]]}` and the throwing handler's chain focuses `[:auth]` — so `re-frame.privacy/collect-redaction-paths` → `:schema-sensitive?` → the handler scope's `:sensitive?` stamp marks the event. **No synthetic trace event is fed to a listener, and redaction is never turned off**: a probe run with `:rf.egress/local-raw` would pass and prove nothing, which is the trap this bead is about.

Before the fix (`clojure -M:test -n re-frame.story.stepper-start-test`, captured exit **1**): 6 failures. The two behavioural assertions failed on each refusal test — `(= :catch branch)` read `:then`, and `(nil? (slot vid))` read `{:remaining [[:dispatch-sync [:probe/inc-and-effect]]], :ran [], :results []}`: a live stepper over failed setup.

Both **preconditions passed in that same red run**, which is what makes it the right defect: the display path really was empty (`(empty? (failure-records vid))`) and the egress filter really was the reason (`(pos? (suppressed-count vid))`). The test is not re-running the already-fixed ordinary case.

After the fix, captured exit **0** — 14 tests, 48 assertions, 0 failures.

### The control is not vacuous

The audit note warns against the over-broad repair — treating *every* suppressed event as a failure. `start-runs-a-healthy-sensitive-variant` exists to catch exactly that, and a new test that also read display assertions would have inherited the original blind spot, so this was checked rather than assumed: planting the over-broad predicate (readiness keyed on `suppressed-count`) turned that control **red** — `(= :then branch)` and `(some? (slot vid))` both fail, and `a-redacted-refusal-reveals-nothing` catches the operation keyword no longer being a real framework op. The plant was reverted and the revert verified by **sha256 of the file bytes**, identical before and after (`2db0e1588b31…`); "unchanged" and "not attempted" are otherwise the same diff.

## Quality gates

| Gate | Command | Captured exit | Result |
|---|---|---|---|
| Story artefact JVM suite | `clojure -M:test` (from `tools/story`) | **0** | 1903 tests, 7007 assertions, 0 failures, 0 errors |
| Focused regression ns | `clojure -M:test -n re-frame.story.stepper-start-test` | **0** | 14 tests, 48 assertions (was exit 1 / 6 failures pre-fix) |
| Require-alias dialect | `python scripts/check_require_alias_dialect.py --verbose` | **0** | 2791 files, 10843 edges, every surface at or under its floor |
| Doc slugs / anchors | `python scripts/check_doc_slugs.py` | **0** | clean (covers `tools/*/spec`) |

Each exit code was captured to its own file and echoed on one command line in one shell — no gate was piped through a filter, and no number here is the harness's report of a run.

The alias gate was confirmed to actually read this worktree and cover the changed file rather than believed on a green: planting `:as cfg` on the new require made it exit **1**, naming `tools/story/src/re_frame/story/canonical.cljc:23` and printing the canonical spelling. Reverted, and the revert verified by sha256 (`76139b1e01ba…` before and after; a `sed -i` line-ending normalisation was undone through the index so the bytes match, not merely the content).

**Skipped, deliberately:** `scripts/test-fast-pr.sh`, `npm run test:cljs` and any shadow-cljs build. Several sibling workers are live in this wave and a build heavy enough that two cannot coexist wedges rather than fails. CI owns the spine; this PR relies on it for the CLJS/browser tiers. The changed CLJS-reachable surface is `.cljc` throughout and is exercised by the JVM suite above.

`mkdocs build --strict` is **not** nominated for the spec edit: `tools/story/spec/` is outside `docs_dir` and is not one of the trees `mkdocs_hooks.py` stages in, so the build cannot see it. `check_doc_slugs.py` is the gate whose roots include `tools/*/spec`, and it is green. Neither gate validates prose or table rendering, so the new table row's **column count was verified by hand** — all five rows carry 3 cells — and the edit adds no links and no anchors.

Closes rf2-k6y2.
