### PR TITLE
fix(ci): the post-merge canary dispatches at a branch ref and fails loud (rf2-amh0)

### DIFF
--- a/.github/workflows/post-merge-workflow-sanity.yml
+++ b/.github/workflows/post-merge-workflow-sanity.yml
@@ -162,6 +162,12 @@ jobs:
         if: steps.changed.outputs.files != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # THE REF TO DISPATCH AGAINST — a BRANCH OR TAG NAME, never a commit
+          # id. See the block above `gh workflow run` below for why, and for the
+          # semantics of dispatching at the tip. Through `env:`, never
+          # interpolated into the run body: the sibling step states that rule at
+          # its own `env:` and `_post-merge-sanity-base.test.cjs` pins it there.
+          DISPATCH_REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           # EXCLUDE list — see header comment for the policy.
@@ -186,9 +192,25 @@ jobs:
             done
             return 1
           }
+          failed=0
           for f in ${{ steps.changed.outputs.files }}; do
             if is_excluded "$f"; then
               echo "skip (excluded): $f"
+              continue
+            fi
+            # DELETED IN THIS PUSH. The diff reports a removed workflow as
+            # changed, and it was already skipped — but only as a side effect of
+            # `grep` exiting non-zero on a file it cannot open, which also put
+            # `No such file or directory` on stderr and then printed the WRONG
+            # reason ("no workflow_dispatch trigger") for the right outcome.
+            # Measured on runs 29638598700 (post-merge-playground-freshness.yml)
+            # and 31924373964 (freehand-bench.yml, freehand-conformance.yml).
+            # An accident is a poor thing to rest on once a dispatch failure is
+            # fatal, so the skip is stated rather than inferred. This is the one
+            # case the old `|| { echo WARN; }` could plausibly have been
+            # protecting; with it explicit here, that swallow protects nothing.
+            if [ ! -f ".github/workflows/$f" ]; then
+              echo "skip (deleted in this push): $f"
               continue
             fi
             # Only dispatch if the workflow declares workflow_dispatch.
@@ -196,8 +218,55 @@ jobs:
               echo "skip (no workflow_dispatch trigger): $f"
               continue
             fi
-            echo "dispatching: $f"
-            gh workflow run "$f" --ref "${{ github.sha }}" || {
-              echo "WARN: gh workflow run failed for $f (non-fatal)"
-            }
+            # --ref TAKES A BRANCH OR TAG NAME. The Actions "create a workflow
+            # dispatch event" endpoint resolves `ref` in the ref namespace, so a
+            # 40-character commit id — which is what `github.sha` always is —
+            # cannot resolve and the call returns HTTP 422 "No ref found for:
+            # <sha>". This is not a trade-off between two workable targets: the
+            # merge commit was never dispatchable.
+            #
+            # MEASURED (rf2-amh0). This step passed the `github.sha` context
+            # value as the ref from the file's first commit until this one — an
+            # expression not written out here, because Actions substitutes
+            # expressions everywhere in a `run:` body, comments included. Across
+            # the 155 runs whose logs are still readable (2026-06-08 to
+            # 2026-09-05), 26 reached a dispatch and made 27 attempts; ALL 27
+            # returned that same 422, and all 26 runs concluded `success`,
+            # because a `|| { echo WARN; }` swallow that this commit removes took
+            # every one of them. Zero dispatches have ever succeeded. The
+            # 19 older runs (2026-05-28 to 2026-06-05) have expired logs (HTTP
+            # 410) so they are unmeasured, not clean — the argument was identical
+            # in their revisions, so any attempt they made failed the same way.
+            #
+            # THE TIP, NOT THE MERGE COMMIT — deliberate. `github.ref_name` is
+            # the branch this event is on (`main` for the push trigger; whatever
+            # branch an operator chose under `workflow_dispatch`, which a literal
+            # `main` would get wrong). Two workflow-editing merges landing close
+            # together therefore share one dispatch of the later tip. That is the
+            # right target for the question this canary asks — "does the edited
+            # workflow still run?" — because the tip is exactly what the next
+            # cron tick will use, and `concurrency: cancel-in-progress` above
+            # already collapses back-to-back pushes onto the latest SHA.
+            #
+            # FAIL LOUD, NOT FAIL OPEN — the same call the base resolution makes
+            # above, for the same reason. Nothing consumes this canary's verdict,
+            # so a red costs one visible failure and blocks nobody, whereas a
+            # green that means "we tried" reads to every reader as "it ran" and
+            # is how a broken dispatcher survived 78 days. Every ordinary reason
+            # to skip is handled by the four guards above; what is left is
+            # exceptional. Failures are counted rather than aborting the loop, so
+            # one bad workflow cannot hide the fate of the others, and the
+            # `dispatched:` line makes a success provable from the log whatever
+            # `gh` prints for itself.
+            echo "dispatching: $f (ref $DISPATCH_REF)"
+            if gh workflow run "$f" --ref "$DISPATCH_REF"; then
+              echo "dispatched: $f (ref $DISPATCH_REF)"
+            else
+              echo "::error::post-merge workflow sanity could not dispatch $f at $DISPATCH_REF. The 24h feedback gap this canary exists to close is still OPEN for that workflow — its next verification is the cron tick."
+              failed=$((failed + 1))
+            fi
           done
