### PR TITLE
fix(ssr): presence-value-truthy? tests NaN with NaN?, not a JVM-dead self-inequality (rf2-u82a)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -578,9 +578,24 @@
   this is `.cljc`: the JVM has no JS coercion, and the two runtimes must emit
   the same bytes for the same tree (the render-tree hash compares them).
   Beyond strings and numbers everything is truthy — keywords, collections,
-  objects — matching JS, where every object is truthy. `NaN` is JS-falsy and
-  is tested as `(not= v v)`, the one NaN check that reads the same on both
-  runtimes.
+  objects — matching JS, where every object is truthy.
+
+  `NaN` IS JS-FALSY, AND `NaN?` IS THE CHECK — NOT the self-inequality idiom
+  `(not= v v)`, which this predicate shipped with and which is DEAD CODE on
+  the JVM. `clojure.lang.Util/equiv` short-circuits on reference identity
+  before it ever compares numerically, and a predicate parameter is ONE boxed
+  object handed to both argument positions, so `(= v v)` answers `true` for
+  every value a caller can supply — `NaN` included — and `(not= v v)` is
+  therefore `false` for all of them. Nothing errors and no branch is skipped;
+  the NaN arm simply never runs. What makes the idiom so convincing is that it
+  is genuinely correct in CLJS, where `=` on numbers reaches `identical?` and
+  `NaN === NaN` is false: it is right on one runtime and inert on the other,
+  and the JVM is the runtime that renders. `NaN?` is `clojure.core`'s since
+  1.11 and `cljs.core`'s, it is correct for a boxed argument on both, and it
+  says what it tests. (`==` also discriminates `NaN` correctly on both hosts —
+  `Numbers/equiv` takes no identity shortcut — but `(== v v)` has to be
+  decoded before it reads as a NaN test, and this predicate exists to be
+  read.)
 
   TOTAL over every value an attribute map can carry, `nil` and booleans
   included, rather than documented as undefined for them. `attr-string` does
@@ -593,7 +608,7 @@
     (nil? v)     false
     (boolean? v) v
     (string? v)  (not= "" v)
