### PR TITLE
docs(mayor-method): clause 5's job-name bullet is conditional on the workflow being one a change runs (rf2-n7tb)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -229,7 +229,14 @@ them**. The count alone gives opposite verdicts for the same number:
 * nine changed lines that are all cache steps add no job and rename no check. The
   matrix is intact; merge.
 * four changed lines that add a job name with its own condition **are** a new
-  required check. Update the branch and re-check.
+  required check — *but only where your changes run that workflow at all*. A job added
+  to a workflow that nothing but a schedule or a manual button starts appears in no
+  change's rollup, so the check set is intact and the merge should proceed. Unqualified
+  this bullet fails **closed**, blocking a merge that should have gone; it is a
+  qualification to the bullet rather than a case of its own because the bullet is what a
+  skimming reader acts on. The diff that gave you the count also names the files it came
+  from — read which events run each, keep only the keys in workflows your changes run,
+  and where any survive, update the branch and re-check.
 
 A display-name rename is a third case and reads like the second: the check set is
 identical, the count is unchanged, only a label moved. That is intact — but you only


### PR DESCRIPTION
Closes the reading defect filed as rf2-n7tb.

## What was wrong

`docs/the-mayor-method/loops.md` clause 5 enumerates two bullets under *"The count alone gives opposite verdicts for the same number"*. The second stated outright that

> four changed lines that add a job name with its own condition **are** a new required check.

That is false for a job added to a workflow no change ever runs. A workflow started only by a schedule or a manual button contributes nothing to any change's rollup, so the check set is unchanged and the merge should proceed. Clause 5's general instruction — *count, then read them* — gestures at the right idea, but the enumerated bullet a reader lands on gave the wrong verdict, and an enumerated example beats a general instruction every time.

This is not exotic: 7 of the 11 workflow files in this repository carry no `pull_request` trigger at all, so most of the directory the job-key discriminator reads can never move a rollup.

## Where the correction went, and why

Two constraints decided placement, and neither is the one that decided the companion change to the agent-instructions file.

1. **The bullet is what a skimming reader acts on.** A fourth case added below the list would leave the false sentence unqualified exactly where it is read. The defect is the bullet, so the repair is on the bullet.
2. **Clause 5 has a count-word constraint the list is load-bearing for.** The paragraph under the list opens *"A display-name rename is a third case and reads like the second"* — two ordinal references bound to the two bullets. A third bullet inserted into the list silently falsifies both. The list still has exactly two bullets after this change, so both references stay correct.

For contrast: the companion qualification in the agent-instructions file was written onto its trap (a) because that bullet's framing sentence reads *"each fails OPEN"*, which a fail-closed peer would have falsified. Clause 5 carries **no** analogous framing constraint — its framing sentence is about the count giving opposite verdicts, and its two bullets already point in opposite directions (one merges, one blocks), while the clause immediately above it bolds one of its own traps as failing **closed**. So the same placement was reached here by a different route.

**Direction is stated in the text**, as the item required: unqualified, this bullet fails **closed** — it blocks a merge that should have gone — which is the opposite direction to the merge-criterion traps recorded in the agent-instructions file.

## Keeping the two documents from restating each other

`loops.md` declares the division itself at its head: *"This page is the generic body; your copy pins the concrete values … your gate command, your tracker CLI, your hot-zone file list, your worktree parent directory, your check-count band — are facts about one repository, and they belong in that repository's agent-instructions file."* The agent-instructions file's own text mirrors it from the other side, calling itself the CLI concretion that clause 5 does not name.

So the discharge is given here at this page's altitude — *the diff that gave you the count also names the files it came from, so read which events run each* — and the command form, the paths, the measured PR numbers and the `test.yml` carve-out stay where they already are. Measured before writing: `loops.md` contains **zero** fenced code blocks across its whole length, and its 50 inline code spans are file names and generic literals, never a recipe. This change adds no backtick, no fence, no command and no repository-specific path, so that house style is intact.

**The two-space job-key discriminator is untouched**, in both letter and substance. It is a separate, fail-open hazard, it lives in the agent-instructions file, and nothing here narrows it — a zero from that discriminator is still the reassuring answer it warns about.

## Quality gates

All run in the foreground on the final rebased base, exit codes captured to file on the same command line and quoted from those files, never from a harness report.

| Gate | Captured exit | Notes |
|---|---|---|
| `python -m mkdocs build --strict` | **0** | `docs/` is inside `docs_dir`, so this file is built. Zero WARNING and zero ERROR lines in 105 lines of output. |
| `python scripts/check_doc_slugs.py` | **0** | The only anchor gate; its roots include `docs/`. |
| `python scripts/check_view_lifetime_residue.py --verbose` | **0** | Repo-wide banned-word ratchet, permitted count zero, over tracked content **and** paths. Reads prose, so it genuinely grades this diff. |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | Import edges only. A markdown-only diff cannot move it, so this exit 0 is **honest but uninformative** — recorded for completeness, not as evidence about this change. |

Each gate was confirmed to have read this branch's tree, by whichever of the two routes it affords:

- **`mkdocs`** prints its build root, and that line named this worker's worktree.
- **`check_doc_slugs.py`** prints nothing at all on success, so it was verified by a planted fault: a broken anchor inserted at a line this change already edits. The gate went **red, exit 1**, naming the file, line 239 and the planted anchor by name. Since the fault existed only in this tree, a run that had wandered into another checkout would have come back green.
- **`check_view_lifetime_residue.py`** also prints no root, so it too was sabotage-verified: the banned stem planted on an edited line took it **red, exit 1**, quoting the planted line back.
- Both plants were made **after** committing this change, and both restores were verified by comparing git's own **blob** hash against the committed object rather than by reading a diff — a patch that never applied reads clean. Both matched. Each plant's anchor was checked for exactly one match before it was applied; the first residue plant was caught malformed by that check and redone.

### Hand checks — what no gate covers

Neither markdown gate reads inside a fenced code block, and nothing validates prose, tables or rendering, so these were checked by hand:

- **The fence question does not arise.** This change adds no fenced block, no markdown link and no anchor — verified over the added lines, which contain zero backticks, zero `](`, zero table pipes and zero HTML. So the extra strictness that applies to this tree has nothing to bite on here. For the record, that strictness is enforced by `check_doc_slugs.py` itself rather than a separate gate: `FENCED_DOC_LINK_TREES` lists `docs/design/hicasso` and `docs/the-mayor-method`, and in those two trees a doc link inside a fence is itself reported.
- **The enumeration still reads correctly.** The list under *"opposite verdicts for the same number"* still holds exactly two bullets. The count words below it — *"a third case"* and *"reads like the second"* — both still resolve correctly, which they would not have done had this been added as a bullet.
- **Emphasis is balanced within single lines.** The added italic span opens and closes on one line, as does the added bold span; no emphasis crosses a line break.
- **List continuation is intact.** All eight added lines carry the two-space continuation indent, so they remain inside the second list item rather than closing it.
- **Line widths match the neighbourhood** (79–88 columns, against 77–91 in the surrounding clause).

### Pre-push revert check

`git diff origin/main...HEAD` (three-dot, against the merge base) reads one file, one hunk, 8 insertions and 1 deletion. The single deleted line is the one this change rewrites, and its instruction — *update the branch and re-check* — is preserved verbatim at the end of the replacement. Nothing landed by a sibling is undone.
