### PR TITLE
fix(machines-viz): SCXML import ignores executable content instead of inventing states (rf2-qy8p)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -2302,6 +2302,20 @@ back.
 
 ### Not supported (lossy or omitted)
 
+- **SCXML executable content + the data model (rf2-qy8p).**
+  `<onentry>`, `<onexit>`, `<script>`, `<log>`, `<assign>`, `<raise>`,
+  `<send>`, `<datamodel>` / `<data>`, `<invoke>` and any other foreign
+  child of a `<state>` are **IGNORED on import and never emitted on
+  export**. The mapping covers the static TOPOLOGY only, so this is
+  lossy by design — no executable semantics are imported. **Ignored is
+  the whole of the behaviour**: a foreign element is skipped *together
+  with its entire subtree*, so it never becomes a `:states` entry and a
+  `<state>` nested inside one is **not** promoted into the parent's
+  `:states`. Only `<state>`, `<final>`, `<history>` and `<transition>`
+  carry meaning. (Pre-fix the importer accepted every non-`<transition>`
+  tag as a child state, so a conforming `<state id="idle"><onentry/></state>`
+  imported as `{:states {:idle {:states {nil {}}}}}` — a definition
+  `reg-machine`, `MachineChart` and every sibling emitter reject.)
 - `:spawn-all` rows — omitted; the parent state renders without
   spawn affordances.
 - **Internal-default self / proper-ancestor self-transition semantics
@@ -2350,7 +2364,7 @@ sentence, and `ex-message` leads with the sentence and trails the
 
 | `:rf.error/id` | Meaning |
 |---|---|
