### PR TITLE
docs(testing): correct the one false flush-views! fallback docstring; name the wait-until! discriminator (rf2-kuky.28)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
@@ -157,7 +157,16 @@
   Returns a Promise so callers can `await` deterministic completion;
   the synchronous side-effects (dirty components forceUpdate'd,
   Reactions recomputed, :after-render hooks fired, React commit
-  complete) happen by the time `act`'s callback returns.
+  complete) happen by the time `act`'s callback returns. With act()
+  unreachable the drain still runs, synchronously and to completion,
+  but there is nothing to await and the return is nil.
+
+  NOT the canonical cross-substrate hook. The adapter-ns Var
+  `re-frame.adapter.reagent-slim/flush-views!` is the converged
+  nil-returning contract (rf2-b6nm5, Decision 6), surfaced under the
+  same name from every adapter ns and routed through the spine. Reach
+  THIS one only for the Promise return / deterministic Suspense
+  ordering.
 
   Production cost: zero — the body is gated on `goog.DEBUG` so
   `:advanced` + `goog.DEBUG=false` DCEs it entirely."

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -2969,8 +2969,13 @@
   "rf2-b6nm5: the canonical test-flush hook `flush-views!` is surfaced
   from this adapter's ns with the canonical nil-return shape (Decision 6).
   Node-safe (no DOM): pins the SHAPE — the Var is a fn, the 0-arity call
-  returns nil and does not throw under the :node-test runner (act() gated
-  / unreachable there ⇒ the spine degrades to a plain synchronous flush).
+  returns nil and does not throw under the :node-test runner, where act()
+  is gated / unreachable. What a spine DOES with an unreachable act() is
+  per-spine and is deliberately NOT what this pins: the React-hook spine
+  no-ops (`f` never runs), while the ratom spine falls back to its
+  injected synchronous render drain (`f` runs and the render queue
+  drains). Both return nil, and that convergence — not either fallback —
+  is the contract under test.
   The cross-substrate convergence (same name + nil-return on all four
   substrates) is what lets a test suite port touching only the init! Var.
 

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
@@ -401,6 +401,18 @@
   "Poll `pred?` on real timers until it answers truthy. Answers a promise
   of true, or of false if `budget-ms` elapses first.
 
+  Why this is not `re-frame.test-support/poll-until`. That is the one
+  PUBLIC poll, and it DOES run on real timers with a caller-set interval
+  and deadline, so the polling half is the same idea and no claim is made
+  here that it could not carry it. Two things below are not its contract.
+  This RESOLVES FALSE on timeout where `poll-until` REJECTS, which is what
+  lets every row here assert `(is (true? ok) …)` as a named premise at the
+  call site rather than route a rejection past its own assertions. And a
+  truthy predicate does not resolve at once but after a 16 ms quiesce,
+  putting the reading on the far side of the entry reap horizon exactly as
+  [[adopted!]] does. Both would survive as wrapper code around the public
+  poll; whether that layer is worth adding is rf2-kuky.28's to settle.
+
   How a two-root row waits on something that is not a window: the cell
   table, which acquires at COMMIT and therefore cannot mention a frame
   before that frame's root committed. [[adopted!]] is the other per-root


### PR DESCRIPTION
Implements **rf2-kuky.28** — the testing-surface drift bead. Docstrings and prose only; no runtime change.

## The bead's premise (b) does not hold, and following it would have introduced the defect

The bead says all three adapter `flush-views!` Vars route to `substrate/spine.cljs`'s `flush-views!`, which does not run `f` when `act()` is absent, and directs that the Reagent and reagent-slim docstrings be rewritten to the UIx wording. **There are two spines, not one:**

| | `make-react-spine` | `make-ratom-spine` |
|---|---|---|
| act-absent branch | `(when-let [act ...] (act f))` → `f` **never runs** | `(if flush-render-op (flush-render-op f) (f))` → **`f` runs, queue drains** |
| adapters routed to it | uix | **reagent, reagent-slim** |

