### PR TITLE
fix(hooks): the attribution guard matches the address family, spares git's furniture, and grades the PR body (rf2-1ndt)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
   "hooks": {
     "PreCompact": [
       {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1308,9 +1308,34 @@ jobs:
       # the `run:` line itself reds the `js-harness-self-tests` job, while the
       # identical text one step above passes because it sits inside a block
       # scalar. Measured on this step. Keep the pipe.
+      #
+      # TWO SURFACES, ONE STEP. CLAUDE.md forbids the trailers in "commits or
+      # PRs", and a git hook can only ever see the first. The second invocation
+      # grades the PULL REQUEST BODY, which is where the harness writes the
+      # generated-with marker and a bare session URL (#9255 and #9256 carried
+      # exactly that pair). Still one step and still no new job, so nothing is
+      # added to any PR's check rollup and the required-check band the merge
+      # criterion is measured against does not move.
+      #
+      # DEFAULT ACTIVITY TYPES ONLY. The workflow's `pull_request:` trigger
+      # names no `types:`, so it fires on `opened`, `synchronize` and
+      # `reopened` — and `opened` is the one that grades what `gh pr create`
+      # wrote, which is the injection this closes. `edited` is deliberately NOT
+      # added: a hand edit after the push is a mayor read at merge time and is
+      # the accepted residual.
       - name: Enforce the no-AI-attribution rule (rf2-2e8f)
+        env:
+          # THE BODY REACHES THE SHELL AS DATA, NEVER AS TEXT. `${{ }}` is
+          # expanded by the workflow renderer BEFORE any shell sees the script,
+          # so interpolating the body into the `run:` block below would splice
+          # author-controlled prose straight into the source. An `env:` value is
+          # handed to the process instead of pasted into it. On a non-
+          # pull_request event this is empty and the script exits 0 on its event
+          # check before it ever reads stdin.
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           sh scripts/check-commit-attribution.sh "origin/${GITHUB_BASE_REF}"
+          printf '%s\n' "$PR_BODY" | sh scripts/check-commit-attribution.sh --pr-body
 
   jvm-core:
     name: JVM core (clojure -M:test)

--- a/scripts/check-commit-attribution.sh
+++ b/scripts/check-commit-attribution.sh
@@ -2,12 +2,12 @@
 # scripts/check-commit-attribution.sh
 #
 # CI arm of the AI-ATTRIBUTION guard (rf2-2e8f). Fails a pull request whose OWN
-# commits carry AI attribution in their messages — the `Co-Authored-By:` /
-# `Claude-Session:` / generated-with trailers CLAUDE.md > Git Conventions
-# forbids. See scripts/git-hooks/lib/check-commit-attribution.sh for the
-# diagnosis and the matched set; this script only chooses WHICH COMMITS to
-# grade. Both arms share one detector so the local hook and the CI gate can
-# never drift apart.
+# COMMITS carry AI attribution in their messages, or whose BODY carries it —
+# the `Co-Authored-By:` / `Claude-Session:` / generated-with / bare session-URL
+# shapes CLAUDE.md > Git Conventions forbids. See
+# scripts/git-hooks/lib/check-commit-attribution.sh for the diagnosis and the
+# matched set; this script only chooses WHICH TEXT to grade. Every arm shares
+# one detector so the local hook and the CI gate can never drift apart.
 #
 # THE RANGE, WHICH IS THE ONLY REAL DESIGN QUESTION HERE
 #
@@ -58,10 +58,14 @@
 #
 # Usage:
 #   sh scripts/check-commit-attribution.sh [BASE_REF]
+#   sh scripts/check-commit-attribution.sh --pr-body   < body
 #
 #   BASE_REF resolution: argument, else $COMMIT_ATTRIBUTION_BASE_REF. Run it
 #   locally to pre-flight a branch:
 #     sh scripts/check-commit-attribution.sh origin/main
+#
+#   `--pr-body` grades a PULL REQUEST BODY read from stdin instead of a commit
+#   range — the surface a git hook cannot see. See its block below.
 #
 # Cross-platform: POSIX sh. Runs identically on the ubuntu CI runner, on
 # macOS, and under Git Bash on Windows. No bashisms.
@@ -83,6 +87,33 @@ if [ "$EVENT" != "pull_request" ]; then
   printf 'Event is "%s", not a pull request: the attribution guard is not enforced here.\n' "$EVENT"
   printf 'Commits already on a branch history are an operator rewrite decision, not a gate.\n'
   exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# The PR-BODY arm: `sh scripts/check-commit-attribution.sh --pr-body`, body on
+# stdin. No range, no git — the body is just text, and the detector grades
+# lines rather than commits.
+#
+# WHY IT NEEDS AN ARM AT ALL. CLAUDE.md forbids the trailers in "commits or
+# PRs", and a git hook cannot see a body; nothing graded one until now. The two
+# shapes the harness writes there are the generated-with marker and a BARE
+# session URL — the exact pair edited out of #9255 and #9256 by hand.
+#
+# THE BODY IS DATA, NEVER TEXT. The workflow puts it in an `env:` value and
+# pipes that value in. `${{ github.event.pull_request.body }}` is expanded by
+# the workflow renderer BEFORE any shell sees the script, so interpolating it
+# into a `run:` body would splice author-controlled prose into the source.
+#
+# AN EMPTY BODY PASSES, and that is not a hole in the fail-closed policy above.
+# A missing RANGE makes the commit arm inspect nothing while reporting the same
+# silent zero as a clean branch; a missing BODY genuinely contains nothing to
+# grade, and refusing one would red every pull request opened without prose.
+if [ "${1:-}" = "--pr-body" ]; then
+  if check_commit_attribution pr; then
+    printf 'No AI attribution in the pull request body.\n'
+    exit 0
+  fi
+  exit 1
 fi
 
 BASE="${1:-${COMMIT_ATTRIBUTION_BASE_REF:-}}"

--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -21,7 +21,7 @@ disturbing beads-managed segments (`bd hooks install`).
 | `lib/check-hook-install-staleness.sh` | POSIX-sh library used by `post-merge` **and** `post-rewrite` (rf2-zt65l) — one advisory, one home. |
 | `lib/check-mayor-commit-boundary.sh` | POSIX-sh library used by `pre-commit` (rf2-ydl2p). |
 | `lib/check-beads-boundary.sh` | POSIX-sh library carrying two checks over one file: `check_beads_boundary` (rf2-ia8o7), used by `pre-commit` **and** by `scripts/check-beads-pr-boundary.sh`, the CI arm; and `check_beads_truncation` (rf2-or8te), used by `pre-commit` alone. |
-| `lib/check-commit-attribution.sh` | POSIX-sh library used by `commit-msg` **and** by `scripts/check-commit-attribution.sh`, its CI arm (rf2-2e8f) — one detector, two arms. |
+| `lib/check-commit-attribution.sh` | POSIX-sh library used by `commit-msg` **and** by `scripts/check-commit-attribution.sh`, its CI arm over the branch's commits **and** its PR body (rf2-2e8f) — one detector, every arm. |
 | `test-pre-commit.sh` | Library unit tests, sandboxed end-to-end smoke for all three pre-commit blocks and the commit-msg block, both CI arms, the installer, real pulls of both shapes, and the checkpoint helper. |
 
 The unit of installation is a marker block, not a hook: `pre-commit`
@@ -364,26 +364,48 @@ and the trunk said nothing either way because nothing checked.
 
 ### What it matches, and what it deliberately does not
 
-Three shapes, case-insensitive, all anchored at **column 0**:
+Four shapes, case-insensitive, all anchored at **column 0**:
 
 | Shape | Example |
 |-------|---------|
 | the session trailer | a `Claude-Session:` line |
-| the co-author trailer, *when the value names the assistant* | a `Co-Authored-By:` line whose value carries `claude` or `anthropic` |
-| the generated-with marker | a `Generated with …` line naming either |
+| the co-author trailer, *when the address is the assistant's* | a `Co-Authored-By:` line whose value carries `@anthropic.com` |
+| the generated-with marker | a `Generated with …` line naming `claude` or `anthropic` |
+| the bare session URL | an `https://claude.ai/code/session_…` line with no key in front |
 
 That is the whole set. This is **not** a commit-message linter: it does not
 grade subject length, mood or trailer hygiene, and a `Co-Authored-By:` naming a
 human colleague is ordinary git and stays permitted. Only AI attribution, which
 is the only thing the convention forbids.
 
+**The co-author rule matches the address family, not the name.** All 31
+trailers in this repository's log carry `@anthropic.com` and the documented
+harness default is `Claude <claude@anthropic.com>`, so the address is both
+sufficient and precise. A name substring is neither — it refuses
+`Co-Authored-By: Jean-Claude Martin <jcm@example.invalid>`, a colleague turned
+away for their own name. Layer 10b pins three human spellings against 10a's two
+assistant ones.
+
+The fourth shape is the first shape's URL with its key removed, which is how
+the harness writes it into a **PR body**; it slips past all three keyed rules,
+so it needs one of its own.
+
 **Column 0 is the escape hatch, and it is load-bearing.** A line indented by
 even one space is exempt, so a commit message may quote the forbidden trailers
 — which any commit documenting the rule, or citing one of the three above, has
 to do. Without that carve-out the guard would refuse the very commit that
-introduces it, which is the fastest route to `--no-verify` becoming habit. It
-also buys two free immunities: `git commit`'s own `#`-prefixed template
-comments, and the `+`/`-` diff body `git commit -v` appends, can never trip it.
+introduces it, which is the fastest route to `--no-verify` becoming habit.
+
+**Git's own furniture is exempt too, and that part is not free.** `#`-prefixed
+template comments are exempt outright, and the detector stops reading at git's
+scissors line, below which `git commit -v` writes the diff. Neither falls out
+of the column-0 anchor: a `#` line *starts* at column 0, and while rules 1, 2
+and 4 are prefix tests that a `#` displaces for free, rule 3 is a **substring**
+test that it does not — so `# 🤖 Generated with [Claude Code]` was refused.
+That bit for real, because `commit-msg` reads `COMMIT_EDITMSG` *before* git
+strips the comments and the diff: any `git commit -v` whose diff touched
+`CLAUDE.md`, the detector or its tests was refused with `--no-verify` the only
+escape. Layer 10d pins both halves.
 
 ### Why `commit-msg` and not `pre-commit`
 
@@ -429,9 +451,40 @@ Enforcement is `pull_request` only. On a push the commits are already history,
 and refusing one there blocks the trunk over a rewrite decision the gate does
 not own.
 
-**Scope: commit messages.** The convention also covers PR descriptions; a git
-hook cannot see one and neither arm here reads one. Left unbuilt rather than
-half-built.
+### The PR-body arm
+
+The convention covers PR **descriptions** as well, and a git hook cannot see
+one — so the CI arm grades that too, reading the body on stdin:
+
+```sh
+printf '%s\n' "$PR_BODY" | sh scripts/check-commit-attribution.sh --pr-body
+```
+
+It is a second invocation in the **same** `beads-pr-boundary` step, not a job
+of its own, so nothing is added to any PR's check rollup. `test.yml` passes the
+body through an `env:` value: `${{ }}` is expanded by the workflow renderer
+before any shell sees the script, so interpolating a body — author-controlled
+prose — into the `run:` text would splice it into the source. The body is data.
+
+Enforcement rides the workflow's default `pull_request` activity types
+(`opened`, `synchronize`, `reopened`). `opened` grades what `gh pr create`
+wrote, which is the injection this closes; `edited` is deliberately absent, so
+a hand edit after the push is a mayor read at merge time and the accepted
+residual.
+
+An **empty body passes**, and that is not a hole in the fail-closed policy
+above. A missing range makes the commit arm inspect nothing while reporting the
+same silent zero as a clean branch; a missing body genuinely contains nothing
+to grade.
+
+### Closing the source
+
+The guard catches the trailers. `.claude/settings.json` stops them being
+written: `"attribution": { "commit": "", "pr": "", "sessionUrl": false }`
+alongside the `bd prime` hooks. An empty string removes that part of the
+harness's injected instruction. The guard stays regardless — the local
+worktree commits that carried a session URL contradict the documentation's
+claim that they cannot, so the enforcement is not retired on a promise.
 
 ## Testing
 

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -4,8 +4,9 @@
 # ONE marker block.
 #
 #   rf2-2e8f — refuses a commit message carrying AI ATTRIBUTION: a
-#              `Co-Authored-By:` naming the assistant, a `Claude-Session:`
-#              trailer, or a generated-with marker.
+#              `Co-Authored-By:` whose address is the assistant's, a
+#              `Claude-Session:` trailer, a generated-with marker, or a bare
+#              session URL.
 #
 # WHY A HOOK AT ALL. CLAUDE.md > Git Conventions has forbidden these since the
 # project began, and three commits carrying them still reached main —

--- a/scripts/git-hooks/lib/check-commit-attribution.sh
+++ b/scripts/git-hooks/lib/check-commit-attribution.sh
@@ -6,7 +6,8 @@
 #
 #   1. scripts/git-hooks/commit-msg          — refuses the message being written.
 #   2. scripts/check-commit-attribution.sh   — the CI arm; refuses a pull request
-#                                              whose OWN commits carry one.
+#                                              whose OWN commits carry one, and
+#                                              (`--pr-body`) one whose BODY does.
 #
 # THE RULE. CLAUDE.md > Git Conventions: "No AI attribution in commits or PRs.
 # ... Commit and PR text should read as the user's own work."
@@ -29,17 +30,31 @@
 #
 # WHAT IT MATCHES, AND WHY THE SET IS SMALL
 #
-#   Three shapes, all case-insensitive, all anchored at COLUMN 0:
+#   Four shapes, all case-insensitive, all anchored at COLUMN 0:
 #
 #     `Claude-Session: <url>`                       the session trailer
-#     `Co-Authored-By: ... claude|anthropic ...`    the co-author trailer
+#     `Co-Authored-By: ... @anthropic.com ...`      the co-author trailer
 #     `... Generated with ... claude|anthropic ...` the generated-with marker
+#     `https://claude.ai/code/session_...`          the bare session URL
 #
 #   That is the whole set, deliberately. This is a convention checker and they
 #   metastasise: it is NOT a commit-message linter, it does not grade subject
 #   length, mood, or trailer hygiene generally, and it does not object to
 #   `Co-Authored-By:` naming a HUMAN, which is ordinary and correct git. Only
 #   AI attribution — which is the only thing CLAUDE.md forbids.
+#
+#   THE CO-AUTHOR RULE MATCHES THE ADDRESS FAMILY, NOT THE NAME, and that is a
+#   correctness point rather than a nicety. Every one of the 31 trailers in
+#   this repository's log carries `@anthropic.com`, and the documented harness
+#   default is `Claude <claude@anthropic.com>` — so the address is both
+#   sufficient and precise. A name substring is neither: it refuses
+#   `Co-Authored-By: Jean-Claude Martin <jcm@example.invalid>`, a human
+#   colleague turned away for their own name. An earlier revision of this file
+#   shipped exactly that.
+#
+#   The fourth shape is the same session URL as the first with no key in front
+#   of it, which is how the harness writes it into a PULL REQUEST BODY. It
+#   passes all three keyed rules untouched, so it needs a rule of its own.
 #
 # COLUMN 0 IS THE ESCAPE HATCH, AND IT IS LOAD-BEARING
 #
@@ -50,9 +65,20 @@
 #   would refuse the very commit that documents it, which is the fastest route
 #   to it being disabled with `--no-verify` and never re-enabled.
 #
-#   It also gives the check two free immunities that matter in practice:
-#   `git commit`'s own `#`-prefixed comment lines, and the `+`/`-` prefixed
-#   diff body that `git commit -v` appends, can never trip it.
+# GIT'S OWN FURNITURE IS EXEMPT, AND IT IS NOT FREE
+#
+#   `#`-prefixed template comments are exempt outright, and the detector STOPS
+#   READING at git's scissors line — `# ------------------------ >8 ---...` —
+#   below which `git commit -v` writes the diff.
+#
+#   NEITHER FALLS OUT OF THE COLUMN-0 ANCHOR, which is what an earlier revision
+#   of this file claimed. A `#` line starts at column 0, and rules 1, 2 and 4
+#   are prefix tests that a `#` displaces for free while rule 3 is a SUBSTRING
+#   test that it does not — so `# 🤖 Generated with [Claude Code]` was refused.
+#   That bit for real: `commit-msg` reads COMMIT_EDITMSG BEFORE git strips the
+#   comments and the diff, so any `git commit -v` whose diff touched CLAUDE.md,
+#   this file or its tests was refused with `--no-verify` the only escape — a
+#   guard punishing the commit that repairs it. Layer 10d pins both halves.
 #
 # WHY FOLDING BEATS `grep -i`
 #
@@ -64,9 +90,10 @@
 #   `tr 'A-Z' 'a-z'` is an explicit ASCII range, so UTF-8 continuation bytes
 #   (the robot emoji the generated-with marker leads with) pass through intact.
 #
-# SCOPE: COMMIT MESSAGES. CLAUDE.md's rule also covers PR descriptions; a git
-# hook cannot see one and neither arm here reads one. Left deliberately unbuilt
-# rather than half-built.
+# SCOPE: COMMIT MESSAGES AND PULL REQUEST BODIES. CLAUDE.md's rule covers both,
+# and the detector below is text-agnostic — it grades lines, not commits. A git
+# hook cannot see a body, so the body is graded by the CI arm alone
+# (`check-commit-attribution.sh --pr-body`), which reads it on stdin.
 #
 # This file is a pure shell library (no `set -e`, no global state mutation) so
 # scripts/git-hooks/test-pre-commit.sh can drive it with synthetic stdin and
@@ -88,9 +115,12 @@
 rf2_attribution_is_offending_line() {
   _rf2a_line="$1"
 
-  # Indented -> exempt. See "COLUMN 0 IS THE ESCAPE HATCH" above.
+  # Indented, or one of git's own `#` template comments -> exempt. See
+  # "COLUMN 0 IS THE ESCAPE HATCH" and "GIT'S OWN FURNITURE" above. The `#`
+  # arm is load-bearing for rule 3 alone: the other three are prefix tests a
+  # `#` already displaces.
   case "$_rf2a_line" in
-    ' '*|'	'*) return 1 ;;
+    ' '*|'	'*|'#'*) return 1 ;;
   esac
 
   _rf2a_low=$(printf '%s' "$_rf2a_line" | tr 'A-Z' 'a-z')
@@ -100,12 +130,14 @@ rf2_attribution_is_offending_line() {
     claude-session:*) return 0 ;;
   esac
 
-  # 2. The co-author trailer, but only when the VALUE names the assistant.
-  #    `Co-Authored-By: <a colleague>` is ordinary git and stays permitted.
+  # 2. The co-author trailer, but only when the ADDRESS is the assistant's.
+  #    `Co-Authored-By: <a colleague>` is ordinary git and stays permitted —
+  #    including a colleague whose NAME contains "claude", which is why this
+  #    tests the address family rather than a name substring.
   case "$_rf2a_low" in
     co-authored-by:*)
       case "$_rf2a_low" in
-        *claude*|*anthropic*) return 0 ;;
+        *@anthropic.com*) return 0 ;;
       esac
       ;;
   esac
