### PR TITLE
docs(uix): the imperative-effect recipe derefs its ref (rf2-coka)

### DIFF
--- a/implementation/adapters/uix/README.md
+++ b/implementation/adapters/uix/README.md
@@ -58,7 +58,7 @@ Compose `use-effect` with the standard outer/inner split: the outer `defui` read
         {:keys [dispatch]} (uix-adapter/use-frame)]   ;; frame api via hook — reads the surrounding provider
     (uix/use-effect
       (fn []
-        (let [el       (.-current ref)
+        (let [el       @ref   ;; deref — UIx's use-ref is atom-like; a .-current read is a lint error
               listener (fn [_evt] (dispatch [:tile/finished-merging tile-id]))]
           (.addEventListener el "animationend" listener)
           (fn cleanup []


### PR DESCRIPTION
The canonical imperative-effect recipe in the UIx adapter README read its ref
with `(.-current ref)`. Markdown compiles nothing, so this redded no gate — but
it is the source the next transcription copies, and that is not hypothetical:
`570d07d286` transcribed this recipe into a 251-line test, carried the two
`.-current` reads with it, and redded the zero-warning compile gate for **every**
CLJS diff in the repo until rf2-8crk (#9293) fixed the test sites. The README was
left saying the thing that caused it.

## Recipe, not a deliberate contrast

The judgement call the bead flagged. The expression sits inside the complete,
copy-pasteable `defui` under **### Outer / inner pattern** — a recipe. Three
things decided it:

- Nothing in the README mentions `@ref`, `deref`, or the atom-like nature of
  `use-ref` anywhere. A deliberate contrast needs both forms present; only one is.
  Repo-wide, `@ref` appears in **zero** markdown files.
- The "4 things matter" list under the block teaches four points — frame api via
  the hook, mandatory cleanup, the deps vector, no `use-subscribe` inside the
  effect body. None is about the ref read; it is incidental mechanism.
- It was in fact transcribed verbatim into a test, which is what a recipe is for.

So the fix is the one-expression change, plus one clause of inline comment in the
block's own existing comment idiom (lines 58 and 66 already carry trailing `;;`
notes) so the next reader does not revert it to the React spelling. Flagging that
comment explicitly: the bead said "nothing else", and it is one line beyond the
literal minimum — trim it if you disagree.

## The equivalence, verified at source

Read from the pinned `com.pitch/uix.core` 1.4.4 jar, `uix/core.cljs:104-131` —
not assumed:

```clojure
(defn use-ref
  ([] (use-ref nil))
  ([value]
   (let [ref (hooks/use-ref nil)]
     (when (nil? (.-current ref))
       (set! (.-current ref)
             (specify! #js {:current value}
                       IDeref (-deref [this] (.-current this))
                       IReset ... ISwap ...)))
     (.-current ref))))
```

`use-ref` returns the `specify!`'d `#js {:current value}` object itself, and its
`-deref` **is** `(.-current this)` — same property, same object, no coercion.
That same object is what `($ :div {:ref ref})` hands React, so React writes the
DOM node into the very `.current` both forms read. `@ref` and `(.-current ref)`
are interchangeable at this site; the linter's preference is idiom, not
correctness. The linter's own error message (`uix/linter.clj:283`) spells the
wanted form: "use-ref hook in UIx returns Atom-like ref, use @ instead of
.-current to access its value."

Empirical confirmation that the replacement compiles clean: #9293 applies the
identical `(.-current ref)` → `@ref` change, in the identical shape, to the two
sites transcribed from this recipe, and carries `CLJS (shadow-cljs :node-test)`
and `CLJS (shadow-cljs :browser-test, headless Chromium)` **SUCCESS** — the two
lanes that were red on trunk. In particular the deps vector needs no change:
`@ref` introduces no missing-deps warning.

## Census — three axes, both controls biting

Over git-tracked files at tip. Axis 1 counts matching *lines*; axes 2 and 3 count
*occurrences*, so the totals are not directly comparable.

| needle | line-oriented | flattened | markers-stripped + flattened |
|---|---|---|---|
| `.-current` | 65 (19 files) | 81 | 81 |
| `(.-current ref)` | 8 (4 files) | 12 | 12 |
| `use-ref` | 20 (11 files) | 30 | 30 |
| `@ref` | 11 (4 files) | 14 | 14 |
| CONTROL — line-broken interop form | **0** | **1** | **1** |
| CONTROL — phrase spanning a `;;` continuation | **0** | **0** | **1** |

Both controls share the target's shape and each bites on exactly the axis it was
built for: the first is invisible line-oriented, the second is invisible until the
comment markers come off. A zero on any row above is therefore a measurement, not
an unexercised pattern.

**Under `implementation/adapters/`, `.-current` occurs in exactly two files**: this
README (1) and `test/re_frame/adapter/uix_effect_frame_deps_dom_cljs_test.cljs` (2)
— the sites #9293 owns, untouched here. Markdown-wide, `.-current` occurs in only
two files repo-wide: this one and `docs/design/freehand/fable-design.md`, whose
single hit is `(.-currentTarget e)` — a different DOM property, not a ref read, in
the retired-freehand design tree.

**No sibling adapter README carries the recipe.** All four siblings
(`implementation/adapters/README.md`, `reagent/`, `reagent-slim/`, `test-react/`)
contain zero `.-current`. The only other markdown carrying `use-ref` is
`migration/from-re-frame-v1/README.md`, whose two hits are prose about the
Form-2-closure to hook substitution and the placement rule; it carries no ref read
and no recipe. Nothing else belongs in this bead.

## Quality gates

All foreground, exit codes captured on the same command line as the redirect and
quoted from the captured file — not from harness-reported status. All re-run on
the final rebased base (`d3e7052b26`).

| gate | exit | note |
|---|---|---|
| `python scripts/check_readme_links.py --ci` | **0** | the correct gate for a README beside source |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | import edges only — honest but **uninformative**: a markdown-only diff cannot move it |
| `python scripts/check_view_lifetime_residue.py --verbose` | **0** | repo-wide banned-word scan at permitted zero; does read prose, so it does grade the added comment |

Additional ratchets that could plausibly grade a README under
`implementation/adapters/` or scan prose repo-wide, all run foreground with
captured exits, all **0**: `check_readme_inventories.py`,
`check_adapter_disposition.py`, `check_retired_spellings.py`,
`check_retired_composition_vocab.py`, `check_retired_image_keys.py`,
`check_inject_cofx_residue.py`, `check_allocation_non_claim.py`,
`check_failure_corpus_residue.py`, `check_runtime_subsystem_grading.py`.

`scripts/check_doc_slugs.py` is **not** nominated: its roots exclude
`implementation/`, so it would return a green that inspected nothing changed here.

### The gate is blind to the region actually edited — measured in both directions

`check_readme_links.py` prints no root, so its colour was proved by planted faults
rather than by a path it reports. Both plants were made from a committed tree and
restored by git blob hash (`06f4c99cad27ac95aedceebcfa8634d23843b94a` before and
after each), with the anchor match count read as 1 before each run:

- **In prose** (a broken link target on line 9): exit **1**, naming
  `implementation/adapters/uix/README.md:9` and the planted target. The fault
  existed only in this worktree, so this is what proves the gate read this tree
  and that this file is inside its roster.
- **Inside the fenced code block** (the same class of broken link, on line 57):
  exit **0**, silent. Both link gates strip fences before reading a single link,
  so neither can see the region this PR changes.

**So the links and anchors in the edited block were checked by hand**: the block
(lines 49-73) contains **zero** markdown link or anchor constructs — it is pure
Clojure — and the added comment introduces none. Control for that zero: the same
pattern over lines 1-48 of the same file reads **3**. Nothing outside the block
was touched, so no other link in the file moved.

## Out of fence, untouched

`implementation/adapters/uix/test/**` is rf2-8crk's. `git diff origin/main --`
over that directory is empty on this branch. #9293 was still open at the time of
writing, so this branch's base still carries the two
`:uix.linter/interop-ref-read` warnings at
`uix_effect_frame_deps_dom_cljs_test.cljs:120,139` — the known trunk condition,
deliberately not fixed here. No linter or gate configuration is touched: the gate
is correct, and it caught a real idiom violation within hours of it landing.

Bead: rf2-coka. Left `in_progress`; not closed.
