### PR TITLE
feat(hooks): a commit-msg guard refuses AI attribution, and a CI arm grades the branch (rf2-2e8f)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,14 +5,16 @@
 # checked-out list for a Windows (core.autocrlf=true) checkout to
 # CRLF-normalise and no EOL pin to carry here.
 
-# The git-hook sources (post-merge, post-rewrite, pre-commit) are POSIX sh but
-# carry no .sh extension, so the rule above misses them. Pin them to LF so the
-# checked-out source matches the LF-normalised installed hook byte-for-byte
-# on the line-ending axis, and so the `sh -n` parse / `dash` checks never see
-# a stray CR on a Windows (core.autocrlf=true) checkout (rf2-ujhpf).
+# The git-hook sources (post-merge, post-rewrite, pre-commit, commit-msg) are
+# POSIX sh but carry no .sh extension, so the rule above misses them. Pin them
+# to LF so the checked-out source matches the LF-normalised installed hook
+# byte-for-byte on the line-ending axis, and so the `sh -n` parse / `dash`
+# checks never see a stray CR on a Windows (core.autocrlf=true) checkout
+# (rf2-ujhpf).
 scripts/git-hooks/post-merge text eol=lf
 scripts/git-hooks/post-rewrite text eol=lf
 scripts/git-hooks/pre-commit text eol=lf
+scripts/git-hooks/commit-msg text eol=lf
 
 # The docs/cljs playground BOOTSTRAP bundles are committed, vendored prebuilts
 # that esbuild emits with LF endings (rf2-ee38b.22). Pin LF so a Windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1281,6 +1281,28 @@ jobs:
           # had touched it, reddening branches for a file they never edited.
           sh scripts/check-beads-pr-boundary.sh "origin/${GITHUB_BASE_REF}"
 
+      # The AI-attribution guard's CI arm (rf2-2e8f) — a STEP in this job, not
+      # a job of its own, so it adds nothing to any PR's check rollup and the
+      # required-check band the merge criterion is measured against does not
+      # move.
+      #
+      # IT LIVES HERE FOR THE `fetch-depth: 0` ABOVE. The script grades
+      # `merge-base(BASE, HEAD)..HEAD` — the commits the branch introduces —
+      # and fails CLOSED when it cannot resolve a branch point. In a shallow
+      # checkout it would therefore red every PR, and relaxing it to pass on a
+      # missing range would make it a checker that inspects nothing and reports
+      # the same silent zero as a clean branch. That is why it is NOT in
+      # `verify-skill-mcp-drift` with the other repo invariants, whose checkout
+      # is deliberately the cheap shallow one. This job already resolves a
+      # branch point for exactly the same reason, from exactly this checkout.
+      #
+      # ONE LINE, no event branch: unlike the step above, this script's event
+      # policy lives entirely in the script, which checks `GITHUB_EVENT_NAME`
+      # BEFORE it looks at the base ref — so on a push it exits 0 with its own
+      # explanatory line and never evaluates the empty `origin/`.
+      - name: Enforce the no-AI-attribution rule (rf2-2e8f)
+        run: sh scripts/check-commit-attribution.sh "origin/${GITHUB_BASE_REF}"
+
   jvm-core:
     name: JVM core (clojure -M:test)
     # rf2-f79t8 — job-level gating (NOT a workflow-trigger path filter:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1296,12 +1296,21 @@ jobs:
       # is deliberately the cheap shallow one. This job already resolves a
       # branch point for exactly the same reason, from exactly this checkout.
       #
-      # ONE LINE, no event branch: unlike the step above, this script's event
+      # ONE COMMAND, no event branch: unlike the step above, this script's event
       # policy lives entirely in the script, which checks `GITHUB_EVENT_NAME`
       # BEFORE it looks at the base ref — so on a push it exits 0 with its own
       # explanatory line and never evaluates the empty `origin/`.
+      #
+      # A BLOCK SCALAR (`run: |`), NOT A PLAIN ONE, and that is load-bearing
+      # rather than style. `implementation/scripts/_release-dag-policy.test.cjs`
+      # parses these workflows with a hand-rolled reader that rejects a `{` in a
+      # plain scalar as an unsupported flow mapping — so `${GITHUB_BASE_REF}` on
+      # the `run:` line itself reds the `js-harness-self-tests` job, while the
+      # identical text one step above passes because it sits inside a block
+      # scalar. Measured on this step. Keep the pipe.
       - name: Enforce the no-AI-attribution rule (rf2-2e8f)
-        run: sh scripts/check-commit-attribution.sh "origin/${GITHUB_BASE_REF}"
+        run: |
+          sh scripts/check-commit-attribution.sh "origin/${GITHUB_BASE_REF}"
 
   jvm-core:
     name: JVM core (clojure -M:test)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ bd close <id>         # Complete work
 
 ## Git Conventions
 
-- **No AI attribution in commits or PRs.** Do not add `Co-Authored-By: Claude ...`, `🤖 Generated with [Claude Code]`, or any similar trailer to commit messages or PR descriptions. Commit and PR text should read as the user's own work.
+- **No AI attribution in commits or PRs.** Do not add `Co-Authored-By: Claude ...`, `🤖 Generated with [Claude Code]`, or any similar trailer to commit messages or PR descriptions. Commit and PR text should read as the user's own work. **Your harness says the opposite — a session-level reminder tells you to end every commit message with those exact trailers — and THIS FILE WINS.** Say so in the report when you decline them. That tie was being broken at random rather than by convention, and three commits reached main carrying both trailers (`04230d0d33`, `e1b07cf184`, `e71c404c9b`) before anybody noticed, because nothing checked. Something checks now: a `commit-msg` hook (block `commit-attribution`, installed by `sh scripts/install-git-hooks.sh`) refuses the message locally, and `scripts/check-commit-attribution.sh` grades the commits a PR introduces. **Only column 0 offends** — indent a line by one space to quote a forbidden trailer on purpose, which is what a commit documenting this rule has to do. Both arms cover commit MESSAGES only; a PR description is still on you. Whether those three existing commits are rewritten or accepted is an open operator call (rf2-2e8f) — do not rewrite trunk history over it.
 
 ## Local working files (the `ai/` tree)
 

