### PR TITLE
fix(machines-viz): the SCXML root scan respects subtree boundaries (rf2-qy8p)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -2316,6 +2316,19 @@ back.
   tag as a child state, so a conforming `<state id="idle"><onentry/></state>`
   imported as `{:states {:idle {:states {nil {}}}}}` — a definition
   `reg-machine`, `MachineChart` and every sibling emitter reject.)
+  **Nor into the ROOT.** Whether a document is a parallel-root or a flat
+  machine is decided from the root's **direct** children, so an
+  unsupported subtree cannot supply the `<parallel>` that decides it.
+  W3C SCXML §6.4 makes that reachable from a *conforming* document —
+  `<invoke>` may carry a whole nested `<scxml>` inline through
+  `<content>` — and such a payload is ignored exactly like any other
+  unsupported subtree: **never rejected** (it is valid SCXML) and
+  **never adopted**. (Pre-fix the root scan searched every token in the
+  root body for the first open `<parallel>`, so an invoked document's
+  topology replaced the importing machine's outright; because the
+  substitute is itself well formed, the `grammar/valid-definition?`
+  import postcondition returned true over it — a confidently wrong
+  machine, with no diagnostic anywhere.)
 - `:spawn-all` rows — omitted; the parent state renders without
   spawn affordances.
 - **Internal-default self / proper-ancestor self-transition semantics

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -1283,10 +1283,11 @@
   is skipped WITH ITS WHOLE SUBTREE.
 
   Nested `<parallel>` is deliberately absent: the exporter emits `<parallel>`
-  only as the ROOT (`emit-parallel`), `scxml->spec` handles that root case
-  before it ever reaches this collector, and `parse-state-block` has no
-  nested-parallel branch — so a nested `<parallel>` would have become a
-  malformed state, not a region. Ignoring it is the lossy-by-design answer."
+  only as the ROOT (`emit-parallel`), `scxml->spec` selects that root case
+  from the same `direct-children` scan this collector reads, and
+  `parse-state-block` has no nested-parallel branch — so a nested
+  `<parallel>` would have become a malformed state, not a region. Ignoring it
+  is the lossy-by-design answer."
   #{"state" "final" "history"})
 
 (defn- scan-element-body
@@ -1330,55 +1331,60 @@
       :else
       (recur (conj body (first rs)) depth (rest rs)))))
 