+          if [ "$failed" -gt 0 ]; then
+            echo "$failed dispatch(es) failed; see the annotations above."
+            exit 1
+          fi


### PR DESCRIPTION
**Leave rf2-amh0 open** — its acceptance check can only run after this merges, and not even at this merge. See *What I verified* below.

## The defect

`.github/workflows/post-merge-workflow-sanity.yml` dispatched with
`gh workflow run "$f" --ref "<the github.sha context value>"`. The Actions
"create a workflow dispatch event" endpoint resolves `ref` in the **ref
namespace** — a branch or a tag — and `github.sha` is always a commit id, so the
call could never succeed as written. It returned `HTTP 422: No ref found for:
<sha>`, and `|| { echo "WARN: ... (non-fatal)"; }` swallowed it, so the job
reported **success**. The workflow whose entire purpose is to close a 24-hour
feedback gap on workflow edits has been reporting success while dispatching
nothing.

## Measured history

The bead recorded 1 attempt / 1 failure and asked explicitly that the real
history be established before a stronger claim was written into the file. It is
worse than the bead could establish.

| | |
|---|---|
| Sanity runs, all time | 256 (2026-05-28 → 2026-09-05), **every one concluded `success`** |
| Runs whose dispatch step executed | 174 |
| Runs whose logs are still readable | 155 (2026-06-08 → 2026-09-05); the other 19 return HTTP 410 |
| Runs that reached a dispatch | 26 |
| Dispatch attempts | **27** |
| Attempts that succeeded | **0** |
| Attempts returning `HTTP 422 No ref found for: <sha>` | **27 — all of them** |

Targets attempted: `expensive-tests.yml` ×18, `freehand-conformance.yml` ×5,
`freehand-bench.yml` ×4. First attempt 2026-06-19, most recent 2026-09-05 — 78
days.

**Instrument control.** `gh run view --log` interleaves the step's ANSI-coloured
source echo (`ESC[36;1m`) with its runtime output, and matching the echo lines
tells you nothing. The census drops every line containing an ESC byte, then
matches `dispatching: `. Exercised against run `33946468214`, known to have
printed a real dispatch line: unfiltered **2** hits, filtered **1**, and the
survivor is the genuine runtime line. Counts were taken separately from any
listing, never through `head`.

**What is still not established.** The 19 runs from 2026-05-28 → 2026-06-05 have
expired logs, so they are *unmeasured*, not clean. The `--ref` argument is
byte-identical in every revision of this file back to its introducing commit
`0e708c17d9`, so any attempt they made failed the same way — a deduction from
the unchanged source, not a measurement, and the file's comment says so in those
terms.

Corroborating from the other side: `expensive-tests.yml` has 6 lifetime
`workflow_dispatch` runs, every one on a **branch** ref (`main`, `worker/…`) —
manual dispatches. None came from this canary.

## The change

