### PR TITLE
fix(xray): first-open discovery defers to an explicit target frame (rf2-88f1)

### DIFF
--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -370,6 +370,23 @@ becomes selected only by one of the three sources above:
   resolution); it is **unique resolution, not synthesis** — when no
   focusable cascade exists the target stays UNSELECTED.
 
+**Discovery is the FALLBACK, and only runs while the target is still
+UNSELECTED (rf2-88f1).** The three sources above are not peers: an
+explicit target — from host config or the picker — outranks the
+mount-time policy, because discovery *guesses* which frame the operator
+is looking at while an explicit target is what the host or the operator
+*said*. So first open re-derives a seed frame only when nothing has
+chosen one; where a choice is already in the slot, first open preserves
+it and re-seeds `:epoch-history` from that frame.
+
+The collision is new, and that is why the ordering had not needed
+stating: until `set-target-frame!` seated `:rf/xray` itself (below), no
+target could be selected *before* first open, so discovery never met one.
+Unordered, the loss was silent both ways — a cold ring resolves to `nil`,
+which `:rf.xray/set-target-frame` writes as a full RESET (clearing
+`:target-frame`, `[:focus :frame]` and `:epoch-history`), and a warm ring
+substitutes whichever frame happens to head the pre-open trace.
+
 `set-target-frame!` **seats `:rf/xray` before it dispatches** (rf2-88f1).
 The own-frame singleton is normally seated the moment the host runtime is
 ready, from the preload's readiness loop (rf2-avi7) — but that loop polls

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -651,7 +651,17 @@
     `:rf.xray/set-target-frame` event writes `:target-frame` and
     re-seeds `:epoch-history` from `(rf/epoch-history seed-frame)`
     in lockstep — symmetric with the picker path and the public
-    `core/set-target-frame!` API."
+    `core/set-target-frame!` API.
+
+    Discovery runs only where the slot is still UNSELECTED (rf2-88f1).
+    `core/set-target-frame!` seats `:rf/xray` itself, so a host can target a
+    frame before anything opens Xray and this hook can now find an explicit
+    choice already in the slot — an ordering that did not exist when the seed
+    was written. An explicit target wins: discovery is the operator-present
+    guess at what the user is looking at, and it does not overrule what the
+    host said. The preserved target is still re-dispatched through the same
+    event, so `:epoch-history` picks up whatever the host recorded between
+    its call and first open and the two axes stay in lockstep."
   ([] (ensure-xray-frame! shell/default-frame-id))
   ([frame-id]
    ;; `:rf.trace/frame-no-emit? true` marks the shell frame a tool /
@@ -724,6 +734,21 @@
   ;; Xray-internal hard-filter) to derive the seed-frame. Without the
   ;; internal filter a tool-frame event-bundle could be chosen as the head,
   ;; which the user never sees in the L2 list.
