### PR TITLE
docs(mayor-method): the zero-search rule gets a third comment-stripped axis (rf2-d9wg)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -1069,23 +1069,31 @@ claim, run it once against something it should find. **And make that control sha
 the target**, because a pattern fails on a feature, and a control that lacks the feature passes
 without exercising it. Measured: a word-boundary anchor placed after a `$` matched a letter-final
 control and missed every punctuation-final hit, so the census read zero on four real sites while
-its control read green. If the target ends in punctuation, carries a backslash, or spans a line,
-the control must too.
+its control read green. If the target ends in punctuation, carries a backslash, spans a line, or
+sits behind a comment marker, the control must too — and must carry EVERY one of those features
+the target has, at once, because a control that matches on the axis it shares says nothing about
+the axis it does not.
 
 **But for the line-spanning case that advice is inert, and it is the one case where a matched
 control actively reassures you.** Most search tools take a LINE as their unit, so a target broken
 across two lines is not merely hard to match — it cannot be seen at all, whatever the pattern. A
 control sharing that shape is invisible in exactly the same way: both come back zero, and the
 check reports a clean pattern over an unsearched target. Every other hazard here is caught by a
-control that bites; this one is caught only by changing the instrument. **Run the search twice —
-once line-oriented, once over the text with whitespace collapsed — because neither result is a
-superset of the other.** Measured four times in one session: a census found one site
+control that bites; this one is caught only by changing the instrument. **Run the search three
+times — once line-oriented, once over the text with whitespace collapsed, and once with comment
+markers stripped before collapsing.** Neither of the first two is a superset of the other, and the
+third reaches what neither can. Measured four times in one session: a census found one site
 line-oriented and missed four line-broken ones, then found those four flattened and missed the
 first; a second census caught a stale phrase only when flattened; and twice a hand-written probe
-of a wrapped field reported data loss that had not happened. **Wrapped text is the common case,
-not the exotic one** — anything hard-wrapped to a column, which is most prose documents and many
-tracker fields, will break a long enough probe somewhere. So keep a probe short enough to sit
-inside one line, and where the target is genuinely longer, flatten before believing a zero.
+of a wrapped field reported data loss that had not happened. **The third pass answers the case
+that reads zero on BOTH of the others**: a phrase inside a commented sample broke across lines AND
+the continuation carried a comment marker, which SURVIVES a plain flatten — the collapsed text
+read `the FOUR ;; live emitters` and matched nothing. Stripping the markers first found it, and a
+second stale site the other two had missed. **Wrapped text is the common case, not the exotic
+one** — anything hard-wrapped to a column, which is most prose documents and many tracker fields,
+will break a long enough probe somewhere, and every commented block and fenced sample puts a
+marker at the break. So keep a probe short enough to sit inside one line, and where the target is
+genuinely longer, flatten — and strip the markers — before believing a zero.
 
 **This is not a fact about searching, and reading it as one is how it gets past you.** ANY
 instrument that can answer "nothing here" gives the same answer when misused, and a misused one


### PR DESCRIPTION
Corrects the project's own worker-dispatch template, not the framework. rf2-d9wg.

## What changed

`docs/the-mayor-method/dispatch-prompt-template.md`, gate-mechanics block, two adjacent
paragraphs under *A search that returns ZERO is not a check that passed*.