-| `:scxml/invalid-spec` | Input spec fails the canonical **recursive** grammar gate (`grammar/valid-definition?` — rf2-j538f7.18): not just a missing root `:initial` / `:states` (or `:type :parallel` / `:regions`), but any structural defect the runtime machine contract rejects at `reg-machine` — a nested compound missing `:initial`, a dangling / malformed transition target, an unknown bare node / spawn key, a malformed history / final-state / `:tags` / `:after`-delay shape. The thrown ex-data carries the value-free `grammar/definition-summary` under `:spec-summary` (its `:defect :category` is the canonical `:rf.error/machine-*` id) — see [The value-free definition summary](#the-value-free-definition-summary) for exactly what that may and may not name. |
+| `:scxml/invalid-spec` | The definition crossing the boundary fails the canonical **recursive** grammar gate (`grammar/valid-definition?` — rf2-j538f7.18): not just a missing root `:initial` / `:states` (or `:type :parallel` / `:regions`), but any structural defect the runtime machine contract rejects at `reg-machine` — a nested compound missing `:initial`, a dangling / malformed transition target, an unknown bare node / spawn key, a malformed history / final-state / `:tags` / `:after`-delay shape. **BOTH directions (rf2-qy8p):** on export it gates the spec handed to `spec->scxml`; on import it is `scxml->spec`'s POSTCONDITION — parser output that cannot be represented as a valid re-frame2 definition throws here rather than being returned, so a successful import always yields a machine every other boundary accepts. The thrown ex-data carries the value-free `grammar/definition-summary` under `:spec-summary` (its `:defect :category` is the canonical `:rf.error/machine-*` id) — never the raw spec and never the raw XML — see [The value-free definition summary](#the-value-free-definition-summary) for exactly what that may and may not name. |
 | `:scxml/parse-error`  | Input XML is malformed or missing the `<scxml>` root. |
 
 ## AI-generate-a-machine (v1.1, rf2-1bncf)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -76,6 +76,15 @@
 
   ## Not supported (lossy or omitted)
 
+  - SCXML EXECUTABLE CONTENT and the DATA MODEL — `<onentry>`, `<onexit>`,
+    `<script>`, `<log>`, `<assign>`, `<raise>`, `<send>`, `<datamodel>` /
+    `<data>`, `<invoke>` and any other foreign child of a `<state>`. The
+    import models the static TOPOLOGY only, so on the way IN every such
+    element is IGNORED together with its whole subtree, and on the way OUT
+    none is emitted. Ignoring is the whole of the behaviour (rf2-qy8p): a
+    foreign element never becomes a `:states` entry, and a `<state>` nested
+    inside one is NOT promoted into the parent's `:states`. Only `<state>`,
+    `<final>`, `<history>` and `<transition>` carry meaning here.
   - `:spawn-all` rows — omitted; the parent state renders without
     spawn affordances.
   - INTERNAL-default self / proper-ancestor SELF-TRANSITION semantics
@@ -1250,23 +1259,102 @@
 
 (declare parse-state-block)
 
+;; rf2-qy8p — the CLOSED set of child tags the importer models as topology.
+;; W3C SCXML §3.3 lets a conforming `<state>` carry executable content
+;; (`<onentry>`, `<onexit>`, `<script>`, `<log>`, `<assign>`), a `<datamodel>`
+;; and `<invoke>`. This importer covers the static topology only, so those
+;; families are LOSSY BY DESIGN — the ns docstring's "Not supported" list says
+;; so, and ignoring them is coherent.
+;;
+;; What is NOT coherent is what the collector did before this set existed: it
+;; special-cased `<transition>` and then accepted EVERY remaining tag as a
+;; child state. An `<onentry/>` has no `id`, so `id-string->abs-path nil` →
+;; `[nil]` → a `:states` entry keyed by `nil`; several such elements
+;; overwrote one another; and a `<state>` nested inside one got PROMOTED into
+;; the parent's `:states`. The import then returned a definition
+;; `grammar/valid-definition?` rejects, so the failure surfaced far downstream
+;; as a compound-state error naming a state the programmer never authored.
+(def ^:private topology-child-tags
+  "The SCXML child elements `group-children-by-state` collects as re-frame2
+  topology: `<state>` / `<final>` (ordinary + terminal states) and
+  `<history>` (the pseudo-state `parse-state-block` routes to
+  `parse-history-block`). `<transition>` is handled earlier by
+  `consume-transitions` and skipped here. Every other tag is unsupported and
+  is skipped WITH ITS WHOLE SUBTREE.
+
+  Nested `<parallel>` is deliberately absent: the exporter emits `<parallel>`
+  only as the ROOT (`emit-parallel`), `scxml->spec` handles that root case
+  before it ever reaches this collector, and `parse-state-block` has no
+  nested-parallel branch — so a nested `<parallel>` would have become a
+  malformed state, not a region. Ignoring it is the lossy-by-design answer."
+  #{"state" "final" "history"})
+
+(defn- scan-element-body
+  "Consume one balanced `<tag> … </tag>` element body from `rs` (the tokens
+  AFTER the open tag). Returns `[body rest-tokens]`, where `body` is the
+  interior tokens and `rest-tokens` the stream past the matching close.
+
+  Throws the documented `:scxml/parse-error` for an unclosed element — the
+  same error the inline scan this replaces threw, so malformed-input error
+  ids are unchanged. Shared by the recognised-tag branch (which keeps the
+  body) and the unsupported-tag branch (which discards it), so an
+  unsupported element can never leak its subtree back into the token stream."
+  [tag rs]
+  (loop [body  []
+         depth 1
+         rs    rs]
+    (cond
+      (empty? rs)
+      (rf.error/throw-error!
+        :scxml/parse-error
+        'machines-viz/scxml->spec
+        (str "SCXML import: unclosed <" tag
+             "> element; add the matching </"
+             tag "> closing tag.")
+        {:recovery :close-the-open-element
+         :extra    {:tag tag}})
+
+      (and (= :end (:kind (first rs)))
+           (= tag (:tag (first rs)))
+           (= 1 depth))
+      [body (rest rs)]
+
+      (and (= :start (:kind (first rs)))
+           (= tag (:tag (first rs))))
+      (recur (conj body (first rs)) (inc depth) (rest rs))
+
+      (and (= :end (:kind (first rs)))
+           (= tag (:tag (first rs))))
+      (recur (conj body (first rs)) (dec depth) (rest rs))
+
+      :else
+      (recur (conj body (first rs)) depth (rest rs)))))
+
 (defn- group-children-by-state
   "Given a flat seq of tokens that sit inside one `<state>` body
-  (already excluding transitions), pair every `<state>` /
-  `<final>` open token with its matching close + interior tokens.
-  Returns a seq of `{:start ... :body ... :self? bool}` maps."
+  (already excluding transitions), pair every `<state>` / `<final>` /
+  `<history>` open token with its matching close + interior tokens.
+  Returns a seq of `{:start ... :body ... :self? bool}` maps.
+
+  rf2-qy8p — the tag test is an ALLOWLIST (`topology-child-tags`), not
+  \"everything that is not a `<transition>`\". An unsupported element is
+  skipped: a self-closing one outright, an open one TOGETHER WITH ITS WHOLE
+  SUBTREE (via `scan-element-body`), so markup nested inside it — a `<state>`
+  buried in an `<onentry>`, a `<data>` in a `<datamodel>` — cannot be
+  promoted into the parent's `:states`."
   [tokens]
   (loop [remaining tokens
          acc       []]
     (if (empty? remaining)
       acc
-      (let [t (first remaining)]
+      (let [t   (first remaining)
+            tag (:tag t)]
         (cond
           ;; Transitions are not state blocks — skip them at this
           ;; level. consume-transitions picks up the direct
           ;; transitions before group-children-by-state is called
           ;; on the children-tokens.
-          (and (= "transition" (:tag t))
+          (and (= "transition" tag)
                (or (= :self (:kind t))
                    (= :start (:kind t))
                    (= :end (:kind t))))
@@ -1274,41 +1362,20 @@
 
           (= :self (:kind t))
           (recur (rest remaining)
-                 (conj acc {:start t :body [] :self? true}))
+                 (if (contains? topology-child-tags tag)
+                   (conj acc {:start t :body [] :self? true})
+                   ;; Unsupported self-closing element — ignored (lossy).
+                   acc))
 
           (= :start (:kind t))
-          (let [tag (:tag t)
-                [body rest-tokens] (loop [body []
-                                          depth 1
-                                          rs (rest remaining)]
-                                     (cond
-                                       (empty? rs)
-                                       (rf.error/throw-error!
-                                         :scxml/parse-error
-                                         'machines-viz/scxml->spec
-                                         (str "SCXML import: unclosed <" tag
-                                              "> element; add the matching </"
-                                              tag "> closing tag.")
-                                         {:recovery :close-the-open-element
-                                          :extra    {:tag tag}})
-
-                                       (and (= :end (:kind (first rs)))
-                                            (= tag (:tag (first rs)))
-                                            (= 1 depth))
-                                       [body (rest rs)]
-
-                                       (and (= :start (:kind (first rs)))
-                                            (= tag (:tag (first rs))))
-                                       (recur (conj body (first rs)) (inc depth) (rest rs))
-
-                                       (and (= :end (:kind (first rs)))
-                                            (= tag (:tag (first rs))))
-                                       (recur (conj body (first rs)) (dec depth) (rest rs))
-
-                                       :else
-                                       (recur (conj body (first rs)) depth (rest rs))))]
+          ;; The body is consumed either way; only a recognised tag keeps it.
+          (let [[body rest-tokens] (scan-element-body tag (rest remaining))]
             (recur rest-tokens
-                   (conj acc {:start t :body body :self? false})))
+                   (if (contains? topology-child-tags tag)
+                     (conj acc {:start t :body body :self? false})
+                     ;; Unsupported open element — the WHOLE subtree is
+                     ;; dropped, so nothing inside it is reachable as topology.
+                     acc)))
 
           :else
           (recur (rest remaining) acc))))))
@@ -1459,6 +1526,43 @@
       (:on coll)    (assoc :on    (into {} (map (fn [[ev cs]] [ev (simplify-candidates cs)]) (:on coll))))
       (:after coll) (assoc :after (into {} (map (fn [[k cs]] [k (simplify-candidates cs)]) (:after coll)))))))
 