`reagent.cljs` and `reagent_slim.cljs` both take `(:flush-views! spine-fns)` from `spine/make-ratom-spine`, and both inject a `:flush-render!` op (Reagent's is literally `(fn [f] (f) (r/flush))`). The ratom spine's own comment states the discriminator outright: *"the ratom family has a real synchronous render drain even without act (unlike the React-hook spine `flush-views!`, which no-ops)"*.

So *"degrades to a plain synchronous flush (still runs `f` and drains the render queue)"* is **correct** for both Reagent adapters. Rewriting them to the UIx wording — and rewriting `docs/api/re-frame.adapter.reagent.md:134` and the two adapter test docstrings alongside, as the bead's coverage note directed — would have made five true statements false.

**The bead's first acceptance criterion is therefore refuted, not met.** `git grep -n 'degrades to a plain synchronous flush'` still returns hits, deliberately. Nine of the ten occurrences are accurate and were left alone.

## The one real defect, and why the widened pathspec was essential

Exactly one site was wrong: `assert-flush-views-canonical-shape` in `implementation/core/test/re_frame/adapter/react_shared_suite.cljs`. Its **sole caller** is `uix_after_render_dom_cljs_test.cljs`, which passes `uix-adapter/flush-views!` — the *React-hook* spine, which no-ops. Its parenthetical claimed the synchronous-flush fallback precisely where that fallback does not exist.

**I widened the acceptance pathspec to `-- implementation docs spec`, per the bead's coverage note, and this is the site that proves the widening mattered** — it lives under `implementation/core/test/`, which the bead's own pathspec (`implementation/adapters/reagent` + `reagent-slim/src/re_frame` + `docs` + `spec`) does not reach at all. All three of the note's unnamed docstrings were caught and each was adjudicated at source; two turned out to be correct, and this one was not.

The docstring now names both spines and says the nil-return convergence — not either fallback — is what the assertion pins.

## (c) — pointer added where a caller actually reads it

The reverse cross-pointer already existed, on the **private** `resolve-act`. It was missing from the public `flush-views!` docstring. Added there; `resolve-act` left untouched so a recent deliberate rewrite of that paragraph is not reverted. Also recorded that the act-absent path returns `nil`, not a Promise — which `client_cljs_test.cljs` already works around with `js/Promise.resolve`.

## (a) — no runtime change, honest discriminator

`poll-until`'s CLJS arity **can** express real timers with a caller-set interval and deadline, so no impossibility is claimed. The docstring now states the two genuine discriminators: resolve-false-on-timeout (vs reject), which is what lets each row assert `(is (true? ok) ...)` as a named premise at the call site; and the 16 ms quiesce that puts the reading past the entry reap horizon. Composing over `poll-until` keeps both as wrapper code — a live option, left to the bead.

## Three-axis census

Target: `degrades to a plain synchronous flush`, over git-tracked files, with a control sharing the target's shape (line-spanning **and** `;;`-prefixed continuation).

| | axis 1 line-oriented | axis 2 ws-collapsed | axis 3 markers-stripped + collapsed |
|---|---|---|---|
| target (before) | 8 | 9 | 9 files, 10 occurrences |
| **control** `degrade to a plain synchronous flush so a :node-test runner` | **0** | **0** | **1** |
| control 2 `When act() is unreachable ... synchronous flush` | **0** | 2 | 3 |

**No axis is a superset of another.** Axis 1 misses `reagent.cljs` (phrase wraps mid-line). Axes 1 and 2 *both* read a false zero on the control, which exists at `spine.cljs:3883-4` — it breaks across lines *and* its continuation carries `;;`, so flattening without stripping markers leaves `to ;; a`. Only axis 3 finds it, and only axis 3 finds the second occurrence in `client.cljs:114-5`.

## Quality gates

Run foreground in the worker worktree, exit codes captured with the redirect on one command line. Re-run in full on the final rebase base.

| Gate | Captured exit | Evidence |
|---|---|---|
| `check_view_lifetime_residue.py --verbose` | **0** | clean; **sabotage-proven** — see below |
| `check_require_alias_dialect.py --verbose` | **0** | 2797 files, 10870 edges, every surface at/under floor |
| `compile-node-test.cjs node-test` | **1** | **pre-existing, not mine** — see below |
| `node out/node-test.js` | **0** | `Ran 11260 tests containing 57198 assertions. 0 failures, 0 errors.` |
| `node out/node-test.js --test=` (3 touched suites) | **0** | `Ran 23 tests containing 44 assertions. 0 failures, 0 errors.` |
| `shadow-cljs compile browser-test` | **0** | `Build completed. (1025 files, 7 warnings)` — none name my files |
| `serve-and-run-browser-tests.cjs` | **0** | `Ran 786 tests containing 4311 assertions. 0 failures, 0 errors.` |

**The node-test compile exit 1 is `rf2-8crk`, not this PR.** Both warnings are `:uix.linter/interop-ref-read` at `adapters/uix/test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs:120,139`. That file is unchanged on this branch (`git diff origin/main...HEAD -- implementation/adapters/uix/` is empty). Those are the *only* two warnings across 1904 files; none name my three files, and no `Use of undeclared Var` appeared — which matters here, because that compile gate exists precisely to catch a stray double-quote closing a docstring early, the failure mode a docstring-only PR could plausibly cause.

**Gate-read-my-tree verification.** The residue ratchet prints no root, so it was verified by planting a banned word on a line I was already editing: captured exit went **1**, naming `react_shared_suite.cljs:2974` and the planted text. The fault existed only in this worktree, so a run that had wandered elsewhere would have come back green. Restore verified by git blob hash (`ab5f4a72...` before the plant, `4051191b...` planted, `ab5f4a72...` after restore), and the gate re-run clean afterwards. The compile and browser gates print their root, and both named this worktree.

**Coverage, stated honestly: nothing in this repo validates docstring prose.** Every green above proves only that I broke no code. The correctness of each corrected sentence is hand-verified against source, quoted in the commit message and above: `spine.cljs` `make-react-spine`/`make-ratom-spine` for the two-spine split, the adapters' `spine-fns` bindings for which adapter routes where, and `uix_after_render_dom_cljs_test.cljs:71` for the shared suite's sole caller. `check_require_alias_dialect.py` grades import edges only, so its exit 0 is honest but uninformative about this diff; the residue ratchet reads docstrings and is the one gate that genuinely grades it.

API manifest not run and not needed: no Var added or removed, and the manifests reference none of the three touched files.

## Not changed, deliberately

`reagent.cljs`, `reagent_slim.cljs`, `docs/api/re-frame.adapter.reagent.md`, `reagent-slim/IMPL-SPEC.md`, both adapter `flush_views` test docstrings, `spine.cljs` — all verified accurate. `migration/**` correct per the bead's census. Nothing touched under the fenced peer surfaces (`core.cljc`, `core_resources.cljc`, `error_emit.cljc`, `test_support.cljc`, `spec/**`, api manifests, workflows, `.beads/**`).
