### PR TITLE
docs(method): brief workers to run ratchet gates, and record why condensing strands (rf2-3udw)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -679,6 +679,23 @@ dressed as proportionality. One mayor did it once, on a session's smallest dispa
 pasted the full block on every larger one; the worker behaved anyway, and the outcome does not
 validate the shortcut.
 
+**Measured since, on a dispatch smaller still: the worker did not behave.** A mayor condensed the
+gate-mechanics block for a two-file rename, and the worker ended its turn waiting to be woken — the
+exact failure that block names, refutes and closes, in text the mayor had read and chose not to
+send. Nothing new had to be written to prevent it. **And note WHICH part went missing**, because it
+is not random: a mayor condensing drops what looks least relevant to this task, and what stranded
+the worker was a mechanic belonging to the harness rather than to the task — precisely what looks
+least relevant. A condensed block is not a shorter block; it is a block with the harness mechanics
+taken out of it.
+
+**The pressure is structural, because the block only ever grows.** Every failure it closes adds
+lines, so the better it gets the more it dwarfs a small task, and the more condensing it reads as
+proportionality — a ratchet turning against the one rule that holds it. No wording fixes that, and
+a block cannot be kept short enough to be safe. The defence is that the extraction is MECHANICAL,
+and a mechanical extraction costs the same on the session's smallest dispatch as on its largest:
+if you are weighing which parts this worker needs, you have stopped extracting and started
+paraphrasing.
+
 **But "verbatim" forbids WEAKENING a block, not adding to it — and the paragraphs addressed to YOU
 are not part of what travels.** Where the payload is FENCED, the fence settles it: take the
 fence, and every line outside it is yours. Two of the three here are fenced, and their
@@ -1139,6 +1156,28 @@ restore. Five cautions on the plant itself:
 **Scope a plant to the suite under test.** Where the runner executes a whole lane in one block
 without catching exceptions, a plant that crashes any namespace stops every namespace after it and
 the log still looks plausible. Compare namespace and assertion counts against a control run.
+
+**The gates the brief nominated are not the whole obligation, because a project's RATCHET gates
+grade the PATHS you touched rather than the change you made.** A ratchet permits a recorded count
+and refuses any increase: a per-surface floor that a surface carrying baselined debt already sits
+exactly on, or a retired-vocabulary scan whose permitted count is zero. On either shape an ordinary
+new file — or one word in a comment — is a regression, and no brief nominated the gate, because the
+change looked nothing like its subject. So before you open the change, find the ratchets covering
+your paths, run them, and treat each gate's own output as the authority on what it wants: one that
+fails prints the exact spelling it wanted, so a worker who runs it once needs no further guidance.
+A project keeps them together — a checks directory, and the job lists of the workflows that run
+them — which is where to look. **Do not ask for a list of them, and do not write one**: the set
+grows, and an enumeration is a count, which is the thing that goes stale first.
+
+**Two properties of that repair, both learned by getting them wrong.** These gates grade more than
+the lines you think you changed — some read the whole tracked file, comments and docstrings
+included, so a sentence naming the design you REJECTED fails while the code it describes passes;
+others grade a form nobody counts as part of the change, such as an import edge. And a ratchet is
+repaired by changing your own lines, never by moving its floor: raising a recorded count to admit
+the new debt inverts the gate, and walking that debt down is another item's job, so repairing
+pre-existing violations in files you did not otherwise touch is sprawl into it. Read the gate's
+WHOLE output before you fix — it names every surface over its floor, where a number quoted into a
+brief from a failed run names one.
 
 **Re-run the gates on the final base after every rebase.** A pre-rebase green is evidence about a
 tree that no longer exists, and nothing warns you: the rebase reports success and the old log still


### PR DESCRIPTION
Fixes rf2-3udw. Two defects in `docs/the-mayor-method/dispatch-prompt-template.md`, measured in one dispatch wave. One file changed, 39 insertions, 0 deletions.

## Half one — content that was missing (gate-mechanics block)

Dispatch briefs never mentioned the project's **ratchet gates**, so a worker adding an ordinary new test file trips a per-surface floor, or writes one word in an explanatory comment and trips a zero-tolerance vocabulary scan. The failure surfaces only in CI, after the worker has reported done and marked its PR ready, costing a draft-conversion, a fix dispatch, a rebase, a suite re-run and a second review.

Two paragraphs added to the gate-mechanics block, beside the other pre-push obligations (re-run after rebase, diff against merge base).

