### PR TITLE
docs(aliases): canonical rf.* aliases in the adapter-boot recipe (rf2-lwx8)

### DIFF
--- a/migration/from-re-frame-v1/README.md
+++ b/migration/from-re-frame-v1/README.md
@@ -1692,10 +1692,10 @@ The interceptor's `:before` receives a ctx `{:request :args :frame :event}` and 
 
 1. Identify every call site of `(rf/init!)` / `(rf/init! :keyword)`.
 2. For each, add a `:require` of the relevant adapter ns (if not already present):
-   - Reagent: `[re-frame.adapter.reagent :as reagent]`
-   - UIx: `[re-frame.adapter.uix :as uix]`
-   - SSR (JVM-side): `[re-frame.ssr :as ssr]`
-   - Plain-atom (headless tests): `[re-frame.substrate.plain-atom :as plain-atom]`
+   - Reagent: `[re-frame.adapter.reagent :as rf.adapter.reagent]`
+   - UIx: `[re-frame.adapter.uix :as rf.adapter.uix]`
+   - SSR (JVM-side): `[re-frame.ssr :as rf.ssr]`
+   - Plain-atom (headless tests): `[re-frame.substrate.plain-atom :as rf.substrate.plain-atom]`
 3. Replace the call:
 
 ```clojure
@@ -1703,13 +1703,13 @@ The interceptor's `:before` receives a ctx `{:request :args :frame :event}` and 
 (rf/init!)
 
 ;; after — Reagent
-(rf/init! reagent/adapter)
+(rf/init! rf.adapter.reagent/adapter)
 
 ;; after — UIx
-(rf/init! uix/adapter)
+(rf/init! rf.adapter.uix/adapter)
 
 ;; after — SSR (JVM-side bootstrap)
-(rf/init! ssr/adapter)
+(rf/init! rf.ssr/adapter)
 ```
 
 **Error categories dropped:** `:rf.error/no-adapter-registered`, `:rf.error/multiple-default-adapters`, `:rf.error/unknown-adapter-key` (none survive — there is no registry to disambiguate). The replacement single category is `:rf.error/no-adapter-specified`.

--- a/skills/re-frame-migration/references/setup.md
+++ b/skills/re-frame-migration/references/setup.md
@@ -116,7 +116,7 @@ All three become `day8/re-frame2` + the matching adapter artefact.
 |---|---|
 | `:require [reagent.core ...]` anywhere in the source tree | `day8/re-frame2-reagent` |
 | `:require [uix.core ...]` and Reagent has been removed | `day8/re-frame2-uix` |
-| No view layer (backend-only / headless / a test harness) | **No adapter artefact.** The headless plain-atom adapter ships *inside* `day8/re-frame2`: `(:require [re-frame.substrate.plain-atom :as plain-atom])`, then `(rf/init! plain-atom/adapter)`. Phase-0b's React floor does not apply |
+| No view layer (backend-only / headless / a test harness) | **No adapter artefact.** The headless plain-atom adapter ships *inside* `day8/re-frame2`: `(:require [re-frame.substrate.plain-atom :as rf.substrate.plain-atom])`, then `(rf/init! rf.substrate.plain-atom/adapter)`. Phase-0b's React floor does not apply |
 
 The canonical adapter inventory — every adapter's `:kind`, published namespace, and Maven coordinate — is [`spec/006-ReactiveSubstrate.md` §CLJS reference scope](https://github.com/day8/re-frame2/blob/main/spec/006-ReactiveSubstrate.md#cljs-reference-scope). Do **not** add `day8/re-frame2-reagent` to an app with no view layer: it declares stock Reagent, which drags the React 19 npm peers into a project that never renders, and makes the Phase-0b floor gate apply to a build that has no floor to clear.
 

--- a/skills/re-frame2-pair/references/wire-size-budget.md
+++ b/skills/re-frame2-pair/references/wire-size-budget.md
@@ -34,9 +34,9 @@ artefact both MCP servers share; the codec was vendored into it from
 coordinate):
 
 ```clojure
-(require '[re-frame.mcp-base.dedup :as dedup])
+(require '[re-frame.mcp-base.dedup :as rf.mcp-base.dedup])
 
-(dedup/expand (get payload :rf.mcp/dedup-table))
+(rf.mcp-base.dedup/expand (get payload :rf.mcp/dedup-table))
 ;; => the original structure with sharing restored
 ```
 
@@ -95,7 +95,7 @@ All four are returned **in place of** the requested payload (or slot)
 when their condition fires. Check for them at the top level (or
 inside the relevant slice) before treating a result as raw data:
 