@@ -119,19 +151,34 @@ rf2_attribution_is_offending_line() {
       ;;
   esac
 
+  # 4. The bare session URL — rule 1's URL with no key in front of it, which is
+  #    the shape the harness writes into a pull request body.
+  case "$_rf2a_low" in
+    https://claude.ai/code/session_*) return 0 ;;
+  esac
+
   return 1
 }
 
 # rf2_attribution_offending_lines
 #
-# Reads a commit message (or any text) from stdin; prints every offending line
-# to stdout, one per line, with any trailing CR stripped so the listing reads
-# cleanly on Windows. Always returns 0 — the CALLER decides what an offence
-# means, which is what lets the CI arm accumulate hits across many commits
-# before it prints anything.
+# Reads a commit message, a pull request body, or any text from stdin; prints
+# every offending line to stdout, one per line, with any trailing CR stripped
+# so the listing reads cleanly on Windows. Always returns 0 — the CALLER
+# decides what an offence means, which is what lets the CI arm accumulate hits
+# across many commits before it prints anything.
+#
+# READING STOPS AT GIT'S SCISSORS LINE. Below it sits the diff `git commit -v`
+# appends, whose `+` lines are not the author's text at all — and a commit that
+# EDITS this guard adds the forbidden trailers there by construction.
 rf2_attribution_offending_lines() {
   while IFS= read -r _rf2a_l || [ -n "$_rf2a_l" ]; do
     _rf2a_l=$(printf '%s' "$_rf2a_l" | tr -d '\r')
+    # Matched on the scissors PAYLOAD rather than the whole line, so a
+    # non-default `core.commentChar` cannot smuggle the tail past it.
+    case "$_rf2a_l" in
+      *'------------------------ >8 ------------------------') break ;;
+    esac
     if rf2_attribution_is_offending_line "$_rf2a_l"; then
       printf '%s\n' "$_rf2a_l"
     fi
