### PR TITLE
docs(api-manifest): the Story projection allowlist carries no facade export (rf2-i6kh)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/story_spec_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/story_spec_check.clj
@@ -9,15 +9,31 @@
   Story surface does not carry — a renamed / removed facade fn — turns
   this red.
 
-  SCOPE. Story's API.md mixes `re-frame.story` FACADE var-rows (the
-  resolution target) with sub-namespace surfaces (`re-frame.story.theme.*`,
-  `re-frame.story.ui.*`, `re-frame.story.xray-preset/*`) that live OUTSIDE
-  the manifest's whole-namespace introspection set, plus a handful of
-  CLJS-only facade vars the JVM generator cannot `ns-publics`. Those are
-  carried on the `:story-spec-known-unmanifested` allowlist in the sidecar
-  (silenced once, by name) so any OTHER unresolved facade reference still
-  fails. Keyword-id rows (`:story/set-arg`, `:rf.assert/*`), namespace
-  cells, and prose cells are not var-rows and are skipped by construction."
+  SCOPE. Story's API.md documents more than the `re-frame.story` facade, and
+  two different mechanisms keep the extra material out of this check.
+
+  Skipped BY CONSTRUCTION — any first cell that is not one back-tick-quoted
+  simple identifier: the qualified and dotted sub-namespace spellings
+  (`re-frame.story.theme.typography`, `xray-preset/wire-cross-host!`,
+  `keybindings/bindings`), keyword-id rows (`:story/set-arg`,
+  `:rf.assert/*`), namespace cells and prose cells. No allowlist involved.
+
+  Silenced BY NAME — the two sub-namespaces that document their vars with a
+  BARE first cell, and so do parse as var-rows while living outside the
+  manifest's whole-namespace introspection set: `re-frame.story.test-support`
+  (`use-fixtures`, `with-clean-registry`) and `re-frame.story.ui.xray-embed`
+  (`xray-embed-panel`, `mount-fn-for`, `popout-full-shell!`). Those five, and
+  only those, are the sidecar's `:story-spec-known-unmanifested` set, so any
+  OTHER unresolved reference still fails.
+
+  NO FACADE EXPORT IS ON THAT ALLOWLIST, and none may be added. Four once
+  were: `re-frame.story` is a split-host `.cljc` whose `#?(:cljs …)` arm
+  publishes five facade fns the JVM generator cannot `ns-publics`, and
+  silencing them kept those four out of the manifest entirely — beyond the
+  reach of the facade-audit invariants (tier / action / justification).
+  rf2-i6kh dropped the exemptions and gave all five real `:cljs-only` rows,
+  which this check resolves like any other var-row. A facade var missing from
+  the manifest is a row to add, never a name to silence here."
   (:require [re-frame.api-manifest.gen :as gen]
             [re-frame.api-manifest.projection :as proj]))
 


### PR DESCRIPTION
`rf2-i6kh`'s post-merge audit of #9228 reopened the bead for exactly one residual: `story_spec_check`'s scope docstring still described four CLJS-only facade vars as silenced on the sidecar's `:story-spec-known-unmanifested` allowlist, which #9228 had already removed. This is that one docstring.

## What was actually wrong

