### PR TITLE
fix(realworld-http): the follow latch outlives the profile it was taken on (rf2-8icg)

### DIFF
--- a/examples/real-apps/realworld_http/profile.cljs
+++ b/examples/real-apps/realworld_http/profile.cljs
@@ -39,19 +39,30 @@
 (defn request-slice []
   {:status :idle :data nil :error nil :loaded-at nil :attempt 0})
 
-(defn banner-slice
-  "The banner's own slice: the standard shape plus `:follow-pending?`, the
-   one-at-a-time latch the follow/unfollow toggle serialises on (see
-   SERIALISING THE TOGGLE, below the loads). Only this slice carries it — the
-   two list slices have no mutation of their own to serialise."
-  []
-  (assoc (request-slice) :follow-pending? false))
-
 ;; Which profile are we on? It's in the URL. The route lives in runtime-db, and
 ;; `username-from-db` digs the :username param out of it (handlers receive
 ;; runtime-db via the `:rf.db/runtime` coeffect).
 (defn username-from-db [runtime-db]
   (get-in runtime-db [:rf.runtime/routing :current :params :username]))
+
+;; `:profile.follow-pending` is the set of profiles with a follow/unfollow
+;; mutation in flight — the toggle's one-at-a-time latch, keyed by username.
+;; It is a TOP-LEVEL slice rather than a field of `[:profile]` on purpose, and
+;; the reason is the whole of the navigation story: see SERIALISING THE TOGGLE,
+;; below the loads.
+;;
+;; The two writers below reach for it through `fnil`, because hydration
+;; replaces app-db wholesale with the SSR payload (Spec 011's
+;; `:replace-frame-state`) and this set is deliberately not in it — an in-flight
+;; mutation is a fact about this browser tab, not about the server's render.
+;; See `ssr-app-slice-keys` in ssr.cljc.
+(defn follow-pending-for?
+  "Is a follow/unfollow already outstanding for `username`? The latch both
+   toggle handlers refuse a second intent on, and the button disables itself
+   on. Note the argument: this asks about a NAMED profile, where the
+   `:profile/follow-pending?` sub asks about the one on screen."
+  [db username]
+  (contains? (:profile.follow-pending db) username))
 
 ;; ============================================================================
 ;; THE CORRELATION GATE — the profile the page is on owns every settle
