### PR TITLE
fix(ssr-node): both remaining error-text paths onto public refusals stop at the caller boundary (rf2-2hmg)

### DIFF
--- a/implementation/ssr-node/README.md
+++ b/implementation/ssr-node/README.md
@@ -372,7 +372,7 @@ rather than presenting a well-formed shorter page.
 | `:rf.ssr-node/build-identity-mismatch` | caller's `buildId` ≠ the bundle's |
 | `:rf.ssr-node/render-timeout` | deadline expired; the isolate was terminated |
 | `:rf.ssr-node/render-threw` | the render module threw, emitted nothing, or returned a value |
-| `:rf.ssr-node/isolate-lost` | the worker died mid-render, or an exception escaped the render call |
+| `:rf.ssr-node/isolate-lost` | the worker died mid-render, an exception escaped the render call, or the pool could not replace a terminated isolate |
 | `:rf.ssr-node/service-saturated` | no isolate free within the admission budget |
 | `:rf.ssr-node/service-closed` | the service is shutting down |
 | `:rf.ssr-node/malformed-render-module` | the bundle failed validation at boot |
@@ -518,6 +518,38 @@ filesystem. It goes to the same stderr, and on this path that is not
 merely the better channel but the only one — the worker never caught
 anything, so nothing inside it ever saw the fault. `test/egress.test.cjs`
 §5 is the witness, driving one Error down both routes as a matched pair.
+
+A **replacement isolate that will not boot** states the same law from a
+third place, and it is the one where the law nearly got away. A boot
+refusal is allowed to carry the module's own message, its stack and the
+module path, on the stated ground that boot fails before the service
+listens — so its reader is the operator standing at a process that would
+not start. That is true when the pool starts. It is false when the pool
+*replaces*: a replacement boots while the service is live, and the failure
+is delivered to whoever is queued waiting for capacity. Every boot refusal
+therefore stops at that boundary. A waiter is told
+`:rf.ssr-node/isolate-lost` with this contract's wording and a `detail` of
+`poolSize`, and the module's message, the module path and any `code` the
+module put on its boot error stay off the wire — the last of these
+mattering for the reason a module-set `code` always does, since the boot
+receiver builds its refusal without consulting the family. The failure
+itself goes to the sidecar's stderr **unconditionally**, which is a
+strengthening and not a trade: the old handler's only statement was the
+loop over waiters, so a replacement that failed with nobody queued told no
+one at all and the pool quietly shrank by an isolate.
+
+The last receiver is one no application can reach on purpose: a render that
+rejects with something that is **not a `Refusal` at all**. It is a fault in
+this package rather than in the application — every receiver between the
+module and the caller builds a refusal, so anything else got past all of
+them — and it is reachable, by an in-process caller whose request carries
+an accessor. Validation reads a partition value and the structured clone
+reads it again, so a getter or a Proxy can be a string the first time and
+unclonable the second, and the resulting `DataCloneError` names the value
+it choked on. A caller's own value on a public refusal is the same egress
+as any other, so this arm carries the contract's `render-threw` wording and
+sends the real fault to the operator. `test/egress.test.cjs` §6 and §7 are
+the witnesses.
 
 The CLJS half — the thing behind `MY_APP_SSR.renderToString` — is a
 per-request `gensym` frame made with no initial events,
@@ -751,10 +783,21 @@ and nothing else.
 
 The suite drives the service against reference render modules under
 `test/fixtures/` — well-behaved, mutating, sloppy-mode, hanging, throwing
-(inside the call and escaping it), chunking, byte-hostile, leaky and
-null-returning — because every guarantee here is a
+(inside the call and escaping it), chunking, byte-hostile, leaky,
+null-returning and boot-flaky — because every guarantee here is a
 property of the service, and a fixture that misbehaves on purpose is the
 only way to see a guard fire.
+
+The boot-flaky one is the odd member and its oddity is the point: it boots
+the first time and refuses the next, which is the only way to reach a
+REPLACEMENT boot. Every other boot-failure fixture fails on its first boot,
+where the service never comes up and the reader of the refusal is the
+operator — so none of them can reach the receiver where that same refusal
+goes to a caller instead. Isolates share no module state, so the switch is
+an environment flag: a worker thread inherits a copy of `process.env` taken
+when it is constructed, which makes a flag set after the pool is up
+invisible to the isolates already running and visible to every replacement
+spawned afterwards.
 
 A fixture reports what it observed by rendering it, as a base64
 attribute on markup it was emitting anyway, and the witnesses read it back
@@ -781,6 +824,20 @@ the ESCAPING one's scheduled callback intercepted before it fires and shown
 really throwing that sentinel —
 before its zero is believed; and the absence scan is shown finding a
 planted reference before its zero is believed.
+
+The replacement-boot rows need two controls rather than one, and the second
+is the kind that is easy not to write. The first is the ordinary one: the
+flaky fixture is shown really refusing to boot, carrying its sentinel and
+its spoofed `code`. The second is about the SCENARIO rather than the
+fixture — every claim in that section is about what a *waiting* caller
+receives, so a run in which nobody happened to be queued, or in which the
+pool never tried to replace anything, would be green about a path it never
+took. Both facts are read off the service's own counters (`waiting`, and
+`replacements` rising to 1) before any refusal is inspected. The
+uncontracted-rejection rows carry the same shape of control, and there it
+is a fact about the tree rather than about the fix: the partition value is
+asserted to have been read *twice*, because nothing but the structured
+clone reads it a second time.
 
 One of those controls is worth reading twice, because it guards against a
 row going quiet rather than against a row going wrong. The status-spoof

