### PR TITLE
chore(tests): sweep three machine registrations onto reg-machine (rf2-u91d)

### DIFF
--- a/implementation/core/test/re_frame/hot_reload_test.clj
+++ b/implementation/core/test/re_frame/hot_reload_test.clj
@@ -20,7 +20,9 @@
   performs both registrations within one test body."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.machines :as rf.machines]
+            ;; Publishes the late-bind hook `rf/reg-machine` lowers onto.
+            ;; Side-effect require; alias unused.
+            [re-frame.machines]
             [re-frame.frame :as rf.frame]
             [re-frame.registrar :as rf.registrar]
             [re-frame.schemas :as rf.schemas]
@@ -47,9 +49,10 @@
   ;; registrations so :rf/hydrate, :rf.nav/push-url etc. resurrect.
   (require 're-frame.routing :reload)
   (require 're-frame.ssr    :reload)
-  ;; The snapshot test uses `rf.machines/make-machine-handler`; re-load machines so
-  ;; the artefact's reg surface is live in isolated runs too (the snapshot
-  ;; slot lives in runtime-db per EP-0001).
+  ;; The snapshot test uses `rf/reg-machine`, which lowers onto the machines
+  ;; artefact's late-bound registration hook; re-load machines so that reg
+  ;; surface is live in isolated runs too (the snapshot slot lives in
+  ;; runtime-db per EP-0001).
   (require 're-frame.machines :reload)
   (test-fn))
 
@@ -260,19 +263,18 @@
     (rf/make-frame {:id :tenant :doc       "v1 metadata"
                     :tenant-id :acme})
     ;; Build a tiny machine and dispatch into it so [:rf.runtime/machines :snapshots] is
-    ;; populated. We use a machine handler so the snapshot lands at
+    ;; populated. We register a machine so the snapshot lands at
     ;; [:rf.runtime/machines :snapshots :traffic-light] per Spec 005.
-    (rf/reg-event :traffic-light
-      (rf.machines/make-machine-handler
-        {:initial :red
-         :data    {:ticks 0}
-         :actions {:tick-action
-                   (fn [{data :data}]
-                     {:data (update data :ticks inc)})}
-         :states
-         {:red    {:on {:tick {:target :green :action :tick-action}}}
-          :green  {:on {:tick {:target :yellow :action :tick-action}}}
-          :yellow {:on {:tick {:target :red    :action :tick-action}}}}}))
+    (rf/reg-machine :traffic-light
+      {:initial :red
+       :data    {:ticks 0}
+       :actions {:tick-action
+                 (fn [{data :data}]
+                   {:data (update data :ticks inc)})}
+       :states
+       {:red    {:on {:tick {:target :green :action :tick-action}}}
+        :green  {:on {:tick {:target :yellow :action :tick-action}}}
+        :yellow {:on {:tick {:target :red    :action :tick-action}}}}})
     ;; Drive the machine forward twice in :tenant.
     (rf/dispatch-sync [:traffic-light [:tick]] {:frame :tenant})
     (rf/dispatch-sync [:traffic-light [:tick]] {:frame :tenant})

--- a/implementation/core/test/re_frame/pattern_smoke_test.clj
+++ b/implementation/core/test/re_frame/pattern_smoke_test.clj
@@ -139,17 +139,16 @@
       (is (true? (:app/booted? db)) "chained-events boot reached :app/ready")
       (is (= {:loaded? true} (:config db)))))
   (testing "machine boot — :configuring → :loading → :ready"
-    (rf/reg-event :app/boot
-      (rf.machines/make-machine-handler
-        {:initial :configuring
-         :data    {:config nil}
-         :actions {:record-config (fn [{data :data [_ c] :event}]
-                                    {:data (assoc data :config c)})}
-         :states
-         {:configuring {:on {:configured {:target :loading
-                                          :action :record-config}}}
-          :loading     {:on {:loaded     {:target :ready}}}
-          :ready       {}}}))
+    (rf/reg-machine :app/boot
+      {:initial :configuring
+       :data    {:config nil}
+       :actions {:record-config (fn [{data :data [_ c] :event}]
+                                  {:data (assoc data :config c)})}
+       :states
+       {:configuring {:on {:configured {:target :loading
+                                        :action :record-config}}}
+        :loading     {:on {:loaded     {:target :ready}}}
+        :ready       {}}})
     ;; :initial-events kick the boot machine; subsequent dispatched lifecycle
     ;; events drive the documented progression to :ready.
     (let [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/boot [:configured {:url "/api"}]]]})]

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -809,42 +809,42 @@
         {:platforms #{:server :client}}
         (fn [_ {:keys [token]}] (reset! stored token)))
 