**The search rule goes from two axes to three.** It told every worker to run a search
*"once line-oriented, once over the text with whitespace collapsed"*. Measured 2026-09-05
(schemas-a worker, rf2-fxp5 / PR #9295): a phrase inside a commented schema sample read
**ZERO on both**. It broke across lines, and the continuation line carried a `;;` comment
prefix that **survives a plain flatten** — the collapsed text read `the FOUR ;; live emitters`
and matched nothing. Stripping the comment markers and then collapsing found it, and surfaced
a second stale site the first two passes had missed. The positive control was shape-matched
(equally line-broken, equally comment-prefixed) and read `line=0 / flat=0 / flat+decomment=1`;
the negative control read 0 throughout.

**The control-shape rule moves with it**, because the two are the same argument: the control
must carry *every* feature the target has, at once — a control that matches on the axis it
shares says nothing about the axis it does not. The block already made that argument for the
punctuation and backslash cases; this reaches one level further.

The existing paragraph's structure and all four of its measurements are kept verbatim. The
new axis is an addition to the same finding, and the closing point — wrapped text is the
common case, not the exotic one — is strengthened rather than changed.

**Form chosen:** the third pass is named **inside the existing bolded imperative sentence**,
not as a following sentence scoped to commented code. The bold sentence is what survives a
skim; leaving it reading *"Run the search twice"* while a later sentence said three would put
a contradiction inside one paragraph, and a skimmer resolves that in favour of the bold text.
The measurement that justifies the third pass is one short following sentence, so the
imperative itself grows by one clause. Net +17/-9 lines on a block whose length is a known
cost.

**Kept out of `CLAUDE.md`'s territory.** `CLAUDE.md`'s instruments bullet carries the related
grep item as **(e)** (a pattern joined from `jq` output matching only its last alternative —
a CRLF defect in a specific toolchain). This finding is a different mechanism and is written
tool-agnostically: no tool, flag or shell is named, matching the surrounding block. Per
`loops.md:10-16`, `CLAUDE.md` is the CLI concretion and the method doc the generic body.

## Quality gates

Run from `docs/the-mayor-method/` worktree, foreground, exit code captured on the same command
line and quoted from the captured `.exit` file (never the harness's report). All re-run on the
**final** base after the rebase onto `origin/main`.

| Gate | Exit | Tree-read proof |
|---|---|---|
| `python -m mkdocs build --strict` | **0** | Prints its root: `Building documentation to directory: <worktree>/site`; log names `the-mayor-method\dispatch-prompt-template.md` among the pages built. No WARNING/ERROR lines. |
| `python scripts/check_doc_slugs.py` | **0** | Silent gate — proved by planted fault. |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | Honest but **uninformative**: it grades import edges only, so a markdown-only diff cannot move it. Reported as a clean run, not as evidence about this change. |
| `python scripts/check_view_lifetime_residue.py --verbose` | **0** | Repo-wide banned-word scan at permitted count ZERO over tracked content **and** paths — it reads prose, so it genuinely grades this diff. Proved by planted fault. |

**Planted faults (2 of 2 bit).** Both applied through the editor rather than the shell, both
match-counted before the run, both restored and verified by git **blob** hash.

1. `check_doc_slugs.py` — a broken in-page anchor `[plant](#no-such-anchor-tmplaxis-a)` in the
   file being edited (pre-plant count 0, post-plant count 1). Gate went **exit 1**:
   `BROKEN ANCHOR: docs\the-mayor-method\dispatch-prompt-template.md:1097 -> #no-such-anchor-tmplaxis-a`.
   The plant existed only in this worktree, so a run that had wandered into a sibling checkout
   would have come back green.
2. `check_view_lifetime_residue.py` — one banned-stem token on the same line. Counted with the
   gate's **own** regex before and after (0 → 1) rather than with a plain grep, because a plain
   `grep -ci` reads 1 on the untouched file: the tree already contains *released*, which the
   gate's `(?<!re)` lookbehind excludes. Gate went **exit 1** naming the file, the line number
   and the planted line.

Both restores verified by blob hash `ea8d53a3918a6c846aae6951478df50f2b0bd4ef`, identical to
the committed object, before and after each plant. Edits were committed *before* any plant, so
the `git checkout HEAD --` restore could not discard the work under test.

## Hand checks (nothing validates prose, tables or rendering)

- Both edited paragraphs still read as **one paragraph each** — blank lines at 1076 and 1097 only.
- Count words match their items: *"three times"* ↔ three named passes (line-oriented,
  whitespace-collapsed, comment-markers-stripped-then-collapsed); *"Neither of the first two"*
  ↔ two; *"Measured four times in one session"* ↔ the four existing instances, **unchanged** —
  the new measurement is from a different session and is not folded into that count.
- Fence toggles even and unchanged: 4 before, 4 after (the two `text` blocks at 756/812 and
  821/902). This region is **not** fenced, so the added backticks are inline code in prose.
- No links or headings added, so no new anchors and no nav change.
- No duplicate copy of this paragraph elsewhere in the tracked tree — censused on all three
  axes this PR now mandates. The census is its own demonstration: the needle
  *"neither result is a superset of the other"* read **line=4 / flat=6**, and the one hit in
  this file was invisible line-oriented because it spans lines 1081→1082.

## Not in scope, not touched

`docs/the-mayor-method/loops.md` (rf2-n7tb / PR #9299), `CLAUDE.md` (PR #9283),
`spec/*`, `implementation/*`, `.beads/**`. Diff is one file.
