### PR TITLE
spec(006): the incarnation fence past-tenses its retired throwing sibling (rf2-pyav)

### DIFF
--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -572,12 +572,21 @@ close this window; either is individually sufficient for its axis, and together 
    resolves for the enqueue or read. There is therefore **no liveness-check-to-bare-id-use window**: on
    the concurrent JVM host, an actor that destroys the captured incarnation and reseats a same-id
    successor between the capture's liveness pre-check and its ordinary address-directed consumption can
-   never redirect the stale op into that successor (rf2-dlld6). This is the async-safe, recover-but-emit
-   sibling of the synchronous **throwing** incarnation fence the `(frame)` accessor bundle already
-   applies; it is the last-line guard for a predecessor cleanup — including a throwing-host quarantine
+   never redirect the stale op into that successor (rf2-dlld6). This fence is **recover-but-emit**, not
+   throwing: it is the last-line guard for a predecessor cleanup — including a throwing-host quarantine
    React later self-completes — that fires after both the successor adapter and a same-id successor
-   frame are live. A capture whose id was **not** live at capture (the `capture-frame` 1-arity
+   frame are live, and these ops run from host cleanup, where a throw would break the very teardown
+   running them. A capture whose id was **not** live at capture (the `capture-frame` 1-arity
    lock-to-id form used from outside any scope) pins nothing and stays address-directed.
+
+   A **throwing** synchronous sibling of this fence existed until 2026-08-16, and is recorded rather
+   than dropped because an older cross-reference may still send a reader looking for it: it was the
+   retired `re-frame.ui` `(frame)` operation bundle's own incarnation check, and it went with that
+   artefact (rf2-0yp7w). Nothing replaced it, so the recover-but-emit fence above is the only
+   incarnation fence there is — as [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue)
+   records for `:rf.error/frame-destroyed`, whose `:op` realm enum is exactly `:dispatch` /
+   `:dispatch-sync` / `:subscribe` since the fourth value `:capture`, which named that retired read
+   alone, was struck on 2026-09-04 (rf2-xtqs).
 
 This is consistent with **"Disposal is total"** and **"no state survives"** (the adapter-revertibility
 contract above): the surviving `:tearing-down` claim is a **host-ownership quarantine** tracking a


### PR DESCRIPTION
Closes the spec/006 half of the rf2-6g6e sweep (bead rf2-pyav, sweep b).

## The defect

`spec/006-ReactiveSubstrate.md:576` (re-derived at tip three times — the audit's original
`555-556` is stale) described the captured-op incarnation fence as:

> This is the async-safe, recover-but-emit **sibling of the synchronous throwing incarnation fence
> the `(frame)` accessor bundle already applies**

That is a present-tense claim about a surface that no longer exists. The throwing fence belonged to
the `re-frame.ui` `(frame)` operation bundle, retired and removed with that artefact on 2026-08-16
(rf2-0yp7w, PR #8322). Nothing replaced it.

The authority is `implementation/core/src/re_frame/capture_frame.cljc`'s own header (lines 47-48 and
61-62), which states the live successor recovers-but-emits *rather than* throwing — because these ops
fire from host cleanup, where a throw would break the host teardown — and explicitly contrasts itself
with "a synchronous fence [that] throws". That fence was the retired bundle.

## The repair

Prose only; no runtime change. Two parts, both confined to the one passage under
`#### Successor-generation settlement fence`:

1. The sentence now states the fence's own behaviour positively (**recover-but-emit**, not throwing)
   and gives the reason `capture_frame.cljc` gives — a throw would break the very host teardown
   running the op — instead of defining it against a dead sibling.
2. A following paragraph past-tenses the retired sibling **in place, as retirement bookkeeping rather
   than deletion**, carrying its date and rf2-0yp7w. This follows the repo's standing position on
   donor references, and matches the shape PR #9290 (rf2-rfjf) landed on `spec/Privacy.md` for this
   same bead family — same "stood/existed until 2026-08-16", same "recorded because an older
   cross-reference may still send a reader looking for it", same 009 cross-link.

The new paragraph also reconciles 006 with `spec/009-Instrumentation.md:2164`, whose
`:rf.error/frame-destroyed` row already records this retirement and states the `:op` realm enum is
exactly `:dispatch` / `:dispatch-sync` / `:subscribe` since the fourth value `:capture` — which named
the retired ui `(frame)` read alone — was struck on 2026-09-04 (rf2-xtqs). 009's formulation is
adopted rather than a new one invented. 006 never declared `:capture` itself (0 occurrences), so
nothing is struck here; the passage already names exactly the three live ops.

### One deliberate wording limit

The paragraph says the recover-but-emit form is the only **incarnation fence** there is, and does not
claim `:rf.error/frame-destroyed` has no throwing surface anywhere. It still has one:
`implementation/ssr/src/re_frame/ssr/render_state.cljc`'s `require-live-frame!` throws that error id
when SSR render-state project/restore is handed a non-live frame. That is an SSR precondition, not an
incarnation fence and not the `(frame)` accessor bundle, so it is outside this passage's claim — but
scoping the sentence to the fence keeps 006 true without overreaching. Flagged below as an
out-of-fence observation.

## Fence

`spec/006-ReactiveSubstrate.md` only — one file, one hunk, 13 insertions / 4 deletions. The file is
hot-zone with six `rf2-kuky` children queued behind it, so the diff is kept to this one passage.
No open PR held the file when this started (all 5 open PRs enumerated; the file-listing route
exercised against a control that returned `spec/Privacy.md` for #9290).

The `## View tagging contract` section PR #9277 folded into this page (line 747) is 150+ lines below
the hunk and is untouched. `spec/View-Hierarchy-Capture.md` no longer exists; this diff introduces
zero references to it.

## Quality gates

All run foreground from the worker worktree, exit codes captured on the runner's own command line
(never through a filter) and re-run on the **final** base after the last rebase (`c4d8d49f24`).

| Gate | Captured exit | Evidence it read this tree |
| --- | --- | --- |
| `python -m mkdocs build --strict` | **0** | Prints its root, and the line names this worktree's own `site` directory. Its not-in-nav listing includes `spec\006-ReactiveSubstrate.md`, confirming `mkdocs_hooks.py`'s `on_pre_build` staged `spec/` and the edited page was scanned. A bare local run needs no manual staging. |
| `python scripts/check_doc_slugs.py` | **0** | Prints nothing on success, so proven by planted fault: breaking the new link's anchor to `#error-event-catalogue-NO-SUCH-ANCHOR-PYAV` returned **exit 1**, `1 broken anchor link(s) found`, naming `spec\006-ReactiveSubstrate.md:586`. The fault existed only in this tree, so a run that had wandered elsewhere would have come back green. |
| `python scripts/check_view_lifetime_residue.py --verbose` | **0** | Repo-wide banned-word scan at permitted count zero over tracked content **and** paths; it reads prose, so it genuinely grades this diff. Proven by planted fault: a banned-stem word in the new paragraph returned **exit 1** naming `spec/006-ReactiveSubstrate.md:585`. Clean message: `zero 'lease' residue in tracked content or paths`. |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | Grades **import edges only**, so a markdown-only diff cannot move it. This zero is honest but **uninformative** and is not offered as evidence for this change. (`2795 file(s), 10870 re-frame require edge(s), 2446 non-canonical, every surface at or under its floor`.) |

Both plants were applied from an already-committed tree and restored with `git checkout HEAD --`,
each restore verified by **git blob hash** against the committed object (`74ac3be7a1…`), not by
reading a diff. Each plant's anchor match count was read as exactly `1` before the gate ran; the
first residue plant was discarded and re-made because its shell quoting produced a string containing
no banned stem — it would have come back green for the wrong reason.

Full gate output was read, not just the first line.

### Hand checks (nothing validates prose, tables, rendering or nav)

- **Not inside a fenced code block.** 24 fence markers precede the hunk (even), so both link gates
  read this edit rather than skipping it. Verified rather than assumed, because neither gate looks
  inside a fence.
- **No heading added, removed or renamed.** The md5 of the file's heading *text* is byte-identical
  before and after; only the heading *list with line numbers* shifts, and that is the 9-line insert.
  No inbound anchor can break.
- **No table touched.** Zero pipe-leading lines in the diff, so no column-count check applies.
- **The one new link resolves both ways.** `009-Instrumentation.md#error-event-catalogue` is the
  spelling this page already uses twice, the target heading exists (`### Error event catalogue`), and
  the near-duplicate `### Error event catalogue (single source of truth)` slugs differently, so there
  is no collision. Validated by both gates and by the planted-anchor control.
- **No line-number citation was shifted.** The insert adds 9 lines at 583+. The only line-number
  citation into this file outside `.beads` is `implementation/core/test/re_frame/adapter/react_shared_suite.cljs:2042`,
  which cites lines 154-170 — above the insert, so unshifted.
- **Markdown list structure preserved.** The new paragraph is indented to stay inside ordered-list
  item 2; the surrounding item's own final sentence is unchanged.

### CI surfaces

`.github/scripts/report-changed-surfaces.sh spec/006-ReactiveSubstrate.md` arms `implementation_jvm`
and nothing else. The classifier was first invoked wrongly (revisions where it expects paths) and
returned every surface false — the failure mode that looks exactly like a genuinely unaffected
change — so it was re-run with paths and exercised against a control
(`implementation/core/src/re_frame/router.cljc`, which arms 16 surfaces). No JVM test pins this
page's content: the only test-tree reference is the prose citation above.

## Out of fence — reported, not touched

- `implementation/ssr/src/re_frame/ssr/render_state.cljc` (`require-live-frame!`, ~line 299) throws
  `:rf.error/frame-destroyed`. 009's row says "recover-but-emit is now this category's only
  behaviour"; that reads as scoped to the dispatch/subscribe ops the row describes, and the SSR site
  is a render-state precondition rather than one of those three. Worth a ruling, but 009 is out of
  fence and this PR does not depend on the answer.
- `spec/006-ReactiveSubstrate.md:1210` says "attempts to subscribe to `F` **raise**
  `:rf.error/frame-destroyed`", where line 1166 on the same page correctly says `subscribe-once`
  emits and "does NOT throw". "Raise" is loose there rather than wrong-by-retirement, it is a
  different passage, and widening this diff would block the six `rf2-kuky` children queued on this
  hot-zone file. Left for a follow-up.
