### PR TITLE
docs(core): error_emit + capture_frame_test stop narrating the retired ui (frame) bundle as live (rf2-ljao)

### DIFF
--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -371,8 +371,11 @@
       SEPARATE registries), so it pivots on the exact operation realm the
       record already carries in `op` (rf2-xgkgx / rf2-a2x2w — the `:op` realm
       attribution the record carries, RATIFIED PUBLIC wherever the realm is
-      known: the frame-bundle stale-op seam, the `capture-frame` pre-check
-      seam, and the router's late captured-op fences all stamp it — see
+      known: core's `capture-frame` stale-op pre-check seam and the router's
+      late captured-op fences stamp it, and the subs SUBSCRIBE emitter stamps
+      it unconditionally (rf2-alk8a). The retired `re-frame.ui` `(frame)`
+      bundle's stale-op seam was a further stamping site until it went with
+      that artefact on 2026-08-16 (rf2-0yp7w), and nothing replaced it — see
       `router/emit-frame-destroyed!` and Spec 009 §Error contract):
         - `:dispatch` / `:dispatch-sync` → the failing op is a DISPATCH, so
           the coord lives under `[:event id]`.
@@ -484,9 +487,9 @@
   The trailing `route-frame?` (default true) gates ONLY the EP-0015
   frame-owned observability sink route below — the corpus-wide listener
   fan-out (axis 1's off-box source of truth) ALWAYS fires regardless.
-  A caller passes false for a KNOWN-DEAD-incarnation `(frame)`-bundle
-  emission: the captured bare frame id
-  no longer names the incarnation the failure belongs to, so resolving it to a
+  A caller passes false for a KNOWN-DEAD-incarnation emission (the two live
+  ones are named below): the captured bare frame id no longer names the
+  incarnation the failure belongs to, so resolving it to a
   live same-id SUCCESSOR would deliver a dead incarnation's failure into the
   successor's own `:observability :errors` sink. This is the event-centric
   mirror of the union-path `route-frame?` seam rf2-vxgfnd.118 added for the
@@ -602,9 +605,12 @@
              ;; app-db-walks `:event` and the same coincidental integer path
              ;; redacts identity here. Late-bound to avoid a require cycle.
              ;; `route-frame?` false (rf2-bf0io) SUPPRESSES ONLY this route for a
-             ;; known-dead-incarnation UI-bundle emission, so a dead incarnation's
-             ;; bare id can never resolve to a same-id successor's error sink; the
-             ;; corpus fan-out above still fired.
+             ;; known-dead-incarnation emission — core's router / subs
+             ;; frame-destroyed emitters since rf2-qjfrw, the retired
+             ;; `re-frame.ui` `(frame)` bundle before it went with that artefact
+             ;; (rf2-0yp7w) — so a dead incarnation's bare id can never resolve
+             ;; to a same-id successor's error sink; the corpus fan-out above
+             ;; still fired.
              (when (and route-frame? (rf.trace/continuation-live?))
                (when-let [route-error! (rf.late-bind/get-fn-cached
                                          :observability/route-error)]
@@ -678,9 +684,12 @@
 
   The trailing `route-frame?` (default true — rf2-bf0io) threads straight into
   [[dispatch-on-error!]]'s frame-owned sink route gate: false suppresses ONLY
-  that route (the corpus record + the axis-2 dev trace still fire), for the UI
-  dead-incarnation `(frame)`-bundle emit that must not deliver a dead
-  incarnation's failure into a same-id successor's sink."
+  that route (the corpus record + the axis-2 dev trace still fire), for a
+  known-dead-incarnation emit that must not deliver a dead incarnation's
+  failure into a same-id successor's sink. rf2-bf0io cut the gate for the
+  retired `re-frame.ui` `(frame)` bundle; rf2-qjfrw carried it into core's
+  `capture-frame` primitive, and the live callers are
+  `router/emit-frame-destroyed!` and `subs/emit-frame-destroyed-recovery!`."
   ([category event event-id frame exception elapsed-ms time trace-tags]
    (emit-error-both! category event event-id frame exception elapsed-ms time
                      trace-tags nil true))

--- a/implementation/core/test/re_frame/capture_frame_test.clj
+++ b/implementation/core/test/re_frame/capture_frame_test.clj
@@ -152,8 +152,13 @@
   (testing "rf2-tdjv7p — a capture pinned to incarnation A, after A is destroyed
             and a same-id successor B reseats, MUST NOT subscribe into B (reading
             B's app-db, caching a reaction in B's sub-cache). It recover-but-
-            emits :rf.error/frame-destroyed and returns nil — the async-safe
-            sibling of the throwing synchronous (frame)-bundle subscribe fence."
+            emits :rf.error/frame-destroyed and returns nil rather than
+            throwing — these ops fire from host cleanup, where a throw would
+            break the host teardown. Recover-but-emit is this category's ONLY
+            behaviour: the retired re-frame.ui (frame) bundle was a second,
+            THROWING surface for it until it went with that artefact on
+            2026-08-16 (rf2-0yp7w), and nothing replaced it (Spec 009 §Error
+            contract, the :rf.error/frame-destroyed row)."
     (rf/reg-event :fh/seed (fn [{:keys [db]} [_ v]] {:db {:value v}}))
     (rf/reg-sub :fh/value (fn [db _] (:value db)))
     ;; Incarnation A of :fh/sub-stale, seeded with :A-value.


### PR DESCRIPTION
Closes the implementation half of rf2-6g6e's post-merge audit, filed as **rf2-ljao**.

The `re-frame.ui` `(frame)` operation bundle went with that artefact on 2026-08-16 (rf2-0yp7w, PR #8322). PR #9182 past-tensed the `spec/009` `:rf.error/frame-destroyed` row accordingly; the audit of that PR found the same narration still standing in core. This PR repairs the four sites inside its fence. **Comments and docstrings only — no runtime change, no behavioural change, no test added or removed.**

`spec/006-ReactiveSubstrate.md`, `spec/Privacy.md` and `spec/Spec-Schemas.md` are the audit's remaining residuals; each is hot-zone and single-toucher and is being routed separately. They are deliberately untouched here.

## The fact that decides the wording

There is **no live throwing surface for `:rf.error/frame-destroyed` at all**. `capture_frame.cljc`'s own header (lines 46-48) states the live behaviour:

> The fence PINS the incarnation live at capture and treats a superseded target as destroyed (recover-but-emit `:rf.error/frame-destroyed`, NOT a throw — these ops fire from host cleanup where a throw would break the host teardown).

The synchronous fence that *did* throw was the retired ui bundle, so recover-but-emit is now the category's only behaviour — which is exactly what the landed `spec/009` row says. Retirement bookkeeping is **retained and dated to rf2-0yp7w** rather than deleted, per the standing position that a donor reference is history or a reserved value, never something to delete on sight.

## Sites repaired

Line numbers re-derived at the rebased base `87612f0e33`; three PRs wrote to this file within one hour on 2026-09-04, and the bead's numbers had all moved.

| # | Site (bead's number → at tip) | Was | Now |
|---|---|---|---|
| 1 | `error_emit.cljc` :374 → **:374** | listed "the frame-bundle stale-op seam" as a **current** `:op`-stamping site, beside `capture-frame`'s | names the three live stampers, and past-tenses the ui bundle's seam to rf2-0yp7w |
| 2 | `error_emit.cljc` :479-480 → **:487** | "A caller passes false for a KNOWN-DEAD-incarnation `(frame)`-bundle emission" | drops the dead-bundle attribution; the same docstring 10 lines below already names the two live callers correctly |
| 3 | `error_emit.cljc` (**not in the bead**) → **:605** | inline comment: "known-dead-incarnation **UI-bundle** emission" | same repair as #2, with the rf2-qjfrw hand-off stated |
| 4 | `error_emit.cljc` :671-675 → **:681** | "for the **UI** dead-incarnation `(frame)`-bundle emit" | generic "known-dead-incarnation emit", with rf2-bf0io → rf2-qjfrw provenance and the two live callers named |
| 5 | `capture_frame_test.clj` :151-156 → **:155** | "the async-safe sibling of the **throwing synchronous** (frame)-bundle subscribe fence" | states the live reason (host cleanup), then records that the retired bundle was the throwing counterpart until rf2-0yp7w and nothing replaced it |

Site 3 was **not enumerated on the bead**. A line-oriented search finds the four sites the bead lists; running the census again over the file with whitespace collapsed surfaced this fifth occurrence, whose distinct spelling (`UI-bundle`, not `(frame)`-bundle) the bead's phrasing did not reach.

### What was deliberately left alone

`capture_frame.cljc:61` — "where a synchronous fence throws on a superseded incarnation, this one emits … and drops the op". Left, agreeing with the prior pass: it names no surface and reads as a generic contrast, not a claim that a throwing fence exists. It is also outside this PR's fence.

## Quality gates

Every exit code below is the runner's own `$?`, redirected to a file on the same command line and read back — never a pipeline status and never a harness-reported number.

| Gate | Base | Captured exit | Result |
|---|---|---|---|
| `implementation/core` JVM — `clojure -M:test` | `87612f0e33` (final) | **0** | 2187 tests, 11320 assertions, 0 failures, 0 errors |
| `implementation/core` JVM, focused (`capture-frame-test` + `error-catalogue-channel-conformance-test`) | `c584337f70` | **0** | 54 tests, 255 assertions, 0 failures, 0 errors |
| `scripts/check_view_lifetime_residue.py --verbose` | `87612f0e33` (final) | **0** | zero residue in tracked content and paths |
| `scripts/check_require_alias_dialect.py --verbose` | `87612f0e33` (final) | **0** | 2794 files, 10867 re-frame require edges, every surface at or under its floor |
| CLJS node — `node out/node-test.js` | `c584337f70` | **0** | 11253 tests, 57131 assertions, 0 failures, 0 errors |
| CLJS compile — `node scripts/compile-node-test.cjs node-test out/node-test.js` | `c584337f70` | **1** | pre-existing, not from this diff — see below |

Surfaces derived from `.github/scripts/report-changed-surfaces.sh` run over the two changed paths rather than hand-listed; it armed `implementation_jvm`, `cljs_node_test`, `cljs_browser`, `cljs_prod` and others. The classifier was exercised once against an input it should *not* flag (`docs/README.md` → zero surfaces true), so its output here is a discrimination rather than a default.

**The CLJS compile exit 1 is not from this change.** Both warnings are `:uix.linter/interop-ref-read` in `implementation/adapters/uix/test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs` (lines 120 and 139), a file this branch does not touch — last changed on main by `570d07d286`. The compile log mentions neither changed file (0 occurrences of `error_emit` or `capture_frame`), and the build output it produced ran green. Flagged for separate triage.

**The residue ratchet is the only gate that genuinely grades this diff**, since it reads comments and docstrings. It was proved to be reading this branch's tree rather than a sibling's: planting the banned vocabulary at a line this PR edits turned it **red at exit 1**, naming `implementation/core/src/re_frame/error_emit.cljc:608` and quoting the planted text. The fault existed only in this checkout, so a run that had wandered elsewhere would have come back green. Restored and verified by git blob hash against the committed object (`6eb2f5e4f6…` before the plant, identical after the restore, working tree clean); the gate then re-ran green.

**The alias-dialect ratchet's green is honest but uninformative** and is not offered as evidence: it grades import edges only and strips comments and strings before it reads anything, so a comment-only diff cannot move it either way. It is run because it is a repo-wide ratchet over the touched paths, not because it says anything about this change.

### Coverage, stated honestly

**Nothing in this repository validates the prose of a Clojure docstring.** The suites above prove only that this change did not break code — which, for a comment-only diff, is the correct and complete automated claim. The substantive claim is verified by hand:

- *Site 1 — the live `:op` stampers.* `spec/009`'s `:rf.error/frame-destroyed` row: "present wherever the emit site KNOWS the realm: the core `capture-frame` stale-op **pre-check** seam, AND the core router/subs **late captured-op** recovery fences (rf2-a2x2w)", plus "rf2-alk8a extends `:op :subscribe` to the **ordinary address-directed SUBSCRIBE** recover-and-emit path too". `error_emit.cljc`'s own `op`-absent bullet at :380-385 already agreed, and `subs.cljc` stamps `:op :subscribe` unconditionally. The retired seam is a fourth, dead one.
- *Sites 2, 3, 4 — the `route-frame?` false callers.* `error_emit.cljc`:496-506, unchanged by this PR: "rf2-qjfrw carried the seam from the retired view artefact's `(frame)` bundle into core's own `capture-frame` primitive, and two production sites drive it: `router/emit-frame-destroyed!` passes `(nil? op)` … and `subs/emit-frame-destroyed-recovery!` passes a literal false". That paragraph is the self-contradiction the audit named: it was already correct while three passages in the same file said the caller was the dead UI bundle.
- *Site 5 — no live throwing counterpart.* `capture_frame.cljc`:46-48 and :60-62, quoted above, plus `spec/009`:2164 — "nothing replaced it, so **recover-but-emit is now this category's only behaviour**".
- *Nothing present-tense survives.* Censused after the edit on two token axes and with two instruments (line-oriented and whitespace-collapsed, since neither result is a superset of the other). Every surviving `re-frame.ui` / `(frame)`-bundle mention in both files is now either dated retirement bookkeeping citing rf2-0yp7w or a historical provenance statement (rf2-bf0io → rf2-qjfrw). The remaining "throwing" hits in `error_emit.cljc` (:761-764, :918) belong to the unrelated emit-then-throw idiom.
- *Both files still read as Clojure*, since the JVM suite loads `error_emit.cljc` and runs `capture_frame_test.clj`, and the CLJS build compiles the `.cljc`.

### Outside the fence, verified at tip

`classification.cljc:1173` was flagged by an earlier audit note as retaining a dead UI half. **It is already fixed at tip** — it now reads "the SAME `:op :subscribe` realm the core emitters stamp". PR #9182 made that repair. No follow-up needed.