-    (number? v)  (not (or (zero? v) (not= v v)))
+    (number? v)  (not (or (zero? v) (NaN? v)))
     :else        true))
 
 (defn boolean-attr-class

--- a/implementation/ssr/test/re_frame/ssr/presence_truthiness_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/presence_truthiness_cljs_test.cljc
@@ -1,0 +1,173 @@
+(ns re-frame.ssr.presence-truthiness-cljs-test
+  "rf2-u82a (second pass) — `re-frame.ssr.html-helpers/presence-value-truthy?`
+  driven on BOTH runtimes, because the defect this file exists for was a
+  HOST ASYMMETRY and every other test of the predicate is JVM-only.
+
+  ## Why this file is `.cljc` and not another `.clj` beside the parity test
+
+  The predicate answers one question — *would react-dom treat this value on a
+  presence attribute as present?* — for two serialisers
+  (`re-frame.ssr.emit`'s hiccup path and `re-frame.ssr.ui-tree`'s structural
+  path) on two runtimes. `ssr_boolean_attr_react_parity_test` pins it against
+  react-dom's own measured bytes, which is the right anchor and the reason the
+  rosters are trustworthy; but it is a `.clj`, so it speaks about the JVM
+  alone. A predicate written to make TWO RUNTIMES emit the same bytes needs at
+  least one suite that runs on both, and the bug below is precisely the shape
+  that slips through when there is none.
+
+  ## The bug, and why it read as cross-platform
+
+  The predicate's NaN arm shipped as the self-inequality idiom `(not= v v)`,
+  documented as *the one NaN check that reads the same on both runtimes*. It
+  does not. In ClojureScript it is correct — `=` on numbers reaches
+  `identical?`, and `NaN === NaN` is false. On the JVM it is DEAD CODE:
+  `clojure.lang.Util/equiv` short-circuits on reference identity before
+  comparing numerically, and a predicate parameter hands ONE boxed object to
+  both argument positions, so `(= v v)` is `true` for every value a caller can
+  supply and `(not= v v)` is `false` for all of them — NaN included. Nothing
+  throws, no branch is skipped, and the arm simply never runs.
+
+  So the value fell through to `true`, and BOTH public JVM emitters wrote a
+  presence attribute react-dom omits: `[:button {:disabled ##NaN}]` rendered
+  `<button disabled>` and the structural path `<button disabled=\"\">`, where
+  react-dom 19.2.0 renders `<button>`. Sharing one predicate — which is what
+  rf2-u82a's first pass correctly did — made the two serialisers agree on the
+  same wrong answer, so no parity test BETWEEN them could see it either.
+
+  That is also why these assertions are not symmetric evidence: on the old
+  source they are GREEN in ClojureScript and RED on the JVM. The runtime that
+  renders server-side is the JVM, so the half that was broken is the half that
+  ships. Keeping both halves in one file is the point — the contract is that
+  they agree, not that either is separately plausible.
+
+  ## Why NaN is worth a suite at all
+
+  It is not an exotic input: NaN is what arithmetic on a missing or
+  non-numeric app-db value produces, so it arrives at a view attribute by
+  accident rather than by authorship — and a wrong answer here is a
+  server/client hydration divergence, which Spec 011 records React does not
+  guarantee to patch. A server-rendered button is DISABLED where the browser
+  believes the attribute absent; nothing errors and nothing repairs it.
+
+  The controls beside it are the values a repair is most likely to take with
+  it: the number `0` and `\"\"` must stay absent (JS-falsy, logically TRUE in
+  Clojure), the STRING `\"0\"` and a whitespace string must stay present
+  (truthy — only the NUMBER 0 is not), and infinity must stay present (JS
+  truthiness is not finiteness). The overloaded pair is driven too, because a
+  presence-class repair that reaches `download` is the failure mode the class
+  split was introduced to stop."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ssr.emit :as rf.ssr.emit]
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]
+            [re-frame.ssr.ui-tree :as rf.ssr.ui-tree]))
+
+;; ---------------------------------------------------------------------------
+;; 1. The shared predicate.
+;; ---------------------------------------------------------------------------
+
+(deftest presence-value-truthy-answers-nan-the-way-javascript-does
+  (testing "rf2-u82a — NaN is JS-falsy, so a presence attribute given NaN is
+            ABSENT. This is the assertion the `(not= v v)` arm could not
+            satisfy on the JVM, where reference identity short-circuits `=`
+            before it compares numerically"
+    (is (false? (rf.ssr.html-helpers/presence-value-truthy? ##NaN))
+        "NaN is falsy in JavaScript: react-dom writes no attribute"))
+
+  (testing "rf2-u82a — and the repair did not widen. Every other number keeps
+            the answer it had: zero (in both its integer and its floating
+            spellings) is the OTHER value Clojure and JavaScript disagree
+            about, and infinity is the reminder that JS truthiness is not
+            finiteness"
+    (is (false? (rf.ssr.html-helpers/presence-value-truthy? 0))
+        "the NUMBER 0 is JS-falsy: absent")
+    (is (false? (rf.ssr.html-helpers/presence-value-truthy? 0.0))
+        "and so is 0.0 — the same number, and `zero?` sees both")
+    (is (true? (rf.ssr.html-helpers/presence-value-truthy? 1))
+        "an ordinary number is present")
+    (is (true? (rf.ssr.html-helpers/presence-value-truthy? ##Inf))
+        "infinity is truthy in JS — falsiness is not the same as unusualness")
+    (is (true? (rf.ssr.html-helpers/presence-value-truthy? ##-Inf))
+        "including negative infinity"))
+
+  (testing "rf2-u82a — the non-numeric controls, unchanged. The STRING \"0\"
+            is the trap in the other direction: it is a non-empty string and
+            therefore truthy, where the NUMBER 0 is not"
+    (is (true? (rf.ssr.html-helpers/presence-value-truthy? "0"))
+        "the STRING \"0\" is truthy — only the number is not")
+    (is (true? (rf.ssr.html-helpers/presence-value-truthy? " "))
+        "a whitespace string is non-empty, so truthy — not `str/blank?`")
+    (is (false? (rf.ssr.html-helpers/presence-value-truthy? ""))
+        "the empty string is JS-falsy")
+    (is (true? (rf.ssr.html-helpers/presence-value-truthy? "yes"))
+        "an ordinary string is truthy")
+    (is (false? (rf.ssr.html-helpers/presence-value-truthy? nil))
+        "`null` is falsy in JS, and the predicate is total over nil")
+    (is (true? (rf.ssr.html-helpers/presence-value-truthy? true)))
+    (is (false? (rf.ssr.html-helpers/presence-value-truthy? false)))))
+
+;; ---------------------------------------------------------------------------
+;; 2. The two public emitters — the same answer, through the shipped surface.
+;;
+;; A predicate assertion alone would not have caught the original defect being
+;; USER-VISIBLE: what makes it a bug rather than a wart is that both public
+;; render paths wrote the attribute. Both are driven here, each against its
+;; OWN no-attribute baseline, because the two pipelines spell presence
+;; differently by design (bare `disabled` / `disabled=""`, 004B: one table,
+;; two pipelines) and a byte comparison between them would fail for the wrong
+;; reason.
+;; ---------------------------------------------------------------------------
+
+(defn- tree-html [attrs]
+  (rf.ssr.ui-tree/emit-ui-tree {:rf.ui/tree-version 1 :tag :button :attrs attrs}))
+
+(defn- hiccup-html [attrs]
+  (rf.ssr.emit/render-to-string [:button attrs] {}))
+
+(deftest both-public-emitters-omit-a-presence-attribute-given-nan
+  (testing "rf2-u82a — the PUBLIC hiccup path. `[:button {:disabled ##NaN}]`
+            must render exactly what the empty attribute map renders; on the
+            old source it rendered `<button disabled>`"
+    (is (= (hiccup-html {}) (hiccup-html {:disabled ##NaN}))
+        "NaN writes no presence attribute at all"))
+
+  (testing "rf2-u82a — the PUBLIC structural-tree path, which reaches the same
+            shared predicate. On the old source it rendered `disabled=\"\"`,
+            so the two pipelines agreed on the wrong answer and no parity test
+            between them could see it"
+    (is (= (tree-html {}) (tree-html {:disabled ##NaN}))
+        "NaN writes no presence attribute at all"))
+
+  (testing "rf2-u82a — and the emitters still disagree with nothing. The
+            controls that a repair could plausibly have taken with it: the
+            number 0 stays absent, the string \"0\" stays present"
+    (is (= (hiccup-html {}) (hiccup-html {:disabled 0}))
+        "the NUMBER 0 is JS-falsy: no attribute")
+    (is (= (tree-html {}) (tree-html {:disabled 0}))
+        "and the structural path agrees")
+    (is (not= (hiccup-html {}) (hiccup-html {:disabled "0"}))
+        "the STRING \"0\" is truthy: the attribute is written")
+    (is (not= (tree-html {}) (tree-html {:disabled "0"}))
+        "and the structural path agrees")))
+
+;; ---------------------------------------------------------------------------
+;; 3. The class split survives.
+;; ---------------------------------------------------------------------------
+
+(deftest an-overloaded-attribute-never-consults-the-presence-predicate
+  (testing "rf2-u82a — `download` and `capture` are `:overloaded`: the two
+            booleans behave exactly as `:presence`, but a NON-boolean value is
+            KEPT rather than collapsed. They must therefore be unreachable
+            from any change to the presence truthiness rule — a repair that
+            collapsed NaN here would take `download=\"report.pdf\"` with it,
+            which is the whole reason the class was split out of `:presence`
+            in the first place"
+    (is (not= (rf.ssr.emit/render-to-string [:a {}] {})
+              (rf.ssr.emit/render-to-string [:a {:download ##NaN}] {}))
+        "an overloaded name keeps a non-boolean value, NaN included")
+    (is (not= (rf.ssr.emit/render-to-string [:a {}] {})
+              (rf.ssr.emit/render-to-string [:a {:download 0}] {}))
+        "and keeps the number 0, which the presence class omits")
+    (is (= :overloaded (rf.ssr.html-helpers/boolean-attr-class "download"))
+        "the split itself is still in place")
+    (is (= :presence (rf.ssr.html-helpers/boolean-attr-class "disabled"))
+        "and `disabled` is still the presence class this file drives")))


### PR DESCRIPTION
## The contract question, settled first

The bead asks which contract `re-frame.ssr.html-helpers` is held to before any code is touched. **It is the Spec 004B class contract, not react-dom byte-parity — and under that contract this is a defect.** Verified at source at tip, not taken from the bead's note:

- **`spec/011-SSR.md` §54 rules OUT byte-parity explicitly**: *"Byte-for-byte HTML equality is **not required** — different HTML serialisers may emit semantically-equivalent strings that differ in attribute order, whitespace, or boolean-attribute spelling."* So `disabled` vs `disabled=""` — the documented difference between this repo's two SSR pipelines — is permitted. An attribute being **present when it must be absent** is not a spelling difference; it is a different document.
- **`spec/004B-UI-Tree-and-Conversion.md` §Booleans and their neighbours, line 566 (the `hidden` probe-corrected row) is the actual rule**: *"a **pure boolean** attr, not an enumerated exception: `true`/`"until-found"`/any truthy → bare presence (`hidden=""`), `false`/absent → omitted. The pre-probe draft's `"until-found"` string-value carve-out was **falsified**."* The presence class collapses on **truthiness**, and 004B derives that truthiness from react-dom/server 19.2.0 by probe. NaN is JS-falsy, so 004B requires omission.

So the spec and react-dom agree, and the implementation contradicted both. This is not a deliberate 004B divergence of the `value` kind, and no contract is broken by fixing it.

**Why it matters (the bead's P3 argument, confirmed at source).** `spec/011-SSR.md` §851 records React's own contract: *"there are no guarantees that attribute differences will be patched up in case of mismatches"* — an attribute-only divergence *"leaves the server-supplied attribute in the DOM, and calls **neither** `onRecoverableError` nor any production equivalent."* A server-rendered control is therefore **disabled** where the browser believes the attribute absent, silently.

## What was actually wrong

The bead's headline premise — *presence attributes with a non-boolean value emit `name="value"`* — **had already been fixed and merged** by PR #9267 (merge commit `f39c043448e7a994a280879bf989c1d9e6a4944a`). What remained live was the audit residual recorded on the bead: the NaN arm of `presence-value-truthy?`.

That arm shipped as `(not= v v)`, documented as *"the one NaN check that reads the same on both runtimes"*. It is not — **on the JVM it is dead code**:

- `clojure.lang.Util/equiv` short-circuits on reference identity (`k1 == k2`) before comparing numerically.
- A predicate parameter hands **one boxed object** to both argument positions, so `(= v v)` is `true` for *every* value a caller can supply and `(not= v v)` is `false` for all of them — NaN included.
- Nothing throws and no branch is skipped. The NaN arm simply never runs.

Measured with an Object-typed parameter (the predicate's own shape), Clojure 1.12.4:

| value | `(not= v v)` | `(== v v)` | `(NaN? v)` |
|---|---|---|---|
| `0` (Long) | false | true | false |
| `0.0` | false | true | false |
| `1` | false | true | false |
| **NaN (Double)** | **false** | **false** | **true** |
| NaN (Float) | false | false | true |
| Infinity | false | true | false |
| `1/2`, `1M`, `1N` | false | true | false |

`(not= v v)` is false in every row — it discriminates nothing. It is genuinely correct in ClojureScript, where `=` on numbers reaches `identical?` and `NaN === NaN` is false, which is exactly what made it look cross-platform: **right on one runtime, inert on the other, and the JVM is the runtime that renders server-side.**

User-visible consequence on the pre-fix source, through the public surfaces:

| input | `emit/render-to-string` | `ui-tree/emit-ui-tree` | react-dom 19.2.0 |
|---|---|---|---|
| `[:button {:disabled ##NaN} "Click"]` | `<button disabled>Click</button>` | `<button disabled="">Click</button>` | `<button>Click</button>` |

Because #9267 correctly gave both serialisers **one shared predicate**, they agreed on the same wrong answer — so no parity test *between* them could see it, which is the structural point the parity suite already makes about shared tables.

## The fix

`(number? v) (not (or (zero? v) (NaN? v)))` — one token. `NaN?` is `clojure.core`'s since 1.11 and `cljs.core`'s, is correct for a boxed argument on both hosts, and says what it tests. (`==` also discriminates NaN correctly — `Numbers/equiv` takes no identity shortcut — but `(== v v)` has to be decoded before it reads as a NaN test, and this predicate exists to be read.) The docstring's false claim is replaced with the mechanism, so the idiom is not reintroduced.

No new abstraction, no API change, and the `:presence` / `:overloaded` split and the documented `ismap` divergence are untouched.

## react-dom 19.2.0 probe — raw table (EVIDENCE, not a gate)

Measured against the **installed** react-dom via production `renderToStaticMarkup`, names and probe elements taken from the committed `ssr/test/react_dom_probe/boolean_attr_classes.edn`. Columns are the five values the bead names plus NaN.

```
=== PRESENCE class (react-dom 19.2.0) - 28 names ===
attribute               true         ""           0            "0"          "yes"        NaN
allowFullScreen         =""          OMITTED      OMITTED      =""          =""          OMITTED
async                   =""          OMITTED      OMITTED      =""          =""          OMITTED
autoFocus               =""          OMITTED      OMITTED      =""          =""          OMITTED
autoPlay                =""          OMITTED      OMITTED      =""          =""          OMITTED
checked                 =""          OMITTED      OMITTED      =""          =""          OMITTED
controls                =""          OMITTED      OMITTED      =""          =""          OMITTED
default                 =""          OMITTED      OMITTED      =""          =""          OMITTED
defer                   =""          OMITTED      OMITTED      =""          =""          OMITTED
disablePictureInPicture =""          OMITTED      OMITTED      =""          =""          OMITTED
disableRemotePlayback   =""          OMITTED      OMITTED      =""          =""          OMITTED
disabled                =""          OMITTED      OMITTED      =""          =""          OMITTED
formNoValidate          =""          OMITTED      OMITTED      =""          =""          OMITTED
hidden                  =""          OMITTED      OMITTED      =""          =""          OMITTED
inert                   =""          OMITTED      OMITTED      =""          =""          OMITTED
itemScope               =""          OMITTED      OMITTED      =""          =""          OMITTED
loop                    =""          OMITTED      OMITTED      =""          =""          OMITTED
multiple                =""          OMITTED      OMITTED      =""          =""          OMITTED
muted                   =""          OMITTED      OMITTED      =""          =""          OMITTED
noModule                =""          OMITTED      OMITTED      =""          =""          OMITTED
noValidate              =""          OMITTED      OMITTED      =""          =""          OMITTED
open                    =""          OMITTED      OMITTED      =""          =""          OMITTED
playsInline             =""          OMITTED      OMITTED      =""          =""          OMITTED
readOnly                =""          OMITTED      OMITTED      =""          =""          OMITTED
required                =""          OMITTED      OMITTED      =""          =""          OMITTED
reversed                =""          OMITTED      OMITTED      =""          =""          OMITTED
scoped                  =""          OMITTED      OMITTED      =""          =""          OMITTED
seamless                =""          OMITTED      OMITTED      =""          =""          OMITTED
selected                =""          OMITTED      OMITTED      =""          =""          OMITTED

28/28 conform, zero anomalies.

=== OVERLOADED class (react-dom 19.2.0) - 2 names ===
capture                 =""          =""          ="0"         ="0"         ="yes"       ="NaN"
download                =""          =""          ="0"         ="0"         ="yes"       ="NaN"
```

This reproduces the prior worker's 28/28 result and extends it with the NaN column: **react-dom OMITS on `""`, `0` and NaN, and EMITS on `"0"`, `"yes"` and `true`.** The asymmetry the bead flags is confirmed — **the STRING `"0"` is truthy; only the NUMBER `0` is not** — and it is pinned by a control assertion in the new suite. After this change the fixed predicate agrees with all 28 presence names on all six values.

## The test, and why it is `.cljc`

`implementation/ssr/test/re_frame/ssr/presence_truthiness_cljs_test.cljc` — new, dual-host.

The defect was a **host asymmetry**, and every existing test of this predicate is JVM-only (`ssr_boolean_attr_react_parity_test.clj`). A predicate written so two runtimes emit the same bytes needs at least one suite that runs on both; that absence is how a half-working check survived review. Verified to run on both: the JVM cognitect runner loads `.cljc` under `ssr/test`, and the ns ends `-cljs-test` so the `:node-test` build's `cljs-test$` regexp picks it up (compiled artefact confirmed present, with all three `deftest` vars and their assertion messages in the emitted JS).

It drives the shared predicate, **both public emitters** (`emit/render-to-string` and `ui-tree/emit-ui-tree`, each against its own no-attribute baseline so the two pipelines' different presence spellings are not compared byte-wise), and the `:overloaded` pair. Controls pin exactly what a repair could take with it: the number `0` and `""` stay absent, the string `"0"` and a whitespace string stay present, both infinities stay present, and `download` keeps every value including NaN.

**Red/green control (planted fault).** With `(NaN? v)` reverted to `(not= v v)` on an otherwise identical tree, the suite fails **3 of 23 assertions** — naming the predicate and both emitter outputs verbatim (`<button disabled></button>`, `<button disabled=""></button>`) — and passes 23/23 with the fix. Assertion counts match across both runs, so the plant did not abort a namespace. Source restored and verified by git blob hash (`7840650a4dac2c5142d64d807de4a122f189bbad`), with `git diff --exit-code` clean.

## Quality gates

Run foreground to completion in the worker worktree, exit codes captured on the same command line as the redirect and quoted from the capture (never from a harness report, never through a pipe). Re-run on the **final** base after rebasing onto `37197f5834`.

| Gate | Command | Result | Captured exit |
|---|---|---|---|
| ssr JVM suite | `clojure -M:test` in `implementation/ssr` | **642 tests, 4204 assertions, 0 failures, 0 errors** | **0** |
| New suite alone (JVM) | `clojure -M:test -n re-frame.ssr.presence-truthiness-cljs-test` | 3 tests, 23 assertions, 0 failures | **0** |
| Planted-fault control | same, with the pre-fix NaN arm restored | **3 failures / 23 assertions — the gate bites** | **1** (as required) |
| CLJS node integration | `node scripts/compile-node-test.cjs node-test out/node-test.js` then `node out/node-test.js` | **11256 tests, 57154 assertions, 0 failures, 0 errors** | **0** |
| Require-alias dialect | `python scripts/check_require_alias_dialect.py --verbose` | 2795 files, 10870 re-frame require edges, **2446 non-canonical (unchanged)**, every surface at or under its floor | **0** |
| View-lifetime residue | `python scripts/check_view_lifetime_residue.py --verbose` | zero residue in tracked content and paths | **0** |
| Fast-PR spine | `scripts/test-fast-pr.sh` | 49 lanes pass; **1 failure, not from this diff** — see below | 1 |
| react-dom probe | production `renderToStaticMarkup`, installed 19.2.0 | 28/28 presence names conform, zero anomalies | 0 (evidence, not a gate) |

The new file adds **3 canonical** re-frame require edges (`rf.ssr.emit`, `rf.ssr.html-helpers`, `rf.ssr.ui-tree`) and **zero** non-canonical ones, so `implementation/ssr`'s floor of 399 is unmoved.

Surfaces armed by this diff, from `.github/scripts/report-changed-surfaces.sh` given the two changed paths: `implementation_jvm`, `cljs_node_test`, `cljs_browser`, `examples_compile`, `cljs_prod`, `bundle_isolation`, `skills_structural`. (The script takes **paths**, not revisions — handed revisions it reports every surface unaffected, which is indistinguishable from a genuinely unaffected change; controlled against `implementation/shadow-cljs.edn`, which flags a different and larger set.)

### The one failing lane is pre-existing on main and outside this fence

`FAIL CLJS node integration` is the spine's **compile** step, not its test step. `implementation/scripts/compile-node-test.cjs` exits 1 on 2 `:uix.linter/interop-ref-read` warnings in `implementation/adapters/uix/test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs`, lines 120 and 139 (*"use-ref hook in UIx returns Atom-like ref, use @ instead of .-current to access its value"*). That file is **byte-identical between this branch and `origin/main`** (`git diff origin/main HEAD -- <path>` is empty); it was last touched by `570d07d286 fix(uix): the imperative effect recipe follows its frame (rf2-tug6)`, landed today. The node **test** step itself is green (exit 0, 0 failures). `implementation/adapters/**` is out of this bead's fence, so this is reported rather than fixed.

## Not fixed here, reported instead

`canonical-number` deliberately excludes NaN from canonicalisation, so NaN falls through to `pr-str` and the **non-presence** classes emit `##NaN`:

- `[:a {:download ##NaN}]` renders `<a download="##NaN">` where react-dom emits `download="NaN"`
- `[:div {:title ##NaN}]` renders `<div title="##NaN">` where react-dom emits `title="NaN"`

Both hosts agree on `##NaN`, so this is not a JVM/CLJS split and the render-tree hash is self-consistent — but it does look like a spec divergence, and 004B points two ways at once, so which governs is a ruling rather than a worker's call:

- `spec/004B` lines 233–234 say *"`NaN` and the infinities take their JavaScript spellings"*, which would require `NaN`.
- `spec/004B` lines 318–323 say `##NaN` *"is not data either"* and that such values are *"rejected exactly as any other non-data value is, **at the site that recorded them**"* — which would make a tree carrying NaN invalid before a serialiser ever sees it.

Repairing this touches `canonical-number`, which also feeds the render-tree hash, so it is outside this bead's stated bounded completion (*"No new abstraction or API is needed"*) and is left for the mayor to file. Nothing in this PR is undone by either outcome: if NaN is later rejected at the recording site, the presence branch simply becomes unreachable for it.

Bead: rf2-u82a. Not closed here — left `in_progress` for the mayor to close on merge.