@@ -227,9 +238,10 @@
 (rf/reg-event :profile/initialise
   (fn [{:keys [db]} _]
     {:db (-> db
-             (assoc :profile (banner-slice))
+             (assoc :profile (request-slice))
              (assoc :profile.articles (assoc (request-slice) :data []))
-             (assoc :profile.favorites (assoc (request-slice) :data [])))
+             (assoc :profile.favorites (assoc (request-slice) :data []))
+             (assoc :profile.follow-pending #{}))
      :fx [[:dispatch [:ui/profile [:reset]]]]}))
 
 ;; ============================================================================
@@ -247,16 +259,18 @@
          — see THE CORRELATION GATE above. A same-username re-entry is a
          refresh (keep the banner up, `:fetching`); a different username is a
          new identity, so the slice resets and alice's banner is never
-         renderable under `/profile/bob`."
+         renderable under `/profile/bob`.
+
+         What it does NOT reset is the follow/unfollow latch: that belongs to
+         the mutation rather than to the screen, and lives in its own
+         username-keyed slice for exactly that reason. See SERIALISING THE
+         TOGGLE below."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [username (username-from-db rt)
           refresh? (reply-for-current-profile? db :profile username)
-          ;; A refresh keeps the slice — including a follow still in flight,
-          ;; whose settle is still coming and still correlated. A new identity
-          ;; builds a fresh banner slice, which is also how the toggle's latch
-          ;; is released on navigation: it goes with the slice it belonged to.
-          slice    (if refresh? (:profile db) (banner-slice))]
+          ;; A refresh keeps the slice; a new identity starts a fresh one.
+          slice    (if refresh? (:profile db) (request-slice))]
       {:db (assoc db :profile
                   (-> slice
                       (assoc :username username
@@ -422,11 +436,12 @@
 ;;
 ;; Button-driven rather than route-driven, but they write the ROUTE-OWNED
 ;; `[:profile ...]` slice, so their settles carry the username they were issued
-;; on and gate on it exactly as the loads do. This pair is why the gate is the
-;; mechanism and a request-id scheme is not: arriving at bob issues no new
-;; follow, so nothing supersedes an alice follow still in flight, and
-;; `:profile/followed` re-seeds the WHOLE banner map from its reply. See THE
-;; CORRELATION GATE above.
+;; on and gate that WRITE on it exactly as the loads do — plus one outcome the
+;; loads do not have, which SERIALISING THE TOGGLE below takes up. This pair is
+;; why the gate is the mechanism and a request-id scheme is not: arriving at
+;; bob issues no new follow, so nothing supersedes an alice follow still in
+;; flight, and `:profile/followed` re-seeds the WHOLE banner map from its
+;; reply. See THE CORRELATION GATE above.
 ;;
 ;; The issuing username comes from `[:profile :username]` — the identity the
 ;; slice recorded and the settle will be gated against — rather than from the
@@ -453,19 +468,44 @@
 ;; inverts the same way. Arrival order is not intent order, and nothing in a
 ;; username-keyed gate can tell these two apart.
 ;;
-;; So the toggle is SERIALISED rather than superseded. `:follow-pending?` on
-;; the banner slice latches while a mutation is in flight; both handlers refuse
-;; a second intent while it is set; the button disables itself on it; and every
-;; correlated settle — success or rollback — clears it. One mutation per
-;; profile at a time means there is never a pair to reorder. That is the
-;; smallest policy honest about both facts above: abort is not proof, and
-;; arrival order is not intent order.
+;; So the toggle is SERIALISED rather than superseded. `:profile.follow-pending`
+;; holds the usernames with a mutation in flight; both handlers refuse a second
+;; intent for a profile already in it; the button disables itself on it; and
+;; every settle — success or rollback — takes its own username back out. One
+;; mutation per profile at a time means there is never a pair to reorder. That
+;; is the smallest policy honest about both facts above: abort is not proof,
+;; and arrival order is not intent order.
+;;
+;; THE LATCH IS NOT IN THE BANNER SLICE, and that is the navigation half of the
+;; same law. A latch living in `[:profile]` dies when `:profile/load` rebuilds
+;; the slice for a new username — so alice → bob → alice, with alice's POST
+;; still in flight, would come back to an UNLATCHED alice. Her return GET can
+;; truthfully report `:following` true (the server applied that POST; only its
+;; reply is still in the air), the reader clicks Unfollow, and the very pair
+;; the latch exists to prevent is out on the wire — with the older POST free to
+;; land last and re-seed `:following` true over the newer accepted intent. So
+;; the latch belongs to the MUTATION, not to the screen; keyed by username, it
+;; latches alice and nobody else, and outlives every walk away and back until
+;; the mutation it was taken for settles.
+;;
+;; Which splits each of the three settles below in two, the way comments.cljs
+;; splits its ten (TWO QUESTIONS, over there). Ask the owner that matches the
+;; OUTCOME:
+;;
+;;   - the WRITE into `[:profile :data]` is the SLICE's, so it is gated on
+;;     `reply-for-current-profile?` exactly as every load settle is. A reply
+;;     for a profile the reader has left writes nothing.
+;;
+;;   - the LATCH RELEASE is the MUTATION's own, so it is UNCONDITIONAL. It has
+;;     to be: gate it on the current screen and alice's settle, arriving while
+;;     the reader is on bob, would leave alice latched for the rest of the
+;;     session — her button dead on every later visit with nothing in flight
+;;     left to free it. Keying is what makes an unconditional release safe:
+;;     alice's reply can only ever release alice's latch, never bob's.
 ;;
 ;; The alternative — keep rapid replacement, carry a generation, and reconcile
 ;; against server truth — buys a responsiveness this page has no need for, and
 ;; costs a reconciliation it would then have to get right. Not worth it here.
-;; Navigating away needs no handling of its own: a new username rebuilds the
-;; banner slice and the latch goes with it.
 
 (rf/reg-event :profile/follow
   {:doc "Mark the profile followed right away, then reconcile when the reply
@@ -474,25 +514,25 @@
          so a logged-out click heads to login instead of flipping `:following`
          optimistically only to walk it back after the backend 401s.
 
-         Refuses outright while a follow/unfollow is already in flight — see
-         SERIALISING THE TOGGLE above."
+         Refuses outright while a follow/unfollow for THIS profile is already
+         in flight — see SERIALISING THE TOGGLE above."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db]} _]
-    (cond
-      (nil? (get-in db [:auth :user]))
-      {:fx [[:dispatch [:rf.route/navigate {:to :realworld.auth/login}]]]}
+    (let [username (get-in db [:profile :username])]
+      (cond
+        (nil? (get-in db [:auth :user]))
+        {:fx [[:dispatch [:rf.route/navigate {:to :realworld.auth/login}]]]}
 
-      ;; One mutation per profile at a time. The button is disabled while this
-      ;; is set, so this is the belt to the view's braces — a refused click,
-      ;; not a queued one.
-      (get-in db [:profile :follow-pending?])
-      {}
+        ;; One mutation per profile at a time. The button is disabled while
+        ;; this holds, so this is the belt to the view's braces — a refused
+        ;; click, not a queued one.
+        (follow-pending-for? db username)
+        {}
 
-      :else
-      (let [username (get-in db [:profile :username])]
+        :else
         {:db (-> db
                  (assoc-in [:profile :data :following] true)
-                 (assoc-in [:profile :follow-pending?] true))
+                 (update :profile.follow-pending (fnil conj #{}) username))
          :fx [[:rf.http/managed
                (rh/request {:method     :post
                             :path       (str "/profiles/" username "/follow")
@@ -502,33 +542,37 @@
 
 (rf/reg-event :profile/followed
   {:doc "The follow POST's `:on-success`, carrying the username the flip was
-         issued on. This is the write that most needs the gate: it re-seeds the
-         whole banner map, so a late reply for a profile the reader has left
-         would put that profile's name, bio and avatar under the current URL.
-         Releases the toggle's latch, so the button comes back."}
+         issued on. Two owners, two questions (SERIALISING THE TOGGLE above).
+
+         The banner write is the SLICE's, so it is correlation-gated — and this
+         is the write that most needs the gate, because it re-seeds the whole
+         banner map: a late reply for a profile the reader has left would put
+         that profile's name, bio and avatar under the current URL. Releasing
+         the latch is the MUTATION's own, so it happens wherever the reader has
+         got to; being keyed by username, it can only ever release the follow
+         it belongs to."}
   (fn [{:keys [db]} [_ username {:keys [value]}]]
-    (when (reply-for-current-profile? db :profile username)
-      {:db (-> db
-               (assoc-in [:profile :data] (:profile value))
-               (assoc-in [:profile :follow-pending?] false))})))
+    (let [mine? (reply-for-current-profile? db :profile username)]
+      {:db (cond-> (update db :profile.follow-pending disj username)
+             mine? (assoc-in [:profile :data] (:profile value)))})))
 
 (rf/reg-event :profile/unfollow
   {:doc "Clear the followed flag right away, then reconcile on the reply.
          Auth-gated and serialised, same as `:profile/follow` above."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db]} _]
-    (cond
-      (nil? (get-in db [:auth :user]))
-      {:fx [[:dispatch [:rf.route/navigate {:to :realworld.auth/login}]]]}
+    (let [username (get-in db [:profile :username])]
+      (cond
+        (nil? (get-in db [:auth :user]))
+        {:fx [[:dispatch [:rf.route/navigate {:to :realworld.auth/login}]]]}
 
-      (get-in db [:profile :follow-pending?])
-      {}
+        (follow-pending-for? db username)
+        {}
 
-      :else
-      (let [username (get-in db [:profile :username])]
+        :else
         {:db (-> db
                  (assoc-in [:profile :data :following] false)
-                 (assoc-in [:profile :follow-pending?] true))
+                 (update :profile.follow-pending (fnil conj #{}) username))
          :fx [[:rf.http/managed
                (rh/request {:method     :delete
                             :path       (str "/profiles/" username "/follow")
@@ -537,25 +581,25 @@
                             :on-failure [:profile/follow-rollback username true]})]]}))))
 
 (rf/reg-event :profile/unfollowed
-  {:doc "The unfollow DELETE's `:on-success`, correlated and latch-releasing
+  {:doc "The unfollow DELETE's `:on-success`, split between the two owners
          exactly as `:profile/followed` is."}
   (fn [{:keys [db]} [_ username {:keys [value]}]]
-    (when (reply-for-current-profile? db :profile username)
-      {:db (-> db
-               (assoc-in [:profile :data] (:profile value))
-               (assoc-in [:profile :follow-pending?] false))})))
+    (let [mine? (reply-for-current-profile? db :profile username)]
+      {:db (cond-> (update db :profile.follow-pending disj username)
+             mine? (assoc-in [:profile :data] (:profile value)))})))
 
 (rf/reg-event :profile/follow-rollback
-  {:doc "The shared `:on-failure` for both, correlated the same way. Refusing a
-         stale rollback strands nothing: the optimistic flip it would undo went
+  {:doc "The shared `:on-failure` for both, split the same way. Refusing the
+         stale half strands nothing: the optimistic flip it would undo went
          with the slice when `:profile/load` reset it for the new username, and
          returning to that profile re-reads the true flag from the server. The
-         latch went with that slice too, so there is nothing left latched."}
+         release half is never refused — it is the mutation's own, and it is
+         what lets the reader try again after a 500 rather than facing a button
+         disabled for good."}
   (fn [{:keys [db]} [_ username previous-value _failure-payload]]
-    (when (reply-for-current-profile? db :profile username)
-      {:db (-> db
-               (assoc-in [:profile :data :following] previous-value)
-               (assoc-in [:profile :follow-pending?] false))})))
+    (let [mine? (reply-for-current-profile? db :profile username)]
+      {:db (cond-> (update db :profile.follow-pending disj username)
+             mine? (assoc-in [:profile :data :following] previous-value))})))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS
@@ -566,12 +610,17 @@
 (rf/reg-sub :profile/error   :<- [:profile/slice] (fn [s _] (:error s)))
 
 (rf/reg-sub :profile/follow-pending?
-  {:doc "Is a follow/unfollow mutation in flight for the profile on screen? The
-         toggle is serialised on this (see SERIALISING THE TOGGLE), so the
-         button reads it to disable itself while a reply is outstanding —
-         ask, don't tell."}
-  :<- [:profile/slice]
-  (fn sub-profile-follow-pending? [s _] (boolean (:follow-pending? s))))
+  {:doc "Is a follow/unfollow mutation in flight for the profile ON SCREEN? The
+         toggle is serialised on it (see SERIALISING THE TOGGLE), so the button
+         reads this to disable itself while a reply is outstanding — ask, don't
+         tell.
+
+         Two facts, not one: the latch is keyed by username and the screen has
+         a username. So walking back to a profile whose own mutation is still
+         out finds the button correctly disabled, while any OTHER profile finds
+         it live — a latch never leaks onto a bystander."}
+  (fn sub-profile-follow-pending? [db _]
+    (follow-pending-for? db (get-in db [:profile :username]))))
 
 ;; The read-time half of THE CORRELATION GATE. The gate on the settles keeps a
 ;; stale reply from LANDING in a slice; this keeps an already-landed list from

--- a/examples/real-apps/realworld_http/schema.cljs
+++ b/examples/real-apps/realworld_http/schema.cljs
@@ -55,12 +55,13 @@
    left can't overwrite the current one's data, status, error, timestamp or
    machine presentation. Same law as `:slug`, different route param.
 
-   `:follow-pending?` is the follow/unfollow latch. Only `:profile` carries it
-   — it is the one slice with a mutation of its own — and the toggle is
-   serialised on it: while it is set both handlers refuse a second intent and
-   the button disables itself, so a rapid Follow→Unfollow can never leave two
-   settles for the SAME profile racing, which the username correlation cannot
-   tell apart. See SERIALISING THE TOGGLE in profile.cljs."
+   What is NOT here is the follow/unfollow latch. It used to ride on
+   `:profile` as a `:follow-pending?` boolean, which meant it died whenever
+   `:profile/load` rebuilt that slice for a new username — so a walk away and
+   back returned an unlatched profile with its mutation still in flight. The
+   latch belongs to the MUTATION rather than to the screen, so it lives in its
+   own top-level `:profile.follow-pending` slice, keyed by username. See
+   SERIALISING THE TOGGLE in profile.cljs."
   [:map
    [:status         [:enum :idle :loading :fetching :loaded :error]]
    [:data           {:default nil} :any]
@@ -70,7 +71,6 @@
    [:articles-count {:optional true} :int]
    [:slug           {:optional true} [:maybe :string]]
    [:username       {:optional true} [:maybe :string]]
-   [:follow-pending? {:optional true} :boolean]
    [:stale-after-ms {:optional true} [:maybe :int]]])
 
 (def AuthSlice
@@ -245,6 +245,11 @@
    [:profile.articles :data]        [:maybe [:vector ws/Article]]
    [:profile.favorites]             [:maybe RequestSlice]
    [:profile.favorites :data]       [:maybe [:vector ws/Article]]
+   ;; Not a RequestSlice — the profiles with a follow/unfollow in flight. Its
+   ;; `:maybe` is load-bearing beyond the boot window the note above describes:
+   ;; hydration replaces app-db with the SSR payload, which deliberately omits
+   ;; this one (profile.cljs, SERIALISING THE TOGGLE).
+   [:profile.follow-pending]        [:maybe [:set :string]]
    [:comments]                      [:maybe RequestSlice]
    [:comments :data]                [:maybe [:vector ws/Comment]]
    [:feed]                          [:maybe RequestSlice]

--- a/examples/real-apps/realworld_http/ssr.cljc
+++ b/examples/real-apps/realworld_http/ssr.cljc
@@ -22,7 +22,14 @@
 (def ssr-app-slice-keys
   "The top-level app-db slices the SSR payload ships. Application data only —
   the framework's own subsystem trees (routing, machines, elision) live in the
-  separate runtime-db partition and travel under :rf/runtime-db instead."
+  separate runtime-db partition and travel under :rf/runtime-db instead.
+
+  One deliberate absentee, since the hydrate policy is `:replace-frame-state`
+  and an omission here is an absence on the client: `:profile.follow-pending`,
+  the profiles with a follow/unfollow in flight. It is a fact about one browser
+  tab's outstanding writes, not about the server's render — the server issues
+  no mutations, so it would ship empty every time. profile.cljs's two writers
+  are total against its absence for exactly this reason."
   [:auth
    :articles
    :article

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -3221,10 +3221,20 @@
 ;;
 ;; The app's answer is to serialise rather than supersede (`:request-id` would
 ;; abort the in-flight write, and an abort is no proof the server declined it).
-;; `:follow-pending?` latches while a mutation is outstanding, both handlers
-;; refuse a second intent, the button disables on it, and every correlated
-;; settle clears it. So the witness below is a COUNT: the second intent never
-;; becomes a second request, which removes the pair rather than refereeing it.
+;; `:profile.follow-pending` holds the profiles with a mutation outstanding,
+;; both handlers refuse a second intent for a profile already in it, the button
+;; disables on it, and every settle takes its own username back out. So the
+;; first witness below is a COUNT: the second intent never becomes a second
+;; request, which removes the pair rather than refereeing it.
+;;
+;; That latch is keyed by username and lives OUTSIDE the banner slice, and the
+;; two tests after it are the two halves of what the keying buys. A latch must
+;; SURVIVE its profile leaving the screen — alice → bob → alice with the POST
+;; still out is the ordering the immediate-toggle test cannot reach, because a
+;; latch that died with the banner slice hands the reader a live button on the
+;; way back and the pair goes out after all. And it must not LEAK onto a
+;; bystander, in either direction: bob's button stays live while alice's
+;; mutation is out, and alice's settle releases alice alone.
 
 (defn- follow-requests
   "Every captured follow/unfollow request for `username`, in lowering order."
@@ -3298,7 +3308,71 @@
           "a FAILED mutation releases the latch as surely as a successful one —
            otherwise a single 500 would disable the button for good"))))
 
-(defn- profile-follow-latch-does-not-outlive-its-profile-test []
+(defn- profile-follow-latch-survives-a-walk-away-and-back-test []
+  (with-held-profile-fx :realworld.test/profile-follow-latch-return
+    (fn [f lowered]
+      ;; Alice, unfollowed, banner settled. Follow — the POST is held open.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/profile/alice"] {:frame f})
+      (settle-ok! f (:on-success (req-by-id @lowered [:profile/load "alice"]))
+                  {:profile (full-profile "alice" false)})
+      (rf/dispatch-sync [:profile/follow] {:frame f})
+      (let [a-follow (req-by-method+url @lowered :post "/profiles/alice/follow")]
+        (is (some? a-follow) "the follow POST went out and is held open")
+        (is (= 1 (count (follow-requests @lowered "alice")))
+            "exactly one mutation out")
+
+        ;; ---- away to bob, and straight back, the POST still in flight ----
+        (rf/dispatch-sync [:rf.route/handle-url-change "/profile/bob"] {:frame f})
+        (settle-ok! f (:on-success (req-by-id @lowered [:profile/load "bob"]))
+                    {:profile (full-profile "bob" false)})
+        (reset! lowered [])
+        (rf/dispatch-sync [:rf.route/handle-url-change "/profile/alice"] {:frame f})
+        ;; The RETURN GET reports the server's truth, and the truth is that the
+        ;; POST was applied — only its REPLY is still in the air. So the reader
+        ;; is looking at a followed alice with a mutation still outstanding,
+        ;; which is exactly the state a slice-borne latch could not represent.
+        (settle-ok! f (:on-success (req-by-id @lowered [:profile/load "alice"]))
+                    {:profile (full-profile "alice" true)})
+        (is (true? (:following (pf-sub* f [:profile/data])))
+            "the return GET truthfully reports :following true")
+        (is (= #{"alice"} (pf-slice* f :profile.follow-pending))
+            "…and alice is still latched: the latch outlived the banner slice
+             that was rebuilt twice under it, because it belongs to the
+             MUTATION and the mutation has not settled")
+        (is (true? (pf-sub* f [:profile/follow-pending?]))
+            "…which the public sub reports, so the button comes back DISABLED.
+             This is the whole fix — a latch that died with the slice would
+             hand the reader a live button here")
+
+        ;; ---- so the second intent is refused, and no pair reaches the wire ----
+        (let [before (pf-slice* f :profile)]
+          (rf/dispatch-sync [:profile/unfollow] {:frame f})
+          (is (= before (pf-slice* f :profile))
+              "the Unfollow is refused outright — nothing flipped")
+          (is (empty? (follow-requests @lowered "alice"))
+              "…and issued NO second mutation. That DELETE could have settled
+               BEFORE the held POST, leaving the older reply to re-seed
+               :following true over the newer accepted intent; it never exists")
+          (is (nil? (req-by-method+url @lowered :delete "/profiles/alice/follow"))
+              "specifically, no alice DELETE is out at all"))
+
+        ;; ---- the held POST lands, correlated: it seeds AND releases ----
+        (settle-ok! f (:on-success a-follow) {:profile (full-profile "alice" true)})
+        (is (true? (:following (pf-sub* f [:profile/data])))
+            "the reader is back on alice, so the banner write IS accepted")
+        (is (false? (pf-sub* f [:profile/follow-pending?]))
+            "…and the mutation's own settle released its latch")
+
+        ;; NON-VACUITY: the refusal above was the latch doing its job, not a
+        ;; toggle broken for good.
+        (rf/dispatch-sync [:profile/unfollow] {:frame f})
+        (is (false? (:following (pf-sub* f [:profile/data])))
+            "the unfollow the reader wanted is accepted now, optimistically")
+        (is (some? (req-by-method+url @lowered :delete "/profiles/alice/follow"))
+            "…issuing the very DELETE that was refused a moment ago — strictly
+             after the POST it would otherwise have raced")))))
+
+(defn- profile-follow-latch-does-not-leak-to-a-bystander-test []
   (with-held-profile-fx :realworld.test/profile-follow-latch-nav
     (fn [f lowered]
       (rf/dispatch-sync [:rf.route/handle-url-change "/profile/alice"] {:frame f})
@@ -3306,31 +3380,54 @@
                   {:profile (full-profile "alice" false)})
       (rf/dispatch-sync [:profile/follow] {:frame f})
       (is (true? (pf-sub* f [:profile/follow-pending?])) "alice's toggle is latched")
+      (let [a-follow (req-by-method+url @lowered :post "/profiles/alice/follow")]
 
-      ;; The reader navigates away while it is still outstanding. Alice's settle
-      ;; will be refused by the correlation gate when it lands, so nothing will
-      ;; ever clear HER latch. It must not become bob's problem — a latch that
-      ;; outlived its profile would disable bob's button with no way back.
-      (rf/dispatch-sync [:rf.route/handle-url-change "/profile/bob"] {:frame f})
-      (settle-ok! f (:on-success (req-by-id @lowered [:profile/load "bob"]))
-                  {:profile (full-profile "bob" false)})
-      (is (false? (pf-sub* f [:profile/follow-pending?]))
-          "the new identity rebuilt the banner slice and the latch went with it")
+        ;; The reader walks away while alice's POST is still out. Her latch goes
+        ;; on holding ALICE — but it is keyed, so it must not disable BOB.
+        (rf/dispatch-sync [:rf.route/handle-url-change "/profile/bob"] {:frame f})
+        (settle-ok! f (:on-success (req-by-id @lowered [:profile/load "bob"]))
+                    {:profile (full-profile "bob" false)})
+        (is (= #{"alice"} (pf-slice* f :profile.follow-pending))
+            "alice stays latched across the navigation")
+        (is (false? (pf-sub* f [:profile/follow-pending?]))
+            "…yet bob's button is LIVE: a latch is taken on a profile, not on
+             the page, so it never disables a bystander")
 
-      (rf/dispatch-sync [:profile/follow] {:frame f})
-      (is (some? (req-by-method+url @lowered :post "/profiles/bob/follow"))
-          "…so bob's own follow issues normally")
+        (rf/dispatch-sync [:profile/follow] {:frame f})
+        (is (some? (req-by-method+url @lowered :post "/profiles/bob/follow"))
+            "…so bob's own follow issues normally, alongside alice's")
+        (is (= #{"alice" "bob"} (pf-slice* f :profile.follow-pending))
+            "two mutations outstanding at once, each under its own username")
 
-      ;; Alice's orphaned settle arrives now: still refused, and it must not
-      ;; release BOB's latch either.
-      (settle-ok! f (:on-success (req-by-method+url @lowered :post
-                                                    "/profiles/alice/follow"))
-                  {:profile (full-profile "alice" true)})
-      (is (= "bob" (:username (pf-sub* f [:profile/data])))
-          "the orphaned alice success is still refused by the correlation gate")
-      (is (true? (pf-sub* f [:profile/follow-pending?]))
-          "…and did not unlatch bob's in-flight mutation — releasing the latch
-           is correlated too, not a side effect any settle may cause"))))
+        ;; ALICE's settle now arrives with BOB's mutation still pending — an
+        ;; older reply landing underneath a newer operation. It must release its
+        ;; own latch and touch nothing else.
+        (let [before (pf-slice* f :profile)]
+          (settle-ok! f (:on-success a-follow) {:profile (full-profile "alice" true)})
+          (is (= before (pf-slice* f :profile))
+              "the off-screen alice success is refused by the correlation gate —
+               bob's banner is untouched, name, bio and flag alike")
+          (is (= #{"bob"} (pf-slice* f :profile.follow-pending))
+              "…and it released ALICE only. Releasing is keyed too, not a side
+               effect any settle may cause on whatever is latched")
+          (is (true? (pf-sub* f [:profile/follow-pending?]))
+              "…so bob's own in-flight mutation is still latched"))
+
+        ;; The ROLLBACK branch releases exactly as narrowly. Walk on to carol,
+        ;; latch her, and let bob's failure land underneath.
+        (rf/dispatch-sync [:rf.route/handle-url-change "/profile/carol"] {:frame f})
+        (settle-ok! f (:on-success (req-by-id @lowered [:profile/load "carol"]))
+                    {:profile (full-profile "carol" false)})
+        (rf/dispatch-sync [:profile/follow] {:frame f})
+        (is (= #{"bob" "carol"} (pf-slice* f :profile.follow-pending))
+            "bob's is still out; carol's joins it")
+        (settle-fail! f (:on-failure (req-by-method+url @lowered :post
+                                                        "/profiles/bob/follow")))
+        (is (= #{"carol"} (pf-slice* f :profile.follow-pending))
+            "bob's late ROLLBACK releases bob and leaves carol latched — a
+             failure frees its own mutation exactly as a success does")
+        (is (true? (pf-sub* f [:profile/follow-pending?]))
+            "…so carol's button is still correctly disabled")))))
 
 (deftest realworld-profile-page-cross-username
   (testing "cross-username banner/authored requests are independently
@@ -3355,10 +3452,16 @@
             intent issues no second request and there is no pair to reorder;
             both a success and a rollback release the latch (rf2-8icg)"
     (profile-follow-toggle-is-serialised-test))
-  (testing "a latch does not outlive the profile it was taken on: navigating
-            away rebuilds the banner slice and frees the button, and a stale
-            settle cannot release the CURRENT profile's latch (rf2-8icg)"
-    (profile-follow-latch-does-not-outlive-its-profile-test)))
+  (testing "the latch OUTLIVES a walk away and back, because it belongs to the
+            mutation rather than to the banner slice: alice → bob → alice with
+            the POST still in flight comes back disabled, so the newer Unfollow
+            the older POST would have overwritten is never issued (rf2-8icg)"
+    (profile-follow-latch-survives-a-walk-away-and-back-test))
+  (testing "the latch is KEYED, so it never leaks onto a bystander: bob's
+            button stays live while alice's mutation is out, two profiles can
+            be latched at once, and an older settle — success or rollback —
+            releases its own username alone (rf2-8icg)"
+    (profile-follow-latch-does-not-leak-to-a-bystander-test)))
 
 ;; ============================================================================
 ;; http — failure->message + pure pagination/query helpers


### PR DESCRIPTION
Closes the live instruction on rf2-8icg — which is **not** the bead's description. The description's cross-username defect was fixed by PR #9236 and is intact; PR #9260 added the same-profile `:follow-pending?` latch. The newest note on the bead (2026-09-05 13:33, the PR #9260 audit residual) names what remains, and that is what this PR does.

## The defect

The latch that serialises Follow/Unfollow rode on the banner slice as `:follow-pending?`, and `:profile/load` rebuilds that slice on every username change. So:

1. On `/profile/alice`, Follow flips `:following` true, latches, issues the POST. The reply is held.
2. Alice → Bob → Alice. Each hop rebuilds `[:profile]`, so the latch is gone; Alice comes back **unlatched**.
3. Alice's return GET truthfully reports `:following` true — the server *applied* that POST, only its reply is still in the air.
4. The reader clicks Unfollow. A DELETE goes out **alongside the still-outstanding POST** — the very pair the latch exists to prevent.
5. DELETE settles first, the older POST settles last. Both reply vectors carry only `"alice"`, so both pass `reply-for-current-profile?`, and `:profile/followed` re-seeds the whole banner `:following` true over the newer accepted intent.

## The fix

The latch belongs to the **mutation**, not to the screen. It moves out of the banner slice into its own top-level `:profile.follow-pending` slice — a set of usernames — which `:profile/load` never touches. So it survives any walk away and back, and latches exactly one profile rather than whichever page happens to be showing.

That splits each of the three follow settles between two owners — the shape `comments.cljs` already spells for its ten under **TWO QUESTIONS**, which is why this is the precedent's idea rather than a second mechanism:

- the **banner write** is the *slice's*, so it stays gated on `reply-for-current-profile?`;
- the **latch release** is the *mutation's own*, so it is unconditional. It has to be: gated on the current screen, Alice's settle arriving while the reader is on Bob would leave Alice latched for the rest of the session, her button dead on every later visit with nothing in flight left to free it. Keying is what makes that safe — Alice's reply can only ever release Alice.

`(fnil conj #{})` on the two writers is load-bearing rather than defensive: hydration is `:replace-frame-state`, and this set is deliberately absent from `ssr-app-slice-keys` (an in-flight mutation is a fact about one browser tab, not about the server's render). That omission is now stated in `ssr.cljc`.

Prose corrected in three places, per the bead: the "navigating away needs no handling of its own" claim in `profile.cljs`, the `:follow-pending?` paragraph in `schema.cljs`, and the SSR payload note.

## Premises checked at source

| Bead premise | Verdict |
| --- | --- |
| Managed HTTP supersedes only on a **same** `:request-id` | **Holds.** `docs/async/http.md:312`; `spec/014-HTTPRequests.md:1610` ("Same-`:request-id` supersede"). Line numbers had drifted from the bead's `312-316` / `1573-1580`. |
| The resources variant is immune by construction | **Holds.** Cache identity is `[scope resource-id canonical-params]` with `:username` in `:params` (`realworld_resources/resources.cljs`). Untouched. |
| The bead's `profile.cljs` line citations | **Stale, as expected.** The file is 774 lines at tip against the bead's largest citation of 502; #9236/#9260 moved everything. Every site was re-located by reading, not by line number. |
| The stranded-`:error` half is a second defect | **Already closed by #9236, not by me.** With the correlation gate in place no cross-identity `:fetch-failed` reaches the machine, and every path to `:loaded` for the identity the page *is* on passes through `:fetch-started` first — so the missing `fetch-succeeded` edge on `:error` is unreachable rather than merely unused. Pinned by `profile-cross-username-late-failure-is-refused-test`. Nothing left to file. |

## Tests

Option (a) from the brief — a CLJS unit test in the framework test tree. Nothing was added under `examples/` (the rf2-8cevm test-free lock holds).

`implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`, both under `realworld-profile-page-cross-username`:

- **`profile-follow-latch-survives-a-walk-away-and-back-test`** (new) — the held-transport Alice → Bob → Alice witness. The POST is held open across both hops; the return GET reports the server's truth; Alice comes back latched; the Unfollow is refused and issues no second request; the held POST then seeds *and* releases, and the toggle works again (non-vacuity).
- **`profile-follow-latch-does-not-leak-to-a-bystander-test`** (replaces `profile-follow-latch-does-not-outlive-its-profile-test`, which pinned the behaviour this PR corrects) — Bob's button stays live while Alice's mutation is out; two profiles are latched at once; an older **success** and an older **rollback** each release their own username alone, with a newer operation still pending.

The cross-username tests and the immediate-toggle serialisation test are unchanged and still green.

## Quality gates

All run foreground or detached-with-in-turn-polling, exit codes captured to a file and quoted from that file — never from the harness's report, which disagreed once here (it reported 0 for the `npm run test:cljs` run whose captured code was 1).

| Gate | Captured exit | Result |
| --- | --- | --- |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | 2795 files, 10863 re-frame require edges, 2446 non-canonical, every surface at or under its floor |
| `python scripts/check_view_lifetime_residue.py --verbose` | **0** | zero `lease` residue in tracked content or paths |
| `npx shadow-cljs compile examples/realworld` | **0** | 333 files, 332 compiled, **0 warnings** |
| `node out/node-test.js` (final tree, freshly compiled) | **0** | **11254 tests, 57029 assertions, 0 failures, 0 errors** |
| `scripts/test-fast-pr.sh` | **1** | 49 PASS, **one** FAIL — `CLJS node integration`, on a pre-existing warning on `main` (see below). JVM tier green: `implementation/core` 2187 tests / 11320 assertions, 0 failures; `adapters/reagent` 0/0. clj-kondo, the 29-check always-on block and the lane/roster bijections all passed. |
| `npm run test:cljs` | **1** | Same pre-existing `main` warning; see below. |

**Gate coverage derived, not assumed.** `node implementation/scripts/check-examples-compile.cjs --list` enumerates 58 builds; my diff touches exactly one of them, `examples/realworld`, which is what I compiled (the script has no per-build filter, so running its single build directly is the targeted equivalent). `.github/scripts/report-changed-surfaces.sh` on my four paths arms `examples_compile`, `cljs_node_test`, `implementation_jvm`, `cljs_browser`, `cljs_prod`, `bundle_isolation`, `adapter_testbed_smokes`, `adapter_diagnostic`, `tools_jvm`, `mcp_conformance`, `mcp_live`, `template_expensive` — CI owns the lanes the local spine has no tier for. The spine's `--plan` classified the documentation tier **skip**: this diff carries no markdown, so `check_doc_slugs.py`, `check_readme_links.py` and `mkdocs build --strict` are not the gates for it.

**Gate-read-my-tree verification.** Both routes were available and both were used. shadow-cljs and the spine each print their root, and both named this worktree. And the discriminating proof, since a repo-relative path cannot tell two checkouts apart — a **planted fault**: restoring the old "the latch dies with the slice" behaviour as one line in `:profile/load` (`(update db :profile.follow-pending disj username)`) took the suite to **captured exit 1, 5 failures**, every one of them inside `profile-follow-latch-survives-a-walk-away-and-back-test` and named by its `testing` string. Test and assertion counts were **identical** to the control run (11254 / 57029), so the plant crashed no namespace and skewed no count; `out/node-test.js` was rebuilt after the plant, so the runtime observed it. Restored with `git checkout HEAD --`, verified by blob hash against the committed object: `b41616c1ec85c5d84f11dcb01dabc32e09f612b8` before the plant and after the restore, `9dbb2bd5f93a339dca8953c678b60365d7629609` while planted.

### One red that is not this PR's

`scripts/test-fast-pr.sh` and `npm run test:cljs` both fail at `compile-node-test`'s zero-warning gate, on **two `:uix.linter/interop-ref-read` warnings** in `implementation/adapters/uix/test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs:120` and `:139` — *"use-ref hook in UIx returns Atom-like ref, use `@` instead of `.-current`"*.

That file is **byte-identical to `origin/main`** in this branch (`git diff origin/main -- <that path>` is empty); it was last touched by `570d07d286` / `dc795fb3b5`, neither of them mine. So `main` is currently red on that gate, and the compiled suite still emits, which is why the direct `node out/node-test.js` run above is the honest verdict for this PR's own change: **0 failures across 11254 tests**. No open bead carries it (searched the tracker for uix + warning/linter/interop terms and for `interop-ref-read`; a control search for `uix` alone returns 2 open beads, so the zero is honest, not a broken instrument). Flagging for the mayor to file — it is outside this PR's fence.