@@ -147,21 +194,31 @@ rf2_attribution_offending_lines() {
 #
 # Reads an already-collected listing from stdin (the hook passes offending
 # lines; the CI arm passes `<sha> <subject>` headers interleaved with them) and
-# prints the didactic refusal block to stderr. CONTEXT is `commit` (default) or
-# `ci` and selects the remedy stanza — the diagnosis is identical, the fix
-# differs by where you are.
+# prints the didactic refusal block to stderr. CONTEXT is `commit` (default),
+# `ci` or `pr`, and selects the headline and the remedy stanza — the diagnosis
+# is identical, the fix differs by which text you are holding.
 rf2_attribution_refusal() {
   _rf2a_context="${1:-commit}"
   _rf2a_listing=$(cat)
 
   printf '\n' >&2
-  printf 'ERROR: AI attribution in a commit message.\n' >&2
-  printf '\n' >&2
-  if [ "$_rf2a_context" = "ci" ]; then
-    printf '  Attribution lines in the commits this PR introduces:\n' >&2
-  else
-    printf '  Attribution lines in this commit message:\n' >&2
-  fi
+  case "$_rf2a_context" in
+    pr)
+      printf 'ERROR: AI attribution in a pull request body.\n' >&2
+      printf '\n' >&2
+      printf '  Attribution lines in this pull request body:\n' >&2
+      ;;
+    ci)
+      printf 'ERROR: AI attribution in a commit message.\n' >&2
+      printf '\n' >&2
+      printf '  Attribution lines in the commits this PR introduces:\n' >&2
+      ;;
+    *)
+      printf 'ERROR: AI attribution in a commit message.\n' >&2
+      printf '\n' >&2
+      printf '  Attribution lines in this commit message:\n' >&2
+      ;;
+  esac
   printf '%s\n' "$_rf2a_listing" | while IFS= read -r _rf2a_l; do
     [ -n "$_rf2a_l" ] && printf '    %s\n' "$_rf2a_l" >&2
   done