+(defn- import-postcondition
+  "rf2-qy8p — the IMPORT-side counterpart of the check `spec->scxml` already
+  makes: a definition `scxml->spec` is about to return must be one the rest of
+  re-frame2 accepts. Returns `definition` when it is projectable; otherwise
+  throws the documented `:scxml/invalid-spec`.
+
+  The export side routes its shape check through `grammar/valid-definition?`
+  (rf2-egupfk) and so do `share`, Mermaid, AI-generate and the chart
+  projector — the import side was the ONE public boundary that returned its
+  assembled map unchecked, so a parse that could not be represented as a
+  re-frame2 definition reported SUCCESS and displaced the failure to
+  `reg-machine` / `MachineChart` / the next export. This closes that seam with
+  the same gate, giving the surface one law: a successful import yields a
+  machine every other boundary accepts.
+
+  EP-0015 / Spec 015 §exception-path residual — the ex-data carries the shared
+  value-FREE `grammar/definition-summary` under this ns's `:spec-summary` key.
+  NEITHER the raw SCXML input NOR the parsed definition appears: an imported
+  document is untrusted content and its ids are attacker-chosen in content and
+  size, which is precisely the case the summary exists to describe."
+  [definition]
+  (when-not (g/valid-definition? definition)
+    (rf.error/throw-error!
+      :scxml/invalid-spec
+      'machines-viz/scxml->spec
+      (str "SCXML import: the document parsed, but its topology is not a "
+           "re-frame2 machine definition. A machine needs a keyword :initial "
+           "plus a non-empty :states map (or :type :parallel plus :regions), "
+           "and every compound state needs its own :initial naming one of its "
+           "children. Note that unsupported SCXML executable / data-model "
+           "content is IGNORED rather than imported as topology, so check the "
+           "document's <state> / <final> / <history> structure.")
+      {:recovery :fix-the-imported-machine-topology
+       ;; rf2-8nzxib — value-FREE; never the raw input or the parsed map.
+       :extra    {:spec-summary (g/definition-summary definition)}}))
+  definition)
+
 (defn scxml->spec
   "Parse an SCXML XML string into a re-frame2 machine spec.
 
@@ -1475,7 +1579,24 @@
   document our parser recognises (missing root `<scxml>`, unclosed tags,
   etc.). Throws `:scxml/invalid-spec` if
   the parsed structure is missing required keys (no `:initial`, no
-  `:states`)."
+  `:states`).
+
+  rf2-qy8p — **unsupported SCXML child content is IGNORED, never
+  reinterpreted as topology.** Only `<state>`, `<final>`, `<history>` and
+  `<transition>` are modelled (`topology-child-tags`); a conforming
+  document's `<onentry>`, `<onexit>`, `<script>`, `<log>`, `<assign>`,
+  `<datamodel>` / `<data>` and `<invoke>` are skipped together with their
+  whole subtrees. That is LOSSY, as the ns docstring's \"Not supported\"
+  list says — no executable semantics are imported and nothing nested
+  inside such an element is promoted into `:states`.
+
+  rf2-qy8p — **and success is a postcondition, not a hope**: every
+  definition this returns has passed the canonical recursive grammar gate
+  (`grammar/valid-definition?`), the same one `spec->scxml`, Mermaid,
+  AI-generate, the share codec and the chart projector use. Parser output
+  that cannot be represented as a valid re-frame2 definition throws
+  `:scxml/invalid-spec` (with a value-free `:spec-summary`) rather than
+  returning a structurally invalid map."
   [scxml-string]
   (when-not (string? scxml-string)
     (rf.error/throw-error!
@@ -1528,7 +1649,8 @@
           (first (filter #(and (= "parallel" (:tag %))
                                (= :start (:kind %)))
                          root-body))]
