### PR TITLE
fix(uix): the effect recipe reads its ref with @, not .-current (rf2-8crk)

### DIFF
--- a/implementation/adapters/uix/test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs
@@ -117,7 +117,7 @@
         {:keys [dispatch-sync]} (rf.adapter.uix/use-frame)]
     (uix/use-effect
       (fn []
-        (let [el       (.-current ref)
+        (let [el       @ref
               listener (fn [_evt] (dispatch-sync [::finished tile-id]))]
           (swap! effect-log conj :setup)
           (.addEventListener el "animationend" listener)
@@ -136,7 +136,7 @@
         {:keys [dispatch-sync]} (rf.adapter.uix/use-frame)]
     (uix/use-effect
       (fn []
-        (let [el       (.-current ref)
+        (let [el       @ref
               listener (fn [_evt] (dispatch-sync [::finished tile-id]))]
           (swap! effect-log conj :setup)
           (.addEventListener el "animationend" listener)


### PR DESCRIPTION
Trunk red. `implementation/scripts/compile-node-test.cjs` refused the `:node-test` compile under its zero-warning floor on two `:uix.linter/interop-ref-read` warnings, at lines 120 and 139 of `implementation/adapters/uix/test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs`. Both are `(.-current ref)` inside a `uix/use-effect` body.

**It is the compile step, not the test step.** The node suite is green throughout — it is the compile that produces it that failed. That is why this survived merge: in CI `cljs_node_test` is surface-gated by the classifier, so a PR that does not arm the CLJS surface has it skipped, and a skip counts as passed in the rollup. Locally it reds `scripts/test-fast-pr.sh` and `npm run test:cljs` for *any* diff, which is how it was found — twice, independently, by workers establishing it was not their own change.

The file arrived with `570d07d286` (rf2-tug6) and is byte-identical to `origin/main`, so this is trunk state rather than anyone's diff.

## The fix, and why it is safe

Two reads change from `(.-current ref)` to `@ref`. Nothing else.

The linter is telling the truth, and the two forms are **the same property read on the same object** — established from UIx's own source (`com.pitch/uix.core` 1.4.4, `uix/core.cljs`), where `use-ref` returns

```clojure
(specify! #js {:current value}
          IDeref
          (-deref [this] (.-current this))
          ...)
```

`-deref` *is* `(.-current this)`. The atom-like wrapper is also the object handed to React as `($ :div {:ref ref ...})`, so React assigns the DOM node into the very `.current` that both forms read. There is no coercion and no second indirection: `@ref` and `(.-current ref)` return the identical value at these sites. The interop form was reaching through the abstraction for nothing.

## Scope of the rule, and the census

`:uix.linter/interop-ref-read` fires only where both conditions hold: a `.-current` host-field read whose target's **local binding init form is a `use-ref` call** (`uix.linter/interop-ref-read?`), inside a body reached by `uix.linter/lint!` — which `uix.core` calls from `defui` and `uix.core/fn` only. So the rule is scoped to UIx component bodies.

Census run on two token axes (line-oriented and whitespace-collapsed, since neither result is a superset of the other), with a shape-sharing fixed-string control that returned non-zero. Both axes agree:

| Site | Flagged? | Why |
| --- | --- | --- |
| `adapters/uix/test/.../uix_effect_frame_deps_dom_cljs_test.cljs:120,139` | yes | `use-ref`-bound `.-current` inside `defui` — **fixed here** |
| `adapters/uix/README.md:61` | no | markdown; never compiled, so the linter cannot see it |
| `hicasso/test/.../imperative_sdk_dom_cljs_test.cljs` | no | Hicasso refs, not `uix/use-ref`, and not in a `defui` body |
| 15 further `.-current` sites (story, xray, bench, core, hicasso) | no | none is a `use-ref`-bound read in a UIx component body |

The gate is consistent, not arbitrary. Nothing was suppressed: no ignore comment, no threshold change, no exclusion — `compile-node-test.cjs` and every linter/gate configuration are untouched. The zero-warning floor caught a real idiom violation within hours of it landing, which is the gate working.

One thing worth a follow-up, deliberately **not** done here to keep this P1 to two lines: `adapters/uix/README.md:61` carries the same `(.-current ref)` in the canonical outer/inner recipe that this test transcribes. It reds nothing, but it is the source the next transcription copies.

## Quality gates

Every exit code below is the runner's own, captured to a file on the same command line, not a harness report. All runs on the final rebased base.

| Gate | Before | After |
| --- | --- | --- |
| `compile-node-test.cjs node-test` (**the red gate**) | **exit 1** — `1901 of 1902 files, 2 warnings` | **exit 0** — `Build completed. (1904 files, 1004 compiled, 0 warnings, 87.67s)` |
| `node out/node-test.js` | exit 0 | **exit 0** — `Ran 11260 tests containing 57198 assertions. 0 failures, 0 errors.` |
| `scripts/test-fast-pr.sh` | red on trunk for this reason | **exit 0** — `PASS fast PR spine` (`docs=false jvm=true node=true`), its own node tier reading `[:node-test] Build completed. (1903 files, 1 compiled, 0 warnings, 38.40s)` |
| `shadow-cljs compile browser-test` | — | exit 0, 0 new warnings (5 pre-existing `:infer-warning`s, all in an unrelated hicasso SSR test) |
| browser suite (`serve-and-run-browser-tests.cjs`) | — | exit 0 — `Ran 786 tests containing 4311 assertions. 0 failures, 0 errors.` |
| `python scripts/check_require_alias_dialect.py --verbose` | — | exit 0 — `2794 file(s), 10867 re-frame require edge(s), 2446 non-canonical, every surface at or under its floor.` |
| `python scripts/check_view_lifetime_residue.py --verbose` | — | exit 0 — `zero 'lease' residue in tracked content or paths.` |

The require-alias ratchet grades **import edges** and this diff adds no file and no require, so its exit 0 is honest but uninformative. The lease-residue ratchet is a repo-wide banned-word scan at permitted count zero over tracked content *and* paths, so it does grade the two edited lines and their file's prose.

### The counts held, and a green suite here is not self-evidently evidence

Measured same-base (both runs on the pre-rebase base, only the two lines differing):

* before — `Ran 11253 tests containing 57131 assertions. 0 failures, 0 errors.`
* after — `Ran 11253 tests containing 57131 assertions. 0 failures, 0 errors.`

Identical. The final-base figure is higher (`11260` / `57198`) purely because the trunk gained tests while this was in flight — PR #9284 extended `realworld_cljs_test.cljs`, PR #9286 added `ssr/presence_truthiness_cljs_test.cljc`, and more landed after. Neither this file nor any test of it was touched by any of them: `git log <original base>..origin/main -- <this file>` is empty, so this branch reverts nothing.

The spine's exit 0 was measured one base back (`c4d8d49f`); the trunk then gained `core.cljc` and others, so the branch was rebased again and the two headline numbers — the compile gate that was red, and the node suite — were re-established on the final base rather than carried over. CI is the authority on the merge result.

**But the node lane does not execute these two test bodies at all**, and that has to be said plainly, because it is what would make a green node suite worthless as evidence here. Both deftests self-gate on `(browser?)` and no-op under `:node-test`, contributing one trivial assertion each — the ns docstring says so, and a namespace-scoped run confirms it: `Ran 2 tests containing 2 assertions`. The behaviour lives in the `:browser-test` lane (`-dom-cljs-test$`).

So the fault was planted **there**. Line 120's `@ref` was replaced with a freshly created detached element, the build recompiled so the runtime genuinely observed the plant (3 files recompiled), and the browser suite went **red, exit 1**, with three failures all inside `imperative-effect-follows-the-frame-across-a-provider-swap` — the one test whose component was planted. `omitting-the-frame-dep-keeps-dispatching-into-the-previous-frame`, whose component still read `@ref`, stayed green. The plant existed only in this branch's working tree, so the red is what discriminates it. The file was then restored and verified by **git blob hash** against the committed object — `16a1e70e99f5fca3db56a31ab8aff7c1642970c3`, matching exactly — rather than by reading a diff.

The tests still assert what they asserted, and they still bite.

### CI surfaces this diff arms

From `.github/scripts/report-changed-surfaces.sh` read against `.github/workflows/test.yml`, classified on the changed path (the classifier takes **paths**, not revisions — handed revisions it reports every surface false, which is a false all-clear that looks exactly like a genuinely unaffected change):

`implementation_jvm`, `cljs_node_test`, `adapter_diagnostic`, `cljs_browser`, `examples_compile`, `cljs_prod`, `bundle_isolation`, `adapter_testbed_smokes`, `tools_jvm`, `template_expensive`, `mcp_conformance`, `mcp_live`.

`cljs_node_test` — the job that was red — and `cljs_browser`, the lane that actually exercises these two tests, are both armed.