@@ -171,9 +228,9 @@ rf2_attribution_refusal() {
   printf '\n' >&2
   printf '  YOUR AGENT HARNESS SAYS THE OPPOSITE, and that is why this guard\n' >&2
   printf '  exists (rf2-2e8f). A session-level reminder tells agents to end every\n' >&2
-  printf '  commit message with these trailers; the checked-in CLAUDE.md forbids\n' >&2
-  printf '  them. THE CHECKED-IN FILE WINS. Three commits reached main while the\n' >&2
-  printf '  tie was being broken at random.\n' >&2
+  printf '  commit message AND every PR body with these trailers; the checked-in\n' >&2
+  printf '  CLAUDE.md forbids them. THE CHECKED-IN FILE WINS. Three commits\n' >&2
+  printf '  reached main while the tie was being broken at random.\n' >&2
   printf '\n' >&2
   # THE PUSH IS NAMED IN PROSE RATHER THAN SPELLED AS A COMMAND, deliberately.
   # The safe force-push flag is `--force-with-<the retired view-lifetime word>`,
@@ -181,15 +238,24 @@ rf2_attribution_refusal() {
   # ZERO over tracked file content — it matches that word as a bare token, which
   # is exactly what a git flag name makes it. Spelling the flag out reds the
   # ratchet (measured on this file). Do not "helpfully" restore it.
-  if [ "$_rf2a_context" = "ci" ]; then
-    printf '  Fix — reword the messages on your OWN branch, then force-push it:\n' >&2
-    printf '    git rebase -i <base>     # reword each commit named above\n' >&2
-    printf '\n' >&2
-    printf '  Only your branch. Never rewrite main.\n' >&2
-  else
-    printf '  Fix — drop those lines from the message and commit again.\n' >&2
-    printf '  If you are AMENDING: git commit --amend\n' >&2
-  fi
+  case "$_rf2a_context" in
+    pr)
+      printf '  Fix — drop those lines from the body:\n' >&2
+      printf '    gh pr edit <number> --body-file <file>\n' >&2
+      printf '\n' >&2
+      printf '  Nothing else in the body needs to change.\n' >&2
+      ;;
+    ci)
+      printf '  Fix — reword the messages on your OWN branch, then force-push it:\n' >&2
+      printf '    git rebase -i <base>     # reword each commit named above\n' >&2
+      printf '\n' >&2
+      printf '  Only your branch. Never rewrite main.\n' >&2
+      ;;
+    *)
+      printf '  Fix — drop those lines from the message and commit again.\n' >&2
+      printf '  If you are AMENDING: git commit --amend\n' >&2
+      ;;
+  esac
   printf '\n' >&2
   printf '  TO QUOTE ONE ON PURPOSE — documenting the rule, citing an offending\n' >&2
   printf '  commit — indent the line by one space. Only column 0 offends.\n' >&2
