### PR TITLE
docs(spec): five pattern/prompt pages lead with reg-machine (rf2-z442)

### DIFF
--- a/spec/CP-5-MachineGuide.md
+++ b/spec/CP-5-MachineGuide.md
@@ -29,7 +29,7 @@ Two equivalent surfaces register a machine; CP-5-generated scaffolds default to 
 
 Both forms live in `re-frame.machines` (the `day8/re-frame2-machines` artefact). The `reg-machine` / `defmachine` **macros** are re-exported on the `re-frame.core` façade (they capture call-site source-coords); the plain-fn `reg-machine*` is **not** re-exported — reach it through `re-frame.machines/reg-machine*` (front-porch shrink: the non-registration / plain-fn machine surface stays in its owning namespace). See [API.md §Machines](API.md#machines) and [005 §`reg-machine` — public registration surface](005-StateMachines.md#reg-machine--public-registration-surface) for the canonical contract.
 
-The `reg-event + make-machine-handler` form (visible in [Construction-Prompts.md §CP-5](Construction-Prompts.md#cp-5-scaffold-a-state-machine) examples) registers the *same* slot — `reg-machine` is the convenience surface that wraps it and adds the metadata stamp.
+Beneath both sits `make-machine-handler`, the pure factory that turns a spec into the handler fn. The bare `reg-event` + factory composition reaches the *same* registry slot but does not stamp the registration metadata, so it is the composition seam for callers that must build a handler *without* registering one — code-gen and loader pipelines minting handlers for computed ids — and not the authoring surface. See [005 §`make-machine-handler` is a pure factory](005-StateMachines.md#make-machine-handler-is-a-pure-factory).
 
 ## The inline-fn escape hatch
 
@@ -119,38 +119,36 @@ The media-player example uses two genuinely independent regions (audio and video
 ```clojure
 ;; ---- region 1: audio playback state ---------------------------------------
 
-(rf/reg-event :media/audio
+(rf/reg-machine :media/audio
   {:doc "Audio region — playing / paused."}
-  (rf.machines/make-machine-handler
-    {:initial :paused
-     :data    {:position 0}
-     :states
-     {:paused
-      {:on {:media/play  {:target :playing
-                          :action :media.audio/start}}}
+  {:initial :paused
+   :data    {:position 0}
+   :states
+   {:paused
+    {:on {:media/play  {:target :playing
+                        :action :media.audio/start}}}
 
-      :playing
-      {:on {:media/pause {:target :paused
-                          :action :media.audio/stop}
-            :media/stop  {:target :paused
-                          :action :media.audio/reset}}}}}))
+    :playing
+    {:on {:media/pause {:target :paused
+                        :action :media.audio/stop}
+          :media/stop  {:target :paused
+                        :action :media.audio/reset}}}}})
 
 ;; ---- region 2: video visibility state -------------------------------------
 
-(rf/reg-event :media/video
+(rf/reg-machine :media/video
   {:doc "Video region — visible / hidden."}
-  (rf.machines/make-machine-handler
-    {:initial :hidden
-     :data    {}
-     :states
-     {:hidden
-      {:on {:media/play  {:target :visible
-                          :action :media.video/show}}}
+  {:initial :hidden
+   :data    {}
+   :states
+   {:hidden
+    {:on {:media/play  {:target :visible
+                        :action :media.video/show}}}
 
-      :visible
-      {:on {:media/pause {}                                 ;; pausing leaves the frame visible
-            :media/stop  {:target :hidden
-                          :action :media.video/hide}}}}}))
+    :visible
+    {:on {:media/pause {}                                 ;; pausing leaves the frame visible
+          :media/stop  {:target :hidden
+                        :action :media.video/hide}}}}})
 
 ;; ---- coordinator event — fans out to both regions atomically -------------
 
@@ -224,7 +222,7 @@ For readers familiar with xstate, the explicit list of where re-frame2 chose dif
 | `:context` for extended state | `:data` | Avoid the triply-overloaded "context" name; align with `gen_statem` vocabulary |
 | Compound guards as `{and: [...]}` data | One fn or one named registered compound | Imperative composition is fns; named compounds carry semantic content |
 | Action-vector `[a1 a2 a3]` per slot | One fn or one named registered compound | Same reason as guards |
-| `setup({actors, guards, actions})` per-machine bundle | Per-machine `:guards` / `:actions` maps inside the `make-machine-handler` spec | Convergence: machine-scoped declaration (not globally-registered). Each machine has its own guard/action namespace, validated at registration time; cross-machine reuse is via Clojure vars |
+| `setup({actors, guards, actions})` per-machine bundle | Per-machine `:guards` / `:actions` maps inside the machine spec | Convergence: machine-scoped declaration (not globally-registered). Each machine has its own guard/action namespace, validated at registration time; cross-machine reuse is via Clojure vars |
 | `[:assign {...}]` action data form | Action returns `{:data {...}}` | Symmetric with `reg-event`'s `{:db :fx}`; one fewer DSL to parse |
 | `invoke` (state-node spawn key) | `:spawn` (and `:spawn-all` for parallel-fanout-and-join) | Deliberate name divergence. Convergence is high enough on other keys (`:final?`, `:on-done`, `:guard`, `:action`, `:entry`, `:exit`, `:after`, `:always`, `:tags`) that AI agents trained on xstate would otherwise generate almost-correct code that misses re-frame2's per-feature spec nuances. Renaming the most semantically-loaded slot breaks the convergence trap and aligns the declarative key with the existing imperative `:rf.machine/spawn` fx. See [005 §Deliberate name divergence — `:spawn`](005-StateMachines.md#deliberate-name-divergence--spawn-not-invoke). |
 | v4 `internal: true` (opt OUT of external default) → **v5 `reenter: true`** (opt IN to external; internal is the default) | `:reenter?` boolean — internal self/ancestor transitions by default; `:reenter? true` makes them external | **Convergence with XState v5, not a divergence.** re-frame2 follows the v5 default: a self / proper-ancestor `:target` is internal (no exit/entry, no `:after`/`:spawn` restart) unless `:reenter? true`. This is a deliberate divergence *from SCXML / XState v4* (whose targeted transitions are external by default) and an alignment *to* the v5 gold standard. An author trained on XState v5 ports their `reenter` intuition directly. See [005 §Self-transitions](005-StateMachines.md#self-transitions--internal-default-vs-external-reenter). |

--- a/spec/Construction-Prompts.md
+++ b/spec/Construction-Prompts.md
@@ -354,9 +354,9 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 
 **When to use this prompt:** the user describes a multi-step interaction with discrete, named states — a login flow, a checkout wizard, a video player, a modal lifecycle, a websocket connection. If you can list the states and the events that move between them, you have a machine.
 
-**Key idea: the machine IS the event handler.** A machine is registered as one `reg-event` whose body comes from `make-machine-handler`. Sub-events route in: `(rf/dispatch [:my/machine [:my-input arg ...]])`.
+**Key idea: the machine IS the event handler.** A machine is registered as one event handler with `reg-machine`, whose body interprets the transition table. Sub-events route in: `(rf/dispatch [:my/machine [:my-input arg ...]])`. See [005 §`reg-machine` — public registration surface](005-StateMachines.md#reg-machine--public-registration-surface).
 
-**Default form: named guards and actions in the machine's `:guards` / `:actions` maps.** The transition table references guards and actions by **keyword** (`:under-retry-limit`, `:clear-error`); the bodies live in the machine's own `:guards` / `:actions` maps inside `make-machine-handler`. This is the **default** because the named id is a **name** that is **reusable, addressable, and clearer for humans, tools, and AIs** — visualisers label arrows with the id, AIs and conformance fixtures resolve the id against the machine's `:guards` / `:actions` map, and tests stub by id. (The rationale is *not* source visibility: an inline fn's `:source-code` text is co-located on its enclosing node in dev, per [005 §Source-coord stamping](005-StateMachines.md#source-coord-stamping), so an inline body is inspectable — it just has no public name to address.) Inline fns are an **escape hatch for trivial logic** (one-liners with no branching), not the default form. See [005 §Inspectability bias](005-StateMachines.md#inspectability-bias). **Resolution is machine-local** — there is no global `:machine-guard` / `:machine-action` registry; cross-machine reuse is via Clojure vars referenced from each machine's map.
+**Default form: named guards and actions in the machine's `:guards` / `:actions` maps.** The transition table references guards and actions by **keyword** (`:under-retry-limit`, `:clear-error`); the bodies live in the machine's own `:guards` / `:actions` maps inside the machine spec. This is the **default** because the named id is a **name** that is **reusable, addressable, and clearer for humans, tools, and AIs** — visualisers label arrows with the id, AIs and conformance fixtures resolve the id against the machine's `:guards` / `:actions` map, and tests stub by id. (The rationale is *not* source visibility: an inline fn's `:source-code` text is co-located on its enclosing node in dev, per [005 §Source-coord stamping](005-StateMachines.md#source-coord-stamping), so an inline body is inspectable — it just has no public name to address.) Inline fns are an **escape hatch for trivial logic** (one-liners with no branching), not the default form. See [005 §Inspectability bias](005-StateMachines.md#inspectability-bias). **Resolution is machine-local** — there is no global `:machine-guard` / `:machine-action` registry; cross-machine reuse is via Clojure vars referenced from each machine's map.
 
 **Pre-flight checks:**
 
@@ -366,7 +366,7 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 4. **List the inputs (sub-events) that move between states.** Each input triggers exactly one transition.
 5. **Identify guards and actions; default to naming them in `:guards` / `:actions`.** Each guard `(fn [{:keys [data event]}] boolean)` and each action `(fn [{:keys [data event]}] {:data {...} :fx [...]})` is a key in the machine's `:guards` / `:actions` map (referenced from transitions by keyword). Per every machine callback receives a single context-map argument with `:data`, `:event`, `:state`, `:meta`. **Inline only when the body is a single non-branching expression.**
 
-**Where state lives.** Every machine's snapshot lives at the runtime-managed path `[:rf.runtime/machines :snapshots <machine-id>]` in the frame's **runtime-db** partition (not app-db). For id `:auth.login/flow`, the snapshot is at `[:rf.runtime/machines :snapshots :auth.login/flow]` and contains `{:state ... :data ...}`. You do not pick the path — `make-machine-handler` does not accept a `:path` key. Per-frame isolation is automatic: each frame has its own runtime-db and thus its own `[:rf.runtime/machines :snapshots]` map. See [005 §Where snapshots live](005-StateMachines.md#where-snapshots-live).
+**Where state lives.** Every machine's snapshot lives at the runtime-managed path `[:rf.runtime/machines :snapshots <machine-id>]` in the frame's **runtime-db** partition (not app-db). For id `:auth.login/flow`, the snapshot is at `[:rf.runtime/machines :snapshots :auth.login/flow]` and contains `{:state ... :data ...}`. You do not pick the path — the machine spec has no `:path` key. Per-frame isolation is automatic: each frame has its own runtime-db and thus its own `[:rf.runtime/machines :snapshots]` map. See [005 §Where snapshots live](005-StateMachines.md#where-snapshots-live).
 
 **Reading the snapshot in views.** The framework ships `:rf/machine` as a standard parametric sub. `@(rf/subscribe [:rf/machine :auth.login/flow])` returns the snapshot — no per-machine `reg-sub` needed. Destructure inline, or write a derived sub `:<- [:rf/machine <id>]` for projections. See [005 §Subscribing to machines via the `:rf/machine` sub](005-StateMachines.md#subscribing-to-machines-via-the-rfmachine-sub).
 
@@ -380,80 +380,79 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 ;; machine-local: the runtime calls (get-in spec [:guards :under-retry-limit])
 ;; etc. There is no global :machine-guard / :machine-action registry.
 
-(rf/reg-event :auth.login/flow
+(rf/reg-machine :auth.login/flow
   {:doc "Login flow: idle → submitting → authed / error-shown / locked-out."}
-  (rf.machines/make-machine-handler
-    {:initial :idle
-     :data    {:attempts 0 :error nil}
+  {:initial :idle
+   :data    {:attempts 0 :error nil}
 
-     :guards
-     {:under-retry-limit
-      ;; Has this login had fewer than 3 prior attempts?
-      (fn [{:keys [data]}]
-        (< (:attempts data) 3))}
+   :guards
+   {:under-retry-limit
+    ;; Has this login had fewer than 3 prior attempts?
+    (fn [{:keys [data]}]
+      (< (:attempts data) 3))}
 
-     :actions
-     {:begin-submit
-      ;; Clear the prior error and emit the HTTP request for credential check.
-      ;; Destructure the credentials out of the :event vector.
-      (fn [{[_ creds] :event}]
-        {:data {:error nil}
-         :fx   [[:http {:method     :post
-                        :url        "/api/login"
-                        :body       creds
-                        :on-success [:auth.login/flow [:succeeded]]
-                        :on-error   [:auth.login/flow [:failed]]}]]})
+   :actions
+   {:begin-submit
+    ;; Clear the prior error and emit the HTTP request for credential check.
+    ;; Destructure the credentials out of the :event vector.
+    (fn [{[_ creds] :event}]
+      {:data {:error nil}
+       :fx   [[:http {:method     :post
+                      :url        "/api/login"
+                      :body       creds
+                      :on-success [:auth.login/flow [:succeeded]]
+                      :on-error   [:auth.login/flow [:failed]]}]]})
 
-      :record-failure
-      ;; Bump the attempts counter and surface a credentials error.
-      (fn [{:keys [data]}]
-        {:data {:attempts (inc (:attempts data))
-                :error    :credentials}})
+    :record-failure
+    ;; Bump the attempts counter and surface a credentials error.
+    (fn [{:keys [data]}]
+      {:data {:attempts (inc (:attempts data))
+              :error    :credentials}})
 
-      :lock-out
-      ;; Lock the account after exceeding the retry limit.
-      (fn [_ctx]
-        {:data {:error :locked}})
+    :lock-out
+    ;; Lock the account after exceeding the retry limit.
+    (fn [_ctx]
+      {:data {:error :locked}})
 
-      :clear-error
-      ;; Reset the error before re-submitting.
-      (fn [_ctx]
-        {:data {:error nil}})
+    :clear-error
+    ;; Reset the error before re-submitting.
+    (fn [_ctx]
+      {:data {:error nil}})
 
-      :clear-and-record-success
-      ;; On successful auth, clear any residual error state.
-      (fn [_ctx]
-        {:data {:error nil}})}
+    :clear-and-record-success
+    ;; On successful auth, clear any residual error state.
+    (fn [_ctx]
+      {:data {:error nil}})}
 
-     :states
-     {:idle
-      {:on
-       {:submit
-        {:target :submitting
-         :action :begin-submit}}}                            ;; resolves to :actions :begin-submit
+   :states
+   {:idle
+    {:on
+     {:submit
+      {:target :submitting
+       :action :begin-submit}}}                            ;; resolves to :actions :begin-submit
 
-      :submitting
-      {:on
-       {:succeeded
-        {:target :authed
-         :action :clear-and-record-success}
+    :submitting
+    {:on
+     {:succeeded
+      {:target :authed
+       :action :clear-and-record-success}
 
-        :failed
-        ;; multiple candidates with guards — first match wins
-        [{:target :error-shown
-          :guard  :under-retry-limit                         ;; resolves to :guards :under-retry-limit
-          :action :record-failure}
-         {:target :locked-out
-          :action :lock-out}]}}
+      :failed
+      ;; multiple candidates with guards — first match wins
+      [{:target :error-shown
+        :guard  :under-retry-limit                         ;; resolves to :guards :under-retry-limit
+        :action :record-failure}
+       {:target :locked-out
+        :action :lock-out}]}}
 
-      :error-shown
-      {:on
-       {:dismiss {:target :idle}
-        :submit  {:target :submitting
-                  :action :clear-error}}}
+    :error-shown
+    {:on
+     {:dismiss {:target :idle}
+      :submit  {:target :submitting
+                :action :clear-error}}}
 
-      :authed     {:meta {:terminal? true}}
-      :locked-out {:meta {:terminal? true}}}}))
+    :authed     {:meta {:terminal? true}}
+    :locked-out {:meta {:terminal? true}}}})
 ```
 
 **What "named in `:guards` / `:actions` by default" buys:**
@@ -597,7 +596,7 @@ For projections, compose against `:rf/machine` via `:<-`:
 
 **AI-first checklist:**
 
-- Machine id is namespaced; registered via `reg-event` + `make-machine-handler`.
+- Machine id is namespaced; registered with `reg-machine`.
 - No `:path` key in the machine spec — the runtime stores snapshots at `[:rf.runtime/machines :snapshots <id>]` in runtime-db.
 - All states are listed in `:states`; no string-based or computed state names.
 - Every input the machine listens to is in some state's `:on` map.

--- a/spec/Pattern-Boot.md
+++ b/spec/Pattern-Boot.md
@@ -76,132 +76,131 @@ Each phase uses `:spawn` to spawn the async work; transitions on success or fail
 ### Worked example — six-state boot
 
 ```clojure
-(rf/reg-event :app/boot
+(rf/reg-machine :app/boot
   {:doc "Application boot: config → auth → profile → hydrate → route → ready."}
-  (rf.machines/make-machine-handler
-    {:initial :configuring
-     :data    {:config nil :user nil :error nil :phase-attempt 0}
+  {:initial :configuring
+   :data    {:config nil :user nil :error nil :phase-attempt 0}
 
-     :guards
-     {:has-session-token?
-      (fn [_ctx] (some? (.getItem js/localStorage "auth/token")))
+   :guards
+   {:has-session-token?
+    (fn [_ctx] (some? (.getItem js/localStorage "auth/token")))
 
-      :under-retry-limit?
-      (fn [{:keys [data]}] (< (:phase-attempt data) 3))}
+    :under-retry-limit?
+    (fn [{:keys [data]}] (< (:phase-attempt data) 3))}
 
-     :actions
-     {:set-phase
-      ;; Update visible-progress slice in :data so the boot UI can render.
-      (fn [{:keys [data] [_ phase] :event}]
-        {:data (assoc data :phase phase :phase-attempt 0)})
+   :actions
+   {:set-phase
+    ;; Update visible-progress slice in :data so the boot UI can render.
+    (fn [{:keys [data] [_ phase] :event}]
+      {:data (assoc data :phase phase :phase-attempt 0)})
 
-      :record-config
-      (fn [{:keys [data] [_ config] :event}]
-        {:data (assoc data :config config)})
+    :record-config
+    (fn [{:keys [data] [_ config] :event}]
+      {:data (assoc data :config config)})
 
-      :record-user
-      (fn [{:keys [data] [_ user] :event}]
-        {:data (assoc data :user user)})
+    :record-user
+    (fn [{:keys [data] [_ user] :event}]
+      {:data (assoc data :user user)})
 
-      :bump-attempt
-      (fn [{:keys [data]}]
-        {:data (update data :phase-attempt inc)})
+    :bump-attempt
+    (fn [{:keys [data]}]
+      {:data (update data :phase-attempt inc)})
 
-      :record-error
-      (fn [{:keys [data] [_ err] :event}]
-        {:data (assoc data :error err)})
+    :record-error
+    (fn [{:keys [data] [_ err] :event}]
+      {:data (assoc data :error err)})
 
-      :resolve-initial-route
-      ;; Reads :route from URL and seeds the :route slice (per Spec 012).
-      (fn [_ctx]
-        {:fx [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})
+    :resolve-initial-route
+    ;; Reads :route from URL and seeds the :route slice (per Spec 012).
+    (fn [_ctx]
+      {:fx [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})
 
-      :enter-routing
-      ;; Compound entry action for :routing — :set-phase + :resolve-initial-route
-      ;; in one fn. (Per [005 §State nodes] :entry takes one fn or one
-      ;; registered id, never a vector.)
-      (fn [{:keys [data]}]
-        {:data (assoc data :phase :routing :phase-attempt 0)
-         :fx   [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})}
+    :enter-routing
+    ;; Compound entry action for :routing — :set-phase + :resolve-initial-route
+    ;; in one fn. (Per [005 §State nodes] :entry takes one fn or one
+    ;; registered id, never a vector.)
+    (fn [{:keys [data]}]
+      {:data (assoc data :phase :routing :phase-attempt 0)
+       :fx   [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})}
 
-     :states
-     {;; :configuring runs an explicit Pattern-AsyncEffect instance: the boot
-      ;; machine :spawns a child :http/get actor whose :data carries the URL.
-      ;; The actor fetches /config and :dispatch-replys :succeeded with the body;
-      ;; :record-config writes it into the boot machine's :data for downstream
-      ;; states to thread into their own work.
-      :configuring
-      {:entry  :set-phase
-       :spawn {:machine-id :http/get
-                :data       {:url "/config"}
-                :on-spawn   (fn [{:keys [data id]}] (assoc data :pending id))}
-       :on     {:succeeded {:target :authenticating
-                            :action :record-config}
-                :failed    {:target :fatal-error
-                            :action :record-error}}}
+   :states
+   {;; :configuring runs an explicit Pattern-AsyncEffect instance: the boot
+    ;; machine :spawns a child :http/get actor whose :data carries the URL.
+    ;; The actor fetches /config and :dispatch-replys :succeeded with the body;
+    ;; :record-config writes it into the boot machine's :data for downstream
+    ;; states to thread into their own work.
+    :configuring
+    {:entry  :set-phase
+     :spawn {:machine-id :http/get
+              :data       {:url "/config"}
+              :on-spawn   (fn [{:keys [data id]}] (assoc data :pending id))}
+     :on     {:succeeded {:target :authenticating
+                          :action :record-config}
+              :failed    {:target :fatal-error
+                          :action :record-error}}}
 
-      ;; Subsequent states read from :data :config and thread the values into
-      ;; the next phase's :spawn spawn-spec or dispatched event.
-      :authenticating
-      {:entry  :set-phase
-       :spawn {:machine-id :auth/restore-session
-                ;; Spawn-spec :data fn — read the auth URL out of the boot
-                ;; machine's :data :config (per Pattern-AsyncEffect mechanism 2).
-                ;; The :data fn receives the parent's context map; read its
-                ;; :data from the :snapshot slot (per 005 §Declarative :spawn).
-                :data       (fn [{:keys [snapshot]}]
-                              {:auth-url (-> snapshot :data :config :auth-url)})
-                :on-spawn   (fn [{:keys [data id]}] (assoc data :pending id))}
-       :on     {:succeeded {:target :loading-profile}
-                :failed    [{:target :retrying-auth
-                             :guard  :under-retry-limit?
-                             :action :bump-attempt}
-                            {:target :auth-failed
-                             :action :record-error}]}}
+    ;; Subsequent states read from :data :config and thread the values into
+    ;; the next phase's :spawn spawn-spec or dispatched event.
+    :authenticating
+    {:entry  :set-phase
+     :spawn {:machine-id :auth/restore-session
+              ;; Spawn-spec :data fn — read the auth URL out of the boot
+              ;; machine's :data :config (per Pattern-AsyncEffect mechanism 2).
+              ;; The :data fn receives the parent's context map; read its
+              ;; :data from the :snapshot slot (per 005 §Declarative :spawn).
+              :data       (fn [{:keys [snapshot]}]
+                            {:auth-url (-> snapshot :data :config :auth-url)})
+              :on-spawn   (fn [{:keys [data id]}] (assoc data :pending id))}
+     :on     {:succeeded {:target :loading-profile}
+              :failed    [{:target :retrying-auth
+                           :guard  :under-retry-limit?
+                           :action :bump-attempt}
+                          {:target :auth-failed
+                           :action :record-error}]}}
 
-      :retrying-auth
-      {:after {2000 {:target :authenticating}}}
+    :retrying-auth
+    {:after {2000 {:target :authenticating}}}
 
-      :loading-profile
-      {:entry  :set-phase
-       :spawn {:machine-id :http/get
-                ;; Read the profile URL from the loaded config rather than
-                ;; hardcoding it — the boot machine threads host config in
-                ;; via the spawn-spec :data fn.
-                :data       (fn [{:keys [snapshot]}]
-                              {:url (-> snapshot :data :config :profile-url)})
-                :on-spawn   (fn [{:keys [data id]}] (assoc data :pending id))}
-       :on     {:succeeded {:target :hydrating
-                            :action :record-user}
-                :failed    {:target :profile-failed
-                            :action :record-error}}}
+    :loading-profile
+    {:entry  :set-phase
+     :spawn {:machine-id :http/get
+              ;; Read the profile URL from the loaded config rather than
+              ;; hardcoding it — the boot machine threads host config in
+              ;; via the spawn-spec :data fn.
+              :data       (fn [{:keys [snapshot]}]
+                            {:url (-> snapshot :data :config :profile-url)})
+              :on-spawn   (fn [{:keys [data id]}] (assoc data :pending id))}
+     :on     {:succeeded {:target :hydrating
+                          :action :record-user}
+              :failed    {:target :profile-failed
+                          :action :record-error}}}
 
-      :hydrating
-      {:entry :set-phase
-       ;; :hydrate/done is app-dispatched — by the handler that finishes hydration.
-       :on    {:hydrate/done {:target :routing}}}
+    :hydrating
+    {:entry :set-phase
+     ;; :hydrate/done is app-dispatched — by the handler that finishes hydration.
+     :on    {:hydrate/done {:target :routing}}}
 
-      :routing
-      {:entry :enter-routing
-       ;; If the running app needs the WebSocket URL from config, the :ready
-       ;; transition threads it into the connection machine's :connect event
-       ;; (per Pattern-AsyncEffect mechanism 1):
-       ;;   {:fx [[:dispatch [:ws/connection
-       ;;                     [:ws/connect {:url        (-> data :config :ws-url)
-       ;;                                   :auth-token (-> data :session :token)}]]]]}
-       ;; :boot/route-resolved is app-prefixed and produced by the initial
-       ;; route's :on-match — `{:on-match [[:app/boot [:boot/route-resolved]]]}`
-       ;; on the route metadata, a vector of event vectors the routing runtime
-       ;; fires-and-forgets once the URL resolves to a valid plan (Spec 012
-       ;; §Per-route data loading). Nothing under :rf.route/* is dispatched
-       ;; into an app machine; every route the app can land on at boot carries
-       ;; this :on-match entry.
-       :on    {:boot/route-resolved {:target :ready}}}
+    :routing
+    {:entry :enter-routing
+     ;; If the running app needs the WebSocket URL from config, the :ready
+     ;; transition threads it into the connection machine's :connect event
+     ;; (per Pattern-AsyncEffect mechanism 1):
+     ;;   {:fx [[:dispatch [:ws/connection
+     ;;                     [:ws/connect {:url        (-> data :config :ws-url)
+     ;;                                   :auth-token (-> data :session :token)}]]]]}
+     ;; :boot/route-resolved is app-prefixed and produced by the initial
+     ;; route's :on-match — `{:on-match [[:app/boot [:boot/route-resolved]]]}`
+     ;; on the route metadata, a vector of event vectors the routing runtime
+     ;; fires-and-forgets once the URL resolves to a valid plan (Spec 012
+     ;; §Per-route data loading). Nothing under :rf.route/* is dispatched
+     ;; into an app machine; every route the app can land on at boot carries
+     ;; this :on-match entry.
+     :on    {:boot/route-resolved {:target :ready}}}
 
-      :ready          {:meta {:terminal? true}}
-      :auth-failed    {:meta {:terminal? true}}
-      :profile-failed {:meta {:terminal? true}}
-      :fatal-error    {:meta {:terminal? true}}}}))
+    :ready          {:meta {:terminal? true}}
+    :auth-failed    {:meta {:terminal? true}}
+    :profile-failed {:meta {:terminal? true}}
+    :fatal-error    {:meta {:terminal? true}}}})
 ```
 
 The frame's `:initial-events` dispatch `[:app/boot [:rf.machine/start]]` (or the equivalent per the host); the machine self-initialises (per [005 §Restore semantics]) and runs. `:rf.machine/start` is the **only** reserved creation marker the runtime recognises (xstate parity with `createActor(m).start()`, per [005 §Synthetic creation marker](005-StateMachines.md#synthetic-creation-marker--rfmachinestart)) — there is no `:rf/start`.
@@ -315,45 +314,44 @@ The pattern, distilled to a worked sketch:
 ;; depends on another request succeeding *first*, which is exactly the case
 ;; that doesn't fit inside :rf.http/managed's :retry slot.
 
-(rf/reg-event :auth/flow
-  (rf.machines/make-machine-handler
-    {:initial :loading-me
-     :data    {:token nil :user nil :error nil}
+(rf/reg-machine :auth/flow
+  {:initial :loading-me
+   :data    {:token nil :user nil :error nil}
 
-     :guards
-     ;; rf2-ibksxg — the canonical reply carries the classified :rf.http/* map
-     ;; under :error; branch on (:kind error) / (:status error).
-     {:got-401? (fn [{[_ {:keys [error]}] :event}]
-                  (and (= :rf.http/http-4xx (:kind error))
-                       (= 401 (:status error))))
-      :token-stale? (fn [{:keys [data]}]
-                      (some? (:token data)))}                  ;; refresh viable
+   :guards
+   ;; rf2-ibksxg — the canonical reply carries the classified :rf.http/* map
+   ;; under :error; branch on (:kind error) / (:status error).
+   {:got-401? (fn [{[_ {:keys [error]}] :event}]
+                (and (= :rf.http/http-4xx (:kind error))
+                     (= 401 (:status error))))
+    :token-stale? (fn [{:keys [data]}]
+                    (some? (:token data)))}                  ;; refresh viable
 
-     :actions
-     {:record-token (fn [{:keys [data] [_ {:keys [token]}] :event}] {:data (assoc data :token token)})
-      :record-user  (fn [{:keys [data] [_ {:keys [value]}] :event}] {:data (assoc data :user value)})
-      :record-error (fn [{:keys [data] [_ {:keys [error]}] :event}] {:data (assoc data :error error)})}
+   :actions
+   {:record-token (fn [{:keys [data] [_ {:keys [token]}] :event}] {:data (assoc data :token token)})
+    :record-user  (fn [{:keys [data] [_ {:keys [value]}] :event}] {:data (assoc data :user value)})
+    :record-error (fn [{:keys [data] [_ {:keys [error]}] :event}] {:data (assoc data :error error)})}
 
-     :states
-     {:loading-me
-      {:spawn {:src ::fetch-me
-                :data (fn [{:keys [snapshot]}] {:token (-> snapshot :data :token)})}
-       :on    {:succeeded {:target :authenticated :action :record-user}
-               :failed    [{:guard  :got-401?
-                            :target :refreshing
-                            :action :record-error}
-                           {:target :login                         ;; non-401 → fatal
-                            :action :record-error}]}}
+   :states
+   {:loading-me
+    {:spawn {:src ::fetch-me
+              :data (fn [{:keys [snapshot]}] {:token (-> snapshot :data :token)})}
+     :on    {:succeeded {:target :authenticated :action :record-user}
+             :failed    [{:guard  :got-401?
+                          :target :refreshing
+                          :action :record-error}
+                         {:target :login                         ;; non-401 → fatal
+                          :action :record-error}]}}
 
-      :refreshing
-      {:spawn {:src ::refresh-token}
-       :on    {:succeeded {:target :loading-me                    ;; semantic retry
-                           :action :record-token}
-               :failed    {:target :login                         ;; refresh failed → fatal
-                           :action :record-error}}}
+    :refreshing
+    {:spawn {:src ::refresh-token}
+     :on    {:succeeded {:target :loading-me                    ;; semantic retry
+                         :action :record-token}
+             :failed    {:target :login                         ;; refresh failed → fatal
+                         :action :record-error}}}
 
-      :authenticated {:meta {:terminal? true}}
-      :login         {:meta {:terminal? true}}}}))
+    :authenticated {:meta {:terminal? true}}
+    :login         {:meta {:terminal? true}}}})
 ```
 
 The boundary is teachable in three sentences:

--- a/spec/Pattern-LongRunningWork.md
+++ b/spec/Pattern-LongRunningWork.md
@@ -40,56 +40,55 @@ A state machine that processes one batch per state transition, yields to the bro
 ### Worked example — process N items in chunks of 100
 
 ```clojure
-(rf/reg-event :compute/batch-job
+(rf/reg-machine :compute/batch-job
   {:doc "Long-running batch processing with progress reporting and cancel support."}
-  (rf.machines/make-machine-handler
-    {:initial :idle
-     :data    {:total       0
-               :processed   0
-               :chunk-size  100
-               :input       nil
-               :result      []}
-     :guards
-     {:done?      (fn [{:keys [data]}] (>= (:processed data) (:total data)))
-      :more-work? (fn [{:keys [data]}] (<  (:processed data) (:total data)))}
+  {:initial :idle
+   :data    {:total       0
+             :processed   0
+             :chunk-size  100
+             :input       nil
+             :result      []}
+   :guards
+   {:done?      (fn [{:keys [data]}] (>= (:processed data) (:total data)))
+    :more-work? (fn [{:keys [data]}] (<  (:processed data) (:total data)))}
 
-     :actions
-     {:start-job
-      ;; opts is an optional map; :chunk-size falls back to the default declared in :data above.
-      (fn [{[_ input opts] :event}]
-        {:data {:total      (count input)
-                :input      input
-                :chunk-size (:chunk-size opts 100)
-                :processed  0
-                :result     []}})
+   :actions
+   {:start-job
+    ;; opts is an optional map; :chunk-size falls back to the default declared in :data above.
+    (fn [{[_ input opts] :event}]
+      {:data {:total      (count input)
+              :input      input
+              :chunk-size (:chunk-size opts 100)
+              :processed  0
+              :result     []}})
 
-      :process-chunk
-      (fn [{:keys [data]}]
-        (let [{:keys [input chunk-size processed result]} data
-              chunk    (subvec input processed (min (+ processed chunk-size) (count input)))
-              outputs  (mapv expensive-fn chunk)]
-          {:data {:processed (+ processed (count chunk))
-                  :result    (into result outputs)}}))}
+    :process-chunk
+    (fn [{:keys [data]}]
+      (let [{:keys [input chunk-size processed result]} data
+            chunk    (subvec input processed (min (+ processed chunk-size) (count input)))
+            outputs  (mapv expensive-fn chunk)]
+        {:data {:processed (+ processed (count chunk))
+                :result    (into result outputs)}}))}
 
-     :states
-     {:idle
-      {:on {:start    {:target :processing
-                       :action :start-job}}}
+   :states
+   {:idle
+    {:on {:start    {:target :processing
+                     :action :start-job}}}
 
-      :processing
-      {:entry  :process-chunk
-       :always [{:target :checking-done}]}    ;; immediately re-evaluate
+    :processing
+    {:entry  :process-chunk
+     :always [{:target :checking-done}]}    ;; immediately re-evaluate
 
-      :checking-done
-      {:always [{:guard :done?      :target :complete}
-                {:guard :more-work? :target :yielding}]}
+    :checking-done
+    {:always [{:guard :done?      :target :complete}
+              {:guard :more-work? :target :yielding}]}
 
-      :yielding
-      {:after {0 :processing}                 ;; one browser tick, then next chunk
-       :on    {:cancel :cancelled}}           ;; cancel only meaningful while yielding
+    :yielding
+    {:after {0 :processing}                 ;; one browser tick, then next chunk
+     :on    {:cancel :cancelled}}           ;; cancel only meaningful while yielding
 
-      :complete   {:on {:reset :idle}}
-      :cancelled  {:on {:reset :idle}}}}))
+    :complete   {:on {:reset :idle}}
+    :cancelled  {:on {:reset :idle}}}})
 ```
 
 Walk-through for a 1000-item job with chunk-size 100:

--- a/spec/Pattern-WebSocket.md
+++ b/spec/Pattern-WebSocket.md
@@ -122,441 +122,440 @@ The connection machine composes the locked substrate:
                                           (local-failure rid :ws/connection-lost))])))
                (:in-flight data))})
 
-(rf/reg-event :ws/connection
+(rf/reg-machine :ws/connection
   {:doc "WebSocket connection lifecycle: disconnected → active{:connecting →
          :authenticating → :connected} → reconnecting (with backoff) → failed."}
-  (rf.machines/make-machine-handler
-    {:initial :disconnected
-     :data    {:url            nil               ;; supplied by :ws/connect
-               :cred-ref       nil               ;; OPAQUE credential reference — never the bearer itself (see §Parameters)
-               :retries        0
-               :max-retries    8
-               :base-ms        1000              ;; initial backoff
-               :max-backoff-ms 30000
-               ;; No :socket-id field: the live socket's id lives in the
-               ;; runtime-maintained :rf/spawned slot (read via `socket-id`),
-               ;; which the runtime keeps current and clears on teardown.
-               :subscriptions  #{}               ;; topics to (re-)subscribe on :connected entry
-               :queue          []                ;; whole inbound events buffered while disconnected
-               :in-flight      {}                ;; {request-id → {:reply-event ... :timeout-ms ... :token ...}}
-               :next-token     0                 ;; ticking source for each registration's :token (see :register-request)
-               :error          nil}
+  {:initial :disconnected
+   :data    {:url            nil               ;; supplied by :ws/connect
+             :cred-ref       nil               ;; OPAQUE credential reference — never the bearer itself (see §Parameters)
+             :retries        0
+             :max-retries    8
+             :base-ms        1000              ;; initial backoff
+             :max-backoff-ms 30000
+             ;; No :socket-id field: the live socket's id lives in the
+             ;; runtime-maintained :rf/spawned slot (read via `socket-id`),
+             ;; which the runtime keeps current and clears on teardown.
+             :subscriptions  #{}               ;; topics to (re-)subscribe on :connected entry
+             :queue          []                ;; whole inbound events buffered while disconnected
+             :in-flight      {}                ;; {request-id → {:reply-event ... :timeout-ms ... :token ...}}
+             :next-token     0                 ;; ticking source for each registration's :token (see :register-request)
+             :error          nil}
 
-     :guards
-     {:max-retries-exceeded?
-      (fn [{:keys [data]}]
-        (>= (:retries data) (:max-retries data)))
+   :guards
+   {:max-retries-exceeded?
+    (fn [{:keys [data]}]
+      (>= (:retries data) (:max-retries data)))
 
-      :has-queued-messages?
-      (fn [{:keys [data]}]
-        (seq (:queue data)))
+    :has-queued-messages?
+    (fn [{:keys [data]}]
+      (seq (:queue data)))
 
-      :current-socket?
-      ;; The connection-epoch check (Pattern-StaleDetection): is this event
-      ;; from the socket this machine owns RIGHT NOW? Every inbound socket
-      ;; event stamps the id of the socket it came from (`:source-socket-id`,
-      ;; the actor's `:rf/self-id`); we let it through only if that matches the
-      ;; live id read from `:rf/spawned`. A torn-down socket reads as nil, so
-      ;; every straggler from a replaced connection is dropped for free.
-      (fn [{:keys [data] [_ {:keys [source-socket-id]}] :event}]
-        (current-socket? data source-socket-id))
+    :current-socket?
+    ;; The connection-epoch check (Pattern-StaleDetection): is this event
+    ;; from the socket this machine owns RIGHT NOW? Every inbound socket
+    ;; event stamps the id of the socket it came from (`:source-socket-id`,
+    ;; the actor's `:rf/self-id`); we let it through only if that matches the
+    ;; live id read from `:rf/spawned`. A torn-down socket reads as nil, so
+    ;; every straggler from a replaced connection is dropped for free.
+    (fn [{:keys [data] [_ {:keys [source-socket-id]}] :event}]
+      (current-socket? data source-socket-id))
 
-      :own-request-timeout?
-      ;; The deadline gate, and like `:trusted-frame?` it asks BOTH questions a
-      ;; `:ws/request-timeout` must answer before it may settle anything: is it
-      ;; from the socket we own right now, and is it the timer the registration
-      ;; CURRENTLY in that slot armed?
-      ;;
-      ;; The epoch check alone rejects timers from an old CONNECTION; it says
-      ;; nothing about an old REGISTRATION on the same live socket, and that gap
-      ;; needs no reconnect to open. A `:request-id` is the app's own value and
-      ;; the app is invited to reuse one (see §Message correlation), so on one
-      ;; long-lived socket the same id can be registered, settled, and
-      ;; registered again well inside the first request's timeout window. The
-      ;; first timer is still armed and still stamped with the live socket, so
-      ;; it passes the epoch check, names an id the SECOND request now holds,
-      ;; and settles a request whose deadline has not elapsed.
-      ;;
-      ;; So `:register-request` stamps each registration with a `:token` and
-      ;; schedules the timeout carrying it. This is also what makes shipping no
-      ;; timer-cancellation facility safe: an obsolete timer is not cancelled,
-      ;; it is inert — it fires, fails this guard, and is dropped like any other
-      ;; straggler.
-      (fn [{:keys [data] [_ {:keys [source-socket-id request-id token]}] :event}]
-        (and (current-socket? data source-socket-id)
-             (when-let [entry (get-in data [:in-flight request-id])]
-               (= token (:token entry)))))
+    :own-request-timeout?
+    ;; The deadline gate, and like `:trusted-frame?` it asks BOTH questions a
+    ;; `:ws/request-timeout` must answer before it may settle anything: is it
+    ;; from the socket we own right now, and is it the timer the registration
+    ;; CURRENTLY in that slot armed?
+    ;;
+    ;; The epoch check alone rejects timers from an old CONNECTION; it says
+    ;; nothing about an old REGISTRATION on the same live socket, and that gap
+    ;; needs no reconnect to open. A `:request-id` is the app's own value and
+    ;; the app is invited to reuse one (see §Message correlation), so on one
+    ;; long-lived socket the same id can be registered, settled, and
+    ;; registered again well inside the first request's timeout window. The
+    ;; first timer is still armed and still stamped with the live socket, so
+    ;; it passes the epoch check, names an id the SECOND request now holds,
+    ;; and settles a request whose deadline has not elapsed.
+    ;;
+    ;; So `:register-request` stamps each registration with a `:token` and
+    ;; schedules the timeout carrying it. This is also what makes shipping no
+    ;; timer-cancellation facility safe: an obsolete timer is not cancelled,
+    ;; it is inert — it fires, fails this guard, and is dropped like any other
+    ;; straggler.
+    (fn [{:keys [data] [_ {:keys [source-socket-id request-id token]}] :event}]
+      (and (current-socket? data source-socket-id)
+           (when-let [entry (get-in data [:in-flight request-id])]
+             (= token (:token entry)))))
 
-      :trusted-frame?
-      ;; The inbound gate. Vouching for the SENDER is not vouching for the
-      ;; BYTES, and `:receive-message` clears an `:in-flight` slot the frame
-      ;; itself names — so the frame is held to the closed `InboundMessage`
-      ;; contract here, before any branching or state change. See §Vet the
-      ;; frame before the machine acts on it. One named guard rather than an
-      ;; `:and` of two — 005 ships no guard combinator data form; compound
-      ;; logic goes in one guard whose NAME carries the meaning.
-      (fn [{:keys [data] [_ {:keys [source-socket-id body]}] :event}]
-        (and (current-socket? data source-socket-id)
-             (valid-inbound-frame? body)))}      ;; a compiled InboundMessage validator
+    :trusted-frame?
+    ;; The inbound gate. Vouching for the SENDER is not vouching for the
+    ;; BYTES, and `:receive-message` clears an `:in-flight` slot the frame
+    ;; itself names — so the frame is held to the closed `InboundMessage`
+    ;; contract here, before any branching or state change. See §Vet the
+    ;; frame before the machine acts on it. One named guard rather than an
+    ;; `:and` of two — 005 ships no guard combinator data form; compound
+    ;; logic goes in one guard whose NAME carries the meaning.
+    (fn [{:keys [data] [_ {:keys [source-socket-id body]}] :event}]
+      (and (current-socket? data source-socket-id)
+           (valid-inbound-frame? body)))}      ;; a compiled InboundMessage validator
 
-     :actions
-     {:record-connection-opts
-      ;; Caller passes the URL + an OPAQUE credential reference on
-      ;; :ws/connect; opts land in :data and every subsequent reconnect
-      ;; re-reads them via :spawn's :data fn. Never the bearer itself —
-      ;; see §Parameters.
-      (fn [{:keys [data] [_ {:keys [url cred-ref]}] :event}]
-        {:data (assoc data :url url :cred-ref cred-ref)})
+   :actions
+   {:record-connection-opts
+    ;; Caller passes the URL + an OPAQUE credential reference on
+    ;; :ws/connect; opts land in :data and every subsequent reconnect
+    ;; re-reads them via :spawn's :data fn. Never the bearer itself —
+    ;; see §Parameters.
+    (fn [{:keys [data] [_ {:keys [url cred-ref]}] :event}]
+      {:data (assoc data :url url :cred-ref cred-ref)})
 
-      :rotate-cred
-      ;; The auth machine calls this after an out-of-band credential
-      ;; rotation; only the new opaque reference crosses the dispatch
-      ;; boundary, and the next :active entry's :spawn :data fn picks it up.
-      (fn [{:keys [data] [_ new-cred-ref] :event}]
-        {:data (assoc data :cred-ref new-cred-ref)})
+    :rotate-cred
+    ;; The auth machine calls this after an out-of-band credential
+    ;; rotation; only the new opaque reference crosses the dispatch
+    ;; boundary, and the next :active entry's :spawn :data fn picks it up.
+    (fn [{:keys [data] [_ new-cred-ref] :event}]
+      {:data (assoc data :cred-ref new-cred-ref)})
 
-      :on-socket-lost
-      ;; The live socket dropped (a :ws/closed that passed :current-socket?).
-      ;; Heading for :reconnecting, two things happen:
-      ;;   1. Bump the retry counter — it drives the :after backoff and the
-      ;;      :max-retries-exceeded? guard.
-      ;;   2. FAIL every in-flight request, through the shared `fail-in-flight`
-      ;;      helper above — the same half of the job the clean-disconnect and
-      ;;      fatal doors do. Each waiting :reply-event fires with
-      ;;      {:origin :ws/local :ok false :error :ws/connection-lost} so the
-      ;;      caller learns the outcome instead of hanging forever. See the
-      ;;      helper for the full leak/replay story.
-      (fn [{:keys [data]}]
-        (-> (fail-in-flight data)
-            (update :data update :retries inc)))
+    :on-socket-lost
+    ;; The live socket dropped (a :ws/closed that passed :current-socket?).
+    ;; Heading for :reconnecting, two things happen:
+    ;;   1. Bump the retry counter — it drives the :after backoff and the
+    ;;      :max-retries-exceeded? guard.
+    ;;   2. FAIL every in-flight request, through the shared `fail-in-flight`
+    ;;      helper above — the same half of the job the clean-disconnect and
+    ;;      fatal doors do. Each waiting :reply-event fires with
+    ;;      {:origin :ws/local :ok false :error :ws/connection-lost} so the
+    ;;      caller learns the outcome instead of hanging forever. See the
+    ;;      helper for the full leak/replay story.
+    (fn [{:keys [data]}]
+      (-> (fail-in-flight data)
+          (update :data update :retries inc)))
 
-      :fail-in-flight
-      ;; The clean door. A :ws/disconnect out of :active destroys the socket
-      ;; just as surely as a drop does, so the SAME invariant applies: every
-      ;; request accepted into :in-flight settles exactly once on the way out.
-      ;; Unlike :on-socket-lost there is no retry bump — the app asked for this
-      ;; disconnect, so it is not a connection failure; only the requests still
-      ;; riding the wire fail, with the same documented body.
-      (fn [{:keys [data]}]
-        (fail-in-flight data))
+    :fail-in-flight
+    ;; The clean door. A :ws/disconnect out of :active destroys the socket
+    ;; just as surely as a drop does, so the SAME invariant applies: every
+    ;; request accepted into :in-flight settles exactly once on the way out.
+    ;; Unlike :on-socket-lost there is no retry bump — the app asked for this
+    ;; disconnect, so it is not a connection failure; only the requests still
+    ;; riding the wire fail, with the same documented body.
+    (fn [{:keys [data]}]
+      (fail-in-flight data))
 
-      :on-fatal-error
-      ;; :ws/fatal is the app-level escape hatch out of :active — the app
-      ;; itself declaring the connection unrecoverable (a protocol violation, a
-      ;; server telling us not to come back) and going straight to :failed
-      ;; without retrying. It leaves :active, so the runtime destroys the
-      ;; socket just as surely as a drop or a clean disconnect does, and
-      ;; recording the error is only HALF the job: without the fail-in-flight
-      ;; half the slot and its waiting :reply-event survive teardown forever,
-      ;; because the scheduled timeout carries the destroyed socket's id and
-      ;; :current-socket? rejects it once the socket is gone. That leak
-      ;; outlives a later manual :ws/connect out of :failed too, so the caller
-      ;; never learns anything. No retry bump: we are giving up, not retrying.
-      (fn [{:keys [data] [_ {:keys [error]}] :event}]
-        (-> (fail-in-flight data)
-            (update :data assoc :error error)))
+    :on-fatal-error
+    ;; :ws/fatal is the app-level escape hatch out of :active — the app
+    ;; itself declaring the connection unrecoverable (a protocol violation, a
+    ;; server telling us not to come back) and going straight to :failed
+    ;; without retrying. It leaves :active, so the runtime destroys the
+    ;; socket just as surely as a drop or a clean disconnect does, and
+    ;; recording the error is only HALF the job: without the fail-in-flight
+    ;; half the slot and its waiting :reply-event survive teardown forever,
+    ;; because the scheduled timeout carries the destroyed socket's id and
+    ;; :current-socket? rejects it once the socket is gone. That leak
+    ;; outlives a later manual :ws/connect out of :failed too, so the caller
+    ;; never learns anything. No retry bump: we are giving up, not retrying.
+    (fn [{:keys [data] [_ {:keys [error]}] :event}]
+      (-> (fail-in-flight data)
+          (update :data assoc :error error)))
 
-      :send-auth
-      ;; Route an :auth message into the live socket actor. NO token in
-      ;; the payload: the actor resolved the bearer from :cred-ref inside
-      ;; its own host closure at socket-open and attaches it to the wire
-      ;; frame itself — the credential never rides a dispatch.
-      (fn [{:keys [data]}]
-        {:fx [[:dispatch [(socket-id data) [:send {:type :auth}]]]]})
+    :send-auth
+    ;; Route an :auth message into the live socket actor. NO token in
+    ;; the payload: the actor resolved the bearer from :cred-ref inside
+    ;; its own host closure at socket-open and attaches it to the wire
+    ;; frame itself — the credential never rides a dispatch.
+    (fn [{:keys [data]}]
+      {:fx [[:dispatch [(socket-id data) [:send {:type :auth}]]]]})
 
-      :on-connected
-      ;; Compound entry action for :connected — reset the retry counter (we
-      ;; made it) and re-issue a subscribe for every tracked topic, so
-      ;; subscriptions survive the reconnect. The queued-message flush is the
-      ;; separate :always step below; this action leaves :queue for it to find.
-      ;; (Per [005 §State nodes] :entry takes one fn or one registered id,
-      ;; never a vector.)
-      (fn [{:keys [data]}]
-        {:data (assoc data :retries 0)
-         :fx   (mapv (fn [topic]
-                       [:dispatch [(socket-id data)
-                                   [:send {:type :subscribe :topic topic}]]])
-                     (:subscriptions data))})
+    :on-connected
+    ;; Compound entry action for :connected — reset the retry counter (we
+    ;; made it) and re-issue a subscribe for every tracked topic, so
+    ;; subscriptions survive the reconnect. The queued-message flush is the
+    ;; separate :always step below; this action leaves :queue for it to find.
+    ;; (Per [005 §State nodes] :entry takes one fn or one registered id,
+    ;; never a vector.)
+    (fn [{:keys [data]}]
+      {:data (assoc data :retries 0)
+       :fx   (mapv (fn [topic]
+                     [:dispatch [(socket-id data)
+                                 [:send {:type :subscribe :topic topic}]]])
+                   (:subscriptions data))})
 
-      :flush-queue
-      ;; The :always step on :connected: replay everything buffered while off
-      ;; connection. Each queued item is the ORIGINAL inbound event, so
-      ;; re-dispatch it INTO the connection machine — now :connected, so a
-      ;; :ws/send takes :send-now and a :ws/request takes :register-request
-      ;; (in-flight slot + correlation + timeout), exactly as if issued while
-      ;; connected. Clearing :queue first stops the replay re-enqueuing.
-      (fn [{:keys [data]}]
-        {:data (assoc data :queue [])
-         :fx   (mapv (fn [event] [:dispatch [:ws/connection event]])
-                     (:queue data))})
+    :flush-queue
+    ;; The :always step on :connected: replay everything buffered while off
+    ;; connection. Each queued item is the ORIGINAL inbound event, so
+    ;; re-dispatch it INTO the connection machine — now :connected, so a
+    ;; :ws/send takes :send-now and a :ws/request takes :register-request
+    ;; (in-flight slot + correlation + timeout), exactly as if issued while
+    ;; connected. Clearing :queue first stops the replay re-enqueuing.
+    (fn [{:keys [data]}]
+      {:data (assoc data :queue [])
+       :fx   (mapv (fn [event] [:dispatch [:ws/connection event]])
+                   (:queue data))})
 
-      :enqueue-message
-      ;; Off connection there's no socket to send on, so buffer the WHOLE
-      ;; inbound event ([:ws/send …] or [:ws/request …]), not just its body.
-      ;; :flush-queue re-dispatches each verbatim on the next :connected entry,
-      ;; so a queued request rejoins :register-request and gets correlated.
-      ;; (Buffering a bare body instead would put a request's whole envelope on
-      ;; the wire as the payload — uncorrelated, never answered.)
-      (fn [{:keys [data] event :event}]
-        {:data (update data :queue conj event)})
+    :enqueue-message
+    ;; Off connection there's no socket to send on, so buffer the WHOLE
+    ;; inbound event ([:ws/send …] or [:ws/request …]), not just its body.
+    ;; :flush-queue re-dispatches each verbatim on the next :connected entry,
+    ;; so a queued request rejoins :register-request and gets correlated.
+    ;; (Buffering a bare body instead would put a request's whole envelope on
+    ;; the wire as the payload — uncorrelated, never answered.)
+    (fn [{:keys [data] event :event}]
+      {:data (update data :queue conj event)})
 
-      :register-request
-      ;; Caller: [:ws/request {:request-id ..., :body ..., :reply ...}].
-      ;; Record the in-flight entry, forward to the socket, schedule a timeout.
-      ;;
-      ;; Three details here are about the correlation id being the APP's, and
-      ;; therefore reusable. (1) The registration takes the next `:token`, which
-      ;; goes into the slot AND onto the scheduled timeout, so that timer can
-      ;; only ever settle THIS registration — see `:own-request-timeout?`.
-      ;; (2) The same token goes ON THE WIRE as `:request-token`, and the
-      ;; `ReplyMessage` arm of the inbound contract requires it back, so a
-      ;; server reply can name the registration it answers rather than only the
-      ;; slot it was filed under — see item 6 below.
-      ;; (3) Re-registering an id that is still in flight SUPERSEDES: the
-      ;; displaced caller is settled with `:ws/superseded` before the new
-      ;; request goes out, so it is never stranded. See item 6 below.
-      (fn [{:keys [data] [_ {:keys [request-id body reply timeout-ms]
-                             :or   {timeout-ms 30000}}] :event}]
-        (let [token     (:next-token data)
-              displaced (:reply-event (get-in data [:in-flight request-id]))
-              send+arm  [[:dispatch [(socket-id data)
-                                     [:send (assoc body
-                                                   :request-id    request-id
-                                                   :request-token token)]]]
-                         ;; The timeout event carries the live socket-id too, so
-                         ;; the same epoch check quietly discards a timeout left
-                         ;; over from a connection we've already moved past.
-                         [:dispatch-later
-                          {:ms    timeout-ms
-                           :event [:ws/connection
-                                   [:ws/request-timeout
-                                    {:request-id       request-id
-                                     :token            token
-                                     :source-socket-id (socket-id data)}]]}]]]
-          {:data (-> data
-                     (assoc :next-token (inc token))
-                     (assoc-in [:in-flight request-id]
-                               {:reply-event reply
-                                :timeout-ms  timeout-ms
-                                :token       token}))
-           ;; Settle the displaced caller FIRST — it is done either way, and it
-           ;; should learn that before the wire moves on.
-           :fx   (if displaced
-                   (into [[:dispatch (conj displaced
-                                           (local-failure request-id :ws/superseded))]]
-                         send+arm)
-                   send+arm)}))
-
-      :clear-request
-      ;; A request's deadline fired — a `:ws/request-timeout` that passed
-      ;; `:own-request-timeout?`, so the socket is still live, the slot is still
-      ;; occupied, and THIS registration is the one that armed the timer, but
-      ;; the reply never came. FAIL the request, don't just forget it: clear the
-      ;; in-flight slot AND fire the waiting `:reply-event` with a timeout body, so a
-      ;; request that times out on a live socket learns its outcome instead of
-      ;; hanging forever. This is `fail-in-flight`'s per-request twin — same
-      ;; local-failure shape, scoped to the single request whose timer elapsed
-      ;; rather than the whole in-flight set. (A request registered without a
-      ;; `:reply` has a nil `:reply-event`, so the dispatch is guarded.)
-      (fn [{:keys [data] [_ {:keys [request-id]}] :event}]
-        (let [{:keys [reply-event]} (get-in data [:in-flight request-id])]
-          {:data (update data :in-flight dissoc request-id)
-           :fx   (cond-> []
-                   reply-event (conj [:dispatch
-                                      (conj reply-event
-                                            (local-failure request-id
-                                                           :ws/timeout))]))}))
-
-      :record-and-reset
-      ;; Compound action — record fresh opts AND reset the retry counter.
-      ;; Used on manual :ws/connect from :reconnecting / :failed (the
-      ;; running app has rotated its credential; reconnect immediately).
-      (fn [{:keys [data] [_ {:keys [url cred-ref]}] :event}]
+    :register-request
+    ;; Caller: [:ws/request {:request-id ..., :body ..., :reply ...}].
+    ;; Record the in-flight entry, forward to the socket, schedule a timeout.
+    ;;
+    ;; Three details here are about the correlation id being the APP's, and
+    ;; therefore reusable. (1) The registration takes the next `:token`, which
+    ;; goes into the slot AND onto the scheduled timeout, so that timer can
+    ;; only ever settle THIS registration — see `:own-request-timeout?`.
+    ;; (2) The same token goes ON THE WIRE as `:request-token`, and the
+    ;; `ReplyMessage` arm of the inbound contract requires it back, so a
+    ;; server reply can name the registration it answers rather than only the
+    ;; slot it was filed under — see item 6 below.
+    ;; (3) Re-registering an id that is still in flight SUPERSEDES: the
+    ;; displaced caller is settled with `:ws/superseded` before the new
+    ;; request goes out, so it is never stranded. See item 6 below.
+    (fn [{:keys [data] [_ {:keys [request-id body reply timeout-ms]
+                           :or   {timeout-ms 30000}}] :event}]
+      (let [token     (:next-token data)
+            displaced (:reply-event (get-in data [:in-flight request-id]))
+            send+arm  [[:dispatch [(socket-id data)
+                                   [:send (assoc body
+                                                 :request-id    request-id
+                                                 :request-token token)]]]
+                       ;; The timeout event carries the live socket-id too, so
+                       ;; the same epoch check quietly discards a timeout left
+                       ;; over from a connection we've already moved past.
+                       [:dispatch-later
+                        {:ms    timeout-ms
+                         :event [:ws/connection
+                                 [:ws/request-timeout
+                                  {:request-id       request-id
+                                   :token            token
+                                   :source-socket-id (socket-id data)}]]}]]]
         {:data (-> data
-                   (assoc :url url :cred-ref cred-ref)
-                   (assoc :retries 0))})
+                   (assoc :next-token (inc token))
+                   (assoc-in [:in-flight request-id]
+                             {:reply-event reply
+                              :timeout-ms  timeout-ms
+                              :token       token}))
+         ;; Settle the displaced caller FIRST — it is done either way, and it
+         ;; should learn that before the wire moves on.
+         :fx   (if displaced
+                 (into [[:dispatch (conj displaced
+                                         (local-failure request-id :ws/superseded))]]
+                       send+arm)
+                 send+arm)}))
 
-      :record-error
-      ;; Socket-sourced error events carry a map payload — {:source-socket-id
-      ;; … :error …} — so the :error rides alongside the id the guards read.
-      (fn [{:keys [data] [_ {:keys [error]}] :event}] {:data (assoc data :error error)})}
+    :clear-request
+    ;; A request's deadline fired — a `:ws/request-timeout` that passed
+    ;; `:own-request-timeout?`, so the socket is still live, the slot is still
+    ;; occupied, and THIS registration is the one that armed the timer, but
+    ;; the reply never came. FAIL the request, don't just forget it: clear the
+    ;; in-flight slot AND fire the waiting `:reply-event` with a timeout body, so a
+    ;; request that times out on a live socket learns its outcome instead of
+    ;; hanging forever. This is `fail-in-flight`'s per-request twin — same
+    ;; local-failure shape, scoped to the single request whose timer elapsed
+    ;; rather than the whole in-flight set. (A request registered without a
+    ;; `:reply` has a nil `:reply-event`, so the dispatch is guarded.)
+    (fn [{:keys [data] [_ {:keys [request-id]}] :event}]
+      (let [{:keys [reply-event]} (get-in data [:in-flight request-id])]
+        {:data (update data :in-flight dissoc request-id)
+         :fx   (cond-> []
+                 reply-event (conj [:dispatch
+                                    (conj reply-event
+                                          (local-failure request-id
+                                                         :ws/timeout))]))}))
+
+    :record-and-reset
+    ;; Compound action — record fresh opts AND reset the retry counter.
+    ;; Used on manual :ws/connect from :reconnecting / :failed (the
+    ;; running app has rotated its credential; reconnect immediately).
+    (fn [{:keys [data] [_ {:keys [url cred-ref]}] :event}]
+      {:data (-> data
+                 (assoc :url url :cred-ref cred-ref)
+                 (assoc :retries 0))})
+
+    :record-error
+    ;; Socket-sourced error events carry a map payload — {:source-socket-id
+    ;; … :error …} — so the :error rides alongside the id the guards read.
+    (fn [{:keys [data] [_ {:keys [error]}] :event}] {:data (assoc data :error error)})}
+
+   :states
+   {:disconnected
+    {:on {:ws/connect {:target [:active]
+                       :action :record-connection-opts}
+          :ws/send    {:action :enqueue-message}
+          :ws/request {:action :enqueue-message}}}
+
+    :active
+    {;; The socket actor is invoked at the parent level — its lifetime
+     ;; spans :connecting, :authenticating, and :connected. Any transition
+     ;; that exits :active (to :reconnecting, :failed, or :disconnected)
+     ;; destroys it and clears its id from :rf/spawned; re-entering :active
+     ;; spawns a fresh one.
+     :spawn {:machine-id :websocket/socket
+              ;; Mechanism 2 from Pattern-AsyncEffect §Parameter passing
+              ;; across the boundary — the child reads URL + the opaque
+              ;; :cred-ref from the parent's :data at spawn time (the
+              ;; child resolves the reference to the real bearer inside
+              ;; its own host closure — see §Parameters). Every re-entry
+              ;; to :active picks up whatever the parent's :data currently
+              ;; holds, so a :rotate-cred between reconnects flows in
+              ;; without any extra wiring.
+              :data       (fn [{snap :snapshot}]
+                            {:url      (-> snap :data :url)
+                             :cred-ref (-> snap :data :cred-ref)})}
+              ;; Recording the socket-id needs no :on-spawn write and no
+              ;; :exit cleanup: on every declarative :spawn the runtime binds
+              ;; the newborn actor's id into THIS machine's :data under
+              ;; :rf/spawned, keyed by the :spawn-bearing state's path
+              ;; ([:active]) — read it via the `socket-id` helper above — and
+              ;; CLEARS it automatically when the actor is torn down. First-
+              ;; class :rf/spawned idiom (005 §Recording the spawned id
+              ;; user-side), preferred over the older carry-the-id-back
+              ;; self-dispatch.
+
+     ;; Parent-level transitions inherited by every leaf
+     ;; (per [005 §Transition resolution]). Any transport-level close during
+     ;; :connecting / :authenticating / :connected routes through here.
+     ;; :ws/closed is epoch-guarded like every socket-sourced event, so a
+     ;; close from a socket we've already replaced can't tear down the live
+     ;; connection; :on-socket-lost bumps the retry counter AND fails every
+     ;; in-flight request (see above).
+     :on    {:ws/closed   {:guard  :current-socket?
+                           :target :reconnecting
+                           :action :on-socket-lost}
+             ;; The app-level escape hatch. It leaves :active, so it kills
+             ;; the wire — and therefore settles the in-flight set on the way
+             ;; out as well as recording the error (see :on-fatal-error).
+             :ws/fatal    {:target :failed
+                           :action :on-fatal-error}
+             ;; The clean door out. It kills the wire too, so it settles the
+             ;; in-flight set on the way out (see :fail-in-flight). Every
+             ;; door out of :active reachable from :connected — this one, the
+             ;; guarded :ws/closed drop and :ws/fatal — settles :in-flight
+             ;; exactly once.
+             :ws/disconnect {:target :disconnected
+                             :action :fail-in-flight}
+             :ws/send     {:action :enqueue-message}
+             :ws/rotate-cred {:action :rotate-cred}
+             ;; A request issued before the connection is :connected is
+             ;; queued like any other send (the whole event is buffered, so
+             ;; its :request-id survives); the :connected leaf overrides
+             ;; below.
+             :ws/request  {:action :enqueue-message}}
+
+     :initial :connecting
 
      :states
-     {:disconnected
-      {:on {:ws/connect {:target [:active]
-                         :action :record-connection-opts}
-            :ws/send    {:action :enqueue-message}
-            :ws/request {:action :enqueue-message}}}
+     {:connecting
+      ;; Guarded like every socket-sourced lifecycle event: an :ws/opened
+      ;; from a socket we've already replaced (a slow open landing after a
+      ;; disconnect+reconnect) must not advance THIS connection.
+      {:on {:ws/opened {:guard  :current-socket?
+                        :target :authenticating}}}
 
-      :active
-      {;; The socket actor is invoked at the parent level — its lifetime
-       ;; spans :connecting, :authenticating, and :connected. Any transition
-       ;; that exits :active (to :reconnecting, :failed, or :disconnected)
-       ;; destroys it and clears its id from :rf/spawned; re-entering :active
-       ;; spawns a fresh one.
-       :spawn {:machine-id :websocket/socket
-                ;; Mechanism 2 from Pattern-AsyncEffect §Parameter passing
-                ;; across the boundary — the child reads URL + the opaque
-                ;; :cred-ref from the parent's :data at spawn time (the
-                ;; child resolves the reference to the real bearer inside
-                ;; its own host closure — see §Parameters). Every re-entry
-                ;; to :active picks up whatever the parent's :data currently
-                ;; holds, so a :rotate-cred between reconnects flows in
-                ;; without any extra wiring.
-                :data       (fn [{snap :snapshot}]
-                              {:url      (-> snap :data :url)
-                               :cred-ref (-> snap :data :cred-ref)})}
-                ;; Recording the socket-id needs no :on-spawn write and no
-                ;; :exit cleanup: on every declarative :spawn the runtime binds
-                ;; the newborn actor's id into THIS machine's :data under
-                ;; :rf/spawned, keyed by the :spawn-bearing state's path
-                ;; ([:active]) — read it via the `socket-id` helper above — and
-                ;; CLEARS it automatically when the actor is torn down. First-
-                ;; class :rf/spawned idiom (005 §Recording the spawned id
-                ;; user-side), preferred over the older carry-the-id-back
-                ;; self-dispatch.
+      :authenticating
+      {:entry :send-auth
+       ;; Both auth outcomes are epoch-guarded: a straggler :ws/auth-ok from
+       ;; a replaced socket must not prematurely mark us :connected, and a
+       ;; straggler :ws/auth-failed must not tear a fresh attempt to :failed.
+       :on    {:ws/auth-ok     {:guard  :current-socket?
+                                :target :connected}
+               ;; This door leaves :active too, but it needs no in-flight
+               ;; settlement — plain :record-error is correct here, not an
+               ;; oversight. :register-request is the only writer into
+               ;; :in-flight and it is bound only on :connected, so reaching
+               ;; :authenticating means :in-flight is provably empty.
+               :ws/auth-failed {:guard  :current-socket?
+                                :target [:failed]
+                                :action :record-error}}}
 
-       ;; Parent-level transitions inherited by every leaf
-       ;; (per [005 §Transition resolution]). Any transport-level close during
-       ;; :connecting / :authenticating / :connected routes through here.
-       ;; :ws/closed is epoch-guarded like every socket-sourced event, so a
-       ;; close from a socket we've already replaced can't tear down the live
-       ;; connection; :on-socket-lost bumps the retry counter AND fails every
-       ;; in-flight request (see above).
-       :on    {:ws/closed   {:guard  :current-socket?
-                             :target :reconnecting
-                             :action :on-socket-lost}
-               ;; The app-level escape hatch. It leaves :active, so it kills
-               ;; the wire — and therefore settles the in-flight set on the way
-               ;; out as well as recording the error (see :on-fatal-error).
-               :ws/fatal    {:target :failed
-                             :action :on-fatal-error}
-               ;; The clean door out. It kills the wire too, so it settles the
-               ;; in-flight set on the way out (see :fail-in-flight). Every
-               ;; door out of :active reachable from :connected — this one, the
-               ;; guarded :ws/closed drop and :ws/fatal — settles :in-flight
-               ;; exactly once.
-               :ws/disconnect {:target :disconnected
-                               :action :fail-in-flight}
-               :ws/send     {:action :enqueue-message}
-               :ws/rotate-cred {:action :rotate-cred}
-               ;; A request issued before the connection is :connected is
-               ;; queued like any other send (the whole event is buffered, so
-               ;; its :request-id survives); the :connected leaf overrides
-               ;; below.
-               :ws/request  {:action :enqueue-message}}
+      :connected
+      {:entry  :on-connected
+       :always [{:guard :has-queued-messages? :action :flush-queue}]
+       :on     {;; Inbound frame. TWO candidates, first-match-wins: a frame
+                ;; must clear both halves of the gate — :current-socket?
+                ;; (not a straggler from a socket we have replaced) AND the
+                ;; closed InboundMessage wire contract — before this machine
+                ;; acts on it. See §Vet the frame before the machine acts on
+                ;; it for why the app-db ingress check downstream is not
+                ;; sufficient on its own.
+                :ws/received [{:guard  :trusted-frame?
+                               :action (fn [{:keys [data] [_ {:keys [body]}] :event}]
+                                         ;; Branch on the VETTED :type, not on
+                                         ;; "is there a :request-id?". Then
+                                         ;; correlate on the REGISTRATION: the
+                                         ;; echoed :request-token must still be
+                                         ;; the one in the slot, or this reply
+                                         ;; answers a registration that is no
+                                         ;; longer there (item 6).
+                                         (if (= :reply (:type body))
+                                           (let [rid   (:request-id body)
+                                                 entry (when-let [e (get-in data [:in-flight rid])]
+                                                         (when (= (:request-token body) (:token e)) e))]
+                                             (cond-> {:fx [[:dispatch [:ws/handle-message body]]]}
+                                               entry
+                                               (assoc :data (update data :in-flight dissoc rid))
+                                               (:reply-event entry)
+                                               ;; :origin is the machine's own
+                                               ;; stamp — see §Message correlation.
+                                               (update :fx conj
+                                                       [:dispatch (conj (:reply-event entry)
+                                                                        (assoc body :origin :ws/server))])))
+                                           ;; Server push — translate to a
+                                           ;; named running-app event.
+                                           {:fx [[:dispatch [:ws/handle-message body]]]}))}
+                              ;; Failed the wire contract: hand it to the
+                              ;; ingress, which owns refusal, and change
+                              ;; nothing. Note the absent :data key.
+                              {:guard  :current-socket?
+                               :action (fn [{[_ {:keys [body]}] :event}]
+                                         {:fx [[:dispatch [:ws/handle-message body]]]})}]
 
-       :initial :connecting
+                ;; Override the parent's :ws/send: while :connected the
+                ;; message goes straight to the wire instead of queueing.
+                :ws/send    {:action (fn [{:keys [data] [_ msg] :event}]
+                                       {:fx [[:dispatch [(socket-id data)
+                                                         [:send msg]]]]})}
 
-       :states
-       {:connecting
-        ;; Guarded like every socket-sourced lifecycle event: an :ws/opened
-        ;; from a socket we've already replaced (a slow open landing after a
-        ;; disconnect+reconnect) must not advance THIS connection.
-        {:on {:ws/opened {:guard  :current-socket?
-                          :target :authenticating}}}
+                ;; Override the parent's :ws/request: while :connected
+                ;; the request is registered + sent immediately.
+                :ws/request {:action :register-request}
 
-        :authenticating
-        {:entry :send-auth
-         ;; Both auth outcomes are epoch-guarded: a straggler :ws/auth-ok from
-         ;; a replaced socket must not prematurely mark us :connected, and a
-         ;; straggler :ws/auth-failed must not tear a fresh attempt to :failed.
-         :on    {:ws/auth-ok     {:guard  :current-socket?
-                                  :target :connected}
-                 ;; This door leaves :active too, but it needs no in-flight
-                 ;; settlement — plain :record-error is correct here, not an
-                 ;; oversight. :register-request is the only writer into
-                 ;; :in-flight and it is bound only on :connected, so reaching
-                 ;; :authenticating means :in-flight is provably empty.
-                 :ws/auth-failed {:guard  :current-socket?
-                                  :target [:failed]
-                                  :action :record-error}}}
+                ;; A deadline elapsed. Two questions, one guard: is the socket
+                ;; still ours, and is this the timer the registration
+                ;; currently in the slot armed? See :own-request-timeout?.
+                :ws/request-timeout
+                {:guard  :own-request-timeout?
+                 :action :clear-request}}}}}
 
-        :connected
-        {:entry  :on-connected
-         :always [{:guard :has-queued-messages? :action :flush-queue}]
-         :on     {;; Inbound frame. TWO candidates, first-match-wins: a frame
-                  ;; must clear both halves of the gate — :current-socket?
-                  ;; (not a straggler from a socket we have replaced) AND the
-                  ;; closed InboundMessage wire contract — before this machine
-                  ;; acts on it. See §Vet the frame before the machine acts on
-                  ;; it for why the app-db ingress check downstream is not
-                  ;; sufficient on its own.
-                  :ws/received [{:guard  :trusted-frame?
-                                 :action (fn [{:keys [data] [_ {:keys [body]}] :event}]
-                                           ;; Branch on the VETTED :type, not on
-                                           ;; "is there a :request-id?". Then
-                                           ;; correlate on the REGISTRATION: the
-                                           ;; echoed :request-token must still be
-                                           ;; the one in the slot, or this reply
-                                           ;; answers a registration that is no
-                                           ;; longer there (item 6).
-                                           (if (= :reply (:type body))
-                                             (let [rid   (:request-id body)
-                                                   entry (when-let [e (get-in data [:in-flight rid])]
-                                                           (when (= (:request-token body) (:token e)) e))]
-                                               (cond-> {:fx [[:dispatch [:ws/handle-message body]]]}
-                                                 entry
-                                                 (assoc :data (update data :in-flight dissoc rid))
-                                                 (:reply-event entry)
-                                                 ;; :origin is the machine's own
-                                                 ;; stamp — see §Message correlation.
-                                                 (update :fx conj
-                                                         [:dispatch (conj (:reply-event entry)
-                                                                          (assoc body :origin :ws/server))])))
-                                             ;; Server push — translate to a
-                                             ;; named running-app event.
-                                             {:fx [[:dispatch [:ws/handle-message body]]]}))}
-                                ;; Failed the wire contract: hand it to the
-                                ;; ingress, which owns refusal, and change
-                                ;; nothing. Note the absent :data key.
-                                {:guard  :current-socket?
-                                 :action (fn [{[_ {:keys [body]}] :event}]
-                                           {:fx [[:dispatch [:ws/handle-message body]]]})}]
+    :reconnecting
+    {:always [{:guard :max-retries-exceeded? :target :failed}]
+     ;; Exponential backoff, computed at state entry from the current
+     ;; retry count. Per [005 §Value shape] the fn-form delay is called
+     ;; once at entry against the entering snapshot; the :after epoch
+     ;; carries through the synthetic timer event so a transition out
+     ;; of :reconnecting (e.g., a manual :ws/connect) makes the in-flight
+     ;; backoff timer stale. Add a jitter term in production.
+     :after  {(fn [{:keys [snapshot]}]
+                (let [{:keys [retries base-ms max-backoff-ms]} (:data snapshot)]
+                  (min (* base-ms (Math/pow 2 retries))
+                       max-backoff-ms)))
+              {:target [:active]}}
+     :on     {;; Manual reconnect (e.g., after the auth machine rotates
+              ;; the credential) — short-circuit the backoff, record fresh
+              ;; opts, zero the retry counter, re-enter :active.
+              :ws/connect {:target [:active]
+                           :action :record-and-reset}
+              :ws/send    {:action :enqueue-message}
+              :ws/request {:action :enqueue-message}
+              :ws/rotate-cred {:action :rotate-cred}}}
 
-                  ;; Override the parent's :ws/send: while :connected the
-                  ;; message goes straight to the wire instead of queueing.
-                  :ws/send    {:action (fn [{:keys [data] [_ msg] :event}]
-                                         {:fx [[:dispatch [(socket-id data)
-                                                           [:send msg]]]]})}
-
-                  ;; Override the parent's :ws/request: while :connected
-                  ;; the request is registered + sent immediately.
-                  :ws/request {:action :register-request}
-
-                  ;; A deadline elapsed. Two questions, one guard: is the socket
-                  ;; still ours, and is this the timer the registration
-                  ;; currently in the slot armed? See :own-request-timeout?.
-                  :ws/request-timeout
-                  {:guard  :own-request-timeout?
-                   :action :clear-request}}}}}
-
-      :reconnecting
-      {:always [{:guard :max-retries-exceeded? :target :failed}]
-       ;; Exponential backoff, computed at state entry from the current
-       ;; retry count. Per [005 §Value shape] the fn-form delay is called
-       ;; once at entry against the entering snapshot; the :after epoch
-       ;; carries through the synthetic timer event so a transition out
-       ;; of :reconnecting (e.g., a manual :ws/connect) makes the in-flight
-       ;; backoff timer stale. Add a jitter term in production.
-       :after  {(fn [{:keys [snapshot]}]
-                  (let [{:keys [retries base-ms max-backoff-ms]} (:data snapshot)]
-                    (min (* base-ms (Math/pow 2 retries))
-                         max-backoff-ms)))
-                {:target [:active]}}
-       :on     {;; Manual reconnect (e.g., after the auth machine rotates
-                ;; the credential) — short-circuit the backoff, record fresh
-                ;; opts, zero the retry counter, re-enter :active.
-                :ws/connect {:target [:active]
-                             :action :record-and-reset}
-                :ws/send    {:action :enqueue-message}
-                :ws/request {:action :enqueue-message}
-                :ws/rotate-cred {:action :rotate-cred}}}
-
-      :failed
-      {:on {:ws/connect     {:target [:active]
-                             :action :record-and-reset}
-            :ws/rotate-cred {:action :rotate-cred}}}}}))
+    :failed
+    {:on {:ws/connect     {:target [:active]
+                           :action :record-and-reset}
+          :ws/rotate-cred {:action :rotate-cred}}}}})
 ```
 
 The `:websocket/socket` invoked actor is itself a small machine (or fx-backed event handler) that owns the JS `WebSocket` instance and translates `:open`, `:message`, `:error`, `:close` events into dispatches back to the parent connection machine. It is also where the opaque `:cred-ref` becomes a real credential: the actor resolves the reference inside its own host closure **at the auth write**, attaches the bearer to that wire frame, and lets it go out of scope in the same expression — the bearer never enters machine `:data` or a dispatch (see §Parameters). Resolve it in the enclosing scope instead and the socket handle, which is retained for the socket's whole life, closes over the bearer for just as long: a live credential parked host-side that no snapshot sweep can see. Every outgoing dispatch carries `:source-socket-id` (the actor's `:rf/self-id`, per [005 §Runtime stamps on the spawned actor's `:data`](005-StateMachines.md#runtime-stamps-on-the-spawned-actors-data)) so the parent's `:current-socket?` guard can suppress messages from a prior socket if one happens to dispatch in flight as the cascade tears it down. The actor's lifetime is bound to `:active` — leaving `:active` (whether to `:reconnecting` on error or `:failed` fatally) destroys it; re-entering `:active` creates a fresh socket.


### PR DESCRIPTION
## What

`spec/005-StateMachines.md` §Registration has led with `rf/reg-machine` since PR #9309 (rf2-kuky.26). Five Construction-Prompt and Pattern pages still spelled the underlying `(rf/reg-event id opts (rf.machines/make-machine-handler spec))` composition in call position, so they contradicted it. These are the surfaces an AI agent or a new reader copies from verbatim, which is why it is worth doing.

**`make-machine-handler` is not deprecated and stays public.** It is the machine's `reg-view*` — the composition seam for code-gen and loader pipelines minting handlers for computed ids. This is a change of **teaching order**, not of API. No warnings were added telling anyone off for using it.

## The split — documents vs teaches

The bead's counts are *total* occurrences of the symbol, not occurrences in call position, so the whole judgement was separating two populations.

**Swept (9 sites)** — taught the composition as the default registration shape:

| page | sites |
|---|---|
| `spec/CP-5-MachineGuide.md` | `:media/audio`, `:media/video` worked examples |
| `spec/Construction-Prompts.md` | `:auth.login/flow` worked example; the CP-5 **"Key idea"** sentence; the **AI-first checklist** item |
| `spec/Pattern-Boot.md` | `:app/boot`, `:auth/flow` |
| `spec/Pattern-LongRunningWork.md` | `:compute/batch-job` |
| `spec/Pattern-WebSocket.md` | `:ws/connection` |

The `{:doc …}` map moves into `reg-machine`'s canonical MIDDLE opts slot (005 §Surface signature), matching 005's own `:drawer/editor` example.

**Kept (6 sites)** — document the primitive rather than teaching a registration shape:

- `CP-5-MachineGuide.md` §v1 grammar subset — the foundation roster.
- `Construction-Prompts.md` ×2 — the primitive validates keyword references against `:guards` / `:actions` at registration time. True of the primitive and worth stating precisely.
- `Construction-Prompts.md` §Testing **Level 2** — `(let [handler (rf.machines/make-machine-handler …)] …)`. **Call position, but deliberately not swept**: it builds a handler *without* registering one, which is the primitive's whole reason for staying public. Call position alone was never the criterion.
- `CP-5-MachineGuide.md` §Registration — the note that the composition reaches the same slot.

**Referent repairs (3 sites)** — these named the machine *spec* **by** the primitive ("inside `make-machine-handler`", "`make-machine-handler` does not accept a `:path` key"). After the sweep no reader of those pages sees the primitive written in code, so the phrase pointed at nothing on the page; re-referred to "the machine spec". This is a coherence consequence of the sweep, not scope creep.

`CP-5-MachineGuide.md` §Registration's parenthetical cited Construction-Prompts' CP-5 *examples* for a form they no longer show, so it is repointed at 005 §`make-machine-handler` is a pure factory.

## Corroboration

The three Pattern pages' runnable counterparts under `examples/patterns/{boot,websocket,long_running_work}/` **already** register with `rf/reg-machine`; the spec pages now agree with the shipped code. The two remaining `make-machine-handler` mentions under `examples/` are both comments, confirming the bead's "composition 0 in examples".

## Gates — and what they did *not* inspect

**Almost every code change here is inside a fenced Clojure block, and neither link gate looks inside a fence** — both share one extractor that strips fences before reading a link. A green run from either inspected essentially nothing in the fences. So:

- **Fences hand-checked**: every one of the 9 rewritten blocks was read in full for indentation and alignment. A delimiter-balance pass over **all 70 `clojure` fences in the five pages** reports `depth=0` on every fence, before and after, with the only diff being line-number shifts. The whitespace-ignoring diff is 20 insertions / 27 deletions across the five files — i.e. the substantive change is exactly the 9 headers and 9 dropped parens; everything else in the raw diff is the two-column de-indent.
- **Table column counts hand-checked**: one table cell changed (the xstate-comparison row in `CP-5-MachineGuide.md`); 4 pipes before and after, matching its 3-column header.
- **Anchors**: the two links added/changed are in *prose*, so `check_doc_slugs.py` does cover them.

Captured exit codes, foreground, unpiped, redirect and echo on one command line, all re-run **after** the rebase onto current `main`:

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_readme_links.py --ci` | **0** |
| `python -m mkdocs build --strict` | **0** |
| all 42 `scripts/check_*.py` ratchets | **0** (42/42) |

**Proof the gates read this tree.** `check_doc_slugs.py` is silent on success, so a planted fault was used: a broken anchor in a line this PR authors (`CP-5-MachineGuide.md:32`), match count verified as 1 before the run. The gate went **red, exit 1**, naming the file, the line and the planted anchor. Restored and verified by *blob* hash — working file `226bbea3663ed9a0855e8d3a5076f82021c711ca`, identical to the committed object, zero residue. The fault existed only here, so a run that had wandered into a sibling worktree would have come back green.

`mkdocs build --strict` needed no plant: it affords the positive route. The built site carries this tree's content — `make-machine-handler` is **0** in the built HTML of all three Pattern pages and `reg-machine` is present in all five, against an untouched control (`005-StateMachines`) that still shows both.

The spec-reading ratchets are silent on success too, so each was exercised against inputs it should flag via its own `--self-test --verbose` (e.g. `check_retired_spellings.py`: 54 self-tests, all passing, positive and negative fixtures both).

**No digest-pin or samples-coverage lock covers these pages** — checked three ways: `check_guide_samples.py`'s `GUIDE_DIR` is `docs/core/hicasso` only; `check_provenance_pins.py`'s root is `docs/design/hicasso` only; and no suite reads any of the five (the one test that slurps `spec/*.md` by roster, `spec_elision_registry_tense_conformance_test.clj`, pins `["Tool-Pair.md" "Security.md"]`). References to these pages from `pattern_smoke_test.clj`, `boot_cljs_test.cljs` and `websocket_cljs_test.cljs` are docstrings and comments — no `slurp`, no `io/file`.

`.github/scripts/report-changed-surfaces.sh`, fed **paths**, reports `implementation_jvm=true` and nothing else. That is the deliberate `spec/*` catch-all ("WHOLESALE on purpose … over-classify"), not a pin — none of these five is on its eleven-page pinned roster. The classifier was exercised in both directions: `implementation/shadow-cljs.edn` arms 9 different surfaces, and the documented misuse of feeding it revisions reports every surface false.

## Out of fence

Three implementation-side stragglers of the same sweep were found and **not** touched (outside this bead's fence): `implementation/core/test/re_frame/pattern_smoke_test.clj:143`, `implementation/core/test/re_frame/hot_reload_test.clj:266` and `implementation/core/test/re_frame/smoke_test.clj:815` each register via `(rf/reg-event id (rf.machines/make-machine-handler …))`. A follow-up bead is filed. Other `implementation/machines/test/**` hits are Level-2 factory tests and are correct as they stand.
