### PR TITLE
fix(ssr-node): an exception that escapes the render call carries nothing the module authored (rf2-c38b)

### DIFF
--- a/implementation/ssr-node/README.md
+++ b/implementation/ssr-node/README.md
@@ -372,7 +372,7 @@ rather than presenting a well-formed shorter page.
 | `:rf.ssr-node/build-identity-mismatch` | caller's `buildId` ≠ the bundle's |
 | `:rf.ssr-node/render-timeout` | deadline expired; the isolate was terminated |
 | `:rf.ssr-node/render-threw` | the render module threw, emitted nothing, or returned a value |
-| `:rf.ssr-node/isolate-lost` | the worker died mid-render |
+| `:rf.ssr-node/isolate-lost` | the worker died mid-render, or an exception escaped the render call |
 | `:rf.ssr-node/service-saturated` | no isolate free within the admission budget |
 | `:rf.ssr-node/service-closed` | the service is shutting down |
 | `:rf.ssr-node/malformed-render-module` | the bundle failed validation at boot |
@@ -502,6 +502,22 @@ another machine. Two audiences, two channels, and no flag to get wrong.
 There is nothing for a render module to do about any of this: throw
 whatever is natural, and the boundary holds. `test/egress.test.cjs` §4 is
 the witness, with planted sentinels on all three fields.
+
+An exception that **escapes the render call** — thrown from a callback the
+render scheduled, so it lands on a later tick with no `try` above it — is
+an uncaught exception in the worker thread, and Node terminates the thread
+rather than delivering it to the render. The law is the same and the
+outcome is honestly different: the refusal is `:rf.ssr-node/isolate-lost`,
+because the render did not finish *and* the isolate is not reusable, so
+the pool replaces it. The code is not smoothed into `render-threw` — a
+caller acts on the difference — but the wording is this contract's, the
+`detail` is the service's own (`isolate`, `threadId`), and the exception's
+message and stack stay off the wire. The stack matters twice over here: on
+top of the module's wording it names absolute paths in the deployment's
+filesystem. It goes to the same stderr, and on this path that is not
+merely the better channel but the only one — the worker never caught
+anything, so nothing inside it ever saw the fault. `test/egress.test.cjs`
+§5 is the witness, driving one Error down both routes as a matched pair.
 
 The CLJS half — the thing behind `MY_APP_SSR.renderToString` — is a
 per-request `gensym` frame made with no initial events,
@@ -734,8 +750,9 @@ below: the changed-surface classifier, which is the repo's own answer to
 and nothing else.
 
 The suite drives the service against reference render modules under
-`test/fixtures/` — well-behaved, mutating, sloppy-mode, hanging, throwing,
-chunking, byte-hostile, leaky and null-returning — because every guarantee here is a
+`test/fixtures/` — well-behaved, mutating, sloppy-mode, hanging, throwing
+(inside the call and escaping it), chunking, byte-hostile, leaky and
+null-returning — because every guarantee here is a
 property of the service, and a fixture that misbehaves on purpose is the
 only way to see a guard fire.
 
@@ -759,7 +776,9 @@ agreeing; the runaway render is shown still running after 400 ms before a
 planted leak — and the leaky fixture shown really returning one, and the
 null-returning fixture shown really returning `null` rather than drifting
 into falling off its end, and the throwing fixture shown really carrying a
-distinct sentinel on each of `code`, `message` and a nested `detail` —
+distinct sentinel on each of `code`, `message` and a nested `detail`, and
+the ESCAPING one's scheduled callback intercepted before it fires and shown
+really throwing that sentinel —
 before its zero is believed; and the absence scan is shown finding a
 planted reference before its zero is believed.
 

--- a/implementation/ssr-node/src/isolate.cjs
+++ b/implementation/ssr-node/src/isolate.cjs
@@ -33,9 +33,39 @@
 
 const path = require('node:path');
 const { Worker } = require('node:worker_threads');
-const { CODE, Refusal, chunkFrame, isRefusalCode } = require('./protocol.cjs');
+const {
+  CODE,
+  Refusal,
+  chunkFrame,
+  isRefusalCode,
+  ISOLATE_LOST_REFUSAL,
+} = require('./protocol.cjs');
 
 const WORKER_PATH = path.join(__dirname, 'worker.cjs');
