### PR TITLE
test: pin the reply ENVELOPE work-identity spelling (rf2-xy3g) + deterministic Nine States overlap witness (rf2-5bmi)

### DIFF
--- a/implementation/event-conformance/test/re_frame/event_reply_envelope_conformance_cljs_test.cljc
+++ b/implementation/event-conformance/test/re_frame/event_reply_envelope_conformance_cljs_test.cljc
@@ -49,14 +49,22 @@
 
 (def ^:private completed-at-ms 1781078400456)
 
+;; CROSS-RECORD SPELLING (rf2-l7s7b7, Managed-Effects §The reply map). The
+;; TRANSIENT reply envelope single-roots the work identity as
+;; `:rf.reply/work-id` / `:rf.reply/work-kind`. The SAME fact is spelled bare
+;; `:work/id` / `:work/kind` on the DURABLE work-ledger row, the runtime
+;; verification payload, and an entry's `:current-work` — and on the data-only
+;; carried/current stale-gate maps below, which are ledger correlation rather
+;; than envelope fields. Two spellings, two record layers, one fact each. A
+;; fixture is an executable example, so it must model the layer it claims.
 (def ^:private canonical-reply
-  {:status       :ok
-   :value        {:article {:id 42 :title "Welcome"}}
-   :work/id      [:rf.work/resource [:rf.scope/global :article/by-id {:id 42}] 1]
-   :work/kind    :resource
+  {:status                :ok
+   :value                 {:article {:id 42 :title "Welcome"}}
+   :rf.reply/work-id      [:rf.work/resource [:rf.scope/global :article/by-id {:id 42}] 1]
+   :rf.reply/work-kind    :resource
    :rf.reply/work-status  :completed
-   :rf.frame/id  :rf/default
-   :completed-at completed-at-ms})
+   :rf.frame/id           :rf/default
+   :completed-at          completed-at-ms})
 
 ;; Image resolution stores the registration descriptor plus its selection keys
 ;; (mirrors `event_frame_isolation_conformance`): a frame's OWN image handler,
@@ -117,11 +125,22 @@
                 ":value preserved")
             (is (nil? (:error delivered-reply)) "no :error on an :ok reply")
             (is (= [:rf.work/resource [:rf.scope/global :article/by-id {:id 42}] 1]
-                   (:work/id delivered-reply))
-                ":work/id tuple preserved")
-            (is (= :rf.work/resource (first (:work/id delivered-reply)))
-                ":work/id head is the family head")
-            (is (= :resource (:work/kind delivered-reply)) ":work/kind preserved")
+                   (:rf.reply/work-id delivered-reply))
+                ":rf.reply/work-id tuple preserved")
+            (is (= :rf.work/resource (first (:rf.reply/work-id delivered-reply)))
+                ":rf.reply/work-id head is the family head")
+            (is (= :resource (:rf.reply/work-kind delivered-reply))
+                ":rf.reply/work-kind preserved")
+            (testing "TOOTH — ordinary delivery keeps the identity on the
+                      TRANSIENT-ENVELOPE spelling and grows NO top-level bare
+                      ledger alias beside it (rf2-xy3g). A runtime that
+                      regressed to the durable `:work/id` spelling, or that
+                      carried both, is caught here rather than passing a
+                      fixture that modelled the wrong record layer."
+              (is (not (contains? delivered-reply :work/id))
+                  "no top-level bare :work/id alias on a delivered reply envelope")
+              (is (not (contains? delivered-reply :work/kind))
+                  "no top-level bare :work/kind alias on a delivered reply envelope"))
             (is (= :completed (:rf.reply/work-status delivered-reply))
                 ":rf.reply/work-status preserved")
             (is (= :rf/default (:rf.frame/id delivered-reply)) ":rf.frame/id preserved")
@@ -171,6 +190,10 @@
                            image-registrations)
           ;; A PLAIN app-shaped target — nothing capability-bearing rides it.
           reply-target [:article/loaded {:id 42}]
+          ;; The carried/current stale-GATE maps are data-only LEDGER
+          ;; correlation, so they keep the bare `:work/id` spelling. Reading
+          ;; that bare fact and placing it under `:rf.reply/work-id` in `extra`
+          ;; IS the record -> envelope hop, spelled out.
           carried-correlation
           {:work/id [:rf.work/resource [:rf.scope/global :r {}] 4]
            :generation 4}
@@ -179,9 +202,9 @@
            :generation 5}
           suppression-outcome
           (rf.reply/suppress reply-target carried-correlation current-correlation
-            {:rf.reply/work-id (:work/id carried-correlation)
-                     :work/kind        :resource
-                     :rf.frame/id      :evt.reply/frame})]
+            {:rf.reply/work-id   (:work/id carried-correlation)
+             :rf.reply/work-kind :resource
+             :rf.frame/id        :evt.reply/frame})]
       (testing "TOOTH — app non-delivery: the suppress outcome is universally
                 non-delivering, so the ONLY way the stale reply reaches a handler
                 is a deliberate observer self-dispatch"
@@ -205,6 +228,24 @@
               "the delivered envelope is :status :stale")
           (is (= :suppressed (:rf.reply/work-status delivered-reply))
               ":rf.reply/work-status :suppressed")
+          (testing "TOOTH — the suppression boundary carries the identity
+                    forward on the TRANSIENT-ENVELOPE spelling and grows NO
+                    top-level bare ledger alias (rf2-xy3g). The carried gate
+                    map keeps its bare `:work/id`; the envelope does not
+                    inherit it."
+            (is (= (:work/id carried-correlation) (:rf.reply/work-id delivered-reply))
+                "the CARRIED work id rides the stale envelope as :rf.reply/work-id")
+            (is (= :resource (:rf.reply/work-kind delivered-reply))
+                ":rf.reply/work-kind rides the stale envelope")
+            (is (not (contains? delivered-reply :work/id))
+                "no top-level bare :work/id alias on the stale reply envelope")
+            (is (not (contains? delivered-reply :work/kind))
+                "no top-level bare :work/kind alias on the stale reply envelope")
+            (is (= (:work/id carried-correlation)
+                   (:rf.reply/work-id (:trace suppression-outcome)))
+                "the suppression TRACE reads its work id off the envelope spelling")
+            (is (= carried-correlation (:rf.reply/carried (:trace suppression-outcome)))
+                "the trace keeps the carried LEDGER gate map verbatim, bare keys intact"))
           (is (true? (:stale? delivered-reply)) "the :stale? marker rides")
           (is (some? (:rf.reply/stale-reason delivered-reply))
               "a :rf.reply/stale-reason rides")