+  ;;
+  ;; DISCOVERY IS THE FALLBACK, NOT THE OVERRIDE (rf2-88f1). Since
+  ;; `core/set-target-frame!` seats `:rf/xray` itself, a host can target a
+  ;; frame BEFORE anything opens Xray — so by the time this hook runs the
+  ;; slot may already carry an explicit choice, which it never could when
+  ;; the seed was written. Discovery is the operator-present tier that
+  ;; guesses what the user is looking at; an explicit target is what the
+  ;; host SAID. The guess must not overwrite the statement, and on a cold
+  ;; ring it does not even guess: `focusable-head-frame-id` returns nil,
+  ;; and `:rf.xray/set-target-frame` writes nil as a RESET (dissoc
+  ;; `:target-frame`, clear `[:focus :frame]`, empty `:epoch-history`), so
+  ;; the host's boot intent vanished at first open with nothing to read.
+  ;; Reading the slot first makes this the ordering the two tiers already
+  ;; imply — host config, then picker, then discovery (see
+  ;; `defaults/default-target-frame`).
   (fn [frame-id]
     ;; `snapshot-from-rings` reads the rings synchronously (the
     ;; production coalescer instead refreshes them via an async
@@ -732,10 +757,13 @@
     ;; dispatch-sync the snapshot through `:rf.xray/sync-trace-buffer`
     ;; so the first-mount render reads against pre-mount events
     ;; deterministically.
-    (let [buffer     (trace-collector/snapshot-from-rings)
+    (let [buffer          (trace-collector/snapshot-from-rings)
           event-bundles   (self-noise/filtered-event-bundles buffer)
-          seed-frame (or (spine/focusable-head-frame-id event-bundles)
-                         defaults/default-target-frame)]
+          explicit-target (rf/with-frame frame-id
+                            (rf/subscribe-once [:rf.xray/target-frame]))
+          seed-frame      (or explicit-target
+                              (spine/focusable-head-frame-id event-bundles)
+                              defaults/default-target-frame)]
       (rf/with-frame frame-id
         (rf/dispatch-sync [:rf.xray/sync-trace-buffer buffer])
         ;; rf2-boyc2 — seed via `:rf.xray/set-target-frame` so
@@ -744,6 +772,15 @@
         ;; (the head focusable event-bundle's frame). Mirrors the picker-
         ;; driven `set-frame-reducer` path and `core/set-target-
         ;; frame!`.
+        ;;
+        ;; Re-dispatching a PRESERVED target is deliberate rather than a
+        ;; skippable no-op: `:epoch-history` re-seeds from
+        ;; `(rf/epoch-history seed-frame)` on every write, so routing the
+        ;; preserved target through the same event harvests the epochs the
+        ;; host recorded between its call and first open. Skipping the
+        ;; dispatch would keep the target and strand the history at the
+        ;; value it had at boot — which is the lockstep rf2-boyc2 exists
+        ;; to hold.
         (rf/dispatch-sync [:rf.xray/set-target-frame seed-frame])))))
 
 (register-first-mount-hook!

--- a/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
@@ -1271,7 +1271,15 @@
             guard so a subsequent `ensure-xray-frame!` call performs a
             fresh first-mount seed again (the fixture-reset contract
             every Xray test fixture relies on via
-            `test-support/reset-sentinels!`)"
+            `test-support/reset-sentinels!`).
+
+            The witness is POSITIVE — a target that only the seed hook could
+            have written — rather than the target going back to nil.
+            rf2-88f1 makes discovery defer to an explicit target, so a
+            re-fired hook no longer clears one and the old
+            disappearing-value witness would report a guarded no-op and a
+            re-fire identically. The subject of this deftest is unchanged;
+            only the evidence for it had to stop being an absence."
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn]} (mk-render-stub)]
@@ -1280,16 +1288,26 @@
             (mount/open!)
             (rf/with-frame :rf/xray
               (rf/dispatch-sync [:rf.xray/set-target-frame :other-frame]))