+
+/**
+ * The operator's copy of the fault that killed an isolate mid-render —
+ * everything the refusal deliberately does not carry.
+ *
+ * The counterpart of `worker.cjs`'s `reportRenderException`, on this side
+ * of the thread boundary and for the faults that side never sees: an
+ * exception thrown from a callback the render scheduled is never caught by
+ * anything in the worker, so its `try/catch` — and therefore its stderr
+ * write — never runs. This is the only place the exception exists.
+ *
+ * WHICH IS WHY THIS FUNCTION IS PART OF THE FIX RATHER THAN A COURTESY.
+ * Closing the refusal's wording without opening this would have traded a
+ * leak for a silence, and a failure nobody can diagnose is its own defect.
+ *
+ * NOT A NEW SUBSYSTEM and no flag, for the reasons `reportRenderException`
+ * gives: `bin/serve.cjs` already writes `[rf.ssr-node] …` here, so this is
+ * that stream under that prefix, and a diagnostic that can be switched off
+ * is off on the day it is wanted.
+ */
+function reportIsolateFault(isolateSeq, err) {
+  const trace = err && err.stack ? err.stack : String(err);
+  process.stderr.write(`[rf.ssr-node] isolate ${isolateSeq} died mid-render: ${trace}\n`);
+}
 
 let nextIsolateSeq = 0;
 
