### PR TITLE
fix(xray): seat the :rf/xray frame on runtime readiness, not on first open (rf2-avi7)

### DIFF
--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -259,9 +259,9 @@ single source of truth.
 ```
 
 The preload registers Xray's listeners under `register-listener!`
-and `register-epoch-listener!`, installs the browser API/keybinding, then
-auto-opens into the configured layout host once `rf/init!` has
-installed a substrate adapter.
+and `register-epoch-listener!` and installs the browser API/keybinding; then,
+once `rf/init!` has installed a substrate adapter, it seats the `:rf/xray`
+frame and auto-opens into the configured layout host.
 
 Tool-owned pages that deliberately do not allocate app layout real
 estate for Xray (for example Story-only browser-test canvases) MAY
@@ -275,8 +275,11 @@ suppress only the default page-load open before `rf/init!`:
 This does not disable Xray. The collectors, browser API, keybinding,
 and explicit `open!` / `toggle!` calls remain installed; if an explicit
 open has no host, it MUST still emit the normal actionable missing-host
-diagnostic. App dev pages should keep the default `true` posture and
-provide `[data-rf-xray-host]`.
+diagnostic. **The `:rf/xray` frame is still seated on adapter readiness**
+(§Mount lifecycle), so such a page can drive Xray by dispatch — which is
+what a tool-owned page embedding Xray's panels itself typically does. App
+dev pages should keep the default `true` posture and provide
+`[data-rf-xray-host]`.
 
 ### Disable
 
@@ -565,9 +568,32 @@ available. The lifecycle is normative.
    the artefact is always present in an Xray build.
 4. Attach a global `Ctrl+Shift+C` keydown listener on
    `document`.
-5. Schedule default true-inline auto-open once the substrate adapter
-   is ready, unless `:rf.xray/auto-open?` is false before the probe
-   observes readiness.
+5. Schedule a bounded substrate-adapter readiness probe. On readiness it
+   MUST **seat the `:rf/xray` frame**, and MUST then open the default
+   true-inline shell unless `:rf.xray/auto-open?` is false.
+
+**Seating is unconditional; opening is not (rf2-avi7).** Step 1 registers
+Xray's whole instruction set, but `:rf/xray` is an ordinary frame, so
+`rf/make-frame` needs an installed substrate adapter and cannot run at
+preload namespace load (`:rf.error/no-adapter-installed`). Adapter readiness
+is therefore the earliest moment the frame can exist, and the probe of step 5
+MUST seat it there whether or not it goes on to open — a host is entitled to
+drive Xray purely by dispatch (`set-target-frame!`, `focus!`, the
+`:rf.xray/*` events) without ever showing the shell.
+
+Binding the seat to the open instead leaves Xray **addressable but not
+writable** for the whole window between preload and first open: a dispatch
+into an unseated `:rf/xray` recovers-but-emits `:rf.error/frame-destroyed`
+per [Spec 002 §Run-to-completion](../../../spec/002-Frames.md), drops the
+host's intent, and — because a `frame-destroyed` source-coord resolves out of
+the `[:event id]` registry — names the handler's registration site rather
+than the caller. For a host that suppresses auto-open the window never closes
+at all. Seating stays idempotent, so a later `open!` re-seats as a no-op.
+
+What remains lazy is the **first-mount seed/hydrate pass** (`:trace-buffer`
+and `:epoch-history`, per rf2-1barg / rf2-boyc2):
+it harvests the history the user produced *before* opening Xray, so it MUST
+fire on first open, not at seating.
 
 There is no view-evidence acquire step, and none is missing (rf2-l86mm).
 Two predecessors sat at exactly this position: the first claimed the

--- a/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
@@ -72,7 +72,9 @@
   ## Hydration
 
   `hydrate!` runs at install time (preload) AND from
-  `mount/ensure-xray-frame!` on first open. Re-entrant — the dispatch
+  `mount/ensure-xray-frame!` on first open. The preload call lands before
+  `boot-on-runtime-ready!` has seated `:rf/xray`, so it still short-circuits.
+  Re-entrant — the dispatch
   is a wholesale `(assoc db :focus (assoc focus :frame …))`. Guards
   on `(rf.frame/frame defaults/default-frame-id)` so the pre-mount call short-circuits
   cleanly. Mirrors the `filters/hydrate!` shape so the two surfaces

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -549,14 +549,27 @@
   that frame's app-db. Handlers are NOT re-registered per frame (the
   registry is process-global) — only the per-frame app-db seed runs.
 
-  ## Why here, not at preload time
+  ## What is lazy here, and what no longer is (rf2-avi7)
 
-  Per rf2-in6l2 the registration was attempted at preload time but
-  reverted (rf2-e9s81): the preload runs before the host's `rf/init!`
-  has installed a substrate adapter, and the `:initial-events` seed
-  dispatch needs a running adapter to be reactive. The first
-  Ctrl+Shift+C keypress fires from the user well after `rf/init!`, so
-  `open!` is the canonical lazy-registration point.
+  Per rf2-in6l2 the registration was attempted at preload LOAD time but
+  reverted (rf2-e9s81): the preload runs before the host's `rf/init!` has
+  installed a substrate adapter, and `rf/make-frame` raises
+  `:rf.error/no-adapter-installed` without one.
+
+  That constraint is about the adapter, not about opening, and the two came
+  apart once `boot-on-runtime-ready!` grew a readiness loop: the SEAT now runs
+  from there the moment `rf/init!` lands, so `:rf/xray` exists whether or not
+  anything ever opens Xray. Tying it to `open!` had left Xray addressable but
+  not writable between preload and first open — see that fn's docstring for
+  the `:rf.error/frame-destroyed` this closes.
+
+  So the `seat-xray-frame!` call below is normally a cheap re-seat skip, and
+  what this fn contributes is the FIRST-MOUNT hook fan-out: seeding
+  `:trace-buffer` and `:epoch-history` from the history the user produced
+  BEFORE opening Xray. That belongs at first open and stays here, guarded by
+  `seeded-frame-ids`. The seat is kept unconditional so a caller reaching this
+  fn without the preload's loop (a testbed's second shell, a direct `open!`)
+  still gets its frame.
 
   ## First-mount hook table (rf2-y1saa)
 
@@ -1145,36 +1158,82 @@
   (reset! auto-open-state {:started? false :attempts 0})
   nil)
 
-(defn auto-open-inline!
-  "Preload entry: wait briefly for the host app to call `rf/init!`, then
-  open Xray in the true-inline host. Missing host emits a single
-  actionable diagnostic; no alert and no blocking startup."
+(defn boot-on-runtime-ready!
+  "Preload entry: wait briefly for the host app to call `rf/init!`, then run
+  Xray's two runtime-dependent boot steps — SEAT the shell frame, and open
+  Xray in the true-inline host unless the host disabled auto-open. Missing
+  host emits a single actionable diagnostic; no alert and no blocking startup.
+
+  ## Why the frame is seated here (rf2-avi7)
+
+  `:rf/xray` is an ordinary frame, so `rf/make-frame` needs an installed
+  substrate adapter: it raises `:rf.error/no-adapter-installed` before the
+  host's `rf/init!`, which is why rf2-e9s81 reverted seating at preload LOAD
+  time. Adapter readiness is therefore the earliest moment the frame can exist
+  at all, and this loop is the one place in Xray already watching for it.
+
+  Seating used to ride `open!` alone, which tied the frame's existence to a
+  React commit. Xray's whole `:rf.xray/*` instruction set is registered at
+  preload, so between preload and first open Xray was ADDRESSABLE BUT NOT
+  WRITABLE: every dispatch into `:rf/xray` — `core/set-target-frame!`,
+  `focus!`, a host re-orienting the observed frame — recovered-but-emitted
+  `:rf.error/frame-destroyed`, dropped the host's intent, and named the
+  HANDLER's registration coord rather than the caller, so the diagnostic
+  pointed at the wrong file. A host that sets `:rf.xray/auto-open? false`
+  never left that window until it opened a panel of its own. Seating here
+  closes it: the frame exists as soon as the runtime does, opened or not.
+
+  What stays lazy is the FIRST-MOUNT seed/hydrate fan-out. It harvests the
+  trace rings the user has already produced BEFORE opening Xray, so it belongs
+  at first open and keeps its own `seeded-frame-ids` guard inside
+  `ensure-xray-frame!` — which skips the redundant re-seat and runs the hooks."
   []
   (when (compare-and-set! auto-open-state {:started? false :attempts 0}
                           {:started? true :attempts 0})
+    ;; `auto-open-enabled?` is read INSIDE the tick and nowhere else. The
+    ;; documented ordering is `configure!` → `rf/init!`, and BOTH run after the
+    ;; preload's load-time block has called this fn — so a read taken out here
+    ;; would see the default `true` on every host that suppresses the open, and
+    ;; the `:auto-open-disabled` diagnostic would never be recorded.
+    ;;
+    ;; What it no longer gates is the SEAT. A host that turns auto-open off is
+    ;; exactly the host most likely to drive Xray by dispatch instead, so the
+    ;; frame is seated on readiness either way and only the open is suppressed.
     (letfn [(tick! []
               (let [{:keys [attempts]} @auto-open-state]
                 (cond
-                  (not (config/auto-open-enabled?))
-                  (note-auto-open-disabled!)
-
                   @mount-state nil
 
                   (rf.substrate.adapter/current-adapter)
-                  (open!)
+                  (do
+                    ;; Idempotent (`xray-frame-seated?` skips a re-seat), and
+                    ;; seed-free — `open!` here, or a later first open, still
+                    ;; runs the first-mount hooks through `ensure-xray-frame!`.
+                    (image-reads/seat-xray-frame! shell/default-frame-id)
+                    (if (config/auto-open-enabled?)
+                      (open!)
+                      (note-auto-open-disabled!)))
 
                   (< attempts 120)
                   (do
                     (swap! auto-open-state update :attempts inc)
                     (js/setTimeout tick! 50))
 
-                  :else
+                  ;; Gave up waiting for the host runtime. The missing-adapter
+                  ;; diagnostic is about auto-OPEN failing, so it is reported
+                  ;; only to a host that wanted the open; one that suppressed
+                  ;; it is told just that, and its unseated frame is the
+                  ;; consequence of its own missing `rf/init!`.
+                  (config/auto-open-enabled?)
                   (report-diagnostic!
                     {:ok? false
                      :reason :no-substrate-adapter
                      :message "Xray preload could not auto-open because no re-frame2 substrate adapter was installed. Call (rf/init! adapter) before app render."
                      :selector (config/get-layout-host-selector)
-                     :snippet  config/default-layout-host-snippet}))))]
+                     :snippet  config/default-layout-host-snippet})
+
+                  :else
+                  (note-auto-open-disabled!))))]
       (tick!)))
   nil)
 

--- a/tools/xray/src/day8/re_frame2_xray/preload.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/preload.cljs
@@ -11,12 +11,14 @@
      `:rf.xray/trace-collector` — see `re-frame2-xray.trace-collector`.
   3. Attaches a global Ctrl+Shift+C keydown listener — see
      `re-frame2-xray.keybinding`.
-  4. Auto-opens the full shell into the host app's normal-flow
-     `[data-rf-xray-host]` layout host once the substrate adapter is
-     ready, unless the host configured `:rf.xray/auto-open? false`
-     before adapter readiness. Missing host is reported via
-     `console.error` and the inspectable Xray status API; startup is
-     not blocked.
+  4. Once the substrate adapter is ready, SEATS the `:rf/xray` frame and —
+     unless the host configured `:rf.xray/auto-open? false` — auto-opens the
+     full shell into the host app's normal-flow `[data-rf-xray-host]` layout
+     host. The seat is unconditional: it is what makes the `:rf.xray/*`
+     instruction set registered in step 1 actually WRITABLE, so a host can
+     dispatch into Xray (`set-target-frame!`, `focus!`) without ever opening
+     the shell (rf2-avi7). Missing host is reported via `console.error` and
+     the inspectable Xray status API; startup is not blocked.
 
   All four are idempotent: re-loading the namespace (shadow-cljs
   `:after-load`) re-runs the side-effects but each step
@@ -114,9 +116,10 @@
   (settings-effects/apply-all!)
   ;; Auto-open-on-error watcher — NOT installed here.
   ;; The watcher subscribes to `:rf.xray/issues-ribbon`, a sub that
-  ;; reads from `:rf/xray`'s app-db; but `:rf/xray` is
-  ;; lazy-registered by `mount/ensure-xray-frame!` on first open
-  ;; (see mount.cljs §Why here, not at preload time). Subscribing
+  ;; reads from `:rf/xray`'s app-db; but `:rf/xray` is seated only once
+  ;; the host's `rf/init!` has installed a substrate adapter, which is
+  ;; strictly later than this load-time block (see `mount/boot-on-runtime-
+  ;; ready!` §Why the frame is seated here). Subscribing
   ;; here would return nil, and `(add-watch nil ...)` throws
   ;; `No protocol method IWatchable.-add-watch defined for type
   ;; null` in test runtimes that never open Xray (Story testbeds).
@@ -127,4 +130,4 @@
   ;;   2. `:rf.xray/settings-update` — on flip-on, install; on
   ;;      flip-off, detach (covers the runtime toggle).
   ;; Both paths are idempotent via the `auto-open-watcher` atom.
-  (mount/auto-open-inline!))
+  (mount/boot-on-runtime-ready!))

--- a/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/effects.cljs
@@ -549,9 +549,10 @@
 ;; ## Why not install at preload
 ;;
 ;; The watcher subscribes to a sub that reads from `:rf/xray`'s
-;; app-db; but `:rf/xray` is lazy-registered by
-;; `mount/ensure-xray-frame!` on first open (see mount.cljs §Why
-;; here, not at preload time). Subscribing into a non-existent frame
+;; app-db; but `:rf/xray` is seated only once the host's `rf/init!`
+;; has installed a substrate adapter, which is strictly later than
+;; preload load time (see `mount/boot-on-runtime-ready!`).
+;; Subscribing into a non-existent frame
 ;; returns nil, and `(add-watch nil ...)` throws under Story
 ;; testbeds that never open Xray. The frame-presence guard below
 ;; makes the install a defensive no-op pre-mount; the install
@@ -583,11 +584,11 @@
   surrounding dynamic-frame scope. The reaction is held in a `defonce`
   atom so re-install on `:after-load` does not double-watch."
   []
-  ;; Defensive: the `:rf/xray` frame is lazy-registered by
-  ;; `mount.cljs/ensure-xray-frame!` on the first `open!` call (see
-  ;; mount.cljs §Why here, not at preload time). If we land here
-  ;; before that registration — e.g. preload runs in a Story testbed
-  ;; where the user never opens Xray — `rf/subscribe` returns nil
+  ;; Defensive: the `:rf/xray` frame is seated by
+  ;; `mount.cljs/boot-on-runtime-ready!` once the host's `rf/init!` has
+  ;; installed a substrate adapter — later than preload load time, and
+  ;; never at all in a host that omits `rf/init!`. If we land here
+  ;; before that seat, `rf/subscribe` returns nil
   ;; and `(add-watch nil ...)` throws
   ;; `No protocol method IWatchable.-add-watch defined for type null`.
   ;; The frame guard makes pre-mount calls a silent no-op; the install

--- a/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
@@ -878,7 +878,7 @@
             (is (false? (mount/mounted?)))
             (is (false? (mount/visible?)))))))))
 
-(deftest auto-open-inline!-honours-disabled-launch-config
+(deftest boot-on-runtime-ready!-honours-disabled-launch-config
   (testing "Story/tool pages can suppress only the preload's default
             auto-open before adapter readiness; explicit open! keeps
             the normal missing-host diagnostic path"
@@ -894,7 +894,7 @@
                                                   (swap! console-calls conj args)
                                                   nil)))
               (try
-                (mount/auto-open-inline!)
+                (mount/boot-on-runtime-ready!)
                 (is (nil? @@#'mount/mount-state)
                     "auto-open disabled does not mount")
                 (is (zero? (count @calls))
@@ -992,14 +992,15 @@
                 "mounted? flips back to false after teardown!")))))))
 
 ;; -------------------------------------------------------------------------
-;; (8) Lazy `:rf/xray` frame registration (rf2-in6l2)
+;; (8) `:rf/xray` frame seating (rf2-in6l2, rf2-avi7)
 ;; -------------------------------------------------------------------------
 ;;
-;; Per rf2-in6l2 the `:rf/xray` frame is lazy-registered by `open!` —
-;; the preload runs before `rf/init!` has installed a substrate adapter
-;; so `make-frame` cannot run there (per rf2-e9s81). The first Ctrl+
-;; Shift+C keypress fires `open!` AFTER `rf/init!`, so that's the
-;; canonical registration point. Subsequent toggles surgical-update
+;; The `:rf/xray` frame cannot be seated at preload LOAD time: the preload
+;; runs before `rf/init!` has installed a substrate adapter, so `make-frame`
+;; raises there (per rf2-e9s81). Per rf2-avi7 the seat rides adapter
+;; READINESS instead of `open!` — `boot-on-runtime-ready!` seats as soon as
+;; `rf/init!` lands, opened or not — and `open!` still seats unconditionally
+;; for callers that bypass that loop. Subsequent toggles surgical-update
 ;; (make-frame's re-register semantics) — the frame's app-db and sub-
 ;; cache are preserved across keypresses.
 

--- a/tools/xray/test/day8/re_frame2_xray/preload_decoupling_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/preload_decoupling_cljs_test.cljs
@@ -257,14 +257,15 @@
 
 (deftest configure!-auto-open-false-is-honoured-at-boot
   (testing "rf2-5w06uu — :rf.xray/auto-open? false set via configure! before
-            boot wins: the preload's auto-open-inline! short-circuits to the
-            disabled diagnostic rather than mounting."
+            boot wins: the preload's boot-on-runtime-ready! records the
+            disabled diagnostic rather than mounting. rf2-avi7 — it still
+            SEATS `:rf/xray`; only the OPEN is suppressed."
     (core/configure! {:rf.xray/auto-open? false})
     (is (= false (config/auto-open-enabled?))
         "auto-open slot is off before any auto-open attempt")
-    (mount/auto-open-inline!)
+    (mount/boot-on-runtime-ready!)
     (is (not (mount/mounted?))
-        "auto-open-inline! did not mount when auto-open? false")
+        "boot-on-runtime-ready! did not mount when auto-open? false")
     (is (= :auto-open-disabled (get-in (mount/status) [:diagnostic :reason]))
         "auto-open short-circuited to the disabled diagnostic")))
 

--- a/tools/xray/test/day8/re_frame2_xray/target_frame_seating_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/target_frame_seating_cljs_test.cljs
@@ -1,0 +1,141 @@
+(ns day8.re-frame2-xray.target-frame-seating-cljs-test
+  "rf2-avi7 — Xray's own frame is seated when the host RUNTIME comes up, not
+  when Xray's UI opens, so a host can drive Xray by dispatch without ever
+  opening the shell.
+
+  ## The gap this closes
+
+  Xray registers its whole `:rf.xray/*` instruction set at preload, but the
+  `:rf/xray` frame those handlers write to used to be created by `open!` — a
+  React commit. Between the two, Xray was ADDRESSABLE BUT NOT WRITABLE: every
+  dispatch into `:rf/xray` recovered-but-emitted `:rf.error/frame-destroyed`
+  (Spec 002 §Run-to-completion, the rf2-2hvga recover-but-emit ruling), the
+  host's intent was silently dropped, and — because `error-emit/error-source-
+  coord` resolves a `frame-destroyed` coord out of the `[:event id]` registry —
+  the diagnostic named the HANDLER's registration site rather than the caller.
+
+  A host that sets `:rf.xray/auto-open? false` — a supported, documented
+  config — never left that window at all until it opened a panel of its own,
+  so `core/set-target-frame!`, `core/focus!` and any direct `:rf.xray/*`
+  dispatch were dead on arrival for its whole session. That is the general
+  case; the field report was a Story feature-load run emitting one such record
+  per page load.
+
+  ## The three deftests
+
+  1. `control-…` proves the emission is REAL on an unseated frame, and pins
+     the exact record shape the field report carried. Without it, (2)'s empty
+     capture would be vacuous — an `:errors` listener that never fires reads
+     identically to one with nothing to report.
+  2. `host-dispatch-…` is the REGRESSION: with auto-open OFF and the shell
+     never mounted, the dispatch lands and the slot reads back.
+  3. `reading-a-destroyed-…` pins the REFUTATION. The original diagnosis put
+     the fault in `epoch.cljs`'s `(rf/epoch-history target)` read against a
+     destroyed TARGET frame. That read cannot emit: it resolves through the
+     `:epoch/epoch-history` late-bind hook to a plain ring-buffer map lookup
+     that consults no frame registry. Keeping the case here stops the fix
+     drifting back into the handler.
+
+  Node-test (`npm run test:cljs`) — no DOM needed, because the whole point is
+  that nothing mounts."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.core :as core]
+            [day8.re-frame2-xray.mount :as mount]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+;; `mount/teardown!` clears BOTH the mount state and the `boot-on-runtime-
+;; ready!` run-once latch, which `mount/reset-for-test!` (the `seeded-frame-ids`
+;; guard only) does not touch — without it the second deftest's boot call is a
+;; no-op on the first one's latch and passes for the wrong reason.
+(use-fixtures :each
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier :runtime :post-reset mount/teardown!}))
+
+(def ^:private capture-id ::error-capture)
+
+(defn- capture-errors!
+  "Attach an always-on `:errors` listener collecting records into an atom."
+  []
+  (let [seen (atom [])]
+    (rf/register-listener! :errors capture-id (fn [record] (swap! seen conj record)))
+    seen))
+
+(defn- frame-destroyed-records [seen]
+  (rf/unregister-listener! :errors capture-id)
+  (filterv #(= :rf.error/frame-destroyed (:error %)) @seen))
+
+(defn- dispatch-target-frame! [frame-id]
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/set-target-frame frame-id])))
+
+;; ---- (1) control — the emission is real on an unseated frame -------------
+
+(deftest control-an-unseated-xray-frame-drops-the-dispatch-and-emits
+  (testing "With `:rf/xray` unseated, a host dispatch of
+            `:rf.xray/set-target-frame` recovers-but-emits
+            `:rf.error/frame-destroyed` attributed to `:rf/xray` — the exact
+            record the field report carried, and the machinery deftest (2)
+            relies on being live."
+    (registry/register-xray-handlers!)
+    (is (nil? (rf.frame/frame :rf/xray))
+        "precondition: nothing has seated Xray's frame")
+    (let [seen (capture-errors!)]
+      (dispatch-target-frame! :app/main)
+      (let [records (frame-destroyed-records seen)]
+        (is (= 1 (count records))
+            "exactly one recover-but-emit per rejected dispatch")
+        (is (= {:error    :rf.error/frame-destroyed
+                :event-id :rf.xray/set-target-frame
+                :frame    :rf/xray}
+               (select-keys (first records) [:error :event-id :frame]))
+            "the `:frame` slot names the DISPATCH TARGET — Xray's own frame,
+             which is the frame that is missing")))))
+
+;; ---- (2) the regression — a host drives Xray without opening it ----------
+
+(deftest host-dispatch-lands-without-ever-opening-xray
+  (testing "rf2-avi7 — `boot-on-runtime-ready!` seats `:rf/xray` as soon as a
+            substrate adapter exists, even with `:rf.xray/auto-open? false`,
+            so a host that never opens the shell can still tell Xray which
+            frame to observe."
+    (registry/register-xray-handlers!)
+    (config/set-auto-open! false)
+    (mount/boot-on-runtime-ready!)
+    (is (false? (mount/mounted?))
+        "the shell is NOT opened — only the frame is seated")
+    (is (some? (rf.frame/frame :rf/xray))
+        "the runtime-ready boot seated Xray's frame")
+    (let [seen (capture-errors!)]
+      (dispatch-target-frame! :app/main)
+      (is (empty? (frame-destroyed-records seen))
+          "the dispatch landed — nothing recovered-but-emitted"))
+    (is (= :app/main (core/target-frame))
+        "and the host's intent is readable through the public facade")))
+
+;; ---- (3) refutation pin — the epoch read is not the emitter --------------
+
+(deftest reading-a-destroyed-target-frames-epoch-history-is-silent
+  (testing "rf2-avi7 — targeting a DESTROYED host frame emits nothing.
+            `:rf.xray/set-target-frame`'s `(rf/epoch-history target)` is a ring
+            lookup keyed by frame-id (`re-frame.epoch.state/history-for`); it
+            consults no frame registry and cannot raise `frame-destroyed`. An
+            unresolvable target simply reads the empty ring, which is the
+            documented contract — so no guard belongs on that read."
+    (registry/register-xray-handlers!)
+    (config/set-auto-open! false)
+    (mount/boot-on-runtime-ready!)
+    (rf/make-frame {:id :host/gone})
+    (rf/destroy-frame! :host/gone)
+    (let [seen (capture-errors!)]
+      (dispatch-target-frame! :host/gone)
+      (is (empty? (frame-destroyed-records seen))
+          "reading a destroyed frame's epoch history is not an error"))
+    (is (= :host/gone (core/target-frame))
+        "the target is recorded even though the frame is gone — Xray's picker
+         is free to name a frame that has since been torn down")
+    (is (= [] (rf/with-frame :rf/xray (rf/subscribe-once [:rf.xray/epoch-history])))
+        "and its history reads as the empty ring")))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -180,7 +180,7 @@ const STAGED_SURFACES = [
 
 // How long `openXray` waits for the preload's auto-open to reach a
 // terminal state before it touches the toggle chord — see the race note
-// in `openXray` (rf2-7jevo). This is `mount/auto-open-inline!`'s OWN
+// in `openXray` (rf2-7jevo). This is `mount/boot-on-runtime-ready!`'s OWN
 // retry budget (120 attempts × 50ms), not a guess: after it elapses the
 // tick has either mounted the shell or reported `:no-substrate-adapter`
 // and stopped for good, so at that point auto-open provably cannot fire
@@ -192,7 +192,7 @@ const AUTO_OPEN_SETTLE_MS = 120 * 50;
 // ## Why this settles before pressing the chord (rf2-7jevo)
 //
 // `Ctrl+Shift+C` is a TOGGLE (`mount/toggle!`), and Xray's preload runs
-// a second, concurrent opener: `mount/auto-open-inline!` polls every
+// a second, concurrent opener: `mount/boot-on-runtime-ready!` polls every
 // 50ms until the host's `rf/init!` has installed the substrate adapter,
 // then calls `open!`. Sampling the shell once and pressing the chord on
 // a miss races that tick — when auto-open lands in the gap between the

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -686,10 +686,10 @@
 ;; <frame-id>]` (re-seeding :target-frame + :epoch-history) without flipping
 ;; the operator's chosen L4 tab.
 ;;
-;; The :rf/xray frame is lazy-registered by Xray's preload AFTER the host's
-;; rf/init! (mount/auto-open-inline! polls for the adapter then opens). So at
-;; BOOT — when `run` auto-selects :door before Xray has mounted — the frame
-;; may not exist yet. We guard on `(rf/frame-meta :rf/xray)`: pre-mount the
+;; The :rf/xray frame is seated by Xray's preload AFTER the host's rf/init!
+;; (mount/boot-on-runtime-ready! polls for the adapter, then seats). So at
+;; BOOT — when `run` auto-selects :door before that poll lands — the frame
+;; may not exist yet. We guard on `(rf/frame-meta :rf/xray)`: pre-seat the
 ;; re-point is a no-op (Xray's head-frame default already scopes to the most
 ;; recent event's frame, which IS the just-booted machine frame), and any
 ;; user SELECT after Xray opens re-points explicitly. This keeps the boot


### PR DESCRIPTION
## The bead's diagnosis was wrong, and the measurement says so

rf2-avi7 recorded the mechanism as *"Xray holds a STALE TARGET FRAME across a Story
variant switch; `:rf.xray/set-target-frame`'s handler reads `(rf/epoch-history target)`
against the destroyed frame … the record is attributed to `:rf/xray`, which is alive."*

That is an inference from the record shape, not a measurement, and it is backwards.
`rf/epoch-history` resolves through the `:epoch/epoch-history` late-bind hook to
`re-frame.epoch.state/history-for`, which is `(or (get @histories frame-id) [])` — a plain
ring-buffer lookup that consults no frame registry and cannot raise `frame-destroyed`.
Meanwhile `router/emit-frame-destroyed!` stamps `:frame` with the **dispatch target**, and
`error-emit/error-source-coord` resolves a `frame-destroyed` coord out of the `[:event id]`
registry — so `:frame :rf/xray` + `epoch.cljs:108` says *"a dispatch of
`:rf.xray/set-target-frame` into `:rf/xray` was rejected because `:rf/xray` is missing"*,
and the coord names the handler's `reg-event` line rather than the caller.

Measured with a three-way probe on the node-test runner:

| probe | `:rf/xray` | read target | records emitted |
|---|---|---|---|
| A — the bead's claim | **alive** | destroyed | **`[]` — nothing** |
| B | **absent** | live | the exact field-report record |
| C | **destroyed** | live | the exact field-report record |

The destroyed frame is Xray's own, and it is the **dispatch target**, not the read target.

## The general-case defect

Xray registers its whole `:rf.xray/*` instruction set at preload, but `:rf/xray` — the
frame those handlers write to — was created by `open!`, a React commit. Between the two,
**Xray is addressable but not writable**: every dispatch into `:rf/xray`
(`core/set-target-frame!`, `focus!`, a host re-orienting the observed frame)
recovers-but-emits `:rf.error/frame-destroyed`, silently drops the host's intent, and
points the diagnostic at the wrong file. A host that sets `:rf.xray/auto-open? false` — a
supported, documented config — never leaves that window at all until it opens a panel of
its own.

## The fix, and why this one

`:rf/xray` genuinely cannot be seated at preload load time: `rf/make-frame` needs an
installed substrate adapter and raises `:rf.error/no-adapter-installed` without one, which
is what rf2-e9s81 reverted. But that constraint is about the **adapter**, not about
**opening** — and the preload already runs a bounded readiness loop watching for exactly
that moment. So the seat moves there:

> **Xray's frame exists as soon as the host runtime does, not when Xray's UI opens.**

One statement, no guard, no new API, no special case — and it *removes* a coupling rather
than adding machinery. `auto-open-inline!` is renamed `boot-on-runtime-ready!` because the
open is now the conditional half of what it does. The first-mount seed/hydrate fan-out
stays lazy behind its own `seeded-frame-ids` guard: it harvests the trace rings the user
produced *before* opening Xray, so it belongs at first open.

The rejected alternative was guarding the `(rf/epoch-history target)` read. Probe A shows
there is nothing there to guard, and a guard would have left the general case — a dropped
host dispatch — untouched while making the bug look fixed.

## Effect on `npm run test:story-feature-load`

Measured on one tree carrying **both** this change and #9306, against the same tree with
this commit reverted (exact counterfactual, not a hand-plant):

| | `frame-destroyed` | `drain-depth-exceeded` | console errors |
|---|---|---|---|
| this commit reverted | **97** | 4 | 101 |
| this commit | **2** | 4 | 6 |

**Removed at source, not masked** — the emissions stop because the dispatch now lands and
writes the slot, which the regression test asserts directly (`core/target-frame` reads
back `:app/main`).

**This PR alone does not turn that gate green, and two things outside this fence remain.**
Both are filed:

1. **The residual 2** are a boot-instant race, at `t≈550ms`, one page: Story's
   `shell.cljs:406` hand-rolls `(rf/with-frame :rf/xray (rf/dispatch-sync …))` into
   another tool's frame in the same breath as `rf/init!`, before the readiness poll's next
   50ms tick. No Xray-side change reaches it — Story should call Xray's facade.
2. **The 4 `drain-depth-exceeded`** are a separate pre-existing defect (identical count in
   both columns): Xray's own `:rf.xray/epoch-recorded` fan-out floods `:rf/xray`'s queue
   under the 20-event load (`:queue-size 101, :depth 100`). Nothing to do with rf2-avi7.

## Test

`target_frame_seating_cljs_test.cljs`, three deftests: a **control** proving the emission
is real on an unseated frame and pinning the field-report record shape (so the regression's
empty capture is not vacuous), the **regression** itself (auto-open off, shell never
mounted, dispatch lands and reads back), and a **refutation pin** keeping the fix from
drifting back into `epoch.cljs`.

Pre-fix RED proven by planting the seat removal on the committed tree: **6 failures, all in
this namespace**, the first naming
`{:error :rf.error/frame-destroyed, :event-id :rf.xray/set-target-frame, :frame :rf/xray …}`.
Restored and verified by blob hash (`7bf43b6676…`, identical before and after). The control
deftest stayed green under the plant, as it must.

## Spec

`tools/xray/spec/011-Launch-Modes.md` §Mount lifecycle: step 5 of the two-phase boot now
seats the frame and opens conditionally, with a normative paragraph on why seating is
unconditional and what stays lazy. The §Suppress auto-open prose says the frame is still
seated. Anchors and the one new cross-file link checked by hand; both tables left untouched.

## Gates (captured exit codes, final base `ba9b78acb1`)

Surfaces from `.github/scripts/report-changed-surfaces.sh` over the changed **paths**:
`cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance`,
`story_xray_browser`.

| gate | exit |
|---|---|
| `compile-node-test.cjs node-test` (0 warnings) | 0 |
| `node out/node-test.js` — 11275 tests / 56928 assertions, 0 failures | 0 |
| `npm run test:browser` — 786 tests / 4311 assertions, 0 failures | 0 |
| `npm run test:examples-compile` — all 58 swept builds, 0 warnings | 0 |
| `sh scripts/test-jvm-tools.sh` | 0 |
| `npm run test:mcp-conformance` (default profile, 6/6) | 0 |
| `npm run test:xray-feature-gate:smoke` — 5 scenarios, 10 matrix rows, 0 failures | 0 |
| `npm run test:story-play-scripts` — 31 play rows, 0 unexpected | 0 |
| `npm run test:story-feature-load` (this branch) | 0 |
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_readme_links.py --ci` | 0 |

Every gate ran after the rebase onto `ba9b78acb1`; each shadow-cljs run names this
worktree's `shadow-cljs.edn` in its first line, and the planted-fault run discriminates the
node-test suite independently.