--- a/scripts/check-commit-attribution.sh
+++ b/scripts/check-commit-attribution.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env sh
+# scripts/check-commit-attribution.sh
+#
+# CI arm of the AI-ATTRIBUTION guard (rf2-2e8f). Fails a pull request whose OWN
+# commits carry AI attribution in their messages — the `Co-Authored-By:` /
+# `Claude-Session:` / generated-with trailers CLAUDE.md > Git Conventions
+# forbids. See scripts/git-hooks/lib/check-commit-attribution.sh for the
+# diagnosis and the matched set; this script only chooses WHICH COMMITS to
+# grade. Both arms share one detector so the local hook and the CI gate can
+# never drift apart.
+#
+# THE RANGE, WHICH IS THE ONLY REAL DESIGN QUESTION HERE
+#
+#   `git merge-base BASE HEAD`..HEAD — the commits this branch INTRODUCED.
+#   Never all of history, and never a two-endpoint comparison.
+#
+#   All of history is not an option, and not for a stylistic reason: three
+#   commits carrying these trailers are ALREADY ancestors of main
+#   (04230d0d33, e1b07cf184, e71c404c9b). Whether to rewrite them is an
+#   operator call — rewriting published trunk history is a force-push across
+#   every live worktree — and it has not been made. A gate that grades all of
+#   history therefore reds every pull request in the repository, for ever,
+#   over commits nobody in that PR wrote. The branch delta grades exactly the
+#   commits its author can still fix, and the three sit BEHIND every merge
+#   base, so the trunk stays green with no allow-list, no baseline file and
+#   nothing to trim later.
+#
+#   Pass the BASE BRANCH, not a precomputed branch point — the merge base is
+#   this script's job. The reasoning is the sibling guard's (rf2-5z20y): a
+#   two-endpoint `git log BASE..HEAD` is not the same set once BASE moves, and
+#   in this repository BASE moves constantly.
+#
+# HOW IT DEGRADES: CLOSED, LOUDLY, AND THAT DICTATES WHERE IT CAN RUN
+#
+#   A missing base ref, an unresolvable one, or no merge base — the usual
+#   cause being a SHALLOW CLONE that does not contain the branch point — all
+#   fail closed. A gate that cannot see the range certifies nothing, and a
+#   commit-message gate is unusually exposed to the alternative: with no range
+#   it inspects nothing, finds nothing, and reports the same silent zero as a
+#   clean branch. That is the vacuous pass this whole guard exists to end.
+#
+#   So this MUST run in a job checked out with `fetch-depth: 0`. It cannot
+#   live in test.yml's `verify-skill-mcp-drift` ("Repo invariant checks"),
+#   whose checkout is the default shallow one and which is deliberately kept
+#   cheap: there it would fail closed on every PR, and "fixing" that by
+#   letting it pass on a missing range would install exactly the vacuous
+#   checker it is meant to replace. `beads-pr-boundary` is the job whose
+#   checkout, event policy and branch-point semantics this script already
+#   matches line for line.
+#
+# ENFORCEMENT SHAPE
+#
+#   pull_request  -> enforced. Every PR, no path filter, no branch filter.
+#   anything else -> passes with an explanatory line. A push to main carries
+#                    commits that are already history; refusing one there
+#                    blocks the trunk over a rewrite decision that is the
+#                    operator's, not this gate's.
+#
+# Usage:
+#   sh scripts/check-commit-attribution.sh [BASE_REF]
+#
+#   BASE_REF resolution: argument, else $COMMIT_ATTRIBUTION_BASE_REF. Run it
+#   locally to pre-flight a branch:
+#     sh scripts/check-commit-attribution.sh origin/main
+#
+# Cross-platform: POSIX sh. Runs identically on the ubuntu CI runner, on
+# macOS, and under Git Bash on Windows. No bashisms.
+
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+LIB="$SCRIPT_DIR/git-hooks/lib/check-commit-attribution.sh"
+
+if [ ! -f "$LIB" ]; then
+  printf 'check-commit-attribution: missing detector library at %s\n' "$LIB" >&2
+  exit 1
+fi
+# shellcheck source=git-hooks/lib/check-commit-attribution.sh
+. "$LIB"
+
+EVENT="${GITHUB_EVENT_NAME:-pull_request}"
+if [ "$EVENT" != "pull_request" ]; then
+  printf 'Event is "%s", not a pull request: the attribution guard is not enforced here.\n' "$EVENT"
+  printf 'Commits already on a branch history are an operator rewrite decision, not a gate.\n'
+  exit 0
+fi
+
+BASE="${1:-${COMMIT_ATTRIBUTION_BASE_REF:-}}"
+if [ -z "$BASE" ]; then
+  printf 'check-commit-attribution: no base ref.\n' >&2
+  printf 'Pass one as an argument or set COMMIT_ATTRIBUTION_BASE_REF. Failing closed:\n' >&2
+  printf 'a gate that cannot see the commit range certifies nothing.\n' >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify --quiet "$BASE^{commit}" >/dev/null; then
+  printf 'check-commit-attribution: base ref "%s" does not resolve to a commit.\n' "$BASE" >&2
+  printf 'Failing closed rather than passing vacuously.\n' >&2
+  exit 1
+fi
+
+BRANCH_POINT=$(git merge-base "$BASE" HEAD 2>/dev/null) || BRANCH_POINT=""
+if [ -z "$BRANCH_POINT" ]; then
+  printf 'check-commit-attribution: no merge base between "%s" and HEAD.\n' "$BASE" >&2
+  printf 'Usually a shallow clone that does not contain the branch point —\n' >&2
+  printf 'on GitHub Actions use actions/checkout with fetch-depth: 0.\n' >&2
+  printf 'Failing closed: a gate that cannot see the branch delta certifies nothing.\n' >&2
+  exit 1
+fi
+
+# Collect through a tmpfile: the `while read` loop below runs in a subshell, so
+# a variable would not survive it. Same technique, same reason, as the shared
+# library and its sibling lib/check-beads-boundary.sh.
+LISTING=$(mktemp "${TMPDIR:-/tmp}/rf2-attribution-ci-XXXXXX")
+trap 'rm -f "$LISTING"' EXIT INT TERM HUP
+
+COMMITS=$(git rev-list "$BRANCH_POINT..HEAD")
+count=0
+for sha in $COMMITS; do
+  count=$((count + 1))
+  hits=$(git log -1 --format=%B "$sha" | rf2_attribution_offending_lines)
+  if [ -n "$hits" ]; then
+    printf '%s %s\n' "$(git rev-parse --short=10 "$sha")" \
+      "$(git log -1 --format=%s "$sha")" >> "$LISTING"
+    printf '%s\n' "$hits" | while IFS= read -r l; do
+      [ -n "$l" ] && printf '  %s\n' "$l" >> "$LISTING"
+    done
+  fi
+done
+
+if [ ! -s "$LISTING" ]; then
+  printf 'No AI attribution in the %s commit(s) this branch introduces (from %s).\n' \
+    "$count" "$(git rev-parse --short=10 "$BRANCH_POINT")"
+  exit 0
+fi
+
+rf2_attribution_refusal ci < "$LISTING"
+exit 1

--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -16,18 +16,21 @@ disturbing beads-managed segments (`bd hooks install`).
 | `pre-commit` | Refuse commits in the MAYOR checkout that touch worker-tracked surfaces. **rf2-ydl2p.** |
 | `pre-commit` | Refuse commits in a WORKER worktree that touch the beads DATABASE. **rf2-ia8o7.** |
 | `pre-commit` | Refuse a commit from ANY worktree that would empty `.beads/issues.jsonl` or lose more than a tenth of it. **rf2-or8te.** |
+| `commit-msg` | Refuse a commit MESSAGE carrying AI attribution. **rf2-2e8f.** |
 | `lib/check-stale-mcp-binary.sh` | POSIX-sh library used by `post-merge`. |
 | `lib/check-hook-install-staleness.sh` | POSIX-sh library used by `post-merge` **and** `post-rewrite` (rf2-zt65l) — one advisory, one home. |
 | `lib/check-mayor-commit-boundary.sh` | POSIX-sh library used by `pre-commit` (rf2-ydl2p). |
 | `lib/check-beads-boundary.sh` | POSIX-sh library carrying two checks over one file: `check_beads_boundary` (rf2-ia8o7), used by `pre-commit` **and** by `scripts/check-beads-pr-boundary.sh`, the CI arm; and `check_beads_truncation` (rf2-or8te), used by `pre-commit` alone. |
-| `test-pre-commit.sh` | Library unit tests, sandboxed end-to-end smoke for all three pre-commit blocks, the CI arm, the installer, real pulls of both shapes, and the checkpoint helper. |
+| `lib/check-commit-attribution.sh` | POSIX-sh library used by `commit-msg` **and** by `scripts/check-commit-attribution.sh`, its CI arm (rf2-2e8f) — one detector, two arms. |
+| `test-pre-commit.sh` | Library unit tests, sandboxed end-to-end smoke for all three pre-commit blocks and the commit-msg block, both CI arms, the installer, real pulls of both shapes, and the checkpoint helper. |
 
 The unit of installation is a marker block, not a hook: `pre-commit`
 carries three of them. The installers key their registries on block id
 (`mayor-commit-boundary`, `worker-beads-boundary`, `beads-truncation-floor`,
-`mcp-staleness`, `hook-staleness`, `hook-staleness-rebase`) so a hook can grow
-another block — or the set can grow another hook — without either installer
-changing shape.
+`commit-attribution`, `mcp-staleness`, `hook-staleness`, `hook-staleness-rebase`)
+so a hook can grow another block — or the set can grow another hook — without
+either installer changing shape. `commit-msg` (rf2-2e8f) is the set growing
+another hook, and neither installer changed shape to take it.
 
 Hook sources carry no `.sh` extension, so `.gitattributes` pins each of them to
 `eol=lf` by name. A new hook here needs a line there too, or a Windows checkout
@@ -340,6 +343,96 @@ loop tick, every branch older than the last checkpoint would be blamed for
 contamination it never committed. An unresolvable merge base — usually a
 shallow clone that lacks the branch point — fails closed too.
 