1. **`--ref` now receives `github.ref_name`**, passed through `env:` as
   `DISPATCH_REF` rather than interpolated into the run body — the rule the
   sibling step states at its own `env:` and that
   `_post-merge-sanity-base.test.cjs` pins there.

   *Semantics, decided deliberately.* This dispatches at the **branch tip**, not
   at the merge commit. That is not a choice between two workable targets — the
   merge commit was never dispatchable — but it is a real change in what gets
   verified: two workflow-editing merges landing close together share one
   dispatch of the later tip. The tip is the right target for the question this
   canary asks ("does the edited workflow still run?"), because the tip is
   exactly what the next cron tick will use, and `concurrency:
   cancel-in-progress` already collapses back-to-back pushes onto the latest
   SHA. `github.ref_name` rather than a literal `main` because this workflow
   also declares `workflow_dispatch:`, under which `ref_name` is the branch the
   operator chose and a literal `main` would be wrong.

2. **A failed dispatch now reds the step and raises a `::error::` annotation**,
   visible without opening the log — the same fail-loud call the base resolution
   above already makes, for the reason its comment gives (this canary gates
   nothing, so a red costs one visible failure and blocks nobody). Failures are
   counted rather than aborting the loop, so one bad workflow cannot hide the
   fate of the others, and an explicit `dispatched:` line makes a success
   provable from the log whatever `gh` prints for itself.

3. **A workflow deleted in the same push is now skipped explicitly.** The bead
   asked that the `||` be narrowed rather than deleted if it protected a real
   case. This is the only candidate, and measurement shows the loop *already*
   skipped it — but only as a side effect of `grep` exiting non-zero on a file
   it cannot open, which also put `No such file or directory` on stderr and then
   printed the wrong reason ("no workflow_dispatch trigger") for the right
   outcome. Measured on runs `29638598700`
   (`post-merge-playground-freshness.yml`) and `31924373964`
   (`freehand-bench.yml`, `freehand-conformance.yml`). An accident is a poor
   thing to rest on once a dispatch failure is fatal, so it is stated. With it
   explicit, the swallow protects nothing and goes.

## What I verified, and what I could not

**Verified — the argument shape, live, against the real API, starting no run.**
`expensive-tests.yml` is the heavyweight nightly matrix and now carries a
Windows leg, so it was not spent as a syntax check. Instead, two probes that
both return 422 and therefore create nothing, chosen so their *different*
messages isolate the ref:

| Probe | Result |
|---|---|
| dispatchable workflow + **commit sha** as `--ref` | `422: No ref found for: 46e197f356…` — ref resolution **failed** |
| non-dispatchable workflow (`test.yml`) + **branch name** `main` as `--ref` | `422: Workflow does not have 'workflow_dispatch' trigger` — ref **resolved**; the API got past ref resolution to the trigger check |

`gh api repos/day8/re-frame2/git/ref/heads/main` resolves; `…/git/ref/<sha>`
returns 404 — a commit id is not in the ref namespace. Confirmed afterwards that
neither probe created a run (`expensive-tests.yml`'s newest run remains the
2026-09-04 schedule).

**Could NOT verify — the merged behaviour.** A `workflow_dispatch` runs the
workflow file **on the default branch**, so none of this can be proven from a PR
branch.

### Acceptance check — and a correction to the dispatch brief

The brief expected this PR to be its own witness, since it is itself a
workflow-editing commit. **It is not**, and the reason is in the file:
`post-merge-workflow-sanity.yml` is on its own EXCLUDE list (`# self`). This
merge will therefore run the canary and print `skip (excluded)`, dispatching
nothing.

`expensive-tests.yml` is the **only** workflow that is both dispatchable and not
excluded — `docs.yml`, `lint.yml` and `portability.yml` all declare
`workflow_dispatch:` but are excluded as already running on push. So the witness
is **the next merge to `main` that edits `expensive-tests.yml`**, whose sanity
run must print:

```
dispatching: expensive-tests.yml (ref main)
dispatched: expensive-tests.yml (ref main)
```

with a corresponding `workflow_dispatch` run of `expensive-tests.yml` appearing.
A failure now reds the job and posts an annotation instead of a `WARN` line.

