### PR TITLE
fix(pair-mcp): a trace-window / watch-epochs cursor owns the frame it resolved (rf2-yo4s)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cursor.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cursor.cljs
@@ -40,7 +40,9 @@
      :until-ms <int-or-nil>          ; first-call clock; bounds the
                                      ; window so trace-window doesn't
                                      ; admit fresh epochs mid-page
-     :frame <keyword-or-nil>}
+     :frame <keyword-or-nil>}          ; the frame page 1 RESOLVED and
+                                       ; read, not the frame it was
+                                       ; asked for — see below
 
   ## Why `:after-id` is `:any`, not `string?`
 
@@ -73,6 +75,26 @@
   The runtime already surfaces `:id-aged-out? true` from `epochs-since`
   when the cursor's id can't be found — we lift that signal to a
   top-level error.
+
+  ## Cursor frame ownership
+
+  `:frame` carries the id page 1 RESOLVED and read against — lifted out
+  of the eval result, never the caller's argument. Both epoch tools
+  resolve the operating frame browser-side (explicit `frame` -> session
+  pin -> sole app frame; see
+  `re-frame2-pair-mcp.tools.frame-resolve`), and page 1 typically
+  supplies none of the first tier, so the argument is nil while the
+  read is not. A cursor built from the argument therefore stored nil,
+  and page 2 — which also names no frame — re-resolved against whatever
+  the session said by then.
+
+  That makes a pin change, or a second app frame registering
+  mid-pagination, silently redirect the continuation to a DIFFERENT
+  ring: the live `:after-id` is not in it, `epochs-since` answers
+  `:id-aged-out? true`, and a healthy cursor is reported stale. The
+  frame REFUSAL cannot cover this one — the newly-resolved frame is
+  perfectly unambiguous, it is just not the ring the agent was reading.
+  Only ownership from page 1 closes it (rf2-yo4s).
 
   ## Why opaque
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/frame_resolve.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/frame_resolve.cljs
@@ -86,6 +86,30 @@
   [sym & args]
   (apply ef/rt-call sym (concat args [(ef/rt-raw resolved-frame-sym)])))
 
+(def resolved-frame-entry
+  "Map entry an inner form puts in its result map so the id it ACTUALLY
+  read against travels back to the tool body — read out with
+  [[resolved-frame]].
+
+  A PAGINATED tool needs this and a single-shot one does not. Page 1
+  normally arrives with neither a `frame` argument nor a cursor, so the
+  operating frame exists only as [[resolved-frame-sym]], browser-side.
+  A tool that built `:next-cursor` from what it ASKED for would store
+  nil — and page 2, carrying no frame either, re-resolves against
+  whatever the session says by then. Pin a second frame, or select a
+  different one, and the continuation silently walks a DIFFERENT ring:
+  the live `:after-id` isn't in it, so a healthy cursor is reported
+  aged-out (rf2-yo4s). Carrying the resolved id makes a cursor OWN its
+  frame from page 1, which is the same \"one resolution, one truth\"
+  this namespace already gives the read."
+  (str ":frame " resolved-frame-sym))
+
+(defn resolved-frame
+  "The frame id [[with-resolved-frame]] resolved, lifted off a successful
+  eval result whose inner form carried [[resolved-frame-entry]]."
+  [v]
+  (:frame v))
+
 (defn refusal?
   "True when a runtime eval result is a structured refusal rather than
   the payload the tool asked for — `{:ok? false ...}`, which under

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
@@ -34,7 +34,16 @@
   \"nothing happened\" in the same voice as a genuinely quiet window.
   The empty-result advisory above could not catch that: it read the
   SAME implicit-frame history, so both sides came back empty together
-  (rf2-yo4s)."
+  (rf2-yo4s).
+
+  The resolved id then rides BACK out of the eval and into
+  `:next-cursor`, so a cursor owns the frame it is iterating from page
+  1 — not from page 2, which is all a cursor built out of the caller's
+  ARGUMENTS could manage. Page 1 normally names no frame at all, so
+  that cursor stored nil and page 2 re-resolved against whatever the
+  session said by then: pin a second frame in between and the
+  continuation walked a different ring, where the live `:after-id` is
+  absent and the healthy cursor reads as stale (rf2-yo4s)."
   (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.frame-resolve :as fr]
@@ -145,6 +154,10 @@
                             " :head-id (some-> hist peek :epoch-id)"
                             " :next-id next-id"
                             " :history-count (count hist)"
+                            ;; The id this page was actually read
+                            ;; against, so `:next-cursor` can own it —
+                            ;; see `read-frame` below.
+                            " " fr/resolved-frame-entry
                             " :remaining (max 0 (- (count filtered) (count page)))}"))))
             ;; Resolve once, refuse at nil, THEN slice. The sticky frame
             ;; is the tier-1 override, so a cursor's frame outranks the
