### PR TITLE
fix(examples): dev:example treats any pre-first-build watch exit as terminal (rf2-qwy3)

### DIFF
--- a/examples/scripts/serve-example.cjs
+++ b/examples/scripts/serve-example.cjs
@@ -34,7 +34,9 @@
  *      bundle before printing the live URL (rf2-qwy3) — the freshly cleaned
  *      output dir has no `main.js` until it lands, so announcing the page any
  *      earlier advertises one that comes up blank. It says it is waiting
- *      meanwhile, so a slow cold compile never looks like a hung tool.
+ *      meanwhile, so a slow cold compile never looks like a hung tool — and
+ *      while that wait is pending ANY watcher exit ends the run with a direct
+ *      diagnostic, so the runner never waits on a compiler that has gone.
  *
  * The shared staging + harness helpers do the hardened work (cross-platform
  * shell-free spawning, process-tree teardown, port pre-flight); this script
@@ -124,6 +126,37 @@ function decideRunnerExit({ server = null, watch = null, interrupted = false } =
     return false; // code null + no signal => clean exit
   };
   return childFailed(server) || childFailed(watch) ? 1 : 0;
+}
+
+// Classify a `shadow-cljs watch` termination while the runner is still up
+// (rf2-qwy3). PURE — the same shape as decideRunnerExit above, so the branch is
+// exercisable without a watcher, a server or a compile.
+//
+// THE PHASE IS THE WHOLE DECISION. Before first-build readiness the watcher is
+// the ONLY thing that can produce the bundle the live banner promises, and the
+// wait below ends only when that bundle is served or this predicate aborts it.
+// So EVERY watcher termination the runner did not itself ask for is terminal
+// there — a CLEAN `code 0` exit included. Reading a clean exit as "nothing to
+// see" in that window leaves the server up, the abort flag false and the wait
+// polling for an entrypoint no process will ever write: the runner hangs
+// silently, forever, instead of reporting a first build that never happened.
+//
+// After readiness the bundle is served and the page boots, so only an
+// UNEXPECTED termination (non-zero code, or a signal kill we did not ask for)
+// tears the server down; a clean exit is an ordinary shutdown that
+// decideRunnerExit already grades 0.
+//
+// A user interrupt (Ctrl+C) is our own teardown in either phase, never a crash.
+function watchExitAbortsRun({
+  code = null,
+  signal = null,
+  interrupted = false,
+  firstBuildReady = false,
+} = {}) {
+  if (interrupted) return false; // our own teardown
+  if (!firstBuildReady) return true; // nothing else can publish the entrypoint
+  if (typeof code === 'number') return code !== 0;
+  return signal != null;
 }
 
 // The compiled entrypoint every example host page loads. Hardcoding the name is
@@ -302,11 +335,16 @@ async function main() {
   }
   let watchOutcome = null;
   let serverOutcome = null;
-  // Set true if the shadow-cljs watch dies unexpectedly, so the watch-exit
-  // handler below can abort the server readiness wait (the shared harness ORs
-  // this into its own server-exited abort). Declared before the watch handler
-  // so that listener can flip it.
+  // Set true if the shadow-cljs watch terminates while the runner still needs
+  // it, so the watch-exit handler below can abort the server + first-build
+  // readiness waits (the shared harness ORs this into its own server-exited
+  // abort). Declared before the watch handler so that listener can flip it.
   let watchDied = false;
+  // Flipped once this run's first bundle is provably served. It is what makes a
+  // clean `code 0` watcher exit terminal BEFORE that point and ordinary after
+  // it — see watchExitAbortsRun. Read inside the exit handler, so it must be
+  // declared before the listener is installed.
+  let firstBuildReady = false;
 
   if (watch) {
     const watchProc = cleanup.trackProcess(
@@ -315,21 +353,27 @@ async function main() {
         stdio: 'inherit',
       }),
     );