-      ;; The login machine. Mirrors the structure of examples/login/core.cljs's
-      ;; :auth.login/flow — five states, deepest-wins, multi-guard branch.
-      (rf/reg-event :auth.login/flow
-        (rf.machines/make-machine-handler
-          ;; Per Spec 005: spec map does NOT carry :id; the id comes
-          ;; from the enclosing reg-event call.
-          {:initial :idle
-           :data    {:attempts 0 :error nil}
-           :guards
-           {:under-retry-limit
-            (fn [{data :data}] (< (:attempts data) 3))}
-           :actions
-           {:clear-error    (fn [_] {:data {:error nil}})
-            :issue-request  (fn [{[_ creds] :event}]
-                              {:fx [[:http {:method     :post
-                                            :url        "/api/login"
-                                            :body       creds
-                                            :on-success [:auth.login/flow [:auth.login/success]]
-                                            :on-error   [:auth.login/flow [:auth.login/failure]]}]]})
-            :record-error   (fn [{data :data [_ err] :event}]
-                              {:data (-> data
-                                         (update :attempts inc)
-                                         (assoc :error (or (:message err) "Login failed.")))})
-            :lock-account   (fn [_] {:fx []})
-            :store-session  (fn [{[_ {:keys [token]}] :event}]
-                              {:fx [[:auth.session/store {:token token}]]})}
-           :states
-           {:idle        {:on {:auth.login/submit {:target :submitting :action :clear-error}}}
-            :submitting  {:entry :issue-request
-                          :on    {:auth.login/success {:target :authed :action :store-session}
-                                  :auth.login/failure [{:target :error-shown :guard :under-retry-limit :action :record-error}
-                                                       {:target :locked-out :action :lock-account}]}}
-            :error-shown {:on {:auth.login/dismiss {:target :idle}
-                               :auth.login/submit  {:target :submitting}}}
-            :authed      {}
-            :locked-out  {}}}))
+      ;; The login machine. Mirrors the structure of
+      ;; examples/core/login/model.cljc's :auth.login/flow — five states,
+      ;; deepest-wins, multi-guard branch.
+      (rf/reg-machine :auth.login/flow
+        ;; Per Spec 005: spec map does NOT carry :id; the id comes
+        ;; from the enclosing reg-machine call.
+        {:initial :idle
+         :data    {:attempts 0 :error nil}
+         :guards
+         {:under-retry-limit
+          (fn [{data :data}] (< (:attempts data) 3))}
+         :actions
+         {:clear-error    (fn [_] {:data {:error nil}})
+          :issue-request  (fn [{[_ creds] :event}]
+                            {:fx [[:http {:method     :post
+                                          :url        "/api/login"
+                                          :body       creds
+                                          :on-success [:auth.login/flow [:auth.login/success]]
+                                          :on-error   [:auth.login/flow [:auth.login/failure]]}]]})
+          :record-error   (fn [{data :data [_ err] :event}]
+                            {:data (-> data
+                                       (update :attempts inc)
+                                       (assoc :error (or (:message err) "Login failed.")))})
+          :lock-account   (fn [_] {:fx []})
+          :store-session  (fn [{[_ {:keys [token]}] :event}]
+                            {:fx [[:auth.session/store {:token token}]]})}
+         :states
+         {:idle        {:on {:auth.login/submit {:target :submitting :action :clear-error}}}
+          :submitting  {:entry :issue-request
+                        :on    {:auth.login/success {:target :authed :action :store-session}
+                                :auth.login/failure [{:target :error-shown :guard :under-retry-limit :action :record-error}
+                                                     {:target :locked-out :action :lock-account}]}}
+          :error-shown {:on {:auth.login/dismiss {:target :idle}
+                             :auth.login/submit  {:target :submitting}}}
+          :authed      {}
+          :locked-out  {}}})
 
       ;; Subs over the machine snapshot. EP-0001 (rf2-vzld77): machine
       ;; snapshots are durable runtime-db state, so this composes off the