**A discovery instruction, not a list of gates**, per the bead. The measured reason is stronger than the bead knew: a census of `scripts/` finds **18** gates self-describing as ratchet / residue / retired-vocabulary / floor / baseline, of which at least nine are the shape an ordinary change can trip — not the three the bead names. Any enumeration would need amending on every new gate. The document's own `Counts are claims, and they go stale first` section already rules that a brief should "name the class rather than the count", so this follows a rule the page already carries.

Carries the two non-obvious properties the bead requires: these gates grade **more than the lines you think you changed** — prose and comments for the residue scans, an import edge for the alias ratchet — and a ratchet is **repaired by changing your own lines, never by moving its floor**, with the "read the gate's whole output" lesson from the bead's third measured case.

The added paragraph carries **no markdown link**, deliberately: the travelling block currently contains zero links, and the page forbids handing a worker a pointer to a neighbouring section it cannot see.

## Half two — content that already existed and was not delivered (Pasting a block)

A fix dispatch stranded by ending its turn on a monitor. The gate-mechanics block already states that rule, already names the class rather than the instances, and already refutes the harness promise that keeps re-arming it. It failed only because the brief was condensed instead of pasted.

That section's sole evidence was a case where condensing proved harmless ("the worker behaved anyway"). This records the case where it did not, and adds the shape of the failure: a mayor condensing drops what looks least relevant to the task, and the harness mechanics are exactly what looks least relevant — so a condensed block is not a shorter block, it is a block with the harness mechanics taken out.

**The two halves interact, and the document now says so.** Adding half one lengthens the block, which increases the pressure to condense it on small dispatches — the very pressure that produced half two. Two things follow, both deliberate: half two's text is placed in mayor-facing prose **outside** the block that travels, so the payload does not grow by it; and the new paragraph states that no wording fixes the pressure and a block cannot be kept short enough to be safe — the defence is that the extraction is mechanical, costing the same on the smallest dispatch as the largest.

## Quality gates

Every gate was redirected to a log with the runner's own exit code echoed on one command line in one shell; none piped through a filter. All numbers below are the captured exit codes, not harness-reported ones. All four re-run on the final base after the rebase onto `origin/main`.

| Gate | Captured exit | Covers this change? |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | Yes — the gate for this path |
| `python scripts/check_readme_links.py --ci` | **0** | **No — vacuous here, see below** |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | Yes (repo-wide) |
| `python scripts/check_view_lifetime_residue.py --verbose` | **0** | Yes (repo-wide) |

4 passed, 0 failed.

**Non-vacuity proof.** Both link gates exit 0 with an empty log, so a green alone proves nothing. A broken anchor was planted mid-line at a line already being edited (match count read as exactly 1 before running; `core.autocrlf=true`, so the anchor avoids end-of-line). Blob hash moved `db7c9891` -> `54d9e18c`, proving the plant applied rather than silently no-opping. On that planted tree:

- `check_doc_slugs.py` -> **exit 1**, naming the file, line 1170 and the planted anchor. Non-vacuous.
- `check_readme_links.py --ci` -> **exit 0**, empty log, on the *same* planted tree.

That second result is the finding, not a pass: `check_readme_links.py` excludes `DOCS_GATE_ROOTS`, which contains `docs/`, so it does not cover `docs/the-mayor-method/` at all. Its green is reported here as vacuous rather than claimed as coverage.

Restore verified by **git blob hash**, not by reading a diff: back to `db7c9891...`, byte-identical to pre-plant, with the working tree clean against HEAD. The edit was committed before anything was planted, so the restore could not discard it.

**`mkdocs build --strict` — checked, not nominated.** `mkdocs.yml`'s `exclude_docs` lists `tools/playground/`, the two codemod trees, and `design/freehand|hicasso|retirement/` only; `docs_dir` is `docs`. So `docs/the-mayor-method/` is **not** excluded and the strict build does cover it for link *resolution*. It is skipped here for a different reason: this change adds no links whatever (net zero), so the build has nothing new to resolve; it does not validate heading anchors in any case (MkDocs grades those at INFO, which `--strict` does not promote), which is the class the planted fault was in; and siblings are live, so heavyweight gates were kept off the machine. `docs.yml` runs it in CI regardless.

**Markdown tables:** the file contains zero table rows and the diff adds zero, so there were no pipes to count. Nothing validates the added prose itself; it was proofread by hand.

No AI-attribution trailer on the commit or in this body, per the checked-in project convention.