-    // A `shadow-cljs watch` that dies unexpectedly (compile loop crash, JVM
-    // OOM, killed) must NOT leave the runner happily serving a now-frozen
-    // bundle and exiting 0. Record its outcome, abort the readiness wait, and
-    // tear the tree down (stopping http-server, which resolves the main wait)
-    // so the runner returns non-zero via decideRunnerExit.
+    // A `shadow-cljs watch` that stops when the runner still needs it must NOT
+    // leave the runner happily serving a now-frozen bundle and exiting 0 — nor,
+    // before the first build, waiting forever for an entrypoint that is now
+    // nobody's job to write. Record its outcome, and where the exit ends the
+    // run (watchExitAbortsRun) abort the readiness waits and tear the tree down
+    // (stopping http-server, which resolves the main wait) so the runner
+    // reports the failure with a non-zero exit.
     watchProc.on('exit', (code, signal) => {
       watchOutcome = { code, signal };
-      if (!interrupted && !(typeof code === 'number' && code === 0)) {
-        console.error(`shadow-cljs watch exited unexpectedly (code=${code}, signal=${signal}).`);
-        watchDied = true; // abort the server readiness wait below if still pending
-        // Stop http-server too; the watch is the source of truth for a live
-        // build. cleanup() is idempotent and safe to call alongside the
-        // signal handlers.
-        cleanup.cleanup().catch(() => {});
-      }
+      if (!watchExitAbortsRun({ code, signal, interrupted, firstBuildReady })) return;
+      console.error(
+        firstBuildReady
+          ? `shadow-cljs watch exited unexpectedly (code=${code}, signal=${signal}).`
+          : `shadow-cljs watch exited (code=${code}, signal=${signal}) before its first ` +
+            `build published ${BUILD_ENTRYPOINT}; nothing can produce it now.`,
+      );
+      watchDied = true; // abort the readiness waits below if still pending
+      // Stop http-server too; the watch is the source of truth for a live
+      // build. cleanup() is idempotent and safe to call alongside the
+      // signal handlers.
+      cleanup.cleanup().catch(() => {});
     });
   }
 
@@ -380,11 +424,14 @@ async function main() {
       console.error(
         `\nserve-example: ${entry.build} — the first build never produced a served ` +
           `${BUILD_ENTRYPOINT}, so the example was never runnable. No URL was ` +
-          'advertised. See the shadow-cljs output above for the compile error.',
+          'advertised. See the shadow-cljs output above.',
       );
       await cleanup.cleanup().catch(() => {});
       return 1;
     }
+    // The bundle is provably served. From here a clean watcher exit is an
+    // ordinary shutdown rather than a run-ending one (watchExitAbortsRun).
+    firstBuildReady = true;
   }
 
   console.log(
@@ -433,4 +480,10 @@ async function cleanupAndExit(code) {
   process.exit(code == null ? 1 : code);
 }
 
-module.exports = { decideRunnerExit, parseArgs, waitForFirstBuild, BUILD_ENTRYPOINT };
+module.exports = {
+  decideRunnerExit,
+  parseArgs,
+  waitForFirstBuild,
+  watchExitAbortsRun,
+  BUILD_ENTRYPOINT,
+};

--- a/implementation/scripts/_examples-staging.test.cjs
+++ b/implementation/scripts/_examples-staging.test.cjs
@@ -998,11 +998,22 @@ itAsync('TEETH: a fake watcher that exits 0 before publishing aborts the wait ra
     }
   };
 
+  // The regression's SIGNATURE is an unbounded poll, so the witness bounds it:
+  // a misclassified exit must fail this test loudly rather than spin the suite
+  // until CI times out. (Measured — with the pre-audit classification planted,
+  // an unbounded version of this case hangs instead of reporting.)
   let probes = 0;