--- a/implementation/http/test/re_frame/nine_states_overlap_cljs_test.cljs
+++ b/implementation/http/test/re_frame/nine_states_overlap_cljs_test.cljs
@@ -1,0 +1,484 @@
+(ns re-frame.nine-states-overlap-cljs-test
+  "rf2-5bmi — the DETERMINISTIC overlap witness for the Nine States example's
+  newest-intent-wins guarantee (rf2-t9va landed the shared stable
+  `:request-id`; this proves it does the work claimed for it).
+
+  ## Why it lives here and not beside the example
+
+  The example tree is TEST-FREE by a locked project rule (rf2-8cevm) — no
+  `*.spec.cjs`, and no test namespace of any kind, may live under `examples/`.
+  So the fixtures that exercise an example live in the framework test tree, and
+  `implementation/http/test/` is the right shelf for THIS one: its subject is
+  the managed-HTTP in-flight registry and its same-`:request-id` supersession
+  boundary, which is this artefact's own contract. The sibling
+  `re-frame.http-managed-demo-frame-isolation-cljs-test` is the standing
+  precedent — an example-behaviour regression parked here for exactly that
+  reason. Both resolve their example namespace because the consolidated
+  `:node-test` CLJS build carries `http/test` and the `../examples/*` roots on
+  one classpath, so `nine-states.core` registers its events / subs / machine at
+  ns-load and this suite drives the SHIPPED events rather than a copy of them.
+
+  ## Why the example's own stub cannot prove this
+
+  The running app routes `:rf.http/managed` through an `:fx-overrides` demo
+  stub, and an override REPLACES the effect outright: the framework's in-flight
+  registry — and with it supersession — never runs, and the canned replies
+  settle synchronously one at a time. So no gate executed the superseding path
+  for this example at all. These tests therefore create their frames with NO
+  `:fx-overrides`, so the REAL `:rf.http/managed` effect runs, and control only
+  the TRANSPORT.
+
+  ## Why it is deterministic rather than a race
+
+  Nothing here sleeps and hopes. `js/fetch` is stubbed with a transport that
+  PARKS each attempt inside its own body read: the response headers resolve
+  immediately, and `.text()` hands back a promise whose resolver the TEST holds.
+  An attempt therefore sits open, mid-finalisation, until this file settles it
+  by hand — so the interleaving is PLACED, not raced. `poll-until` waits only
+  for a state this file then acts on, and never for a deadline to decide an
+  assertion. That harness is the one `re-frame.http-cljs-test` already uses for
+  its supersede-race coverage (`with-controlled-body-fetch`); this is the
+  multi-attempt form of it.
+
+  ## The teeth
+
+  Each row holds attempt A open, issues attempt B through the shipped example
+  event while A is still open, then settles A FIRST and proves the machine did
+  not move — A's reply reached no app target and mutated nothing — before
+  settling B and proving exactly B's result. One row crosses request KIND in
+  each direction, so `:nine-states.demo/load` and
+  `:nine-states.demo/load-with-failure` are proven to share ONE replacement
+  lane. A reset-then-reload row covers the window `:reset` alone leaves open.
+  And a negative control issues the overlap under a DIFFERENT id and asserts
+  the OPPOSITE outcome — the stale reply lands and clobbers the machine —
+  so the shared id is shown to be what does the work.
+
+  ## Per-row isolation
+
+  `cljs.test` runs a wrap-style `use-fixtures` around the whole `deftest`, which
+  would tear down before an `async` body finished, and a `:each` fixture resets
+  once per `deftest` and NOT once per row of a table. Both are wrong here, so
+  this ns does neither: setup is inline (mirroring `re-frame.http-cljs-test`,
+  which carries `async` tests for the same reason) and EVERY row builds its own
+  fresh frame and clears the in-flight registry itself, inside the driver. Each
+  row's assertions read that row's own frame, so a row cannot observe a board an
+  earlier row left behind. `overlap-cross-kind-row-in-isolation` runs one row on
+  its own to pin that claim from the other side."
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [clojure.string :as string]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            ;; Drives the REAL managed pipeline: fx registration + the
+            ;; in-flight registry whose same-id supersession is the subject.
+            [re-frame.http.managed :as rf.http.managed]
+            [re-frame.http.registry :as rf.http.registry]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.views]
+            ;; The example's production source. Requiring it registers the
+            ;; events / subs / machine this suite drives.
+            [nine-states.core :as nine-states]))
+
+;; ---------------------------------------------------------------------------
+;; The controlled transport — the interleaving is PLACED, never raced
+;; ---------------------------------------------------------------------------
+
+(def ^:private fail-url-re
+  "The example's rigged-to-fail endpoint. `:nine-states.demo/load-with-failure`
+  issues it; every other load hits the succeeding one. Matched rather than
+  compared because the transport appends the query string."
+  #"/api/todos/fail")
+
+(defn- parked-response
+  "A Fetch `Response` stand-in whose HEADERS resolve immediately but whose
+  `.text()` body reader returns a promise this file settles by hand. Sets
+  `read-fired` true the moment the reader is invoked (the framework has the
+  Response and is mid-finalisation) and captures the resolver into `settle`.
+  `status` selects the success / failure arm, matching the example's own
+  URL routing."
+  [status read-fired settle]
+  #js {:ok         (and (>= status 200) (< status 300))
+       :status     status
+       :statusText ""
+       ;; Fetch-`Headers`-like: `forEach (value key)`.
+       :headers    #js {:forEach (fn [cb] (cb "application/json" "content-type"))}
+       :text       (fn []
+                     (reset! read-fired true)
+                     (js/Promise. (fn [res _] (reset! settle res))))})
+
+(defn- with-parked-fetch
+  "Stub `js/fetch` so EVERY attempt parks inside its own body read. Returns
+  `{:restore :attempts}`, where `attempts` is an atom holding one map per
+  attempt IN ISSUE ORDER — `{:url :read-fired :settle}`. Ordering by issue is
+  what lets a row address 'the older attempt' and 'the newer attempt' without
+  keying off a URL, so two loads of the SAME kind are still separable."
+  []
+  (let [orig     (.-fetch js/globalThis)
+        attempts (atom [])]
+    (set! (.-fetch js/globalThis)
+          (fn [url _init]
+            (let [url-str    (str url)
+                  read-fired (atom false)
+                  settle     (atom nil)
+                  status     (if (re-find fail-url-re url-str) 500 200)]
+              (swap! attempts conj {:url        url-str
+                                    :read-fired read-fired
+                                    :settle     settle})
+              (js/Promise.resolve (parked-response status read-fired settle)))))
+    {:restore  (fn [] (set! (.-fetch js/globalThis) orig))
+     :attempts attempts}))
+
+(defn- attempt-open?
+  "True once attempt `i` has been issued AND is parked inside its body read —
+  the exact moment this file can act on it."
+  [attempts i]
+  (let [a (get @attempts i)]
+    (boolean (and a @(:read-fired a) (some? @(:settle a))))))
+
+(defn- settle-attempt!
+  "Settle attempt `i`'s parked body with `body-text`."
+  [attempts i body-text]
+  (let [res @(:settle (get @attempts i))]
+    (res body-text)))
+
+(defn- next-macrotask
+  "Resolves on the next `setTimeout 0` macrotask, so every queued microtask
+  (handle-response! -> finalise-*) drains. A suppressed reply would have landed
+  by the time this settles, which is what makes the 'machine did not move'
+  assertions load-bearing rather than merely early."
+  []
+  (js/Promise. (fn [resolve _] (js/setTimeout resolve 0))))
+
+;; ---------------------------------------------------------------------------
+;; Example-shaped fixtures
+;; ---------------------------------------------------------------------------
+
+(defn- todos-json
+  "`n` todos as the JSON body the example's decode expects. `json-parse`
+  keywordizes object keys, so this decodes to the `Todo` shape the machine's
+  `[:schemas :data]` slot validates on every transition."
+  [n]
+  (str "["
+       (string/join
+         ","
+         (for [i (range n)]
+           (str "{\"id\":\"todo-" i "\",\"title\":\"Todo #" (inc i) "\",\"done?\":false}")))
+       "]"))
+
+(def ^:private failure-json
+  "A body for the rigged-to-fail endpoint. The 500 classifies before the body
+  matters, but the reader still runs, so it must be well-formed."
+  "{\"message\":\"Network unreachable.\"}")
+
+(defn- body-for
+  "The body text an attempt at `url` should settle with. `n` sizes the success
+  payload so a row can pin WHICH load won by cardinality alone."
+  [url n]
+  (if (re-find fail-url-re url)
+    failure-json
+    (todos-json n)))
+
+(defn- fresh-frame!
+  "A frame per ROW — this is the per-row reset. No `:fx-overrides`, so the REAL
+  `:rf.http/managed` runs. `:nine-states.app/initialise` seeds the form slice
+  and broadcasts `:reset`, so the machine starts every row at `:nothing` with
+  its owned data cleared."
+  [label]
+  (rf.http.managed/clear-all-in-flight!)
+  (let [f (rf.frame/make-anon-frame-record! {:doc label})]
+    (rf/dispatch-sync [:nine-states.app/initialise] {:frame f})
+    f))
+
+(defn- snapshot
+  "The `:ui/nine-states` machine snapshot — `:state` (region -> state for a
+  parallel machine), the `:tags` union, and the shared `:data`."
+  [frame]
+  (get-in (rf/frame-state-value frame)
+          [:rf.db/runtime :rf.runtime/machines :snapshots :ui/nine-states]))
+
+(defn- data-state [frame] (get-in (snapshot frame) [:state :data]))
+(defn- tags [frame] (:tags (snapshot frame)))
+(defn- items [frame] (get-in (snapshot frame) [:data :items]))
+(defn- recorded-error [frame] (get-in (snapshot frame) [:data :error]))
+(defn- render-model [frame] (rf/compute-sub [:ui/render] (rf/frame-state-value frame)))
+
+;; ---------------------------------------------------------------------------
+;; The row driver
+;; ---------------------------------------------------------------------------
+
+(defn- run-overlap-row!
+  "Drive ONE overlap row and return a promise that settles when its assertions
+  are done.
+
+  `older` / `newer` are shipped example events. `older-n` / `newer-n` size each
+  attempt's success payload. `expect` pins the settled board.
+
+  The sequence is fixed and fully placed:
+    1. issue `older`      -> park attempt 0 mid body read
+    2. issue `newer`      -> park attempt 1; same `:request-id` supersedes 0
+    3. settle attempt 0   -> drain -> the machine MUST NOT have moved
+    4. settle attempt 1   -> drain -> exactly the newer result"
+  [{:keys [label older newer older-n newer-n expect]}]
+  (let [{:keys [restore attempts]} (with-parked-fetch)
+        frame (fresh-frame! label)]
+    (testing label
+      (is (= :nothing (data-state frame))
+          "the row starts from a clean board — the per-row frame + :reset")
+      (rf/dispatch-sync older {:frame frame})
+      (-> (rf.test-support/poll-until
+            #(when (attempt-open? attempts 0) true)
+            {:timeout-ms 2000 :label "nine-states overlap: older attempt open"})
+          (.then
+            (fn [_]
+              (is (= :loading (data-state frame))
+                  "the older intent moved the :data region to :loading")
+              (is (= :loading (render-model frame)) "and :ui/render says :loading")
+              (is (some? (rf.http.registry/lookup-in-flight
+                           frame nine-states/data-load-request-id))
+                  "the older attempt is registered under the page's ONE data-load id")
+              ;; The newer intent, issued while the older is still open.
+              (rf/dispatch-sync newer {:frame frame})
+              (rf.test-support/poll-until
+                #(when (attempt-open? attempts 1) true)
+                {:timeout-ms 2000 :label "nine-states overlap: newer attempt open"})))
+          (.then
+            (fn [_]
+              (is (= 2 (count @attempts))
+                  "both intents really reached the transport — the overlap is real")
+              (is (some? (rf.http.registry/lookup-in-flight
+                           frame nine-states/data-load-request-id))
+                  "the newer attempt REPLACED the older one under the same id")
+              ;; Settle the SUPERSEDED attempt first. This is the whole point.
+              (settle-attempt! attempts 0 (body-for (:url (get @attempts 0)) older-n))
+              (next-macrotask)))
+          (.then (fn [_] (next-macrotask)))
+          (.then
+            (fn [_]
+              (testing "TOOTH — the superseded attempt's completion reaches NO app
+                        target and cannot move or mutate the machine"
+                (is (= :loading (data-state frame))
+                    "the :data region is STILL :loading — the stale reply moved nothing")
+                (is (= :loading (render-model frame))
+                    ":ui/render is still :loading")
+                (is (empty? (items frame))
+                    "no :items were written by the superseded attempt")
+                (is (nil? (recorded-error frame))
+                    "no :error was recorded by the superseded attempt"))
+              ;; Now the winner.
+              (settle-attempt! attempts 1 (body-for (:url (get @attempts 1)) newer-n))
+              (next-macrotask)))
+          (.then (fn [_] (next-macrotask)))
+          (.then
+            (fn [_]
+              (testing "the NEWER intent's result is the one that lands, whole"
+                (is (= (:data-state expect) (data-state frame))
+                    "the :data region settled on the newer attempt's bucket")
+                (is (contains? (tags frame) (:tag expect))
+                    "the newer attempt's tag is in the machine's tag union")
+                (is (= (:render expect) (render-model frame))
+                    ":ui/render resolves to the newer attempt's view")
+                (is (= (:item-count expect) (count (items frame)))
+                    "exactly the newer attempt's :items")
+                (if (:error? expect)
+                  (is (some? (recorded-error frame))
+                      "the newer FAILURE recorded its :error")
+                  (is (nil? (recorded-error frame))
+                      "a newer SUCCESS leaves no :error behind")))))
+          (.catch (fn [e]
+                    (is false (str "rf2-5bmi — unexpected in row " label ": " e))
+                    nil))
+          (.finally (fn [] (restore)))))))
+
+(def ^:private overlap-rows
+  "Newest-intent-wins across every combination that matters. `too-many-threshold`
+  is 7, so 25 items is `:too-many`, 1 is `:one`, 4 is `:some`."
+  [{:label      "same kind — an older success is superseded by a newer success"
+    :older      [:nine-states.demo/load {:n 25}]
+    :newer      [:nine-states.demo/load {:n 1}]
+    :older-n    25
+    :newer-n    1
+    :expect     {:data-state :one :tag :data/one :render :one
+                 :item-count 1 :error? false}}
+
+   {:label      "CROSS KIND — an older success is superseded by a newer failure"
+    :older      [:nine-states.demo/load {:n 4}]
+    :newer      [:nine-states.demo/load-with-failure]
+    :older-n    4
+    :newer-n    0
+    :expect     {:data-state :error :tag :data/error :render :error
+                 :item-count 0 :error? true}}
+
+   {:label      "CROSS KIND — an older failure is superseded by a newer success"
+    :older      [:nine-states.demo/load-with-failure]
+    :newer      [:nine-states.demo/load {:n 4}]
+    :older-n    0
+    :newer-n    4
+    :expect     {:data-state :some :tag :data/some :render :some
+                 :item-count 4 :error? false}}])
+
+(defn- run-rows!
+  "Sequential promise chain over the rows. Sequential because each row owns the
+  global `js/fetch` stub for its duration."
+  [rows]
+  (if-let [row (first rows)]
+    (-> (run-overlap-row! row)
+        (.then (fn [_] (run-rows! (rest rows)))))
+    (js/Promise.resolve :done)))
+
+;; ---------------------------------------------------------------------------
+;; The witness
+;; ---------------------------------------------------------------------------
+
+(deftest overlapping-loads-are-newest-intent-wins
+  (testing "rf2-5bmi / rf2-t9va — both shipped load events fill ONE data-load
+  slot under one stable :request-id, so issuing either while the other is still
+  in flight supersedes it. The superseded attempt's completion — success or
+  failure — reaches no app target and cannot move the :ui/nine-states machine;
+  the newest intent's result lands whole."
+    (async done
+      ;; Inline setup: a wrap-style `use-fixtures` would tear down before this
+      ;; async body finished, and a `:each` fixture would reset once for the
+      ;; whole deftest rather than once per ROW. Each row resets itself.
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (-> (run-rows! overlap-rows)
+          (.catch (fn [e] (is false (str "rf2-5bmi — unexpected: " e)) nil))
+          (.then (fn [_] (done)))))))
+
+(deftest overlap-cross-kind-row-in-isolation
+  (testing "rf2-5bmi — the same cross-kind row run ALONE. A table-driven suite
+  can pass only because an earlier row left the board in a helpful state, so one
+  row is pinned in isolation too; it must reach the identical verdict."
+    (async done
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (-> (run-overlap-row! (second overlap-rows))
+          (.catch (fn [e] (is false (str "rf2-5bmi — unexpected: " e)) nil))
+          (.then (fn [_] (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; Reset-then-reload — the window `:reset` alone leaves open
+;; ---------------------------------------------------------------------------
+
+(deftest reset-then-reload-cannot-be-overwritten-by-the-pre-reset-attempt
+  (testing "rf2-5bmi — `:reset` abandons the view but NOT the request: it drops
+  :data to :nothing and leaves the in-flight attempt live. The existing
+  reset-to-:nothing coverage settles a completion while still AT :nothing, where
+  it is trivially ignored. The dangerous window is the RELOAD, which puts the
+  region back at :loading — a state that accepts :fetch-succeeded. What closes
+  it is the same-id supersession on that reload, and this is that proof."
+    (async done
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (let [{:keys [restore attempts]} (with-parked-fetch)
+            frame (fresh-frame! "reset-then-reload")]
+        (rf/dispatch-sync [:nine-states.demo/load {:n 25}] {:frame frame})
+        (-> (rf.test-support/poll-until
+              #(when (attempt-open? attempts 0) true)
+              {:timeout-ms 2000 :label "reset-then-reload: pre-reset attempt open"})
+            (.then
+              (fn [_]
+                (is (= :loading (data-state frame)) "the pre-reset load is in flight")
+                ;; `:reset` — the view goes back to square one, the request does not.
+                (rf/dispatch-sync [:nine-states.app/initialise] {:frame frame})
+                (is (= :nothing (data-state frame))
+                    ":reset dropped the :data region to :nothing")
+                (is (some? (rf.http.registry/lookup-in-flight
+                             frame nine-states/data-load-request-id))
+                    "TOOTH — :reset did NOT abort the in-flight attempt; it is still registered")
+                ;; The reload. THIS is what supersedes the abandoned attempt.
+                (rf/dispatch-sync [:nine-states.demo/load {:n 1}] {:frame frame})
+                (rf.test-support/poll-until
+                  #(when (attempt-open? attempts 1) true)
+                  {:timeout-ms 2000 :label "reset-then-reload: reload attempt open"})))
+            (.then
+              (fn [_]
+                (is (= :loading (data-state frame))
+                    "the reload put the region back at :loading — the state that would
+                     have accepted the abandoned attempt's reply")
+                (settle-attempt! attempts 0 (todos-json 25))
+                (next-macrotask)))
+            (.then (fn [_] (next-macrotask)))
+            (.then
+              (fn [_]
+                (is (= :loading (data-state frame))
+                    "the pre-reset attempt's completion did NOT resurrect its result")
+                (is (empty? (items frame))
+                    "no pre-reset :items were written")
+                (settle-attempt! attempts 1 (todos-json 1))
+                (next-macrotask)))
+            (.then (fn [_] (next-macrotask)))
+            (.then
+              (fn [_]
+                (is (= :one (data-state frame)) "the RELOAD's result is the one that lands")
+                (is (= 1 (count (items frame))) "exactly the reload's single item")
+                (is (= :one (render-model frame)) ":ui/render follows the reload")))
+            (.catch (fn [e] (is false (str "rf2-5bmi — unexpected: " e)) nil))
+            (.then (fn [_] (restore) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; Negative control — the shared id is what does the work
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event :nine-states.overlap-test/load-under-a-different-id
+  {:doc "NEGATIVE CONTROL (rf2-5bmi). Byte-for-byte the shipped
+         `:nine-states.demo/load` request, except for the one field under test:
+         a DIFFERENT `:request-id`. Test-local; the example is untouched. If
+         the shared id were incidental rather than load-bearing, this event
+         would behave exactly like the shipped one and the control below would
+         be unable to tell them apart."}
+  (fn handler-overlap-test-load [_ [_ {:keys [n]}]]
+    {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
+          [:rf.http/managed
+           {:request    {:method :get
+                         :url    "/api/todos"
+                         :query  {:n (or n 0)}}
+            :decode     :json
+            :request-id :nine-states.overlap-test/a-different-slot
+            :on-success [:nine-states.demo/loaded]
+            :on-failure [:nine-states.demo/load-failed]}]]}))
+
+(deftest a-different-request-id-lets-the-stale-reply-through
+  (testing "rf2-5bmi NEGATIVE CONTROL — run the identical overlap with the newer
+  request issued under a DIFFERENT :request-id and the witness inverts: nothing
+  supersedes the older attempt, so its late completion DOES reach
+  :nine-states.demo/loaded and DOES clobber the machine with the stale result.
+  That is the failure the shared `data-load-request-id` exists to prevent, and
+  it is what makes every assertion above a property of the shared id rather than
+  of the harness."
+    (async done
+      (rf/init! rf.adapter.reagent/adapter)
+      (rf.frame/ensure-default-frame!)
+      (let [{:keys [restore attempts]} (with-parked-fetch)
+            frame (fresh-frame! "negative control — different request id")]
+        (rf/dispatch-sync [:nine-states.demo/load {:n 25}] {:frame frame})
+        (-> (rf.test-support/poll-until
+              #(when (attempt-open? attempts 0) true)
+              {:timeout-ms 2000 :label "negative control: older attempt open"})
+            (.then
+              (fn [_]
+                ;; Same overlap, one field different.
+                (rf/dispatch-sync
+                  [:nine-states.overlap-test/load-under-a-different-id {:n 1}]
+                  {:frame frame})
+                (rf.test-support/poll-until
+                  #(when (attempt-open? attempts 1) true)
+                  {:timeout-ms 2000 :label "negative control: newer attempt open"})))
+            (.then
+              (fn [_]
+                (is (some? (rf.http.registry/lookup-in-flight
+                             frame nine-states/data-load-request-id))
+                    "the older attempt is STILL registered under its own id — nothing superseded it")
+                (settle-attempt! attempts 0 (todos-json 25))
+                (next-macrotask)))
+            (.then (fn [_] (next-macrotask)))
+            (.then
+              (fn [_]
+                (testing "TOOTH (inverted) — with no shared id the stale reply lands"
+                  (is (= :too-many (data-state frame))
+                      "the SUPERSEDED-in-intent attempt moved the machine — the very
+                       thing the shared id prevents")
+                  (is (= 25 (count (items frame)))
+                      "and wrote its stale :items"))))
+            (.catch (fn [e] (is false (str "rf2-5bmi — unexpected: " e)) nil))
+            (.then (fn [_] (restore) (done))))))))

--- a/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
@@ -30,6 +30,16 @@
   [x]
   (gen/contains-string? x sentinel))
 
+;; CROSS-RECORD SPELLING (rf2-l7s7b7, Managed-Effects §The reply map). Every
+;; top-level REPLY ENVELOPE below single-roots the work identity as
+;; `:rf.reply/work-id` / `:rf.reply/work-kind`. The bare `:work/id` spelling is
+;; the DURABLE work-ledger / verification-payload fact and survives here only on
+;; the data-only carried/current stale-gate maps, which are exactly that layer.
+;; `trace-summary` projects the wire slots and otherwise preserves the supplied
+;; map verbatim, so a fixture that modelled the ledger layer would let this
+;; suite stay green while proving nothing about the identity that actually
+;; egresses (rf2-xy3g).
+;;
 ;; `trace-summary` elides each wire slot rooted at its OWN value (not at the
 ;; reply-map root), so classification paths are relative to each slot value:
 ;;   :value slot value       {:token <secret> :doc <big>}        → [:token] / [:doc]
@@ -61,7 +71,8 @@
                                     :detail {:token sentinel}}
                      :correlation  {:partner-key sentinel :trace-id "t-1"}
                      :meta         {:token sentinel :note "ok"}
-                     :work/id      [:rf.work/http :article/by-id 1]
+                     :rf.reply/work-id      [:rf.work/http :article/by-id 1]
+                     :rf.reply/work-kind    :http
                      :rf.reply/work-status  :failed
                      :rf.frame/id  :reply/framed
                      :completed-at 1781078400456}
@@ -82,10 +93,18 @@
       (is (not (contains-sentinel? (:meta out))))
       ;; Framework identity facts remain available for tool correlation.
       (is (= :partial (:status out)))
-      (is (= [:rf.work/http :article/by-id 1] (:work/id out)) "canonical :work/id verbatim")
+      (is (= [:rf.work/http :article/by-id 1] (:rf.reply/work-id out))
+          "canonical :rf.reply/work-id verbatim")
+      (is (= :http (:rf.reply/work-kind out)) "canonical :rf.reply/work-kind verbatim")
       (is (= :failed (:rf.reply/work-status out)))
       (is (= :reply/framed (:rf.frame/id out)))
-      (is (= 1781078400456 (:completed-at out)) "causal completion timestamp verbatim"))))
+      (is (= 1781078400456 (:completed-at out)) "causal completion timestamp verbatim")
+      (testing "TOOTH — framed egress preserves the TRANSIENT-ENVELOPE identity
+                and grows NO top-level bare ledger alias beside it (rf2-xy3g)"
+        (is (not (contains? out :work/id))
+            "no top-level bare :work/id alias survives framed trace egress")
+        (is (not (contains? out :work/kind))
+            "no top-level bare :work/kind alias survives framed trace egress")))))
 
 (deftest trace-summary-delegates-to-shared-walker
   (testing "each wire slot in the trace summary equals elide-wire-value under
@@ -95,7 +114,8 @@
     (let [opts {:frame :reply/deleg}
           value {:token sentinel :doc big-string :public 7}
           reply-map {:status :ok :value value
-                     :work/id [:rf.work/http :x 1] :rf.reply/work-status :completed}
+                     :rf.reply/work-id [:rf.work/http :x 1]
+                     :rf.reply/work-status :completed}
           out (reply/trace-summary reply-map opts)]
       (is (= (:value out) (elision/elide-wire-value value opts))
           ":value slot is exactly elide-wire-value under the resolved opts"))))
@@ -110,7 +130,7 @@
                        :error       {:kind :rf.http/cors :detail sentinel}
                        :correlation {:partner-key sentinel}
                        :meta        {:secret sentinel}
-                       :work/id     [:rf.work/http :y 2]
+                       :rf.reply/work-id [:rf.work/http :y 2]
                        :rf.reply/work-status :failed}
             out (reply/trace-summary reply-map nil)]
         (is (gen/redacted? (:error out)) ":error fails closed (whole slot redacted)")
@@ -118,11 +138,13 @@
         (is (gen/redacted? (:meta out)) ":meta fails closed")
         (is (not (contains-sentinel? out)) "no sentinel survives frameless egress")
         (is (= :error (:status out)))
-        (is (= [:rf.work/http :y 2] (:work/id out)))
-        (is (= :failed (:rf.reply/work-status out))))
+        (is (= [:rf.work/http :y 2] (:rf.reply/work-id out)))
+        (is (= :failed (:rf.reply/work-status out)))
+        (is (not (contains? out :work/id))
+            "TOOTH — frameless egress grows no top-level bare :work/id alias (rf2-xy3g)"))
       ;; Explicit sensitive inclusion is the trusted-local opt-out.
       (let [out (reply/trace-summary {:status :ok :value {:token sentinel}
-                                      :work/id [:rf.work/http :z 3]
+                                      :rf.reply/work-id [:rf.work/http :z 3]
                                       :rf.reply/work-status :completed}
                   {:rf.size/include-sensitive? true})]
         (is (= sentinel (get-in out [:value :token]))
@@ -134,7 +156,8 @@
   validate-reply-legal), but every present wire slot plants the sentinel."
   (gen/gen-fmap
     (fn [[status work-status]]
-      (let [base {:work/id     [:rf.work/http :gen 1]
+      (let [base {:rf.reply/work-id   [:rf.work/http :gen 1]
+                  :rf.reply/work-kind :http
                   :rf.reply/work-status work-status
                   :rf.frame/id :reply/corpus
                   :correlation {:partner-key sentinel :trace-id "tc"}
@@ -173,10 +196,18 @@
                             (not (contains-sentinel? (:error out)))
                             (not (contains-sentinel? (:correlation out)))
                             (not (contains-sentinel? (:meta out)))
-                            (contains? reply/statuses (:status out))))))]
+                            (contains? reply/statuses (:status out))
+                            ;; rf2-xy3g — across every status the canonical
+                            ;; TRANSIENT-ENVELOPE identity survives egress and
+                            ;; no bare ledger alias appears beside it.
+                            (= [:rf.work/http :gen 1] (:rf.reply/work-id out))
+                            (= :http (:rf.reply/work-kind out))
+                            (not (contains? out :work/id))
+                            (not (contains? out :work/kind))))))]
       (is (nil? result)
           (str "a reply trace summary shipped the sentinel / left the closed "
-               "taxonomy: " (pr-str (when result (dissoc result :threw))))))))
+               "taxonomy / lost the canonical envelope identity: "
+               (pr-str (when result (dissoc result :threw))))))))
 
 (deftest stale-suppression-never-delivers-app-target-or-value
   (testing "suppress on a superseded completion yields :deliver? false,
@@ -185,8 +216,12 @@
     (let [carried {:work/id [:rf.work/http :a 1] :generation 1}
           current {:work/id [:rf.work/http :a 1] :generation 2}
           ;; Model a caller threading a full natural success reply as `extra`.
+          ;; It is a REPLY ENVELOPE, so its identity is single-rooted; the
+          ;; carried/current gate maps above are ledger data and stay bare.
           natural {:status :ok :value {:token sentinel}
-                   :rf.reply/work-status :completed :work/id [:rf.work/http :a 1]
+                   :rf.reply/work-status :completed
+                   :rf.reply/work-id [:rf.work/http :a 1]
+                   :rf.reply/work-kind :http
                    :rf.frame/id :reply/stale :completed-at 1781078400456}
           {:keys [deliver? reply] :as outcome} (reply/suppress nil carried current natural)]
       (is (false? deliver?) "a superseded app reply is NOT delivered")
@@ -195,15 +230,28 @@
       (is (= :suppressed (:rf.reply/work-status reply)) ":rf.reply/work-status forced to :suppressed")
       (is (not (contains? reply :value)) ":value is STRIPPED — no app mutation can ride")
       (is (not (contains-sentinel? reply)) "the secret value never rides the stale reply")
-      (is (= [:rf.work/http :a 1] (:work/id reply)) "carried :work/id survives")
+      (is (= [:rf.work/http :a 1] (:rf.reply/work-id reply))
+          "the work identity survives on the envelope spelling")
+      (is (= :http (:rf.reply/work-kind reply)) ":rf.reply/work-kind survives")
+      (is (not (contains? reply :work/id))
+          "TOOTH — suppression grows no top-level bare :work/id alias (rf2-xy3g)")
       (is (= :reply/stale (:rf.frame/id reply)))
       (is (= 1781078400456 (:completed-at reply)) "causal completion time survives")
       (is (reply/valid-reply? reply) "the suppression reply is contract-valid")
       ;; Suppression traces retain correlation without carrying the value.
       (let [trace (:trace outcome)]
         (is (true? (:rf.reply/suppressed? trace)))
+        ;; The trace reads its work id off `:rf.reply/work-id` on the reply, so
+        ;; a fixture spelling the identity the LEDGER way left this nil while
+        ;; the suite stayed green (rf2-xy3g). This is that tooth.
+        (is (= [:rf.work/http :a 1] (:rf.reply/work-id trace))
+            "the suppression trace carries the canonical envelope work id")
+        ;; The carried/current gate maps ARE ledger correlation, so the trace
+        ;; keeps them verbatim with their bare `:work/id` intact.
         (is (= carried (:rf.reply/carried trace)))
         (is (= current (:rf.reply/current trace)))
+        (is (= [:rf.work/http :a 1] (:work/id (:rf.reply/carried trace)))
+            "the carried LEDGER gate keeps the bare spelling — not renamed")
         (is (not (contains-sentinel? trace)) "the suppression trace carries no sentinel")))))
 
 (deftest app-target-cannot-obtain-stale-delivery
@@ -237,7 +285,8 @@
     ;; A function is a host handle on both runtimes.
     (let [handle (fn [] :callback)
           reply-with-handle {:status :ok :value {:on-done handle}
-                             :work/id [:rf.work/http :h 1] :rf.reply/work-status :completed}
+                             :rf.reply/work-id [:rf.work/http :h 1]
+                             :rf.reply/work-status :completed}
           problems (reply/validate-reply reply-with-handle)]
       (is (some #(= :rf.reply/host-handle (:rf.reply/problem %)) problems)
           "validate-reply flags the host handle in the reply :value"))
@@ -249,5 +298,6 @@
       (is (= :rf.error/reply-non-data-target (:rf.error/id data))
           "a host handle in a durable target's public field fails loud"))
     (is (reply/valid-reply? {:status :ok :value {:public 1}
-                             :work/id [:rf.work/http :h 2] :rf.reply/work-status :completed}))
+                             :rf.reply/work-id [:rf.work/http :h 2]
+                             :rf.reply/work-status :completed}))
     (is (reply/data-only-target? {:event [:app/on-reply] :delivery :append}))))


