### PR TITLE
fix(pair-mcp): route the `:machine` kind through the runtime preload door (rf2-kuky.29)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1137,16 +1137,32 @@
 ;; ---------------------------------------------------------------------------
 
 (defn machines-list
-  "(rf.machines/machines) — all registered machine ids."
+  "(rf.machines/machines) — all registered machine ids, SORTED.
+
+   The sort is the contract, not a courtesy: `registrar-list` sorts, the
+   MCP `list-handlers` tool documents one stable id vector across every
+   kind, and machines are the one kind whose ids arrive in registration
+   order. Sorting here keeps the two branches of that tool agreeing."
   []
-  (vec (rf.machines/machines)))
+  (-> (rf.machines/machines) sort vec))
 
 (defn machine-describe
   "(rf.machines/machine-meta id) — registered spec map for one machine, or
-   `{:ok? false :reason :not-a-machine}`."
+   `{:ok? false :reason :not-a-machine}`.
+
+   `strip-fns` for the reason `registrar-describe` runs it: a machine spec
+   carries FN VALUES nested under `:guards` and `:actions` (Spec 005), and
+   `pr-str` of a Function emits `#object[Function …]` — unreadable EDN that
+   trips the MCP wire codec's `:unserializable` path and costs the caller
+   the whole spec. The walk replaces each with the readable `:rf/fn`
+   sentinel, so the inspectable structure (which guards and actions a
+   machine declares, its `:initial` / `:states` / `:data`) survives the
+   wire. `dissoc :handler-fn` first for the top-level slot, exactly as
+   `registrar-describe` does."
   [machine-id]
-  (or (rf.machines/machine-meta machine-id)
-      {:ok? false :reason :not-a-machine :id machine-id}))
+  (if-let [spec (rf.machines/machine-meta machine-id)]
+    (-> spec (dissoc :handler-fn) strip-fns)
+    {:ok? false :reason :not-a-machine :id machine-id}))
 
 (defn machine-state
   "Snapshot of one machine in the operating frame. Per Spec 005,

--- a/skills/re-frame2-pair/tests/runtime/machine_describe_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/machine_describe_test.clj
@@ -1,0 +1,186 @@
+;;;; tests/runtime/machine_describe_test.clj
+;;;;
+;;;; Babashka-runnable pin for the preload's MACHINE DOOR — `machine-describe`
+;;;; and `machines-list`, the two fns the MCP `handler-meta` / `list-handlers`
+;;;; tools call for the virtual `:machine` kind (rf2-kuky.29).
+;;;;
+;;;; Why this test exists:
+;;;;
+;;;; 1. A machine spec carries FN VALUES nested under `:guards` and
+;;;;    `:actions` (Spec 005). `pr-str` of a Function emits
+;;;;    `#object[Function …]` — unreadable EDN, which the MCP result codec
+;;;;    tags `:unserializable`, hiding the whole spec behind a preview. A
+;;;;    top-level `dissoc :handler-fn` cannot reach a nested fn, so the door
+;;;;    has to run the same recursive `strip-fns` walk `registrar-describe`
+;;;;    does. That is the same defect rf2-f8s9g6 fixed for the resources
+;;;;    kinds, one door along.
+;;;;
+;;;; 2. `machines-list` must SORT. The MCP tool documents one stable id
+;;;;    vector across every kind, `registrar-list` sorts, and machines are
+;;;;    the one kind whose ids arrive in registration order.
+;;;;
+;;;; The second half of this file is BEHAVIOURAL, not structural: it reads
+;;;; `fn-slot-sentinel` and `strip-fns` out of the preload's own source,
+;;;; evaluates them, and runs the real walk over a real machine spec. The
+;;;; preload as a whole cannot be loaded here (it requires the re-frame
+;;;; runtime and targets a browser), but those two forms are plain Clojure,
+;;;; so the assertion is over the shipped code rather than over a copy of it.
+;;;;
+;;;; Run: bb tests/runtime/machine_describe_test.clj
+;;;; Exit: 0 = pass, non-zero = fail.
+
+(load-file (str (.getParent (java.io.File. *file*)) "/_support.clj"))
+
+(ns machine-describe-test
+  (:require [clojure.test :refer [deftest is run-tests]]
+            [clojure.edn :as edn]
+            [runtime-support :as rt]))
+
+(def ^:private defn-form rt/defn-named)
+(def ^:private form-contains? rt/form-contains?)
+
+(defn- calls? [form sym]
+  ;; True when `form` invokes `sym` as the head of any sub-list.
+  (form-contains? (fn [node] (and (seq? node) (= sym (first node)))) form))
+
+(def ^:private machine-describe-form (defn-form 'machine-describe))
+(def ^:private machines-list-form    (defn-form 'machines-list))
+
+;; ---------------------------------------------------------------------------
+;; The door exists, and it is PUBLIC.
+;;
+;; Public matters: the MCP tools reach these by name inside an eval form
+;; shipped over nREPL. A `defn-` is spelled identically and is unreachable.
+;; ---------------------------------------------------------------------------
+
+(deftest machine-door-fns-are-present
+  (is (some? machine-describe-form)
+      (str "preload/re_frame2_pair/runtime.cljs must define `machine-describe` "
+           "— the runtime surface the MCP `handler-meta {kind \"machine\"}` tool "
+           "calls."))
+  (is (some? machines-list-form)
+      (str "preload/re_frame2_pair/runtime.cljs must define `machines-list` "
+           "— the runtime surface the MCP `list-handlers {kind \"machine\"}` tool "
+           "calls.")))
+
+(deftest machine-door-fns-are-public
+  (is (= 'defn (first machine-describe-form))
+      "machine-describe must be a PUBLIC defn — an eval form cannot reach a defn-")
+  (is (= 'defn (first machines-list-form))
+      "machines-list must be a PUBLIC defn — an eval form cannot reach a defn-"))
+
+;; ---------------------------------------------------------------------------
+;; machine-describe strips fns.
+;; ---------------------------------------------------------------------------
+
+(deftest machine-describe-strips-nested-fns
+  ;; Matched as a bare SYMBOL rather than a call head: the body threads
+  ;; (`-> spec (dissoc …) strip-fns`), exactly as `registrar-describe` does,
+  ;; so the walker never appears at the head of a list.
+  (is (form-contains? (fn [node] (= 'strip-fns node)) machine-describe-form)
+      (str "machine-describe MUST run `strip-fns` over the spec it returns. A "
+           "machine spec's `:guards` / `:actions` are maps of FN VALUES (Spec "
+           "005), and `pr-str` of a Function emits `#object[Function …]` — the "
+           "MCP result codec then tags the WHOLE response `:unserializable` and "
+           "the caller loses the spec entirely. This is rf2-f8s9g6's defect one "
+           "door along; see rf2-kuky.29.")))
+
+(deftest machine-describe-dissocs-handler-fn
+  (is (form-contains? (fn [node]
+                        (and (seq? node)
+                             (= 'dissoc (first node))
+                             (some #(= :handler-fn %) (rest node))))
+                      machine-describe-form)
+      (str "machine-describe should drop the top-level `:handler-fn` slot for "
+           "the same reason `registrar-describe` does — the raw Function ref is "
+           "unreadable EDN on the MCP wire.")))
+
+(deftest machine-describe-still-reports-a-miss
+  (is (form-contains? (fn [node] (= :not-a-machine node)) machine-describe-form)
+      (str "machine-describe must keep returning a structured "
+           "`{:ok? false :reason :not-a-machine :id id}` on a miss — the MCP "
+           "handler-meta tool renames that reason to `:not-registered` so the "
+           "miss envelope is uniform across kinds, and a nil would instead "
+           "surface as `:unexpected-shape`.")))
+
+;; ---------------------------------------------------------------------------
+;; machines-list sorts.
+;; ---------------------------------------------------------------------------
+
+(deftest machines-list-sorts-its-ids
+  (is (form-contains? (fn [node] (= 'sort node)) machines-list-form)
+      (str "machines-list must SORT the id vector. `registrar-list` sorts, and "
+           "tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md documents "
+           "`list-handlers` as returning a stable sorted vector for every kind "
+           "— machines are the one kind whose ids arrive in registration order, "
+           "so an unsorted door made the two branches of that tool disagree.")))
+
+;; ---------------------------------------------------------------------------
+;; BEHAVIOURAL — the shipped strip-fns walk over a real machine spec.
+;;
+;; `fn-slot-sentinel` and `strip-fns` are read out of the preload source and
+;; evaluated here, so what runs below is the code that ships, not a copy. The
+;; rest of the preload cannot be loaded (it requires the re-frame runtime), but
+;; these two forms are plain Clojure.
+;; ---------------------------------------------------------------------------
+
+(def ^:private sentinel-form
+  ;; A plain `def`, not a `defn`, so `rt/defn-named` does not see it.
+  (some (fn [form]
+          (when (and (seq? form)
+                     (= 'def (first form))
+                     (= 'fn-slot-sentinel (second form)))
+            form))
+        rt/all-forms))
+
+(def ^:private strip-fns-fn
+  (let [sentinel sentinel-form
+        walker   (rt/defn-named 'strip-fns)]
+    (when (and sentinel walker)
+      (binding [*ns* (create-ns 'machine-describe-test.shipped)]
+        (refer-clojure)
+        (eval sentinel)
+        (eval walker)
+        @(ns-resolve 'machine-describe-test.shipped 'strip-fns)))))
+
+(def ^:private machine-spec-with-fns
+  "A machine spec shaped like Spec 005's: fn values nested one level down under
+  `:guards` and `:actions`, beside the serializable structure a caller wants."
+  {:initial :idle
+   :states  {:idle {:on {:go :running}} :running {}}
+   :data    {:retries 0}
+   :guards  {:can-go? (fn [_ _] true)}
+   :actions {:log! (fn [_ _] nil)}})
+
+(deftest shipped-strip-fns-is-loadable
+  (is (some? sentinel-form)
+      "fn-slot-sentinel must be a top-level def in the preload — nothing to substitute without it")
+  (is (some? strip-fns-fn)
+      (str "strip-fns must be readable and evaluable out of the preload source. "
+           "If this fails the two assertions below prove nothing, so it is "
+           "asserted rather than assumed.")))
+
+(deftest shipped-strip-fns-replaces-guard-and-action-fns
+  (let [stripped (strip-fns-fn machine-spec-with-fns)]
+    (is (= :rf/fn (get-in stripped [:guards :can-go?]))
+        "a fn-valued :guards entry arrives as the readable :rf/fn sentinel")
+    (is (= :rf/fn (get-in stripped [:actions :log!]))
+        "a fn-valued :actions entry arrives as the readable :rf/fn sentinel")
+    (is (= {:idle {:on {:go :running}} :running {}} (:states stripped))
+        "the serializable structure around the fns is untouched")
+    (is (= {:retries 0} (:data stripped))
+        "…including the :data map")))
+
+(deftest shipped-strip-fns-output-round-trips-as-edn
+  ;; The whole point: the response has to survive `pr-str` → read on the MCP
+  ;; wire. A raw Function would print as `#object[Function …]` and the read
+  ;; below would throw, which is what the codec turns into `:unserializable`.
+  (let [stripped (strip-fns-fn machine-spec-with-fns)
+        printed  (pr-str stripped)]
+    (is (not (clojure.string/includes? printed "#object"))
+        "no raw Function survives into the printed EDN")
+    (is (= stripped (edn/read-string printed))
+        "the stripped spec round-trips through EDN unchanged")))
+
+(let [{:keys [fail error]} (run-tests 'machine-describe-test)]
+  (System/exit (if (zero? (+ (or fail 0) (or error 0))) 0 1)))

--- a/skills/re-frame2-pair/tests/runtime/machine_describe_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/machine_describe_test.clj
@@ -34,14 +34,11 @@
 (ns machine-describe-test
   (:require [clojure.test :refer [deftest is run-tests]]
             [clojure.edn :as edn]
+            [clojure.string :as str]
             [runtime-support :as rt]))
 
 (def ^:private defn-form rt/defn-named)
 (def ^:private form-contains? rt/form-contains?)
-
-(defn- calls? [form sym]
-  ;; True when `form` invokes `sym` as the head of any sub-list.
-  (form-contains? (fn [node] (and (seq? node) (= sym (first node)))) form))
 
 (def ^:private machine-describe-form (defn-form 'machine-describe))
 (def ^:private machines-list-form    (defn-form 'machines-list))
@@ -177,7 +174,7 @@
   ;; below would throw, which is what the codec turns into `:unserializable`.
   (let [stripped (strip-fns-fn machine-spec-with-fns)
         printed  (pr-str stripped)]
-    (is (not (clojure.string/includes? printed "#object"))
+    (is (not (str/includes? printed "#object"))
         "no raw Function survives into the printed EDN")
     (is (= stripped (edn/read-string printed))
         "the stripped spec round-trips through EDN unchanged")))

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -3227,10 +3227,22 @@ consequences. `registrar-describe`'s `strip-fns` (rf2-f8s9g6) replaces
 the nested handler fns (`:request` / `:tags` / `:invalidates` /
 `:populates` / `:resolve`) with the readable `:rf/fn` sentinel so the
 meta is EDN-clean on the wire. The `:machine`
-kind routes through `(re-frame.core/machine-meta id)` instead —
-machines are registered as `:event` handlers carrying `:rf/machine?
-true` (Spec 005 §Querying machines), and `machine-meta` unwraps that
-slot to surface the spec.
+kind routes through `(re-frame2-pair.runtime/machine-describe id)`
+instead — machines are registered as `:event` handlers carrying
+`:rf/machine? true` (Spec 005 §Querying machines), and that door wraps
+`re-frame.machines/machine-meta`, which unwraps the `:rf/machine` slot
+to surface the spec. It runs the same `strip-fns` walk, so a machine's
+fn-valued `:guards` / `:actions` arrive as `:rf/fn` sentinels rather
+than tripping the `:unserializable` path. The door reports a miss as
+`:not-a-machine`; the tool renames it to `:not-registered` so the miss
+envelope is the same across every kind.
+
+**No form this tool ships names a framework var.** Every kind, machine
+included, is one `(re-frame2-pair.runtime/…)` call — the preload is the
+single place a framework symbol is spelled, so a framework rename is one
+edit there. That is enforced rather than merely intended: the
+`runtime-door` tests read the preload's own source and assert every
+symbol these forms emit is a public top-level `defn` in it.
 
 **Returns** on a hit:
 
@@ -3320,8 +3332,10 @@ map via `(re-frame2-pair.runtime/registrar-list kind)` —
 `list-handlers {kind "resource-scope"}` enumerates a resources app's
 named scope resolvers, `list-handlers {kind "interceptor"}` the ids
 registered via `reg-interceptor`. The
-`:machine` kind wraps `(re-frame.core/machines)` — every event
-handler flagged `:rf/machine? true` (Spec 005 §Querying machines).
+`:machine` kind lifts its ids from
+`(re-frame2-pair.runtime/machines-list)` — every event handler flagged
+`:rf/machine? true` (Spec 005 §Querying machines), sorted by the door
+so the vector is stable across kinds.
 
 **Returns**:
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
@@ -64,8 +64,9 @@
   a registrar kind; their metadata lives in the schemas
   artefact's per-frame side-table, surfaced via `rf/app-schemas` /
   `rf/app-schema-meta-at`. The fourteen registrar kinds map directly to
-  `rf/handler-meta`; `machine` routes
-  through the dedicated `rf.machines/machine-meta` surface (Spec 005 §Querying machines —
+  `rf/handler-meta`; `machine` routes through the runtime preload's
+  `re-frame2-pair.runtime/machine-describe` door, which wraps
+  `rf.machines/machine-meta` (Spec 005 §Querying machines —
   machines are registered as `:event` handlers carrying
   `:rf/machine? true` with their spec in the `:rf/machine` slot, and
   `machine-meta` unwraps that slot).
@@ -85,8 +86,26 @@
   `error-projector` / `resource` / `mutation` / `resource-scope`) the
   list comes from
   `re-frame2-pair.runtime/registrar-list`. For `machine` the list
-  comes from `re-frame.core/machines` — every event handler flagged
-  `:rf/machine? true`.
+  comes from `re-frame2-pair.runtime/machines-list` — every event
+  handler flagged `:rf/machine? true`.
+
+  ## Every read is a call on the runtime preload — no framework var here
+
+  Both tools name ONLY `re-frame2-pair.runtime/…` fns in the forms they
+  ship. That is the whole of the coupling, and it is deliberate: the
+  preload is the single place a framework var is spelled, so a rename or
+  a relocation on the framework side is one edit THERE and invisible
+  here. The rule was learned the expensive way (rf2-kuky.29) — the two
+  `:machine` forms were once hand-built strings naming a `machines` and
+  a `machine-meta` var on the FACADE, which the facade does not define
+  and never did: the machine query surface lives on `re-frame.machines`,
+  per spec/API.md's front-porch boundary, and both reads therefore
+  returned an eval error against every running app. Nothing in this
+  build could see it: the coupling is a STRING, so there is no
+  `:require`, no compiler error and no classpath scan that reaches it.
+  The runtime-door tests in `handler_meta_test.cljs` are the witness
+  that closes that hole — they read the preload's own source and assert
+  every symbol these forms emit is published there.
 
   ## Why not `eval-cljs`?
 
@@ -109,7 +128,8 @@
 ;; The MCP arg comes in as a JS string ("event", "sub", …). We coerce
 ;; to the runtime keyword the registrar uses. `machine` is the one
 ;; logical kind that doesn't map 1:1 to a registrar kind — it routes
-;; through `rf.machines/machine-meta` instead.
+;; through the preload's `machine-describe` / `machines-list` door
+;; instead.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private registrar-kinds
@@ -145,9 +165,10 @@
   App-db schemas are intentionally absent — they are NOT
   a registrar kind; their metadata lives in the schemas artefact's
   per-frame side-table. `machine` is intentionally absent here too —
-  it routes through `rf.machines/machine-meta` (which inspects `:event`-kind
-  metadata for the `:rf/machine?` flag) — but is in `supported-kinds`
-  below."
+  it routes through the preload's `machine-describe` / `machines-list`
+  (which wrap `rf.machines/machine-meta` / `rf.machines/machines`, the
+  derived views over `:event`-kind metadata carrying the `:rf/machine?`
+  flag) — but is in `supported-kinds` below."
   #{:event :sub :fx :cofx :interceptor :view :frame :route :flow :head
     :error-projector :resource :mutation :resource-scope})
 
@@ -215,10 +236,9 @@
 ;;
 ;; Eval-form composition: for the fourteen registrar kinds we route through
 ;; `re-frame2-pair.runtime/registrar-describe` (already published; carries
-;; the `:not-registered` envelope on miss). For `:machine` we wrap
-;; `re-frame.core/machine-meta` directly — the runtime ns has no
-;; machine-aware wrapper, so the wrapping lives on the tool's caller
-;; side rather than in the runtime preload.
+;; the `:not-registered` envelope on miss). `:machine` routes through the
+;; preload's `machine-describe` the same way — one `rt-call`, one
+;; round-trip, no framework var spelled here.
 ;; ---------------------------------------------------------------------------
 
 (defn- registrar-form
@@ -242,25 +262,31 @@
     (ef/emit (ef/rt-call 'registrar-describe kind id))))
 
 (defn- machine-form
-  "Build the eval form that wraps `re-frame.core/machine-meta` with the
-  same envelope shape `registrar-describe` returns — either the meta
-  map or a structured `:not-registered` map. Keeps the tool's response
-  shape uniform across kinds.
+  "Build the eval form for a `:machine` drill — `machine-describe` on the
+  runtime preload, which reads `rf.machines/machine-meta` and runs the
+  same `strip-fns` walk `registrar-describe` does, so a spec's fn-valued
+  `:guards` / `:actions` (Spec 005) arrive as the readable `:rf/fn`
+  sentinel instead of tripping the wire codec's `:unserializable` path.
 
-  `dissoc :handler-fn` for the same reason `registrar-describe`
-  drops it — a raw Function ref is unreadable on the EDN wire and would
-  make the tool envelope misreport :unexpected-shape. The machine
-  surface doesn't always carry one, but the dissoc is idempotent and
-  cheap and keeps the response shape EDN-clean by construction across
-  both kinds.
-
-  The composed form is one expression so the eval is a single
-  round-trip — composition is the same idiom every other tool uses."
+  One `rt-call`, exactly like every other kind: a single expression, a
+  single round-trip, and no framework var named on this side of the
+  wire."
   [id]
-  (let [id-edn (pr-str id)]
-    (str "(if-let [m (re-frame.core/machine-meta " id-edn ")]"
-         "  (dissoc m :handler-fn)"
-         "  {:ok? false :reason :not-registered :kind :machine :id " id-edn "})")))
+  (ef/emit (ef/rt-call 'machine-describe id)))
+
+(defn- uniform-miss
+  "Normalise the runtime's machine-door miss reason to the tool's.
+
+  `machine-describe` reports a miss as `:not-a-machine` — its own
+  vocabulary, the one `ops.md` documents and other preload consumers
+  read. Every registrar kind reports `:not-registered`, and the tool
+  speaks ONE miss vocabulary across kinds so an agent can branch on
+  `:reason` without knowing which door answered. The rename happens
+  here, at the tool boundary, rather than in the preload: the preload is
+  shared, this uniformity is not."
+  [m]
+  (cond-> m
+    (= :not-a-machine (:reason m)) (assoc :reason :not-registered)))
 
 (defn handler-meta-tool [conn args]
   (let [build-id   (wire/arg-build conn args)
@@ -332,7 +358,10 @@
                       ;;   - hit (map with no :reason): merge :ok? true
                       ;;     + the requested kind/id.
                       ;;   - miss (`{:ok? false :reason :not-registered}`):
-                      ;;     pass through, stamped with kind/id.
+                      ;;     pass through, stamped with kind/id — via
+                      ;;     `uniform-miss`, which renames the machine
+                      ;;     door's `:not-a-machine` to the one miss
+                      ;;     vocabulary the tool speaks.
                       ;;   - genuine non-map (should not happen against a
                       ;;     healthy runtime): surface :unexpected-shape.
                       (stamp-frame
@@ -350,7 +379,7 @@
                              :kind kind :id id-val :value meta-map})
 
                           (false? (:ok? meta-map))
-                          (assoc meta-map :kind kind :id id-val)
+                          (-> meta-map uniform-miss (assoc :kind kind :id id-val))
 
                           :else
                           (assoc meta-map :ok? true :kind kind :id id-val)))))
@@ -372,9 +401,9 @@
   "Build the eval form returning the sorted id vector for a kind.
 
   DEFAULT (`frame` nil): the fourteen registrar kinds route through
-  `re-frame2-pair.runtime/registrar-list`; `:machine` wraps
-  `re-frame.core/machines` (Spec 005 §Querying machines — every event handler
-  with `:rf/machine? true`).
+  `re-frame2-pair.runtime/registrar-list`; `:machine` through
+  `re-frame2-pair.runtime/machines-list`, which sorts the same way (Spec
+  005 §Querying machines — every event handler with `:rf/machine? true`).
 
   EXPLICIT FRAME (`frame` set): route through
   `re-frame2-pair.runtime/frame-registrar-list`, which enumerates only the
@@ -383,7 +412,7 @@
   reaching here when a frame is supplied (machines are not in the resolver)."
   [frame kind]
   (cond
-    (= :machine kind) "(vec (sort (re-frame.core/machines)))"
+    (= :machine kind) (ef/emit (ef/rt-call 'machines-list))
     (some? frame)     (ef/emit (ef/rt-call 'frame-registrar-list frame kind))
     :else             (ef/emit (ef/rt-call 'registrar-list kind))))
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
@@ -911,15 +911,24 @@
                        "the machine drill is among the captured symbols")
                    (is (contains? syms "machines-list")
                        "the machine enumeration is among the captured symbols")
-                   (doseq [s (sort syms)]
-                     ;; A PUBLIC `defn` at column 0. `defn-` would not match,
-                     ;; and must not: a private fn is unreachable from an eval
-                     ;; form even though the name is spelled identically.
-                     (is (str/includes? src (str "\n(defn " s "\n"))
-                         (str "re-frame2-pair.runtime must publish " s
-                              " — an emitted form calls it by name across a process "
-                              "boundary, so a rename on the preload is a runtime failure "
-                              "here and nowhere else"))))))
+                   ;; A PUBLIC `defn` at column 0. `defn-` would not match, and
+                   ;; must not: a private fn is unreachable from an eval form
+                   ;; even though the name is spelled identically.
+                   ;;
+                   ;; Asserted as ONE set difference rather than an `is` per
+                   ;; symbol: `is` renders the whole form it was handed, and a
+                   ;; per-symbol `str/includes?` over the preload therefore
+                   ;; prints four thousand lines of somebody else's source
+                   ;; around the one word that matters.
+                   (let [missing (into (sorted-set)
+                                       (remove #(str/includes? src (str "\n(defn " % "\n")))
+                                       syms)]
+                     (is (empty? missing)
+                         (str "re-frame2-pair.runtime must publish every symbol an emitted "
+                              "form names — missing: " (pr-str (vec missing))
+                              ". Each is called by name across a process boundary, so a "
+                              "rename on the preload is a runtime failure here and "
+                              "nowhere else."))))))
         (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
         (.then (fn [_] (done))))))
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
@@ -1,11 +1,13 @@
 (ns re-frame2-pair-mcp.handler-meta-test
   "Unit tests for the `handler-meta` + `list-handlers` MCP tools.
 
-  Both tools build a CLJS form that calls into the preloaded runtime
-  (`re-frame2-pair.runtime/registrar-describe` / `registrar-list` for
-  the ten registrar kinds; `re-frame.core/machine-meta` /
-  `re-frame.core/machines` for the `:machine` kind). Live end-to-end
-  coverage runs against a shadow-cljs runtime; these tests pin:
+  Both tools build a CLJS form that calls into the preloaded runtime,
+  and into NOTHING ELSE: `re-frame2-pair.runtime/registrar-describe` /
+  `registrar-list` for the fourteen registrar kinds,
+  `frame-registrar-describe` / `frame-registrar-list` for the
+  frame-targeted reads, and `machine-describe` / `machines-list` for the
+  virtual `:machine` kind. Live end-to-end coverage runs against a
+  shadow-cljs runtime; these tests pin:
 
     1. The descriptor wire-up — both tools surface on `tool-descriptors`
        and `tool-descriptors-js` with the right shape (required args,
@@ -14,16 +16,36 @@
        unknown / malformed values are rejected with structured envelopes;
        EDN-encoded ids round-trip cleanly.
     3. The form composition — given a valid (kind, id) pair the right
-       runtime fn is called (`registrar-describe` for the six registrar
-       kinds; `machine-meta` for `:machine`).
+       runtime fn is called (`registrar-describe` for the registrar
+       kinds; `machine-describe` for `:machine`).
     4. Error envelopes — missing / invalid kind / id arguments surface
-       structured `:reason` slots an agent can read."
+       structured `:reason` slots an agent can read.
+    5. THE RUNTIME DOOR (rf2-kuky.29) — every symbol an emitted form
+       names is a public top-level `defn` in the preload's own source,
+       and no emitted form names a framework var at all.
+
+  ## Why (5) reads another artefact's source
+
+  The coupling between these tools and the runtime they call is a
+  STRING interpolated into CLJS source and shipped over nREPL. There is
+  no `:require`, no classpath edge, and therefore no compiler error and
+  no static check in this build that can see it. Points (1)–(4) are the
+  emitter tested against itself: they stay green while the form names a
+  var that does not exist anywhere, which is exactly what happened — the
+  `:machine` branches named a `machines` and a `machine-meta` var on the
+  FACADE, where the machine query surface has never lived (it is
+  `re-frame.machines`, per spec/API.md's front-porch boundary), and both
+  `:machine` reads returned an eval error against every running app
+  while this suite passed. Point (5) is the both-sides witness that
+  closes it, in the shape `hicasso_wire_test.cljs` established for the
+  same class of string coupling."
   (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
             [clojure.string :as str]
             [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.tools :as tools]
+            [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.handler-meta :as hm]))
 
 ;; ---------------------------------------------------------------------------
@@ -426,8 +448,8 @@
 ;; `machine-form` would fail here. Each EP-0016 kind is driven through
 ;; the tool with a canned runtime response, asserting (a) the kind is
 ;; accepted (not :invalid-kind), (b) the emitted form routes through the
-;; registrar-describe / registrar-list path (never machine-meta /
-;; machines), and (c) the requested kind/id ride back stamped on the
+;; registrar-describe / registrar-list path (never machine-describe /
+;; machines-list), and (c) the requested kind/id ride back stamped on the
 ;; response.
 ;;
 ;; One focused test per (tool, kind) — the file's one-concern style.
@@ -476,7 +498,7 @@
 
 (defn- handler-meta-routes-through-registrar-test
   "Assert handler-meta for `kind-str` emits a registrar-describe form
-  (NOT machine-meta) carrying the kind keyword `kw-str`."
+  (NOT machine-describe) carrying the kind keyword `kw-str`."
   [kind-str kw-str done]
   (let [form   (atom nil)
         canned {:ns 'app.x :line 1 :handler-fn-hash 7}]
@@ -486,23 +508,23 @@
                 (.then (fn [_]
                          (is (str/includes? @form "registrar-describe")
                              (str kind-str " routes through registrar-describe"))
-                         (is (not (str/includes? @form "machine-meta"))
-                             (str kind-str " is NOT mis-routed through the machine wrapper"))
+                         (is (not (str/includes? @form "machine-describe"))
+                             (str kind-str " is NOT mis-routed through the machine door"))
                          (is (str/includes? @form kw-str)
                              (str "the form carries the " kw-str " kind keyword")))))))
         (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
         (.then (fn [_] (done))))))
 
 (deftest handler-meta-resource-routes-through-registrar
-  (testing "kind \"resource\" emits a registrar-describe form, never machine-meta"
+  (testing "kind \"resource\" emits a registrar-describe form, never machine-describe"
     (async done (handler-meta-routes-through-registrar-test "resource" ":resource" done))))
 
 (deftest handler-meta-mutation-routes-through-registrar
-  (testing "kind \"mutation\" emits a registrar-describe form, never machine-meta"
+  (testing "kind \"mutation\" emits a registrar-describe form, never machine-describe"
     (async done (handler-meta-routes-through-registrar-test "mutation" ":mutation" done))))
 
 (deftest handler-meta-resource-scope-routes-through-registrar
-  (testing "kind \"resource-scope\" emits a registrar-describe form, never machine-meta"
+  (testing "kind \"resource-scope\" emits a registrar-describe form, never machine-describe"
     (async done (handler-meta-routes-through-registrar-test "resource-scope" ":resource-scope" done))))
 
 (deftest handler-meta-resource-scope-surfaces-inputs-and-cost
@@ -579,7 +601,7 @@
                 (.then (fn [_]
                          (is (str/includes? @form "registrar-list")
                              (str kind-str " routes through registrar-list"))
-                         (is (not (str/includes? @form "re-frame.core/machines"))
+                         (is (not (str/includes? @form "machines-list"))
                              (str kind-str " is NOT mis-routed through the machines enumerator"))
                          (is (str/includes? @form kw-str)
                              (str "the form carries the " kw-str " kind keyword")))))))
@@ -703,3 +725,220 @@
             (str tool-name " exposes the optional :frame property"))
         (is (not (contains? (set required) "frame"))
             (str tool-name " does not require :frame (default registrar is the common case)"))))))
+
+;; ---------------------------------------------------------------------------
+;; The :machine kind — POSITIVE coverage for both tools (rf2-kuky.29).
+;;
+;; Every test above the machine kind was NEGATIVE ("this other kind is not
+;; mis-routed through the machine branch"), which is why the machine branch
+;; could name two vars that do not exist for as long as it did: nothing ever
+;; asserted what it DOES emit. These pin the door it routes through, the id it
+;; threads, and the miss envelope it hands back.
+;; ---------------------------------------------------------------------------
+
+(deftest handler-meta-machine-routes-through-the-runtime-door
+  (testing "kind \"machine\" emits (re-frame2-pair.runtime/machine-describe id) and names no framework var"
+    (async done
+      (let [form   (atom nil)
+            canned {:initial :idle :states {:idle {}} :guards {:can? :rf/fn}}]
+        (-> (with-form-capture! form canned
+              (fn []
+                (-> (hm/handler-meta-tool nil (args-js {:kind "machine"
+                                                        :id   ":auth/session"}))
+                    (.then (fn [result]
+                             (let [edn (extract-edn result)]
+                               (is (str/includes? @form "re-frame2-pair.runtime/machine-describe")
+                                   "the machine drill routes through the preload's machine door")
+                               (is (str/includes? @form ":auth/session")
+                                   "the requested id is threaded into the form")
+                               (is (not (str/includes? @form "re-frame.core/"))
+                                   "no facade var is named on this side of the wire")
+                               (is (not (str/includes? @form "re-frame.machines/"))
+                                   "no artefact var either — the preload is the only place one is spelled")
+                               (is (true? (:ok? edn)))
+                               (is (= :machine (:kind edn)))
+                               (is (= :auth/session (:id edn)))
+                               (is (= {:can? :rf/fn} (:guards edn))
+                                   "the door's stripped :guards ride through as readable EDN")))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
+
+(deftest handler-meta-machine-miss-is-the-uniform-not-registered-envelope
+  (testing "the door's :not-a-machine is renamed to the one miss vocabulary the tool speaks"
+    (async done
+      ;; What `machine-describe` actually returns on a miss — the preload's
+      ;; own vocabulary, which `ops.md` documents and other consumers read.
+      (let [canned {:ok? false :reason :not-a-machine :id :nope/nothing}]
+        (-> (with-canned-eval! canned
+              (fn []
+                (-> (hm/handler-meta-tool nil (args-js {:kind "machine"
+                                                        :id   ":nope/nothing"}))
+                    (.then (fn [result]
+                             (let [edn (extract-edn result)]
+                               (is (false? (:ok? edn)))
+                               (is (= :not-registered (:reason edn))
+                                   "an agent branches on ONE miss reason across every kind")
+                               (is (= :machine (:kind edn)))
+                               (is (= :nope/nothing (:id edn)))))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
+
+(deftest list-handlers-machine-routes-through-the-runtime-door
+  (testing "kind \"machine\" emits (re-frame2-pair.runtime/machines-list) and names no framework var"
+    (async done
+      (let [form (atom nil)
+            ids  [:auth/session :cart/checkout]]
+        (-> (with-form-capture! form ids
+              (fn []
+                (-> (hm/list-handlers-tool nil (args-js {:kind "machine"}))
+                    (.then (fn [result]
+                             (let [edn (extract-edn result)]
+                               (is (str/includes? @form "re-frame2-pair.runtime/machines-list")
+                                   "the machine enumeration routes through the preload's list door")
+                               (is (not (str/includes? @form "re-frame.core/"))
+                                   "no facade var is named on this side of the wire")
+                               (is (not (str/includes? @form "re-frame.machines/"))
+                                   "no artefact var either")
+                               (is (true? (:ok? edn)))
+                               (is (= :machine (:kind edn)))
+                               (is (= ids (:ids edn)))
+                               (is (= 2 (:count edn)))))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; THE RUNTIME DOOR — the both-sides witness (rf2-kuky.29).
+;;
+;; See the ns docstring for why this reads another artefact's source. In one
+;; line: the coupling is a string, so nothing in this build can see it, and a
+;; suite that only reads the emitter back to itself stays green over a var that
+;; exists nowhere. `hicasso_wire_test.cljs` established the shape for the same
+;; class of coupling; this is its registry-introspection twin.
+;;
+;; The symbols are extracted from ACTUAL EMITTED FORMS rather than from a
+;; hand-written vector — a vector would prove only that two lists agree, and it
+;; is the string on the wire that has to resolve.
+;; ---------------------------------------------------------------------------
+
+(def ^:private fs (js/require "fs"))
+(def ^:private path (js/require "path"))
+
+(defn- repo-root
+  "Walk upward from the test process's cwd to the repository root — the first
+  directory holding both this artefact and the preload the emitted forms call.
+  Robust against the runner's working directory (`tools/re-frame2-pair-mcp` vs
+  repo root)."
+  []
+  (loop [d (.cwd js/process)]
+    (cond
+      (and (.existsSync fs (.join path d "tools/re-frame2-pair-mcp/src"))
+           (.existsSync fs (.join path d "skills/re-frame2-pair/preload")))
+      d
+
+      (= d (.dirname path d))
+      (throw (ex-info (str "Could not locate the repository root from cwd — the runtime-door "
+                           "witness needs both tools/re-frame2-pair-mcp/src and "
+                           "skills/re-frame2-pair/preload to compare the two sides.")
+                      {:cwd (.cwd js/process)}))
+
+      :else (recur (.dirname path d)))))
+
+(def ^:private preload-src
+  ;; CR stripped: the `\n(defn ` anchor below is line-start-anchored, and a
+  ;; CRLF checkout would otherwise fail every assertion for a reason that has
+  ;; nothing to do with the door.
+  (delay
+    (let [rel  "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
+          full (.join path (repo-root) rel)]
+      (when-not (.existsSync fs full)
+        (throw (ex-info (str "the runtime preload is missing: " rel
+                             " — every form these tools ship targets it by string, so its "
+                             "absence is the failure this witness exists to report.")
+                        {:path full})))
+      (str/replace (.toString (.readFileSync fs full)) "\r" ""))))
+
+(def ^:private door-cases
+  "Every branch of the two tools' form builders that reaches a runtime call.
+  `:machine` with a `:frame` is refused before a form is built (machines are
+  not in the image generation resolver), so it is not a case here.
+
+  `:canned` is the value the stubbed eval resolves with — a metadata map for
+  `handler-meta`, an id vector for `list-handlers`, so each tool's own
+  post-processing runs rather than throwing on the way to the assertion."
+  [{:tool hm/handler-meta-tool  :args {:kind "event"   :id ":a/b"}                      :canned {:ns 'a.b :line 1}}
+   {:tool hm/handler-meta-tool  :args {:kind "event"   :id ":a/b" :frame ":blue/main"}  :canned {:ns 'a.b :line 1}}
+   {:tool hm/handler-meta-tool  :args {:kind "machine" :id ":auth/session"}             :canned {:initial :idle}}
+   {:tool hm/list-handlers-tool :args {:kind "event"}                                   :canned [:a/b]}
+   {:tool hm/list-handlers-tool :args {:kind "event"   :frame ":blue/main"}             :canned [:a/b]}
+   {:tool hm/list-handlers-tool :args {:kind "machine"}                                 :canned [:auth/session]}])
+
+(defn- capture-emitted-forms
+  "Drive every `door-cases` entry through its tool with a capturing eval stub,
+  resolving with the vector of form strings the tools actually shipped. Serial
+  rather than parallel: the stub is installed by a bare `set!` on one var, so
+  two in flight would capture each other's forms."
+  []
+  (reduce
+    (fn [p {:keys [tool args canned]}]
+      (.then p (fn [acc]
+                 (let [form (atom nil)]
+                   (-> (with-form-capture! form canned
+                         (fn [] (tool nil (args-js args))))
+                       (.then (fn [_] (conj acc @form))))))))
+    (js/Promise.resolve [])
+    door-cases))
+
+(defn- runtime-symbols
+  "Every fn name a form resolves off the runtime preload, as a set. Parsed out
+  of the emitted source rather than read off the DSL, because the source string
+  is what crosses the wire."
+  [form]
+  (into #{}
+        (map second)
+        (re-seq (re-pattern (str "\\(" (str/replace ef/runtime-ns "." "\\.")
+                                 "/([^\\s)]+)"))
+                form)))
+
+(deftest every-emitted-runtime-symbol-is-published-by-the-preload
+  (async done
+    (-> (capture-emitted-forms)
+        (.then (fn [forms]
+                 (let [src  @preload-src
+                       syms (into #{} (mapcat runtime-symbols) forms)]
+                   (is (= (count door-cases) (count forms))
+                       "every door case emitted a form to check")
+                   (is (contains? syms "machine-describe")
+                       "the machine drill is among the captured symbols")
+                   (is (contains? syms "machines-list")
+                       "the machine enumeration is among the captured symbols")
+                   (doseq [s (sort syms)]
+                     ;; A PUBLIC `defn` at column 0. `defn-` would not match,
+                     ;; and must not: a private fn is unreachable from an eval
+                     ;; form even though the name is spelled identically.
+                     (is (str/includes? src (str "\n(defn " s "\n"))
+                         (str "re-frame2-pair.runtime must publish " s
+                              " — an emitted form calls it by name across a process "
+                              "boundary, so a rename on the preload is a runtime failure "
+                              "here and nowhere else"))))))
+        (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+        (.then (fn [_] (done))))))
+
+(deftest no-emitted-form-names-a-framework-var
+  ;; The other half of the contract, and the one rf2-kuky.29 broke: the preload
+  ;; is the SINGLE place a framework symbol is spelled. A form that reaches
+  ;; past it compiles, passes every emitter test, and fails only in someone
+  ;; else's process — which is exactly what two hand-built `:machine` strings
+  ;; did for the whole life of that kind.
+  (async done
+    (-> (capture-emitted-forms)
+        (.then (fn [forms]
+                 (doseq [form forms]
+                   (doseq [ns-prefix ["re-frame.core/" "re-frame.machines/"
+                                      "re-frame.schemas/" "re-frame.routing/"
+                                      "re-frame.flows/"]]
+                     (is (not (str/includes? form ns-prefix))
+                         (str "an emitted form names " ns-prefix
+                              " directly — route it through the preload instead: "
+                              form))))))
+        (.catch (fn [e] (is false (str "rejected: " (.-message e))) nil))
+        (.then (fn [_] (done))))))


### PR DESCRIPTION
Closes the `:machine` kind's two broken eval forms in the pair-MCP server (rf2-kuky.29).

## The defect, re-derived at tip

`handler-meta {kind "machine"}` and `list-handlers {kind "machine"}` built their eval
forms by hand, naming two vars on the facade:

- `handler_meta.cljs:261` — `machine-form` built `"(if-let [m (re-frame.core/machine-meta " id-edn ")] …)"`
- `handler_meta.cljs:386` — `list-form`'s `:machine` branch was the literal `"(vec (sort (re-frame.core/machines)))"`

Both line citations held exactly at the base this branch left the trunk, as did the
stale docstring claims at `:88`, `:219`, `:245`, `:376`, the test ns docstring at
`:6-7`, and the tool spec at `:3230` / `:3323`.

`re-frame.core` defines neither. Searching that file for `machine-meta` returns zero
and for `machines` returns only docstring mentions, namespace names and keywords; the
control on the same file — `handler-meta`, which the facade does define at `core.cljc:1836`
— returns 20 hits, so the zero is honest rather than an artefact of the pattern. Against
a running app both forms evaluated an undefined symbol and the wire returned the
eval-error envelope instead of a machine list or a spec.

## Where the machine registry actually lives

**On `re-frame.machines`, and that is a public artefact namespace — so this is the
"a correct accessor exists" case. No facade addition, no public-surface change, nothing
outside the fence.**

- `implementation/machines/src/re_frame/machines.cljc:180` — `machines`, which filters
  `(rf.registrar/registrations :event)` for `:rf/machine? true`.
- `implementation/machines/src/re_frame/machines.cljc:189` — `machine-meta`, which reads
  the registered spec out of the `:rf/machine` slot.

Machines are not a separate registrar kind; these two are thin derived views over the
event registrar, and the file's own section comment says so.

`spec/API.md`'s front-porch boundary is explicit that this is deliberate rather than an
oversight: the optional features' **non-registration query / introspection / lifecycle
helpers are NOT re-exported** from `re-frame.core`, and it names
`re-frame.machines (reg-machine* / make-machine-handler / machine-transition / machines /
machine-meta / machine-by-system-id)` in the list. So re-exporting them onto the facade
would have been the wrong repair in the exact direction the spec rules against.

The forms do not name `re-frame.machines` either. Every other kind already routes through
the runtime preload, and the preload already carried the machine door —
`re-frame2-pair.runtime/machines-list` and `machine-describe`, which wrap those two vars.
Pointing at the door instead of the vars keeps the preload the single place a framework
symbol is spelled, so a relocation on the framework side is one edit there.

## What changed

`tools/re-frame2-pair-mcp/src/…/tools/handler_meta.cljs`

- `machine-form` is now `(ef/emit (ef/rt-call 'machine-describe id))` — one `rt-call`,
  one round-trip, the same shape every other kind uses.
- `list-form`'s `:machine` branch is now `(ef/emit (ef/rt-call 'machines-list))`.
- New `uniform-miss` renames the door's `:not-a-machine` to `:not-registered` at the
  tool boundary, so the miss envelope this spec documents stays the same across every
  kind. The rename is here rather than in the preload because the preload is shared and
  this uniformity is not — `references/ops.md` documents `:not-a-machine` and other
  consumers read it.
- Docstrings and comments corrected, plus a short section recording why no framework var
  is named on this side of the wire.

`skills/re-frame2-pair/preload/…/runtime.cljs` — two repairs on the door, load-bearing
for the fix rather than incidental:

- `machine-describe` now runs `strip-fns`. A machine spec carries fn values nested under
  `:guards` / `:actions` (Spec 005), and `dissoc :handler-fn` cannot reach a nested fn.
  Without the walk the response would `pr-str` to `#object[Function …]` and trip the wire
  codec's `:unserializable` path — swapping one broken read for another. This is the same
  defect rf2-f8s9g6 fixed for the resources kinds, one door along.
- `machines-list` now sorts. `spec/003-Tool-Catalogue.md` already documents the id vector
  as sorted for every kind, `registrar-list` sorts, and machines were the one kind whose
  ids arrived in registration order.

`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md` — both routes corrected, the miss
rename recorded, the strip-fns behaviour stated.

## How the eval path is pinned

A test that only builds the string proves nothing about the symbol resolving, which is
where this failed. The pair-MCP suite runs on Node and cannot load the browser preload,
so the honest pin is a **both-sides witness** rather than a live eval — the shape
`hicasso_wire_test.cljs` already established in this artefact for exactly this class of
string coupling.

`handler_meta_test.cljs` now drives every branch of both tools' form builders through a
capturing eval stub, extracts the `re-frame2-pair.runtime/<sym>` occurrences **out of the
forms the tools actually shipped** (not off a hand-written list), reads the preload's own
source, and asserts:

- every captured symbol is a **public** top-level `defn` there — `defn-` deliberately
  does not match, since a private fn is unreachable from an eval form though spelled
  identically;
- no emitted form names `re-frame.core/`, `re-frame.machines/`, `re-frame.schemas/`,
  `re-frame.routing/` or `re-frame.flows/` at all.

The captured set is the six the bead enumerated: `registrar-describe`,
`frame-registrar-describe`, `registrar-list`, `frame-registrar-list`, `machine-describe`,
`machines-list`.

Plus positive pins the machine kind never had — every existing machine test was a
*negative* one about some other kind, which is why the two dead vars survived: the
machine drill emits `machine-describe` with the id threaded, the enumeration emits
`machines-list`, and a miss returns `{:ok? false :reason :not-registered :kind :machine :id …}`.

`skills/re-frame2-pair/tests/runtime/machine_describe_test.clj` (new, picked up
automatically by the CI loop over `tests/runtime/*_test.clj`) pins the door itself. Its
second half is behavioural rather than structural: it reads `fn-slot-sentinel` and
`strip-fns` out of the preload's source, evaluates them, and runs the shipped walk over a
machine spec with fn-valued `:guards` / `:actions` — asserting `:rf/fn` sentinels, that
the structure around them survives, that no `#object` reaches the printed EDN, and that
the result round-trips through `pr-str` → `read-string`.

### Sabotage witness

Misspelling the emitted symbol (`machine-describe` → `machine-describ`) in
`handler_meta.cljs`, recompiling and re-running took `node out/server-test.js` to
**exit 1** with three failures, the runtime-door assertion naming
`missing: ["machine-describ"]`. Restored by `git checkout HEAD --`; the git blob hash
returned to `ece4159ffb5739a7bdb757555950dff83ed3b506`, byte-identical to the pre-plant
commit. The plant existed only in this worktree, so a run that had wandered elsewhere
would have come back green.

The first sabotage run also showed the failure rendering dumping the whole preload source
into the log — 400KB across three assertions. That is fixed here (one set difference
instead of an `is` per symbol); the second sabotage run reproduced the same red in 3.8KB.

The require-alias ratchet was exercised the same way: planting `[re-frame.core :as reframe]`
in the new `.clj` file took it to **exit 1**, `skills: 1 violation(s), floor 0`, naming
file and line. Restored, blob hash back to `c226a9fc06c271885cddabeaa004b212737b93ab`.

## Quality gates

All run in the foreground on the **final rebased base**, exit codes captured on the same
command line as the redirect and quoted from the captured file — never from a harness
report, and never through a filter.

| Gate | Exit | Result |
|---|---|---|
| `node out/server-test.js` (**the verdict**) | **0** | `Ran 1152 tests containing 4238 assertions. 0 failures, 0 errors.` — 0 `FAIL in` lines |
| `shadow-cljs compile server-test` | 0 | *not a verdict here* — `:autorun true` means a red suite still compiles clean |
| `npm run check:descriptors` | 0 | `OK: tool-descriptors.edn in sync (30 tools).` |
| `npm run build` (shipped `:server` bundle) | 0 | `Build completed. (136 files, 135 compiled, 0 warnings)` |
| `bb tests/prompts/…` + all 13 `bb tests/runtime/*_test.clj` | 0 | every file `0 failures, 0 errors` |
| `python scripts/check_require_alias_dialect.py --verbose` | 0 | `2796 file(s), 10870 re-frame require edge(s) … every surface at or under its floor` |
| `python scripts/check_view_lifetime_residue.py --verbose` | 0 | `zero 'lease' residue in tracked content or paths` |
| `python scripts/check_doc_slugs.py` | 0 | covers `tools/*/spec` — the edited catalogue |
| `python scripts/check_readme_links.py --ci` | 0 | |
| `clj-kondo --lint` (the four changed Clojure files) | 0 | `errors: 0, warnings: 0` |

The suite grew from 1147 tests / 4185 assertions to 1152 / 4238.

**The live hermetic suite (`test:re-frame2-pair-live-hermetic-suite`) did NOT run locally,
and this is a deliberate call rather than an omission.** Playwright is not resolvable from
either `tools/mcp-conformance` or `implementation` in this worktree, so running it would
mean an `npm ci` plus a browser download; and the hermetic fixture registers no machine
(its `deps.edn` pulls the machines artefact only so the preload's `:require` resolves), so
it would have exercised that the edited preload compiles and boots, not the machine door.
CI runs it: this diff arms `mcp_live` from both `tools/re-frame2-pair-mcp/*` and
`skills/re-frame2-pair/preload/*`.

### Surfaces this diff arms

From `.github/scripts/report-changed-surfaces.sh` read against `.github/workflows/test.yml`,
run on the actual changed paths — `cljs_browser`, `examples_compile`, `tools_jvm`,
`mcp_conformance`, `mcp_live`, `skills_structural`. The classifier was exercised against a
control (`LICENSE`) that armed nothing, so the six trues are discriminating rather than a
default.

### Verified by hand

The acceptance census, on both token axes with a positive control:
`re-frame.core/machines` and `re-frame.core/machine-meta` return **0** across
`tools/re-frame2-pair-mcp` and `skills/re-frame2-pair` — line-oriented and with whitespace
collapsed over every git-tracked file — while the controls
`re-frame2-pair.runtime/machine-describe` (1) and `rf.machines/machine-meta` (2) return
non-zero. The prose in the new docstrings deliberately describes the retired route without
spelling either symbol, so the census stays honest.

Markdown anchors and table column counts in the edited catalogue sections checked by hand:
the edits are prose and inline code inside existing sections, adding no links, no headings
and no table rows.

## Scope

Fence respected on `implementation/**` (read `machines.cljc` and `core.cljc`, edited
neither), `spec/API.md`, `spec/Conventions.md`, `spec/005-StateMachines.md`,
`spec/api-manifest*.edn`, `.github/workflows/**`, `.beads/**`.

`skills/re-frame2-pair/**` **is** touched, and that is the one place this PR follows the
bead over the dispatch brief, which had put the tree out of scope. The bead's acceptance
criteria name `skills/re-frame2-pair/tests/runtime/` explicitly and require the census to
cover `skills/re-frame2-pair`, and the runtime change is load-bearing: routing the tool at
a `machine-describe` that does not strip fns trades an eval error for an
`:unserializable`, which is not a fix. The brief records the tree as free of live peers.

`skills/re-frame2-pair/references/ops.md:46-47` documents the two door fns and stays
accurate — no edit needed there. Nothing in `skills/re-frame2-pair/**` carried the false
`re-frame.core/…` claim.

No public API change. No `spec/api-manifest.edn` change. `tools/mcp-conformance`'s
classification fixtures key on tool NAME and pin no eval string, so they are unaffected.