@@ -161,6 +174,17 @@
               (wire/err-text v)
               (let [v          (if (map? v) v {})
                     aged-out?  (:id-aged-out? v)
+                    ;; The frame this page was READ against, not the one
+                    ;; it was asked for. On page 1 those differ: the
+                    ;; caller normally names no frame and carries no
+                    ;; cursor, so `sticky-frame` is nil while the read
+                    ;; resolved a real id from the session pin or the
+                    ;; sole app frame. Stamping nil into `:next-cursor`
+                    ;; is what let page 2 re-resolve and walk a
+                    ;; DIFFERENT ring (rf2-yo4s). Falls back to
+                    ;; `sticky-frame` only for a blank runtime result,
+                    ;; where there is no page to continue anyway.
+                    read-frame (or (fr/resolved-frame v) sticky-frame)
                     raw-epochs (vec (:epochs v))]
                 (if aged-out?
                   (cursor/cursor-stale-result "trace-window"
@@ -180,7 +204,12 @@
                                          :after-id next-id
                                          :ms       window-ms
                                          :until-ms until-ms
-                                         :frame    sticky-frame}))
+                                         ;; The cursor OWNS its frame
+                                         ;; from page 1 onward, so a pin
+                                         ;; changed mid-pagination
+                                         ;; cannot move the ring under
+                                         ;; the agent.
+                                         :frame    read-frame}))
                         has-more?     (some? next-cursor)
                         remaining     (or (:remaining v) 0)
                         history-count (or (:history-count v) 0)