### PR DESCRIPTION
Closes the implementation-side slice of the `reg-machine` teaching-order sweep. rf2-kuky.26 (PR #9309) established that **`rf/reg-machine` is the authoring surface** and `make-machine-handler` the primitive beneath it; rf2-z442 (PR #9315) swept the five spec Construction-Prompt and Pattern pages. These are the three `implementation/core/test/` sites both of those fences excluded.

## The discrimination

Call position is **not** the criterion — *"is this a registration shape?"* is. `make-machine-handler` is **not** deprecated and stays public: it is the machine's `reg-view*`, the seam for building a handler **without** registering one, and `machine_schema_arity_test.clj` pins the bare `(reg-event id meta (make-machine-handler spec))` path as a specified, fail-loud path. Nothing here deprecates it, warns on it, or touches its callers.

| file | occurrences | swept | kept |
| --- | --- | --- | --- |
| `pattern_smoke_test.clj` | 1 | `:app/boot` (`reg-event` + factory in call position) | — |
| `hot_reload_test.clj` | 2 | `:traffic-light` (same shape) | 1 prose mention in the fixture comment |
| `smoke_test.clj` | 2 | `:auth.login/flow` (same shape) | `:700` — `(let [handler (make-machine-handler machine)] …)`, named do-not-sweep by rf2-u91d |

Each sweep is `(rf/reg-event <id> (rf.machines/make-machine-handler {spec}))` → `(rf/reg-machine <id> {spec})`: the spec map de-indents by two and loses one closing paren. No behaviour change — the same handler registers under the same id, which the suite is the proof of.

## Comments and docstrings realigned with what the code now does

A test whose prose describes a form it no longer uses is worse than either alone, so four stale statements move with the code:

- `hot_reload_test.clj`'s fixture comment named `rf.machines/make-machine-handler` as what the snapshot test uses; it now names `rf/reg-machine` and the late-bind hook it lowers onto.
- `hot_reload_test.clj`'s `[re-frame.machines :as rf.machines]` lost its last alias user, but the require is still **load-bearing** — it publishes the hook `reg-machine` lowers onto (`reg-machine-impl`'s late-bind throw fires without it) — so it becomes a side-effect require, matching the `re-frame.http.managed` precedent already in `smoke_test.clj`.
- `smoke_test.clj`'s "Mirrors the structure of `examples/login/core.cljs`" named a path that has moved: it is `examples/core/login/model.cljc`, which itself registers `:auth.login/flow` via `rf/reg-machine`.
- `smoke_test.clj`'s inner "the id comes from the enclosing `reg-event` call" now says `reg-machine`.

`pattern_smoke_test.clj`'s docstring citations were checked and left alone: `Pattern-Boot.md` still carries §The simple form — chained events, §The state-machine canonical form and §Standard boot states. It was the **code** that had drifted from the page, not the citation — the page now shows `rf/reg-machine :app/boot` at all three of its machine sites.

## Gates

Run foreground to completion, exit captured on the same command line as the redirect, never piped through a filter.

| gate | exit | result |
| --- | --- | --- |
| `clojure -M:test` (`implementation/core`, the jvm-core lane) | **0** | 2197 tests, 11368 assertions, 0 failures, 0 errors |
| `check_require_alias_dialect.py` | **0** | |
| `check_retired_composition_vocab.py` | **0** | |
| `check_retired_spellings.py` | **0** | |
| `check_test_lane_bijection.py` | **0** | |
| `check_jvm_lane_rosters.py` | **0** | |
| `check_architecture_census.py` | **0** | |

The suite prints no namespace names, so **two planted faults** prove each gate read this branch's tree rather than a sibling's, each restored and verified by git blob hash against the committed object (both matched exactly; no CRLF-filter disagreement, so the byte-comparison fallback was not needed):

- `pattern_smoke_test.clj:158` expected value replaced with a token existing only here → **exit 1**, `FAIL in (pattern-boot-shape) (pattern_smoke_test.clj:158)`, `actual: (not (= :rf2-u91d/PLANTED-FAULT :ready))`. Namespace and assertion counts were identical to the control run (2197 / 11368), so the plant stopped no namespace. That failure line is also incidental evidence the sweep is behaviour-preserving: the swept `reg-machine` registration drove the machine to `:ready` exactly as the `reg-event` + factory form did.
- A wrong-dialect alias planted in `hot_reload_test.clj`'s ns form → `check_require_alias_dialect.py` **exit 1**, naming `implementation/core/test/re_frame/hot_reload_test.clj:26`.

`.github/scripts/report-changed-surfaces.sh` (fed **paths**, not revisions) reports `implementation_jvm=true` for these three files; exercised once against `README.md` as a control, where it reports every surface false. The CLJS surfaces it arms are coarse-grained — these are `.clj` files in no CLJS build — and CI owns those lanes.

Branch diffed against its **merge base** (`origin/main...HEAD`) before pushing: three files, 64 insertions / 63 deletions, nothing reverted from a sibling's landing.

## Out of scope, deliberately

No API change; no deprecation or warning on `make-machine-handler` (the project stance's *"we trust the programmer"* rejects that); no edit to the Level-2 factory tests under `implementation/machines/test/**`; `spec/005-StateMachines.md` and the five pattern/prompt pages are already done by #9309 and #9315 and are untouched here.