@@ -206,8 +272,9 @@ rf2_attribution_refusal() {
 
 # check_commit_attribution [CONTEXT]
 #
-# Reads a commit message from stdin. Returns 0 when clean; otherwise prints the
-# refusal block to stderr and returns 1.
+# Reads a commit message (CONTEXT `commit`, the default, or `ci`) or a pull
+# request body (CONTEXT `pr`) from stdin. Returns 0 when clean; otherwise
+# prints the refusal block to stderr and returns 1.
 check_commit_attribution() {
   _rf2a_ctx="${1:-commit}"
 

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -1944,6 +1944,18 @@ rm -f "$rc_t" "$TERR"
 # branch. That is not a nicety: three such commits ARE on main, whether to
 # rewrite them is an unmade operator call, and a gate that graded all of
 # history would red every pull request in the repository for ever.
+#
+# THE PAIRING DISCIPLINE IS WHAT THIS LAYER MEASURES, AND IT WAS ONCE SHORT.
+# The first revision paired `Co-Authored-By:` against a human named Mike, and a
+# `#`-prefixed line against the two rules a `#` exempts for FREE — so it proved
+# the detector was awake on shapes it could not have been asleep on, and missed
+# both false positives it was built to catch. Three additions close that, each
+# red before its repair: humans NAMED Claude (10b, against the address-family
+# rule), the generated-with marker under a `#` and below a scissors line (10d,
+# the `git commit -v` refusal), and the bare session URL (10a, rule 4).
+#
+# 10p GRADES A PULL REQUEST BODY, which is the surface no git hook can reach
+# and the one the harness writes the marker and the session URL into.
 # ----------------------------------------------------------------------------
 
 printf '\n[10] AI-attribution guard: the message surface (rf2-2e8f)\n'
@@ -1954,11 +1966,22 @@ ATTR_CI="$REPO_ROOT/scripts/check-commit-attribution.sh"
 
 AERR=/tmp/rf2-attr-test.err
 
-# The three forbidden shapes, built at runtime so the generated-with marker
-# carries its real leading emoji without putting a non-ASCII byte in this file.
+# The forbidden shapes, built at runtime so the generated-with marker carries
+# its real leading emoji without putting a non-ASCII byte in this file. Both
+# co-author spellings are here because the rule matches the ADDRESS FAMILY:
+# `noreply@` is what the trunk's 31 offenders carry, `claude@` is the
+# documented harness default, and 10b pairs them against humans.
 TRAILER_COAUTHOR='Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>'
-TRAILER_SESSION='Claude-Session: https://claude.ai/session/0000'
+TRAILER_COAUTHOR_SHORT='Co-Authored-By: Claude <claude@anthropic.com>'
+TRAILER_SESSION='Claude-Session: https://claude.ai/code/session_01MAi87DChEUnjARRXTV1pZX'
 TRAILER_GENWITH=$(printf '\360\237\244\226 Generated with [Claude Code](https://claude.com/claude-code)')
+# The BARE session URL — the same URL with no key in front of it. It is what
+# the harness writes into a PR BODY, and it passes the three keyed rules.
+TRAILER_SESSION_URL='https://claude.ai/code/session_01MAi87DChEUnjARRXTV1pZX'
+
+# git's scissors line. `git commit -v` writes the diff BELOW it, and the
+# commit-msg hook reads COMMIT_EDITMSG BEFORE git strips either.
+SCISSORS='# ------------------------ >8 ------------------------'
 
 run_attr_lib() {
   # stdin: a commit message. Echoes EXIT=<n>; the refusal block lands on
@@ -1973,7 +1996,8 @@ run_attr_lib() {
 }
 
 # 10a: each forbidden shape is refused, and the refusal QUOTES the line.
-for t in "$TRAILER_COAUTHOR" "$TRAILER_SESSION" "$TRAILER_GENWITH"; do
+for t in "$TRAILER_COAUTHOR" "$TRAILER_COAUTHOR_SHORT" "$TRAILER_SESSION" \
+         "$TRAILER_GENWITH" "$TRAILER_SESSION_URL"; do
   key=$(printf '%s' "$t" | cut -c1-24)
   out=$(printf 'fix(thing): a real change\n\n%s\n' "$t" | run_attr_lib 2>"$AERR") || true
   case "$out" in
@@ -1989,22 +2013,32 @@ for t in "$TRAILER_COAUTHOR" "$TRAILER_SESSION" "$TRAILER_GENWITH"; do
   esac
 done
 
-# 10b: a HUMAN co-author is ordinary git and stays permitted. Paired with 10a's
-# first case: same trailer key, same column, only the value differs — so this
+# 10b: a HUMAN co-author is ordinary git and stays permitted — INCLUDING a
+# colleague whose NAME contains "claude", which is why rule 2 matches the
+# assistant's ADDRESS FAMILY and not a name substring. Paired with 10a's first
+# two cases: same trailer key, same column, only the ADDRESS differs, so this
 # passing does not merely say "the detector is asleep".
-out=$(printf 'fix(thing): a real change\n\nCo-Authored-By: Mike Thompson <mike@example.invalid>\n' \
-  | run_attr_lib 2>"$AERR") || true
-case "$out" in
-  *EXIT=0*)
-    if [ ! -s "$AERR" ]; then
-      pass "(10b) Co-Authored-By naming a colleague passes, silently"
-    else
-      fail "(10b) a human co-author produced diagnostics"
-      cat "$AERR" >&2
-    fi
-    ;;
-  *) fail "(10b) FALSE POSITIVE: a human co-author was refused ($out)" ;;
-esac
+#
+# The last spelling is the prose one that already sits on main (9dd06ab77d):
+# no colon, so it is not a trailer at all and rule 2 must not reach it.
+for t in 'Co-Authored-By: Mike Thompson <mike@example.invalid>' \
+         'Co-Authored-By: Claude Martin <claude.martin@example.invalid>' \
+         'Co-Authored-By: Jean-Claude Martin <jcm@example.invalid>' \
+         'Co-Authored-By line intentionally omitted per project convention.'; do
+  key=$(printf '%s' "$t" | cut -c1-40)
+  out=$(printf 'fix(thing): a real change\n\n%s\n' "$t" | run_attr_lib 2>"$AERR") || true
+  case "$out" in
+    *EXIT=0*)
+      if [ ! -s "$AERR" ]; then
+        pass "(10b) permitted, silently: $key..."
+      else
+        fail "(10b) a permitted co-author line produced diagnostics: $key..."
+        cat "$AERR" >&2
+      fi
+      ;;
+    *) fail "(10b) FALSE POSITIVE: a human co-author was refused: $key... ($out)" ;;
+  esac
+done
 
 # 10c: THE ESCAPE HATCH. The same line, indented by one space, is permitted —
 # which is what lets a commit message document the rule or cite an offending
