### PR TITLE
docs(spec): FrameDestroyedTags four-emitter reconciliation is past-tensed; two of the four retired (rf2-fxp5)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -1220,12 +1220,24 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
   ;; here because `:rf.error/frame-destroyed` is an `:error` envelope; `:op`'s
   ;; optionality is a per-emit-site axis, not a per-branch one).
   ;;
-  ;; rf2-g8ict — the payload slots below are reconciled against what the FOUR
-  ;; live emitters actually stamp. This schema previously declared `:rf.event/v`
-  ;; and `:rf.sub/query-v` as the payload pair; `:rf.event/v` was PHANTOM for
-  ;; this category (no emitter stamps it), while the slots three of the four
-  ;; emitters DO stamp — the bare `:event`, `:query-v`, `:reason`, `:where`,
-  ;; `:rf.sub/id` — were undeclared.
+  ;; rf2-g8ict (2026-07-19) — the payload slots below were reconciled against
+  ;; what the emitters live ON THAT DATE actually stamp. This schema previously
+  ;; declared `:rf.event/v` and `:rf.sub/query-v` as the payload pair;
+  ;; `:rf.event/v` was PHANTOM for this category (no emitter stamps it), while
+  ;; the slots those emitters DO stamp — the bare `:event`, `:query-v`,
+  ;; `:reason`, `:where`, `:rf.sub/id` — were undeclared.
+  ;;
+  ;; THAT RECONCILIATION COUNTED FOUR LIVE EMITTERS; TWO REMAIN. The paragraph
+  ;; above is left in its own terms because two of the five slots it names went
+  ;; with the pair that retired: `ui/frames/emit-and-throw-frame-destroyed!`,
+  ;; removed with `re-frame.ui` on 2026-08-16 (rf2-0yp7w — the ownership note
+  ;; below), and `substrate/observation/throw-frame-destroyed!`, removed with
+  ;; the internal observation port on 2026-08-21 (rf2-63t1i — the retirement
+  ;; that struck `:where` / `:rf.sub/id` / `:rf.sub/query-v` from the
+  ;; declaration, below). The survivors are `router/emit-frame-destroyed!` and
+  ;; `subs/emit-frame-destroyed-recovery!` — the only two sites in the corpus
+  ;; that build these tags — and between them they stamp every slot the `[:map]`
+  ;; still declares.
   ;;
   ;; The bare `:event` spelling is NOT an accident to be normalised away: it is
   ;; a first-class, classification-aware slot. `re-frame.classification/project-
@@ -1235,7 +1247,8 @@ A schema and its catalogue row are **co-edited**, and a conformance test holds t
   ;; redaction chokepoint consults. `:rf.event/v` is the DISPATCH-PIPELINE
   ;; spelling (`:rf.event/run-start`, `:rf.event/dispatched`, …); the bare
   ;; `:event` is the ERROR-tag spelling. So the document was wrong, not the
-  ;; runtime, and the repair is here rather than at four emit sites.
+  ;; runtime, and the repair was here rather than at the emitters' own emit
+  ;; sites.
   ;;
   ;; `:recovery` is deliberately ABSENT: `trace/build-event` `dissoc`s it from
   ;; `:tags` on EVERY branch and hoists it to the envelope's top level, so a


### PR DESCRIPTION
## The verdict: the count IS wrong, and it was never re-measured

`rf2-fxp5` is the one item of the #9182 audit's seven that the prior pass declared out of fence and never measured line by line — a claim, not a finding. It has now been measured, and it holds.

`spec/Spec-Schemas.md`'s `FrameDestroyedTags` commentary was written on 2026-07-19 (commit `4a800a6254`, rf2-g8ict) against **four** live emitters, and still asserted that count in the present tense at three places:

| line | text |
| --- | --- |
| :1223 | "reconciled against what the **FOUR live emitters** actually stamp" |
| :1226 | "the slots **three of the four** emitters DO stamp" |
| :1238 | "the repair is here rather than at **four emit sites**" |

Two of those four have since retired, and **the same comment block already records both retirements 30-40 lines below** without reconciling the paragraph that depends on them.

## Counted at source, not by subtraction

Exactly **two** sites in the corpus build these tags:

- `implementation/core/src/re_frame/router.cljc:2254` `emit-frame-destroyed!` — its `emit-error-both!` call at :2330-2336 is the sole one for this category in the file.
- `implementation/core/src/re_frame/subs.cljc:971` `emit-frame-destroyed-recovery!` — sole call at :1013-1026.

Every other occurrence of `:rf.error/frame-destroyed` under `implementation/*/src/` (46 across 15 files) is prose, a docstring, or a classification / source-coord predicate — not a tag construction. Those two carry **10 external call sites** between them (router 8, subs 2, plus router's own 3-arity to 4-arity delegation), so no reading of "emit site" lands on four either.

The two that went:

- `ui/frames/emit-and-throw-frame-destroyed!` — removed with `re-frame.ui` on 2026-08-16 (rf2-0yp7w, PR #8322). `git ls-files implementation/ui/` returns 0; the symbol has no definition anywhere in the tree.
- `substrate/observation/throw-frame-destroyed!` — removed with the internal observation port on 2026-08-21 (rf2-63t1i). Likewise no definition, and it is the retirement that struck `:where` / `:rf.sub/id` / `:rf.sub/query-v` from the declaration below — **two of the five slots the stale paragraph names as undeclared**, which is why the paragraph could not simply be renumbered.

Both retired names survive only as past-tense bookkeeping (`error_catalogue_channel_conformance_test.clj:1940`, `frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc:10`) and in the retirement paragraph in this file itself.

### Three token axes, because two were not enough

A line-oriented search and a whitespace-collapsed one **both returned zero** for `FOUR live emitters` — the phrase is broken across two lines *and* the continuation line carries a `;;` comment prefix that survives a plain whitespace flatten. Only a third normalisation, stripping the comment marker before flattening, found it. Controls both ways: the negative control returned 0, and a shape-matched positive control (the sentence beginning "`:op :capture` was the FOURTH declared enum value until 2026-09-04 and is GONE", equally line-broken and comment-prefixed) read `line=0 flat=0 flat+decomment=1`. All three axes then agreed on the population: three stale count claims, all in the rf2-g8ict paragraph. The other `four`/`fourth` hits in the file (CrossFrameCarriedOpTags' "four surviving fields", the four commit-plane effects, StorageClass, the four-value `:outcome` enum, 010-Schemas' four normative claims) were inspected and are unrelated and correct.

## The repair

Retirement bookkeeping in the shape PR #9290 used for `spec/Privacy.md`, not deletion. The rf2-g8ict paragraph keeps its own terms and gains its date; a following paragraph records the count that was, the count that is, both retirements with dates and bead ids, and the two survivors. The stale count is dropped from the `:event`-spelling argument, which never needed it.

Prose only, inside the `(def FrameDestroyedTags …)` comment block. No slot, type, enum or `[:map]` line changed. No runtime change. 20 insertions, 7 deletions, one file, one passage.

## Quality gates

Captured exit codes (redirect plus `echo $?` on one command line, never through a filter), re-run on the final rebased base `c4d8d49f24`:

| gate | exit |
| --- | --- |
| `python -m mkdocs build --strict` | **0** |
| `python scripts/check_doc_slugs.py --verbose` | **0** |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** |
| `python scripts/check_view_lifetime_residue.py --verbose` | **0** |
| `python scripts/check_retired_spellings.py --verbose` | **0** |
| `python scripts/check_retired_composition_vocab.py --verbose` | **0** |
| `python scripts/check_inject_cofx_residue.py --verbose` | **0** |
| `python scripts/check_retired_image_keys.py --verbose` | **0** |
| `python scripts/check_readme_links.py --ci` | **0** |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** |
| `clojure -M:test -n re-frame.error-catalogue-channel-conformance-test` | **0** (30 tests, 179 assertions) |

**What each green is worth here.**

- `check_require_alias_dialect.py` grades **import edges only** (2794 files, 10867 re-frame require edges). A markdown-only diff cannot move it, so its 0 is honest but **uninformative** about this change.
- `check_view_lifetime_residue.py` is a repo-wide banned-word scan at permitted count zero over tracked file **content and paths**, so it does read this prose and genuinely grades the diff. It does **not** read commit messages.
- `check_retired_composition_vocab.py` and `check_inject_cofx_residue.py` both scan the 51 markdown files under `spec/`, so they read this file too.
- The catalogue-channel conformance test **parses `FrameDestroyedTags` out of this markdown** (`parse-tags-schemas`, reading `../../spec/Spec-Schemas.md`) and diffs its key set against the Spec 009 catalogue row. Its green proves the extraction survived a comment-only edit inside the `def`; it says nothing about the prose.

**Which tree the gates read — proved by planted fault, not by a printed path.** Two plants, one experiment:

- **Plant B, outside the fence** (a broken link in prose at :64): `check_doc_slugs.py` gave **exit 1**, naming `spec\Spec-Schemas.md:64 -> Zzz-No-Such-File-Plant-B.md#…`; `mkdocs build --strict` gave **exit 1**, "Aborted with 1 warnings in strict mode!" naming the same target. The fault existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green.
- **Plant A, inside the fence** at the edited paragraph, the identical broken link: `check_doc_slugs.py` gave **exit 0** and its log does not mention it. This is the fence-blindness demonstration, on this file, at this line.

Restore verified by **git blob hash** against the committed object, not by reading a diff: `69b85a955ee5e6b01b719961cf46526f14f97b37` before the plants and after the restore, with zero plant residue. The first plant attempt matched **zero** lines and was caught by reading the match count before spending a run — the working file is CRLF under `core.autocrlf=true`, so an anchor ending at the text rather than at the line ending matches nothing.

### Hand checks, because no gate covers them

**The edit is inside a fenced code block, so neither link gate inspected it.** The enclosing fence opens at `spec/Spec-Schemas.md:928` and closes at :2453; 71 toggles precede the edited paragraph (odd, therefore inside). Both link gates share one extractor that strips fences before reading a link, and Plant A above measures exactly that. So the greens above bound nothing about this passage's links, and these were checked by hand:

- **Links and anchors: none added.** The 20 added lines contain **0** occurrences of `](`, **0** of `http`, and **0** `#`. Nothing to validate, by hand or otherwise. No link or anchor was removed either (0 `](` in the 7 removed lines).
- **Headings: unchanged.** 78 headings before, 78 after, byte-identical lists. No heading added, removed or renamed, so no anchor anywhere in the repo can have been broken by this diff.
- **Tables: untouched.** 97 table rows before, 97 after, byte-identical. The added lines contain **0** pipe characters, so no header/separator column-count question arises in the diff. (The two tables in this PR description are new prose here, not in the file.)
- **Fence integrity: 140 toggles, even, therefore balanced**, unchanged by the diff (0 fence markers added or removed).
- **Clojure form integrity:** all 20 added lines are `;;` comment lines inside the `(def FrameDestroyedTags …)` form; no parens, brackets or schema entries changed. The conformance test's green is the machine check on that.

### Content verified against source, by hand

Every factual claim in the new paragraph was checked at tip rather than copied from the bead or the brief:

- both retired symbols have **no definition anywhere** in the tree (searched by bare symbol, not by a guessed `defn` / `defn-` prefix — the one-character control failure recorded on rf2-22ks);
- `git ls-files implementation/ui/*` returns **0**;
- the two survivors resolve to the file and line cited;
- the dates and bead ids (2026-08-16 / rf2-0yp7w, 2026-08-21 / rf2-63t1i) match the retirement paragraphs already in this same comment block at :1258-1262 and :1273-1281.

`git diff origin/main...HEAD` (three-dot, against the merge base) was read for reverts: both hunks are confined to the one passage, every removed line is one rewritten in place, and **no commit that landed while this branch was open touched `spec/Spec-Schemas.md`** (`git log 0e2ed1827f..origin/main -- spec/Spec-Schemas.md` is empty). Nothing is undone. The file is hot-zone with six `rf2-kuky` children queued behind it, and no open PR held it when this branch was cut.