--- a/implementation/ssr-node/src/pool.cjs
+++ b/implementation/ssr-node/src/pool.cjs
@@ -19,8 +19,43 @@
 //               requests, which is precisely the skew the build identity
 //               exists to catch. It is refused rather than absorbed.
 
-const { CODE, Refusal } = require('./protocol.cjs');
+const { CODE, Refusal, REPLACEMENT_FAILED_REFUSAL } = require('./protocol.cjs');
 const { Isolate } = require('./isolate.cjs');
+
+/**
+ * The operator's copy of a replacement boot that failed — everything the
+ * waiters' refusal deliberately does not carry.
+ *
+ * The third of these, after `worker.cjs`'s `reportRenderException` and
+ * `isolate.cjs`'s `reportIsolateFault`, and written for the same reason:
+ * closing a refusal's wording without opening the operator's copy trades a
+ * leak for a silence. Not a new subsystem and no flag — `bin/serve.cjs`
+ * already writes `[rf.ssr-node] …` here, so this is that stream under that
+ * prefix, and a diagnostic that can be switched off is off on the day it is
+ * wanted.
+ *
+ * UNCONDITIONAL, WHICH THE OTHER TWO ARE NOT. `reportIsolateFault` is
+ * guarded on there being a pending render because the unguarded half of
+ * that handler is the boot phase, which has its own diagnostic. This path
+ * has no second reporter at all: the caller-facing statement is a loop over
+ * `waiters`, so a replacement that failed with an EMPTY queue used to reach
+ * nobody — the pool shrank by an isolate and the process said nothing. That
+ * silence is the more dangerous of the two failures being fixed here,
+ * because a leak is at least visible to somebody.
+ *
+ * The `Refusal` arriving here carries the real trace in its `detail`
+ * (`isolate.cjs`'s boot receiver puts `err.stack` there), so `detail` is
+ * printed as well as the message — otherwise the operator's copy would be
+ * the one thing this function exists to avoid, a message with no stack.
+ */
+function reportReplacementFault(modulePath, err) {
+  const trace = err && err.stack ? err.stack : String(err);
+  const detail =
+    err && err.detail && Object.keys(err.detail).length ? ` ${JSON.stringify(err.detail)}` : '';
+  process.stderr.write(
+    `[rf.ssr-node] a replacement isolate failed to boot from ${modulePath}: ${trace}${detail}\n`,
+  );
+}
 
 class Pool {
   constructor({ modulePath, size = 2, admissionTimeoutMs = 250, bootTimeoutMs = 30000 }) {
@@ -169,13 +204,37 @@ class Pool {
         // A pool that cannot replace an isolate is a pool that shrinks.
         // Every waiter is refused rather than left holding a promise that
         // will only ever be settled by its own admission timer.
+        //
+        // AND EVERY BOOT REFUSAL STOPS HERE, which is the whole of the
+        // change rf2-2hmg made. This arm used to forward `err` untouched
+        // whenever it was already a `Refusal`, and to interpolate
+        // `err.message` when it was not — so both halves of the ternary
+        // published something a waiter had no business seeing, and the
+        // pass-through was the wider of the two. What arrives here is a
+        // BOOT refusal, and `isolate.cjs` builds those for an operator
+        // standing at a process that would not start: the module's own
+        // message, `err.stack` in the `detail`, the module path, and a
+        // `code` the module chose, since the boot receiver does not consult
+        // `isRefusalCode` the way the render receiver does. On
+        // `Pool.start()` that audience is real. Here it is a caller across a
+        // wire, and none of it is theirs.
+        //
+        // So the audience decides the wording, not the failure: one
+        // service-owned refusal, one code from the closed family, and a
+        // `detail` naming only what this file knows. `poolSize` is the same
+        // service-owned fact the `SERVICE_SATURATED` refusal above carries,
+        // and for the same reason — it is what a waiter that has just been
+        // refused capacity would ask next.
+        //
+        // The real failure goes to stderr FIRST, and unconditionally; see
+        // `reportReplacementFault` for why that is part of the fix rather
+        // than a courtesy.
         (err) => {
+          reportReplacementFault(this.modulePath, err);
           for (const waiter of this.waiters.splice(0)) {
             clearTimeout(waiter.timer);
             waiter.reject(
-              err instanceof Refusal
-                ? err
-                : new Refusal(CODE.ISOLATE_LOST, `could not replace an isolate: ${err.message}`, {}),
+              new Refusal(CODE.ISOLATE_LOST, REPLACEMENT_FAILED_REFUSAL, { poolSize: this.size }),
             );
           }
         },

--- a/implementation/ssr-node/src/protocol.cjs
+++ b/implementation/ssr-node/src/protocol.cjs
@@ -299,6 +299,49 @@ const ISOLATE_LOST_REFUSAL =
   'its stack, is on the sidecar\'s stderr for the operator.';
 
 /**
+ * What a caller waiting for capacity is told when the pool could not
+ * replace a terminated isolate.
+ *
+ * THE SAME LAW AGAIN, STATED BY A THIRD RECEIVER — and this one exists
+ * because a refusal's AUDIENCE changed under it rather than because a new
+ * refusal was needed. `isolate.cjs` builds one refusal for every boot
+ * failure, and it carries the module's own `message` and `stack` on
+ * purpose: boot fails before the service listens, so its reader is the
+ * operator standing at the process they just started. That reasoning is
+ * sound for `Pool.start()` and false for `Pool._startReplacement()`. A
+ * replacement boots while the service is LIVE, and `Pool.release()` hands
+ * its failure to everyone queued in `acquire()` — a caller across a wire,
+ * reading a refusal written for somebody standing at a terminal.
+ *
+ * IT WAS THE WIDEST OF THE THREE LEAKS. The module's boot wording, the
+ * absolute module path this deployment was pointed at, and — because the
+ * boot receiver builds its `Refusal` straight from the posted `code`
+ * without consulting `isRefusalCode` — a code the MODULE chose, which is
+ * the spoof `RENDER_THREW_REFUSAL` closes on the render path arriving on
+ * the boot path instead. A module that types `:rf.ssr-node/service-
+ * saturated` onto its boot error turns its own broken bundle into the 503
+ * a caller's retry policy sleeps on.
+ *
+ * THE CODE STAYS `ISOLATE_LOST`, for the reason its own constant gives:
+ * an isolate really was lost and really was not replaced, and a caller
+ * acts on that rather than on why the boot failed.
+ *
+ * The diagnosis moves to the operator, and on this path that is a strict
+ * improvement rather than a trade. The handler's only statement used to be
+ * the loop over waiters, so a replacement that failed with NOBODY queued
+ * told no one at all: the pool shrank by an isolate in silence. The stderr
+ * write is therefore unconditional.
+ */
+const REPLACEMENT_FAILED_REFUSAL =
+  'the service could not replace a terminated isolate, so the capacity you were waiting for ' +
+  'will not arrive. Why the replacement would not boot belongs to the application and to this ' +
+  'deployment, not to this contract: the module\'s own message, the `code` it carried and the ' +
+  'path this service was pointed at do not cross this boundary — a module-chosen `code` would ' +
+  'let a broken bundle present itself as a caller fault, a saturation or a deadline, and the ' +
+  'path names the server\'s filesystem. The full failure, with its stack, is on the sidecar\'s ' +
+  'stderr for the operator.';
+
+/**
  * Is this one of the refusal codes this service publishes?
  *
  * The family is closed — `CODE` is the whole of it — and this is the test
@@ -647,6 +690,7 @@ module.exports = {
   MODULE_RETURN_REFUSAL,
   RENDER_THREW_REFUSAL,
   ISOLATE_LOST_REFUSAL,
+  REPLACEMENT_FAILED_REFUSAL,
   isRefusalCode,
   Refusal,
   validateModule,

--- a/implementation/ssr-node/src/service.cjs
+++ b/implementation/ssr-node/src/service.cjs
@@ -38,9 +38,34 @@
 // and it checks the frames rather than the HTTP response, because HTTP
 // dropping a field is a fact about HTTP and not a guarantee about this.
 
-const { CODE, Refusal, validateRequest, completeFrame } = require('./protocol.cjs');
+const {
+  CODE,
+  Refusal,
+  RENDER_THREW_REFUSAL,
+  validateRequest,
+  completeFrame,
+} = require('./protocol.cjs');
 const { Pool } = require('./pool.cjs');
 const { PROTOCOL_VERSION } = require('./protocol.cjs');
+
+/**
+ * The operator's copy of a render that rejected with something this
+ * package's own contract does not describe.
+ *
+ * A fault reaching this is a fault in the SIDECAR rather than in the
+ * application — every receiver between here and the module builds a
+ * `Refusal`, so anything else got past all of them — and it is the one
+ * class of failure nothing upstream will have logged. Without this the
+ * wording handed to the caller would again be the only copy in existence,
+ * which is the trade `isolate.cjs`'s `reportIsolateFault` exists to refuse.
+ */
+function reportUncontractedFault(err) {
+  const trace = err && err.stack ? err.stack : String(err);
+  process.stderr.write(
+    `[rf.ssr-node] a render rejected with something other than a Refusal — this is a fault in ` +
+      `the sidecar, not in the application: ${trace}\n`,
+  );
+}
 
 class Service {
   constructor(pool, limits) {
@@ -104,8 +129,40 @@ class Service {
           renderResult = result;
         },
         (error) => {
-          renderFailure =
-            error instanceof Refusal ? error : new Refusal(CODE.RENDER_THREW, String(error), {});
+          if (error instanceof Refusal) {
+            renderFailure = error;
+            return;
+          }
+          // THE LAST RECEIVER, and it states the same law as the other
+          // three (rf2-2hmg). This arm used to put `String(error)` on the
+          // public refusal, on the reading that it was unreachable and
+          // would carry only this package's own text if it were not.
+          // Neither half survived being measured.
+          //
+          // It is reached by an ORDINARY IN-PROCESS CALL. `validatePartition`
+          // returns the caller's own partition object rather than a copy, so
+          // the object the validator inspects and the object `postMessage`
+          // structured-clones are one object read twice — and anything with
+          // an accessor on it (a getter, a Proxy, a lazily-materialised row
+          // out of a serializer) can be a string on the first read and
+          // unclonable on the second. `postMessage` then throws
+          // `DataCloneError` synchronously inside `render()`'s executor,
+          // which never passed through a receiver that could have made it a
+          // `Refusal`.
+          //
+          // And the text is the CALLER'S, not ours: a `DataCloneError` names
+          // the value it choked on, so the caller's own value was
+          // interpolated into a message published on the widest surface this
+          // package has — the egress this file's header says does not exist.
+          //
+          // THE ARM ITSELF IS NOT THE DEFECT AND IS NOT REMOVED. It is what
+          // guarantees `renderFrames` throws nothing but a `Refusal`, which
+          // is the property every transport is written against; deleting it
+          // would let a raw `Error` reach `statusFor` with no code at all.
+          // Only the wording was ever wrong, and the contract already owns
+          // the wording.
+          reportUncontractedFault(error);
+          renderFailure = new Refusal(CODE.RENDER_THREW, RENDER_THREW_REFUSAL, {});
         },
       )
       .then(() => {

--- a/implementation/ssr-node/test/egress.test.cjs
+++ b/implementation/ssr-node/test/egress.test.cjs
@@ -1136,6 +1136,14 @@ test('CONTROL — the request really does pass validation and then fail the CLON
   // Without this the section could be green about a request that never got
   // past `validateRequest` — a caller-fault refusal looks nothing like the
   // one being hunted, but "no sentinel in the frame" is true of it too.
+  //
+  // THE SECOND READ IS THE WHOLE DISCRIMINATOR, and it is deliberately a
+  // fact about the tree rather than about the fix: nothing but the
+  // structured clone reads that value again, so `reads === 2` says the
+  // request reached `postMessage` and died there. A control that asserted
+  // on the stderr copy instead would only be able to pass once the fix
+  // existed, which is not a control — it could not have told the red tree
+  // apart from a tree where the request never got that far.
   const run = await uncontractedRejection();
   assert.strictEqual(run.reads, 2, 'the partition value must be read by the validator AND the clone');
   assert.ok(run.refusal, 'the call must be refused');
@@ -1143,10 +1151,6 @@ test('CONTROL — the request really does pass validation and then fail the CLON
     run.refusal.code,
     CODE.BAD_REQUEST_FIELD,
     'and refused past validation, not by it — this row is about the clone',
-  );
-  assert.ok(
-    run.stderr.includes('DataCloneError'),
-    'and the fault really is the structured clone, which is what makes it uncontracted',
   );
 });
 

--- a/implementation/ssr-node/test/egress.test.cjs
+++ b/implementation/ssr-node/test/egress.test.cjs
@@ -113,6 +113,8 @@ const {
   MODULE_RETURN_REFUSAL,
   RENDER_THREW_REFUSAL,
   ISOLATE_LOST_REFUSAL,
+  REPLACEMENT_FAILED_REFUSAL,
+  isRefusalCode,
 } = require('../src/protocol.cjs');
 const { serve, statusFor } = require('../src/http.cjs');
 const LEAKY = require('./fixtures/leaky.cjs');
@@ -885,4 +887,290 @@ test('a stream torn by an ESCAPED exception is destroyed, and still says nothing
       await http.close();
     }
   });
+});
+
+// ---------------------------------------------------------------------------
+// 6. The THIRD RECEIVER — a REPLACEMENT isolate that cannot boot (rf2-2hmg)
+//
+// Sections 4 and 5 are both about a render. This one is about a BOOT, and
+// the reason a boot belongs in an egress file at all is that the audience
+// for a boot refusal is not fixed.
+//
+// `isolate.cjs` builds one refusal for every boot failure and says, in a
+// comment, why it may carry the module's own `message` and `stack`: boot
+// fails before the service listens, so the reader is the operator standing
+// at the process they just started rather than a caller across a wire.
+// That is true of `Pool.start()`. It is FALSE of `Pool._startReplacement()`
+// — a replacement boots while the service is live and serving, and
+// `Pool.release()` hands its failure straight to everyone queued in
+// `acquire()`. Same refusal, second audience, and the comment authorising
+// the wording was written about the first one.
+//
+// So this section is the same law as sections 4 and 5, stated by a third
+// receiver, and the leak it closes is the widest of the three: the module's
+// boot message, the absolute module path this deployment was pointed at,
+// AND a `code` the module chose — the spoof section 4 closed for a render
+// exception, still open on the boot path because a different piece of code
+// builds this refusal and it does not consult `isRefusalCode`.
+//
+// THE HALF THE PATTERN ALSO REQUIRES. Before this, a replacement failure
+// with NO waiter queued reached nobody at all: the handler's only statement
+// is the loop over `waiters`, so an empty queue discarded the error and the
+// pool silently shrank by an isolate. Closing the refusal without opening
+// the operator's copy would have made that the only outcome, which is the
+// trade PR #9278 named — a leak for a silence.
+// ---------------------------------------------------------------------------
+
+const FLAKY_BOOT = require('./fixtures/flaky-boot.cjs');
+const { FAIL_FLAG, BOOT_SENTINEL, BOOT_SPOOF_CODE } = FLAKY_BOOT;
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/**
+ * Drive one replacement-boot failure and report everything it produced.
+ *
+ * The shape is forced by the path. A replacement is only ever spawned by
+ * `release()` seeing a DEAD isolate, and the only way to kill one from
+ * outside is the deadline — so the scenario is: hang the single isolate,
+ * queue a second caller behind it, arm the fixture's boot failure while
+ * both are in flight, and read what the QUEUED caller is handed when the
+ * pool tries to restore capacity and cannot.
+ *
+ * `admissionTimeoutMs` is far above the deadline on purpose: the waiter
+ * must still be waiting when the replacement fails, or the row measures an
+ * ordinary saturation refusal instead of the one it came for.
+ */
+async function replacementBootFailure() {
+  const captured = [];
+  const realWrite = process.stderr.write;
+  process.stderr.write = function (chunk, ...rest) {
+    captured.push(String(chunk));
+    return realWrite.call(this, chunk, ...rest);
+  };
+  try {
+    return await withService(
+      'flaky-boot',
+      { isolates: 1, admissionTimeoutMs: 5000, defaultTimeoutMs: 300, maxTimeoutMs: 5000 },
+      async (service) => {
+        const hung = refusalOf(() => collect(service, { protocol: 1, entry: 'app/hang' }));
+        await tick();
+        await tick();
+        const queued = refusalOf(() => collect(service, { protocol: 1, entry: 'app/root' }));
+        await tick();
+        await tick();
+        const statsWhileQueued = service.stats();
+        // Armed only now: the isolates already running took their copy of
+        // `process.env` when they were constructed, so this reaches the
+        // replacement and nothing else.
+        process.env[FAIL_FLAG] = '1';
+        const [hungRefusal, queuedRefusal] = await Promise.all([hung, queued]);
+        return {
+          hungRefusal,
+          queuedRefusal,
+          statsWhileQueued,
+          statsAfter: service.stats(),
+          stderr: captured.join(''),
+        };
+      },
+    );
+  } finally {
+    delete process.env[FAIL_FLAG];
+    process.stderr.write = realWrite;
+  }
+}
+
+test('CONTROL — the flaky fixture really does refuse to boot, with all three payloads', () => {
+  // The fixture measured directly rather than trusted. A fixture that had
+  // quietly stopped throwing — or that threw without the `code`, which is
+  // the half the boot receiver does not check — would make every row below
+  // pass while hunting nothing.
+  const modulePath = require.resolve('./fixtures/flaky-boot.cjs');
+  process.env[FAIL_FLAG] = '1';
+  delete require.cache[modulePath];
+  let thrown = null;
+  try {
+    require('./fixtures/flaky-boot.cjs');
+  } catch (err) {
+    thrown = err;
+  } finally {
+    delete process.env[FAIL_FLAG];
+    delete require.cache[modulePath];
+    require('./fixtures/flaky-boot.cjs'); // leave the cache holding the good one
+  }
+  assert.ok(thrown, 'the fixture must actually throw when the flag is armed');
+  assert.ok(thrown.message.includes(BOOT_SENTINEL), 'and carry the sentinel on its message');
+  assert.strictEqual(thrown.code, BOOT_SPOOF_CODE, 'and carry the spoofed code');
+  assert.ok(isRefusalCode(BOOT_SPOOF_CODE), 'which must be a real member, or nothing is spoofed');
+});
+
+test('CONTROL — a caller really is QUEUED when the replacement is attempted', async () => {
+  // The discriminator. Every assertion in this section is about what a
+  // WAITER receives, so a run in which nobody was waiting — or in which the
+  // pool never tried to replace anything — would be green about a path it
+  // never took. Both halves are read from the service's own counters.
+  const run = await replacementBootFailure();
+  assert.strictEqual(run.statsWhileQueued.waiting, 1, 'a caller must be queued in acquire()');
+  assert.strictEqual(run.statsWhileQueued.busy, 1, 'and the only isolate must be held by the hang');
+  assert.strictEqual(run.hungRefusal.code, CODE.RENDER_TIMEOUT, 'the deadline is what kills it');
+  assert.strictEqual(run.statsAfter.replacements, 1, 'and the pool must have tried to replace it');
+  assert.ok(run.queuedRefusal, 'the queued caller must have been refused, not served');
+});
+
+test('a WAITING CALLER is told nothing the module or the deployment authored', async () => {
+  const run = await replacementBootFailure();
+  const frame = run.queuedRefusal.toFrame('corr-boot');
+  const text = JSON.stringify(frame);
+
+  assert.ok(
+    !text.includes(BOOT_SENTINEL),
+    'the module\'s boot wording must not cross to a caller',
+  );
+  assert.ok(
+    !/[A-Za-z]:[\\/]|\/(?:home|srv|usr|opt)\//.test(text),
+    `no absolute deployment path may cross either; got ${text}`,
+  );
+  assert.strictEqual(
+    run.queuedRefusal.message,
+    REPLACEMENT_FAILED_REFUSAL,
+    'the wording is this contract\'s',
+  );
+  assert.strictEqual(run.queuedRefusal.code, CODE.ISOLATE_LOST, 'an isolate was lost and not replaced');
+  assert.ok(isRefusalCode(frame.code), 'and the code is a member of the closed family');
+  assert.strictEqual(
+    statusFor(frame.code),
+    500,
+    'so the module cannot turn its own boot failure into a 503 a retry policy sleeps on',
+  );
+});
+
+test('and the OPERATOR gets the boot failure, in full, on the sidecar stderr', async () => {
+  // The other half, and not optional for the reason section 5 gives. On
+  // this path the operator's position is worse than it was there: with no
+  // waiter queued the handler said nothing to ANYONE, so a pool could
+  // shrink to nothing in silence. The write is therefore unconditional —
+  // it is not guarded on there being a waiter to have leaked to.
+  const run = await replacementBootFailure();
+  assert.ok(
+    run.stderr.split('\n').some((line) => line.includes('[rf.ssr-node]')),
+    'the operator was told nothing at all',
+  );
+  assert.ok(run.stderr.includes(BOOT_SENTINEL), 'the operator copy must be the REAL failure');
+  assert.ok(
+    run.stderr.includes('flaky-boot.cjs'),
+    'and must name the module that would not load, which is the first thing to go look at',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 7. The FOURTH RECEIVER — a rejection that is not a `Refusal` at all
+//
+// `service.renderFrames` wraps the render's rejection in a last-resort arm
+// for anything that did not arrive as a `Refusal`. It was reported as
+// unreachable — every `isolate.render()` path was believed to reject with a
+// `Refusal` — and as harmless if reached, on the ground that it could only
+// carry this package's own error text. Both halves are false, and the row
+// below is the measurement rather than the argument.
+//
+// THE ROUTE IS AN ORDINARY IN-PROCESS CALL, with no internals stubbed.
+// `validatePartition` returns the CALLER'S OWN partition object rather than
+// a copy, so the object the validator reads and the object `postMessage`
+// structured-clones are the same live object, read twice. Anything with an
+// accessor on it — a getter, a Proxy, a lazily-materialised row from a
+// serializer — can therefore satisfy `typeof value === 'string'` on the
+// first read and hand back something unclonable on the second.
+// `postMessage` then throws `DataCloneError` synchronously inside
+// `render()`'s promise executor, which is not a `Refusal` and never passed
+// through a receiver that could have made it one.
+//
+// AND THE TEXT IT CARRIES IS THE CALLER'S. A `DataCloneError` names the
+// value it choked on, so the caller's own value is interpolated into the
+// message and published on the public refusal frame — the same egress
+// sections 4 and 5 refuse, arriving through the one door still open.
+// ---------------------------------------------------------------------------
+
+const CLONE_SENTINEL = 'rf2-2hmg-caller-7c19ab';
+
+/**
+ * A `state` partition whose one value is a string when the validator reads
+ * it and an unclonable, sentinel-bearing `Symbol` when the clone does.
+ *
+ * A `Symbol` rather than a function on purpose: `DataCloneError` renders a
+ * function as its source text, which would carry nothing the caller chose,
+ * while a symbol renders its DESCRIPTION — so this is the shape that shows
+ * whether caller-authored text crosses, which is the claim being tested.
+ */
+function twoFacedState() {
+  const state = {};
+  let reads = 0;
+  Object.defineProperty(state, ':route', {
+    enumerable: true,
+    configurable: true,
+    get() {
+      reads += 1;
+      return reads === 1 ? '{:name :ok}' : Symbol(CLONE_SENTINEL);
+    },
+  });
+  return { state, reads: () => reads };
+}
+
+/** Drive one such request, capturing the sidecar's stderr alongside. */
+async function uncontractedRejection() {
+  const captured = [];
+  const realWrite = process.stderr.write;
+  process.stderr.write = function (chunk, ...rest) {
+    captured.push(String(chunk));
+    return realWrite.call(this, chunk, ...rest);
+  };
+  try {
+    const twoFaced = twoFacedState();
+    const refusal = await withService('reference', { isolates: 1 }, (service) =>
+      refusalOf(() => collect(service, { protocol: 1, entry: 'app/root', state: twoFaced.state })),
+    );
+    return { refusal, reads: twoFaced.reads(), stderr: captured.join('') };
+  } finally {
+    process.stderr.write = realWrite;
+  }
+}
+
+test('CONTROL — the request really does pass validation and then fail the CLONE', async () => {
+  // Without this the section could be green about a request that never got
+  // past `validateRequest` — a caller-fault refusal looks nothing like the
+  // one being hunted, but "no sentinel in the frame" is true of it too.
+  const run = await uncontractedRejection();
+  assert.strictEqual(run.reads, 2, 'the partition value must be read by the validator AND the clone');
+  assert.ok(run.refusal, 'the call must be refused');
+  assert.notStrictEqual(
+    run.refusal.code,
+    CODE.BAD_REQUEST_FIELD,
+    'and refused past validation, not by it — this row is about the clone',
+  );
+  assert.ok(
+    run.stderr.includes('DataCloneError'),
+    'and the fault really is the structured clone, which is what makes it uncontracted',
+  );
+});
+
+test('a rejection that is not a Refusal carries nothing the CALLER authored', async () => {
+  const run = await uncontractedRejection();
+  const frame = run.refusal.toFrame('corr-clone');
+  assert.ok(
+    !JSON.stringify(frame).includes(CLONE_SENTINEL),
+    'the caller\'s own value must not be reflected back on a public refusal',
+  );
+  assert.strictEqual(run.refusal.message, RENDER_THREW_REFUSAL, 'the wording is this contract\'s');
+  assert.ok(isRefusalCode(frame.code), 'and the code is a member of the closed family');
+});
+
+test('and the OPERATOR gets the uncontracted fault, because nothing else would', async () => {
+  // A fault here is a fault in the SIDECAR rather than in the application:
+  // a render rejected with something the package's own contract does not
+  // describe. Nothing upstream logged it — the worker never saw it and the
+  // isolate never built a refusal for it — so before this the leaked
+  // wording was, once again, the only copy in existence.
+  const run = await uncontractedRejection();
+  assert.ok(
+    run.stderr.split('\n').some((line) => line.includes('[rf.ssr-node]')),
+    'the operator was told nothing at all',
+  );
+  assert.ok(run.stderr.includes(CLONE_SENTINEL), 'the operator copy must be the REAL fault');
 });

--- a/implementation/ssr-node/test/fixtures/flaky-boot.cjs
+++ b/implementation/ssr-node/test/fixtures/flaky-boot.cjs
@@ -1,0 +1,70 @@
+'use strict';
+// A MODULE THAT BOOTS, AND THEN STOPS BOOTING — the fixture the REPLACEMENT
+// path needs (rf2-2hmg).
+//
+// Every other boot-failure fixture here fails on the FIRST boot, which is
+// `Pool.start()`: the service never comes up, and the operator reading the
+// refusal is standing at the process they just started. The path this
+// fixture exists for is the other one. A replacement isolate boots while
+// the service is LIVE and serving, so its boot failure is delivered to
+// whoever is waiting for capacity — a caller across a wire — and no
+// fixture that fails on its first boot can ever reach that receiver.
+//
+// THE SWITCH IS AN ENV FLAG BECAUSE ISOLATES SHARE NO STATE. Each isolate
+// is a separate V8 isolate with its own module registry, so a module-level
+// "have I booted before" counter is per-thread and always reads zero. What
+// a worker thread does inherit is a COPY of `process.env`, taken when the
+// thread is constructed — so a flag the test sets after the pool is up is
+// invisible to the isolates already running and visible to every
+// replacement spawned afterwards, which is exactly the discrimination the
+// witness needs.
+//
+// The thrown Error is built to carry all three things the refusal must not
+// pass on: a message the application authored, a `code` outside the closed
+// refusal family, and — by way of `worker.cjs`'s boot post and
+// `isolate.cjs`'s boot receiver — the module path this deployment was
+// pointed at.
+
+const FAIL_FLAG = 'RF2_SSR_NODE_FLAKY_BOOT';
+
+/** The sentinel is the fixture's, so the witness and the fixture cannot drift. */
+const BOOT_SENTINEL = 'rf2-2hmg-boot-4d21fe';
+
+/**
+ * A refusal code the module has no business choosing. Spelled as a real
+ * member of the family so the row is testing the boundary rather than a
+ * typo: if this reached `statusFor` it would turn a 500 into a 503, which
+ * is the status a caller's retry policy sleeps on.
+ */
+const BOOT_SPOOF_CODE = ':rf.ssr-node/service-saturated';
+
+if (process.env[FAIL_FLAG] === '1') {
+  const err = new Error(`the bundle refused to load: ${BOOT_SENTINEL}`);
+  err.code = BOOT_SPOOF_CODE;
+  throw err;
+}
+
+module.exports = {
+  protocol: 1,
+  buildId: 'flaky-boot-build-1',
+  entries: {
+    // Synchronous, for the reason `hang.cjs` gives: the deadline has to
+    // reach a render no cooperative cancel could, because that is the one
+    // that gets the isolate TERMINATED and therefore replaced.
+    'app/hang': { stateAllowlist: [], runtimeAllowlist: [] },
+    'app/root': { stateAllowlist: [], runtimeAllowlist: [] },
+  },
+
+  render({ entry }, emit) {
+    if (entry === 'app/hang') {
+      while (true) {
+        Math.sqrt(Date.now());
+      }
+    }
+    emit('<p>ok</p>');
+  },
+};
+
+module.exports.FAIL_FLAG = FAIL_FLAG;
+module.exports.BOOT_SENTINEL = BOOT_SENTINEL;
+module.exports.BOOT_SPOOF_CODE = BOOT_SPOOF_CODE;


### PR DESCRIPTION
Closes the two error-text paths onto public refusals that PR #9278 reported rather than changed (rf2-2hmg). Both were reported as *claims*; **neither claim survived being measured**, and that is most of what this PR is.

## The ruling, per site

**Site 1 — `pool.cjs` (the replacement-boot refusal): FIXED. Implementation, not a decision.** PR #9278's shape applies cleanly, so it was taken: the diagnostic goes to the sidecar's own stderr, the public `Refusal` carries the closed-taxonomy code and fixed contract wording.

The premise held, and the leak is **wider than the bead named**. The bead named the `${err.message}` interpolation. The bigger half is the `err instanceof Refusal ? err : …` **pass-through beside it**, because what arrives there is a *boot* refusal, and `isolate.cjs` builds those for an operator standing at a process that would not start — its comment says so in as many words. That reasoning is sound for `Pool.start()` and **false for `Pool._startReplacement()`**: a replacement boots while the service is live and serving, and `Pool.release()` hands its failure straight to everyone queued in `acquire()`. Measured, one waiting caller received:

```json
{"type":"refusal","code":"service-saturated",
 "message":"the bundle refused to load: <module's own text>",
 "detail":{"modulePath":"<absolute deployment path>"}}
```

Three faults on one refusal: the module's own boot wording, an absolute deployment filesystem path, and **a `code` the module chose** — the spoof #9278 closed on the render path, still open on the boot path because the boot receiver builds its `Refusal` without consulting `isRefusalCode`. A module typing `:rf.ssr-node/service-saturated` onto its boot error turns its own broken bundle into the 503 a caller's retry policy sleeps on.

So every boot refusal now stops at that boundary: `ISOLATE_LOST` + `REPLACEMENT_FAILED_REFUSAL` + a `detail` of `poolSize` only. The code is deliberately unchanged — an isolate really was lost and really was not replaced, and a caller acts on that.

**The silence was the more dangerous half.** The handler's only statement was the loop over `waiters`, so a replacement that failed with an **empty queue reached nobody at all** — the pool shrank by an isolate and the process said nothing. `reportReplacementFault` is therefore unconditional, unlike the two existing reporters.

**Site 2 — `service.cjs` (the last-resort `String(error)`): FIXED, because both halves of the "leave it" case are false.** I went in expecting to rule "leave it" and write the comment; the measurement inverted it.

- *"Unreachable today — every `isolate.render()` path rejects with a `Refusal`."* **Reached by an ordinary in-process call, nothing stubbed.** `validatePartition` returns the **caller's own** partition object rather than a copy, so the object the validator inspects and the object `postMessage` structured-clones are one object read twice. An accessor — a getter, a Proxy, a lazily-materialised row from a serializer — can be a string on the first read and unclonable on the second. `postMessage` then throws `DataCloneError` **synchronously inside `render()`'s promise executor**, which never passed through a receiver that could have made it a `Refusal`.
- *"Would carry only this package's own error text."* **It carries the CALLER's.** A `DataCloneError` names the value it choked on. With a `Symbol` second read, the caller's own description was reflected verbatim onto the public refusal frame:

  ```
  message = "DataCloneError: Symbol(rf2-2hmg-caller-7c19ab) could not be cloned."
  sentinelInFrame = true
  ```

The arm itself is **not** the defect and is not removed — it is what guarantees `renderFrames` throws nothing but a `Refusal`, the property every transport is written against. Only the wording was wrong, and `RENDER_THREW_REFUSAL` already owns it, so this adds no machinery.

**Why they were one bead, settled:** the reasoning that would have justified leaving site 2 — *unreachable, and only our own text* — is the same reasoning that left site 1 leaking, written into `isolate.cjs`'s boot-arm comment. Site 1 is direct evidence in this very diff that judgements of that shape do not survive a new caller path.

## Both premises, and how the reachability check was controlled

Not a grep. A **static enumeration** of all seven rejection paths out of `Isolate.render()` (three guards, the deadline, the `t:'error'` branch, both `_failPendingRender` callers, `close()`), then a **dynamic refutation**: a probe drove a real non-`Refusal` through the real `Service` end to end and read what came out. The enumeration was complete for the paths it covered and still wrong overall, because the reaching route is the promise executor's synchronous throw, which is not a `reject(...)` call and so appears in no enumeration of them. The measurement is what caught it.

The test-side control is fix-independent by construction: the partition value is asserted to have been read **twice**, because nothing but the structured clone reads it a second time. A control asserting on the stderr copy instead could only pass once the fix existed, which is not a control.

## The RED, quoted

Both sites proven red on the unfixed tree before either was touched (`test/egress.test.cjs`, captured exit **1**):

```
ℹ tests 33   ℹ pass 28   ℹ fail 5

✖ a WAITING CALLER is told nothing the module or the deployment authored
  AssertionError: the module's boot wording must not cross to a caller
✖ and the OPERATOR gets the boot failure, in full, on the sidecar stderr
  AssertionError: the operator was told nothing at all
✖ CONTROL — the request really does pass validation and then fail the CLONE
✖ a rejection that is not a Refusal carries nothing the CALLER authored
  AssertionError: the caller's own value must not be reflected back on a public refusal
✖ and the OPERATOR gets the uncontracted fault, because nothing else would
  AssertionError: the operator was told nothing at all
```

Both site-1 **controls passed while those failed** — the fixture control and the "a caller really is QUEUED / a replacement really was attempted" discriminator — so the reds are about the path, not about a scenario that never ran. After the fix: 33/33, exit 0.

The `flaky-boot` fixture is the one new piece of machinery, and it is unavoidable: every other boot-failure fixture fails on its *first* boot, which is `Pool.start()`, where the audience genuinely is the operator. Only a module that boots once and then refuses can reach the replacement receiver. Isolates share no module state, so the switch is an env flag — a worker inherits a copy of `process.env` taken at thread construction.

## Quality gates

All foreground, exit code captured on the same command line as the redirect, all **re-run on the final base after rebase**.

| Gate | Exit | Result |
|---|---|---|
| `npm test` (package suite) | **0** | 128 rows / 9 suites, 0 fail (121 before → +7, 0 regressions) |
| `clojure -M:crossing-test` | **0** | 10 tests / 107 assertions |
| `check_require_alias_dialect.py --verbose` | **0** | see caveat below |
| `check_view_lifetime_residue.py --verbose` | **0** | zero `lease` residue |
| `check_readme_links.py --ci` | **0** | the right gate for a README beside source |

**The alias ratchet's 0 is not evidence for this PR and is not offered as any.** It grades *import edges* against a per-surface floor; this diff is `.cjs`-only and cannot move it. It was run because it is a repo-wide ratchet, not because it covers anything here.

**Armed CI surfaces derived from one path** — `.github/scripts/report-changed-surfaces.sh` read against `.github/workflows/test.yml`, not hand-listed: `ssr_node=true`, **every other output false**. That arms `jvm-node-crossing` (`clojure -M:crossing-test`, run above); `node-ssr-node` runs unconditionally by design. The classifier was itself controlled in both directions — a core path arms 16 surfaces and *not* `ssr_node`; a nonsense path arms nothing — so the all-false reading is real rather than a misused-instrument zero.

**Each silent gate was proven to bite, on this worktree.** Planted faults, each restored and the restore verified by **blob hash** (never by reading a diff), with the match count read before each plant:

- Residue ratchet: a bare `lease` planted in `pool.cjs` → **exit 1**, naming `implementation/ssr-node/src/pool.cjs:51` and quoting the line. Restored, blob `bb636bc5…` → `bb636bc5…`.
- README links: a broken anchor planted in the ssr-node README → **exit 1**, naming `README.md:791 -> #no-such-heading-planted-…`. Restored, blob `ecc518ef…` → `ecc518ef…`.
- **Gate nomination confirmed in both directions on that same planted tree**: `check_readme_links.py --ci` exit 1, `check_doc_slugs.py` exit **0** — its roots do not include READMEs beside source.

The package suite prints its own root, and it named this worktree on every run.

Verified by hand, since no gate reads it: the refusal table is uniform at 2 columns including the row I widened (every row 3 pipes), and the paragraphs added introduce no new links or anchors.

## No spec change is owed

`spec/Conventions.md` catalogues the `:rf.ssr-node/*` code **members**; this diff adds and removes none and does not change which code any path returns. `REPLACEMENT_FAILED_REFUSAL` is a message constant beside `ISOLATE_LOST_REFUSAL` and `RENDER_THREW_REFUSAL`, which is exactly how #9278 added its own. Fence respected: `implementation/ssr-node/**` only.

## Two findings reported, not fixed — neither in this bead's question

Both are inside the fence but outside what rf2-2hmg asked, so they are recorded rather than actioned:

1. **A TOCTOU between validation and the clone.** `validatePartition` returns the caller's own object rather than a copy, which is the mechanism that makes site 2 reachable. It fails *closed* — the outcome is a clean refusal — so hardening site 2's wording fully closes the egress. Making the partition a copy is a separate change with its own semantics.
2. **A stuck isolate on that same path.** `render()` assigns `this.pendingRender` *before* `postMessage`, so a throwing `postMessage` leaves the isolate `busy` with its deadline armed. It self-heals when the deadline fires (which then terminates and replaces the isolate), but until then every further render on it refuses `service-saturated`. Self-limiting, and a different repair from this one.