+  const PROBE_CEILING = 50;
   const result = await waitForFirstBuild({
     fetchBody: async () => {
       probes++;
       if (probes === 2) onWatchExit({ code: 0, signal: null }); // a clean early exit
+      if (probes > PROBE_CEILING) {
+        throw new Error(
+          `still polling after ${PROBE_CEILING} probes with the watcher already gone: ` +
+            'the runner hangs instead of reporting a first build that never happened',
+        );
+      }
       return null; // the entrypoint is never published
     },
     isAborted: () => watchDied,
@@ -1010,6 +1021,7 @@ itAsync('TEETH: a fake watcher that exits 0 before publishing aborts the wait ra
   });
 
   assert.ok(watchDied, 'the clean early exit must be classified as terminal');
+  assert.ok(probes <= 3, 'the wait must stop at the exit, not keep polling');
   assert.deepStrictEqual(
     result,
     { ok: false, reason: 'child-exited' },

--- a/implementation/scripts/_examples-staging.test.cjs
+++ b/implementation/scripts/_examples-staging.test.cjs
@@ -909,6 +909,138 @@ it('serve-example keeps the wait on the WATCH path only, and tears down on first
   );
 });
 
+// ---- watch termination before the first build (rf2-qwy3, merged-PR audit) --
+//
+// The first-build wait above closed the "live URL, absent bundle" window, but
+// the watch exit handler that ABORTS that wait only fired on a NON-ZERO exit.
+// A `shadow-cljs watch` that terminated with code 0 before publishing main.js
+// therefore left the server up, the abort flag false and waitForFirstBuild
+// polling forever: the runner hung silently, with no URL, no diagnostic and no
+// exit — the one outcome the acceptance criterion ("any watch-child exit before
+// readiness must tear down and exit non-zero") rules out.
+//
+// The classification now lives in the pure, exported watchExitAbortsRun, and
+// the handler holds none of its own — which is what makes these cases
+// authoritative for the handler, and is pinned as such below.
+
+const { watchExitAbortsRun } = require('../../examples/scripts/serve-example.cjs');
+
+it('TEETH: a CLEAN (code 0) watch exit BEFORE the first build ends the run (rf2-qwy3)', () => {
+  // The audit's case, stated on its own: exiting 0 is not "nothing to see" while
+  // the watcher is still the only thing that can publish the entrypoint.
+  assert.strictEqual(
+    watchExitAbortsRun({ code: 0, signal: null, interrupted: false, firstBuildReady: false }),
+    true,
+    'a watcher that exits 0 before publishing the entrypoint leaves nobody to produce it',
+  );
+});
+
+it('TEETH: every unasked-for watch termination before the first build is terminal (rf2-qwy3)', () => {
+  for (const outcome of [
+    { code: 1, signal: null }, // compile-loop crash / JVM error
+    { code: 0, signal: null }, // the audit's case: a clean early exit
+    { code: null, signal: 'SIGKILL' }, // OOM-killed
+    { code: null, signal: null }, // gone, with nothing to say
+  ]) {
+    assert.strictEqual(
+      watchExitAbortsRun({ ...outcome, interrupted: false, firstBuildReady: false }),
+      true,
+      `a pre-readiness watch exit ${JSON.stringify(outcome)} must end the run`,
+    );
+  }
+});
+
+it('after the first build, a clean watch exit is an ordinary shutdown (rf2-qwy3)', () => {
+  // The repair is bounded to the pre-readiness phase on purpose: once the bundle
+  // is served the page works, and decideRunnerExit already grades a clean exit 0.
+  assert.strictEqual(
+    watchExitAbortsRun({ code: 0, signal: null, interrupted: false, firstBuildReady: true }),
+    false,
+  );
+  // ...but an UNEXPECTED termination still tears the server down, as before.
+  assert.strictEqual(watchExitAbortsRun({ code: 2, firstBuildReady: true }), true);
+  assert.strictEqual(
+    watchExitAbortsRun({ code: null, signal: 'SIGKILL', firstBuildReady: true }),
+    true,
+  );
+});
+
+it('an interrupt (Ctrl+C) is never a watch crash, in either phase (rf2-qwy3)', () => {
+  for (const firstBuildReady of [false, true]) {
+    assert.strictEqual(
+      watchExitAbortsRun({ code: null, signal: 'SIGINT', interrupted: true, firstBuildReady }),
+      false,
+      'a child stopped by the teardown the user asked for is not a failure',
+    );
+  }
+});
+
+itAsync('TEETH: a fake watcher that exits 0 before publishing aborts the wait rather than hanging (rf2-qwy3)', async () => {
+  // The runner's own composition, driven by a fake watch child: its exit
+  // handler classifies the outcome with watchExitAbortsRun and flips the abort
+  // flag the first-build wait reads. This is the behaviour the injected
+  // `watchDied = true` witness above could not reach, because it skipped the
+  // classification entirely.
+  const preAudit = ({ code }, interrupted) =>
+    !interrupted && !(typeof code === 'number' && code === 0);
+  assert.strictEqual(
+    preAudit({ code: 0, signal: null }, false),
+    false,
+    'control: the pre-audit classification read this exact outcome as benign, ' +
+      'which is why the wait below used to poll forever',
+  );
+
+  let watchDied = false;
+  const firstBuildReady = false; // the wait has not yet proven a served bundle
+  const onWatchExit = ({ code, signal }) => {
+    if (watchExitAbortsRun({ code, signal, interrupted: false, firstBuildReady })) {
+      watchDied = true;
+    }
+  };
+
+  let probes = 0;
+  const result = await waitForFirstBuild({
+    fetchBody: async () => {
+      probes++;
+      if (probes === 2) onWatchExit({ code: 0, signal: null }); // a clean early exit
+      return null; // the entrypoint is never published
+    },
+    isAborted: () => watchDied,
+    sleep: async () => {},
+  });
+
+  assert.ok(watchDied, 'the clean early exit must be classified as terminal');
+  assert.deepStrictEqual(
+    result,
+    { ok: false, reason: 'child-exited' },
+    'the wait must abort so the caller reports the failure non-zero, never hang',
+  );
+});
+
+it('TEETH: the watch exit handler delegates its classification to watchExitAbortsRun (rf2-qwy3)', () => {
+  // The predicate cases above are authoritative for the handler only while the
+  // handler keeps no classification of its own, so pin both halves.
+  assert.ok(
+    /watchProc\.on\('exit',[\s\S]{0,400}?watchExitAbortsRun\(\{[^}]*firstBuildReady[^}]*\}\)/.test(
+      SERVE_EXAMPLE_SRC,
+    ),
+    "the watch 'exit' handler must classify via watchExitAbortsRun, passing the readiness phase",
+  );
+  assert.ok(
+    !/!\(typeof code === 'number' && code === 0\)/.test(SERVE_EXAMPLE_SRC),
+    'the pre-audit inline "a code-0 exit is benign" test must not survive in the handler',
+  );
+  // And the phase flag must only be asserted AFTER the wait proves the bundle
+  // is served — set it earlier and the code-0 hole reopens under a new name.
+  const setAt = SERVE_EXAMPLE_SRC.indexOf('firstBuildReady = true;');
+  const waitAt = SERVE_EXAMPLE_SRC.indexOf('await waitForFirstBuild(');
+  assert.ok(setAt !== -1, 'the runner must record when the first build became ready');
+  assert.ok(
+    waitAt !== -1 && waitAt < setAt,
+    'first-build readiness must be asserted only after the wait that proves it',
+  );
+});
+
 // Drain the queued async cases, then own the summary + exit code for the whole
 // file (both the synchronous `it` results already counted in `failed` and these).
 (async () => {


### PR DESCRIPTION
Closes the remaining seam on rf2-qwy3, as recorded by the merged-PR audit note on the bead (2026-09-05).

## What was still wrong

The first fix composed server ownership with first-build readiness: `waitForFirstBuild` polls the loopback server the runner already owns until `main.js` is genuinely served, and only then prints the live URL. That probe is sound. The **child-exit wiring behind it was not**.

The watch exit handler aborted that wait only on a **non-zero** exit:

```js
if (!interrupted && !(typeof code === 'number' && code === 0)) { … watchDied = true … }
```

So a `shadow-cljs watch` that terminated with **code 0** before publishing `main.js` fell through every branch: the server stayed up, `watchDied` stayed false, `isDown()` stayed false, and `waitForFirstBuild` polled forever. The runner **hung silently** — no URL, no diagnostic, no exit — which is the one outcome the bead's acceptance criterion rules out ("If the watch child exits before first-build readiness, the runner does not announce the app as live, tears down the server, and exits nonzero with a direct initial-build diagnostic").

The existing witnesses could not see it. The unit witness injected `watchDied = true` directly, skipping the classification entirely; the source-order pins only checked that the wait precedes the banner.

## The change

**The phase is the whole decision.** Before first-build readiness the watcher is the only thing that can publish the entrypoint, so *every* termination the runner did not itself ask for is terminal there — a clean `code 0` exit included. After readiness the bundle is served and the page boots, so only an unexpected termination tears the server down; a clean exit stays an ordinary shutdown that `decideRunnerExit` already grades 0. A user interrupt is our own teardown in either phase.

That is one pure predicate, `watchExitAbortsRun`, deliberately shaped like the `decideRunnerExit` that already lives beside it:

```js
function watchExitAbortsRun({ code = null, signal = null, interrupted = false, firstBuildReady = false } = {}) {
  if (interrupted) return false;      // our own teardown
  if (!firstBuildReady) return true;  // nothing else can publish the entrypoint
  if (typeof code === 'number') return code !== 0;
  return signal != null;
}
```

The handler now holds **no classification of its own** — it calls the predicate and reports. A new `firstBuildReady` flag is set only after the wait proves the bundle is served, and the pre-readiness diagnostic says what actually happened rather than reusing the crash wording:

> `shadow-cljs watch exited (code=…, signal=…) before its first build published main.js; nothing can produce it now.`

### Reasoning on the design questions the brief raised

- **The harness readiness handshake is untouched.** `local-browser-harness.cjs` is not in this diff. Its `/.rf-harness-token` publish-and-fetch proves "this responder serves this run's root", which is correct for its own purpose and cannot prove build artefacts by design. First-build readiness stays composed in `serve-example.cjs`.
- **No shadow-cljs protocol, no log parsing.** Already settled by the first fix and unchanged here: the runner fetches the entrypoint back over the server it already owns, which proves the advertised fact directly. (`manifest.edn` was considered and rejected there: its name is build-config-settable and its presence proves a flush, not reachability.)
- **The wait stays unbounded for a HEALTHY watcher — and this is where the bead overrode the dispatch brief.** The brief asked for a bounded wait with a timeout message. The bead's live note says the opposite in terms: *"Keep the runner-local architecture and unbounded wait for a watcher that is still alive."* The bead governs, and it is right: a cold JVM plus a first compile is slow, and a compile error is fixable in place — shadow-cljs keeps watching, its inherited stdio shows the error, and the URL goes live the moment fixed source produces output. A timeout would abort a run that was about to succeed. **The bound is on the watcher's LIVENESS, not on the clock**: the wait ends when the entrypoint is served, or when the watcher (or server) is gone. That is the failure mode a wall-clock bound was reaching for, addressed at its cause. Measured below in a real run: a first compile that fails leaves the runner waiting and honest, and a watcher that dies ends it in about two seconds.
- **Scope held to the audit's bound.** A clean watcher exit *after* readiness is deliberately still non-terminal — the bundle is served and the page works. Widening that is the bead's own non-goal ("this issue owns only the first truthful runnable status after a clean launch").
- **`--no-watch` untouched**, as required: it compiles synchronously before the server starts and never enters this path.
- **`examples/README.md` not edited.** Checked at tip: it already describes the wait accurately ("The URL appears only once that first compile has produced the bundle the page loads…"). Nothing in this change makes that text wrong, so the file stays out of the diff.
- **No `*.spec.cjs` added under `examples/`** — the test-free lock (rf2-8cevm) holds. The regression lives in `implementation/scripts/_examples-staging.test.cjs`, beside the existing rf2-qwy3 witnesses.

## Quality gates

All exit codes below are the **captured** number (`cmd > log 2>&1; echo $? > exit`, one shell, never piped), re-run on the **final rebased base** where marked.

| Gate | Result | Captured exit |
|---|---|---|
| `node implementation/scripts/_examples-staging.test.cjs` (post-rebase) | 41 PASS, 0 FAIL | **0** |
| `npm run test:scripts` (the CI `cljs` job's own command) | tests 123, pass 123, fail 0 | **0** |
| `node --test` over the six serve-example-adjacent suites | 6 files, pass 6, fail 0 | **0** |
| `python scripts/check_require_alias_dialect.py --verbose` (post-rebase) | 2794 files, 10867 edges, 2446 non-canonical, every surface at or under its floor | **0** |
| `python scripts/check_view_lifetime_residue.py --verbose` (post-rebase) | zero `lease` residue in tracked content or paths | **0** |
| `python scripts/check_readme_links.py --ci` | clean | **0** |
| `node examples/scripts/check-examples-assets.cjs` | 33 host pages resolve their assets; `_shared` intact | **0** |
| `node implementation/scripts/check-examples-compile.cjs --list` | roster of **58** builds (asked the tool, not grepped) | **0** |
| `.github/scripts/report-changed-surfaces.sh` on this diff | see below | **0** |

Full output was read on every gate, not just the first line.

### The suites bite — sabotage, twice

Restoring the pre-audit classification in **both** places (the predicate body and the handler condition) — anchors matched exactly once each, checked before running:

- Run 1 (unbounded witness): **3 FAILs**, then the suite **hung past a 300 s ceiling with no exit file** — the planted bug reproducing itself literally. No verdict, so no pass claimed.
- That hang is a defect in the witness, not just the runner: a regression that spins is a regression CI reports as a timeout. The fake-watcher case now carries a probe ceiling.
- Run 2 (bounded witness): **captured exit 1, 4 FAILED**, promptly, naming the cause — *"still polling after 50 probes with the watcher already gone: the runner hangs instead of reporting a first build that never happened."*

Restore verified by **git blob hash** against the committed object both times (`9fa663802582535e595c29f63805868a930420fc`), never by reading a diff.

The `lease` ratchet was separately proved to be reading *this* worktree rather than a sibling: a planted line came back **exit 1** naming the planted file and line number, and green again (**exit 0**) after a hash-verified restore. The surface classifier was controlled the same way — a different input set flags a different surface set (`tools_jvm`, `mcp_conformance`, `story_xray_browser` true, `bundle_isolation`/`cljs_prod` false), so its mostly-false answer on this diff is a reading, not a vacuous default.

### Required CI checks this diff arms

Derived from `.github/scripts/report-changed-surfaces.sh` read against `.github/workflows/test.yml`, not hand-listed. Surfaces true: `cljs_node_test`, `cljs_browser`, `examples_compile`, `cljs_prod`, `bundle_isolation`, `reagent_slim_bundle`. Those gate `cljs` (which is where `npm run test:scripts` — and therefore this diff's regression — runs), `cljs-browser`, `cljs-examples-compile`, the three `cljs_prod` jobs, `cljs-bundle-isolation` and `cljs-reagent-slim-bundle-isolation`, plus the unguarded `verify-readme-links`. `cljs-examples-compile` is a 58-build sweep that CI owns; it was not run locally.

## Run evidence — this is a dev-only runner, so the evidence is runs

Real invocations of `node examples/scripts/serve-example.cjs --build examples/counter` against a **cold** output directory (`rm -rf out/examples/counter` before each), from this worktree.

**1. Cold start — the banner now follows the bundle.** The runner said it was waiting at t+4 s with `main.js` genuinely absent, and printed the live URL 84 seconds later with a 32 MB bundle in place:

```
[t+4s]  runner printed the WAITING line; main.js present? NO
[t+88s] runner printed IS LIVE; main.js present? YES size=32337163
```

```
serve-example: examples/counter — server ready on http://127.0.0.1:8050/, waiting for the first shadow-cljs build.
  Not openable yet: the page needs main.js, which the first compile produces. The shadow-cljs output shows progress and any compile error — fix the source and the URL goes live.
…
serve-example: examples/counter is live at http://127.0.0.1:8050/  (shadow-cljs watch running — edits recompile live)
```

That 84-second gap is the window the pre-fix runner advertised as live.

**2. Failed first compile — honest, and still fixable in place.** With a deliberate reader error planted in `examples/core/counter/core.cljs` (restored afterwards; blob hash verified against HEAD, `87ab0f0248e934fb312f5f00994ca6161027738c`), the runner printed the waiting line and **never** printed `is live` (`grep -c "is live at"` → **0**) across a 180-second observation, while shadow-cljs reported the error inline for the developer to fix:

```
[:examples/counter] Build failure:
counter/core.cljs [line 125, col 1] Unexpected EOF while reading item 0 of vector, starting at line 124 and column 25.
```

The watcher was healthy, so the runner kept waiting — the designed behaviour, not a hang.

**3. Watcher dies before the first build — the case this PR fixes, end to end.** Cold start, then the shadow-cljs watch child alone was killed while the runner sat in the first-build wait. `grep -c "is live at"` → **0**, and:

```
serve-example: examples/counter — server ready on http://127.0.0.1:8050/, waiting for the first shadow-cljs build.
shadow-cljs watch exited (code=4294967295, signal=null) before its first build published main.js; nothing can produce it now.
serve-example: examples/counter — the first build never produced a served main.js, so the example was never runnable. No URL was advertised. See the shadow-cljs output above.
http-server exited unexpectedly (code=1, signal=null).

RUNNER_EXIT_CODE=1   (waited 2s after the kill)
```

Diagnostic, teardown, non-zero exit, no URL — within two seconds.

**Stated plainly: the `code === 0` discrimination specifically is proved by the unit witnesses, not by a real run.** Real `shadow-cljs watch` cannot be made to exit 0 on demand, and the only injection point would be a fake runner path added to production code purely for a test — machinery this change does not earn. The sabotage above is what carries that case: with the pre-audit classification restored, the code-0 witnesses go red and the fake-watcher composition reports the hang by name.

## Premises checked

- The bead's own line citations describe the **pre-fix** file and no longer resolve at tip (the first fix moved everything): `serve-example.cjs:186-202` is now `parseArgs`, `:241-264` is the unknown-build error path, and so on. The harness citation **holds** — `local-browser-harness.cjs:636-722` is still the ownership-token publish through the owned-readiness result inside `startLocalHttpServer`.
- `implementation/scripts/check-examples-assets.cjs` **does not exist**; the gate is `examples/scripts/check-examples-assets.cjs`. Its substance was as described: `BUILD_OUTPUTS` exempts `main.js` from source-tree existence checks while every host page must carry a live reference — which is what licenses the runner to key readiness on a fixed filename.
- The "33 host pages" and "34 standalone hosts" figures are **both correct** and count different rosters: `check-examples-assets` scans 33 host pages, `listStandaloneExamples()` returns 34.
