### PR TITLE
fix(ssr-node): the validator keeps what it checked, and a post that throws leaves the isolate free (rf2-ey07)

### DIFF
--- a/implementation/ssr-node/README.md
+++ b/implementation/ssr-node/README.md
@@ -145,6 +145,19 @@ it". The failure mode it guards is the asymmetric one that dossier names:
 a client payload allowlist that is too narrow costs a recompute, while a
 render projection that is too narrow is a silently wrong page.
 
+**Every field is read exactly once.** `validateRequest` takes each field
+off the caller's object one time and returns what it took — the two
+partitions as fresh objects of the values it checked, never the caller's
+own. That is not tidiness: what it returns is what `postMessage`
+structured-clones, and a clone is a second read the validator has no say
+over. A field backed by an accessor — a getter, a Proxy, a lazily
+materialised row out of a serializer — could otherwise be well-formed EDN
+text when the checks read it and something else when the clone did, so the
+checks would have been about a value the wire never saw. Read-once removes
+the class rather than guarding the symptom: there is no second read left
+to disagree with the first, and so no defensive copy of the request, no
+re-check and no freeze to maintain.
+
 ### 3. One in-flight render per isolate
 
 An isolate accepts one render at a time. A second dispatch to a busy
@@ -154,6 +167,12 @@ because it only ever hands work to an idle isolate and answers
 none free. Back-pressure, not an unbounded queue: a request that waits
 forever for capacity is a request whose outcome is being decided by the
 caller's timeout, which is the wrong process deciding.
+
+The guarantee has a second half: an isolate that is marked busy is busy
+**with something**. `render()` hands the message to `postMessage` before it
+arms the deadline or sets the in-flight record, so a post that throws
+unwinds leaving the isolate exactly as free as it was — nothing to clear,
+and nothing that only the deadline could clear.
 
 The qualifier the bead attaches — "until proven otherwise" — is the honest
 state of it, and the reason is source-located. The Hicasso render entry
@@ -542,14 +561,22 @@ The last receiver is one no application can reach on purpose: a render that
 rejects with something that is **not a `Refusal` at all**. It is a fault in
 this package rather than in the application — every receiver between the
 module and the caller builds a refusal, so anything else got past all of
-them — and it is reachable, by an in-process caller whose request carries
-an accessor. Validation reads a partition value and the structured clone
-reads it again, so a getter or a Proxy can be a string the first time and
-unclonable the second, and the resulting `DataCloneError` names the value
+them. It was once reachable, by an in-process caller whose request carried
+an accessor: validation read a partition value and the structured clone
+read it again, so a getter or a Proxy could be a string the first time and
+unclonable the second, and the resulting `DataCloneError` named the value
 it choked on. A caller's own value on a public refusal is the same egress
 as any other, so this arm carries the contract's `render-threw` wording and
-sends the real fault to the operator. `test/egress.test.cjs` §6 and §7 are
-the witnesses.
+sends the real fault to the operator.
+
+**That route is closed** — the read-once rule under guarantee 2 means a
+request that passes validation is a request that can be cloned — and the
+arm stays anyway. It is what guarantees `renderFrames` throws nothing but a
+`Refusal`, which is the property every transport is written against;
+removing it would let a raw `Error` reach `statusFor` with no code at all.
+`test/egress.test.cjs` §6 and §7 are the witnesses: §7's first row holds
+the closed route open to inspection by counting the reads, and the rest
+drive the arm at the seam it guards.
 
 The CLJS half — the thing behind `MY_APP_SSR.renderToString` — is a
 per-request `gensym` frame made with no initial events,