Note the cheap-looking shortcut is not one: dispatching `expensive-tests.yml` by
hand to force the evidence spends the nightly matrix, including the new Windows
leg. Per the brief, don't — the scheduled 15:17 UTC run covers it and rf2-2qa7
owns reading that result.

## Not fixed, deliberately

`for f in ${{ steps.changed.outputs.files }}` remains the one expression
interpolated into this run body. It is fed from basenames of git-diffed
`.github/workflows/*.yml` paths, and the unquoted expansion is load-bearing for
the word split, so changing it is a separate decision with its own behavioural
risk. Flagged, not touched.

## Quality gates

Every gate run foreground in the worker worktree, exit code captured on the same
command line as the redirect, and quoted from the captured file — never from a
harness report. All re-run on the final rebased base (`e9744f511c`).

| Gate | Exit | Result |
|---|---|---|
| `python scripts/check_workflow_yaml.py --self-test` | **0** | PASS, 5 cases |
| `python scripts/check_workflow_yaml.py` | **0** | PASS, 11 files under `.github/workflows` |
| `python scripts/check_workflow_job_timeouts.py --self-test` | **0** | PASS, 4 accept + 5 reject cases |
| `python scripts/check_workflow_job_timeouts.py --verbose` | **0** | PASS, 117 jobs across 11 files |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | 2794 files, 10867 re-frame require edges, 2446 non-canonical, every surface at or under its floor |
| `python scripts/check_view_lifetime_residue.py --verbose` | **0** | zero residue in tracked content or paths |
| `node --test`, the 4 workflow-reading policy tests | **0** | 384 assertions passed — `_changed-surfaces` 366, `_post-merge-sanity-base` 9, `_docs-workflow-policy` 5, `_lint-workflow-policy` 4 |
| `bash -n` on the extracted `run:` body | **0** | control: a deliberately broken copy exits 2 |

**Sabotage control — proves the gates read *this* worktree.** An unmatched quote
was planted on the `DISPATCH_REF:` line after committing.
`check_workflow_yaml.py` → **exit 1**, naming
`post-merge-workflow-sanity.yml: line 175, column 14`;
`check_workflow_job_timeouts.py` → **exit 2**, `is not well-formed YAML`. The
fault existed only in this worktree, so a run that had wandered into a sibling
checkout would have come back green. Restore verified by **git blob hash**
(`5a95e41b45…`), not by reading a diff.

The first plant attempt **silently no-opped** — the blob hash was unchanged —
because the anchor ended in `$` and these lines end `}}\r`. Perl saw 0 matches
where `grep` saw 1. The hash check caught it before a run was spent; re-planted
without the end-of-line anchor.

**Gate coverage, derived not assumed.** `.github/scripts/report-changed-surfaces.sh`
classifies this path as arming **no** tiered surface — every flag `false`
(controls: `implementation/core/src/re_frame/core.cljs` arms 16, a nonsense path
arms none). The jobs that will grade this diff are the unconditional ones:
`check_workflow_job_timeouts` in `test.yml`, `js-harness-self-tests`
(`npm run test:scripts`, which owns all four policy tests above),
`verify-readme-links`, plus `lint` / `docs` / `portability` as separate runs.

**One brief premise did not hold.** `portability.yml`'s shellcheck covers
`scripts/*.sh` and `.github/scripts/*.sh` — **script files**. Nothing in the
repo shellchecks embedded `run:` blocks in workflow YAML, and there is no
actionlint. shellcheck is also not installed on this machine. So the embedded
shell was checked by hand: the body was extracted through the repo's own
`lib/workflow-yaml.cjs`, `bash -n`'d with a control, and grepped for the SC2016
shape (single-quoted strings containing `$` or a backtick) — none, with a
control confirming the grep does find a planted one.

**Found while writing.** The first draft quoted the old `--ref "<expression>"`
verbatim inside a `#` comment in the run body. Actions substitutes expressions
everywhere in a `run:` body, comments included, so that would have been a live
interpolation. Reworded; the body now carries exactly one expression, the
pre-existing `steps.changed.outputs.files`.