@@ -204,7 +233,13 @@
                         advisory      (when (and (zero? count)
                                                  (pos? history-count))
                                         {:reason            :window-excludes-history
-                                         :frame             sticky-frame
+                                         ;; Names the frame the count
+                                         ;; came from, which is the
+                                         ;; resolved one — an advisory
+                                         ;; reporting `:frame nil`
+                                         ;; describes a read that never
+                                         ;; happened.
+                                         :frame             read-frame
                                          :epochs-in-history history-count
                                          :window-ms         window-ms
                                          :hint              (str history-count

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
@@ -39,7 +39,17 @@
   falsehoods at once: `:count 0` (\"nothing matched\") and, because a
   cursor id cannot be found in an empty history, `:id-aged-out? true`
   (\"your cursor fell out of the ring\") — a live cursor declared dead
-  (rf2-yo4s)."
+  (rf2-yo4s).
+
+  The resolved id then rides BACK out of the eval and into
+  `:next-cursor`, so a cursor owns the frame it is iterating from page
+  1 — not from page 2, which is all a cursor built out of the caller's
+  ARGUMENTS could manage. Page 1 normally names no frame, so that
+  cursor stored nil and page 2 re-resolved against whatever the session
+  said by then. That reached the SAME dead-cursor falsehood by a second
+  route, and one the frame refusal cannot cover, because the new frame
+  resolves perfectly well — it is simply not the ring the agent was
+  reading (rf2-yo4s)."
   (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.frame-resolve :as fr]
@@ -147,6 +157,10 @@
                             " :next-id next-id"
                             " :history-count history-count"
                             " :since-count since-count"
+                            ;; The id this poll was actually read
+                            ;; against, so `:next-cursor` can own it —
+                            ;; see `read-frame` below.
+                            " " fr/resolved-frame-entry
                             " :remaining (max 0 (- (count matches) (count page)))}"))))
             ;; Resolve once, refuse at nil, THEN poll. The sticky frame
             ;; is the tier-1 override, so a cursor's frame outranks the
@@ -165,7 +179,17 @@
               ;; wrong frame.
               (wire/err-text v)
               (let [v          (if (map? v) v {})
-                    aged-out?  (:id-aged-out? v)]
+                    aged-out?  (:id-aged-out? v)
+                    ;; The frame this poll was READ against, not the one
+                    ;; it was asked for — the two differ on page 1,
+                    ;; where the caller names no frame and the id comes
+                    ;; from the session pin or the sole app frame.
+                    ;; Stamping the asked-for nil into `:next-cursor`
+                    ;; let a later pin change move the ring under the
+                    ;; agent, and then the poll declared the live cursor
+                    ;; aged out — the very falsehood this tool's frame
+                    ;; refusal exists to stop (rf2-yo4s).
+                    read-frame (or (fr/resolved-frame v) sticky-frame)]
                 (if (and aged-out? (some? effective-after))
                   (cursor/cursor-stale-result "watch-epochs"
                                               {:requested-id (or (:requested-id v) effective-after)
@@ -185,7 +209,12 @@
                                            :after-id next-id
                                            :ms       nil
                                            :until-ms nil
-                                           :frame    sticky-frame
+                                           ;; The cursor OWNS its frame
+                                           ;; from page 1 onward, so a
+                                           ;; pin changed mid-pagination
+                                           ;; cannot move the ring under
+                                           ;; the agent.
+                                           :frame    read-frame
                                            ;; Carry the sticky
                                            ;; predicate so page 2+ keeps
                                            ;; filtering. nil when no pred was
@@ -213,7 +242,9 @@
                                (zero? since-count)
                                (pos? history-count))
                           {:reason            :no-events-since-id
-                           :frame             sticky-frame
+                           ;; The frame the count came from — the
+                           ;; resolved one, never the asked-for nil.
+                           :frame             read-frame
                            :epochs-in-history history-count
                            :requested-id      effective-after
                            :hint              (str "Per-frame history holds "
@@ -226,7 +257,9 @@
                           (and (zero? count)
                                (pos? since-count))
                           {:reason            :pred-excludes-history
-                           :frame             sticky-frame
+                           ;; The frame the count came from — the
+                           ;; resolved one, never the asked-for nil.
+                           :frame             read-frame
                            :epochs-in-history history-count
                            :epochs-since-id   since-count
                            :hint              (str since-count

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/epoch_frame_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/epoch_frame_test.cljs
@@ -34,7 +34,25 @@
   frame's ring, reproducing `epochs-since`'s real not-found semantics.
   On the pre-fix form the frame is nil, the ring is `[]`, and the
   falsehoods appear on their own — which is what makes these witnesses
-  fail on the pre-fix tree rather than merely assert the fixed shape."
+  fail on the pre-fix tree rather than merely assert the fixed shape.
+
+  ## And what the refusal does NOT reach
+
+  Both tools are cursor-paged, so resolving page 1 correctly is only
+  half the contract. The resolved id has to travel BACK out of the eval
+  and into `:next-cursor`, because page 1 typically names no frame:
+  a cursor built from the ARGUMENTS stores nil, and page 2 — naming no
+  frame either — re-resolves against whatever the session says by then.
+
+  The refusal cannot cover that second call. By page 2 there is usually
+  nothing to refuse: pin a frame, or register a second one, and the
+  session resolves cleanly — to a DIFFERENT ring, in which the live
+  `:after-id` is absent, so `epochs-since` calls the healthy cursor
+  aged out. Same falsehood as the original bug, reached from the other
+  side. The `## Cursor frame ownership` witnesses below drive real
+  page-1-generated cursors through exactly those two session changes;
+  the simulator answers `:frame fid` and pages at the emitted `(take
+  N …)` so a page-1 cursor exists at all."
   (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
             [clojure.string :as str]
             [re-frame2-pair-mcp.test-utils :as tu]
@@ -117,15 +135,38 @@
                           "Pass `frame` (one of " (pr-str app-frames) ") or pin one with "
                           "`select-frame!` / set-operating-frame, then retry.")})
 
+(defn- read-token
+  "An emitted scalar literal back as a value. Epoch-ids are `:any` per
+  the schema; the reference runtime emits integers, and the tools also
+  ship string ids, so both shapes round-trip here."
+  [tok]
+  (cond
+    (nil? tok)                  nil
+    (= "nil" tok)               nil
+    (str/starts-with? tok "\"") (subs tok 1 (dec (count tok)))
+    :else                       (js/parseInt tok 10)))
+
 (defn- since-id-of
   "The `:since-id` / cursor `:after-id` the form asked `epochs-since`
   for, as it appears in the emitted source (`nil` when absent)."
   [form]
-  (when-let [tok (second (re-find #"epochs-since\s+(\"[^\"]*\"|\S+?)[\s)]" form))]
-    (cond
-      (= "nil" tok)              nil
-      (str/starts-with? tok "\"") (subs tok 1 (dec (count tok)))
-      :else                      (js/parseInt tok 10))))
+  (read-token (second (re-find #"epochs-since\s+(\"[^\"]*\"|\S+?)[\s)]" form))))
+
+(defn- after-id-of
+  "`trace-window`'s cursor watermark, read off the `after-id` LET
+  BINDING the tool emits (`(let [hist … after-id 7 …] …)`). The later
+  textual uses of the name are expressions (`(and after-id …)`), which
+  the literal alternation cannot match, so the binding is the only hit."
+  [form]
+  (read-token (second (re-find #"\bafter-id (nil|\d+|\"[^\"]*\")" form))))
+
+(defn- limit-of
+  "The page size the form asked for — the `(take N …)` both tools write
+  from their `:limit` arg. Paging is simulated because a cursor only
+  EXISTS when a page is capped, and a page-1 cursor is what the
+  ownership witnesses below are about."
+  [form]
+  (or (some-> (second (re-find #"\(take (\d+) " form)) (js/parseInt 10)) 50))
 
 (defn- epochs-since*
   "`re-frame2-pair.runtime/epochs-since` semantics, reproduced: nil id ->
@@ -150,7 +191,14 @@
 (defn- runtime-answer
   "Answer `form` as a live runtime would, given the session described by
   `app-frames` / `pin` / `rings` (a frame-id -> ring vector map). The
-  FRAME is whatever the form resolves, which is the whole point."
+  FRAME is whatever the form resolves, which is the whole point.
+
+  Both arms mirror the emitted form's own slice-then-cap pipeline and
+  report `:frame fid` — the id the read RESOLVED, which is the slot the
+  tool builds `:next-cursor` from. The time filter `trace-window` emits
+  between them is a no-op here by construction: every fixture epoch is
+  stamped `(js/Date.now)` and every fixture window is 60s wide, so
+  `filtered` = `sliced` and paging is the only cap that bites."
   [form {:keys [operation app-frames pin rings]}]
   (let [fid (resolved-id form app-frames pin)]
     (if (and (nil? fid) (guards-ambiguity? form operation))
@@ -158,25 +206,40 @@
       ;; No guard (or an unambiguous session): the read proceeds. For a
       ;; nil frame the per-frame lookup misses and the ring is EMPTY —
       ;; reproducing the pre-fix falsehoods exactly.
-      (let [history (vec (get rings fid))]
+      (let [history (vec (get rings fid))
+            limit   (limit-of form)]
         (if (= :trace-window operation)
-          {:epochs        history
-           :id-aged-out?  false
-           :requested-id  nil
-           :head-id       (some-> (peek history) :epoch-id)
-           :next-id       nil
-           :history-count (count history)
-           :remaining     0}
+          (let [after-id  (after-id-of form)
+                aged-out? (boolean (and after-id
+                                        (not-any? #(= after-id (:epoch-id %)) history)))
+                filtered  (cond
+                            aged-out? []
+                            after-id  (vec (rest (drop-while #(not= after-id (:epoch-id %))
+                                                             history)))
+                            :else     history)
+                page      (vec (take limit filtered))]
+            {:epochs        page
+             :id-aged-out?  aged-out?
+             :requested-id  after-id
+             :head-id       (some-> (peek history) :epoch-id)
+             :next-id       (when (< (count page) (count filtered))
+                              (:epoch-id (last page)))
+             :history-count (count history)
+             :frame         fid
+             :remaining     (max 0 (- (count filtered) (count page)))})
           (let [{:keys [epochs id-aged-out? head-id requested-id]}
-                (epochs-since* history (since-id-of form))]
-            {:matches       epochs
+                (epochs-since* history (since-id-of form))
+                page (vec (take limit epochs))]
+            {:matches       page
              :id-aged-out?  id-aged-out?
              :requested-id  requested-id
              :head-id       head-id
-             :next-id       nil
+             :next-id       (when (< (count page) (count epochs))
+                              (:epoch-id (last page)))
              :history-count (count history)
              :since-count   (count epochs)
-             :remaining     0}))))))
+             :frame         fid
+             :remaining     (max 0 (- (count epochs) (count page)))}))))))
 
 (defn- stub-runtime!
   "Install the simulator. The preload sentinel is answered directly; the
@@ -371,20 +434,222 @@
   ;; call is ALREADY iterating rides in the cursor, and page 2 must stay
   ;; on it even when the session was pinned elsewhere in between.
   (async done
+    ;; Epoch 1 is live in BOTH rings, so the watermark resolves either
+    ;; way and the count is what discriminates: one epoch follows it in
+    ;; `:stories`, two in `:rf/default`. A cursor that fell through to
+    ;; the pin would answer 2.
     (let [c (cursor/encode-cursor {:v 1 :after-id 1 :ms 60000
                                    :until-ms (+ (js/Date.now) 1000)
                                    :frame :stories})]
       (stub-runtime! nil {:operation  :trace-window
                           :app-frames two-frames
                           :pin        :rf/default
-                          :rings      {:rf/default [(epoch 1) (epoch 2)]
-                                       :stories    [(epoch 7)]}})
+                          :rings      {:rf/default [(epoch 1) (epoch 2) (epoch 3)]
+                                       :stories    [(epoch 1) (epoch 7)]}})
       (-> (tw/trace-window-tool nil (tu/args->js {:cursor c}))
           (.then (fn [r]
                    (let [edn (read-edn r)]
                      (is (not (err? r)))
                      (is (= 1 (:count edn))
                          "page 2 stayed on the cursor's frame, not the session pin"))
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; ## Cursor frame ownership — the residual the refusal does not reach.
+;; ---------------------------------------------------------------------------
+;;
+;; The refusal above answers page 1's ambiguity. It cannot answer page 2's,
+;; because by page 2 there is usually no ambiguity left to refuse: the
+;; session resolves a frame perfectly well — just not the one page 1 read.
+;; So the cursor has to CARRY the resolved id, and page 1 is the only call
+;; that can put it there.
+;;
+;; `a-cursors-sticky-frame-outranks-the-session-pin` above proves a cursor
+;; that ALREADY owns a frame is honoured, but it hand-builds that cursor, so
+;; it never exercised CREATION — the half where the id has to come back out
+;; of the eval. Every cursor below is one the tool itself returned.
+
+(defn- cursor-payload
+  "The `:next-cursor` a tool returned, decoded back to its payload map."
+  [r]
+  (cursor/decode-cursor (:next-cursor (read-edn r))))
+
+(deftest the-emitted-forms-carry-the-resolved-id-back
+  ;; The cursor can only own what the eval hands back. Both inner forms
+  ;; put the resolved binding in their result map, beside the page.
+  (async done
+    (let [captured (atom nil)]
+      (stub-runtime! captured {:operation  :trace-window
+                               :app-frames [:rf/default]
+                               :pin        nil
+                               :rings      {:rf/default [(epoch 1)]}})
+      (-> (tw/trace-window-tool nil (tu/args->js {}))
+          (.then (fn [_]
+                   (is (str/includes? @captured ":frame fid")
+                       "trace-window reports the id it read against, not the one it was asked for")))
+          (.then (fn [_]
+                   (let [captured2 (atom nil)]
+                     (stub-runtime! captured2 {:operation  :watch-epochs
+                                               :app-frames [:rf/default]
+                                               :pin        nil
+                                               :rings      {:rf/default [(epoch 1)]}})
+                     (-> (we/watch-epochs-tool nil (tu/args->js {}))
+                         (.then (fn [_]
+                                  (is (str/includes? @captured2 ":frame fid")
+                                      "so does watch-epochs")
+                                  (done)))))))))))
+
+(deftest trace-window-page-1-cursor-owns-the-pin-it-resolved
+  ;; Tier 2. Page 1 names no frame, so pre-fix the cursor stored nil and
+  ;; page 2 re-resolved — landing on whatever the pin said by then.
+  (async done
+    (let [session {:operation  :trace-window
+                   :app-frames two-frames
+                   :pin        :stories
+                   :rings      {:rf/default [(epoch 1) (epoch 2) (epoch 3) (epoch 4)]
+                                :stories    [(epoch 7) (epoch 8) (epoch 9)]}}]
+      (stub-runtime! nil session)
+      (-> (tw/trace-window-tool nil (tu/args->js {:ms 60000 :limit 1}))
+          (.then (fn [r1]
+                   (let [c (cursor-payload r1)]
+                     (is (= :stories (:frame c))
+                         "REGRESSION: the cursor must carry the id the PIN resolved, not the nil it was asked for")
+                     (is (= 7 (:after-id c)) "and the watermark it actually emitted")
+                     ;; The session moves under the agent, mid-pagination.
+                     (stub-runtime! nil (assoc session :pin :rf/default))
+                     (tw/trace-window-tool
+                       nil (tu/args->js {:cursor (:next-cursor (read-edn r1)) :limit 1})))))
+          (.then (fn [r2]
+                   (let [edn (read-edn r2)]
+                     (is (not (err? r2))
+                         "REGRESSION: a re-pinned session must not capture the continuation")
+                     (is (not= :rf.mcp/cursor-stale (:reason edn))
+                         "REGRESSION: epoch 7 is alive in :stories — the cursor is not stale")
+                     (is (= 1 (:count edn)) "page 2 read the ORIGINAL ring")
+                     (is (= :stories (:frame (cursor-payload r2)))
+                         "and page 3 inherits the same ownership"))
+                   (done)))))))
+
+(deftest trace-window-page-2-survives-a-second-frame-registering
+  ;; Tier 3, and the sharper half: the session does not merely move, it
+  ;; becomes AMBIGUOUS. A fresh call would now be refused — an owned
+  ;; cursor must not be, because it already knows its ring.
+  (async done
+    (let [ring {:rf/default [(epoch 1) (epoch 2) (epoch 3)]}]
+      (stub-runtime! nil {:operation  :trace-window
+                          :app-frames [:rf/default]
+                          :pin        nil
+                          :rings      ring})
+      (-> (tw/trace-window-tool nil (tu/args->js {:ms 60000 :limit 1}))
+          (.then (fn [r1]
+                   (is (= :rf/default (:frame (cursor-payload r1)))
+                       "REGRESSION: the SOLE app frame is the id the read resolved; a namespaced keyword round-trips the codec")
+                   (stub-runtime! nil {:operation  :trace-window
+                                       :app-frames two-frames
+                                       :pin        nil
+                                       :rings      (assoc ring :stories [(epoch 7)])})
+                   (tw/trace-window-tool
+                     nil (tu/args->js {:cursor (:next-cursor (read-edn r1)) :limit 1}))))
+          (.then (fn [r2]
+                   (let [edn (read-edn r2)]
+                     (is (not (err? r2))
+                         "REGRESSION: an owned cursor stays answerable where a FRESH call would now be ambiguous")
+                     (is (not= :ambiguous-frame (:reason edn)))
+                     (is (= 1 (:count edn)) "and it read the frame it started on"))
+                   (done)))))))
+
+(deftest watch-epochs-page-1-cursor-owns-the-pin-it-resolved
+  ;; The same creation defect on the tool where losing the ring is worst:
+  ;; a poll that re-resolves cannot find the caller's id in the new ring,
+  ;; so it reports the LIVE cursor dead — the exact falsehood this tool's
+  ;; frame refusal exists to stop, reached by a second route.
+  (async done
+    (let [session {:operation  :watch-epochs
+                   :app-frames two-frames
+                   :pin        :stories
+                   :rings      {:rf/default [(epoch 1) (epoch 2) (epoch 3) (epoch 4)]
+                                :stories    [(epoch 7) (epoch 8) (epoch 9)]}}]
+      (stub-runtime! nil session)
+      (-> (we/watch-epochs-tool nil (tu/args->js {:limit 1}))
+          (.then (fn [r1]
+                   (let [c (cursor-payload r1)]
+                     (is (= :stories (:frame c))
+                         "REGRESSION: the cursor must carry the id the PIN resolved, not nil")
+                     (is (= 7 (:after-id c)))
+                     (stub-runtime! nil (assoc session :pin :rf/default))
+                     (we/watch-epochs-tool
+                       nil (tu/args->js {:cursor (:next-cursor (read-edn r1)) :limit 1})))))
+          (.then (fn [r2]
+                   (let [edn (read-edn r2)]
+                     (is (not (err? r2))
+                         "REGRESSION: the re-pinned session must not capture the poll")
+                     (is (not= :rf.mcp/cursor-stale (:reason edn))
+                         "REGRESSION: epoch 7 is alive in :stories — the cursor is not stale")
+                     (is (not (true? (:id-aged-out? edn)))
+                         "REGRESSION: a live cursor must not be reported dead")
+                     (is (= 1 (:count edn)) "page 2 polled the ORIGINAL ring"))
+                   (done)))))))
+
+(deftest watch-epochs-page-2-survives-a-second-frame-registering
+  (async done
+    (let [ring {:rf/default [(epoch 1) (epoch 2) (epoch 3)]}]
+      (stub-runtime! nil {:operation  :watch-epochs
+                          :app-frames [:rf/default]
+                          :pin        nil
+                          :rings      ring})
+      (-> (we/watch-epochs-tool nil (tu/args->js {:limit 1}))
+          (.then (fn [r1]
+                   (is (= :rf/default (:frame (cursor-payload r1)))
+                       "REGRESSION: the sole app frame is what the cursor owns")
+                   (stub-runtime! nil {:operation  :watch-epochs
+                                       :app-frames two-frames
+                                       :pin        nil
+                                       :rings      (assoc ring :stories [(epoch 7)])})
+                   (we/watch-epochs-tool
+                     nil (tu/args->js {:cursor (:next-cursor (read-edn r1)) :limit 1}))))
+          (.then (fn [r2]
+                   (let [edn (read-edn r2)]
+                     (is (not (err? r2))
+                         "REGRESSION: an owned cursor stays answerable where a FRESH poll would now be ambiguous")
+                     (is (not= :ambiguous-frame (:reason edn)))
+                     (is (not (true? (:id-aged-out? edn))))
+                     (is (= 1 (:count edn))))
+                   (done)))))))
+
+(deftest an-explicit-frame-is-the-id-the-cursor-owns
+  ;; Control: tier 1 still outranks the pin, and it is the RESOLVED id
+  ;; — not the raw argument — that the cursor stores. The two agree
+  ;; here, which is the point: the fix must not move an explicit target.
+  (async done
+    (stub-runtime! nil {:operation  :trace-window
+                        :app-frames two-frames
+                        :pin        :rf/default
+                        :rings      {:rf/default [(epoch 1) (epoch 2)]
+                                     :stories    [(epoch 7) (epoch 8) (epoch 9)]}})
+    (-> (tw/trace-window-tool nil (tu/args->js {:ms 60000 :limit 1 :frame ":stories"}))
+        (.then (fn [r]
+                 (is (= :stories (:frame (cursor-payload r)))
+                     "the explicit frame, not the session pin, is what the cursor owns")
+                 (done))))))
+
+(deftest an-advisory-names-the-frame-its-count-came-from
+  ;; The other half of the same seam. The advisory reports `:frame`, and
+  ;; pre-fix it reported the ASKED-for nil while quoting a history count
+  ;; read from a real frame — a sentence about a frame the call never
+  ;; named.
+  (async done
+    (let [ring (mapv epoch (range 1 10))]
+      (stub-runtime! nil {:operation  :watch-epochs
+                          :app-frames [:step-deck]
+                          :pin        nil
+                          :rings      {:step-deck ring}})
+      (-> (we/watch-epochs-tool nil (tu/args->js {:since-id 9}))
+          (.then (fn [r]
+                   (let [advisory (:advisory (read-edn r))]
+                     (is (= :no-events-since-id (:reason advisory)))
+                     (is (= 9 (:epochs-in-history advisory)))
+                     (is (= :step-deck (:frame advisory))
+                         "REGRESSION: the advisory names the resolved frame its count came from, not nil"))
                    (done)))))))
 
 (deftest a-genuinely-empty-ring-in-a-resolvable-frame-still-answers


### PR DESCRIPTION
Closes the audit residual on rf2-yo4s.

## What was already done, and what was left

PR #9262 landed the bead's original repair: `trace-window` and `watch-epochs` now resolve the operating frame once via `frame-resolve/with-resolved-frame` and refuse at nil with the runtime's own `ambiguous-frame-error`. That is verified at tip and unchanged here.

That answers **page 1**. It does not answer page 2, and the bead was reopened for exactly that.

## The residual

Both tools are cursor-paged and carry sticky `:frame` state in the cursor. They built that cursor from what the call was **asked** for:

```clojure
sticky-frame (or (:frame cursor-in) frame)   ; nil on a normal page-1 call
...
:frame sticky-frame                          ; stamped into :next-cursor
```

Page 1 normally names no frame and carries no cursor, so `sticky-frame` is nil — while the read itself resolved a real id browser-side from the session pin or the sole app frame. The cursor therefore stored `nil`, and page 2 (also naming no frame) **re-resolved** against whatever the session said by then.

Change the pin, or register a second app frame, between pages and the continuation silently walks a **different ring**. The live `:after-id` is not in it, so `epochs-since` answers `:id-aged-out? true` and a healthy cursor is reported stale — the same falsehood the frame refusal exists to stop, reached from the other side.

**The refusal cannot cover this one**: by page 2 the newly-resolved frame is perfectly unambiguous. It is simply not the ring the agent was reading. Only ownership from page 1 closes it.

The same nil also reached the `:advisory` maps, which reported `:frame nil` beside a history count read from a real frame.

## The fix

Resolve-once already binds the id as `fid` inside the emitted form. It now rides **back** out in the existing result map and fills the **existing** cursor slot:

- `frame-resolve/resolved-frame-entry` — the `:frame fid` map entry an inner form carries.
- `frame-resolve/resolved-frame` — the read half, so the key is spelled once.
- Both tools bind `read-frame` and use it for `:next-cursor` and for the advisories.

No new tool, argument, public error vocabulary, or pagination machinery. Cursors are not clobbered or half-advanced: a refusal still returns before any cursor is built, and the encoded shape is unchanged (`:frame` was always there — it now carries the truth).

Tier order is unchanged and pinned: the cursor's sticky frame is passed as the **tier-1 override**, so it still outranks the session pin.

## Tests

`epoch_frame_test.cljs` gains 7 witnesses. The existing sticky-frame test hand-built its cursor, so it proved **consumption** of an already-owned cursor and never exercised **creation**; every cursor below is one the tool itself returned.

- `the-emitted-forms-carry-the-resolved-id-back` — both forms emit `:frame fid`.
- `trace-window-page-1-cursor-owns-the-pin-it-resolved` — tier-2 creation, then the pin moves; page 2 stays on the original ring and page 3 inherits ownership.
- `trace-window-page-2-survives-a-second-frame-registering` — tier-3 creation (namespaced `:rf/default` round-trips the codec), then a second frame registers so a *fresh* call would be refused; the owned cursor is still answerable.
- `watch-epochs-page-1-cursor-owns-the-pin-it-resolved` / `watch-epochs-page-2-survives-a-second-frame-registering` — the same two on the tool where the loss is worst, asserting the live cursor is not declared aged out.
- `an-explicit-frame-is-the-id-the-cursor-owns` — control: tier 1 still wins and is what gets stored.
- `an-advisory-names-the-frame-its-count-came-from` — the advisory half.

The runtime simulator was made more faithful to support them: it answers `:frame fid`, pages at the emitted `(take N ...)` (a cursor only exists when a page is capped), and slices on `after-id` the way the emitted form does. One existing fixture was reshaped so its assertion still discriminates under the stricter simulator — epoch 1 is now live in both rings, and the post-watermark counts differ.

## Census re-run

Re-ran the bead's census on the current tree, over both token axes (line-oriented and whitespace-flattened), across every `rt-call` / `frame-sym-call` the pair-mcp tools emit, cross-referenced against the runtime fns that call `ambiguous-frame-error`.

**No third tool has this hole.** The callees the bead's census did not enumerate were checked at source and are all correctly not frame-targeted reads: `registrar-list` / `registrar-describe` are the process-global registrar; `frame-registrar-list` / `frame-registrar-describe` take an explicit `frame-id` and fail loud on an unresolvable one, and `handler-meta` documents an absent `:frame` as the process-global path rather than an implicit-frame read; `read-recording` is keyed by recording-id; `orient` reports the operating frame honestly; `snapshot-state` is the deliberate multi-frame mega-op.

Control re-run rather than trusted: `read-sub!`, `sub-cache-info`, `describe-image`, `start-recording!` (`record`) and `sample-signals` (`subs-sample`) all do return the refusal, so the instrument detects the pattern.

## Premises checked at source

- `epoch-history/1` and `epochs-since/1` both default to `(current-frame)` — **holds**.
- `history-for` returns `[]` for an unknown frame — **behaviour holds**, but the line citation is stale: it is at `implementation/epoch/src/re_frame/epoch/state.cljc:285-288`, not 219-222.
- `trace-window`'s `:count-0` advisory cannot catch the ambiguity because it reads the same implicit history — **holds**.

## Quality gates

All run in the foreground on the final rebased base, exit codes captured on the same command line and quoted from the captured file (never from a harness report). `shadow-cljs compile` exits 0 with failing tests on this repo, so the verdict quoted is the separate `node out/server-test.js` step.

| Gate | Command | Exit | Result |
|---|---|---|---|
| pair-mcp CLJS suite (compile) | `shadow-cljs compile server-test` | **0** | build completed |
| pair-mcp CLJS suite (verdict) | `node out/server-test.js` | **0** | **1147 tests, 4185 assertions, 0 failures, 0 errors** |
| Tool-descriptor drift | `npm run check:descriptors` | **0** | `tool-descriptors.edn` in sync (30 tools) |
| pair-mcp server bundle | `shadow-cljs compile server` | **0** | 136 files, 0 warnings |
| MCP-client conformance | `npm run test:re-frame2-pair` | **0** | `RE-FRAME2-PAIR-MCP MCP-CLIENT CONFORMANCE GREEN` |
| Require-alias dialect ratchet | `python scripts/check_require_alias_dialect.py --verbose` | **0** | 2794 files, 10867 edges, every surface at or under its floor |
| View-lifetime residue ratchet | `python scripts/check_view_lifetime_residue.py --verbose` | **0** | zero residue in tracked content or paths |

Baseline before the change was 1140 tests / 4158 assertions; the +7 / +27 is exactly the new witnesses.

`npm ci` for the conformance harness was run from its own lockfile in this worktree. No shared `node_modules` was linked into this worktree at any point, so no installer could reach a shared tree.

### Gate discrimination (each gate proved to read this worktree, not a sibling's)

- **CLJS suite** — reverted `:frame read-frame` to `:frame sticky-frame` in `trace_window.cljs` alone. Sabotage run went **red: exit 1, 9 failures**, all in the two trace-window ownership witnesses, `watch-epochs` correctly still green, and suite totals unchanged at 1147/4185 so nothing was skipped. Restored and verified by git blob hash against the committed object (`90b403ee...`, matched) rather than by reading a diff. The build also prints its config path, which names this worktree.
- **View-lifetime ratchet** — planted the banned term; **exit 1**, naming the planted file and line.
- **Require-alias ratchet** — the first control did **not** bite, because it lacked the target's shape: the gate grades only `re-frame` / `re-frame.`-headed require edges, and `clojure.string` is not one. Re-planted a genuine `[re-frame.core :as reframe]` edge and it went **exit 1** (`tools: 6 violation(s), floor 5`, naming the line). So the real exit 0 is honest but narrow — this diff introduces no gradeable require edges at all. Both control files restored and verified by blob hash.

### Armed CI surfaces (derived, not hand-listed)

`.github/scripts/report-changed-surfaces.sh` run on this PR's actual changed paths reports `tools_jvm=true`, `mcp_conformance=true`, `mcp_live=true`. Controlled twice: `spec/API.md` arms a different set (`cljs_node_test=true`), and handing it revisions instead of paths arms **zero** surfaces — the silent false-negative to avoid.

## Out-of-fence

Nothing edited outside `tools/re-frame2-pair-mcp/**`. The runtime's nil-tolerance in `implementation/epoch/**` is upstream and deliberately untouched; `skills/re-frame2-pair/**`, `spec/**` and `.github/workflows/**` were read only.