@@ -96,9 +126,43 @@ class Isolate {
       worker.on('message', handleBootMessage);
       worker.on('error', (err) => {
         clearTimeout(bootTimer);
+        // ONE HANDLER, TWO PHASES, AND THEY ARE NOT THE SAME AUDIENCE. It
+        // stays registered for the worker's whole life, so before boot
+        // resolves the `reject` below is live and `_failPendingRender` is a
+        // no-op; afterwards the promise is settled and it is the other way
+        // round. The two arms answer different people and that is why only
+        // one of them changed.
+        //
+        // THE RENDER ARM — a fault that reached a CALLER. `handleRender`'s
+        // own catch never saw this one: an exception thrown from a callback
+        // the render scheduled runs on a later tick with no `try` above it,
+        // so Node killed the thread and the `Error` arrived here instead.
+        // That made this the second receiver of the response law, and for a
+        // while the only one not stating it — `err.message` was the module's
+        // wording and `err.stack` was that wording plus every absolute path
+        // in the deployment, both published on the public `Refusal` and
+        // serialised into the HTTP body. So: the contract's wording, and a
+        // `detail` this file builds. `isolate` and `threadId` are the same
+        // two service-owned facts the deadline refusal above carries, and
+        // for the same reason — they name the thread an operator is about
+        // to go looking for, and neither originates in the module.
+        //
+        // The real exception goes to stderr first, and on this path that is
+        // the only copy that has ever existed; see `reportIsolateFault`.
+        if (this.pendingRender) reportIsolateFault(this.seq, err);
         this._failPendingRender(
-          new Refusal(CODE.ISOLATE_LOST, err.message, { stack: err.stack }),
+          new Refusal(CODE.ISOLATE_LOST, ISOLATE_LOST_REFUSAL, {
+            isolate: this.seq,
+            threadId: this.threadId,
+          }),
         );
+        // THE BOOT ARM — untouched, deliberately. Boot fails before the
+        // service listens, so this refusal is read by the operator standing
+        // at the process they just started rather than by a caller across a
+        // wire; `worker.cjs`'s boot post names this handler as where the
+        // real stack survives, and it is the diagnostic for a module that
+        // cannot be loaded at all. Two audiences, and this one is already
+        // the operator.
         reject(new Refusal(CODE.MALFORMED_MODULE, err.message, { stack: err.stack }));
       });
       worker.on('exit', () => {

--- a/implementation/ssr-node/src/protocol.cjs
+++ b/implementation/ssr-node/src/protocol.cjs
@@ -258,6 +258,47 @@ const RENDER_THREW_REFUSAL =
   'sidecar\'s stderr for the operator.';
 
 /**
+ * What a caller is told when the isolate died under their render.
+ *
+ * THE SAME LAW AS `RENDER_THREW_REFUSAL`, STATED BY THE OTHER RECEIVER —
+ * and that there were two receivers is the whole of why this constant
+ * exists. `RENDER_THREW_REFUSAL` closes the throw `worker.cjs` is standing
+ * in front of: the module throws while the service is inside
+ * `await renderModule.render()`, so a `try` has it. A throw from a callback
+ * the render SCHEDULED has no `try` above it anywhere — a timer, an
+ * unhandled `.then`, an event listener — so it is an uncaught exception in
+ * the worker thread. Node terminates the thread and raises `'error'` on the
+ * parent's `Worker`, and `isolate.cjs` builds the refusal from an `Error`
+ * that came from the application.
+ *
+ * It carried `err.message` and `err.stack`. The message is the module's own
+ * wording, leaking for the reason `RENDER_THREW_REFUSAL` sets out at
+ * length; the stack is worse than the message, because on top of that
+ * wording it names every absolute path in the deployment's filesystem.
+ * Both were on the public `Refusal` and in the HTTP JSON body.
+ *
+ * THE CODE STAYS `ISOLATE_LOST` AND IS NOT SMOOTHED INTO `RENDER_THREW`.
+ * The two are different facts and the caller acts on the difference: a
+ * render that threw leaves a healthy isolate the pool may reuse, while this
+ * one is a dead thread the pool must replace. Closing the wording is not a
+ * licence to describe a crashed worker as a reusable one.
+ *
+ * The diagnosis is not lost. `isolate.cjs` writes the real exception, stack
+ * and all, to the sidecar's stderr under the prefix `bin/serve.cjs` already
+ * uses — and on this path that is not merely the better channel, it is the
+ * only one there has ever been: the worker never caught anything, so its
+ * own `reportRenderException` never ran. Before this, an operator's sole
+ * copy of the fault was the one the caller was wrongly being handed.
+ */
+const ISOLATE_LOST_REFUSAL =
+  'the isolate died while rendering. The exception belongs to the application, not to this ' +
+  'contract: its message and its stack are the module\'s own — and the stack names the ' +
+  'server\'s filesystem besides — so neither crosses this boundary, for the same reason a ' +
+  'render that threw inside the call does not carry its wording out. The render did not ' +
+  'finish and this isolate is not reusable; the pool replaces it. The full exception, with ' +
+  'its stack, is on the sidecar\'s stderr for the operator.';
+
+/**
  * Is this one of the refusal codes this service publishes?
  *
  * The family is closed — `CODE` is the whole of it — and this is the test
@@ -605,6 +646,7 @@ module.exports = {
   COMPLETE_FIELDS,
   MODULE_RETURN_REFUSAL,
   RENDER_THREW_REFUSAL,
+  ISOLATE_LOST_REFUSAL,
   isRefusalCode,
   Refusal,
   validateModule,

--- a/implementation/ssr-node/test/egress.test.cjs
+++ b/implementation/ssr-node/test/egress.test.cjs
@@ -68,6 +68,29 @@
 // so an application render fault could present itself as a 400 the caller
 // blames itself for, a 503 a retry policy sleeps on, or a 504.
 //
+// ## AND THE THROWING DOOR HAS TWO SIDES, WHICH IS SECTION 5
+//
+// Section 4 closed the throw the SERVICE IS STANDING IN FRONT OF: the
+// module throws while `worker.cjs` is inside `await renderModule.render()`,
+// so its own try/catch has the stack. That is not the only way a render
+// exception escapes. A throw from a callback the render SCHEDULED — a
+// timer, an unhandled `.then`, an event listener — happens on a later tick
+// with no `try` anywhere above it, so it is an uncaught exception in the
+// worker thread; Node kills the thread and raises `'error'` on the parent's
+// `Worker`. That receiver is in `isolate.cjs`, it is a different piece of
+// code with its own refusal to build, and section 4's rows cannot reach it
+// because their fixture throws synchronously.
+//
+// So the same law was being stated by two receivers and only one of them
+// had been made to state it. The second put `err.message` on the refusal
+// and `err.stack` in its `detail` — the module's wording, and with it every
+// absolute path in the deployment's filesystem — under `isolate-lost`.
+// Section 5's fixture is a MATCHED PAIR for exactly this reason: the same
+// Error, built the same way, reaching the service down the two different
+// paths. Before the fix the awaited arm was clean and the scheduled one
+// leaked, which is what a hole in one of two receivers looks like from
+// outside.
+//
 // ## EVERY ROW HAS A CONTROL, AND THE CONTROLS ARE ORDINARY ROWS
 //
 // The suite-wide discipline (see the package README) applies here with
@@ -89,11 +112,13 @@ const {
   COMPLETE_FIELDS,
   MODULE_RETURN_REFUSAL,
   RENDER_THREW_REFUSAL,
+  ISOLATE_LOST_REFUSAL,
 } = require('../src/protocol.cjs');
 const { serve, statusFor } = require('../src/http.cjs');
 const LEAKY = require('./fixtures/leaky.cjs');
 const NULL_RETURN = require('./fixtures/null-return.cjs');
 const THROWS_DATA = require('./fixtures/throws-data.cjs');
+const THROWS_ASYNC = require('./fixtures/throws-async.cjs');
 
 // ---------------------------------------------------------------------------
 // The two checkers. Both are ordinary functions so a control can feed them
@@ -618,6 +643,243 @@ test('a streaming response torn by a throw is DESTROYED, not completed', async (
       assert.ok(
         !String(read.err).includes(THROW_SENTINELS[1]),
         'not even the transport error may carry the module’s wording',
+      );
+    } finally {
+      await http.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. The SECOND RECEIVER — an exception that escapes the render call
+//
+// See the header. Everything in section 4 throws while the service is
+// inside the awaited `render()`; these rows throw from a callback the
+// render scheduled, which no `try` in `worker.cjs` is standing in front of.
+// Node terminates the thread and the parent's `worker.on('error')` builds
+// the refusal instead — a different receiver stating the same law.
+// ---------------------------------------------------------------------------
+
+// One sentinel, from an allowlisted state key, on an Error the fixture
+// reaches by two different routes. Distinctive for the reason `SENTINELS`
+// gives: a value that could occur in framing or in a stack trace would
+// make a zero meaningless.
+const ASYNC_STATE = { ':for-uncaught': '"rf2-c38b-async-9f31c4"' };
+const ASYNC_SENTINEL = 'rf2-c38b-async-9f31c4';
+
+const asyncReq = (entry) => ({ protocol: 1, entry, state: ASYNC_STATE });
+
+/** The same reading as `refusalLeaks`, for this section's single sentinel. */
+const asyncLeaks = (err) => [
+  ...scanForEgress([err.toFrame('corr-async')], [ASYNC_SENTINEL]),
+  ...((err.stack ?? '').includes(ASYNC_SENTINEL)
+    ? [{ type: 'stack', sentinel: ASYNC_SENTINEL, in: err.stack }]
+    : []),
+];
+
+test('CONTROL — the scheduled callback really does throw the sentinel-bearing Error', () => {
+  // The control this section cannot do without, and it has to be built
+  // differently from section 4's: the whole point of this fixture is that
+  // its throw is UNCAUGHT, so calling `render` and letting the callback run
+  // would take down the test process rather than hand back an Error.
+  //
+  // So the callback is intercepted instead of allowed to fire.
+  // `setImmediate` is swapped for the duration of the call, which captures
+  // the exact function the worker thread would have run, and the row then
+  // throws it on purpose and reads what came out. That is a measurement of
+  // the real callback rather than of a fixture's promise about it.
+  const scheduled = [];
+  const realSetImmediate = globalThis.setImmediate;
+  globalThis.setImmediate = (fn) => {
+    scheduled.push(fn);
+    return { unref() {} };
+  };
+  try {
+    THROWS_ASYNC.render({ entry: 'app/uncaught', state: ASYNC_STATE }, () => {});
+  } finally {
+    globalThis.setImmediate = realSetImmediate;
+  }
+
+  assert.strictEqual(scheduled.length, 1, 'the render must schedule exactly one callback');
+  let thrown = null;
+  try {
+    scheduled[0]();
+  } catch (err) {
+    thrown = err;
+  }
+  assert.ok(thrown, 'the scheduled callback must actually throw');
+  assert.ok(thrown.message.includes(ASYNC_SENTINEL), 'and its message carries the sentinel');
+  assert.strictEqual(
+    thrown.code,
+    THROWS_ASYNC.SPOOFED_CODE,
+    'it also types a `code`, as a module with its own taxonomy would',
+  );
+  // Without this the status row below could go vacuous exactly the way
+  // section 4's could: rename a member of `CODE` and the fixture's
+  // hard-coded string stops being a spoof at all.
+  assert.ok(
+    new Set(Object.values(CODE)).has(THROWS_ASYNC.SPOOFED_CODE),
+    'the spoofed code must still be a real member of the family',
+  );
+});
+
+test('CONTROL — the AWAITED arm of the same fixture is refused by the other receiver', async () => {
+  // The discriminator, and the row that makes this a section rather than a
+  // repeat. `app/rejected` hands the identical Error back by rejecting the
+  // promise `render` returned, so `worker.cjs` catches it and section 4's
+  // door closes on it. A green here beside a green below is two receivers
+  // both holding the law; a green here beside a red below — which is what
+  // this file measured before the fix — is precisely one of them holding it.
+  await withService('throws-async', { isolates: 1 }, async (service) => {
+    const err = await refusalOf(() => collect(service, asyncReq('app/rejected')));
+    assert.ok(err, 'a rejected render must refuse');
+    assert.strictEqual(err.code, CODE.RENDER_THREW, 'the awaited door, and its code');
+    assert.strictEqual(err.message, RENDER_THREW_REFUSAL);
+    assert.deepStrictEqual(asyncLeaks(err), [], 'the awaited arm leaked');
+  });
+});
+
+test('an exception that ESCAPES the render call carries nothing the module authored', async () => {
+  // The case. `render` returns a promise that never settles and throws from
+  // a scheduled callback, so nothing awaits the exception: the thread dies
+  // and `isolate.cjs`'s `worker.on('error')` is what answers the caller.
+  //
+  // It answered with `err.message` and `err.stack`, which is the module's
+  // own wording plus every absolute path in the deployment's filesystem,
+  // published on the in-process refusal and serialised over HTTP.
+  await withService('throws-async', { isolates: 1 }, async (service) => {
+    const err = await refusalOf(() => collect(service, asyncReq('app/uncaught')));
+    assert.ok(err, 'the render must not have succeeded');
+
+    // The isolate really is lost — the distinction is kept, not smoothed
+    // into `render-threw`. A crashed worker is not a reusable one, and the
+    // code is how the pool and the operator are told so.
+    assert.strictEqual(err.code, CODE.ISOLATE_LOST, 'the fault is what it is');
+    assert.strictEqual(err.message, ISOLATE_LOST_REFUSAL, 'the contract owns the wording');
+    assert.deepStrictEqual(
+      Object.keys(err.detail).sort(),
+      ['isolate', 'threadId'],
+      'the detail is service-owned: which isolate died, and its thread',
+    );
+    assert.strictEqual(typeof err.detail.threadId, 'number');
+
+    assert.deepStrictEqual(
+      asyncLeaks(err),
+      [],
+      'the escaped exception reached the public refusal',
+    );
+    // The stack carried MORE than the sentinel, and this is that second
+    // half: it names the file the render came from, which is an absolute
+    // path in the deployment's filesystem. The key-list assertion above
+    // already says `detail.stack` is gone; this says what its going was
+    // worth, and it scans the serialised frame rather than the field, so a
+    // future `detail` member that reached for a path is caught too.
+    assert.ok(
+      !JSON.stringify(err.toFrame()).includes('throws-async.cjs'),
+      'a serialised stack names the server’s own filesystem',
+    );
+  });
+});
+
+test('and the OPERATOR still gets the exception, in full, on the sidecar stderr', async () => {
+  // The other half of closing a diagnostic, and the reason this row is not
+  // optional: before the fix the escaped exception reached NOBODY except
+  // through the refusal — the worker's own `reportRenderException` never
+  // runs, because the worker never caught anything. Closing the refusal
+  // without opening the operator's copy would have traded a leak for a
+  // silence, and "fail loudly" is a requirement rather than a preference.
+  //
+  // Not a new channel: `bin/serve.cjs` already writes `[rf.ssr-node] …` to
+  // stderr and this is that stream under that prefix. The write happens in
+  // the PARENT — which, in this suite, is this process — so the row can
+  // read it directly.
+  const captured = [];
+  const realWrite = process.stderr.write;
+  process.stderr.write = function (chunk, ...rest) {
+    captured.push(String(chunk));
+    return realWrite.call(this, chunk, ...rest);
+  };
+  try {
+    await withService('throws-async', { isolates: 1 }, async (service) => {
+      await refusalOf(() => collect(service, asyncReq('app/uncaught')));
+    });
+  } finally {
+    process.stderr.write = realWrite;
+  }
+
+  const log = captured.join('');
+  // The prefix is on the FIRST line only — a stack is many lines and the
+  // rest of them are the stack's own — so the line filter establishes that
+  // the sidecar's own channel is what spoke, and the whole capture is what
+  // the content is then read from. Filtering the content by prefix would
+  // discard every frame and quietly turn the stack assertion below into a
+  // test of the first line.
+  assert.ok(
+    log.split('\n').some((line) => line.includes('[rf.ssr-node]')),
+    'the operator was told nothing at all',
+  );
+  assert.ok(log.includes(ASYNC_SENTINEL), 'the operator copy must be the REAL exception');
+  assert.ok(log.includes('throws-async.cjs'), 'and it must carry the stack, which is the point');
+});
+
+test('an escaped exception cannot choose the refusal header either', async () => {
+  // The transport corollary. `isolate-lost` and `render-threw` are both
+  // 500, so the status is not the spoof vector on this path — the HEADER
+  // is, and so is the code a JVM host branches on. The module typed a
+  // 400-mapped member of the family onto its Error; neither may move.
+  await withService('throws-async', { isolates: 1 }, async (service) => {
+    const http = await serve({ service, port: 0 });
+    try {
+      const res = await post(`http://127.0.0.1:${http.port}/render`, asyncReq('app/uncaught'));
+      assert.strictEqual(res.status, 500, 'the module chose its own HTTP status');
+      assert.notStrictEqual(
+        statusFor(THROWS_ASYNC.SPOOFED_CODE),
+        500,
+        'the spoofed code must map somewhere else, or there is nothing to spoof',
+      );
+      assert.strictEqual(
+        res.headers.get('x-rf-ssr-refusal'),
+        CODE.ISOLATE_LOST,
+        'the module chose its own refusal header',
+      );
+
+      const headers = JSON.stringify(Object.fromEntries(res.headers.entries()));
+      assert.ok(!res.text.includes(ASYNC_SENTINEL), 'the JSON body leaked the sentinel');
+      assert.ok(!headers.includes(ASYNC_SENTINEL), 'a header leaked the sentinel');
+      assert.strictEqual(
+        JSON.parse(res.text).message,
+        ISOLATE_LOST_REFUSAL,
+        'the body carries the contract wording',
+      );
+    } finally {
+      await http.close();
+    }
+  });
+});
+
+test('a stream torn by an ESCAPED exception is destroyed, and still says nothing', async () => {
+  // The post-emit arm, over the transport, for the second receiver. Bytes
+  // already left under a 200, so there is no status left to send and the
+  // socket is destroyed rather than the response completed — the caller
+  // must see a broken transfer, not a well-formed shorter page it would
+  // cache. Same requirement section 4 makes of the first receiver.
+  await withService('throws-async', { isolates: 1 }, async (service) => {
+    const http = await serve({ service, port: 0 });
+    try {
+      const res = await fetch(`http://127.0.0.1:${http.port}/render?stream=1`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(asyncReq('app/uncaught-torn')),
+      });
+      assert.strictEqual(res.status, 200, 'the first chunk really did go out');
+      const read = await res.text().then(
+        (text) => ({ ok: true, text }),
+        (err) => ({ ok: false, err }),
+      );
+      assert.strictEqual(read.ok, false, 'a torn stream must not read as a complete body');
+      assert.ok(
+        !String(read.err).includes(ASYNC_SENTINEL),
+        'not even the transport error may carry the module wording',
       );
     } finally {
       await http.close();

--- a/implementation/ssr-node/test/fixtures/throws-async.cjs
+++ b/implementation/ssr-node/test/fixtures/throws-async.cjs
@@ -1,0 +1,76 @@
+'use strict';
+// A render whose exception ESCAPES THE RENDER CALL — thrown from a callback
+// the render scheduled, on a tick after `render` already handed its promise
+// back to the service.
+//
+// `throws-data.cjs` is the synchronous thrower: it throws while the service
+// is inside `await renderModule.render(...)`, so `worker.cjs`'s own
+// try/catch is holding the stack and the exception door closes on it. This
+// fixture is the shape that try/catch cannot see. A callback scheduled with
+// `setImmediate`/`setTimeout`, a `.then` with no rejection handler, an
+// event emitter's listener — none of them run inside the awaited call, so a
+// throw from one is an UNCAUGHT EXCEPTION IN THE WORKER THREAD. Node
+// terminates the thread and raises `'error'` on the parent's `Worker`, which
+// is a different receiver in a different file with its own refusal to build.
+//
+// That is not an exotic module. A renderer that kicks off a timer, resolves
+// data asynchronously, or subscribes to anything is one bug away from it,
+// and the bug is the ordinary kind — the callback dereferences the thing it
+// was rendering. So the sentinel is built the way every real one is: out of
+// the request state the module was handed.
+//
+// THE ENTRIES ARE A MATCHED PAIR, which is what makes this a measurement of
+// the second door rather than a re-run of the first:
+//
+//   `app/rejected`  — the SAME Error, reaching the service by rejecting the
+//                     promise it returned. Awaited, so `handleRender`
+//                     catches it: this is the already-closed door, and it is
+//                     here as the control that says the two paths differ.
+//   `app/uncaught`  — the same Error, thrown from a scheduled callback while
+//                     the returned promise never settles. Nothing awaits it.
+//   `app/uncaught-torn` — the same again, after a chunk has already left, so
+//                     the response is torn rather than clean.
+//
+// The Error carries a `code` that is a real member of the service's closed
+// refusal family, for the same reason `throws-data.cjs` does: a module with
+// its own error taxonomy will set `code`, and a boundary that believed it
+// would let a render fault choose its own HTTP status.
+
+const ENTRY = { stateAllowlist: [':for-uncaught'], runtimeAllowlist: [] };
+
+/** A real member of the service's family — see the header. 400, not 500. */
+const SPOOFED_CODE = ':rf.ssr-node/unknown-entry';
+
+module.exports = {
+  protocol: 1,
+  buildId: 'throws-async-build-1',
+  entries: {
+    'app/rejected': ENTRY,
+    'app/uncaught': ENTRY,
+    'app/uncaught-torn': ENTRY,
+  },
+
+  SPOOFED_CODE,
+
+  render({ entry, state }, emit) {
+    const err = new Error(`render callback saw ${state[':for-uncaught']}`);
+    err.code = SPOOFED_CODE;
+    err.detail = { echoed: state[':for-uncaught'] };
+
+    // The control: awaited, so the exception door already closed on it.
+    if (entry === 'app/rejected') return Promise.reject(err);
+
+    if (entry === 'app/uncaught-torn') emit('<p>first</p>');
+
+    // The case. Thrown on a later tick, outside every `try` in this
+    // process's render path — an uncaught exception in the worker thread.
+    setImmediate(() => {
+      throw err;
+    });
+
+    // And the render never finishes, so the only thing that can settle this
+    // request is the worker dying under it. A promise that resolved would
+    // let `handleRender` complete first and hide the whole path.
+    return new Promise(() => {});
+  },
+};


### PR DESCRIPTION
Closes the render-exception egress path that reopened `rf2-c38b` after PR #9258.

## What was still open

PR #9258 closed the throw `worker.cjs` is standing in front of — the module throws while the service is inside `await renderModule.render()`, so its own `try/catch` has the exception. That is not the only way a render exception escapes.

A throw from a callback the render **scheduled** — a timer, an unhandled `.then`, an event listener — lands on a later tick with no `try` above it anywhere. It is an uncaught exception in the worker thread: Node terminates the thread and raises `'error'` on the parent's `Worker`. That receiver is `isolate.cjs`, a different piece of code with its own refusal to build, and it was the only one of the two not stating the law:

```js
new Refusal(CODE.ISOLATE_LOST, err.message, { stack: err.stack })
```

Both fields are application-authored. The message is the module's own wording; the stack is that wording **plus every absolute path in the deployment's filesystem**. Both reached the public in-process `Refusal` and were serialised into the HTTP JSON body.

Reproduced before editing, on the tree at tip, with a matched pair driving one Error down both routes:

| route | code | sentinel in refusal | sentinel in HTTP body |
|---|---|---|---|
| `app/rejected` — rejects the returned promise (awaited) | `render-threw` | absent | absent |
| `app/uncaught` — throws from a scheduled callback | `isolate-lost` | **present** (message + `detail.stack`) | **present** |

The awaited arm being clean beside the scheduled arm leaking is exactly what a hole in one of two receivers looks like from outside.

## The two decisions the brief asked to be explicit about

**1. What survives the exception door.** The refusal now carries the contract's own `ISOLATE_LOST_REFUSAL` (added to `protocol.cjs` beside `RENDER_THREW_REFUSAL`) and a service-built `detail` of `{isolate, threadId}` — the same two service-owned facts the deadline refusal in the same file already carries, and neither originates in the module.

The diagnosis is **not** lost, and on this path it was never anywhere else. The worker never caught anything, so its own `reportRenderException` never ran: before this change, an operator's *only* copy of the fault was the one the caller was wrongly being handed. Closing the refusal without opening a diagnostic would have traded a leak for a silence. The full exception with its stack now goes to the sidecar's stderr under the `[rf.ssr-node]` prefix `bin/serve.cjs` already uses — no new observability channel, no flag. A dedicated test row asserts it, and removing the one line that writes it turns that row red (negative control 3 below).

**2. The code field.** `isolate-lost` **stays** `isolate-lost` and is deliberately not smoothed into `render-threw`. The two are different facts and the caller acts on the difference: a render that threw leaves a healthy isolate the pool may reuse, while this is a dead thread the pool must replace. Closing the wording is not a licence to describe a crashed worker as a reusable one.

The code is not the spoof vector on this path — it is built by the service, so a module's `err.code` never reached it — and `isolate-lost` and `render-threw` both map to 500, so the status is not either. What *is* spoofable here is the `x-rf-ssr-refusal` header and the code a JVM host branches on, so the fixture types a 400-mapped member of the family onto its Error and a row asserts neither moves.

**The boot arm of the same handler is untouched, deliberately.** One handler covers two phases: before boot resolves the `reject` is live and `_failPendingRender` is a no-op; afterwards it is the other way round. They answer different audiences — boot fails before the service listens, so that refusal is read by the operator at the process they just started rather than by a caller across a wire, and `worker.cjs`'s boot post names this handler as where the real stack survives. The bead's non-goals fence boot off and the audit note says to preserve it.

## The test

`test/egress.test.cjs` gains section 5 (+6 rows) driving the new `test/fixtures/throws-async.cjs`, whose three entries are one Error reaching the service by three routes: `app/rejected` (awaited — the already-closed door, as the discriminator), `app/uncaught`, and `app/uncaught-torn` (emits first).

The section's control had to be built differently from section 4's. The whole point of this fixture is that its throw is uncaught, so calling `render` and letting the callback fire would take down the test process rather than hand back an Error. It **intercepts** the callback instead, swapping `setImmediate` for the duration of the call, then throws the captured function on purpose and reads what came out — a measurement of the exact function the worker thread would have run.

Rows: the interception control; the awaited-arm discriminator; the in-process refusal (code, contract wording, `detail` key list asserted exactly, sentinel scan over `toFrame()` and `stack`, plus a check that the serialised frame does not name the fixture's own file — the stack's *second* leak); the operator's stderr copy; the HTTP header/body; and the torn stream destroying the socket.

**Watched red before the fix**, then green: 23 pass / 3 fail → 26 pass / 0 fail in that suite. The three reds were the in-process message leak, the HTTP body leak, and *"the operator was told nothing at all"* — that last one is the row that justifies the stderr write existing.

## Negative controls (acceptance criterion 5)

Each restored one pass-through, ran the suite, then restored the file — verified by hashing the bytes back to the committed blob `2aa72580f610f4c47341e036e2d3f658f14bf168`, not by reading a diff.

| planted | captured exit | rows that went red |
|---|---|---|
| `message` pass-through restored | 1 | in-process refusal; HTTP body |
| `stack` restored into `detail` | 1 | `detail` key list; HTTP body |
| stderr diagnostic removed | 1 | operator's copy |

The residue ratchet was also exercised against an input it should flag — a banned word planted in the new fixture returned exit 1 naming `throws-async.cjs:78` — confirming the gate genuinely reads the added files rather than returning a vacuous zero.

## Scope

`implementation/ssr-node/**` only, 5 files. The return-value door is untouched, as instructed. No spec file, workflow, `implementation/ssr/**`, or `.beads` path is in the diff.

**No normative contract moves.** `spec/Conventions.md` catalogues the `:rf.ssr-node/*` **code members** and says nothing about refusal wording or `detail` shape; this change adds and removes no member and does not alter which code is returned. A repo-wide search for `isolate-lost` finds no consumer outside this package other than that catalogue entry, so no JVM-side reader depends on the old message.

## Quality gates

| gate | result | captured exit |
|---|---|---|
| `npm test` (`node test/run.cjs`) — the package suite, post-rebase | **121 rows / 9 suites, 121 pass, 0 fail** (115 before; +6 new rows, 0 regressions) | **0** |
| `clojure -M:crossing-test` (ssr-ring JVM→Node→JVM), post-rebase | **10 tests / 107 assertions, 0 failures, 0 errors** | **0** |
| `python scripts/check_require_alias_dialect.py --verbose` | 2794 files, 10867 edges, every surface at or under its floor | **0** |
| `python scripts/check_view_lifetime_residue.py --verbose` | zero residue in tracked content or paths | **0** |
| `python scripts/check_readme_links.py --ci` | clean | **0** |

Full output of both ratchets was read, not just the first line; each is a single summary line naming no failing surface.

**Which CI checks this diff arms** was derived from `.github/scripts/report-changed-surfaces.sh` rather than hand-listed: exactly one surface, `ssr_node=true`, every other output `false`. Read against `.github/workflows/test.yml` that is `jvm-node-crossing` (armed on `ssr_node`), plus `node-ssr-node` and `verify-readme-links`, which are unconditional. All three were run locally and are in the table above; `check_readme_links.py --ci` is named because `implementation/ssr-node/README.md` is *its* surface and not `check_doc_slugs.py`'s, whose roots exclude READMEs beside source.

Every gate was run in the foreground to completion with its exit code captured on the same command line as the redirect, and quoted from that capture. The package gate prints its own root, which named this worktree on every run. All gates were re-run on the final base after the rebase.

`scripts/test-fast-pr.sh` was skipped deliberately: sibling workers are live on other surfaces and the machine is contended (one early run wedged a 30 s worker boot before recovering), and the classifier shows this diff arming a single surface whose gates are all above. CI owns the spine.

## Noted, outside this fence

Two adjacent sites state the same law differently. Neither is reachable with application data today and both are outside the bead's non-goals, so they are reported rather than changed:

- `src/pool.cjs:178` interpolates `err.message` into an `ISOLATE_LOST` refusal handed to waiting callers when a **replacement** isolate cannot boot. That is boot diagnostics reaching a caller at runtime, which the non-goals fence off explicitly.
- `src/service.cjs:108` puts `String(error)` on a public refusal in a last-resort arm. Every path in `isolate.render()` rejects with a `Refusal`, so it is unreachable today and, if reached, would carry only this package's own error — unlike the analogous `worker.cjs` arm PR #9258 hardened, which sits on an application-adjacent path.