--- a/implementation/ssr-node/src/isolate.cjs
+++ b/implementation/ssr-node/src/isolate.cjs
@@ -179,7 +179,16 @@ class Isolate {
    * arrives — never buffered here, because a layer that buffers is a layer
    * that has to be rewritten when a streaming module lands.
    *
-   * Resolves with the terminal facts; rejects with a `Refusal`.
+   * Resolves with the terminal facts; rejects with a `Refusal` — with one
+   * deliberate exception, named because a docstring that quietly overstates
+   * its contract is worse than one that admits the edge. A `postMessage`
+   * that throws rejects with the RAW fault: that is a fault in the sidecar
+   * rather than in the application, and `service.cjs`'s last receiver is
+   * the only thing that both writes the real trace to the operator's stderr
+   * and publishes the contract's own wording to the caller. Building a
+   * `Refusal` here would satisfy the sentence above and leave the operator
+   * with no copy of the failure at all, which is the trade rf2-2hmg
+   * refused.
    */
   render(request, { timeoutMs, onChunk }) {
     if (this.dead) {
@@ -200,6 +209,27 @@ class Isolate {
     const renderId = this._nextRenderId++;
 
     return new Promise((resolve, reject) => {
+      // THE POST COMES FIRST, AND NOTHING IS MARKED UNTIL IT LANDS
+      // (rf2-ey07). `postMessage` throws — a structured clone refuses any
+      // value it cannot copy — and this used to run last, after the flag
+      // and the timer were already set. A throw then left the isolate
+      // marked busy with a render that had already rejected, and only the
+      // deadline could clear it: `pendingRender` is the sole reading of
+      // `busy`, and every other path that clears it is a message about a
+      // render this one never sent. So the pool took the isolate back
+      // (`dead` was false, so nothing replaced it), handed it to the next
+      // caller, and that caller was refused SERVICE_SATURATED by an isolate
+      // doing nothing at all — until the deadline fired and TERMINATED a
+      // healthy worker thread, costing one more request and a boot.
+      //
+      // Ordering is the whole fix, and it needs no new state: a throw here
+      // unwinds the executor with the timer unarmed and `pendingRender`
+      // untouched, so the isolate is exactly as free as it was a line ago.
+      // The reverse ordering is safe because nothing can observe the gap —
+      // a reply from another thread cannot arrive until this synchronous
+      // executor has run to its end.
+      this.worker.postMessage({ t: 'render', id: renderId, request });
+
       const deadlineTimer = setTimeout(() => {
         // HARD TERMINATION. Not a cancel, not a reject-and-hope: the
         // thread is stopped, because a synchronous render cannot be asked
@@ -227,7 +257,6 @@ class Isolate {
         onChunk,
         chunkCount: 0,
       };
-      this.worker.postMessage({ t: 'render', id: renderId, request });
     });
   }
 

--- a/implementation/ssr-node/src/protocol.cjs
+++ b/implementation/ssr-node/src/protocol.cjs
@@ -476,18 +476,28 @@ function validateModule(renderModule, moduleLabel = '<render module>') {
 
 /**
  * Validate one partition of a request — `state` or `runtime` — against
- * the entry's allowlist for it. Returns `{ partition, bytes }`: the
- * partition as sent (an empty object when the field was absent) and the
- * UTF-8 byte count of every key and value in it, so the caller can hold
- * both partitions to one ceiling. Throws `Refusal`.
+ * the entry's allowlist for it. Returns `{ partition, bytes }`: a SNAPSHOT
+ * of the partition as sent (an empty object when the field was absent) and
+ * the UTF-8 byte count of every key and value in it, so the caller can
+ * hold both partitions to one ceiling. Throws `Refusal`.
+ *
+ * A SNAPSHOT AND NOT THE CALLER'S OWN OBJECT (rf2-ey07). What this returns
+ * is what `isolate.cjs` hands to `postMessage`, and a structured clone is a
+ * SECOND READ of every value in it. Returning the caller's object put that
+ * second read outside the validator's reach: a value backed by an accessor
+ * — a getter, a Proxy, a lazily materialised row out of a serializer —
+ * could be a well-formed EDN string when the checks below read it and
+ * something else when the clone did, so the checks were about a value the
+ * wire never saw. Copying the already-read, already-checked value into a
+ * fresh object closes that gap at its cause rather than guarding its
+ * symptom: there is no second read to disagree with the first.
  */
 function validatePartition(
-  request,
+  partition,
   entryConfig,
   entryId,
   { field: partitionField, allowlist: allowlistField, keys: partitionLabel },
 ) {
-  const partition = request[partitionField];
   if (partition === undefined) return { partition: {}, bytes: 0 };
   if (!isPlainObject(partition)) {
     refuse(
@@ -498,6 +508,7 @@ function validatePartition(
     );
   }
   let partitionBytes = 0;
+  const validated = {};
   for (const [partitionKey, ednText] of Object.entries(partition)) {
     if (!KEY_TEXT.test(partitionKey)) {
       refuse(
@@ -527,10 +538,11 @@ function validatePartition(
         },
       );
     }
+    validated[partitionKey] = ednText;
     partitionBytes +=
       Buffer.byteLength(partitionKey, 'utf8') + Buffer.byteLength(ednText, 'utf8');
   }
-  return { partition, bytes: partitionBytes };
+  return { partition: validated, bytes: partitionBytes };
 }
 
 /**
@@ -542,6 +554,14 @@ function validatePartition(
  * Order matters and is deliberate: shape, then identity, then content. A
  * caller reading its first refusal wants the field it got wrong, not the
  * consequence three checks downstream.
+ *
+ * AND EVERY FIELD IS READ EXACTLY ONCE (rf2-ey07). The request that comes
+ * back is built from the values the checks below actually inspected, never
+ * from a fresh read of the caller's object — because this request is what
+ * `postMessage` structured-clones, and that clone is a second read the
+ * validator has no say over. Read-once is the whole of the discipline: it
+ * needs no defensive copy of the request, no freeze and no re-check, and
+ * it removes the class rather than the instance.
  */
 function validateRequest(request, moduleTables, limits = {}) {
   const { defaultTimeoutMs = 1000, maxTimeoutMs = 5000, maxRequestBytes = 1 << 20 } = limits;
@@ -568,21 +588,34 @@ function validateRequest(request, moduleTables, limits = {}) {
     }
   }
 
-  if (request.protocol !== PROTOCOL_VERSION) {
+  // ---- read once; everything below reads these, never `request` ----------
+  // The one place this function touches the caller's object. What follows
+  // validates these bindings and returns these bindings, so there is no
+  // read left for an accessor to answer differently — see the header.
+  const protocol = request.protocol;
+  const entry = request.entry;
+  const requestId = request.requestId;
+  const args = request.args;
+  const buildId = request.buildId;
+  const timeout = request.timeoutMs;
+  const state = request[PARTITIONS[0].field];
+  const runtime = request[PARTITIONS[1].field];
+
+  if (protocol !== PROTOCOL_VERSION) {
     refuse(
       CODE.PROTOCOL_VERSION,
-      `request declares protocol ${JSON.stringify(request.protocol)}; this service speaks ${PROTOCOL_VERSION}`,
-      { declared: request.protocol, expected: PROTOCOL_VERSION },
+      `request declares protocol ${JSON.stringify(protocol)}; this service speaks ${PROTOCOL_VERSION}`,
+      { declared: protocol, expected: PROTOCOL_VERSION },
     );
   }
 
-  if (typeof request.entry !== 'string' || request.entry.length === 0) {
+  if (typeof entry !== 'string' || entry.length === 0) {
     refuse(CODE.BAD_REQUEST_FIELD, '`entry` must be a non-empty string', { field: 'entry' });
   }
-  if (request.requestId !== undefined && typeof request.requestId !== 'string') {
+  if (requestId !== undefined && typeof requestId !== 'string') {
     refuse(CODE.BAD_REQUEST_FIELD, '`requestId` must be a string', { field: 'requestId' });
   }
-  if (request.args !== undefined && typeof request.args !== 'string') {
+  if (args !== undefined && typeof args !== 'string') {
     refuse(
       CODE.BAD_REQUEST_FIELD,
       '`args` is the root arguments as EDN TEXT, not a decoded value — the service does not ' +
@@ -590,7 +623,7 @@ function validateRequest(request, moduleTables, limits = {}) {
       { field: 'args' },
     );
   }
-  if (request.buildId !== undefined && typeof request.buildId !== 'string') {
+  if (buildId !== undefined && typeof buildId !== 'string') {
     refuse(CODE.BAD_REQUEST_FIELD, '`buildId` must be a string', { field: 'buildId' });
   }
 
@@ -599,29 +632,29 @@ function validateRequest(request, moduleTables, limits = {}) {
   // id it deployed against turns "the two artefacts are from different
   // builds" — which otherwise has nothing to compare, and fails as two
   // different applications answering one request — into a refusal.
-  if (request.buildId !== undefined && request.buildId !== moduleTables.buildId) {
+  if (buildId !== undefined && buildId !== moduleTables.buildId) {
     refuse(
       CODE.BUILD_IDENTITY_MISMATCH,
-      `request expects build ${JSON.stringify(request.buildId)} but this sidecar is serving ` +
+      `request expects build ${JSON.stringify(buildId)} but this sidecar is serving ` +
         `${JSON.stringify(moduleTables.buildId)}`,
-      { expected: request.buildId, serving: moduleTables.buildId },
+      { expected: buildId, serving: moduleTables.buildId },
     );
   }
 
   // ---- the entry table ---------------------------------------------------
-  const entryConfig = Object.prototype.hasOwnProperty.call(moduleTables.entries, request.entry)
-    ? moduleTables.entries[request.entry]
+  const entryConfig = Object.prototype.hasOwnProperty.call(moduleTables.entries, entry)
+    ? moduleTables.entries[entry]
     : undefined;
   if (entryConfig === undefined) {
-    refuse(CODE.UNKNOWN_ENTRY, `no entry named ${JSON.stringify(request.entry)} in this bundle`, {
-      entry: request.entry,
+    refuse(CODE.UNKNOWN_ENTRY, `no entry named ${JSON.stringify(entry)} in this bundle`, {
+      entry,
       known: Object.keys(moduleTables.entries),
     });
   }
 
   // ---- the two partitions, and their render-visibility allowlists --------
-  const stateValidation = validatePartition(request, entryConfig, request.entry, PARTITIONS[0]);
-  const runtimeValidation = validatePartition(request, entryConfig, request.entry, PARTITIONS[1]);
+  const stateValidation = validatePartition(state, entryConfig, entry, PARTITIONS[0]);
+  const runtimeValidation = validatePartition(runtime, entryConfig, entry, PARTITIONS[1]);
   // ONE ceiling over both partitions: the budget is the request's EDN
   // text, and a partition is a way of naming it, not a second allowance.
   const requestBytes = stateValidation.bytes + runtimeValidation.bytes;
@@ -635,12 +668,8 @@ function validateRequest(request, moduleTables, limits = {}) {
 
   // ---- the deadline ------------------------------------------------------
   let timeoutMs = defaultTimeoutMs;
-  if (request.timeoutMs !== undefined) {
-    if (
-      typeof request.timeoutMs !== 'number' ||
-      !Number.isFinite(request.timeoutMs) ||
-      request.timeoutMs <= 0
-    ) {
+  if (timeout !== undefined) {
+    if (typeof timeout !== 'number' || !Number.isFinite(timeout) || timeout <= 0) {
       refuse(CODE.BAD_REQUEST_FIELD, '`timeoutMs` must be a positive finite number', {
         field: 'timeoutMs',
       });
@@ -648,16 +677,16 @@ function validateRequest(request, moduleTables, limits = {}) {
     // Clamped rather than refused: a caller asking for longer than the
     // service will ever wait has made a configuration mistake, and the
     // service's own ceiling is the one that binds either way.
-    timeoutMs = Math.min(request.timeoutMs, maxTimeoutMs);
+    timeoutMs = Math.min(timeout, maxTimeoutMs);
   }
 
   return {
     protocol: PROTOCOL_VERSION,
-    entry: request.entry,
+    entry,
     state: stateValidation.partition,
     runtime: runtimeValidation.partition,
-    args: request.args,
-    requestId: request.requestId,
+    args,
+    requestId,
     timeoutMs,
   };
 }

--- a/implementation/ssr-node/src/service.cjs
+++ b/implementation/ssr-node/src/service.cjs
@@ -139,28 +139,36 @@ class Service {
           // would carry only this package's own text if it were not.
           // Neither half survived being measured.
           //
-          // It is reached by an ORDINARY IN-PROCESS CALL. `validatePartition`
-          // returns the caller's own partition object rather than a copy, so
-          // the object the validator inspects and the object `postMessage`
-          // structured-clones are one object read twice — and anything with
-          // an accessor on it (a getter, a Proxy, a lazily-materialised row
-          // out of a serializer) can be a string on the first read and
-          // unclonable on the second. `postMessage` then throws
+          // It was reached by an ORDINARY IN-PROCESS CALL. `validatePartition`
+          // used to return the caller's own partition object rather than a
+          // copy, so the object the validator inspected and the object
+          // `postMessage` structured-clones were one object read twice — and
+          // anything with an accessor on it (a getter, a Proxy, a lazily
+          // materialised row out of a serializer) could be a string on the
+          // first read and unclonable on the second. `postMessage` then threw
           // `DataCloneError` synchronously inside `render()`'s executor,
           // which never passed through a receiver that could have made it a
           // `Refusal`.
           //
-          // And the text is the CALLER'S, not ours: a `DataCloneError` names
+          // And the text was the CALLER'S, not ours: a `DataCloneError` names
           // the value it choked on, so the caller's own value was
           // interpolated into a message published on the widest surface this
           // package has — the egress this file's header says does not exist.
           //
-          // THE ARM ITSELF IS NOT THE DEFECT AND IS NOT REMOVED. It is what
+          // THAT ROUTE IS CLOSED (rf2-ey07): `validateRequest` now reads every
+          // field exactly once and returns what it read, so a request that
+          // validates is a request that clones.
+          //
+          // THE ARM ITSELF WAS NEVER THE DEFECT AND IS NOT REMOVED, and being
+          // unreachable from a caller is not a reason to remove it. It is what
           // guarantees `renderFrames` throws nothing but a `Refusal`, which
           // is the property every transport is written against; deleting it
-          // would let a raw `Error` reach `statusFor` with no code at all.
-          // Only the wording was ever wrong, and the contract already owns
-          // the wording.
+          // would let a raw `Error` reach `statusFor` with no code at all —
+          // and `isolate.cjs`'s `render` deliberately lets a `postMessage`
+          // that throws reject RAW rather than dressing it as a `Refusal`,
+          // precisely so this arm is what states the wording and writes the
+          // operator's copy. Only the wording was ever wrong, and the
+          // contract already owns the wording.
           reportUncontractedFault(error);
           renderFailure = new Refusal(CODE.RENDER_THREW, RENDER_THREW_REFUSAL, {});
         },

--- a/implementation/ssr-node/test/concurrency.test.cjs
+++ b/implementation/ssr-node/test/concurrency.test.cjs
@@ -86,6 +86,50 @@ test('an isolate refuses a second dispatch outright', async () => {
   }
 });
 
+test('a post that THROWS leaves the isolate free, not stuck busy (rf2-ey07)', async () => {
+  // Guarantee 3 has a second half nobody had asked about: an isolate that
+  // is marked busy must be busy WITH something. `render()` used to set
+  // `pendingRender` and arm the deadline before handing the message to
+  // `postMessage`, so a post that threw — and a structured clone throws on
+  // any value it cannot copy — left the flag set with the render it was
+  // supposed to describe already rejected. Nothing but the deadline could
+  // clear it, and clearing it that way is not a release: the deadline's own
+  // callback TERMINATES the worker thread, so a healthy isolate is killed
+  // and the pool has to boot a replacement.
+  //
+  // NO STUB AND NO PLANT — the throw is `postMessage`'s own, raised by
+  // Node's structured clone on a value the request really carries.
+  //
+  // This row is deliberately at the ISOLATE rather than through a service.
+  // `validateRequest` no longer lets such a request past (see
+  // protocol.test.cjs), which is the other half of rf2-ey07 — so a
+  // service-level version of this row would go green on the validator's
+  // repair and stop saying anything about the ordering here.
+  const isolate = await new Isolate({ modulePath: FIXTURE }).start();
+  try {
+    const err = await refusalOf(() =>
+      isolate.render(
+        { entry: 'app/root', state: { ':route': Symbol('rf2-ey07') }, protocol: 1 },
+        { timeoutMs: 5000, onChunk: () => {} },
+      ),
+    );
+    assert.ok(err, 'the render must fail — the request cannot cross the thread boundary');
+    assert.strictEqual(isolate.busy, false, 'a post that threw must leave nothing in flight');
+    assert.strictEqual(isolate.dead, false, 'and must not have cost the isolate its life either');
+
+    // The flag is the mechanism; THIS is the consequence, and it is what a
+    // caller would have met: the next request handed this isolate.
+    const chunks = [];
+    await isolate.render(
+      { entry: 'app/root', state: { ':todos': '[]' }, protocol: 1 },
+      { timeoutMs: 5000, onChunk: (frame) => chunks.push(frame) },
+    );
+    assert.strictEqual(chunks.length, 1, 'the isolate must still serve the request after it');
+  } finally {
+    await isolate.close();
+  }
+});
+
 test('a saturated pool REFUSES rather than queueing without a bottom', async () => {
   await withService('reference', { isolates: 1, admissionTimeoutMs: 20 }, async (service) => {
     const slow = collect(service, req({ state: { ':todos': '[]', ':delay': '250' } }));

--- a/implementation/ssr-node/test/egress.test.cjs
+++ b/implementation/ssr-node/test/egress.test.cjs
@@ -106,7 +106,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-const { withService, collect, refusalOf, post } = require('./_support.cjs');
+const { withService, collect, observed, refusalOf, post } = require('./_support.cjs');
 const {
   CODE,
   COMPLETE_FIELDS,
@@ -116,6 +116,7 @@ const {
   REPLACEMENT_FAILED_REFUSAL,
   isRefusalCode,
 } = require('../src/protocol.cjs');
+const { Service } = require('../src/service.cjs');
 const { serve, statusFor } = require('../src/http.cjs');
 const LEAKY = require('./fixtures/leaky.cjs');
 const NULL_RETURN = require('./fixtures/null-return.cjs');
@@ -1068,31 +1069,44 @@ test('and the OPERATOR gets the boot failure, in full, on the sidecar stderr', a
 // for anything that did not arrive as a `Refusal`. It was reported as
 // unreachable — every `isolate.render()` path was believed to reject with a
 // `Refusal` — and as harmless if reached, on the ground that it could only
-// carry this package's own error text. Both halves are false, and the row
-// below is the measurement rather than the argument.
+// carry this package's own error text. Both halves were false, and this
+// section was the measurement rather than the argument.
 //
-// THE ROUTE IS AN ORDINARY IN-PROCESS CALL, with no internals stubbed.
-// `validatePartition` returns the CALLER'S OWN partition object rather than
-// a copy, so the object the validator reads and the object `postMessage`
-// structured-clones are the same live object, read twice. Anything with an
-// accessor on it — a getter, a Proxy, a lazily-materialised row from a
-// serializer — can therefore satisfy `typeof value === 'string'` on the
-// first read and hand back something unclonable on the second.
-// `postMessage` then throws `DataCloneError` synchronously inside
-// `render()`'s promise executor, which is not a `Refusal` and never passed
-// through a receiver that could have made it one.
+// THE ROUTE WAS AN ORDINARY IN-PROCESS CALL, and rf2-ey07 has since CLOSED
+// it at the cause. `validatePartition` used to return the CALLER'S OWN
+// partition object rather than a copy, so the object the validator read and
+// the object `postMessage` structured-cloned were one live object read
+// twice — and anything with an accessor on it (a getter, a Proxy, a lazily
+// materialised row from a serializer) could satisfy `typeof value ===
+// 'string'` on the first read and hand back something unclonable on the
+// second, at which point `postMessage` threw `DataCloneError` synchronously
+// inside `render()`'s executor with no receiver above it. `validateRequest`
+// now reads every field exactly once and returns what it read, so a request
+// that passes validation is a request that can be cloned, and a caller has
+// no second say.
 //
-// AND THE TEXT IT CARRIES IS THE CALLER'S. A `DataCloneError` names the
-// value it choked on, so the caller's own value is interpolated into the
-// message and published on the public refusal frame — the same egress
-// sections 4 and 5 refuse, arriving through the one door still open.
+// SO THE SECTION KEEPS BOTH HALVES, and they are different claims now.
+// The first row is the ROUTE, and it is the same two-faced request driven
+// the same way through the same real service — the read count simply reads
+// 1 where it read 2, which is what closing the gap looks like from outside.
+// Keeping it is not sentiment: it is the only thing that would notice the
+// day somebody reintroduces the second read.
+//
+// The rows after it are the ARM, which stays exactly as rf2-2hmg left it —
+// deleting it would let a raw `Error` reach `statusFor` with no code at
+// all. With the caller's route closed there is no longer a request that
+// reaches it, so it is driven at the seam it actually guards: a `Service`
+// over a stand-in pool whose isolate rejects with a raw `Error`. That is a
+// weaker witness than a live route and it is said plainly here rather than
+// dressed up — but an unreachable backstop with no witness is how a
+// backstop stops working without anyone noticing.
 // ---------------------------------------------------------------------------
 
 const CLONE_SENTINEL = 'rf2-2hmg-caller-7c19ab';
 
 /**
- * A `state` partition whose one value is a string when the validator reads
- * it and an unclonable, sentinel-bearing `Symbol` when the clone does.
+ * A `state` partition whose one value is a string on its first read and an
+ * unclonable, sentinel-bearing `Symbol` on every read after it.
  *
  * A `Symbol` rather than a function on purpose: `DataCloneError` renders a
  * function as its source text, which would carry nothing the caller chose,
@@ -1113,7 +1127,54 @@ function twoFacedState() {
   return { state, reads: () => reads };
 }
 
-/** Drive one such request, capturing the sidecar's stderr alongside. */
+test('the CLONE gets no second say — the validator keeps what it checked (rf2-ey07)', async () => {
+  // THE READ COUNT IS THE WHOLE DISCRIMINATOR, and it is deliberately a
+  // fact about the tree rather than about the fix: nothing but the
+  // structured clone would read that value again. Two reads said the
+  // caller's own object reached `postMessage`; one says the validator
+  // captured the value and the clone copied the capture.
+  //
+  // The render therefore SUCCEEDS, which is the outcome that was owed all
+  // along — the request was well-formed on every value anyone validated,
+  // and refusing it was the defect rather than the safety.
+  const twoFaced = twoFacedState();
+  const run = await withService('reference', { isolates: 1 }, (service) =>
+    collect(service, { protocol: 1, entry: 'app/root', state: twoFaced.state }),
+  );
+  assert.strictEqual(twoFaced.reads(), 1, 'nothing may read the caller\'s value a second time');
+  assert.strictEqual(run.chunks.length, 1, 'and the request must render rather than refuse');
+  assert.strictEqual(
+    observed(run).readRoute,
+    '{:name :ok}',
+    'the module must be handed the value the validator approved',
+  );
+});
+
+/**
+ * A `Service` whose one isolate rejects with `error`, over a pool that is
+ * three methods and two tables — everything `renderFrames` reads and
+ * nothing more.
+ *
+ * A stand-in and not a fixture, because the fault being staged is one no
+ * render module can produce: a rejection that is not a `Refusal` means
+ * every receiver between the module and here was bypassed, and a fixture
+ * reaching this arm would be a fixture that had found a fifth route.
+ */
+function serviceOverRejectingIsolate(error) {
+  const pool = {
+    buildId: 'reference-build-1',
+    entries: { 'app/root': { stateAllowlist: [':route'], runtimeAllowlist: [] } },
+    acquire: async () => ({ render: () => Promise.reject(error) }),
+    release: () => {},
+  };
+  return new Service(pool, {
+    defaultTimeoutMs: 1000,
+    maxTimeoutMs: 5000,
+    maxRequestBytes: 1 << 20,
+  });
+}
+
+/** Drive one such render, capturing the sidecar's stderr alongside. */
 async function uncontractedRejection() {
   const captured = [];
   const realWrite = process.stderr.write;
@@ -1122,35 +1183,31 @@ async function uncontractedRejection() {
     return realWrite.call(this, chunk, ...rest);
   };
   try {
-    const twoFaced = twoFacedState();
-    const refusal = await withService('reference', { isolates: 1 }, (service) =>
-      refusalOf(() => collect(service, { protocol: 1, entry: 'app/root', state: twoFaced.state })),
+    // The wording a real `DataCloneError` carried on the closed route: the
+    // caller's own value, interpolated by the runtime into a message
+    // nothing downstream was going to redact.
+    const service = serviceOverRejectingIsolate(
+      new TypeError(`Symbol(${CLONE_SENTINEL}) could not be cloned.`),
     );
-    return { refusal, reads: twoFaced.reads(), stderr: captured.join('') };
+    const refusal = await refusalOf(() =>
+      collect(service, { protocol: 1, entry: 'app/root', state: { ':route': '{:name :ok}' } }),
+    );
+    return { refusal, stderr: captured.join('') };
   } finally {
     process.stderr.write = realWrite;
   }
 }
 
-test('CONTROL — the request really does pass validation and then fail the CLONE', async () => {
-  // Without this the section could be green about a request that never got
-  // past `validateRequest` — a caller-fault refusal looks nothing like the
-  // one being hunted, but "no sentinel in the frame" is true of it too.
-  //
-  // THE SECOND READ IS THE WHOLE DISCRIMINATOR, and it is deliberately a
-  // fact about the tree rather than about the fix: nothing but the
-  // structured clone reads that value again, so `reads === 2` says the
-  // request reached `postMessage` and died there. A control that asserted
-  // on the stderr copy instead would only be able to pass once the fix
-  // existed, which is not a control — it could not have told the red tree
-  // apart from a tree where the request never got that far.
+test('CONTROL — the staged fault really does reach the arm, past validation', async () => {
+  // Without this the two rows below could be green about a request the
+  // validator refused — "no sentinel in the frame" is true of a caller-fault
+  // refusal too, and it would prove nothing about the arm.
   const run = await uncontractedRejection();
-  assert.strictEqual(run.reads, 2, 'the partition value must be read by the validator AND the clone');
   assert.ok(run.refusal, 'the call must be refused');
-  assert.notStrictEqual(
+  assert.strictEqual(
     run.refusal.code,
-    CODE.BAD_REQUEST_FIELD,
-    'and refused past validation, not by it — this row is about the clone',
+    CODE.RENDER_THREW,
+    'and refused BY the last-resort arm, which is the only thing that answers with this code here',
   );
 });
 

--- a/implementation/ssr-node/test/protocol.test.cjs
+++ b/implementation/ssr-node/test/protocol.test.cjs
@@ -287,6 +287,119 @@ test('a deadline over the service ceiling is clamped rather than refused', () =>
 });
 
 // ---------------------------------------------------------------------------
+// THE NORMALIZED REQUEST IS A SNAPSHOT (rf2-ey07)
+//
+// Everything above asks whether a bad request is refused. This asks the
+// question one step later, and it is a different question: of the request
+// that PASSED, is what comes out the thing that was checked?
+//
+// It has to be, because the returned object is what `isolate.render` hands
+// to `postMessage`, and a structured clone is a SECOND READ of every value
+// in it. A field backed by an accessor — a getter, a Proxy, a lazily
+// materialised row out of a serializer — can be a well-formed string when
+// the validator reads it and something else entirely when the clone does.
+// A validator that returns the caller's own object has therefore checked a
+// value the wire will never see, and the fail-closed guarantee above is
+// about that unchecked second read rather than about the request.
+//
+// THE READ COUNT IS THE DISCRIMINATOR, and it is deliberately a fact about
+// the tree rather than about the fix: a witness that merely passes a bad
+// value proves nothing about a time-of-check/time-of-use gap, because a
+// value that is bad on BOTH reads is refused by the ordinary type checks
+// thirty lines up. Only a value that CHANGES between reads separates the
+// two, and only a read count can see it change.
+// ---------------------------------------------------------------------------
+
+/**
+ * Install a property on `host` that is `honestValue` for its first
+ * `honestReads` reads and an unclonable `Symbol` on every read after that.
+ * Returns the read counter.
+ *
+ * A `Symbol` rather than a function or a big object because it is the
+ * shape that cannot be smuggled past anything: no coercion turns one into
+ * a string by accident, `typeof` names it, and a structured clone refuses
+ * it outright.
+ */
+function twoFaced(host, key, honestValue, honestReads = 1) {
+  let reads = 0;
+  Object.defineProperty(host, key, {
+    enumerable: true,
+    configurable: true,
+    get() {
+      reads += 1;
+      return reads <= honestReads ? honestValue : Symbol('rf2-ey07-second-read');
+    },
+  });
+  return () => reads;
+}
+
+test('a partition value is CAPTURED, so the request carries what was validated', () => {
+  const state = {};
+  const reads = twoFaced(state, ':route', '{:name :ok}');
+  const out = validateRequest({ protocol: 1, entry: 'app/root', state }, TABLES);
+
+  assert.notStrictEqual(
+    out.state,
+    state,
+    "the normalized request must not alias the caller's own partition object",
+  );
+  assert.strictEqual(
+    out.state[':route'],
+    '{:name :ok}',
+    'it must carry the value the validator checked, not a fresh read of the accessor behind it',
+  );
+  assert.strictEqual(
+    reads(),
+    1,
+    "and reading the normalized request must not reach back into the caller's object",
+  );
+});
+
+test('`args` is captured too — the partition is the shape, not the whole of it', () => {
+  // Same defect, a field away. `args` was read by its `!== undefined` test,
+  // read again by its `typeof` test, and read a THIRD time to build the
+  // returned request — so a caller could satisfy both checks and still put
+  // something else on the wire. A fix that closed the partition and left
+  // this open would have moved the defect rather than closed it.
+  const req = { protocol: 1, entry: 'app/root', state: { ':todos': '[]' } };
+  const reads = twoFaced(req, 'args', '[1 2 3]', 2);
+  const out = validateRequest(req, TABLES);
+  assert.strictEqual(
+    out.args,
+    '[1 2 3]',
+    'the request must carry the EDN text that was validated',
+  );
+  assert.strictEqual(reads(), 1, 'and one read is all a validated field ever needs');
+});
+
+test('every field the normalized request carries is read exactly ONCE', () => {
+  // The invariant the two rows above are consequences of, stated directly
+  // and over the whole field list rather than over the two fields that
+  // happened to be reachable. This one uses an honest accessor: it changes
+  // no value and forces no failure, it only counts. A field read twice is
+  // a field whose second read nobody validated, whatever it returns today.
+  const req = {};
+  const counters = {
+    protocol: twoFaced(req, 'protocol', 1, Infinity),
+    entry: twoFaced(req, 'entry', 'app/root', Infinity),
+    buildId: twoFaced(req, 'buildId', TABLES.buildId, Infinity),
+    args: twoFaced(req, 'args', '[1 2 3]', Infinity),
+    requestId: twoFaced(req, 'requestId', 'corr-1', Infinity),
+    timeoutMs: twoFaced(req, 'timeoutMs', 250, Infinity),
+    state: twoFaced(req, 'state', { ':todos': '[]' }, Infinity),
+    runtime: twoFaced(req, 'runtime', {}, Infinity),
+  };
+
+  const out = validateRequest(req, TABLES);
+  assert.strictEqual(out.entry, 'app/root', 'the control: this request must actually validate');
+
+  const readTwice = Object.entries(counters)
+    .filter(([, reads]) => reads() !== 1)
+    .map(([field, reads]) => `${field} (${reads()})`);
+  assert.deepStrictEqual(readTwice, [], 'these fields were read more than once');
+});
+
+// ---------------------------------------------------------------------------
 // The module's own tables are fail-closed too
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
`render()` did work in an order that assumed `postMessage` cannot throw. Both defects on rf2-ey07 are real at tip, both were proven red before the repair, and **both are fixed** — neither repair subsumes the other.

## The ruling on each defect

**DEFECT 1 — validation/clone TOCTOU. CONFIRMED, FIXED, and WIDER than filed.**

`validatePartition` returned the caller's own partition object (`protocol.cjs:490` read it, `:533` returned it), so the object the validator inspected and the object `postMessage` structured-clones were one object read twice. The bead's claim holds exactly as written.

It is not confined to the partition. `validateRequest` built its returned request from *fresh reads* of the caller's object for every scalar too, so the same gap existed a field away. Measured on the unfixed tree, reads per field on one validating request: **`entry` 7, `timeoutMs` 5, `buildId` 4, `args` 3, `requestId` 3.** A fix that copied the partition and left those would have moved the defect rather than closed it — the outcome the bead warns about.

So the repair is the principle rather than the instance: **read once, validate what you read, return what you validated.** Every field comes off the caller's object one time, the checks read those bindings, and those bindings are what is returned; the two partitions come back as fresh objects of the values that were checked. There is no second read left to disagree with the first, so this needs no defensive copy of the request, no freeze and no re-check — it removes the class.

The user-visible consequence closed: a well-formed request was **refused** for a value nobody had validated. It failed closed, so nothing was ever rendered wrong — but the refusal itself was the defect.

**DEFECT 2 — stuck isolate. CONFIRMED, FIXED, and the exposure is worse than "a bounded busy window".**

`pendingRender` was set at `isolate.cjs:222` and `postMessage` called at `:230`. The bead's claim holds.

The bound is real — `createService`'s `defaultTimeoutMs = 1000`, `maxTimeoutMs = 5000`, so at most **5000 ms, and 1000 ms by default** — but "releases at the deadline" understates it, and that is why this was not accepted as-is under *don't litigate the minutiae*. `pendingRender` is the sole reading of `busy`, and every other path that clears it is a message about a render this one never sent, so only the deadline could clear it. Meanwhile `dead` stayed false, so `pool.release()` put the isolate straight back on the idle list still marked busy, and the next caller handed it was refused `SERVICE_SATURATED` by an isolate doing nothing at all. Then the deadline's own callback ran `_terminateWorker()` — so a **healthy worker thread was killed**, the pool had to boot a replacement, and one further request burned `ISOLATE_LOST` before it healed.

Posting before marking is the whole fix and costs three lines of reordering with no new state: a throw unwinds the executor with the timer unarmed and `pendingRender` untouched, so the isolate is exactly as free as it was a line earlier. The reverse ordering is safe because nothing can observe the gap — a reply from another thread cannot arrive until the synchronous executor has run to its end.

**Neither repair subsumes the other, and the two interact the way the bead predicted.** Read-once removes the *caller's* route to the throw, so through `service.renderFrames` defect 2 is now unreachable. It is not closed: `Isolate.render()` takes an unvalidated request, and the reorder closes the stranding whatever throws. Conversely defect 2's fix alone would have left a well-formed request still refused for an unvalidated value. Fixing one and citing it as cover for the other would have been exactly the "moved the problem" outcome.

**A postMessage that throws still rejects RAW, deliberately.** `service.cjs`'s last receiver is the only thing that both writes the real trace to the operator's stderr and publishes the contract's wording; building a `Refusal` in the isolate would satisfy `render()`'s docstring and leave the operator with no copy of the failure at all — the trade rf2-2hmg refused. The docstring now says so rather than overstating itself.

## Proving the gap before the fix closed it

Every witness was written first and watched go red on the unfixed tree.

| Witness | RED before the fix |
|---|---|
| `protocol.test.cjs` — the normalized request must not alias the caller's partition | `AssertionError: the normalized request must not alias the caller's own partition object` |
| `protocol.test.cjs` — `args` carries the EDN text that was validated | `the request must carry the EDN text that was validated` / actual `Symbol(rf2-ey07-second-read)` |
| `protocol.test.cjs` — every field is read exactly once | `these fields were read more than once` / actual `entry (7)`, `buildId (4)`, `args (3)`, `requestId (3)`, `timeoutMs (5)` |
| `concurrency.test.cjs` — a post that throws leaves the isolate free | `a post that threw must leave nothing in flight` / `true !== false` |

The isolate witness stages no stub and plants nothing: the throw is `postMessage`'s own `DataCloneError`, raised by Node's structured clone on a value the request really carries. It sits at the isolate rather than through a service on purpose — read-once means a service-level version would go green on the *validator's* repair and stop saying anything about the ordering.

**The read count is kept, per the note #9297 established.** Only the structured clone reads the value again, so counting reads is what separates a TOCTOU from a request that merely carried a bad value. `egress.test.cjs` section 7 keeps the same two-faced request driven the same way through the same real service; it now reads **1 where it read 2**, and the render succeeds with the first-read value. That is what closing the gap looks like from outside, and it is the only row that would notice the day the second read comes back.

**Section 7's other three rows changed, and honestly.** They went red after the fix because the fix removed their route — that red is itself the evidence the caller route is closed (`the partition value must be read by the validator AND the clone`). The last-resort arm is not removed: it is what guarantees `renderFrames` throws nothing but a `Refusal`. With no caller able to reach it, it is now driven at the seam it guards — a `Service` over a stand-in pool of three methods and two tables. That is a weaker witness than a live route, and section 7's header says so in those words rather than dressing it up; an unreachable backstop with no witness is how a backstop stops working without anyone noticing.

## Scope

No `:rf.ssr-node/*` code member added or removed, so no `spec/Conventions.md` edit is owed — the same bar #9297 met. Nothing outside `implementation/ssr-node/**` is touched. `service.cjs`'s comment and the README both described the now-closed route in the present tense, and are corrected in the same commit.

## Quality gates

Every exit code below is the runner's own, captured on one command line and quoted from the captured file — never a harness report. All were re-run on the final rebased base (`origin/main` at `77f6c11b49`) after a clean rebase.

| Gate | Command | Captured exit | Result |
|---|---|---|---|
| ssr-node package suite (primary) | `node implementation/ssr-node/test/run.cjs` | **0** | 9 suites, **133 rows**, all green (baseline before this change: 128) |
| JVM to Node to JVM crossing | `clojure -M:crossing-test` in `implementation/ssr-ring` | **0** | 10 tests, 107 assertions, 0 failures |
| ESLint | `npm run lint:js` | **0** | 0 errors; 1 pre-existing warning in `implementation/ssr/test/react_dom_probe/boolean_attr_classes.cjs`, untouched and out of fence |
| README links | `python scripts/check_readme_links.py --ci` | **0** | clean |
| require-alias dialect ratchet | `python scripts/check_require_alias_dialect.py --verbose` | **0** | 2797 files, 10870 edges, every surface at or under its floor |
| view-lifetime residue ratchet | `python scripts/check_view_lifetime_residue.py --verbose` | **0** | zero residue in tracked content or paths |
| every other repo check script | `scripts/check_*.py` | **0** on all 42 | 42 of 42 clean |

**Which checks this diff arms, derived from one path.** `.github/scripts/report-changed-surfaces.sh` was given the six changed **paths** (not revisions) and reports exactly one surface: `ssr_node=true`. Against `.github/workflows/test.yml` that arms `node-ssr-node` (`npm run test:ssr-node`) and `jvm-node-crossing` (`implementation_jvm == 'true' || ssr_node == 'true'`); `verify-readme-links` carries no surface guard and runs regardless; and `lint.yml`'s own classifier arms `eslint` off the `*.cjs` extension. All four are run above.

The classifier was controlled in both directions, because a wrong-input all-clear is indistinguishable from a genuinely unaffected diff: `implementation/core/src/re_frame/core.cljc` arms 12 surfaces, and the misuse the brief warns about — passing `origin/main HEAD` as if they were paths — reproduces here as **zero surfaces true**.

**Every gate was shown to read this checkout, not a sibling's.** `test/run.cjs` prints its own root and named this worktree on every run. For the README gate, which prints nothing on success, the proof is a planted fault: a broken link and a broken anchor added to the README returned exit **1** naming `implementation/ssr-node/README.md:163` for both — a red that could only come from this tree. Restored and verified by git blob hash, `668fb3829444d7c59b585678d8c634d2922aabc2` before the plant and identical after, with the working edits committed first so the restore could not silently discard them.

`check_require_alias_dialect.py`'s exit 0 is **honest but uninformative** about this change: it grades import edges, and a `.cjs`-and-Markdown diff cannot move one. It is reported for completeness, not offered as evidence. `check_view_lifetime_residue.py` does read this diff's content and prose, and is evidence.

## Notes

- Anchors and table column counts in the README were checked by hand: neither markdown gate reads inside a fenced block, and the README's guarantee table is unchanged in shape.
- `docs.yml` does not cover a README beside source (`docs_dir` is `docs`, so this path was never a candidate for `exclude_docs`), so `mkdocs build --strict` is not the gate here and is not nominated.