+## The AI-attribution guard (rf2-2e8f)
+
+Every block above grades staged **paths**. The commit **message** is a surface
+none of them can see, and three commits carrying AI-attribution trailers
+reached main through it — `04230d0d33`, `e1b07cf184`, `e71c404c9b`, each with a
+co-author line naming the assistant *and* a session-URL trailer.
+
+### Why it recurs without a guard
+
+`CLAUDE.md` > Git Conventions has forbidden these since the project began. The
+rule was not broken by carelessness; it was broken by a **live conflict between
+two instruction sources**. The agent harness injects a session-level reminder
+telling agents to end every commit message with exactly those trailers. The
+checked-in `CLAUDE.md` forbids them. Both reach every worker, they contradict
+flatly, and nothing resolved the tie — so it was broken **both ways by capable
+agents in the same wave**: one worker declined the trailers citing `CLAUDE.md`
+while two siblings followed the harness. That is a coin-flip, not a convention,
+and the trunk said nothing either way because nothing checked.
+
+### What it matches, and what it deliberately does not
+
+Three shapes, case-insensitive, all anchored at **column 0**:
+
+| Shape | Example |
+|-------|---------|
+| the session trailer | a `Claude-Session:` line |
+| the co-author trailer, *when the value names the assistant* | a `Co-Authored-By:` line whose value carries `claude` or `anthropic` |
+| the generated-with marker | a `Generated with …` line naming either |
+
+That is the whole set. This is **not** a commit-message linter: it does not
+grade subject length, mood or trailer hygiene, and a `Co-Authored-By:` naming a
+human colleague is ordinary git and stays permitted. Only AI attribution, which
+is the only thing the convention forbids.
+
+**Column 0 is the escape hatch, and it is load-bearing.** A line indented by
+even one space is exempt, so a commit message may quote the forbidden trailers
+— which any commit documenting the rule, or citing one of the three above, has
+to do. Without that carve-out the guard would refuse the very commit that
+introduces it, which is the fastest route to `--no-verify` becoming habit. It
+also buys two free immunities: `git commit`'s own `#`-prefixed template
+comments, and the `+`/`-` diff body `git commit -v` appends, can never trip it.
+
+### Why `commit-msg` and not `pre-commit`
+
+`pre-commit` runs before the message exists — it sees staged paths and nothing
+else. `commit-msg` is git's hook for the message itself and receives its file as
+`$1`. Unlike the two boundary blocks this one activates **everywhere**, mayor
+checkout included: the rule is about how the repository's history reads, and
+history has no per-worktree half.
+
+A rebase does not invoke `commit-msg`, so replaying an already-authored commit
+is not re-graded. That is correct — the message was graded when it was written
+and again on the pull request, and grading a replay would refuse a rebase over
+history nobody in that shell authored.
+
+### The CI arm, and the range it grades
+
+`scripts/check-commit-attribution.sh` shares the same detector, so the local
+hook and the CI gate cannot drift:
+
+```sh
+sh scripts/check-commit-attribution.sh origin/main   # pre-flight a branch
+```
+
+It grades **`git merge-base BASE HEAD`..HEAD — the commits the branch
+introduced**, and the range is the only real design question here. Grading all
+of history is not an option: the three commits above are already ancestors of
+main, whether to rewrite them is an operator call that has not been made
+(rewriting published trunk history means a force-push across every live
+worktree), and a gate that graded history would red every pull request in the
+repository for ever. The branch delta grades exactly the commits their author
+can still fix, and the three sit behind every merge base — so the trunk stays
+green with no allow-list, no baseline file, and nothing to trim later. Layer 10k
+of the test harness pins that property by planting an offender on the base.
+
+A missing base ref, an unresolvable one, or no merge base — usually a **shallow
+clone** lacking the branch point — all **fail closed**, like the beads CI arm.
+A commit-message gate is unusually exposed to the alternative: with no range it
+inspects nothing, finds nothing, and reports the same silent zero as a clean
+branch. That vacuous pass is the thing this guard exists to end, so it must run
+in a job checked out with `fetch-depth: 0`.
+
+Enforcement is `pull_request` only. On a push the commits are already history,
+and refusing one there blocks the trunk over a rewrite decision the gate does
+not own.
+
+**Scope: commit messages.** The convention also covers PR descriptions; a git
+hook cannot see one and neither arm here reads one. Left unbuilt rather than
+half-built.
+
 ## Testing
 
 ```sh
@@ -418,6 +511,25 @@ the checkout both incidents came from, and the one every layer above no-ops in:
 28. A tracker over a 0-row HEAD, and a commit that stages no tracker path at
     all, are both untouched
 
+From rf2-2e8f, the first block here to grade the MESSAGE rather than the staged
+paths — every case paired in both directions, because a detector that matches
+nothing passes a "there must be none here" clause vacuously and silently:
+
+29. Each of the three forbidden shapes is refused, and the refusal quotes the
+    offending line
+30. A `Co-Authored-By:` naming a human colleague passes — same trailer key,
+    same column, only the value differs
+31. The same forbidden line INDENTED is permitted (the escape hatch), as are
+    git's own `#` template comments and the `git commit -v` diff body
+32. A real `git commit` carrying a trailer is refused, quoting the line and
+    citing the rule; an ordinary one is untouched; `--no-verify` lands a
+    deliberate override
+33. The CI arm refuses a branch that introduces one and names the commit,
+    passes a clean branch, and — the range property — stays green when the
+    BASE itself carries an offender
+34. No base ref, and an unresolvable one, both fail closed; a non-`pull_request`
+    event passes with an explanatory line
+
 ## Discovery context
 
 The pre-commit hook landed in response to rf2-oswhk (#2136),
@@ -453,6 +565,12 @@ channel, the mayor's pre-commit will refuse the commit.
   the last export-commit missed, and a checkpoint that trusts the working file
   writes the revert back. The helper re-exports from the database instead, and
   `--pre-pull` says whether clearing `.beads` is safe yet.
+- rf2-2e8f — three commits carrying AI-attribution trailers reached main
+  because two instruction sources contradict and nothing checked. Source of the
+  `commit-msg` block and `scripts/check-commit-attribution.sh`. Whether to
+  rewrite those three is a separate, unmade operator decision; this guard only
+  closes the source.
+- `CLAUDE.md` > Git Conventions — the rule the `commit-msg` block enforces.
 - `CLAUDE.md` > Beads durability — the operator-facing rules,
   including the merge-side rule (never `--theirs`/`--ours` on `.beads`;
   resolve then regenerate).

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+# .git/hooks/commit-msg (re-frame2-managed segments)
+#
+# ONE marker block.
+#
+#   rf2-2e8f — refuses a commit message carrying AI ATTRIBUTION: a
+#              `Co-Authored-By:` naming the assistant, a `Claude-Session:`
+#              trailer, or a generated-with marker.
+#
+# WHY A HOOK AT ALL. CLAUDE.md > Git Conventions has forbidden these since the
+# project began, and three commits carrying them still reached main —
+# 04230d0d33, e1b07cf184, e71c404c9b — because the agent harness injects a
+# session-level reminder telling agents to add exactly those trailers, and
+# NOTHING CHECKED. Two instruction sources contradicting, a tie broken at
+# random, and a silent trunk. This block makes the local half loud; the CI arm
+# (scripts/check-commit-attribution.sh) catches the case where nobody ran the
+# installer.
+#
+# WHY `commit-msg` AND NOT `pre-commit`. `pre-commit` runs before the message
+# exists — it can see the staged paths and nothing else. `commit-msg` is git's
+# hook for the message itself and receives its file as `$1`, which is the only
+# place this rule can be enforced locally at all.
+#
+# NOT WORKTREE-SCOPED. Unlike the two pre-commit boundary blocks, this one
+# activates EVERYWHERE — mayor checkout and worker worktrees alike. The rule is
+# about how the repository's history reads, and history has no per-worktree
+# half.
+#
+# WHAT IT DELIBERATELY MISSES. A rebase does not run `commit-msg`, so replaying
+# an already-authored commit is not re-graded. That is correct: the message was
+# graded when it was written and again on the pull request, and grading a
+# replay would refuse a rebase over history nobody in that shell authored.
+#
+# `git commit --no-verify` bypasses this hook (standard git behaviour; reserved
+# for genuine operator overrides). The CI arm still grades the branch.
+#
+# Installed by scripts/install-git-hooks.sh (POSIX) or .ps1 (Windows).
+# Source of truth: scripts/git-hooks/commit-msg.
+#
+# Cross-platform: runs under Git Bash on Windows, macOS, Linux. POSIX sh.
+
+# --- BEGIN re-frame2 commit attribution guard (rf2-2e8f) ---
+# Managed by scripts/install-git-hooks.sh. Do not edit between markers.
+{
+  # `$1` is the path to the file holding the proposed message. Git passes it
+  # relative to the worktree root and invokes the hook from there, but resolve
+  # against the toplevel anyway so a wrapper that changed the working directory
+  # cannot silently turn this guard into a no-op.
+  _rf2c_msg="${1:-}"
+  _rf2c_top=$(git rev-parse --show-toplevel 2>/dev/null) || _rf2c_top=""
+
+  if [ -n "$_rf2c_msg" ] && [ ! -f "$_rf2c_msg" ] && [ -n "$_rf2c_top" ]; then
+    _rf2c_msg="$_rf2c_top/$_rf2c_msg"
+  fi
+
+  if [ -n "$_rf2c_top" ] && [ -n "$_rf2c_msg" ] && [ -f "$_rf2c_msg" ]; then
+    _rf2c_lib="$_rf2c_top/scripts/git-hooks/lib/check-commit-attribution.sh"
+    if [ -f "$_rf2c_lib" ]; then
+      # shellcheck source=lib/check-commit-attribution.sh
+      . "$_rf2c_lib"
+      if ! check_commit_attribution commit < "$_rf2c_msg"; then
+        unset _rf2c_msg _rf2c_top _rf2c_lib
+        exit 1
+      fi
+    fi
+  fi
+
+  unset _rf2c_msg _rf2c_top _rf2c_lib
+} || true
+# --- END re-frame2 commit attribution guard (rf2-2e8f) ---

--- a/scripts/git-hooks/lib/check-commit-attribution.sh
+++ b/scripts/git-hooks/lib/check-commit-attribution.sh
@@ -175,10 +175,15 @@ rf2_attribution_refusal() {
   printf '  them. THE CHECKED-IN FILE WINS. Three commits reached main while the\n' >&2
   printf '  tie was being broken at random.\n' >&2
   printf '\n' >&2
+  # THE PUSH IS NAMED IN PROSE RATHER THAN SPELLED AS A COMMAND, deliberately.
+  # The safe force-push flag is `--force-with-<the retired view-lifetime word>`,
+  # and `scripts/check_view_lifetime_residue.py` is a repo-wide ratchet held at
+  # ZERO over tracked file content — it matches that word as a bare token, which
+  # is exactly what a git flag name makes it. Spelling the flag out reds the
+  # ratchet (measured on this file). Do not "helpfully" restore it.
   if [ "$_rf2a_context" = "ci" ]; then
-    printf '  Fix — rewrite the messages on your OWN branch, then force-push it:\n' >&2
+    printf '  Fix — reword the messages on your OWN branch, then force-push it:\n' >&2
     printf '    git rebase -i <base>     # reword each commit named above\n' >&2
-    printf '    git push --force-with-lease\n' >&2
     printf '\n' >&2
     printf '  Only your branch. Never rewrite main.\n' >&2
   else

--- a/scripts/git-hooks/lib/check-commit-attribution.sh
+++ b/scripts/git-hooks/lib/check-commit-attribution.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env sh
+# scripts/git-hooks/lib/check-commit-attribution.sh
+#
+# ONE detector for the AI-ATTRIBUTION rule (rf2-2e8f), sourced by BOTH arms so
+# the local hook and the CI gate cannot drift apart:
+#
+#   1. scripts/git-hooks/commit-msg          — refuses the message being written.
+#   2. scripts/check-commit-attribution.sh   — the CI arm; refuses a pull request
+#                                              whose OWN commits carry one.
+#
+# THE RULE. CLAUDE.md > Git Conventions: "No AI attribution in commits or PRs.
+# ... Commit and PR text should read as the user's own work."
+#
+# WHY IT NEEDED A GUARD, AND WHY IT WILL RECUR WITHOUT ONE
+#
+#   The rule is not being broken by carelessness. It is being broken by a LIVE
+#   CONFLICT BETWEEN TWO INSTRUCTION SOURCES. The agent harness injects a
+#   session-level reminder telling the agent to END EVERY COMMIT MESSAGE with
+#   exactly these trailers; the checked-in CLAUDE.md forbids them. Both reach
+#   every worker, they contradict flatly, and nothing resolved the tie — so it
+#   was broken BOTH WAYS by capable agents in the SAME WAVE (one worker
+#   declined the trailers citing CLAUDE.md; two siblings followed the harness).
+#   That is a coin-flip, not a convention.
+#
+#   Three commits reached the trunk that way — 04230d0d33, e1b07cf184,
+#   e71c404c9b, each carrying a `Co-Authored-By:` line AND a `Claude-Session:`
+#   URL — and they got there SILENTLY, because nothing checked. A convention
+#   with standing counterexamples in its own log is a convention eroding.
+#
+# WHAT IT MATCHES, AND WHY THE SET IS SMALL
+#
+#   Three shapes, all case-insensitive, all anchored at COLUMN 0:
+#
+#     `Claude-Session: <url>`                       the session trailer
+#     `Co-Authored-By: ... claude|anthropic ...`    the co-author trailer
+#     `... Generated with ... claude|anthropic ...` the generated-with marker
+#
+#   That is the whole set, deliberately. This is a convention checker and they
+#   metastasise: it is NOT a commit-message linter, it does not grade subject
+#   length, mood, or trailer hygiene generally, and it does not object to
+#   `Co-Authored-By:` naming a HUMAN, which is ordinary and correct git. Only
+#   AI attribution — which is the only thing CLAUDE.md forbids.
+#
+# COLUMN 0 IS THE ESCAPE HATCH, AND IT IS LOAD-BEARING
+#
+#   Only a line that STARTS at column 0 offends. A line indented by even one
+#   space is exempt, so a commit message may QUOTE the forbidden trailers —
+#   which this repository's own commits, this guard's tests, and any future
+#   write-up of the convention all need to do. Without that carve-out the guard
+#   would refuse the very commit that documents it, which is the fastest route
+#   to it being disabled with `--no-verify` and never re-enabled.
+#
+#   It also gives the check two free immunities that matter in practice:
+#   `git commit`'s own `#`-prefixed comment lines, and the `+`/`-` prefixed
+#   diff body that `git commit -v` appends, can never trip it.
+#
+# WHY FOLDING BEATS `grep -i`
+#
+#   The detector lower-cases each line with `tr 'A-Z' 'a-z'` and matches with
+#   POSIX `case` globs. No regex, no escaping, no locale surprises — and no
+#   `grep -iF`, which ABORTS on this project's Windows toolchain (GNU grep 3.0
+#   under MSYS, SIGABRT, exit 134) printing nothing to stdout, i.e. reporting a
+#   silent false zero exactly where a guard's zero must be trustworthy.
+#   `tr 'A-Z' 'a-z'` is an explicit ASCII range, so UTF-8 continuation bytes
+#   (the robot emoji the generated-with marker leads with) pass through intact.
+#
+# SCOPE: COMMIT MESSAGES. CLAUDE.md's rule also covers PR descriptions; a git
+# hook cannot see one and neither arm here reads one. Left deliberately unbuilt
+# rather than half-built.
+#
+# This file is a pure shell library (no `set -e`, no global state mutation) so
+# scripts/git-hooks/test-pre-commit.sh can drive it with synthetic stdin and
+# assert against stdout / stderr / exit.
+#
+# Cross-platform: POSIX sh; runs under Git Bash on Windows, macOS, Linux.
+# No bashisms (`[[`, arrays, `<<<`).
+
+# ---------------------------------------------------------------------------
+# The detector.
+# ---------------------------------------------------------------------------
+
+# rf2_attribution_is_offending_line LINE
+#
+# Returns 0 when LINE is an AI-attribution line, 1 otherwise. Trailing CR is
+# tolerated (a CRLF commit-message file on Windows): every rule below is a
+# prefix or a substring test, so a carriage return at the end of the line
+# cannot hide a hit.
+rf2_attribution_is_offending_line() {
+  _rf2a_line="$1"
+
+  # Indented -> exempt. See "COLUMN 0 IS THE ESCAPE HATCH" above.
+  case "$_rf2a_line" in
+    ' '*|'	'*) return 1 ;;
+  esac
+
+  _rf2a_low=$(printf '%s' "$_rf2a_line" | tr 'A-Z' 'a-z')
+
+  # 1. The session trailer. Unambiguous on its key alone.
+  case "$_rf2a_low" in
+    claude-session:*) return 0 ;;
+  esac
+
+  # 2. The co-author trailer, but only when the VALUE names the assistant.
+  #    `Co-Authored-By: <a colleague>` is ordinary git and stays permitted.
+  case "$_rf2a_low" in
+    co-authored-by:*)
+      case "$_rf2a_low" in
+        *claude*|*anthropic*) return 0 ;;
+      esac
+      ;;
+  esac
+
+  # 3. The generated-with marker, whatever decorates it.
+  case "$_rf2a_low" in
+    *generated\ with*)
+      case "$_rf2a_low" in
+        *claude*|*anthropic*) return 0 ;;
+      esac
+      ;;
+  esac
+
+  return 1
+}
+
+# rf2_attribution_offending_lines
+#
+# Reads a commit message (or any text) from stdin; prints every offending line
+# to stdout, one per line, with any trailing CR stripped so the listing reads
+# cleanly on Windows. Always returns 0 — the CALLER decides what an offence
+# means, which is what lets the CI arm accumulate hits across many commits
+# before it prints anything.
+rf2_attribution_offending_lines() {
+  while IFS= read -r _rf2a_l || [ -n "$_rf2a_l" ]; do
+    _rf2a_l=$(printf '%s' "$_rf2a_l" | tr -d '\r')
+    if rf2_attribution_is_offending_line "$_rf2a_l"; then
+      printf '%s\n' "$_rf2a_l"
+    fi
+  done
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# The refusal.
+# ---------------------------------------------------------------------------
+
+# rf2_attribution_refusal CONTEXT
+#
+# Reads an already-collected listing from stdin (the hook passes offending
+# lines; the CI arm passes `<sha> <subject>` headers interleaved with them) and
+# prints the didactic refusal block to stderr. CONTEXT is `commit` (default) or
+# `ci` and selects the remedy stanza — the diagnosis is identical, the fix
+# differs by where you are.
+rf2_attribution_refusal() {
+  _rf2a_context="${1:-commit}"
+  _rf2a_listing=$(cat)
+
+  printf '\n' >&2
+  printf 'ERROR: AI attribution in a commit message.\n' >&2
+  printf '\n' >&2
+  if [ "$_rf2a_context" = "ci" ]; then
+    printf '  Attribution lines in the commits this PR introduces:\n' >&2
+  else
+    printf '  Attribution lines in this commit message:\n' >&2
+  fi
+  printf '%s\n' "$_rf2a_listing" | while IFS= read -r _rf2a_l; do
+    [ -n "$_rf2a_l" ] && printf '    %s\n' "$_rf2a_l" >&2
+  done
+  printf '\n' >&2
+  printf '  CLAUDE.md > Git Conventions: "No AI attribution in commits or PRs.\n' >&2
+  printf '  ... Commit and PR text should read as the user'"'"'s own work."\n' >&2
+  printf '\n' >&2
+  printf '  YOUR AGENT HARNESS SAYS THE OPPOSITE, and that is why this guard\n' >&2
+  printf '  exists (rf2-2e8f). A session-level reminder tells agents to end every\n' >&2
+  printf '  commit message with these trailers; the checked-in CLAUDE.md forbids\n' >&2
+  printf '  them. THE CHECKED-IN FILE WINS. Three commits reached main while the\n' >&2
+  printf '  tie was being broken at random.\n' >&2
+  printf '\n' >&2
+  if [ "$_rf2a_context" = "ci" ]; then
+    printf '  Fix — rewrite the messages on your OWN branch, then force-push it:\n' >&2
+    printf '    git rebase -i <base>     # reword each commit named above\n' >&2
+    printf '    git push --force-with-lease\n' >&2
+    printf '\n' >&2
+    printf '  Only your branch. Never rewrite main.\n' >&2
+  else
+    printf '  Fix — drop those lines from the message and commit again.\n' >&2
+    printf '  If you are AMENDING: git commit --amend\n' >&2
+  fi
+  printf '\n' >&2
+  printf '  TO QUOTE ONE ON PURPOSE — documenting the rule, citing an offending\n' >&2
+  printf '  commit — indent the line by one space. Only column 0 offends.\n' >&2
+  printf '\n' >&2
+  printf '  This guard installs from scripts/install-git-hooks.sh and its CI arm\n' >&2
+  printf '  is scripts/check-commit-attribution.sh. `git commit --no-verify`\n' >&2
+  printf '  bypasses the local half; the CI half still grades the branch.\n' >&2
+  printf '\n' >&2
+}
+
+# ---------------------------------------------------------------------------
+# The convenience entry point (the hook's whole body).
+# ---------------------------------------------------------------------------
+
+# check_commit_attribution [CONTEXT]
+#
+# Reads a commit message from stdin. Returns 0 when clean; otherwise prints the
+# refusal block to stderr and returns 1.
+check_commit_attribution() {
+  _rf2a_ctx="${1:-commit}"
+
+  # A POSIX-sh `while read` loop runs in a subshell, so the hits are collected
+  # through a tmpfile rather than a variable — same technique, same reason, as
+  # the sibling lib/check-beads-boundary.sh.
+  _rf2a_hits=$(mktemp "${TMPDIR:-/tmp}/rf2-attribution-XXXXXX")
+  trap 'rm -f "$_rf2a_hits"' EXIT INT TERM HUP
+
+  rf2_attribution_offending_lines > "$_rf2a_hits"
+
+  if [ ! -s "$_rf2a_hits" ]; then
+    rm -f "$_rf2a_hits"
+    trap - EXIT INT TERM HUP
+    return 0
+  fi
+
+  rf2_attribution_refusal "$_rf2a_ctx" < "$_rf2a_hits"
+
+  rm -f "$_rf2a_hits"
+  trap - EXIT INT TERM HUP
+  return 1
+}

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -6,13 +6,15 @@
 # (rf2-ia8o7). They are mirror images, so one harness covers both.
 #
 # The harness has since grown to cover the whole local-durability surface those
-# two blocks belong to — NINE layers. Layers 1-4 are the pre-commit hook
+# two blocks belong to — TEN layers. Layers 1-4 are the pre-commit hook
 # itself; 5 is the CI arm that shares its classifier; 6-7 are the installer
 # that puts the hooks on disk and the advisory that notices when they go stale;
 # 8 is the checkpoint helper on the other side of the same boundary; 9 is the
 # truncation floor the hook grew after that helper's guard was routed around
-# twice. It keeps its name because `.github/workflows/test.yml` runs it by name,
-# unconditionally, on every pull request.
+# twice; 10 is the commit-msg guard, the first block here to grade the message
+# rather than the staged paths. It keeps its name because
+# `.github/workflows/test.yml` runs it by name, unconditionally, on every pull
+# request — which is also why layer 10's guard reaches CI without a new job.
 #
 #   1. Library unit tests — invoke
 #      scripts/git-hooks/lib/check-mayor-commit-boundary.sh directly with
@@ -66,6 +68,13 @@
 #      commit that emptied the tracker was a plain `git add` from the MAYOR
 #      checkout and never went through the helper. Driven in the layer-2
 #      sandbox's PRIMARY worktree, which is where both incidents happened.
+#
+#  10. The AI-ATTRIBUTION guard (rf2-2e8f) — the commit MESSAGE, the one
+#      surface no layer above can see. Library units in BOTH directions, the
+#      `commit-msg` hook driven by real `git commit`s, and the CI arm's RANGE:
+#      an offending commit on the BASE must not red a clean branch, because
+#      three such commits are already on main and whether to rewrite them is
+#      an unmade operator call.
 #
 # Usage:
 #   sh scripts/git-hooks/test-pre-commit.sh
@@ -843,7 +852,7 @@ INSTALLER="$REPO_ROOT/scripts/install-git-hooks.sh"
   # named whichever installer had written it.
   [ -f "$REPO_ROOT/scripts/install-git-hooks.ps1" ] \
     && cp "$REPO_ROOT/scripts/install-git-hooks.ps1" scripts/
-  for h in post-merge post-rewrite pre-commit; do
+  for h in post-merge post-rewrite pre-commit commit-msg; do
     [ -f "$REPO_ROOT/scripts/git-hooks/$h" ] \
       && cp "$REPO_ROOT/scripts/git-hooks/$h" scripts/git-hooks/
   done
@@ -881,7 +890,8 @@ for spec in \
   "pre-commit:# --- BEGIN re-frame2 beads truncation floor (rf2-or8te) ---" \
   "post-merge:# --- BEGIN re-frame2 MCP-staleness check (rf2-6jj3r) ---" \
   "post-merge:# --- BEGIN re-frame2 hook-install staleness check (rf2-zt65l) ---" \
-  "post-rewrite:# --- BEGIN re-frame2 hook-install staleness check, rebase path (rf2-zt65l) ---"; do
+  "post-rewrite:# --- BEGIN re-frame2 hook-install staleness check, rebase path (rf2-zt65l) ---" \
+  "commit-msg:# --- BEGIN re-frame2 commit attribution guard (rf2-2e8f) ---"; do
   hook_file="$IREPO/.git/hooks/${spec%%:*}"
   marker="${spec#*:}"
   if ! grep -Fq "$marker" "$hook_file" 2>/dev/null; then
@@ -1049,7 +1059,7 @@ RCL="$RBOX/clone"
   git config user.name 'hookpull-test'
   git config commit.gpgsign false
   cp "$INSTALLER" scripts/
-  for h in post-merge post-rewrite pre-commit; do
+  for h in post-merge post-rewrite pre-commit commit-msg; do
     [ -f "$REPO_ROOT/scripts/git-hooks/$h" ] \
       && cp "$REPO_ROOT/scripts/git-hooks/$h" scripts/git-hooks/
   done
@@ -1910,6 +1920,301 @@ else
   cat "$TERR" >&2
 fi
 rm -f "$rc_t" "$TERR"
+
+# ----------------------------------------------------------------------------
+# Layer 10: the AI-ATTRIBUTION guard, both arms (rf2-2e8f).
+#
+# Every layer above grades staged PATHS. The commit MESSAGE is a surface none
+# of them can see, and three commits carrying AI-attribution trailers reached
+# main through it — 04230d0d33, e1b07cf184, e71c404c9b — because the agent
+# harness injects a reminder telling agents to add exactly those trailers while
+# CLAUDE.md forbids them, and NOTHING CHECKED. Same shape as rf2-zt65l: a rule
+# that was documented, agreed, and unenforced.
+#
+# THE TWO DIRECTIONS ARE BOTH LOAD-BEARING, and the second is the one that gets
+# skipped. A detector that matches NOTHING passes every "there must be none
+# here" clause silently and vacuously, and reads exactly like a clean tree —
+# PR #9307 disarmed a checker that way and nothing on screen said so. So every
+# permitted case below is paired with an offending one of the SAME SHAPE:
+# `Co-Authored-By:` naming a colleague against one naming the assistant, an
+# indented quotation against the same line at column 0.
+#
+# AND THE RANGE IS TESTED, NOT JUST THE DETECTOR (10k). The CI arm grades the
+# branch delta, so an offending commit sitting on the BASE must not red a clean
+# branch. That is not a nicety: three such commits ARE on main, whether to
+# rewrite them is an unmade operator call, and a gate that graded all of
+# history would red every pull request in the repository for ever.
+# ----------------------------------------------------------------------------
+
+printf '\n[10] AI-attribution guard: the message surface (rf2-2e8f)\n'
+
+ATTR_LIB="$REPO_ROOT/scripts/git-hooks/lib/check-commit-attribution.sh"
+ATTR_HOOK="$REPO_ROOT/scripts/git-hooks/commit-msg"
+ATTR_CI="$REPO_ROOT/scripts/check-commit-attribution.sh"
+
+AERR=/tmp/rf2-attr-test.err
+
+# The three forbidden shapes, built at runtime so the generated-with marker
+# carries its real leading emoji without putting a non-ASCII byte in this file.
+TRAILER_COAUTHOR='Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>'
+TRAILER_SESSION='Claude-Session: https://claude.ai/session/0000'
+TRAILER_GENWITH=$(printf '\360\237\244\226 Generated with [Claude Code](https://claude.com/claude-code)')
+
+run_attr_lib() {
+  # stdin: a commit message. Echoes EXIT=<n>; the refusal block lands on
+  # stderr. `set +e` is load-bearing for the same dash-vs-bash reason spelled
+  # out at layer 1's run_lib.
+  (
+    set +e
+    . "$ATTR_LIB"
+    check_commit_attribution "${1:-commit}"
+    echo "EXIT=$?"
+  )
+}
+
+# 10a: each forbidden shape is refused, and the refusal QUOTES the line.
+for t in "$TRAILER_COAUTHOR" "$TRAILER_SESSION" "$TRAILER_GENWITH"; do
+  key=$(printf '%s' "$t" | cut -c1-24)
+  out=$(printf 'fix(thing): a real change\n\n%s\n' "$t" | run_attr_lib 2>"$AERR") || true
+  case "$out" in
+    *EXIT=1*)
+      if grep -Fq "$t" "$AERR" && grep -q 'AI attribution' "$AERR"; then
+        pass "(10a) refused and quoted: $key..."
+      else
+        fail "(10a) refused but the diagnostic never quoted the line: $key..."
+        cat "$AERR" >&2
+      fi
+      ;;
+    *) fail "(10a) FALSE GREEN: attribution line not detected: $key... ($out)" ;;
+  esac
+done
+
+# 10b: a HUMAN co-author is ordinary git and stays permitted. Paired with 10a's
+# first case: same trailer key, same column, only the value differs — so this
+# passing does not merely say "the detector is asleep".
+out=$(printf 'fix(thing): a real change\n\nCo-Authored-By: Mike Thompson <mike@example.invalid>\n' \
+  | run_attr_lib 2>"$AERR") || true
+case "$out" in
+  *EXIT=0*)
+    if [ ! -s "$AERR" ]; then
+      pass "(10b) Co-Authored-By naming a colleague passes, silently"
+    else
+      fail "(10b) a human co-author produced diagnostics"
+      cat "$AERR" >&2
+    fi
+    ;;
+  *) fail "(10b) FALSE POSITIVE: a human co-author was refused ($out)" ;;
+esac
+
+# 10c: THE ESCAPE HATCH. The same line, indented by one space, is permitted —
+# which is what lets a commit message document the rule or cite an offending
+# commit. Without this the guard would refuse the commit that introduces it.
+out=$(printf 'docs: record the attribution rule\n\n %s\n' "$TRAILER_COAUTHOR" \
+  | run_attr_lib 2>"$AERR") || true
+case "$out" in
+  *EXIT=0*) pass "(10c) an INDENTED quotation of the trailer is permitted" ;;
+  *) fail "(10c) the escape hatch is closed: an indented quotation was refused ($out)"
+     cat "$AERR" >&2 ;;
+esac
+
+# 10d: git's own furniture cannot trip it — `#` comment lines from the editor
+# template, and the `+` diff body `git commit -v` appends.
+out=$(printf 'feat: thing\n\n# %s\n+%s\n' "$TRAILER_COAUTHOR" "$TRAILER_SESSION" \
+  | run_attr_lib 2>"$AERR") || true
+case "$out" in
+  *EXIT=0*) pass "(10d) comment lines and diff-body lines are permitted" ;;
+  *) fail "(10d) FALSE POSITIVE: git's own message furniture was refused ($out)"
+     cat "$AERR" >&2 ;;
+esac
+
+# 10e: an ordinary message is clean and silent.
+out=$(printf 'fix(ssr-ring): a Node 200 that names no build is refused\n\nBody text.\n' \
+  | run_attr_lib 2>"$AERR") || true
+case "$out" in
+  *EXIT=0*)
+    if [ ! -s "$AERR" ]; then
+      pass "(10e) an ordinary commit message passes, silently"
+    else
+      fail "(10e) an ordinary message produced diagnostics"; cat "$AERR" >&2
+    fi
+    ;;
+  *) fail "(10e) FALSE POSITIVE: an ordinary message was refused ($out)" ;;
+esac
+
+# --- End-to-end: the hook, driven by real `git commit` -----------------------
+
+ABOX=$(mktemp -d "${TMPDIR:-/tmp}/rf2-attr-sandbox-XXXXXX")
+AREPO="$ABOX/repo"
+
+(
+  mkdir -p "$AREPO/scripts/git-hooks/lib"
+  cd "$AREPO"
+  git init -q -b main
+  git config user.email 'attr-test@example.invalid'
+  git config user.name 'attr-test'
+  git config commit.gpgsign false
+  cp "$ATTR_LIB" scripts/git-hooks/lib/
+  echo seed > seed.txt
+  git add .
+  git commit -q -m 'seed'
+) >/dev/null 2>&1
+
+ACOMMON=$(git -C "$AREPO" rev-parse --git-common-dir)
+case "$ACOMMON" in /*|[A-Za-z]:[\\/]*) ;; *) ACOMMON="$AREPO/$ACOMMON" ;; esac
+mkdir -p "$ACOMMON/hooks"
+cp "$ATTR_HOOK" "$ACOMMON/hooks/commit-msg"
+chmod +x "$ACOMMON/hooks/commit-msg"
+
+# attr_commit MSGFILE_CONTENT [--no-verify] — commit in the sandbox with the
+# given message; echoes EXIT=<n>, stderr to $AERR.
+attr_commit() {
+  _msg="$1"; shift
+  printf '%s\n' "$_msg" > "$ABOX/msg.txt"
+  (
+    cd "$AREPO"
+    date +%s%N > churn.txt 2>/dev/null || echo churn > churn.txt
+    git add churn.txt
+    git commit "$@" -q -F "$ABOX/msg.txt"
+  ) >/dev/null 2>"$AERR" && echo "EXIT=0" || echo "EXIT=$?"
+}
+
+# 10f: THE BITE. A real `git commit` carrying the trailer is refused, and the
+# message names the offending line and points at the rule.
+out=$(attr_commit "$(printf 'fix: something\n\n%s\n%s\n' "$TRAILER_COAUTHOR" "$TRAILER_SESSION")")
+case "$out" in
+  EXIT=0) fail "(10f) FALSE GREEN: git commit with AI attribution was allowed" ;;
+  *)
+    if grep -Fq "$TRAILER_SESSION" "$AERR" && grep -q 'CLAUDE.md' "$AERR"; then
+      pass "(10f) commit-msg hook BITES: refused, quotes the line, cites the rule"
+    else
+      fail "(10f) refused, but the diagnostic is missing the line or the rule"
+      cat "$AERR" >&2
+    fi
+    ;;
+esac
+
+# 10g: NO FALSE POSITIVE. An ordinary commit in the same repo is untouched.
+out=$(attr_commit 'fix: an ordinary change')
+case "$out" in
+  EXIT=0) pass "(10g) an ordinary commit passes with the hook installed" ;;
+  *) fail "(10g) FALSE POSITIVE: an ordinary commit was refused ($out)"; cat "$AERR" >&2 ;;
+esac
+
+# 10h: `--no-verify` is the operator escape, and it works. A guard whose escape
+# does not work gets removed rather than bypassed. It is also how 10k plants
+# an offending commit on the base below.
+out=$(attr_commit "$(printf 'chore: deliberate override\n\n%s\n' "$TRAILER_COAUTHOR")" --no-verify)
+case "$out" in
+  EXIT=0) pass "(10h) --no-verify lands a deliberate override" ;;
+  *) fail "(10h) the documented escape does not work ($out)"; cat "$AERR" >&2 ;;
+esac
+
+# --- The CI arm --------------------------------------------------------------
+#
+# Invoked at its real path, against the sandbox repo as the working directory:
+# the script resolves its detector library beside itself and its COMMITS from
+# the current repository, which is exactly how CI runs it.
+
+run_attr_ci() {
+  ( cd "$AREPO" && GITHUB_EVENT_NAME="${ATTR_EVENT:-pull_request}" \
+      sh "$ATTR_CI" "$@" ) >/dev/null 2>"$AERR" && echo "EXIT=0" || echo "EXIT=$?"
+}
+
+# The base now carries an offending commit (10h landed one with --no-verify) —
+# which is the trunk's real situation. Mark it as the base and branch from it.
+git -C "$AREPO" branch -f base main >/dev/null 2>&1
+
+# 10i: a branch that INTRODUCES an offending commit is refused, and the report
+# names the commit.
+git -C "$AREPO" checkout -q -b feature/dirty base >/dev/null 2>&1
+out=$(attr_commit "$(printf 'feat: branch work\n\n%s\n' "$TRAILER_SESSION")" --no-verify)
+case "$out" in
+  EXIT=0) : ;;
+  *) fail "(10i-setup) could not plant the offending commit ($out)"; cat "$AERR" >&2 ;;
+esac
+dirty_sha=$(git -C "$AREPO" rev-parse --short=10 HEAD)
+out=$(run_attr_ci base)
+case "$out" in
+  EXIT=0) fail "(10i) FALSE GREEN: the CI arm passed a branch carrying attribution" ;;
+  *)
+    if grep -Fq "$dirty_sha" "$AERR" && grep -Fq "$TRAILER_SESSION" "$AERR"; then
+      pass "(10i) CI arm refuses the branch and names the commit ($dirty_sha)"
+    else
+      fail "(10i) refused, but the report names neither the sha nor the line"
+      cat "$AERR" >&2
+    fi
+    ;;
+esac
+
+# 10j: a clean branch off the same base passes.
+git -C "$AREPO" checkout -q -b feature/clean base >/dev/null 2>&1
+out=$(attr_commit 'feat: clean branch work')
+case "$out" in
+  EXIT=0) : ;;
+  *) fail "(10j-setup) could not make the clean commit ($out)"; cat "$AERR" >&2 ;;
+esac
+out=$(run_attr_ci base)
+case "$out" in
+  EXIT=0) pass "(10j) CI arm passes a clean branch" ;;
+  *) fail "(10j) FALSE POSITIVE: a clean branch was refused ($out)"; cat "$AERR" >&2 ;;
+esac
+
+# 10k: THE RANGE. The base carries an offending commit of its own (10h), and
+# this branch is still green — because the gate grades the branch delta, not
+# all of history. Without this the three commits already on main would red
+# every pull request in the repository, for ever.
+base_offender=$(git -C "$AREPO" log base --format='%H' -1)
+if git -C "$AREPO" log -1 --format=%B "$base_offender" \
+     | grep -Fq "$TRAILER_COAUTHOR"; then
+  out=$(run_attr_ci base)
+  case "$out" in
+    EXIT=0) pass "(10k) an offending commit on the BASE does not red a clean branch" ;;
+    *) fail "(10k) the gate graded history behind the merge base ($out)"
+       cat "$AERR" >&2 ;;
+  esac
+else
+  fail "(10k-setup) the base does not carry the planted offender — test is vacuous"
+fi
+
+# 10l: no base ref -> FAILS CLOSED. With no range the gate inspects nothing,
+# finds nothing, and would otherwise report the same silent zero as a clean
+# branch: the vacuous pass this whole guard exists to end.
+out=$(run_attr_ci)
+case "$out" in
+  EXIT=0) fail "(10l) FALSE GREEN: the CI arm passed with no base ref" ;;
+  *)
+    if grep -q 'certifies nothing' "$AERR"; then
+      pass "(10l) no base ref -> fails closed and says why"
+    else
+      fail "(10l) failed, but not with the fail-closed diagnostic"; cat "$AERR" >&2
+    fi
+    ;;
+esac
+
+# 10m: an unresolvable base ref -> fails closed too (the shallow-clone shape).
+out=$(run_attr_ci no/such/ref)
+case "$out" in
+  EXIT=0) fail "(10m) FALSE GREEN: the CI arm passed on an unresolvable base" ;;
+  *) pass "(10m) an unresolvable base ref -> fails closed" ;;
+esac
+
+# 10n: enforcement is pull_request only. On any other event the commits are
+# already history, and rewriting published history is an operator decision
+# rather than a gate's.
+#
+# A prefix assignment on a FUNCTION call persists after it returns in some
+# shells and not others, so the variable is set and cleared explicitly.
+ATTR_EVENT=push
+out=$(run_attr_ci base)
+ATTR_EVENT=pull_request
+case "$out" in
+  EXIT=0) pass "(10n) a non-pull_request event passes with an explanatory line" ;;
+  *) fail "(10n) the guard enforced outside a pull request ($out)"; cat "$AERR" >&2 ;;
+esac
+
+git -C "$AREPO" checkout -q main >/dev/null 2>&1 || true
+rm -rf "$ABOX"
+rm -f "$AERR"
 
 # ----------------------------------------------------------------------------
 # Summary

--- a/scripts/install-git-hooks.ps1
+++ b/scripts/install-git-hooks.ps1
@@ -36,6 +36,12 @@
 #                       failure: an empty export reached main twice from
 #                       the MAYOR checkout, by plain `git add`, where they
 #                       no-op.
+#   - commit-msg       (rf2-2e8f) refuses a commit MESSAGE carrying AI
+#                       attribution (`Co-Authored-By:` naming the assistant,
+#                       `Claude-Session:`, a generated-with marker). Every
+#                       block above grades staged PATHS; the message is a
+#                       surface none of them can see, and three such commits
+#                       reached main while nothing checked.
 #   - mayor-marker     (rf2-ydl2p) sentinel at <common-dir>/mayor-marker;
 #                       hook activation gate. Worker worktrees have a
 #                       distinct per-worktree git dir, so they never see
@@ -95,6 +101,11 @@ $hookBlocks = @{
         'pre-commit',
         '# --- BEGIN re-frame2 beads truncation floor (rf2-or8te) ---',
         '# --- END re-frame2 beads truncation floor (rf2-or8te) ---'
+    )
+    'commit-attribution' = @(
+        'commit-msg',
+        '# --- BEGIN re-frame2 commit attribution guard (rf2-2e8f) ---',
+        '# --- END re-frame2 commit attribution guard (rf2-2e8f) ---'
     )
 }
 
@@ -268,6 +279,7 @@ try {
     Install-Block -BlockId 'mayor-commit-boundary'
     Install-Block -BlockId 'worker-beads-boundary'
     Install-Block -BlockId 'beads-truncation-floor'
+    Install-Block -BlockId 'commit-attribution'
     Install-MayorMarker
 }
 catch {

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -31,6 +31,11 @@
 #                 it. Neither of the two blocks above could see the failure:
 #                 an empty export reached main twice from the MAYOR
 #                 checkout, by plain `git add`, where they no-op.
+#   - commit-msg  (rf2-2e8f) refuses a commit MESSAGE carrying AI attribution
+#                 (`Co-Authored-By:` naming the assistant, `Claude-Session:`,
+#                 a generated-with marker). Every block above grades staged
+#                 PATHS; the message is a surface none of them can see, and
+#                 three such commits reached main while nothing checked.
 #
 # Usage:
 #   scripts/install-git-hooks.sh           # install/refresh
@@ -75,6 +80,9 @@ block_spec() {
       ;;
     beads-truncation-floor)
       printf 'pre-commit\t# --- BEGIN re-frame2 beads truncation floor (rf2-or8te) ---\t# --- END re-frame2 beads truncation floor (rf2-or8te) ---\n'
+      ;;
+    commit-attribution)
+      printf 'commit-msg\t# --- BEGIN re-frame2 commit attribution guard (rf2-2e8f) ---\t# --- END re-frame2 commit attribution guard (rf2-2e8f) ---\n'
       ;;
     *)
       printf 'install-git-hooks: unknown block id: %s\n' "$1" >&2
@@ -245,6 +253,7 @@ install_block hook-staleness-rebase || rc=$?
 install_block mayor-commit-boundary || rc=$?
 install_block worker-beads-boundary || rc=$?
 install_block beads-truncation-floor || rc=$?
+install_block commit-attribution || rc=$?
 install_mayor_marker || rc=$?
 
 if [ "$MODE" = "check" ] && [ "$rc" -ne 0 ]; then


### PR DESCRIPTION
Closes the source half of rf2-2e8f. **The other half — whether the three existing commits are rewritten or accepted — is untouched here and still awaits Mike.** Nothing in this PR rewrites history and nothing force-pushes.

## The problem

Three commits on main carry AI-attribution trailers that `CLAUDE.md` > Git Conventions forbids: `04230d0d33`, `e1b07cf184`, `e71c404c9b`, each with a co-author line naming the assistant *and* a session-URL trailer. Re-measured over the last 400 trunk commits at `6e1f46fc19`: **exactly those three, no others.**

They got there silently because **nothing checked**. And the rule is not being broken by carelessness — it is broken by a live conflict between two instruction sources. The agent harness injects a session-level reminder telling agents to end every commit message with exactly those trailers; the checked-in `CLAUDE.md` forbids them. Both reach every worker, so the tie was broken **both ways by capable agents in the same wave**. That is a coin-flip, not a convention.

There was no existing mechanism to extend: `check_view_lifetime_residue.py` and its banned-word siblings read git-tracked file **content and paths**, and no checker in `scripts/` reads commit messages at all. Commit messages are a genuinely unreached surface.

## What this adds

Two arms over **one** detector — the shape the `.beads` boundary already uses, so the local hook and the CI gate cannot drift:

| File | Role |
|---|---|
| `scripts/git-hooks/lib/check-commit-attribution.sh` | the detector |
| `scripts/git-hooks/commit-msg` | the local hook (new hook, one marker block, `commit-attribution`) |
| `scripts/check-commit-attribution.sh` | the CI arm |

Scope is deliberately tiny: three shapes (a `Claude-Session:` line, a `Co-Authored-By:` whose value names the assistant, a generated-with marker). Not a commit-message linter — no subject-length rule, no trailer hygiene, and a `Co-Authored-By:` naming a human colleague stays permitted.

**Only column 0 offends**, which is the escape hatch: an indented line may quote a forbidden trailer, so a commit documenting the rule — or citing one of the three — is not refused by it. Git's own `#` template comments and the `commit -v` diff body are immune for free.

## The range the CI arm grades

`git merge-base BASE HEAD`..HEAD — the commits the branch introduces.

Grading all of history is not an option: the three above are already ancestors of main, whether to rewrite them is an unmade operator call, and a gate over history would red every PR in this repository for ever. They sit behind every merge base, so **the trunk stays green with no allow-list, no baseline file, and nothing to trim later**.

A missing base ref, an unresolvable one, or no merge base (a shallow clone) all **fail closed**. With no range the gate would inspect nothing, find nothing, and report the same silent zero as a clean branch — the vacuous pass this exists to end.

## Proof it bites in both directions

A detector that matches nothing passes a "there must be none here" clause vacuously and silently, so every permitted case is paired with an offending one of the same shape.

Against the **real** trunk commits, with the real script:

```
04230d0d33 offending_lines=2      6d513ba07f offending_lines=0
e1b07cf184 offending_lines=2      a37412b8ed offending_lines=0
e71c404c9b offending_lines=2      722d1f54f6 offending_lines=0
```

A planted commit on a throwaway branch, real repo, real script: **exit 1**, naming the sha and quoting both lines. This branch against `origin/main`: **exit 0** — `No AI attribution in the 1 commit(s) this branch introduces`.

Layer 10 of `scripts/git-hooks/test-pre-commit.sh` pins all of it — 16 cases including 10k, which plants an offender on the **base** and asserts the clean branch stays green.

## Wired into CI: a STEP, never a job — the band does not move

The CI arm now runs, as one step added to the existing `beads-pr-boundary` job in `test.yml`. **No job is added.** Measured against `origin/main`:

| | |
|---|---|
| job keys on `origin/main` | **73** |
| job keys on this branch | **73** |
| added job keys in the diff | **0** (control: the discriminator reads **1** on a planted key, so the zero is a real zero) |
| steps added | **1** |

It goes in that job for its `fetch-depth: 0`, which I confirmed by reading the job's own checkout block — it sets `fetch-depth: 0` explicitly, with a comment saying the guard diffs from the branch point. The script grades `merge-base(BASE, HEAD)..HEAD` and **fails closed** when it cannot resolve one, so a shallow checkout would red every PR — and relaxing that to pass on a missing range would make it a checker that inspects nothing and reports the same silent zero as a clean branch. That is why it is **not** in `verify-skill-mcp-drift` with the other repo invariants, whose checkout is deliberately the cheap shallow one.

One command, no event branch: the script checks `GITHUB_EVENT_NAME` *before* it looks at the base ref, so on a push it exits 0 with its own explanatory line and never evaluates the empty `origin/`. The event policy has exactly one home — the script.

**`.github/workflows/test.yml` is the only workflow file touched**, and the diff there is purely additive (+31, 0 deletions): no reformatting, no adjacent-step edits, no trigger or `fetch-depth` change.

## Two reds found and fixed after the first push

**1. `check_view_lifetime_residue.py` — the repo-wide banned-word ratchet at zero.** The safe force-push flag spells the retired view-lifetime word as a bare token, which is exactly what a flag name makes it, and my CI remedy stanza printed that flag. The remedy now names the force-push in prose and does not spell the flag, with a source comment saying why so nobody helpfully restores it. **The gate itself is unchanged** — no allow-list, no exemption, no edit to the checker; its own self-test still passes 21/21, so the zero is a real zero.

**2. `js-harness-self-tests` — `line 1304: flow mappings are not supported`.** `implementation/scripts/_release-dag-policy.test.cjs` parses the workflows with a hand-rolled reader that rejects a `{` in a **plain** scalar. So `${GITHUB_BASE_REF}` written on the `run:` line itself reds the job, while the byte-identical text one step above passes because that step's body sits inside a `run: |` block. The step now uses a block scalar, matching its neighbour, with a comment recording that the pipe is load-bearing rather than stylistic. Proved in both directions on one tree: that test is **red** on the plain-scalar form and **green** on the block form, nothing else changed.

## Gates

| Gate | Exit |
|---|---|
| `sh scripts/git-hooks/test-pre-commit.sh` — 88 passed, 0 failed | 0 |
| full repo-invariants roster, 61 checkers | 0 (all 61) |
| `python scripts/check_view_lifetime_residue.py --verbose` | 0 |
| `python scripts/check_view_lifetime_residue.py --self-test` — 21/21, gate unmodified | 0 |
| `node --test "scripts/_release-dag-policy.test.cjs"` — 13 passed | 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 |
| `sh scripts/check-commit-attribution.sh origin/main` | 0 |
| fail-closed re-proof after wiring: no base ref / unresolvable base | 1 / 1 |
| `sh -n` on all four new/edited shell sources | 0 |

`report-changed-surfaces.sh` arms **no** classifier surface for these paths (control: `implementation/core/src/re_frame/core.cljc` arms eight), so the gated lanes are correctly skipped. `mkdocs build --strict` is not the gate here — neither edited markdown file (`scripts/git-hooks/README.md`, `CLAUDE.md`) is under `docs_dir` or the doc-slug gate's roots; both are `check_readme_links.py --ci`'s surface, which ran green.

`sh scripts/install-git-hooks.sh --check` exits **1**, naming `commit-msg` as missing — the correct answer for a newly added block. **After merge, run `sh scripts/install-git-hooks.sh` once** from the mayor checkout to arm it; worktrees share the primary's hooks directory, so one run covers them all. It was not run from this worker worktree because the installer writes into the shared hooks directory outside it.

## Deliberately not built

PR **descriptions**. The convention covers them too; a git hook cannot see one and neither arm reads one. Left unbuilt rather than half-built.