### PR DESCRIPTION
Two beads, both about a test asserting the wrong thing. Test-only — no production, spec, or example change.

## rf2-xy3g — canonical reply fixtures pinned the LEDGER work keys, not the ENVELOPE's

Two contract-support suites hand-authored maps they called canonical managed-async reply envelopes while putting work identity on bare `:work/id` / `:work/kind`. Those are the **durable work-ledger / verification-payload** spellings; a transient reply envelope single-roots the same fact as `:rf.reply/work-id` / `:rf.reply/work-kind` (`spec/Managed-Effects.md` §The reply map, rf2-l7s7b7).

Verified at source, and the direction holds: the spec explicitly names the record↔reply boundary, and the comparison surface (`reply-conformance`) already uses the envelope spelling.

They did not merely *describe* the wrong layer — they **asserted** it, so each was a control constructed so it could not catch its own case. A real envelope with the correct single-rooted keys would have failed them; a runtime that regressed to ledger spellings would have passed. Nothing else exposed the mistake: `validate-reply` never reads the work fields, and `trace-summary` projects only the wire slots and preserves the rest of the map verbatim.

- Every top-level reply envelope in both suites now uses the envelope spelling.
- Assertions are **renamed, not loosened** — no assertion accepts both spellings.
- Bare `:work/id` survives exactly where it is genuine ledger correlation: the data-only carried/current stale-gate maps, which `suppress` keeps verbatim on its trace. A new assertion pins that they were *not* renamed.
- New teeth at each distinct boundary — ordinary delivered event, stale suppression, framed trace egress, frameless fail-closed egress, and the 300-row generated corpus — assert the namespaced identity survives **and** that no top-level bare alias grows beside it.