@@ -2019,11 +2053,33 @@ esac
 
 # 10d: git's own furniture cannot trip it — `#` comment lines from the editor
 # template, and the `+` diff body `git commit -v` appends.
-out=$(printf 'feat: thing\n\n# %s\n+%s\n' "$TRAILER_COAUTHOR" "$TRAILER_SESSION" \
+#
+# THE GENERATED-WITH MARKER IS THE CASE THAT MATTERS, and the earlier revision
+# of 10d never fed it: rules 1 and 2 are PREFIX tests, so a `#` in front of them
+# exempts them for free and testing only those two proves nothing about the one
+# rule that is a SUBSTRING test. `# <marker>` reached rule 3 and was refused —
+# and because `commit-msg` reads COMMIT_EDITMSG BEFORE git strips the comments,
+# every `git commit -v` whose diff touched CLAUDE.md, this detector or these
+# very tests was refused with `--no-verify` the only escape.
+out=$(printf 'feat: thing\n\n# %s\n+%s\n# %s\n' \
+  "$TRAILER_COAUTHOR" "$TRAILER_SESSION" "$TRAILER_GENWITH" \
   | run_attr_lib 2>"$AERR") || true
 case "$out" in
-  *EXIT=0*) pass "(10d) comment lines and diff-body lines are permitted" ;;
+  *EXIT=0*) pass "(10d) template comment lines are permitted, the marker included" ;;
   *) fail "(10d) FALSE POSITIVE: git's own message furniture was refused ($out)"