-(defn- group-children-by-state
-  "Given a flat seq of tokens that sit inside one `<state>` body
-  (already excluding transitions), pair every `<state>` / `<final>` /
-  `<history>` open token with its matching close + interior tokens.
-  Returns a seq of `{:start ... :body ... :self? bool}` maps.
+(defn- direct-children
+  "Split a flat seq of tokens composing ONE element's body into that element's
+  DIRECT child elements, in document order, as
+  `{:start <token> :body <interior tokens> :self? bool}` maps.
 
-  rf2-qy8p — the tag test is an ALLOWLIST (`topology-child-tags`), not
-  \"everything that is not a `<transition>`\". An unsupported element is
-  skipped: a self-closing one outright, an open one TOGETHER WITH ITS WHOLE
-  SUBTREE (via `scan-element-body`), so markup nested inside it — a `<state>`
-  buried in an `<onentry>`, a `<data>` in a `<datamodel>` — cannot be
-  promoted into the parent's `:states`."
+  rf2-qy8p — **this is the one place the importer learns where a subtree
+  ends**, and every decision the importer makes about an element's children
+  reads it: the topology collector (`group-children-by-state`) and
+  `scxml->spec`'s root-`<parallel>` selection alike. A descendant token always
+  sits inside its own ancestor's `:body`, never at this level, so no element —
+  supported or not — can contribute markup to the scope enclosing it.
+
+  That is a property of the SCAN rather than of any tag, which is what the
+  bead's residual needed. `<invoke>` is the reachable case (W3C SCXML §6.4
+  lets it carry a whole nested `<scxml>` document inline through `<content>`),
+  but it is not a special one: `<datamodel>`/`<data>` §5.3, `<send>`'s and
+  `<donedata>`'s `<content>`, and an unsupported nested `<parallel>` all carry
+  opaque markup by the same rule, and a scan that respects boundaries covers
+  every one of them without naming any."
   [tokens]
   (loop [remaining tokens
          acc       []]
     (if (empty? remaining)
       acc
-      (let [t   (first remaining)
-            tag (:tag t)]
-        (cond
-          ;; Transitions are not state blocks — skip them at this
-          ;; level. consume-transitions picks up the direct
-          ;; transitions before group-children-by-state is called
-          ;; on the children-tokens.
-          (and (= "transition" tag)
-               (or (= :self (:kind t))
-                   (= :start (:kind t))
-                   (= :end (:kind t))))
-          (recur (rest remaining) acc)
-
-          (= :self (:kind t))
-          (recur (rest remaining)
-                 (if (contains? topology-child-tags tag)
-                   (conj acc {:start t :body [] :self? true})
-                   ;; Unsupported self-closing element — ignored (lossy).
-                   acc))
-
-          (= :start (:kind t))
-          ;; The body is consumed either way; only a recognised tag keeps it.
-          (let [[body rest-tokens] (scan-element-body tag (rest remaining))]
-            (recur rest-tokens
-                   (if (contains? topology-child-tags tag)
-                     (conj acc {:start t :body body :self? false})
-                     ;; Unsupported open element — the WHOLE subtree is
-                     ;; dropped, so nothing inside it is reachable as topology.
-                     acc)))
-
-          :else
+      (let [t (first remaining)]
+        (case (:kind t)
+          :self  (recur (rest remaining) (conj acc {:start t :body [] :self? true}))
+          :start (let [[body rest-tokens] (scan-element-body (:tag t) (rest remaining))]
+                   (recur rest-tokens (conj acc {:start t :body body :self? false})))
+          ;; A stray `:end` closes nothing open at this level (an unmatched
+          ;; close, or a `</transition>` `consume-transitions` already lifted
+          ;; its opening token out of the stream). It names no child here.
           (recur (rest remaining) acc))))))
+
+(defn- topology-blocks
+  "Narrow a `direct-children` seq to the blocks the importer models as
+  topology (`topology-child-tags`).
+
+  rf2-qy8p — the tag test is an ALLOWLIST, not \"everything that is not a
+  `<transition>`\", and it applies AFTER the scan: an unsupported element is
+  dropped together with its whole subtree, so markup nested inside it — a
+  `<state>` buried in an `<onentry>`, a `<data>` in a `<datamodel>` — cannot
+  be promoted into the enclosing scope. `<transition>` needs no branch of its
+  own: it is simply not on the allowlist, and `consume-transitions` has
+  already taken the direct ones it cares about."
+  [children]
+  (filter #(contains? topology-child-tags (:tag (:start %))) children))
+
+(defn- group-children-by-state
+  "The `<state>` / `<final>` / `<history>` children of one element's body —
+  `direct-children` narrowed by `topology-blocks`. Returns a seq of
+  `{:start ... :body ... :self? bool}` maps."
+  [tokens]
+  (topology-blocks (direct-children tokens)))
 
 (defn- parse-history-block
   "rf2-m285a — parse a W3C SCXML `<history>` pseudo-state element back into
@@ -1590,6 +1596,15 @@
   list says — no executable semantics are imported and nothing nested
   inside such an element is promoted into `:states`.
 
+  **Nor into the ROOT.** Whether a document is a parallel-root or a flat
+  machine is decided from the root's DIRECT children, so an unsupported
+  subtree cannot supply the `<parallel>` that decides it. This matters for a
+  CONFORMING document: W3C SCXML §6.4 lets `<invoke>` carry a whole nested
+  `<scxml>` inline through `<content>`, and reading into it let the invoked
+  document's topology replace the importing one outright. Such a payload is
+  ignored, exactly like every other unsupported subtree — never rejected
+  (it is valid SCXML) and never adopted.
+
   rf2-qy8p — **and success is a postcondition, not a hope**: every
   definition this returns has passed the canonical recursive grammar gate
   (`grammar/valid-definition?`), the same one `spec->scxml`, Mermaid,
@@ -1645,39 +1660,30 @@
                             (recur (inc i) depth)))]
             (subvec tail 0 end-idx))
 
-          parallel-token
-          (first (filter #(and (= "parallel" (:tag %))
-                               (= :start (:kind %)))
-                         root-body))]
+          ;; rf2-qy8p — the root topology decision (parallel-root vs flat)
+          ;; reads the root's DIRECT children, the same boundary-respecting
+          ;; scan `group-children-by-state` reads. It used to search every
+          ;; token in the root body for the first open `<parallel>`, which ran
+          ;; BEFORE any collector could drop an unsupported subtree — so a
+          ;; `<parallel>` the importer had already declared unreachable could
+          ;; still choose, and wholly define, the imported machine. A W3C
+          ;; SCXML §6.4 `<invoke><content><scxml>…</scxml></content></invoke>`
+          ;; reaches that from a CONFORMING document: the invoked document's
+          ;; topology replaced the outer one entirely, and because the
+          ;; substitute is itself well-formed, `grammar/valid-definition?`
+          ;; returned true over it — a confidently wrong machine, silently.
+          ;; Scanning direct children closes it for every opaque subtree at
+          ;; once rather than for `<invoke>` by name.
+          root-children (direct-children root-body)
+
+          parallel-child
+          (first (filter #(and (= "parallel" (:tag (:start %)))
+                               (not (:self? %)))
+                         root-children))]
       (import-postcondition
-       (if parallel-token
+       (if parallel-child
         ;; Parallel definition
-        (let [p-start-idx (some (fn [i] (when (identical? (nth root-body i) parallel-token) i))
-                                (range (count root-body)))
-              tail (subvec root-body (inc p-start-idx))
-              end-idx (loop [i 0 depth 1]
-                        (cond
-                          (>= i (count tail))
-                          (rf.error/throw-error!
-                            :scxml/parse-error
-                            'machines-viz/scxml->spec
-                            (str "SCXML import: unclosed <parallel> element; "
-                                 "add the matching </parallel> closing tag.")
-                            {:recovery :close-the-parallel-element})
-
-                          (and (= :start (:kind (nth tail i)))
-                               (= "parallel" (:tag (nth tail i))))
-                          (recur (inc i) (inc depth))
-
-                          (and (= :end (:kind (nth tail i)))
-                               (= "parallel" (:tag (nth tail i))))
-                          (if (= 1 depth)
-                            i
-                            (recur (inc i) (dec depth)))
-
-                          :else
-                          (recur (inc i) depth)))
-              parallel-body (subvec tail 0 end-idx)
+        (let [parallel-body (:body parallel-child)
               ;; rf2-41goo — the parallel-root `:on-done` rides a
               ;; `done.state.<parallel-id>` transition that is a DIRECT
               ;; child of `<parallel>`. `parse-parallel-body` (via
@@ -1701,13 +1707,11 @@
 
         ;; Flat / compound definition
         (let [initial-str (get-in root-start [:attrs "initial"])
-              ;; group-children-by-state itself skips <transition>
-              ;; tokens at the current depth — so root-level
-              ;; transitions are dropped (we have no slot for them
-              ;; in our spec grammar) and nested transitions stay
-              ;; inside their owning state's body for
-              ;; consume-transitions to pick up.
-              top-state-blocks (group-children-by-state root-body)
+              ;; The topology allowlist keeps <state>/<final>/<history> — so
+              ;; root-level transitions are dropped (we have no slot for them
+              ;; in our spec grammar) and nested transitions stay inside their
+              ;; owning state's body for consume-transitions to pick up.
+              top-state-blocks (topology-blocks root-children)
               states (into {}
                            (map parse-state-block top-state-blocks))]
           (when (empty? states)

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -1715,3 +1715,108 @@
         (is (g/valid-definition? imported)
             (str "import of " (pr-str (or (:initial spec) (:type spec))) " must be projectable"))
         (is (= spec imported) "and the round-trip stays value-equal")))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-qy8p — "ignored wholesale" has to hold for the ROOT topology too.
+;;
+;; The allowlist above stops an unsupported subtree contributing a `:states`
+;; entry. It says nothing about the earlier decision `scxml->spec` makes
+;; BEFORE any collector runs: parallel-root or flat? That scan used to search
+;; EVERY token in the root body for the first open `<parallel>`, so markup the
+;; importer had already declared unreachable could still choose — and wholly
+;; define — the imported machine.
+;;
+;; W3C SCXML §6.4 makes this reachable from a CONFORMING document: `<invoke>`
+;; carries a whole nested `<scxml>` inline through `<content>`. That is a real
+;; SCXML feature, so the answer is not to reject it; the answer is that the
+;; outer parser must not read into it. Pre-fix the inner document's
+;; `<parallel>` REPLACED the outer machine outright and
+;; `grammar/valid-definition?` still returned true — the substitute is itself
+;; well-formed, so the importer produced a confidently wrong machine with no
+;; diagnostic anywhere.
+;;
+;; `<invoke>` is not special here, and the fix does not name it: a nested
+;; `<parallel>` inside an ordinary `<state>` (unsupported by design — see
+;; `topology-child-tags`) reached the same selector by the same route.
+
+(def invoked-inner-parallel
+  "The payload document: a two-region parallel machine, emitted by our own
+  exporter so the fixture cannot drift from the emitter."
+  {:type    :parallel
+   :regions {:left  {:initial :a :states {:a {}}}
+             :right {:initial :b :states {:b {}}}}})
+
+(def outer-flat-machine
+  "The OUTER machine — the one an import of the assembled document must
+  return, unchanged, whatever the invoked payload contains."
+  {:initial :idle
+   :states  {:idle {:on {:go :done}}
+             :done {:final? true}}})
+
+(defn- inline-invoked-scxml
+  "Assemble the outer machine's SCXML with `inner-scxml` embedded verbatim in
+  a W3C §6.4 `<invoke><content>` payload on `<state id='idle'>`. The inner
+  document's XML declaration is dropped so the assembled document is
+  well-formed."
+  [inner-scxml]
+  (str "<scxml xmlns='http://www.w3.org/2005/07/scxml' version='1.0' initial='idle'>"
+       "<state id='idle'>"
+       "<transition event='go' target='done'/>"
+       "<invoke type='http://www.w3.org/TR/scxml/'><content>"
+       (str/replace inner-scxml #"(?s)^\s*<\?xml[^?]*\?>\s*" "")
+       "</content></invoke>"
+       "</state>"
+       "<final id='done'/>"
+       "</scxml>"))
+
+(deftest import-does-not-adopt-a-parallel-root-from-an-invoked-document
+  (testing "rf2-qy8p — an inline <invoke><content><scxml> payload cannot
+            replace the outer machine's topology"
+    (let [spec (scxml/scxml->spec
+                 (inline-invoked-scxml (scxml/spec->scxml invoked-inner-parallel)))]
+      (is (= outer-flat-machine spec)
+          "the OUTER flat machine imports exactly; the invoked payload is ignored wholesale")
+      (is (nil? (:type spec))
+          "the inner <parallel> must not make this a parallel machine")
+      (is (nil? (:regions spec))
+          "and must not contribute regions")
+      (is (= #{:idle :done} (set (keys (:states spec))))
+          "the outer states survive; :left/:right never appear")
+      (is (g/valid-definition? spec)))))
+
+(deftest import-does-not-adopt-a-parallel-root-nested-in-a-state
+  (testing "rf2-qy8p — the same holds for a <parallel> nested in an ordinary
+            <state> (unsupported by design): <invoke> is not a special case"
+    (let [spec (scxml/scxml->spec
+                 (str "<scxml xmlns='http://www.w3.org/2005/07/scxml' version='1.0' initial='idle'>"
+                      "<state id='idle'>"
+                      "<transition event='go' target='done'/>"
+                      "<parallel id='nested'>"
+                      "<state id='nested___left' initial='nested___left___a'>"
+                      "<state id='nested___left___a'/></state>"
+                      "<state id='nested___right' initial='nested___right___b'>"
+                      "<state id='nested___right___b'/></state>"
+                      "</parallel>"
+                      "</state>"
+                      "<final id='done'/>"
+                      "</scxml>"))]
+      (is (= outer-flat-machine spec)
+          "the nested <parallel> is dropped with its subtree, not promoted to the root")
+      (is (nil? (:type spec)))
+      (is (g/valid-definition? spec)))))
+
+(deftest import-still-reads-a-real-root-parallel-and-a-flat-invoked-payload
+  (testing "rf2-qy8p — the controls: a DIRECT root <parallel> still imports,
+            and an invoked FLAT payload leaves the outer definition exact"
+    ;; Control 1 — the supported location. A `<parallel>` that really is a
+    ;; direct child of `<scxml>` must still select the parallel branch.
+    (is (= parallel-machine
+           (scxml/scxml->spec (scxml/spec->scxml parallel-machine)))
+        "a genuine root <parallel> still round-trips value-equal")
+    ;; Control 2 — the same invoked-payload shape carrying a FLAT document.
+    ;; This passed before the fix too: that is what makes it a control on the
+    ;; subtree drop rather than on the parallel selector.
+    (is (= outer-flat-machine
+           (scxml/scxml->spec
+             (inline-invoked-scxml (scxml/spec->scxml idle-loading-success-error))))
+        "an invoked flat payload contributes nothing either")))


### PR DESCRIPTION
Closes the residual a post-merge audit of #9273 found and reopened rf2-qy8p for.

## The defect

`scxml->spec` decides parallel-root vs flat by looking for a `<parallel>` in the
root body. That scan searched **every token** in the root body for the first open
`<parallel>` — flat, boundary-blind, and it ran *before* any collector could drop
an unsupported subtree. So a `<parallel>` the importer had already declared
unreachable could still choose, and wholly define, the imported machine.

W3C SCXML [§6.4](https://www.w3.org/TR/scxml/#invoke) makes that reachable from a
**conforming** document: `<invoke>` may carry a whole nested `<scxml>` inline
through `<content>`. The invoked document's topology replaced the importing one
outright — outer states, transitions and all gone — and because the substitute is
itself well formed, the `grammar/valid-definition?` postcondition returned `true`
over it. A confidently wrong machine, with no diagnostic anywhere.

## Three judgement calls, stated

**1. `<invoke><content>` is a legitimate construct and is not rejected.** The fix
is that the outer parser stops reading *into* it. Erroring on nested content would
break a valid SCXML feature; the payload is ignored exactly like every other
unsupported subtree — never rejected, never adopted.

**2. `<invoke>` is not special, and the fix does not name it.** Checked before
deciding: a nested `<parallel>` inside an ordinary `<state>` reaches the same
selector by the same route (reproduced — see the second regression below), and
`<datamodel>`/`<data>` (§5.3), `<send>`'s `<content>` and `<donedata>`'s all carry
opaque markup by the same rule. So the repair teaches the **scan** about the
boundary, once, in one place, rather than special-casing a tag:

- `direct-children` splits a body into its direct child elements using the
  existing `scan-element-body`. It is now the single place the importer learns
  where a subtree ends.
- `topology-blocks` narrows that to the `topology-child-tags` allowlist.
- `group-children-by-state` becomes those two composed, and `scxml->spec`'s root
  decision reads the same scan.

Net effect beyond the fix: the duplicated balanced-scan inside `scxml->spec`
disappears, and `<transition>` loses its bespoke branch in the collector — it is
simply not on the allowlist.

**3. The `grammar/valid-definition?` half is deliberately left alone, and that is
the substantive call.** The grammar gate validates the *shape* of a definition;
the inner parallel machine is a perfectly shaped definition. What was wrong was
its *provenance* — which document it came from — and provenance is not something
`grammar.cljc` can see or should know about. Teaching it to would be a check in
the wrong layer that could not be expressed there anyway.

Under *fail closed, fail loudly* the instrument that had to change is the parser,
and after this change it does the right thing in both directions: it returns the
outer machine when there is one, and a document whose *only* topology sits inside
an unsupported subtree now reaches the flat branch with no states and throws the
documented `:scxml/invalid-spec` rather than silently adopting the payload. The
postcondition then validates the right definition — which is what makes it worth
keeping. Adding a second, weaker check beside it would be the gold-plating the
project stance rejects.

## The gap was proved before it was closed

The regressions were written against the **unfixed** tree and run first. Captured
RED, `tools/machines-viz` JVM lane, exit **1**, 652 tests / 2833 assertions,
**6 failures**:

```
FAIL in (import-does-not-adopt-a-parallel-root-from-an-invoked-document)
the OUTER flat machine imports exactly; the invoked payload is ignored wholesale
expected: (= outer-flat-machine spec)
  actual: (not (= {:initial :idle, :states {:idle {:on {:go :done}}, :done {:final? true}}}
                  {:type :parallel, :regions {:left {:initial :a, :states {:a {}}},
                                              :right {:initial :b, :states {:b {}}}}}))

FAIL in (import-does-not-adopt-a-parallel-root-nested-in-a-state)
the nested <parallel> is dropped with its subtree, not promoted to the root
expected: (= outer-flat-machine spec)
  actual: (not (= {:initial :idle, ...} {:type :parallel, :regions {...}}))
```

The outer machine did not merely lose a state — it was replaced entirely
(`#{:idle :done}` became `#{}`), by both routes. Two controls **passed
throughout**, before and after, which is what makes them controls: a genuine
direct-root `<parallel>` still round-trips value-equal, and an invoked *flat*
payload leaves the outer definition exact.

## Error surface

The unclosed-`<parallel>` message and its `:rf.error/id` (`:scxml/parse-error`)
are byte-identical, since `scan-element-body` interpolates the tag into the same
sentence. Only `:recovery` refines from the bespoke `:close-the-parallel-element`
to the shared `:close-the-open-element` every other element already throws.
Nothing in the tree pinned the bespoke keyword (sole occurrence was its own
definition site). Verified by probe alongside three untouched controls:

| input | id | recovery |
|---|---|---|
| unclosed root `<parallel>` | `:scxml/parse-error` | `:close-the-open-element` (was `:close-the-parallel-element`; same message) |
| self-closing `<parallel/>` root | `:scxml/invalid-spec` | `:add-a-state-or-final-element` (unchanged) |
| unclosed `<scxml>` root | `:scxml/parse-error` | `:close-the-scxml-root` (unchanged) |
| no root element | `:scxml/parse-error` | `:wrap-in-an-scxml-root` (unchanged) |

## Spec

`tools/machines-viz/spec/API.md` §Not supported claimed "**Ignored is the whole of
the behaviour**" while documenting only the `:states` half. That claim is now true,
so the bullet states the root half it was silently missing. Anchors and the added
table column counts were checked by hand; neither doc gate reads inside a fenced
block, and the one link I first wrote pointed at a heading that does not exist —
caught before commit and removed rather than papered over.

## Quality gates

All foreground to completion, exit codes captured on the runner's own command line
and quoted from the captured file, all re-run on the **final** rebased base
(`87612f0e33`) after `main` moved 9 commits under me — none of which touched
`tools/machines-viz`.

| gate | result | exit |
|---|---|---|
| `tools/machines-viz` JVM (`clojure -M:test`) — pre-fix RED | 652 tests / 2833 assertions, **6 failures** | **1** |
| `tools/machines-viz` JVM — post-fix | 652 tests / 2833 assertions, 0 failures, 0 errors | **0** |
| `tools/machines-viz` CLJS compile (`machines-viz-node-test`) | 216 files, 0 warnings | 0 |
| `tools/machines-viz` CLJS `node out/...js` — the real verdict | 855 tests / 3794 assertions, 0 failures, 0 errors | **0** |
| `scripts/test-jvm-tools.sh` (full sweep, 10 artefacts) | 4732 tests / 21156 assertions, 0 failures, 0 errors | **0** |
| `scripts/check_require_alias_dialect.py --verbose` | 2794 files, 10867 edges, 2446 non-canonical, every surface at or under its floor | **0** |
| `scripts/check_view_lifetime_residue.py --verbose` | zero residue in tracked content **or commit messages** | **0** |
| `scripts/check_doc_slugs.py` | clean | **0** |
| `scripts/check_readme_links.py --ci` | clean | **0** |

`shadow-cljs compile` exits 0 with failing tests on this repo (`:autorun`), so the
CLJS verdict quoted above is the separate `node` step's captured code, not the
compile's.

**Each gate was shown to read this branch, not a sibling.** `test-jvm-tools.sh`
prints its resolved root, and it named this worktree. The CLJS bundle's
`SHADOW_IMPORT_PATH` names this worktree, and its compiled `cljs-runtime` carries
both new `deftest`s and the new `direct-children` fn — positive evidence the
runtime observed this tree rather than a cached one. `check_doc_slugs.py` prints
nothing on success, so it was proved by a planted fault instead: a broken anchor
at a line already being edited took it to exit **1** naming the file, line 2319
and the invented anchor; restore was verified by git blob hash
(`c4a0fbf26170647029d9d610c98af1ad6593d6ca`, equal to the committed object) and
the gate re-run green. The surface classifier was likewise exercised against a
control — `spec/API.md` alone arms 0 surfaces where the source file arms 6 — so
its answer is a measurement, not a default.

## CI surfaces armed

Derived from `.github/scripts/report-changed-surfaces.sh` read against
`.github/workflows/test.yml`: `cljs_node_test`, `cljs_browser`, `examples_compile`,
`tools_jvm_machines_viz`, `tools_cljs_machines_viz`, `machines_viz_viewer_page`,
mapping to jobs `cljs`, `cljs-browser`, `cljs-examples-compile`,
`jvm-tools-machines-viz`, `cljs-tools-machines-viz`, `machines-viz-viewer-page`.

## Fence

Confined to `tools/machines-viz/{src,test,spec}`. No repo-root `spec/*`, no
`implementation/**`, no `.github/workflows/**`, no peer-lane tools, no `.beads/`,
no `ai/`. Diffed against the merge base and read for reverts: every deletion is
the old collector body being replaced by the scan/narrow split (behaviour and all
its rf2-qy8p reasoning carried into the new docstrings) or the balanced-scan the
fix makes redundant. Nothing #9273 landed — `scan-element-body`,
`topology-child-tags`, `import-postcondition`, the postcondition docstring — is
touched by a deletion.