One of those was a **live false green**: `suppress` reads its trace work id off `:rf.reply/work-id`, so the security fixture's ledger spelling left `(:rf.reply/work-id trace)` nil while the suite stayed green.

## rf2-5bmi — deterministic overlap witness for Nine States newest-intent-wins

rf2-t9va landed the shared `:request-id` but its deterministic CLJS regression was deferred. Nothing had ever executed the superseding path for this example: the app routes `:rf.http/managed` through an `:fx-overrides` demo stub, and an override replaces the effect outright, so the in-flight registry — and with it supersession — never ran there.

**Where it went, and why that respects the locked rule.** `implementation/http/test/re_frame/nine_states_overlap_cljs_test.cljs`. Examples are test-free (rf2-8cevm), so example fixtures live in the framework test tree; this artefact is the right shelf because the subject is the managed-HTTP in-flight registry and its same-`:request-id` supersession — this artefact's own contract. `http_managed_demo_frame_isolation_cljs_test.cljs` is the standing precedent for exactly that placement, and `implementation/shadow-cljs.edn`'s own comment on the `../examples/*` source roots says it outright: "The example tree is test-free (rf2-8cevm): headless fixtures live in the framework test tree." Nothing under `examples/` is touched.

**Deterministic means the interleaving is placed, not raced.** `js/fetch` is stubbed with a transport that parks each attempt inside its own body read — headers resolve, `.text()` returns a promise whose resolver the test holds — so an attempt sits open mid-finalisation until the test settles it by hand. That is the multi-attempt form of the harness `re-frame.http-cljs-test` already uses for its supersede-race coverage. Nothing sleeps and hopes; `poll-until` only waits for a state the test then acts on, never for a deadline to decide an assertion.