-      (if parallel-token
+      (import-postcondition
+       (if parallel-token
         ;; Parallel definition
         (let [p-start-idx (some (fn [i] (when (identical? (nth root-body i) parallel-token) i))
                                 (range (count root-body)))
@@ -1599,4 +1721,4 @@
             ;; rf2-mnp93.7 — the root `initial` is a top-level state's
             ;; qualified id; the re-frame2 `:initial` is its local key.
             initial-str (assoc :initial (abs-path->local-key
-                                         (id-string->abs-path initial-str)))))))))
+                                         (id-string->abs-path initial-str))))))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -16,6 +16,11 @@
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [clojure.string :as str]
             [clojure.walk :as walk]
+            ;; rf2-qy8p — the canonical recursive grammar gate. The import
+            ;; regressions below assert the POSTCONDITION `scxml->spec` now
+            ;; carries: a successful import is a definition every emitter,
+            ;; the chart projector and `reg-machine` accept.
+            [day8.re-frame2-machines-viz.grammar :as g]
             [day8.re-frame2-machines-viz.scxml :as scxml]))
 
 (defn- deep-strings
@@ -1526,3 +1531,187 @@
       ;; the bead's negative regression: NO retired/foreign cofx vocabulary
       (is (not (str/includes? out "rf.world/inputs")))
       (is (not (str/includes? out "inject-cofx"))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-qy8p — SCXML executable / data-model content is IGNORED, never
+;; reinterpreted as topology
+;;
+;; W3C SCXML §3.3 lets a conforming `<state>` carry `<onentry>`, `<onexit>`,
+;; `<invoke>`, `<datamodel>` and friends. The re-frame2 importer models
+;; TOPOLOGY only — `<state>` / `<final>` / `<history>` / `<transition>` — so
+;; those bodies are LOSSY BY DESIGN, exactly as the ns docstring's
+;; "Not supported" list says.
+;;
+;; What is NOT acceptable is inventing topology out of them. Pre-fix the
+;; direct-child collector accepted EVERY non-transition tag, so an
+;; `<onentry/>` became an id-less `:states` entry keyed by `nil`, and the
+;; import returned a definition `grammar/valid-definition?` — and therefore
+;; `reg-machine`, `MachineChart` and every sibling emitter — rejects. The
+;; failure surfaced far downstream as a compound-state error naming a state
+;; the programmer never authored.
+;;
+;; Two invariants are pinned here:
+;;   1. only recognised topology tags are collected as child states;
+;;   2. every SUCCESSFUL `scxml->spec` result passes the canonical recursive
+;;      grammar gate (the postcondition the public docstring promises).
+
+(def onentry-only-scxml
+  "The minimal reproduction: a conforming `<state>` whose only child is an
+  empty `<onentry/>`."
+  (str "<scxml xmlns='http://www.w3.org/2005/07/scxml' version='1.0' initial='idle'>"
+       "<state id='idle'><onentry/></state>"
+       "</scxml>"))
+
+(deftest import-ignores-empty-onentry-executable-content
+  (testing "rf2-qy8p — an empty <onentry/> is ignored, not promoted to a nil-keyed state"
+    (let [spec (scxml/scxml->spec onentry-only-scxml)]
+      (is (= {:initial :idle :states {:idle {}}} spec)
+          "the state imports bare; the executable body leaves no trace")
+      (is (not (contains? (:states spec) nil))
+          "no phantom nil-keyed state")
+      (is (empty? (get-in spec [:states :idle :states]))
+          "the leaf stays a leaf — <onentry> is not a child state")
+      (is (g/valid-definition? spec)
+          "a successful import passes the canonical recursive grammar gate")
+      (is (nil? (g/definition-defect spec))))))
+
+(def executable-and-datamodel-scxml
+  "Every unsupported family the bead names — `<datamodel>`/`<data>` at the
+  root, `<onentry>` with a `<log>` body, `<invoke>` with a `<param>`, and
+  `<onexit>` with an `<assign>` — wrapped around otherwise supported states
+  and transitions."
+  (str "<scxml xmlns='http://www.w3.org/2005/07/scxml' version='1.0' initial='go'>"
+       "<datamodel><data id='counter' expr='0'/></datamodel>"
+       "<state id='go'>"
+       "<onentry><log expr='entering'/></onentry>"
+       "<invoke type='http://www.w3.org/TR/scxml/'><param name='p' expr='1'/></invoke>"
+       "<transition event='next' target='wait'/>"
+       "</state>"
+       "<state id='wait'>"
+       "<onexit><assign location='counter' expr='counter'/></onexit>"
+       "<transition event='finish' target='done'/>"
+       "</state>"
+       "<final id='done'/>"
+       "</scxml>"))
+
+(deftest import-ignores-executable-and-datamodel-subtrees-wholesale
+  (testing "rf2-qy8p — <datamodel>/<onentry>/<onexit>/<invoke> subtrees are dropped
+            wholesale while the real ids and transitions import exactly"
+    (let [spec (scxml/scxml->spec executable-and-datamodel-scxml)]
+      (is (= {:initial :go
+              :states  {:go   {:on {:next :wait}}
+                        :wait {:on {:finish :done}}
+                        :done {:final? true}}}
+             spec)
+          "topology is exact; every unsupported subtree is ignored")
+      (is (= #{:go :wait :done} (set (keys (:states spec))))
+          "no phantom state from <datamodel> at the root")
+      (is (not (contains? (set (keys (:states spec))) nil)))
+      ;; the unsupported subtrees' own attributes must not leak in as ids
+      (is (not (contains? (:states spec) :counter))
+          "<data id='counter'> is data-model, not a state")
+      (is (g/valid-definition? spec)))))
+
+(def nested-state-inside-unsupported-scxml
+  "An unsupported element that CONTAINS a `<state>`. Skipping only the open
+  tag would promote the nested element into the parent's `:states`; the whole
+  subtree has to go."
+  (str "<scxml xmlns='http://www.w3.org/2005/07/scxml' version='1.0' initial='a'>"
+       "<state id='a'>"
+       "<onentry><state id='sneaky'/><final id='sneakier'/></onentry>"
+       "<transition event='go' target='b'/>"
+       "</state>"
+       "<state id='b'/>"
+       "</scxml>"))
+
+(deftest import-does-not-promote-a-state-nested-in-an-unsupported-element
+  (testing "rf2-qy8p — only DIRECT recognised children are collected; an
+            unsupported element is skipped together with its whole subtree"
+    (let [spec (scxml/scxml->spec nested-state-inside-unsupported-scxml)]
+      (is (= {:initial :a
+              :states  {:a {:on {:go :b}}
+                        :b {}}}
+             spec))
+      (is (empty? (get-in spec [:states :a :states]))
+          "the <state> buried inside <onentry> is NOT promoted")
+      (is (not (contains? (:states spec) :sneaky)))
+      (is (not (contains? (:states spec) :sneakier)))
+      (is (g/valid-definition? spec)))))
+
+(deftest import-tolerates-unsupported-content-around-history-and-compounds
+  (testing "rf2-qy8p — the allowlist keeps <history> and nested compounds; only
+            the unsupported families are dropped"
+    (let [spec (scxml/scxml->spec
+                 (str "<scxml xmlns='http://www.w3.org/2005/07/scxml' version='1.0' initial='outer'>"
+                      "<state id='outer' initial='outer___one'>"
+                      "<onentry><log expr='x'/></onentry>"
+                      "<history id='outer___hist' type='deep'>"
+                      "<transition target='outer___one'/>"
+                      "</history>"
+                      "<state id='outer___one'>"
+                      "<onexit/>"
+                      "<transition event='next' target='outer___two'/>"
+                      "</state>"
+                      "<state id='outer___two'/>"
+                      "</state>"
+                      "</scxml>"))]
+      (is (= {:initial :outer
+              :states  {:outer {:initial :one
+                                :states  {:hist {:type :history :deep? true
+                                                 :default-target :one}
+                                          :one  {:on {:next :two}}
+                                          :two  {}}}}}
+             spec))
+      (is (g/valid-definition? spec)))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-qy8p — the import POSTCONDITION: success implies a projectable
+;; definition. Parser output that cannot be represented as a valid re-frame2
+;; definition throws the documented `:scxml/invalid-spec`, value-free.
+
+(def missing-initial-scxml
+  "No root `initial` — the machine contract wants a keyword `:initial`.
+  Pre-fix this returned `{:states {:a {}}}` silently, contradicting the
+  public docstring's stated error boundary."
+  (str "<scxml xmlns='http://www.w3.org/2005/07/scxml' version='1.0'>"
+       "<state id='a'/></scxml>"))
+
+(deftest import-throws-invalid-spec-rather-than-returning-a-malformed-definition
+  (testing "rf2-qy8p — a document whose topology cannot be a valid re-frame2
+            definition throws :scxml/invalid-spec instead of returning it"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                 (scxml/scxml->spec missing-initial-scxml)))
+    (let [d (try (scxml/scxml->spec missing-initial-scxml)
+                 nil
+                 (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :scxml/invalid-spec (:rf.error/id d)) "the documented discriminator"))))
+
+(deftest import-invalid-spec-error-is-value-free
+  (testing "rf2-qy8p — the import-side invalid-spec ex-data carries only the
+            shared value-free summary: no raw XML, no parsed definition"
+    (let [secret "patientrecordsecret42"
+          xml    (str "<scxml xmlns='http://www.w3.org/2005/07/scxml' version='1.0'>"
+                      "<state id='" secret "'/></scxml>")
+          d      (try (scxml/scxml->spec xml) nil
+                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e)))]
+      (is (= :scxml/invalid-spec (:rf.error/id d)))
+      (is (some? (:spec-summary d)) "value-free summary present")
+      (is (not (contains? d :input)) "no raw :input slot")
+      (is (not (contains? d :spec)) "no raw :spec slot")
+      (is (not (some #(str/includes? % secret) (deep-strings d)))
+          "the id must not survive anywhere in ex-data"))))
+
+(deftest every-supported-fixture-imports-to-a-valid-definition
+  (testing "rf2-qy8p — the postcondition holds across the whole supported
+            round-trip corpus (the guard against a gate that rejects real imports)"
+    (doseq [spec [idle-loading-success-error
+                  compound-machine
+                  namespaced-machine
+                  guarded-machine
+                  after-machine
+                  always-machine
+                  parallel-machine]]
+      (let [imported (scxml/scxml->spec (scxml/spec->scxml spec))]
+        (is (g/valid-definition? imported)
+            (str "import of " (pr-str (or (:initial spec) (:type spec))) " must be projectable"))
+        (is (= spec imported) "and the round-trip stays value-equal")))))


### PR DESCRIPTION
Fixes rf2-qy8p.

## The defect

`scxml->spec` turned ordinary SCXML executable-content elements into `:states`
entries, so a **conforming** W3C SCXML document imported as a structurally
invalid machine — and reported success.

`group-children-by-state`'s docstring said it paired `<state>` / `<final>`
blocks, but after special-casing `<transition>` its `:self` and `:start`
branches accepted *every* tag. `consume-transitions` leaves `<onentry>`,
`<onexit>`, `<datamodel>`, `<data>`, `<invoke>`, `<log>` in `:children-tokens`,
and `parse-state-block` fed them straight back to that grouper. An element with
no `id` became a state keyed by `nil` (`id-string->abs-path nil` → `[nil]`);
several such elements overwrote one another; a `<state>` nested inside one was
promoted into the parent's `:states`.

Measured on the base commit (W3C SCXML §3.3 explicitly permits `<onentry>`
under `<state>`):

```clojure
;; <scxml … initial='idle'><state id='idle'><onentry/></state></scxml>
{:states {:idle {:states {nil {}}}}, :initial :idle}
;; grammar/valid-definition? => false
;; defect => {:category :rf.error/machine-compound-state-missing-initial :path [:idle]}
```

Three more measured cases: `<onentry><log/></onentry>` → nested `{nil {:states
{nil {}}}}`; a root `<datamodel><data id='counter'/></datamodel>` → a top-level
`nil` state holding `:counter`; `<onentry><state id='sneaky'/></onentry>` →
`:sneaky` promoted. The import path also had no final grammar check —
`spec->scxml` validates with `grammar/valid-definition?` and so do share,
Mermaid, AI-generate and the chart projector, but `scxml->spec` returned its
assembled map unchecked. So the public importer reported success with a
definition `reg-machine`, `MachineChart` and every sibling emitter reject, and
the failure surfaced far downstream as a compound-state error naming a state
the programmer never authored.

## The repair

Two bounded changes at the boundaries that already exist. No new XML framework,
no parser replacement.

**1 — the direct-child collector classifies against an allowlist.**
`topology-child-tags` = `#{"state" "final" "history"}` (the tags
`parse-state-block` / `parse-history-block` actually model; `<transition>` is
consumed earlier). An unsupported self-closing element is skipped; an
unsupported *open* element is skipped **together with its whole subtree**, so
nested markup cannot be promoted. The balanced-tag scan is extracted as
`scan-element-body` and shared by both branches, so the recognised branch keeps
the body and the unsupported branch discards it through the same code — and the
unclosed-element `:scxml/parse-error` is unchanged.

Nested `<parallel>` is deliberately **absent** from the allowlist: the exporter
emits `<parallel>` only as the root, `scxml->spec` handles that root case before
the collector ever sees it, and `parse-state-block` has no nested-parallel
branch — so accepting one would mint a malformed state rather than a region.
Ignoring it is the lossy-by-design answer.

**2 — `scxml->spec` gained a postcondition.** `import-postcondition` routes the
assembled definition through the same `grammar/valid-definition?` gate the
export side uses, and throws the documented `:scxml/invalid-spec` rather than
returning a malformed map. Its ex-data carries the shared value-free
`grammar/definition-summary` under this ns's `:spec-summary` key — never the raw
XML, never the parsed definition (EP-0015 / rf2-8nzxib; an imported document is
untrusted content whose ids are attacker-chosen in content and size). This also
makes the behaviour match the docstring, which already promised
`:scxml/invalid-spec` for missing required structure.

**Preserved, as the item requires:** the public `spec->scxml` / `scxml->spec`
signatures, the supported topology mapping, the regex-reader posture (untouched
— no XML parser was introduced), the id codec, and exporter round-trips.

## Red-then-green evidence

Regressions were written **first** and shown red on the unfixed source.

| Run | Command | Result |
|---|---|---|
| RED (tests only, no fix) | `clojure -M:test -n day8.re-frame2-machines-viz.scxml-cljs-test` | **exit 1** — 72 tests, 325 assertions, **17 failures**, 0 errors — all 17 in the six new `deftest`s |
| GREEN (fix applied) | same | **exit 0** — 72 tests, 325 assertions, 0 failures, 0 errors |
| SABOTAGE (fix reverted to the catch-all) | same | **exit 1** — 4 errors, each the new `:scxml/invalid-spec` throw firing on a fixture the catch-all corrupts |

The red log carries the defect verbatim, e.g.

```
expected: (g/valid-definition? spec)
  actual: (not (g/valid-definition? {:states {:idle {:states {nil {}}}}, :initial :idle}))
```

**Negative control.** The pre-fix catch-all was restored by replacing both
`(contains? topology-child-tags tag)` tests with `true`; the source sha256 moved
`b4efffe9…` → `54e4bcec…`, proving the plant was not a silent no-op, and the run
went red. The restore was verified **by hashing the bytes**: the file is back at
`b4efffe944c2283ecac23f930fa03df24ffa2b50fdf23fe1ae42128e135d9c3a`, byte-identical
to the pre-plant state, with both occurrences present again. (The sabotage run
reports *errors* rather than *failures* because with both halves of the fix
present the new postcondition throws before the assertion is reached — the two
halves are independently load-bearing. The plain nil-key-state failure is the
first row above, measured before either half existed.)

**Control on the control.** Each new test was checked against "could this pass
without reaching the defect?". The `<onentry/>` case asserts the *whole* spec
map by equality (not just "no exception"), plus `(not (contains? (:states spec)
nil))`, plus the grammar gate — the pre-fix output fails all three. No existing
test pinned the broken output (`grep '{nil'` on the test file: zero hits,
against a working control of 56 hits for `scxml->spec` in the same file), and no
existing test could have reached the defect: emitter output never creates the
triggering tokens, and the file contained no `<onentry>` / `<onexit>` /
`<datamodel>` / `<invoke>` fixture at all. So these are **additions**, not
replacements — nothing had to be flipped or renamed.

### Round-trip coverage (the "traded one defect for another" guard)

`every-supported-fixture-imports-to-a-valid-definition` walks the flat,
compound, namespaced, guarded, `:after`, `:always` and parallel fixtures and
asserts **both** `(= spec (scxml->spec (spec->scxml spec)))` **and**
`(g/valid-definition? imported)` — so a postcondition that rejected real imports
would red immediately. It passed on the *unfixed* source too, which is the point:
the gate does not narrow what already round-trips. The 40+ pre-existing
round-trip tests (id codec, history, error-finals, reenter axis, on-done,
parallel-root on/after, mixed candidates, non-Latin-1 ids) are all still green,
and the malformed-root / unclosed-input error ids are untouched.

`import-tolerates-unsupported-content-around-history-and-compounds` is the
complement: `<onentry>` and `<onexit>` sitting beside a `<history type='deep'>`
with a default transition and a nested compound — the unsupported families drop,
the `<history>` and the nesting survive exactly.

## Quality gates

| Gate | Command | Exit | Result |
|---|---|---|---|
| machines-viz JVM suite (full artefact, `:test` alias per its own `deps.edn`) | `clojure -M:test` from `tools/machines-viz` | **0** | 649 tests, 2823 assertions, 0 failures, 0 errors |
| machines-viz scxml namespace (focused) | `clojure -M:test -n day8.re-frame2-machines-viz.scxml-cljs-test` | **0** | 72 tests, 325 assertions, 0 failures, 0 errors |
| require-alias dialect ratchet | `python scripts/check_require_alias_dialect.py --verbose` | **0** | clean: 2793 files, 10851 re-frame require edges, every surface at or under its floor |
| view-lifetime-residue ratchet | `python scripts/check_view_lifetime_residue.py --verbose` | **0** | clean: zero residue in tracked content or paths |
| doc-slug link/anchor gate | `python scripts/check_doc_slugs.py` | **0** | silent-clean (`tools/*/spec` is one of its roots, and `spec/API.md` changed) |

Every exit code above is the runner's own, captured to a per-worktree,
per-attempt `.exit` file and read back — no gate was piped through a filter.

**Skipped, with reason:** `scripts/test-fast-pr.sh`, `npm run test:cljs` and any
shadow-cljs build were **not** run — sibling workers are live in this session and
a heavyweight gate wedges rather than fails. **CI owns the spine**, including the
CLJS half of these `.cljc` tests (the `:machines-viz-node-test` shadow build) and
`cljs-examples-compile`. The changed test file is `.cljc`, so the identical
assertions run in both runtimes there.

## Xray spec

**Spec unchanged because no page under `tools/xray/spec/` documents this
surface** — measured, not assumed: `grep -rl 'scxml\|SCXML' tools/xray/spec/`
returns zero across all 33 files (exit 1) against a working control (`xray`
matches throughout the same tree). SCXML import/export is owned by
`tools/machines-viz/spec/API.md` §SCXML import / export, **which this PR
updates**: a new "Not supported (lossy or omitted)" bullet stating that
executable content and the data model are ignored wholesale together with their
subtrees, and an expanded `:scxml/invalid-spec` error row recording that the
gate now binds both directions and that the import-side ex-data carries neither
raw XML nor the parsed definition. The `scxml.cljc` ns docstring and
`scxml->spec`'s own docstring carry the same two statements.

## Verification done by hand

The two link gates do not read prose, tables or rendering, so: the new API.md
bullet adds **no heading** and **no link**, so no anchor is minted or referenced;
the edited `:scxml/invalid-spec` row keeps the table at its existing **2
columns** and its one pre-existing intra-page link
(`#the-value-free-definition-summary`) unchanged. `check_doc_slugs.py` was run
anyway and is green.