+     cat "$AERR" >&2 ;;
+esac
+
+# 10d(ii): THE SCISSORS TAIL. Everything below git's cut line is the diff
+# `git commit -v` appends, not the author's message — including `+` lines that
+# ADD the forbidden trailers, which is precisely what a commit editing this
+# guard writes. The detector stops reading there.
+out=$(printf 'docs: describe the guard\n\n%s\n# Do not modify or remove the line above.\ndiff --git a/x b/x\n+%s\n+%s\n' \
+  "$SCISSORS" "$TRAILER_GENWITH" "$TRAILER_COAUTHOR" \
+  | run_attr_lib 2>"$AERR") || true
+case "$out" in
+  *EXIT=0*) pass "(10d) a git commit -v scissors tail is not graded as message" ;;
+  *) fail "(10d) FALSE POSITIVE: the scissors tail was graded as message ($out)"
      cat "$AERR" >&2 ;;
 esac
 
@@ -2210,6 +2266,75 @@ ATTR_EVENT=pull_request
 case "$out" in
   EXIT=0) pass "(10n) a non-pull_request event passes with an explanatory line" ;;
   *) fail "(10n) the guard enforced outside a pull request ($out)"; cat "$AERR" >&2 ;;
+esac
+
+# 10o: back at the DETECTOR — rule 4's permitted pair. 10a refuses the bare
+# session URL at column 0; these two prove that refusal is a rule about one URL
+# and not a blanket allergy to `https://`. Same shape, same column, so neither
+# can pass by the detector merely being asleep.
+out=$(printf 'docs: cite the pull request\n\nhttps://github.com/day8/re-frame2/pull/9317\n' \
+  | run_attr_lib 2>"$AERR") || true
+case "$out" in
+  *EXIT=0*) pass "(10o) an ordinary URL at column 0 is permitted" ;;
+  *) fail "(10o) FALSE POSITIVE: an ordinary URL line was refused ($out)"
+     cat "$AERR" >&2 ;;
+esac
+
+out=$(printf 'docs: quote the session URL on purpose\n\n %s\n' "$TRAILER_SESSION_URL" \
+  | run_attr_lib 2>"$AERR") || true
+case "$out" in
+  *EXIT=0*) pass "(10o) an INDENTED session URL is permitted (the escape hatch)" ;;
+  *) fail "(10o) the escape hatch does not reach rule 4 ($out)"; cat "$AERR" >&2 ;;
+esac
+
+# 10p: THE PR-BODY ARM. CLAUDE.md's rule covers "commits or PRs" and a git hook
+# cannot see a body at all, so this is the only arm that grades one. The two
+# shapes the harness writes there are the generated-with marker and the BARE
+# session URL — the exact pair edited out of #9255 and #9256 by hand.
+#
+# The body arrives on STDIN as DATA. In test.yml it reaches the shell through
+# an `env:` value and is never interpolated into the script text: a PR body is
+# author-controlled prose, and `${{ }}` would splice it into the source.
+run_attr_body() {
+  ( GITHUB_EVENT_NAME="${ATTR_EVENT:-pull_request}" sh "$ATTR_CI" --pr-body ) \
+    >/dev/null 2>"$AERR" && echo "EXIT=0" || echo "EXIT=$?"
+}
+
+out=$(printf 'Fixes the thing.\n\n%s\n%s\n' "$TRAILER_GENWITH" "$TRAILER_SESSION_URL" \
+  | run_attr_body)
+case "$out" in
+  EXIT=0) fail "(10p) FALSE GREEN: a PR body carrying AI attribution was allowed" ;;
+  *)
+    if grep -Fq "$TRAILER_GENWITH" "$AERR" && grep -Fq "$TRAILER_SESSION_URL" "$AERR" \
+       && grep -q 'pull request body' "$AERR"; then
+      pass "(10p) PR-body arm refuses a body and quotes BOTH offending lines"
+    else
+      fail "(10p) refused, but the report misses a line or the PR-body context"
+      cat "$AERR" >&2
+    fi
+    ;;
+esac
+
+out=$(printf 'Fixes the thing.\n\nSee https://github.com/day8/re-frame2/pull/9317.\n' \
+  | run_attr_body)
+case "$out" in
+  EXIT=0)
+    if [ ! -s "$AERR" ]; then
+      pass "(10p) PR-body arm passes a clean body"
+    else
+      fail "(10p) a clean PR body produced diagnostics"; cat "$AERR" >&2
+    fi
+    ;;
+  *) fail "(10p) FALSE POSITIVE: a clean PR body was refused ($out)"; cat "$AERR" >&2 ;;
+esac
+
+# An EMPTY body passes. A pull request may legitimately have none, and unlike a
+# missing commit RANGE — which silently grades nothing, and so fails closed —
+# a missing body genuinely contains nothing to grade.
+out=$(printf '' | run_attr_body)
+case "$out" in
+  EXIT=0) pass "(10p) PR-body arm passes an empty body" ;;
+  *) fail "(10p) FALSE POSITIVE: an empty PR body was refused ($out)"; cat "$AERR" >&2 ;;
 esac
 
 git -C "$AREPO" checkout -q main >/dev/null 2>&1 || true