Frames carry no `:fx-overrides`, so the real effect runs. Coverage:

- Three overlap rows: same-kind, and **cross-kind in both directions** (old success vs new failure, old failure vs new success), so both producer events are proven to share one replacement lane.
- Each row settles the **older** attempt first and proves the machine did not move — still `:loading`, no `:items`, no `:error` — before settling the newer and proving exactly its `:items` / `:error`, `:data` region state, tag, and `:ui/render`.
- Reset-then-reload: asserts `:reset` does **not** abort the in-flight attempt (it is still registered), so the protection is the same-id supersession on the reload — not the existing reset-to-`:nothing` test, which settles at `:nothing` where a completion is trivially ignored.
- **Negative control as an executable assertion**, not a one-shot manual mutation: a test-local event issues the identical request under a *different* `:request-id` and the witness inverts — the stale reply lands and clobbers the machine. Every assertion above is therefore a property of the shared id, not of the harness.

**Per-row isolation is handled inside the driver, not by a fixture.** A `:each` fixture resets once per `deftest`, not once per table row, and a wrap-style fixture would tear down before an `async` body finished. Each row builds its own frame and clears the in-flight registry itself; one row is additionally pinned running alone, so it is proven to pass in isolation *and* in sequence.

## Quality gates

| Gate | Command | Exit |
|---|---|---|
| event-conformance JVM (baseline, pre-change) | `clojure -M:test` in `implementation/event-conformance` | **0** — 44 tests / 186 assertions |
| event-conformance JVM (after) | `clojure -M:test` | **0** — 44 tests / **194** assertions (+8) |
| security JVM (baseline, pre-change) | `clojure -M:test` in `implementation/security` | **0** — 92 tests / 717 assertions |
| security JVM (after) | `clojure -M:test` | **0** — 92 tests / **725** assertions (+8) |
| http JVM | `clojure -M:test` in `implementation/http` | **0** — 525 tests / 3969 assertions |
| require-alias dialect ratchet | `python scripts/check_require_alias_dialect.py --verbose` | **0** |
| view-lifetime residue ratchet | `python scripts/check_view_lifetime_residue.py --verbose` | **0** |
| residue ratchet self-test (positive control) | `python scripts/check_view_lifetime_residue.py --self-test` | **0** |
| clj-kondo on the new file | `clj-kondo --lint …nine_states_overlap_cljs_test.cljs` | **0** — 0 errors, 0 warnings |