+            ;; Hand the next pass something to DISCOVER, and leave the slot
+            ;; unselected so discovery is the only thing that could fill it.
+            (trace-collector/seed-trace-for-test!
+              (pre-mount-dispatch-event 1 100 :cart-frame :cart/add-item))
+            (rf/with-frame :rf/xray
+              (rf/dispatch-sync [:rf.xray/set-target-frame nil])
+              (is (nil? @(rf/subscribe [:rf.xray/target-frame]))
+                  "precondition: the slot is UNSELECTED, so the assertion
+                   below cannot pass on a leftover value"))
             ;; Without a reset, a second call is a guarded no-op (proven
             ;; by the sibling test above).
             (mount/reset-for-test!)
             (mount/ensure-xray-frame!)
             (rf/with-frame :rf/xray
-              (is (nil? @(rf/subscribe [:rf.xray/target-frame]))
-                  "post-reset, ensure-xray-frame! re-ran the seed hook —
-                   cold start (no pre-mount cascades) seeds :target-frame
-                   back to UNSELECTED (nil), proving the hook actually
-                   re-fired rather than staying guarded"))))))))
+              (is (= :cart-frame @(rf/subscribe [:rf.xray/target-frame]))
+                  "post-reset, ensure-xray-frame! re-ran the seed hook — it
+                   projected the ring and seeded :target-frame from the head
+                   focusable event-bundle's frame, which nothing but the hook
+                   writes; a still-guarded call would have left the slot
+                   UNSELECTED"))))))))
 
 ;; -------------------------------------------------------------------------
 ;; (9) Teardown covers both mount singletons (rf2-yudol, rf2-sbfb7)

--- a/tools/xray/test/day8/re_frame2_xray/target_frame_seating_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/target_frame_seating_cljs_test.cljs
@@ -48,7 +48,16 @@
      `mount/ensure-seated!`, not `mount/ensure-xray-frame!`. The latter also
      runs the run-once first-mount hook fan-out, whose whole job is to harvest
      the rings the user filled before opening Xray; firing it from a setter
-     would spend that one run on an empty boot-time ring.
+     would spend that one run on an empty boot-time ring. It ALSO pins the
+     other half of that split: deferring the fan-out means the fan-out then
+     lands on a frame the host has already targeted, so first-open discovery
+     must not overwrite the explicit target it finds there.
+  6. `first-open-discovery-yields-…` is the same contract with a COMPETING
+     candidate: an explicit target survives even when the ring offers a
+     focusable bundle from a different frame.
+  7. `first-open-discovery-selects-…` is (6)'s control — same ring, same
+     entry point, no explicit target — proving the preservation in (5)/(6) is
+     a deference to the host and not a disabled discovery policy.
 
   Node-test (`npm run test:cljs`) — no DOM needed, because the whole point is
   that nothing mounts."
@@ -59,7 +68,8 @@
             [day8.re-frame2-xray.core :as core]
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.test-support :as xray-test-support]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
 ;; `mount/teardown!` clears BOTH the mount state and the `boot-on-runtime-
 ;; ready!` run-once latch, which `mount/reset-for-test!` (the `seeded-frame-ids`
@@ -103,6 +113,51 @@
   []
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/clear-reset-flash])))
+
+(defn- xray-read [query]
+  (rf/with-frame :rf/xray (rf/subscribe-once query)))
+
+(defn- focus-frame
+  "The `[:focus :frame]` axis, read through the spine's raw `:rf.xray/focus-
+  slot` sub. `:rf.xray/set-target-frame` writes this in lockstep with
+  `:target-frame` (rf2-ulpp8), so a survival claim about one is only half a
+  claim: the axes encode the same gesture and both have to hold."
+  []
+  (:frame (xray-read [:rf.xray/focus-slot])))
+
+(def ^:private main-epochs
+  "Stand-in for the framework's per-frame epoch ring on `:app/main`. Non-empty
+  on purpose: `:rf.xray/set-target-frame` re-seeds `:epoch-history` from
+  `(rf/epoch-history target)`, so a target silently reset to nil leaves the
+  slot `[]` — a discriminating value the empty ring could not supply."
+  [{:epoch-id      :e-main-1
+    :frame         :app/main
+    :db-before     {}
+    :db-after      {:ready? true}
+    :trigger-event [:app/boot]
+    :event-id      :app/boot
+    :trace-events  []}])
+
+(defn- stub-epoch-history
+  "`rf/epoch-history` narrowed to the frames these deftests name. In production
+  the framework's ring already carries these records; stubbing keeps the
+  assertion about Xray's seeding, not about the ring."
+  [frame-id]
+  (case frame-id
+    :app/main main-epochs
+    []))
+
+(defn- pre-mount-dispatch-event
+  "A trace event the projection groups into a focusable event-bundle for
+  `frame-id` — the shape `event/dispatched` emits. Seeded into the ring so
+  first-open discovery has a candidate to find."
+  [id dispatch-id frame-id event-id]
+  {:id        id
+   :op-type   :rf.event
+   :operation :rf.event/dispatched
+   :tags      {:rf.trace/dispatch-id dispatch-id
+               :frame                frame-id
+               :rf.event/v           [event-id]}})
 
 ;; ---- (1) control — the emission is real on an unseated frame -------------
 
@@ -207,14 +262,89 @@
             setter would snapshot an empty ring at boot and then skip, leaving
             a later first open with no pre-open history to show. So after the
             facade has seated the frame, `ensure-xray-frame!` must still have
-            its hooks to run."
+            its hooks to run.
+
+            Deferring the fan-out is only half a contract, and the other half
+            is asserted below: because the hooks now run AFTER the host has
+            targeted a frame, first-open discovery meets an explicit target
+            that was not there before rf2-88f1. It must defer to it. On a cold
+            ring `spine/focusable-head-frame-id` finds no candidate and the
+            discovery seed is `defaults/default-target-frame` = nil, which
+            `:rf.xray/set-target-frame` writes as a RESET — dissoc'ing
+            `:target-frame`, clearing `[:focus :frame]` and emptying
+            `:epoch-history`. The host's boot intent would be gone at first
+            open, silently, with no error to read."
     (registry/register-xray-handlers!)
     (config/set-auto-open! false)
-    (core/set-target-frame! :app/main)
-    (is (some? (rf.frame/frame :rf/xray))
-        "the facade seated the frame")
-    (is (not (contains? (seeded-frame-ids) :rf/xray))
-        "but did NOT mark it seeded — the first-mount hooks are still pending")
-    (mount/ensure-xray-frame!)
-    (is (contains? (seeded-frame-ids) :rf/xray)
-        "and first open still gets its one hook fan-out")))
+    (with-redefs [rf/epoch-history stub-epoch-history]
+      (core/set-target-frame! :app/main)
+      (is (some? (rf.frame/frame :rf/xray))
+          "the facade seated the frame")
+      (is (not (contains? (seeded-frame-ids) :rf/xray))
+          "but did NOT mark it seeded — the first-mount hooks are still pending")
+      (flush-xray-queue!)
+      (is (= :app/main (core/target-frame))
+          "precondition: the host's explicit pre-open target has landed")
+      (mount/ensure-xray-frame!)
+      (is (contains? (seeded-frame-ids) :rf/xray)
+          "and first open still gets its one hook fan-out")
+      (is (= :app/main (core/target-frame))
+          "the explicit pre-open target SURVIVES first open — discovery on an
+           empty ring must not reset a target the host already chose")
+      (is (= :app/main (focus-frame))
+          "and so does the `[:focus :frame]` axis the reducer moves with it —
+           a surviving `:target-frame` beside a cleared focus slot would leave
+           the L2 list unfiltered against the frame the panels name")
+      (is (= main-epochs (xray-read [:rf.xray/epoch-history]))
+          "and `:epoch-history` still reads the target's ring rather than the
+           `[]` a reset to nil leaves behind"))))
+
+;; ---- (6) the same contract against a COMPETING discovery candidate -------
+
+(deftest first-open-discovery-yields-to-an-explicit-target
+  (testing "rf2-88f1 — the empty-ring case above resets the target to nil; a
+            ring that DOES carry a focusable bundle reaches the same loss by
+            the other road, replacing the host's target with whichever frame
+            happens to head the pre-open trace. Deftest (7) is this deftest
+            with the explicit target removed and everything else identical,
+            so the pair pins deference rather than a disabled policy."
+    (registry/register-xray-handlers!)
+    (config/set-auto-open! false)
+    (with-redefs [rf/epoch-history stub-epoch-history]
+      (trace-collector/seed-trace-for-test!
+        (pre-mount-dispatch-event 1 100 :other/frame :other/event))
+      (core/set-target-frame! :app/main)
+      (flush-xray-queue!)
+      (is (= :app/main (core/target-frame))
+          "precondition: the host targeted `:app/main` before first open")
+      (mount/ensure-xray-frame!)
+      (is (= :app/main (core/target-frame))
+          "the host's target outranks the discovered head bundle's frame")
+      (is (= :app/main (focus-frame))
+          "on the focus axis too")
+      (is (= main-epochs (xray-read [:rf.xray/epoch-history]))
+          "and the epoch history stays keyed on the surviving target"))))
+
+;; ---- (7) the control — discovery still runs when nothing was chosen ------
+
+(deftest first-open-discovery-selects-when-no-explicit-target
+  (testing "rf2-88f1 control — same ring and same entry point as deftest (6),
+            with no pre-open `set-target-frame!`. The mount-time discovery
+            policy (EP-0002's operator-present tier) still resolves the head
+            focusable bundle's frame, so the preservation above is a deference
+            to an explicit host choice and NOT a first-open seed that stopped
+            writing."
+    (registry/register-xray-handlers!)
+    (config/set-auto-open! false)
+    (with-redefs [rf/epoch-history stub-epoch-history]
+      (trace-collector/seed-trace-for-test!
+        (pre-mount-dispatch-event 1 100 :other/frame :other/event))
+      (mount/ensure-seated!)
+      (is (nil? (core/target-frame))
+          "precondition: nothing has chosen a target")
+      (mount/ensure-xray-frame!)
+      (is (= :other/frame (core/target-frame))
+          "discovery selects the head focusable bundle's frame, as it did
+           before rf2-88f1")
+      (is (= :other/frame (focus-frame))
+          "aligning the focus axis with it"))))


### PR DESCRIPTION
## rf2-88f1 — first-open discovery burned an explicit pre-open target

Reopened by the merged-PR audit of #9320. The audit inspected the merged
source and found a live defect that CI could not see.

### The defect

`core/set-target-frame!` now seats `:rf/xray` itself, so a host can choose a
target **before** anything opens Xray. That ordering did not exist when the
first-mount seed hook was written, so the hook derived a target from the
pre-open trace ring and dispatched it **unconditionally** — straight over the
host's choice. Two roads to the same loss:

- **cold ring** — `focusable-head-frame-id` returns nil, and
  `:rf.xray/set-target-frame` writes nil as a full RESET: `:target-frame`
  dissoc'd, `[:focus :frame]` cleared, `:epoch-history` emptied.
- **warm ring** — whichever frame happens to head the pre-open trace replaces
  the host's target.

Both are silent. Nothing errors; the host's boot intent is simply gone at
first open.

### Why CI was green

The existing `the-facade-seat-does-not-burn-the-first-mount-seed` exercises
this exact edge but asserted only the `seeded-frame-ids` sentinel — never the
surviving target. 11,284 tests and 56,974 assertions did not see it. That is
the same class as the rest of this campaign: a test that runs, passes, and
asserts the wrong half.

### The fix

Discovery is the **fallback**, not the override. The seed hook reads the slot
first and derives a seed only when nothing has chosen one. A preserved target
is still re-dispatched through the same event, so `:epoch-history` picks up
epochs recorded between the host's call and first open and the two axes stay
in lockstep (the rf2-boyc2 guarantee).

Not a public-API expansion; the first-mount hooks are not eagerly spent.

### Failing first

The new assertions fail against the merge base and pass with the fix:

| case | before | after |
|---|---|---|
| explicit target, cold ring | `nil` | `:app/main` |
| explicit target, competing bundle | `:other/frame` | `:app/main` |
| **control** — no explicit target, same bundle | `:other/frame` | `:other/frame` |

The control passed **before** the fix too, which is the point: discovery still
selects when nothing has been chosen, so this is deference to the host and not
a seed that stopped writing.

### One repaired sibling

`ensure-xray-frame-reset-for-test-restores-fresh-first-mount-pass` witnessed a
re-fired hook by the target going back to `nil` — the behaviour this change
removes, which would have made a guarded no-op and a genuine re-fire read
alike. Its subject is unchanged; its witness is now positive (a discovered
frame only the hook could have written).

### Spec

`tools/xray/spec/008-Embedding-Contract.md` listed the three target sources as
peers and never stated their precedence — the gap this defect fell through. It
now states that discovery runs only while the target is UNSELECTED, and why
the collision is new.

### Gates

Captured exit codes; compile and run reported separately, nothing piped.

| gate | exit |
|---|---|
| `compile-node-test.cjs node-test` | 0 |
| `node out/node-test.js` | 0 — 11286 tests / 56986 assertions, 0 failures |
| `test:xray-feature-gate:smoke` | 0 — 5 scenarios, 10 matrix rows |
| `test:story-play-scripts` | 0 — 31 rows, 0 unexpected |
| `test:browser` | 0 — 787 tests / 4318 assertions |
| `scripts/test-jvm-tools.sh` | 0 |
| `test:mcp-conformance` | 0 — 6/6 default profile |
| `check_doc_slugs.py` | 0 |
| `api-manifest xray-spec-check` | 0 |
| `check_require_alias_dialect.py` | 0 — every surface at or under its floor |

Surfaces derived from `.github/scripts/report-changed-surfaces.sh` over the
changed paths, controlled against a core path that arms `implementation_jvm`.
Assertion delta vs the CI baseline is exactly +2 deftests / +12 assertions.