-- `{:rf.mcp/dedup-table <cache-map>}` — call `dedup/expand`.
+- `{:rf.mcp/dedup-table <cache-map>}` — call `rf.mcp-base.dedup/expand`.
 - `{:rf.mcp/overflow {:tool ... :estimated-tokens ... :hint ...}}` —
   narrow the call.
 - `{:rf.mcp/cache-hit {:hash ... :unchanged-since ... :hint ...}}` —

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -2034,31 +2034,31 @@ The plain-atom adapter is **trivially** revertibility-compliant ([§Reference-ad
 ```clojure
 ;; Reagent (CLJS, day8/re-frame2-reagent):
 (require '[re-frame.core :as rf]
-         '[re-frame.adapter.reagent :as reagent])
-(rf/init! reagent/adapter)
+         '[re-frame.adapter.reagent :as rf.adapter.reagent])
+(rf/init! rf.adapter.reagent/adapter)
 
 ;; reagent-slim (CLJS, day8/reagent-slim) — the slim jar publishes its
 ;; adapter at the CANONICAL `re-frame.adapter.reagent` ns (renamed from the
 ;; in-tree `-slim` ns at publication), so it is a drop-in swap for the stock
 ;; jar's require:
 (require '[re-frame.core :as rf]
-         '[re-frame.adapter.reagent :as reagent])
-(rf/init! reagent/adapter)
+         '[re-frame.adapter.reagent :as rf.adapter.reagent])
+(rf/init! rf.adapter.reagent/adapter)
 
 ;; UIx (CLJS, day8/re-frame2-uix):
 (require '[re-frame.core :as rf]
-         '[re-frame.adapter.uix :as uix])
-(rf/init! uix/adapter)
+         '[re-frame.adapter.uix :as rf.adapter.uix])
+(rf/init! rf.adapter.uix/adapter)
 
 ;; SSR / JVM (day8/re-frame2-ssr):
 (require '[re-frame.core :as rf]
-         '[re-frame.ssr :as ssr])
-(rf/init! ssr/adapter)
+         '[re-frame.ssr :as rf.ssr])
+(rf/init! rf.ssr/adapter)
 
 ;; Headless / plain-atom (re-frame.substrate.plain-atom in core):
 (require '[re-frame.core :as rf]
-         '[re-frame.substrate.plain-atom :as plain-atom])
-(rf/init! plain-atom/adapter)
+         '[re-frame.substrate.plain-atom :as rf.substrate.plain-atom])
+(rf/init! rf.substrate.plain-atom/adapter)
 ```
 
 `(rf/init! …)` accepts exactly one argument shape:
@@ -2178,7 +2178,7 @@ Per [011](011-SSR.md), the server-side render path doesn't use the adapter's rea
 
 No Reagent. No React. No reactivity. Pure data → pure data → string.
 
-The server-side adapter is the distinct **`re-frame.ssr` adapter** (`:kind :rf.adapter/ssr`) — a headless, plain-atom-*shaped* adapter that binds its own `render-to-string`. The caller boots it **explicitly** with `(rf/init! ssr/adapter)` (per [§Adapter selection at boot](#adapter-selection-at-boot)); nothing auto-selects it by platform. It is distinct from the core plain-atom adapter, which some headless SSR paths also use — both live in the [canonical inventory](#cljs-reference-scope).
+The server-side adapter is the distinct **`re-frame.ssr` adapter** (`:kind :rf.adapter/ssr`) — a headless, plain-atom-*shaped* adapter that binds its own `render-to-string`. The caller boots it **explicitly** with `(rf/init! rf.ssr/adapter)` (per [§Adapter selection at boot](#adapter-selection-at-boot)); nothing auto-selects it by platform. It is distinct from the core plain-atom adapter, which some headless SSR paths also use — both live in the [canonical inventory](#cljs-reference-scope).
 
 ## CLJS reference scope
 


### PR DESCRIPTION
## What

`spec/Conventions.md` §Require-alias dialect makes `rf.<tail>` the canonical alias for every framework namespace and reserves the bare leaf form for **application** namespaces. `spec/006-ReactiveSubstrate.md` §Adapter selection at boot taught the bare form back — **normative spec contradicting normative spec**, which is the one defect in this bead's prose population that is a correctness problem rather than cosmetics.

The five boot recipes there, and the one cross-reference that names that section, now spell the canonical alias — matching `skills/re-frame2-setup/`, which already does (`rf.adapter.reagent/adapter` throughout).

Two further sites carry the same recipe and would have been left contradicting the spec, so they travel with it:

- the M-40 "add a `:require`" list and its `;; after` block in the v1 migration guide;
- the headless plain-atom cell in `skills/re-frame-migration/references/setup.md` (a site this bead names by line).

The MCP dedup snippet in the pair skill goes too: `re-frame.mcp-base.dedup` is spelled `rf.mcp-base.dedup` at **all 13** of its call sites in shipped code, and the alias occurs nowhere else in prose (the three other `dedup/` hits in the corpus are English — "rAF/dedup/teardown").

22 insertions, 22 deletions — a pure rename, no prose added or removed.

## What was deliberately NOT changed, and why

Each verified at source, not assumed. Renaming these would be wrong, not merely unnecessary:

- **v1 "before" / SEARCH material** — `re-frame.db`, `re-frame.router`, `re-frame.subs`, `re-frame.events`, `re-frame.registrar`, `re-frame.utils`, `re-frame.loggers`, `re-frame.alpha`, `re-frame.test`. These namespaces **do not exist in re-frame2**; they are what the reader greps for in their *v1* tree. Canonicalising them would break the guide's own grep targets and teach a reader to look for a namespace v1 never had.
- **Framework-internal `ns` pseudocode** (`006:1726-1728`, `006:1984`). It illustrates `re-frame.adapter.reagent` / `re-frame.substrate.plain-atom`'s own ns forms, and the real files bind `:as r` / `ratom` / `rdc` / `spine` / `views` — part of `implementation/adapters`' baselined floor of 337. This moves when that surface does.
- **M-38's rename demonstration**, whose prose explicitly states *"the local alias on the right of `:as` is the consumer's choice and is left untouched"* — the example's whole subject is that only the namespace moves.
- **The host-conditional exemption** in `skills/re-frame2/references/cross-cutting/testing.md` (`:clj` plain-atom / `:cljs` a substrate under one alias), which this bead already records as legitimate.
- **Docstring and string-literal codemod inputs** under `migration/reagent-to-hicasso/`. These are the codemod's own test *data* modelling arbitrary consumer files; the ratchet masks strings and docstrings by design, which is why it correctly reports `migration 0`.
- **Paths that merely look like aliases** — `examples/substrates/uix/counter/`, and the `implementation/adapters/reagent/` column of the inventory table.

## Gates — captured exit codes, all re-run on the final base after rebase

| Gate | Exit |
|---|---|
| `check_require_alias_dialect.py --report` | 0 |
| `check_require_alias_dialect.py --self-test` | 0 (79 passed) |
| Full repo-invariants roster (46 checkers under `scripts/`) | 0 |
| `check_doc_slugs.py` | 0 |
| `check_readme_links.py --ci` | 0 |
| `python -m mkdocs build --strict` | 0 |
| `check-beads-pr-boundary.sh origin/main` | 0 |

**No floor moved.** `scripts/require-alias-baseline.edn` is untouched: the ratchet reads git-tracked `.clj`/`.cljs`/`.cljc` only, and this diff is markdown. It reads identically before and after — 2798 files, 10872 edges, 2441 non-canonical.

The full roster was run rather than only the expected checks, because an alias rename can silently disarm a checker keying on literal alias text. None does: no script under `scripts/` or `.github/scripts/` keys on any alias changed here, and the two skill-drift checkers that anchor `spec/006` anchor its UIx-hooks paragraph, not the boot block.

`.github/scripts/report-changed-surfaces.sh`, fed **paths**, reports `skills_structural=true`, `implementation_jvm=true`, and `migration_v1_codemod=false` — no compile unit changed, so the codemod suite is not implicated.

## Proof the gates read this tree

A broken anchor was planted at `006:2181` — a line this PR edits, in prose rather than a fence, so the gate can see it. `check_doc_slugs.py` went **exit 1**, naming `spec/006-ReactiveSubstrate.md:2181 -> #adapter-selection-at-boot-PLANTED-...`. The discrimination is the red itself: that content existed only in this worktree, so a run that had wandered elsewhere would have come back green. Restored and verified by git **blob** hash (`68126f57191a601d1d30be09bd68b653102ad909` before the plant, after the restore, and for the working file), then re-run green.

## Hand-verification (no gate covers it)

Neither link gate looks inside a fenced code block — both share one extractor that strips fences first — so the fenced edits (the `006` boot block, the migration guide's `;; after` block, the dedup `require` block) are **hand-checked, not gate-covered**. Checked by hand:

- every renamed alias's use sites move with its binding, within the same snippet;
- the table row in `setup.md` still carries 3 pipes, matching its sibling rows;
- the `#adapter-selection-at-boot` anchor at `006:2181` resolves (and is what the planted-fault run exercised);
- no path-shaped near-miss was rewritten.