Exit codes are captured from the runner on one command line and read back from a file, never through a pipeline.

**The alias ratchet was confirmed to see the new file** (a zero is not a check that passed): staging it moved the gate's census 2793 → 2794 files and 10851 → 10857 `re-frame` require edges, with the non-canonical count unchanged at 2446 — so all six of its `re-frame.*` aliases are canonical.

### Red-then-green

**rf2-xy3g** — controls run against the fixed tree with each envelope construction mutated back to the ledger spelling, assertions left namespaced:

- event-conformance: **exit 1, 10 failures** across *both* distinct boundaries (ordinary delivery, and stale suppression / trace).
- security: **exit 1, 11 failures** across *all four* distinct boundaries (framed egress, frameless fail-closed, generated corpus, stale suppression).

Both mutations were then reverted and the restore verified **by hashing the bytes** — `sha256sum -c` OK on both files against their pre-mutation digests, exit 0 — so "unchanged" is distinguished from "not attempted". The green runs above are at those exact digests.

### Skipped, with reason

- **`npm run test:cljs` was not run.** It is the only lane that executes the rf2-5bmi regression (`.cljs`, resolved through the consolidated `:node-test` build), but it compiles a shadow-cljs build, and concurrent workers are live in this wave where a heavyweight build wedges rather than fails. **CI owns this one.** The file is lint-clean, and every framework API it calls was verified against its definition: `make-anon-frame-record!` (returns the frame **id**, which is what `dispatch-sync {:frame …}`, `frame-state-value` and the 2-arg `lookup-in-flight` each take), `clear-all-in-flight!`, `lookup-in-flight`, `compute-sub`, `frame-state-value`, `poll-until`, and `nine-states.core/data-load-request-id`.
- The new file is `.cljs`, so the http artefact's JVM runner does not load it; the green http JVM run above shows the artefact is otherwise untouched.
- `mkdocs`, doc-slug and README-link gates are not nominated: no markdown changed.

### One follow-up, not done here

`examples/patterns/nine_states/core.cljs`'s docstring points readers at the adapter test tree as the home of this example's headless fixtures. It is now also exercised from `implementation/http/test/`. Updating that pointer touches `examples/`, which this PR deliberately does not, so it is left for whoever next has that tree.