Verified at source rather than taken from the audit. `94818b2d75` (PR #9228) deleted exactly four entries from `:story-spec-known-unmanifested`:

```diff
-#{"mount-shell!"            ; CLJS-only shell lifecycle (re-frame.story.shell), JVM-unloadable
-   "unmount-shell!"          ; CLJS-only shell lifecycle
-   "active-shell"            ; CLJS-only shell lifecycle
-   "registered-substrates"   ; CLJS-only facade var (reader-conditional :cljs branch)
```

and gave all five of the facade's `#?(:cljs …)` exports — those four plus `register-substrate!` — real `:cljs-only` rows carrying `:facade? true` in `spec/api-manifest-metadata.edn`. That commit did not touch the checker, so its docstring was left documenting an exception path that no longer exists.

The five surviving allowlist entries are sub-namespace vars only: `use-fixtures` and `with-clean-registry` (`re-frame.story.test-support`), plus `xray-embed-panel`, `mount-fn-for` and `popout-full-shell!` (`re-frame.story.ui.xray-embed`).

## What the docstring says now

Three things, all checked against the code rather than asserted:

1. **Two mechanisms, not one.** The old parenthetical named `re-frame.story.theme.*`, `re-frame.story.ui.*` and `re-frame.story.xray-preset/*` as though the allowlist handled them. It does not and cannot: `projection/first-cell-backtick-ident` accepts only `[a-zA-Z][a-zA-Z0-9*!?<>=+-]*`, so a dotted first cell (`re-frame.story.theme.typography`) or a slash-qualified one (`xray-preset/wire-cross-host!`, `keybindings/bindings`) is not a var-row at all and never reaches the allowlist. Those are skipped by construction, alongside keyword-id rows and prose cells. Only the two sub-namespaces that document their vars with a **bare** first cell need silencing by name.
2. **The exact allowlist roster**, so a reader can compare the docstring against `spec/api-manifest-metadata.edn` without leaving the file.
3. **The invariant the audit asked for**: no facade export is on that allowlist and none may be added. Silencing the four kept them out of the manifest entirely, beyond the reach of the facade-audit invariants (tier / action / justification) — a facade var missing from the manifest is a row to add, never a name to silence here.

## Scope

Docstring only; no behaviour change, one file. No test is added: the text is prose, and the parsing contract it describes is already pinned by `projection_test.clj` (`first-cell-backtick-ident` / `table-var-rows`). Worth noting separately that `story_spec_check` has no dedicated test namespace where `xray_spec_check_test.clj` does — that is a pre-existing gap, not this change's to close.

## Quality gates

All run in the foreground on the rebased base, exit codes captured to file and quoted from that file (never from the harness).

| Gate | Command | Exit | Result |
| --- | --- | --- | --- |
| api-manifest drift-check | `clojure -M -m re-frame.api-manifest.gen --check` | **0** | `spec/api-manifest.edn in sync (548 public vars)` |
| Story spec projection | `clojure -M -m re-frame.api-manifest.story-spec-check` | **0** | `69 public-var references checked` (floor is 20) |
| api-manifest reconciler tests | `clojure -M:test` | **0** | 98 tests, 194 assertions, 0 failures, 0 errors |
| require-alias dialect ratchet | `python scripts/check_require_alias_dialect.py --verbose` | **0** | 2794 files, 10867 re-frame edges, 2446 non-canonical, every surface at or under its floor |
| view-lifetime residue ratchet | `python scripts/check_view_lifetime_residue.py --verbose` | **0** | zero residue in tracked content and paths |
| clj-kondo | `clj-kondo --fail-level error --lint <the changed file>` | **0** | 0 errors, 0 warnings |

The first three are the four steps `lint.yml`'s `api-manifest` job runs against this tree; a `.clj` file sets `detect.lint_surface=true`, so that job and `clj-kondo` are both armed. `.github/scripts/report-changed-surfaces.sh` reports `cljs_node_test`, `cljs_browser`, `cljs_prod`, `bundle_isolation` and `reagent_slim_bundle` for this path in `test.yml`.

**Sabotage controls.** Two gates were proven to be reading this branch's tree rather than a sibling's, since neither prints its root:

- A planted `leased` in the docstring turned the residue ratchet **red at exit 1**, naming the file and line 20 of the plant.
- Repointing `story-ns` at a non-existent namespace turned the Story projection check **red at exit 1** with 64 unresolved var-rows.

Both plants were made from a committed tree and restored with `git checkout`; the restore was verified by git blob hash against the committed object (`40c9827add…`) both times, not by reading a diff, and the plant match count was read before each run so a no-op plant could not masquerade as a clean gate.

**Honest coverage note.** Nothing in this repo validates the prose of a Clojure docstring. Every green above says the checker still behaves as it did — which is the point, since this change asserts no behaviour changed — but none of them grades whether the new sentences are true. Those were hand-verified against the code they describe: the removed exemptions against `94818b2d75`'s diff, the surviving roster against the `:story-spec-known-unmanifested` set in `spec/api-manifest-metadata.edn`, the five `:cljs-only` rows against the `re-frame.story` rows in the same file, and the skipped-by-construction claim against `first-cell-backtick-ident`'s regex.

`scripts/test-jvm-implementation.sh` and `scripts/test-jvm-tools.sh` were not run: their rosters were read, and neither `artefacts=(…)` nor `tools=(…)` contains `implementation/scripts/api-manifest`, so neither sweep reaches this path.
