### PR TITLE
test(xray/popout): the two-document keyboard witness awaits the dispatch it sent, and joins the PR-smoke tier (rf2-61i5)

### DIFF
--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -4,6 +4,7 @@ const {
   expectTextEquals,
   expectVisible,
   navigate,
+  waitForStableValue,
   waitForValue,
 } = require('../../../../examples/scripts/spec-helpers.cjs');
 const {
@@ -474,6 +475,303 @@ async function assertSourceCoordBridge(page, state, ctx, opts) {
   return record;
 }
 
+/*
+ * rf2-61i5 — read the pop-out document's spine + palette DOM, plus the
+ * OPENER's mount state, in one cross-realm snapshot.
+ *
+ * `window.open('', 'rf-xray-popout')` re-acquires the already-open window
+ * by name rather than opening a second one. `document` inside the callback
+ * is still the OPENER's, so the two `opener*` fields read the opener while
+ * everything else reads the pop-out — which is the whole point of the
+ * probe: one read, both realms, no ambiguity about which document a value
+ * came from.
+ *
+ * `focusedIndex` is the index of the single `aria-pressed="true"` row
+ * within the rendered L2 row order. `shell.cljs`'s event list renders the
+ * event-bundle vector in order and `spine/step-event-bundle` walks that
+ * same vector by ±1, so "one spine step" is exactly "the focused row moved
+ * to its immediate neighbour in this array". `focusedCount` is reported
+ * separately so a zero-or-many focus state fails loudly instead of
+ * degrading into a silent `-1`.
+ */
+async function readPopoutKeyboardState(page) {
+  return page.evaluate(() => {
+    const win = window.open('', 'rf-xray-popout');
+    const doc = win && win.document;
+    if (!doc) return { ok: false, reason: 'pop-out document unreachable' };
+    const shell = doc.querySelector('[data-testid="rf-xray-shell"]');
+    if (!shell) return { ok: false, reason: 'pop-out shell not rendered' };
+    const rows = Array.from(doc.querySelectorAll('[data-testid^="rf-xray-event-row-"]'));
+    const focused = rows.filter((row) => row.getAttribute('aria-pressed') === 'true');
+    const openerRoot = document.getElementById('rf-xray-root');
+    return {
+      ok: true,
+      rows: rows.map((row) => row.getAttribute('data-testid')),
+      focusedCount: focused.length,
+      focusedIndex: focused.length === 1 ? rows.indexOf(focused[0]) : -1,
+      focusedTestId: focused.length === 1 ? focused[0].getAttribute('data-testid') : null,
+      paletteOpen: Boolean(doc.querySelector('[data-testid="rf-xray-palette-dialog"]')),
+      // The OPENER's mount state — what a pop-out keystroke must never move.
+      // `[data-testid="rf-xray-shell"]` under the opener's `document`
+      // cannot match the pop-out's shell: they are different documents.
+      openerRootMode: openerRoot ? openerRoot.getAttribute('data-rf-xray-mode') : null,
+      openerShells: document.querySelectorAll('[data-testid="rf-xray-shell"]').length,
+    };
+  });
+}
+
+function openerMountOf(snapshot) {
+  return JSON.stringify({
+    rootMode: snapshot.openerRootMode,
+    shells: snapshot.openerShells,
+  });
+}
+
+/*
+ * Dispatch one synthetic keydown INSIDE the pop-out document and report
+ * whether Xray consumed it.
+ *
+ * The event is constructed from the POP-OUT realm's `KeyboardEvent`, or
+ * the capture listener there would receive a foreign-realm object. It is
+ * dispatched on the pop-out shell (bubbling + cancelable), so a
+ * capture-phase listener on the pop-out DOCUMENT sees it on the way down —
+ * which is precisely the listener rf2-61i5 installs, and precisely the one
+ * an opener-only listener could never be.
+ */
+async function sendPopoutKey(page, init) {
+  const sent = await page.evaluate((keyInit) => {
+    const win = window.open('', 'rf-xray-popout');
+    const doc = win && win.document;
+    const shell = doc && doc.querySelector('[data-testid="rf-xray-shell"]');
+    if (!shell) return { ok: false, reason: 'pop-out shell not rendered' };
+    const Ctor = win.KeyboardEvent || window.KeyboardEvent;
+    const ev = new Ctor('keydown', Object.assign(
+      { bubbles: true, cancelable: true, composed: true }, keyInit));
+    shell.dispatchEvent(ev);
+    return { ok: true, defaultPrevented: ev.defaultPrevented };
+  }, init);
+  if (!sent.ok) {
+    failWithDetails('Could not send a key into the pop-out document (rf2-61i5)', {
+      key: init,
+      observed: sent,
+    });
+  }
+  return sent;
+}
+
+/*
+ * rf2-61i5 — the pop-out document's OWN keyboard, end to end.
+ *
+ * DOM key events do not cross realms, so a keydown made in the pop-out
+ * window can only be seen by a listener installed on the POP-OUT
+ * document. Sending a key into that document is therefore the one probe
+ * that distinguishes "Xray has a keyboard here" from "Xray has a keyboard
+ * in the opener" — the boundary the older pop-out coverage (root/shell
+ * presence, shared cascade rendering) never crossed, because it sent no
+ * key at all.
+ *
+ * EVERY assertion downstream of a key is POLLED, never read in the same
+ * `page.evaluate` callback that sent it. The keys drive re-frame
+ * dispatches; `router` drains the queue on a next-tick and the shell
+ * re-renders only once the subscription changes, so a same-callback read
+ * can only ever observe the PRE-key DOM. That read passes vacuously
+ * whenever the pre-key DOM already resembles the post-key one — an open
+ * palette staying open across a toggle being the sharp case — which is the
+ * defect the merged-PR audit of #9263 found in the first version of this
+ * probe.
+ *
+ * The two positive assertions match the acceptance rf2-61i5 names: a spine
+ * step key moves focus by EXACTLY ONE row on the shared `:rf/xray` frame,
+ * and Cmd/Ctrl+K opens the palette in the pop-out WITHOUT moving the
+ * opener's mount state. `Ctrl+Shift+C` is asserted inert here, per the same
+ * bead's non-goal.
+ *
+ * NOT asserted, deliberately: that the opener's palette stays closed. The
+ * palette's open state lives on `:rf/xray`, which BOTH windows render
+ * (tools/xray/spec/011-Launch-Modes.md §The pop-out has its own keyboard),
+ * so it appears wherever a shell is on screen. The contract is about the
+ * opener's MOUNT state, not about where the palette paints.
+ */
+async function assertPopoutKeyboard(page, state) {
+  // (0) STAGE a step-able spine. The scenario cleared the trace bus and
+  //     dispatched a single host event, and one event has nowhere to step
+  //     to — `focus-step-reducer` clamps at the edge and returns `db`
+  //     unchanged, so a probe run against it would assert nothing. Two
+  //     more host dispatches give the walk room in both directions.
+  await clickHostButtonByLabel(page, '+');
+  await clickHostButtonByLabel(page, '+');
+
+  const staged = await waitForValue(
+    () => readPopoutKeyboardState(page),
+    (s) => s.ok && s.rows.length >= 3 && s.focusedCount === 1,
+    {
+      timeoutMs: 15000,
+      description: 'pop-out L2 spine carrying >=3 rows with exactly one focused row',
+    },
+  );
+
+  // (1) STAGE a CLOSED palette. Nothing in this scenario opens it, but a
+  //     probe that merely assumes the starting state is the probe the
+  //     audit rejected: assert it, and if a previous run left one open,
+  //     close it through the same chord and wait for that to land.
+  let opening = staged;
+  if (opening.paletteOpen) {
+    await sendPopoutKey(page, { key: 'k', code: 'KeyK', ctrlKey: true });
+    opening = await waitForValue(
+      () => readPopoutKeyboardState(page),
+      (s) => s.ok && !s.paletteOpen && s.focusedCount === 1,
+      { timeoutMs: 5000, description: 'pop-out palette closed before the probe starts' },
+    );
+  }
+
+  // (2) STAGE a PINNED focus. In LIVE mode the spine tracks head, so the
+  //     focused row moves whenever the host dispatches. One `j` steps back
+  //     off head, which flips the spine to RETRO and pins focus — after
+  //     which the measured step below is a step from a KNOWN row rather
+  //     than from whatever head happened to be at keypress time.
+  const pin = await sendPopoutKey(page, { key: 'j', code: 'KeyJ' });
+  if (!pin.defaultPrevented) {
+    failWithDetails(
+      'Pop-out document has no Xray keydown listener: a spine step key was not consumed there (rf2-61i5)',
+      { observed: { staged, pin } });
+  }
+  const before = await waitForValue(
+    () => readPopoutKeyboardState(page),
+    (s) => s.ok && s.focusedCount === 1 && s.focusedIndex >= 1
+      && s.focusedTestId !== opening.focusedTestId,
+    {
+      timeoutMs: 5000,
+      description: `pop-out spine to pin off head (was ${opening.focusedTestId}) with a row still to its left`,
+    },
+  );
+
+  // (3) MEASURE one spine step. `j` is prev, and the L2 list renders the
+  //     event-bundle vector in order, so the focused row must land on its
+  //     immediate PREDECESSOR — one row, in the documented direction.
+  //     Rows only ever append, so an index captured in `before.rows`
+  //     still names the same row afterwards even if the host dispatched
+  //     again in between.
+  const step = await sendPopoutKey(page, { key: 'j', code: 'KeyJ' });
+  if (!step.defaultPrevented) {
+    failWithDetails(
+      'A pop-out spine step key was not consumed by the pop-out listener (rf2-61i5)',
+      { observed: { before, step } });
+  }
+  const expectedTestId = before.rows[before.focusedIndex - 1];
+  const afterStep = await waitForValue(
+    () => readPopoutKeyboardState(page),
+    (s) => s.ok && s.focusedCount === 1 && s.focusedTestId !== before.focusedTestId,
+    {
+      timeoutMs: 5000,
+      description: `pop-out spine focus to move off ${before.focusedTestId} after j`,
+    },
+  );
+  if (afterStep.focusedTestId !== expectedTestId) {
+    failWithDetails(
+      '`j` in the pop-out did not step the spine focus exactly one row back (rf2-61i5)',
+      { observed: { before, afterStep, expectedTestId } });
+  }
+  if (afterStep.paletteOpen) {
+    failWithDetails(
+      'A bare spine key opened the command palette in the pop-out (rf2-61i5)',
+      { observed: afterStep });
+  }
+
+  // (4) MEASURE the palette chord. Cmd/Ctrl+K must open the palette in the
+  //     pop-out, must NOT be read as the bare `k` spine key, and must not
+  //     move the opener's mount state.
+  const paletteOpen = await sendPopoutKey(page, { key: 'k', code: 'KeyK', ctrlKey: true });
+  if (!paletteOpen.defaultPrevented) {
+    failWithDetails(
+      'Cmd/Ctrl+K was not consumed in the pop-out document (rf2-61i5)',
+      { observed: { afterStep, paletteOpen } });
+  }
+  const afterPalette = await waitForValue(
+    () => readPopoutKeyboardState(page),
+    (s) => s.ok && s.paletteOpen,
+    {
+      timeoutMs: 5000,
+      description: 'command palette open in the POP-OUT document after Cmd/Ctrl+K',
+    },
+  );
+  if (afterPalette.focusedTestId !== afterStep.focusedTestId) {
+    failWithDetails(
+      'Cmd/Ctrl+K in the pop-out also stepped the spine — the chord was read as the bare `k` key (rf2-61i5)',
+      { observed: { afterStep, afterPalette } });
+  }
+
+  // (5) CLOSE it again through the same chord. A one-way observation
+  //     cannot tell an opened palette from one that was already open;
+  //     the round trip can, and it leaves the pop-out clean for whatever
+  //     runs next.
+  const paletteClose = await sendPopoutKey(page, { key: 'k', code: 'KeyK', ctrlKey: true });
+  const afterClose = await waitForValue(
+    () => readPopoutKeyboardState(page),
+    (s) => s.ok && !s.paletteOpen,
+    {
+      timeoutMs: 5000,
+      description: 'command palette closed again in the POP-OUT document after a second Cmd/Ctrl+K',
+    },
+  );
+
+  // (6) The OPENER's mount state is unmoved by every one of those keys.
+  //     `mount/toggle!` / `open!` mutate the DOM synchronously inside the
+  //     handler — before the palette dispatch is even queued — so a read
+  //     taken after the palette has been observed is strictly after any
+  //     mount change those keys could have caused.
+  const baseline = openerMountOf(before);
+  for (const [when, snapshot] of [
+    ['after the j spine step', afterStep],
+    ['after Cmd/Ctrl+K opened the palette', afterPalette],
+    ['after Cmd/Ctrl+K closed it again', afterClose],
+  ]) {
+    if (openerMountOf(snapshot) !== baseline) {
+      failWithDetails(
+        `Keys pressed in the pop-out moved the OPENER's shell mount state ${when} (rf2-61i5)`,
+        { observed: { baseline, when, snapshot } });
+    }
+  }
+
+  // (7) Ctrl+Shift+C stays OPENER-owned. In the pop-out it is left
+  //     entirely alone — not dispatched and not `preventDefault`ed — so it
+  //     falls through to the browser like any unbound key, and the
+  //     opener's in-app shell must not flip. `toggle!` is a synchronous
+  //     DOM mutation with no dispatch in the path, so settling the opener
+  //     mount over consecutive reads is a sound negative observation.
+  const shellChord = await sendPopoutKey(page, {
+    key: 'C', code: 'KeyC', ctrlKey: true, shiftKey: true,
+  });
+  if (shellChord.defaultPrevented) {
+    failWithDetails(
+      'Ctrl+Shift+C was consumed in the pop-out — the opener-owned shell chord must fall through there (rf2-61i5)',
+      { observed: shellChord });
+  }
+  const settledOpenerMount = await waitForStableValue(
+    async () => openerMountOf(await readPopoutKeyboardState(page)),
+    { intervalMs: 100, samples: 3, timeoutMs: 3000 },
+  );
+  if (settledOpenerMount !== baseline) {
+    failWithDetails(
+      "Ctrl+Shift+C pressed in the pop-out toggled the OPENER's in-app shell (rf2-61i5)",
+      { observed: { baseline, settledOpenerMount } });
+  }
+
+  state.popoutKeyboard = {
+    rowsAtStart: staged.rows.length,
+    pinnedFrom: opening.focusedTestId,
+    steppedFrom: before.focusedTestId,
+    steppedTo: afterStep.focusedTestId,
+    expectedTestId,
+    paletteOpenedInPopout: afterPalette.paletteOpen,
+    paletteClosedAgain: !afterClose.paletteOpen,
+    paletteChordConsumed: paletteOpen.defaultPrevented,
+    paletteCloseChordConsumed: paletteClose.defaultPrevented,
+    shellChordFellThrough: !shellChord.defaultPrevented,
+    openerMount: baseline,
+  };
+  return state.popoutKeyboard;
+}
+
 async function assertDefaultInlineLaunchModes(page, state) {
   const countBefore = await waitForValue(
     () => readHostCounter(page),
@@ -581,89 +879,10 @@ async function assertDefaultInlineLaunchModes(page, state) {
     }
   });
 
-  // rf2-61i5 — the pop-out document's OWN keyboard.
-  //
-  // DOM key events do not cross realms, so a keydown made in the pop-out
-  // window can only be seen by a listener installed on the POP-OUT
-  // document. Dispatching into that document is therefore the one probe
-  // that distinguishes "Xray has a keyboard here" from "Xray has a
-  // keyboard in the opener" — the boundary the pre-existing pop-out
-  // coverage (root/shell presence, shared cascade rendering) never
-  // crossed, because it sent no key at all.
-  //
-  // The two assertions match the acceptance the bead names: a spine step
-  // key moves focus on the shared :rf/xray frame, and Cmd/Ctrl+K opens the
-  // palette in the pop-out WITHOUT disturbing the opener's inline shell.
-  const popoutKeyboard = await page.evaluate(() => {
-    const win = window.open('', 'rf-xray-popout');
-    const doc = win && win.document;
-    if (!doc) return { ok: false, reason: 'pop-out document unreachable' };
-
-    const shell = doc.querySelector('[data-testid="rf-xray-shell"]');
-    if (!shell) return { ok: false, reason: 'pop-out shell not rendered' };
-
-    // The opener's inline shell, whose mount state must not move.
-    const openerRootMode = () => {
-      const root = document.getElementById('rf-xray-root');
-      return root ? root.getAttribute('data-rf-xray-mode') : null;
-    };
-    const openerShellCount = () =>
-      document.querySelectorAll('[data-testid="rf-xray-shell"]').length;
-
-    const before = { rootMode: openerRootMode(), shells: openerShellCount() };
-
-    // KeyboardEvent must be constructed from the POP-OUT realm, or the
-    // capture listener there receives a foreign-realm object.
-    const send = (init) => {
-      const Ctor = win.KeyboardEvent || window.KeyboardEvent;
-      const ev = new Ctor('keydown', Object.assign(
-        { bubbles: true, cancelable: true, composed: true }, init));
-      shell.dispatchEvent(ev);
-      return ev.defaultPrevented;
-    };
-
-    // (a) a spine STEP key — j / k walk the event feed.
-    const stepPrevented = send({ key: 'j', code: 'KeyJ' });
-
-    // (b) the palette chord.
-    const palettePrevented = send({ key: 'k', code: 'KeyK', ctrlKey: true });
-
-    const after = { rootMode: openerRootMode(), shells: openerShellCount() };
-
-    return {
-      ok: true,
-      stepPrevented,
-      palettePrevented,
-      paletteInPopout: Boolean(doc.querySelector('[data-testid="rf-xray-palette-dialog"]')),
-      openerBefore: before,
-      openerAfter: after,
-    };
-  });
-
-  if (!popoutKeyboard.ok) {
-    failWithDetails('Pop-out keyboard probe could not run', { observed: popoutKeyboard });
-  }
-  if (!popoutKeyboard.stepPrevented) {
-    failWithDetails(
-      'Pop-out document has no Xray keydown listener: a spine step key was not consumed there (rf2-61i5)',
-      { observed: popoutKeyboard });
-  }
-  if (!popoutKeyboard.palettePrevented) {
-    failWithDetails(
-      'Cmd/Ctrl+K was not consumed in the pop-out document (rf2-61i5)',
-      { observed: popoutKeyboard });
-  }
-  if (!popoutKeyboard.paletteInPopout) {
-    failWithDetails(
-      'Cmd/Ctrl+K in the pop-out did not open the palette in that window (rf2-61i5)',
-      { observed: popoutKeyboard });
-  }
-  if (popoutKeyboard.openerBefore.rootMode !== popoutKeyboard.openerAfter.rootMode
-      || popoutKeyboard.openerBefore.shells !== popoutKeyboard.openerAfter.shells) {
-    failWithDetails(
-      "Keys pressed in the pop-out moved the OPENER's shell mount state (rf2-61i5)",
-      { observed: popoutKeyboard });
-  }
+  // rf2-61i5 — the pop-out document's OWN keyboard. Every key is sent into
+  // the pop-out realm and every consequence is POLLED for, because the
+  // consequences are re-frame dispatches and dispatch is asynchronous.
+  const popoutKeyboard = await assertPopoutKeyboard(page, state);
 
   state.launchModes = {
     inlineDefault: {
@@ -3546,6 +3765,17 @@ const SCENARIOS = [
   {
     name: 'source coordinates and launch-mode availability',
     url: '/counter/',
+    // PR-smoke tier (rf2-61i5). This scenario carries the ONLY browser
+    // proof that the pop-out document has its own keyboard listener —
+    // DOM key events do not cross realms, so no unit test and no
+    // opener-side scenario can stand in for it. Left nightly-only, the
+    // regression class it guards is absent from exactly the runs a merge
+    // decision reads, which is how the first version of the probe merged
+    // green without ever having been executed. It rides `/counter/`,
+    // already staged for the smoke tier by the shell-sweep and palette
+    // scenarios, so promotion costs one scenario's runtime and no extra
+    // compile.
+    smoke: true,
     panels: ['trace'],
     coveredRows: [
       'Open in Editor / Source Coordinates',

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -593,20 +593,37 @@ async function sendPopoutKey(page, init) {
  * opener's MOUNT state, not about where the palette paints.
  */
 async function assertPopoutKeyboard(page, state) {
-  // (0) STAGE a step-able spine. The scenario cleared the trace bus and
-  //     dispatched a single host event, and one event has nowhere to step
-  //     to — `focus-step-reducer` clamps at the edge and returns `db`
-  //     unchanged, so a probe run against it would assert nothing. Two
-  //     more host dispatches give the walk room in both directions.
+  // (0) STAGE a step-able spine, and let it SETTLE before reading it.
+  //
+  //     The scenario cleared the trace bus and dispatched a single host
+  //     event, and one event has nowhere to step to — `focus-step-reducer`
+  //     clamps at the edge and returns `db` unchanged, so a probe run
+  //     against it would assert nothing. Two more host dispatches give the
+  //     walk room; the counter surface emits nothing on its own, so once
+  //     the row list stops growing no further host dispatch is in flight.
+  //
+  //     Settling is load-bearing rather than tidy. In LIVE mode the spine
+  //     tracks head, so a row arriving between the read and the keypress
+  //     silently moves the row this probe believes it is stepping from.
   await clickHostButtonByLabel(page, '+');
   await clickHostButtonByLabel(page, '+');
 
+  await waitForStableValue(
+    async () => JSON.stringify((await readPopoutKeyboardState(page)).rows || null),
+    { intervalMs: 150, samples: 3, timeoutMs: 20000 },
+  );
+  //     `focusedIndex >= 2` is the real precondition, not a row count:
+  //     the probe takes TWO steps back, so the focused row needs two rows
+  //     to its left. Deriving it from the focused position rather than
+  //     asserting focus sits at head keeps the probe independent of the
+  //     small difference between the rows the L2 list RENDERS and the
+  //     event-bundles the spine considers FOCUSABLE.
   const staged = await waitForValue(
     () => readPopoutKeyboardState(page),
-    (s) => s.ok && s.rows.length >= 3 && s.focusedCount === 1,
+    (s) => s.ok && s.focusedCount === 1 && s.focusedIndex >= 2,
     {
-      timeoutMs: 15000,
-      description: 'pop-out L2 spine carrying >=3 rows with exactly one focused row',
+      timeoutMs: 10000,
+      description: 'settled pop-out L2 spine with one focused row and two rows to step back through',
     },
   );
 
@@ -624,11 +641,21 @@ async function assertPopoutKeyboard(page, state) {
     );
   }
 
-  // (2) STAGE a PINNED focus. In LIVE mode the spine tracks head, so the
-  //     focused row moves whenever the host dispatches. One `j` steps back
-  //     off head, which flips the spine to RETRO and pins focus — after
-  //     which the measured step below is a step from a KNOWN row rather
-  //     than from whatever head happened to be at keypress time.
+  // (2) STAGE a PINNED focus. In LIVE mode the spine tracks head; one `j`
+  //     steps back off head, which flips the spine to RETRO and pins the
+  //     focus, so the measured step below starts from a KNOWN row.
+  //
+  //     EVERY wait from here on names the EXACT row it expects, never
+  //     merely "a row other than the one we last saw". A not-equal
+  //     predicate is also satisfied by a LIVE head that moved, so it can
+  //     return while the step it is waiting for is still queued — after
+  //     which the next assertion measures the previous key's effect and
+  //     attributes it to this one. That is the same false-pass class as
+  //     reading in the callback that sent the key, reached through the
+  //     predicate instead of through the clock; it was measured on the
+  //     first draft of this probe, which reported Cmd/Ctrl+K stepping the
+  //     spine when the step was a `j` landing late.
+  const pinnedTestId = staged.rows[staged.focusedIndex - 1];
   const pin = await sendPopoutKey(page, { key: 'j', code: 'KeyJ' });
   if (!pin.defaultPrevented) {
     failWithDetails(
@@ -637,39 +664,42 @@ async function assertPopoutKeyboard(page, state) {
   }
   const before = await waitForValue(
     () => readPopoutKeyboardState(page),
-    (s) => s.ok && s.focusedCount === 1 && s.focusedIndex >= 1
-      && s.focusedTestId !== opening.focusedTestId,
+    (s) => s.ok && s.focusedCount === 1 && s.focusedTestId === pinnedTestId,
     {
       timeoutMs: 5000,
-      description: `pop-out spine to pin off head (was ${opening.focusedTestId}) with a row still to its left`,
+      description: `pop-out spine focus pinned on ${pinnedTestId} after j (was ${staged.focusedTestId})`,
     },
   );
 
   // (3) MEASURE one spine step. `j` is prev, and the L2 list renders the
   //     event-bundle vector in order, so the focused row must land on its
-  //     immediate PREDECESSOR — one row, in the documented direction.
-  //     Rows only ever append, so an index captured in `before.rows`
-  //     still names the same row afterwards even if the host dispatched
-  //     again in between.
+  //     immediate PREDECESSOR — one row, in the documented direction. The
+  //     stability check after it is what makes "exactly one" a measurement
+  //     rather than a hope: arriving at the neighbour proves the step is
+  //     not short, and STAYING there proves it is not long.
+  const expectedTestId = staged.rows[staged.focusedIndex - 2];
   const step = await sendPopoutKey(page, { key: 'j', code: 'KeyJ' });
   if (!step.defaultPrevented) {
     failWithDetails(
       'A pop-out spine step key was not consumed by the pop-out listener (rf2-61i5)',
       { observed: { before, step } });
   }
-  const expectedTestId = before.rows[before.focusedIndex - 1];
   const afterStep = await waitForValue(
     () => readPopoutKeyboardState(page),
-    (s) => s.ok && s.focusedCount === 1 && s.focusedTestId !== before.focusedTestId,
+    (s) => s.ok && s.focusedCount === 1 && s.focusedTestId === expectedTestId,
     {
       timeoutMs: 5000,
-      description: `pop-out spine focus to move off ${before.focusedTestId} after j`,
+      description: `pop-out spine focus to step exactly one row back, ${pinnedTestId} -> ${expectedTestId}`,
     },
   );
-  if (afterStep.focusedTestId !== expectedTestId) {
+  const settledAfterStep = await waitForStableValue(
+    async () => (await readPopoutKeyboardState(page)).focusedTestId,
+    { intervalMs: 100, samples: 3, timeoutMs: 3000 },
+  );
+  if (settledAfterStep !== expectedTestId) {
     failWithDetails(
-      '`j` in the pop-out did not step the spine focus exactly one row back (rf2-61i5)',
-      { observed: { before, afterStep, expectedTestId } });
+      'One `j` in the pop-out stepped the spine focus more than one row (rf2-61i5)',
+      { observed: { before, afterStep, expectedTestId, settledAfterStep } });
   }
   if (afterStep.paletteOpen) {
     failWithDetails(
@@ -694,10 +724,10 @@ async function assertPopoutKeyboard(page, state) {
       description: 'command palette open in the POP-OUT document after Cmd/Ctrl+K',
     },
   );
-  if (afterPalette.focusedTestId !== afterStep.focusedTestId) {
+  if (afterPalette.focusedTestId !== expectedTestId) {
     failWithDetails(
       'Cmd/Ctrl+K in the pop-out also stepped the spine — the chord was read as the bare `k` key (rf2-61i5)',
-      { observed: { afterStep, afterPalette } });
+      { observed: { expectedTestId, afterStep, afterPalette } });
   }
 
   // (5) CLOSE it again through the same chord. A one-way observation
@@ -758,9 +788,10 @@ async function assertPopoutKeyboard(page, state) {
 
   state.popoutKeyboard = {
     rowsAtStart: staged.rows.length,
-    pinnedFrom: opening.focusedTestId,
-    steppedFrom: before.focusedTestId,
+    stagedFocus: opening.focusedTestId,
+    pinnedOn: before.focusedTestId,
     steppedTo: afterStep.focusedTestId,
+    settledAfterStep,
     expectedTestId,
     paletteOpenedInPopout: afterPalette.paletteOpen,
     paletteClosedAgain: !afterClose.paletteOpen,


### PR DESCRIPTION
Follow-on to the merged-PR audit of #9263 recorded on rf2-61i5. The production
fix — the pop-out document's own capture-phase keydown listener, the
surface-parameterised handler, and the `teardown-popout-state!` disposal path —
landed with #9263 and is untouched here. What the audit found incomplete was the
**browser witness**, and that is the whole of this PR.

## The defect in the witness

`tools/xray/testbeds/feature_matrix/scenarios.cjs` sent `j` and `Ctrl+K` into the
pop-out and then read `paletteInPopout` and `openerAfter` in the **same
synchronous `page.evaluate` callback**. Both keys drive re-frame dispatches:
`router` drains its queue on a next-tick and `palette.cljs` renders only once its
subscription changes, so that read can only ever observe the *pre-key* DOM. With
the palette closed it could not see the toggle at all; with one already open it
would have passed while the toggle was closing it. The `j` assertion checked
`defaultPrevented` alone and never the focus step acceptance criterion 2 names.

## The witness now

Staged, then measured, with every consequence polled:

- **stage a step-able spine** — two more host dispatches, because one event has
  nowhere to step to (`focus-step-reducer` clamps at the edge and returns `db`
  unchanged), then `waitForStableValue` on the row list. The counter surface
  emits nothing on its own, so a row list that has stopped growing means no host
  dispatch is in flight;
- **stage a closed palette**, and a **pinned focus** — one `j` steps off head into
  RETRO, so the measured step starts from a known row rather than from whatever
  LIVE head happened to be at keypress time;
- **measure one `j`** — the `aria-pressed="true"` row must land on its immediate
  predecessor in the rendered L2 order, and `waitForStableValue` must hold it
  there. Arriving proves the step was not short; staying proves it was not long;
- **measure `Cmd/Ctrl+K`** — the palette opens in the **pop-out**, does not also
  step the spine (the chord is not the bare `k` key), and closes again on a
  second press;
- **measure `Ctrl+Shift+C`** — not consumed in the pop-out, and the opener's
  mount state settles unchanged.

The opener's **mount** state is asserted unmoved after every key. Its **palette**
deliberately is not: that state lives on `:rf/xray`, which both windows render
(`tools/xray/spec/011-Launch-Modes.md` §The pop-out has its own keyboard), so it
appears wherever a shell is on screen. Asserting otherwise would pin the wrong
contract.

Every wait names the **exact** row it expects, never "a row other than the one we
last saw". That is not stylistic. The first local run of this probe went red
blaming `Cmd/Ctrl+K` for stepping the spine: in LIVE mode a not-equal predicate
is also satisfied by a row *arriving*, so the staging wait returned on a head
move while the staging `j` was still queued, the next wait then observed that `j`
landing and credited it to the step, and the chord was finally blamed for a press
number two had made. It is the same false-pass class as reading in the sending
callback, reached through the predicate instead of through the clock.

## The scenario joins the PR-smoke tier

`source coordinates and launch-mode availability` carried the only browser proof
that key events reach the pop-out realm — DOM key events do not cross realms, so
no unit test and no opener-side scenario can stand in for it — and it had no
`smoke: true`, so it ran nightly only. That is why the first version of the probe
merged green **without ever having been executed**: the audit's own note points at
CI run 33943148594, green over four PR-smoke scenarios, none of them this one. It
rides `/counter/`, already staged for the smoke tier by the shell-sweep and
palette scenarios, so promotion costs one scenario's runtime and **no extra
compile**. The tier counts in
`implementation/scripts/serve-and-run-xray-feature-gate.cjs` are derived and
printed live every run (that file's own comment says to read the printed pair,
not the dated snapshot in its prose), so nothing there needed editing — and it is
outside this dispatch's fence in any case.

## What is pinned vs hand-verified

A pop-out is a second browser window, and this probe drives it with **synthetic**
`KeyboardEvent`s constructed from the pop-out realm and dispatched on the pop-out
shell. That exercises the real listener, the real capture path, the real handler
and the real dispatches, and it is the part a headless run can own.

What it does **not** model is the browser's own focus routing — that a physical
keypress made while the pop-out window has OS focus is delivered to the pop-out
document rather than the opener's. That is browser behaviour, not Xray's, and no
headless test can assert it.

Hand-verified separately, and **still hand-verified** after this PR: nothing.
This PR adds no product behaviour, so there is no new manual step. The two
consequences of a genuinely detached window — real OS focus routing, and a real
`window.open` popup rather than a same-context tab — remain outside every gate,
as they were before.

Also not browser-pinned, deliberately, and covered by unit tests instead
(`tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs` §10, landed with
#9263): `Cmd/Ctrl+Shift+M`, `,` / `s`, and the repeat / editable / activatable /
modal guards. They are surface-independent by construction — the handler's `cond`
reaches them identically from both surfaces — so a second browser assertion would
re-measure the shared arms rather than the realm boundary this scenario exists to
cross.

## Spec

**Spec unchanged because** the normative contract for the pop-out's own keyboard
already landed with the fix in #9263, as
`tools/xray/spec/011-Launch-Modes.md` §The pop-out has its own keyboard. This PR
changes no behaviour and no contract — only the witness for one. That section was
re-read against `keybinding.cljs` at tip while writing this probe and is accurate,
including the point the probe relies on: the palette's open state lives on
`:rf/xray` and paints wherever a shell is on screen, so what must not move is the
opener's *mount* state. `tools/xray/spec/018` was left alone (rf2-mv9e holds it).

## Quality gates

Every number below is the **captured** exit code — runner redirected to a log and
`echo $?` to an exit file, on one command line in one shell — not a
harness-reported one. The two disagreed twice in this session: both browser runs
that failed were reported as exit 0 by the harness and captured as exit 1.

| gate | run | result | captured exit |
|---|---|---|---|
| `serve-and-run-xray-feature-gate.cjs --smoke` (attempt 1, pre-fix probe) | local, foreground-polled | **FAIL** — 5 scenarios, 1 failure; found the LIVE-head race in my own staging | `1` |
| `serve-and-run-xray-feature-gate.cjs --smoke` (attempt 2, after the fix) | local | PASS — 5 scenarios, 0 failures | `0` |
| **negative control** — same gate with `install-popout-keydown!` disabled | local | **FAIL as required**, naming `Pop-out document has no Xray keydown listener: a spine step key was not consumed there (rf2-61i5)`; the other 4 scenarios still passed | `1` |
| `serve-and-run-xray-feature-gate.cjs --smoke` (attempt 3, re-run on the rebased base) | local | PASS — 5 scenarios, 0 failures, 156/157/250 files recompiled | `0` |
| `npm run lint:js` (root ESLint) | local, x3 | PASS — 0 errors, 1 pre-existing warning in `implementation/ssr/test/react_dom_probe/boolean_attr_classes.cjs`, untouched here | `0` |
| `python scripts/check_require_alias_dialect.py --verbose` | local, x2 | PASS — 2794 files, 10867 re-frame require edges, every surface at or under its floor | `0` |
| `python scripts/check_view_lifetime_residue.py --verbose` | local, x2 | PASS — zero residue in tracked content or paths | `0` |
| **negative control** — banned word planted in the file this PR edits | local | **FAIL as required**, naming the planted line by file and line number | `1` |
| `node --check tools/xray/testbeds/feature_matrix/scenarios.cjs` | local | PASS | `0` |

The require-alias gate is unaffected by construction: this PR adds no `.cljs` or
`.cljc` file and touches no require form. It was run anyway, twice, because a
floor is per-surface and a green has to be measured rather than argued.

**Both browser gates were verified to have read this branch's tree, by both
available routes** — the runner prints its `shadow-cljs.edn` and serving paths and
both named this branch's worktree, and the sabotage run's red discriminates on a
fault that existed only there. The negative control's plant was restored and
confirmed by git blob hash (`9ed1ebba…` before, byte-identical after), and so was
the residue gate's.

Gates were re-run on the final base after rebasing past #9273 / #9274 / #9275; the
rebase moved 156–250 files into the recompile, so the pre-rebase green was
evidence about a tree that no longer existed.

## Surfaces this diff arms

Derived, not hand-listed, from `.github/scripts/report-changed-surfaces.sh` read
against `.github/workflows/test.yml` (and exercised once against
`implementation/core/src/re_frame/core.cljc` as a control, which arms a different
set):

`examples_compile`, `tools_jvm`, `mcp_conformance`, `story_xray_browser`.

`story_xray_browser` is the one that matters: `test.yml` runs
`npm run test:xray-feature-gate:smoke` on it, so with `smoke: true` added **this
PR's own CI executes the scenario it changes** — which is exactly what did not
happen for #9263. The other three are armed by path (`tools/xray/testbeds/*`,
`tools/**`) rather than by content: this diff is a single Playwright scenario
file, and `node implementation/scripts/check-examples-compile.cjs --list`
enumerates 58 build ids, none of which compiles a `.cjs` scenario.