### PR DESCRIPTION
Finishes the AI-attribution guard: three detector repairs, the PR-body arm, and the settings key that closes the source. rf2-1ndt, carrying the residue of rf2-2e8f Parts 1-3 after #9317 merged ahead of the repairs its ruling required.

## The three detector repairs

Each is a small, local change inside `rf2_attribution_is_offending_line()`, and each has a layer-10 case that was **red before the fix and green after**.

**(a) The co-author rule refused humans for their name.** It tested the whole lowercased line for the substring `claude` or `anthropic`, so `Co-Authored-By: Jean-Claude Martin <jcm@example.invalid>` was refused — a colleague turned away for their own name. It now tests the assistant's **address family**, `@anthropic.com`: all 31 trailers in this log carry it and the documented harness default is the same address, so the address is sufficient and precise where the name is neither.

**(b) The generated-with rule broke `git commit -v`, and it was live.** That rule is a substring test with no prefix anchoring, so a column-0 `#` comment line carrying the marker reached it and was refused. `commit-msg` reads `COMMIT_EDITMSG` **before** git strips the comments and the diff, so any verbose commit whose diff touched `CLAUDE.md`, the detector or its tests was refused with `--no-verify` the only escape. Measured on this very change: a `-v`-shaped message file built from this PR's own diff of the detector is refused by the merged detector (exit 1, quoting a `+` line from below the scissors) and accepted by the repaired one (exit 0). Comment lines are now exempt outright, and the detector stops reading at git's scissors line.

**(c) A bare session URL passed all three rules.** `https://claude.ai/code/session_...` with no key in front of it is what the harness writes into a PR body. It is now a fourth shape.

The indent escape hatch was **not** touched — it was already correct, and `CLAUDE.md`'s sentence about it is true of the tree.

## The PR-body arm

`scripts/check-commit-attribution.sh --pr-body` reads the body on stdin and runs it through the same detector. In `test.yml` it is a **second invocation in the same `beads-pr-boundary` step** — no new job, no new workflow file, no `edited` activity type — so nothing is added to any PR's check rollup and the required-check band does not move.

The body is passed as an `env:` value and never interpolated into the `run:` text: `${{ }}` is expanded by the workflow renderer before any shell sees the script, so interpolating author-controlled prose would splice it into the source. An empty body passes; unlike a missing commit range, which silently grades nothing, a missing body genuinely contains nothing to grade.

## Closing the source

`.claude/settings.json` gains `"attribution": { "commit": "", "pr": "", "sessionUrl": false }` beside the two `bd prime` hooks. Nothing else changes.

## Tests

Layer 10 goes **88 to 99 assertions**. New coverage, each red first:

- three human co-author spellings including two named Claude, against 10a's two assistant ones (repair a)
- the marker under a `#` prefix and inside a scissors tail (repair b) — the earlier 10d fed only the two prefix-anchored rules, which a `#` exempts for free, so it could not have caught this
- the bare session URL as a refusal, paired with an ordinary URL and an indented one as permitted controls (repair c)
- three cases for the body arm: refuses and quotes both lines, passes a clean body, passes an empty one

Cases 10c, 10i and 10k are kept unchanged.

## Gates

- `scripts/git-hooks/test-pre-commit.sh` — **99 passed, 0 failed**, exit 0 (baseline before this change: 88/0)
- full repo-invariants roster — **62 checkers, 0 red**, exit 0; runner verified to bite on a planted failure
- `sh -n` on all four shell sources — exit 0 each
- `sh scripts/check-commit-attribution.sh origin/main` — exit 0
- `check_readme_links.py --ci` and `check_doc_slugs.py` — exit 0 (in the roster above)
- `node --test` over the workflow-parsing self-tests including `_release-dag-policy.test.cjs` — 0 fail, exit 0; the `run: |` block scalar is kept
- `report-changed-surfaces.sh`: the six script/settings paths arm **no** surface; `.github/workflows/test.yml` arms all 29, as any workflow edit does

All re-run on the final rebased base.
