### PR TITLE
refactor(alias): canonical require-alias dialect for epoch, flows, hicasso, adapters (rf2-7sx1, fenced subset)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -14,8 +14,8 @@
             [reagent2.ratom            :as ratom]
             [reagent2.dom.client       :as rdc]
             [reagent2.impl.template    :as template]
-            [re-frame.substrate.spine   :as spine]
-            [re-frame.views            :as views]))
+            [re-frame.substrate.spine   :as rf.substrate.spine]
+            [re-frame.views            :as rf.views]))
 
 ;; ---- shared ratom-spine wiring --------------------------------------------
 ;;
@@ -24,7 +24,7 @@
 ;; stock `reagent.*` is structurally absent from the slim dependency graph.
 
 (def ^:private spine-fns
-  (spine/make-ratom-spine
+  (rf.substrate.spine/make-ratom-spine
     {;; Keep generated watch ids attributable in mixed-adapter test bundles.
      :gensym-prefix-sub "rf-reagent-slim-sub-"
      ;; Each op is a thin call-through lambda rather than the bare Var
@@ -119,14 +119,14 @@
   The shared ratom spine owns rendering, disposal, hook routing, and SSR
   publication. It receives only injected `reagent2.*` operations, preserving
   the invariant that stock Reagent is absent from slim bundles."
-  (spine/make-ratom-adapter
+  (rf.substrate.spine/make-ratom-adapter
     spine-fns
     {:kind :rf.adapter/reagent-slim
      ;; The returned component receives the frame keyword at render time.
-     :register-context-provider (fn [_frame-keyword] (views/build-frame-provider))
+     :register-context-provider (fn [_frame-keyword] (rf.views/build-frame-provider))
      ;; reagent2 reactions do not implement stock Reagent's IDisposable; the
      ;; spine handles re-frame-owned disposal before these substrate ops.
-     :current-frame     views/current-frame
+     :current-frame     rf.views/current-frame
      :current-component r/current-component
      :atom              r/atom
      :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
@@ -150,5 +150,5 @@
 ;; fixtures re-arm both caches. Keeping this wiring in the adapter avoids a
 ;; `reagent2.*` to `re-frame.*` dependency; the private cache intentionally has
 ;; no arm-state probe.
-(spine/install-clear-warn-once-step! template/clear-warned-keyword-prop!
+(rf.substrate.spine/install-clear-warn-once-step! template/clear-warned-keyword-prop!
                                      {:label :reagent-slim/warned-keyword-prop})

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/current_component_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/current_component_cljs_test.cljs
@@ -31,7 +31,7 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [reagent2.core :as r]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             ;; ns-load registers the :adapter/current-component hook.
             [re-frame.adapter.reagent-slim]))
 
@@ -41,27 +41,27 @@
   even when the bridge's ns-load registered a different reader after the
   slim ns loaded."
   [f]
-  (let [original (late-bind/get-fn :adapter/current-component)]
+  (let [original (rf.late-bind/get-fn :adapter/current-component)]
     (try
-      (late-bind/set-fn! :adapter/current-component r/current-component)
+      (rf.late-bind/set-fn! :adapter/current-component r/current-component)
       (f)
       (finally
-        (late-bind/set-fn! :adapter/current-component original)))))
+        (rf.late-bind/set-fn! :adapter/current-component original)))))
 
 (deftest slim-adapter-installs-hook
   (testing "requiring re-frame.adapter.reagent-slim registers a current-component hook"
     (with-slim-hook
       (fn []
-        (is (some? (late-bind/get-fn :adapter/current-component))
+        (is (some? (rf.late-bind/get-fn :adapter/current-component))
             "the hook is installed")
         (is (identical? r/current-component
-                        (late-bind/get-fn :adapter/current-component))
+                        (rf.late-bind/get-fn :adapter/current-component))
             "the hook points at reagent2.core/current-component (the slim build)")))))
 
 (deftest slim-hook-returns-nil-outside-render
   (testing "calling the installed slim hook outside a render returns nil"
     (with-slim-hook
       (fn []
-        (let [hook (late-bind/get-fn :adapter/current-component)]
+        (let [hook (rf.late-bind/get-fn :adapter/current-component)]
           (is (nil? (hook))
               "no in-flight slim component → nil"))))))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_client_root_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_client_root_cljs_test.cljs
@@ -9,23 +9,23 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent2.dom.client :as rdc]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.adapter.reagent-slim :as slim]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]))
 
 (defn- with-fresh-slim-adapter [test-fn]
-  (reset! frame/frames {})
+  (reset! rf.frame/frames {})
   ;; Drain Roots earlier suites stranded in the slim adapter's singleton
   ;; active set (see the Reagent twin), so the counts are this test's own.
   (with-redefs [rdc/unmount (fn [_] nil)]
-    (adapter/reset-lifecycle-state-for-tests!)
-    (adapter/install-adapter! slim/adapter)
-    (adapter/dispose-adapter!))
-  (adapter/reset-lifecycle-state-for-tests!)
-  (adapter/install-adapter! slim/adapter)
+    (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
+    (rf.substrate.adapter/install-adapter! rf.adapter.reagent-slim/adapter)
+    (rf.substrate.adapter/dispose-adapter!))
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
+  (rf.substrate.adapter/install-adapter! rf.adapter.reagent-slim/adapter)
   (test-fn)
-  (reset! frame/frames {})
-  (adapter/reset-lifecycle-state-for-tests!))
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!))
 
 (use-fixtures :each with-fresh-slim-adapter)
 
@@ -73,7 +73,7 @@
 
 (deftest client-root-does-no-dom-work
   (testing "allocating a handle touches none of the Root API"
-    (is (empty? (record-root-api-calls [] (fn [] (slim/client-root)))))))
+    (is (empty? (record-root-api-calls [] (fn [] (rf.adapter.reagent-slim/client-root)))))))
 
 (deftest cold-first-render-creates-once-later-renders-update-the-same-root
   (testing "first render! creates once; later renders reuse the identical Root"
@@ -81,10 +81,10 @@
           mount #js {:rf-test-mount :cold}
           calls (record-root-api-calls [root (make-fake-root :never)]
                   (fn []
-                    (let [h (slim/client-root)]
-                      (slim/render! h [:div "v1"] mount)
-                      (slim/render! h [:div "v2"] mount)
-                      (slim/render! h [:div "v3"] mount))))]
+                    (let [h (rf.adapter.reagent-slim/client-root)]
+                      (rf.adapter.reagent-slim/render! h [:div "v1"] mount)
+                      (rf.adapter.reagent-slim/render! h [:div "v2"] mount)
+                      (rf.adapter.reagent-slim/render! h [:div "v3"] mount))))]
       (is (= [[:create-root mount]] (calls-of-kind calls :create-root)))
       (is (empty? (calls-of-kind calls :hydrate-root)))
       (is (= [[:render root [:div "v1"]] [:render root [:div "v2"]] [:render root [:div "v3"]]]
@@ -98,10 +98,10 @@
           mount #js {:rf-test-mount :hydrated}
           calls (record-root-api-calls [root (make-fake-root :never)]
                   (fn []
-                    (let [h (slim/client-root)]
-                      (slim/render! h [:div "ssr"] mount {:hydrate? true})
-                      (slim/render! h [:div "v2"] mount {:hydrate? true})
-                      (slim/render! h [:div "v3"] mount))))]
+                    (let [h (rf.adapter.reagent-slim/client-root)]
+                      (rf.adapter.reagent-slim/render! h [:div "ssr"] mount {:hydrate? true})
+                      (rf.adapter.reagent-slim/render! h [:div "v2"] mount {:hydrate? true})
+                      (rf.adapter.reagent-slim/render! h [:div "v3"] mount))))]
       (is (= [[:hydrate-root mount [:div "ssr"]]]
              (calls-of-kind calls :hydrate-root)))
       (is (empty? (calls-of-kind calls :create-root)))
@@ -115,11 +115,11 @@
           mount  #js {:rf-test-mount :again}
           calls  (record-root-api-calls [root-1 root-2]
                    (fn []
-                     (let [h (slim/client-root)]
-                       (slim/render! h [:div "v1"] mount)
-                       (slim/unmount! h)
-                       (slim/unmount! h)
-                       (slim/render! h [:div "v2"] mount))))]
+                     (let [h (rf.adapter.reagent-slim/client-root)]
+                       (rf.adapter.reagent-slim/render! h [:div "v1"] mount)
+                       (rf.adapter.reagent-slim/unmount! h)
+                       (rf.adapter.reagent-slim/unmount! h)
+                       (rf.adapter.reagent-slim/render! h [:div "v2"] mount))))]
       (is (= [[:unmount root-1]] (calls-of-kind calls :unmount)))
       (is (= [[:create-root mount] [:create-root mount]]
              (calls-of-kind calls :create-root)))
@@ -132,14 +132,14 @@
           root-gone (make-fake-root :gone)
           calls     (record-root-api-calls [root-live root-gone]
                       (fn []
-                        (let [live (slim/client-root)
-                              gone (slim/client-root)]
-                          (slim/render! live [:div "live"] #js {})
-                          (slim/render! gone [:div "gone"] #js {})
-                          (slim/unmount! gone)
-                          (adapter/dispose-adapter!)
-                          (slim/unmount! live)
-                          (slim/unmount! gone))))]
+                        (let [live (rf.adapter.reagent-slim/client-root)
+                              gone (rf.adapter.reagent-slim/client-root)]
+                          (rf.adapter.reagent-slim/render! live [:div "live"] #js {})
+                          (rf.adapter.reagent-slim/render! gone [:div "gone"] #js {})
+                          (rf.adapter.reagent-slim/unmount! gone)
+                          (rf.substrate.adapter/dispose-adapter!)
+                          (rf.adapter.reagent-slim/unmount! live)
+                          (rf.adapter.reagent-slim/unmount! gone))))]
       (is (= 1 (count (filter #(identical? root-live (second %))
                               (calls-of-kind calls :unmount)))))
       (is (= 1 (count (filter #(identical? root-gone (second %))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_cljs_test.cljs
@@ -26,8 +26,8 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.adapter.reagent-slim :as reagent-slim]
-            [re-frame.late-bind :as late-bind]))
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.late-bind :as rf.late-bind]))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers
@@ -42,11 +42,11 @@
 (defn- with-cleared-hiccup-emitter
   "Run `f` with the adapter's hiccup-emitter forced to nil."
   [f]
-  (reagent-slim/set-hiccup-emitter! nil)
+  (rf.adapter.reagent-slim/set-hiccup-emitter! nil)
   (try
     (f)
     (finally
-      (reagent-slim/set-hiccup-emitter! nil))))
+      (rf.adapter.reagent-slim/set-hiccup-emitter! nil))))
 
 ;; ---------------------------------------------------------------------------
 ;; Adapter map shape (per IMPL-SPEC §2.1 + Spec 006 §CLJS reference)
@@ -55,7 +55,7 @@
 (deftest adapter-has-canonical-keys
   (testing "the adapter map carries the substrate-shape keys + :kind discriminator
             (incl. the optional rf2-40a84 :flush-render! slot)"
-    (let [k (set (keys reagent-slim/adapter))]
+    (let [k (set (keys rf.adapter.reagent-slim/adapter))]
       (is (= #{:kind
               :make-state-container
               :read-container
@@ -70,12 +70,12 @@
               :dispose-adapter!}
              k)
           "every slot named in re-frame.substrate.adapter is present plus :kind")
-      (is (= :rf.adapter/reagent-slim (:kind reagent-slim/adapter))
+      (is (= :rf.adapter/reagent-slim (:kind rf.adapter.reagent-slim/adapter))
           ":kind matches the canonical reagent-slim discriminator"))))
 
 (deftest adapter-slot-fns-callable
   (testing "every adapter contract slot value is a fn (excludes the :kind discriminator)"
-    (doseq [[k v] (dissoc reagent-slim/adapter :kind)]
+    (doseq [[k v] (dissoc rf.adapter.reagent-slim/adapter :kind)]
       (is (fn? v) (str "adapter slot " k " is callable")))))
 
 ;; ---------------------------------------------------------------------------
@@ -84,9 +84,9 @@
 
 (deftest state-container-roundtrip
   (testing "make-state-container / read / replace cycle"
-    (let [make    (:make-state-container reagent-slim/adapter)
-          read    (:read-container        reagent-slim/adapter)
-          replace (:replace-container!    reagent-slim/adapter)
+    (let [make    (:make-state-container rf.adapter.reagent-slim/adapter)
+          read    (:read-container        rf.adapter.reagent-slim/adapter)
+          replace (:replace-container!    rf.adapter.reagent-slim/adapter)
           c       (make {:n 0})]
       (is (= {:n 0} (read c)) "initial value flows through")
       (replace c {:n 42})
@@ -94,9 +94,9 @@
 
 (deftest state-container-subscribe
   (testing "subscribe-container fires on change; unsubscribe stops"
-    (let [make      (:make-state-container reagent-slim/adapter)
-          replace   (:replace-container!    reagent-slim/adapter)
-          subscribe (:subscribe-container  reagent-slim/adapter)
+    (let [make      (:make-state-container rf.adapter.reagent-slim/adapter)
+          replace   (:replace-container!    rf.adapter.reagent-slim/adapter)
+          subscribe (:subscribe-container  rf.adapter.reagent-slim/adapter)
           c         (make {:n 0})
           seen      (atom [])
           unsub     (subscribe c (fn [_prev nu] (swap! seen conj nu)))]
@@ -113,9 +113,9 @@
 
 (deftest derived-value-tracks-source
   (testing "make-derived-value produces a Reaction that tracks its sources"
-    (let [make-c    (:make-state-container reagent-slim/adapter)
-          replace   (:replace-container!    reagent-slim/adapter)
-          make-d    (:make-derived-value   reagent-slim/adapter)
+    (let [make-c    (:make-state-container rf.adapter.reagent-slim/adapter)
+          replace   (:replace-container!    rf.adapter.reagent-slim/adapter)
+          make-d    (:make-derived-value   rf.adapter.reagent-slim/adapter)
           src       (make-c 1)
           derived   (make-d [src] (fn [v] (* v 100)))]
       (is (= 100 @derived) "initial derived value")
@@ -130,15 +130,15 @@
   (testing "render-to-string raises when no hiccup-emitter installed"
     (with-cleared-hiccup-emitter
       (fn []
-        (let [render-to-string (:render-to-string reagent-slim/adapter)]
+        (let [render-to-string (:render-to-string rf.adapter.reagent-slim/adapter)]
           (is (thrown? :default (render-to-string [:div] {}))))))))
 
 (deftest set-hiccup-emitter-installs-fn
   (testing "set-hiccup-emitter! lets render-to-string emit"
     (with-cleared-hiccup-emitter
       (fn []
-        (reagent-slim/set-hiccup-emitter! mock-hiccup-emitter)
-        (let [render-to-string (:render-to-string reagent-slim/adapter)
+        (rf.adapter.reagent-slim/set-hiccup-emitter! mock-hiccup-emitter)
+        (let [render-to-string (:render-to-string rf.adapter.reagent-slim/adapter)
               tree             [:div "ok"]
               html             (render-to-string tree {})]
           (is (str/starts-with? html "<mock>")
@@ -153,16 +153,16 @@
             slot, so SSR's `re-frame.ssr.emit` ns-load can auto-wire
             render-to-string without a direct `set-hiccup-emitter!`
             call from user code."
-    (let [hook-fn (late-bind/get-fn :reagent/set-hiccup-emitter!)]
+    (let [hook-fn (rf.late-bind/get-fn :reagent/set-hiccup-emitter!)]
       (is (some? hook-fn)
           "the chained hook is registered after the Reagent Slim adapter ns has loaded")
       (with-cleared-hiccup-emitter
         (fn []
-          (let [render-to-string (:render-to-string reagent-slim/adapter)]
+          (let [render-to-string (:render-to-string rf.adapter.reagent-slim/adapter)]
             (is (thrown? :default (render-to-string [:div] {}))
                 "precondition: emitter cleared"))
           (hook-fn mock-hiccup-emitter)
-          (let [render-to-string (:render-to-string reagent-slim/adapter)
+          (let [render-to-string (:render-to-string rf.adapter.reagent-slim/adapter)
                 html             (render-to-string [:div "via-chain"] {})]
             (is (str/starts-with? html "<mock>")
                 "the chained hook wired the Reagent Slim adapter's emitter slot"))
@@ -174,7 +174,7 @@
 
 (deftest dispose-adapter-runs-cleanly
   (testing "dispose-adapter! returns nil and doesn't throw"
-    (let [dispose (:dispose-adapter! reagent-slim/adapter)]
+    (let [dispose (:dispose-adapter! rf.adapter.reagent-slim/adapter)]
       (is (nil? (dispose))))))
 
 ;; ---------------------------------------------------------------------------
@@ -187,7 +187,7 @@
   ;; live in reagent2.dom.client-cljs-test (with stub roots) and
   ;; browser-test (with jsdom).
   (testing "render slot is callable"
-    (is (fn? (:render reagent-slim/adapter)))))
+    (is (fn? (:render rf.adapter.reagent-slim/adapter)))))
 
 ;; ---------------------------------------------------------------------------
 ;; register-context-provider returns the views ns's frame-provider
@@ -195,7 +195,7 @@
 
 (deftest register-context-provider-returns-component
   (testing "register-context-provider returns a component value"
-    (let [reg (:register-context-provider reagent-slim/adapter)
+    (let [reg (:register-context-provider rf.adapter.reagent-slim/adapter)
           provider (reg :rf/some-frame)]
       (is (some? provider)
           "register-context-provider returned a non-nil component"))))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_derived_container_replaced_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_derived_container_replaced_cljs_test.cljs
@@ -23,12 +23,12 @@
   Per bead rf2-8wrzz.3."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent2.ratom :as ratom]
-            [re-frame.adapter.reagent-slim :as reagent-slim]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]
             ;; Load the tooling sibling so the listener API's late-bind
             ;; hooks resolve (mirrors the plain-atom suite + trace-listener-test).
             [re-frame.trace.tooling]))
@@ -48,7 +48,7 @@
 ;; recompute into a later React-adapter test.
 
 (def ^:private reset-runtime
-  (test-support/make-reset-runtime-fixture {:adapter reagent-slim/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.adapter.reagent-slim/adapter}))
 
 (defn with-reagent-slim [test-fn]
   ;; Drain reagent2's process-global Reaction flush queue around the reset
@@ -65,11 +65,11 @@
 (defn- capture-errors [body-fn]
   (let [seen (atom [])
         k    ::reagent-slim-derived-replaced-capture]
-    (trace/register-listener! k (fn [ev]
+    (rf.trace/register-listener! k (fn [ev]
                                   (when (= :error (:op-type ev))
                                     (swap! seen conj ev))))
     (try (body-fn)
-         (finally (trace/unregister-listener! k)))
+         (finally (rf.trace/unregister-listener! k)))
     @seen))
 
 (defn- with-derived
@@ -79,21 +79,21 @@
   test. Disposal routes through `interop/dispose!` → the slim adapter's
   `:adapter/dispose!` hook, the same path the sub-cache uses."
   [src body]
-  (let [derived (adapter/make-derived-value [src] (fn [v] (:n v)))]
+  (let [derived (rf.substrate.adapter/make-derived-value [src] (fn [v] (:n v)))]
     (try (body derived)
-         (finally (interop/dispose! derived)))))
+         (finally (rf.interop/dispose! derived)))))
 
 ;; ---- tests ----------------------------------------------------------------
 
 (deftest derived-container-hook-separates-reaction-from-base-ratom
   (testing "the routed :adapter/derived-container? hook flags a Reaction (derived) but not an r/atom (base)"
-    (let [hook (late-bind/get-fn :adapter/derived-container?)]
+    (let [hook (rf.late-bind/get-fn :adapter/derived-container?)]
       (is (some? hook) "the :adapter/derived-container? hook is published")
-      (let [src (adapter/make-state-container {:n 1})]
+      (let [src (rf.substrate.adapter/make-state-container {:n 1})]
         (with-derived src
           (fn [derived]
             ;; Read the derived value once so the reaction baseline is seeded.
-            (is (= 1 (adapter/read-container derived)) "precondition: derived reads its computed value")
+            (is (= 1 (rf.substrate.adapter/read-container derived)) "precondition: derived reads its computed value")
             (is (false? (boolean (hook src)))
                 "a base r/atom is NOT a derived container (even though it reifies IAtom)")
             (is (true? (boolean (hook derived)))
@@ -101,21 +101,21 @@
 
 (deftest replace-on-base-ratom-succeeds
   (testing "the happy path is untouched: writing to a base r/atom still works under reagent-slim"
-    (let [c (adapter/make-state-container {:n 0})]
-      (is (= {:n 0} (adapter/read-container c)) "precondition")
-      (is (nil? (adapter/replace-container! c {:n 1}))
+    (let [c (rf.substrate.adapter/make-state-container {:n 0})]
+      (is (= {:n 0} (rf.substrate.adapter/read-container c)) "precondition")
+      (is (nil? (rf.substrate.adapter/replace-container! c {:n 1}))
           "replace-container! on a base container returns nil")
-      (is (= {:n 1} (adapter/read-container c))
+      (is (= {:n 1} (rf.substrate.adapter/read-container c))
           "the base container holds the new value"))))
 
 (deftest replace-on-reaction-throws
   (testing "replace-container! on a reagent-slim Reaction throws the canonical ex-info"
-    (let [src (adapter/make-state-container {:n 7})]
+    (let [src (rf.substrate.adapter/make-state-container {:n 7})]
       (with-derived src
         (fn [derived]
-          (is (= 7 (adapter/read-container derived))
+          (is (= 7 (rf.substrate.adapter/read-container derived))
               "precondition: the derived container reads its computed value")
-          (let [thrown (is (thrown? js/Error (adapter/replace-container! derived 42))
+          (let [thrown (is (thrown? js/Error (rf.substrate.adapter/replace-container! derived 42))
                            "writing to a Reaction throws")]
             (is (= :rf.error/derived-container-replaced
                    (:rf.error/id (ex-data thrown)))
@@ -131,12 +131,12 @@
 
 (deftest replace-on-reaction-emits-error-trace
   (testing "replace-container! on a Reaction emits the :rf.error/derived-container-replaced trace"
-    (let [src (adapter/make-state-container {:n 1})]
+    (let [src (rf.substrate.adapter/make-state-container {:n 1})]
       (with-derived src
         (fn [derived]
           (let [errs (capture-errors
                        (fn []
-                         (try (adapter/replace-container! derived 99)
+                         (try (rf.substrate.adapter/replace-container! derived 99)
                               (catch :default _ nil))))
                 ev   (first (filter #(= :rf.error/derived-container-replaced (:operation %)) errs))]
             (is (some? ev) "a :rf.error/derived-container-replaced error trace was emitted")
@@ -148,19 +148,19 @@
 
 (deftest reaction-value-unchanged-after-rejected-write
   (testing "the rejected write does NOT mutate the derived value — the adapter replace-container! is never invoked"
-    (let [src (adapter/make-state-container {:n 5})]
+    (let [src (rf.substrate.adapter/make-state-container {:n 5})]
       (with-derived src
         (fn [derived]
-          (is (= 5 (adapter/read-container derived)) "seed the reaction baseline")
-          (try (adapter/replace-container! derived 1000)
+          (is (= 5 (rf.substrate.adapter/read-container derived)) "seed the reaction baseline")
+          (try (rf.substrate.adapter/replace-container! derived 1000)
                (catch :default _ nil))
-          (is (= 5 (adapter/read-container derived))
+          (is (= 5 (rf.substrate.adapter/read-container derived))
               "the derived value still reflects its source — the write was rejected")
           ;; Writing to the SOURCE flows through to the derived value, proving the
           ;; source remains a normal writable container and the guard fires only
           ;; on the Reaction shape.
-          (adapter/replace-container! src {:n 6})
-          (is (= 6 (adapter/read-container derived))
+          (rf.substrate.adapter/replace-container! src {:n 6})
+          (is (= 6 (rf.substrate.adapter/read-container derived))
               "writing to the source recomputes the derived value normally"))))))
 
 ;; ---- copied / wrapped adapter map routes to the live hook (rf2-dkl5z1) -----
@@ -175,21 +175,21 @@
 
 (deftest copied-adapter-map-routes-to-live-derived-container-hook
   (testing "a copied reagent-slim adapter map still drives the live :adapter/derived-container? hook (rf2-dkl5z1)"
-    (let [original (adapter/current-adapter-spec)
-          copied   (assoc reagent-slim/adapter :rf.test/instrumentation-wrapper true)]
+    (let [original (rf.substrate.adapter/current-adapter-spec)
+          copied   (assoc rf.adapter.reagent-slim/adapter :rf.test/instrumentation-wrapper true)]
       (try
-        (adapter/dispose-adapter!)
-        (adapter/install-adapter! copied)
-        (is (false? (identical? reagent-slim/adapter (adapter/current-adapter-spec)))
+        (rf.substrate.adapter/dispose-adapter!)
+        (rf.substrate.adapter/install-adapter! copied)
+        (is (false? (identical? rf.adapter.reagent-slim/adapter (rf.substrate.adapter/current-adapter-spec)))
             "precondition: the installed copy is NOT identical to the routed canonical map")
-        (is (= :rf.adapter/reagent-slim (adapter/current-adapter))
+        (is (= :rf.adapter/reagent-slim (rf.substrate.adapter/current-adapter))
             "precondition: the copy preserves the canonical :kind token")
-        (let [hook (late-bind/get-fn :adapter/derived-container?)
-              src  (adapter/make-state-container {:n 1})]
+        (let [hook (rf.late-bind/get-fn :adapter/derived-container?)
+              src  (rf.substrate.adapter/make-state-container {:n 1})]
           (is (some? hook) "the :adapter/derived-container? hook is published")
           (with-derived src
             (fn [derived]
-              (is (= 1 (adapter/read-container derived)) "precondition: derived reads its computed value")
+              (is (= 1 (rf.substrate.adapter/read-container derived)) "precondition: derived reads its computed value")
               (is (false? (boolean (hook src)))
                   "under the copied map, a base r/atom is STILL not a derived container")
               (is (true? (boolean (hook derived)))
@@ -197,8 +197,8 @@
                        " as a derived container — the routed hook fired its live impl"
                        " despite the copy's distinct identity (rf2-dkl5z1)"))
               ;; End-to-end: the choke point STILL rejects a write to the Reaction.
-              (is (thrown? js/Error (adapter/replace-container! derived 42))
+              (is (thrown? js/Error (rf.substrate.adapter/replace-container! derived 42))
                   "replace-container! on the Reaction STILL throws under the copied map"))))
         (finally
-          (adapter/dispose-adapter!)
-          (adapter/install-adapter! original))))))
+          (rf.substrate.adapter/dispose-adapter!)
+          (rf.substrate.adapter/install-adapter! original))))))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_drain_roots_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_drain_roots_cljs_test.cljs
@@ -23,9 +23,9 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent2.dom.client :as rdc]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]))
 
 ;; ---- fixture --------------------------------------------------------------
 ;;
@@ -36,12 +36,12 @@
 ;; empty registry (this file pins MUST 2 + 3, not MUST 1).
 
 (defn with-fresh-slim-adapter [test-fn]
-  (adapter/reset-lifecycle-state-for-tests!)
-  (reset! frame/frames {})
-  (adapter/install-adapter! reagent-slim-adapter/adapter)
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/install-adapter! rf.adapter.reagent-slim/adapter)
   (test-fn)
-  (reset! frame/frames {})
-  (adapter/reset-lifecycle-state-for-tests!))
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!))
 
 (use-fixtures :each with-fresh-slim-adapter)
 
@@ -74,7 +74,7 @@
                                       ([_ _ _]   nil)
                                       ([_ _ _ _] nil))
                     rdc/unmount     (fn [root] (swap! unmount-calls conj root) nil)]
-        (let [render-fn (:render reagent-slim-adapter/adapter)]
+        (let [render-fn (:render rf.adapter.reagent-slim/adapter)]
           ;; Mount three roots; do NOT call the returned unmount thunks
           ;; — they are now "stranded" (mounted-but-not-unmounted).
           (render-fn [:div "a"] #js {} nil)
@@ -84,7 +84,7 @@
               "precondition: no roots unmounted before dispose")
 
           ;; Drive the drain.
-          (adapter/dispose-adapter!)
+          (rf.substrate.adapter/dispose-adapter!)
 
           (is (= 3 (count @unmount-calls))
               "dispose-adapter! unmounted all three stranded roots")
@@ -105,7 +105,7 @@
                                       ([_ _] (let [[r] @roots] (swap! roots rest) r)))
                     rdc/render      (fn ([_ _] nil) ([_ _ _] nil) ([_ _ _ _] nil))
                     rdc/unmount     (fn [root] (swap! unmount-calls conj root) nil)]
-        (let [render-fn (:render reagent-slim-adapter/adapter)
+        (let [render-fn (:render rf.adapter.reagent-slim/adapter)
               _live-thunk (render-fn [:div "live"] #js {} nil)
               gone-thunk  (render-fn [:div "gone"] #js {} nil)]
           ;; Explicitly unmount the second root via its thunk.
@@ -114,7 +114,7 @@
               "precondition: explicit unmount fired exactly once for the gone root")
 
           ;; Dispose: only the still-live root should be drained.
-          (adapter/dispose-adapter!)
+          (rf.substrate.adapter/dispose-adapter!)
 
           (is (= 1 (count (filter #(identical? root-gone %) @unmount-calls)))
               "the explicitly-unmounted root is NOT unmounted a second time")
@@ -139,14 +139,14 @@
                                       (when (identical? root bad-root)
                                         (throw sentinel))
                                       nil)]
-        (let [render-fn (:render reagent-slim-adapter/adapter)]
+        (let [render-fn (:render rf.adapter.reagent-slim/adapter)]
           (render-fn [:div "bad"] #js {} nil)
           (render-fn [:div "good"] #js {} nil)
           ;; The bad root's throw must not ABORT the drain — but it must
           ;; still reach the caller once the drain is done. Both adapters
           ;; share one spine drain, so this is the slim-side witness of the
           ;; same Spec 006 rule.
-          (let [thrown (try (adapter/dispose-adapter!)
+          (let [thrown (try (rf.substrate.adapter/dispose-adapter!)
                             ::returned-normally
                             (catch :default e e))]
             (is (some #(identical? bad-root %) @unmount-calls)
@@ -164,19 +164,19 @@
             installed fn (which captures re-frame.ssr state) does not
             survive teardown — rf2-7v82h MUST 3"
     ;; Install an emitter and prove render-to-string resolves it.
-    (reagent-slim-adapter/set-hiccup-emitter!
+    (rf.adapter.reagent-slim/set-hiccup-emitter!
       (fn [tree _opts] (str "EMITTED:" (pr-str tree))))
     (is (= "EMITTED:[:p \"hi\"]"
-           ((:render-to-string reagent-slim-adapter/adapter) [:p "hi"] nil))
+           ((:render-to-string rf.adapter.reagent-slim/adapter) [:p "hi"] nil))
         "precondition: the installed emitter is live before dispose")
 
     ;; Dispose drains the emitter.
-    (adapter/dispose-adapter!)
+    (rf.substrate.adapter/dispose-adapter!)
 
     ;; Post-dispose: render-to-string raises the no-emitter-bound error
     ;; (the only black-box proof the emitter atom was reset to nil).
     (is (thrown-with-msg?
           cljs.core.ExceptionInfo
           #":rf.error/no-hiccup-emitter-bound"
-          ((:render-to-string reagent-slim-adapter/adapter) [:p "hi"] nil))
+          ((:render-to-string rf.adapter.reagent-slim/adapter) [:p "hi"] nil))
         "after dispose the emitter is nil; render-to-string raises no-emitter-bound")))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_sub_cache_walk_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_sub_cache_walk_cljs_test.cljs
@@ -24,9 +24,9 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent2.ratom :as ratom]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]))
 
 ;; ---- fixture --------------------------------------------------------------
 ;;
@@ -40,18 +40,18 @@
   ;; frame registry — so the test starts from a never-installed cold
   ;; state. The `reset-lifecycle-state-for-tests!` seam exists for
   ;; exactly this purpose (rf2-6wxys).
-  (adapter/reset-lifecycle-state-for-tests!)
-  (reset! frame/frames {})
-  (rf/init! reagent-slim-adapter/adapter)
-  (frame/ensure-default-frame!)
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
+  (reset! rf.frame/frames {})
+  (rf/init! rf.adapter.reagent-slim/adapter)
+  (rf.frame/ensure-default-frame!)
   (test-fn)
   ;; Best-effort post-clean: if the test body left the adapter
   ;; installed, dispose it; if already disposed, the breadcrumb
   ;; lookup makes this a no-op.
-  (when (adapter/current-adapter)
-    (adapter/dispose-adapter!))
-  (reset! frame/frames {})
-  (adapter/reset-lifecycle-state-for-tests!))
+  (when (rf.substrate.adapter/current-adapter)
+    (rf.substrate.adapter/dispose-adapter!))
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!))
 
 (use-fixtures :each with-fresh-slim-adapter)
 
@@ -62,7 +62,7 @@
   sub-cache. Walks `@frame/frames` the same way the adapter's
   `dispose-adapter!` walk does."
   []
-  (for [[_ frame-record] @frame/frames
+  (for [[_ frame-record] @rf.frame/frames
         :let  [cache (:sub-cache frame-record)]
         :when cache
         [_k entry] @cache
@@ -74,7 +74,7 @@
   "Return `{frame-id <entry-count>}` for every frame with a sub-cache."
   []
   (into {}
-        (for [[fid frame-record] @frame/frames
+        (for [[fid frame-record] @rf.frame/frames
               :let [cache (:sub-cache frame-record)]
               :when cache]
           [fid (count @cache)])))
@@ -121,7 +121,7 @@
             (ratom/add-on-dispose! r (fn [& _] (swap! disposed conj r))))
 
           ;; Drive the walk.
-          (adapter/dispose-adapter!)
+          (rf.substrate.adapter/dispose-adapter!)
 
           ;; Invariant 1: every previously-cached Reaction is now
           ;; disposed. Assert through reagent2's public disposal callback
@@ -132,7 +132,7 @@
                      " on a frame's sub-cache fired its dispose hook")))))
 
       ;; Invariant 2: every frame's sub-cache atom is empty.
-      (doseq [[fid frame-record] @frame/frames
+      (doseq [[fid frame-record] @rf.frame/frames
               :let [cache (:sub-cache frame-record)]
               :when cache]
         (is (= {} @cache)
@@ -200,7 +200,7 @@
       ;; walk/a's cache AND walk/b's cache, and then surface this exact value.
       (let [sentinel (ex-info "poison entry disposal" {::poison true})
             attempts (atom 0)
-            cache-a  (:sub-cache (frame/frame :walk/a))]
+            cache-a  (:sub-cache (rf.frame/frame :walk/a))]
         (swap! cache-a assoc [:poison]
                {:reaction (throwing-cached-reaction sentinel attempts)})
 
@@ -209,7 +209,7 @@
           (doseq [r reactions-before]
             (ratom/add-on-dispose! r (fn [& _] (swap! disposed conj r))))
 
-          (let [thrown (try (adapter/dispose-adapter!)
+          (let [thrown (try (rf.substrate.adapter/dispose-adapter!)
                             ::returned-normally
                             (catch :default e e))]
             ;; (1) THE POISON ACTUALLY FIRED. Without this the rest of the
@@ -223,9 +223,9 @@
             (doseq [r reactions-before]
               (is (contains? @disposed r)
                   "the walk reached and disposed the real Reaction past the poison entry"))
-            (is (= {} @(:sub-cache (frame/frame :walk/a)))
+            (is (= {} @(:sub-cache (rf.frame/frame :walk/a)))
                 "walk/a's cache was still cleared despite the throw")
-            (is (= {} @(:sub-cache (frame/frame :walk/b)))
+            (is (= {} @(:sub-cache (rf.frame/frame :walk/b)))
                 "walk/b's cache was still cleared after the throwing walk/a entry")
 
             ;; (3) RETHROW, and the IDENTICAL value rather than a wrapper.
@@ -240,8 +240,8 @@
     ;; make-reset-runtime-fixture shape: the fixture resets frames BEFORE
     ;; calling dispose-adapter!, so dispose-adapter! sees an empty
     ;; registry.
-    (reset! frame/frames {})
-    (is (nil? (adapter/dispose-adapter!))
+    (reset! rf.frame/frames {})
+    (is (nil? (rf.substrate.adapter/dispose-adapter!))
         "dispose-adapter! returns nil with an empty frames registry — no throw")
-    (is (true? (adapter/adapter-disposed?))
+    (is (true? (rf.substrate.adapter/adapter-disposed?))
         "the disposed-adapter breadcrumb is set after the no-op walk")))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_flush_render_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_flush_render_dom_cljs_test.cljs
@@ -57,8 +57,8 @@
             [reagent2.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 ;; EP-0002 (rf2-9o48ih): `:ambient-frame nil` opts out of the fixture's default
@@ -70,8 +70,8 @@
 ;; subscribe would read :rf/default's (empty) app-db instead of the provider's
 ;; (the seeded probe frame), rendering "n=" instead of the counter value.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter
      :ambient-frame nil}))
 
 (defn- browser? []
@@ -87,7 +87,7 @@
     (if-not (browser?)
       (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
       (let [frame-kw :rf.reagent-slim-flush-render/probe-frame
-            flush!   (:flush-render! reagent-slim-adapter/adapter)]
+            flush!   (:flush-render! rf.adapter.reagent-slim/adapter)]
         (is (fn? flush!)
             "the reagent-slim adapter map exposes :flush-render! (rf2-0bz5ah contract slot)")
         (rf/make-frame {:id frame-kw :doc "flush-render! synchronous-commit probe frame"})

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_flush_views_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_flush_views_cljs_test.cljs
@@ -22,15 +22,15 @@
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.adapter.reagent-slim :as reagent-slim]))
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]))
 
 (deftest flush-views-canonical-shape
   (testing "reagent-slim — flush-views! surfaced from the ADAPTER ns with
             the canonical nil-return shape (rf2-b6nm5 / Decision 6),
             converged with the substrate-ns Promise-returning primitive"
-    (is (fn? reagent-slim/flush-views!)
+    (is (fn? rf.adapter.reagent-slim/flush-views!)
         "the slim adapter ns exposes flush-views! as a fn (previously only the substrate ns did)")
-    (is (nil? (reagent-slim/flush-views!))
+    (is (nil? (rf.adapter.reagent-slim/flush-views!))
         "0-arity flush-views! returns nil — the converged contract (NOT the substrate-ns Promise)")
-    (is (nil? (reagent-slim/flush-views! (fn [] nil)))
+    (is (nil? (rf.adapter.reagent-slim/flush-views! (fn [] nil)))
         "1-arity flush-views! also returns nil")))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_late_bind_publication_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_late_bind_publication_cljs_test.cljs
@@ -30,8 +30,8 @@
             ;; Loading the Reagent Slim adapter triggers its ns-load
             ;; publication side effects - that's the point of this test.
             [re-frame.adapter.reagent-slim]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.late-bind.directory :as directory]))
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.late-bind.directory :as rf.late-bind.directory]))
 
 (def ^:private expected-hook-keys
   "Every late-bind hook the Reagent Slim adapter publishes at ns-load."
@@ -59,11 +59,11 @@
 (defn- directory-entry
   [k]
   (some (fn [entry] (when (= k (:key entry)) entry))
-        directory/hooks))
+        rf.late-bind.directory/hooks))
 
 (defn- directory-hook-keys-for
   [producer-ns]
-  (->> directory/hooks
+  (->> rf.late-bind.directory/hooks
        (filter #(some #{producer-ns} (producers %)))
        (map :key)
        set))
@@ -74,7 +74,7 @@
             adapter ns has loaded. A future refactor that drops or
             renames a hook trips this test."
     (doseq [k expected-hook-keys]
-      (is (some? (late-bind/get-fn k))
+      (is (some? (rf.late-bind/get-fn k))
           (str "expected the Reagent Slim adapter to publish " k
                " through the late-bind hook table at ns-load")))))
 

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_make_derived_value_arity_spec_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_make_derived_value_arity_spec_cljs_test.cljs
@@ -18,16 +18,16 @@
     * ≥3-arity: fallback path
     * source-vector order preserved through the recompute closure"
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.adapter.reagent-slim :as adapter]))
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]))
 
 (defn- make-source [v]
-  ((:make-state-container adapter/adapter) v))
+  ((:make-state-container rf.adapter.reagent-slim/adapter) v))
 
 (defn- write! [c v]
-  ((:replace-container! adapter/adapter) c v))
+  ((:replace-container! rf.adapter.reagent-slim/adapter) c v))
 
 (defn- make-derived-value [sources f]
-  ((:make-derived-value adapter/adapter) sources f))
+  ((:make-derived-value rf.adapter.reagent-slim/adapter) sources f))
 
 (deftest derived-zero-arity-cljs-test
   (testing "0 sources — compute-fn called with no args"

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_render_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_render_cljs_test.cljs
@@ -29,7 +29,7 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [reagent2.dom.client :as rdc]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]))
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -74,7 +74,7 @@
                     rdc/unmount      (fn [arg]
                                        (swap! calls conj [:unmount arg])
                                        nil)]
-        (let [render-fn (:render reagent-slim-adapter/adapter)
+        (let [render-fn (:render rf.adapter.reagent-slim/adapter)
               unmount   (render-fn fake-tree fake-mount nil)]
           (is (fn? unmount)
               "render returns an unmount thunk")
@@ -131,7 +131,7 @@
                     rdc/unmount      (fn [arg]
                                        (swap! calls conj [:unmount arg])
                                        nil)]
-        (let [render-fn (:render reagent-slim-adapter/adapter)
+        (let [render-fn (:render rf.adapter.reagent-slim/adapter)
               unmount   (render-fn fake-tree fake-mount {:hydrate? true})]
           (is (fn? unmount))
           (is (= 1 (count @calls))
@@ -164,7 +164,7 @@
                                        ([_ _]   fake-root)
                                        ([_ _ _] fake-root))
                     rdc/unmount      (fn [_] nil)]
-        (let [render-fn (:render reagent-slim-adapter/adapter)]
+        (let [render-fn (:render rf.adapter.reagent-slim/adapter)]
           (render-fn [:div] fake-mount nil)
           (is (= 1 (count @render-calls)))
           (let [[root tree] (first @render-calls)]

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_scu_argv_gate_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_scu_argv_gate_dom_cljs_test.cljs
@@ -36,8 +36,8 @@
             [reagent2.core :as r]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 ;; EP-0002 (rf2-9o48ih): `:ambient-frame nil` opts out of the fixture's
@@ -45,8 +45,8 @@
 ;; subscribes resolve their frame from the enclosing `frame-provider` via the
 ;; React-context tier (mirrors the flush-render DOM twin).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter
      :ambient-frame nil}))
 
 (defn- browser? []
@@ -62,7 +62,7 @@
     (if-not (browser?)
       (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
       (let [frame-kw     :rf.reagent-slim-scu/probe-frame
-            flush!       (:flush-render! reagent-slim-adapter/adapter)
+            flush!       (:flush-render! rf.adapter.reagent-slim/adapter)
             render-count (atom 0)
             update-count (atom 0)
             ;; The child's ONLY input is the arg its parent passes down — it

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_dom_cljs_test.cljs
@@ -27,13 +27,13 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_dom_elision_prod_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_dom_elision_prod_test.cljs
@@ -29,12 +29,12 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter}))
 
 (defn- root-attr
   "Pull the :data-rf2-source-coord value from the root attrs map of a

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_form3_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_form3_cljs_test.cljs
@@ -29,18 +29,18 @@
             [clojure.string :as str]
             [goog.object :as gobj]
             [re-frame.core :as rf]
-            [re-frame.views.source-coord-annotation :as source-coord]
+            [re-frame.views.source-coord-annotation :as rf.views.source-coord-annotation]
             [reagent2.core :as r2]
             ;; ns-load wires the hiccup -> React-element `as-element` seam that
             ;; the class's `render` method delegates through (lifecycle test).
             [reagent2.impl.template]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter}))
 
 ;; ---- helper: capture console.warn calls -----------------------------------
 
@@ -69,7 +69,7 @@
             identity was lost."
     (let [slim-class (r2/create-class {:reagent-render (fn [] [:div "form-3 body"])
                                        :display-name   "SlimForm3"})
-          out        (source-coord/inject-source-coord-attr
+          out        (rf.views.source-coord-annotation/inject-source-coord-attr
                        :rf.slim-src-coord/form-3
                        "rf.slim-src-coord:form-3:1:1"
                        slim-class)]
@@ -93,7 +93,7 @@
             shapes are classified Form-3."
     (let [stock-shape (fn stock-form-3 [])]
       (set! (.-prototype stock-shape) #js {:reagentRender (fn [])})
-      (let [out (source-coord/inject-source-coord-attr
+      (let [out (rf.views.source-coord-annotation/inject-source-coord-attr
                   :rf.slim-src-coord/stock-shape
                   "rf.slim-src-coord:stock-shape:1:1"
                   stock-shape)]
@@ -126,7 +126,7 @@
           warnings   (with-captured-console-warn
                        (fn []
                          (dotimes [_ 5]
-                           (source-coord/inject-source-coord-attr
+                           (rf.views.source-coord-annotation/inject-source-coord-attr
                              :rf.slim-src-coord/warn-once-f3
                              "rf.slim-src-coord:warn-once-f3:1:1"
                              slim-class))))]
@@ -148,7 +148,7 @@
                        {:reagent-render      (fn [] [:p "lifecycle-intact"])
                         :component-did-mount (fn [_this] (reset! mounted? true))
                         :display-name        "SlimForm3Lifecycle"})
-          out        (source-coord/inject-source-coord-attr
+          out        (rf.views.source-coord-annotation/inject-source-coord-attr
                        :rf.slim-src-coord/lifecycle-f3
                        "rf.slim-src-coord:lifecycle-f3:1:1"
                        slim-class)

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_warn_once_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_warn_once_cljs_test.cljs
@@ -27,13 +27,13 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter}))
 
 ;; ---- helper: capture console.warn calls ----------------------------------
 

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_strict_mode_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_strict_mode_dom_cljs_test.cljs
@@ -104,8 +104,8 @@
             [reagent2.core :as r]
             ["react" :as React]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 ;; MAP-FORM fixture (`:async? true`): cljs.test requires `:each` fixtures to be
@@ -119,8 +119,8 @@
 ;; React-context tier — an ambient :rf/default scope would shadow that tier and
 ;; read the wrong (empty) app-db. Mirrors the flush-render / sCU-gate DOM twins.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter
      :async? true
      :ambient-frame nil}))
 
@@ -172,7 +172,7 @@
     (is true ":node-test: no DOM — :browser-test runner exercises the assertions")
     (async done
       (let [frame-kw     :rf.reagent-slim-strict/probe-frame
-            flush!       (:flush-render! reagent-slim-adapter/adapter)
+            flush!       (:flush-render! rf.adapter.reagent-slim/adapter)
             ;; A plain reagent2 RAtom the probe view ALSO derefs. The render
             ;; Reaction wires a watch onto it via the SAME deref-capture edge it
             ;; uses for the subscription, so its `.-watches` count is a

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_synthetic_event_frame_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_synthetic_event_frame_dom_cljs_test.cljs
@@ -41,8 +41,8 @@
             [reagent2.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -55,8 +55,8 @@
 ;; never runs under an ambient binding. `:async? true` because the working
 ;; half awaits the async dispatch drain.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter :async? true :ambient-frame nil}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter :async? true :ambient-frame nil}))
 
 ;; ---- browser gate ----------------------------------------------------------
 
@@ -164,7 +164,7 @@
                 ;; Causal settle: poll the frame's app-db until the async
                 ;; router drain lands the increment — no fixed sleep.
                 (.click captured)
-                (-> (test-support/poll-until
+                (-> (rf.test-support/poll-until
                       #(= 1 (:n (rf/app-db-value target)))
                       {:label      "reagent-slim injected dispatch advances the render frame to {:n 1}"
                        :timeout-ms 1000})

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_view_id_attr_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_view_id_attr_cljs_test.cljs
@@ -25,13 +25,13 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/server_subscribe_ssr_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/server_subscribe_ssr_cljs_test.cljs
@@ -55,8 +55,8 @@
   `npm run test:cljs`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]
             [reagent2.dom.server :as server])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -65,8 +65,8 @@
 ;; rolling back user registrations on the way out (the same fixture the
 ;; other reg-view-driven slim adapter tests use).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter}))
 
 ;; ---- the counter dataflow, mirroring examples/substrates/reagent_slim ---------------
 ;;

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/diag_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/diag_cljs_test.cljs
@@ -39,7 +39,7 @@
   (:require [clojure.string :as str]
             [cljs.test :refer-macros [deftest is testing]]
             [reagent2.impl.diag :as diag]
-            [re-frame.error :as error]))
+            [re-frame.error :as rf.error]))
 
 ;; ---- per-branch shape coverage --------------------------------------------
 
@@ -170,11 +170,11 @@
   (testing "the slim mirror agrees with re-frame.error/diag-value-summary
             byte-for-byte over the corpus (drift guard for the hand-copy)"
     (doseq [v parity-corpus]
-      (is (= (error/diag-value-summary v) (diag/value-summary v))
+      (is (= (rf.error/diag-value-summary v) (diag/value-summary v))
           (str "mirror drift for value: " (pr-str v))))))
 
 (deftest value-summary-mirrors-on-fn-and-lambda
   (testing "a fn value summarises to the SAME bare {:type :fn} on both twins"
     (let [f (fn [] :x)]
-      (is (= (error/diag-value-summary f) (diag/value-summary f)))
+      (is (= (rf.error/diag-value-summary f) (diag/value-summary f)))
       (is (= {:type :fn} (diag/value-summary f))))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_keyword_prop_warn_once_clear_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_keyword_prop_warn_once_clear_cljs_test.cljs
@@ -29,7 +29,7 @@
             ;; `spine/install-clear-warn-once-step!` registration that wires
             ;; template/clear-warned-keyword-prop! into the chained hook.
             [re-frame.adapter.reagent-slim]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             [reagent2.impl.template :as template]))
 
 (defn- with-warn-spy
@@ -68,7 +68,7 @@
       (is (= 1 (count phase-1))
           (str "phase-1 sanity: warn fires exactly once within a phase; got "
                (count phase-1) ": " (pr-str phase-1)))
-      (let [chained-hook (late-bind/get-fn :adapter/clear-warn-once-caches!)]
+      (let [chained-hook (rf.late-bind/get-fn :adapter/clear-warn-once-caches!)]
         (is (some? chained-hook)
             "precondition: the chained :adapter/clear-warn-once-caches! hook is registered")
         (chained-hook)

--- a/implementation/adapters/reagent-slim/testbed/adapter_testbed_reagent_slim/core.cljs
+++ b/implementation/adapters/reagent-slim/testbed/adapter_testbed_reagent_slim/core.cljs
@@ -29,7 +29,7 @@
    grep, and the Xray feature gate."
   (:require [re-frame.core                 :as rf]
             [re-frame.views]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- Events / subs ----------------------------------------------------------
@@ -73,7 +73,7 @@
 ;; The adapter-owned client root (rf2-k5r9t) — the same trio the stock
 ;; Reagent adapter publishes, from the same shared spine, so the slim smoke
 ;; mounts exactly the way the stock one does.
-(defonce app-root (reagent-slim-adapter/client-root))
+(defonce app-root (rf.adapter.reagent-slim/client-root))
 
 (defn ^:export init []
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
@@ -81,10 +81,10 @@
   ;; explicitly here (init! installs only the slim adapter). The boot
   ;; dispatch runs under the frame scope and the render is wrapped in a
   ;; `frame-provider` so in-tree dispatch/subscribe resolve to it.
-  (rf/init! reagent-slim-adapter/adapter)
+  (rf/init! rf.adapter.reagent-slim/adapter)
   (rf/make-frame {:id :rf/default})
   (rf/with-frame :rf/default
     (rf/dispatch-sync [:counter/init]))
-  (reagent-slim-adapter/render! app-root
+  (rf.adapter.reagent-slim/render! app-root
     [rf/frame-provider {:frame :rf/default} [root]]
     (js/document.getElementById "app")))

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -4,8 +4,8 @@
   (:require [reagent.core :as r]
             [reagent.ratom :as ratom]
             [reagent.dom.client :as rdc]
-            [re-frame.substrate.spine :as spine]
-            [re-frame.views :as views]))
+            [re-frame.substrate.spine :as rf.substrate.spine]
+            [re-frame.views :as rf.views]))
 
 ;; ---- exactly-once Reaction disposal (rf2-rzeko) ---------------------------
 ;;
@@ -86,7 +86,7 @@
 ;; that dependency direction keeps stock Reagent out of slim bundles.
 
 (def ^:private spine-fns
-  (spine/make-ratom-spine
+  (rf.substrate.spine/make-ratom-spine
     {;; Keep generated watch ids attributable in mixed-adapter test bundles.
      :gensym-prefix-sub "rf-reagent-sub-"
      ;; Each op is a thin call-through lambda rather than the bare Var
@@ -192,13 +192,13 @@
   `make-ratom-spine` and `make-ratom-adapter` own the logic shared with
   reagent-slim. The Reagent-shaped frame-provider remains injected from
   `re-frame.views`, keeping the spine independent of that component layer."
-  (spine/make-ratom-adapter
+  (rf.substrate.spine/make-ratom-adapter
     spine-fns
     {:kind :rf.adapter/reagent
      ;; The returned component receives the frame keyword at render time.
-     :register-context-provider (fn [_frame-keyword] (views/build-frame-provider))
+     :register-context-provider (fn [_frame-keyword] (rf.views/build-frame-provider))
      ;; The spine handles re-frame-owned disposal before these substrate ops.
-     :current-frame     views/current-frame
+     :current-frame     rf.views/current-frame
      :current-component r/current-component
      :atom              r/atom
      :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))

--- a/implementation/adapters/reagent/test/re_frame/adapter_after_render_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_after_render_cljs_test.cljs
@@ -42,10 +42,10 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
-            [re-frame.interop :as interop]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; The `:adapter/after-render` hook is routed: `interop/after-render`
 ;; runs Reagent's `r/after-render` ONLY when the Reagent adapter is the
@@ -60,8 +60,8 @@
 ;; queue / pending fake-raf (`r/flush`) so an enqueued callback can't leak
 ;; into a later test ns sharing the bundle.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter :ambient-frame nil})
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter :ambient-frame nil})
   (fn [test-fn] (try (test-fn) (finally (r/flush)))))
 
 ;; ---- (1) the hook is reachable through interop under the Reagent adapter ---
@@ -75,7 +75,7 @@
       ;; The return value is Reagent-internal (stock r/after-render arms a
       ;; deferred drain and hands back its scheduler token); we assert the
       ;; DEFERRAL contract, not the token shape.
-      (interop/after-render (fn [] (swap! fired inc)))
+      (rf.interop/after-render (fn [] (swap! fired inc)))
       (is (zero? @fired)
           "after-render defers — the callback does not fire synchronously
            during the enqueue call"))))
@@ -87,14 +87,14 @@
             adapter FIRES when Reagent's render queue drains; (r/flush)
             forces that drain synchronously"
     (let [fired (atom 0)]
-      (interop/after-render (fn [] (swap! fired inc)))
+      (rf.interop/after-render (fn [] (swap! fired inc)))
       (is (zero? @fired) "not fired before the drain")
       (r/flush)
       (is (= 1 @fired)
           "callback fired exactly once after the render queue drained")
       ;; The queue is re-armed per drain (not a one-shot): a second
       ;; enqueue + drain fires again, and does NOT re-fire the first.
-      (interop/after-render (fn [] (swap! fired inc)))
+      (rf.interop/after-render (fn [] (swap! fired inc)))
       (r/flush)
       (is (= 2 @fired)
           "a subsequent after-render callback also fires on the next drain")
@@ -110,9 +110,9 @@
   (testing "multiple callbacks enqueued before a single drain all fire,
             in enqueue order (Reagent's afterRender queue is FIFO)"
     (let [order (atom [])]
-      (interop/after-render (fn [] (swap! order conj :first)))
-      (interop/after-render (fn [] (swap! order conj :second)))
-      (interop/after-render (fn [] (swap! order conj :third)))
+      (rf.interop/after-render (fn [] (swap! order conj :first)))
+      (rf.interop/after-render (fn [] (swap! order conj :second)))
+      (rf.interop/after-render (fn [] (swap! order conj :third)))
       (is (= [] @order) "none fire before the drain")
       (r/flush)
       (is (= [:first :second :third] @order)
@@ -130,17 +130,17 @@
 (deftest copied-adapter-map-routes-to-live-after-render-hook
   (testing "a copied stock-Reagent adapter map still drives the live
             :adapter/after-render hook (rf2-dkl5z1)"
-    (let [original (substrate-adapter/current-adapter-spec)
-          copied   (assoc reagent-adapter/adapter :rf.test/instrumentation-wrapper true)
+    (let [original (rf.substrate.adapter/current-adapter-spec)
+          copied   (assoc rf.adapter.reagent/adapter :rf.test/instrumentation-wrapper true)
           fired    (atom 0)]
-      (substrate-adapter/dispose-adapter!)
-      (substrate-adapter/install-adapter! copied)
+      (rf.substrate.adapter/dispose-adapter!)
+      (rf.substrate.adapter/install-adapter! copied)
       (try
-        (is (false? (identical? reagent-adapter/adapter (substrate-adapter/current-adapter-spec)))
+        (is (false? (identical? rf.adapter.reagent/adapter (rf.substrate.adapter/current-adapter-spec)))
             "precondition: the installed copy is NOT identical to the routed canonical map")
-        (is (= :rf.adapter/reagent (substrate-adapter/current-adapter))
+        (is (= :rf.adapter/reagent (rf.substrate.adapter/current-adapter))
             "precondition: the copy preserves the canonical :kind token")
-        (interop/after-render (fn [] (swap! fired inc)))
+        (rf.interop/after-render (fn [] (swap! fired inc)))
         (is (zero? @fired) "after-render still DEFERS under the copied map")
         (r/flush)
         (is (= 1 @fired)
@@ -150,5 +150,5 @@
                  " identity (rf2-dkl5z1)"))
         (finally
           (r/flush)
-          (substrate-adapter/dispose-adapter!)
-          (substrate-adapter/install-adapter! original))))))
+          (rf.substrate.adapter/dispose-adapter!)
+          (rf.substrate.adapter/install-adapter! original))))))

--- a/implementation/adapters/reagent/test/re_frame/adapter_client_root_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_client_root_cljs_test.cljs
@@ -24,29 +24,29 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.dom.client :as rdc]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; Cold-start fixture (mirrors the slim dispose-drain pins): the unit under
 ;; test spans render, unmount and the adapter drain, so install the adapter
 ;; here and wipe frames so the drain's sub-cache walk sees an empty registry.
 (defn- fresh-reagent [test-fn]
-  (reset! frame/frames {})
+  (reset! rf.frame/frames {})
   ;; The adapter's active-root set is a namespace-level singleton, and
   ;; earlier suites in the shared bundle strand fake Roots in it (the
   ;; one-shot `:render` pins never unmount theirs). Drain them first, with
   ;; the host unmount stubbed so a stale fake Root goes quietly, so every
   ;; count below is this test's own.
   (with-redefs [rdc/unmount (fn [_] nil)]
-    (adapter/reset-lifecycle-state-for-tests!)
-    (adapter/install-adapter! reagent-adapter/adapter)
-    (adapter/dispose-adapter!))
-  (adapter/reset-lifecycle-state-for-tests!)
-  (adapter/install-adapter! reagent-adapter/adapter)
+    (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
+    (rf.substrate.adapter/install-adapter! rf.adapter.reagent/adapter)
+    (rf.substrate.adapter/dispose-adapter!))
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
+  (rf.substrate.adapter/install-adapter! rf.adapter.reagent/adapter)
   (test-fn)
-  (reset! frame/frames {})
-  (adapter/reset-lifecycle-state-for-tests!))
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!))
 
 (use-fixtures :each fresh-reagent)
 
@@ -81,7 +81,7 @@
 
 (deftest client-root-does-no-dom-work
   (testing "allocating a handle touches none of the Root API"
-    (let [calls (spy-rdc! [] (fn [] (reagent-adapter/client-root)))]
+    (let [calls (spy-rdc! [] (fn [] (rf.adapter.reagent/client-root)))]
       (is (empty? calls) "client-root is inert: no create/hydrate/render/unmount"))))
 
 ;; ---- 2. cold first render, later renders update the same Root -------------
@@ -93,10 +93,10 @@
           mount #js {:rf-test-mount :cold}
           calls (spy-rdc! [root (fake-root :never)]
                   (fn []
-                    (let [h (reagent-adapter/client-root)]
-                      (reagent-adapter/render! h [:div "v1"] mount)
-                      (reagent-adapter/render! h [:div "v2"] mount)
-                      (reagent-adapter/render! h [:div "v3"] mount))))]
+                    (let [h (rf.adapter.reagent/client-root)]
+                      (rf.adapter.reagent/render! h [:div "v1"] mount)
+                      (rf.adapter.reagent/render! h [:div "v2"] mount)
+                      (rf.adapter.reagent/render! h [:div "v3"] mount))))]
       (is (= [[:create-root mount]] (of-kind calls :create-root))
           "create-root called exactly once, with the mount point")
       (is (empty? (of-kind calls :hydrate-root))
@@ -120,10 +120,10 @@
           mount #js {:rf-test-mount :hydrated}
           calls (spy-rdc! [root (fake-root :never)]
                   (fn []
-                    (let [h (reagent-adapter/client-root)]
-                      (reagent-adapter/render! h [:div "ssr"] mount {:hydrate? true})
-                      (reagent-adapter/render! h [:div "v2"] mount {:hydrate? true})
-                      (reagent-adapter/render! h [:div "v3"] mount))))]
+                    (let [h (rf.adapter.reagent/client-root)]
+                      (rf.adapter.reagent/render! h [:div "ssr"] mount {:hydrate? true})
+                      (rf.adapter.reagent/render! h [:div "v2"] mount {:hydrate? true})
+                      (rf.adapter.reagent/render! h [:div "v3"] mount))))]
       (is (= [[:hydrate-root mount [:div "ssr"]]] (of-kind calls :hydrate-root))
           "hydrate-root called exactly once, with the mount point and the first tree")
       (is (empty? (of-kind calls :create-root))
@@ -143,11 +143,11 @@
           mount  #js {:rf-test-mount :again}
           calls  (spy-rdc! [root-1 root-2]
                    (fn []
-                     (let [h (reagent-adapter/client-root)]
-                       (reagent-adapter/render! h [:div "v1"] mount)
-                       (reagent-adapter/unmount! h)
-                       (reagent-adapter/unmount! h)
-                       (reagent-adapter/render! h [:div "v2"] mount))))]
+                     (let [h (rf.adapter.reagent/client-root)]
+                       (rf.adapter.reagent/render! h [:div "v1"] mount)
+                       (rf.adapter.reagent/unmount! h)
+                       (rf.adapter.reagent/unmount! h)
+                       (rf.adapter.reagent/render! h [:div "v2"] mount))))]
       (is (= [[:unmount root-1]] (of-kind calls :unmount))
           "the underlying unmount is reached exactly once for the first Root")
       (is (= [[:create-root mount] [:create-root mount]] (of-kind calls :create-root))
@@ -166,15 +166,15 @@
           root-gone (fake-root :gone)
           calls     (spy-rdc! [root-live root-gone]
                       (fn []
-                        (let [live (reagent-adapter/client-root)
-                              gone (reagent-adapter/client-root)]
-                          (reagent-adapter/render! live [:div "live"] #js {})
-                          (reagent-adapter/render! gone [:div "gone"] #js {})
-                          (reagent-adapter/unmount! gone)
-                          (adapter/dispose-adapter!)
+                        (let [live (rf.adapter.reagent/client-root)
+                              gone (rf.adapter.reagent/client-root)]
+                          (rf.adapter.reagent/render! live [:div "live"] #js {})
+                          (rf.adapter.reagent/render! gone [:div "gone"] #js {})
+                          (rf.adapter.reagent/unmount! gone)
+                          (rf.substrate.adapter/dispose-adapter!)
                           ;; Post-drain: both handles are already released.
-                          (reagent-adapter/unmount! live)
-                          (reagent-adapter/unmount! gone))))]
+                          (rf.adapter.reagent/unmount! live)
+                          (rf.adapter.reagent/unmount! gone))))]
       (is (= 1 (count (filter #(identical? root-live (second %)) (of-kind calls :unmount))))
           "the still-live handle's Root was released exactly once (by the drain)")
       (is (= 1 (count (filter #(identical? root-gone (second %)) (of-kind calls :unmount))))

--- a/implementation/adapters/reagent/test/re_frame/adapter_client_root_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_client_root_dom_cljs_test.cljs
@@ -23,15 +23,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; Async tests need the map-form fixture. No frame is involved — the trees
 ;; below are plain hiccup — so `:ambient-frame nil`.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter :async? true :ambient-frame nil}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter :async? true :ambient-frame nil}))
 
 (defn- browser? []
   (and (exists? js/document)
@@ -88,23 +88,23 @@
     (if-not (browser?)
       (is true ":node-test: no DOM — the :browser-test build runs the assertions")
       (let [el (host! nil)
-            h  (reagent-adapter/client-root)]
+            h  (rf.adapter.reagent/client-root)]
         (with-counting-rdc!
           (fn [counts]
             ;; Wrap in flushSync so the React 19 render commits before we read
             ;; the DOM (mirrors the adapter flush-render DOM proof's mount).
-            (react-dom/flushSync (fn [] (reagent-adapter/render! h (tree "v1") el)))
+            (react-dom/flushSync (fn [] (rf.adapter.reagent/render! h (tree "v1") el)))
             (is (= "v1" (some-> (probe el) .-textContent)) "first render committed v1")
-            (react-dom/flushSync (fn [] (reagent-adapter/render! h (tree "v2") el)))
+            (react-dom/flushSync (fn [] (rf.adapter.reagent/render! h (tree "v2") el)))
             (is (= "v2" (some-> (probe el) .-textContent)) "second render committed v2")
             (is (= 1 (.-length (.-children el)))
                 "one tree owns the container — the second render replaced, not appended")
             (is (= 1 (:create-root @counts))
                 "create-root was called exactly once across the two renders")
             (is (= 0 (:hydrate-root @counts)) "a cold mount never hydrates")
-            (react-dom/flushSync (fn [] (reagent-adapter/unmount! h)))
+            (react-dom/flushSync (fn [] (rf.adapter.reagent/unmount! h)))
             (is (nil? (probe el)) "unmount! removed the tree")
-            (react-dom/flushSync (fn [] (reagent-adapter/unmount! h)))
+            (react-dom/flushSync (fn [] (rf.adapter.reagent/unmount! h)))
             (is (= 1 (:unmount @counts)) "the second unmount! reached React no second time")))
         (drop-host! el)))))
 
@@ -118,14 +118,14 @@
       (is true ":node-test: no DOM — the :browser-test build runs the assertions")
       (async done
         (let [el         (host! "<div><p data-testid=\"rf-client-root-probe\">v1</p></div>")
-              h          (reagent-adapter/client-root)
+              h          (rf.adapter.reagent/client-root)
               server-p   (probe el)
               counts     (atom nil)]
           (is (some? server-p) "the server node is planted before hydration")
           (reset! counts
                   (with-counting-rdc!
                     (fn [_]
-                      (reagent-adapter/render! h (tree "v1") el {:hydrate? true}))))
+                      (rf.adapter.reagent/render! h (tree "v1") el {:hydrate? true}))))
           ;; Hydration commits on React's schedule — observe after a yield.
           ;; The body is bracketed so a throw still reaches `done`: an
           ;; uncaught error in an async row stalls the WHOLE browser lane
@@ -141,7 +141,7 @@
                       (with-counting-rdc!
                         (fn [_]
                           (react-dom/flushSync
-                            (fn [] (reagent-adapter/render! h (tree "v2") el {:hydrate? true}))))))
+                            (fn [] (rf.adapter.reagent/render! h (tree "v2") el {:hydrate? true}))))))
               (is (= "v2" (some-> (probe el) .-textContent))
                   "the later render committed the new tree through the hydrated Root")
               (is (= 0 (:hydrate-root @counts)) "no second hydration")
@@ -149,7 +149,7 @@
               (catch :default e
                 (is false (str "hydrating render threw: " (pr-str e))))
               (finally
-                (try (react-dom/flushSync (fn [] (reagent-adapter/unmount! h)))
+                (try (react-dom/flushSync (fn [] (rf.adapter.reagent/unmount! h)))
                      (catch :default _ nil))
                 (drop-host! el)
                 (done))))
@@ -165,25 +165,25 @@
       (is true ":node-test: no DOM — the :browser-test build runs the assertions")
       (let [el-live (host! nil)
             el-gone (host! nil)
-            live    (reagent-adapter/client-root)
-            gone    (reagent-adapter/client-root)]
+            live    (rf.adapter.reagent/client-root)
+            gone    (rf.adapter.reagent/client-root)]
         ;; Drain Roots earlier suites in the browser bundle may have stranded
         ;; in the adapter's singleton active set, so the unmount counts below
         ;; are this test's own.
-        (adapter/dispose-adapter!)
-        (adapter/install-adapter! reagent-adapter/adapter)
+        (rf.substrate.adapter/dispose-adapter!)
+        (rf.substrate.adapter/install-adapter! rf.adapter.reagent/adapter)
         (with-counting-rdc!
           (fn [counts]
-            (react-dom/flushSync (fn [] (reagent-adapter/render! live (tree "live") el-live)))
-            (react-dom/flushSync (fn [] (reagent-adapter/render! gone (tree "gone") el-gone)))
-            (react-dom/flushSync (fn [] (reagent-adapter/unmount! gone)))
+            (react-dom/flushSync (fn [] (rf.adapter.reagent/render! live (tree "live") el-live)))
+            (react-dom/flushSync (fn [] (rf.adapter.reagent/render! gone (tree "gone") el-gone)))
+            (react-dom/flushSync (fn [] (rf.adapter.reagent/unmount! gone)))
             (is (= 1 (:unmount @counts)) "explicit unmount! released the second handle once")
-            (react-dom/flushSync (fn [] (adapter/dispose-adapter!)))
+            (react-dom/flushSync (fn [] (rf.substrate.adapter/dispose-adapter!)))
             (is (= 2 (:unmount @counts))
                 "the drain released the still-live handle once and the unmounted one not again")
             (is (nil? (probe el-live)) "the still-live tree is gone from the DOM")
-            (react-dom/flushSync (fn [] (reagent-adapter/unmount! live)))
-            (react-dom/flushSync (fn [] (reagent-adapter/unmount! gone)))
+            (react-dom/flushSync (fn [] (rf.adapter.reagent/unmount! live)))
+            (react-dom/flushSync (fn [] (rf.adapter.reagent/unmount! gone)))
             (is (= 2 (:unmount @counts)) "later unmount! calls reach React no further time")))
         (drop-host! el-live)
         (drop-host! el-gone)))))

--- a/implementation/adapters/reagent/test/re_frame/adapter_current_component_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_current_component_cljs_test.cljs
@@ -33,7 +33,7 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [reagent.core :as r]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             ;; ns-load registers the :adapter/current-component hook.
             [re-frame.adapter.reagent]))
 
@@ -43,21 +43,21 @@
   binding even when the slim ns-load registered a different reader after
   the bridge ns loaded."
   [f]
-  (let [original (late-bind/get-fn :adapter/current-component)]
+  (let [original (rf.late-bind/get-fn :adapter/current-component)]
     (try
-      (late-bind/set-fn! :adapter/current-component r/current-component)
+      (rf.late-bind/set-fn! :adapter/current-component r/current-component)
       (f)
       (finally
-        (late-bind/set-fn! :adapter/current-component original)))))
+        (rf.late-bind/set-fn! :adapter/current-component original)))))
 
 (deftest classic-bridge-installs-hook
   (testing "requiring re-frame.adapter.reagent registers :adapter/current-component"
     (with-bridge-hook
       (fn []
-        (is (some? (late-bind/get-fn :adapter/current-component))
+        (is (some? (rf.late-bind/get-fn :adapter/current-component))
             "the hook is installed")
         (is (identical? r/current-component
-                        (late-bind/get-fn :adapter/current-component))
+                        (rf.late-bind/get-fn :adapter/current-component))
             "the hook points at stock reagent.core/current-component")))))
 
 (deftest hook-returns-nil-outside-render
@@ -67,6 +67,6 @@
     ;; skip the React-context tier and fall through to :rf/default.
     (with-bridge-hook
       (fn []
-        (let [hook (late-bind/get-fn :adapter/current-component)]
+        (let [hook (rf.late-bind/get-fn :adapter/current-component)]
           (is (nil? (hook))
               "no in-flight component → nil"))))))

--- a/implementation/adapters/reagent/test/re_frame/adapter_flush_render_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_flush_render_dom_cljs_test.cljs
@@ -29,8 +29,8 @@
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 ;; EP-0002 (rf2-9o48ih): `:ambient-frame nil` opts out of the fixture's default
@@ -41,8 +41,8 @@
 ;; :rf/default scope would shadow the React-context tier at tier 1 and the
 ;; subscribe would read :rf/default's (empty) app-db instead of the provider's.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :ambient-frame nil}))
 
 (defn- browser? []
@@ -58,7 +58,7 @@
     (if-not (browser?)
       (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
       (let [frame-kw :rf.reagent-flush-render/probe-frame
-            flush!   (:flush-render! reagent-adapter/adapter)]
+            flush!   (:flush-render! rf.adapter.reagent/adapter)]
         (is (fn? flush!)
             "the Reagent adapter map exposes :flush-render! (rf2-40a84 contract slot)")
         (rf/make-frame {:id frame-kw :doc "flush-render! synchronous-commit probe frame"})

--- a/implementation/adapters/reagent/test/re_frame/adapter_flush_views_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_flush_views_cljs_test.cljs
@@ -20,14 +20,14 @@
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 (deftest flush-views-canonical-shape
   (testing "Reagent — flush-views! surfaced from the adapter ns with the
             canonical nil-return shape (rf2-b6nm5 / Decision 6)"
-    (is (fn? reagent-adapter/flush-views!)
+    (is (fn? rf.adapter.reagent/flush-views!)
         "the Reagent adapter ns exposes flush-views! as a fn (previously absent)")
-    (is (nil? (reagent-adapter/flush-views!))
+    (is (nil? (rf.adapter.reagent/flush-views!))
         "0-arity flush-views! returns nil — the converged contract across all four substrates")
-    (is (nil? (reagent-adapter/flush-views! (fn [] nil)))
+    (is (nil? (rf.adapter.reagent/flush-views! (fn [] nil)))
         "1-arity flush-views! also returns nil")))

--- a/implementation/adapters/reagent/test/re_frame/adapter_make_derived_value_arity_spec_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_make_derived_value_arity_spec_cljs_test.cljs
@@ -17,16 +17,16 @@
     * mid-render mutation of a source produces a new derived value
       on next deref (no caching at the substrate layer)"
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.adapter.reagent :as adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 (defn- make-source [v]
-  ((:make-state-container adapter/adapter) v))
+  ((:make-state-container rf.adapter.reagent/adapter) v))
 
 (defn- write! [c v]
-  ((:replace-container! adapter/adapter) c v))
+  ((:replace-container! rf.adapter.reagent/adapter) c v))
 
 (defn- derive [sources f]
-  ((:make-derived-value adapter/adapter) sources f))
+  ((:make-derived-value rf.adapter.reagent/adapter) sources f))
 
 (deftest derived-zero-arity-cljs-test
   (testing "0 sources — compute-fn called with no args"

--- a/implementation/adapters/reagent/test/re_frame/adapter_reaction_dispose_exactly_once_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_reaction_dispose_exactly_once_cljs_test.cljs
@@ -34,10 +34,10 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ---- fixture --------------------------------------------------------------
 ;;
@@ -47,15 +47,15 @@
 ;; up so a re-run is idempotent.
 
 (defn- cold-start-fixture [test-fn]
-  (adapter/reset-lifecycle-state-for-tests!)
-  (reset! frame/frames {})
-  (rf/init! reagent-adapter/adapter)
-  (frame/ensure-default-frame!)
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
+  (reset! rf.frame/frames {})
+  (rf/init! rf.adapter.reagent/adapter)
+  (rf.frame/ensure-default-frame!)
   (test-fn)
-  (when (adapter/current-adapter)
-    (adapter/dispose-adapter!))
-  (reset! frame/frames {})
-  (adapter/reset-lifecycle-state-for-tests!))
+  (when (rf.substrate.adapter/current-adapter)
+    (rf.substrate.adapter/dispose-adapter!))
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!))
 
 (use-fixtures :each cold-start-fixture)
 
@@ -66,8 +66,8 @@
   map's own contract slots. `compute-count` observes recomputes so tests
   can assert the source wire is released by disposal."
   [initial compute-count]
-  (let [make-container (:make-state-container reagent-adapter/adapter)
-        make-derived   (:make-derived-value reagent-adapter/adapter)
+  (let [make-container (:make-state-container rf.adapter.reagent/adapter)
+        make-derived   (:make-derived-value rf.adapter.reagent/adapter)
         src            (make-container initial)
         rx             (make-derived [src] (fn [v]
                                              (swap! compute-count inc)
@@ -77,7 +77,7 @@
 (defn- cached-reaction
   "The `:reaction` cached for `frame-id`'s single sub-cache entry."
   [frame-id]
-  (let [cache (:sub-cache (frame/frame frame-id))]
+  (let [cache (:sub-cache (rf.frame/frame frame-id))]
     (some (fn [[_k entry]] (:reaction entry)) @cache)))
 
 ;; ---- 1. double dispose --------------------------------------------------
@@ -89,12 +89,12 @@
           {:keys [rx]}  (make-source-and-derived 1 compute-count)
           fired         (atom [])]
       (is (= 2 @rx) "precondition: the derived value computes")
-      (interop/add-on-dispose! rx (fn [_] (swap! fired conj :cb-1)))
-      (interop/add-on-dispose! rx (fn [_] (swap! fired conj :cb-2)))
-      (interop/dispose! rx)
+      (rf.interop/add-on-dispose! rx (fn [_] (swap! fired conj :cb-1)))
+      (rf.interop/add-on-dispose! rx (fn [_] (swap! fired conj :cb-2)))
+      (rf.interop/dispose! rx)
       (is (= [:cb-1 :cb-2] @fired)
           "first dispose! fired both callbacks, in registration order")
-      (interop/dispose! rx)
+      (rf.interop/dispose! rx)
       (is (= [:cb-1 :cb-2] @fired)
           "second dispose! re-fired nothing (exactly-once)"))))
 
@@ -110,14 +110,14 @@
       (is (= 2 @rx) "precondition: the derived value computes")
       ;; Conditional re-entry (first invocation only) so that WITHOUT the
       ;; guard this proof goes red by count rather than by stack overflow.
-      (interop/add-on-dispose! rx
+      (rf.interop/add-on-dispose! rx
         (fn [r]
           (swap! fired conj :re-entrant-cb)
           (when-not @re-entered?
             (reset! re-entered? true)
-            (interop/dispose! r))))
-      (interop/add-on-dispose! rx (fn [_] (swap! fired conj :after-cb)))
-      (interop/dispose! rx)
+            (rf.interop/dispose! r))))
+      (rf.interop/add-on-dispose! rx (fn [_] (swap! fired conj :after-cb)))
+      (rf.interop/dispose! rx)
       (is (= [:re-entrant-cb :after-cb] @fired)
           "each callback fired exactly once despite the re-entrant dispose!"))))
 
@@ -136,11 +136,11 @@
           fired         (atom 0)]
       (is (= 2 @rx) "precondition: the derived value computes")
       ;; Put the Reaction on the push path so it holds a live source watch.
-      (interop/activate-derived-value! rx)
-      (interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
+      (rf.interop/activate-derived-value! rx)
+      (rf.interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
       (add-watch rx ::owner (fn [_ _ _ _] nil))
       (let [computes-before-dispose @compute-count]
-        (interop/dispose! rx)
+        (rf.interop/dispose! rx)
         (is (= 1 @fired) "explicit disposal fired the callback once")
         ;; One-shot path intact: the source wire is released, so a source
         ;; write no longer recomputes the disposed Reaction.
@@ -160,11 +160,11 @@
           {:keys [rx]}  (make-source-and-derived 1 compute-count)
           fired         (atom 0)]
       (is (= 2 @rx) "precondition: the derived value computes")
-      (interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
+      (rf.interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
       (add-watch rx ::owner (fn [_ _ _ _] nil))
       (remove-watch rx ::owner)
       (is (= 1 @fired) "stock auto-disposal fired the callback once")
-      (interop/dispose! rx)
+      (rf.interop/dispose! rx)
       (is (= 1 @fired)
           "explicit disposal after stock auto-disposal re-fired nothing"))))
 
@@ -188,10 +188,10 @@
           rx     (cached-reaction :once/a)
           fired  (atom 0)]
       (is (some? rx) "precondition: the sub-cache holds the Reaction")
-      (interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
+      (rf.interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
       ;; A mounted owner watches the cached Reaction across shutdown.
       (add-watch rx ::owner (fn [_ _ _ _] nil))
-      (adapter/dispose-adapter!)
+      (rf.substrate.adapter/dispose-adapter!)
       (is (= 1 @fired)
           "claimed-generation shutdown disposed the cached Reaction once")
       ;; The owner unmounts after shutdown: stock auto-disposal re-enters
@@ -212,7 +212,7 @@
           rx     (cached-reaction :once/b)
           fired  (atom 0)]
       (is (some? rx) "precondition: the sub-cache holds the Reaction")
-      (interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
+      (rf.interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
       (add-watch rx ::owner (fn [_ _ _ _] nil))
       ;; The owner unmounts first: stock auto-disposal fires the teardown,
       ;; whose sub-cache closure evicts the slot (pre-existing behaviour).
@@ -222,6 +222,6 @@
           "auto-disposal evicted the sub-cache slot (teardown preserved)")
       ;; Adapter shutdown then walks a cache that no longer holds it — and
       ;; even a direct second disposal of the same Reaction is a no-op.
-      (adapter/dispose-adapter!)
+      (rf.substrate.adapter/dispose-adapter!)
       (is (= 1 @fired)
           "adapter shutdown after unmount re-fired no teardown callback"))))

--- a/implementation/adapters/reagent/test/re_frame/adapter_render_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_render_cljs_test.cljs
@@ -26,7 +26,7 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [reagent.dom.client :as rdc]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -77,7 +77,7 @@
                     rdc/unmount       (fn [arg]
                                         (swap! calls conj [:unmount arg])
                                         nil)]
-        (let [render-fn (:render reagent-adapter/adapter)
+        (let [render-fn (:render rf.adapter.reagent/adapter)
               unmount   (render-fn fake-tree fake-mount nil)]
           (is (fn? unmount)
               "render returns an unmount thunk")
@@ -142,7 +142,7 @@
                     rdc/unmount      (fn [arg]
                                        (swap! calls conj [:unmount arg])
                                        nil)]
-        (let [render-fn (:render reagent-adapter/adapter)
+        (let [render-fn (:render rf.adapter.reagent/adapter)
               unmount   (render-fn fake-tree fake-mount {:hydrate? true})]
           (is (fn? unmount))
           (is (= 1 (count @calls))
@@ -181,7 +181,7 @@
                                        ([_ _]   fake-root)
                                        ([_ _ _] fake-root))
                     rdc/unmount      (fn [_] nil)]
-        (let [render-fn (:render reagent-adapter/adapter)]
+        (let [render-fn (:render rf.adapter.reagent/adapter)]
           (render-fn [:div] fake-mount nil)
           (is (= 1 (count @render-calls)))
           (let [[root tree] (first @render-calls)]

--- a/implementation/adapters/reagent/test/re_frame/adapter_render_to_string_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_render_to_string_cljs_test.cljs
@@ -25,7 +25,7 @@
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             ;; Loading `re-frame.ssr` here is the canonical wiring path
             ;; — its ns-load resolves the `:reagent/set-hiccup-emitter!`
             ;; hook and installs the emitter (Spec 011 + rf2-uo7v).
@@ -47,12 +47,12 @@
         ;; re-frame.ssr/render-to-string (re-exported from
         ;; re-frame.ssr.emit/render-to-string).
         ssr-emitter (resolve 're-frame.ssr/render-to-string)]
-    (reagent-adapter/set-hiccup-emitter! nil)
+    (rf.adapter.reagent/set-hiccup-emitter! nil)
     (try
       (f)
       (finally
         (when ssr-emitter
-          (reagent-adapter/set-hiccup-emitter! @ssr-emitter))))))
+          (rf.adapter.reagent/set-hiccup-emitter! @ssr-emitter))))))
 
 ;; ---- test (1) — pre-wire failure: ex-info shape ----------------------------
 
@@ -64,7 +64,7 @@
             tree)"
     (with-cleared-emitter
       (fn []
-        (let [render-fn (:render-to-string reagent-adapter/adapter)
+        (let [render-fn (:render-to-string rf.adapter.reagent/adapter)
               ;; The body carries a recognisable token; the EP-0015 fix
               ;; means it MUST NOT survive into the thrown diagnostic.
               tree      [:div "smoke-secret-xyzzy"]
@@ -101,7 +101,7 @@
   (testing "rf2-8k0g3: with re-frame.ssr loaded (the canonical wiring path
             via the :reagent/set-hiccup-emitter! late-bind hook), calling
             render-to-string returns a non-throwing HTML string"
-    (let [render-fn (:render-to-string reagent-adapter/adapter)
+    (let [render-fn (:render-to-string rf.adapter.reagent/adapter)
           html      (render-fn [:div "ok"] {})]
       (is (string? html)
           "render-to-string returns a string")

--- a/implementation/adapters/reagent/test/re_frame/adapter_unmount_idempotent_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_unmount_idempotent_cljs_test.cljs
@@ -17,29 +17,29 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.dom.client :as rdc]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; Cold-start fixture (mirrors the slim dispose-drain pins): the unit under
 ;; test is the render/unmount/dispose trio, so install the adapter here and
 ;; wipe frames so the drain's sub-cache walk sees an empty registry.
 (defn- fresh-reagent [test-fn]
-  (reset! frame/frames {})
+  (reset! rf.frame/frames {})
   ;; The adapter's active-root set is a namespace-level singleton, and
   ;; earlier suites in the shared bundle strand fake Roots in it (the
   ;; one-shot `:render` pins never unmount theirs). Drain them first, with
   ;; the host unmount stubbed so a stale fake Root goes quietly, so every
   ;; count below is this test's own.
   (with-redefs [rdc/unmount (fn [_] nil)]
-    (adapter/reset-lifecycle-state-for-tests!)
-    (adapter/install-adapter! reagent-adapter/adapter)
-    (adapter/dispose-adapter!))
-  (adapter/reset-lifecycle-state-for-tests!)
-  (adapter/install-adapter! reagent-adapter/adapter)
+    (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
+    (rf.substrate.adapter/install-adapter! rf.adapter.reagent/adapter)
+    (rf.substrate.adapter/dispose-adapter!))
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
+  (rf.substrate.adapter/install-adapter! rf.adapter.reagent/adapter)
   (test-fn)
-  (reset! frame/frames {})
-  (adapter/reset-lifecycle-state-for-tests!))
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!))
 
 (use-fixtures :each fresh-reagent)
 
@@ -55,7 +55,7 @@
                     rdc/render       (fn ([_ _] nil) ([_ _ _] nil) ([_ _ _ _] nil))
                     rdc/hydrate-root (fn ([_ _] root) ([_ _ _] root))
                     rdc/unmount      (fn [r] (swap! unmounts conj r) nil)]
-        (let [unmount ((:render reagent-adapter/adapter) [:div "x"] #js {} nil)]
+        (let [unmount ((:render rf.adapter.reagent/adapter) [:div "x"] #js {} nil)]
           (unmount)
           (is (= [root] @unmounts) "first call unmounts the Root")
           (unmount)
@@ -71,8 +71,8 @@
                     rdc/render       (fn ([_ _] nil) ([_ _ _] nil) ([_ _ _ _] nil))
                     rdc/hydrate-root (fn ([_ _] root) ([_ _ _] root))
                     rdc/unmount      (fn [r] (swap! unmounts conj r) nil)]
-        (let [unmount ((:render reagent-adapter/adapter) [:div "x"] #js {} nil)]
-          (adapter/dispose-adapter!)
+        (let [unmount ((:render rf.adapter.reagent/adapter) [:div "x"] #js {} nil)]
+          (rf.substrate.adapter/dispose-adapter!)
           (is (= [root] @unmounts) "the drain released the live root once")
           (unmount)
           (is (= [root] @unmounts)

--- a/implementation/adapters/reagent/test/re_frame/auto_inject_form2_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/auto_inject_form2_cljs_test.cljs
@@ -35,14 +35,14 @@
   feature)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- Form-1 baseline: dispatch / subscribe are auto-injected -------------
 

--- a/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
@@ -36,16 +36,16 @@
        :data."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             ;; The schemas Malli adapter publishes the registered validator
             ;; the `:where :machine-data` boundary routes through; boot.core
             ;; pulls it transitively (via boot.schema), require explicitly so
             ;; this ns is self-sufficient.
-            [re-frame.schemas :as schemas]
+            [re-frame.schemas :as rf.schemas]
             [re-frame.schemas.malli]
             [boot.schema :as boot-schema]
             [re-frame.views]
@@ -77,7 +77,7 @@
   (rf/reg-fx fx-id
     {:platforms #{:client :server}}
     (fn [frame-ctx args]
-      (let [stub  (registrar/handler :fx :rf.http/managed-canned-success)
+      (let [stub  (rf.registrar/handler :fx :rf.http/managed-canned-success)
             url   (-> args :request :url)
             value (url->value url)]
         (stub frame-ctx (assoc args :value value))))))
@@ -88,7 +88,7 @@
   (rf/reg-fx fx-id
     {:platforms #{:client :server}}
     (fn [frame-ctx args]
-      (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+      (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-failure)]
         (stub frame-ctx (assoc args :kind kind :tags tags))))))
 
 ;; ============================================================================
@@ -130,14 +130,14 @@
 ;; ============================================================================
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     ;; EP-0002 (rf2-9o48ih): each test spins its OWN top-level frame via
     ;; `make-frame` (inside `with-new-frame`); opt out of the ambient
     ;; `:rf/default` scope so the new frame's `:initial-events` drain
     ;; synchronously (top-level boot) rather than being treated as a
     ;; mid-cascade child-frame creation. In-body dispatches run inside the
     ;; `with-new-frame` scope, so they do not rely on the ambient frame.
-    {:adapter       reagent-adapter/adapter
+    {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil}))
 
 ;; ============================================================================
@@ -154,7 +154,7 @@
   (testing "happy path: boot machine traverses :configuring → :loading-deps → :hydrating → :ready and all slices land"
     (reg-canned-success-by-url! :boot.test/canned-boot-success payload-for)
 
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:boot/initialise]]
                           :fx-overrides {:rf.http/managed
                                          :boot.test/canned-boot-success}})]
@@ -183,7 +183,7 @@
   (testing "per-child :data fns thread spawn-spec identity; no cross-talk between siblings"
     (reg-canned-success-by-url! :boot.test/canned-boot-success payload-for)
 
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:boot/initialise]]
                           :fx-overrides {:rf.http/managed
                                          :boot.test/canned-boot-success}})]
@@ -213,7 +213,7 @@
                          {:status 500
                           :body   "boot dependency unreachable"})
 
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:boot/initialise]]
                           :fx-overrides {:rf.http/managed
                                          :boot.test/canned-boot-fail}})]
@@ -253,22 +253,22 @@
 
 (deftest boot-data-schema-attached
   (testing "the :app/boot machine carries BootData on its [:schemas :data] slot"
-    (let [meta (machines/machine-meta :app/boot)]
+    (let [meta (rf.machines/machine-meta :app/boot)]
       (is (some? meta) "machine-meta resolves the registered :app/boot machine")
       (is (= boot-schema/BootData (get-in meta [:schemas :data]))
           "the [:schemas :data] schema round-trips as boot.schema/BootData")))
   (testing "BootData validates the :data slot only (rejects a malformed :config)"
-    (is (true?  (schemas/validate-with-registered-fn
+    (is (true?  (rf.schemas/validate-with-registered-fn
                   boot-schema/BootData
                   {:phase :configuring :config nil :flags nil
                    :user nil :routes nil :error nil}))
         "the initial all-nil :data conforms")
-    (is (true?  (schemas/validate-with-registered-fn
+    (is (true?  (rf.schemas/validate-with-registered-fn
                   boot-schema/BootData
                   {:phase :hydrating :config test-config :flags nil
                    :user nil :routes nil :error nil}))
         "a well-formed promoted :config conforms")
-    (is (false? (schemas/validate-with-registered-fn
+    (is (false? (rf.schemas/validate-with-registered-fn
                   boot-schema/BootData
                   {:phase :loading-deps :config {:api-base "/api"} :flags nil
                    :user nil :routes nil :error nil}))
@@ -288,7 +288,7 @@
     (let [frame  (atom nil)
           traces (collect-machine-data-traces!
                    #(reset! frame
-                      (frame/make-anon-frame-record!
+                      (rf.frame/make-anon-frame-record!
                         {:initial-events [[:boot/initialise]]
                          :fx-overrides {:rf.http/managed
                                         :boot.test/canned-bad-config}})))]
@@ -317,7 +317,7 @@
                                           (= :app-db (-> ev :tags :where)))
                                  (swap! app-traces conj ev))))
       (try
-        (with-new-frame [f (frame/make-anon-frame-record! {})]
+        (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
           (rf/reg-app-schema [:config] {:frame f} [:maybe boot-schema/Config])
           (rf/dispatch-sync [::write-bad-config] {:frame f}))
         (finally (rf/unregister-listener! :trace ::app)))

--- a/implementation/adapters/reagent/test/re_frame/cross_adapter_chained_emitter_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_adapter_chained_emitter_cljs_test.cljs
@@ -64,11 +64,11 @@
             ;; Loading every adapter ns here forces all three to publish
             ;; their chain steps before this test's deftest runs. Every
             ;; require is load-bearing — do not trim.
-            [re-frame.adapter.reagent       :as reagent-adapter]
-            [re-frame.adapter.reagent-slim  :as reagent-slim-adapter]
-            [re-frame.adapter.uix           :as uix-adapter]
-            [re-frame.late-bind             :as late-bind]
-            [re-frame.late-bind.directory   :as directory]))
+            [re-frame.adapter.reagent       :as rf.adapter.reagent]
+            [re-frame.adapter.reagent-slim  :as rf.adapter.reagent-slim]
+            [re-frame.adapter.uix           :as rf.adapter.uix]
+            [re-frame.late-bind             :as rf.late-bind]
+            [re-frame.late-bind.directory   :as rf.late-bind.directory]))
 
 (def ^:private hook-key :reagent/set-hiccup-emitter!)
 
@@ -94,7 +94,7 @@
             a producer. If a future change drops one or flips the flag,
             this test trips before the silent-clobber bug ships."
     (let [entry (some (fn [e] (when (= hook-key (:key e)) e))
-                      directory/hooks)
+                      rf.late-bind.directory/hooks)
           producers (set (let [p (:producer-ns entry)]
                            (if (sequential? p) p [p])))
           react-adapters '#{re-frame.adapter.reagent
@@ -122,15 +122,15 @@
             the install."
     ;; Step 1: clear every adapter's emitter cell so we observe ONLY
     ;; the install driven through the chained hook below.
-    (reagent-adapter/set-hiccup-emitter! nil)
-    (reagent-slim-adapter/set-hiccup-emitter! nil)
-    (uix-adapter/set-hiccup-emitter! nil)
+    (rf.adapter.reagent/set-hiccup-emitter! nil)
+    (rf.adapter.reagent-slim/set-hiccup-emitter! nil)
+    (rf.adapter.uix/set-hiccup-emitter! nil)
     ;; Step 2: confirm the cleared state — render-to-string must throw
     ;; on every adapter. This sanity-check rules out a stale install
     ;; from a prior test masking a fan-out failure below.
-    (doseq [[adapter-name adapter-map] [["reagent"      reagent-adapter/adapter]
-                                        ["reagent-slim" reagent-slim-adapter/adapter]
-                                        ["uix"          uix-adapter/adapter]]]
+    (doseq [[adapter-name adapter-map] [["reagent"      rf.adapter.reagent/adapter]
+                                        ["reagent-slim" rf.adapter.reagent-slim/adapter]
+                                        ["uix"          rf.adapter.uix/adapter]]]
       (is (thrown-with-msg?
             js/Error
             #":rf\.error/no-hiccup-emitter-bound"
@@ -142,7 +142,7 @@
     ;; Step 3: resolve the chained hook and install the sentinel.
     ;; Every producer's chain step should run and write the sentinel
     ;; into its own adapter's cell.
-    (let [chained-install! (late-bind/get-fn hook-key)
+    (let [chained-install! (rf.late-bind/get-fn hook-key)
           marker           ::fan-out-marker
           sentinel         (sentinel-emitter marker)]
       (is (some? chained-install!)
@@ -153,9 +153,9 @@
       ;; Step 4: each adapter's render-to-string must now route through
       ;; the sentinel. If any one returns ≠ marker (or throws), that
       ;; adapter's chain step did NOT run — the chain was clobbered.
-      (doseq [[adapter-name adapter-map] [["reagent"      reagent-adapter/adapter]
-                                          ["reagent-slim" reagent-slim-adapter/adapter]
-                                          ["uix"          uix-adapter/adapter]]]
+      (doseq [[adapter-name adapter-map] [["reagent"      rf.adapter.reagent/adapter]
+                                          ["reagent-slim" rf.adapter.reagent-slim/adapter]
+                                          ["uix"          rf.adapter.uix/adapter]]]
         (is (= marker (adapter-render-to-string adapter-map))
             (str "fan-out failure: " adapter-name
                  " adapter's render-to-string did NOT route to the "
@@ -170,6 +170,6 @@
     ;; explicit emitter install does so itself, and the SSR ns-load
     ;; (if it loaded earlier in the bundle) is the only thing relied
     ;; upon to wire it for ssr-routed tests.
-    (reagent-adapter/set-hiccup-emitter! nil)
-    (reagent-slim-adapter/set-hiccup-emitter! nil)
-    (uix-adapter/set-hiccup-emitter! nil)))
+    (rf.adapter.reagent/set-hiccup-emitter! nil)
+    (rf.adapter.reagent-slim/set-hiccup-emitter! nil)
+    (rf.adapter.uix/set-hiccup-emitter! nil)))

--- a/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
@@ -26,13 +26,13 @@
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.frame :as frame]
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.fx :as rf.fx]
+            [re-frame.frame :as rf.frame]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             ;; rf2-k682: routing ships in day8/re-frame2-routing.
             ;; Required here so its load-time hook + reg-sub
             ;; registrations fire before this ns's reg-route calls.
-            [re-frame.routing :as routing]
+            [re-frame.routing :as rf.routing]
             ;; rf2-2hrj8 — the `:browser-test` build was narrowed to
             ;; `-dom-cljs-test$` so the full implementation/test corpus no
             ;; longer fans `re-frame.machines` / `re-frame.flows` /
@@ -43,11 +43,11 @@
             [re-frame.machines]
             [re-frame.flows]
             [re-frame.epoch]
-            [re-frame.ssr :as ssr]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views])
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
@@ -92,8 +92,8 @@
 ;; locally with `(binding [frame/*current-frame* nil] …)` where tier-2 is under
 ;; test.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter :async? true}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter :async? true}))
 
 ;; ---- deferred-teardown await (rf2-7r78l) ----------------------------------
 ;;
@@ -227,7 +227,7 @@
   ;; rf2-cufbh) between a synchronous top-level drain and an async child-frame
   ;; queue. This test models a TOP-LEVEL boot — clear the ambient scope so the
   ;; `:initial-events` cascade drains synchronously and its seed is observable.
-  (binding [frame/*current-frame* nil]
+  (binding [rf.frame/*current-frame* nil]
     (rf/make-frame {:id :booted :initial-events [[:init-shape]]}))
   (let [rt (:rf.db/runtime (rf/frame-state-value :booted))]
     (is (= :armed (get-in rt [:rf.runtime/machines :snapshots :flow/boot :state]))
@@ -324,7 +324,7 @@
   ;; Re-register the framework nav fx (reset-runtime cleared the
   ;; registrar) so this test exercises the same platform-gating shape
   ;; the production fx use.
-  (fx/reg-fx :rf.nav/push-url
+  (rf.fx/reg-fx :rf.nav/push-url
     {:platforms #{:client}}
     (fn [_ _] :should-not-run-on-server))
   (rf/reg-event :emit-nav
@@ -337,7 +337,7 @@
               @traces)
         ":rf.nav/push-url emits :rf.fx/skipped-on-platform under :server"))
   (testing "routes round-trip the same as on the client"
-    (let [m (routing/match-url "/users/42")]
+    (let [m (rf.routing/match-url "/users/42")]
       (is (= :user/show (:route-id m)))
       (is (= "42" (:id (:params m)))))))
 
@@ -351,14 +351,14 @@
    match-url returns nil-id for an unmatched URL; route-not-found is
    normal control flow, not an :rf.error trace."
   (rf/reg-route :user/show {} "/users/:id")
-  (let [m (routing/match-url "/no-such-thing")]
+  (let [m (rf.routing/match-url "/no-such-thing")]
     (is (nil? (:route-id m))
         "match-url surfaces no route-id for an unmatched URL"))
   ;; The error-projector contract is the user-side concern; here we
   ;; confirm that match-url itself does not emit :rf.error traces for
   ;; an unmatched URL — i.e., a missing route is signal, not an error.
   (with-trace-recorder! [traces]
-    (routing/match-url "/no-such-thing")
+    (rf.routing/match-url "/no-such-thing")
     (is (empty? (filter #(= :error (:op-type %)) @traces))
         "match-url is pure: route-not-found does not emit error traces")))
 
@@ -398,7 +398,7 @@
           ;; commit-then-dispose ordering.
           render-fn    (fn []
                          (let [n (swap! render-count inc)
-                               container (frame/app-db-container target-frame)
+                               container (rf.frame/app-db-container target-frame)
                                db (when container @container)]
                            (when (= 1 n)
                              ;; Mid-render destroy. Per Spec 002 §Destroy
@@ -460,7 +460,7 @@
                             (= target-frame (get-in % [:tags :frame])))
                       @traces)
                 ":rf.frame/destroyed trace fired — destroy-frame! ran the disposal pipeline")
-            (is (nil? (frame/frame target-frame))
+            (is (nil? (rf.frame/frame target-frame))
                 "the frame is gone from the registry after destroy")
             ;; Post-destroy dispatch raises :rf.error/frame-destroyed (per
             ;; Spec 002 §Destroy). The trace channel is the public surface.
@@ -559,7 +559,7 @@
           ;; test would never fire. With the scope cleared the plain fn (no
           ;; :contextType) cannot read context and resolves nil → the loud
           ;; :rf.error/no-frame-context this test pins.
-          (binding [frame/*current-frame* nil]
+          (binding [rf.frame/*current-frame* nil]
             (react-dom/flushSync
               (fn []
                 (rdc/render root
@@ -599,7 +599,7 @@
           ;; :rf/default scope around the synchronous render so the
           ;; no-provider → no-frame-context contract is actually exercised
           ;; (the ambient scope would otherwise resolve :rf/default at tier 1).
-          (binding [frame/*current-frame* nil]
+          (binding [rf.frame/*current-frame* nil]
             (react-dom/flushSync
               (fn []
                 ;; No frame-provider — the React-context tier resolves to
@@ -684,7 +684,7 @@
             mount-node  (make-mount-node!)
             root        (rdc/create-root mount-node)]
         (try
-          (binding [frame/*current-frame* nil]
+          (binding [rf.frame/*current-frame* nil]
             (react-dom/flushSync
               (fn []
                 (rdc/render root [rf/frame-provider {:frame target-frame}
@@ -725,7 +725,7 @@
             mount-node (make-mount-node!)
             root       (rdc/create-root mount-node)]
         (try
-          (binding [frame/*current-frame* nil]
+          (binding [rf.frame/*current-frame* nil]
             (react-dom/flushSync
               (fn []
                 (rdc/render root [rf/frame-provider {:frame target-frame}
@@ -772,7 +772,7 @@
             mount-node (make-mount-node!)
             root       (rdc/create-root mount-node)]
         (try
-          (binding [frame/*current-frame* nil]
+          (binding [rf.frame/*current-frame* nil]
             (react-dom/flushSync
               (fn []
                 (rdc/render root [rf/frame-provider {:frame target-frame}
@@ -829,7 +829,7 @@
         (try
           ;; Ambient scope cleared: the ONLY thing that can route these
           ;; reads is the explicit authority — not any leaked default.
-          (binding [frame/*current-frame* nil]
+          (binding [rf.frame/*current-frame* nil]
             (react-dom/flushSync
               (fn []
                 (rdc/render root [rf/frame-provider {:frame target-frame}
@@ -880,13 +880,13 @@
               finish     (fn []
                            (-> (await-teardown! root)
                                (.then (fn [_]
-                                        (trace-tooling/unregister-listener! ::reg-view-no-warn-unmounts)
+                                        (rf.trace.tooling/unregister-listener! ::reg-view-no-warn-unmounts)
                                         (is (= 1 (count @unmounts))
                                             (str "rf2-7r78l: exactly one :rf.view/unmounted fired for "
                                                  ":rf.cross-spec-10/registered-view WITHIN the awaited window "
                                                  "— teardown awaited, not leaked; got " (count @unmounts)))
                                         (done)))))]
-          (trace-tooling/register-listener! ::reg-view-no-warn-unmounts
+          (rf.trace.tooling/register-listener! ::reg-view-no-warn-unmounts
             (fn [ev]
               (when (and (= :rf.view/unmounted (:operation ev))
                          (= :rf.cross-spec-10/registered-view (-> ev :tags :rf.view/id)))
@@ -962,13 +962,13 @@
                 finish     (fn []
                              (-> (await-teardown! root)
                                  (.then (fn [_]
-                                          (trace-tooling/unregister-listener! ::d4sf-probe-unmounts)
+                                          (rf.trace.tooling/unregister-listener! ::d4sf-probe-unmounts)
                                           (is (= 1 (count @unmounts))
                                               (str "rf2-7r78l: exactly one :rf.view/unmounted fired for "
                                                    ":rf.cross-spec-d4sf/probe WITHIN the awaited window; got "
                                                    (count @unmounts)))
                                           (done)))))]
-            (trace-tooling/register-listener! ::d4sf-probe-unmounts
+            (rf.trace.tooling/register-listener! ::d4sf-probe-unmounts
               (fn [ev]
                 (when (and (= :rf.view/unmounted (:operation ev))
                            (= :rf.cross-spec-d4sf/probe (-> ev :tags :rf.view/id)))
@@ -983,7 +983,7 @@
               ;; (tier 2) under test. Clear the ambient scope around the render so
               ;; the provider's frame is actually resolved via React context —
               ;; the contract this test pins.
-              (binding [frame/*current-frame* nil]
+              (binding [rf.frame/*current-frame* nil]
                 (react-dom/flushSync
                   (fn []
                     (rdc/render root [rf/frame-provider {:frame target-frame}
@@ -1022,13 +1022,13 @@
               finish     (fn []
                            (-> (await-teardown! root)
                                (.then (fn [_]
-                                        (trace-tooling/unregister-listener! ::d4sf-probe-no-provider-unmounts)
+                                        (rf.trace.tooling/unregister-listener! ::d4sf-probe-no-provider-unmounts)
                                         (is (= 1 (count @unmounts))
                                             (str "rf2-7r78l: exactly one :rf.view/unmounted fired for "
                                                  ":rf.cross-spec-d4sf/probe-no-provider WITHIN the awaited window; got "
                                                  (count @unmounts)))
                                         (done)))))]
-          (trace-tooling/register-listener! ::d4sf-probe-no-provider-unmounts
+          (rf.trace.tooling/register-listener! ::d4sf-probe-no-provider-unmounts
             (fn [ev]
               (when (and (= :rf.view/unmounted (:operation ev))
                          (= :rf.cross-spec-d4sf/probe-no-provider (-> ev :tags :rf.view/id)))
@@ -1085,28 +1085,28 @@
   ;; so the `_currentValue` read (the contract under test) is actually
   ;; exercised; otherwise the dynamic-var tier shadows it and every read
   ;; resolves to :rf/default before the context is inspected.
-  (binding [frame/*current-frame* nil]
-  (let [original (.-_currentValue ^js adapter-context/frame-context)]
+  (binding [rf.frame/*current-frame* nil]
+  (let [original (.-_currentValue ^js rf.adapter.context/frame-context)]
     (try
       ;; String shape — what Reagent's prop-conversion produces.
-      (set! (.-_currentValue ^js adapter-context/frame-context) "tenant-prop-converted")
-      (is (= :tenant-prop-converted (adapter-context/function-component-current-frame))
+      (set! (.-_currentValue ^js rf.adapter.context/frame-context) "tenant-prop-converted")
+      (is (= :tenant-prop-converted (rf.adapter.context/function-component-current-frame))
           "stringified keyword is round-tripped back to a keyword")
       ;; Keyword shape — what the createContext default and CLJS-direct
       ;; paths produce.
-      (set! (.-_currentValue ^js adapter-context/frame-context) :tenant-keyword-shape)
-      (is (= :tenant-keyword-shape (adapter-context/function-component-current-frame))
+      (set! (.-_currentValue ^js rf.adapter.context/frame-context) :tenant-keyword-shape)
+      (is (= :tenant-keyword-shape (rf.adapter.context/function-component-current-frame))
           "keyword shape is preserved")
       ;; Empty-string shape — EP-0002 (rf2-9o48ih): an empty string is not a
       ;; coercible keyword and not the no-provider sentinel, so it is a
       ;; corrupted `_currentValue`. The reader returns nil (no synthesised
       ;; :rf/default floor); a public op reading nil then raises
       ;; :rf.error/no-frame-context.
-      (set! (.-_currentValue ^js adapter-context/frame-context) "")
-      (is (nil? (adapter-context/function-component-current-frame))
+      (set! (.-_currentValue ^js rf.adapter.context/frame-context) "")
+      (is (nil? (rf.adapter.context/function-component-current-frame))
           "empty-string is corrupted — resolves to nil, no :rf/default floor")
       (finally
-        (set! (.-_currentValue ^js adapter-context/frame-context) original))))))
+        (set! (.-_currentValue ^js rf.adapter.context/frame-context) original))))))
 
 (deftest dispatch-default-frame-routes-via-react-context
   "rf2-d4sf — the dispatch envelope's `:frame` default is built via the
@@ -1132,13 +1132,13 @@
               finish     (fn []
                            (-> (await-teardown! root)
                                (.then (fn [_]
-                                        (trace-tooling/unregister-listener! ::d4sf-dispatcher-probe-unmounts)
+                                        (rf.trace.tooling/unregister-listener! ::d4sf-dispatcher-probe-unmounts)
                                         (is (= 1 (count @unmounts))
                                             (str "rf2-7r78l: exactly one :rf.view/unmounted fired for "
                                                  ":rf.cross-spec-d4sf/dispatcher-probe WITHIN the awaited window; got "
                                                  (count @unmounts)))
                                         (done)))))]
-          (trace-tooling/register-listener! ::d4sf-dispatcher-probe-unmounts
+          (rf.trace.tooling/register-listener! ::d4sf-dispatcher-probe-unmounts
             (fn [ev]
               (when (and (= :rf.view/unmounted (:operation ev))
                          (= :rf.cross-spec-d4sf/dispatcher-probe (-> ev :tags :rf.view/id)))
@@ -1148,7 +1148,7 @@
             ;; :rf/default scope around the synchronous render so the dispatch's
             ;; `:frame` default resolves via the React-context tier (the provider's
             ;; frame), not the ambient :rf/default that tier 1 would otherwise win.
-            (binding [frame/*current-frame* nil]
+            (binding [rf.frame/*current-frame* nil]
               (react-dom/flushSync
                 (fn []
                   (rdc/render root [rf/frame-provider {:frame target-frame}
@@ -1313,7 +1313,7 @@
       ;; Tool-Pair-style revert: write the RUNTIME-DB PARTITION to a snapshot
       ;; where the machine is in :idle (EP-0001 rf2-vzld77 — machine snapshots
       ;; are durable runtime-db state, so revert via swap-runtime-db!).
-      (frame/swap-runtime-db! :rf/default
+      (rf.frame/swap-runtime-db! :rf/default
         (fn [rt] (assoc-in rt [:rf.runtime/machines :snapshots :test/m :state] :idle)))
       (is (= :idle (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                            [:rf.runtime/machines :snapshots :test/m :state]))
@@ -1370,7 +1370,7 @@
       ;; AND the resolved response carries that projection's :status.
       ;; This is the seam an SSR host uses to build the wire response.
       (let [err          (first errs)
-            public-error (ssr/apply-error-projection! :req err)]
+            public-error (rf.ssr/apply-error-projection! :req err)]
         (is (= 500 (:status public-error))
             "default projector maps :rf.error/handler-exception → :status 500")
         (is (= :internal-error (:code public-error))
@@ -1379,7 +1379,7 @@
             "default projector's :retryable? is false (handler exception is not retryable)")
         (is (string? (:message public-error))
             "default projector emits a one-sentence human :message")
-        (is (= 500 (:status (ssr/get-response :req)))
+        (is (= 500 (:status (rf.ssr/get-response :req)))
             "the projector's :status is stamped onto the [:rf/response] accumulator")))))
 
 ;; ---------------------------------------------------------------------------
@@ -1472,7 +1472,7 @@
   ;; reset-runtime has already installed the Reagent adapter; calling
   ;; install-adapter! again should throw.
   (let [thrown? (try
-                  (rf/install-adapter! reagent-adapter/adapter)
+                  (rf/install-adapter! rf.adapter.reagent/adapter)
                   false
                   (catch :default e
                     ;; rf2-vvixub — branch on the canonical :rf.error/id
@@ -1483,6 +1483,6 @@
         "second install-adapter! raises :rf.error/adapter-already-installed"))
   ;; Sanity-check the destroy-then-install path remains valid.
   (rf/destroy-adapter!)
-  (rf/install-adapter! reagent-adapter/adapter)
-  (is (some? (adapter/current-adapter))
+  (rf/install-adapter! rf.adapter.reagent/adapter)
+  (is (some? (rf.substrate.adapter/current-adapter))
       "after destroy, install succeeds again — clean swap path"))

--- a/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
@@ -31,9 +31,9 @@
   dynamic-binding tier."
   (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; Per cljs.test: async tests require fixtures supplied as a MAP — a
 ;; fn-form fixture's teardown runs before an `(async done)` body
@@ -44,8 +44,8 @@
 ;; behaviour — every dispatch here carries an explicit `{:frame …}`.
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter :async? true :ambient-frame nil}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter :async? true :ambient-frame nil}))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -65,7 +65,7 @@
 (defn- received
   "Return the :received vector for a frame's current app-db."
   [frame-id]
-  (let [db (frame/frame-app-db-value frame-id)]
+  (let [db (rf.frame/frame-app-db-value frame-id)]
     (:received db)))
 
 ;; ---- 1. Synchronous direct rf/dispatch ------------------------------------

--- a/implementation/adapters/reagent/test/re_frame/dispose_adapter_sub_cache_walk_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispose_adapter_sub_cache_walk_cljs_test.cljs
@@ -31,9 +31,9 @@
             [reagent.ratom :as ratom]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ---- fixture --------------------------------------------------------------
 ;;
@@ -47,18 +47,18 @@
   ;; frame registry — so the test starts from a never-installed cold
   ;; state. The `reset-lifecycle-state-for-tests!` seam exists for
   ;; exactly this purpose (rf2-6wxys).
-  (adapter/reset-lifecycle-state-for-tests!)
-  (reset! frame/frames {})
-  (rf/init! reagent-adapter/adapter)
-  (frame/ensure-default-frame!)
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
+  (reset! rf.frame/frames {})
+  (rf/init! rf.adapter.reagent/adapter)
+  (rf.frame/ensure-default-frame!)
   (test-fn)
   ;; Best-effort post-clean: if the test body left the adapter
   ;; installed, dispose it; if already disposed, the breadcrumb
   ;; lookup makes this a no-op.
-  (when (adapter/current-adapter)
-    (adapter/dispose-adapter!))
-  (reset! frame/frames {})
-  (adapter/reset-lifecycle-state-for-tests!))
+  (when (rf.substrate.adapter/current-adapter)
+    (rf.substrate.adapter/dispose-adapter!))
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!))
 
 (use-fixtures :each cold-start-fixture)
 
@@ -69,7 +69,7 @@
   sub-cache. Walks `@frame/frames` the same way the adapter's
   `dispose-adapter!` walk does."
   []
-  (for [[_ frame-record] @frame/frames
+  (for [[_ frame-record] @rf.frame/frames
         :let  [cache (:sub-cache frame-record)]
         :when cache
         [_k entry] @cache
@@ -81,7 +81,7 @@
   "Return `{frame-id <entry-count>}` for every frame with a sub-cache."
   []
   (into {}
-        (for [[fid frame-record] @frame/frames
+        (for [[fid frame-record] @rf.frame/frames
               :let [cache (:sub-cache frame-record)]
               :when cache]
           [fid (count @cache)])))
@@ -128,7 +128,7 @@
             (ratom/add-on-dispose! r (fn [& _] (swap! disposed conj r))))
 
           ;; Drive the walk.
-          (adapter/dispose-adapter!)
+          (rf.substrate.adapter/dispose-adapter!)
 
           ;; Invariant 1: every previously-cached Reaction is now
           ;; disposed. Assert through Reagent's public disposal callback
@@ -139,7 +139,7 @@
                      " on a frame's sub-cache fired its dispose hook")))))
 
       ;; Invariant 2: every frame's sub-cache atom is empty.
-      (doseq [[fid frame-record] @frame/frames
+      (doseq [[fid frame-record] @rf.frame/frames
               :let [cache (:sub-cache frame-record)]
               :when cache]
         (is (= {} @cache)
@@ -208,7 +208,7 @@
       ;; walk/b's cache, and then surface this exact value.
       (let [sentinel (ex-info "poison entry disposal" {::poison true})
             attempts (atom 0)
-            cache-a  (:sub-cache (frame/frame :walk/a))]
+            cache-a  (:sub-cache (rf.frame/frame :walk/a))]
         (swap! cache-a assoc [:poison]
                {:reaction (throwing-cached-reaction sentinel attempts)})
 
@@ -217,7 +217,7 @@
           (doseq [r reactions-before]
             (ratom/add-on-dispose! r (fn [& _] (swap! disposed conj r))))
 
-          (let [thrown (try (adapter/dispose-adapter!)
+          (let [thrown (try (rf.substrate.adapter/dispose-adapter!)
                             ::returned-normally
                             (catch :default e e))]
             ;; (1) DRAIN EVERYTHING — the siblings past the poison entry,
@@ -225,9 +225,9 @@
             (doseq [r reactions-before]
               (is (contains? @disposed r)
                   "the walk reached and disposed the real Reaction past the poison entry"))
-            (is (= {} @(:sub-cache (frame/frame :walk/a)))
+            (is (= {} @(:sub-cache (rf.frame/frame :walk/a)))
                 "walk/a's cache was still cleared despite the throw")
-            (is (= {} @(:sub-cache (frame/frame :walk/b)))
+            (is (= {} @(:sub-cache (rf.frame/frame :walk/b)))
                 "walk/b's cache was still cleared after the throwing walk/a entry")
             (is (= 1 @attempts)
                 "the poison entry was disposed exactly once — not retried")
@@ -240,12 +240,12 @@
                 unwrapped, after the drain finished")
 
             ;; (4) Terminal lifecycle state despite the throw.
-            (is (nil? (adapter/current-adapter-spec))
+            (is (nil? (rf.substrate.adapter/current-adapter-spec))
                 "the install slot is cleared even though cleanup threw")
-            (is (true? (adapter/adapter-disposed?))
+            (is (true? (rf.substrate.adapter/adapter-disposed?))
                 "the disposed breadcrumb is set even though cleanup threw")
             (is (= :rf.error/adapter-disposed
-                   (try (adapter/make-state-container {})
+                   (try (rf.substrate.adapter/make-state-container {})
                         nil
                         (catch :default e (:rf.error/id (ex-data e)))))
                 "public delegation reports :rf.error/adapter-disposed after a failed teardown")))))))
@@ -260,12 +260,12 @@
           ;; into the cache map is the traversal order the drain sees.
           poisons  (mapv (fn [i] (ex-info (str "poison " i) {::poison i}))
                          (range 3))
-          cache    (:sub-cache (frame/frame :walk/multi))]
+          cache    (:sub-cache (rf.frame/frame :walk/multi))]
       (doseq [[i sentinel] (map-indexed vector poisons)]
         (swap! cache assoc [:poison i]
                {:reaction (throwing-cached-reaction sentinel attempts)}))
 
-      (let [thrown (try (adapter/dispose-adapter!)
+      (let [thrown (try (rf.substrate.adapter/dispose-adapter!)
                         ::returned-normally
                         (catch :default e e))
             ;; Traversal order over a CLJS map is not a contract, so the
@@ -296,11 +296,11 @@
   a truthiness accumulator would silently drop it and report clean success"
     (rf/make-frame {:id :walk/falsey})
     (let [attempts (atom 0)
-          cache    (:sub-cache (frame/frame :walk/falsey))
+          cache    (:sub-cache (rf.frame/frame :walk/falsey))
           outcome  (atom ::unset)]
       (swap! cache assoc [:poison]
              {:reaction (throwing-cached-reaction nil attempts)})
-      (try (adapter/dispose-adapter!)
+      (try (rf.substrate.adapter/dispose-adapter!)
            (reset! outcome ::returned-normally)
            (catch :default e (reset! outcome [::threw e])))
       (is (= 1 @attempts) "the nil-throwing entry was attempted")
@@ -317,7 +317,7 @@
     ;; `reagent.dom.client`. Both adapter ops resolve their rdc fn at CALL
     ;; time precisely so `with-redefs` reaches them, which keeps this proof
     ;; deterministic and DOM-free under :node-test.
-    (reset! frame/frames {})
+    (reset! rf.frame/frames {})
     (let [sentinel      (ex-info "root unmount" {::root true})
           unmount-calls (atom [])
           bad-root      #js {:rf-test-root-tag "bad"  :unmount (fn [] nil)}
@@ -332,11 +332,11 @@
                                       (when (identical? root bad-root)
                                         (throw sentinel))
                                       nil)]
-        (let [render-fn (:render reagent-adapter/adapter)]
+        (let [render-fn (:render rf.adapter.reagent/adapter)]
           (render-fn [:div "bad"] #js {} nil)
           (render-fn [:div "good"] #js {} nil)
 
-          (let [thrown (try (adapter/dispose-adapter!)
+          (let [thrown (try (rf.substrate.adapter/dispose-adapter!)
                             ::returned-normally
                             (catch :default e e))]
             (is (some #(identical? bad-root %) @unmount-calls)
@@ -347,27 +347,27 @@
                 "each snapshot root was attempted exactly once — no retry of a consumed root")
             (is (identical? sentinel thrown)
                 "the identical root-unmount failure reached the caller, after the drain")
-            (is (true? (adapter/adapter-disposed?))
+            (is (true? (rf.substrate.adapter/adapter-disposed?))
                 "the disposed breadcrumb is set even though a root unmount threw")
-            (is (nil? (adapter/current-adapter-spec))
+            (is (nil? (rf.substrate.adapter/current-adapter-spec))
                 "active-root ownership released with the install slot despite the throw")))))))
 
 (deftest dispose-adapter-happy-teardown-still-returns-nil
   (testing "a teardown with nothing failing is unchanged: nil return, and an
   empty frames/roots registry stays no-op-safe"
-    (reset! frame/frames {})
+    (reset! rf.frame/frames {})
     (rf/make-frame {:id :walk/clean})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed] {:frame :walk/clean})
     (is (= 1 @(rf/subscribe [:n] {:frame :walk/clean})))
-    (is (nil? (adapter/dispose-adapter!))
+    (is (nil? (rf.substrate.adapter/dispose-adapter!))
         "a clean drain still returns nil — the rethrow is failure-only")
-    (is (true? (adapter/adapter-disposed?)))
+    (is (true? (rf.substrate.adapter/adapter-disposed?)))
 
     ;; And a fresh generation installs over the disposed one.
-    (rf/init! reagent-adapter/adapter)
-    (is (= :rf.adapter/reagent (adapter/current-adapter))
+    (rf/init! rf.adapter.reagent/adapter)
+    (is (= :rf.adapter/reagent (rf.substrate.adapter/current-adapter))
         "a fresh rf/init! installs a new generation after teardown")))
 
 (deftest claimed-generation-cleanup-keeps-public-delegation-terminal
@@ -385,16 +385,16 @@
        (fn [& _]
          (let [delegation-error
                (try
-                 (adapter/make-state-container {})
+                 (rf.substrate.adapter/make-state-container {})
                  nil
                  (catch :default e
                    (:rf.error/id (ex-data e))))]
            (reset! observed
-                   {:current-spec (adapter/current-adapter-spec)
+                   {:current-spec (rf.substrate.adapter/current-adapter-spec)
                     :delegation-error delegation-error
-                    :nested-destroy (adapter/dispose-adapter!)}))))
+                    :nested-destroy (rf.substrate.adapter/dispose-adapter!)}))))
 
-      (adapter/dispose-adapter!)
+      (rf.substrate.adapter/dispose-adapter!)
 
       (is (= {:current-spec nil
               :delegation-error :rf.error/adapter-disposed
@@ -409,8 +409,8 @@
     ;; make-reset-runtime-fixture shape: the fixture resets frames BEFORE
     ;; calling dispose-adapter!, so dispose-adapter! sees an empty
     ;; registry.
-    (reset! frame/frames {})
-    (is (nil? (adapter/dispose-adapter!))
+    (reset! rf.frame/frames {})
+    (is (nil? (rf.substrate.adapter/dispose-adapter!))
         "dispose-adapter! returns nil with an empty frames registry — no throw")
-    (is (true? (adapter/adapter-disposed?))
+    (is (true? (rf.substrate.adapter/adapter-disposed?))
         "the disposed-adapter breadcrumb is set after the no-op walk")))

--- a/implementation/adapters/reagent/test/re_frame/events_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/events_cljs_test.cljs
@@ -17,12 +17,12 @@
   ns ends in -cljs-test so shadow-cljs ':node-test' picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; EP-0022 reference-only flip (rf2-0adhqs.9): an INLINE interceptor value in a
 ;; chain now throws `:rf.error/inline-interceptor-removed` at registration.

--- a/implementation/adapters/reagent/test/re_frame/flows_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/flows_example_cljs_test.cljs
@@ -31,8 +31,8 @@
    which is precisely the browser/DOM split the seam is built around."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]
             ;; the flows artefact (the example requires it too; explicit here
             ;; so the fixture's late-bound flows-registry reset is armed even
@@ -45,8 +45,8 @@
   (:require-macros [re-frame.core :refer [with-frame]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 (defn- cart [] (:cart (rf/app-db-value :rf/default)))
 

--- a/implementation/adapters/reagent/test/re_frame/form_3_lifecycle_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/form_3_lifecycle_dom_cljs_test.cljs
@@ -18,15 +18,15 @@
             [reagent.dom.client :as rdc]
             ["react" :as React]
             ["react-dom" :as react-dom]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter :async? true :ambient-frame nil}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter :async? true :ambient-frame nil}))
 
 (def ^:private frame-a ::frame-a)
 (def ^:private frame-b ::frame-b)
@@ -81,7 +81,7 @@
   (into {}
         (map (fn [[query-v {:keys [inputs ref-count]}]]
                [query-v {:inputs inputs :ref-count ref-count}]))
-        @(:sub-cache (frame/frame frame-id))))
+        @(:sub-cache (rf.frame/frame frame-id))))
 
 (defn- ref-count [cache query-v]
   (or (get-in cache [query-v :ref-count]) 0))

--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
@@ -83,13 +83,13 @@
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             [re-frame.views]
-            [re-frame.views.frame-boundary :as boundary])
+            [re-frame.views.frame-boundary :as rf.views.frame-boundary])
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; MAP-FORM fixture (`:async? true`): cljs.test requires `:each` fixtures to be
@@ -111,8 +111,8 @@
 ;; resolution honest. (Scenario-3 + the prop-stringified cases additionally
 ;; `(binding [*current-frame* nil] …)` for belt-and-braces; that is idempotent.)
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter :async? true :ambient-frame nil}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter :async? true :ambient-frame nil}))
 
 ;; ---- browser gate ----------------------------------------------------------
 
@@ -229,7 +229,7 @@
                           (reset! resolved-frame (rf/current-frame-id))
                           (reset! resolved-value @(rf/subscribe [:scenario-1/v]))
                           [:div "probe"]))
-          (trace-tooling/register-listener! ::scenario-1-unmounts
+          (rf.trace.tooling/register-listener! ::scenario-1-unmounts
             (fn [ev]
               (when (and (= :rf.view/unmounted (:operation ev))
                          (= :rf.22ds-1/probe (-> ev :tags :rf.view/id)))
@@ -243,7 +243,7 @@
                 finish     (fn []
                              (-> (await-teardown! root)
                                  (.then (fn [_]
-                                          (trace-tooling/unregister-listener! ::scenario-1-unmounts)
+                                          (rf.trace.tooling/unregister-listener! ::scenario-1-unmounts)
                                           (is (= 1 (count @unmounts))
                                               (str "SOURCE fix (rf2-vp3m9): exactly one "
                                                    ":rf.view/unmounted fired for :rf.22ds-1/probe "
@@ -389,14 +389,14 @@
   ;; corruption detection) is actually exercised; otherwise the dynamic-var
   ;; tier shadows it and the read resolves to :rf/default before the context
   ;; is ever inspected.
-  (binding [frame/*current-frame* nil]
-  (let [original (.-_currentValue ^js adapter-context/frame-context)]
+  (binding [rf.frame/*current-frame* nil]
+  (let [original (.-_currentValue ^js rf.adapter.context/frame-context)]
     (with-trace-recorder! [traces]
       (try
         (testing "nil _currentValue: error trace fires; resolves to nil (no-frame-context)"
           (reset! traces [])
-          (set! (.-_currentValue ^js adapter-context/frame-context) nil)
-          (is (nil? (adapter-context/function-component-current-frame))
+          (set! (.-_currentValue ^js rf.adapter.context/frame-context) nil)
+          (is (nil? (rf.adapter.context/function-component-current-frame))
               "returns nil — no synthesised :rf/default (EP-0002 carried invariant)")
           (let [errs (corruption-traces traces)]
             (is (= 1 (count errs))
@@ -411,8 +411,8 @@
                 ":tags :received carries the offending value")))
         (testing "false _currentValue: error trace fires; resolves to nil"
           (reset! traces [])
-          (set! (.-_currentValue ^js adapter-context/frame-context) false)
-          (is (nil? (adapter-context/function-component-current-frame))
+          (set! (.-_currentValue ^js rf.adapter.context/frame-context) false)
+          (is (nil? (rf.adapter.context/function-component-current-frame))
               "returns nil")
           (let [errs (corruption-traces traces)]
             (is (= 1 (count errs))
@@ -421,8 +421,8 @@
                 ":tags :type identifies false as a boolean shape")))
         (testing "numeric _currentValue: error trace fires; resolves to nil"
           (reset! traces [])
-          (set! (.-_currentValue ^js adapter-context/frame-context) 42)
-          (is (nil? (adapter-context/function-component-current-frame))
+          (set! (.-_currentValue ^js rf.adapter.context/frame-context) 42)
+          (is (nil? (rf.adapter.context/function-component-current-frame))
               "returns nil")
           (let [errs (corruption-traces traces)]
             (is (= 1 (count errs))
@@ -433,8 +433,8 @@
                 ":tags :received echoes the offending value")))
         (testing "JS object _currentValue: error trace fires; resolves to nil"
           (reset! traces [])
-          (set! (.-_currentValue ^js adapter-context/frame-context) #js {:not "a frame"})
-          (is (nil? (adapter-context/function-component-current-frame))
+          (set! (.-_currentValue ^js rf.adapter.context/frame-context) #js {:not "a frame"})
+          (is (nil? (rf.adapter.context/function-component-current-frame))
               "returns nil")
           (let [errs (corruption-traces traces)]
             (is (= 1 (count errs))
@@ -443,8 +443,8 @@
                 ":tags :type identifies the JS object shape")))
         (testing "empty-string _currentValue: error trace fires; resolves to nil"
           (reset! traces [])
-          (set! (.-_currentValue ^js adapter-context/frame-context) "")
-          (is (nil? (adapter-context/function-component-current-frame))
+          (set! (.-_currentValue ^js rf.adapter.context/frame-context) "")
+          (is (nil? (rf.adapter.context/function-component-current-frame))
               "returns nil")
           (let [errs (corruption-traces traces)]
             (is (= 1 (count errs))
@@ -452,7 +452,7 @@
             (is (= :empty-string (-> errs first :tags :type))
                 ":tags :type identifies empty-string distinctly from string")))
         (finally
-          (set! (.-_currentValue ^js adapter-context/frame-context) original)))))))
+          (set! (.-_currentValue ^js rf.adapter.context/frame-context) original)))))))
 
 ;; ---- Scenario 4: cross-frame subscribe resolution -------------------------
 ;;
@@ -693,9 +693,9 @@
             root       (react-dom-client/createRoot mount-node)
             cleanup!   (fn []
                          (try (.unmount root) (catch :default _ nil))
-                         (try (frame/destroy-frame! target) (catch :default _ nil)))
+                         (try (rf.frame/destroy-frame! target) (catch :default _ nil)))
             child      (React/createElement "div" #js {} "frame-root-strict")
-            ensure-el  (boundary/frame-root-react-element
+            ensure-el  (rf.views.frame-boundary/frame-root-react-element
                          {:id target :initial-events [[:rf/set-db {:n 7}]]}
                          child
                          'scenario-6-frame-root-strict-mode-and-hot-reload-reuse-without-reseed)
@@ -718,7 +718,7 @@
                 (fn [_]
                   ;; (1) Sanity: the commit-phase ensure created the frame +
                   ;; seeded durable state.
-                  (is (some? (frame/frame target))
+                  (is (some? (rf.frame/frame target))
                       "frame-root created the frame at COMMIT (useLayoutEffect)")
                   (is (= {:n 7} (rf/app-db-value target))
                       ":initial-events seeded the durable app-db ONCE")
@@ -734,7 +734,7 @@
                   ;; survives (frame-root has no destroy effect; StrictMode did
                   ;; not corrupt it or re-seed it — the double-invoked effect's
                   ;; second make-frame was idempotent, not a replay).
-                  (is (some? (frame/frame target))
+                  (is (some? (rf.frame/frame target))
                       (str "the frame-root frame is STILL LIVE after the StrictMode "
                            "cycle — frame-root has no destroy-on-unmount"))
                   (is (= {:n 7} (rf/app-db-value target))
@@ -752,7 +752,7 @@
                   ;; commit re-ensures under the same :id (idempotent make-frame),
                   ;; so durable {:n 42} is preserved, NOT re-seeded to {:n 999}.
                   (let [reload-child (React/createElement "div" #js {} "frame-root-reload")
-                        reload-el    (boundary/frame-root-react-element
+                        reload-el    (rf.views.frame-boundary/frame-root-react-element
                                        {:id target :initial-events [[:rf/set-db {:n 999}]]}
                                        reload-child
                                        'scenario-6-frame-root-strict-mode-and-hot-reload-reuse-without-reseed)
@@ -761,7 +761,7 @@
                     (js/Promise.resolve (act-fn (fn [] (.render root reload-tree)))))))
               (.then
                 (fn [_]
-                  (is (some? (frame/frame target))
+                  (is (some? (rf.frame/frame target))
                       "the frame is REUSED across the hot-reload remount (still live)")
                   (is (= {:n 42} (rf/app-db-value target))
                       (str "REUSE-NO-RESEED: durable {:n 42} survived the hot-reload "
@@ -807,9 +807,9 @@
             ;; Pure React mount so `frame-root-fc` commits under React's effect
             ;; passes.
             root       (react-dom-client/createRoot mount-node)
-            cleanup!   (fn [] (try (frame/destroy-frame! target) (catch :default _ nil)))
+            cleanup!   (fn [] (try (rf.frame/destroy-frame! target) (catch :default _ nil)))
             child      (React/createElement "div" #js {} "frame-root-survives")
-            ensure-el  (boundary/frame-root-react-element
+            ensure-el  (rf.views.frame-boundary/frame-root-react-element
                          {:id target :initial-events [[:rf/set-db {:n 3}]]}
                          child
                          'scenario-6-frame-root-genuine-unmount-leaves-frame-live)
@@ -824,7 +824,7 @@
           (-> (js/Promise.resolve (act-fn (fn [] (.render root ensure-el))))
               (.then
                 (fn [_]
-                  (is (some? (frame/frame target)) "frame created at commit")
+                  (is (some? (rf.frame/frame target)) "frame created at commit")
                   (is (= {:n 3} (rf/app-db-value target)) ":initial-events seeded app-db")
                   ;; Genuine unmount — frame-root does NOT destroy.
                   (js/Promise.resolve (act-fn (fn [] (.unmount root))))))
@@ -844,7 +844,7 @@
                         4)))))
               (.then
                 (fn [_]
-                  (is (some? (frame/frame target))
+                  (is (some? (rf.frame/frame target))
                       "genuine unmount LEFT the frame live (frame-root has no destroy-on-unmount)")
                   (is (= {:n 3} (rf/app-db-value target))
                       "durable app-db survived the unmount intact")
@@ -914,7 +914,7 @@
             root       (react-dom-client/createRoot mount-node)
             cleanup!   (fn []
                          (try (.unmount root) (catch :default _ nil))
-                         (try (frame/destroy-frame! target) (catch :default _ nil)))
+                         (try (rf.frame/destroy-frame! target) (catch :default _ nil)))
             ;; frame-root beside a SIBLING that throws during render. Because
             ;; frame-root's PASS-1 render emits no descendant subtree, a THROWING
             ;; CHILD would never run (frame-root would commit fine and its effect
@@ -924,7 +924,7 @@
             ;; committing — so frame-root's layout effect never runs and no frame
             ;; is created. The error boundary catches the throw and re-renders a
             ;; fallback (which does NOT contain frame-root).
-            frame-root-el (boundary/frame-root-react-element
+            frame-root-el (rf.views.frame-boundary/frame-root-react-element
                             {:id target :initial-events [[:rf/set-db {:n 7}]]}
                             (React/createElement "div" #js {} "root-child")
                             'scenario-6-frame-root-discarded-render-creates-no-frame)
@@ -948,7 +948,7 @@
                   (js/Promise. (fn [resolve _] (js/setTimeout (fn [] (resolve nil)) 8)))))
               (.then
                 (fn [_]
-                  (is (nil? (frame/frame target))
+                  (is (nil? (rf.frame/frame target))
                       (str "GHOST-FRAME FIX: an aborted (never-committed) render "
                            "created NO frame under " (pr-str target)
                            " (frame-root ensures at commit, not during render)"))
@@ -959,7 +959,7 @@
                   ;; error-boundary timing; the invariant still holds — no frame.
                   ;; This arm ASSERTS rather than merely reports, and it still
                   ;; does not finish: the single `done!` is on the tail below.
-                  (is (nil? (frame/frame target))
+                  (is (nil? (rf.frame/frame target))
                       "aborted render created NO frame (error path)")
                   nil))
               ;; Both arms cleaned up identically, so it rides the single

--- a/implementation/adapters/reagent/test/re_frame/frame_provider_render_key_elision_prod_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_render_key_elision_prod_test.cljs
@@ -37,15 +37,15 @@
   trace fires for every render."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
-            [re-frame.views :as views]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.views :as rf.views]
             ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`.
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- :view/render trace does not fire under prod -------------------------
 
@@ -58,7 +58,7 @@
             renders. The wrapper still calls the user fn — only the
             trace metadata elides."
     (let [seen (atom [])]
-      (trace-tooling/register-listener!
+      (rf.trace.tooling/register-listener!
         ::prod-view-listener
         (fn [ev] (swap! seen conj ev)))
       (rf/reg-view* :prod-frame-provider/sample
@@ -70,7 +70,7 @@
       (is (empty? @seen)
           "no trace events delivered — :view/render elides under
            :advanced + goog.DEBUG=false")
-      (trace-tooling/unregister-listener! ::prod-view-listener))))
+      (rf.trace.tooling/unregister-listener! ::prod-view-listener))))
 
 ;; ---- current-render-key still binds under prod ---------------------------
 
@@ -87,7 +87,7 @@
     (let [observed-key (atom nil)]
       (rf/reg-view* :prod-frame-provider/key-reader
         (fn []
-          (reset! observed-key (views/current-render-key))
+          (reset! observed-key (rf.views/current-render-key))
           [:span "key-reader"]))
       (let [wrapper (rf/view :prod-frame-provider/key-reader)
             _out    (wrapper)]
@@ -107,8 +107,8 @@
             under prod returns a fresh integer. The token's only
             consumer (the trace emit and the dev source-coord stamp)
             elides, but the mint surface itself is safe to call."
-    (let [t1 (views/mint-instance-token!)
-          t2 (views/mint-instance-token!)]
+    (let [t1 (rf.views/mint-instance-token!)
+          t2 (rf.views/mint-instance-token!)]
       (is (integer? t1) "mint returns an integer under prod")
       (is (integer? t2) "second call also returns an integer")
       (is (not= t1 t2)
@@ -128,6 +128,6 @@
             shape too (e.g. headless tests calling `current-render-key`
             outside any reg-view* wrapper)."
     (is (= [:rf.view/anonymous nil]
-           (views/current-render-key))
+           (rf.views/current-render-key))
         "current-render-key returns the anonymous fallback outside a
          render under prod")))

--- a/implementation/adapters/reagent/test/re_frame/hot_reload_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/hot_reload_cljs_test.cljs
@@ -27,14 +27,14 @@
   don't leak into other test ns runs."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views])
   (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- (4) :view re-register flips the next render to the new body --------
 

--- a/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
@@ -34,16 +34,16 @@
             ;; validator; without this require they'd soft-pass.
             [re-frame.schemas.malli]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.frame :as frame]
-            [re-frame.http.managed :as http-managed]
+            [re-frame.fx :as rf.fx]
+            [re-frame.frame :as rf.frame]
+            [re-frame.http.managed :as rf.http.managed]
             ;; rf2-cdmle — canned-stub fxs (`:rf.http/managed-canned-success`,
             ;; `:rf.http/managed-canned-failure`) gate on explicit
             ;; test-support require. This file uses :fx-overrides into
             ;; both fx ids throughout, so we opt in here.
             [re-frame.http.test-support]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; Snapshot/restore the registrar around each test (rf2-am9d). The
 ;; framework-shipped :rf.http/managed family registers at ns-load and
@@ -52,11 +52,11 @@
 (use-fixtures :each
   (fn [test-fn]
     ;; Drop any in-flight registry leaks between tests.
-    (http-managed/clear-all-in-flight!)
-    ((test-support/make-reset-runtime-fixture
-       {:adapter reagent-adapter/adapter})
+    (rf.http.managed/clear-all-in-flight!)
+    ((rf.test-support/make-reset-runtime-fixture
+       {:adapter rf.adapter.reagent/adapter})
       test-fn)
-    (http-managed/clear-all-in-flight!)))
+    (rf.http.managed/clear-all-in-flight!)))
 
 ;; ---- 1. canned-success: unified :reply-to addressing ----------------------
 
@@ -178,7 +178,7 @@
             (NO per-call :fx-overrides) is intercepted by the stub and the real
             :rf.http/managed fx slot is NEVER invoked"
     (let [real-fx-invoked? (atom false)]
-      (fx/reg-fx :rf.http/managed
+      (rf.fx/reg-fx :rf.http/managed
                  (fn [_frame-ctx _args] (reset! real-fx-invoked? true) nil))
       (rf/reg-event :rzqan/load
         (fn [_ [_ msg reply]]
@@ -220,7 +220,7 @@
             a PRE-CREATED sealed make-frame {} frame routes through the stub and
             NEVER invokes the real :rf.http/managed transport"
     (let [real-fx-invoked? (atom false)]
-      (fx/reg-fx :rf.http/managed
+      (rf.fx/reg-fx :rf.http/managed
                  (fn [_frame-ctx _args] (reset! real-fx-invoked? true) nil))
       (rf/reg-event :bxc8kf/load
         (fn [{:keys [db]} [_ msg reply]]
@@ -323,10 +323,10 @@
           {:fx [[:rf.http/managed
                  {:reply-to [:article/load msg] :request {:method :get :url "/articles/hello"}
                   :decode  :json}]]})))
-    (let [left  (frame/make-anon-frame-record! {:doc "left"
+    (let [left  (rf.frame/make-anon-frame-record! {:doc "left"
                                 :fx-overrides
                                 {:rf.http/managed :rf.http/managed-canned-success}})
-          right (frame/make-anon-frame-record! {:doc "right"
+          right (rf.frame/make-anon-frame-record! {:doc "right"
                                 :fx-overrides
                                 {:rf.http/managed :rf.http/managed-canned-success}})]
       (rf/dispatch-sync [:article/load] {:frame left})

--- a/implementation/adapters/reagent/test/re_frame/infinite_feed_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/infinite_feed_example_cljs_test.cljs
@@ -33,10 +33,10 @@
    isolation discipline."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.fx :as rf.fx]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]
             ;; production HTTP + resources surfaces (so the resource runtime,
             ;; managed-HTTP lowering, the infinite sub family, and the
@@ -45,15 +45,15 @@
             [re-frame.http.managed]
             [re-frame.http.test-support]
             [re-frame.resources]
-            [re-frame.resources.route :as resources-route]
-            [re-frame.resources.state :as state]
+            [re-frame.resources.route :as rf.resources.route]
+            [re-frame.resources.state :as rf.resources.state]
             [re-frame.resources.test-support]
-            [re-frame.routing :as routing]
+            [re-frame.routing :as rf.routing]
             ;; the framework trace-ring buffer (Spec 009) — cleared around each
             ;; test so this resource-registering suite leaves no trace residue
             ;; for later cross-cutting tooling tests (same leak the resources-
             ;; example suite closes).
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             ;; the example's production source — registers its :feed/timeline
             ;; infinite resource, routes, and views at ns-load.
             [infinite-feed.core]))
@@ -73,7 +73,7 @@
 ;; registration — not a test-local copy. See the resources-example sibling for
 ;; the full rationale.
 (def ^:private resource-kind-snapshot
-  (get @registrar/kind->id->metadata :resource))
+  (get @rf.registrar/kind->id->metadata :resource))
 
 ;; AT NS LOAD, remove THIS example's `:resource` registration (by id) from the
 ;; SHARED live registrar — after snapshotting it above. Reinstated per-test by
@@ -82,7 +82,7 @@
 ;; registrar until some OTHER suite's reset clears it, mirroring a frameless
 ;; `:rf.registry/handler-cleared` burst into a cross-cutting tooling test's
 ;; cascade seed. We remove only OUR ids (not the whole kind).
-(swap! registrar/kind->id->metadata update :resource
+(swap! rf.registrar/kind->id->metadata update :resource
        (fn [m] (apply dissoc m (keys resource-kind-snapshot))))
 
 (defn- init!
@@ -120,13 +120,13 @@
   ;; store in lockstep and marks the live-frame projection dirty, so the
   ;; frame's next resolution sees the reinstated registrations.
   (doseq [[id meta] resource-kind-snapshot]
-    (registrar/register! :resource id meta))
-  (routing/reset-counters!)
-  (resources-route/install-routing-integration!)
+    (rf.registrar/register! :resource id meta))
+  (rf.routing/reset-counters!)
+  (rf.resources.route/install-routing-integration!)
   ;; Capturing no-op: the reply is replayed explicitly by the test so the
   ;; 3-element internal reply event matches what the live transport produces.
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
   ;; LAST — see the ordering note in the docstring. Everything the frame's
   ;; construction-time URL sync needs (the reinstated `:resource` rows, the
   ;; routing integration, the stubbed fx) is registered above.
@@ -138,15 +138,15 @@
    residue into later cross-cutting tooling tests (see the resources-example
    sibling for the full rationale of the frameless-handler-cleared burst)."
   [f]
-  (trace-tooling/clear-listeners!)
-  (trace-tooling/clear-trace-rings!)
+  (rf.trace.tooling/clear-listeners!)
+  (rf.trace.tooling/clear-trace-rings!)
   (f)
-  (trace-tooling/clear-listeners!)
-  (trace-tooling/clear-trace-rings!))
+  (rf.trace.tooling/clear-listeners!)
+  (rf.trace.tooling/clear-trace-rings!))
 
 (use-fixtures :each
   isolate-trace-bus-fixture
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     ;; BUNDLE CO-LOAD HYGIENE: this app registers the reserved per-app
     ;; `:rf.route/not-found` route at ns load, and every co-loaded example app
     ;; does the same — two provenance rows for one id fail default-image
@@ -154,7 +154,7 @@
     ;; app loads. `:app-ns` names OUR OWN app (never a sibling's): the fixture
     ;; keeps its rows out of every suite's baseline and reinstates them for
     ;; this suite's own tests (rf2-kuky.27).
-    {:adapter reagent-adapter/adapter
+    {:adapter rf.adapter.reagent/adapter
      :app-ns  "infinite-feed."
      :init-fn init!}))
 
@@ -165,9 +165,9 @@
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
 
 (defn- feed-key []
-  (state/scoped-resource-key :rf.scope/global :feed/timeline {}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :feed/timeline {}))
 
-(defn- entry [] (get-in (runtime-db) (state/entry-path (feed-key))))
+(defn- entry [] (get-in (runtime-db) (rf.resources.state/entry-path (feed-key))))
 
 (def ^:private feed-query
   {:resource :feed/timeline :scope :rf.scope/global :params {}})
@@ -221,7 +221,7 @@
     (let [slice     (get-in (runtime-db) [:rf.runtime/routing :current])
           nav-token (:nav-token slice)
           e         (entry)]
-      (is (state/infinite-entry? e) "seeded an infinite feed entry (R1 — one entry per feed)")
+      (is (rf.resources.state/infinite-entry? e) "seeded an infinite feed entry (R1 — one entry per feed)")
       (is (= :loading (:status e)) "first load (page 0) → :loading")
       (is (contains? (:active-owners e) [:route :infinite-feed.app/timeline nav-token])
           "owned by the route nav-token owner [:route route-id nav-token]")

--- a/implementation/adapters/reagent/test/re_frame/init_resolver_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/init_resolver_cljs_test.cljs
@@ -11,8 +11,8 @@
   ns ends in -cljs-test so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.adapter.reagent :as reagent-adapter]))
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
 
 ;; ---- fixture --------------------------------------------------------------
 ;;
@@ -22,9 +22,9 @@
 ;; the unit under test IS init!.
 
 (defn- cold-start-fixture [test-fn]
-  (adapter/dispose-adapter!)
+  (rf.substrate.adapter/dispose-adapter!)
   (test-fn)
-  (adapter/dispose-adapter!))
+  (rf.substrate.adapter/dispose-adapter!))
 
 (use-fixtures :each cold-start-fixture)
 
@@ -32,25 +32,25 @@
 
 (deftest reagent-ns-load-has-no-side-effects
   (testing "requiring re-frame.adapter.reagent does NOT auto-install or auto-register"
-    (is (nil? (adapter/current-adapter))
+    (is (nil? (rf.substrate.adapter/current-adapter))
         "ns-load does not install the adapter")
-    (is (map? reagent-adapter/adapter)
+    (is (map? rf.adapter.reagent/adapter)
         "the adapter ns exports its spec as the public `adapter` var")
-    (is (= 10 (count (filter fn? (vals reagent-adapter/adapter))))
+    (is (= 10 (count (filter fn? (vals rf.adapter.reagent/adapter))))
         "the exported adapter map carries the full contract — the six required +
          subscribe-container + register-context-provider + dispose-adapter! +
          the optional rf2-40a84 flush-render! fn")
-    (is (= :rf.adapter/reagent (:kind reagent-adapter/adapter))
+    (is (= :rf.adapter/reagent (:kind rf.adapter.reagent/adapter))
         "the adapter map carries its discriminator keyword under :kind")))
 
 (deftest init-explicit-installs-reagent
   (testing "(rf/init! reagent/adapter) installs the Reagent adapter"
-    (is (nil? (adapter/current-adapter))
+    (is (nil? (rf.substrate.adapter/current-adapter))
         "precondition: no adapter installed")
-    (rf/init! reagent-adapter/adapter)
-    (is (identical? reagent-adapter/adapter (adapter/current-adapter-spec))
+    (rf/init! rf.adapter.reagent/adapter)
+    (is (identical? rf.adapter.reagent/adapter (rf.substrate.adapter/current-adapter-spec))
         "explicit init! installed the Reagent adapter (map identity)")
-    (is (= :rf.adapter/reagent (adapter/current-adapter))
+    (is (= :rf.adapter/reagent (rf.substrate.adapter/current-adapter))
         "current-adapter returns the discriminator keyword per Spec 006")))
 
 (deftest init-no-arg-raises-arity-error
@@ -67,7 +67,7 @@
                    (catch :default e e))]
       (is (some? thrown)
           "rf/init! with no args raises (cut arity)"))
-    (is (nil? (adapter/current-adapter))
+    (is (nil? (rf.substrate.adapter/current-adapter))
         "the failed init! did NOT install any adapter")))
 
 (deftest init-keyword-raises
@@ -84,5 +84,5 @@
       (let [data (ex-data thrown)]
         (is (= :reagent (:received data))
             "ex-data echoes the offending keyword")))
-    (is (nil? (adapter/current-adapter))
+    (is (nil? (rf.substrate.adapter/current-adapter))
         "the failed init! did NOT install any adapter")))

--- a/implementation/adapters/reagent/test/re_frame/late_bind_hooks_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/late_bind_hooks_cljs_test.cljs
@@ -35,8 +35,8 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.adapter.reagent]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.late-bind.directory :as directory]))
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.late-bind.directory :as rf.late-bind.directory]))
 
 ;; The closed set of hooks `re-frame.adapter.reagent` is documented (in
 ;; the late-bind directory + the adapter ns) to publish at ns-load
@@ -64,7 +64,7 @@
   (testing "every hook re-frame.adapter.reagent is documented to publish is
             present in the in-process late-bind hook table after the
             adapter ns is loaded (rf2-z3q3s)"
-    (let [installed-keys (set (keys @late-bind/hooks))
+    (let [installed-keys (set (keys @rf.late-bind/hooks))
           missing        (clojure.set/difference reagent-adapter-published-hooks
                                                   installed-keys)]
       (is (empty? missing)
@@ -80,7 +80,7 @@
             re-frame.late-bind.directory with re-frame.adapter.reagent
             as a producer (rf2-z3q3s)"
     (doseq [hook reagent-adapter-published-hooks]
-      (let [entry      (directory/entry hook)
+      (let [entry      (rf.late-bind.directory/entry hook)
             producer   (:producer-ns entry)
             producers  (if (sequential? producer) (set producer) #{producer})]
         (is (some? entry)

--- a/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
@@ -37,16 +37,16 @@
    the `:mutation` registrar kind alongside `:resource` (the write counterpart)."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.fx :as fx]
-            [re-frame.registrar :as registrar]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fx :as rf.fx]
+            [re-frame.registrar :as rf.registrar]
             ;; the provenance store behind the registrar — section 0's control
             ;; reads it to find WHICH namespace owns each rival "/" route row,
             ;; so it can drop them through the ownership-guarded two-leg pairing
             ;; below rather than by a raw registrar write.
-            [re-frame.source-store :as source-store]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.source-store :as rf.source-store]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]
             ;; production HTTP + resources surfaces (so the resource runtime,
             ;; the mutation runtime, managed-HTTP lowering, and the late-bound
@@ -55,14 +55,14 @@
             [re-frame.http.managed]
             [re-frame.http.test-support]
             [re-frame.resources]
-            [re-frame.resources.route :as resources-route]
-            [re-frame.resources.state :as state]
+            [re-frame.resources.route :as rf.resources.route]
+            [re-frame.resources.state :as rf.resources.state]
             [re-frame.resources.test-support]
-            [re-frame.routing :as routing]
+            [re-frame.routing :as rf.routing]
             ;; the framework trace-ring buffer (Spec 009) — cleared around each
             ;; test so this resource/mutation-registering suite leaves no trace
             ;; residue for later cross-cutting tooling tests.
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             ;; the example's production source — registers its :linearlite/board
             ;; resource, the three optimistic mutations, routes, events, subs,
             ;; and views at ns-load.
@@ -83,7 +83,7 @@
 ;; registrations — not test-local copies. See the infinite-feed / realworld-
 ;; resources siblings for the full rationale.
 (def ^:private resource-kind-snapshots
-  (select-keys @registrar/kind->id->metadata [:resource :mutation]))
+  (select-keys @rf.registrar/kind->id->metadata [:resource :mutation]))
 
 ;; AT NS LOAD, remove THIS example's `:resource` / `:mutation` registrations (by
 ;; id) from the SHARED live registrar — after snapshotting them above. Reinstated
@@ -92,7 +92,7 @@
 ;; registrar until some OTHER suite's reset clears them, mirroring a frameless
 ;; `:rf.registry/handler-cleared` burst into a cross-cutting tooling test's
 ;; cascade seed. We remove only OUR ids (not the whole kind).
-(swap! registrar/kind->id->metadata
+(swap! rf.registrar/kind->id->metadata
        (fn [reg]
          (reduce (fn [r [kind id->meta]]
                    (update r kind (fn [m] (apply dissoc m (keys id->meta)))))
@@ -143,11 +143,11 @@
   ;; frame's next resolution sees the reinstated registrations.
   (doseq [[kind id->meta] resource-kind-snapshots
           [id meta] id->meta]
-    (registrar/register! kind id meta))
-  (routing/reset-counters!)
-  (resources-route/install-routing-integration!)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+    (rf.registrar/register! kind id meta))
+  (rf.routing/reset-counters!)
+  (rf.resources.route/install-routing-integration!)
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
   ;; LAST — see the ordering note in the docstring. Everything the frame's
   ;; construction-time URL sync needs (the reinstated `:resource` / `:mutation`
   ;; rows, the routing integration, the stubbed fx) is registered above.
@@ -159,15 +159,15 @@
    trace residue into later cross-cutting tooling tests (see the infinite-feed /
    realworld-resources siblings for the frameless-handler-cleared burst)."
   [f]
-  (trace-tooling/clear-listeners!)
-  (trace-tooling/clear-trace-rings!)
+  (rf.trace.tooling/clear-listeners!)
+  (rf.trace.tooling/clear-trace-rings!)
   (f)
-  (trace-tooling/clear-listeners!)
-  (trace-tooling/clear-trace-rings!))
+  (rf.trace.tooling/clear-listeners!)
+  (rf.trace.tooling/clear-trace-rings!))
 
 (use-fixtures :each
   isolate-trace-bus-fixture
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     ;; BUNDLE CO-LOAD HYGIENE: this app registers the reserved per-app
     ;; `:rf.route/not-found` route at ns load, and every co-loaded example app
     ;; does the same — two provenance rows for one id fail default-image
@@ -175,7 +175,7 @@
     ;; app loads. `:app-ns` names OUR OWN app (never a sibling's): the fixture
     ;; keeps its rows out of every suite's baseline and reinstates them for
     ;; this suite's own tests (rf2-kuky.27).
-    {:adapter reagent-adapter/adapter
+    {:adapter rf.adapter.reagent/adapter
      :app-ns  "linearlite."
      :init-fn init!}))
 
@@ -189,9 +189,9 @@
   {:resource :linearlite/board :scope :rf.scope/global :params {}})
 
 (defn- board-key []
-  (state/scoped-resource-key :rf.scope/global :linearlite/board {}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :linearlite/board {}))
 
-(defn- entry [] (get-in (runtime-db) (state/entry-path (board-key))))
+(defn- entry [] (get-in (runtime-db) (rf.resources.state/entry-path (board-key))))
 
 (defn- board-data
   "The passive board `:data` the example's view reads (the `:rf.resource/data`
@@ -291,10 +291,10 @@
   "The `[route-id provenance-ns]` source slots of every OTHER app that also owns
    \"/\" in this consolidated bundle."
   []
-  (for [[id metadata] (registrar/registrations :route)
+  (for [[id metadata] (rf.registrar/registrations :route)
         :when         (and (= "/" (:path metadata))
                            (not= :linearlite.app/board id))
-        provenance-ns (keys (source-store/descriptors-for :route id))]
+        provenance-ns (keys (rf.source-store/descriptors-for :route id))]
     [id provenance-ns]))
 
 (defn- drop-route-row!
@@ -316,17 +316,17 @@
    only when that writer IS `provenance-ns`. `registrar/unregister!` would be
    wrong here — it forgets EVERY provenance slot for the id."
   [id provenance-ns]
-  (when-let [row (get-in @source-store/kind->id->ns->descriptor
+  (when-let [row (get-in @rf.source-store/kind->id->ns->descriptor
                          [:route id provenance-ns])]
-    (swap! registrar/kind->id->metadata update :route
+    (swap! rf.registrar/kind->id->metadata update :route
            (fn [m]
              (let [cur    (get m id)
-                   cur-ns (or (get cur source-store/provenance-ns-key)
+                   cur-ns (or (get cur rf.source-store/provenance-ns-key)
                               (some-> (:ns cur) str))]
                (if (and cur (= cur-ns (str provenance-ns)))
                  (dissoc m id)
                  m))))
-    (source-store/forget-descriptor! :route id provenance-ns)
+    (rf.source-store/forget-descriptor! :route id provenance-ns)
     row))
 
 (defn- restore-route-row!
@@ -336,7 +336,7 @@
    would be invisible to its generation. No-op on nil."
   [descriptor]
   (when descriptor
-    (registrar/register! (:kind descriptor) (:id descriptor) descriptor))
+    (rf.registrar/register! (:kind descriptor) (:id descriptor) descriptor))
   nil)
 
 (deftest init-refills-the-registrar-before-it-makes-the-url-bound-frame
@@ -350,9 +350,9 @@
         (doseq [[id provenance-ns] (root-path-rivals)]
           (when-let [row (drop-route-row! id provenance-ns)]
             (swap! removed conj row)))
-        (registrar/clear-kind! :resource)
-        (registrar/clear-kind! :mutation)
-        (reset! frame/frames {})
+        (rf.registrar/clear-kind! :resource)
+        (rf.registrar/clear-kind! :mutation)
+        (reset! rf.frame/frames {})
         (init!)
         (let [slice (get-in (runtime-db) [:rf.runtime/routing :current])]
           (is (= :linearlite.app/board (:route-id slice))
@@ -370,7 +370,7 @@
                clears it"))
         (finally
           (run! restore-route-row! @removed)
-          (reset! frame/frames {}))))))
+          (reset! rf.frame/frames {}))))))
 
 ;; ============================================================================
 ;; 1. ROUTE ENTRY ensures the board resource (the route OWNS the read)
@@ -567,7 +567,7 @@
    the args it built — and deliver nothing."
   []
   (doseq [fx-id canned-fx-ids]
-    (fx/reg-fx fx-id
+    (rf.fx/reg-fx fx-id
       {:doc "linearlite armed-demo-backend test parker (per-test; section 5)."}
       (fn [_ctx args]
         (swap! parked-replies conj {:fx-id    fx-id
@@ -582,7 +582,7 @@
    the example's own mutation produces."
   [request]
   (reset! parked-replies [])
-  ((registrar/handler :fx :linearlite.demo/http-stub)
+  ((rf.registrar/handler :fx :linearlite.demo/http-stub)
    {:frame :rf/default}
    {:request  request
     :decode   :json
@@ -931,7 +931,7 @@
   [{:keys [writer peer dispatch-a! reply-a dispatch-b! reply-b
            peer-desc peer-holds? writer-desc writer-committed? final]}
    order]
-  (reset! frame/frames {})
+  (reset! rf.frame/frames {})
   (init!)
   (load-board!)
   (let [inst-a (dispatch-a!)

--- a/implementation/adapters/reagent/test/re_frame/login_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/login_cljs_test.cljs
@@ -33,21 +33,21 @@
        the stale `:error` as the machine re-enters `:submitting`."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             ;; The schemas Malli adapter publishes the registered validator
             ;; the `:where :machine-data` boundary routes through; login.model
             ;; pulls it transitively, require here so the ns is self-sufficient.
-            [re-frame.schemas :as schemas]
+            [re-frame.schemas :as rf.schemas]
             [re-frame.schemas.malli]
             [login.model])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers
@@ -96,16 +96,16 @@
 
 (deftest data-schema-attached
   (testing "the login machine carries AuthLoginData on its [:schemas :data] slot"
-    (let [meta (machines/machine-meta :auth.login/flow)]
+    (let [meta (rf.machines/machine-meta :auth.login/flow)]
       (is (some? meta) "machine-meta resolves the registered login machine")
       (is (= login.model/AuthLoginData (get-in meta [:schemas :data]))
           "the [:schemas :data] schema round-trips as login.model/AuthLoginData")))
   (testing "AuthLoginData validates the :data slot only (rejects a non-string :error)"
-    (is (true?  (schemas/validate-with-registered-fn login.model/AuthLoginData {:attempts 0 :error nil})))
-    (is (true?  (schemas/validate-with-registered-fn login.model/AuthLoginData {:attempts 1 :error "Login failed."})))
-    (is (false? (schemas/validate-with-registered-fn login.model/AuthLoginData {:attempts 0 :error {:not "a string"}}))
+    (is (true?  (rf.schemas/validate-with-registered-fn login.model/AuthLoginData {:attempts 0 :error nil})))
+    (is (true?  (rf.schemas/validate-with-registered-fn login.model/AuthLoginData {:attempts 1 :error "Login failed."})))
+    (is (false? (rf.schemas/validate-with-registered-fn login.model/AuthLoginData {:attempts 0 :error {:not "a string"}}))
         "a non-string :error fails the data-slot schema")
-    (is (false? (schemas/validate-with-registered-fn login.model/AuthLoginData {:attempts "x" :error nil}))
+    (is (false? (rf.schemas/validate-with-registered-fn login.model/AuthLoginData {:attempts "x" :error nil}))
         "a non-int :attempts fails the data-slot schema")))
 
 ;; ---------------------------------------------------------------------------
@@ -114,7 +114,7 @@
 
 (deftest malformed-data-fails-boundary
   (testing "a failure whose message is non-string drives :record-error to write a bad :error, failing the :machine-data boundary and rolling back"
-    (with-new-frame [f (frame/make-anon-frame-record! {})]
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
       ;; A bare :submit signal drives :idle → :submitting; then a :failure whose
       ;; message is a non-string map makes :record-error write that map into
       ;; :error — which AuthLoginData's [:maybe :string] rejects.
@@ -141,7 +141,7 @@
 
 (deftest well-formed-data-passes
   (testing "a normal failing login (string message) settles with no :machine-data trace"
-    (with-new-frame [f (frame/make-anon-frame-record! {})]
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
       (let [traces (collect-machine-data-traces!
                      (fn []
                        (submit! f)
@@ -159,7 +159,7 @@
 
 (deftest retry-clears-prior-error
   (testing "a direct retry from :error-shown clears the stale :error as the machine re-enters :submitting"
-    (with-new-frame [f (frame/make-anon-frame-record! {})]
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
       ;; Drive idle → submitting → (string failure) → error-shown.
       (submit! f)
       (fail! f "Invalid credentials.")

--- a/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
@@ -27,20 +27,20 @@
    subsequent test ns."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]
             [long-running-work.worker])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     ;; EP-0002 (rf2-9o48ih): each test spins its OWN top-level frame via
     ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
     ;; frame's `:initial-events` drain synchronously (top-level boot) rather than
     ;; being treated as a mid-cascade child-frame creation.
-    {:adapter       reagent-adapter/adapter
+    {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil}))
 
 ;; ============================================================================
@@ -67,7 +67,7 @@
    Both reach the same end-state: parent machine at :idle with cleared
    :data."
   []
-  (frame/make-anon-frame-record! {:initial-events [[:work/flow [:reset]]]}))
+  (rf.frame/make-anon-frame-record! {:initial-events [[:work/flow [:reset]]]}))
 
 (defn- dispatch-synthetic-child-completion!
   "Synthesise one child's :on-child-done arrival, carrying the SAME

--- a/implementation/adapters/reagent/test/re_frame/m11_recipe_reactive_owner_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/m11_recipe_reactive_owner_cljs_test.cljs
@@ -38,14 +38,14 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
             [reagent.ratom :as ratom]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 (def ^:private fid ::gauge-frame)
 (def ^:private gauge-query [::gauge-value])
@@ -60,10 +60,10 @@
   (rf/dispatch-sync [::seed n] {:frame fid}))
 
 (defn- ref-count []
-  (or (:ref-count (get @(:sub-cache (frame/frame fid)) gauge-query)) 0))
+  (or (:ref-count (get @(:sub-cache (rf.frame/frame fid)) gauge-query)) 0))
 
 (defn- node-reaction []
-  (:reaction (get @(:sub-cache (frame/frame fid)) gauge-query)))
+  (:reaction (get @(:sub-cache (rf.frame/frame fid)) gauge-query)))
 
 ;; White-box, and only ever CORROBORATING: `watching` is the Reagent field that
 ;; says "this reaction is subscribed to its sources". Every arm that consults it

--- a/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
@@ -25,9 +25,9 @@
    leaves them intact for any subsequent test ns."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]
             ;; `re-frame.http.test-support` registers
             ;; `:rf.http/managed-canned-failure` — the fx the failing Story
@@ -48,12 +48,12 @@
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     ;; EP-0002 (rf2-9o48ih): each test spins its OWN top-level frame via
     ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
     ;; frame's `:initial-events` drain synchronously (top-level boot) rather than
     ;; being treated as a mid-cascade child-frame creation.
-    {:adapter       reagent-adapter/adapter
+    {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil}))
 
 ;; ----------------------------------------------------------------------------
@@ -83,7 +83,7 @@
   {:rf.http/managed :nine-states.http/managed-demo})
 
 (defn- new-frame []
-  (frame/make-anon-frame-record!
+  (rf.frame/make-anon-frame-record!
     {:initial-events [[:nine-states.app/initialise]]
      :fx-overrides demo-overrides}))
 
@@ -308,7 +308,7 @@
     ;; setup event.
     (is (some? (rf/handler-meta :event :nine-states.story/load-failing))
         ":nine-states.story/load-failing registered (stories.cljs required)")
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:nine-states.app/initialise]]
                           :fx-overrides story-failure-overrides})]
       ;; Drive the variant's setup load event. The canned-failure stub
@@ -334,7 +334,7 @@
     ;; with no per-variant override. Guards that success and failure stay
     ;; SEPARATELY represented (acceptance: keep the success lifecycle
     ;; variant proving canned-success).
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:nine-states.app/initialise]]
                           :fx-overrides {:rf.http/managed
                                          :rf.http/managed-canned-success}})]

--- a/implementation/adapters/reagent/test/re_frame/pair_dispatch_and_settle_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/pair_dispatch_and_settle_dom_cljs_test.cljs
@@ -47,9 +47,9 @@
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
-            [re-frame.views :as views]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.views :as rf.views]
             [re-frame2-pair.runtime :as pair]))
 
 ;; EP-0002 (rf2-9o48ih): `:ambient-frame nil` opts out of the fixture's default
@@ -62,8 +62,8 @@
 ;; carries explicit `{:frame …}` on its dispatch, so it does not rely on the
 ;; ambient scope either.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :ambient-frame nil}))
 
 (defn- browser? []
@@ -178,7 +178,7 @@
                   "child REMOVED from the DOM synchronously on the settle")
               ;; The teardown emit React fires post-commit — same surface,
               ;; fired now that [:hide] is the most-recently-settled epoch.
-              (views/emit-view-unmounted! :rf.pair-settle/child
+              (rf.views/emit-view-unmounted! :rf.pair-settle/child
                                           [:rf.pair-settle/child 1]
                                           frame-kw)
               ;; Re-read the SAME epoch the settle returned — the unmount

--- a/implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/react_click_handler_frame_routing_cljs_test.cljs
@@ -33,9 +33,9 @@
   unreliable in production."
   (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; Async map-form fixture (a fn-form fixture's teardown would restore the
 ;; registrar before an `(async done)` body completes). `make-reset-runtime-
@@ -47,8 +47,8 @@
 ;; leak shows as 'reducer ran on the wrong frame's db'; those registrations
 ;; roll back with the per-test registrar snapshot.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
      :async?        true
      :ambient-frame nil
      :init-fn       (fn []
@@ -64,14 +64,14 @@
   "Return the :mode slot of a frame's app-db. nil if the frame doesn't
   carry the slot."
   [frame-id]
-  (get (frame/frame-app-db-value frame-id) :mode))
+  (get (rf.frame/frame-app-db-value frame-id) :mode))
 
 (defn- await-mode
   "Poll until the named frame's :mode slot equals `expected`. The router
   drain is async (goog.async.nextTick microtask) so a queued dispatch
   needs one or two macrotasks before its reducer lands."
   [frame-id expected]
-  (test-support/poll-until
+  (rf.test-support/poll-until
     #(= expected (mode-of frame-id))
     {:label      (str frame-id " :mode = " expected)
      :timeout-ms 1000}))
@@ -188,7 +188,7 @@
             escape, any concurrent renderer transition."
     (async done
       ;; Wrap under :rf/xray.
-      (let [wrapped (frame/bind-fn :rf/xray
+      (let [wrapped (rf.frame/bind-fn :rf/xray
                       (fn [mode] (rf/dispatch [:rf-tvu99/set-mode mode])))]
         (-> (inside-set-timeout
               (fn [] (wrapped :all)))
@@ -210,7 +210,7 @@
             still routes to the captured frame."
     (async done
       (let [wrapped (rf/with-frame :rf/xray
-                      (frame/bind-fn :rf/xray
+                      (rf.frame/bind-fn :rf/xray
                         (fn [mode] (rf/dispatch [:rf-tvu99/set-mode mode]))))]
         (-> (inside-set-timeout
               (fn [] (wrapped :all)))
@@ -230,7 +230,7 @@
   (testing "rf2-tvu99 — `dispatch-sync` inside the wrapped callback
             also routes to the captured frame. The binding tier is
             the same; nothing about the sync drain bypasses it."
-    (let [wrapped (frame/bind-fn :rf/xray
+    (let [wrapped (rf.frame/bind-fn :rf/xray
                     (fn [mode] (rf/dispatch-sync [:rf-tvu99/set-mode mode])))]
       (wrapped :all)
       (is (= :all (mode-of :rf/xray))

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -26,10 +26,10 @@
   (:require [clojure.string :as str]
             [cljs.test :refer-macros [deftest testing use-fixtures is async]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             ;; Activate the default Malli validator (rf2-t0hq): without this
             ;; require the CLJS default validator soft-passes and the durable
             ;; AuthSlice regression below could never observe a rollback. This is
@@ -91,7 +91,7 @@
   (rf/reg-fx fx-id
     {:platforms #{:client :server}}
     (fn [frame-ctx args]
-      (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+      (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-success)]
         (stub frame-ctx (assoc args :value value))))))
 
 (defn- reg-canned-success-by-url!
@@ -103,7 +103,7 @@
   (rf/reg-fx fx-id
     {:platforms #{:client :server}}
     (fn [frame-ctx args]
-      (let [stub   (registrar/handler :fx :rf.http/managed-canned-success)
+      (let [stub   (rf.registrar/handler :fx :rf.http/managed-canned-success)
             req    (:request args)
             method (or (:method req) :get)
             url    (:url req)
@@ -122,7 +122,7 @@
   (rf/reg-fx fx-id
     {:platforms #{:client :server}}
     (fn [frame-ctx args]
-      (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+      (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-failure)]
         (stub frame-ctx (assoc args :kind kind :tags tags))))))
 
 ;; A generic success stub: every :rf.http/managed call resolves :success
@@ -134,13 +134,13 @@
 (reg-canned-success! :realworld.test/canned-success-empty {})
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     ;; EP-0002 (rf2-9o48ih): each helper spins its OWN top-level frame via
     ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
     ;; frame's `:initial-events` drain synchronously (top-level boot) rather than
     ;; being treated as a mid-cascade child-frame creation. In-body dispatches
     ;; carry explicit `{:frame f}` or run inside the `with-new-frame` scope.
-    {:adapter       reagent-adapter/adapter
+    {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil
      ;; Map-form (rf2-k5lbd): the production-seam receipt at the bottom is an
      ;; `(async done …)` row — it awaits the demo backend's deferred replies —
@@ -169,7 +169,7 @@
                                :bio      nil
                                :image    nil}})
 
-  (with-new-frame [f (frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed      :realworld.test/login-success
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed      :realworld.test/login-success
                                                     :auth.session/persist :rf/no-op}})]
     ;; EP-0017 (rf2-16ck78): `:auth/initialise` consumes the recordable
     ;; `:auth.session/token` coeffect. Live, its registered supplier reads
@@ -205,7 +205,7 @@
   ;; provided (it has a generator), and carries a supplier fn (the localStorage
   ;; read). A declaring handler receives the generated value FLAT under
   ;; `:auth.session/token` via `:rf.cofx/requires`.
-  (let [cofx-meta (registrar/handler-meta :cofx :auth.session/token)]
+  (let [cofx-meta (rf.registrar/handler-meta :cofx :auth.session/token)]
     (is (true? (:recordable? cofx-meta))
         "the cofx is recordable — its value rides the recorded token")
     (is (not (:provided? cofx-meta))
@@ -219,7 +219,7 @@
                        {:status 422
                         :body   {:errors {:body ["email or password is invalid"]}}})
 
-  (with-new-frame [f (frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed :realworld.test/login-failure}})]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed :realworld.test/login-failure}})]
     ;; EP-0017 (rf2-16ck78): pin the recordable `:auth.session/token` through the
     ;; dispatch-site `:rf.cofx` stub (nil node-side, as the supplier would give).
     (rf/dispatch-sync [:auth/initialise]
@@ -281,7 +281,7 @@
 
   ;; --- DURABLE contract: the token-free session user is stored AND validates
   ;;     against the real AuthSlice under the real post-commit validator ---
-  (with-new-frame [f (frame/make-anon-frame-record! {})]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
     ;; Register the ACTUAL production AuthSlice on THIS frame so the post-commit
     ;; validator consults it — the wiring the anon-frame tests route around.
     (rf/reg-app-schema [:auth] {:frame f} app-schema/AuthSlice)
@@ -326,7 +326,7 @@
                                              :following false}}]
                         :articlesCount 1})
 
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-articles}})]
     (is (= :idle (:status (rf/compute-sub [:articles/slice] (rf/frame-state-value f)))))
     (rf/dispatch-sync [:articles/load] {:frame f})
@@ -345,7 +345,7 @@
                        {:status 500
                         :body   "server error"})
 
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-articles-failure}})]
     (rf/dispatch-sync [:articles/load] {:frame f})
     (is (= :error (:status (rf/compute-sub [:articles/slice] (rf/frame-state-value f)))))
@@ -368,7 +368,7 @@
                                   :favoritesCount 0
                                   :author {:username "alice" :bio nil :image nil :following false}}})
 
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-editor-save}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     ;; The :mode region starts at :create; the :lifecycle region starts
@@ -391,7 +391,7 @@
     (is (false? (rf/compute-sub [:editor/dirty?] (rf/frame-state-value f))))))
 
 (defn- editor-can-leave-test []
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     (is (true? (rf/compute-sub [:editor/can-leave?] (rf/frame-state-value f))))
@@ -428,7 +428,7 @@
                                              :favoritesCount 0
                                              :author {:username "alice" :bio nil :image nil :following false}}})))
 
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-article-and-comments}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})
@@ -467,7 +467,7 @@
                                              :favoritesCount 0
                                              :author {:username "alice" :bio nil :image nil :following false}}})))
 
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-comment-post}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})
@@ -488,7 +488,7 @@
   ;; or a concurrent delete), a stale index can point past the current
   ;; vector. The rollback's `subvec` must NOT throw IndexOutOfBounds — it
   ;; clamps the index to the current length and re-inserts at the tail.
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:comments/initialise] {:frame f})
     ;; Seed a single comment (the list is now length 1). :comments/loaded
@@ -533,7 +533,7 @@
                        {:status 400
                         :body   {:errors {:body ["rollback"]}}})
 
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/favorite-rollback}})]
     (rf/dispatch-sync [:articles/initialise] {:frame f})
     ;; :article/toggle-favorite is auth-gated (rf2-ygh4m): a logged-out
@@ -583,7 +583,7 @@
                                                :favoritesCount 0
                                                :author {:username "eve" :bio nil :image nil :following false}}]})))
 
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-profile}})]
     (rf/dispatch-sync [:profile/initialise] {:frame f})
     (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
@@ -621,7 +621,7 @@
                                :bio "New bio"
                                :image nil}})
 
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed    :realworld.test/canned-settings-save
                                                 :auth.session/persist :rf/no-op}})]
     ;; After :app/initialise → :settings/initialise → [:reset], the
@@ -685,7 +685,7 @@
   (reg-canned-failure! :realworld.test/canned-settings-failure
                        :rf.http/http-5xx
                        {:status 500 :body "server error"})
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed    :realworld.test/canned-settings-failure
                                                 :auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
@@ -717,7 +717,7 @@
   ;; validate inside :settings/submit would dispatch :submit-invalid
   ;; when the draft failed validation, matching Pattern-Forms'
   ;; §Standard events table.
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed       :realworld.test/canned-success-empty
                                                 :auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
@@ -765,7 +765,7 @@
                   (rf/frame-state-value frame)))
 
 (defn- tag-query-test []
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; rf2-e90vfv route-shape conformance: applying a tag navigates to the
     ;; official `/tag/:tag` PATH route, so the active tag is a route PARAM (read
@@ -781,7 +781,7 @@
   ;; The :tags lifecycle — load happy path through the machine.
   (reg-canned-success! :realworld.test/canned-tags
                        {:tags ["intro" "demo" "clojure"]})
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-tags}})]
     ;; After :app/initialise → :tags/initialise → [:reset], the machine
     ;; sits at :idle with empty :data.
@@ -825,7 +825,7 @@
   (reg-canned-failure! :realworld.test/canned-tags-failure
                        :rf.http/http-5xx
                        {:status 500 :body "server error"})
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-tags-failure}})]
     (rf/dispatch-sync [:tags/load] {:frame f})
     (let [db   (rf/frame-state-value f)
@@ -841,7 +841,7 @@
 ;; ============================================================================
 
 (defn- routing-tests []
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:rf.route/navigate {:to :realworld.article/show :params {:slug "hello"}}] {:frame f})
     (is (= :realworld.article/show (rf/compute-sub [:rf.route/id] (rf/frame-state-value f))))
@@ -876,7 +876,7 @@
   ;; one pipeline runs the guard on every door. Entry denial is TERMINAL: it
   ;; commits nothing and creates NO pending value, so the return after sign-in
   ;; is a FRESH navigate, not a resume.
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; Unauthenticated: navigating to a :requires-auth route
     ;; (:realworld.user/settings) is denied by :can-enter → :rf.route/entry-denied
@@ -923,7 +923,7 @@
   ;; three doors redirect to login (no frame interceptor needed).
 
   ;; --- direct-URL / reload / popstate (`:rf.route/handle-url-change`) ---
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; Logged-out direct URL (or reload) to a :requires-auth route.
     (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame f})
@@ -948,7 +948,7 @@
         "logged-out direct-URL to a non-auth route is unaffected"))
 
   ;; --- anchor click (`:rf.route/url-requested`) ---
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; An anchor whose href targets a :requires-auth route. The
     ;; framework `rf/route-link` dispatches `:rf.route/url-requested` with the
@@ -976,7 +976,7 @@
         "logged-out anchor to a non-auth route is unaffected"))
 
   ;; --- authenticated: every entry point now PASSES through ---
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
     ;; direct-URL / reload to a guarded route proceeds when logged in.
@@ -1000,7 +1000,7 @@
   ;; auth.cljs `:auth/post-login-redirect`).
 
   ;; --- 1. destination deep-link carrying BOTH query and fragment ---
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; Logged-out deep-link to the guarded editor with a query AND a fragment.
     ;; (`:tab` is an undeclared query key — the guarded routes declare none — so
@@ -1031,7 +1031,7 @@
         "the crumb was read AND cleared in one step"))
 
   ;; --- 2. in-place edit under an expired session ---
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; Enter the editor legitimately, then let the session expire.
     (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
@@ -1052,7 +1052,7 @@
         "the in-place edit's resolved destination (current route + new #fragment) is stashed whole"))
 
   ;; --- 3. an unmatchable raw URL stays a RAW destination ---
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; The runtime never rewrites a destination it cannot reify without
     ;; changing the requested URL: an unmatched in-app URL stays `{:url …}`
@@ -1141,7 +1141,7 @@
     (is (str/includes? p "offset=20") "page 3 → offset 20")))
 
 (defn- pagination-nav-events-test []
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     ;; --- :home/show-page carries the active feed forward ---
     ;; Global feed, then page 3: the home route, no ?feed=, ?page=3.
@@ -1207,7 +1207,7 @@
 
   ;; --- RESTORE STAYS PUT: a cold boot with a saved token restores the session
   ;;     without navigating (a deep link must survive a refresh) ---
-  (with-new-frame [f (frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed       :realworld.test/restore-user
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed       :realworld.test/restore-user
                                                     :auth.session/persist :rf/no-op}})]
     ;; Land on a deep link (a public article), as a refresh would.
     (rf/dispatch-sync [:rf.route/handle-url-change "/article/some-slug"] {:frame f})
@@ -1232,7 +1232,7 @@
   ;; --- CONTRAST: an INTERACTIVE login DOES bounce (proves navigation is
   ;;     observable here, so the restore's non-navigation above is a real
   ;;     signal, not a harness that simply never navigates) ---
-  (with-new-frame [f (frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed       :realworld.test/restore-user
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:fx-overrides {:rf.http/managed       :realworld.test/restore-user
                                                     :auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:rf.route/handle-url-change "/article/some-slug"] {:frame f})
     (rf/dispatch-sync [:auth/initialise]
@@ -1327,7 +1327,7 @@
    the recordable coeffect is stubbed at the one seam its own registration
    documents, and node's absent localStorage is not in the way."
   [url token sink]
-  (frame/make-anon-frame-record!
+  (rf.frame/make-anon-frame-record!
     {:url-bound?     true
      :url-strategy   (decode-to-url-strategy url)
      :initial-events [[:auth/classify-token]
@@ -1459,7 +1459,7 @@
 ;; ============================================================================
 
 (defn- app-smoke-test []
-  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
                                  :fx-overrides {:rf.http/managed      :realworld.test/canned-success-empty
                                                 :auth.session/persist :rf/no-op}})]
     ;; EP-0017 (rf2-16ck78): `:auth/initialise` is no longer in the
@@ -1623,7 +1623,7 @@
                    :createdAt "2026-05-01" :updatedAt "2026-05-01"
                    :favorited false :favoritesCount 0
                    :author {:username "alice" :bio nil :image nil :following false}}}))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/editor-edit}})]
       ;; /editor/:slug is :requires-auth — sign in so the :can-enter guard passes and
@@ -1659,7 +1659,7 @@
 (defn- editor-load-failure-test []
   (reg-canned-failure! :realworld.test/editor-load-fail
                        :rf.http/http-5xx {:status 500 :body "server error"})
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/editor-load-fail}})]
     (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -1678,7 +1678,7 @@
         {:article {:slug "doomed" :title "Doomed" :description "d" :body "b" :tagList []
                    :createdAt "x" :updatedAt "x" :favorited false :favoritesCount 0
                    :author {:username "alice" :bio nil :image nil :following false}}}))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/editor-delete}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -1698,7 +1698,7 @@
           "the :mode region resets to :create after a delete"))))
 
 (defn- editor-invalid-submit-test []
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
@@ -1727,7 +1727,7 @@
     (rf/reg-fx :realworld.test/editor-in-flight
       {:platforms #{:client :server}}
       (fn [_frame-ctx args] (reset! in-flight args) nil))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/editor-in-flight}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -1790,7 +1790,7 @@
     (rf/reg-fx :realworld.test/editor-cross-slug
       {:platforms #{:client :server}}
       (fn [_frame-ctx args] (swap! lowered conj args) nil))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/editor-cross-slug}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -1850,7 +1850,7 @@
     (rf/reg-fx :realworld.test/editor-cross-slug-fail
       {:platforms #{:client :server}}
       (fn [_frame-ctx args] (swap! lowered conj args) nil))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/editor-cross-slug-fail}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -1959,7 +1959,7 @@
     (rf/reg-fx :realworld.test/article-cross-slug
       {:platforms #{:client :server}}
       (fn [_frame-ctx args] (swap! lowered conj args) nil))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/article-cross-slug}})]
       (rf/dispatch-sync [:article/initialise] {:frame f})
@@ -2015,7 +2015,7 @@
     (rf/reg-fx :realworld.test/article-cross-slug-fail
       {:platforms #{:client :server}}
       (fn [_frame-ctx args] (swap! lowered conj args) nil))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/article-cross-slug-fail}})]
       (rf/dispatch-sync [:article/initialise] {:frame f})
@@ -2062,7 +2062,7 @@
     (rf/reg-fx :realworld.test/article-transition
       {:platforms #{:client :server}}
       (fn [_frame-ctx args] (swap! lowered conj args) nil))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed :realworld.test/article-transition}})]
       (rf/dispatch-sync [:article/initialise] {:frame f})
@@ -2177,7 +2177,7 @@
     (rf/reg-fx fx-id
       {:platforms #{:client :server}}
       (fn [_frame-ctx args] (swap! lowered conj args) nil))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed fx-id}})]
       (rf/dispatch-sync [:article/initialise] {:frame f})
@@ -2717,7 +2717,7 @@
                :createdAt "x" :updatedAt "x"
                :favorited true :favoritesCount 42
                :author {:username "alice" :bio nil :image nil :following false}}})
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/favorite-ok}})]
     (rf/dispatch-sync [:articles/initialise] {:frame f})
@@ -2751,7 +2751,7 @@
                          :tagList [] :createdAt "x" :updatedAt "x"
                          :favorited false :favoritesCount 0
                          :author {:username "eve" :bio nil :image nil :following false}}})))
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/follow-author}})]
     (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -2782,7 +2782,7 @@
         {:article {:slug "hello" :title "Hello" :description "d" :body "b" :tagList []
                    :createdAt "x" :updatedAt "x" :favorited false :favoritesCount 0
                    :author {:username "alice" :bio nil :image nil :following false}}})))
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/detail-delete}})]
     (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -2801,7 +2801,7 @@
 
 (defn- comment-blank-body-test []
   ;; :comment-form/submit with a blank body → client-side validation, no round trip.
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -2821,7 +2821,7 @@
                  :createdAt "x" :updatedAt "x" :favorited false :favoritesCount 0
                  :author {:username "bob" :bio nil :image nil :following true}}]
      :articlesCount 7})
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/feed-ok}})]
     (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -2835,7 +2835,7 @@
 
 (defn- feed-load-failure-test []
   (reg-canned-failure! :realworld.test/feed-fail :rf.http/http-5xx {:status 500 :body "boom"})
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/feed-fail}})]
     (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -2858,7 +2858,7 @@
                            :createdAt "x" :updatedAt "x" :favorited true :favoritesCount 3
                            :author {:username "eve" :bio nil :image nil :following false}}]
                :articlesCount 3})))
-  (with-new-frame [f (frame/make-anon-frame-record!
+  (with-new-frame [f (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides {:rf.http/managed :realworld.test/profile-follow}})]
     (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -2978,7 +2978,7 @@
     (rf/reg-fx fx-id
       {:platforms #{:client :server}}
       (fn [_frame-ctx args] (swap! lowered conj args) nil))
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:initial-events [[:app/initialise]]
                           :fx-overrides {:rf.http/managed fx-id}})]
       (rf/dispatch-sync [:auth/store-session {:username "zed" :email "z@b.c"
@@ -3515,7 +3515,7 @@
     (async done
       ;; The documented reset boundary: this receipt's world, and nobody else's.
       (reset! rh/demo-state (demo/fresh-state))
-      (let [f        (frame/make-anon-frame-record!
+      (let [f        (rf.frame/make-anon-frame-record!
                        {:initial-events [[:app/initialise]]
                         :fx-overrides   {:rf.http/managed :realworld.demo/http-stub}})
             slug     "hello-conduit"
@@ -3529,7 +3529,7 @@
         (rf/dispatch-sync [:rf.route/handle-url-change (str "/article/" slug)] {:frame f})
         (is (= :loading (status))
             "the route's own :comments/load is in flight against the demo backend")
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(= :loaded (status))
               {:label "the route's comments load settles from the demo backend"})
             (.then (fn [_]
@@ -3544,7 +3544,7 @@
                          "the optimistic temp card is on screen before the backend answers")
                      (is (str/starts-with? (str (:id (second (comments)))) "temp-")
                          "…under its recordable temp-id")
-                     (test-support/poll-until
+                     (rf.test-support/poll-until
                        #(= 1000 (:id (second (comments))))
                        {:label "the POST settles from the demo backend and the saved comment replaces the temp card"})))
             (.then (fn [_]
@@ -3554,7 +3554,7 @@
                      (rf/dispatch-sync [:comments/load] {:frame f})
                      (is (= :fetching (status))
                          "a same-slug re-load keeps the list up while it refreshes")
-                     (test-support/poll-until
+                     (rf.test-support/poll-until
                        #(= :loaded (status))
                        {:label "the later load settles from the demo backend"})))
             (.then (fn [_]

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -53,11 +53,11 @@
   (:require [clojure.string :as str]
             [cljs.test :refer-macros [deftest testing use-fixtures is async]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.fx :as rf.fx]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             ;; Activate the default Malli validator (rf2-t0hq): the CLJS default
             ;; validator soft-passes without this require, so the durable
             ;; AuthSlice regression below could never observe a rollback. The
@@ -68,15 +68,15 @@
             [re-frame.http.managed]
             [re-frame.http.test-support]
             [re-frame.resources]
-            [re-frame.resources.route :as resources-route]
-            [re-frame.resources.state :as state]
+            [re-frame.resources.route :as rf.resources.route]
+            [re-frame.resources.state :as rf.resources.state]
             [re-frame.resources.test-support]
-            [re-frame.routing :as routing]
+            [re-frame.routing :as rf.routing]
             ;; the framework trace-ring buffer (Spec 009) — cleared around each
             ;; test body so this dispatching suite leaves no trace residue for a
             ;; later cross-cutting tooling test (e.g. the Xray/Story panel e2e
             ;; seeds, which read the rings). See `clear-trace-rings-fixture`.
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             ;; the example's production source — chains in every feature ns.
             [realworld-resources.core :as core]
             [realworld-resources.scope :as scope]
@@ -123,7 +123,7 @@
 ;; `reg-resource-scope` declarations. (Routes / the auth machine live under kinds
 ;; the reset does NOT clear, so they survive via the fixture's ns-load baseline.)
 (def ^:private resource-kind-snapshots
-  (select-keys @registrar/kind->id->metadata
+  (select-keys @rf.registrar/kind->id->metadata
                [:resource :mutation :resource-scope]))
 
 ;; AT NS LOAD, immediately remove THIS example's `:resource` / `:mutation` /
@@ -138,7 +138,7 @@
 ;; `:rf.registry/handler-cleared` burst into its cascade seed (a false-positive
 ;; `:rf.xray/cascades`). We remove only OUR ids (not the whole kind) so a sibling
 ;; suite's ns-load registrations are untouched; ours re-install via `init!`.
-(swap! registrar/kind->id->metadata
+(swap! rf.registrar/kind->id->metadata
        (fn [reg]
          (reduce (fn [r [kind id->meta]]
                    (update r kind (fn [m] (apply dissoc m (keys id->meta)))))
@@ -183,14 +183,14 @@
   ;; frame's next resolution sees the reinstated registrations.
   (doseq [[kind id->meta] resource-kind-snapshots
           [id meta] id->meta]
-    (registrar/register! kind id meta))
-  (routing/reset-counters!)
-  (resources-route/install-routing-integration!)
-  (fx/reg-fx :rf.http/managed (fn [_ctx args]
+    (rf.registrar/register! kind id meta))
+  (rf.routing/reset-counters!)
+  (rf.resources.route/install-routing-integration!)
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args]
                                 (reset! last-managed-args args)
                                 (swap! managed-args-log conj args)
                                 nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
   ;; LAST — see the ordering note in the docstring. Everything the frame's
   ;; construction-time URL sync needs (the reinstated `:resource` / `:mutation`
   ;; rows, the routing integration, the stubbed fx) is registered above.
@@ -232,16 +232,16 @@
    its own collector (its helper calls `reset-sentinels!` +
    `register-trace-collector!`), so clearing here is safe."
   {:before (fn []
-             (trace-tooling/clear-listeners!)
-             (trace-tooling/clear-trace-rings!))
+             (rf.trace.tooling/clear-listeners!)
+             (rf.trace.tooling/clear-trace-rings!))
    :after  (fn []
-             (trace-tooling/clear-listeners!)
-             (trace-tooling/clear-trace-rings!))})
+             (rf.trace.tooling/clear-listeners!)
+             (rf.trace.tooling/clear-trace-rings!))})
 
 (use-fixtures :each
   isolate-trace-bus-fixture
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :init-fn init!
      ;; Map-form (rf2-k5lbd): §11's production-seam receipt is an
      ;; `(async done …)` row, and cljs.test runs one only under map fixtures.
@@ -269,7 +269,7 @@
 
 (defn- entry
   ([scoped-key] (entry :rf/default scoped-key))
-  ([frame-id scoped-key] (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
+  ([frame-id scoped-key] (get-in (runtime-db frame-id) (rf.resources.state/entry-path scoped-key))))
 
 (defn- viewer-scope
   "The concrete `[:rf.scope/viewer {:username …}]` scope for a signed-in reader —
@@ -290,20 +290,20 @@
 ;; explicit viewer for the cross-viewer leak tests.
 (defn- article-key
   ([slug] (article-key "alice" slug))
-  ([viewer slug] (state/scoped-resource-key (viewer-scope viewer) :realworld/article {:slug slug})))
+  ([viewer slug] (rf.resources.state/scoped-resource-key (viewer-scope viewer) :realworld/article {:slug slug})))
 
 (defn- feed-key
   "The session-scoped :realworld/feed key for username + page."
   [username page]
-  (state/scoped-resource-key [:rf.scope/session {:username username}] :realworld/feed {:page page}))
+  (rf.resources.state/scoped-resource-key [:rf.scope/session {:username username}] :realworld/feed {:page page}))
 
 (defn- profile-key
   ([subject] (profile-key "alice" subject))
-  ([viewer subject] (state/scoped-resource-key (viewer-scope viewer) :realworld/profile {:username subject})))
+  ([viewer subject] (rf.resources.state/scoped-resource-key (viewer-scope viewer) :realworld/profile {:username subject})))
 
 (defn- comments-key
   ([slug] (comments-key "alice" slug))
-  ([viewer slug] (state/scoped-resource-key (viewer-scope viewer) :realworld/comments {:slug slug})))
+  ([viewer slug] (rf.resources.state/scoped-resource-key (viewer-scope viewer) :realworld/comments {:slug slug})))
 
 ;; The two profile tabs' own paginated lists. Both are viewer-scoped like the
 ;; banner, and both take the route's `{:username :page}` params — `:page` defaults
@@ -312,19 +312,19 @@
 (defn- author-articles-key
   ([subject page] (author-articles-key "alice" subject page))
   ([viewer subject page]
-   (state/scoped-resource-key (viewer-scope viewer) :realworld/author-articles
+   (rf.resources.state/scoped-resource-key (viewer-scope viewer) :realworld/author-articles
                               {:username subject :page page})))
 
 (defn- favorited-articles-key
   ([subject page] (favorited-articles-key "alice" subject page))
   ([viewer subject page]
-   (state/scoped-resource-key (viewer-scope viewer) :realworld/favorited-articles
+   (rf.resources.state/scoped-resource-key (viewer-scope viewer) :realworld/favorited-articles
                               {:username subject :page page})))
 
 (defn- tags-key
   "The truly-invariant global-scope :realworld/tags key (the one read still global)."
   []
-  (state/scoped-resource-key :rf.scope/global :realworld/tags {}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :realworld/tags {}))
 
 (defn- reply-success!
   "Replay the captured `:on-success` with the transport's success result
@@ -358,7 +358,7 @@
    in-place request resolves against it); url-push is a no-op so navigation is
    deterministic without a browser."
   []
-  (frame/make-anon-frame-record! {:url-bound?   true
+  (rf.frame/make-anon-frame-record! {:url-bound?   true
                                   :fx-overrides {:rf.nav/push-url :rf/no-op}}))
 
 (defn- gc-recheck!
@@ -476,13 +476,13 @@
             [:auth :token] from the cascade's frame and injects
             `Authorization: Token <jwt>`; it is a no-op when logged out"
     ;; LOGGED OUT — the public reads must not carry an auth header.
-    (with-new-frame [f (frame/make-anon-frame-record! {})]
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
       (let [ctx {:frame f :request {:url "/articles"}}]
         (is (nil? (get-in (core/bearer-auth-interceptor ctx)
                           [:request :headers "Authorization"]))
             "no token → no Authorization header (logged-out reads unaffected)")))
     ;; AUTHED — the token in the frame's app-db is injected as a Bearer header.
-    (with-new-frame [f (frame/make-anon-frame-record! {})]
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt-xyz"}] {:frame f})
       (let [ctx {:frame f :request {:url "/articles/feed"}}]
         (is (= "Token jwt-xyz"
@@ -528,7 +528,7 @@
     (is (true? (:sensitive? (vec-map-slot-props ws/User :token)))
         "the wire User's :token slot stays classified :sensitive? true")
     ;; DURABLE contract — the token-free session user commits and validates.
-    (with-new-frame [f (frame/make-anon-frame-record! {})]
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {})]
       ;; The REAL production AuthSlice on THIS frame → the real validator runs.
       (rf/reg-app-schema [:auth] {:frame f} app-schema/AuthSlice)
       (with-trace-recorder! [traces]
@@ -562,7 +562,7 @@
             global article tags AND the session feed in one set of per-target
             descriptors, and fires no extra wiring; the call-site :reply-to
             continuation fires exactly once on settle"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       ;; log in so the session feed scope resolves
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -615,7 +615,7 @@
             valid-AND-dirty into app-db; a blank draft is invalid; a valid+dirty
             draft submits the save mutation; the :reply-to [:editor/replied]
             continuation re-seeds a clean draft and navigates to the saved article"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       ;; Boot registers the :editor/can-submit? flow ONCE against the frame
       ;; (`:app/initialise` -> `:editor/register-flow`, rf2-xugvye); the create-route
@@ -660,7 +660,7 @@
             favorited/following flags) via :rf.resource/clear-scope, so the next
             user can never read a stale entry of theirs. Only the truly-invariant
             global tags read is left alone (rf2-j538f7.29)."
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       ;; alice's SESSION feed
@@ -703,7 +703,7 @@
   (testing "examples/real-apps/realworld_resources — the :auth/flow machine drives
             :idle → :submitting → :authed on a login success and stores the
             session (auth is a command/machine, deliberately NOT a read-resource)"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op
                                                       :realworld-resources.session/persist :rf/no-op}})]
       ;; boot the machine at :idle (token nil → the has-token? guard routes to no-op)
@@ -740,7 +740,7 @@
             (cofx.md §Decision tree). The generator runs at processing-start, is
             recorded onto the causal token, and replay re-presents the captured
             value verbatim."
-    (let [cofx-meta (registrar/handler-meta :cofx :realworld-resources.session/token)]
+    (let [cofx-meta (rf.registrar/handler-meta :cofx :realworld-resources.session/token)]
       (is (true? (:recordable? cofx-meta))
           "the cofx is recordable — its value rides the recorded token")
       (is (not (:provided? cofx-meta))
@@ -762,7 +762,7 @@
             :profile/go-to-page keep the active feed / tag / route + username and
             swap only ?page=, and page 1 drops the ?page= param (the canonical
             first-page URL) so page N and N+1 share a filter under distinct keys"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       ;; global feed, page 2 → ?page=2 on the home route
       (rf/dispatch-sync [:home/show-global-feed] {:frame f})
@@ -822,7 +822,7 @@
             the read under [:route :realworld.editor/edit nav-token]; navigating
             edit→New Article releases that owner (the route leave) so the article
             entry is reclaimed (rf2-y4mgw)"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       ;; EDIT-MODE ENTRY: navigating to /editor/:slug runs the route plan (owns
@@ -876,7 +876,7 @@
             old app-minted [:app :editor/article slug] was released only on
             new/A→B/delete/unmount — so a plain edit→home stranded it. With the
             read re-homed onto the route `:resources`, route leave IS the release"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       (rf/dispatch-sync [:rf.route/navigate {:to :realworld.editor/edit :params {:slug "hello-conduit"}}] {:frame f})
@@ -908,7 +908,7 @@
             the delete branch clears the slice and navigates home, and that
             navigate-home leaves the edit route, so the runtime releases the
             route-owned article read on the way out (rf2-y4mgw)"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       (rf/dispatch-sync [:rf.route/navigate {:to :realworld.editor/edit :params {:slug "doomed"}}] {:frame f})
@@ -944,7 +944,7 @@
             B draft the user now edits; now `:editor/article-loaded` seeds only
             while the current route still targets the reply's slug, so the late A
             reply is dropped and the B draft survives"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       ;; ENTER edit A. Capture A's in-flight read WITHOUT settling it — A's fetch is
@@ -1003,7 +1003,7 @@
             baseline, so the typing survives and stays dirty; every untouched
             field takes the loaded article's value in both, so the dirty-check
             still compares against what the server holds."
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       ;; ENTER edit A. Capture A's read WITHOUT settling it — the fetch is still
@@ -1068,7 +1068,7 @@
 (defn- articles-list-key
   "The :realworld/articles home-list key for a viewer scope + page."
   ([scope] (articles-list-key scope 1))
-  ([scope page] (state/scoped-resource-key scope :realworld/articles {:tag nil :page page})))
+  ([scope page] (rf.resources.state/scoped-resource-key scope :realworld/articles {:tag nil :page page})))
 
 (defn- slice
   "The live route slice `{:route-id :params :query :fragment :transition :error :nav-token}`."
@@ -1090,20 +1090,20 @@
   "The byte-keyed `{<key-id> <scoped-key>}` carrier shape the plan / blocking slots
    hold, built from scoped keys — so a slot can be asserted whole."
   [& scoped-keys]
-  (into {} (map (juxt state/key-id identity)) scoped-keys))
+  (into {} (map (juxt rf.resources.state/key-id identity)) scoped-keys))
 
 (defn- entries-for
   "Every cache entry for `resource-id`, under ANY scope."
   [frame resource-id]
   (into [] (comp (map val) (filter #(= resource-id (second (:resource/key %)))))
-        (get-in (runtime-db frame) (state/entries-path))))
+        (get-in (runtime-db frame) (rf.resources.state/entries-path))))
 
 (defn- restore-frame!
   "A URL-owning anon frame for the restore tests: url-push and the session-persist
    fx are no-op'd so navigation is deterministic and the token never reaches
    localStorage."
   []
-  (frame/make-anon-frame-record! {:url-bound? true
+  (rf.frame/make-anon-frame-record! {:url-bound? true
                                   :fx-overrides {:rf.nav/push-url :rf/no-op
                                                  :realworld-resources.session/persist :rf/no-op}}))
 
@@ -1267,10 +1267,10 @@
       ;; Capture the host nav fxs GLOBALLY (both platforms) so a push / scroll
       ;; would be observable; the frame below therefore does NOT override
       ;; `:rf.nav/push-url`.
-      (fx/reg-fx :rf.nav/push-url    {:platforms #{:server :client}} (fn [_ url]  (swap! pushed conj url)))
-      (fx/reg-fx :rf.nav/replace-url {:platforms #{:server :client}} (fn [_ url]  (swap! pushed conj url)))
-      (fx/reg-fx :rf.nav/scroll      {:platforms #{:server :client}} (fn [_ args] (swap! scrolled conj args)))
-      (with-new-frame [f (frame/make-anon-frame-record!
+      (rf.fx/reg-fx :rf.nav/push-url    {:platforms #{:server :client}} (fn [_ url]  (swap! pushed conj url)))
+      (rf.fx/reg-fx :rf.nav/replace-url {:platforms #{:server :client}} (fn [_ url]  (swap! pushed conj url)))
+      (rf.fx/reg-fx :rf.nav/scroll      {:platforms #{:server :client}} (fn [_ args] (swap! scrolled conj args)))
+      (with-new-frame [f (rf.frame/make-anon-frame-record!
                            {:url-bound?   true
                             :fx-overrides {:realworld-resources.session/persist :rf/no-op}})]
         (rf/dispatch-sync [:auth/initialise]
@@ -1377,8 +1377,8 @@
                                                :params {:username "celeb"}}]
                           {:frame f})
         (let [{:keys [nav-token] :as before} (slice f)
-              banner-key (state/scoped-resource-key anon-viewer-scope :realworld/profile {:username "celeb"})
-              fav-key    (state/scoped-resource-key anon-viewer-scope :realworld/favorited-articles
+              banner-key (rf.resources.state/scoped-resource-key anon-viewer-scope :realworld/profile {:username "celeb"})
+              fav-key    (rf.resources.state/scoped-resource-key anon-viewer-scope :realworld/favorited-articles
                                                     {:username "celeb" :page 1})]
           (is (= :rf.error/resource-route-plan (:rf.error/id (:error before)))
               "route entry failed closed while the viewer was unresolved")
@@ -1421,11 +1421,11 @@
         ;; during restore the viewer read fails closed — nothing stored anywhere
         (is (nil? (entry f (article-key "alice" "public-post"))))
         (is (nil? (entry f (article-key "public-post"))) "not under a signed-in viewer")
-        (is (nil? (entry f (state/scoped-resource-key anon-viewer-scope :realworld/article {:slug "public-post"})))
+        (is (nil? (entry f (rf.resources.state/scoped-resource-key anon-viewer-scope :realworld/article {:slug "public-post"})))
             "not under the anonymous viewer yet either (viewer still unresolved)")
         (let [token-before (:nav-token (slice f))
-              anon-article (state/scoped-resource-key anon-viewer-scope :realworld/article {:slug "public-post"})
-              anon-comments (state/scoped-resource-key anon-viewer-scope :realworld/comments {:slug "public-post"})]
+              anon-article (rf.resources.state/scoped-resource-key anon-viewer-scope :realworld/article {:slug "public-post"})
+              anon-comments (rf.resources.state/scoped-resource-key anon-viewer-scope :realworld/comments {:slug "public-post"})]
           ;; GET /user is REJECTED (401) → :auth/restore-failed → :abandon-restore
           (rf/dispatch-sync (conj (:on-failure restore-req) {:status :error :error {:rf.http/status 401}})
                             {:frame f})
@@ -1445,7 +1445,7 @@
               "…and so is its :when-admitted comments sub-resource")
           (is (nil? (entry f (article-key "alice" "public-post")))
               "never stored under a signed-in viewer")
-          (is (nil? (entry f (state/scoped-resource-key :rf.scope/global :realworld/article {:slug "public-post"})))
+          (is (nil? (entry f (rf.resources.state/scoped-resource-key :rf.scope/global :realworld/article {:slug "public-post"})))
               "never stored under :rf.scope/global")
           (is (= (by-id anon-article anon-comments) (plan-slot f token-before))
               "the plan slot records exactly the replanned membership")
@@ -1459,7 +1459,7 @@
             reader's UI — and the favorite verb (POST vs DELETE) is therefore chosen
             from the CURRENT viewer's bytes, not the departing one's (rf2-j538f7.29,
             gates 3 + 4)"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       ;; ALICE loads the article; her representation carries favorited=true.
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt-a"}] {:frame f})
@@ -1508,7 +1508,7 @@
             patch (toggle-article-fav) clamps :favoritesCount at zero, so an
             over-eager unfavorite of an already-zero article can't go negative
             (mutations.cljs zero-clamp adversarial edge)"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       ;; Seed the article detail with favorited=true, favoritesCount=0 (the edge:
@@ -1543,7 +1543,7 @@
   (testing "examples/real-apps/realworld_resources — :realworld/follow / :realworld/unfollow
             seed the [:profile username] banner from their reply (:populates), so the
             banner's :following flips immediately without waiting on the refetch"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       ;; own + load the profile banner (following=false) so :populates has an
@@ -1578,7 +1578,7 @@
   (testing "examples/real-apps/realworld_resources — :realworld/post-comment and
             :realworld/delete-comment invalidate [:comments slug], so the mounted
             article page's owned comments read refetches to truth"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       ;; own + load the comments read so the invalidation has a live owner to
@@ -1617,7 +1617,7 @@
             :realworld/update-settings mutation; the :reply-to [:settings/replied]
             continuation folds the saved User into the auth slice and navigates to
             the profile on :ok"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op
                                                       :realworld-resources.session/persist :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :email "a@b.c" :token "jwt"
@@ -1645,7 +1645,7 @@
             continuation re-stales [:article slug] so the detail page's embedded
             author flag refetches (the follow mutation itself only invalidates
             [:profile username])"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       ;; own + load the article detail so the re-stale has a live owner to
@@ -1671,7 +1671,7 @@
   (testing "examples/real-apps/realworld_resources — :ui/delete-article fires the
             :realworld/delete-article mutation with :reply-to [:ui/article-deleted];
             the continuation clears the instance and navigates home on :ok"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       ;; Land somewhere other than home so the navigate-home is observable.
@@ -1825,7 +1825,7 @@
             `:parent :realworld.profile/show` contributes and the leaf's own
             :realworld/favorited-articles, under the one active-route owner, while
             the parent's authored list stays gated off by its `:when` (rf2-8vccg)"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       (rf/dispatch-sync [:rf.route/navigate {:to     :realworld.profile/favorites
@@ -1857,7 +1857,7 @@
             refetched (generation unchanged, data intact), while the departed tab's
             own list loses the route owner and the arriving tab's list is ensured —
             EP-0037 R2 partial revalidation, on the shipped table (rf2-8vccg)"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
       (rf/dispatch-sync [:rf.route/navigate {:to     :realworld.profile/favorites
@@ -1911,10 +1911,10 @@
 (deftest route-link-egress-carries-the-arms-own-mount-base
   (testing "egress: a route-link rendered on the Reagent arm's frame config
             targets the arm's OWN served mount base"
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:url-strategy app-routing/url-strategy})]
       (let [[_ attrs] (rf/with-frame f
-                        (routing/route-link-render {:to :realworld.auth/login}))]
+                        (rf.routing/route-link-render {:to :realworld.auth/login}))]
         (is (= "/realworld-resources/login" (:href attrs))
             "the Reagent arm's generated link carries its own mount base")))))
 
@@ -1962,7 +1962,7 @@
    URL-owning, with managed HTTP redirected to this app's PRODUCTION demo-backend
    seam. url-push and the session-persist fx are no-op'd, as in `restore-frame!`."
   []
-  (frame/make-anon-frame-record!
+  (rf.frame/make-anon-frame-record!
     {:url-bound?   true
      :fx-overrides {:rf.http/managed                     :realworld-resources.demo/http-stub
                     :rf.nav/push-url                     :rf/no-op
@@ -2000,7 +2000,7 @@
                           {:frame f})
         (is (= :loading (:status (entry f k)))
             "route entry planned the comments read under the demo viewer, in flight")
-        (-> (test-support/poll-until
+        (-> (rf.test-support/poll-until
               #(= :loaded (:status (entry f k)))
               {:label "the route-owned comments read settles from the demo backend"})
             (.then (fn [_]
@@ -2015,7 +2015,7 @@
                      ;; runtime, never to the entry: `:invalidates`, no `:populates`.
                      (rf/dispatch-sync [:comment-form/edit "great read"] {:frame f})
                      (rf/dispatch-sync [:comment-form/submit slug] {:frame f})
-                     (test-support/poll-until
+                     (rf.test-support/poll-until
                        #(let [e (entry f k)
                               m (rf/compute-sub [:rf/mutation {:instance [:post-comment slug]}]
                                                 (state-value f))]

--- a/implementation/adapters/reagent/test/re_frame/reg_view_devtools_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_devtools_cljs_test.cljs
@@ -29,16 +29,16 @@
   build (sentinel `rf2-frame` in `scripts/check-elision.cjs`) and by
   `reg_view_devtools_elision_prod_test.cljs`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
-            [re-frame.performance :as performance]
-            [re-frame.test-support :as test-support]
+            [re-frame.performance :as rf.performance]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -86,14 +86,14 @@
                  [] [:p "x"])
     (let [id      :rf.devtools-test/one-identifier
           wrapped (rf/view id)]
-      (is (= (performance/build-name :render id)
+      (is (= (rf.performance/build-name :render id)
              (str "rf:render:" (.-displayName ^js wrapped)))
           "the render measure name is exactly \"rf:render:\" + displayName")
       ;; Non-vacuous on both sides: a namespaced keyword, and a measure
       ;; name that really does carry the namespace (so the equality is not
       ;; satisfied by two empty strings).
       (is (= "rf:render:rf.devtools-test/one-identifier"
-             (performance/build-name :render id))
+             (rf.performance/build-name :render id))
           "the measure name is the documented shape for a namespaced id"))))
 
 ;; ---- JSX source-coord props (regression: must NOT be injected) -----------
@@ -164,5 +164,5 @@
             inspector renders `rf2-frame.Provider` rather than the
             opaque default"
     (is (= "rf2-frame"
-           (.-displayName ^js adapter-context/frame-context))
+           (.-displayName ^js rf.adapter.context/frame-context))
         "frame-context.displayName is set to \"rf2-frame\"")))

--- a/implementation/adapters/reagent/test/re_frame/reg_view_devtools_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_devtools_dom_cljs_test.cljs
@@ -22,17 +22,17 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.adapter.react-test-support :as react-test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.adapter.react-test-support :as rf.adapter.react-test-support]
             [re-frame.core :as rf]
-            [re-frame.performance :as performance]
-            [re-frame.test-support :as test-support]
+            [re-frame.performance :as rf.performance]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 (defn- browser? []
   (and (exists? js/document)
@@ -52,7 +52,7 @@
         root      (rdc/create-root node)]
     (try
       (react-dom/flushSync (fn [] (rdc/render root [render-fn])))
-      (react-test-support/devtools-names-above
+      (rf.adapter.react-test-support/devtools-names-above
         (.querySelector node "[data-testid='devtools-dom-root']"))
       (finally
         (try (rdc/unmount root) (catch :default _ nil))))))
@@ -64,7 +64,7 @@
             performance/display projection — no leading colon"
     (if-not (browser?)
       (is true ":node-test: no DOM — the :browser-test runner exercises this")
-      (let [expected (performance/entry-id view-id)
+      (let [expected (rf.performance/entry-id view-id)
             names    (mount-and-read-names)]
         (is (some #{expected} names)
             (str "the mounted component is named " (pr-str expected)
@@ -81,10 +81,10 @@
             alone"
     (if-not (browser?)
       (is true ":node-test: no DOM — the :browser-test runner exercises this")
-      (let [visible (first (filter #{(performance/entry-id view-id)}
+      (let [visible (first (filter #{(rf.performance/entry-id view-id)}
                                    (mount-and-read-names)))]
         (is (some? visible) "the mounted component carries a resolvable name")
-        (is (= (performance/build-name :render view-id)
+        (is (= (rf.performance/build-name :render view-id)
                (str "rf:render:" visible))
             "the render measure name is exactly \"rf:render:\" + the
              DevTools-visible component name")))))

--- a/implementation/adapters/reagent/test/re_frame/reg_view_devtools_elision_prod_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_devtools_elision_prod_test.cljs
@@ -40,12 +40,12 @@
   ONLY by the `:browser-test-prod-elision` build."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 (defn- root-attrs
   "The root element's attrs map, or nil when the root carries none.

--- a/implementation/adapters/reagent/test/re_frame/reg_view_react_key_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_react_key_cljs_test.cljs
@@ -26,14 +26,14 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; A registered view + a plain Reagent fn rendering the SAME shape, so
 ;; the parity assertions compare like with like.

--- a/implementation/adapters/reagent/test/re_frame/reg_view_react_key_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/reg_view_react_key_dom_cljs_test.cljs
@@ -22,14 +22,14 @@
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 (defn- browser? []
   (and (exists? js/document)

--- a/implementation/adapters/reagent/test/re_frame/render_key_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/render_key_cljs_test.cljs
@@ -18,14 +18,14 @@
     - The instance-counter monotonically increases."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
-            [re-frame.views :as views])
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.views :as rf.views])
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -40,7 +40,7 @@
     (let [observed (atom nil)]
       (rf/reg-view* :rf.test/probe
         (fn []
-          (reset! observed views/*render-key*)
+          (reset! observed rf.views/*render-key*)
           [:p "ok"]))
       (let [wrapper (rf/view :rf.test/probe)]
         (wrapper)
@@ -59,7 +59,7 @@
     (let [observed (atom [])]
       (rf/reg-view* :rf.test/two-instances
         (fn []
-          (swap! observed conj views/*render-key*)
+          (swap! observed conj rf.views/*render-key*)
           [:p "ok"]))
       (let [wrapper (rf/view :rf.test/two-instances)]
         (wrapper)                                ;; instance A
@@ -75,9 +75,9 @@
 
 (deftest dynamic-var-unbound-outside-render
   (testing "*render-key* is nil outside an in-flight render"
-    (is (nil? views/*render-key*)
+    (is (nil? rf.views/*render-key*)
         "outside any render, *render-key* is unbound (nil)")
-    (is (= [:rf.view/anonymous nil] (views/current-render-key))
+    (is (= [:rf.view/anonymous nil] (rf.views/current-render-key))
         "current-render-key returns the documented anonymous fallback
         when no render-key is bound (plain Reagent fn case)")))
 
@@ -108,9 +108,9 @@
 
 (deftest mint-instance-token-is-monotonic
   (testing "mint-instance-token! returns strictly increasing integers"
-    (let [a (views/mint-instance-token!)
-          b (views/mint-instance-token!)
-          c (views/mint-instance-token!)]
+    (let [a (rf.views/mint-instance-token!)
+          b (rf.views/mint-instance-token!)
+          c (rf.views/mint-instance-token!)]
       (is (int? a))
       (is (< a b c) "tokens monotonically increase"))))
 
@@ -122,7 +122,7 @@
             [:rf.view/anonymous nil] when *render-key* is unbound"
     (let [observed (atom nil)
           plain-fn (fn []
-                     (reset! observed (views/current-render-key))
+                     (reset! observed (rf.views/current-render-key))
                      [:p "plain"])]
       (plain-fn)
       (is (= [:rf.view/anonymous nil] @observed)

--- a/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
@@ -32,11 +32,11 @@
    any subsequent test ns."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.fx :as rf.fx]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]
             ;; production HTTP + resources surfaces (so the resource runtime,
             ;; managed-HTTP lowering, and the late-bound routing integration
@@ -44,17 +44,17 @@
             [re-frame.http.managed]
             [re-frame.http.test-support]
             [re-frame.resources]
-            [re-frame.resources.route :as resources-route]
-            [re-frame.resources.state :as state]
+            [re-frame.resources.route :as rf.resources.route]
+            [re-frame.resources.state :as rf.resources.state]
             [re-frame.resources.test-support]
-            [re-frame.routing :as routing]
+            [re-frame.routing :as rf.routing]
             ;; the framework trace-ring buffer (Spec 009). The shared
             ;; `make-reset-runtime-fixture` resets `frame/frames` but NOT the
             ;; process-global trace rings, so a dispatching test's trace residue
             ;; survives into later cross-cutting tooling tests that read the
             ;; rings. We clear the rings around each test body (below) so this
             ;; suite leaves no trace residue.
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             ;; the example's production source — registers its resources, routes,
             ;; events, subs, and the reader machine at ns-load.
             [resources.core])
@@ -77,7 +77,7 @@
 ;; (Routes / the reader machine live under kinds the reset does NOT clear, so
 ;; they survive via the fixture's ns-load baseline.)
 (def ^:private resource-kind-snapshot
-  (get @registrar/kind->id->metadata :resource))
+  (get @rf.registrar/kind->id->metadata :resource))
 
 ;; AT NS LOAD, immediately remove THIS example's `:resource` registrations (by id)
 ;; from the SHARED live registrar — after snapshotting them above. They are
@@ -89,7 +89,7 @@
 ;; mirror the resulting frameless `:rf.registry/handler-cleared` burst into its
 ;; cascade seed (a false-positive `:rf.xray/cascades`). We remove only OUR ids
 ;; (not the whole kind) so a sibling suite's ns-load resources are untouched.
-(swap! registrar/kind->id->metadata update :resource
+(swap! rf.registrar/kind->id->metadata update :resource
        (fn [m] (apply dissoc m (keys resource-kind-snapshot))))
 
 (defn- init!
@@ -128,13 +128,13 @@
   ;; store in lockstep and marks the live-frame projection dirty, so the
   ;; frame's next resolution sees the reinstated registrations.
   (doseq [[id meta] resource-kind-snapshot]
-    (registrar/register! :resource id meta))
-  (routing/reset-counters!)
-  (resources-route/install-routing-integration!)
+    (rf.registrar/register! :resource id meta))
+  (rf.routing/reset-counters!)
+  (rf.resources.route/install-routing-integration!)
   ;; Capturing no-op: the reply is replayed explicitly by the test so the
   ;; 3-element internal reply event matches what the live transport produces.
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf.fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
   ;; LAST — see the ordering note in the docstring. Everything the frame's
   ;; construction-time URL sync needs (the reinstated `:resource` rows, the
   ;; routing integration, the stubbed fx) is registered above.
@@ -169,15 +169,15 @@
    calls `reset-sentinels!` + `register-trace-collector!`), so clearing here is
    safe."
   [f]
-  (trace-tooling/clear-listeners!)
-  (trace-tooling/clear-trace-rings!)
+  (rf.trace.tooling/clear-listeners!)
+  (rf.trace.tooling/clear-trace-rings!)
   (f)
-  (trace-tooling/clear-listeners!)
-  (trace-tooling/clear-trace-rings!))
+  (rf.trace.tooling/clear-listeners!)
+  (rf.trace.tooling/clear-trace-rings!))
 
 (use-fixtures :each
   isolate-trace-bus-fixture
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     ;; BUNDLE CO-LOAD HYGIENE: this app registers the reserved per-app
     ;; `:rf.route/not-found` route at ns load, and every co-loaded example app
     ;; does the same — two provenance rows for one id fail default-image
@@ -185,7 +185,7 @@
     ;; app loads. `:app-ns` names OUR OWN app (never a sibling's): the fixture
     ;; keeps its rows out of every suite's baseline and reinstates them for
     ;; this suite's own tests (rf2-kuky.27).
-    {:adapter reagent-adapter/adapter
+    {:adapter rf.adapter.reagent/adapter
      :app-ns  "resources."
      :init-fn init!}))
 
@@ -196,20 +196,20 @@
 (defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
 
 (defn- entry [scoped-key]
-  (get-in (runtime-db) (state/entry-path scoped-key)))
+  (get-in (runtime-db) (rf.resources.state/entry-path scoped-key)))
 
 (defn- entry-in
   "Read a resource entry from an EXPLICIT frame's runtime-db. The preview
    tests drive their own anon frame (via `with-new-frame`), not `:rf/default`,
    so they resolve entries against that frame rather than the shared helper."
   [f scoped-key]
-  (get-in (:rf.db/runtime (rf/frame-state-value f)) (state/entry-path scoped-key)))
+  (get-in (:rf.db/runtime (rf/frame-state-value f)) (rf.resources.state/entry-path scoped-key)))
 
 (defn- list-key []
-  (state/scoped-resource-key :rf.scope/global :articles/list {}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :articles/list {}))
 
 (defn- detail-key [slug]
-  (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug slug}))
+  (rf.resources.state/scoped-resource-key :rf.scope/global :article/by-slug {:slug slug}))
 
 (defn- reply-success!
   "Replay the captured `:on-success` with the transport's success result
@@ -280,7 +280,7 @@
             :resources.app/preview-closed releases the owner so the entry can GC
             (the mandatory release path for an app-minted owner, Spec 016 §Active
             owners)"
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (let [preview-owner [:resources.app/preview-opened "fresh-skip"]
             dkey          (detail-key "fresh-skip")]
@@ -289,7 +289,7 @@
         (is (= "fresh-skip"
                (rf/compute-sub [:resources.app/preview-slug] (rf/frame-state-value f)))
             "the open preview slug is in app-db")
-        (let [e (get-in (:rf.db/runtime (rf/frame-state-value f)) (state/entry-path dkey))]
+        (let [e (get-in (:rf.db/runtime (rf/frame-state-value f)) (rf.resources.state/entry-path dkey))]
           (is (= :loading (:status e)) "the owner ensured a first load")
           (is (contains? (:active-owners e) preview-owner)
               "owned by the app-event owner [:resources.app/preview-opened slug]"))
@@ -297,7 +297,7 @@
         (rf/dispatch-sync [:resources.app/preview-closed "fresh-skip"] {:frame f})
         (is (nil? (rf/compute-sub [:resources.app/preview-slug] (rf/frame-state-value f)))
             "closing clears the open slug")
-        (let [e (get-in (:rf.db/runtime (rf/frame-state-value f)) (state/entry-path dkey))]
+        (let [e (get-in (:rf.db/runtime (rf/frame-state-value f)) (rf.resources.state/entry-path dkey))]
           (is (not (contains? (:active-owners e) preview-owner))
               "the owner was released — no dangling owner pins the entry"))))))
 
@@ -317,7 +317,7 @@
             proves NEITHER owner remains (the single Close control only ever
             reaches the current slug, so a replaced owner left attached would
             leak forever — rf2-5jtsh)."
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (let [owner-a [:resources.app/preview-opened "resources-101"]
             owner-b [:resources.app/preview-opened "owners-vs-causes"]
@@ -356,7 +356,7 @@
             churning it. A release+reacquire would bump the entry's :revision
             (detach of a present owner bumps it, Spec 016 rf2-cxwuhl); a clean
             re-ensure leaves it untouched."
-    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (let [owner-a [:resources.app/preview-opened "fresh-skip"]
             dkey-a  (detail-key "fresh-skip")]

--- a/implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
@@ -23,11 +23,11 @@
   §Multi-frame routing."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.subs :as subs]
-            [re-frame.routing :as routing]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.subs :as rf.subs]
+            [re-frame.routing :as rf.routing]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; Snapshot/restore the registrar around each test (rf2-am9d). We do NOT
 ;; call (registrar/clear-all!): it would wipe routing's framework events
@@ -36,9 +36,9 @@
 ;; them. routing/reset-counters! runs in :init-fn so per-test counter
 ;; sequences (nav-token, pending-nav, …) start from zero.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
-     :init-fn routing/reset-counters!}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
+     :init-fn rf.routing/reset-counters!}))
 
 ;; ---- Spec 012 §URL changes are events / §Reading the route is a sub -----
 
@@ -52,7 +52,7 @@
     ;;
     ;; Test isolation: a fresh frame so prior tests' [:rf.db/runtime :rf.runtime/routing :current]
     ;; slices don't leak in.
-    (let [f (frame/make-anon-frame-record! {:doc "isolated frame for this test"})]
+    (let [f (rf.frame/make-anon-frame-record! {:doc "isolated frame for this test"})]
       (rf/reg-route :route.cljs/home
                     {} "/cljs/home")
       (rf/reg-route :route.cljs/article
@@ -62,9 +62,9 @@
                        (fn [{:keys [db]} _] {:db (assoc db :article-loaded? true)}))
       ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db
       ;; state — these custom subs read the runtime-db partition.
-      (subs/reg-runtime-sub :rf.cljs.route/id
+      (rf.subs/reg-runtime-sub :rf.cljs.route/id
                   (fn [rt _] (get-in rt [:rf.runtime/routing :current :route-id])))
-      (subs/reg-runtime-sub :rf.cljs.route/params
+      (rf.subs/reg-runtime-sub :rf.cljs.route/params
                   (fn [rt _] (get-in rt [:rf.runtime/routing :current :params])))
 
       ;; URL-driven nav. The slice is set; :on-match dispatches.
@@ -98,10 +98,10 @@
     (rf/reg-route :route.cljs2/home          {} "/cljs2/")
     (rf/reg-route :route.cljs2/articles      {} "/cljs2/articles")
     (rf/reg-route :route.cljs2/article       {:params [:map [:id :string]]} "/cljs2/articles/:id")
-    (subs/reg-runtime-sub :rf.cljs2/route (fn [rt _] (get-in rt [:rf.runtime/routing :current])))
+    (rf.subs/reg-runtime-sub :rf.cljs2/route (fn [rt _] (get-in rt [:rf.runtime/routing :current])))
 
-    (let [left  (frame/make-anon-frame-record! {:doc "left tab frame"})
-          right (frame/make-anon-frame-record! {:doc "right tab frame"})]
+    (let [left  (rf.frame/make-anon-frame-record! {:doc "left tab frame"})
+          right (rf.frame/make-anon-frame-record! {:doc "right tab frame"})]
 
       ;; Each frame navigates independently.
       (rf/dispatch-sync [:rf.route/transitioned "/cljs2/articles"]

--- a/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -5,26 +5,26 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.source-store :as source-store]
+            [re-frame.source-store :as rf.source-store]
             ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             ;; rf2-bmzq0: sub-cache-snapshot lives in re-frame.subs.tooling.
-            [re-frame.subs.tooling :as subs-tooling]
+            [re-frame.subs.tooling :as rf.subs.tooling]
             ;; rf2-0sr0ai: reg-runtime-sub (framework runtime-db sub) is an
             ;; internal subs surface, not on the rf/ facade — required for
             ;; the two-partition projection-equality invalidation pins below.
-            [re-frame.subs :as subs]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
+            [re-frame.subs :as rf.subs]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
             ;; rf2-k682: routing ships in day8/re-frame2-routing.
             ;; Required here so its load-time hook + reg-sub
             ;; registrations fire before this ns's reg-route call.
-            [re-frame.routing :as routing]
+            [re-frame.routing :as rf.routing]
             ;; rf2-tfw3: flows ships in day8/re-frame2-flows.
             ;; Required here so its load-time hook registrations
             ;; fire before this ns's reg-flow call.
             [re-frame.flows]
-            [re-frame.ssr :as ssr]
+            [re-frame.ssr :as rf.ssr]
             ;; rf2-lt4e: epoch ships in day8/re-frame2-epoch.
             ;; Required here so its load-time hook publications
             ;; (`:epoch/settle!`, `:epoch/capture-event`,
@@ -33,8 +33,8 @@
             ;; fire before the epoch-history-cljs / restore-* tests
             ;; below reach into the late-bind table at call time.
             [re-frame.epoch]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views])
   (:require-macros [re-frame.core :refer [with-frame with-new-frame
                                           reg-view]]))
@@ -46,8 +46,8 @@
 ;; once cleared they're gone for the rest of the test run. Snapshot/restore
 ;; preserves them while still rolling back per-test registrations.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- shared dispatch + sub --------------------------------------------------
 
@@ -172,9 +172,9 @@
           ;; keyword form. If the runtime were intercepting, both would
           ;; render through the same registered fn and produce identical
           ;; structure (the registered body); they wouldn't differ.
-          h-keyword-form   (ssr/render-tree-hash [:foo/intercept-me 1])
-          h-other-form     (ssr/render-tree-hash [:foo/some-other-tag 1])
-          h-via-var        (ssr/render-tree-hash registered-body)]
+          h-keyword-form   (rf.ssr/render-tree-hash [:foo/intercept-me 1])
+          h-other-form     (rf.ssr/render-tree-hash [:foo/some-other-tag 1])
+          h-via-var        (rf.ssr/render-tree-hash registered-body)]
       ;; Keyword-form hashes differ — they are HTML element tags,
       ;; structurally distinct based on the tag keyword.
       (is (not= h-keyword-form h-other-form)
@@ -206,7 +206,7 @@
     (doseq [[kind id] [[:event :counter/init]
                        [:event :counter/inc]
                        [:sub   :count]]]
-      (source-store/forget-id! kind id))
+      (rf.source-store/forget-id! kind id))
     (rf/make-frame {:id :left :doc "left frame"})
     (rf/make-frame {:id :right :doc "right frame"})
     (rf/reg-event :counter/init (fn [{:keys [db]} [_ n]] {:db {:count n}}))
@@ -276,10 +276,10 @@
 (deftest match-and-unparse-routes
   (testing "match-url and route-url round-trip on CLJS"
     (rf/reg-route :user/show {} "/users/:id")
-    (let [m (routing/match-url "/users/42")]
+    (let [m (rf.routing/match-url "/users/42")]
       (is (= :user/show (:route-id m)))
       (is (= "42"       (:id (:params m)))))
-    (is (= "/users/42" (routing/route-url {:to :user/show :params {:id 42}})))))
+    (is (= "/users/42" (rf.routing/route-url {:to :user/show :params {:id 42}})))))
 
 ;; ---- machines (pure machine-transition) -----------------------------------
 
@@ -291,7 +291,7 @@
              {:red    {:on {:tick {:target :green}}}
               :green  {:on {:tick {:target :yellow}}}
               :yellow {:on {:tick {:target :red}}}}}
-          {s :snapshot} (machines/machine-transition m {:state :red :data {}} [:tick])]
+          {s :snapshot} (rf.machines/machine-transition m {:state :red :data {}} [:tick])]
       (is (= :green (:state s))))))
 
 ;; ---- error paths ----------------------------------------------------------
@@ -306,11 +306,11 @@
         (count (.something items))))
     (rf/dispatch-sync [:init])
     (let [traces (atom [])]
-      (trace-tooling/register-listener! ::sub-err (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::sub-err (fn [ev] (swap! traces conj ev)))
       (let [v (rf/subscribe-once [:items-count])]
         (is (nil? v)
             "the sub returns nil under :replaced-with-default recovery"))
-      (trace-tooling/unregister-listener! ::sub-err)
+      (rf.trace.tooling/unregister-listener! ::sub-err)
       (is (some (fn [ev]
                   (= :rf.error/sub-exception (:operation ev)))
                 @traces)
@@ -324,9 +324,9 @@
 
 (deftest render-tree-hash-cljs
   (testing "render-tree-hash returns 8-char lowercase hex deterministically"
-    (let [r2h   (ssr/render-tree-hash [:div {:class "x"} [:p "hi"]])
-          r2h-2 (ssr/render-tree-hash [:div {:class "x"} [:p "hi"]])
-          r2h-3 (ssr/render-tree-hash [:div {:class "y"} [:p "hi"]])]
+    (let [r2h   (rf.ssr/render-tree-hash [:div {:class "x"} [:p "hi"]])
+          r2h-2 (rf.ssr/render-tree-hash [:div {:class "x"} [:p "hi"]])
+          r2h-3 (rf.ssr/render-tree-hash [:div {:class "y"} [:p "hi"]])]
       (is (= r2h r2h-2))
       (is (not= r2h r2h-3))
       (is (re-matches #"[0-9a-f]{8}" r2h)))))
@@ -530,7 +530,7 @@
       (reg-fw-runtime-handler! :inval/seed-rt
         (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {:current {:route-id :home}}}}))
       (rf/dispatch-sync [:inval/seed-rt])
-      (subs/reg-runtime-sub :inval/rt-sub
+      (rf.subs/reg-runtime-sub :inval/rt-sub
         (fn [runtime-db _] (swap! runs inc) (get-in runtime-db [:rf.runtime/routing :current :route-id])))
       (let [r (rf/subscribe [:inval/rt-sub])]
         (add-watch r ::touch (fn [_ _ _ _] nil))
@@ -560,7 +560,7 @@
         (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:m 1}}}))
       (rf/dispatch-sync [:inval/seed-rt2])
       (rf/reg-sub :inval/app-sub2 (fn [db _] (swap! app-runs inc) (:n db)))
-      (subs/reg-runtime-sub :inval/rt-sub2
+      (rf.subs/reg-runtime-sub :inval/rt-sub2
         (fn [runtime-db _] (swap! rt-runs inc) (get-in runtime-db [:rf.runtime/machines :m])))
       (let [ra (rf/subscribe [:inval/app-sub2])
             rr (rf/subscribe [:inval/rt-sub2])]
@@ -597,14 +597,14 @@
 (deftest dispatch-sync-in-handler-errors-cljs
   (testing "calling dispatch-sync from inside a handler raises a structured error"
     (let [traces (atom [])]
-      (trace-tooling/register-listener! ::dsih (fn [ev] (swap! traces conj ev)))
+      (rf.trace.tooling/register-listener! ::dsih (fn [ev] (swap! traces conj ev)))
       (rf/reg-event :outer (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
       (rf/reg-event :nested
         (fn [_ _]
           (rf/dispatch-sync [:outer])
           {}))
       (rf/dispatch-sync [:nested])
-      (trace-tooling/unregister-listener! ::dsih)
+      (rf.trace.tooling/unregister-listener! ::dsih)
       (is (some (fn [ev]
                   (and (= :rf.error/dispatch-sync-in-handler (:operation ev))
                        (= :error (:op-type ev))))
@@ -624,12 +624,12 @@
     (rf/reg-sub :name* (fn [db _] (:name db)))
     (rf/dispatch-sync [:seed])
     ;; Empty cache is the {} baseline.
-    (is (= {} (subs-tooling/sub-cache-snapshot :rf/default))
+    (is (= {} (rf.subs.tooling/sub-cache-snapshot :rf/default))
         "no subs materialised yet → empty map")
     (let [r1 (rf/subscribe [:n])
           r2 (rf/subscribe [:n])
           r3 (rf/subscribe [:name*])
-          snapshot (subs-tooling/sub-cache-snapshot :rf/default)]
+          snapshot (rf.subs.tooling/sub-cache-snapshot :rf/default)]
       (is (= 2 (count snapshot))
           "snapshot contains one entry per materialised query-v")
       (is (= 7     (get-in snapshot [[:n]     :value])))
@@ -643,13 +643,13 @@
       (is (= []  (get-in snapshot [[:n]     :realized-inputs]))
           "layer-1 reader has no realized input edges")
       ;; Default no-arg form uses the active frame.
-      (is (= snapshot (subs-tooling/sub-cache-snapshot (rf/current-frame-id)))
+      (is (= snapshot (rf.subs.tooling/sub-cache-snapshot (rf/current-frame-id)))
           "no-arg form returns the active frame's snapshot")
       (rf/unsubscribe [:n])
       (rf/unsubscribe [:n])
       (rf/unsubscribe [:name*]))
     ;; Missing frame yields nil rather than throwing.
-    (is (nil? (subs-tooling/sub-cache-snapshot :no-such-frame))
+    (is (nil? (rf.subs.tooling/sub-cache-snapshot :no-such-frame))
         "missing frame returns nil")))
 
 (deftest sub-cache-surfaces-static-realized-inputs
@@ -663,7 +663,7 @@
                 (fn [[items _filter] _] items))
     (rf/dispatch-sync [:seed2])
     (let [r (rf/subscribe [:visible-items])
-          snapshot (subs-tooling/sub-cache-snapshot :rf/default)
+          snapshot (rf.subs.tooling/sub-cache-snapshot :rf/default)
           entry (get snapshot [:visible-items])]
       (is (= :static (:input-kind entry))
           "a :<- sub is :input-kind :static")
@@ -689,7 +689,7 @@
                   {:article article :comments comments :viewer viewer}))
     (rf/dispatch-sync [:seed3])
     (let [r (rf/subscribe [:article/page :a1])
-          snapshot (subs-tooling/sub-cache-snapshot :rf/default)
+          snapshot (rf.subs.tooling/sub-cache-snapshot :rf/default)
           entry (get snapshot [:article/page :a1])]
       (is (= :parametric (:input-kind entry))
           "the input-fn sub is :input-kind :parametric")
@@ -700,7 +700,7 @@
           "realized-inputs are the (input-fn query-v) result — concrete edges for :a1")
       ;; The static topology must NOT enumerate these — only the live cache does.
       ;; CLJS calls the tooling ns directly (rf/sub-topology is a JVM-only alias).
-      (is (= :parametric (:inputs ((subs-tooling/sub-topology) :article/page)))
+      (is (= :parametric (:inputs ((rf.subs.tooling/sub-topology) :article/page)))
           "static sub-topology reports the :parametric sentinel, not the realized edges")
       (rf/unsubscribe [:article/page :a1]))))
 
@@ -722,12 +722,12 @@
     (rf/reg-sub :name* (fn [db _] (:name db)))
     (rf/dispatch-sync [:seed-av])
     ;; Empty cache is the {} baseline.
-    (is (= {} (subs-tooling/sub-cache-algebra-view :rf/default))
+    (is (= {} (rf.subs.tooling/sub-cache-algebra-view :rf/default))
         "no subs materialised yet → empty map")
     (let [r1   (rf/subscribe [:n])
           r2   (rf/subscribe [:n])
           r3   (rf/subscribe [:name*])
-          view (subs-tooling/sub-cache-algebra-view :rf/default)]
+          view (rf.subs.tooling/sub-cache-algebra-view :rf/default)]
       (is (= 2 (count view))
           "one algebra node per materialised query-v")
       (let [node-n (get view [:n])]
@@ -749,13 +749,13 @@
         (is (= 2 (:ref-count node-n))
             "ref-count is the lifecycle evidence the cache-entry owner is kept alive")))
     ;; No-arg-by-id parity with the active frame.
-    (is (= (subs-tooling/sub-cache-algebra-view :rf/default)
-           (subs-tooling/sub-cache-algebra-view (rf/current-frame-id)))
+    (is (= (rf.subs.tooling/sub-cache-algebra-view :rf/default)
+           (rf.subs.tooling/sub-cache-algebra-view (rf/current-frame-id)))
         "the named-frame view equals the active-frame view")
     (rf/unsubscribe [:n])
     (rf/unsubscribe [:n])
     (rf/unsubscribe [:name*])
-    (is (nil? (subs-tooling/sub-cache-algebra-view :no-such-frame))
+    (is (nil? (rf.subs.tooling/sub-cache-algebra-view :no-such-frame))
         "missing frame returns nil")))
 
 (deftest sub-cache-algebra-view-lowers-static-realized-edges
@@ -769,7 +769,7 @@
                 (fn [[items _filter] _] items))
     (rf/dispatch-sync [:seed-av2])
     (let [r    (rf/subscribe [:visible-items])
-          view (subs-tooling/sub-cache-algebra-view :rf/default)
+          view (rf.subs.tooling/sub-cache-algebra-view :rf/default)
           node (get view [:visible-items])]
       (is (= :static (:input-kind node)))
       (is (= [[:sub [:items]] [:sub [:filter]]] (:inputs node))
@@ -793,7 +793,7 @@
                   {:article article :comments comments}))
     (rf/dispatch-sync [:seed-av3])
     (let [r    (rf/subscribe [:article/page :a1])
-          view (subs-tooling/sub-cache-algebra-view :rf/default)
+          view (rf.subs.tooling/sub-cache-algebra-view :rf/default)
           node (get view [:article/page :a1])]
       (is (= [:article/page :a1] (:id node))
           "the live node id is the concrete parametric query vector")
@@ -803,7 +803,7 @@
              (:inputs node))
           "the live view reports the REALIZED [:sub …] edges for :a1")
       ;; The static view reports the marker, never these realized edges.
-      (is (= :parametric (:inputs (subs-tooling/sub-algebra-view :article/page)))
+      (is (= :parametric (:inputs (rf.subs.tooling/sub-algebra-view :article/page)))
           "the static algebra view reports the :parametric marker, not the realized edges")
       (rf/unsubscribe [:article/page :a1]))))
 
@@ -992,7 +992,7 @@
 
 (defn- cache-keys-of
   [frame-id]
-  (set (keys @(:sub-cache (frame/frame frame-id)))))
+  (set (keys @(:sub-cache (rf.frame/frame frame-id)))))
 
 (deftest sub-cache-sync-disposes-on-last-unsubscribe
   (testing "ref-count → 0 disposes the slot synchronously (rf2-cmfln)"

--- a/implementation/adapters/reagent/test/re_frame/schema_reject_notification_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/schema_reject_notification_cljs_test.cljs
@@ -24,15 +24,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             ;; Publishes the Malli validator into the late-bind table so
             ;; reg-app-schema validation actually runs.
             [re-frame.schemas.malli]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 (deftest schema-rejection-zero-reaction-notifications
   (testing "a schema-rejected dispatch dirties NO Reagent reaction and a

--- a/implementation/adapters/reagent/test/re_frame/source_coord_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/source_coord_dom_cljs_test.cljs
@@ -26,13 +26,13 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/adapters/reagent/test/re_frame/source_coord_dom_elision_prod_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/source_coord_dom_elision_prod_test.cljs
@@ -27,12 +27,12 @@
   which is only true under prod-mode."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 (defn- root-attr
   "Pull the :data-rf2-source-coord value from the root attrs map of a

--- a/implementation/adapters/reagent/test/re_frame/source_coord_parity_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/source_coord_parity_cljs_test.cljs
@@ -24,10 +24,10 @@
   the SAME literals. If either host's formatter drifts, its test fails.
   The literals ARE the byte-comparison point — both sides pin independently."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.source-coords :as source-coords]
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.source-coords :as rf.source-coords]
             [re-frame.views]
-            [re-frame.views.source-coord-annotation :as source-coord]))
+            [re-frame.views.source-coord-annotation :as rf.views.source-coord-annotation]))
 
 ;; ---- the canonical attribute-value shape (shared spec) -------------------
 ;;
@@ -80,10 +80,10 @@
   (testing "rf2-8vi4q — CLJS `format-view-id` produces `(str id)`, the same
             `data-rf-view` value the JVM host now stamps. Both hosts emit
             this attribute; before rf2-8vi4q only the client did."
-    (is (= expected-view-id (source-coord/format-view-id fixture-id))
+    (is (= expected-view-id (rf.views.source-coord-annotation/format-view-id fixture-id))
         (str "CLJS `format-view-id` MUST produce `(str id)`. Expected: "
              (pr-str expected-view-id) " — got: "
-             (pr-str (source-coord/format-view-id fixture-id))))))
+             (pr-str (rf.views.source-coord-annotation/format-view-id fixture-id))))))
 
 ;; ---- CLJS side: degraded shape (no line / col) pins the canonical -------
 
@@ -120,14 +120,14 @@
             the canonical literals and the adapter.context var is the identical
             fn object."
     (is (= expected-attr
-           (source-coords/format-source-coord fixture-id fixture-meta))
+           (rf.source-coords/format-source-coord fixture-id fixture-meta))
         "neutral owner must emit the canonical data-rf2-source-coord literal")
     (is (= expected-view-id
-           (source-coords/format-view-id fixture-id))
+           (rf.source-coords/format-view-id fixture-id))
         "neutral owner must emit the canonical data-rf-view literal")
-    (is (identical? source-coords/format-source-coord
-                    adapter-context/format-source-coord)
+    (is (identical? rf.source-coords/format-source-coord
+                    rf.adapter.context/format-source-coord)
         "CLJS format-source-coord must be an alias of the neutral owner")
-    (is (identical? source-coords/format-view-id
-                    adapter-context/format-view-id)
+    (is (identical? rf.source-coords/format-view-id
+                    rf.adapter.context/format-view-id)
         "CLJS format-view-id must be an alias of the neutral owner")))

--- a/implementation/adapters/reagent/test/re_frame/source_coord_warn_once_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/source_coord_warn_once_cljs_test.cljs
@@ -25,13 +25,13 @@
             [clojure.string :as str]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- helper: capture console.warn calls ----------------------------------
 

--- a/implementation/adapters/reagent/test/re_frame/ssr_keyword_child_hydration_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_keyword_child_hydration_dom_cljs_test.cljs
@@ -43,9 +43,9 @@
             ["react-dom/client" :as react-dom-client]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.ssr.install :as install]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.ssr.install :as rf.ssr.install]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private test-frame :ssr-keyword-child-hydration/frame)
 
@@ -57,15 +57,15 @@
                 (fn [card-id] [:div.card [:h3 (str card-id)]])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :init-fn init!})
   ;; No test here INSTALLS a hydration payload, but the ledger is a
   ;; process-global `defonce` that neither `clear-all!` nor a frames
   ;; reset touches (rf2-aorfy), so a future edit that adds an install
   ;; would leak into sibling namespaces rather than fail here. Resetting
   ;; unconditionally keeps that trap shut.
-  (fn [f] (install/reset-installed-payloads!) (f)))
+  (fn [f] (rf.ssr.install/reset-installed-payloads!) (f)))
 
 (defn- browser? []
   (and (exists? js/document)

--- a/implementation/adapters/reagent/test/re_frame/ssr_keyword_head_contract_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_keyword_head_contract_cljs_test.cljs
@@ -58,8 +58,8 @@
             [clojure.string :as str]
             [reagent.dom.server :as rds]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private test-frame :ssr-keyword-head-contract-cljs-test/frame)
 
@@ -71,8 +71,8 @@
                 (fn [card-id] [:div.card [:h3 (str card-id)]])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :init-fn init!}))
 
 (defn- render

--- a/implementation/adapters/reagent/test/re_frame/ssr_reg_view_hydration_adoption_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_reg_view_hydration_adoption_dom_cljs_test.cljs
@@ -52,10 +52,10 @@
             ["react-dom/client" :as react-dom-client]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.views :as views]
-            [re-frame.views.source-coord-annotation :as source-coord]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.views :as rf.views]
+            [re-frame.views.source-coord-annotation :as rf.views.source-coord-annotation]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private test-frame :ssr-reg-view-hydration-adoption/frame)
 (def ^:private test-view-id :adoption-demo/card)
@@ -71,8 +71,8 @@
                 (fn [label] [:div.card [:h3 label]])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :init-fn init!}))
 
 (defn- browser? []
@@ -85,8 +85,8 @@
 ;; The values the CLIENT reg-view render stamps for `test-view-id` — read
 ;; off the SAME shared formatters the JVM emitter uses, so the GREEN server
 ;; fixture below is the real cross-host dialect, not a hand-typed guess.
-(def ^:private expected-coord (views/format-source-coord test-view-id {}))
-(def ^:private expected-view  (source-coord/format-view-id test-view-id))
+(def ^:private expected-coord (rf.views/format-source-coord test-view-id {}))
+(def ^:private expected-view  (rf.views.source-coord-annotation/format-view-id test-view-id))
 
 ;; ---------------------------------------------------------------------------
 ;; The harness

--- a/implementation/adapters/reagent/test/re_frame/ssr_streaming_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_streaming_example_cljs_test.cljs
@@ -38,10 +38,10 @@
             [clojure.string :as str]
             [reagent.dom.server :as rds]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             ;; The failed-boundary record the example's boundaries consult.
-            [re-frame.ssr.suspense :as suspense]
+            [re-frame.ssr.suspense :as rf.ssr.suspense]
             ;; the example's production source — registers :dashboard/root,
             ;; :dashboard/card, :dashboard/card-skeleton and the two subs at
             ;; ns-load.
@@ -69,8 +69,8 @@
 ;; leaves `(rf/view :dashboard/root)` nil. The fixture folds this ns's stable
 ;; ns-load baseline back over the live registrar before each test.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :init-fn init!}))
 
 (defn- render-client-tree
@@ -104,8 +104,8 @@
                    :signups {:title "New signups (last 7 days)" :value 318}
                    :latency {:title "P50 latency (ms)"          :value 24}})}))
   (rf/dispatch-sync [::seed] {:frame test-frame})
-  (suspense/reset-failed-boundaries!)
-  (suspense/record-failed-boundaries! #{:card.flaky}))
+  (rf.ssr.suspense/reset-failed-boundaries!)
+  (rf.ssr.suspense/record-failed-boundaries! #{:card.flaky}))
 
 ;; ---- (1) no server-only marker leaks into the client DOM -------------------
 
@@ -165,7 +165,7 @@
             proof: nothing about app-db decides this, the recorded failure
             does"
     (seed-cards!)
-    (suspense/reset-failed-boundaries!)
+    (rf.ssr.suspense/reset-failed-boundaries!)
     (is (thrown? :default (render-client-tree))
         (str "with no recorded failure the boundary must render its body "
              "(`throwing-card`), not silently keep showing the fallback"))))

--- a/implementation/adapters/reagent/test/re_frame/standard_epochs_diamond_recompute_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/standard_epochs_diamond_recompute_cljs_test.cljs
@@ -47,12 +47,12 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [reagent.ratom :as ratom]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ===========================================================================
 ;; The standard-epochs diamond, replicated verbatim from the testbed

--- a/implementation/adapters/reagent/test/re_frame/standard_epochs_views_subs_lifecycle_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/standard_epochs_views_subs_lifecycle_cljs_test.cljs
@@ -57,14 +57,14 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support])
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ===========================================================================
 ;; The standard-epochs Views/subs section, replicated verbatim
@@ -115,7 +115,7 @@
   "The frame's live sub-cache map (cache-key → entry). Keys are the
   query-vectors themselves (cache-key = identity)."
   []
-  @(:sub-cache (frame/frame :rf/default)))
+  @(:sub-cache (rf.frame/frame :rf/default)))
 
 (defn- cached?
   "Is `query-v` present in the live sub-cache?"
@@ -212,7 +212,7 @@
       ;; recomputes through to the leaf the view derefs.
       (rf/dispatch-sync [:standard-epochs/perturb-chain])
 
-      (is (= 2 (get-in (frame/frame-app-db-value :rf/default)
+      (is (= 2 (get-in (rf.frame/frame-app-db-value :rf/default)
                        [:views :chain-input]))
           "L1 source advanced 1 → 2")
       (is (= "2×input = 4" @(:chain held))

--- a/implementation/adapters/reagent/test/re_frame/sub_dispose_view_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/sub_dispose_view_cljs_test.cljs
@@ -57,14 +57,14 @@
             [reagent.core :as r]
             [reagent.ratom :as ratom]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support])
+            [re-frame.interop :as rf.interop]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -322,7 +322,7 @@
         ;; install-unmount-hook! test pattern, which similarly
         ;; disposes the reaction directly to drive the on-dispose
         ;; callback chain headlessly.
-        (interop/dispose! sum-rea)
+        (rf.interop/dispose! sum-rea)
 
         ;; The cache's `add-on-dispose!` cascade ran: each input was
         ;; `unsubscribe`d, dropping their ref-counts to 0, evicting

--- a/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
@@ -43,9 +43,9 @@
    carried — run-order independence is now the fixture's contract."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]
             ;; todomvc.events requires re-frame.routing at load time
             ;; (reg-route). Required transitively via todomvc.core, but
@@ -55,12 +55,12 @@
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     ;; EP-0002 (rf2-9o48ih): the test spins its OWN top-level frame via
     ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
     ;; frame's `:initial-events` drain synchronously (top-level boot) rather than
     ;; being treated as a mid-cascade child-frame creation.
-    {:adapter       reagent-adapter/adapter
+    {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil}))
 
 (defn- todos [frame]
@@ -77,7 +77,7 @@
     ;; so it exercises the empty / first-run path and coerces nil to an empty
     ;; `(sorted-map)`. No manual `:rf.cofx` supply — the registered generator
     ;; provides the fact, which is the whole point of the EP-0017 generator shape.
-    (with-new-frame [f (frame/make-anon-frame-record!
+    (with-new-frame [f (rf.frame/make-anon-frame-record!
                          {:fx-overrides   {:todo.storage/save :rf/no-op}
                           :initial-events [[:todo/initialise]]})]
       ;; The invariant the whole bug hinges on: :todos must be a

--- a/implementation/adapters/reagent/test/re_frame/view_id_attr_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_id_attr_cljs_test.cljs
@@ -24,13 +24,13 @@
   `data-rf-view` sentinel registered in `scripts/check-elision.cjs`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/adapters/reagent/test/re_frame/view_render_trigger_handler_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_render_trigger_handler_cljs_test.cljs
@@ -25,14 +25,14 @@
   and `implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views])
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/adapters/reagent/test/re_frame/view_rendered_op_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_rendered_op_cljs_test.cljs
@@ -20,16 +20,16 @@
                       distinct, first-seen order, capped at 100"
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.elision :as elision]
-            [re-frame.frame :as frame]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.elision :as rf.elision]
+            [re-frame.frame :as rf.frame]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.epoch]) ;; load so :epoch/run-cause hook is bound
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -189,8 +189,8 @@
       ;; egress projection consults to elide the render arg at emit, and the
       ;; same write a `reg-event` returning `:sensitive` performs. The fixture
       ;; make-frames the ambient :rf/default the render lands in.
-      (frame/swap-runtime-db! :rf/default
-        (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
+      (rf.frame/swap-runtime-db! :rf/default
+        (fn [rt] (rf.elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
       (rf/reg-view ^{:rf/id :rf2-rpgq8/sensitive} sensitive-view [_props]
         [:span "ok"])
       ((rf/view :rf2-rpgq8/sensitive) {:auth {:username "ada" :password "hunter2"}})

--- a/implementation/adapters/reagent/test/re_frame/view_side_capture_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_side_capture_cljs_test.cljs
@@ -28,16 +28,16 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
-            [re-frame.views :as views]
+            [re-frame.interop :as rf.interop]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.views :as rf.views]
             [re-frame.epoch]) ;; load so :epoch/run-cause hook is bound
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -131,11 +131,11 @@
    backs :rf.view/mount? (a real Reagent instance reuses its render-key across
    re-renders, so the same key recurs)"
     (let [rk [:rf2-9hoos/instance 42]]
-      (is (true? (views/first-render?! rk))
+      (is (true? (rf.views/first-render?! rk))
           "first sighting of the render-key → mount")
-      (is (false? (views/first-render?! rk))
+      (is (false? (rf.views/first-render?! rk))
           "second sighting (a re-render of the same instance) → rerender")
-      (is (false? (views/first-render?! rk))
+      (is (false? (rf.views/first-render?! rk))
           "third sighting → still a rerender"))))
 
 (deftest distinct-instances-each-mount
@@ -163,7 +163,7 @@
    :rf.view/id, :frame and the :rf.view/render-key instance tuple"
     (with-trace-recorder! [observed {:pred  (in-op-set #{:rf.view/unmounted})
                                      :shape :by-op}]
-      (views/emit-view-unmounted! :rf2-9hoos/torn [:rf2-9hoos/torn 7] :rf/default)
+      (rf.views/emit-view-unmounted! :rf2-9hoos/torn [:rf2-9hoos/torn 7] :rf/default)
       (let [ev (first (:rf.view/unmounted @observed))
             t  (:tags ev)]
         (is (some? ev) "an :rf.view/unmounted event was emitted")
@@ -180,7 +180,7 @@
    spine-dispose-cljs-test."
     (with-trace-recorder! [observed {:pred  (in-op-set #{:rf.view/unmounted})
                                      :shape :by-op}]
-      (let [rea (views/install-unmount-hook! :rf2-9hoos/lifecycle
+      (let [rea (rf.views/install-unmount-hook! :rf2-9hoos/lifecycle
                                              [:rf2-9hoos/lifecycle 1]
                                              :rf/default)]
         (is (some? rea)
@@ -190,7 +190,7 @@
         ;; Deref once so the reaction is realised, then dispose — the
         ;; teardown signal a real componentWillUnmount sends.
         @rea
-        (interop/dispose! rea)
+        (rf.interop/dispose! rea)
         (let [ev (first (:rf.view/unmounted @observed))]
           (is (some? ev) ":rf.view/unmounted fired on reaction disposal")
           (is (= :rf2-9hoos/lifecycle (get-in ev [:tags :rf.view/id])))

--- a/implementation/adapters/reagent/test/re_frame/views_synthetic_event_frame_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/views_synthetic_event_frame_dom_cljs_test.cljs
@@ -47,9 +47,9 @@
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling])
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace.tooling :as rf.trace.tooling])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; `:ambient-frame nil` OPTS OUT of the fixture's default ambient
@@ -61,8 +61,8 @@
 ;; never runs under an ambient binding. `:async? true` because the working
 ;; half awaits the async dispatch drain.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter :async? true :ambient-frame nil}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter :async? true :ambient-frame nil}))
 
 ;; ---- browser gate ----------------------------------------------------------
 
@@ -176,7 +176,7 @@
                                (.then (fn [_]
                                         (when-let [n @node-atom] (try (.remove n) (catch :default _ nil)))
                                         (try (rf/destroy-frame! target) (catch :default _ nil))
-                                        (trace-tooling/unregister-listener! ::proof-view-unmounts)
+                                        (rf.trace.tooling/unregister-listener! ::proof-view-unmounts)
                                         (is (= 1 (count @unmounts))
                                             (str "rf2-7r78l: exactly one :rf.view/unmounted fired for "
                                                  "proof-view WITHIN the awaited window — teardown awaited, "
@@ -184,7 +184,7 @@
                                         (done))))))]
         (try
           (reset! raised nil)
-          (trace-tooling/register-listener! ::proof-view-unmounts
+          (rf.trace.tooling/register-listener! ::proof-view-unmounts
             (fn [ev]
               (when (and (= :rf.view/unmounted (:operation ev))
                          (= proof-view-id (-> ev :tags :rf.view/id)))
@@ -223,7 +223,7 @@
                 ;; Causal settle: poll the frame's app-db until the async
                 ;; router drain lands the increment — no fixed sleep.
                 (.click captured)
-                (-> (test-support/poll-until
+                (-> (rf.test-support/poll-until
                       #(= 1 (:n (rf/app-db-value target)))
                       {:label      "injected dispatch advances the render frame to {:n 1}"
                        :timeout-ms 1000})

--- a/implementation/adapters/reagent/test/re_frame/warn_once_fixture_isolation_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/warn_once_fixture_isolation_cljs_test.cljs
@@ -38,13 +38,13 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- helper: capture console.warn calls (mirrors source-coord-warn-once) -
 
@@ -71,8 +71,8 @@
   warn-once cache clear) so the assertion below tests the production
   surface — not a private fn."
   [thunk]
-  (let [fixture (test-support/make-reset-runtime-fixture
-                  {:adapter reagent-adapter/adapter})]
+  (let [fixture (rf.test-support/make-reset-runtime-fixture
+                  {:adapter rf.adapter.reagent/adapter})]
     (fixture thunk)))
 
 ;; ---- regression: warn-once cache survives the same render twice ----------

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -23,13 +23,13 @@
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.subs :as subs]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.frame :as frame]
+            [re-frame.fx :as rf.fx]
+            [re-frame.subs :as rf.subs]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.frame :as rf.frame]
             [re-frame.substrate.adapter]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.views]
             [websocket.schema :as ws.schema]
             [websocket.connection :as ws.connection]
@@ -76,24 +76,24 @@
    the `:rf.machine/has-tag?` sub returns false even when the tag is in
    the snapshot."
   []
-  (when-let [spawn-fx (late-bind/get-fn :machines/spawn-fx)]
-    (fx/reg-fx :rf.machine/spawn spawn-fx))
-  (when-let [destroy-fx (late-bind/get-fn :machines/destroy-machine-fx)]
-    (fx/reg-fx :rf.machine/destroy destroy-fx))
-  (when-let [spawn-all-init-fx (late-bind/get-fn :machines/spawn-all-init-fx)]
-    (fx/reg-fx :rf.machine/spawn-all-init spawn-all-init-fx))
-  (when-let [after-schedule-fx (late-bind/get-fn :machines/after-schedule-fx)]
-    (fx/reg-fx :rf.machine/after-schedule after-schedule-fx))
-  (when-let [after-cancel-fx (late-bind/get-fn :machines/after-cancel-fx)]
-    (fx/reg-fx :rf.machine/after-cancel after-cancel-fx))
+  (when-let [spawn-fx (rf.late-bind/get-fn :machines/spawn-fx)]
+    (rf.fx/reg-fx :rf.machine/spawn spawn-fx))
+  (when-let [destroy-fx (rf.late-bind/get-fn :machines/destroy-machine-fx)]
+    (rf.fx/reg-fx :rf.machine/destroy destroy-fx))
+  (when-let [spawn-all-init-fx (rf.late-bind/get-fn :machines/spawn-all-init-fx)]
+    (rf.fx/reg-fx :rf.machine/spawn-all-init spawn-all-init-fx))
+  (when-let [after-schedule-fx (rf.late-bind/get-fn :machines/after-schedule-fx)]
+    (rf.fx/reg-fx :rf.machine/after-schedule after-schedule-fx))
+  (when-let [after-cancel-fx (rf.late-bind/get-fn :machines/after-cancel-fx)]
+    (rf.fx/reg-fx :rf.machine/after-cancel after-cancel-fx))
   ;; The framework subs that read machine state — both registered at
   ;; machines.cljc ns-load time and equally vulnerable to `clear-all!`.
   ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db state, so
   ;; these are runtime-db subs (the `db`-position arg is the runtime-db value).
-  (subs/reg-runtime-sub :rf/machine
+  (rf.subs/reg-runtime-sub :rf/machine
     (fn [rt [_ machine-id]]
       (get-in rt [:rf.runtime/machines :snapshots machine-id])))
-  (subs/reg-runtime-sub :rf.machine/has-tag?
+  (rf.subs/reg-runtime-sub :rf.machine/has-tag?
     (fn [rt [_ machine-id tag]]
       (contains? (get-in rt [:rf.runtime/machines :snapshots machine-id :tags]) tag))))
 
@@ -147,8 +147,8 @@
 ;; this reset the prior tests' mock-socket entries are still in the table
 ;; and `send-server-push!` ends up delivering N copies of every push.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
      :init-fn (fn []
                 (register-all!)
                 (messages/reset-mock-server!))}))
@@ -194,7 +194,7 @@
   ;; way. (We DO need the synthetic `[:rf.machine.timer/after-elapsed
   ;; delay epoch]` events to drive `:after` directly, which we do by
   ;; dispatching them ourselves.)
-  (frame/make-anon-frame-record! {:initial-events [[:ws.app/initialise]]
+  (rf.frame/make-anon-frame-record! {:initial-events [[:ws.app/initialise]]
                   :fx-overrides {:dispatch-later nil}}))
 
 (defn- with-sync-mock! [f]

--- a/implementation/adapters/reagent/test/re_frame/write_after_destroy_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/write_after_destroy_cljs_test.cljs
@@ -34,15 +34,15 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support])
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support])
   (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 (def ^:private write-after-destroy-pred
   (fn [ev]
@@ -56,7 +56,7 @@
             container is a documented no-op + :rf.error/write-after-destroy
             (rf2-ft2b, rf2-9od6t, rf2-500ech)"
     (with-trace-recorder! [errs {:pred write-after-destroy-pred}]
-      (is (nil? (adapter/replace-container! nil {:any :value}))
+      (is (nil? (rf.substrate.adapter/replace-container! nil {:any :value}))
           "nil container must NOT throw (background-thread NPE was the original bug)")
       (is (= 1 (count @errs))
           "exactly one :rf.error/write-after-destroy fires per nil-write")
@@ -74,10 +74,10 @@
       (with-trace-recorder! [errs {:pred write-after-destroy-pred}]
         (rf/make-frame {:id frame-id :doc "rf2-9od6t race reproducer"})
         (rf/destroy-frame! frame-id)
-        (let [container (frame/app-db-container frame-id)]
+        (let [container (rf.frame/app-db-container frame-id)]
           (is (nil? container)
               "app-db-container on a destroyed frame returns nil — the rf2-ft2b precondition")
-          (is (nil? (adapter/replace-container! container {:would :have :npe'd true}))
+          (is (nil? (rf.substrate.adapter/replace-container! container {:would :have :npe'd true}))
               "writing through the nil container is a documented no-op"))
         (is (pos? (count @errs))
             ":rf.error/write-after-destroy fired for the post-destroy write")

--- a/implementation/adapters/reagent/testbed/adapter_testbed_reagent/core.cljs
+++ b/implementation/adapters/reagent/testbed/adapter_testbed_reagent/core.cljs
@@ -10,7 +10,7 @@
    Minimal by design. Don't grow it. Real coverage is the framework's
    CLJS / browser tests and the Xray feature gate."
   (:require [re-frame.core    :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as rf.adapter.reagent])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; -- Events / subs ----------------------------------------------------------
@@ -59,7 +59,7 @@
 ;; React Root is created by the first `render!` through it and updated by
 ;; every later one — the same shape the boot guide and the generated
 ;; template teach, so this smoke mounts the way an app does.
-(defonce app-root (reagent-adapter/client-root))
+(defonce app-root (rf.adapter.reagent/client-root))
 
 (defn ^:export init []
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
@@ -67,10 +67,10 @@
   ;; explicitly here (init! installs only the adapter). The boot dispatch
   ;; runs under the frame scope and the render is wrapped in a
   ;; `frame-provider` so in-tree dispatch/subscribe resolve to it.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (rf/make-frame {:id :rf/default})
   (rf/with-frame :rf/default
     (rf/dispatch-sync [:counter/init]))
-  (reagent-adapter/render! app-root
+  (rf.adapter.reagent/render! app-root
     [rf/frame-provider {:frame :rf/default} [root]]
     (js/document.getElementById "app")))

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -27,12 +27,12 @@
         (test-react/unmount! m)
         (mapv :phase (test-react/lifecycle-log m)))
       ;; => [:constructor :render :did-mount :render :did-update :will-unmount]"
-  (:require [re-frame.error :as error]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.substrate.atom-container :as atom-container]
-            [re-frame.subs.cache :as subs-cache]
-            [re-frame.frame :as frame]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.substrate.atom-container :as rf.substrate.atom-container]
+            [re-frame.subs.cache :as rf.subs.cache]
+            [re-frame.frame :as rf.frame]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -166,7 +166,7 @@
     (let [mount @self-ref]
       (when @(:mounted? mount)
         (when (rendering?)
-          (error/throw-error!
+          (rf.error/throw-error!
             :rf.error/sync-unmount-during-render
             'rf/test-react-unmount
             (str "Attempted to synchronously unmount a root"
@@ -307,7 +307,7 @@
   [render-tree]
   (let [parent *rendering-mount*]
     (when (nil? parent)
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/mount-child-outside-render
         'rf/test-react-mount-child!
         (str "mount-child! must be called from inside an"
@@ -337,7 +337,7 @@
 (defn- render-to-string [render-tree opts]
   (if-let [emit @hiccup-emitter]
     (emit render-tree opts)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/no-hiccup-emitter-bound
       'rf/render-to-string
       (str "Test-React adapter has no built-in hiccup emitter; call "
@@ -346,7 +346,7 @@
       ;; Diagnostics may be captured before path-based classification, so never
       ;; attach the raw render tree.
       {:recovery :call-set-hiccup-emitter
-       :extra    {:render-tree/summary (error/diag-value-summary render-tree)}})))
+       :extra    {:render-tree/summary (rf.error/diag-value-summary render-tree)}})))
 
 ;; ---- frame-provider --------------------------------------------------------
 
@@ -391,7 +391,7 @@
   ;; guard deliberately cannot block. The trailing `reset! active-mounts #{}` is
   ;; belt-and-suspenders: the primitive already disj'd each drained record.
   ;;
-  (subs-cache/clear-all-frame-sub-caches!)
+  (rf.subs.cache/clear-all-frame-sub-caches!)
   (doseq [mount @active-mounts]
     (force-teardown-record! mount))
   (reset! active-mounts #{})
@@ -413,10 +413,10 @@
   class-3 lifecycle simulator and its global unmount-during-render guard. See
   `mount!`, `trigger-update!`, and `unmount!` for the test driver."
   {:kind                      :rf.adapter/test-react
-   :make-state-container      atom-container/make-state-container
-   :read-container            atom-container/read-container
-   :replace-container!        atom-container/replace-container!
-   :subscribe-container       atom-container/subscribe-container
+   :make-state-container      rf.substrate.atom-container/make-state-container
+   :read-container            rf.substrate.atom-container/read-container
+   :replace-container!        rf.substrate.atom-container/replace-container!
+   :subscribe-container       rf.substrate.atom-container/subscribe-container
    :make-derived-value        make-derived-value
    :render                    render
    :render-to-string          render-to-string
@@ -454,13 +454,13 @@
   `:kind`, e.g. one `assoc`'d with an instrumentation wrapper) is still
   accepted, matching the routed hooks' acceptance of the same copy."
   [render-tree]
-  (when-not (substrate-adapter/same-adapter? adapter (substrate-adapter/current-adapter-spec))
-    (error/throw-error!
+  (when-not (rf.substrate.adapter/same-adapter? adapter (rf.substrate.adapter/current-adapter-spec))
+    (rf.error/throw-error!
       :rf.error/test-react-not-installed
       'rf/test-react-mount!
       (str "test-react/mount! requires the Test-React adapter"
            " to be the (rf/init!)-installed adapter; got "
-           (substrate-adapter/current-adapter)
+           (rf.substrate.adapter/current-adapter)
            ". Call (rf/init! test-react/adapter) before mount!.")
       {:recovery :install-the-test-react-adapter}))
   (mount-tree! render-tree))
@@ -489,7 +489,7 @@
   already correct."
   [mount new-render-tree]
   (when-not @(:mounted? mount)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/update-after-unmount
       'rf/test-react-trigger-update!
       (str "trigger-update! called on a mount that has already been "
@@ -582,11 +582,11 @@
 ;; paths that reach for them under a non-React adapter indicate a
 ;; misconfiguration that should surface, not be papered over.
 
-(substrate-adapter/route-hook! adapter :adapter/current-frame
-  (fn test-react-current-frame [] (frame/current-frame))
-  #(frame/current-frame))
+(rf.substrate.adapter/route-hook! adapter :adapter/current-frame
+  (fn test-react-current-frame [] (rf.frame/current-frame))
+  #(rf.frame/current-frame))
 
 ;; SSR emitter install — chains onto the existing :reagent/set-hiccup-emitter!
 ;; late-bind hook so a single `(require '[re-frame.ssr])` wires
 ;; render-to-string for whichever adapter ends up (rf/init!)-installed.
-(late-bind/chain-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
+(rf.late-bind/chain-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
@@ -35,8 +35,8 @@
      wrong installed adapter, the no-emitter render-to-string throw, unmount!
      idempotency, the substrate :render entry point returning a working
      unmount thunk, and deep (grandchild) leaf-upward cascade ordering."
-  (:require [re-frame.adapter.test-react :as test-react]
-            [re-frame.substrate.adapter :as substrate-adapter]
+  (:require [re-frame.adapter.test-react :as rf.adapter.test-react]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
             #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])))
 
@@ -46,12 +46,12 @@
   ;; Clean install/dispose around each test. `install-adapter!` throws
   ;; if an adapter is still installed; the test-only seam wipes the
   ;; lifecycle state so each case starts cold.
-  (substrate-adapter/reset-lifecycle-state-for-tests!)
-  (substrate-adapter/install-adapter! test-react/adapter)
+  (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
+  (rf.substrate.adapter/install-adapter! rf.adapter.test-react/adapter)
   (try
     (t)
     (finally
-      (substrate-adapter/dispose-adapter!))))
+      (rf.substrate.adapter/dispose-adapter!))))
 
 (use-fixtures :each install-test-react!)
 
@@ -65,7 +65,7 @@
 (defn- phase-count
   "How many `phase` entries the mount's lifecycle log holds."
   [mount phase]
-  (->> (test-react/lifecycle-log mount)
+  (->> (rf.adapter.test-react/lifecycle-log mount)
        (filter (comp #{phase} :phase))
        count))
 
@@ -77,7 +77,7 @@
   which collapsed to equal integers for a sub-millisecond teardown cascade and
   made the ORDER check vacuous (it could not fail on a reversed teardown)."
   [mount phase]
-  (->> (test-react/lifecycle-log mount)
+  (->> (rf.adapter.test-react/lifecycle-log mount)
        (filter (comp #{phase} :phase))
        first
        :seq))
@@ -90,11 +90,11 @@
 
 (deftest happy-path-lifecycle-ordering
   (testing "constructor → render → did-mount → did-update → will-unmount"
-    (let [mount (test-react/mount! [:div "v1"])]
-      (test-react/trigger-update! mount [:div "v2"])
-      (test-react/unmount! mount)
+    (let [mount (rf.adapter.test-react/mount! [:div "v1"])]
+      (rf.adapter.test-react/trigger-update! mount [:div "v2"])
+      (rf.adapter.test-react/unmount! mount)
       (is (= [:constructor :render :did-mount :render :did-update :will-unmount]
-             (mapv :phase (test-react/lifecycle-log mount)))
+             (mapv :phase (rf.adapter.test-react/lifecycle-log mount)))
           "the simulated lifecycle records constructor, mount-render+did-mount, update-render+did-update, will-unmount"))))
 
 (deftest lifecycle-log-entries-carry-exactly-phase-and-seq
@@ -103,10 +103,10 @@
             is fixed-arity precisely so nothing can smuggle an extra key in
             (rf2-6r9j.83); this pins that, and would fail if a stray field —
             or a merge that clobbered :phase / :seq — ever reappeared."
-    (let [mount (test-react/mount! [:div "v1"])]
-      (test-react/trigger-update! mount [:div "v2"])
-      (test-react/unmount! mount)
-      (let [log (test-react/lifecycle-log mount)]
+    (let [mount (rf.adapter.test-react/mount! [:div "v1"])]
+      (rf.adapter.test-react/trigger-update! mount [:div "v2"])
+      (rf.adapter.test-react/unmount! mount)
+      (let [log (rf.adapter.test-react/lifecycle-log mount)]
         (is (seq log) "precondition: the log recorded entries at all")
         (is (= #{#{:phase :seq}}
                (into #{} (map (comp set keys)) log))
@@ -118,18 +118,18 @@
 
 (deftest mounted-components-and-current-render-tree
   (testing "mounted-components tracks live mounts; current-render-tree returns the latest hiccup"
-    (let [mount (test-react/mount! [:div "initial"])]
-      (is (= 1 (count (test-react/mounted-components))))
-      (is (= [:div "initial"] (test-react/current-render-tree mount)))
-      (test-react/trigger-update! mount [:div "updated"])
-      (is (= [:div "updated"] (test-react/current-render-tree mount)))
-      (test-react/unmount! mount)
+    (let [mount (rf.adapter.test-react/mount! [:div "initial"])]
+      (is (= 1 (count (rf.adapter.test-react/mounted-components))))
+      (is (= [:div "initial"] (rf.adapter.test-react/current-render-tree mount)))
+      (rf.adapter.test-react/trigger-update! mount [:div "updated"])
+      (is (= [:div "updated"] (rf.adapter.test-react/current-render-tree mount)))
+      (rf.adapter.test-react/unmount! mount)
       ;; Exercise the compatibility alias after canonical-name coverage above.
       #_{:clj-kondo/ignore [:deprecated-var]}
-      (let [legacy-mounted-roots (deref #'test-react/mounted-roots)]
-        (is (and (true? (:deprecated (meta #'test-react/mounted-roots)))
+      (let [legacy-mounted-roots (deref #'rf.adapter.test-react/mounted-roots)]
+        (is (and (true? (:deprecated (meta #'rf.adapter.test-react/mounted-roots)))
                  (zero? (count (legacy-mounted-roots))))))
-      (is (nil? (test-react/current-render-tree mount))))))
+      (is (nil? (rf.adapter.test-react/current-render-tree mount))))))
 
 (deftest unmount-actually-evicts-from-the-raw-active-set
   (testing "unmount! removes the mount from the RAW active-mounts set, not just
@@ -140,19 +140,19 @@
             disj the exact record conj'd, or the dead record leaks for the
             adapter's lifetime (defrecord equality includes :unmount-fn, so the
             pre-assoc skeleton would not match)."
-    (let [active @#'test-react/active-mounts]
+    (let [active @#'rf.adapter.test-react/active-mounts]
       (is (zero? (count @active))
           "precondition: raw active set starts empty")
-      (let [mount (test-react/mount! [:div "live"])]
+      (let [mount (rf.adapter.test-react/mount! [:div "live"])]
         (is (= 1 (count @active))
             "mount registered exactly one record in the raw set")
-        (test-react/unmount! mount)
+        (rf.adapter.test-react/unmount! mount)
         (is (zero? (count @active))
             "unmount! EVICTED the record from the raw set — no leaked dead record"))
       ;; Many mount/unmount cycles must not grow the raw set (the leak symptom
       ;; was monotonic growth masked by the :mounted? filter).
       (dotimes [_ 25]
-        (test-react/unmount! (test-react/mount! [:div "churn"])))
+        (rf.adapter.test-react/unmount! (rf.adapter.test-react/mount! [:div "churn"])))
       (is (zero? (count @active))
           "25 mount/unmount cycles left the raw active set empty — no accumulation"))))
 
@@ -160,17 +160,17 @@
 
 (deftest dispose-adapter-drains-stranded-mounts
   (testing "dispose-adapter! drains mounts the test forgot to unmount; log carries :forced-teardown breadcrumb"
-    (let [mount (test-react/mount! [:div "leaked"])]
+    (let [mount (rf.adapter.test-react/mount! [:div "leaked"])]
       ;; The :each fixture's `dispose-adapter!` will fire on the way
       ;; out; we invoke it explicitly here so the assertions land in
       ;; the test body rather than the fixture.
-      (substrate-adapter/dispose-adapter!)
+      (rf.substrate.adapter/dispose-adapter!)
       (is (not @(:mounted? mount))
           ":mounted? flips to false on forced teardown")
-      (is (some #{:forced-teardown} (mapv :phase (test-react/lifecycle-log mount)))
+      (is (some #{:forced-teardown} (mapv :phase (rf.adapter.test-react/lifecycle-log mount)))
           ":forced-teardown phase records the drain so tests can spot leaked mounts")
       ;; Re-install so the fixture's outer dispose call below is a no-op.
-      (substrate-adapter/install-adapter! test-react/adapter))))
+      (rf.substrate.adapter/install-adapter! rf.adapter.test-react/adapter))))
 
 ;; ---- mount! returns the exact record it created ---------------------------
 
@@ -182,22 +182,22 @@
     ;; Mount a dozen components without unmounting any (they stay live), then
     ;; mount one more with a unique sentinel render-tree.
     (let [earlier (doall (for [i (range 12)]
-                           (test-react/mount! [:div (str "v" i)])))
-          latest  (test-react/mount! [:div "SENTINEL-LATEST"])]
-      (is (= [:div "SENTINEL-LATEST"] (test-react/current-render-tree latest))
+                           (rf.adapter.test-react/mount! [:div (str "v" i)])))
+          latest  (rf.adapter.test-react/mount! [:div "SENTINEL-LATEST"])]
+      (is (= [:div "SENTINEL-LATEST"] (rf.adapter.test-react/current-render-tree latest))
           "mount! returned the record for the mount it just created")
-      (is (= 13 (count (test-react/mounted-components)))
+      (is (= 13 (count (rf.adapter.test-react/mounted-components)))
           "all thirteen mounts are live")
       ;; The unmount thunk on the returned record tears down the SENTINEL
       ;; mount specifically — not a neighbour.
-      (test-react/unmount! latest)
-      (is (nil? (test-react/current-render-tree latest))
+      (rf.adapter.test-react/unmount! latest)
+      (is (nil? (rf.adapter.test-react/current-render-tree latest))
           "unmounting the returned record tore down the correct (latest) mount")
-      (is (= 12 (count (test-react/mounted-components)))
+      (is (= 12 (count (rf.adapter.test-react/mounted-components)))
           "exactly one mount torn down; the other twelve remain live")
       ;; Drain the 12 still-live earlier mounts so the fixture's
       ;; dispose-adapter! has nothing surprising to forcibly tear down.
-      (doseq [m earlier] (test-react/unmount! m)))))
+      (doseq [m earlier] (rf.adapter.test-react/unmount! m)))))
 
 ;; ---- render-to-string survives a dispose/reinstall cycle ------------------
 
@@ -219,20 +219,20 @@
             test-react JVM run (core + test-quiet only, no re-frame.ssr) the
             durable slot is unset, the replay no-ops, and test-react's own
             un-cleared stub survives."
-    (test-react/set-hiccup-emitter! (fn [tree _opts] (str "HTML:" (pr-str tree))))
+    (rf.adapter.test-react/set-hiccup-emitter! (fn [tree _opts] (str "HTML:" (pr-str tree))))
     (try
       (is (= "HTML:[:div \"a\"]"
-             (substrate-adapter/render-to-string [:div "a"] nil))
+             (rf.substrate.adapter/render-to-string [:div "a"] nil))
           "the transient emitter is bound before the dispose cycle")
       ;; Dispose + reinstall (the standard fixture shape).
-      (substrate-adapter/dispose-adapter!)
-      (substrate-adapter/install-adapter! test-react/adapter)
-      (let [html (substrate-adapter/render-to-string [:div "b"] nil)]
+      (rf.substrate.adapter/dispose-adapter!)
+      (rf.substrate.adapter/install-adapter! rf.adapter.test-react/adapter)
+      (let [html (rf.substrate.adapter/render-to-string [:div "b"] nil)]
         (is (and (string? html) (re-find #"b" html))
             "render-to-string still armed after dispose + reinstall — it renders
              the tree and never throws :rf.error/no-hiccup-emitter-bound"))
       (finally
-        (test-react/set-hiccup-emitter! nil)))))
+        (rf.adapter.test-react/set-hiccup-emitter! nil)))))
 
 ;; ----------------------------------------------------------------------------
 ;; A'. Recursive child mounting — the structural seam the regressions ride on
@@ -244,29 +244,29 @@
             child of the parent, and is torn down children-first when the
             parent unmounts"
     (let [child-ref (atom nil)
-          parent    (test-react/mount!
+          parent    (rf.adapter.test-react/mount!
                       {:rf/component
                        (fn [_parent]
                          (reset! child-ref
-                                 (test-react/mount-child! [:span "child"])))})]
+                                 (rf.adapter.test-react/mount-child! [:span "child"])))})]
       ;; The child ran its full mount lifecycle.
       (is (= [:constructor :render :did-mount]
-             (mapv :phase (test-react/lifecycle-log @child-ref)))
+             (mapv :phase (rf.adapter.test-react/lifecycle-log @child-ref)))
           "child recursed through its own class-3 mount lifecycle")
       ;; The forest holds both mounts; the parent records the child.
-      (is (= 2 (count (test-react/mounted-components)))
+      (is (= 2 (count (rf.adapter.test-react/mounted-components)))
           "parent + child are both live in the forest")
       ;; Exercise the compatibility alias; later checks use mounted-children.
       #_{:clj-kondo/ignore [:deprecated-var]}
-      (let [legacy-children (deref #'test-react/children)]
-        (is (and (true? (:deprecated (meta #'test-react/children)))
+      (let [legacy-children (deref #'rf.adapter.test-react/children)]
+        (is (and (true? (:deprecated (meta #'rf.adapter.test-react/children)))
                  (= [@child-ref] (legacy-children parent)))
             "the deprecated alias remains callable and returns the live child"))
       ;; Unmounting the parent cascades to the child, children-first.
-      (test-react/unmount! parent)
-      (is (zero? (count (test-react/mounted-components)))
+      (rf.adapter.test-react/unmount! parent)
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "parent unmount cascaded to the child — nothing leaks")
-      (is (some #{:will-unmount} (mapv :phase (test-react/lifecycle-log @child-ref)))
+      (is (some #{:will-unmount} (mapv :phase (rf.adapter.test-react/lifecycle-log @child-ref)))
           "the child saw its own :will-unmount during the cascade")
       (let [child-unmount-seq  (phase-first-seq @child-ref :will-unmount)
             parent-unmount-seq (phase-first-seq parent :will-unmount)]
@@ -297,19 +297,19 @@
             :rf.error/sync-unmount-during-render ORGANICALLY (no fabricated
             in-flight state) — the rf2-4l7t2 bug condition, reproduced"
     ;; Mount panel A as a standalone root (the host's current child).
-    (let [panel-a (test-react/mount! [:div.panel "A"])]
-      (is (= 1 (count (test-react/mounted-components))))
+    (let [panel-a (rf.adapter.test-react/mount! [:div.panel "A"])]
+      (is (= 1 (count (rf.adapter.test-react/mounted-components))))
       ;; The host re-renders to switch to panel B. The BUGGY render body
       ;; synchronously unmounts panel A's root mid-render (the senbl pattern
       ;; before the microtask-defer fix).
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #":rf.error/sync-unmount-during-render"
-            (test-react/mount!
+            (rf.adapter.test-react/mount!
               {:rf/component
                (fn [_host]
                  ;; BUG: synchronous unmount of a separate root during render.
-                 (test-react/unmount! panel-a))}))
+                 (rf.adapter.test-react/unmount! panel-a))}))
           "the guard fires organically: the unmount happens while the host's
            render is in flight, which is React's actual guard condition")
       ;; The host's render body THREW, yet run-render!'s `finally` decremented
@@ -320,38 +320,38 @@
       ;; covered indirectly (the trailing unmount! below would throw a
       ;; confusing uncaught ExceptionInfo if depth leaked, and that coverage
       ;; vanished if the trailing unmount was ever refactored away).
-      (is (false? (test-react/rendering?))
+      (is (false? (rf.adapter.test-react/rendering?))
           "run-render!'s finally restored render-depth to zero even though the
            render body threw — no leaked in-flight state poisons later tests")
       ;; mount-tree! registers into active-mounts only AFTER run-render!
       ;; returns, so a throw mid-render never registers the host — the
       ;; partially-constructed root cannot leak into the live forest.
-      (is (= 1 (count (test-react/mounted-components)))
+      (is (= 1 (count (rf.adapter.test-react/mounted-components)))
           "only panel A is live — the throwing host never registered, no leak")
       ;; Panel A is still mounted — the guard short-circuited the unmount
       ;; before it could tear the root down (matching React: it refuses the
       ;; synchronous unmount rather than racing).
       (is (true? @(:mounted? panel-a))
           "the guard refused the synchronous unmount — panel A was NOT torn down")
-      (test-react/unmount! panel-a))))
+      (rf.adapter.test-react/unmount! panel-a))))
 
 (deftest deferred-unmount-after-render-is-safe-rf2-4l7t2-fix
   (testing "the rf2-4l7t2 FIX shape: unmounting the previous panel's root AFTER
             the host's render has completed (the microtask-defer) does not trip
             the guard — proves the guard discriminates in-render from
             after-render, so it is not a blunt always-throw"
-    (let [panel-a (test-react/mount! [:div.panel "A"])
+    (let [panel-a (rf.adapter.test-react/mount! [:div.panel "A"])
           ;; Host re-renders to switch to B WITHOUT unmounting A mid-render.
-          host    (test-react/mount! {:rf/component (fn [_host] :switched-to-B)})]
-      (is (= 2 (count (test-react/mounted-components))))
+          host    (rf.adapter.test-react/mount! {:rf/component (fn [_host] :switched-to-B)})]
+      (is (= 2 (count (rf.adapter.test-react/mounted-components))))
       ;; Now that no render is in flight, unmounting panel A is safe (this is
       ;; what queueMicrotask buys you in the production fix).
-      (is (false? (test-react/rendering?))
+      (is (false? (rf.adapter.test-react/rendering?))
           "no render in flight after the host's render completed")
-      (test-react/unmount! panel-a)        ; must NOT throw
-      (is (= 1 (count (test-react/mounted-components)))
+      (rf.adapter.test-react/unmount! panel-a)        ; must NOT throw
+      (is (= 1 (count (rf.adapter.test-react/mounted-components)))
           "deferred unmount tore down panel A cleanly")
-      (test-react/unmount! host))))
+      (rf.adapter.test-react/unmount! host))))
 
 ;; ----------------------------------------------------------------------------
 ;; B.2 — Unbalanced subscribe/dispose (mount/unmount ref-count)
@@ -375,48 +375,48 @@
           ;; the standalone `mount!` seam (think: an effect that creates a
           ;; Reagent root but forgets to register its unmount thunk for
           ;; teardown). `mount!` does NOT attach to the parent's :children.
-          host (test-react/mount!
+          host (rf.adapter.test-react/mount!
                  {:rf/component
                   (fn [_host]
-                    (test-react/mount-child! [:section "tracked-child"])
-                    (reset! orphan-ref (test-react/mount! [:section "ORPHAN"])))})]
-      (is (= 3 (count (test-react/mounted-components)))
+                    (rf.adapter.test-react/mount-child! [:section "tracked-child"])
+                    (reset! orphan-ref (rf.adapter.test-react/mount! [:section "ORPHAN"])))})]
+      (is (= 3 (count (rf.adapter.test-react/mounted-components)))
           "host + tracked child + orphaned root are all live")
-      (is (= 1 (count (test-react/mounted-children host)))
+      (is (= 1 (count (rf.adapter.test-react/mounted-children host)))
           "the host only KNOWS about the one tracked child (the orphan is untracked)")
       ;; Correct-looking teardown: unmount the host. Its cascade tears down the
       ;; tracked child — but cannot reach the untracked orphan.
-      (test-react/unmount! host)
+      (rf.adapter.test-react/unmount! host)
       ;; Symptom: the orphan is still mounted; the count never returned to zero.
-      (is (= 1 (count (test-react/mounted-components)))
+      (is (= 1 (count (rf.adapter.test-react/mounted-components)))
           "the orphaned root leaks — subscribe/dispose imbalance detected")
       (is (true? @(:mounted? @orphan-ref))
           "the specific leaked root is the orphan the host forgot to track")
       ;; Clean up the orphan so the fixture's drain has nothing to forcibly tear.
-      (test-react/unmount! @orphan-ref))))
+      (rf.adapter.test-react/unmount! @orphan-ref))))
 
 (deftest balanced-subscribe-dispose-returns-to-zero
   (testing "the CORRECT counterpart: a parent that lets the cascade tear all
             children down returns the live-mount count to zero and empties its
             tracked-child set — the green state a regression in B.2 would break"
-    (let [parent (test-react/mount!
+    (let [parent (rf.adapter.test-react/mount!
                    {:rf/component
                     (fn [_parent]
-                      (test-react/mount-child! [:li "a"])
-                      (test-react/mount-child! [:li "b"]))})]
-      (is (= 3 (count (test-react/mounted-components))))
-      (is (= 2 (count (test-react/mounted-children parent)))
+                      (rf.adapter.test-react/mount-child! [:li "a"])
+                      (rf.adapter.test-react/mount-child! [:li "b"]))})]
+      (is (= 3 (count (rf.adapter.test-react/mounted-components))))
+      (is (= 2 (count (rf.adapter.test-react/mounted-children parent)))
           "both children are tracked under the parent before teardown")
       ;; Correct teardown: just unmount the parent; the cascade tears every
       ;; child down leaf-first — no per-resource bookkeeping needed.
-      (test-react/unmount! parent)
-      (is (zero? (count (test-react/mounted-components)))
+      (rf.adapter.test-react/unmount! parent)
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "cascade tore every child down — nothing leaks")
       ;; `mounted-children` returns only STILL-MOUNTED children, so an empty result
       ;; after teardown is a REAL framework property: the cascade set every
       ;; tracked child's mounted? false. A child the cascade failed to reach
       ;; would still read as mounted and show up here.
-      (is (empty? (test-react/mounted-children parent))
+      (is (empty? (rf.adapter.test-react/mounted-children parent))
           "the parent's live-child set drained — the cascade reached every child"))))
 
 ;; ----------------------------------------------------------------------------
@@ -433,12 +433,12 @@
   (testing "a buggy update path that re-renders twice for one logical change
             records TWO :did-update :render pairs; the symptom is a render
             count of 2 where the contract is 1"
-    (let [mount (test-react/mount! [:div "v1"])]
+    (let [mount (rf.adapter.test-react/mount! [:div "v1"])]
       ;; CONTRACT: one logical change → one update render.
       ;; BUG: the update path fires trigger-update! twice (the redundant
       ;; second render real double-render bugs produce).
-      (test-react/trigger-update! mount [:div "v2"])
-      (test-react/trigger-update! mount [:div "v2"]) ; redundant re-render
+      (rf.adapter.test-react/trigger-update! mount [:div "v2"])
+      (rf.adapter.test-react/trigger-update! mount [:div "v2"]) ; redundant re-render
       (let [renders (phase-count mount :render)
             updates (phase-count mount :did-update)]
         ;; Mount render + two update renders = 3.
@@ -446,16 +446,16 @@
             "render count is 3 (1 mount + 2 update) — the doubled update render is visible")
         (is (= 2 updates)
             "two :did-update entries expose the redundant second render"))
-      (test-react/unmount! mount))))
+      (rf.adapter.test-react/unmount! mount))))
 
 (deftest single-render-is-the-balanced-baseline
   (testing "the CORRECT counterpart: one logical change → exactly one update
             render (one :did-update). A double-render regression breaks this."
-    (let [mount (test-react/mount! [:div "v1"])]
-      (test-react/trigger-update! mount [:div "v2"])
+    (let [mount (rf.adapter.test-react/mount! [:div "v1"])]
+      (rf.adapter.test-react/trigger-update! mount [:div "v2"])
       (is (= 1 (phase-count mount :did-update))
           "exactly one update render for one logical change")
-      (test-react/unmount! mount))))
+      (rf.adapter.test-react/unmount! mount))))
 
 ;; ----------------------------------------------------------------------------
 ;; B.4 — Transactional failed initial mount (rf2-3fc89f.2)
@@ -487,15 +487,15 @@
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #"boom-parent-render"
-            (test-react/mount!
+            (rf.adapter.test-react/mount!
               {:rf/component
                (fn [_parent]
-                 (reset! child-ref (test-react/mount-child! [:span "child"]))
+                 (reset! child-ref (rf.adapter.test-react/mount-child! [:span "child"]))
                  (throw (ex-info "boom-parent-render" {})))}))
           "the ORIGINAL render exception propagates — rollback never masks it")
-      (is (false? (test-react/rendering?))
+      (is (false? (rf.adapter.test-react/rendering?))
           "run-render!'s finally restored render-depth to zero on unwind")
-      (is (zero? (count (test-react/mounted-components)))
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "the live forest is empty — the child mounted before the throw was
            rolled back, not leaked as a phantom live mount (this FAILS pre-fix)")
       (is (false? @(:mounted? @child-ref))
@@ -503,7 +503,7 @@
       (is (= 1 (phase-count @child-ref :forced-teardown))
           "the rollback recorded a :forced-teardown on the child — teardown
            logging is preserved, not a silent drop")
-      (is (nil? (test-react/current-render-tree @child-ref))
+      (is (nil? (rf.adapter.test-react/current-render-tree @child-ref))
           "the child's render tree was cleared by the forced teardown"))))
 
 (deftest failed-initial-render-rolls-back-nested-subtree-rf2-3fc89f2
@@ -516,18 +516,18 @@
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #"boom-nested-parent"
-            (test-react/mount!
+            (rf.adapter.test-react/mount!
               {:rf/component
                (fn [_parent]
                  (reset! child-ref
-                         (test-react/mount-child!
+                         (rf.adapter.test-react/mount-child!
                            {:rf/component
                             (fn [_child]
                               (reset! grandchild-ref
-                                      (test-react/mount-child! [:span "leaf"])))}))
+                                      (rf.adapter.test-react/mount-child! [:span "leaf"])))}))
                  (throw (ex-info "boom-nested-parent" {})))}))
           "the original render exception escapes")
-      (is (zero? (count (test-react/mounted-components)))
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "no descendant leaks — child AND grandchild both left the forest
            (pre-fix this is 2)")
       (is (and (false? @(:mounted? @child-ref))
@@ -552,19 +552,19 @@
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #"boom-child-render"
-            (test-react/mount!
+            (rf.adapter.test-react/mount!
               {:rf/component
                (fn [_parent]
-                 (test-react/mount-child!
+                 (rf.adapter.test-react/mount-child!
                    {:rf/component
                     (fn [_child]
                       (reset! grandchild-ref
-                              (test-react/mount-child! [:span "leaf"]))
+                              (rf.adapter.test-react/mount-child! [:span "leaf"]))
                       (throw (ex-info "boom-child-render" {})))}))}))
           "the child's render exception propagates out through the parent")
-      (is (false? (test-react/rendering?))
+      (is (false? (rf.adapter.test-react/rendering?))
           "every nested run-render! finally unwound render-depth to zero")
-      (is (zero? (count (test-react/mounted-components)))
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "the grandchild the failing child mounted was rolled back — no
            orphaned descendant survives the nested failure")
       (is (false? @(:mounted? @grandchild-ref))
@@ -574,25 +574,25 @@
   (testing "a failed initial mount records NO :did-mount for the throwing
             parent, registers nothing in the live forest, and does not disturb
             a separate root that was already live before the failed mount"
-    (let [survivor  (test-react/mount! [:div "survivor"])
+    (let [survivor  (rf.adapter.test-react/mount! [:div "survivor"])
           parent-ref (atom nil)
           child-ref  (atom nil)]
-      (is (= 1 (count (test-react/mounted-components)))
+      (is (= 1 (count (rf.adapter.test-react/mounted-components)))
           "precondition: exactly the survivor root is live")
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #"boom-with-sibling"
-            (test-react/mount!
+            (rf.adapter.test-react/mount!
               {:rf/component
                (fn [parent]
                  (reset! parent-ref parent)
-                 (reset! child-ref (test-react/mount-child! [:span "child"]))
+                 (reset! child-ref (rf.adapter.test-react/mount-child! [:span "child"]))
                  (throw (ex-info "boom-with-sibling" {})))}))
           "the failed mount throws its original exception")
       (is (zero? (phase-count @parent-ref :did-mount))
           "the throwing parent never reached :did-mount — a failed render does
            NOT emit the mount-completed phase")
-      (is (= [survivor] (test-react/mounted-components))
+      (is (= [survivor] (rf.adapter.test-react/mounted-components))
           "the ONLY live root is the pre-existing survivor: the parent never
            registered and the child was rolled back — no hidden leaked record
            remains in the live forest for a later test to trip over")
@@ -604,7 +604,7 @@
       (is (false? @(:mounted? @child-ref))
           "the speculative child is torn down, not a manually-cleanable phantom")
       ;; Clean up the survivor so the fixture's drain has nothing to force.
-      (test-react/unmount! survivor))))
+      (rf.adapter.test-react/unmount! survivor))))
 
 (deftest rollback-does-not-mask-guard-and-spares-guard-target-rf2-3fc89f2
   (testing "the transactional rollback COMPOSES with the B.1 guard: a render
@@ -613,30 +613,30 @@
             (rollback does not mask that guard error), the guard's target root
             stays mounted (the guard refused the unmount), and the tracked
             child the same body mounted IS rolled back"
-    (let [target    (test-react/mount! [:div.panel "target"])
+    (let [target    (rf.adapter.test-react/mount! [:div.panel "target"])
           child-ref (atom nil)]
-      (is (= 1 (count (test-react/mounted-components)))
+      (is (= 1 (count (rf.adapter.test-react/mounted-components)))
           "precondition: only the guard's target root is live")
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #":rf.error/sync-unmount-during-render"
-            (test-react/mount!
+            (rf.adapter.test-react/mount!
               {:rf/component
                (fn [_host]
                  ;; Mount a tracked child (registers in the forest), THEN trip
                  ;; the sync-unmount-during-render guard on a separate root.
-                 (reset! child-ref (test-react/mount-child! [:span "child"]))
-                 (test-react/unmount! target))}))
+                 (reset! child-ref (rf.adapter.test-react/mount-child! [:span "child"]))
+                 (rf.adapter.test-react/unmount! target))}))
           "the guard error — NOT the rollback — is what escapes; rollback does
            not swallow or replace the render body's exception")
       (is (true? @(:mounted? target))
           "the guard refused the synchronous unmount — the target root survives")
-      (is (= [target] (test-react/mounted-components))
+      (is (= [target] (rf.adapter.test-react/mounted-components))
           "only the target is live: the host never registered and its tracked
            child was rolled back despite the render failing via the guard")
       (is (false? @(:mounted? @child-ref))
           "the child mounted before the guard tripped was rolled back too")
-      (test-react/unmount! target))))
+      (rf.adapter.test-react/unmount! target))))
 
 ;; ----------------------------------------------------------------------------
 ;; B.5 — Failed update unmounts the whole root (rf2-j538f7.1)
@@ -670,28 +670,28 @@
             exception escapes unmasked, the root AND its speculative child leave
             the forest with cleared render trees, and NO :did-update is logged"
     (let [child-ref (atom nil)
-          mount     (test-react/mount! [:div "committed-v1"])]
-      (is (= 1 (count (test-react/mounted-components)))
+          mount     (rf.adapter.test-react/mount! [:div "committed-v1"])]
+      (is (= 1 (count (rf.adapter.test-react/mounted-components)))
           "precondition: the root is live on its committed tree")
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #"boom-update-body"
-            (test-react/trigger-update!
+            (rf.adapter.test-react/trigger-update!
               mount
               {:rf/component
                (fn [_mount]
-                 (reset! child-ref (test-react/mount-child! [:span "speculative"]))
+                 (reset! child-ref (rf.adapter.test-react/mount-child! [:span "speculative"]))
                  (throw (ex-info "boom-update-body" {})))}))
           "the ORIGINAL update exception propagates — teardown never masks it")
-      (is (false? (test-react/rendering?))
+      (is (false? (rf.adapter.test-react/rendering?))
           "run-render!'s finally restored render-depth to zero on unwind")
       (is (false? @(:mounted? mount))
           "the root was UNMOUNTED — a throwing update tears the root down, it is
            NOT left live on a preserved tree (this FAILS pre-fix: root stays live)")
-      (is (nil? (test-react/current-render-tree mount))
+      (is (nil? (rf.adapter.test-react/current-render-tree mount))
           "the root's render tree was CLEARED — the throwing candidate is not
            exposed as committed (pre-fix the candidate leaked as current tree)")
-      (is (zero? (count (test-react/mounted-components)))
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "the live forest is empty — root AND its speculative child both left
            (pre-fix this is 2: candidate root + leaked child)")
       (is (false? @(:mounted? @child-ref))
@@ -703,7 +703,7 @@
       (is (zero? (phase-count mount :did-update))
           "a FAILED update publishes NO :did-update — the update did not commit")
       (is (= [:constructor :render :did-mount :render :forced-teardown]
-             (mapv :phase (test-react/lifecycle-log mount)))
+             (mapv :phase (rf.adapter.test-react/lifecycle-log mount)))
           "the root logged mount lifecycle, the failed update's :render, then a
            :forced-teardown — no :did-update, matching React's unmount-the-root"))))
 
@@ -716,29 +716,29 @@
     (let [child-a-ref (atom nil)
           child-b-ref (atom nil)
           ;; Initial mount whose render body mounts a pre-existing child (A).
-          parent      (test-react/mount!
+          parent      (rf.adapter.test-react/mount!
                         {:rf/component
                          (fn [_parent]
                            (reset! child-a-ref
-                                   (test-react/mount-child! [:span "child-a"])))})]
-      (is (= 2 (count (test-react/mounted-components)))
+                                   (rf.adapter.test-react/mount-child! [:span "child-a"])))})]
+      (is (= 2 (count (rf.adapter.test-react/mounted-components)))
           "precondition: parent + pre-existing child A are live")
-      (is (= [@child-a-ref] (test-react/mounted-children parent))
+      (is (= [@child-a-ref] (rf.adapter.test-react/mounted-children parent))
           "precondition: A is the parent's only tracked child")
       ;; Update fails after mounting a second child (B).
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #"boom-update-with-preexisting"
-            (test-react/trigger-update!
+            (rf.adapter.test-react/trigger-update!
               parent
               {:rf/component
                (fn [_parent]
-                 (reset! child-b-ref (test-react/mount-child! [:span "child-b"]))
+                 (reset! child-b-ref (rf.adapter.test-react/mount-child! [:span "child-b"]))
                  (throw (ex-info "boom-update-with-preexisting" {})))}))
           "the original update exception propagates")
       (is (false? @(:mounted? parent))
           "the root was unmounted whole")
-      (is (nil? (test-react/current-render-tree parent))
+      (is (nil? (rf.adapter.test-react/current-render-tree parent))
           "the root's render tree was cleared — no candidate survives")
       (is (and (false? @(:mounted? @child-a-ref))
                (false? @(:mounted? @child-b-ref)))
@@ -748,7 +748,7 @@
       (is (and (= 1 (phase-count @child-a-ref :forced-teardown))
                (= 1 (phase-count @child-b-ref :forced-teardown)))
           "each child recorded exactly one :forced-teardown")
-      (is (zero? (count (test-react/mounted-components)))
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "the live forest is empty — parent + both children all gone")
       (let [a-seq      (phase-first-seq @child-a-ref :forced-teardown)
             b-seq      (phase-first-seq @child-b-ref :forced-teardown)
@@ -763,27 +763,27 @@
             (root, child AND grandchild) is torn down leaf-upward"
     (let [child-ref      (atom nil)
           grandchild-ref (atom nil)
-          parent         (test-react/mount! [:div "old"])]
+          parent         (rf.adapter.test-react/mount! [:div "old"])]
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #"boom-nested-update"
-            (test-react/trigger-update!
+            (rf.adapter.test-react/trigger-update!
               parent
               {:rf/component
                (fn [_parent]
                  (reset! child-ref
-                         (test-react/mount-child!
+                         (rf.adapter.test-react/mount-child!
                            {:rf/component
                             (fn [_child]
                               (reset! grandchild-ref
-                                      (test-react/mount-child! [:span "leaf"])))}))
+                                      (rf.adapter.test-react/mount-child! [:span "leaf"])))}))
                  (throw (ex-info "boom-nested-update" {})))}))
           "the original update exception escapes")
       (is (false? @(:mounted? parent))
           "the root was unmounted whole")
-      (is (nil? (test-react/current-render-tree parent))
+      (is (nil? (rf.adapter.test-react/current-render-tree parent))
           "the root's render tree was cleared")
-      (is (zero? (count (test-react/mounted-components)))
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "no node leaks — root, child AND grandchild all left the forest
            (pre-fix this is 3)")
       (is (and (false? @(:mounted? @child-ref))
@@ -800,63 +800,63 @@
   (testing "a failed update on one root does NOT disturb a separate live sibling
             root: teardown is scoped to the updated root and its own subtree —
             the sibling and its committed tree are untouched"
-    (let [sibling (test-react/mount! [:div "sibling"])
-          target  (test-react/mount! [:div "target-v1"])]
-      (is (= 2 (count (test-react/mounted-components)))
+    (let [sibling (rf.adapter.test-react/mount! [:div "sibling"])
+          target  (rf.adapter.test-react/mount! [:div "target-v1"])]
+      (is (= 2 (count (rf.adapter.test-react/mounted-components)))
           "precondition: sibling + target both live")
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #"boom-scoped-update"
-            (test-react/trigger-update!
+            (rf.adapter.test-react/trigger-update!
               target
               {:rf/component
                (fn [_target]
-                 (test-react/mount-child! [:span "speculative"])
+                 (rf.adapter.test-react/mount-child! [:span "speculative"])
                  (throw (ex-info "boom-scoped-update" {})))}))
           "the target's update exception propagates")
       (is (true? @(:mounted? sibling))
           "the unrelated sibling root stays live")
-      (is (= [:div "sibling"] (test-react/current-render-tree sibling))
+      (is (= [:div "sibling"] (rf.adapter.test-react/current-render-tree sibling))
           "the sibling's committed tree is untouched")
       (is (zero? (phase-count sibling :forced-teardown))
           "the sibling took no forced teardown — teardown did not reach it")
       (is (false? @(:mounted? target))
           "the target root was unmounted whole by its failed update")
-      (is (nil? (test-react/current-render-tree target))
+      (is (nil? (rf.adapter.test-react/current-render-tree target))
           "the target's render tree was cleared")
-      (is (= [sibling] (test-react/mounted-components))
+      (is (= [sibling] (rf.adapter.test-react/mounted-components))
           "only the sibling remains live — the target and its speculative child
            are gone, the sibling is scoped out")
-      (test-react/unmount! sibling))))
+      (rf.adapter.test-react/unmount! sibling))))
 
 (deftest failed-update-fully-unmounts-root-so-later-update-is-rejected-rf2-j538f71
   (testing "a failed update UNMOUNTS the root for real (not just clears its
             tree): a subsequent trigger-update! on it is rejected with
             :rf.error/update-after-unmount — the update-after-unmount guard sees
             a dead mount, proving the teardown fully evicted it"
-    (let [mount (test-react/mount! [:div "v1"])]
+    (let [mount (rf.adapter.test-react/mount! [:div "v1"])]
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #"boom-then-dead"
-            (test-react/trigger-update!
+            (rf.adapter.test-react/trigger-update!
               mount
               {:rf/component
                (fn [_mount]
-                 (test-react/mount-child! [:span "speculative"])
+                 (rf.adapter.test-react/mount-child! [:span "speculative"])
                  (throw (ex-info "boom-then-dead" {})))}))
           "the update fails")
       (is (false? @(:mounted? mount))
           "the root is unmounted after the failed update")
-      (is (nil? (test-react/current-render-tree mount))
+      (is (nil? (rf.adapter.test-react/current-render-tree mount))
           "its render tree was cleared")
-      (is (zero? (count (test-react/mounted-components)))
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "the forest is empty")
       ;; The mount is genuinely dead — a later update must be rejected, not
       ;; silently re-render a torn-down root.
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #":rf.error/update-after-unmount"
-            (test-react/trigger-update! mount [:div "v2"]))
+            (rf.adapter.test-react/trigger-update! mount [:div "v2"]))
           "trigger-update! refuses the unmounted root — the failed update fully
            evicted it, so the update-after-unmount guard fires (pre-fix the root
            stayed live and this update would have silently re-rendered it)"))))
@@ -868,32 +868,32 @@
             (teardown does not mask it); the guard's target survives (the guard
             refused its unmount), while the HOST root — whose update threw via
             the guard — is unmounted whole along with its speculative child"
-    (let [target    (test-react/mount! [:div.panel "target"])
-          host      (test-react/mount! [:div "host-v1"])
+    (let [target    (rf.adapter.test-react/mount! [:div.panel "target"])
+          host      (rf.adapter.test-react/mount! [:div "host-v1"])
           child-ref (atom nil)]
-      (is (= 2 (count (test-react/mounted-components)))
+      (is (= 2 (count (rf.adapter.test-react/mounted-components)))
           "precondition: guard target + host both live")
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #":rf.error/sync-unmount-during-render"
-            (test-react/trigger-update!
+            (rf.adapter.test-react/trigger-update!
               host
               {:rf/component
                (fn [_host]
-                 (reset! child-ref (test-react/mount-child! [:span "child"]))
-                 (test-react/unmount! target))}))
+                 (reset! child-ref (rf.adapter.test-react/mount-child! [:span "child"]))
+                 (rf.adapter.test-react/unmount! target))}))
           "the guard error — NOT the teardown — is what escapes")
       (is (true? @(:mounted? target))
           "the guard refused the synchronous unmount — the target survives")
       (is (false? @(:mounted? host))
           "the host root, whose update threw via the guard, was unmounted whole")
-      (is (nil? (test-react/current-render-tree host))
+      (is (nil? (rf.adapter.test-react/current-render-tree host))
           "the host's render tree was cleared")
       (is (false? @(:mounted? @child-ref))
           "the child the host mounted before the guard tripped was torn down too")
-      (is (= [target] (test-react/mounted-components))
+      (is (= [target] (rf.adapter.test-react/mounted-components))
           "only the guard's target is live — host + its speculative child are gone")
-      (test-react/unmount! target))))
+      (rf.adapter.test-react/unmount! target))))
 
 ;; ----------------------------------------------------------------------------
 ;; C. Harness-contract guards (rf2-ynjts.6)
@@ -922,15 +922,15 @@
             :rf.error/update-after-unmount — you cannot re-render a dead mount.
             The lifecycle log is untouched (no stray :render / :did-update),
             so the throw is a true short-circuit, not a render-then-throw."
-    (let [mount (test-react/mount! [:div "v1"])
-          _     (test-react/unmount! mount)
-          log-before (test-react/lifecycle-log mount)]
+    (let [mount (rf.adapter.test-react/mount! [:div "v1"])
+          _     (rf.adapter.test-react/unmount! mount)
+          log-before (rf.adapter.test-react/lifecycle-log mount)]
       (is (thrown-with-msg?
             #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
             #":rf.error/update-after-unmount"
-            (test-react/trigger-update! mount [:div "v2"]))
+            (rf.adapter.test-react/trigger-update! mount [:div "v2"]))
           "trigger-update! refuses an unmounted mount")
-      (is (= log-before (test-react/lifecycle-log mount))
+      (is (= log-before (rf.adapter.test-react/lifecycle-log mount))
           "no :render / :did-update leaked onto the log — the guard short-circuited before run-render!"))))
 
 ;; ---- unmount! is idempotent ------------------------------------------------
@@ -940,16 +940,16 @@
             it does NOT throw, and records no second :will-unmount entry (so a
             double-teardown in downstream code can't double-count or corrupt
             the log)"
-    (let [mount (test-react/mount! [:div "once"])]
-      (test-react/unmount! mount)
+    (let [mount (rf.adapter.test-react/mount! [:div "once"])]
+      (rf.adapter.test-react/unmount! mount)
       (is (= 1 (phase-count mount :will-unmount))
           "first unmount recorded exactly one :will-unmount")
       ;; Second call must neither throw nor append a second :will-unmount.
-      (is (nil? (test-react/unmount! mount))
+      (is (nil? (rf.adapter.test-react/unmount! mount))
           "second unmount! returns nil without throwing")
       (is (= 1 (phase-count mount :will-unmount))
           "second unmount! recorded NO additional :will-unmount — idempotent")
-      (is (zero? (count (test-react/mounted-components)))
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "the forest stays empty across the redundant teardown"))))
 
 ;; ---- mount-child! outside a render body throws ----------------------------
@@ -959,14 +959,14 @@
             throws :rf.error/mount-child-outside-render — a child needs a parent
             render to attach to. Guards the recursive-child seam against a stray
             top-level call that would otherwise produce an unparented mount."
-    (is (false? (test-react/rendering?))
+    (is (false? (rf.adapter.test-react/rendering?))
         "precondition: no render in flight at the test top level")
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
           #":rf.error/mount-child-outside-render"
-          (test-react/mount-child! [:span "orphan"]))
+          (rf.adapter.test-react/mount-child! [:span "orphan"]))
         "mount-child! demands an in-flight render body")
-    (is (zero? (count (test-react/mounted-components)))
+    (is (zero? (count (rf.adapter.test-react/mounted-components)))
         "the failed mount-child! left nothing in the forest")))
 
 ;; ---- mount! under the wrong installed adapter throws ----------------------
@@ -982,18 +982,18 @@
                             :dispose-adapter! (fn [] nil)}]
       ;; Tear down the fixture-installed test-react adapter and seat the
       ;; sentinel in its place.
-      (substrate-adapter/dispose-adapter!)
-      (substrate-adapter/install-adapter! sentinel-adapter)
+      (rf.substrate.adapter/dispose-adapter!)
+      (rf.substrate.adapter/install-adapter! sentinel-adapter)
       (try
         (is (thrown-with-msg?
               #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
               #":rf.error/test-react-not-installed"
-              (test-react/mount! [:div "nope"]))
+              (rf.adapter.test-react/mount! [:div "nope"]))
             "mount! refuses to run when test-react is not the installed adapter")
         (finally
           ;; Restore the test-react adapter the :each fixture expects to dispose.
-          (substrate-adapter/dispose-adapter!)
-          (substrate-adapter/install-adapter! test-react/adapter))))))
+          (rf.substrate.adapter/dispose-adapter!)
+          (rf.substrate.adapter/install-adapter! rf.adapter.test-react/adapter))))))
 
 ;; ---- mount! under a COPIED test-react adapter map succeeds (rf2-dkl5z1) ----
 
@@ -1005,26 +1005,26 @@
             normally. Mirrors the wrong-adapter test's swap-and-restore, but
             asserts the POSITIVE case the identity guard wrongly rejected
             pre-fix (rf2-dkl5z1)."
-    (let [copied (assoc test-react/adapter :rf.test/instrumentation-wrapper true)]
+    (let [copied (assoc rf.adapter.test-react/adapter :rf.test/instrumentation-wrapper true)]
       ;; Tear down the fixture-installed canonical map and seat the copy.
-      (substrate-adapter/dispose-adapter!)
-      (substrate-adapter/install-adapter! copied)
+      (rf.substrate.adapter/dispose-adapter!)
+      (rf.substrate.adapter/install-adapter! copied)
       (try
-        (is (false? (identical? test-react/adapter (substrate-adapter/current-adapter-spec)))
+        (is (false? (identical? rf.adapter.test-react/adapter (rf.substrate.adapter/current-adapter-spec)))
             "precondition: the installed copy is NOT identical to the canonical map")
-        (is (= :rf.adapter/test-react (substrate-adapter/current-adapter))
+        (is (= :rf.adapter/test-react (rf.substrate.adapter/current-adapter))
             "precondition: the copy preserves the canonical :kind token")
-        (let [mount (test-react/mount! [:div "via-copied-map"])]
+        (let [mount (rf.adapter.test-react/mount! [:div "via-copied-map"])]
           (is (some? mount)
               "mount! returned a MountedComponent record under the copied map")
           (is (= [:constructor :render :did-mount]
-                 (mapv :phase (test-react/lifecycle-log mount)))
+                 (mapv :phase (rf.adapter.test-react/lifecycle-log mount)))
               "the copied map drove a normal mount lifecycle (no test-react-not-installed throw)")
-          (test-react/unmount! mount))
+          (rf.adapter.test-react/unmount! mount))
         (finally
           ;; Restore the canonical map the :each fixture expects to dispose.
-          (substrate-adapter/dispose-adapter!)
-          (substrate-adapter/install-adapter! test-react/adapter))))))
+          (rf.substrate.adapter/dispose-adapter!)
+          (rf.substrate.adapter/install-adapter! rf.adapter.test-react/adapter))))))
 
 ;; ---- render-to-string with no emitter bound throws ------------------------
 
@@ -1034,11 +1034,11 @@
             emitter, so a test that needs HTML must install one. We force the
             emitter cell to nil (it may carry a leftover SSR chain install) and
             assert the throw, then leave it nil for downstream tests."
-    (test-react/set-hiccup-emitter! nil)
+    (rf.adapter.test-react/set-hiccup-emitter! nil)
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
           #":rf.error/no-hiccup-emitter-bound"
-          (substrate-adapter/render-to-string [:div "x"] nil))
+          (rf.substrate.adapter/render-to-string [:div "x"] nil))
         "no emitter bound → render-to-string throws the documented error")))
 
 ;; ---- the substrate :render entry point returns a working unmount thunk ----
@@ -1051,13 +1051,13 @@
             hands back ONLY the thunk. Pinning this proves THIS fixture's
             substrate-facing :render slot stays a live unmount handle, not just
             the inspection-friendly mount!."
-    (let [thunk (substrate-adapter/render [:div "via-render"] nil nil)]
+    (let [thunk (rf.substrate.adapter/render [:div "via-render"] nil nil)]
       (is (fn? thunk)
           ":render returns a callable unmount thunk")
-      (is (= 1 (count (test-react/mounted-components)))
+      (is (= 1 (count (rf.adapter.test-react/mounted-components)))
           "the :render entry point mounted exactly one root")
       (thunk)
-      (is (zero? (count (test-react/mounted-components)))
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "calling the returned thunk tore that root down")
       ;; The thunk is idempotent too — same contract as unmount!.
       (is (nil? (thunk))
@@ -1074,15 +1074,15 @@
             levels — the recursive cascade real component trees rely on."
     (let [grandchild-ref (atom nil)
           child-ref      (atom nil)
-          parent (test-react/mount!
+          parent (rf.adapter.test-react/mount!
                    {:rf/component
                     (fn [_parent]
                       (reset! child-ref
-                              (test-react/mount-child!
+                              (rf.adapter.test-react/mount-child!
                                 {:rf/component
                                  (fn [_child]
                                    (reset! grandchild-ref
-                                           (test-react/mount-child! [:span "leaf"])))})))})]
+                                           (rf.adapter.test-react/mount-child! [:span "leaf"])))})))})]
       ;; The parent's render nested two levels deep (parent → child →
       ;; grandchild), so the global render-depth climbed to 3 then unwound.
       ;; Because it is a COUNTER, not a boolean (src note ~lines 128-129), each
@@ -1092,17 +1092,17 @@
       ;; while an outer render was still notionally in flight. This pins the
       ;; counter-not-boolean nested-unwind restore, which no test checked
       ;; directly before.
-      (is (false? (test-react/rendering?))
+      (is (false? (rf.adapter.test-react/rendering?))
           "render-depth restored to zero after a two-level nested render
            unwound — the counter decrements each nested level independently")
-      (is (= 3 (count (test-react/mounted-components)))
+      (is (= 3 (count (rf.adapter.test-react/mounted-components)))
           "parent + child + grandchild all live")
-      (is (= [@child-ref] (test-react/mounted-children parent))
+      (is (= [@child-ref] (rf.adapter.test-react/mounted-children parent))
           "child recorded under parent")
-      (is (= [@grandchild-ref] (test-react/mounted-children @child-ref))
+      (is (= [@grandchild-ref] (rf.adapter.test-react/mounted-children @child-ref))
           "grandchild recorded under child — the tree is two levels deep")
-      (test-react/unmount! parent)
-      (is (zero? (count (test-react/mounted-components)))
+      (rf.adapter.test-react/unmount! parent)
+      (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "the whole forest drained — no orphaned descendant")
       (let [gc-seq     (phase-first-seq @grandchild-ref :will-unmount)
             child-seq  (phase-first-seq @child-ref :will-unmount)

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
@@ -26,25 +26,25 @@
   JVM cognitect runner. It uses the standard `make-reset-runtime-fixture`
   (mirroring `plain_atom_dispose_cljs_test`) for airtight per-test isolation
   rather than hand-managing frame/registrar state."
-  (:require [re-frame.adapter.test-react :as test-react]
-            [re-frame.substrate.adapter :as substrate-adapter]
+  (:require [re-frame.adapter.test-react :as rf.adapter.test-react]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
             [re-frame.core :as rf]
-            [re-frame.subs :as subs]
-            [re-frame.frame :as frame]
-            [re-frame.test-support :as test-support]
+            [re-frame.subs :as rf.subs]
+            [re-frame.frame :as rf.frame]
+            [re-frame.test-support :as rf.test-support]
             #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter test-react/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.adapter.test-react/adapter}))
 
 (defn- sub-cache-keys []
-  (if-let [cache (:sub-cache (frame/frame :rf/default))]
+  (if-let [cache (:sub-cache (rf.frame/frame :rf/default))]
     (set (keys @cache))
     #{}))
 
 (defn- entry-ref-count [query-v]
-  (get-in @(:sub-cache (frame/frame :rf/default)) [query-v :ref-count]))
+  (get-in @(:sub-cache (rf.frame/frame :rf/default)) [query-v :ref-count]))
 
 (deftest dispose-adapter-clears-sub-cache-and-recomputes-fresh
   (testing "rf2-ghfkkk — test-react dispose-adapter! disposes + clears every
@@ -55,27 +55,27 @@
     (rf/dispatch-sync [::seed 1])
 
     ;; Materialise a real sub-cache slot (ref-count 1).
-    (let [r (subs/subscribe [::n] {:frame :rf/default})]
+    (let [r (rf.subs/subscribe [::n] {:frame :rf/default})]
       (is (= 1 @r) "sub reads the seeded value")
       (is (contains? (sub-cache-keys) [::n]) "subscribe materialised a cache slot")
       (is (= 1 (entry-ref-count [::n])) "slot ref-count = 1"))
 
     ;; Dispose the adapter — the cache MUST be cleared (entries + ref-counts).
-    (substrate-adapter/dispose-adapter!)
+    (rf.substrate.adapter/dispose-adapter!)
     (is (empty? (sub-cache-keys))
         "dispose-adapter! cleared the frame's sub-cache")
     (is (nil? (entry-ref-count [::n]))
         "no stale ref-count carried across the dispose")
 
     ;; Reinstall, mutate app-db, re-subscribe — must reflect the NEW value.
-    (substrate-adapter/install-adapter! test-react/adapter)
+    (rf.substrate.adapter/install-adapter! rf.adapter.test-react/adapter)
     (rf/dispatch-sync [::seed 99])
-    (let [r2 (subs/subscribe [::n] {:frame :rf/default})]
+    (let [r2 (rf.subs/subscribe [::n] {:frame :rf/default})]
       (is (= 99 @r2)
           "re-subscribe recomputed from the current app-db, not a stale slot")
       (is (= 1 (entry-ref-count [::n]))
           "rebuilt slot is a fresh cache miss (ref-count 1)")
-      (subs/unsubscribe :rf/default [::n]))))
+      (rf.subs/unsubscribe :rf/default [::n]))))
 
 (deftest dispose-adapter-clears-sub-caches-across-multiple-frames
   (testing "rf2-ghfkkk — the walk covers EVERY live frame, not just
@@ -83,22 +83,22 @@
             and cleared by the same dispose-adapter! call"
     (rf/reg-event ::seed (fn [_ctx [_ v]] {:db {:n v}}))
     (rf/reg-sub ::n (fn [db _] (:n db)))
-    (let [other (frame/make-anon-frame-record! {:doc "second frame"})]
+    (let [other (rf.frame/make-anon-frame-record! {:doc "second frame"})]
       ;; Seed + subscribe in BOTH frames so each carries a live cache slot.
       ;; Frame targeting rides the opts map (`:frame`), the explicit-
       ;; override 2-arity — no frame-positional arity.
       (rf/dispatch-sync [::seed 1] {:frame :rf/default})
       (rf/dispatch-sync [::seed 2] {:frame other})
-      (subs/subscribe [::n] {:frame :rf/default})
-      (subs/subscribe [::n] {:frame other})
-      (is (contains? (set (keys @(:sub-cache (frame/frame :rf/default)))) [::n])
+      (rf.subs/subscribe [::n] {:frame :rf/default})
+      (rf.subs/subscribe [::n] {:frame other})
+      (is (contains? (set (keys @(:sub-cache (rf.frame/frame :rf/default)))) [::n])
           ":rf/default carries a slot")
-      (is (contains? (set (keys @(:sub-cache (frame/frame other)))) [::n])
+      (is (contains? (set (keys @(:sub-cache (rf.frame/frame other)))) [::n])
           "the second frame carries a slot")
 
-      (substrate-adapter/dispose-adapter!)
-      (is (empty? (set (keys @(:sub-cache (frame/frame :rf/default)))))
+      (rf.substrate.adapter/dispose-adapter!)
+      (is (empty? (set (keys @(:sub-cache (rf.frame/frame :rf/default)))))
           ":rf/default sub-cache cleared")
-      (is (empty? (set (keys @(:sub-cache (frame/frame other)))))
+      (is (empty? (set (keys @(:sub-cache (rf.frame/frame other)))))
           "the second frame's sub-cache cleared too — walk covers every frame")
-      (substrate-adapter/install-adapter! test-react/adapter))))
+      (rf.substrate.adapter/install-adapter! rf.adapter.test-react/adapter))))

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -13,10 +13,10 @@
   (:require [uix.core          :as uix :refer-macros [defui]]
             [uix.hooks.alpha   :as uix-hooks]
             [uix.compiler.input]
-            [re-frame.frame             :as frame]
-            [re-frame.substrate.spine   :as spine]
-            [re-frame.adapter.use-frame :as use-frame-hook]
-            [re-frame.views.frame-boundary :as boundary]))
+            [re-frame.frame             :as rf.frame]
+            [re-frame.substrate.spine   :as rf.substrate.spine]
+            [re-frame.adapter.use-frame :as rf.adapter.use-frame]
+            [re-frame.views.frame-boundary :as rf.views.frame-boundary]))
 
 ;; ---- controlled inputs: React's implementation, not the classpath's -------
 ;;
@@ -46,7 +46,7 @@
 ;; ---- shared spine wiring --------------------------------------------------
 
 (def ^:private spine-fns
-  (spine/make-react-spine
+  (rf.substrate.spine/make-react-spine
     {:substrate-name        "UIx"
      :gensym-prefix-sub     "rf-uix-sub-"
      :gensym-prefix-derived "rf-uix-derived-"
@@ -95,15 +95,15 @@
   `:children` before this body delegates to the shared scope core."
   [props]
   (when (contains? props :id)
-    (boundary/reject-frame-provider-id!
+    (rf.views.frame-boundary/reject-frame-provider-id!
       (:id props) 're-frame.adapter.uix/frame-provider))
   ;; Validate before consulting the registry so malformed ids get the
   ;; configuration error rather than the absent-frame error.
-  (let [frame-kw (frame/require-frame-provider-target!
+  (let [frame-kw (rf.frame/require-frame-provider-target!
                    (:frame props) 're-frame.adapter.uix/frame-provider)]
-    (boundary/require-live-frame-for-scope!
+    (rf.views.frame-boundary/require-live-frame-for-scope!
       frame-kw 're-frame.adapter.uix/frame-provider)
-    (spine/build-frame-provider-element frame-kw (:children props))))
+    (rf.substrate.spine/build-frame-provider-element frame-kw (:children props))))
 
 (defui frame-root
   "ENSURE a named frame for descendant UIx components (rf2-nyea0r split) — a
@@ -132,7 +132,7 @@
   map, preserving namespaced keyword values, and folds trailing children into
   `:children` before this body delegates to the shared two-pass core."
   [props]
-  (boundary/frame-root-react-element
+  (rf.views.frame-boundary/frame-root-react-element
     props
     (:children props)
     're-frame.adapter.uix/frame-root))
@@ -168,7 +168,7 @@
   incarnation it was captured against (rf2-40kv). No options map, no
   variants — for an explicit frame call `(rf/capture-frame frame-id)`
   directly."
-  use-frame-hook/use-frame)
+  rf.adapter.use-frame/use-frame)
 
 (def flush-views!
   "Flush pending UIx renders synchronously. Wraps React's act() —
@@ -235,7 +235,7 @@
   `spine/make-react-adapter` owns the shared React-hook routing and
   lifecycle wiring. The native provider stays in this namespace so the spine
   has no dependency on UIx's element macro."
-  (spine/make-react-adapter spine-fns
+  (rf.substrate.spine/make-react-adapter spine-fns
                             {:kind              :rf.adapter/uix
                              :frame-provider    frame-provider
                              :componentize-view componentize-view}))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
@@ -19,17 +19,17 @@
   smoke + the self-gated behaviour no-op."
   (:require [cljs.test :refer-macros [deftest use-fixtures]]
             [uix.core :as uix :refer-macros [defui $]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.adapter.react-shared-suite :as suite]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.adapter.react-shared-suite :as rf.adapter.react-shared-suite]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; `:async? true` returns the map-form fixture required by the async
 ;; native-hydration-mismatch DOM test below (rf2-qfz65); a plain-fn fixture
 ;; aborts an async cljs.test with "Async tests require fixtures to be specified
 ;; as maps". The map form runs the file's synchronous tests identically.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter :async? true}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter :async? true}))
 
 (defui Probe []
   ;; Bare UIx component — the rf2-334d9 sentinel is injected by the
@@ -37,24 +37,24 @@
   ($ :div "probe"))
 
 (def ^:private cfg
-  {:adapter       uix-adapter/adapter
+  {:adapter       rf.adapter.uix/adapter
    :name          "UIx"
    :probe-element (fn [] ($ Probe))
    ;; rf2-b6nm5 — the canonical test-flush Var for the parity shape pin.
-   :flush-views!  uix-adapter/flush-views!})
+   :flush-views!  rf.adapter.uix/flush-views!})
 
 (deftest after-render-hook-wired-under-uix
-  (suite/assert-after-render-hook-wired cfg))
+  (rf.adapter.react-shared-suite/assert-after-render-hook-wired cfg))
 
 (deftest after-render-runs-callback-after-next-commit-uix
-  (suite/assert-after-render-runs-after-commit cfg))
+  (rf.adapter.react-shared-suite/assert-after-render-runs-after-commit cfg))
 
 ;; rf2-t0x90 — after-render parity on the NATIVE-mount path (raw
 ;; createRoot + .render, the documented boot idiom that bypasses the
 ;; spine's Fragment-wrap sentinel). The singleton driver root restores
 ;; post-commit timing previously only the :render-slot path got.
 (deftest after-render-fires-on-native-mount-uix
-  (suite/assert-after-render-fires-on-native-mount cfg))
+  (rf.adapter.react-shared-suite/assert-after-render-fires-on-native-mount cfg))
 
 ;; rf2-he7se finding 3 — the native after-render driver-root setter is
 ;; installed from a LAYOUT effect (flushSync always flushes layout effects
@@ -62,29 +62,29 @@
 ;; app state synchronously via the post-commit layout-effect drain rather
 ;; than the (version-dependent) queueMicrotask fallback.
 (deftest after-render-observes-commit-synchronously-on-native-first-call-uix
-  (suite/assert-after-render-observes-commit-synchronously-on-native-first-call cfg))
+  (rf.adapter.react-shared-suite/assert-after-render-observes-commit-synchronously-on-native-first-call cfg))
 
 ;; rf2-b6nm5 — flush-views! is surfaced from the adapter ns with the
 ;; canonical nil-return shape (Decision 6), converged across all four
 ;; substrates. Node-safe shape pin.
 (deftest flush-views-canonical-shape-uix
-  (suite/assert-flush-views-canonical-shape cfg))
+  (rf.adapter.react-shared-suite/assert-flush-views-canonical-shape cfg))
 
 ;; rf2-ee38b.1 — the spine `make-render` :hydrate? true branch
 ;; (hydrateRoot) had no React-hook coverage; this closes it.
 (deftest render-hydrate-branch-mounts-without-remount-uix
-  (suite/assert-render-hydrate-branch-mounts-without-remount cfg))
+  (rf.adapter.react-shared-suite/assert-render-hydrate-branch-mounts-without-remount cfg))
 
 ;; rf2-qfz65 — a hydrating native root that adopts DIVERGENT server markup now
 ;; surfaces the framework :rf.ssr/hydration-mismatch diagnostic (composed
 ;; onRecoverableError), a host :on-recoverable-error still fires, and a clean
 ;; adoption stays silent. Browser-only mounted DOM proof.
 (deftest native-hydration-mismatch-surfaces-diagnostic-uix
-  (suite/assert-native-hydration-mismatch-surfaces-diagnostic cfg))
+  (rf.adapter.react-shared-suite/assert-native-hydration-mismatch-surfaces-diagnostic cfg))
 
 ;; rf2-qfz65 residual — the native reporter's framework emit is bounded to the
 ;; hydration ADOPTION WINDOW: after the window closes (the adoption-window-closer
 ;; clears the flag on the hydration commit) a later recoverable error no longer
 ;; emits a FALSE :rf.ssr/hydration-mismatch, but the host callback still fires.
 (deftest native-hydration-window-bounds-emit-uix
-  (suite/assert-native-hydration-window-bounds-emit cfg))
+  (rf.adapter.react-shared-suite/assert-native-hydration-window-bounds-emit cfg))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_boot_order_source_coord_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_boot_order_source_coord_dom_cljs_test.cljs
@@ -48,9 +48,9 @@
             ["react-dom/client" :as react-dom-client]
             [uix.core :refer-macros [$]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; The `use-fixtures` call is NOT here. It sits below the ns-load registration
 ;; further down, and the position is load-bearing: `make-reset-runtime-fixture`
@@ -90,8 +90,8 @@
 
 ;; NOW the fixture — see the note under the ns form for why the order matters.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -156,13 +156,13 @@
   [act-fn head]
   (let [mount-node (.createElement js/document "div")
         react-root (react-dom-client/createRoot mount-node)]
-    (binding [frame/*current-frame* nil]
+    (binding [rf.frame/*current-frame* nil]
       (let [diagnostics (capture-console-diagnostics
                           (fn []
                             (act-fn
                               (fn []
                                 (.render react-root
-                                  ($ uix-adapter/frame-provider {:frame probe-frame}
+                                  ($ rf.adapter.uix/frame-provider {:frame probe-frame}
                                      ($ head)))))))
             view-root   (.querySelector mount-node "[data-testid='probe']")]
         (try

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_controlled_input_default_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_controlled_input_default_cljs_test.cljs
@@ -25,7 +25,7 @@
   shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest testing is]]
             [uix.compiler.input]
-            [re-frame.adapter.uix :as uix-adapter]))
+            [re-frame.adapter.uix :as rf.adapter.uix]))
 
 (def ^:private reagent-input-enabled-at-load?
   "The var as `re-frame.adapter.uix`'s load left it, snapshotted at THIS
@@ -49,7 +49,7 @@
 (deftest react-controlled-input-is-the-adapters-default
   (testing "requiring the adapter is enough: a UIx `:input` is a plain React
            controlled input"
-    (is (some? uix-adapter/adapter)
+    (is (some? rf.adapter.uix/adapter)
         "the adapter namespace is loaded — which is what runs the pin")
     (is (false? reagent-input-enabled-at-load?)
         "the adapter's load left the var at false — asserted from the

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
@@ -12,9 +12,9 @@
 
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest async use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.adapter.react-shared-suite :as suite]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.adapter.react-shared-suite :as rf.adapter.react-shared-suite]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; Async map-form fixture (a fn-form fixture's teardown would restore the
 ;; registrar before an `(async done)` body completes). `make-reset-runtime-
@@ -25,32 +25,32 @@
 ;; validation rollbacks against this test's frames). `:ambient-frame nil`
 ;; preserves the suite's no-ambient-scope behaviour.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter :async? true :ambient-frame nil}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter :async? true :ambient-frame nil}))
 
 (def ^:private cfg
-  {:adapter      uix-adapter/adapter
+  {:adapter      rf.adapter.uix/adapter
    :substrate-kw :uix
    :name         "UIx"})
 
 ;; ---- synchronous cases ----------------------------------------------------
 
 (deftest sync-dispatch-routes-to-handlers-frame
-  (suite/assert-dfc-sync-dispatch-routes-to-handlers-frame cfg))
+  (rf.adapter.react-shared-suite/assert-dfc-sync-dispatch-routes-to-handlers-frame cfg))
 
 (deftest fx-dispatch-routes-to-handlers-frame
-  (suite/assert-dfc-fx-dispatch-routes-to-handlers-frame cfg))
+  (rf.adapter.react-shared-suite/assert-dfc-fx-dispatch-routes-to-handlers-frame cfg))
 
 (deftest sync-dispatch-isolation
-  (suite/assert-dfc-sync-dispatch-isolation cfg))
+  (rf.adapter.react-shared-suite/assert-dfc-sync-dispatch-isolation cfg))
 
 ;; ---- asynchronous cases (map-form fixture mandatory) ----------------------
 
 (deftest raw-dispatch-from-set-timeout-falls-through
-  (async done (suite/assert-dfc-raw-dispatch-from-set-timeout-falls-through cfg done)))
+  (async done (rf.adapter.react-shared-suite/assert-dfc-raw-dispatch-from-set-timeout-falls-through cfg done)))
 
 (deftest dispatch-later-survives-the-timer
-  (async done (suite/assert-dfc-dispatch-later-survives-the-timer cfg done)))
+  (async done (rf.adapter.react-shared-suite/assert-dfc-dispatch-later-survives-the-timer cfg done)))
 
 (deftest dispatcher-survives-set-timeout
-  (async done (suite/assert-dfc-dispatcher-survives-set-timeout cfg done)))
+  (async done (rf.adapter.react-shared-suite/assert-dfc-dispatcher-survives-set-timeout cfg done)))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_frame_root_ensure_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_frame_root_ensure_dom_cljs_test.cljs
@@ -34,13 +34,13 @@
             ["react-dom/client" :as react-dom-client]
             [uix.core :as uix :refer-macros [defui $]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter}))
 
 ;; ---- side-channel atom + descendant probe ---------------------------------
 ;; The probe is a top-level `defui` reading the ENSURED frame's value via the
@@ -50,7 +50,7 @@
 (def ^:private ensure-observed (atom []))
 
 (defui ProbeEnsure []
-  (let [v (uix-adapter/use-subscribe [:rf.uix-ensure/k])]
+  (let [v (rf.adapter.uix/use-subscribe [:rf.uix-ensure/k])]
     (swap! ensure-observed conj v)
     ($ :div (str "k=" v))))
 
@@ -86,7 +86,7 @@
           ;; 1-arg `use-subscribe` in ProbeEnsure resolves through the ENSURE
           ;; provider's React-context tier (the created frame), not a
           ;; shadowing dynamic frame. Mirrors the SCOPE-arm regression's note.
-          (binding [frame/*current-frame* nil]
+          (binding [rf.frame/*current-frame* nil]
             (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
             (reset! ensure-observed [])
             ;; Register the layer-1 db-reader the descendant reads. Default
@@ -106,7 +106,7 @@
                     ;; must survive `glue-args` before the `defui` hands them
                     ;; to `frame-root-react-element`.
                     (.render root
-                      ($ uix-adapter/frame-root
+                      ($ rf.adapter.uix/frame-root
                          {:id             frame-kw
                           :initial-events [[:rf/set-db {:k :ensured}]]
                           :url-bound?     false}
@@ -114,7 +114,7 @@
                 ;; :id survived $ as a KEYWORD — a stringified id would have
                 ;; thrown :rf.error/frame-root-missing-id, and the frame would
                 ;; not be registered under the keyword.
-                (is (some? (frame/frame frame-kw))
+                (is (some? (rf.frame/frame frame-kw))
                     "ENSURE created a live frame under the keyword :id (proves :id survived $ as a keyword)")
                 ;; The nested [[:rf/set-db {:k :ensured}]] vector + namespaced
                 ;; keyword + nested map survived glue-args: the seed ran at
@@ -138,7 +138,7 @@
       (let [act-fn (get-act)]
         (if (nil? act-fn)
           (is true "act() not reachable from this runner; skipping")
-          (binding [frame/*current-frame* nil]
+          (binding [rf.frame/*current-frame* nil]
             (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
             (let [frame-kw   :rf.uix-ensure/image-frame
                   mount-node (.createElement js/document "div")
@@ -153,12 +153,12 @@
                     ;; validate-images! would throw here; if the inline event
                     ;; id were lost, the seed would not apply below.
                     (.render root
-                      ($ uix-adapter/frame-root
+                      ($ rf.adapter.uix/frame-root
                          {:id             frame-kw
                           :images         [ensure-image]
                           :initial-events [[:rf.uix-ensure/seed :img-ensured]]}
                          ($ :div "ensure-images-child")))))
-                (is (some? (frame/frame frame-kw))
+                (is (some? (rf.frame/frame frame-kw))
                     "ENSURE created a live frame under the keyword :id")
                 ;; The image's inline :reg-event resolved in the ensured
                 ;; frame's generation and the :initial-events dispatch seeded

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_react_shared_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_react_shared_cljs_test.cljs
@@ -48,16 +48,16 @@
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.adapter.react-shared-suite]
-            [re-frame.test-support :as test-support])
+            [re-frame.test-support :as rf.test-support])
   (:require-macros
    [re-frame.adapter.react-shared-suite-tests
     :refer [define-react-shared-suite-tests!]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter}))
 
 ;; rf2-7kjz8 / rf2-z7hfp / rf2-7kii2 — the frame-provider branch assertions
 ;; now target the substrate-agnostic spine core
@@ -67,13 +67,13 @@
 ;; DOM twin + the trailing-children regression test (folded from the prior
 ;; per-adapter uix_frame_provider_branches_cljs_test.cljs).
 (def ^:private cfg
-  {:adapter          uix-adapter/adapter
+  {:adapter          rf.adapter.uix/adapter
    :substrate-kw     :uix
    :name             "UIx"
    :producer-ns      're-frame.adapter.uix
-   :wrap-view        uix-adapter/wrap-view
-   :set-emitter!     uix-adapter/set-hiccup-emitter!
-   :render-to-string (:render-to-string uix-adapter/adapter)
+   :wrap-view        rf.adapter.uix/wrap-view
+   :set-emitter!     rf.adapter.uix/set-hiccup-emitter!
+   :render-to-string (:render-to-string rf.adapter.uix/adapter)
    ;; rf2-6j09b / rf2-6r9j.36 — the public Vars the suite's public-surface
    ;; guard asserts (presence/kind/distinctness). Substrate-specific because
    ;; each adapter's re-exports are distinct objects the suite cannot name
@@ -90,14 +90,14 @@
    :public-surface-keys [:set-hiccup-emitter! :use-current-frame :frame-provider
                          :frame-root :use-subscribe :use-frame :flush-views!
                          :wrap-view]
-   :public-surface   {:set-hiccup-emitter! uix-adapter/set-hiccup-emitter!
-                      :use-current-frame   uix-adapter/use-current-frame
-                      :frame-provider      uix-adapter/frame-provider
-                      :frame-root          uix-adapter/frame-root
-                      :use-subscribe       uix-adapter/use-subscribe
-                      :use-frame           uix-adapter/use-frame
-                      :flush-views!        uix-adapter/flush-views!
-                      :wrap-view           uix-adapter/wrap-view}})
+   :public-surface   {:set-hiccup-emitter! rf.adapter.uix/set-hiccup-emitter!
+                      :use-current-frame   rf.adapter.uix/use-current-frame
+                      :frame-provider      rf.adapter.uix/frame-provider
+                      :frame-root          rf.adapter.uix/frame-root
+                      :use-subscribe       rf.adapter.uix/use-subscribe
+                      :use-frame           rf.adapter.uix/use-frame
+                      :flush-views!        rf.adapter.uix/flush-views!
+                      :wrap-view           rf.adapter.uix/wrap-view}})
 
 ;; Emit one (deftest name (re-frame.adapter.react-shared-suite/assert-name cfg))
 ;; per row in `react-shared-suite-tests/test-specs`. The macro ns owns

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_reg_view_devtools_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_reg_view_devtools_dom_cljs_test.cljs
@@ -16,19 +16,19 @@
   SHOWS for the component, read off the committed fiber's `type` rather
   than off the fn property the framework stamped."
   (:require [cljs.test :refer-macros [deftest use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.adapter.react-shared-suite :as suite]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.adapter.react-shared-suite :as rf.adapter.react-shared-suite]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter}))
 
 (def ^:private cfg
-  {:adapter      uix-adapter/adapter
+  {:adapter      rf.adapter.uix/adapter
    :substrate-kw :uix
    :name         "UIx"
-   :wrap-view    uix-adapter/wrap-view})
+   :wrap-view    rf.adapter.uix/wrap-view})
 
 (deftest mounted-display-name-is-devtools-visible-uix
-  (suite/assert-mounted-display-name-is-devtools-visible cfg))
+  (rf.adapter.react-shared-suite/assert-mounted-display-name-is-devtools-visible cfg))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_reg_view_direct_mount_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_reg_view_direct_mount_dom_cljs_test.cljs
@@ -58,9 +58,9 @@
             ["react-dom/client" :as react-dom-client]
             [uix.core :as uix :refer-macros [defui $]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; The `use-fixtures` call is NOT here. It sits below the ns-load registration
 ;; further down the file, and the position is load-bearing —
@@ -174,8 +174,8 @@
   captured under a broken boundary would be locked to the wrong frame, and
   the dispatch would move a `:n` nothing on screen is reading."
   [{:keys [payload children]}]
-  (let [n   (uix-adapter/use-subscribe probe-query)
-        ops (uix-adapter/use-frame)]
+  (let [n   (rf.adapter.uix/use-subscribe probe-query)
+        ops (rf.adapter.uix/use-frame)]
     (reset! observed-payload payload)
     (reset! observed-children (some? children))
     (reset! observed-ops ops)
@@ -215,8 +215,8 @@
 
 ;; NOW the fixture — see the note under the ns form for why the order matters.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter}))
 
 ;; ---- shared registration + world setup -------------------------------------
 
@@ -250,13 +250,13 @@
     ;; Clear the fixture's ambient `:rf/default` dynamic scope so the
     ;; 1-arg `use-subscribe` resolves through the React-context (provider)
     ;; tier — the shape a real app has.
-    (binding [frame/*current-frame* nil]
+    (binding [rf.frame/*current-frame* nil]
       (let [mount-diagnostics (capture-render-diagnostics
                                 (fn []
                                   (act-fn
                                     (fn []
                                       (.render react-root
-                                        ($ uix-adapter/frame-provider {:frame probe-frame}
+                                        ($ rf.adapter.uix/frame-provider {:frame probe-frame}
                                            ($ head
                                               {:payload probe-payload}
                                               ($ :em {:data-testid "child"} "kid"))))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_source_coord_dom_elision_prod_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_source_coord_dom_elision_prod_test.cljs
@@ -25,18 +25,18 @@
   (:require ["react" :as React]
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             ;; rf2-5g21s — the react-element-attr accessor lives in the
             ;; dependency-free shared test home (hoisted there to dedupe
             ;; the since-removed Helix twin); reference it rather than
             ;; carry a copy. Kept separate from react-shared-suite so this
             ;; prod-elision build does not pull the suite's heavy deps.
             [re-frame.adapter.react-test-support :refer [react-element-attr]]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter}))
 
 ;; ---- annotation elides under :advanced + goog.DEBUG=false ----------------
 
@@ -100,7 +100,7 @@
         (is (some? view-head) "the view is registered")
         (is (nil? (.-displayName ^js view-head))
             "no .displayName on the registered view under prod-mode")
-        (is (nil? (.-displayName ^js (uix-adapter/wrap-view
+        (is (nil? (.-displayName ^js (rf.adapter.uix/wrap-view
                                        :rf.uix-prod-elision-test/dn-elided-head
                                        {} view-fn)))
             "no .displayName on a directly-built wrap-view head either —

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_current_frame_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_current_frame_dom_cljs_test.cljs
@@ -27,14 +27,14 @@
             ["react-dom/client" :as react-dom-client]
             [uix.core :as uix :refer-macros [defui $]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.context :as context]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter}))
 
 ;; ---- side-channel atom + probe --------------------------------------------
 ;; The probe records every `use-current-frame` return into a side-channel atom
@@ -44,7 +44,7 @@
 (def ^:private observed (atom []))
 
 (defui ProbeCurrentFrame []
-  (let [f (uix-adapter/use-current-frame)]
+  (let [f (rf.adapter.uix/use-current-frame)]
     (swap! observed conj f)
     ($ :div (str "f=" f))))
 
@@ -77,7 +77,7 @@
           ;; `:rf/default` dynamic scope is not strictly required; we do it so
           ;; the three cases turn purely on the React-context boundary above
           ;; the probe.
-          (binding [frame/*current-frame* nil]
+          (binding [rf.frame/*current-frame* nil]
             (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
 
             (testing "under frame-provider (SCOPE) → the scoped frame id"
@@ -86,30 +86,30 @@
                 (rf/make-frame {:id frame-kw
                                 :doc "rf2-kopcit use-current-frame SCOPE probe"})
                 (mount-and-render! act-fn
-                  ($ uix-adapter/frame-provider {:frame frame-kw}
+                  ($ rf.adapter.uix/frame-provider {:frame frame-kw}
                      ($ ProbeCurrentFrame)))
                 (is (some #{frame-kw} @observed)
                     "use-current-frame read the SCOPE-provided frame id from the shared context")
-                (is (not-any? #{context/no-provider-sentinel} @observed)
+                (is (not-any? #{rf.adapter.context/no-provider-sentinel} @observed)
                     "no sentinel leaked while a frame-provider sat above")))
 
             (testing "under frame-root (ENSURE) → the ENSUREd frame id"
               (reset! observed [])
               (let [frame-kw :rf.uix-ucf/root-frame]
                 (mount-and-render! act-fn
-                  ($ uix-adapter/frame-root {:id frame-kw}
+                  ($ rf.adapter.uix/frame-root {:id frame-kw}
                      ($ ProbeCurrentFrame)))
-                (is (some? (frame/frame frame-kw))
+                (is (some? (rf.frame/frame frame-kw))
                     "frame-root ENSUREd a live frame at commit")
                 (is (some #{frame-kw} @observed)
                     "use-current-frame read the ENSUREd frame id from the SAME shared context — proves frame-root installs it, not only frame-provider")
-                (is (not-any? #{context/no-provider-sentinel} @observed)
+                (is (not-any? #{rf.adapter.context/no-provider-sentinel} @observed)
                     "no sentinel leaked while a frame-root sat above")))
 
             (testing "under neither boundary → the no-provider sentinel"
               (reset! observed [])
               (mount-and-render! act-fn ($ ProbeCurrentFrame))
-              (is (some #{context/no-provider-sentinel} @observed)
+              (is (some #{rf.adapter.context/no-provider-sentinel} @observed)
                   "with no boundary above, use-current-frame returns the context default sentinel (:rf.frame/no-provider)")
               (is (not-any? #{:rf/default} @observed)
                   "the sentinel is emphatically NOT the :rf/default floor"))))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -30,11 +30,11 @@
             ["react-dom/client" :as react-dom-client]
             [uix.core :as uix :refer-macros [defui $]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.adapter.react-shared-suite :as suite]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.adapter.react-shared-suite :as rf.adapter.react-shared-suite]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; MAP-FORM fixture with `:async? true` (rf2-2rtt6.25): the provisional-horizon
 ;; assertions below are `(async done …)` tests, and cljs.test refuses to run an
@@ -44,8 +44,8 @@
 ;; `setTimeout 4` since rf2-2rtt6.71 — and nothing synchronous crosses it; the
 ;; suite's own settles wait PAST it (`settle-past-the-horizon!`).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter :async? true}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter :async? true}))
 
 ;; ---- side-channel atoms ----------------------------------------------------
 ;; Read by the UIx probe components below. The probes are defui top-levels
@@ -68,12 +68,12 @@
 
 (defui Probe []
   (let [target @refcount-target
-        v (uix-adapter/use-subscribe target [:rf.uix-use-subscribe-test/n])]
+        v (rf.adapter.uix/use-subscribe target [:rf.uix-use-subscribe-test/n])]
     (swap! probe-observed conj v)
     ($ :div (str "n=" v))))
 
 (defui ProbeFrameProvider []
-  (let [v (uix-adapter/use-subscribe [:rf.uix-use-subscribe-test/k])]
+  (let [v (rf.adapter.uix/use-subscribe [:rf.uix-use-subscribe-test/k])]
     (swap! probe-frame-provider-observed conj v)
     ($ :div (str "k=" v))))
 
@@ -96,13 +96,13 @@
 (def ^:private ssr-slot-observed (atom nil))
 
 (defui ProbeSsrSlots []
-  (let [ctx adapter-context/frame-context]
+  (let [ctx rf.adapter.context/frame-context]
     (reset! ssr-slot-observed
             {:current-value  (.-_currentValue ^js ctx)
              :current-value2 (.-_currentValue2 ^js ctx)
              :use-context    (React/useContext ctx)
-             :reader         (adapter-context/function-component-current-frame)
-             :resolve        (frame/resolve-current-frame)})
+             :reader         (rf.adapter.context/function-component-current-frame)
+             :resolve        (rf.frame/resolve-current-frame)})
     ($ :div "slots")))
 
 ;; ---- use-frame probe (rf2-y6dz8t) ------------------------------------------
@@ -113,13 +113,13 @@
 (def ^:private use-frame-observed (atom []))
 
 (defui ProbeUseFrame []
-  (let [ops (uix-adapter/use-frame)]
+  (let [ops (rf.adapter.uix/use-frame)]
     (swap! use-frame-observed conj ops)
     ($ :div "uf")))
 
 (defui ProbeRefcount []
   (let [target @refcount-target
-        v (uix-adapter/use-subscribe target [:rf.uix-use-subscribe-test/m])]
+        v (rf.adapter.uix/use-subscribe target [:rf.uix-use-subscribe-test/m])]
     ($ :div (str "m=" v))))
 
 ;; ---- Suspense abort-before-commit probes (rf2-es09qq) ---------------------
@@ -145,7 +145,7 @@
   ;; Render-phase use-subscribe acquisition happens HERE, before the
   ;; suspending child unwinds the subtree.
   (let [target @refcount-target
-        _v (uix-adapter/use-subscribe target [:rf.uix-use-subscribe-test/m])]
+        _v (rf.adapter.uix/use-subscribe target [:rf.uix-use-subscribe-test/m])]
     ($ :div ($ ProbeSuspender))))
 
 (defn- uix-suspense-abort-element
@@ -170,13 +170,13 @@
 
 (defui ProbeSiblingA []
   (let [target @refcount-target
-        v (uix-adapter/use-subscribe target [:rf.uix-siblings/n])]
+        v (rf.adapter.uix/use-subscribe target [:rf.uix-siblings/n])]
     (swap! siblings-observed-a conj v)
     ($ :span (str "a=" v))))
 
 (defui ProbeSiblingB []
   (let [target @refcount-target
-        v (uix-adapter/use-subscribe target [:rf.uix-siblings/n])]
+        v (rf.adapter.uix/use-subscribe target [:rf.uix-siblings/n])]
     (swap! siblings-observed-b conj v)
     ($ :span (str " b=" v))))
 
@@ -186,12 +186,12 @@
 (def ^:private probe-2arg-b-observed (atom []))
 
 (defui Probe2ArgA []
-  (let [v (uix-adapter/use-subscribe :rf.uix-explicit-pin/tenant-a [:rf.uix-explicit-pin/n])]
+  (let [v (rf.adapter.uix/use-subscribe :rf.uix-explicit-pin/tenant-a [:rf.uix-explicit-pin/n])]
     (swap! probe-2arg-a-observed conj v)
     ($ :div (str "a=" v))))
 
 (defui Probe2ArgB []
-  (let [v (uix-adapter/use-subscribe :rf.uix-explicit-pin/tenant-b [:rf.uix-explicit-pin/n])]
+  (let [v (rf.adapter.uix/use-subscribe :rf.uix-explicit-pin/tenant-b [:rf.uix-explicit-pin/n])]
     (swap! probe-2arg-b-observed conj v)
     ($ :div (str "b=" v))))
 
@@ -204,7 +204,7 @@
 ;; forced re-renders from outside.
 
 (defui ProbeStableDepsChild []
-  (let [v (uix-adapter/use-subscribe :rf.uix-stable-deps/probe-frame [:rf.uix-stable-deps/p])]
+  (let [v (rf.adapter.uix/use-subscribe :rf.uix-stable-deps/probe-frame [:rf.uix-stable-deps/p])]
     ($ :div (str "p=" v))))
 
 (defui ProbeStableDepsParent []
@@ -228,7 +228,7 @@
 (defui ProbeKeyChangeChild []
   (let [fr @key-change-frame
         qv @key-change-query
-        v  (uix-adapter/use-subscribe fr qv)]
+        v  (rf.adapter.uix/use-subscribe fr qv)]
     (swap! key-change-observed conj v)
     ($ :div (str "v=" v))))
 
@@ -257,7 +257,7 @@
 (def ^:private gap-observed     (atom []))
 
 (defui ProbeGapSubscriber []
-  (let [v (uix-adapter/use-subscribe @refcount-target [:rf.uix-gap/n])]
+  (let [v (rf.adapter.uix/use-subscribe @refcount-target [:rf.uix-gap/n])]
     (swap! gap-observed conj v)
     ($ :div (str "g=" v))))
 
@@ -303,7 +303,7 @@
   ;; subscribe. That ordering, not a timer, is what makes the suite's snapshot
   ;; of the numbers deterministic.
   (let [target @refcount-target
-        v      (uix-adapter/use-subscribe target [:rf.uix-use-subscribe-test/m])]
+        v      (rf.adapter.uix/use-subscribe target [:rf.uix-use-subscribe-test/m])]
     (uix/use-effect
       (fn [] (when-let [f @pm-on-commit] (f)) js/undefined)
       [])
@@ -328,14 +328,14 @@
 ;; ---- cfg + forwarded deftests ---------------------------------------------
 
 (def ^:private cfg
-  {:adapter               uix-adapter/adapter
+  {:adapter               rf.adapter.uix/adapter
    :name                  "UIx"
    ;; rf2-z7hfp / rf2-7kii2 — mount the NATIVE frame-provider component via
    ;; UIx's `$` using the idiomatic TRAILING-CHILDREN shape (no `:children`
    ;; prop-map key), not a direct CLJS-fn invocation.
    :frame-provider-mount-element
    (fn [frame-kw child-el]
-     ($ uix-adapter/frame-provider {:frame frame-kw} child-el))
+     ($ rf.adapter.uix/frame-provider {:frame frame-kw} child-el))
    ;; tracks-app-db
    :probe-element         (fn [] (uix/$ Probe))
    :probe-observed        probe-observed
@@ -451,88 +451,88 @@
    :fr-query              :rf.uix-use-subscribe-test/n})
 
 (deftest use-subscribe-tracks-app-db-changes
-  (suite/assert-use-subscribe-tracks-app-db-changes cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-tracks-app-db-changes cfg))
 
 (deftest use-subscribe-frame-provider-resolution
-  (suite/assert-use-subscribe-frame-provider-resolution cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-frame-provider-resolution cfg))
 
 (deftest use-subscribe-ambient-under-ssr
-  (suite/assert-use-subscribe-ambient-under-ssr cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-ambient-under-ssr cfg))
 
 (deftest use-subscribe-2-arg-pins-explicit-frame
-  (suite/assert-use-subscribe-2-arg-pins-explicit-frame cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-2-arg-pins-explicit-frame cfg))
 
 ;; rf2-y6dz8t — use-frame returns EXACTLY the capture-frame ops map for the
 ;; ambient provider frame: shape, provider resolution, dispatch lock, and
 ;; reference stability across re-renders.
 (deftest use-frame-capture-frame-in-hook-position
-  (suite/assert-use-frame-capture-frame-in-hook-position cfg))
+  (rf.adapter.react-shared-suite/assert-use-frame-capture-frame-in-hook-position cfg))
 
 ;; rf2-40kv — the same memo across a same-id REINCARNATION. The row above
 ;; pins that a re-render returns the identical map; this one pins what that
 ;; memo is keyed on, because a frame keyword is `=` across a destroy +
 ;; same-id create and the bundle is pinned to an incarnation.
 (deftest use-frame-retargets-across-a-same-id-reincarnation
-  (suite/assert-use-frame-retargets-across-a-same-id-reincarnation cfg))
+  (rf.adapter.react-shared-suite/assert-use-frame-retargets-across-a-same-id-reincarnation cfg))
 
 ;; rf2-4mi2zj — 1-arg full frame-resolution chain (the bug: spine fed the
 ;; raw use-context read into the explicit 2-arg path, bypassing the chain).
 (deftest use-subscribe-provider-tier-resolution-ambient-cleared
-  (suite/assert-use-subscribe-provider-tier-resolution-ambient-cleared cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-provider-tier-resolution-ambient-cleared cfg))
 
 (deftest use-subscribe-dynamic-var-precedence-over-provider
-  (suite/assert-use-subscribe-dynamic-var-precedence-over-provider cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-dynamic-var-precedence-over-provider cfg))
 
 (deftest use-subscribe-no-provider-no-dynamic-raises-no-frame-context
-  (suite/assert-use-subscribe-no-provider-no-dynamic-raises-no-frame-context cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-no-provider-no-dynamic-raises-no-frame-context cfg))
 
 (deftest use-subscribe-cleanup-decrements-sub-cache-refcount
-  (suite/assert-use-subscribe-cleanup-decrements-refcount cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-cleanup-decrements-refcount cfg))
 
 ;; rf2-e4pyb — two sibling components subscribing to the SAME cached
 ;; reaction must BOTH receive invalidation after one dispatch (the
 ;; hash-of-reaction watch key let the last-mounted sibling overwrite the
 ;; earlier one's useSyncExternalStore callback → stale UI).
 (deftest use-subscribe-siblings-same-query-both-invalidate
-  (suite/assert-use-subscribe-siblings-same-query-both-invalidate cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-siblings-same-query-both-invalidate cfg))
 
 ;; rf2-nymuy — StrictMode double-mount: the refcount/disposal dance under
 ;; React's default-dev double-invoke (the riskiest seam, previously
 ;; untested). Reuses the refcount-probe cfg surface.
 (deftest use-subscribe-strictmode-double-mount-refcount-balances
-  (suite/assert-use-subscribe-strictmode-double-mount-refcount-balances cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-strictmode-double-mount-refcount-balances cfg))
 
 ;; rf2-8u8tx.2 — a useMemo factory re-run on unchanged deps (React's
 ;; documented perf-opt discard) must not leak a sub-cache ref-count.
 (deftest use-subscribe-memo-recompute-no-refcount-leak
-  (suite/assert-use-subscribe-memo-recompute-no-refcount-leak cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-memo-recompute-no-refcount-leak cfg))
 
 ;; rf2-879fe — an abandoned/restarted render that ran use-subscribe before
 ;; commit must leave no pinned sub-cache ref-count.
 (deftest use-subscribe-abandoned-render-no-refcount-leak
-  (suite/assert-use-subscribe-abandoned-render-no-refcount-leak cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-abandoned-render-no-refcount-leak cfg))
 
 ;; rf2-es09qq — a first-mount render aborted BEFORE commit via Suspense must
 ;; leak no sub-cache ref-count (the real abort-before-commit path the rf2-879fe
 ;; ledger could not reach — React discards the never-committed fiber).
 (deftest use-subscribe-suspense-abort-before-commit-no-refcount-leak
-  (suite/assert-use-subscribe-suspense-abort-before-commit-no-refcount-leak cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-suspense-abort-before-commit-no-refcount-leak cfg))
 
 (deftest use-subscribe-stable-deps-key
-  (suite/assert-use-subscribe-stable-deps-key cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-stable-deps-key cfg))
 
 ;; rf2-sqhjtu — getSnapshot must deref the durable COMMITTED reaction, not the
 ;; disposed render-phase handle (the React useSyncExternalStore disposed-
 ;; reaction hazard). Object-identity proof; reuses the refcount-probe surface.
 (deftest use-subscribe-getsnapshot-tracks-committed-reaction
-  (suite/assert-use-subscribe-getsnapshot-tracks-committed-reaction cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-getsnapshot-tracks-committed-reaction cfg))
 
 ;; rf2-2rtt6.13 — the disposed render-phase reaction must be unreachable: every
 ;; deref the spine performs hits the sub-cache's CURRENT tenant, and the cold
 ;; mount itself shows a deref of the committed reaction (React's post-subscribe
 ;; getSnapshot call, which is what still catches a render→commit write).
 (deftest use-subscribe-render-phase-reaction-not-retained
-  (suite/assert-use-subscribe-render-phase-reaction-not-retained cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-render-phase-reaction-not-retained cfg))
 
 ;; rf2-2rtt6.13 (merged-PR audit of #7304) — a write landing in the
 ;; render→commit gap, observed AT THE FIRST COMMIT (layout-visible, i.e.
@@ -542,7 +542,7 @@
 ;; REPORT the movement, so React discards the torn render instead of painting
 ;; state the app-db has already revoked.
 (deftest use-subscribe-render-to-commit-window-first-commit
-  (suite/assert-use-subscribe-render-to-commit-window-first-commit cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-render-to-commit-window-first-commit cfg))
 
 ;; rf2-2rtt6.25 — the hook-scoped provisional hand-off. A cold mount's commit
 ;; ADOPTS the reaction its render built (one construction, not two); the reaper
@@ -550,7 +550,7 @@
 ;; abandoned layer-2 cold render releases parent AND inputs at the horizon; and
 ;; a server render, which never commits at all, nets zero there too.
 (deftest use-subscribe-commit-adopts-the-render-phase-reaction
-  (suite/assert-use-subscribe-commit-adopts-the-render-phase-reaction cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-commit-adopts-the-render-phase-reaction cfg))
 
 ;; rf2-2rtt6.25 (merged-PR audit of #7305) — the same two integers, on the
 ;; PUBLIC mount schedule: `re-frame.substrate.adapter/render`, no act, no
@@ -565,16 +565,16 @@
 ;; pre-commit consistency check runs in the render's own task, before any
 ;; macrotask can reap.
 (deftest use-subscribe-browser-runner-schedule-rebuilds
-  (suite/assert-use-subscribe-browser-runner-schedule-rebuilds cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-browser-runner-schedule-rebuilds cfg))
 
 (deftest use-subscribe-escrow-leg-answers-on-the-public-mount-schedule
-  (suite/assert-use-subscribe-escrow-leg-answers-on-the-public-mount-schedule cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-escrow-leg-answers-on-the-public-mount-schedule cfg))
 
 (deftest use-subscribe-adopted-provisional-reaper-is-a-noop
-  (suite/assert-use-subscribe-adopted-provisional-reaper-is-a-noop cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-adopted-provisional-reaper-is-a-noop cfg))
 
 (deftest use-subscribe-abandoned-layer-2-render-cascades-at-the-horizon
-  (suite/assert-use-subscribe-abandoned-layer-2-render-cascades-at-the-horizon cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-abandoned-layer-2-render-cascades-at-the-horizon cfg))
 
 ;; rf2-2rtt6.25 (merged-PR audit of #7326) — the adversarial row, and the reason
 ;; the ruled horizon is a performance bet and never a correctness one. A
@@ -584,34 +584,34 @@
 ;; — so whichever way the race turns, what changes is a construction and never
 ;; a stale paint.
 (deftest use-subscribe-reaped-provisional-is-never-adopted-by-a-later-mount
-  (suite/assert-use-subscribe-reaped-provisional-is-never-adopted-by-a-later-mount cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-reaped-provisional-is-never-adopted-by-a-later-mount cfg))
 
 (deftest use-subscribe-ssr-render-without-commit-nets-zero-at-the-horizon
-  (suite/assert-use-subscribe-ssr-render-without-commit-nets-zero-at-the-horizon cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-ssr-render-without-commit-nets-zero-at-the-horizon cfg))
 
 ;; rf2-naz09e — a query-v / frame change on a MOUNTED component must render the
 ;; NEW target's value on the change-commit (parity with Reagent's in-render
 ;; recompute), never the previous target's. Value + object-identity proof, plus
 ;; a stable-key control (no over-invalidation).
 (deftest use-subscribe-key-change-serves-new-target
-  (suite/assert-use-subscribe-key-change-serves-new-target cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-key-change-serves-new-target cfg))
 
 ;; rf2-40a84 — flush-render! synchronously commits a pending render (the
 ;; proof the pair-MCP headless dispatch→render loop depends on).
 (deftest flush-render-synchronously-commits
-  (suite/assert-flush-render-synchronously-commits cfg))
+  (rf.adapter.react-shared-suite/assert-flush-render-synchronously-commits cfg))
 
 ;; rf2-gizlj — lock the rf2-cmfln 2-arity contract at the spine cleanup
 ;; call site (regression: the 3-arity grace-opts shape sneaking back in
 ;; would break sync-dispose silently).
 (deftest use-subscribe-cleanup-calls-unsubscribe-with-2-args
-  (suite/assert-use-subscribe-cleanup-calls-unsubscribe-with-2-args cfg))
+  (rf.adapter.react-shared-suite/assert-use-subscribe-cleanup-calls-unsubscribe-with-2-args cfg))
 
 ;; rf2-te71r — :rf.view/unmounted parity for the React-hook spine. The
 ;; probe view + element are built in the suite (raw React/createElement),
 ;; so this forwards on :substrate-kw alone (no substrate `defui`/`$`).
 (deftest view-unmount-emits-on-react-hook-teardown
-  (suite/assert-view-unmount-emits-on-react-hook-teardown
+  (rf.adapter.react-shared-suite/assert-view-unmount-emits-on-react-hook-teardown
     {:substrate-kw :uix :name "UIx"}))
 
 ;; rf2-ghfkkk — a registered view returning a VOID DOM root (<input>) mounts
@@ -619,7 +619,7 @@
 ;; exactly one :rf.view/unmounted (the unmount sentinel rides as a Fragment
 ;; sibling, not a child of the void element). Probe built in the suite.
 (deftest void-root-view-unmount-no-warning
-  (suite/assert-void-root-view-unmount-no-warning
+  (rf.adapter.react-shared-suite/assert-void-root-view-unmount-no-warning
     {:substrate-kw :uix :name "UIx"}))
 
 ;; ---- regression: frame-provider under the idiomatic `$` trailing-children shape (rf2-8svnm / rf2-z7hfp / rf2-7kii2) -
@@ -672,7 +672,7 @@
             ;; resolves via the React-context (provider) tier rather than
             ;; reading the shadowing :rf/default frame. See the suite's
             ;; assert-use-subscribe-frame-provider-resolution masking note.
-            (binding [frame/*current-frame* nil]
+            (binding [rf.frame/*current-frame* nil]
               (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
               (reset! probe-frame-provider-observed [])
               (rf/make-frame {:id frame-kw :doc "rf2-7kii2 trailing-children frame-provider probe"})
@@ -688,7 +688,7 @@
                       ;; children (no `:children` key), flowing through UIx's
                       ;; `$` → `glue-args` → the native `defui` shell.
                       (.render root
-                        ($ uix-adapter/frame-provider
+                        ($ rf.adapter.uix/frame-provider
                            {:frame frame-kw}
                            ($ ProbeFrameProvider)
                            ($ ProbeFrameProvider)))))

--- a/implementation/adapters/uix/testbed/adapter_testbed_uix/core.cljs
+++ b/implementation/adapters/uix/testbed/adapter_testbed_uix/core.cljs
@@ -12,7 +12,7 @@
   (:require [uix.core :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core    :as rf]
-            [re-frame.adapter.uix :as uix-adapter]))
+            [re-frame.adapter.uix :as rf.adapter.uix]))
 
 ;; -- Events / subs ----------------------------------------------------------
 
@@ -28,7 +28,7 @@
 ;; -- View -------------------------------------------------------------------
 
 (defui root []
-  (let [n        (uix-adapter/use-subscribe [:counter/value])
+  (let [n        (rf.adapter.uix/use-subscribe [:counter/value])
         dispatch (:dispatch (rf/capture-frame))]
     ($ :div
        ($ :h1 {:data-testid "rf-adapter-testbed-uix"}
@@ -52,9 +52,9 @@
   ;; `capture-frame` reads inside `root` resolve to it. This is the
   ;; documented boot idiom (the template scaffold's exact shape) — the
   ;; real-DOM path the smoke must cover.
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (uix-dom/render-root
-    ($ uix-adapter/frame-root {:id             :rf/default
+    ($ rf.adapter.uix/frame-root {:id             :rf/default
                                :initial-events [[:counter/init]]}
        ($ root))
     app-root))

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -40,15 +40,15 @@
   `:db-before` / `:db-after` are OPTIONAL app-db projections of that
   frame-state, not the restore target itself. Refused restores emit a
   structured trace and leave the frame state unchanged."
-  (:require [re-frame.epoch.assembly :as assembly]
-            [re-frame.epoch.capture :as capture]
-            [re-frame.epoch.listeners :as listeners]
-            [re-frame.epoch.state :as state]
-            [re-frame.epoch.tool-pair :as tool-pair]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.epoch.assembly :as rf.epoch.assembly]
+            [re-frame.epoch.capture :as rf.epoch.capture]
+            [re-frame.epoch.listeners :as rf.epoch.listeners]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.epoch.tool-pair :as rf.epoch.tool-pair]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- configuration --------------------------------------------------------
 ;;
@@ -109,13 +109,13 @@
   malformed `:redact-fn` (not `fn?` / `nil`) are silently dropped at the
   boundary."
   [opts]
-  (state/merge-config! opts))
+  (rf.epoch.state/merge-config! opts))
 
 (defn current-config
   "Return the current epoch-history configuration map. Public for tests
   and tools that want to display the current depth."
   []
-  (state/current-config))
+  (rf.epoch.state/current-config))
 
 ;; ---- the per-frame ring buffer --------------------------------------------
 ;;
@@ -130,7 +130,7 @@
   depth is 0, which disables recording — including records retained
   before the depth was lowered; see `configure!`)."
   [frame-id]
-  (state/history-for frame-id))
+  (rf.epoch.state/history-for frame-id))
 
 (defn clear-history!
   "Drop every recorded epoch for every frame. Test fixtures use this.
@@ -138,8 +138,8 @@
   Also drop in-flight capture buffers so a later event cannot harvest traces
   left by an interrupted test or run."
   []
-  (state/reset-histories!)
-  (state/reset-capture-buffers!)
+  (rf.epoch.state/reset-histories!)
+  (rf.epoch.state/reset-capture-buffers!)
   nil)
 
 ;; ---- listener registry ----------------------------------------------------
@@ -163,12 +163,12 @@
 
   Returns the id."
   [id f]
-  (state/put-listener! id f))
+  (rf.epoch.state/put-listener! id f))
 
 (defn unregister-epoch-listener!
   "Remove the listener registered under id."
   [id]
-  (state/drop-listener! id))
+  (rf.epoch.state/drop-listener! id))
 
 (defn epoch-silence-current?
   "THE supported receiver decision for a `:rf.epoch.cb/silenced-on-frame-destroy`
@@ -209,11 +209,11 @@
   exposing the race. Per Spec 009 §The delayed-silence emission linearization
   law."
   [tags]
-  (state/silence-current? (:frame tags) (:cb-id tags) (:observed-gen tags)))
+  (rf.epoch.state/silence-current? (:frame tags) (:cb-id tags) (:observed-gen tags)))
 
 (defn clear-epoch-listeners!
   []
-  (state/reset-listeners!))
+  (rf.epoch.state/reset-listeners!))
 
 ;; ---- per-cascade trace capture --------------------------------------------
 ;;
@@ -244,23 +244,23 @@
   [frame-id frame-state-before frame-state-after events committed-at outcome
    halt-reason trigger-event exact-owner-token]
   (let [owner-token (or exact-owner-token
-                        (frame/frame-incarnation-token frame-id))
+                        (rf.frame/frame-incarnation-token frame-id))
         continue?  #(or (nil? exact-owner-token)
-                        (frame/event-continuation-live?
+                        (rf.frame/event-continuation-live?
                           frame-id exact-owner-token))]
     ;; Claim rechecks liveness under the same owner lock used by terminal
     ;; cleanup; a check-then-claim race cannot resurrect stale A ownership.
     (when (and owner-token
-               (state/claim-frame-owner! frame-id owner-token continue?))
+               (rf.epoch.state/claim-frame-owner! frame-id owner-token continue?))
       ;; Resolve the only callback-bearing assembly input before building. A
       ;; digest hook that destroys A (whether it returns or throws) fences every
       ;; state write below.
       (when (continue?)
-        (let [schema-digest (assembly/current-schema-digest frame-id continue?)]
+        (let [schema-digest (rf.epoch.assembly/current-schema-digest frame-id continue?)]
           (when (continue?)
             ;; Whole-frame snapshots are restore units; app-db slots are
             ;; projections. The supplied digest keeps build-record data-only.
-            (let [base-record (assembly/build-record
+            (let [base-record (rf.epoch.assembly/build-record
                                 frame-id frame-state-before frame-state-after events
                                 committed-at outcome halt-reason schema-digest)
                   ;; Pin the explicit trigger only when the buffer did not
@@ -273,21 +273,21 @@
                   ;; transaction. Cleanup-before-commit and B-before-commit
                   ;; reject; commit-before-cleanup is erased by cleanup.
                   published? (and (continue?)
-                                  (state/commit-frame-owner-record!
+                                  (rf.epoch.state/commit-frame-owner-record!
                                     frame-id owner-token record))]
               ;; The optional cascade aggregator is callback-bearing. Its
               ;; result and every later trailer are inert after owner loss.
               (when (and published? (continue?))
-                (when-let [capture-for-epoch! (late-bind/get-fn-cached
+                (when-let [capture-for-epoch! (rf.late-bind/get-fn-cached
                                                 :trace.cascade/capture-for-epoch!)]
                   (try
                     (capture-for-epoch! frame-id (:epoch-id record) (:event-id record) events)
                     (catch #?(:clj Throwable :cljs :default) _ nil))))
               (when (and published? (continue?))
-                (assembly/emit-snapshotted+outcome!
+                (rf.epoch.assembly/emit-snapshotted+outcome!
                   frame-id (:epoch-id record) (:event-id record) outcome continue?))
               (when (and published? (continue?))
-                (listeners/notify-listeners! record continue?))
+                (rf.epoch.listeners/notify-listeners! record continue?))
               (when (and published? (continue?)) record))))))))
 
 (defn settle!
@@ -315,20 +315,20 @@
             outcome halt-reason settling-dispatch-id nil))
   ([frame-id frame-state-before frame-state-after committed-at outcome halt-reason
     settling-dispatch-id {:keys [exact-owner-token]}]
-   (when interop/debug-enabled?
+   (when rf.interop/debug-enabled?
      (if (and exact-owner-token
-              (not (frame/event-continuation-live?
+              (not (rf.frame/event-continuation-live?
                      frame-id exact-owner-token)))
        ;; A's run-start was already harvested by A's synchronous destroy hook;
        ;; tail traces may now sit beside fresh same-id B work. Remove only A's
        ;; dispatch-id evidence and never claim/commit B's epoch stores.
-       (state/drop-dispatch-buffer-events! frame-id settling-dispatch-id)
+       (rf.epoch.state/drop-dispatch-buffer-events! frame-id settling-dispatch-id)
        ;; Take only the settling event's traces, leaving a queued child's
        ;; marker in the buffer for its own settle. The envelope id also scopes
        ;; the no-run-start branch so a rejected or aborted dispatch's own
        ;; error trace is dropped (not returned) rather than committed as a fake
        ;; `:ok` epoch.
-       (let [events (state/harvest-buffer-for-event! frame-id settling-dispatch-id)]
+       (let [events (rf.epoch.state/harvest-buffer-for-event! frame-id settling-dispatch-id)]
          ;; An empty capture has no event context. Rejected dispatches are
          ;; suppressed here; never-run depth halts use `commit-halt-record!`.
          (when (seq events)
@@ -368,17 +368,17 @@
   the rf2-cprm0q elision trap)."
   [frame-id frame-state-after committed-at outcome halt-reason
    trigger-event exact-owner-token]
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (when (or (nil? exact-owner-token)
-              (frame/event-continuation-live? frame-id exact-owner-token))
-      (let [events (state/harvest-buffer! frame-id)
+              (rf.frame/event-continuation-live? frame-id exact-owner-token))
+      (let [events (rf.epoch.state/harvest-buffer! frame-id)
             ;; Source the durable value from the same snapshot restore uses,
             ;; rather than trusting the router's live re-read. Fall back to
             ;; the router-passed value when no `:ok` epoch has landed yet
             ;; (depth-exceed on the first cascade).
-            last-id     (state/last-settled-epoch-id frame-id)
+            last-id     (rf.epoch.state/last-settled-epoch-id frame-id)
             last-record (when last-id
-                          (->> (state/history-for frame-id)
+                          (->> (rf.epoch.state/history-for frame-id)
                                (some (fn [r] (when (= last-id (:epoch-id r)) r)))))
             fs          (if last-record
                           (:frame-state-after last-record)
@@ -425,16 +425,16 @@
 
   Returns `true` on success, `false` on any failure."
   [frame-id epoch-id]
-  (if-not interop/debug-enabled?
+  (if-not rf.interop/debug-enabled?
     false
     (let [{:keys [outcome epoch op tags incarnation-token]}
-          (tool-pair/check-restore-preconditions! frame-id epoch-id)]
+          (rf.epoch.tool-pair/check-restore-preconditions! frame-id epoch-id)]
       (case outcome
         ;; Carry the EXACT incarnation token the preconditions resolved against
         ;; to the write boundary, so a same-id successor seated in between never
         ;; receives this epoch's state (rf2-bjh6y).
-        :ok   (tool-pair/perform-restore! frame-id incarnation-token epoch)
-        :fail (do (tool-pair/emit-precondition-failure! op tags)
+        :ok   (rf.epoch.tool-pair/perform-restore! frame-id incarnation-token epoch)
+        :fail (do (rf.epoch.tool-pair/emit-precondition-failure! op tags)
                   false)))))
 
 ;; ---- replay (Tool-Pair §Replay) --------------------------------------------
@@ -497,12 +497,12 @@
   false) — the same inert value `restore-epoch!` returns."
   ([frame-id epoch-id] (replay-epoch! frame-id epoch-id nil))
   ([frame-id epoch-id opts]
-   (if-not interop/debug-enabled?
+   (if-not rf.interop/debug-enabled?
      false
      (let [{:keys [outcome epoch reason tags]}
-           (tool-pair/check-replay-preconditions! frame-id epoch-id)]
+           (rf.epoch.tool-pair/check-replay-preconditions! frame-id epoch-id)]
        (case outcome
-         :ok   (tool-pair/perform-replay! frame-id epoch opts)
+         :ok   (rf.epoch.tool-pair/perform-replay! frame-id epoch opts)
          :fail (merge {:ok? false :reason reason :frame frame-id :epoch-id epoch-id}
                       tags))))))
 
@@ -531,18 +531,18 @@
   attribution anchor. With no application event in flight, `:committed-at`
   uses `epoch-now-ms`: a durable wall-clock value, not the elapsed-time clock."
   [frame-id incarnation-token frame-state-before frame-state-after]
-  (let [continue? #(frame/event-continuation-live? frame-id incarnation-token)]
+  (let [continue? #(rf.frame/event-continuation-live? frame-id incarnation-token)]
     (when (and incarnation-token
-               (state/claim-frame-owner! frame-id incarnation-token continue?))
+               (rf.epoch.state/claim-frame-owner! frame-id incarnation-token continue?))
       ;; Resolve the only callback-bearing assembly input before building —
       ;; a digest hook that churns A to B fences every state write below.
       (when (continue?)
-        (let [schema-digest (assembly/current-schema-digest frame-id continue?)]
+        (let [schema-digest (rf.epoch.assembly/current-schema-digest frame-id continue?)]
           (when (continue?)
-            (let [record     (assoc (assembly/build-record frame-id
+            (let [record     (assoc (rf.epoch.assembly/build-record frame-id
                                                            frame-state-before
                                                            frame-state-after []
-                                                           (interop/epoch-now-ms)
+                                                           (rf.interop/epoch-now-ms)
                                                            :ok nil schema-digest)
                                     :event-id      :rf.epoch/db-replaced
                                     :trigger-event [:rf.epoch/db-replaced])
@@ -550,14 +550,14 @@
                   ;; cleanup-before-commit and B-before-commit reject,
                   ;; commit-before-cleanup is erased by cleanup.
                   published? (and (continue?)
-                                  (state/commit-frame-owner-record!
+                                  (rf.epoch.state/commit-frame-owner-record!
                                     frame-id incarnation-token record))]
               (when (and published? (continue?))
-                (trace/emit! :rf.epoch :rf.epoch/db-replaced
+                (rf.trace/emit! :rf.epoch :rf.epoch/db-replaced
                              {:frame       frame-id
                               :rf.epoch/id (:epoch-id record)}))
               (when (and published? (continue?))
-                (listeners/notify-listeners! record continue?))
+                (rf.epoch.listeners/notify-listeners! record continue?))
               (when (and published? (continue?)) record))))))))
 
 (defn- perform-replace!
@@ -590,19 +590,19 @@
   lost or silently reverted (rf2-3fc89f.4). A replace invoked reentrantly from
   the active drainer refuses with `:rf.epoch/replace-during-drain`."
   [frame-id incarnation-token build-frame-state-after write-frame-state!]
-  (tool-pair/serialize-tool-write!
+  (rf.epoch.tool-pair/serialize-tool-write!
     frame-id
     :rf.epoch/replace-during-drain
     {:frame frame-id}
     (fn []
-      (if-not (frame/event-continuation-live? frame-id incarnation-token)
+      (if-not (rf.frame/event-continuation-live? frame-id incarnation-token)
         ;; The incarnation these preconditions resolved against is no longer
         ;; live — a same-id SUCCESSOR was seated (or the frame was destroyed /
         ;; is being torn down) between validation and this write. Refuse via
         ;; the SAME canonical no-such-handler failure a destroyed-frame write
         ;; race uses (rf2-gj2bo). The successor stays byte-for-byte untouched;
         ;; no success telemetry fires.
-        (do (tool-pair/emit-precondition-failure! :rf.error/no-such-handler
+        (do (rf.epoch.tool-pair/emit-precondition-failure! :rf.error/no-such-handler
                                                   {:kind :frame :frame frame-id})
             false)
         (let [;; Record the same coherent whole-frame value the write installs.
@@ -613,11 +613,11 @@
               ;; after the gate (destroyed, or reseated — the post-liveness
               ;; race); an empty set is still a successful no-op write against
               ;; the live incarnation.
-              frame-state-before (frame/frame-state-value frame-id)
+              frame-state-before (rf.frame/frame-state-value frame-id)
               frame-state-after  (build-frame-state-after frame-state-before)
               changed-keys       (write-frame-state!)]
           (if (nil? changed-keys)
-            (do (tool-pair/emit-precondition-failure! :rf.error/no-such-handler
+            (do (rf.epoch.tool-pair/emit-precondition-failure! :rf.error/no-such-handler
                                                       {:kind :frame :frame frame-id})
                 false)
             (do (record-synthetic-replace-epoch! frame-id incarnation-token
@@ -642,7 +642,7 @@
                     incarnation-token
                     (fn [frame-state-before]
                       (merge frame-state-before new-frame-state))
-                    #(frame/replace-frame-state! frame-id incarnation-token new-frame-state)))
+                    #(rf.frame/replace-frame-state! frame-id incarnation-token new-frame-state)))
 
 (defn replace-frame-state!
   "Atomically install `new-frame-state` — a PARTIAL frame-state map (any
@@ -684,16 +684,16 @@
 
   Returns `true` on success, `false` on any failure."
   [frame-id new-frame-state]
-  (if-not interop/debug-enabled?
+  (if-not rf.interop/debug-enabled?
     false
     (let [{:keys [outcome op tags incarnation-token]}
-          (tool-pair/check-replace-frame-state-preconditions! frame-id new-frame-state)]
+          (rf.epoch.tool-pair/check-replace-frame-state-preconditions! frame-id new-frame-state)]
       (case outcome
         ;; Carry the EXACT incarnation token the preconditions resolved against
         ;; to the write boundary, so a same-id successor seated in between never
         ;; receives this injection or its synthetic bookkeeping (rf2-gj2bo).
         :ok   (perform-replace-frame-state! frame-id incarnation-token new-frame-state)
-        :fail (do (tool-pair/emit-precondition-failure! op tags)
+        :fail (do (rf.epoch.tool-pair/emit-precondition-failure! op tags)
                   false)))))
 
 ;; ---- projected egress -----------------------------------------------------
@@ -727,16 +727,16 @@
   `:include-large?`, `:include-runtime-db?`, `:include-fx-args?`, and
   `:include-event-args?`; each lifts only its own boundary. The 1-arity uses
   safe defaults. Nil input returns nil."
-  ([record] (tool-pair/projected-record record))
-  ([record opts] (tool-pair/projected-record record opts)))
+  ([record] (rf.epoch.tool-pair/projected-record record))
+  ([record opts] (rf.epoch.tool-pair/projected-record record opts)))
 
 (defn projected-history
   "Convenience: return the projected vector of records for a frame.
   Equivalent to `(mapv #(projected-record % opts) (epoch-history frame-id))`.
   The 2-arity threads egress `opts` to every record; the 1-arity uses the
   safe off-box defaults."
-  ([frame-id] (tool-pair/projected-history frame-id))
-  ([frame-id opts] (tool-pair/projected-history frame-id opts)))
+  ([frame-id] (rf.epoch.tool-pair/projected-history frame-id))
+  ([frame-id opts] (rf.epoch.tool-pair/projected-history frame-id opts)))
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
@@ -745,15 +745,15 @@
 ;; artefact. Most absent-artefact reads degrade to empty/false/no-op; the state
 ;; replacement facade raises because it cannot preserve its undo invariant
 ;; without epoch storage.
-(late-bind/set-fns!
+(rf.late-bind/set-fns!
   {;; ---- per-cascade lifecycle (router + trace capture seam) -------
    :epoch/settle!             settle!
    ;; Per-event halt commit for a depth-exceeded event that never ran, so
    ;; `settle!` would otherwise skip its empty buffer.
    :epoch/commit-halt-record! commit-halt-record!
-   :epoch/capture-event       capture/capture-event!
+   :epoch/capture-event       rf.epoch.capture/capture-event!
    ;; In-flight cause lookup used to attribute render traces.
-   :epoch/run-cause           capture/run-cause
+   :epoch/run-cause           rf.epoch.capture/run-cause
    ;; Post-settle render back-fill. `capture-event!` routes a
    ;; view-render op that fires with no in-flight cascade (a React-
    ;; commit-time async re-render) here so it is attributed to the
@@ -762,22 +762,22 @@
    ;; `re-frame.epoch.listeners` (state back-fill + listener re-notify);
    ;; publishing it through late-bind keeps `capture` free of a require
    ;; on `listeners` (which would close the assembly→capture cycle).
-   :epoch/record-render!      listeners/record-render!
+   :epoch/record-render!      rf.epoch.listeners/record-render!
    ;; Post-settle sub-run back-fill, parallel to render back-fill for the
    ;; same React-deref-time attribution case.
-   :epoch/record-sub-run!     listeners/record-sub-run!
+   :epoch/record-sub-run!     rf.epoch.listeners/record-sub-run!
    ;; Post-settle view-unmount back-fill, the teardown sibling
    ;; of the two above. A `:rf.view/unmounted` fires at React teardown time,
    ;; after the cascade that removed the view settled — too late for the
    ;; capture seam. Back-fills it into the causing (most-recently-settled)
    ;; epoch's `:trace-events`, where Xray's VIEWS step surfaces it.
-   :epoch/record-unmount!     listeners/record-unmount!
+   :epoch/record-unmount!     rf.epoch.listeners/record-unmount!
    ;; rf2-vxgfnd.151: `destroy-frame!` fires this BEFORE dissoc to bind the
    ;; dying incarnation's terminal halted-destroy evidence to a bundle while it
    ;; still solely owns its id-keyed epoch stores; the bundle is threaded to the
    ;; post-dissoc `:epoch/on-frame-destroyed` hook.
-   :epoch/snapshot-frame-destroyed listeners/snapshot-terminal-destroy-evidence!
-   :epoch/on-frame-destroyed  listeners/on-frame-destroyed!
+   :epoch/snapshot-frame-destroyed rf.epoch.listeners/snapshot-terminal-destroy-evidence!
+   :epoch/on-frame-destroyed  rf.epoch.listeners/on-frame-destroyed!
 
    ;; ---- introspection + Tool-Pair write surface --------------------
    :epoch/epoch-history       epoch-history
@@ -800,7 +800,7 @@
    ;; support`'s reset-hook table fires this to restore epoch config to
    ;; the shipped default between tests, keeping the private `state/config`
    ;; var out of test namespaces.
-   :epoch/reset-config!              state/reset-config!
+   :epoch/reset-config!              rf.epoch.state/reset-config!
    :epoch/clear-history!             clear-history!
    :epoch/clear-epoch-listeners!     clear-epoch-listeners!
 

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -17,13 +17,13 @@
 
   `current-schema-digest` pins the schema identity later compared by restore
   preconditions."
-  (:require [re-frame.elision :as elision]
-            [re-frame.epoch.capture :as capture]
-            [re-frame.epoch.state :as state]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.privacy :as privacy]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.elision :as rf.elision]
+            [re-frame.epoch.capture :as rf.epoch.capture]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- consumer-facing outcome enum ----------------------------------------
 ;;
@@ -75,7 +75,7 @@
                               (constantly true)))
   ([frame-id epoch-id event-id outcome continue?]
    (when (continue?)
-     (trace/emit! :rf.epoch :rf.epoch/snapshotted
+     (rf.trace/emit! :rf.epoch :rf.epoch/snapshotted
                   {:frame             frame-id
                    :rf.epoch/id       epoch-id
                    :rf.trace/event-id event-id
@@ -83,7 +83,7 @@
    ;; Trace listeners are synchronous. A snapshotted listener may destroy the
    ;; exact frame owner, in which case the paired outcome fact is suppressed.
    (when (continue?)
-     (trace/emit! :rf.epoch :rf.epoch/outcome
+     (rf.trace/emit! :rf.epoch :rf.epoch/outcome
                   {:frame             frame-id
                    :rf.epoch/id       epoch-id
                    :rf.trace/event-id event-id
@@ -100,7 +100,7 @@
   egress; raw replay storage and listener delivery are never changed. Callers
   own the shared debug gate."
   [record]
-  (if-let [redact-fn (state/redact-fn)]
+  (if-let [redact-fn (rf.epoch.state/redact-fn)]
     (if (some? record)
       (try
         (redact-fn record)
@@ -112,7 +112,7 @@
           ;; elides the warning emit + literals under :advanced +
           ;; goog.DEBUG=false.
           ;; Trace identity is qualified; the record field read below is bare.
-          (trace/emit! :warning :rf.warning/epoch-redact-fn-exception
+          (rf.trace/emit! :warning :rf.warning/epoch-redact-fn-exception
                        {:frame       (:frame record)
                         :rf.epoch/id (:epoch-id record)
                         :ex-msg      #?(:clj (.getMessage ^Throwable redaction-error)
@@ -133,7 +133,7 @@
    (current-schema-digest frame-id (constantly true)))
   ([frame-id continue?]
    (when (continue?)
-     (when-let [schema-digest-fn (late-bind/get-fn :schemas/app-schemas-digest)]
+     (when-let [schema-digest-fn (rf.late-bind/get-fn :schemas/app-schemas-digest)]
        (try
          (schema-digest-fn frame-id)
          (catch #?(:clj Throwable :cljs :default) _
@@ -167,7 +167,7 @@
   "True when any captured trace event carries a top-level `:sensitive?
   true` stamp. The trace surface hoists this boolean from handler scope."
   [events]
-  (boolean (some privacy/sensitive? events)))
+  (boolean (some rf.privacy/sensitive? events)))
 
 (defn- sensitive-paths-for
   "Return the classified sensitive paths for `frame-id`. Empty when
@@ -175,7 +175,7 @@
   `[:rf.runtime/elision :sensitive-declarations]` registry is written by the
   commit-plane classification effects, not schema-populated)."
   [frame-id]
-  (try (keys (elision/sensitive-declarations frame-id))
+  (try (keys (rf.elision/sensitive-declarations frame-id))
        (catch #?(:clj Throwable :cljs :default) _ nil)))
 
 (defn- any-sensitive-leaf?
@@ -319,13 +319,13 @@
          ;; / `:db-after` slots + the sensitive-rollup signal. `frame-state`
          ;; may be nil on a halted-destroy path whose pre-cascade snapshot is
          ;; absent; `(:rf.db/app nil)` is nil, which consumers already tolerate.
-         db-before (get frame-state-before frame/app-partition-key)
-         db-after  (get frame-state-after  frame/app-partition-key)
+         db-before (get frame-state-before rf.frame/app-partition-key)
+         db-after  (get frame-state-after  rf.frame/app-partition-key)
          {:keys [event-id event dispatch-id fx-overrides interceptor-overrides]
           trigger-cofx :rf.cofx}
-         (capture/find-trigger-event events)
+         (rf.epoch.capture/find-trigger-event events)
          ;; One fused walk produces all structured projections.
-         {:keys [sub-runs renders effects]} (capture/project-all events)
+         {:keys [sub-runs renders effects]} (rf.epoch.capture/project-all events)
          ;; Listener and egress consumers can branch on one record-level slot.
          ;; Sensitive declarations target app-db paths, so it reasons over
          ;; the app-db projection (`db-before` / `db-after`).
@@ -338,7 +338,7 @@
          ;; :rf.epoch/sensitive? rollup above).
          redacted-modified-path-count (redacted-modified-paths-count
                                         frame-id db-before db-after)]
-     (cond-> {:epoch-id           (state/next-epoch-id)
+     (cond-> {:epoch-id           (rf.epoch.state/next-epoch-id)
               :frame              frame-id
               ;; Durable causal time is supplied from envelope construction;
               ;; assembly never re-reads the host clock.

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -12,10 +12,10 @@
                           fallback.
 
   Buffer storage and low-level mutation live in `re-frame.epoch.state`."
-  (:require [re-frame.epoch.state :as state]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]))
 
 ;; ---- skip-ops catalogue --------------------------------------------------
 ;;
@@ -157,7 +157,7 @@
   [frame-id]
   (some (fn [trace-event]
           (= :rf.event/run-start (:operation trace-event)))
-        (state/buffer-for frame-id)))
+        (rf.epoch.state/buffer-for frame-id)))
 
 (defn capture-event!
   "Capture one trace event through the `:epoch/capture-event` late-bind hook.
@@ -187,7 +187,7 @@
   back-filled through their dedicated hooks when no event is in flight, while
   synchronous occurrences stay in the current buffer."
   [event]
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (let [operation  (:operation event)
           event-tags (:tags event)
           ;; The canonical raw trace-event frame path, and the ONLY one
@@ -212,8 +212,8 @@
                      (contains? render-ops operation)
                      (contains? sub-run-ops operation)
                      (contains? unmount-ops operation)))
-        (when-let [owner-token (frame/frame-incarnation-token frame-id)]
-          (state/claim-frame-owner! frame-id owner-token)))
+        (when-let [owner-token (rf.frame/frame-incarnation-token frame-id)]
+          (rf.epoch.state/claim-frame-owner! frame-id owner-token)))
       ;; Learn which subscriptions each view reads from the
       ;; `:reader-render-key` stamp the runtime sets on a `:rf.sub/run`
       ;; that recomputes SYNCHRONOUSLY inside a view's render (the mount /
@@ -226,7 +226,7 @@
       (when frame-id
         (when-let [reader-render-key (:rf.sub/reader-render-key event-tags)]
           (when (= :rf.sub/run operation)
-            (state/record-render-deps! frame-id reader-render-key
+            (rf.epoch.state/record-render-deps! frame-id reader-render-key
                                        (:rf.sub/id event-tags)))))
       (when (and frame-id (not (contains? skip-ops operation)))
         (cond
@@ -240,18 +240,18 @@
           ;; the render falls through to the normal buffer path.
           (and (contains? render-ops operation)
                (not (in-flight-cascade? frame-id)))
-          (if-let [record-render! (late-bind/get-fn-cached :epoch/record-render!)]
+          (if-let [record-render! (rf.late-bind/get-fn-cached :epoch/record-render!)]
             (record-render! frame-id event)
-            (state/buffer-event! frame-id event))
+            (rf.epoch.state/buffer-event! frame-id event))
 
           ;; Post-settle sub-run. Same
           ;; back-fill shape, distinct hook. Falls through to the normal
           ;; buffer path during the pre-facade-install load-order window.
           (and (contains? sub-run-ops operation)
                (not (in-flight-cascade? frame-id)))
-          (if-let [record-sub-run! (late-bind/get-fn-cached :epoch/record-sub-run!)]
+          (if-let [record-sub-run! (rf.late-bind/get-fn-cached :epoch/record-sub-run!)]
             (record-sub-run! frame-id event)
-            (state/buffer-event! frame-id event))
+            (rf.epoch.state/buffer-event! frame-id event))
 
           ;; Post-settle view unmount.
           ;; A `:rf.view/unmounted` fires at React teardown time, AFTER the
@@ -268,9 +268,9 @@
           ;; window.
           (and (contains? unmount-ops operation)
                (not (in-flight-cascade? frame-id)))
-          (if-let [record-unmount! (late-bind/get-fn-cached :epoch/record-unmount!)]
+          (if-let [record-unmount! (rf.late-bind/get-fn-cached :epoch/record-unmount!)]
             (record-unmount! frame-id event)
-            (state/buffer-event! frame-id event))
+            (rf.epoch.state/buffer-event! frame-id event))
 
           ;; Drop an out-of-cascade orphan from the epoch capture buffer.
           ;; An emit with NO cascade context (no in-flight cascade for the
@@ -298,7 +298,7 @@
           nil
 
           :else
-          (state/buffer-event! frame-id event))))))
+          (rf.epoch.state/buffer-event! frame-id event))))))
 
 ;; ---- run-cause for render attribution -------------------------------------
 ;;
@@ -357,8 +357,8 @@
   ([frame-id]
    (run-cause frame-id 100))
   ([frame-id sub-cap]
-   (when interop/debug-enabled?
-     (let [buffered-events (state/buffer-for frame-id)
+   (when rf.interop/debug-enabled?
+     (let [buffered-events (rf.epoch.state/buffer-for frame-id)
            ;; Single reduce: capture first :rf.event/run-start, accumulate
            ;; distinct sub-ids in first-seen order up to `sub-cap`, and
            ;; count the existing :rf.view/rendered emits so the views.cljs

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -35,11 +35,11 @@
 
   Listener registry and observation bookkeeping live in
   `re-frame.epoch.state`."
-  (:require [re-frame.epoch.assembly :as assembly]
-            [re-frame.epoch.capture :as capture]
-            [re-frame.epoch.state :as state]
-            [re-frame.interop :as interop]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.epoch.assembly :as rf.epoch.assembly]
+            [re-frame.epoch.capture :as rf.epoch.capture]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.interop :as rf.interop]
+            [re-frame.trace :as rf.trace]))
 
 (defn- deliver-listener-snapshot!
   "Deliver `record` to an already-snapshotted listener generation.
@@ -65,7 +65,7 @@
    (let [frame-id (:frame record)
          emit-listener-exception!
          (fn [callback-id listener-error]
-           (trace/emit-error! :rf.epoch.cb/listener-exception
+           (rf.trace/emit-error! :rf.epoch.cb/listener-exception
                                {:frame       frame-id
                                 :cb-id       callback-id
                                 :rf.epoch/id (:epoch-id record)
@@ -78,7 +78,7 @@
             ;; Stamp only the callback that is actually about to run. A later
             ;; listener suppressed by owner loss must not be reported observed.
             (when record-observation?
-              (state/record-observation! callback-id generation frame-id))
+              (rf.epoch.state/record-observation! callback-id generation frame-id))
             (try
               (callback record)
               (catch #?(:clj Throwable :cljs :default) listener-error
@@ -89,7 +89,7 @@
                    ;; A's terminal callback fault is A's own diagnostic. A same-id
                    ;; B that a listener just installed (possibly no-emit) must not
                    ;; suppress or capture it (rf2-vxgfnd.152).
-                    (trace/call-with-structural-delivery
+                    (rf.trace/call-with-structural-delivery
                       #(emit-listener-exception! callback-id listener-error))
                     (emit-listener-exception! callback-id listener-error)))))
            (recur (next entries))))))))
@@ -113,7 +113,7 @@
   ([record]
    (notify-listeners! record (constantly true)))
   ([record continue?]
-   (let [listener-snapshot (state/listeners-snapshot)]
+   (let [listener-snapshot (rf.epoch.state/listeners-snapshot)]
      (when (continue?)
        (deliver-listener-snapshot! record listener-snapshot continue? true)))))
 
@@ -154,13 +154,13 @@
   first cascade) or when the target epoch has been evicted from the ring
   — `back-fill-render!` returns nil and we skip the re-notify."
   [frame-id event]
-  (when interop/debug-enabled?
-    (when-let [default-epoch-id (state/last-settled-epoch-id frame-id)]
+  (when rf.interop/debug-enabled?
+    (when-let [default-epoch-id (rf.epoch.state/last-settled-epoch-id frame-id)]
       (let [render-key (-> event :tags :rf.view/render-key)
-            target-epoch-id (state/resolve-render-epoch frame-id render-key
+            target-epoch-id (rf.epoch.state/resolve-render-epoch frame-id render-key
                                                          default-epoch-id)]
         ;; Record the mount anchor on first sighting; never overwrites.
-        (state/record-mount-epoch! frame-id render-key target-epoch-id)
+        (rf.epoch.state/record-mount-epoch! frame-id render-key target-epoch-id)
         ;; De-dup a mount-burst tail ONLY when it was REDIRECTED away from
         ;; the settling cascade (`target-epoch-id` ≠ `default-epoch-id`) back to a
         ;; mount epoch where the instance already rendered. A genuine
@@ -170,13 +170,13 @@
         ;; ride their cascade (only the late mount-burst tail is absorbed).
         (when-not (and render-key
                        (not= target-epoch-id default-epoch-id)
-                       (state/render-key-already-in-epoch?
+                       (rf.epoch.state/render-key-already-in-epoch?
                          frame-id target-epoch-id render-key))
           ;; Back-fill stores the raw event and row; egress projection remains
           ;; the only redaction boundary.
           (when-let [updated-record
-                     (state/back-fill-render! frame-id target-epoch-id event
-                                              (capture/render-row event))]
+                     (rf.epoch.state/back-fill-render! frame-id target-epoch-id event
+                                              (rf.epoch.capture/render-row event))]
             ;; Re-fan the corrected record so snapshot consumers re-read
             ;; the ring. The fan-out is failure-isolated per listener
             ;; (same contract as the settle-time fan-out); a render-driven
@@ -202,12 +202,12 @@
   first cascade) or when the target epoch has been evicted from the ring
   — `back-fill-sub-run!` returns nil and we skip the re-notify."
   [frame-id event]
-  (when interop/debug-enabled?
-    (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
+  (when rf.interop/debug-enabled?
+    (when-let [epoch-id (rf.epoch.state/last-settled-epoch-id frame-id)]
       ;; Store raw; projection remains the egress boundary.
       (when-let [updated-record
-                 (state/back-fill-sub-run! frame-id epoch-id event
-                                           (capture/sub-run-row event))]
+                 (rf.epoch.state/back-fill-sub-run! frame-id epoch-id event
+                                           (rf.epoch.capture/sub-run-row event))]
         ;; Re-fan the corrected record so snapshot consumers re-read the
         ;; ring. Same failure-isolated fan-out + no-loop contract as the
         ;; render back-fill above.
@@ -257,11 +257,11 @@
   target epoch has been evicted from the ring — `back-fill-unmount!` returns
   nil and we skip the re-notify."
   [frame-id event]
-  (when interop/debug-enabled?
-    (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
+  (when rf.interop/debug-enabled?
+    (when-let [epoch-id (rf.epoch.state/last-settled-epoch-id frame-id)]
       ;; Unmount has no structured row, so only retained raw trace is updated.
       (when-let [updated-record
-                 (state/back-fill-unmount! frame-id epoch-id event)]
+                 (rf.epoch.state/back-fill-unmount! frame-id epoch-id event)]
         ;; Re-fan the corrected record so snapshot consumers re-read the
         ;; ring. Same failure-isolated fan-out + no-loop contract as the
         ;; render / sub-run back-fill above.
@@ -270,7 +270,7 @@
     ;; the map stays bounded across instance churn (NOT retained until
     ;; whole-frame destroy). Runs whether or not the back-fill found a live
     ;; epoch — the entry is dead once the instance unmounts.
-    (state/drop-render-key-mount-attribution!
+    (rf.epoch.state/drop-render-key-mount-attribution!
       frame-id (-> event :tags :rf.view/render-key))))
 
 (defn snapshot-terminal-destroy-evidence!
@@ -315,12 +315,12 @@
   Schema digesting is intentionally omitted: A's schemas are already torn down
   and a bare-id digest could only resolve absent state or a same-id B."
   [frame-id fs-before fs-after committed-at]
-  (when interop/debug-enabled?
-    (let [buffered-events   (state/buffer-for frame-id)
+  (when rf.interop/debug-enabled?
+    (let [buffered-events   (rf.epoch.state/buffer-for frame-id)
           in-flight?        (some #(= :rf.event/run-start (:operation %))
                                   buffered-events)
           record            (when in-flight?
-                              (assembly/build-record
+                              (rf.epoch.assembly/build-record
                                 frame-id fs-before fs-after buffered-events
                                 committed-at :halted-destroy
                                 {:operation :rf.frame/destroyed-mid-drain}
@@ -329,7 +329,7 @@
           ;; owed-observer generations come from the SAME registry read used to
           ;; qualify them, so a replacement mid-snapshot can never attribute A's
           ;; observation to a fresh generation it never observed under.
-          {:keys [listeners observing]} (state/snapshot-terminal-observers frame-id)
+          {:keys [listeners observing]} (rf.epoch.state/snapshot-terminal-observers frame-id)
           ;; A mid-drain record is fanned to every current listener, so each owes
           ;; a silence under ITS live generation (from the same `listeners` read).
           listener-snapshot (if record listeners {})
@@ -337,11 +337,11 @@
                               record (into (map (fn [[cb {:keys [generation]}]]
                                                   [cb generation]))
                                            listeners))
-          baseline          (state/current-terminal-silence-seq)]
+          baseline          (rf.epoch.state/current-terminal-silence-seq)]
       ;; Open the frame's deferred-silence window BEFORE dissoc so its
       ;; terminal-silence marks survive until this predecessor publishes; the
       ;; paired `close-silence-lineage!` runs in `on-frame-destroyed!`.
-      (state/open-silence-lineage! frame-id)
+      (rf.epoch.state/open-silence-lineage! frame-id)
       {:record               record
        :listener-snapshot    listener-snapshot
        :silenced-cbs         silenced-cbs
@@ -423,7 +423,7 @@
    ;; UNCONDITIONALLY of terminal-evidence; (2) terminal-record/silencing
    ;; PUBLICATION stays conditional on a non-nil bundle. Neither is folded into
    ;; the gate condition itself.
-   (when interop/debug-enabled?
+   (when rf.interop/debug-enabled?
      ;; (1) EXACT-OWNER STORE CLEANUP — runs whether or not terminal-evidence is
      ;; nil. Cleanup authority is the frame-id + owner-token, NOT the snapshot
      ;; bundle: a throwing `:epoch/snapshot-frame-destroyed` hook yields nil
@@ -438,16 +438,16 @@
      ;; winning this comparison is NOT the same fact as "no successor re-armed the
      ;; observers" (a claim without delivery loses it; a re-arm-then-destroy wins
      ;; it), which the per-identity claim resolves precisely.
-     (state/cleanup-frame-owner!
+     (rf.epoch.state/cleanup-frame-owner!
        frame-id owner-token
        (fn []
          ;; Data-only exact-owner transaction: no external callback runs
          ;; between owner comparison and the complete drop.
-         (state/drop-frame-observation! frame-id)
-         (state/drop-frame-history! frame-id)
-         (state/drop-frame-buffer! frame-id)
-         (state/drop-last-settled-epoch! frame-id)
-         (state/drop-frame-mount-attribution! frame-id)
+         (rf.epoch.state/drop-frame-observation! frame-id)
+         (rf.epoch.state/drop-frame-history! frame-id)
+         (rf.epoch.state/drop-frame-buffer! frame-id)
+         (rf.epoch.state/drop-last-settled-epoch! frame-id)
+         (rf.epoch.state/drop-frame-mount-attribution! frame-id)
          true))
      ;; (2) TERMINAL-RECORD + SILENCING PUBLICATION — conditional on a non-nil
      ;; bundle. A non-nil bundle means `snapshot-terminal-destroy-evidence!`
@@ -470,8 +470,8 @@
            ;; Same detailed/coarse trailer pair as normal commits, delivered
            ;; structurally: excluded from capture ownership and immune to a same-id
            ;; B's frame-no-emit policy.
-           (trace/call-with-structural-delivery
-             #(assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
+           (rf.trace/call-with-structural-delivery
+             #(rf.epoch.assembly/emit-snapshotted+outcome! frame-id (:epoch-id record)
                                                   (:event-id record) :halted-destroy))
            (deliver-listener-snapshot! record listener-snapshot))
          ;; PER-IDENTITY atomic-claim-THEN-PUBLISH silencing (rf2-vxgfnd.285 /
@@ -502,18 +502,18 @@
          ;; delivery throws, the reservation is rolled back (under silence-lock)
          ;; and the fault propagates.
          (doseq [[cb-id observed-gen] (sort-by (comp str key) silenced-cbs)]
-           (state/claim-and-publish-delayed-silence!
+           (rf.epoch.state/claim-and-publish-delayed-silence!
              frame-id cb-id observed-gen baseline-silence-seq
              ;; The silencing fact belongs to destroyed A too; never let a
              ;; same-id successor's trace policy suppress or capture it. The
              ;; `:observed-gen` qualifier is what lets the emit run outside the
              ;; ledger locks without reopening the G→H window (rf2-8b9twg).
-             #(trace/call-with-structural-delivery
+             #(rf.trace/call-with-structural-delivery
                 (fn []
-                  (trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
+                  (rf.trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
                                {:frame frame-id :cb-id cb-id
                                 :observed-gen observed-gen}))))))
         (finally
           ;; Close the deferred-silence window opened at snapshot time. When the
           ;; frame's last outstanding predecessor resolves, its marks are reclaimed.
-          (state/close-silence-lineage! frame-id)))))))
+          (rf.epoch.state/close-silence-lineage! frame-id)))))))

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -21,7 +21,7 @@
   per-registration GENERATION token (see the listener-registry section) rather
   than a cross-atom update, so no operation requires an atomic update across two
   of these stores."
-  (:require [re-frame.privacy :as privacy]))
+  (:require [re-frame.privacy :as rf.privacy]))
 
 ;; ---- configuration --------------------------------------------------------
 
@@ -693,7 +693,7 @@
         ;; swap fn ORs it into the rollup fail closed. The OR is
         ;; monotonic/idempotent (only flips false→true, never clears a
         ;; settle-time true), so it rides safely inside the CAS-retried swap.
-        trace-sensitive? (privacy/sensitive? trace-event)
+        trace-sensitive? (rf.privacy/sensitive? trace-event)
         structured-row?  (some? structured-row)
         append-slot-value (fn [record target-slot slot-value]
                             (cond

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -41,17 +41,17 @@
   fan-out steps together. Pure-data shape of the preconditions makes
   the orchestrators a four-line case-match."
   (:require [clojure.string :as str]
-            [re-frame.elision :as elision]
-            [re-frame.epoch.assembly :as assembly]
-            [re-frame.epoch.state :as state]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.classification :as classification]
-            [re-frame.projection :as projection]
-            [re-frame.registrar :as registrar]
-            [re-frame.router :as router]
-            [re-frame.trace :as trace]))
+            [re-frame.elision :as rf.elision]
+            [re-frame.epoch.assembly :as rf.epoch.assembly]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.classification :as rf.classification]
+            [re-frame.projection :as rf.projection]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.router :as rf.router]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- restore failure-mode predicates --------------------------------------
 
@@ -65,7 +65,7 @@
   Callers treat an unbound hook as a soft pass: without a validator they
   cannot disprove validity."
   []
-  (late-bind/get-fn :schemas/malli-validate))
+  (rf.late-bind/get-fn :schemas/malli-validate))
 
 (defn- registered-app-schemas
   "Return the {path → schema-meta} map registered against the named
@@ -74,7 +74,7 @@
   against the frame the epoch belongs to, not a process-global set."
   [frame-id]
   (if-let [schema-entries-for-frame
-           (late-bind/get-fn :schemas/frame-schema-entries)]
+           (rf.late-bind/get-fn :schemas/frame-schema-entries)]
     (schema-entries-for-frame frame-id)
     {}))
 
@@ -113,7 +113,7 @@
   Epoch restore validates against this public surface, not the unrelated
   internal `:head` registrar kind."
   [machine-id]
-  (let [registration (registrar/lookup :event machine-id)]
+  (let [registration (rf.registrar/lookup :event machine-id)]
     (when (:rf/machine? registration)
       registration)))
 
@@ -192,7 +192,7 @@
   `(empty? (failing-runtime-paths frame-id runtime-db))`."
   [frame-id runtime-db]
   (if-let [validate-machine-data!
-           (late-bind/get-fn :machines/validate-machine-data!)]
+           (rf.late-bind/get-fn :machines/validate-machine-data!)]
     (let [validation-result
           (try (validate-machine-data! runtime-db nil frame-id)
                (catch #?(:clj Throwable :cljs :default) _ true))]
@@ -229,7 +229,7 @@
   Returns a vector of {:kind <kind> :id <id>} entries. Empty when
   every reference resolves."
   [runtime-db]
-  (let [actor-resolvable? (late-bind/get-fn :machines/actor-resolvable?)
+  (let [actor-resolvable? (rf.late-bind/get-fn :machines/actor-resolvable?)
         ;; Machines under [:rf.runtime/machines :snapshots]: a singleton
         ;; references a registered machine (`:rf/machine? true`, per Spec
         ;; 005 §Registration); a spawned actor has no
@@ -245,7 +245,7 @@
         ;; Active route
         missing-route
         (when-let [route-id (get-in runtime-db route-current-id-path)]
-          (when-not (registrar/lookup :route route-id)
+          (when-not (rf.registrar/lookup :route route-id)
             [{:kind :route :id route-id}]))]
     (vec (concat missing-machines missing-route))))
 
@@ -278,7 +278,7 @@
       ;; No registered machine under the key: a spawned actor whose TYPE rides
       ;; the snapshot. Resolve the spec the dispatch-time way.
       (let [type-ref      (:rf/machine-type snapshot)
-            from-snapshot (late-bind/get-fn :machines/spec-from-snapshot)
+            from-snapshot (rf.late-bind/get-fn :machines/spec-from-snapshot)
             spec          (when from-snapshot (from-snapshot snapshot))]
         {:current (spec-snapshot-version spec)
          :type    type-ref}))))
@@ -325,7 +325,7 @@
 
 (defn emit-precondition-failure!
   [operation tags]
-  (trace/emit-error! operation
+  (rf.trace/emit-error! operation
                      (assoc tags :recovery :no-recovery)))
 
 (defn- drain-in-flight?
@@ -348,7 +348,7 @@
   time-travel write surface so the no-such-handler tag shape stays
   canonical."
   [frame-id]
-  (if-let [frame-record (frame/frame frame-id)]
+  (if-let [frame-record (rf.frame/frame frame-id)]
     {:outcome :ok :frame-record frame-record}
     {:outcome :fail
      :op      :rf.error/no-such-handler
@@ -406,7 +406,7 @@
                  :rf.epoch/id epoch-id}}
 
       :else
-      (let [history (state/history-for frame-id)
+      (let [history (rf.epoch.state/history-for frame-id)
             epoch-record (find-epoch-in history epoch-id)]
         (cond
           ;; Exact-owner gate on the history/validation snapshot (rf2-qfrh4
@@ -419,7 +419,7 @@
           ;; or validate against a stale incarnation. (Belt-and-braces with the
           ;; record-derived token above: even if a race slips past here the
           ;; ticket still carries A's token, so the exact write rejects B.)
-          (not (frame/event-continuation-live? frame-id incarnation-token))
+          (not (rf.frame/event-continuation-live? frame-id incarnation-token))
           {:outcome :fail
            :op      :rf.error/no-such-handler
            :tags    {:kind  :frame
@@ -457,9 +457,9 @@
                 ;; is malformed/unreachable on the current build path.
                 recorded-frame-state (:frame-state-after epoch-record)
                 recorded-app-db      (get recorded-frame-state
-                                          frame/app-partition-key)
+                                          rf.frame/app-partition-key)
                 recorded-runtime-db  (get recorded-frame-state
-                                          frame/runtime-partition-key)]
+                                          rf.frame/runtime-partition-key)]
             ;; Bind each probe once so each substrate is walked once.
             ;; failure path walks the recorded db / schema set / machine
             ;; map exactly once per check.
@@ -477,7 +477,7 @@
                :tags    {:frame                  frame-id
                          :rf.epoch/id            epoch-id
                          :schema-digest-recorded (:schema-digest epoch-record)
-                         :schema-digest-current  (assembly/current-schema-digest frame-id)
+                         :schema-digest-current  (rf.epoch.assembly/current-schema-digest frame-id)
                          :failing-paths          (vec failing-paths)}}
 
               (if-let [missing-reference-details
@@ -583,7 +583,7 @@
       {:outcome :fail :reason :rf.epoch/replay-during-drain :tags {}}
 
       :else
-      (let [history (state/history-for frame-id)
+      (let [history (rf.epoch.state/history-for frame-id)
             epoch   (find-epoch-in history epoch-id)
             cause   (when epoch (non-replayable-cause epoch))
             fn-ids  (when epoch (fn-override-fx-ids epoch))]
@@ -645,15 +645,15 @@
   and nothing mints."
   [frame-id record opts]
   (let [pre-replay-epoch-ids
-        (into #{} (map :epoch-id) (state/history-for frame-id))]
-    (router/dispatch-sync! (:trigger-event record)
+        (into #{} (map :epoch-id) (rf.epoch.state/history-for frame-id))]
+    (rf.router/dispatch-sync! (:trigger-event record)
                            (replay-dispatch-opts frame-id record opts))
     (let [new-record
           (some (fn [candidate-record]
                   (when-not (contains? pre-replay-epoch-ids
                                        (:epoch-id candidate-record))
                     candidate-record))
-                (state/history-for frame-id))]
+                (rf.epoch.state/history-for frame-id))]
       {:ok?             true
        :frame           frame-id
        :source-epoch-id (:epoch-id record)
@@ -733,10 +733,10 @@
   `drain-in-flight?` precondition and avoiding both self-deadlock and a
   non-linearizable mid-transition splice."
   [frame-id during-drain-op during-drain-tags op]
-  (if (frame/in-drain? frame-id)
+  (if (rf.frame/in-drain? frame-id)
     (do (emit-precondition-failure! during-drain-op during-drain-tags)
         false)
-    (frame/call-serialized-with-drain! frame-id op)))
+    (rf.frame/call-serialized-with-drain! frame-id op)))
 
 ;; ---- runtime-db subsystem reconcile on restore ----------------------------
 ;;
@@ -803,9 +803,9 @@
    (reconcile-runtime-db-on-restore frame-id frame-state restore-time-ms nil))
   ([frame-id frame-state restore-time-ms owner-token]
    (if-let [reconcile-runtime-db!
-            (late-bind/get-fn :resources/reconcile-on-restore)]
-     (if (contains? frame-state frame/runtime-partition-key)
-       (update frame-state frame/runtime-partition-key
+            (rf.late-bind/get-fn :resources/reconcile-on-restore)]
+     (if (contains? frame-state rf.frame/runtime-partition-key)
+       (update frame-state rf.frame/runtime-partition-key
                (fn [runtime-db]
                  (when (some? runtime-db)
                    (reconcile-runtime-db!
@@ -887,10 +887,10 @@
   ([frame-id incarnation-token]
    (let [still-owned? (fn []
                         (or (nil? incarnation-token)
-                            (frame/event-continuation-live? frame-id incarnation-token)))]
+                            (rf.frame/event-continuation-live? frame-id incarnation-token)))]
       (doseq [hook-key restore-quiesce-hooks
               :while   (still-owned?)]
-        (when-let [quiesce-hook (late-bind/get-fn hook-key)]
+        (when-let [quiesce-hook (rf.late-bind/get-fn hook-key)]
           (try (quiesce-hook frame-id)
                (catch #?(:clj Throwable :cljs :default) quiesce-error
                 ;; rf2-vy2hj: the SETTLED path needs the same fence as the
@@ -909,7 +909,7 @@
                 ;; incarnation is unaffected: it emits its one warning and the
                 ;; best-effort chain continues.
                 (when (still-owned?)
-                  (trace/emit-error! :rf.warning/restore-quiesce-hook-exception
+                  (rf.trace/emit-error! :rf.warning/restore-quiesce-hook-exception
                                       {:category  :rf.warning/restore-quiesce-hook-exception
                                        :hook      hook-key
                                        :frame     frame-id
@@ -938,8 +938,8 @@
   seated a same-id successor B."
   [frame-state frame-id incarnation-token]
   (when-let [commit-restore-reconcile!
-             (late-bind/get-fn :resources/commit-restore-reconcile!)]
-    (when-let [runtime-db (get frame-state frame/runtime-partition-key)]
+             (rf.late-bind/get-fn :resources/commit-restore-reconcile!)]
+    (when-let [runtime-db (get frame-state rf.frame/runtime-partition-key)]
       (commit-restore-reconcile! runtime-db frame-id
                                  {:owner-token incarnation-token})))
   nil)
@@ -1003,7 +1003,7 @@
     :rf.epoch/restore-during-drain
     {:frame frame-id :rf.epoch/id (:epoch-id epoch)}
     (fn []
-      (if-not (frame/event-continuation-live? frame-id incarnation-token)
+      (if-not (rf.frame/event-continuation-live? frame-id incarnation-token)
         ;; The incarnation these preconditions resolved against is no longer
         ;; live — a same-id SUCCESSOR was seated (or the frame was destroyed /
         ;; is being torn down) between validation and this write. Refuse BEFORE
@@ -1045,13 +1045,13 @@
               ;; non-nil changed-key-set (even empty) means it landed on the
               ;; exact incarnation.
               changed-keys
-              (frame/replace-frame-state! frame-id incarnation-token
+              (rf.frame/replace-frame-state! frame-id incarnation-token
                                           reconciled-frame-state)]
           (if (nil? changed-keys)
             (do (emit-precondition-failure! :rf.error/no-such-handler
                                             {:kind :frame :frame frame-id})
                 false)
-            (do (trace/emit! :rf.epoch :rf.epoch/restored
+            (do (rf.trace/emit! :rf.epoch :rf.epoch/restored
                              {:frame       frame-id
                               :rf.epoch/id (:epoch-id epoch)})
                 ;; The exact-incarnation install committed, so the public result
@@ -1068,15 +1068,15 @@
                 ;; remaining A-only tail work is STOPPED rather than RETARGETED
                 ;; onto B: no B anchor is stamped, no B resource trace committed,
                 ;; no B host handle released or aborted.
-                (when (frame/event-continuation-live? frame-id incarnation-token)
+                (when (rf.frame/event-continuation-live? frame-id incarnation-token)
                   ;; Restore triggers no ordinary event, so explicitly anchor its
                   ;; repaint/subscription/unmount back-fill to the restored epoch.
-                  (state/set-last-settled-epoch! frame-id (:epoch-id epoch)))
-                (when (frame/event-continuation-live? frame-id incarnation-token)
+                  (rf.epoch.state/set-last-settled-epoch! frame-id (:epoch-id epoch)))
+                (when (rf.frame/event-continuation-live? frame-id incarnation-token)
                   ;; Deferred subsystem success traces are valid only after install.
                   (commit-resources-restore-traces! reconciled-frame-state
                                                      frame-id incarnation-token))
-                (when (frame/event-continuation-live? frame-id incarnation-token)
+                (when (rf.frame/event-continuation-live? frame-id incarnation-token)
                   ;; Host timers and HTTP handles are not frame state; cancel the
                   ;; abandoned timeline only after the new state is installed.
                   (quiesce-orphaned-async-host-work! frame-id incarnation-token))
@@ -1092,7 +1092,7 @@
   "The two recognized `replace-frame-state!` partition keys — the closed
   key-vocabulary the bad-keys precondition (below) validates a caller's
   partial frame-state map against."
-  #{frame/app-partition-key frame/runtime-partition-key})
+  #{rf.frame/app-partition-key rf.frame/runtime-partition-key})
 
 (defn- replace-frame-state-bad-keys
   "Validate `frame-state`'s key set against the closed
@@ -1216,7 +1216,7 @@
         ;; (3) History disabled (depth 0)? The synthetic undo-anchor cannot
         ;; land in the (disabled) ring, so the undo-works-after invariant is
         ;; unsatisfiable, so reject rather than return a false success.
-        (not (pos? (state/depth)))
+        (not (pos? (rf.epoch.state/depth)))
         {:outcome :fail
          :op      :rf.epoch/replace-history-disabled
          :tags    {:frame frame-id}}
@@ -1226,13 +1226,13 @@
         ;; absent key is preserved, not written.
         (let [failing-paths
               (cond-> []
-                (contains? frame-state frame/app-partition-key)
+                (contains? frame-state rf.frame/app-partition-key)
                 (into (failing-schema-paths
-                        frame-id (get frame-state frame/app-partition-key)))
+                        frame-id (get frame-state rf.frame/app-partition-key)))
 
-                (contains? frame-state frame/runtime-partition-key)
+                (contains? frame-state rf.frame/runtime-partition-key)
                 (into (failing-runtime-paths
-                        frame-id (get frame-state frame/runtime-partition-key))))]
+                        frame-id (get frame-state rf.frame/runtime-partition-key))))]
           (cond
             ;; Exact-owner gate on the validation snapshot (rf2-gj2bo,
             ;; mirroring `check-restore-preconditions!`'s history gate). The
@@ -1245,7 +1245,7 @@
             ;; successor's schema verdict. (Belt-and-braces with the
             ;; record-derived token above: even if a race slips past here the
             ;; ticket still carries A's token, so the exact write rejects B.)
-            (not (frame/event-continuation-live? frame-id incarnation-token))
+            (not (rf.frame/event-continuation-live? frame-id incarnation-token))
             {:outcome :fail
              :op      :rf.error/no-such-handler
              :tags    {:kind  :frame
@@ -1294,10 +1294,10 @@
   the error attributed to the epoch helper)."
   [profile]
   (let [profile (or profile default-egress-profile)]
-    (when-not (contains? projection/profiles profile)
+    (when-not (contains? rf.projection/profiles profile)
       ;; Share the projection layer's closed-enum error builder so wording and
       ;; the machine-readable token cannot drift.
-      (throw (projection/unknown-egress-profile-ex 'epoch/projected-record profile)))
+      (throw (rf.projection/unknown-egress-profile-ex 'epoch/projected-record profile)))
     profile))
 
 (defn- egress-opts
@@ -1332,7 +1332,7 @@
   MUST NOT fabricate a value)."
   [payload frame-id opts]
   (when (some? payload)
-    (projection/project-egress payload (egress-opts frame-id opts))))
+    (rf.projection/project-egress payload (egress-opts frame-id opts))))
 
 (defn- project-frame-state-slot
   "Project a `:frame-state-before` / `:frame-state-after` slot for off-box
@@ -1365,7 +1365,7 @@
   (when (some? frame-state)
     (cond-> frame-state
       (contains? frame-state :rf.db/app)
-      (update :rf.db/app projection/project-egress (egress-opts frame-id opts))
+      (update :rf.db/app rf.projection/project-egress (egress-opts frame-id opts))
       ;; Default-redact runtime-db off-box. The
       ;; trusted-local `:include-runtime-db? true` opt-in lifts the
       ;; partition redaction; the value still rides the value walk so its
@@ -1374,7 +1374,7 @@
       (assoc :rf.db/runtime :rf/redacted)
 
       (and (contains? frame-state :rf.db/runtime) include-runtime-db?)
-      (update :rf.db/runtime projection/project-egress (egress-opts frame-id opts)))))
+      (update :rf.db/runtime rf.projection/project-egress (egress-opts frame-id opts)))))
 
 (defn- reroot-trace-event-db-slots
   "The `:rf.event/db-pending` (t1) and
@@ -1418,7 +1418,7 @@
                                (= operation :rf.event/db-pending-post-flow))
                            (some? (get-in trace-event [:tags :rf.event/db])))
                     (update-in trace-event [:tags :rf.event/db]
-                               projection/project-egress
+                               rf.projection/project-egress
                                wire-opts)
                     trace-event))))
             trace-events))))
@@ -1505,7 +1505,7 @@
            :rf.http/http-4xx       [[:body]]
            :rf.http/http-5xx       [[:body]]
            :rf.http/decode-failure [[:body-text]]}
-    interop/debug-enabled?
+    rf.interop/debug-enabled?
     (assoc :rf.http/retry-attempt [[:failure :body] [:failure :body-text]])))
 
 (defn- omit-off-box-http-bodies
@@ -1624,7 +1624,7 @@
   (if (or include-sensitive? (not (sequential? trace-events)))
     trace-events
     (if-let [project-scope-resolved-tags
-             (late-bind/get-fn :resources/project-scope-resolved-egress)]
+             (rf.late-bind/get-fn :resources/project-scope-resolved-egress)]
       (mapv (fn [trace-event]
               (if (and (map? trace-event)
                        (= :rf.resource/scope-resolved
@@ -1689,7 +1689,7 @@
   (if (or include-sensitive? (not (sequential? trace-events)))
     trace-events
     (if-let [project-resource-trace-tags
-             (late-bind/get-fn :resources/project-resource-trace-egress)]
+             (rf.late-bind/get-fn :resources/project-resource-trace-egress)]
       (mapv (fn [trace-event]
               (if (and (map? trace-event)
                        (resource-family-op? (:operation trace-event))
@@ -1737,7 +1737,7 @@
   (if (or include-sensitive? (not (sequential? trace-events)))
     trace-events
     (if-let [project-fx-arg-tags
-             (late-bind/get-fn :resources/project-fx-args-egress)]
+             (rf.late-bind/get-fn :resources/project-fx-args-egress)]
       (mapv (fn [trace-event]
               (if (and (map? trace-event) (map? (:tags trace-event)))
                 (update trace-event :tags project-fx-arg-tags
@@ -1800,9 +1800,9 @@
   (let [mark-slot-value
         (fn [slot-key]
           (fn [slot-value]
-            (if (elision/marker? slot-value)
+            (if (rf.elision/marker? slot-value)
               slot-value
-              (classification/large-marker slot-value [slot-key]))))]
+              (rf.classification/large-marker slot-value [slot-key]))))]
     (cond
       (not (:large? slot-map)) slot-map
       include-large?            (dissoc slot-map :large?)
@@ -1889,7 +1889,7 @@
         ;; `project-egress` has no sub-specific arm, so ordering is otherwise
         ;; immaterial.
         (elide-large-sub-trace-values opts)
-        (projection/project-egress (egress-opts frame-id opts)))))
+        (rf.projection/project-egress (egress-opts frame-id opts)))))
 
 (defn- elide-sub-run-row
   "Project a structured `:sub-runs` row. Its `:prev-value` / `:value`
@@ -2068,7 +2068,7 @@
              (contains? record :effects)
              (update :effects elide-effects-slot opts))]
        ;; Apply the advanced override only to the projected copy.
-       (assembly/apply-redact-fn built-in-projected-record)))))
+       (rf.epoch.assembly/apply-redact-fn built-in-projected-record)))))
 
 (defn projected-history
   "INTERNAL — the public contract lives on
@@ -2077,4 +2077,4 @@
   the 1-arity is the fully-redacted off-box path."
   ([frame-id] (projected-history frame-id nil))
   ([frame-id opts]
-   (mapv #(projected-record % opts) (state/history-for frame-id))))
+   (mapv #(projected-record % opts) (rf.epoch.state/history-for frame-id))))

--- a/implementation/epoch/test/re_frame/actor_revertibility_restore_test.clj
+++ b/implementation/epoch/test/re_frame/actor_revertibility_restore_test.clj
@@ -11,11 +11,11 @@
   state cannot mask a non-revertible actor lifecycle."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
+            [re-frame.registrar :as rf.registrar]
             [re-frame.elision]
-            [re-frame.epoch :as epoch]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; Side-effect require — loads the machines late-bind hooks
             ;; (`:machines/reg-machine`, `:machines/resolve-actor-handler-meta`,
             ;; `:machines/actor-resolvable?`) and the `:rf.machine/spawn` /
@@ -29,11 +29,11 @@
 ;; my tests use the `:rf.machine/spawn` fx, which `clear-all!` would drop.
 ;; Clear the epoch ring/listeners before each test via the :init-fn.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn []
-                (epoch/clear-history!)
-                (epoch/clear-epoch-listeners!))}))
+                (rf.epoch/clear-history!)
+                (rf.epoch/clear-epoch-listeners!))}))
 
 (defn- snapshot [machine-id]
   ;; EP-0001 (rf2-vzld77 / rf2-3aizt1): machine snapshots are runtime-db
@@ -89,7 +89,7 @@
       ;; Spawn the actor.
       (rf/dispatch-sync [:rev/parent [:go]] {:frame :test/main})
       (is (some? (snapshot :rev/child#1)) "actor alive after spawn")
-      (is (nil? (registrar/lookup :event :rev/child#1))
+      (is (nil? (rf.registrar/lookup :event :rev/child#1))
           "spawned actor never registered a per-instance handler")
       ;; Rewind PAST the spawn.
       (let [ok? (rf/restore-epoch! :test/main pre-spawn-epoch)]
@@ -97,7 +97,7 @@
         (is (nil? (snapshot :rev/child#1))
             "rewind-past-spawn: the actor's snapshot is gone")
         ;; Restore preserves the original child id.
-        (is (nil? (registrar/lookup :event :rev/child#1))
+        (is (nil? (rf.registrar/lookup :event :rev/child#1))
             "{:handler-survived-restore? false} — NO orphaned handler
              survives the revert")
         ;; Dispatch to the gone actor → clean no-such-handler.
@@ -162,7 +162,7 @@
       (is (some? (snapshot :rev/child#1)))
       ;; Unregister the TYPE so the recorded snapshot's :rf/machine-type
       ;; no longer resolves.
-      (registrar/unregister! :event :rev/child)
+      (rf.registrar/unregister! :event :rev/child)
       (let [errs (record-trace!)
             pre  (rf/app-db-value :test/main)
             ok?  (rf/restore-epoch! :test/main alive-epoch)]
@@ -319,7 +319,7 @@
     (rf/dispatch-sync [:rev/parent [:go]] {:frame :test/main})
     (let [alive-epoch (last-epoch-id)]
       (is (some? (snapshot :rev/child#1)))
-      (registrar/unregister! :event :rev/child)   ;; clear the TYPE
+      (rf.registrar/unregister! :event :rev/child)   ;; clear the TYPE
       (let [errs (record-trace!)
             ok?  (rf/restore-epoch! :test/main alive-epoch)]
         (rf/unregister-listener! :trace ::rec)

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -63,16 +63,16 @@
   de-duped; a genuine re-render never collapses back to the mount epoch."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             ;; `trace` + `state` are used in test BODIES (`trace/emit!`,
             ;; `trace/frame-trace-disabled?`, the `state/buffer-*!` /
             ;; `state/*-mount-attribution!` private-helper exercises) —
             ;; NOT for fixture config reset.
-            [re-frame.trace :as trace]
+            [re-frame.trace :as rf.trace]
             [re-frame.elision]
-            [re-frame.epoch :as epoch]
-            [re-frame.epoch.state :as state]
-            [re-frame.test-support :as test-support]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.machines]))
 
 ;; ---- fixture ---------------------------------------------------------------
@@ -94,11 +94,11 @@
 ;;     and NOT a reset-hook-table row; inv-7 registers a trace-disabled
 ;;     observer frame, so clear the set between tests.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn []
                 (rf/configure! {:epoch-history {:trace-events-keep 5}})
-                (trace/clear-frame-no-emit!))}))
+                (rf.trace/clear-frame-no-emit!))}))
 
 ;; ---- shared post-settle-emit fixture --------------------------------------
 ;;
@@ -117,7 +117,7 @@
   render-key) or a full render-key tuple."
   [frame-id view-or-rk]
   (let [render-key (if (vector? view-or-rk) view-or-rk [view-or-rk 0])]
-    (trace/emit! :rf.view :rf.view/rendered
+    (rf.trace/emit! :rf.view :rf.view/rendered
                  {:rf.view/render-key render-key
                   :frame      frame-id})))
 
@@ -132,7 +132,7 @@
   [frame-id view-or-rk]
   (let [render-key (if (vector? view-or-rk) view-or-rk [view-or-rk 0])
         view-id    (first render-key)]
-    (trace/emit! :rf.view :rf.view/unmounted
+    (rf.trace/emit! :rf.view :rf.view/unmounted
                  {:rf.view/id         view-id
                   :rf.view/render-key render-key
                   :frame              frame-id})))
@@ -147,7 +147,7 @@
   ([frame-id sub-id prev-value value]
    (emit-sub-run! frame-id sub-id prev-value value nil))
   ([frame-id sub-id prev-value value cause-sub]
-   (trace/emit! :rf.sub :rf.sub/run
+   (rf.trace/emit! :rf.sub :rf.sub/run
                 {:rf.sub/id         sub-id
                  :rf.sub/query-v        [sub-id]
                  :frame          frame-id
@@ -164,7 +164,7 @@
   which subs the view reads). The first recompute always reports
   value-changed? true."
   [frame-id sub-id reader-rk prev-value value]
-  (trace/emit! :rf.sub :rf.sub/run
+  (rf.trace/emit! :rf.sub :rf.sub/run
                {:rf.sub/id            sub-id
                 :rf.sub/query-v           [sub-id]
                 :frame             frame-id
@@ -267,7 +267,7 @@
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event :sub-during
       (fn [{:keys [db]} _]
-        (trace/emit! :rf.sub :rf.sub/run
+        (rf.trace/emit! :rf.sub :rf.sub/run
                      {:rf.sub/id :inline-sub :rf.sub/query-v [:inline-sub]
                       :frame :test/main :rf.sub/value-changed? true
                       :rf.sub/prev-value nil :rf.sub/value :computed
@@ -325,7 +325,7 @@
   render-key) so the runtime back-fills it into the most-recently-settled
   epoch (rf2-wi900 path)."
   [frame-id sub-id prev-value value]
-  (trace/emit! :rf.sub :rf.sub/run
+  (rf.trace/emit! :rf.sub :rf.sub/run
                {:rf.sub/id             sub-id
                 :rf.sub/query-v        [sub-id]
                 :frame                 frame-id
@@ -441,7 +441,7 @@
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event :render-during
       (fn [{:keys [db]} _]
-        (trace/emit! :rf.view :rf.view/rendered
+        (rf.trace/emit! :rf.view :rf.view/rendered
                      {:rf.view/render-key [:inline-view 0] :frame :test/main})
         {:db (update db :n inc)}))
 
@@ -905,10 +905,10 @@
                      :tags {:rf.trace/phase :run-start :rf.trace/dispatch-id 42 :rf.trace/event-id :inc}}
           body      {:op-type :rf.event :operation :rf.event/db-changed
                      :tags {:rf.trace/dispatch-id 42}}]
-      (state/buffer-event! frame orphan)
-      (state/buffer-event! frame run-start)
-      (state/buffer-event! frame body)
-      (let [harvested (state/harvest-buffer-for-event! frame)]
+      (rf.epoch.state/buffer-event! frame orphan)
+      (rf.epoch.state/buffer-event! frame run-start)
+      (rf.epoch.state/buffer-event! frame body)
+      (let [harvested (rf.epoch.state/harvest-buffer-for-event! frame)]
         (is (= [run-start body] harvested)
             "harvest returns ONLY the settling event's (:rf.trace/dispatch-id 42)
              traces — the orphan is left uncorrelated, not vacuumed in")
@@ -916,7 +916,7 @@
             "the orphan :rf.frame/created is not in the settling epoch's harvest")
         ;; The orphan is DISCARDED (self-cleaning harvest), not retained —
         ;; it has no settle event to ever reclaim it.
-        (is (empty? (state/buffer-for frame))
+        (is (empty? (rf.epoch.state/buffer-for frame))
             "the orphan is dropped from the buffer — the harvest is
              self-cleaning, not reliant on the upstream guard")))))
 
@@ -939,19 +939,19 @@
           child-mark {:op-type :rf.event :operation :rf.event/dispatched
                       :tags {:rf.trace/dispatch-id 2 :rf.trace/event-id :child}}
           orphan     {:op-type :rf.frame :operation :rf.frame/created :tags {}}]
-      (state/buffer-event! frame run-start)
-      (state/buffer-event! frame body)
-      (state/buffer-event! frame child-mark)
-      (state/buffer-event! frame orphan)
-      (let [harvested (state/harvest-buffer-for-event! frame)
-            retained  (state/buffer-for frame)]
+      (rf.epoch.state/buffer-event! frame run-start)
+      (rf.epoch.state/buffer-event! frame body)
+      (rf.epoch.state/buffer-event! frame child-mark)
+      (rf.epoch.state/buffer-event! frame orphan)
+      (let [harvested (rf.epoch.state/harvest-buffer-for-event! frame)
+            retained  (rf.epoch.state/buffer-for frame)]
         (is (= [run-start body] harvested)
             "the parent's harvest takes only its own (dispatch-id 1) traces")
         ;; The child marker (dispatch-id 2) is RETAINED VERBATIM; orphan DROPPED.
         (is (= [child-mark] retained)
             "exactly the child's marker stays buffered, bare (no private stamp);
              the nil-id orphan is dropped")
-        (state/drop-frame-buffer! frame)))))
+        (rf.epoch.state/drop-frame-buffer! frame)))))
 
 (deftest inv-6c-harvest-retains-child-marker-across-sibling-settles
   (testing "rf2-bhglx — a child's `:event/dispatched` marker (fired during the
@@ -980,30 +980,30 @@
           body  (fn [id]     {:op-type :rf.event :operation :rf.event/db-changed
                               :tags {:rf.trace/dispatch-id id}})]
       ;; The child marker is stranded into the buffer alongside the FIRST sibling.
-      (state/buffer-event! frame child-mark)
+      (rf.epoch.state/buffer-event! frame child-mark)
       (doseq [[id eid] [[7 :sib-1] [8 :sib-2] [9 :sib-3]]]
-        (state/buffer-event! frame (rs id eid))
-        (state/buffer-event! frame (body id))
-        (let [h (state/harvest-buffer-for-event! frame)]
+        (rf.epoch.state/buffer-event! frame (rs id eid))
+        (rf.epoch.state/buffer-event! frame (body id))
+        (let [h (rf.epoch.state/harvest-buffer-for-event! frame)]
           (is (= [(rs id eid) (body id)] h)
               (str "sibling " eid " harvests ONLY its own traces"))
           (is (not-any? #(= 99 (-> % :tags :rf.trace/dispatch-id)) h)
               "the child marker is never folded into a sibling's epoch")
-          (is (= [child-mark] (state/buffer-for frame))
+          (is (= [child-mark] (rf.epoch.state/buffer-for frame))
               "rf2-bhglx — the child marker survives this sibling settle, kept
                VERBATIM for the child's own settle")))
       ;; Finally the child itself settles — its run-start claims the marker.
-      (state/buffer-event! frame (rs 99 :child))
-      (state/buffer-event! frame (body 99))
-      (let [child-harvest (state/harvest-buffer-for-event! frame)]
+      (rf.epoch.state/buffer-event! frame (rs 99 :child))
+      (rf.epoch.state/buffer-event! frame (body 99))
+      (let [child-harvest (rf.epoch.state/harvest-buffer-for-event! frame)]
         (is (= [child-mark (rs 99 :child) (body 99)] child-harvest)
             "the child's settle finally claims its dispatch marker + own traces —
              the queue-time dispatch/source row survives the FIFO interleaving")
         (is (= 1 (->> child-harvest first :tags :rf.trace/parent-dispatch-id))
             "the claimed marker still carries its parent-dispatch-id (causality)")
-        (is (empty? (state/buffer-for frame))
+        (is (empty? (rf.epoch.state/buffer-for frame))
             "buffer empty after the child settle"))
-      (state/drop-frame-buffer! frame))))
+      (rf.epoch.state/drop-frame-buffer! frame))))
 
 (deftest inv-6c-bound-stranded-marker-cleared-by-terminal-path
   (testing "rf2-bhglx — a child that NEVER runs to a settle (handler
@@ -1018,22 +1018,22 @@
           stranded {:op-type :rf.event :operation :rf.event/dispatched
                     :tags {:rf.trace/dispatch-id 99 :rf.trace/event-id :child-never-ran}}]
       ;; (a) drain-interrupt / frame-destroy terminal clear.
-      (state/buffer-event! frame stranded)
-      (is (= [stranded] (state/buffer-for frame))
+      (rf.epoch.state/buffer-event! frame stranded)
+      (is (= [stranded] (rf.epoch.state/buffer-for frame))
           "the stranded marker is buffered")
-      (state/drop-frame-buffer! frame)
-      (is (empty? (state/buffer-for frame))
+      (rf.epoch.state/drop-frame-buffer! frame)
+      (is (empty? (rf.epoch.state/buffer-for frame))
           "drop-frame-buffer! (destroy / discard) clears the stranded marker")
 
       ;; (b) rejected-dispatch terminal clear: a buffer with NO run-start (the
       ;; child's dispatch was rejected) reaches the no-run-start branch, which
       ;; clears-and-returns the whole buffer.
-      (state/buffer-event! frame stranded)
-      (let [returned (state/harvest-buffer-for-event! frame)]
+      (rf.epoch.state/buffer-event! frame stranded)
+      (let [returned (rf.epoch.state/harvest-buffer-for-event! frame)]
         (is (= [stranded] returned)
             "a no-run-start harvest returns the buffer (the degenerate record is
              suppressed downstream by settle!'s empty-buffer policy)")
-        (is (empty? (state/buffer-for frame))
+        (is (empty? (rf.epoch.state/buffer-for frame))
             "and clears it — the stranded marker does not accrete")))))
 
 (deftest inv-6c-bead-sibling-queued-behind-parent-does-not-drop-child
@@ -1067,35 +1067,35 @@
           c-body   {:op-type :rf.event :operation :rf.event/db-changed
                     :tags {:rf.trace/dispatch-id :C}}]
       ;; A settles, stranding C's marker in the buffer.
-      (state/buffer-event! frame a-rs)
-      (state/buffer-event! frame a-body)
-      (state/buffer-event! frame c-mark)
-      (let [a-harvest (state/harvest-buffer-for-event! frame)]
+      (rf.epoch.state/buffer-event! frame a-rs)
+      (rf.epoch.state/buffer-event! frame a-body)
+      (rf.epoch.state/buffer-event! frame c-mark)
+      (let [a-harvest (rf.epoch.state/harvest-buffer-for-event! frame)]
         (is (= [a-rs a-body] a-harvest) "A's epoch carries A's traces only")
         (is (not-any? #(= :C (-> % :tags :rf.trace/dispatch-id)) a-harvest)
             "A does NOT carry C's dispatch marker"))
 
       ;; B settles next (it was queued ahead of FIFO-tail C). B must leave C's
       ;; marker alone — this is the exact harvest the count-1 reclaim broke.
-      (state/buffer-event! frame b-rs)
-      (state/buffer-event! frame b-body)
-      (let [b-harvest (state/harvest-buffer-for-event! frame)]
+      (rf.epoch.state/buffer-event! frame b-rs)
+      (rf.epoch.state/buffer-event! frame b-body)
+      (let [b-harvest (rf.epoch.state/harvest-buffer-for-event! frame)]
         (is (= [b-rs b-body] b-harvest) "B's epoch carries B's traces only")
         (is (not-any? #(= :C (-> % :tags :rf.trace/dispatch-id)) b-harvest)
             "B does NOT carry C's dispatch marker")
-        (is (= [c-mark] (state/buffer-for frame))
+        (is (= [c-mark] (rf.epoch.state/buffer-for frame))
             "rf2-bhglx — C's marker SURVIVES B's intervening settle (not dropped
              by a harvest-count reclaim)"))
 
       ;; C finally settles — claims its own marker (+ queue-time dispatch row).
-      (state/buffer-event! frame c-rs)
-      (state/buffer-event! frame c-body)
-      (let [c-harvest (state/harvest-buffer-for-event! frame)]
+      (rf.epoch.state/buffer-event! frame c-rs)
+      (rf.epoch.state/buffer-event! frame c-body)
+      (let [c-harvest (rf.epoch.state/harvest-buffer-for-event! frame)]
         (is (= [c-mark c-rs c-body] c-harvest)
             "C's epoch finally claims its :event/dispatched marker + own traces")
         (is (= :A (-> c-harvest first :tags :rf.trace/parent-dispatch-id))
             "C's claimed marker still names parent A (parent-child causality kept)"))
-      (state/drop-frame-buffer! frame))))
+      (rf.epoch.state/drop-frame-buffer! frame))))
 
 ;; ---------------------------------------------------------------------------
 ;; inv-6d — a frame-LIFECYCLE emit for a SIBLING frame, fired while frame A's
@@ -1131,10 +1131,10 @@
 
     (rf/dispatch-sync [:app/reopen] {:frame :test/main})
 
-    (is (not-any? #(= :rf.frame (:op-type %)) (state/buffer-for :test/modal))
+    (is (not-any? #(= :rf.frame (:op-type %)) (rf.epoch.state/buffer-for :test/modal))
         "no frame-lifecycle marker is stranded in the sibling frame's buffer")
     (is (not-any? #(= :rf.frame/re-registered (:operation %))
-                  (state/buffer-for :test/modal))
+                  (rf.epoch.state/buffer-for :test/modal))
         "specifically, the cross-frame :rf.frame/re-registered marker is absent")))
 
 (deftest inv-6d-nested-re-registration-strand-not-swept-into-later-halt-record
@@ -1206,10 +1206,10 @@
       ;; for `:rf/xray`); make-frame routes the flag to the trace gate.
       (rf/make-frame {:id app})
       (rf/make-frame {:id observer :rf.trace/frame-no-emit? true})
-      (is (trace/frame-trace-disabled? observer)
+      (is (rf.trace/frame-trace-disabled? observer)
           "the observer frame is registered trace-disabled (make-frame honoured
            :rf.trace/frame-no-emit?)")
-      (is (not (trace/frame-trace-disabled? app))
+      (is (not (rf.trace/frame-trace-disabled? app))
           "the inspected app frame is NOT trace-disabled")
 
       (rf/reg-event :app/seed (fn [{:keys [db]} _] {:db {:counter 0}}))
@@ -1285,7 +1285,7 @@
 
     ;; Post-settle :rf.view/rendered carrying cause + timing (React-commit
     ;; timing — empty buffer, back-filled to the seed epoch).
-    (trace/emit! :rf.view :rf.view/rendered
+    (rf.trace/emit! :rf.view :rf.view/rendered
                  {:rf.view/render-key   [:counter-view 0]
                   :frame                :test/main
                   :rf.view/mount?       false
@@ -1310,7 +1310,7 @@
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
-    (trace/emit! :rf.view :rf.view/rendered
+    (rf.trace/emit! :rf.view :rf.view/rendered
                  {:rf.view/render-key [:structural-view 0]
                   :frame              :test/main
                   :rf.view/mount?     false
@@ -1348,7 +1348,7 @@
 
     ;; Post-settle :rf.view/rendered carrying the cause attribution (mirrors
     ;; the reactive re-render emit at views.cljs:320-321).
-    (trace/emit! :rf.view :rf.view/rendered
+    (rf.trace/emit! :rf.view :rf.view/rendered
                  {:rf.view/render-key     [:counter-view 0]
                   :frame                  :test/main
                   :rf.view/mount?         false
@@ -1370,7 +1370,7 @@
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/main})
 
-    (trace/emit! :rf.view :rf.view/rendered
+    (rf.trace/emit! :rf.view :rf.view/rendered
                  {:rf.view/render-key [:structural-view 0]
                   :frame              :test/main
                   :rf.view/mount?     false})
@@ -1395,33 +1395,33 @@
           render-key [:my-view 0]]
       ;; Seed the read-set FIRST — the in-render deref typically fires
       ;; before the post-settle render commit.
-      (state/record-render-deps! frame render-key :sub/a)
-      (state/record-render-deps! frame render-key :sub/b)
-      (is (= #{:sub/a :sub/b} (state/render-deps-for frame render-key))
+      (rf.epoch.state/record-render-deps! frame render-key :sub/a)
+      (rf.epoch.state/record-render-deps! frame render-key :sub/b)
+      (is (= #{:sub/a :sub/b} (rf.epoch.state/render-deps-for frame render-key))
           "both deps recorded on the entry's :deps slot")
-      (is (nil? (state/mount-epoch-for frame render-key))
+      (is (nil? (rf.epoch.state/mount-epoch-for frame render-key))
           "mount-epoch slot is still empty — record-render-deps! did not touch it")
 
       ;; Now record the mount-epoch — populates the sibling :epoch-id slot
       ;; on the same entry without clobbering the deps set.
-      (state/record-mount-epoch! frame render-key :epoch/one)
-      (is (= :epoch/one (state/mount-epoch-for frame render-key))
+      (rf.epoch.state/record-mount-epoch! frame render-key :epoch/one)
+      (is (= :epoch/one (rf.epoch.state/mount-epoch-for frame render-key))
           "mount-epoch landed on the entry's :epoch-id slot")
-      (is (= #{:sub/a :sub/b} (state/render-deps-for frame render-key))
+      (is (= #{:sub/a :sub/b} (rf.epoch.state/render-deps-for frame render-key))
           "deps slot survived the mount-epoch write — single entry, two slots")
 
       ;; First-sighting invariant survives the merge: a second
       ;; record-mount-epoch! must NOT overwrite the anchor.
-      (state/record-mount-epoch! frame render-key :epoch/ninety-nine)
-      (is (= :epoch/one (state/mount-epoch-for frame render-key))
+      (rf.epoch.state/record-mount-epoch! frame render-key :epoch/ninety-nine)
+      (is (= :epoch/one (rf.epoch.state/mount-epoch-for frame render-key))
           "re-recording a mount epoch does not move the anchor (first-sighting)")
 
       ;; Single-wipe contract: one `drop-frame-mount-attribution!` clears
       ;; BOTH slots; the bead's "four wipers → two" lift.
-      (state/drop-frame-mount-attribution! frame)
-      (is (nil? (state/mount-epoch-for frame render-key))
+      (rf.epoch.state/drop-frame-mount-attribution! frame)
+      (is (nil? (rf.epoch.state/mount-epoch-for frame render-key))
           "mount-epoch cleared by drop-frame-mount-attribution!")
-      (is (nil? (state/render-deps-for frame render-key))
+      (is (nil? (rf.epoch.state/render-deps-for frame render-key))
           "deps cleared by the same wipe — one swap clears both slots"))))
 
 (deftest mount-attribution-frame-scoping
@@ -1429,22 +1429,22 @@
             dropping one frame's entry does not affect a sibling frame's
             anchor or read-set."
     (let [render-key [:shared-view 0]]
-      (state/record-mount-epoch!  :test/dq2b7-a render-key :epoch/a-1)
-      (state/record-render-deps!  :test/dq2b7-a render-key :sub/a)
-      (state/record-mount-epoch!  :test/dq2b7-b render-key :epoch/b-1)
-      (state/record-render-deps!  :test/dq2b7-b render-key :sub/b)
+      (rf.epoch.state/record-mount-epoch!  :test/dq2b7-a render-key :epoch/a-1)
+      (rf.epoch.state/record-render-deps!  :test/dq2b7-a render-key :sub/a)
+      (rf.epoch.state/record-mount-epoch!  :test/dq2b7-b render-key :epoch/b-1)
+      (rf.epoch.state/record-render-deps!  :test/dq2b7-b render-key :sub/b)
 
       ;; Drop only frame A.
-      (state/drop-frame-mount-attribution! :test/dq2b7-a)
-      (is (nil? (state/mount-epoch-for :test/dq2b7-a render-key)))
-      (is (nil? (state/render-deps-for :test/dq2b7-a render-key)))
+      (rf.epoch.state/drop-frame-mount-attribution! :test/dq2b7-a)
+      (is (nil? (rf.epoch.state/mount-epoch-for :test/dq2b7-a render-key)))
+      (is (nil? (rf.epoch.state/render-deps-for :test/dq2b7-a render-key)))
       ;; Frame B survives intact.
-      (is (= :epoch/b-1 (state/mount-epoch-for :test/dq2b7-b render-key)))
-      (is (= #{:sub/b}  (state/render-deps-for :test/dq2b7-b render-key)))
+      (is (= :epoch/b-1 (rf.epoch.state/mount-epoch-for :test/dq2b7-b render-key)))
+      (is (= #{:sub/b}  (rf.epoch.state/render-deps-for :test/dq2b7-b render-key)))
 
       ;; reset-mount-attribution! wipes everything left.
-      (state/reset-mount-attribution!)
-      (is (nil? (state/mount-epoch-for :test/dq2b7-b render-key))))))
+      (rf.epoch.state/reset-mount-attribution!)
+      (is (nil? (rf.epoch.state/mount-epoch-for :test/dq2b7-b render-key))))))
 
 ;; ===========================================================================
 ;; rf2-bgapd — mount-attribution is bounded across instance churn: a view
@@ -1472,26 +1472,26 @@
     (let [frame :test/bgapd
           rk-a  [:row-view 100]
           rk-b  [:row-view 101]]
-      (state/record-mount-epoch! frame rk-a :epoch/a)
-      (state/record-render-deps! frame rk-a :sub/a)
-      (state/record-mount-epoch! frame rk-b :epoch/b)
-      (state/record-render-deps! frame rk-b :sub/b)
+      (rf.epoch.state/record-mount-epoch! frame rk-a :epoch/a)
+      (rf.epoch.state/record-render-deps! frame rk-a :sub/a)
+      (rf.epoch.state/record-mount-epoch! frame rk-b :epoch/b)
+      (rf.epoch.state/record-render-deps! frame rk-b :sub/b)
 
-      (state/drop-render-key-mount-attribution! frame rk-a)
-      (is (nil? (state/mount-epoch-for frame rk-a))
+      (rf.epoch.state/drop-render-key-mount-attribution! frame rk-a)
+      (is (nil? (rf.epoch.state/mount-epoch-for frame rk-a))
           "instance A's anchor evicted")
-      (is (nil? (state/render-deps-for frame rk-a))
+      (is (nil? (rf.epoch.state/render-deps-for frame rk-a))
           "instance A's read-set evicted")
-      (is (= :epoch/b (state/mount-epoch-for frame rk-b))
+      (is (= :epoch/b (rf.epoch.state/mount-epoch-for frame rk-b))
           "sibling instance B's anchor survives — eviction is per-render-key")
-      (is (= #{:sub/b} (state/render-deps-for frame rk-b))
+      (is (= #{:sub/b} (rf.epoch.state/render-deps-for frame rk-b))
           "sibling instance B's read-set survives")
 
       ;; Idempotent: dropping an already-absent / never-seen render-key is a
       ;; no-op, never a throw (a late tail / double-unmount must be harmless).
-      (state/drop-render-key-mount-attribution! frame rk-a)
-      (state/drop-render-key-mount-attribution! frame [:never-mounted 0])
-      (is (= :epoch/b (state/mount-epoch-for frame rk-b))
+      (rf.epoch.state/drop-render-key-mount-attribution! frame rk-a)
+      (rf.epoch.state/drop-render-key-mount-attribution! frame [:never-mounted 0])
+      (is (= :epoch/b (rf.epoch.state/mount-epoch-for frame rk-b))
           "idempotent prune left the surviving entry intact"))))
 
 (deftest unmount-prunes-mount-attribution-bounded-across-churn
@@ -1522,9 +1522,9 @@
 
       ;; Every instance now carries a mount-attribution entry.
       (doseq [rk render-keys]
-        (is (some? (state/mount-epoch-for :test/main rk))
+        (is (some? (rf.epoch.state/mount-epoch-for :test/main rk))
             (str "instance " rk " has a mount anchor before unmount"))
-        (is (some? (state/render-deps-for :test/main rk))
+        (is (some? (rf.epoch.state/render-deps-for :test/main rk))
             (str "instance " rk " has a learned read-set before unmount")))
 
       ;; The cascade that removes all rows settles; then (React-teardown
@@ -1537,9 +1537,9 @@
       ;; mount-attribution is BOUNDED across churn — pruned per-instance on
       ;; unmount, not held until frame-destroy.
       (doseq [rk render-keys]
-        (is (nil? (state/mount-epoch-for :test/main rk))
+        (is (nil? (rf.epoch.state/mount-epoch-for :test/main rk))
             (str "instance " rk "'s anchor pruned on unmount — not retained"))
-        (is (nil? (state/render-deps-for :test/main rk))
+        (is (nil? (rf.epoch.state/render-deps-for :test/main rk))
             (str "instance " rk "'s read-set pruned on unmount — not retained")))
 
       ;; And the unmount is STILL observable in its causing cascade's
@@ -1662,7 +1662,7 @@
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event :unmount-during
       (fn [{:keys [db]} _]
-        (trace/emit! :rf.view :rf.view/unmounted
+        (rf.trace/emit! :rf.view :rf.view/unmounted
                      {:rf.view/id         :inline-view
                       :rf.view/render-key [:inline-view 0]
                       :frame              :test/main})
@@ -1736,7 +1736,7 @@
         ;; frame's current last-settled (the anchor a naive back-fill would use).
         (is (not= (:epoch-id target-epoch) (:epoch-id stale-epoch))
             "the restore target and the pre-restore last-settled are distinct")
-        (is (= (:epoch-id stale-epoch) (state/last-settled-epoch-id :test/main))
+        (is (= (:epoch-id stale-epoch) (rf.epoch.state/last-settled-epoch-id :test/main))
             "before the restore, the most-recent counter-inc is last-settled")
 
         ;; Rewind the frame to the OLDER target epoch (counter 1).
@@ -1832,7 +1832,7 @@
     (rf/dispatch-sync [:counter-inc] {:frame :test/main})
     (let [live-epoch (last-epoch :test/main)]
 
-      (is (= (:epoch-id live-epoch) (state/last-settled-epoch-id :test/main))
+      (is (= (:epoch-id live-epoch) (rf.epoch.state/last-settled-epoch-id :test/main))
           "the most-recent cascade is last-settled before the failed restore")
 
       ;; A restore to an epoch that is NOT in history fails (no-op).
@@ -1840,7 +1840,7 @@
           "restore to an unknown epoch fails")
 
       ;; THE INVARIANT — the anchor is untouched.
-      (is (= (:epoch-id live-epoch) (state/last-settled-epoch-id :test/main))
+      (is (= (:epoch-id live-epoch) (rf.epoch.state/last-settled-epoch-id :test/main))
           "rf2-w4q9gt — a failed restore left the last-settled anchor unchanged")
 
       ;; A subsequent post-settle render still attributes to the genuine
@@ -1905,8 +1905,8 @@
           ;; PREMISE — the trap is armed: stale is last-settled, the read-set is
           ;; learned, and the stale epoch genuinely carries value-change evidence
           ;; for the view (so an unbounded scan WOULD return it).
-          (is (= (:epoch-id stale-epoch) (state/last-settled-epoch-id :test/main)))
-          (is (contains? (state/render-deps-for :test/main render-key) :counter)
+          (is (= (:epoch-id stale-epoch) (rf.epoch.state/last-settled-epoch-id :test/main)))
+          (is (contains? (rf.epoch.state/render-deps-for :test/main render-key) :counter)
               "the view's read-set is learned — the deps-match arm can fire")
           (is (contains? (sub-run-ids (epoch-by-id :test/main stale-epoch)) :counter)
               "the STALE newer epoch carries the value-change evidence the scan
@@ -2051,7 +2051,7 @@
         ;; Back-fill the target by id. The index is derived inside the swap, so
         ;; eviction cannot redirect the row to a positional neighbour.
         (let [{:keys [event row]} (bf-sub-event :test/main :late-sub 99)]
-          (state/back-fill-sub-run! :test/main target-id event row))
+          (rf.epoch.state/back-fill-sub-run! :test/main target-id event row))
 
         (let [t          (epoch-by-id :test/main target)
               wrong       (epoch-by-id :test/main {:epoch-id (:epoch-id (nth history-after 1))})]
@@ -2088,7 +2088,7 @@
           "the target epoch is no longer in the ring (evicted)")
 
       (let [{:keys [event row]} (bf-sub-event :test/main :ghost-sub 7)
-            result (state/back-fill-sub-run! :test/main target-id event row)]
+            result (rf.epoch.state/back-fill-sub-run! :test/main target-id event row)]
         (is (nil? result)
             "back-fill of an evicted target returns nil (no record to splice)")
         ;; No surviving record received the ghost row.

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -40,28 +40,28 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
-            [re-frame.trace.tooling :as trace-tooling]
-            [re-frame.epoch :as epoch]
-            [re-frame.epoch.listeners :as epoch.listeners]
-            [re-frame.epoch.state :as state]
+            [re-frame.trace.tooling :as rf.trace.tooling]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.epoch.listeners :as rf.epoch.listeners]
+            [re-frame.epoch.state :as rf.epoch.state]
             ;; rf2-gj2bo — the CLJS same-id-successor injection pin interposes
             ;; its churn on the real precondition check via with-redefs.
-            [re-frame.epoch.tool-pair :as tool-pair]
+            [re-frame.epoch.tool-pair :as rf.epoch.tool-pair]
             ;; rf2-vxgfnd.265 — the reentrant claim-before-delivery fixture reads
             ;; the successor incarnation's token to model its pre-first-epoch claim.
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
             ;; rf2-vxgfnd.245 — the reentrant CLJS fail-before fixture wraps the
             ;; `:epoch/on-frame-destroyed` late-bind hook to install + settle a
             ;; same-id successor synchronously inside A's terminal publish.
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             ;; rf2-lo28u — schemas + the Malli adapter so a `:schema`-bearing
             ;; reg-event's `:where :event` violation actually fires (without
             ;; the adapter the default validator soft-passes).
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; The `:node-test` build has no DOM and no Reagent reactive context —
 ;; the plain-atom adapter is the right substrate for epoch coverage
@@ -78,8 +78,8 @@
 ;; :depth) through the public `configure!` boundary — no test ns reaches
 ;; into the private `state/config` var for fixture reset.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
 ;; ---- 1. Recording — happy-path record shape -------------------------------
@@ -208,7 +208,7 @@
           restore-r  (atom ::unset)
           replace-r  (atom ::unset)
           ops        (atom #{})]
-      (trace-tooling/register-listener! ::rec
+      (rf.trace.tooling/register-listener! ::rec
                                         (fn [ev] (swap! ops conj (:operation ev))))
       (rf/reg-event :n/try-writes
         (fn [{:keys [db]} _]
@@ -218,7 +218,7 @@
       ;; If either reentrant call deadlocked re-taking the lock, this
       ;; dispatch-sync would never return.
       (rf/dispatch-sync [:n/try-writes])
-      (trace-tooling/unregister-listener! ::rec)
+      (rf.trace.tooling/unregister-listener! ::rec)
 
       (is (false? @restore-r) "reentrant restore-epoch! returned false")
       (is (false? @replace-r) "reentrant replace-frame-state! returned false")
@@ -251,14 +251,14 @@
     (rf/make-frame {:id :gj2bo/succ})
     (rf/reg-event :gj2bo/set-owner (fn [_ [_ o]] {:db {:owner o}}))
     (rf/dispatch-sync [:gj2bo/set-owner :A] {:frame :gj2bo/succ})
-    (let [real-check tool-pair/check-replace-frame-state-preconditions!
-          a-token    (frame/frame-incarnation-token :gj2bo/succ)
+    (let [real-check rf.epoch.tool-pair/check-replace-frame-state-preconditions!
+          a-token    (rf.frame/frame-incarnation-token :gj2bo/succ)
           checked    (atom nil)
           b-baseline (atom nil)
           ops        (atom #{})]
-      (trace-tooling/register-listener! ::gj2bo-rec
+      (rf.trace.tooling/register-listener! ::gj2bo-rec
                                         (fn [ev] (swap! ops conj (:operation ev))))
-      (with-redefs [tool-pair/check-replace-frame-state-preconditions!
+      (with-redefs [rf.epoch.tool-pair/check-replace-frame-state-preconditions!
                     (fn [frame-id new-frame-state]
                       (let [r (real-check frame-id new-frame-state)]
                         (reset! checked r)
@@ -272,12 +272,12 @@
                                  :history     (rf/epoch-history frame-id)})
                         r))]
         (let [result (rf/replace-frame-state! :gj2bo/succ {:rf.db/app {:owner :STALE-A}})]
-          (trace-tooling/unregister-listener! ::gj2bo-rec)
+          (rf.trace.tooling/unregister-listener! ::gj2bo-rec)
           (is (= :ok (:outcome @checked))
               "the REAL precondition check passed against live incarnation A")
           (is (identical? a-token (:incarnation-token @checked))
               "the :ok ticket carries A's exact record-derived token")
-          (is (not (identical? a-token (frame/frame-incarnation-token :gj2bo/succ)))
+          (is (not (identical? a-token (rf.frame/frame-incarnation-token :gj2bo/succ)))
               "successor B is a fresh incarnation (A/B tokens distinct)")
           (is (false? result) "the stale cross-incarnation injection is REJECTED")
           (is (= {:owner :B} (rf/app-db-value :gj2bo/succ))
@@ -360,7 +360,7 @@
     (let [cb-seen    (atom [])
           trace-seen (atom [])]
       (rf/register-listener! :epoch ::watcher (fn [r] (swap! cb-seen conj r)))
-      (trace-tooling/register-listener! ::recorder
+      (rf.trace.tooling/register-listener! ::recorder
                              (fn [ev]
                                (when (= :rf.epoch/snapshotted (:operation ev))
                                  (swap! trace-seen conj ev))))
@@ -370,7 +370,7 @@
       (rf/dispatch-sync [:n/inc])
 
       (rf/unregister-listener! :epoch ::watcher)
-      (trace-tooling/unregister-listener! ::recorder)
+      (rf.trace.tooling/unregister-listener! ::recorder)
 
       (is (= 3 (count @cb-seen))
           "register-epoch-listener! fired once per dispatch")
@@ -402,7 +402,7 @@
             the grep test would be vacuous (it asserts ABSENCE of
             strings that only enter the bundle when the gate is
             ON in the control build)."
-    (is (true? interop/debug-enabled?)
+    (is (true? rf.interop/debug-enabled?)
         "the dev gate reads true under :node-test — surface is live")
     ;; The surface's actual liveness — recording, listener fan-out, the
     ;; ring buffer, restore-epoch!'s happy / failure paths — is locked
@@ -448,34 +448,34 @@
           c-body   {:op-type :rf.event :operation :rf.event/db-changed
                     :tags {:rf.trace/dispatch-id 99}}]
       ;; Parent (id 7) settles, stranding C's marker; then sibling (id 8) settles.
-      (state/buffer-event! frame c-mark)
-      (state/buffer-event! frame rs-1)
-      (state/buffer-event! frame body-1)
-      (let [h1 (state/harvest-buffer-for-event! frame)]
+      (rf.epoch.state/buffer-event! frame c-mark)
+      (rf.epoch.state/buffer-event! frame rs-1)
+      (rf.epoch.state/buffer-event! frame body-1)
+      (let [h1 (rf.epoch.state/harvest-buffer-for-event! frame)]
         (is (= [rs-1 body-1] h1) "parent harvests ONLY its own traces")
-        (is (= [c-mark] (state/buffer-for frame))
+        (is (= [c-mark] (rf.epoch.state/buffer-for frame))
             "C's marker survives the parent harvest, verbatim"))
-      (state/buffer-event! frame rs-2)
-      (state/buffer-event! frame body-2)
-      (let [h2 (state/harvest-buffer-for-event! frame)]
+      (rf.epoch.state/buffer-event! frame rs-2)
+      (rf.epoch.state/buffer-event! frame body-2)
+      (let [h2 (rf.epoch.state/harvest-buffer-for-event! frame)]
         (is (= [rs-2 body-2] h2) "the sibling harvests ONLY its own traces")
         (is (not-any? #(= 99 (-> % :tags :rf.trace/dispatch-id)) h2)
             "C's marker is never folded into the sibling's epoch")
-        (is (= [c-mark] (state/buffer-for frame))
+        (is (= [c-mark] (rf.epoch.state/buffer-for frame))
             "rf2-bhglx — C's marker SURVIVES the intervening sibling settle"))
       ;; C finally settles, claiming its own marker.
-      (state/buffer-event! frame c-rs)
-      (state/buffer-event! frame c-body)
-      (let [hc (state/harvest-buffer-for-event! frame)]
+      (rf.epoch.state/buffer-event! frame c-rs)
+      (rf.epoch.state/buffer-event! frame c-body)
+      (let [hc (rf.epoch.state/harvest-buffer-for-event! frame)]
         (is (= [c-mark c-rs c-body] hc)
             "C's settle claims its dispatch marker + own traces")
         (is (= 7 (-> hc first :tags :rf.trace/parent-dispatch-id))
             "the claimed marker still names its parent (causality kept)")
-        (is (empty? (state/buffer-for frame)) "buffer empty after C settles"))
+        (is (empty? (rf.epoch.state/buffer-for frame)) "buffer empty after C settles"))
       ;; A truly-stranded marker is bounded by the terminal buffer clear.
-      (state/buffer-event! frame c-mark)
-      (state/drop-frame-buffer! frame)
-      (is (empty? (state/buffer-for frame))
+      (rf.epoch.state/buffer-event! frame c-mark)
+      (rf.epoch.state/drop-frame-buffer! frame)
+      (is (empty? (rf.epoch.state/buffer-for frame))
           "rf2-bhglx — drop-frame-buffer! (terminal path) clears a stranded marker"))))
 
 ;; ---- 7. Same-id listener replacement generation semantics (rf2-j538f7.5) ---
@@ -497,39 +497,39 @@
     (rf/make-frame {:id :j538/main})
     (rf/make-frame {:id :j538/other})
     (let [silences (atom [])]
-      (trace-tooling/register-listener! ::rec
+      (rf.trace.tooling/register-listener! ::rec
         (fn [ev]
           (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
             (swap! silences conj (:tags ev)))))
       ;; Gen 1 registered; capture its token (a stale fan-out snapshot).
       (rf/register-listener! :epoch ::probe (fn [_] nil))
-      (let [gen1 (:generation (get (state/listeners-snapshot) ::probe))]
+      (let [gen1 (:generation (get (rf.epoch.state/listeners-snapshot) ::probe))]
         ;; Gen 1 observes :j538/main.
-        (epoch.listeners/notify-listeners! {:frame :j538/main :epoch-id 1})
-        (is (= [::probe] (state/cbs-observing-frame :j538/main))
+        (rf.epoch.listeners/notify-listeners! {:frame :j538/main :epoch-id 1})
+        (is (= [::probe] (rf.epoch.state/cbs-observing-frame :j538/main))
             "gen 1 is the live observer of :j538/main")
         ;; Same-id replacement → gen 2.
         (rf/register-listener! :epoch ::probe (fn [_] nil))
-        (let [gen2 (:generation (get (state/listeners-snapshot) ::probe))]
+        (let [gen2 (:generation (get (rf.epoch.state/listeners-snapshot) ::probe))]
           (is (not= gen1 gen2) "replacement minted a fresh generation")
           ;; A stale gen-1 fan-out cannot arm the new registration.
-          (state/record-observation! ::probe gen1 :j538/other)
-          (is (not (contains? (get (state/observations-snapshot) ::probe) :j538/other))
+          (rf.epoch.state/record-observation! ::probe gen1 :j538/other)
+          (is (not (contains? (get (rf.epoch.state/observations-snapshot) ::probe) :j538/other))
               "stale old-generation observation refused")
           ;; The gen-1 stamp on :j538/main is no longer live.
-          (is (empty? (state/cbs-observing-frame :j538/main))
+          (is (empty? (rf.epoch.state/cbs-observing-frame :j538/main))
               "the retired generation's :j538/main observation is not live")
           ;; Gen 2 observes :j538/main — survives, stamped under gen 2.
-          (epoch.listeners/notify-listeners! {:frame :j538/main :epoch-id 2})
-          (is (= gen2 (get-in (state/observations-snapshot) [::probe :j538/main]))
+          (rf.epoch.listeners/notify-listeners! {:frame :j538/main :epoch-id 2})
+          (is (= gen2 (get-in (rf.epoch.state/observations-snapshot) [::probe :j538/main]))
               "the new generation re-stamped :j538/main and its observation survives")
-          (is (= [::probe] (state/cbs-observing-frame :j538/main))
+          (is (= [::probe] (rf.epoch.state/cbs-observing-frame :j538/main))
               "gen 2 is the live observer of :j538/main")
           ;; Destroy silences the live generation exactly once.
           (rf/destroy-frame! :j538/main)
           (is (= 1 (count (filter #(= :j538/main (:frame %)) @silences)))
               "exactly one silencing trace for the live generation")))
-      (trace-tooling/unregister-listener! ::rec)
+      (rf.trace.tooling/unregister-listener! ::rec)
       (rf/unregister-listener! :epoch ::probe))))
 
 ;; ---- 8. rf2-vxgfnd.245 — honest delayed silencing after same-id rearm ------
@@ -548,7 +548,7 @@
           received   (atom [])
           silencings (atom [])
           armed?     (atom true)
-          original   (late-bind/get-fn :epoch/on-frame-destroyed)]
+          original   (rf.late-bind/get-fn :epoch/on-frame-destroyed)]
       (rf/reg-event :rf2-245/seed     (fn [{:keys [db]} _] {:db {:n 0}}))
       (rf/reg-event :rf2-245/b-settle (fn [{:keys [db]} _] {:db {:owner :b}}))
       (rf/make-frame {:id id})
@@ -560,7 +560,7 @@
           (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
             (swap! silencings conj ev))))
       (try
-        (late-bind/set-fn! :epoch/on-frame-destroyed
+        (rf.late-bind/set-fn! :epoch/on-frame-destroyed
           (fn [& args]
             ;; On A's FIRST post-dissoc hook, re-entrantly install same-id B and
             ;; settle it: B claims the id-keyed stores and re-arms cb with B's
@@ -585,7 +585,7 @@
         (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
             "exactly one truthful silencing for cb — fired by B's own destroy")
         (finally
-          (late-bind/set-fn! :epoch/on-frame-destroyed original)
+          (rf.late-bind/set-fn! :epoch/on-frame-destroyed original)
           (rf/unregister-listener! :epoch cb)
           (rf/unregister-listener! :trace ::rf2-245-cljs-silencing))))))
 
@@ -603,7 +603,7 @@
           cb         ::rf2-265-claim-cb
           silencings (atom [])
           armed?     (atom true)
-          original   (late-bind/get-fn :epoch/on-frame-destroyed)]
+          original   (rf.late-bind/get-fn :epoch/on-frame-destroyed)]
       (rf/reg-event :rf2-265-claim/seed (fn [{:keys [db]} _] {:db {:n 0}}))
       (rf/make-frame {:id id})
       (rf/register-listener! :epoch cb (fn [_] nil))
@@ -614,23 +614,23 @@
           (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
             (swap! silencings conj ev))))
       (try
-        (late-bind/set-fn! :epoch/on-frame-destroyed
+        (rf.late-bind/set-fn! :epoch/on-frame-destroyed
           (fn [& args]
             (when (and (= id (first args)) (compare-and-set! armed? true false))
               ;; Same-id B claims the id-keyed stores WITHOUT settling — no B
               ;; record reaches cb, so cb never observes B.
               (rf/make-frame {:id id})
-              (state/claim-frame-owner! id (frame/frame-incarnation-token id)))
+              (rf.epoch.state/claim-frame-owner! id (rf.frame/frame-incarnation-token id)))
             (when original (apply original args))))
         (rf/destroy-frame! id)
         ;; THE FIX: cb never observed B, so A owes and emits exactly one silence.
         (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
             "A emits its one owed silence for cb — B claimed but never delivered")
         (finally
-          (late-bind/set-fn! :epoch/on-frame-destroyed original)
+          (rf.late-bind/set-fn! :epoch/on-frame-destroyed original)
           (rf/unregister-listener! :epoch cb)
           (rf/unregister-listener! :trace ::rf2-265-claim-silencing)
-          (when (frame/frame id) (rf/destroy-frame! id)))))))
+          (when (rf.frame/frame id) (rf/destroy-frame! id)))))))
 
 (deftest late-predecessor-does-not-re-emit-silence-a-retired-successor-fired-cljs
   (testing "rf2-vxgfnd.265 (synchronous CLJS, red before fix) — a same-id
@@ -652,20 +652,20 @@
             (swap! silencings conj ev))))
       (try
         ;; A claims + cb observes A.
-        (state/claim-frame-owner! id token-a)
-        (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+        (rf.epoch.state/claim-frame-owner! id token-a)
+        (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
         ;; A snapshots its owed identities + terminal-silence baseline BEFORE the
         ;; successor acts (a same-id B is constructable only after dissoc).
-        (let [a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+        (let [a-ev (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
           ;; B re-arms cb, then RETIRES — its terminal hook fires cb's one silence.
-          (state/claim-frame-owner! id token-b)
-          (epoch.listeners/notify-listeners! {:frame id :epoch-id 2})
-          (epoch.listeners/on-frame-destroyed! id token-b
-            (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
+          (rf.epoch.state/claim-frame-owner! id token-b)
+          (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 2})
+          (rf.epoch.listeners/on-frame-destroyed! id token-b
+            (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
           (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
               "B's retire fired exactly one truthful silence for cb")
           ;; A resumes with its stale snapshot — must add NO silence.
-          (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+          (rf.epoch.listeners/on-frame-destroyed! id token-a a-ev)
           (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
               "late A adds no silence — the retired successor already fired the one signal"))
         (finally
@@ -677,7 +677,7 @@
 (defn- vxgfnd285-total-marks
   "Count of `[frame cb]` terminal-silence marks currently retained."
   []
-  (reduce + 0 (map count (vals (state/terminal-silence-marks-snapshot)))))
+  (reduce + 0 (map count (vals (rf.epoch.state/terminal-silence-marks-snapshot)))))
 
 (deftest vxgfnd285-trace-listener-rearming-later-identity-mid-fan-rechecked-cljs
   (testing "rf2-vxgfnd.285 (reentrant CLJS, red before fix) — LINEARIZABLE. The
@@ -697,21 +697,21 @@
       (rf/register-listener! :epoch trigger (fn [_] nil))
       (rf/register-listener! :epoch target (fn [_] nil))
       (try
-        (state/claim-frame-owner! id token-a)
-        (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
-        (let [target-gen (:generation (get (state/listeners-snapshot) target))
-              a-ev       (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+        (rf.epoch.state/claim-frame-owner! id token-a)
+        (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+        (let [target-gen (:generation (get (rf.epoch.state/listeners-snapshot) target))
+              a-ev       (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
           ;; Live successor B claims (dropping every observation); neither identity
           ;; is a live observer at fan start.
-          (state/claim-frame-owner! id token-b)
+          (rf.epoch.state/claim-frame-owner! id token-b)
           (rf/register-listener! :trace ::rf2-285-rearm-silencing
             (fn [ev]
               (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
                 (swap! silencings conj ev)
                 (when (= trigger (:cb-id (:tags ev)))
                   ;; Re-arm z-target on B mid-fan, before it is reached.
-                  (state/record-observation! target target-gen id)))))
-          (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+                  (rf.epoch.state/record-observation! target target-gen id)))))
+          (rf.epoch.listeners/on-frame-destroyed! id token-a a-ev)
           (is (= 1 (silences-for trigger)) "a-trigger — A-only — is silenced first")
           (is (zero? (silences-for target))
               "z-target — re-armed live mid-fan — is rechecked and skipped"))
@@ -733,10 +733,10 @@
         (dotimes [i n]
           (let [id    (keyword "rf2-285-bounded" (str i))
                 token #js {}]
-            (state/claim-frame-owner! id token)
-            (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
-            (epoch.listeners/on-frame-destroyed! id token
-              (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
+            (rf.epoch.state/claim-frame-owner! id token)
+            (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+            (rf.epoch.listeners/on-frame-destroyed! id token
+              (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
             (is (<= (vxgfnd285-total-marks) 1)
                 "at most one frame's marks are ever retained at once")))
         (is (zero? (vxgfnd285-total-marks))
@@ -752,11 +752,11 @@
           cb ::rf2-285-reset-cb]
       (rf/register-listener! :epoch cb (fn [_] nil))
       ;; cb is owed (never a live observer of id), so the claim reserves a mark.
-      (state/open-silence-lineage! id)
-      (state/claim-and-publish-delayed-silence!
-        id cb (:generation (get (state/listeners-snapshot) cb)) 0 (fn [] nil))
+      (rf.epoch.state/open-silence-lineage! id)
+      (rf.epoch.state/claim-and-publish-delayed-silence!
+        id cb (:generation (get (rf.epoch.state/listeners-snapshot) cb)) 0 (fn [] nil))
       (is (pos? (vxgfnd285-total-marks)) "a terminal-silence mark is present")
-      (state/reset-listeners!)
+      (rf.epoch.state/reset-listeners!)
       (is (zero? (vxgfnd285-total-marks))
           "reset-listeners! clears the terminal-silence lineage, not just the registry"))))
 
@@ -868,7 +868,7 @@
           render-key    ::rf2-oh1y8-nil-evidence-view
           records       (atom [])
           traces        (atom [])
-          original-snap (late-bind/get-fn :epoch/snapshot-frame-destroyed)]
+          original-snap (rf.late-bind/get-fn :epoch/snapshot-frame-destroyed)]
       (rf/make-frame {:id id})
       (rf/reg-event :rf2-oh1y8/seed (fn [_ _] {:db {:audit/seed :from-A}}))
       ;; cb OBSERVES A: fanning the settled record stamps its observation, so a
@@ -882,24 +882,24 @@
         ;; The cascade seeds history + last-settled + cb's observation. Seed the two
         ;; the synchronous cascade cannot: the harvested-empty capture buffer and
         ;; the render mount-attribution (no React commit).
-        (state/buffer-event! id {:operation :rf.event/run-start
+        (rf.epoch.state/buffer-event! id {:operation :rf.event/run-start
                                  :tags {:rf.trace/dispatch-id ::seed-dispatch}})
-        (state/record-mount-epoch! id render-key a-epoch-id)
-        (state/record-render-deps! id render-key ::a-sub)
+        (rf.epoch.state/record-mount-epoch! id render-key a-epoch-id)
+        (rf.epoch.state/record-render-deps! id render-key ::a-sub)
 
         ;; PRE-DESTROY: all five exact-owner stores hold A's state.
-        (is (contains? (set (state/cbs-observing-frame id)) cb)
+        (is (contains? (set (rf.epoch.state/cbs-observing-frame id)) cb)
             "observation stamp seeded — cb observed A")
-        (is (= 1 (count (state/history-for id)))
+        (is (= 1 (count (rf.epoch.state/history-for id)))
             "history seeded — A settled one epoch")
-        (is (seq (state/buffer-for id))
+        (is (seq (rf.epoch.state/buffer-for id))
             "capture buffer seeded")
-        (is (some? (state/last-settled-epoch-id id))
+        (is (some? (rf.epoch.state/last-settled-epoch-id id))
             "last-settled epoch seeded")
-        (is (some? (state/mount-epoch-for id render-key))
+        (is (some? (rf.epoch.state/mount-epoch-for id render-key))
             "mount attribution seeded")
         (try
-          (late-bind/set-fn! :epoch/snapshot-frame-destroyed
+          (rf.late-bind/set-fn! :epoch/snapshot-frame-destroyed
             (fn [& args]
               (if (= id (first args))
                 (throw (ex-info "snapshot blew" {:why :test}))
@@ -907,21 +907,21 @@
           (rf/destroy-frame! id)
 
           ;; (1) All five id-keyed stores are dropped despite the nil bundle.
-          (is (empty? (state/cbs-observing-frame id))
+          (is (empty? (rf.epoch.state/cbs-observing-frame id))
               "observation stamps dropped (drop-frame-observation!)")
-          (is (= [] (state/history-for id))
+          (is (= [] (rf.epoch.state/history-for id))
               "history dropped (drop-frame-history!)")
-          (is (empty? (state/buffer-for id))
+          (is (empty? (rf.epoch.state/buffer-for id))
               "capture buffer dropped (drop-frame-buffer!)")
-          (is (nil? (state/last-settled-epoch-id id))
+          (is (nil? (rf.epoch.state/last-settled-epoch-id id))
               "last-settled epoch dropped (drop-last-settled-epoch!)")
-          (is (nil? (state/mount-epoch-for id render-key))
+          (is (nil? (rf.epoch.state/mount-epoch-for id render-key))
               "mount attribution dropped (drop-frame-mount-attribution!)")
-          (is (nil? (state/render-deps-for id render-key))
+          (is (nil? (rf.epoch.state/render-deps-for id render-key))
               "mount attribution read-set dropped with the frame's entry")
           (is (= [] (rf/epoch-history id))
               "public epoch-history is [] even though the snapshot threw")
-          (is (nil? (frame/frame-incarnation-token id))
+          (is (nil? (rf.frame/frame-incarnation-token id))
               "A is fully destroyed — no live incarnation owns the id")
 
           ;; (2) #5939 NON-FABRICATION: the nil bundle publishes/opens nothing.
@@ -932,11 +932,11 @@
                               @traces))
               "no silencing fires — the nil bundle owed none")
           (is (zero? (reduce + 0 (map count
-                                      (vals (state/terminal-silence-marks-snapshot)))))
+                                      (vals (rf.epoch.state/terminal-silence-marks-snapshot)))))
               "a nil bundle opens no deferred-silence window — no mark accreted")
           (finally
-            (late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)
-            (when (frame/frame id) (rf/destroy-frame! id))
+            (rf.late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)
+            (when (rf.frame/frame id) (rf/destroy-frame! id))
             (rf/unregister-listener! :epoch cb)
             (rf/unregister-listener! :trace ::rf2-oh1y8-nil-evidence-trace)))))))
 
@@ -957,46 +957,46 @@
       (try
         ;; A claims + cb observes A (the state a live incarnation holds before its
         ;; nil-evidence destroy is deferred past a same-id successor).
-        (state/claim-frame-owner! id token-a)
-        (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+        (rf.epoch.state/claim-frame-owner! id token-a)
+        (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
         ;; Same-id B claims the id-keyed stores (dropping A's), then seeds ALL FIVE
         ;; of its own.
-        (state/claim-frame-owner! id token-b)
-        (epoch.listeners/notify-listeners! b-record)   ; cb re-observes under B
-        (state/record! b-record)                       ; history
-        (state/set-last-settled-epoch! id 2)           ; last-settled
-        (state/buffer-event! id {:operation :rf.event/run-start
+        (rf.epoch.state/claim-frame-owner! id token-b)
+        (rf.epoch.listeners/notify-listeners! b-record)   ; cb re-observes under B
+        (rf.epoch.state/record! b-record)                       ; history
+        (rf.epoch.state/set-last-settled-epoch! id 2)           ; last-settled
+        (rf.epoch.state/buffer-event! id {:operation :rf.event/run-start
                                  :tags {:rf.trace/dispatch-id ::b-dispatch}}) ; buffer
-        (state/record-mount-epoch! id render-key 2)    ; mount attribution
-        (state/record-render-deps! id render-key ::b-sub)
+        (rf.epoch.state/record-mount-epoch! id render-key 2)    ; mount attribution
+        (rf.epoch.state/record-render-deps! id render-key ::b-sub)
 
         ;; PRE-RESUME: B's five stores are populated.
-        (is (contains? (set (state/cbs-observing-frame id)) cb))
-        (is (= [b-record] (state/history-for id)))
-        (is (seq (state/buffer-for id)))
-        (is (= 2 (state/last-settled-epoch-id id)))
-        (is (= 2 (state/mount-epoch-for id render-key)))
+        (is (contains? (set (rf.epoch.state/cbs-observing-frame id)) cb))
+        (is (= [b-record] (rf.epoch.state/history-for id)))
+        (is (seq (rf.epoch.state/buffer-for id)))
+        (is (= 2 (rf.epoch.state/last-settled-epoch-id id)))
+        (is (= 2 (rf.epoch.state/mount-epoch-for id render-key)))
 
         ;; Stale A resumes with NIL evidence: cleanup loses the comparison to B.
-        (epoch.listeners/on-frame-destroyed! id token-a nil)
+        (rf.epoch.listeners/on-frame-destroyed! id token-a nil)
 
         ;; B's FIVE stores are byte-identical — A's stale cleanup no-op'd.
-        (is (contains? (set (state/cbs-observing-frame id)) cb)
+        (is (contains? (set (rf.epoch.state/cbs-observing-frame id)) cb)
             "B's observation survives A's stale nil-evidence cleanup")
-        (is (= [b-record] (state/history-for id))
+        (is (= [b-record] (rf.epoch.state/history-for id))
             "B's history survives")
-        (is (seq (state/buffer-for id))
+        (is (seq (rf.epoch.state/buffer-for id))
             "B's capture buffer survives")
-        (is (= 2 (state/last-settled-epoch-id id))
+        (is (= 2 (rf.epoch.state/last-settled-epoch-id id))
             "B's last-settled anchor survives")
-        (is (= 2 (state/mount-epoch-for id render-key))
+        (is (= 2 (rf.epoch.state/mount-epoch-for id render-key))
             "B's mount attribution survives")
-        (is (= #{::b-sub} (state/render-deps-for id render-key))
+        (is (= #{::b-sub} (rf.epoch.state/render-deps-for id render-key))
             "B's mount read-set survives")
         (finally
           ;; B tears itself down (token-b owns → cleanup runs) and releases the
           ;; owner ledger, then unregister cb.
-          (epoch.listeners/on-frame-destroyed! id token-b nil)
+          (rf.epoch.listeners/on-frame-destroyed! id token-b nil)
           (rf/unregister-listener! :epoch cb))))))
 
 ;; ---- rf2-4go8s — a NON-KEYWORD comparable listener id round-trips -----------
@@ -1022,7 +1022,7 @@
         (rf/register-listener! :epoch cb-id (fn [_] nil))
         ;; Observe the frame under the live generation, then destroy it.
         (rf/dispatch-sync [:seed-nonkw] {:frame :test/non-kw-cljs})
-        (let [g-observed (get-in (state/listeners-snapshot) [cb-id :generation])]
+        (let [g-observed (get-in (rf.epoch.state/listeners-snapshot) [cb-id :generation])]
           (is (some? g-observed)
               "the non-keyword id minted a generation on registration")
           (rf/destroy-frame! :test/non-kw-cljs)

--- a/implementation/epoch/test/re_frame/epoch_committed_at_clock_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_committed_at_clock_cljs_test.cljs
@@ -9,12 +9,12 @@
   independently of rendering."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; Sanity floor: a wall-clock epoch ms is far above any plausible
 ;; `performance.now()` origin-relative value. `js/Date.now()` is ~1.78e12 as
@@ -79,9 +79,9 @@
             that the two clock surfaces ARE distinguishable here — so the
             band test above genuinely catches a swap (it would be vacuous if
             both clocks read the same class, as on the JVM)."
-    (is (> (interop/epoch-now-ms) wall-clock-floor)
+    (is (> (rf.interop/epoch-now-ms) wall-clock-floor)
         "epoch-now-ms is a wall-clock epoch ms on CLJS (js/Date.now)")
-    (is (< (interop/now-ms) wall-clock-floor)
+    (is (< (rf.interop/now-ms) wall-clock-floor)
         "now-ms is an origin-relative perf time on CLJS (performance.now),
          below the wall-clock floor — distinct CLASS from epoch-now-ms, so a
          swap is observable on this runtime (JVM-benign)")))

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -97,19 +97,19 @@
   5-7 minutes."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.epoch :as epoch]
+            [re-frame.epoch :as rf.epoch]
             ;; `state` is used in test BODIES for the private back-fill
             ;; path (`state/back-fill-sub-run!`) + the private listeners
             ;; var (`@#'state/listeners`) the concurrency invariants
             ;; exercise directly — NOT for fixture config reset (that now
             ;; flows through `configure!`).
-            [re-frame.epoch.state :as state]
+            [re-frame.epoch.state :as rf.epoch.state]
             ;; `tool-pair` is `with-redefs`'d in Scenario 6 to open the
             ;; validate-then-write TOCTOU window deterministically (the
             ;; barriered precondition check).
-            [re-frame.epoch.tool-pair :as tool-pair]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.epoch.tool-pair :as rf.epoch.tool-pair]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; rf2-v6z0: machines is a separate artefact whose late-bind
             ;; hook publishes `rf/reg-machine` only when loaded. Pulled in
             ;; for symmetry across the suite so the captured ns-load
@@ -127,8 +127,8 @@
 ;; public `configure!` boundary — no test ns reaches into the private
 ;; `state/config` var for fixture reset.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
 ;; ---- stress dials ---------------------------------------------------------
@@ -347,7 +347,7 @@
         (dotimes [i n-churners]
           (rf/unregister-listener! :epoch (keyword "rd7a7.fanout"
                                         (str "churner-" i))))
-        (let [live (deref @#'state/listeners)
+        (let [live (deref @#'rf.epoch.state/listeners)
               churner-keys (filter (fn [k]
                                      (and (keyword? k)
                                           (= "rd7a7.fanout"
@@ -588,7 +588,7 @@
                                 ;; stores the RAW delta — no redact arg
                                 ;; (redaction is projection-side, in
                                 ;; `projected-record`).
-                                (state/back-fill-sub-run!
+                                (rf.epoch.state/back-fill-sub-run!
                                   frame-id epoch-id
                                   (sub-run-event frame-id sid i)
                                   {:sub-id sid :value i})))
@@ -698,7 +698,7 @@
                                   ;; embed the target-id as the row's :value so a
                                   ;; mis-splice is detectable; back-fill returns
                                   ;; nil when the target evicted before the splice.
-                                  result (state/back-fill-sub-run!
+                                  result (rf.epoch.state/back-fill-sub-run!
                                            :qh13yf.race/main target-id
                                            (bf-event target-id)
                                            {:sub-id :race-sub :value target-id})]
@@ -782,7 +782,7 @@
           barrier        (atom nil) ;; {:passed promise :release latch :armed? atom}
           cur-hread      (atom nil) ;; per-iter promise: handler published db
           cur-hrelease   (atom nil) ;; per-iter latch: release the blocked handler
-          orig-check     tool-pair/check-restore-preconditions!]
+          orig-check     rf.epoch.tool-pair/check-restore-preconditions!]
       (rf/make-frame {:id frame-id :doc "restore linearizability stress frame"})
       (rf/reg-event :set (fn [{:keys [db]} [_ v]] {:db {:n v}}))
       ;; The racing event: read db, publish it, block mid-transition holding
@@ -794,7 +794,7 @@
           {:db {:n (inc (:n db))}}))
 
       (with-redefs
-        [tool-pair/check-restore-preconditions!
+        [rf.epoch.tool-pair/check-restore-preconditions!
          (fn [f e]
            (let [result (orig-check f e)
                  b      @barrier]
@@ -950,8 +950,8 @@
         ;;     with the live generation, and its destroy silences EXACTLY once.
         (rf/register-listener! :epoch cb-id (fn [_] nil))
         (rf/dispatch-sync [:bump -1] {:frame :j538.gen/main})
-        (let [obs  (get (state/observations-snapshot) cb-id)
-              live (:generation (get (state/listeners-snapshot) cb-id))]
+        (let [obs  (get (rf.epoch.state/observations-snapshot) cb-id)
+              live (:generation (get (rf.epoch.state/listeners-snapshot) cb-id))]
           (is (= live (get obs :j538.gen/main))
               "the surviving observation is stamped with the LIVE generation")
           (let [before @silence-cnt]

--- a/implementation/epoch/test/re_frame/epoch_drain_serialization_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_drain_serialization_test.clj
@@ -27,11 +27,11 @@
   the frame `:drain-lock` discipline (`re-frame.frame/call-serialized-with-drain!`)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.epoch :as epoch]
-            [re-frame.epoch.state :as state]
-            [re-frame.epoch.tool-pair :as tool-pair]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.epoch.tool-pair :as rf.epoch.tool-pair]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; machines is pulled in for parity with the rest of the epoch
             ;; suite so the ns-load registrar snapshot the fixture restores is
             ;; the same shape (the reconcile hooks stay nil-safe here).
@@ -39,8 +39,8 @@
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- orchestration helpers -------------------------------------------------
 
@@ -95,12 +95,12 @@
         (rf/dispatch-sync [:set 1] {:frame frame-id})
         (rf/dispatch-sync [:set 2] {:frame frame-id})
         (let [eid-1 (target-epoch-id frame-id {:n 1})
-              orig-check tool-pair/check-restore-preconditions!]
+              orig-check rf.epoch.tool-pair/check-restore-preconditions!]
           (is (some? eid-1) "seeded an epoch whose db-after is {:n 1}")
           (is (= {:n 2} (rf/app-db-value frame-id)) "current db is {:n 2}")
 
           (with-redefs
-            [tool-pair/check-restore-preconditions!
+            [rf.epoch.tool-pair/check-restore-preconditions!
              (fn [f e]
                (let [result (orig-check f e)]
                  (when (compare-and-set! barrier-armed? true false)
@@ -183,10 +183,10 @@
         (is (= :r0 (:rf.runtime/marker (:rf.db/runtime (rf/frame-state-value frame-id))))
             "seeded runtime-db marker :r0")
 
-        (let [orig-check tool-pair/check-replace-frame-state-preconditions!
+        (let [orig-check rf.epoch.tool-pair/check-replace-frame-state-preconditions!
               history-before (count (rf/epoch-history frame-id))]
           (with-redefs
-            [tool-pair/check-replace-frame-state-preconditions!
+            [rf.epoch.tool-pair/check-replace-frame-state-preconditions!
              (fn [f fs]
                (let [result (orig-check f fs)]
                  (when (compare-and-set! barrier-armed? true false)

--- a/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
+++ b/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
@@ -79,11 +79,11 @@
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.epoch :as epoch]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.elision :as rf.elision]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---- fixtures --------------------------------------------------------------
 ;;
@@ -94,8 +94,8 @@
 ;; PUBLIC `configure!` boundary — no reach into the private `state/config`.
 ;; plain-atom is the right substrate on both hosts (no DOM under :node-test).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
@@ -133,8 +133,8 @@
   Classification is value-independent, so a cascade that leaves either path
   absent is a harmless no-op."
   []
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects
                rt {:sensitive [[:auth :password]]
                    :large     [[:blob :payload]]})))
   nil)
@@ -196,7 +196,7 @@
     (reg-login!)
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
     (let [raw  (last-record)
-          proj (epoch/projected-record raw)]
+          proj (rf.epoch/projected-record raw)]
       (is (= secret (get-in raw [:db-after :auth :password]))
           "fixture: the raw ring record carries the unredacted secret")
       (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
@@ -218,7 +218,7 @@
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
     (rf/dispatch-sync [:egress/inc]          {:frame frame-id})
     (let [raw  (last-record)
-          proj (epoch/projected-record raw)]
+          proj (rf.epoch/projected-record raw)]
       (is (= secret (get-in raw [:db-before :auth :password]))
           "fixture: raw `:db-before` carries the value")
       (is (= :rf/redacted (get-in proj [:db-before :auth :password]))
@@ -235,10 +235,10 @@
       (fn [{:keys [db]} [_ payload]] {:db (assoc-in db [:blob :payload] payload)}))
     (rf/dispatch-sync [:egress/upload (big-string payload-size)] {:frame frame-id})
     (let [raw  (last-record)
-          proj (epoch/projected-record raw)]
+          proj (rf.epoch/projected-record raw)]
       (is (= payload-size (count (get-in raw [:db-after :blob :payload])))
           "fixture: the raw record carries the full payload")
-      (is (elision/marker? (get-in proj [:db-after :blob :payload]))
+      (is (rf.elision/marker? (get-in proj [:db-after :blob :payload]))
           "the projected slot is a `:rf.size/large-elided` marker")
       (is (pos? (count-leaves-at-least payload-size raw))
           "fixture control: the raw ring DOES contain a large leaf")
@@ -251,13 +251,13 @@
             structural indicators (`:bytes`, `:digest`) that must not
             describe a sensitive value."
     (rf/make-frame {:id frame-id})
-    (frame/swap-runtime-db! frame-id
-      (fn [rt] (elision/apply-classification-effects
+    (rf.frame/swap-runtime-db! frame-id
+      (fn [rt] (rf.elision/apply-classification-effects
                  rt {:sensitive [[:both :slot]] :large [[:both :slot]]})))
     (rf/reg-event :egress/both
       (fn [{:keys [db]} _] {:db (assoc-in db [:both :slot] (str secret (big-string 30000)))}))
     (rf/dispatch-sync [:egress/both] {:frame frame-id})
-    (let [proj (epoch/projected-record (last-record))]
+    (let [proj (rf.epoch/projected-record (last-record))]
       (is (= :rf/redacted (get-in proj [:db-after :both :slot]))
           "sensitive takes precedence over large at the same path")
       (is (not (contains-secret? proj))
@@ -273,7 +273,7 @@
     (reg-login!)
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
     (let [raw  (last-record)
-          proj (epoch/projected-record raw)]
+          proj (rf.epoch/projected-record raw)]
       (doseq [k [:epoch-id :frame :committed-at :event-id :outcome
                  :halt-reason :schema-digest :rf.epoch/sensitive?]]
         (is (= (get raw k) (get proj k))
@@ -309,14 +309,14 @@
     (let [raw       (last-record)
           row-of    (fn [rec id] (->> (:sub-runs rec) (filter #(= id (:sub-id %))) first))
           raw-row   (row-of raw :egress/big)
-          proj      (epoch/projected-record raw)
+          proj      (rf.epoch/projected-record raw)
           proj-row  (row-of proj :egress/big)
           small-row (row-of proj :egress/small)]
       (is (some? raw-row)  "fixture: the `:large?` sub produced a `:sub-runs` row")
       (is (= payload-size (count (:value raw-row)))
           "fixture: the raw row carries the full computed value")
       (is (some? proj-row) "the projected record keeps the row")
-      (is (elision/marker? (:value proj-row))
+      (is (rf.elision/marker? (:value proj-row))
           "the projected `:value` is a `:rf.size/large-elided` marker")
       (is (not (contains? proj-row :large?))
           "the now-spent `:large?` row flag is stripped from the projection")
@@ -352,7 +352,7 @@
         (is (true? (:large? raw-tags))
             "fixture: the emit chokepoint stamped the whole-output `:large?`
              flag on the raw tag — the marker the egress rule honours")
-        (is (elision/marker? (:rf.sub/value proj-tags))
+        (is (rf.elision/marker? (:rf.sub/value proj-tags))
             "rf2-irwsq — the projected `:rf.sub/run` tag's `:rf.sub/value` is a
              `:rf.size/large-elided` MARKER, not the raw payload. A marker and
              not a drop: a tool must be able to tell a value existed and was
@@ -377,7 +377,7 @@
       ;; NEGATIVE CONTROL on the new tag path: the trusted-local opt-in lifts it,
       ;; proving the elision is driven by the classification rather than by some
       ;; unrelated truncation on the way out.
-      (let [lifted (epoch/projected-record raw {:include-large? true})]
+      (let [lifted (rf.epoch/projected-record raw {:include-large? true})]
         (is (= payload-size (count (get-in (->> (:trace-events lifted)
                                                (filter #(= :rf.sub/run (:operation %)))
                                                (filter #(= :egress/big
@@ -391,8 +391,8 @@
   (testing "`projected-record` returns nil for non-map input — a forwarder
             mapping over a ring that contains a nil hole must not throw
             mid-egress on either host."
-    (is (nil? (epoch/projected-record nil)))
-    (is (nil? (epoch/projected-record :not-a-record)))))
+    (is (nil? (rf.epoch/projected-record nil)))
+    (is (nil? (rf.epoch/projected-record :not-a-record)))))
 
 ;; ============================================================================
 ;;  2. The FACADE path — what the browser consumers actually call
@@ -411,7 +411,7 @@
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
     (let [raw     (last-record)
           via-fac (rf/projected-record raw)
-          via-art (epoch/projected-record raw)]
+          via-art (rf.epoch/projected-record raw)]
       (is (some? via-fac)
           "the late-bound hook is published (a nil here would mean the
            artefact was not seen, and every consumer would silently egress
@@ -445,7 +445,7 @@
       (is (= :rf/redacted (get-in (rf/projected-record raw {})
                                   [:db-after :auth :password]))
           "and an empty opts map keeps the fail-closed default")
-      (is (= (epoch/projected-record raw {:rf.egress/profile :rf.egress/off-box-tool})
+      (is (= (rf.epoch/projected-record raw {:rf.egress/profile :rf.egress/off-box-tool})
              (rf/projected-record raw {:rf.egress/profile :rf.egress/off-box-tool}))
           "the named `:rf.egress/off-box-tool` boundary (the MCP wire) agrees
            across facade and artefact"))))
@@ -468,7 +468,7 @@
           shipped  (atom [])]
       (rf/register-listener! :epoch ::raw-tap  (fn [r] (swap! raw-seen conj r)))
       (rf/register-listener! :epoch ::forwarder
-                            (fn [r] (swap! shipped conj (epoch/projected-record r))))
+                            (fn [r] (swap! shipped conj (rf.epoch/projected-record r))))
       (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
       (rf/dispatch-sync [:egress/upload (big-string payload-size)] {:frame frame-id})
       (rf/unregister-listener! :epoch ::raw-tap)
@@ -498,15 +498,15 @@
     (rf/dispatch-sync [:egress/login secret]  {:frame frame-id})
     (rf/dispatch-sync [:egress/inc]           {:frame frame-id})
     (let [raw  (rf/epoch-history frame-id)
-          bulk (epoch/projected-history frame-id)]
+          bulk (rf.epoch/projected-history frame-id)]
       (is (= 3 (count bulk)) "one projected record per raw record")
-      (is (= (mapv epoch/projected-record raw) bulk)
+      (is (= (mapv rf.epoch/projected-record raw) bulk)
           "bulk egress is fn-equivalent to per-record egress")
       (is (= (mapv :epoch-id raw) (mapv :epoch-id bulk))
           "oldest-first order is preserved")
       (is (not (contains-secret? bulk))
           "the bulk shape leaks no secret bytes")
-      (is (= [] (epoch/projected-history :epoch-egress-redaction/no-such-frame))
+      (is (= [] (rf.epoch/projected-history :epoch-egress-redaction/no-such-frame))
           "an unknown frame yields the empty vector, not a throw"))))
 
 (deftest double-projection-is-idempotent-for-both-substitutions
@@ -522,9 +522,9 @@
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
     (rf/dispatch-sync [:egress/upload (big-string payload-size)] {:frame frame-id})
     (let [raw    (rf/epoch-history frame-id)
-          once   (mapv epoch/projected-record raw)
-          twice  (mapv epoch/projected-record once)
-          thrice (mapv epoch/projected-record twice)]
+          once   (mapv rf.epoch/projected-record raw)
+          twice  (mapv rf.epoch/projected-record once)
+          thrice (mapv rf.epoch/projected-record twice)]
       (is (= once twice thrice)
           "projection reaches a fixpoint on the first pass — no drift in the
            large marker's `:bytes` / `:digest` across passes")
@@ -541,8 +541,8 @@
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
     (let [before (rf/epoch-history frame-id)]
       (dotimes [_ 10]
-        (mapv epoch/projected-record before)
-        (epoch/projected-history frame-id))
+        (mapv rf.epoch/projected-record before)
+        (rf.epoch/projected-history frame-id))
       (is (= before (rf/epoch-history frame-id))
           "the ring is structurally unchanged after 20 projection calls")
       (is (contains-secret? (rf/epoch-history frame-id))
@@ -567,7 +567,7 @@
     (rf/dispatch-sync [:egress/do-login {:password secret :token "tok-abc"}]
                       {:frame frame-id})
     (let [raw    (last-record)
-          proj   (epoch/projected-record raw {:include-sensitive? true})
+          proj   (rf.epoch/projected-record raw {:include-sensitive? true})
           fx-row (some #(when (= :egress/login-fx (:fx-id %)) %) (:effects proj))]
       (is (= secret (get-in proj [:db-after :auth :password]))
           "`:include-sensitive? true` reveals the app-db sensitive leaf
@@ -578,7 +578,7 @@
       (is (= :egress/login-fx (:fx-id fx-row))
           "the value-free `:fx-id` is preserved for tool display")
       (is (= :rf/redacted (:args (some #(when (= :egress/login-fx (:fx-id %)) %)
-                                       (:effects (epoch/projected-record raw)))))
+                                       (:effects (rf.epoch/projected-record raw)))))
           "and the bare off-box default redacts the fx args too"))))
 
 (deftest include-sensitive-keeps-runtime-db-partition-redacted
@@ -596,7 +596,7 @@
                                   {:state :live})}))
     (rf/dispatch-sync [:egress/seed-both] {:frame frame-id})
     (let [raw  (last-record)
-          proj (epoch/projected-record raw {:include-sensitive? true})]
+          proj (rf.epoch/projected-record raw {:include-sensitive? true})]
       (is (= {:state :live}
              (get-in raw [:frame-state-after :rf.db/runtime
                           :rf.runtime/machines :snapshots :m/x]))
@@ -607,7 +607,7 @@
           "the `:rf.db/runtime` partition STAYS redacted under
            include-sensitive alone")
       (is (not= :rf/redacted
-                (get-in (epoch/projected-record raw {:include-sensitive?  true
+                (get-in (rf.epoch/projected-record raw {:include-sensitive?  true
                                                      :include-runtime-db? true})
                         [:frame-state-after :rf.db/runtime]))
           "NEGATIVE CONTROL — the explicit `:include-runtime-db? true` opt DOES
@@ -626,16 +626,16 @@
                     (assoc-in [:blob :payload] p))}))
     (rf/dispatch-sync [:egress/both secret (big-string payload-size)] {:frame frame-id})
     (let [raw (last-record)]
-      (let [proj (epoch/projected-record raw {:include-sensitive? true})]
+      (let [proj (rf.epoch/projected-record raw {:include-sensitive? true})]
         (is (= secret (get-in proj [:db-after :auth :password])))
-        (is (elision/marker? (get-in proj [:db-after :blob :payload]))
+        (is (rf.elision/marker? (get-in proj [:db-after :blob :payload]))
             "large stays elided under the sensitive opt-in")
         (is (zero? (count-leaves-at-least payload-size proj))
             "and no raw payload bytes egress anywhere in the record"))
-      (let [proj (epoch/projected-record raw {:include-large? true})]
+      (let [proj (rf.epoch/projected-record raw {:include-large? true})]
         (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
             "sensitive stays redacted under the large opt-in")
-        (is (not (elision/marker? (get-in proj [:db-after :blob :payload])))
+        (is (not (rf.elision/marker? (get-in proj [:db-after :blob :payload])))
             "NEGATIVE CONTROL — `:include-large? true` DOES lift the slot")
         (is (pos? (count-leaves-at-least payload-size proj))
             "and the raw payload bytes ARE present, so the elision
@@ -653,7 +653,7 @@
                     {:redact-fn (fn [r] (assoc r :rf.test/redact-fn-ran true))}})
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
     (let [raw  (last-record)
-          proj (epoch/projected-record raw {:include-sensitive? true})]
+          proj (rf.epoch/projected-record raw {:include-sensitive? true})]
       (is (= secret (get-in proj [:db-after :auth :password]))
           "the sensitive opt-in is in force")
       (is (true? (:rf.test/redact-fn-ran proj))
@@ -674,7 +674,7 @@
     (fresh-frame!)
     (reg-login!)
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
-    (let [proj (epoch/projected-record (last-record))]
+    (let [proj (rf.epoch/projected-record (last-record))]
       (is (= [:egress/login :rf/redacted] (:trigger-event proj))
           "head id retained, positional arg redacted")
       (is (= :egress/login (:event-id proj))
@@ -691,7 +691,7 @@
       (fn [{:keys [db]} [_ {:keys [password]}]]
         {:db (assoc-in db [:auth :password] password)}))
     (rf/dispatch-sync [:egress/auth-login {:password secret}] {:frame frame-id})
-    (let [proj (epoch/projected-record (last-record))]
+    (let [proj (rf.epoch/projected-record (last-record))]
       (is (= [:egress/auth-login :rf/redacted] (:trigger-event proj)))
       (is (not (contains-secret? (:trigger-event proj)))))))
 
@@ -703,13 +703,13 @@
     (reg-login!)
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
     (let [raw (last-record)]
-      (let [proj (epoch/projected-record raw {:include-event-args? true})]
+      (let [proj (rf.epoch/projected-record raw {:include-event-args? true})]
         (is (= [:egress/login secret] (:trigger-event proj))
             "NEGATIVE CONTROL — the opt-in reveals the raw args, so the
              fail-closed assertions above are testing redaction")
         (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
             "the app-db sensitive leaf stays redacted"))
-      (let [proj (epoch/projected-record raw {:include-sensitive? true})]
+      (let [proj (rf.epoch/projected-record raw {:include-sensitive? true})]
         (is (= secret (get-in proj [:db-after :auth :password])))
         (is (= [:egress/login :rf/redacted] (:trigger-event proj))
             "the event args stay redacted under the app-db opt-in")))))
@@ -758,7 +758,7 @@
                  frame-id
                  [{:op-type :rf.event :operation :rf.event/db-pending          :tags tags}
                   {:op-type :rf.event :operation :rf.event/db-pending-post-flow :tags tags}])
-          [t1 t2] (:trace-events (epoch/projected-record rec))]
+          [t1 t2] (:trace-events (rf.epoch/projected-record rec))]
       (is (= :rf/redacted (get-in t1 [:tags :rf.event/db :auth :password]))
           "t1's nested sensitive leaf is re-rooted and redacted")
       (is (= :rf/redacted (get-in t2 [:tags :rf.event/db :auth :password]))
@@ -767,7 +767,7 @@
           "NEGATIVE CONTROL — the unclassified sibling inside the SAME nested
            db survives, so the re-root is redacting by classification rather
            than blanking the tag")
-      (is (not (contains-secret? (epoch/projected-record rec)))
+      (is (not (contains-secret? (rf.epoch/projected-record rec)))
           "and no secret bytes survive anywhere in the projected record"))))
 
 (deftest off-box-omits-an-unschematized-http-response-body
@@ -784,15 +784,15 @@
                  [{:op-type   :rf.trace
                    :operation :rf.http/replied
                    :tags      {:value body :rf.http/off-box-body :omit}}])
-          ev   (first (:trace-events (epoch/projected-record omit)))]
+          ev   (first (:trace-events (rf.epoch/projected-record omit)))]
       (is (= :rf/redacted (:value (:tags ev)))
           "the unschematized body slot is omitted off-box (fail-closed)")
-      (is (not (contains-secret? (epoch/projected-record omit)))
+      (is (not (contains-secret? (rf.epoch/projected-record omit)))
           "the raw token appears nowhere in the projected record")
       (is (contains-secret? omit)
           "NEGATIVE CONTROL — the unprojected record DOES carry the token")
       (is (= body (:value (:tags (first (:trace-events
-                                          (epoch/projected-record
+                                          (rf.epoch/projected-record
                                             omit {:include-sensitive? true}))))))
           "and the trusted-local `:include-sensitive?` opt-in lifts the
            omission, proving the assertion is about the disposition stamp"))))
@@ -814,7 +814,7 @@
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
     (dotimes [_ 4] (rf/dispatch-sync [:egress/inc] {:frame frame-id}))
     (let [raw  (rf/epoch-history frame-id)
-          bulk (epoch/projected-history frame-id)]
+          bulk (rf.epoch/projected-history frame-id)]
       (is (= 5 (count bulk)) "fixture: five records in the ring")
       (is (contains-secret? raw)
           "fixture control: the raw ring carries the secret in every
@@ -836,7 +836,7 @@
     (rf/make-frame {:id control-frame-id})
     (reg-login!)
     (rf/dispatch-sync [:egress/login secret] {:frame control-frame-id})
-    (let [proj (epoch/projected-record (last-record control-frame-id))]
+    (let [proj (rf.epoch/projected-record (last-record control-frame-id))]
       (is (= secret (get-in proj [:db-after :auth :password]))
           "with no classification declared the value rides through RAW")
       (is (contains-secret? proj)
@@ -852,7 +852,7 @@
     (fresh-frame!)
     (reg-login!)
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
-    (is (true? (:rf.epoch/sensitive? (epoch/projected-record (last-record))))
+    (is (true? (:rf.epoch/sensitive? (rf.epoch/projected-record (last-record))))
         "a cascade whose classified path holds a non-nil leaf rolls up true
          and the flag survives projection")))
 
@@ -865,7 +865,7 @@
     (rf/make-frame {:id control-frame-id})
     (rf/reg-event :egress/plain (fn [_ _] {:db {:n 0 :audit {:note benign}}}))
     (rf/dispatch-sync [:egress/plain] {:frame control-frame-id})
-    (is (false? (:rf.epoch/sensitive? (epoch/projected-record
+    (is (false? (:rf.epoch/sensitive? (rf.epoch/projected-record
                                         (last-record control-frame-id))))
         "strict false, not nil and not true")))
 
@@ -878,11 +878,11 @@
     (fresh-frame!)
     (rf/reg-event :egress/seed (fn [_ _] {:db {:n 0}}))
     (rf/reg-event :egress/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
-    (is (= 5 (:trace-events-keep (epoch/current-config)))
+    (is (= 5 (:trace-events-keep (rf.epoch/current-config)))
         "fixture override — the shipped runtime default is 50")
     (rf/dispatch-sync [:egress/seed] {:frame frame-id})
     (dotimes [_ 6] (rf/dispatch-sync [:egress/inc] {:frame frame-id}))
-    (let [bulk (epoch/projected-history frame-id)
+    (let [bulk (rf.epoch/projected-history frame-id)
           n    (count bulk)]
       (is (= 7 n) "fixture: seven records")
       (is (every? #(contains? % :sub-runs) bulk)
@@ -912,7 +912,7 @@
       (rf/unregister-listener! :epoch ::tap))
     (is (= secret (get-in (last-record) [:db-after :auth :password]))
         "the RING record is untouched by the override — restore fidelity")
-    (is (= :rf/redacted (:db-after (epoch/projected-record (last-record))))
+    (is (= :rf/redacted (:db-after (rf.epoch/projected-record (last-record))))
         "the override IS applied at the egress boundary")))
 
 (deftest throwing-redact-fn-falls-back-to-the-projected-record
@@ -927,7 +927,7 @@
     (rf/configure! {:epoch-history
                     {:redact-fn (fn [_] (throw (ex-info "redact-fn blew up" {})))}})
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
-    (let [proj (epoch/projected-record (last-record))]
+    (let [proj (rf.epoch/projected-record (last-record))]
       (is (some? proj) "egress still produces a record")
       (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
           "the fallback is the PROJECTED record — the sensitive leaf is
@@ -937,10 +937,10 @@
     ;; A non-Error throw — reachable only under CLJS's `:default` catch.
     (rf/configure! {:epoch-history {:redact-fn (fn [_] (throw #?(:clj (Exception. "raw")
                                                                  :cljs "a bare string")))}})
-    (let [proj (epoch/projected-record (last-record))]
+    (let [proj (rf.epoch/projected-record (last-record))]
       (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
           "a non-`Error` throw is caught too and still falls back closed")
       (is (not (contains-secret? proj))))
-    (is (fn? (:redact-fn (epoch/current-config)))
+    (is (fn? (:redact-fn (rf.epoch/current-config)))
         "and the throwing override stays registered — failure isolation is
          per-call, not a silent de-registration")))

--- a/implementation/epoch/test/re_frame/epoch_egress_resource_scope_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_scope_test.clj
@@ -24,16 +24,16 @@
   suite which runs without resources)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.epoch :as epoch]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; load-bearing: publishes the :resources/* late-bind hooks,
             ;; including :resources/project-scope-resolved-egress.
             [re-frame.resources]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn []
                 (rf/make-frame {:id :test/rs})
                 ;; a db-reading resolver (the :inherit default — fail-closed
@@ -93,7 +93,7 @@
                        [(scope-resolved-event :rs/session
                                               {:username secret}
                                               [:rf.scope/session {:username secret}])])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           row       (first (:trace-events projected))]
       (is (= :rf/redacted (get-in row [:tags :input-values]))
           "the raw db reads are redacted off-box")
@@ -115,7 +115,7 @@
                        [(scope-resolved-event :rs/public-locale
                                               {:locale "en"}
                                               [:rf.scope/locale {:locale "en"}])])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           row       (first (:trace-events projected))]
       (is (= :rf/redacted (get-in row [:tags :input-values]))
           "the resolved input-values are redacted (no declassify hatch)")

--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -35,18 +35,18 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.walk :as walk]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.epoch :as epoch]
-            [re-frame.frame :as frame]
+            [re-frame.elision :as rf.elision]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.frame :as rf.frame]
             ;; rf2-hbmeb §(8) — `fx/reg-fx`, the plain fn, NOT the `rf/reg-fx`
             ;; macro: see `drive-real-cascade!` for why the difference decides
             ;; whether the frame's default image can still be reprojected.
-            [re-frame.fx :as fx]
-            [re-frame.resources.state :as state]
-            [re-frame.resources.work-ledger :as work-ledger]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.fx :as rf.fx]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             ;; load-bearing: publishes the :resources/* late-bind hooks,
             ;; including :resources/project-resource-trace-egress.
             [re-frame.resources]
@@ -69,8 +69,8 @@
   Reusing the fixture rather than re-implementing the reset is the point: the
   inventory's drives get exactly the runtime every other drive in this
   namespace gets."
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn []
                 (rf/make-frame {:id :test/rt})
                 ;; a :sensitive? resource — scope + params tokenize off-box.
@@ -196,7 +196,7 @@
   "A concrete scoped key `[scope resource-id params]` (the canonical fact
   identity the trace rows copy into their tags)."
   [scope resource-id params]
-  (state/scoped-resource-key scope resource-id params))
+  (rf.resources.state/scoped-resource-key scope resource-id params))
 
 (defn- redacted-component? [c]
   (and (map? c) (contains? c :rf/redacted)))
@@ -231,7 +231,7 @@
                        [(event :rf.resource/cache-hit
                                {:rf.frame/id :test/rt :resource/key scoped-key
                                 :generation 1 :owner [:app :l 1] :cause :ensure})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))
           [pscope rid pparams] (:resource/key tags)]
       (is (= :secret/article rid) "the resource-id (position 1) survives")
@@ -258,7 +258,7 @@
                               {:rf.frame/id :test/rt :mutation :m/del :instance 1
                                :work/id [:rf.work/mutation :m/del 1]
                                :removed [k1]})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))
           [pscope rid pparams] (first (:removed tags))]
       (is (= :big/blob rid) "the resource-id survives")
@@ -293,7 +293,7 @@
                                 :dispositions [{:resource/key scoped-key
                                                 :restored     true
                                                 :conflict     false}]})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))
           row        (first (:dispositions tags))
           [pscope rid pparams] (:resource/key row)]
@@ -325,7 +325,7 @@
                                             :removed   [k-rem]
                                             :rollback  [{:resource/key k-roll
                                                          :revision 3}]}})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))
           ps        (:patch-summary tags)
           [_ rid pparams]   (first (:removed ps))
@@ -352,7 +352,7 @@
                        [(event :rf.resource/cache-hit
                                {:rf.frame/id :test/rt :resource/key scoped-key
                                 :generation 1 :cause :ensure})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))]
       (is (= scoped-key (:resource/key tags))
           "the plain scoped key rides verbatim (no over-redaction)")
@@ -372,7 +372,7 @@
                        [(event :rf.resource/cache-hit
                                {:rf.frame/id :test/rt :resource/key scoped-key
                                 :generation 1 :cause :ensure})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))
           [pscope rid pparams] (:resource/key tags)]
       (is (= :gone/article rid) "the resource-id survives")
@@ -400,7 +400,7 @@
                     (event :rf.mutation/optimistic-rolled-back
                            {:rf.frame/id :test/rt
                             :dispositions [{:resource/key k-disp :restored true}]})])
-          projected (epoch/projected-record record {:include-sensitive? true})
+          projected (rf.epoch/projected-record record {:include-sensitive? true})
           [hit succ roll] (:trace-events projected)]
       (is (= k-hit (:resource/key (:tags hit)))
           "raw :resource/key rides with :include-sensitive?")
@@ -433,7 +433,7 @@
                                 :generation 2 :work/id [:rf.work/resource 2]
                                 :page-param cursor-secret :page-index 1
                                 :page-count 1 :owner [:app :l 1] :cause :load-more})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))]
       (is (redacted-component? (:page-param tags))
           "the cursor is tokenized to an opaque {:rf/redacted <digest>}")
@@ -457,7 +457,7 @@
                                   :work/id [:rf.work/resource 2] :generation 2
                                   :page-index 1 :page-count 2
                                   :next-page-param cursor-secret :terminal? false})])
-          projected    (epoch/projected-record record)
+          projected    (rf.epoch/projected-record record)
           tags         (:tags (first (:trace-events projected)))]
       (is (redacted-component? (:next-page-param tags))
           "the next-page cursor is tokenized")
@@ -477,7 +477,7 @@
                                {:rf.frame/id :test/rt :resource/key scoped-key
                                 :page-param "cursor-page-2" :page-index 1
                                 :page-count 1 :cause :load-more})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))]
       (is (= "cursor-page-2" (:page-param tags))
           "the plain feed's cursor rides verbatim (no over-redaction)")
@@ -491,7 +491,7 @@
                        [(event :rf.resource/load-more
                                {:rf.frame/id :test/rt :resource/key scoped-key
                                 :page-param cursor-secret :page-index 1})])
-          projected  (epoch/projected-record record {:include-sensitive? true})
+          projected  (rf.epoch/projected-record record {:include-sensitive? true})
           tags       (:tags (first (:trace-events projected)))]
       (is (= cursor-secret (:page-param tags))
           "raw cursor rides with :include-sensitive?"))))
@@ -524,7 +524,7 @@
                                 :work/id [:rf.work/resource 1] :generation 1
                                 :status-before :loading :status-after :error
                                 :error http-error-envelope})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))]
       (is (redacted-component? (:error tags))
           "the HTTP failure envelope is tokenized off-box")
@@ -546,7 +546,7 @@
                                 :work/id [:rf.work/resource 1] :generation 2
                                 :status-before :loaded :status-after :loaded
                                 :page-error http-error-envelope})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))]
       (is (redacted-component? (:page-error tags))
           "the load-more failure envelope is tokenized off-box")
@@ -562,7 +562,7 @@
                               {:rf.frame/id :test/rt :instance 7 :mutation :m/save
                                :work/id [:rf.work/mutation :m/save 7] :generation 1
                                :error http-error-envelope})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (redacted-component? (:error tags))
           "the mutation failure envelope is tokenized off-box")
@@ -585,7 +585,7 @@
                                 :generation 5 :cause :ensure
                                 ;; a hypothetical future map slot with NO clause
                                 :future-detail {:hidden (str secret "-future")}})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))]
       (is (redacted-component? (:future-detail tags))
           "an unknown MAP slot is tokenized by the fail-closed default")
@@ -603,7 +603,7 @@
                       [(event :rf.resource/failed
                               {:rf.frame/id :test/rt :status-after :error
                                :error http-error-envelope})])
-          projected (epoch/projected-record record {:include-sensitive? true})
+          projected (rf.epoch/projected-record record {:include-sensitive? true})
           tags      (:tags (first (:trace-events projected)))]
       (is (= http-error-envelope (:error tags))
           "the raw envelope rides with :include-sensitive?"))))
@@ -650,7 +650,7 @@
                         {:auth-token (str secret "-2")})
           record    (record-with
                       [(event :rf.resource/route-plan (route-plan-tags [k1] [k1 k2]))])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))
           [bscope brid bparams] (first (:blocking tags))]
       (testing ":blocking tokenizes per key"
@@ -708,7 +708,7 @@
                                :ensured-identities [ensured]
                                :kept-identities    [kept]
                                :removed-identities [removed]})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))
           partition-slots (juxt :ensured-identities :kept-identities
                                 :removed-identities)]
@@ -750,7 +750,7 @@
                                      :ensured-identities [k1]
                                      :kept-identities    []
                                      :removed-identities [k2]))])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= [k1] (:ensured-identities tags)))
       (is (= [] (:kept-identities tags)) "an empty partition slot survives empty")
@@ -778,7 +778,7 @@
                                :ensured-identities ks
                                :kept-identities    ks
                                :removed-identities ks})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= (:matched tags) (:blocking tags))
           ":blocking projects exactly as the NAMED :matched does")
@@ -799,7 +799,7 @@
     (let [k1        (sk :rf.scope/global :plain/article {:slug "welcome"})
           record    (record-with
                       [(event :rf.resource/route-plan (route-plan-tags [k1] [k1]))])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= [k1] (:blocking tags)) "a plain owner's :blocking rides verbatim")
       (is (= [k1] (:identities tags)) "a plain owner's :identities rides verbatim")
@@ -814,13 +814,13 @@
             slot roster names :work/id, and the value is a vector, so it rode the
             verbatim :else. The shape-driven default reaches it by DEPTH."
     (let [scoped-key (sk :rf.scope/global :secret/article {:auth-token secret})
-          work-id    (work-ledger/resource-work-id scoped-key 3)
+          work-id    (rf.resources.work-ledger/resource-work-id scoped-key 3)
           record     (record-with
                        [(event :rf.resource/work-started
                                {:rf.frame/id :test/rt :resource/key scoped-key
                                 :generation 3 :work/id work-id
                                 :status :running :cause :ensure})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))
           [marker embedded generation] (:work/id tags)]
       (is (= :rf.work/resource marker) "the work-kind marker rides verbatim")
@@ -850,7 +850,7 @@
                                :work/id [:rf.work/mutation :m/del 1]
                                :tags    #{:tag/articles :tag/feed}
                                :left-stale 2})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= [:rf.work/mutation :m/del 1] (:work/id tags))
           "a mutation work-id is scalar-only and rides verbatim")
@@ -867,12 +867,12 @@
             boundary — the shape-driven redaction is the off-box DEFAULT, not an
             unconditional strip)"
     (let [k1        (sk :rf.scope/global :secret/article {:auth-token secret})
-          work-id   (work-ledger/resource-work-id k1 3)
+          work-id   (rf.resources.work-ledger/resource-work-id k1 3)
           record    (record-with
                       [(event :rf.resource/route-plan (route-plan-tags [k1] [k1]))
                        (event :rf.resource/work-started
                               {:rf.frame/id :test/rt :work/id work-id})])
-          projected (epoch/projected-record record {:include-sensitive? true})
+          projected (rf.epoch/projected-record record {:include-sensitive? true})
           [plan work] (:trace-events projected)]
       (is (= [k1] (:blocking (:tags plan))) "raw :blocking rides")
       (is (= [k1] (:identities (:tags plan))) "raw :identities rides")
@@ -930,10 +930,10 @@
   the frame's next default-image reprojection would die on
   `:rf.error/image-duplicate-id`."
   []
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
   (let [rows (atom [])
         k    ::real-cascade-recorder]
-    (trace-tooling/register-listener! k (fn [ev] (swap! rows conj ev)))
+    (rf.trace.tooling/register-listener! k (fn [ev] (swap! rows conj ev)))
     (try
       (rf/dispatch-sync [:rf.resource/ensure
                          {:resource :secret/article
@@ -947,7 +947,7 @@
                         {:frame :test/rt})
       (rf/dispatch-sync [:rf.resource/release-owner {:owner real-owner}]
                         {:frame :test/rt})
-      (finally (trace-tooling/unregister-listener! k)))
+      (finally (rf.trace.tooling/unregister-listener! k)))
     @rows))
 
 (defn- settled-family-rows
@@ -993,7 +993,7 @@
         ;; the plain `ensure` and the `release-owner` each settle their own,
         ;; and the two-sided control needs both owners.
         (let [proj-rows (->> (rf/epoch-history :test/rt)
-                             (map epoch/projected-record)
+                             (map rf.epoch/projected-record)
                              (mapcat :trace-events)
                              (filterv family-row?))
               sens      (->> proj-rows
@@ -1111,7 +1111,7 @@
 (defn- free-scope
   "The `:scope` tag as it egresses from a projected single-row record."
   [record]
-  (:scope (:tags (first (:trace-events (epoch/projected-record record))))))
+  (:scope (:tags (first (:trace-events (rf.epoch/projected-record record))))))
 
 ;; ---------------------------------------------------------------------------
 ;; (1) :rf.resource/invalidated — events.cljc:1811
@@ -1135,7 +1135,7 @@
                             :refetched    1
                             :left-stale   0
                             :exempt       []})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))
           [tier identity-map] (:scope tags)]
       (is (= :rf.scope/session tier)
@@ -1171,7 +1171,7 @@
                                :decision     :refetch
                                :tags         #{:tag/profile}
                                :cause        [:mutation :m/save 1]})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (testing "carrier 1 — the owner-classified scoped key (already correct)"
         (is (redacted-component? (first (:resource/key tags)))
@@ -1213,7 +1213,7 @@
                                :reason       :clear-scope
                                :aborted      []
                                :completed-at 1234})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))
           [tier identity-map] (:scope tags)]
       (is (= :rf.scope/session tier) "the tier keyword rides verbatim")
@@ -1257,7 +1257,7 @@
                                :tag-matched-keys  []
                                :target-unresolved []
                                :cause             [:mutation :m/save 7]})])
-          projected      (epoch/projected-record record)
+          projected      (rf.epoch/projected-record record)
           [started opt]  (:trace-events projected)]
       (testing ":rf.mutation/started"
         (let [tags (:tags started)
@@ -1299,7 +1299,7 @@
                                :active?      true
                                :decision     :refetch
                                :tags         #{:tag/articles}})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= :rf.scope/global (:scope tags))
           "a global scope rides VERBATIM — no over-redaction")
@@ -1327,7 +1327,7 @@
                                :tags         #{:tag/profile}
                                :matched      [k1]
                                :refetched    1})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= :rf.scope/session (first (:scope tags)))
           "the tier keyword rides verbatim")
@@ -1388,7 +1388,7 @@
                                :input-values  {:username secret}
                                :scope         session-scope
                                :resolved-nil? false})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= :rf/redacted (:scope tags))
           "the sibling's sentinel rides through the family projector unchanged")
@@ -1423,7 +1423,7 @@
                               {:rf.frame/id :test/rt :scope session-scope})
                        (event :rf.mutation/optimistic-applied
                               {:rf.frame/id :test/rt :scope session-scope})])
-          projected (epoch/projected-record record {:include-sensitive? true})
+          projected (rf.epoch/projected-record record {:include-sensitive? true})
           scopes    (mapv #(:scope (:tags %)) (:trace-events projected))]
       (is (= [session-scope session-scope session-scope
               session-scope session-scope]
@@ -1553,11 +1553,11 @@
   documents."
   [resource-id]
   (rf/configure! {:epoch-history {:trace-events-keep 50}})
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
-  (frame/swap-runtime-db! :test/rt
-    (fn [rt] (elision/apply-classification-effects
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.frame/swap-runtime-db! :test/rt
+    (fn [rt] (rf.elision/apply-classification-effects
                rt {:sensitive [[:auth :user :username]]})))
-  (frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
+  (rf.frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
   (rf/dispatch-sync [:rf.resource/ensure
                      {:resource resource-id
                       :params   profile-params
@@ -1578,7 +1578,7 @@
             `:rf.fx/args` and again under `:rf.event/fx`."
     (let [records   (drive-session-scoped-ensure! :derived/profile)
           raw       (last records)
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
 
       (testing "FIXTURE — the producer really put an identity-bearing scope on
                 the fx carriers, so the assertions below are not passing over an
@@ -1663,7 +1663,7 @@
             planted there."
     (let [k1        (sk session-scope :derived/profile profile-params)
           args      (managed-args k1 session-scope)
-          projected (epoch/projected-record (fx-carrier-record args))
+          projected (rf.epoch/projected-record (fx-carrier-record args))
           scopes    (carrier-scopes projected)]
       (is (= 4 (count scopes))
           "two payloads per carrier, two carriers — the four paths the bead named")
@@ -1694,7 +1694,7 @@
     (let [k1        (sk :rf.scope/global :plain/article {:slug plain-slug})
           args      (managed-args k1 :rf.scope/global)
           record    (fx-carrier-record args)
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           [handled do-fx] (:trace-events projected)]
       (is (= args (:rf.fx/args (:tags handled)))
           "the whole args map rides verbatim — request, request-id and both
@@ -1719,7 +1719,7 @@
     (let [proj  (fn [scope]
                   (let [k (sk scope :derived/profile profile-params)]
                     (-> (fx-carrier-record (managed-args k scope))
-                        epoch/projected-record
+                        rf.epoch/projected-record
                         carrier-scopes
                         first)))
           s1    (proj session-scope)
@@ -1742,7 +1742,7 @@
             off-box default, not a strip)"
     (let [k1        (sk session-scope :derived/profile profile-params)
           args      (managed-args k1 session-scope)
-          projected (epoch/projected-record (fx-carrier-record args)
+          projected (rf.epoch/projected-record (fx-carrier-record args)
                                             {:include-sensitive? true})]
       (is (= [session-scope session-scope session-scope session-scope]
              (carrier-scopes projected))
@@ -1880,12 +1880,12 @@
   [resource-id]
   (rf/configure! {:epoch-history {:trace-events-keep 80}})
   (let [captured (atom nil)]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
-    (frame/swap-runtime-db! :test/rt
-      (fn [rt] (elision/apply-classification-effects
+    (rf.frame/swap-runtime-db! :test/rt
+      (fn [rt] (rf.elision/apply-classification-effects
                  rt {:sensitive [[:auth :user :username]]})))
-    (frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
+    (rf.frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource resource-id :params reply-params
                         :owner    real-owner  :reply-to read-reply-target}]
@@ -1913,7 +1913,7 @@
       (doseq [[label cache-hit?] [["async settle" false] ["fresh-skip cache hit" true]]]
         (testing label
           (let [raw       (record-carrying-reply records cache-hit?)
-                projected (epoch/projected-record raw)]
+                projected (rf.epoch/projected-record raw)]
 
             (testing "FIXTURE — the producer really put a decoded body on the fx
                       carriers, so the assertions below are not passing over an
@@ -2011,7 +2011,7 @@
             because the resource family speaks only for what it planted."
     (let [k1        (sk session-scope :derived/profile reply-params)
           reply     (read-reply k1 session-scope reply-value)
-          projected (epoch/projected-record (reply-carrier-record reply))
+          projected (rf.epoch/projected-record (reply-carrier-record reply))
           replies   (carrier-replies projected)
           [handled do-fx] (:trace-events projected)]
       (is (= 2 (count replies))
@@ -2047,7 +2047,7 @@
     (let [k1        (sk :rf.scope/global :plain/article {:slug plain-slug})
           reply     (read-reply k1 :rf.scope/global {:title "hello"})
           record    (reply-carrier-record reply)
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           [handled do-fx] (:trace-events projected)]
       (is (= (conj read-reply-target reply) (:rf.fx/args (:tags handled)))
           "the whole dispatched event vector rides verbatim — reply :value,
@@ -2079,7 +2079,7 @@
                            {:rf.frame/id :test/rt :frame :test/rt
                             :rf.fx/id :rf.http/managed
                             :rf.fx/args {:request req}})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           [reply-row req-row] (:trace-events projected)]
       (is (redacted-component? (:params (first (carrier-replies projected))))
           "the reply's :params — a named owner's, read through that owner")
@@ -2104,7 +2104,7 @@
     (let [proj  (fn [params value]
                   (let [k (sk session-scope :derived/profile params)]
                     (-> (reply-carrier-record (read-reply k session-scope value))
-                        epoch/projected-record
+                        rf.epoch/projected-record
                         carrier-replies
                         first)))
           r1    (proj reply-params reply-value)
@@ -2127,7 +2127,7 @@
             debug the workflow at all."
     (let [k1        (sk session-scope :derived/profile reply-params)
           reply     (read-reply k1 session-scope reply-value)
-          projected (epoch/projected-record (reply-carrier-record reply)
+          projected (rf.epoch/projected-record (reply-carrier-record reply)
                                             {:include-sensitive? true})]
       (is (= [reply-value reply-value] (mapv :value (carrier-replies projected)))
           "every carrier's raw :value rides with :include-sensitive?")
@@ -2197,7 +2197,7 @@
                                :rf.fx/id :rf.resource/cancel-timers
                                :rf.fx/args {:frame-id :test/rt
                                             :resource/keys [gone]}})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           [custom audit cancel] (:trace-events projected)]
       (testing "the foreign lookalikes ride verbatim"
         (is (= foreign (first (:rows (:rf.fx/args (:tags custom)))))
@@ -2258,7 +2258,7 @@
           mut-row*  (event :rf.fx/handled
                            {:rf.frame/id :test/rt :frame :test/rt
                             :rf.fx/id :rf.http/managed :rf.fx/args mut-args})
-          project1  (fn [row] (epoch/projected-record (record-with [row])))]
+          project1  (fn [row] (rf.epoch/projected-record (record-with [row])))]
       (testing "the app's own request map is untouched"
         (let [tags (:tags (first (:trace-events (project1 app-row*))))]
           (is (= {:method :post :scope app-scope :body {:x 1}} (:request (:rf.fx/args tags)))
@@ -2306,7 +2306,7 @@
                               {:rf.frame/id :test/rt :frame :test/rt
                                :rf.fx/id :dispatch
                                :rf.fx/args (conj read-reply-target marked)})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           [custom reply-row] (:trace-events projected)
           proj-un   (:rf.fx/args (:tags custom))]
       (testing "the UNMARKED map: the key tokenizes, its foreign neighbours do not"
@@ -2419,7 +2419,7 @@
   []
   (rf/configure! {:epoch-history {:trace-events-keep 80}})
   (let [captured (atom nil)]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :declared/profile :params declared-reply-params
@@ -2448,7 +2448,7 @@
       (doseq [[label cache-hit?] [["async settle" false] ["fresh-skip cache hit" true]]]
         (testing label
           (let [raw       (record-carrying-reply records cache-hit?)
-                projected (epoch/projected-record raw)]
+                projected (rf.epoch/projected-record raw)]
 
             (testing "FIXTURE — the producer really put a decoded body on the fx
                       carriers, and the owner really makes no coarse claim"
@@ -2472,7 +2472,7 @@
               (doseq [r (carrier-replies projected)]
                 (is (= :rf/redacted (:email (:value r)))
                     "the `:sensitive`-declared slot carries the sentinel")
-                (is (elision/marker? (:avatar (:value r)))
+                (is (rf.elision/marker? (:avatar (:value r)))
                     "the `:large`-declared slot carries the size marker")
                 (is (= "Ada" (:display-name (:value r)))
                     "and the slot the owner declared NEITHER axis for rides
@@ -2506,13 +2506,13 @@
             resource family speaks only for what it planted."
     (let [k1        (sk :rf.scope/global :declared/profile declared-reply-params)
           reply     (read-reply k1 :rf.scope/global declared-reply-value)
-          projected (epoch/projected-record (reply-carrier-record reply))
+          projected (rf.epoch/projected-record (reply-carrier-record reply))
           replies   (carrier-replies projected)
           [handled do-fx] (:trace-events projected)]
       (is (= 2 (count replies))
           "one reply per carrier — the two the bead named")
       (is (every? #(and (= :rf/redacted (:email (:value %)))
-                        (elision/marker? (:avatar (:value %)))
+                        (rf.elision/marker? (:avatar (:value %)))
                         (= "Ada" (:display-name (:value %))))
                   replies)
           "each carrier redacts, elides, and rides the three slots identically")
@@ -2542,7 +2542,7 @@
     (let [params    {:account "acct-9911" :slug plain-slug}
           k1        (sk :rf.scope/global :declared/params-owner params)
           reply     (read-reply k1 :rf.scope/global {:ok true})
-          projected (epoch/projected-record (reply-carrier-record reply))
+          projected (rf.epoch/projected-record (reply-carrier-record reply))
           r         (first (carrier-replies projected))]
       (is (= :rf/redacted (:account (:params r)))
           "the `[:params :account]` declaration reaches the reply's :params")
@@ -2566,7 +2566,7 @@
     (let [k1        (sk :rf.scope/global :plain/article {:slug plain-slug})
           reply     (read-reply k1 :rf.scope/global declared-reply-value)
           record    (reply-carrier-record reply)
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           [handled do-fx] (:trace-events projected)]
       (is (= (conj read-reply-target reply) (:rf.fx/args (:tags handled)))
           "the whole dispatched event vector rides verbatim — reply :value,
@@ -2592,7 +2592,7 @@
                       [(event :rf.fx/handled
                               {:rf.frame/id :test/rt :frame :test/rt
                                :rf.fx/id :app/custom :rf.fx/args unmarked})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= declared-reply-value (:value (:rf.fx/args tags)))
           "no marker, no reply, no declaration — the map rides byte-for-byte")
@@ -2612,7 +2612,7 @@
             field could not debug the workflow."
     (let [k1        (sk :rf.scope/global :declared/profile declared-reply-params)
           reply     (read-reply k1 :rf.scope/global declared-reply-value)
-          projected (epoch/projected-record (reply-carrier-record reply)
+          projected (rf.epoch/projected-record (reply-carrier-record reply)
                                             {:include-sensitive? true})]
       (is (= [declared-reply-value declared-reply-value]
              (mapv :value (carrier-replies projected)))
@@ -2702,7 +2702,7 @@
   [resource-id]
   (rf/configure! {:epoch-history {:trace-events-keep 80}})
   (let [captured (atom nil)]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource resource-id :params declared-feed-params
@@ -2732,7 +2732,7 @@
                                   ["fresh-skip cache hit" true]]]
         (testing label
           (let [raw       (record-carrying-reply records cache-hit?)
-                projected (epoch/projected-record raw)]
+                projected (rf.epoch/projected-record raw)]
 
             (testing "FIXTURE — the producer really put the MERGED ITEM LIST on
                       the fx carriers, so the assertions below are not passing
@@ -2764,7 +2764,7 @@
                   (is (= :rf/redacted (:email item))
                       "the `:sensitive`-declared field carries the sentinel in
                        this item")
-                  (is (elision/marker? (:avatar item))
+                  (is (rf.elision/marker? (:avatar item))
                       "the `:large`-declared field carries the size marker"))
                 (is (= ["Ada-a" "Ada-b"] (mapv :display-name (:value r)))
                     "and the field the owner declared NEITHER axis for rides
@@ -2804,7 +2804,7 @@
             shape: the identically-named `:email` / `:avatar` fields that
             redact for `:declared/feed` are fully readable here."
     (let [raw       (record-carrying-reply (drive-feed-reply-to-read! :plain/feed) false)
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
       (is (some? raw) "FIXTURE — the plain feed's continuation reached a carrier")
       (is (= 2 (count (reply-carrier-rows raw)))
           "FIXTURE — both carriers are present, as they are for the declared feed")
@@ -2829,7 +2829,7 @@
                       :display-name "Ada"
                       :meta         {:email (str secret "-nested@example.com")}}]
           reply     (read-reply k1 :rf.scope/global items)
-          projected (epoch/projected-record (reply-carrier-record reply))
+          projected (rf.epoch/projected-record (reply-carrier-record reply))
           item      (first (:value (first (carrier-replies projected))))]
       (is (= :rf/redacted (:email item))
           "the declared field, one index down, redacts")
@@ -2851,7 +2851,7 @@
             debug the workflow."
     (let [k1        (sk :rf.scope/global :declared/feed declared-feed-params)
           reply     (read-reply k1 :rf.scope/global declared-feed-items)
-          projected (epoch/projected-record (reply-carrier-record reply)
+          projected (rf.epoch/projected-record (reply-carrier-record reply)
                                             {:include-sensitive? true})]
       (is (= [declared-feed-items declared-feed-items]
              (mapv :value (carrier-replies projected)))
@@ -2917,7 +2917,7 @@
                         [(str vector-secret "-2")])
           record    (record-with
                       [(event :rf.resource/route-plan (route-plan-tags [k1] [k1 k2]))])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))
           [bscope brid bparams] (first (:blocking tags))]
       (testing ":blocking tokenizes per key"
@@ -2953,7 +2953,7 @@
                                :matched     ks     ; NAMED   -> position arm
                                :blocking    ks     ; UNNAMED -> shape arm
                                :identities  ks})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= (:matched tags) (:blocking tags))
           ":blocking projects exactly as the NAMED :matched does")
@@ -2968,13 +2968,13 @@
             :work/id, so a vector-params key one level down inside it egressed
             raw on every one of them."
     (let [scoped-key (sk :rf.scope/global :secret/vector-params vector-params)
-          work-id    (work-ledger/resource-work-id scoped-key 3)
+          work-id    (rf.resources.work-ledger/resource-work-id scoped-key 3)
           record     (record-with
                        [(event :rf.resource/work-started
                                {:rf.frame/id :test/rt :resource/key scoped-key
                                 :generation 3 :work/id work-id
                                 :status :running :cause :ensure})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))
           [marker embedded generation] (:work/id tags)]
       (is (= :rf.work/resource marker) "the work-kind marker rides verbatim")
@@ -3001,7 +3001,7 @@
     (let [k1        (sk :rf.scope/global :plain/vector-params ["welcome"])
           record    (record-with
                       [(event :rf.resource/route-plan (route-plan-tags [k1] [k1]))])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= [k1] (:blocking tags)) "a plain owner's :blocking rides verbatim")
       (is (= [k1] (:identities tags)) "a plain owner's :identities rides verbatim")
@@ -3024,7 +3024,7 @@
                                :cause       [:mutation :m/save 7]
                                :branch      [:r/root :r/article :r/comments]
                                :nav-token   7})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= [:app :l 1] (:owner tags)) "a view path rides verbatim")
       (is (= [:mutation :m/save 7] (:cause tags))
@@ -3041,12 +3041,12 @@
             keeps the raw vector-params plan membership and the raw embedded
             work-id key."
     (let [k1        (sk :rf.scope/global :secret/vector-params vector-params)
-          work-id   (work-ledger/resource-work-id k1 3)
+          work-id   (rf.resources.work-ledger/resource-work-id k1 3)
           record    (record-with
                       [(event :rf.resource/route-plan (route-plan-tags [k1] [k1]))
                        (event :rf.resource/work-started
                               {:rf.frame/id :test/rt :work/id work-id})])
-          projected (epoch/projected-record record {:include-sensitive? true})
+          projected (rf.epoch/projected-record record {:include-sensitive? true})
           [plan work] (:trace-events projected)]
       (is (= [k1] (:blocking (:tags plan))) "raw :blocking rides")
       (is (= [k1] (:identities (:tags plan))) "raw :identities rides")
@@ -3066,7 +3066,7 @@
             halves inside ONE map."
     (let [k1        (sk :rf.scope/global :secret/vector-params vector-params)
           reply     (read-reply k1 :rf.scope/global {:email (str vector-secret "@example.com")})
-          projected (epoch/projected-record (reply-carrier-record reply))
+          projected (rf.epoch/projected-record (reply-carrier-record reply))
           replies   (carrier-replies projected)]
       (is (= 2 (count replies)) "one reply per carrier")
       (doseq [r replies]
@@ -3094,7 +3094,7 @@
     (let [gone      [:rf.scope/global :gone/vector-params [vector-secret]]
           reply     (assoc (read-reply gone :rf.scope/global {:ok true})
                            :resource :gone/vector-params)
-          projected (epoch/projected-record (reply-carrier-record reply))
+          projected (rf.epoch/projected-record (reply-carrier-record reply))
           replies   (carrier-replies projected)]
       (is (= 2 (count replies)))
       (doseq [r replies]
@@ -3124,7 +3124,7 @@
   []
   (rf/configure! {:epoch-history {:trace-events-keep 80}})
   (let [captured (atom nil)]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :secret/vector-params :params vector-params
@@ -3149,7 +3149,7 @@
       (doseq [[label cache-hit?] [["async settle" false] ["fresh-skip cache hit" true]]]
         (testing label
           (let [raw       (record-carrying-reply records cache-hit?)
-                projected (epoch/projected-record raw)]
+                projected (rf.epoch/projected-record raw)]
             (testing "FIXTURE — the producer really put the vector params on the
                       fx carriers"
               (is (some? raw) "the continuation reached an fx carrier at all")
@@ -3270,12 +3270,12 @@
   [resource-id params envelope]
   (rf/configure! {:epoch-history {:trace-events-keep 80}})
   (let [captured (atom nil)]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
-    (frame/swap-runtime-db! :test/rt
-      (fn [rt] (elision/apply-classification-effects
+    (rf.frame/swap-runtime-db! :test/rt
+      (fn [rt] (rf.elision/apply-classification-effects
                  rt {:sensitive [[:auth :user :username]]})))
-    (frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
+    (rf.frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource resource-id :params params
                         :owner    real-owner  :reply-to read-reply-target}]
@@ -3298,7 +3298,7 @@
     (let [records   (drive-failing-reply-to-read! :derived/profile reply-params
                                                   failure-envelope)
           raw       (record-carrying-reply records false)
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
 
       (testing "FIXTURE — the producer really put the envelope on the fx
                 carriers, so the sweep below is not passing over an empty set"
@@ -3349,7 +3349,7 @@
     (let [records   (drive-failing-reply-to-read! :plain/article {:slug plain-slug}
                                                   failure-envelope)
           raw       (record-carrying-reply records false)
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
       (testing "FIXTURE — a plain owner, and the envelope is the ONLY secret"
         (is (some? raw))
         (is (every? #(= failure-envelope (:error %)) (carrier-replies raw)))
@@ -3430,7 +3430,7 @@
             split."
     (let [k         (sk :rf.scope/global :plain/article {:slug plain-slug})
           reply     (failure-read-reply k :rf.scope/global failure-envelope)
-          projected (epoch/projected-record (both-carriers-of k reply))
+          projected (rf.epoch/projected-record (both-carriers-of k reply))
           row-error (:error (:tags (first (:trace-events projected))))
           replies   (family-carrier-replies projected)]
       (is (= 2 (count replies)) "one reply per carrier")
@@ -3448,7 +3448,7 @@
             `:error`, so it must tokenize on the cancel branch too."
     (let [k         (sk :rf.scope/global :plain/article {:slug plain-slug})
           reply     (failure-read-reply k :rf.scope/global abort-envelope)
-          projected (epoch/projected-record (both-carriers-of k reply))
+          projected (rf.epoch/projected-record (both-carriers-of k reply))
           replies   (family-carrier-replies projected)]
       (is (= :cancelled (:status (first replies))) "it really is the cancel branch")
       (is (= :user-abort (:rf.reply/cancel-reason (first replies)))
@@ -3462,7 +3462,7 @@
     (let [k    (sk :rf.scope/global :plain/article {:slug plain-slug})
           tok  (fn [envelope]
                  (-> (both-carriers-of k (failure-read-reply k :rf.scope/global envelope))
-                     epoch/projected-record
+                     rf.epoch/projected-record
                      family-carrier-replies
                      first
                      :error))]
@@ -3475,9 +3475,9 @@
   (testing "rf2-rnsv2 — an already-projected record re-projects to itself; the
             token is not re-digested (the `redacted-token?` guard)."
     (let [k     (sk :rf.scope/global :plain/article {:slug plain-slug})
-          once  (epoch/projected-record
+          once  (rf.epoch/projected-record
                   (both-carriers-of k (failure-read-reply k :rf.scope/global failure-envelope)))
-          twice (epoch/projected-record once)]
+          twice (rf.epoch/projected-record once)]
       (is (= once twice)))))
 
 ;; ---------------------------------------------------------------------------
@@ -3495,7 +3495,7 @@
                               {:rf.frame/id :test/rt :frame :test/rt
                                :rf.event/fx [[:rf.error/report foreign]
                                              [:dispatch [:app/oops foreign]]]})])
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= [[:rf.error/report foreign] [:dispatch [:app/oops foreign]]]
              (:rf.event/fx tags))
@@ -3518,7 +3518,7 @@
                                {:rf.frame/id :test/rt :frame :test/rt
                                 :rf.fx/id :dispatch
                                 :rf.fx/args [:app/http-done http-reply]})])
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           tags       (:tags (first (:trace-events projected)))]
       (is (= [:app/http-done http-reply] (:rf.fx/args tags))
           "the HTTP family's reply rides through this projector untouched"))))
@@ -3533,7 +3533,7 @@
             debugging a 422 needs the body."
     (let [k         (sk :rf.scope/global :plain/article {:slug plain-slug})
           reply     (failure-read-reply k :rf.scope/global failure-envelope)
-          projected (epoch/projected-record (both-carriers-of k reply)
+          projected (rf.epoch/projected-record (both-carriers-of k reply)
                                             {:include-sensitive? true})]
       (is (= [failure-envelope failure-envelope]
              (mapv :error (family-carrier-replies projected)))
@@ -3591,7 +3591,7 @@
   [mutation-id {:keys [status] :as outcome}]
   (rf/configure! {:epoch-history {:trace-events-keep 80}})
   (let [captured (atom nil)]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/save-replied (fn [_ _ev] {}))
     (rf/reg-mutation :m/save
       {:sensitive     [[:params :slug]]
@@ -3629,7 +3629,7 @@
             closed the sixth."
     (let [records   (drive-mutation-reply-to! :m/save {:status :error :error failure-envelope})
           raw       (first (filter #(seq (family-carrier-replies %)) records))
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
       (testing "FIXTURE — the producer really put the envelope on the carriers"
         (is (some? raw) "the mutation continuation reached an fx carrier")
         (is (every? #(= :mutation (:rf.reply/work-kind %))
@@ -3884,7 +3884,7 @@
         (str "the drive really settled the named branch — " k " = " v)))
   (is (seq (secret-leak-paths raw))
       "FIXTURE — the unprojected record leaks, so the sweep below is real")
-  (is (= [] (secret-leak-paths (epoch/projected-record raw)))
+  (is (= [] (secret-leak-paths (rf.epoch/projected-record raw)))
       "ACCEPTANCE — the canary survives at zero paths of the projected record"))
 
 (defn- drive-session-feed-reply-to!
@@ -3906,7 +3906,7 @@
   [outcome]
   (rf/configure! {:epoch-history {:trace-events-keep 80}})
   (let [captured (atom nil)]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
     (rf/reg-resource :derived/feed
       {:scope           {:from-db :rt/session}
@@ -3923,10 +3923,10 @@
        :sensitive?      true
        :params-schema   [:map [:slug :string]]}
       (fn [_ _] {:request {:method :get :url "/i"}}))
-    (frame/swap-runtime-db! :test/rt
-      (fn [rt] (elision/apply-classification-effects
+    (rf.frame/swap-runtime-db! :test/rt
+      (fn [rt] (rf.elision/apply-classification-effects
                  rt {:sensitive [[:auth :user :username]]})))
-    (frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
+    (rf.frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :derived/feed :params reply-params
                         :owner    real-owner   :reply-to read-reply-target}]
@@ -3943,12 +3943,12 @@
   []
   (rf/configure! {:epoch-history {:trace-events-keep 80}})
   (let [captured (atom nil)]
-    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
-    (frame/swap-runtime-db! :test/rt
-      (fn [rt] (elision/apply-classification-effects
+    (rf.frame/swap-runtime-db! :test/rt
+      (fn [rt] (rf.elision/apply-classification-effects
                  rt {:sensitive [[:auth :user :username]]})))
-    (frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
+    (rf.frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :derived/profile :params reply-params
                         :owner    real-owner :reply-to read-reply-target}]

--- a/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
@@ -46,12 +46,12 @@
        leaf — isolates the egress re-root as the redaction site."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.epoch :as epoch]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.elision :as rf.elision]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; Side-effect require (mirror epoch_test.clj fixture).
             [re-frame.machines]))
 
@@ -65,8 +65,8 @@
 ;; public `configure!` boundary — no test ns reaches into the private
 ;; `state/config` var.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
@@ -79,13 +79,13 @@
 ;; registry write a `reg-event` returning `:sensitive` / `:large` performs.
 ;; The frame container is make-frame'd by each deftest before this runs.
 (defn- install-sensitive-schema! [frame-id]
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
   nil)
 
 (defn- install-large-schema! [frame-id]
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt {:large [[:blob :payload]]})))
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt {:large [[:blob :payload]]})))
   nil)
 
 (defn- big-string [n] (apply str (repeat n "X")))
@@ -160,7 +160,7 @@
     (rf/dispatch-sync [:login] {:frame :test/eg})
 
     (let [raw       (last (rf/epoch-history :test/eg))
-          projected (epoch/projected-record raw)
+          projected (rf.epoch/projected-record raw)
           t-evts    (db-pending-events projected)]
       (is (seq t-evts)
           "the projected record still carries the t1/t2 trace events")
@@ -187,7 +187,7 @@
     (rf/dispatch-sync [:seed]  {:frame :test/eg})
     (rf/dispatch-sync [:login] {:frame :test/eg})
 
-    (let [snapshot (epoch/projected-history :test/eg)]
+    (let [snapshot (rf.epoch/projected-history :test/eg)]
       (is (pos? (count snapshot)))
       (is (not-any? contains-secret? snapshot)
           "no record in the bulk snapshot leaks the secret anywhere —
@@ -227,7 +227,7 @@
                        :sub-runs      []
                        :renders       []
                        :effects       []}
-          projected   (epoch/projected-record record)
+          projected   (rf.epoch/projected-record record)
           [p-t1 p-t2] (:trace-events projected)]
       (is (= :rf/redacted (get-in p-t1 [:tags :rf.event/db :auth :password]))
           "t1 :rf.event/db-pending: nested sensitive leaf re-rooted + redacted")
@@ -263,7 +263,7 @@
                        :sub-runs      []
                        :renders       []
                        :effects       []}
-          projected   (epoch/projected-record record)
+          projected   (rf.epoch/projected-record record)
           p-other     (first (:trace-events projected))]
       (is (= "scoped-marker" (get-in p-other [:tags :some-other-slot :auth :password]))
           "the non-t1/t2 event's nested value is untouched — the re-root is
@@ -293,10 +293,10 @@
                      :sub-runs      []
                      :renders       []
                      :effects       []}
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           p-t1      (first (:trace-events projected))
           leaf      (get-in p-t1 [:tags :rf.event/db :blob :payload])]
-      (is (elision/marker? leaf)
+      (is (rf.elision/marker? leaf)
           "the large leaf nested in the t1 :rf.event/db tag is substituted
            with a :rf.size/large-elided marker — re-root reached it")
       (is (not= payload leaf)
@@ -327,7 +327,7 @@
                      :sub-runs      []
                      :renders       []
                      :effects       []}
-          projected (epoch/projected-record record)]
+          projected (rf.epoch/projected-record record)]
       (is (some? projected) "projection did not throw on the edge shapes")
       (is (= {} (get-in (first (:trace-events projected)) [:tags]))
           "the t1 event lacking :rf.event/db passes through with empty tags")
@@ -351,7 +351,7 @@
                      :sub-runs      []
                      :renders       []
                      :effects       []}
-          projected (epoch/projected-record record)]
+          projected (rf.epoch/projected-record record)]
       (is (= :rf/redacted (:trace-events projected))
           "scalar-sentinel :trace-events passes through the re-root chain"))))
 
@@ -366,8 +366,8 @@
     (rf/dispatch-sync [:login] {:frame :test/eg})
 
     (let [raw    (last (rf/epoch-history :test/eg))
-          once   (epoch/projected-record raw)
-          twice  (epoch/projected-record once)]
+          once   (rf.epoch/projected-record raw)
+          twice  (rf.epoch/projected-record once)]
       (is (= once twice)
           "second projection pass is a no-op — the re-rooted :rf.event/db
            leaves are already :rf/redacted")
@@ -427,7 +427,7 @@
     (rf/make-frame {:id :test/http})
     (let [record    (http-record :test/http :rf.http/replied :value
                                   {:token http-body-secret :user-id 42} :omit)
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           ev        (first (:trace-events projected))]
       (is (= :rf/redacted (get-in ev [:tags :value]))
           "the unschematized body slot is omitted off-box (fail-closed)")
@@ -440,7 +440,7 @@
     (rf/make-frame {:id :test/http})
     (let [record    (http-record :test/http :rf.http/accept-failure :decoded
                                   {:token http-body-secret} :omit)
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           ev        (first (:trace-events projected))]
       (is (= :rf/redacted (get-in ev [:tags :decoded]))
           "the unschematized :decoded body slot is omitted off-box"))))
@@ -456,7 +456,7 @@
     (let [classified {:token :rf/redacted :user-id 42}
           record     (http-record :test/http :rf.http/replied :value
                                    classified :classify)
-          projected  (epoch/projected-record record)
+          projected  (rf.epoch/projected-record record)
           ev         (first (:trace-events projected))]
       (is (= classified (get-in ev [:tags :value]))
           "the classified schema body rides off-box untouched (sensitive
@@ -469,7 +469,7 @@
     (rf/make-frame {:id :test/http})
     (let [body      {:token http-body-secret :user-id 42}
           record    (http-record :test/http :rf.http/replied :value body :omit)
-          projected (epoch/projected-record record {:include-sensitive? true})
+          projected (rf.epoch/projected-record record {:include-sensitive? true})
           ev        (first (:trace-events projected))]
       (is (= body (get-in ev [:tags :value]))
           "with :include-sensitive? true the body is NOT omitted (lifted)"))))
@@ -494,7 +494,7 @@
     (rf/make-frame {:id :test/http})
     (let [body      {:k "v"}
           record    (http-record :test/http :rf.http/replied :value body nil)
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           ev        (first (:trace-events projected))]
       (is (= body (get-in ev [:tags :value]))
           "no stamp ⇒ no omission (the projector only omits an explicit :omit)"))))
@@ -517,7 +517,7 @@
     (rf/make-frame {:id :test/http})
     (let [record    (http-record :test/http :rf.http/http-5xx :body
                                   (str "error echoing " http-body-secret) :omit)
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           ev        (first (:trace-events projected))]
       (is (= :rf/redacted (get-in ev [:tags :body]))
           "the raw 5xx body slot is omitted off-box (fail-closed)")
@@ -529,7 +529,7 @@
     (rf/make-frame {:id :test/http})
     (let [record    (http-record :test/http :rf.http/http-4xx :body
                                   (str "forbidden " http-body-secret) :omit)
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           ev        (first (:trace-events projected))]
       (is (= :rf/redacted (get-in ev [:tags :body])))
       (is (not (contains-http-secret? projected))))))
@@ -540,7 +540,7 @@
     (rf/make-frame {:id :test/http})
     (let [record    (http-record :test/http :rf.http/decode-failure :body-text
                                   (str "not-json " http-body-secret) :omit)
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           ev        (first (:trace-events projected))]
       (is (= :rf/redacted (get-in ev [:tags :body-text]))
           "the raw decode-failure body-text is omitted off-box")
@@ -571,7 +571,7 @@
                      :sub-runs      []
                      :renders       []
                      :effects       []}
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           ev        (first (:trace-events projected))]
       (is (= :rf/redacted (get-in ev [:tags :failure :body]))
           "the nested intermediate-failure raw body is omitted off-box")
@@ -586,7 +586,7 @@
     (rf/make-frame {:id :test/http})
     (let [body      (str "raw error " http-body-secret)
           record    (http-record :test/http :rf.http/http-5xx :body body :omit)
-          projected (epoch/projected-record record {:include-sensitive? true})
+          projected (rf.epoch/projected-record record {:include-sensitive? true})
           ev        (first (:trace-events projected))]
       (is (= body (get-in ev [:tags :body]))
           "with :include-sensitive? true the raw error body is NOT omitted"))))
@@ -635,7 +635,7 @@
       ;; the debug gate false — a cold process-start reproduction. Existing
       ;; tests never reach this: their table loaded gate-true. projected-record
       ;; is a pure transform (it never consults the gate), so it runs after.
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         (require 're-frame.epoch.tool-pair :reload))
       ;; The five PRODUCTION-REAL operations, one per body slot.
       (doseq [[operation body-slot] [[:rf.http/replied        :value]
@@ -645,7 +645,7 @@
                                      [:rf.http/decode-failure :body-text]]]
         (let [record    (http-record :test/http operation body-slot
                                      {:token http-body-secret :user-id 7} :omit)
-              projected (epoch/projected-record record)
+              projected (rf.epoch/projected-record record)
               ev        (first (:trace-events projected))]
           (is (= :rf/redacted (get-in ev [:tags body-slot]))
               (str "cold gate-false: " operation " body slot " body-slot

--- a/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
@@ -44,14 +44,14 @@
   records, populate history, and accept time-travel restores."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
-            [re-frame.epoch :as epoch]
-            [re-frame.epoch.listeners :as epoch.listeners]))
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.epoch.listeners :as rf.epoch.listeners]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- settle! commits no record under prod --------------------------------
 
@@ -160,9 +160,9 @@
         "unregister-listener! :epoch returns nil under prod")
     (is (vector? (rf/epoch-history :rf/default))
         "epoch-history returns a vector (empty) under prod")
-    (is (nil? (epoch/clear-history!))
+    (is (nil? (rf.epoch/clear-history!))
         "clear-history! returns nil under prod")
-    (is (nil? (epoch/clear-epoch-listeners!))
+    (is (nil? (rf.epoch/clear-epoch-listeners!))
         "clear-epoch-listeners! returns nil under prod")))
 
 ;; ---- on-frame-destroyed! is silent under prod ----------------------------
@@ -175,5 +175,5 @@
             observed-frames-by-cb bookkeeping side-effect is dead too.
             Frame-destroy paths that route through this hook do not
             crash."
-    (is (nil? (epoch.listeners/on-frame-destroyed! :rf/default nil nil nil nil))
+    (is (nil? (rf.epoch.listeners/on-frame-destroyed! :rf/default nil nil nil nil))
         "on-frame-destroyed! returns nil under prod even for unknown frames")))

--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -100,10 +100,10 @@
   witness is the half that makes the other half mean something."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.epoch :as epoch]
-            [re-frame.interop :as interop]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.interop :as rf.interop]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; Side-effect require: machines publishes the late-bind hook
             ;; (see epoch_test.clj for the same dance).
             [re-frame.machines]))
@@ -127,8 +127,8 @@
 ;; resolve a carried frame stamp without a hand-rolled `make-frame` + `with-
 ;; frame` dance here. Explicit `{:frame …}` opts in the bodies still win.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
 ;; rf2-t7qh8 — the witness read. See the docstring section above: it is what
@@ -143,7 +143,7 @@
             `:trace-events` payloads land in heap memory — the
             primary motivating concern of the audit (tokens / PII /
             secrets retained in SSR process memory) is addressed."
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (rf/reg-event :prod-gate.epoch/inc
                        (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod-gate.epoch/inc])
@@ -152,7 +152,7 @@
       (is (= 3 (:n (app-db-of :rf/default)))
           "WITNESS: all three dispatches ran their handler and committed —
            so the empty ring below is elision, not a dead dispatch loop")
-      (is (empty? (epoch/epoch-history :rf/default))
+      (is (empty? (rf.epoch/epoch-history :rf/default))
           "epoch ring is empty under disabled debug gate"))))
 
 (deftest epoch-cb-silent-when-debug-disabled
@@ -160,9 +160,9 @@
             fire under the disabled debug gate. No record fan-out
             means no tool/plugin callback in-process can observe
             `:db-before` / `:db-after` / raw trace vectors."
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (let [seen (atom [])]
-        (epoch/register-epoch-listener!
+        (rf.epoch/register-epoch-listener!
           :prod-gate.epoch/recorder
           (fn [record] (swap! seen conj record)))
         (rf/reg-event :prod-gate.epoch/silent
@@ -180,7 +180,7 @@
             surface is dev-only; SSR production processes do NOT
             give arbitrary in-process code the ability to mutate
             `app-db` out of band."
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (is (false? (rf/restore-epoch! :rf/default :some-epoch-id))
           "restore-epoch! returns false (refuses to operate)"))))
 
@@ -200,7 +200,7 @@
         "WITNESS: the probe handler ran — there is a real dispatch to refuse to replay")
     (let [recorded-id (or (:epoch-id (last (rf/epoch-history :rf/default)))
                           :some-epoch-id)]
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         (is (false? (rf/replay-epoch! :rf/default recorded-id))
             "replay-epoch! returns false (refuses to operate)")
         (is (false? (rf/replay-epoch! :rf/default :some-epoch-id {:origin :pair}))
@@ -213,7 +213,7 @@
             when the JVM debug gate is off. Same admin-surface
             concern as `restore-epoch!` — pair-tool writes (Tool-Pair
             §Pair-tool writes) are a dev-only surface."
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (is (false? (rf/replace-frame-state! :rf/default {:rf.db/app {:any "db"}}))
           "replace-frame-state! returns false (refuses to operate)"))))
 
@@ -235,7 +235,7 @@
     (rf/reg-event :prod-gate.epoch/dev-inc
                      (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/dispatch-sync [:prod-gate.epoch/dev-inc])
-    (is (pos? (count (epoch/epoch-history :rf/default)))
+    (is (pos? (count (rf.epoch/epoch-history :rf/default)))
         "epoch ring has at least one record under default gate")))
 
 ;; ---- rf2-vq5o0 privacy-surface JVM false-path coverage ------------------
@@ -248,14 +248,14 @@
             seam; the projection itself is a pure data transform that
             no consumer can reach a record through under the disabled
             gate."
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (rf/reg-event :prod-gate.priv/silent
                        (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod-gate.priv/silent])
       (is (= 1 (:n (app-db-of :rf/default)))
           "WITNESS: the dispatch ran — nothing reached the ring for the
            projection to read")
-      (is (= [] (epoch/projected-history :rf/default))
+      (is (= [] (rf.epoch/projected-history :rf/default))
           "empty projected-history under the disabled gate"))))
 
 (deftest sensitive-rollup-not-computed-under-disabled-gate
@@ -264,7 +264,7 @@
             path elides record assembly entirely; the rollup never
             runs. We verify by asserting the ring stays empty — no
             record means no rollup compute path was reached."
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (rf/reg-event :prod-gate.priv/sensitive
                        {:sensitive? true}
                        (fn [{:keys [db]} _] {:db (assoc db :token "shh")}))
@@ -272,7 +272,7 @@
       (is (= "shh" (:token (app-db-of :rf/default)))
           "WITNESS: the `:sensitive?`-flagged handler ran and wrote the token —
            so the absent rollup below is elision, not an absent event")
-      (is (empty? (epoch/epoch-history :rf/default))
+      (is (empty? (rf.epoch/epoch-history :rf/default))
           "no record assembled — rollup never reached"))))
 
 ;; ---- EP-0015 §15 / open-issue 6 :redact-fn surface JVM coverage ----------
@@ -290,7 +290,7 @@
             is NEVER invoked along the dispatch/storage path. An app that
             ships a `:redact-fn` and flips the gate to false in production
             pays zero invocation cost."
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (let [invocations (atom 0)]
         (rf/configure! {:epoch-history {:redact-fn (fn [r]
                                     (swap! invocations inc)
@@ -306,7 +306,7 @@
         (is (zero? @invocations)
             ":redact-fn was never called along the storage path — it is a
              projection-side hook, and record assembly is elided anyway")
-        (is (empty? (epoch/epoch-history :rf/default))
+        (is (empty? (rf.epoch/epoch-history :rf/default))
             "no record assembled under the disabled gate")
         (rf/configure! {:epoch-history {:redact-fn nil}})))))
 
@@ -328,7 +328,7 @@
       (is (zero? @invocations)
           ":redact-fn NOT invoked by settle — it is projection-side only")
       ;; Projecting the recorded record IS where the override fires.
-      (epoch/projected-record (last (epoch/epoch-history :prod-gate.dev/frame)))
+      (rf.epoch/projected-record (last (rf.epoch/epoch-history :prod-gate.dev/frame)))
       (is (pos? @invocations)
           ":redact-fn fires when projected-record is called (the egress
            override), under the default gate")
@@ -339,7 +339,7 @@
             gated arm that would record the synthetic epoch is elided. The
             :redact-fn (projection-side) is never reached on this path
             regardless; the early-return false is preserved."
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (let [invocations (atom 0)]
         (rf/configure! {:epoch-history {:redact-fn (fn [r]
                                     (swap! invocations inc)
@@ -404,8 +404,8 @@
            :sub-runs      []
            :renders       []
            :effects       []}]
-      (with-redefs [interop/debug-enabled? false]
-        (let [projected (epoch/projected-record synthetic-record)]
+      (with-redefs [rf.interop/debug-enabled? false]
+        (let [projected (rf.epoch/projected-record synthetic-record)]
           (is (some? projected)
               "projection runs even under the disabled gate")
           (is (= 42 (:epoch-id projected))

--- a/implementation/epoch/test/re_frame/epoch_late_bind_missing_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_late_bind_missing_cljs_test.cljs
@@ -36,13 +36,13 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- with-hook-as-nil
   "Run `f` with the named late-bind hook set to nil. Restores the
@@ -52,12 +52,12 @@
   absent-artefact state without unloading the namespace (which
   CLJS cannot do)."
   [hook-key f]
-  (let [original (late-bind/get-fn hook-key)]
+  (let [original (rf.late-bind/get-fn hook-key)]
     (try
-      (late-bind/set-fn! hook-key nil)
+      (rf.late-bind/set-fn! hook-key nil)
       (f)
       (finally
-        (late-bind/set-fn! hook-key original)))))
+        (rf.late-bind/set-fn! hook-key original)))))
 
 (deftest replace-frame-state!-raises-when-epoch-artefact-missing-cljs
   (testing "rf/replace-frame-state! raises :rf.error/epoch-artefact-missing

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -66,17 +66,17 @@
   `test/end-to-end-*.cjs` paths if and when MCP-server epoch tools ship."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.epoch :as epoch]
-            [re-frame.frame :as frame]
+            [re-frame.elision :as rf.elision]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.frame :as rf.frame]
             ;; rf2-isp3i — `fx/reg-fx`, the plain fn, NOT the `rf/reg-fx` macro:
             ;; see `install-resource-family!` for why the difference decides
             ;; whether the frame's default image can still be reprojected.
-            [re-frame.fx :as fx]
-            [re-frame.schemas :as schemas]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.fx :as rf.fx]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace.tooling :as rf.trace.tooling]
             ;; Side-effect requires (mirror epoch_test.clj fixture).
             [re-frame.machines]
             ;; rf2-isp3i — load-bearing: registers the `:rf.resource/*` events
@@ -103,8 +103,8 @@
 ;; public `configure!` boundary — no test ns reaches into the private
 ;; `state/config` var.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
@@ -164,8 +164,8 @@
   some steps, and a classified path is a harmless no-op over an absent
   value.)"
   [frame-id]
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt
                {:sensitive [[:auth :password]
                             ;; rf2-0t7o8 — the SESSION IDENTITY the named scope
                             ;; resolver reads (`install-resource-family!`).
@@ -529,8 +529,8 @@
     catches the pin itself rotting."
   [frame-id]
   (rf/configure! {:epoch-history {:trace-events-keep 50}})
-  (frame/swap-frame-db! frame-id assoc-in [:auth :user :username] secret-password)
-  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf.frame/swap-frame-db! frame-id assoc-in [:auth :user :username] secret-password)
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
   (rf/reg-resource-scope session-scope-id
     {:inputs {:username [:db [:auth :user :username]]}}
     (fn [{:keys [username]} _ctx]
@@ -661,7 +661,7 @@
   [frame-id]
   (let [rows (atom [])
         k    ::resource-family-recorder]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (resource-family-row? ev) (swap! rows conj ev))))
     (try
       (rf/dispatch-sync [:rf.resource/ensure
@@ -699,7 +699,7 @@
                           :params   {:slug session-slug}
                           :owner    session-owner}]
                         {:frame frame-id})
-      (finally (trace-tooling/unregister-listener! k)))
+      (finally (rf.trace.tooling/unregister-listener! k)))
     @rows))
 
 (defn- invalidated-row
@@ -880,7 +880,7 @@
     (let [shipped (atom [])
           ship!   (fn [record]
                     ;; Tool-side forwarder body — project at egress.
-                    (swap! shipped conj (epoch/projected-record record)))]
+                    (swap! shipped conj (rf.epoch/projected-record record)))]
       (rf/register-listener! :epoch ::forwarder ship!)
       (drive-mixed-ring! :test/mcp)
       (is (pos? (count @shipped))
@@ -919,7 +919,7 @@
     (let [shipped (atom [])]
       (rf/register-listener! :epoch ::forwarder
                              (fn [record]
-                               (swap! shipped conj (epoch/projected-record record))))
+                               (swap! shipped conj (rf.epoch/projected-record record))))
       (drive-mixed-ring! :test/mcp)
       (let [raw-leaf-count       (count-leaf-strings-at-least payload-size
                                                               (rf/epoch-history :test/mcp))
@@ -963,14 +963,14 @@
              classification this fixture installs cannot reach it, and the flag
              is the entire contract egress has to honour")
         ;; Both callers of the shared rule, both slots of each, at egress.
-        (is (elision/marker? (:value proj-row))
+        (is (rf.elision/marker? (:value proj-row))
             "`elide-sub-run-row` substituted the marker in the structured row")
-        (is (elision/marker? (:prev-value proj-row))
+        (is (rf.elision/marker? (:prev-value proj-row))
             "…and in that row's PREVIOUS-value slot")
-        (is (elision/marker? (:rf.sub/value proj-tags))
+        (is (rf.elision/marker? (:rf.sub/value proj-tags))
             "`elide-large-sub-trace-values` substituted the marker in the trace
              tag — the slot whose omission was rf2-irwsq's leak")
-        (is (elision/marker? (:rf.sub/prev-value proj-tags))
+        (is (rf.elision/marker? (:rf.sub/prev-value proj-tags))
             "…and in that tag's PREVIOUS-value slot, the fourth and last of the
              pair-of-pairs the one shared rule owns")
         (is (zero? (count-leaf-strings-at-least payload-size proj))
@@ -1015,7 +1015,7 @@
     (install-mcp-style-schemas! :test/mcp)
     (drive-mixed-ring! :test/mcp)
     (let [raw       (rf/epoch-history :test/mcp)
-          projected (mapv epoch/projected-record raw)
+          projected (mapv rf.epoch/projected-record raw)
           bookkeeping-keys [:epoch-id :frame :committed-at :event-id
                             :outcome :halt-reason :schema-digest
                             :rf.epoch/sensitive?]]
@@ -1034,13 +1034,13 @@
     (install-mcp-style-schemas! :test/mcp)
     (drive-mixed-ring! :test/mcp)
     (let [ring-before        (rf/epoch-history :test/mcp)
-          schemas-before     (schemas/snapshot-schemas-by-frame)
+          schemas-before     (rf.schemas/snapshot-schemas-by-frame)
           ;; Hit projected-record many times — a real forwarder might
           ;; project the same record multiple times (re-trigger, replay).
           _                  (dotimes [_ 25]
-                               (mapv epoch/projected-record ring-before))
+                               (mapv rf.epoch/projected-record ring-before))
           ring-after         (rf/epoch-history :test/mcp)
-          schemas-after      (schemas/snapshot-schemas-by-frame)]
+          schemas-after      (rf.schemas/snapshot-schemas-by-frame)]
       (is (= ring-before ring-after)
           "the epoch ring is unchanged — projected-record does not mutate")
       (is (= schemas-before schemas-after)
@@ -1075,9 +1075,9 @@
     (install-mcp-style-schemas! :test/mcp)
     (drive-mixed-ring! :test/mcp)
     (let [raw    (rf/epoch-history :test/mcp)
-          once   (mapv epoch/projected-record raw)
-          twice  (mapv epoch/projected-record once)
-          thrice (mapv epoch/projected-record twice)]
+          once   (mapv rf.epoch/projected-record raw)
+          twice  (mapv rf.epoch/projected-record once)
+          thrice (mapv rf.epoch/projected-record twice)]
       ;; Sensitive substitution holds across all three passes.
       (is (every? (fn [r] (= :rf/redacted (get-in r [:db-after :auth :password])))
                   (rest once))
@@ -1125,14 +1125,14 @@
     (install-mcp-style-schemas! :test/mcp)
     (drive-mixed-ring! :test/mcp)
     (let [raw    (rf/epoch-history :test/mcp)
-          once   (mapv epoch/projected-record raw)
-          twice  (mapv epoch/projected-record once)
-          thrice (mapv epoch/projected-record twice)
+          once   (mapv rf.epoch/projected-record raw)
+          twice  (mapv rf.epoch/projected-record once)
+          thrice (mapv rf.epoch/projected-record twice)
           ;; The :upload cascade is the third one driven (index 2):
           ;; that record is the one whose :db-after carries the large
           ;; payload at the frame-declared `[:blob :payload]` slot.
           large-slot (fn [r] (get-in r [:db-after :blob :payload]))]
-      (is (elision/marker? (large-slot (nth once 2)))
+      (is (rf.elision/marker? (large-slot (nth once 2)))
           "first projection pass substitutes a marker at the large slot")
       (is (= (large-slot (nth once 2))
              (large-slot (nth twice 2)))
@@ -1161,7 +1161,7 @@
     (drive-mixed-ring! :test/mcp)
     (let [raw    (rf/epoch-history :test/mcp)
           mixed  (concat [nil] raw [nil] raw [nil])
-          shaped (mapv epoch/projected-record mixed)]
+          shaped (mapv rf.epoch/projected-record mixed)]
       (is (= (count mixed) (count shaped))
           "every input slot produced an output slot")
       (is (= 3 (count (filter nil? shaped)))
@@ -1185,7 +1185,7 @@
     (rf/make-frame {:id :test/mcp})
     (install-mcp-style-schemas! :test/mcp)
     (drive-mixed-ring! :test/mcp)
-    (let [snapshot (epoch/projected-history :test/mcp)]
+    (let [snapshot (rf.epoch/projected-history :test/mcp)]
       (is (pos? (count snapshot))
           "sanity: the snapshot is non-empty")
       (is (not-any? contains-secret? snapshot)
@@ -1204,8 +1204,8 @@
     (install-mcp-style-schemas! :test/mcp)
     (drive-mixed-ring! :test/mcp)
     (let [raw            (rf/epoch-history :test/mcp)
-          bulk-projection (epoch/projected-history :test/mcp)
-          per-record      (mapv epoch/projected-record raw)]
+          bulk-projection (rf.epoch/projected-history :test/mcp)
+          per-record      (mapv rf.epoch/projected-record raw)]
       (is (= per-record bulk-projection)
           "projected-history is the bulk-shape equivalent of
            (mapv projected-record (epoch-history fid))"))))
@@ -1220,7 +1220,7 @@
     (install-mcp-style-schemas! :test/mcp)
     (drive-mixed-ring! :test/mcp)
     (let [raw      (rf/epoch-history :test/mcp)
-          snapshot (epoch/projected-history :test/mcp)]
+          snapshot (rf.epoch/projected-history :test/mcp)]
       (is (= (mapv :epoch-id raw)
              (mapv :epoch-id snapshot))
           "ordering matches the raw ring epoch-id-by-epoch-id"))))
@@ -1233,9 +1233,9 @@
             shape-stable across the empty case."
     (rf/make-frame {:id :test/mcp})
     (install-mcp-style-schemas! :test/mcp)
-    (is (= [] (epoch/projected-history :test/mcp))
+    (is (= [] (rf.epoch/projected-history :test/mcp))
         "empty-ring snapshot is the empty vector")
-    (is (= [] (epoch/projected-history :rf/no-such-frame))
+    (is (= [] (rf.epoch/projected-history :rf/no-such-frame))
         "missing-frame snapshot is also the empty vector — uniform shape")))
 
 (deftest watch-epochs-projected-history-is-pure-no-side-effects
@@ -1247,10 +1247,10 @@
     (install-mcp-style-schemas! :test/mcp)
     (drive-mixed-ring! :test/mcp)
     (let [ring-before    (rf/epoch-history :test/mcp)
-          schemas-before (schemas/snapshot-schemas-by-frame)
-          _              (dotimes [_ 25] (epoch/projected-history :test/mcp))
+          schemas-before (rf.schemas/snapshot-schemas-by-frame)
+          _              (dotimes [_ 25] (rf.epoch/projected-history :test/mcp))
           ring-after     (rf/epoch-history :test/mcp)
-          schemas-after  (schemas/snapshot-schemas-by-frame)]
+          schemas-after  (rf.schemas/snapshot-schemas-by-frame)]
       (is (= ring-before ring-after)
           "the ring is unchanged after 25 bulk-projection calls")
       (is (= schemas-before schemas-after)
@@ -1301,7 +1301,7 @@
                           :fx [[:fxp/login c]]}))
       (rf/dispatch-sync [:do-login creds] {:frame :test/mcp})
       (let [raw      (last (rf/epoch-history :test/mcp))
-            proj     (epoch/projected-record raw {:include-sensitive? true})
+            proj     (rf.epoch/projected-record raw {:include-sensitive? true})
             fx-row   (some #(when (= :fxp/login (:fx-id %)) %) (:effects proj))]
         ;; App-db sensitive axis: REVEALED by include-sensitive.
         (is (= secret-password (get-in proj [:db-after :auth :password]))
@@ -1331,7 +1331,7 @@
                                                  {:state :live})}))
     (rf/dispatch-sync [:seed-both] {:frame :test/mcp})
     (let [raw  (last (rf/epoch-history :test/mcp))
-          proj (epoch/projected-record raw {:include-sensitive? true})]
+          proj (rf.epoch/projected-record raw {:include-sensitive? true})]
       ;; Sanity: the raw record DOES carry a populated runtime-db partition
       ;; (the machine snapshot we wrote, alongside the frame's elision
       ;; registry which also lives in the runtime-db partition).
@@ -1349,7 +1349,7 @@
            include-sensitive alone — runtime-db is orthogonal to the app-db
            sensitive axis")
       ;; And the explicit runtime-db opt DOES lift it (negative control).
-      (let [proj+rt (epoch/projected-record raw {:include-sensitive?  true
+      (let [proj+rt (rf.epoch/projected-record raw {:include-sensitive?  true
                                                  :include-runtime-db? true})]
         (is (not= :rf/redacted (get-in proj+rt [:frame-state-after :rf.db/runtime]))
             "the explicit `:include-runtime-db? true` opt lifts the partition —
@@ -1367,19 +1367,19 @@
                                 :blob {:payload (big-string payload-size)}}}))
     (rf/dispatch-sync [:seed-large] {:frame :test/mcp})
     (let [raw  (last (rf/epoch-history :test/mcp))
-          proj (epoch/projected-record raw {:include-sensitive? true})]
+          proj (rf.epoch/projected-record raw {:include-sensitive? true})]
       ;; Sensitive REVEALED; large STILL elided.
       (is (= secret-password (get-in proj [:db-after :auth :password]))
           "`:include-sensitive? true` reveals the app-db sensitive leaf")
-      (is (elision/marker? (get-in proj [:db-after :blob :payload]))
+      (is (rf.elision/marker? (get-in proj [:db-after :blob :payload]))
           "the app-db large slot STAYS a `:rf.size/large-elided` marker —
            large elision is orthogonal to the sensitive axis")
       (is (zero? (count-leaf-strings-at-least payload-size proj))
           "no raw large-payload bytes egress under include-sensitive alone")
       ;; Negative control: :include-large? true lifts it.
-      (let [proj+lg (epoch/projected-record raw {:include-sensitive? true
+      (let [proj+lg (rf.epoch/projected-record raw {:include-sensitive? true
                                                  :include-large?     true})]
-        (is (not (elision/marker? (get-in proj+lg [:db-after :blob :payload])))
+        (is (not (rf.elision/marker? (get-in proj+lg [:db-after :blob :payload])))
             "the explicit `:include-large? true` opt lifts the large slot —
              proving the axis is independently governed")))))
 
@@ -1398,7 +1398,7 @@
                      (fn [{:keys [db]} _] {:db {:auth {:password secret-password}}}))
     (rf/dispatch-sync [:seed-sensitive] {:frame :test/mcp})
     (let [raw  (last (rf/epoch-history :test/mcp))
-          proj (epoch/projected-record raw {:include-sensitive? true})]
+          proj (rf.epoch/projected-record raw {:include-sensitive? true})]
       (is (= secret-password (get-in proj [:db-after :auth :password]))
           "`:include-sensitive? true` reveals the app-db sensitive leaf")
       (is (true? (:rf.test/redact-fn-ran proj))
@@ -1424,8 +1424,8 @@
     (install-mcp-style-schemas! :test/mcp)
     (drive-mixed-ring! :test/mcp)
     (let [raw        (rf/epoch-history :test/mcp)
-          bulk       (epoch/projected-history :test/mcp)
-          per-record (mapv epoch/projected-record raw)]
+          bulk       (rf.epoch/projected-history :test/mcp)
+          per-record (mapv rf.epoch/projected-record raw)]
       ;; The :login cascade is the second one driven; pull both shapes'
       ;; corresponding record and compare leaf-by-leaf.
       (let [login-bulk (nth bulk       1)
@@ -1446,9 +1446,9 @@
             per-slot    (get-in upload-per  [:db-after :blob :payload])]
         (is (= bulk-slot per-slot)
             "the large-payload slot substitution matches between bulk and per-record")
-        (is (elision/marker? bulk-slot)
+        (is (rf.elision/marker? bulk-slot)
             "the bulk-shape large slot is an elision marker (`:rf.size/large-elided`)")
-        (is (elision/marker? per-slot)
+        (is (rf.elision/marker? per-slot)
             "the per-record-shape large slot is an elision marker")))))
 
 ;; ============================================================================
@@ -1475,7 +1475,7 @@
                            {:db (assoc-in db [:auth :password] pw)}))
     (let [shipped (atom [])]
       (rf/register-listener! :epoch ::forwarder
-                                   (fn [r] (swap! shipped conj (epoch/projected-record r))))
+                                   (fn [r] (swap! shipped conj (rf.epoch/projected-record r))))
       (rf/dispatch-sync [:login secret-password] {:frame :test/mcp})
       (is (pos? (count @shipped)) "the forwarder saw the cascade")
       (is (not-any? contains-secret? @shipped)
@@ -1495,7 +1495,7 @@
     (rf/reg-event :auth/login (fn [{:keys [db]} [_ {:keys [password]}]]
                                 {:db (assoc-in db [:auth :password] password)}))
     (rf/dispatch-sync [:auth/login {:password secret-password}] {:frame :test/mcp})
-    (let [proj (epoch/projected-record (last (rf/epoch-history :test/mcp)))]
+    (let [proj (rf.epoch/projected-record (last (rf/epoch-history :test/mcp)))]
       (is (= [:auth/login :rf/redacted] (:trigger-event proj)))
       (is (not (contains-secret? (:trigger-event proj)))
           "the map-arg secret is absent from the projected trigger-event"))))
@@ -1513,13 +1513,13 @@
     (rf/dispatch-sync [:login secret-password] {:frame :test/mcp})
     (let [raw (last (rf/epoch-history :test/mcp))]
       ;; include-event-args reveals the args but keeps app-db sensitive redacted.
-      (let [proj (epoch/projected-record raw {:include-event-args? true})]
+      (let [proj (rf.epoch/projected-record raw {:include-event-args? true})]
         (is (= [:login secret-password] (:trigger-event proj))
             "`:include-event-args? true` reveals the raw trigger-event args")
         (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
             "the app-db sensitive leaf STAYS redacted — orthogonal axis"))
       ;; include-sensitive reveals the app-db leaf but keeps event args redacted.
-      (let [proj (epoch/projected-record raw {:include-sensitive? true})]
+      (let [proj (rf.epoch/projected-record raw {:include-sensitive? true})]
         (is (= secret-password (get-in proj [:db-after :auth :password]))
             "`:include-sensitive? true` reveals the app-db sensitive leaf")
         (is (= [:login :rf/redacted] (:trigger-event proj))
@@ -1552,9 +1552,9 @@
     (let [rows      (drive-resource-family! :test/mcp)
           raw-hist  (rf/epoch-history :test/mcp)
           record    (record-carrying-resource-rows :test/mcp rows)
-          projected (epoch/projected-record record)
+          projected (rf.epoch/projected-record record)
           proj-rows (filter resource-family-row? (:trace-events projected))
-          proj-hist (mapv epoch/projected-record raw-hist)]
+          proj-hist (mapv rf.epoch/projected-record raw-hist)]
 
       ;; ---- fixture controls: the shape the scans below must be able to see --
       (testing "FIXTURE — the cascade produced real family rows carrying the
@@ -1846,7 +1846,7 @@
       (testing "idempotent under repeated projection — a forwarder that
                 accidentally projects twice (middleware composition,
                 tool-then-watcher fan-out) MUST NOT re-hash the tokens"
-        (is (= projected (epoch/projected-record projected))
+        (is (= projected (rf.epoch/projected-record projected))
             "re-projecting an already-projected record is a fixed point")))))
 
 (deftest forwarder-projected-record-keeps-plain-resource-owner-verbatim
@@ -1862,8 +1862,8 @@
     (install-mcp-style-schemas! :test/mcp)
     (install-resource-family! :test/mcp)
     (let [rows      (drive-resource-family! :test/mcp)
-          proj-hist (mapv epoch/projected-record (rf/epoch-history :test/mcp))
-          projected (epoch/projected-record
+          proj-hist (mapv rf.epoch/projected-record (rf/epoch-history :test/mcp))
+          projected (rf.epoch/projected-record
                       (record-carrying-resource-rows :test/mcp rows))
           proj-rows (filter resource-family-row? (:trace-events projected))
           plain-key [:rf.scope/global plain-resource-id {:slug plain-slug}]

--- a/implementation/epoch/test/re_frame/epoch_override_capture_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_override_capture_test.clj
@@ -21,11 +21,11 @@
        ruling's pinned scope."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- last-record [frame-id]
   (last (rf/epoch-history frame-id)))

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -21,12 +21,12 @@
   Also covers retention caps and the JVM debug-disabled path."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.epoch :as epoch]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.elision :as rf.elision]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; Side-effect requires (mirrors epoch_test.clj):
             [re-frame.machines]))
 
@@ -52,8 +52,8 @@
 ;; hand-rolled `make-frame` + `with-frame` here. Explicit `{:frame …}` opts
 ;; in the bodies still win.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
@@ -73,8 +73,8 @@
   cascades that legitimately leave `:auth` absent (a non-auth event) or
   clear `:password` mid-cascade need no `:maybe` / `:optional` wrapper."
   [frame-id]
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
   nil)
 
 (defn- install-large-schema!
@@ -83,8 +83,8 @@
   under `:source :effect`). The frame container is make-frame'd by each
   deftest before this runs."
   [frame-id]
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt {:large [[:blob :payload]]})))
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt {:large [[:blob :payload]]})))
   nil)
 
 (defn- big-string [n]
@@ -208,7 +208,7 @@
                              (fn [r] (swap! seen conj r)))
       (rf/reg-event :destroy-self
                        (fn [_ _]
-                         (frame/destroy-frame! :test/main)
+                         (rf.frame/destroy-frame! :test/main)
                          {}))
       ;; The destroy fires inside the drain — on-frame-destroyed!
       ;; emits a :halted-destroy partial record carrying the REAL
@@ -267,7 +267,7 @@
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
       (is (= "topsecret" (get-in raw [:db-after :auth :password]))
           "raw record carries the unredacted value (in-process)")
       (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
@@ -287,7 +287,7 @@
     (rf/dispatch-sync [:inc]  {:frame :test/main})
 
     (let [raw       (last-record :test/main)
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
       (is (= "original-secret"
              (get-in raw [:db-before :auth :password]))
           "raw :db-before carries the value")
@@ -306,14 +306,14 @@
     (rf/dispatch-sync [:store (big-string 50000)] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
-          projected (epoch/projected-record raw)
+          projected (rf.epoch/projected-record raw)
           marked    (get-in projected [:blob :payload])]
       (is (= 50000 (count (get-in raw [:db-after :blob :payload])))
           "raw record carries the full string")
       ;; :large? matches at :db-after.[:blob :payload], so the projected
       ;; record's [:db-after :blob :payload] slot is a marker map.
-      (is (or (elision/marker? (get-in projected [:db-after :blob :payload]))
-              (elision/marker? marked))
+      (is (or (rf.elision/marker? (get-in projected [:db-after :blob :payload]))
+              (rf.elision/marker? marked))
           "projected record substitutes a :rf.size/large-elided marker"))))
 
 (deftest projected-record-elides-large-sub-output
@@ -350,7 +350,7 @@
 
     (let [raw       (last-record :test/main)
           raw-row   (->> (:sub-runs raw)   (filter #(= :big (:sub-id %))) first)
-          projected (epoch/projected-record raw)
+          projected (rf.epoch/projected-record raw)
           proj-row  (->> (:sub-runs projected) (filter #(= :big (:sub-id %))) first)]
       (is (some? raw-row)   "the :big sub produced a structured :sub-runs row")
       (is (some? proj-row)  "the projected record keeps the :big sub-run row")
@@ -363,7 +363,7 @@
           "raw row threads the whole-output :large? marker")
 
       ;; Off-box projected row: value slot is a marker, NOT the raw value.
-      (is (elision/marker? (:value proj-row))
+      (is (rf.elision/marker? (:value proj-row))
           "projected :sub-runs :value is a :rf.size/large-elided marker, not raw")
       (is (not= (:value raw-row) (:value proj-row))
           "the raw 50KB value does NOT egress in the projected :sub-runs")
@@ -372,7 +372,7 @@
       ;; it is never the raw bulky value.
       (when (contains? proj-row :prev-value)
         (is (or (nil? (:prev-value proj-row))
-                (elision/marker? (:prev-value proj-row)))
+                (rf.elision/marker? (:prev-value proj-row)))
             "projected :prev-value is never a raw bulky value"))
 
       ;; Non-value metadata preserved; the spent :large? flag is stripped.
@@ -383,11 +383,11 @@
           "the now-spent :large? row flag is stripped from the projection")
 
       ;; projected-history routes through the same projection.
-      (let [hist-row (->> (epoch/projected-history :test/main)
+      (let [hist-row (->> (rf.epoch/projected-history :test/main)
                           (mapcat :sub-runs)
                           (filter #(= :big (:sub-id %)))
                           first)]
-        (is (elision/marker? (:value hist-row))
+        (is (rf.elision/marker? (:value hist-row))
             "projected-history also elides the large :sub-runs value"))
 
       ;; rf2-irwsq — THE TRACE-TAG TWIN. The same value also rides the
@@ -408,7 +408,7 @@
             "raw on-box trace tag carries the full computed value")
         (is (true? (:large? raw-tags))
             "the emit chokepoint stamped the whole-output :large? flag on the tag")
-        (is (elision/marker? (:rf.sub/value proj-tags))
+        (is (rf.elision/marker? (:rf.sub/value proj-tags))
             "projected :rf.sub/run tag's :rf.sub/value is a :rf.size/large-elided
              marker, not the raw 50KB string")
         (is (not (contains? proj-tags :large?))
@@ -416,10 +416,10 @@
         (is (= (get-in (:value proj-row)          [:rf.size/large-elided :bytes])
                (get-in (:rf.sub/value proj-tags)  [:rf.size/large-elided :bytes]))
             "row marker and tag marker agree on :bytes — one rule built both")
-        (is (elision/marker? (:rf.sub/value
-                               (tags-of (last (epoch/projected-history :test/main)))))
+        (is (rf.elision/marker? (:rf.sub/value
+                               (tags-of (last (rf.epoch/projected-history :test/main)))))
             "projected-history elides the trace-tag twin too")
-        (let [lifted (tags-of (epoch/projected-record raw {:include-large? true}))]
+        (let [lifted (tags-of (rf.epoch/projected-record raw {:include-large? true}))]
           (is (= 50000 (count (:rf.sub/value lifted)))
               "NEGATIVE CONTROL — :include-large? true returns the raw value to
                the tag, so the default elision is classification-driven"))))))
@@ -434,7 +434,7 @@
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
       (doseq [k [:epoch-id :frame :committed-at :event-id :outcome
                  :schema-digest :rf.epoch/sensitive?]]
         (is (= (get raw k) (get projected k))
@@ -460,7 +460,7 @@
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
       (is (= (:sub-runs raw) (:sub-runs projected)))
       (is (= (:renders  raw) (:renders  projected))))))
 
@@ -493,8 +493,8 @@
 
       (let [raw       (last-record :test/main)
             raw-row   (effect-row raw :fxp/login)
-            proj-row  (effect-row (epoch/projected-record raw) :fxp/login)
-            wide-row  (effect-row (epoch/projected-record raw {:include-fx-args? true})
+            proj-row  (effect-row (rf.epoch/projected-record raw) :fxp/login)
+            wide-row  (effect-row (rf.epoch/projected-record raw {:include-fx-args? true})
                                   :fxp/login)]
         ;; Negative control: the raw ring record carries the EXACT secret args.
         (is (= secret (:args raw-row))
@@ -524,7 +524,7 @@
 
       (let [raw      (last-record :test/main)
             raw-row  (effect-row raw :fxp/local-storage)
-            proj-row (effect-row (epoch/projected-record raw) :fxp/local-storage)]
+            proj-row (effect-row (rf.epoch/projected-record raw) :fxp/local-storage)]
         (is (= :skipped-on-platform (:outcome raw-row))
             "fixture produced a skipped-on-platform row")
         (is (= secret (:args raw-row)) "raw ring keeps the exact args")
@@ -545,7 +545,7 @@
 
       (let [raw      (last-record :test/main)
             raw-row  (effect-row raw :fxp/missing)
-            proj-row (effect-row (epoch/projected-record raw) :fxp/missing)]
+            proj-row (effect-row (rf.epoch/projected-record raw) :fxp/missing)]
         (is (some? raw-row) "fixture produced a no-such-fx :effects row")
         (is (= :error (:outcome raw-row)))
         (is (= secret (:args raw-row)) "raw ring keeps the exact args")
@@ -568,7 +568,7 @@
 
       (let [raw      (last-record :test/main)
             raw-row  (effect-row raw :fxp/boom)
-            proj-row (effect-row (epoch/projected-record raw) :fxp/boom)]
+            proj-row (effect-row (rf.epoch/projected-record raw) :fxp/boom)]
         (is (some? raw-row) "fixture produced an fx-handler-exception :effects row")
         (is (= :error (:outcome raw-row)))
         (is (= secret (:args raw-row)) "raw ring keeps the exact args")
@@ -589,8 +589,8 @@
     (rf/dispatch-sync [:do-login {:password "topsecret"}] {:frame :test/main})
 
     (let [raw    (last-record :test/main)
-          once   (epoch/projected-record raw)
-          twice  (epoch/projected-record once)]
+          once   (rf.epoch/projected-record raw)
+          twice  (rf.epoch/projected-record once)]
       (is (= :rf/redacted (:args (effect-row once  :fxp/login))))
       (is (= :rf/redacted (:args (effect-row twice :fxp/login)))
           "double-projection is idempotent at the :args slot"))))
@@ -616,7 +616,7 @@
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
       (is (= [:login "topsecret"] (:trigger-event raw))
           "the raw ring keeps the exact dispatched event vector")
       (is (contains? projected :trigger-event)
@@ -645,7 +645,7 @@
                       {:frame :test/main})
 
     (let [raw       (last-record :test/main)
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
       (is (= [:auth/login {:password "topsecret" :email "a@b.c"}]
              (:trigger-event raw))
           "the raw ring keeps the exact dispatched map arg")
@@ -674,7 +674,7 @@
                        {:db (assoc-in db [:auth :password] password)}))
     (rf/dispatch-sync [:auth/login {:password "topsecret"}] {:frame :test/main})
 
-    (let [projected (epoch/projected-record (last-record :test/main))]
+    (let [projected (rf.epoch/projected-record (last-record :test/main))]
       (is (= [:auth/login :rf/redacted] (:trigger-event projected))
           "a marked event arg still fails closed at the trigger-event slot")
       (is (not (contains-leaf? (:trigger-event projected) "topsecret"))
@@ -694,15 +694,15 @@
 
     (let [raw (last-record :test/main)]
       (is (= [:login "topsecret"]
-             (:trigger-event (epoch/projected-record raw {:include-event-args? true})))
+             (:trigger-event (rf.epoch/projected-record raw {:include-event-args? true})))
           ":include-event-args? true keeps the raw event args off-box")
       ;; Orthogonality: the app-db sensitive/large opt-ins do NOT lift the
       ;; event-args redaction (event args are a different keyspace).
       (is (= [:login :rf/redacted]
-             (:trigger-event (epoch/projected-record raw {:include-sensitive? true})))
+             (:trigger-event (rf.epoch/projected-record raw {:include-sensitive? true})))
           ":include-sensitive? does NOT lift the trigger-event-args redaction")
       (is (= [:login :rf/redacted]
-             (:trigger-event (epoch/projected-record raw {:include-large? true})))
+             (:trigger-event (rf.epoch/projected-record raw {:include-large? true})))
           ":include-large? does NOT lift the trigger-event-args redaction"))))
 
 (deftest projected-record-trigger-event-redaction-idempotent
@@ -716,8 +716,8 @@
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw   (last-record :test/main)
-          once  (epoch/projected-record raw)
-          twice (epoch/projected-record once)]
+          once  (rf.epoch/projected-record raw)
+          twice (rf.epoch/projected-record once)]
       (is (= [:login :rf/redacted] (:trigger-event once)))
       (is (= [:login :rf/redacted] (:trigger-event twice))
           "double-projection is idempotent at the :trigger-event slot"))))
@@ -734,8 +734,8 @@
     ;; sensitive-wins-over-large rule (sensitive is checked before large per
     ;; node), so the projected slot lands as `:rf/redacted`, never a large
     ;; marker, even though both decls are present in the registry.
-    (frame/swap-runtime-db! :test/main
-      (fn [rt] (elision/apply-classification-effects rt
+    (rf.frame/swap-runtime-db! :test/main
+      (fn [rt] (rf.elision/apply-classification-effects rt
                  {:sensitive [[:secret-pdf]]
                   :large     [[:secret-pdf]]})))
     (rf/reg-event :store-pdf
@@ -744,16 +744,16 @@
     (rf/dispatch-sync [:store-pdf (big-string 50000)] {:frame :test/main})
 
     (let [raw       (last-record :test/main)
-          projected (epoch/projected-record raw)]
+          projected (rf.epoch/projected-record raw)]
       (is (= :rf/redacted (get-in projected [:db-after :secret-pdf]))
           "sensitive wins — projected slot is :rf/redacted, not a marker"))))
 
 (deftest projected-record-nil-input-returns-nil
   (testing "nil input — projected-record returns nil (a missing-epoch
             lookup must not throw)"
-    (is (nil? (epoch/projected-record nil)))
-    (is (nil? (epoch/projected-record :not-a-map)))
-    (is (nil? (epoch/projected-record [:not :a :map])))))
+    (is (nil? (rf.epoch/projected-record nil)))
+    (is (nil? (rf.epoch/projected-record :not-a-map)))
+    (is (nil? (rf.epoch/projected-record [:not :a :map])))))
 
 (deftest projected-record-handles-missing-payload-slots
   (testing "a record without one of the four payload slots passes
@@ -771,7 +771,7 @@
                           :renders       []
                           :effects       []
                           :rf.epoch/sensitive? false}
-          projected     (epoch/projected-record partial-record)]
+          projected     (rf.epoch/projected-record partial-record)]
       (is (some? projected))
       (is (nil? (:db-before projected))
           "nil :db-before stays nil — no fabricated value")
@@ -796,7 +796,7 @@
   slot (or nil if the slot is not a marker)."
   [record]
   (let [slot (get-in record [:db-after :blob :payload])]
-    (when (elision/marker? slot)
+    (when (rf.elision/marker? slot)
       (:rf.size/large-elided slot))))
 
 (deftest projected-record-tool-profile-includes-structural-digest
@@ -815,17 +815,17 @@
 
     (let [raw       (last-record :test/main)
           obs-body  (large-marker-body
-                      (epoch/projected-record raw))
+                      (rf.epoch/projected-record raw))
           obs-body2 (large-marker-body
-                      (epoch/projected-record
+                      (rf.epoch/projected-record
                         raw {:rf.egress/profile :rf.egress/off-box-observability}))
           tool-body (large-marker-body
-                      (epoch/projected-record
+                      (rf.epoch/projected-record
                         raw {:rf.egress/profile :rf.egress/off-box-tool}))]
       ;; Both off-box profiles elide the large slot to a marker (no raw bytes).
       (is (some? obs-body)  "observability default elides the large slot")
       (is (some? tool-body) "tool profile elides the large slot")
-      (is (not= 50000 (get-in (epoch/projected-record raw) [:db-after :blob :payload]))
+      (is (not= 50000 (get-in (rf.epoch/projected-record raw) [:db-after :blob :payload]))
           "the raw 50KB string never egresses under either off-box profile")
       ;; The DEFAULT (no profile) == the observability profile.
       (is (= obs-body obs-body2)
@@ -856,7 +856,7 @@
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [raw  (last-record :test/main)
-          tool (epoch/projected-record
+          tool (rf.epoch/projected-record
                  raw {:rf.egress/profile :rf.egress/off-box-tool})]
       (is (= :rf/redacted (get-in tool [:db-after :auth :password]))
           "tool profile still redacts the sensitive slot"))))
@@ -872,7 +872,7 @@
                        {:db (assoc-in db [:blob :payload] payload)}))
     (rf/dispatch-sync [:store (big-string 50000)] {:frame :test/main})
     (let [raw (last-record :test/main)
-          ex  (try (epoch/projected-record raw {:rf.egress/profile :rf.egress/not-a-real-profile})
+          ex  (try (rf.epoch/projected-record raw {:rf.egress/profile :rf.egress/not-a-real-profile})
                    nil
                    (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex) "an unknown profile throws")
@@ -891,7 +891,7 @@
                        {:db (assoc-in db [:blob :payload] payload)}))
     (rf/dispatch-sync [:store (big-string 50000)] {:frame :test/main})
 
-    (let [tool-hist (epoch/projected-history
+    (let [tool-hist (rf.epoch/projected-history
                       :test/main {:rf.egress/profile :rf.egress/off-box-tool})
           last-body (large-marker-body (last tool-hist))]
       (is (some? last-body) "the whole-ring tool egress elides the large slot")
@@ -914,7 +914,7 @@
     (rf/dispatch-sync [:login "secret-2"]  {:frame :test/main})
 
     (let [history (rf/epoch-history :test/main)
-          ph      (epoch/projected-history :test/main)]
+          ph      (rf.epoch/projected-history :test/main)]
       (is (= (count history) (count ph)))
       (is (= (mapv :epoch-id history) (mapv :epoch-id ph))
           "ordering matches the raw ring")
@@ -929,7 +929,7 @@
   (testing "projected-history on a frame with no recorded epochs
             returns the empty vector (matches the epoch-history empty
             shape)"
-    (is (= [] (epoch/projected-history :rf/no-such-frame)))))
+    (is (= [] (rf.epoch/projected-history :rf/no-such-frame)))))
 
 ;; ---- 4. listener delivery defaults to RAW ---------------------------------
 
@@ -962,7 +962,7 @@
     (let [shipped (atom [])
           ship!   (fn [record]
                     ;; Tool-side forwarder body — project here.
-                    (swap! shipped conj (epoch/projected-record record)))]
+                    (swap! shipped conj (rf.epoch/projected-record record)))]
       (rf/register-listener! :epoch ::forwarder ship!)
       (rf/reg-event :login
                        (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
@@ -984,7 +984,7 @@
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
-    (is (= 5 (:trace-events-keep (epoch/current-config)))
+    (is (= 5 (:trace-events-keep (rf.epoch/current-config)))
         "fixture OVERRIDE — the shipped runtime default is 50 (= :depth)")
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -1045,11 +1045,11 @@
             ring (per epoch_jvm_prod_gate_test). projected-history of
             an empty ring is the empty vector — projected-record never
             gets called against a record."
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (rf/reg-event :prod.priv/inc
                        (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod.priv/inc])
-      (is (= [] (epoch/projected-history :rf/default))
+      (is (= [] (rf.epoch/projected-history :rf/default))
           "no records to project under disabled gate"))))
 
 (deftest projected-record-pure-fn-survives-disabled-gate
@@ -1073,8 +1073,8 @@
            :sub-runs      []
            :renders       []
            :effects       []}]
-      (with-redefs [interop/debug-enabled? false]
-        (let [projected (epoch/projected-record synthetic-record)]
+      (with-redefs [rf.interop/debug-enabled? false]
+        (let [projected (rf.epoch/projected-record synthetic-record)]
           (is (some? projected))
           (is (= 1 (:epoch-id projected))
               "the projection runs even under the disabled gate — it
@@ -1084,7 +1084,7 @@
   (testing "no records means no rollup to compute. The gate-disabled
             path drops the entire surface — the rollup is dev-only
             because the records are dev-only."
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (rf/reg-event :prod.priv/silent
                        (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
       (rf/dispatch-sync [:prod.priv/silent])

--- a/implementation/epoch/test/re_frame/epoch_prod_gate_lane_pin_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_prod_gate_lane_pin_test.clj
@@ -65,7 +65,7 @@
   PROPERTY did not arrive; the second when it arrived but the framework did not
   read it. They are different defects and they get different messages."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.interop :as interop]))
+            [re-frame.interop :as rf.interop]))
 
 (deftest ^:prod-gate the-property-really-reached-this-jvm
   (testing "rf2-bo8lq — `-Dre-frame.debug=false` is on THIS JVM's command line.
@@ -82,5 +82,5 @@
             assertion above green means the property arrived but
             `re-frame.interop` did not honour it, which is the load-order defect
             class rf2-9c2jf belonged to."
-    (is (false? interop/debug-enabled?)
+    (is (false? rf.interop/debug-enabled?)
         "re-frame.interop/debug-enabled? must be false under the production gate")))

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
@@ -30,12 +30,12 @@
   projection. It never runs at storage time."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.epoch :as epoch]
-            [re-frame.frame :as frame]
-            [re-frame.privacy :as privacy]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.elision :as rf.elision]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.frame :as rf.frame]
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; Side-effect requires (mirror epoch_test.clj fixture).
             [re-frame.machines]))
 
@@ -49,8 +49,8 @@
 ;; public `configure!` boundary — no test ns reaches into the private
 ;; `state/config` var.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
@@ -66,16 +66,16 @@
 (defn- install-sensitive-schema!
   "Declare a `[:auth :password]` sensitive path against `frame-id`."
   [frame-id]
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
   nil)
 
 (defn- install-two-sensitive-paths-schema!
   "Declare two sensitive paths against `frame-id` — `[:auth :password]`
   and `[:auth :token]`."
   [frame-id]
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt
                {:sensitive [[:auth :password] [:auth :token]]})))
   nil)
 
@@ -109,7 +109,7 @@
       (rf/dispatch-sync [:login "topsecret" "tok-xyz"] {:frame :test/main})
 
       (let [r         (last-record :test/main)
-            projected (epoch/projected-record r)]
+            projected (rf.epoch/projected-record r)]
         (is (= :rf/redacted @observed)
             "the override saw :password ALREADY :rf/redacted — it ran after
              the frame/profile projection")
@@ -139,8 +139,8 @@
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r          (last-record :test/main)
-          projected  (epoch/projected-record r)
-          projected2 (epoch/projected-record projected)]
+          projected  (rf.epoch/projected-record r)
+          projected2 (rf.epoch/projected-record projected)]
       (is (= {:auth {:password "topsecret"}} (:db-after r))
           "the RAW ring :db-after is unredacted")
       (is (= :rf/redacted (:db-after projected))
@@ -176,7 +176,7 @@
     (rf/dispatch-sync [:login "topsecret" "tok-xyz"] {:frame :test/main})
 
     (let [r         (last-record :test/main)
-          projected (epoch/projected-record r)]
+          projected (rf.epoch/projected-record r)]
       (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
           "frame/profile projection redacted the frame-declared :password")
       (is (= :rf/redacted (get-in projected [:db-after :session :token]))
@@ -187,7 +187,7 @@
           "the RAW ring record carries the verbatim password")
 
       (testing "second projection pass is a no-op (idempotent fixpoint)"
-        (is (= projected (epoch/projected-record projected)))))))
+        (is (= projected (rf.epoch/projected-record projected)))))))
 
 ;; ============================================================================
 ;;  D. Rollup is raw-signal-derived — projection (both stages) preserve it
@@ -206,7 +206,7 @@
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r         (last-record :test/main)
-          projected (epoch/projected-record r)]
+          projected (rf.epoch/projected-record r)]
       (is (true? (:rf.epoch/sensitive? r))
           "rollup true on the raw ring record (raw-signal-derived)")
       (is (true? (:rf.epoch/sensitive? projected))
@@ -217,7 +217,7 @@
             privacy/redacted-sentinel. Pinning the identity prevents future
             divergence (a separate sentinel would break the idempotency
             story)."
-    (is (= :rf/redacted privacy/redacted-sentinel)
+    (is (= :rf/redacted rf.privacy/redacted-sentinel)
         "privacy/redacted-sentinel is the keyword :rf/redacted")))
 
 ;; ============================================================================
@@ -327,13 +327,13 @@
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r         (last-record :test/main)
-          projected (epoch/projected-record r)]
+          projected (rf.epoch/projected-record r)]
       (is (= 1 (:rf.epoch/redacted-modified-paths-count r)))
       (is (= 1 (:rf.epoch/redacted-modified-paths-count projected))
           "projection preserves the counter verbatim")
       (is (= (:rf.epoch/redacted-modified-paths-count r)
              (:rf.epoch/redacted-modified-paths-count
-               (epoch/projected-record projected)))
+               (rf.epoch/projected-record projected)))
           "idempotent under a second projection pass"))))
 
 (deftest G7-counter-handles-nil-db-edge
@@ -341,7 +341,7 @@
             (rf2-v0jwt). The counter handles the nil edge."
     (rf/make-frame {:id :test/main})
     (install-sensitive-schema! :test/main)
-    (require '[re-frame.epoch.assembly :as assembly])
+    (require '[re-frame.epoch.assembly :as rf.epoch.assembly])
     (let [count-fn (resolve 're-frame.epoch.assembly/redacted-modified-paths-count)]
       (is (= 0 (count-fn :test/main nil nil))
           "nil → nil at every path: 0 changes")
@@ -376,14 +376,14 @@
            :renders         []
            :effects         []
            :rf.epoch/sensitive? false}
-          projected (epoch/projected-record partial)]
+          projected (rf.epoch/projected-record partial)]
       (is (some? projected) "projection over a nil-slot record returns
                              a non-nil value")
       (is (nil? (:db-before projected)) "nil :db-before stays nil")
       (is (nil? (:db-after projected))  "nil :db-after stays nil")
       (is (= :halted-destroy (:outcome projected))
           "bookkeeping passes through unchanged")
-      (is (= projected (epoch/projected-record projected))
+      (is (= projected (rf.epoch/projected-record projected))
           "idempotent under a second projection pass"))))
 
 (deftest E-projected-record-on-record-with-sentinel-db-after
@@ -413,14 +413,14 @@
            :sub-runs      []
            :renders       []
            :effects       []}
-          projected (epoch/projected-record synthetic)]
+          projected (rf.epoch/projected-record synthetic)]
       (is (= :rf/redacted (:db-after projected))
           "wholly-sentinel'd payload slot stays as the scalar through
            the projection walker")
       (is (= {:n 0} (:db-before projected))
           "the other payload slot is walked normally — the per-slot
            guards do not cross-contaminate")
-      (is (= projected (epoch/projected-record projected))
+      (is (= projected (rf.epoch/projected-record projected))
           "idempotent over the synthetic mixed shape"))))
 
 ;; ============================================================================
@@ -451,7 +451,7 @@
     (rf/dispatch-sync [:login "secret-3"]  {:frame :test/main})
 
     (let [history (rf/epoch-history :test/main)
-          ph      (epoch/projected-history :test/main)]
+          ph      (rf.epoch/projected-history :test/main)]
       (is (= (count history) (count ph))
           "one projected record per ring entry")
       (is (= (mapv :epoch-id history) (mapv :epoch-id ph))
@@ -475,14 +475,14 @@
 
       (testing "projected-history is idempotent — re-projecting each
                 entry produces a structurally-equal vector"
-        (is (= ph (mapv epoch/projected-record ph)))))))
+        (is (= ph (mapv rf.epoch/projected-record ph)))))))
 
 (deftest F-projected-history-empty-with-redact-fn-installed
   (testing "with a redact-fn installed but no cascades recorded,
             projected-history is the empty vector — the override is inert
             until a record exists to project"
     (rf/configure! {:epoch-history {:redact-fn (fn [r] r)}})
-    (is (= [] (epoch/projected-history :rf/no-such-frame)))))
+    (is (= [] (rf.epoch/projected-history :rf/no-such-frame)))))
 
 ;; ============================================================================
 ;;  Composition fixpoint — the core idempotency claim
@@ -510,9 +510,9 @@
     (rf/dispatch-sync [:login "topsecret" "tok-xyz"] {:frame :test/main})
 
     (let [r          (last-record :test/main)
-          projected1 (epoch/projected-record r)
-          projected2 (epoch/projected-record projected1)
-          projected3 (epoch/projected-record projected2)]
+          projected1 (rf.epoch/projected-record r)
+          projected2 (rf.epoch/projected-record projected1)
+          projected3 (rf.epoch/projected-record projected2)]
       (is (= projected1 projected2)
           "second projection pass is a no-op (fixpoint)")
       (is (= projected2 projected3)

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -40,12 +40,12 @@
   shapes silently dropped) — unchanged by the storage→projection move."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.epoch :as epoch]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
-            [re-frame.test-support :as test-support]
+            [re-frame.elision :as rf.elision]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace :as rf.trace]
+            [re-frame.test-support :as rf.test-support]
             ;; Side-effect requires (mirror epoch_test.clj fixture).
             [re-frame.machines]))
 
@@ -65,8 +65,8 @@
 ;; AFTER the post-dispose reset hooks, so the override lands on top of
 ;; the freshly-reset default.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
@@ -81,8 +81,8 @@
 ;; frame container is make-frame'd by each deftest before this runs.
 (defn- install-sensitive-schema!
   [frame-id]
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
   nil)
 
 (defn- record-warnings! []
@@ -105,17 +105,17 @@
             and the slot lands in current-config"
     (let [f (fn [r] r)]
       (rf/configure! {:epoch-history {:redact-fn f}})
-      (is (identical? f (:redact-fn (epoch/current-config)))
+      (is (identical? f (:redact-fn (rf.epoch/current-config)))
           ":redact-fn lands by identity — no wrapping"))))
 
 (deftest configure-accepts-nil-to-clear
   (testing "(rf/configure! {:epoch-history {:redact-fn nil}}) clears a
             previously-installed fn"
     (rf/configure! {:epoch-history {:redact-fn (fn [r] r)}})
-    (is (some? (:redact-fn (epoch/current-config))))
+    (is (some? (:redact-fn (rf.epoch/current-config))))
 
     (rf/configure! {:epoch-history {:redact-fn nil}})
-    (is (nil? (:redact-fn (epoch/current-config)))
+    (is (nil? (:redact-fn (rf.epoch/current-config)))
         "explicit nil clears the slot")))
 
 (deftest configure-rejects-non-fn
@@ -124,19 +124,19 @@
     (let [f (fn [r] r)]
       (rf/configure! {:epoch-history {:redact-fn f}})
       (rf/configure! {:epoch-history {:redact-fn "not-a-fn"}})
-      (is (identical? f (:redact-fn (epoch/current-config)))
+      (is (identical? f (:redact-fn (rf.epoch/current-config)))
           "string silently dropped — prior fn survives")
 
       (rf/configure! {:epoch-history {:redact-fn 42}})
-      (is (identical? f (:redact-fn (epoch/current-config)))
+      (is (identical? f (:redact-fn (rf.epoch/current-config)))
           "number silently dropped")
 
       (rf/configure! {:epoch-history {:redact-fn {:k :v}}})
-      (is (identical? f (:redact-fn (epoch/current-config)))
+      (is (identical? f (:redact-fn (rf.epoch/current-config)))
           "map silently dropped")
 
       (rf/configure! {:epoch-history {:redact-fn [:a :b]}})
-      (is (identical? f (:redact-fn (epoch/current-config)))
+      (is (identical? f (:redact-fn (rf.epoch/current-config)))
           "vector silently dropped"))))
 
 (deftest configure-absent-slot-preserves-existing-fn
@@ -146,9 +146,9 @@
     (let [f (fn [r] r)]
       (rf/configure! {:epoch-history {:redact-fn f}})
       (rf/configure! {:epoch-history {:depth 17}})
-      (is (identical? f (:redact-fn (epoch/current-config)))
+      (is (identical? f (:redact-fn (rf.epoch/current-config)))
           ":redact-fn slot preserved across a :depth-only update")
-      (is (= 17 (:depth (epoch/current-config)))
+      (is (= 17 (:depth (rf.epoch/current-config)))
           "the :depth update was applied"))))
 
 (deftest configure-partial-update-mixed-validity
@@ -157,8 +157,8 @@
     (rf/configure! {:epoch-history {:depth 9}})
     (let [f (fn [r] r)]
       (rf/configure! {:epoch-history {:depth nil :redact-fn f}})
-      (is (identical? f (:redact-fn (epoch/current-config))))
-      (is (= 9 (:depth (epoch/current-config)))
+      (is (identical? f (:redact-fn (rf.epoch/current-config))))
+      (is (= 9 (:depth (rf.epoch/current-config)))
           ":depth nil dropped; prior 9 survives"))))
 
 ;; ============================================================================
@@ -233,7 +233,7 @@
       (rf/dispatch-sync [:seed] {:frame :test/main})
 
       (let [r         (last-record :test/main)
-            projected (epoch/projected-record r)]
+            projected (rf.epoch/projected-record r)]
         (is (= 1 @invocations)
             "one projection call = one :redact-fn invocation")
         (is (= :redacted (:rf/test-tag projected))
@@ -267,7 +267,7 @@
       (rf/dispatch-sync [:login "topsecret" "tok-xyz"] {:frame :test/main})
 
       (let [r         (last-record :test/main)
-            projected (epoch/projected-record r)]
+            projected (rf.epoch/projected-record r)]
         (is (= :rf/redacted @observed)
             "the override observed the frame-declared :password ALREADY
              :rf/redacted by the frame/profile projection (it ran AFTER)")
@@ -290,7 +290,7 @@
       (rf/dispatch-sync [:seed] {:frame :test/main})
 
       (let [r (last-record :test/main)]
-        (dotimes [_ 5] (epoch/projected-record r))
+        (dotimes [_ 5] (rf.epoch/projected-record r))
         (is (= 5 @invocations)
             "five projection calls = five override invocations (one per
              egress); the override is not memoised")))))
@@ -311,7 +311,7 @@
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r         (last-record :test/main)
-          projected (epoch/projected-record r)]
+          projected (rf.epoch/projected-record r)]
       (is (true? (:rf.epoch/sensitive? r))
           "rollup is true on the raw ring record (raw-signal-derived)")
       (is (true? (:rf.epoch/sensitive? projected))
@@ -341,7 +341,7 @@
            storage-side hook")
 
       (let [r         (last-record :test/main)
-            projected (epoch/projected-record r)]
+            projected (rf.epoch/projected-record r)]
         ;; The projection ran the (throwing) override → warning + fallback.
         (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
             "fallback is the PROJECTED record — the frame/profile projection
@@ -376,9 +376,9 @@
                                   (swap! call-count inc)
                                   (throw (ex-info "boom" {})))}})
       (let [r (last-record :test/main)]
-        (epoch/projected-record r)
-        (epoch/projected-record r)
-        (epoch/projected-record r))
+        (rf.epoch/projected-record r)
+        (rf.epoch/projected-record r)
+        (rf.epoch/projected-record r))
       (is (= 3 @call-count)
           "redact-fn re-invoked on every projection despite throwing"))))
 
@@ -401,7 +401,7 @@
     (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
 
     (let [r         (last-record :test/main)
-          projected (epoch/projected-record r)]
+          projected (rf.epoch/projected-record r)]
       (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
           "frame-declared sensitive path redacted by the frame/profile walk")
       (is (= "alice" (get-in projected [:db-after :public :name]))
@@ -436,7 +436,7 @@
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (is (not (contains? (last-record :test/main) :rf/test-tag))
         "settle! path: ring record is RAW (override not applied at storage)")
-    (is (= :redacted (:rf/test-tag (epoch/projected-record
+    (is (= :redacted (:rf/test-tag (rf.epoch/projected-record
                                      (last-record :test/main))))
         "the override IS applied when the record is projected for egress")))
 
@@ -454,7 +454,7 @@
           "frame-state replacement: listener received the raw synthetic record")
       (is (not (contains? (last-record :test/main) :rf/test-tag))
           "frame-state replacement: ring received the raw synthetic record")
-      (is (= :redacted (:rf/test-tag (epoch/projected-record @synthetic)))
+      (is (= :redacted (:rf/test-tag (rf.epoch/projected-record @synthetic)))
           "the override applies when the synthetic record is projected"))))
 
 (deftest wiring-halted-destroy-stores-raw-record
@@ -476,7 +476,7 @@
       (rf/configure! {:epoch-history {:redact-fn (fn [r] (assoc r :rf/test-tag :redacted))}})
       (rf/reg-event :destroy-self
                        (fn [_ _]
-                         (frame/destroy-frame! :test/main)
+                         (rf.frame/destroy-frame! :test/main)
                          {}))
       (try (rf/dispatch-sync [:destroy-self] {:frame :test/main})
            (catch Throwable _ nil))
@@ -488,7 +488,7 @@
         (is (not (contains? halted :rf/test-tag))
             "halted-destroy path: listener received the RAW partial record
              (storage-side redaction was removed)")
-        (is (= :redacted (:rf/test-tag (epoch/projected-record halted)))
+        (is (= :redacted (:rf/test-tag (rf.epoch/projected-record halted)))
             "the override applies when the halted record is projected")))))
 
 ;; ============================================================================
@@ -505,7 +505,7 @@
     (rf/dispatch-sync [:seed] {:frame :test/main})
     (let [r (last-record :test/main)]
       (is (= {:n 0} (:db-after r)))
-      (is (= {:n 0} (:db-after (epoch/projected-record r)))
+      (is (= {:n 0} (:db-after (rf.epoch/projected-record r)))
           "no override — projection of a non-sensitive db is the plain
            frame/profile shape"))))
 
@@ -530,7 +530,7 @@
 ;; `record-unmount!`) routes it into the causing cascade's committed record.
 
 (defn- emit-sub-run! [frame-id sub-id prev-value value]
-  (trace/emit! :rf.sub :rf.sub/run
+  (rf.trace/emit! :rf.sub :rf.sub/run
                {:rf.sub/id             sub-id
                 :rf.sub/query-v        [sub-id]
                 :frame                 frame-id
@@ -601,7 +601,7 @@
     (emit-sub-run! :test/main :secret nil "topsecret")
 
     (let [r         (last-record :test/main)
-          projected (epoch/projected-record r)
+          projected (rf.epoch/projected-record r)
           raw-row   (->> (:sub-runs r)
                          (filter #(= :secret (:sub-id %))) first)
           proj-row  (->> (:sub-runs projected)
@@ -634,7 +634,7 @@
             "the non-sensitive value is RAW in the ring/listener")
         (is (= true (:value-changed? sub-run))
             "the benign sub-run's value-change attribution survives intact")
-        (is (= 42 (:value (->> (:sub-runs (epoch/projected-record renotified))
+        (is (= 42 (:value (->> (:sub-runs (rf.epoch/projected-record renotified))
                                (filter #(= :counter (:sub-id %))) first)))
             "the benign value passes the projection unchanged (no
              over-redaction)")))))
@@ -705,6 +705,6 @@
                               first)]
         (is (= "topsecret" (get-in login-record [:db-after :auth :password]))
             "the durable ring record is RAW (the replay source)")
-        (is (= :rf/redacted (:db-after (epoch/projected-record login-record)))
+        (is (= :rf/redacted (:db-after (rf.epoch/projected-record login-record)))
             "the SAME record projects REDACTED at egress — egress redacts,
              storage stays raw")))))

--- a/implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc
+++ b/implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc
@@ -34,19 +34,19 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.epoch :as epoch]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; Side-effect require — publishes the machines late-bind hooks
             ;; for the restore→replay composition proof below.
             [re-frame.machines]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn []
-                (epoch/clear-history!)
-                (epoch/clear-epoch-listeners!))}))
+                (rf.epoch/clear-history!)
+                (rf.epoch/clear-epoch-listeners!))}))
 
 (def ^:private frame-id :epoch-replay/main)
 
@@ -378,6 +378,6 @@
   (testing "rf/replay-epoch! late-binds to re-frame.epoch/replay-epoch!"
     (rf/make-frame {:id frame-id})
     (let [res-facade   (rf/replay-epoch! frame-id ::nope)
-          res-artefact (epoch/replay-epoch! frame-id ::nope)]
+          res-artefact (rf.epoch/replay-epoch! frame-id ::nope)]
       (is (= res-facade res-artefact))
       (is (= :rf.epoch/replay-unknown-epoch (:reason res-facade))))))

--- a/implementation/epoch/test/re_frame/epoch_run_cause_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_run_cause_test.clj
@@ -21,15 +21,15 @@
   exercised in isolation — no live run needed, fully deterministic."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.epoch :as epoch]
-            [re-frame.epoch.capture :as capture]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.epoch.capture :as rf.epoch.capture]
             ;; `state` is used in test BODIES (`state/buffer-event!` /
             ;; `state/buffer-for`) to populate the in-flight buffer the
             ;; run-cause walk reads — NOT for fixture config reset.
-            [re-frame.epoch.state :as state]
-            [re-frame.interop :as interop]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.interop :as rf.interop]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; Side-effect require (mirror epoch_test.clj fixture).
             [re-frame.machines]))
 
@@ -43,8 +43,8 @@
 ;; public `configure!` boundary — no test ns reaches into the private
 ;; `state/config` var for fixture reset.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
 ;; ---- synthetic-buffer helpers ---------------------------------------------
@@ -74,7 +74,7 @@
   {:op-type :rf.view :operation :rf.view/rendered-cap-reached :tags {}})
 
 (defn- seed-buffer! [frame-id events]
-  (doseq [ev events] (state/buffer-event! frame-id ev)))
+  (doseq [ev events] (rf.epoch.state/buffer-event! frame-id ev)))
 
 ;; ---- empty / out-of-run buffer --------------------------------------------
 
@@ -85,7 +85,7 @@
             :cause-event-id / :cause-subs / :value-changed-subs slots are
             OMITTED, never nil"
     (rf/make-frame {:id :test/cc})
-    (let [result (capture/run-cause :test/cc)]
+    (let [result (rf.epoch.capture/run-cause :test/cc)]
       (is (= {:rendered-so-far 0} result)
           "empty buffer → only :rendered-so-far 0, other slots omitted")
       (is (not (contains? result :cause-event-id)))
@@ -96,7 +96,7 @@
             trigger) still omits :cause-event-id"
     (rf/make-frame {:id :test/cc2})
     (seed-buffer! :test/cc2 [(sub-run :a true)])
-    (let [result (capture/run-cause :test/cc2)]
+    (let [result (rf.epoch.capture/run-cause :test/cc2)]
       (is (not (contains? result :cause-event-id))
           "no run-start ⇒ no :cause-event-id")
       (is (= [:a] (:cause-subs result))
@@ -114,7 +114,7 @@
                    ;; A second run-start (a child event's marker, defensive)
                    ;; must NOT override the first.
                    (run-start :counter/decorate)])
-    (let [result (capture/run-cause :test/cc)]
+    (let [result (rf.epoch.capture/run-cause :test/cc)]
       (is (= :counter/inc (:cause-event-id result))
           "first run-start wins; a later run-start does not clobber it"))))
 
@@ -131,7 +131,7 @@
                    (sub-run :a)          ;; repeat — deduped
                    (sub-run :c)
                    (sub-run :b)])        ;; repeat — deduped
-    (let [result (capture/run-cause :test/cc)]
+    (let [result (rf.epoch.capture/run-cause :test/cc)]
       (is (= [:a :b :c] (:cause-subs result))
           "distinct, first-seen order — repeats collapse, order preserved"))))
 
@@ -145,13 +145,13 @@
                         (map (fn [i] (sub-run (keyword (str "s" i)))))
                         (range 10)))
     (testing "explicit sub-cap of 3 truncates to the first 3 distinct subs"
-      (let [result (capture/run-cause :test/cc 3)]
+      (let [result (rf.epoch.capture/run-cause :test/cc 3)]
         (is (= 3 (count (:cause-subs result)))
             "capped at 3 distinct sub-ids")
         (is (= [:s0 :s1 :s2] (:cause-subs result))
             "the FIRST 3 (first-seen) are kept; the rest dropped")))
     (testing "the default cap (100) admits all 10 subs"
-      (let [result (capture/run-cause :test/cc)]
+      (let [result (rf.epoch.capture/run-cause :test/cc)]
         (is (= 10 (count (:cause-subs result)))
             "well under the default 100 cap — all subs surface")))))
 
@@ -168,7 +168,7 @@
                    (sub-run :changed   true)
                    (sub-run :unchanged false)
                    (sub-run :also-changed true)])
-    (let [result (capture/run-cause :test/cc)]
+    (let [result (rf.epoch.capture/run-cause :test/cc)]
       (is (= [:changed :unchanged :also-changed] (:cause-subs result))
           "all three subs ran (cause-subs carries every distinct one)")
       (is (= #{:changed :also-changed} (:value-changed-subs result))
@@ -184,7 +184,7 @@
                   [(run-start :ev)
                    (sub-run :a false)
                    (sub-run :b false)])
-    (let [result (capture/run-cause :test/cc)]
+    (let [result (rf.epoch.capture/run-cause :test/cc)]
       (is (= [:a :b] (:cause-subs result))
           "the subs still surface in :cause-subs")
       (is (not (contains? result :value-changed-subs))
@@ -199,7 +199,7 @@
                    (sub-run :a true)
                    (sub-run :a true)
                    (sub-run :a true)])
-    (let [result (capture/run-cause :test/cc)]
+    (let [result (rf.epoch.capture/run-cause :test/cc)]
       (is (= #{:a} (:value-changed-subs result))
           "repeats collapse — :value-changed-subs is a deduped set"))))
 
@@ -216,7 +216,7 @@
                         (map (fn [i] (sub-run (keyword (str "v" i)) true)))
                         (range 10)))
     (testing "explicit sub-cap of 3 truncates the value-changed set to 3"
-      (let [result (capture/run-cause :test/cc 3)]
+      (let [result (rf.epoch.capture/run-cause :test/cc 3)]
         (is (= 3 (count (:value-changed-subs result)))
             "value-changed-subs capped at the sub-cap (3), not the 10
              distinct value-changed sub-ids present in the buffer")
@@ -224,7 +224,7 @@
             "the FIRST 3 (first-seen) value-changed subs are kept; the
              rest dropped — independent of the first-seen :subs scan")))
     (testing "the default cap (100) admits all 10 value-changed subs"
-      (let [result (capture/run-cause :test/cc)]
+      (let [result (rf.epoch.capture/run-cause :test/cc)]
         (is (= 10 (count (:value-changed-subs result)))
             "well under the default 100 cap — all value-changed subs surface")))))
 
@@ -241,7 +241,7 @@
                    (sub-run :a)
                    (rendered)
                    (rendered)])
-    (let [result (capture/run-cause :test/cc)]
+    (let [result (rf.epoch.capture/run-cause :test/cc)]
       (is (= 3 (:rendered-so-far result))
           "three :rf.view/rendered emits ⇒ :rendered-so-far 3"))))
 
@@ -256,7 +256,7 @@
                    (rendered)
                    (rendered)
                    (rendered-cap-reached)])
-    (let [result (capture/run-cause :test/cc)]
+    (let [result (rf.epoch.capture/run-cause :test/cc)]
       (is (= 3 (:rendered-so-far result))
           "two :rf.view/rendered + one :rf.view/rendered-cap-reached ⇒ 3 —
            the cap-reached marker increments the counter so the emit site
@@ -276,7 +276,7 @@
                    (rendered)
                    (sub-run :counter/value true)   ;; repeat
                    (rendered)])
-    (let [result (capture/run-cause :test/cc)]
+    (let [result (rf.epoch.capture/run-cause :test/cc)]
       (is (= :counter/inc (:cause-event-id result)))
       (is (= [:counter/value :counter/label] (:cause-subs result))
           "distinct, first-seen; the repeat counter/value collapses")
@@ -293,6 +293,6 @@
             elides — views.cljs gates its consumption under the same gate)"
     (rf/make-frame {:id :test/cc})
     (seed-buffer! :test/cc [(run-start :ev) (sub-run :a true) (rendered)])
-    (with-redefs [interop/debug-enabled? false]
-      (is (nil? (capture/run-cause :test/cc))
+    (with-redefs [rf.interop/debug-enabled? false]
+      (is (nil? (rf.epoch.capture/run-cause :test/cc))
           "run-cause returns nil under the disabled gate"))))

--- a/implementation/epoch/test/re_frame/epoch_silence_contract_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silence_contract_test.clj
@@ -31,12 +31,12 @@
             [re-frame.core :as rf]
             ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
             [re-frame.epoch]
-            [re-frame.epoch.state :as state]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- cb-generation
   "The live generation token under `cb-id`. Artefact-internal: rf2-uhouu retired
@@ -44,7 +44,7 @@
   two-read receiver decision). A consumer asks `rf/epoch-silence-current?`
   instead; this test names the generation only to pin the EMITTED qualifier."
   [cb-id]
-  (get-in (state/listeners-snapshot) [cb-id :generation]))
+  (get-in (rf.epoch.state/listeners-snapshot) [cb-id :generation]))
 
 ;; ---- canonical schema extraction (no drift: read the markdown) --------------
 
@@ -164,10 +164,10 @@
             emit-under-lock or reserve-only-emits authority. A regression to that
             language flips these assertions RED."
     (let [src        (state-source)
-          put-doc    (var-doc #'state/put-listener!)
-          drop-doc   (var-doc #'state/drop-listener!)
-          rec-doc    (var-doc #'state/record-observation!)
-          publish    (var-doc #'state/claim-and-publish-delayed-silence!)]
+          put-doc    (var-doc #'rf.epoch.state/put-listener!)
+          drop-doc   (var-doc #'rf.epoch.state/drop-listener!)
+          rec-doc    (var-doc #'rf.epoch.state/record-observation!)
+          publish    (var-doc #'rf.epoch.state/claim-and-publish-delayed-silence!)]
 
       ;; --- NO emit-under-lock authority (a lock spanning the external emit) ---
       (is (not (str/includes? src "across its eligibility recheck AND the external emit"))

--- a/implementation/epoch/test/re_frame/epoch_silence_decision_atomicity_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silence_decision_atomicity_test.clj
@@ -57,13 +57,13 @@
             ;; Side-effect: publishes the `:epoch/*` late-bind hooks, including
             ;; `:epoch/epoch-silence-current?`.
             [re-frame.epoch]
-            [re-frame.epoch.listeners :as epoch.listeners]
-            [re-frame.epoch.state :as epoch-state]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.epoch.listeners :as rf.epoch.listeners]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -73,15 +73,15 @@
   only recompose the torn decision. Artefact-internal tests read the registry
   snapshot directly."
   [cb]
-  (get-in (epoch-state/listeners-snapshot) [cb :generation]))
+  (get-in (rf.epoch.state/listeners-snapshot) [cb :generation]))
 
 (defn- observe!
   "Register `cb` as an epoch listener and let it consume one record from `frame`,
   so a silence for `(frame, cb)` is owed under `cb`'s live generation."
   [frame token cb]
   (rf/register-listener! :epoch cb (fn [_] nil))
-  (epoch-state/claim-frame-owner! frame token)
-  (epoch.listeners/notify-listeners! {:frame frame :epoch-id 1}))
+  (rf.epoch.state/claim-frame-owner! frame token)
+  (rf.epoch.listeners/notify-listeners! {:frame frame :epoch-id 1}))
 
 (defn- observing-torn
   "Reproduces the observation-continuum predicate's INTERNAL two-deref
@@ -89,9 +89,9 @@
   `mutate!` executed at the seam between them. These are the same two atoms the
   predicate reads, reached through the state ns's own snapshot fns."
   [cb frame mutate!]
-  (let [observed (epoch-state/observations-snapshot)   ; deref 1 — silence-lock domain
+  (let [observed (rf.epoch.state/observations-snapshot)   ; deref 1 — silence-lock domain
         _        (mutate!)                             ; ← THE SEAM
-        live     (epoch-state/listeners-snapshot)      ; deref 2 — registry-lock domain
+        live     (rf.epoch.state/listeners-snapshot)      ; deref 2 — registry-lock domain
         token    (get-in observed [cb frame] ::absent)]
     (and (not= token ::absent)
          (= token (:generation (get live cb))))))
@@ -179,11 +179,11 @@
       (observe! frame token cb)
       ;; Drop the live observation so a silence is genuinely owed — the state a
       ;; deferred predecessor publishes into.
-      (epoch-state/drop-frame-observation! frame)
+      (rf.epoch.state/drop-frame-observation! frame)
       (let [g      (gen cb)
             tags   {:cb-id cb :frame frame :observed-gen g}
             before (rf/epoch-silence-current? tags)
-            torn   (two-read-torn tags #(epoch-state/record-observation! cb g frame))
+            torn   (two-read-torn tags #(rf.epoch.state/record-observation! cb g frame))
             after  (rf/epoch-silence-current? tags)]
         (is (true? before) "BEFORE: genuinely silent — the decision ACCEPTS")
         (is (false? after) "AFTER: the successor's delivery re-armed it — REJECT")
@@ -208,7 +208,7 @@
             torn   (observing-torn cb frame
                      (fn []
                        (rf/register-listener! :epoch cb (fn [_] nil))   ; G → H
-                       (epoch-state/record-observation! cb (gen cb) frame)))
+                       (rf.epoch.state/record-observation! cb (gen cb) frame)))
             after  (observing-now cb frame)]
         (is (true? before) "BEFORE: the callback observes the frame under G")
         (is (true? after)  "AFTER: it observes the frame under H")
@@ -239,7 +239,7 @@
                          (not (observing-torn cb frame
                                 (fn []
                                   (rf/register-listener! :epoch cb (fn [_] nil)) ; G → H
-                                  (epoch-state/record-observation! cb (gen cb) frame))))]
+                                  (rf.epoch.state/record-observation! cb (gen cb) frame))))]
                      (and identity-ok not-observing))
             after  (rf/epoch-silence-current? tags)]
         (is (false? before) "BEFORE: reject — the callback is observing under G")
@@ -261,7 +261,7 @@
           cb    ::uhouu-genuine-cb
           token (Object.)]
       (observe! frame token cb)
-      (epoch-state/drop-frame-observation! frame)
+      (rf.epoch.state/drop-frame-observation! frame)
       (let [g (gen cb)]
         (is (true? (rf/epoch-silence-current? {:cb-id cb :frame frame :observed-gen g}))
             "registration still current, nothing re-armed it — ACCEPT")))))
@@ -276,10 +276,10 @@
           token       (Object.)
           other-token (Object.)]
       (observe! frame token cb)
-      (epoch-state/drop-frame-observation! frame)
+      (rf.epoch.state/drop-frame-observation! frame)
       (let [g (gen cb)]
-        (epoch-state/claim-frame-owner! other-frame other-token)
-        (epoch-state/record-observation! cb g other-frame)
+        (rf.epoch.state/claim-frame-owner! other-frame other-token)
+        (rf.epoch.state/record-observation! cb g other-frame)
         (is (true? (observing-now cb other-frame)) "cb IS observing the unrelated frame")
         (is (true? (rf/epoch-silence-current? {:cb-id cb :frame frame :observed-gen g}))
             "the destroyed frame's silence is still current")

--- a/implementation/epoch/test/re_frame/epoch_silence_receiver_public_api_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silence_receiver_public_api_test.clj
@@ -23,11 +23,11 @@
             ;; Side-effect: publishes the `:epoch/*` late-bind hooks, including
             ;; `:epoch/epoch-silence-current?`.
             [re-frame.epoch]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- silence-tags
   "Drive a frame through one cascade so `cb` observes it, destroy it, and return

--- a/implementation/epoch/test/re_frame/epoch_silencing_emit_deadlock_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silencing_emit_deadlock_test.clj
@@ -68,17 +68,17 @@
   keep the interleave tight."
   (:require [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
             [re-frame.epoch]
-            [re-frame.epoch.listeners :as epoch.listeners]
-            [re-frame.epoch.state :as epoch-state]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.epoch.listeners :as rf.epoch.listeners]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- owe-silence!
   "Register `cb`, observe `frame` under its current generation, then drop the
@@ -87,12 +87,12 @@
   `claim-and-publish-delayed-silence!` for `(frame, cb)` then reaches `publish!`."
   [frame token cb]
   (rf/register-listener! :epoch cb (fn [_] nil))
-  (epoch-state/claim-frame-owner! frame token)
-  (epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
-  (epoch-state/drop-frame-observation! frame))
+  (rf.epoch.state/claim-frame-owner! frame token)
+  (rf.epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
+  (rf.epoch.state/drop-frame-observation! frame))
 
 (defn- cb-generation [cb]
-  (:generation (get (epoch-state/listeners-snapshot) cb)))
+  (:generation (get (rf.epoch.state/listeners-snapshot) cb)))
 
 (deftest claim-and-publish-emit-into-a-dispatch-syncing-listener-does-not-deadlock-a-drain-lock-holder
   ;; The regression: pre-fix HANGS (bounded-timeout -> RED), post-fix COMPLETES.
@@ -119,11 +119,11 @@
               ;; Order B. `other` has not observed `drainee`, so this is a real
               ;; transition that enters `with-silence-lock` (not the no-op).
               t2 (future
-                   (frame/call-serialized-with-drain! drainee
+                   (rf.frame/call-serialized-with-drain! drainee
                      (fn []
                        (.countDown t2-holds-drain)
                        (await-s t2-go)
-                       (epoch-state/record-observation! other other-gen drainee))))]
+                       (rf.epoch.state/record-observation! other other-gen drainee))))]
           (is (await-s t2-holds-drain)
               "T2 holds the frame's :drain-lock (cold serialized section)")
           (let [publish! (fn []
@@ -131,7 +131,7 @@
                            ;; frame whose :drain-lock T2 holds, so it needs it.
                            (.countDown t1-in-publish)
                            (rf/dispatch-sync [:edl/probe] {:frame drainee}))
-                t1       (future (epoch-state/claim-and-publish-delayed-silence!
+                t1       (future (rf.epoch.state/claim-and-publish-delayed-silence!
                                    destroyed cb g 0 publish!))]
             (is (await-s t1-in-publish)
                 "T1 reached the emit (pre-fix: still holding both ledger locks)")

--- a/implementation/epoch/test/re_frame/epoch_silencing_generation_emission_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silencing_generation_emission_test.clj
@@ -43,14 +43,14 @@
             [re-frame.core :as rf]
             ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
             [re-frame.epoch]
-            [re-frame.epoch.listeners :as epoch.listeners]
-            [re-frame.epoch.state :as epoch-state]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.epoch.listeners :as rf.epoch.listeners]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- cb-generation
   "The live generation token currently registered under `cb`. This is an
@@ -62,7 +62,7 @@
   the generation directly because they are pinning the EMISSION's qualifier, not
   the receiver's decision."
   [cb]
-  (get-in (epoch-state/listeners-snapshot) [cb :generation]))
+  (get-in (rf.epoch.state/listeners-snapshot) [cb :generation]))
 
 (defn- owe-silence!
   "Register `cb`, observe `frame` under its current generation, then drop the
@@ -70,9 +70,9 @@
   exactly the state A's compare-owned cleanup leaves for a paused predecessor."
   [frame token cb]
   (rf/register-listener! :epoch cb (fn [_] nil))
-  (epoch-state/claim-frame-owner! frame token)
-  (epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
-  (epoch-state/drop-frame-observation! frame))
+  (rf.epoch.state/claim-frame-owner! frame token)
+  (rf.epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
+  (rf.epoch.state/drop-frame-observation! frame))
 
 ;; ---- TEST A: the emit runs OUTSIDE the ledger locks ------------------------
 
@@ -97,8 +97,8 @@
     ;; `other` also observes and is dropped, so a re-arm is a genuine transition
     ;; that takes silence-lock (not the lock-free no-op fast path).
     (rf/register-listener! :epoch other (fn [_] nil))
-    (epoch.listeners/notify-listeners! {:frame frame :epoch-id 2})
-    (epoch-state/drop-frame-observation! frame)
+    (rf.epoch.listeners/notify-listeners! {:frame frame :epoch-id 2})
+    (rf.epoch.state/drop-frame-observation! frame)
     (rf/register-listener! :epoch reg-target (fn [_] nil))
     (try
       (let [g         (cb-generation cb)
@@ -106,13 +106,13 @@
             publish!  (fn []
                         (.countDown in-claim)
                         (.await release 5 TimeUnit/SECONDS))
-            claimer   (future (epoch-state/claim-and-publish-delayed-silence!
+            claimer   (future (rf.epoch.state/claim-and-publish-delayed-silence!
                                 frame cb g 0 publish!))
             registrar (future (.await in-claim 5 TimeUnit/SECONDS)
                               (rf/register-listener! :epoch reg-target (fn [_] nil))
                               (.countDown put-done))
             observer  (future (.await in-claim 5 TimeUnit/SECONDS)
-                              (epoch-state/record-observation! other other-gen frame)
+                              (rf.epoch.state/record-observation! other other-gen frame)
                               (.countDown obs-done))]
         (is (.await in-claim 5 TimeUnit/SECONDS) "the claim is parked inside publish!")
         ;; The rf2-8b9twg guarantee: NO ledger lock is held during the emit, so
@@ -153,8 +153,8 @@
     ;; Register cb and let it OBSERVE the frame so the destroy snapshot owes it a
     ;; silence under generation G (the real listeners path bakes G onto the wire).
     (rf/register-listener! :epoch cb (fn [_] nil))
-    (epoch-state/claim-frame-owner! frame token)
-    (epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
+    (rf.epoch.state/claim-frame-owner! frame token)
+    (rf.epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
     ;; The trace listener captures the silence AND parks the emit open (outside the
     ;; locks) so a concurrent registrar can land H before the emit returns.
     (rf/register-listener! :trace silence-key
@@ -170,7 +170,7 @@
             ;; per-identity claim owes cb→G. `on-frame-destroyed!` then drops the
             ;; observation (compare-owned cleanup), reserves under the locks,
             ;; releases, and emits the generation-qualified signal.
-            a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! frame nil nil nil)
+            a-ev (rf.epoch.listeners/snapshot-terminal-destroy-evidence! frame nil nil nil)
             registrar (future
                         (.await reached-emit 5 TimeUnit/SECONDS)
                         ;; put-listener! is NOT blocked (the emit holds no lock),
@@ -178,7 +178,7 @@
                         (rf/register-listener! :epoch cb (fn [_] nil))
                         (.countDown h-installed))
             ;; Runs the real emit; blocks (in the trace listener) until H lands.
-            destroyer (future (epoch.listeners/on-frame-destroyed! frame token a-ev))]
+            destroyer (future (rf.epoch.listeners/on-frame-destroyed! frame token a-ev))]
         (is (not= ::timeout (deref registrar 5000 ::timeout))
             "the registrar installed H — put-listener! was not blocked by the emit")
         (is (not= ::timeout (deref destroyer 5000 ::timeout)) "the destroy/emit completed")

--- a/implementation/epoch/test/re_frame/epoch_silencing_lineage_285_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silencing_lineage_285_test.clj
@@ -41,14 +41,14 @@
             [re-frame.core :as rf]
             ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
             [re-frame.epoch]
-            [re-frame.epoch.listeners :as epoch.listeners]
-            [re-frame.epoch.state :as epoch-state]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.epoch.listeners :as rf.epoch.listeners]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [java.util.concurrent CountDownLatch CyclicBarrier TimeUnit]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- silences-for
   "Count silencing traces in `silencings` whose `:cb-id` is `cb`."
@@ -65,12 +65,12 @@
 (defn- cb-generation
   "The live generation token currently registered under `cb`."
   [cb]
-  (:generation (get (epoch-state/listeners-snapshot) cb)))
+  (:generation (get (rf.epoch.state/listeners-snapshot) cb)))
 
 (defn- total-marks
   "Count of `[frame cb]` terminal-silence marks currently retained."
   []
-  (reduce + 0 (map count (vals (epoch-state/terminal-silence-marks-snapshot)))))
+  (reduce + 0 (map count (vals (rf.epoch.state/terminal-silence-marks-snapshot)))))
 
 ;; ---- EXACTNESS ------------------------------------------------------------
 
@@ -84,22 +84,22 @@
         cb ::vxgfnd285-exact-cb]
     (rf/register-listener! :epoch cb (fn [_] nil))
     (try
-      (epoch-state/claim-frame-owner! id (Object.))
-      (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+      (rf.epoch.state/claim-frame-owner! id (Object.))
+      (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
       (let [g (cb-generation cb)
-            observing-1 (:observing (epoch-state/snapshot-terminal-observers id))]
+            observing-1 (:observing (rf.epoch.state/snapshot-terminal-observers id))]
         (is (= g (get observing-1 cb))
             "the owed generation is the exact generation that observed the frame")
         ;; Replace cb → fresh generation H, WITHOUT re-observing (stamp stays G).
         (rf/register-listener! :epoch cb (fn [_] nil))
         (let [h (cb-generation cb)
-              observing-2 (:observing (epoch-state/snapshot-terminal-observers id))]
+              observing-2 (:observing (rf.epoch.state/snapshot-terminal-observers id))]
           (is (not= g h) "replacement minted a fresh generation")
           (is (not (contains? observing-2 cb))
               "a cb replaced after it observed is omitted — H never observed A")
           ;; Re-observe under H → included again, now attributed H (the new stamp).
-          (epoch.listeners/notify-listeners! {:frame id :epoch-id 2})
-          (let [observing-3 (:observing (epoch-state/snapshot-terminal-observers id))]
+          (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 2})
+          (let [observing-3 (:observing (rf.epoch.state/snapshot-terminal-observers id))]
             (is (= h (get observing-3 cb))
                 "re-observing re-includes the cb under its current generation stamp"))))
       (finally
@@ -120,12 +120,12 @@
         (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
           (swap! silencings conj ev))))
     (try
-      (epoch-state/claim-frame-owner! id token-a)
-      (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
-      (let [a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+      (rf.epoch.state/claim-frame-owner! id token-a)
+      (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+      (let [a-ev (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
         ;; cb re-registered to a fresh generation in the deferred window.
         (rf/register-listener! :epoch cb (fn [_] nil))
-        (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+        (rf.epoch.listeners/on-frame-destroyed! id token-a a-ev)
         (is (zero? (silences-for silencings cb))
             "the re-registered generation receives no stale prior-generation silence"))
       (finally
@@ -151,17 +151,17 @@
                      (= id (:frame (:tags ev))))
             (swap! silencings conj ev))))
       (try
-        (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
-        (let [ev-1    (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)
-              ev-2    (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)
+        (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+        (let [ev-1    (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)
+              ev-2    (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)
               ;; Both bundles owe cb; drop its live observation so the silence is
               ;; genuinely owed (as A's own compare-owned cleanup would).
-              _       (epoch-state/drop-frame-observation! id)
+              _       (rf.epoch.state/drop-frame-observation! id)
               barrier (CyclicBarrier. 2)
               publish (fn [ev token]
                         (future
                           (.await barrier 5 TimeUnit/SECONDS)
-                          (epoch.listeners/on-frame-destroyed! id token ev)))
+                          (rf.epoch.listeners/on-frame-destroyed! id token ev)))
               f1      (publish ev-1 (Object.))
               f2      (publish ev-2 (Object.))]
           (is (not= ::timeout (deref f1 5000 ::timeout)) "publisher 1 completes")
@@ -188,16 +188,16 @@
     (rf/register-listener! :epoch trigger (fn [_] nil))
     (rf/register-listener! :epoch target (fn [_] nil))
     (try
-      (epoch-state/claim-frame-owner! id token-a)
-      (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
-      (is (= #{trigger target} (set (epoch-state/cbs-observing-frame id)))
+      (rf.epoch.state/claim-frame-owner! id token-a)
+      (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+      (is (= #{trigger target} (set (rf.epoch.state/cbs-observing-frame id)))
           "both identities observed A")
       (let [target-gen (cb-generation target)
-            a-ev       (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+            a-ev       (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
         ;; A live successor B claims (dropping every observation). Neither
         ;; identity is a live observer at fan start.
-        (epoch-state/claim-frame-owner! id token-b)
-        (is (empty? (epoch-state/cbs-observing-frame id))
+        (rf.epoch.state/claim-frame-owner! id token-b)
+        (is (empty? (rf.epoch.state/cbs-observing-frame id))
             "successor B dropped both observations")
         ;; The trace listener re-arms z-target on B the moment a-trigger's silence
         ;; fires — mid-fan, before z-target is reached.
@@ -206,13 +206,13 @@
             (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
               (swap! silencings conj ev)
               (when (= trigger (:cb-id (:tags ev)))
-                (epoch-state/record-observation! target target-gen id)))))
-        (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+                (rf.epoch.state/record-observation! target target-gen id)))))
+        (rf.epoch.listeners/on-frame-destroyed! id token-a a-ev)
         (is (= 1 (silences-for silencings trigger))
             "a-trigger — A-only — is silenced first")
         (is (zero? (silences-for silencings target))
             "z-target — re-armed live mid-fan — is rechecked and skipped")
-        (is (= [target] (epoch-state/cbs-observing-frame id))
+        (is (= [target] (rf.epoch.state/cbs-observing-frame id))
             "z-target is a live observer of B after the re-arm"))
       (finally
         (rf/unregister-listener! :epoch trigger)
@@ -237,7 +237,7 @@
       ;; cb is owed (not a live observer of id), so the claim reserves the signal.
       (let [g      (cb-generation cb)
             claim! (fn [publish!]
-                     (epoch-state/claim-and-publish-delayed-silence! id cb g 0 publish!))]
+                     (rf.epoch.state/claim-and-publish-delayed-silence! id cb g 0 publish!))]
         ;; A publish that throws propagates AND releases the reservation.
         (is (thrown? clojure.lang.ExceptionInfo
               (claim! (fn [] (throw (ex-info "delivery failed" {})))))
@@ -266,14 +266,14 @@
       (let [g           (cb-generation cb)
             superseded? (atom nil)]
         (is (thrown? clojure.lang.ExceptionInfo
-              (epoch-state/claim-and-publish-delayed-silence! id cb g 0
+              (rf.epoch.state/claim-and-publish-delayed-silence! id cb g 0
                 (fn []
                   ;; Locks are released here, so a successor publisher — whose
                   ;; baseline sits above our fresh mark — can claim the identity
                   ;; between our reservation and our (failing) delivery.
                   (reset! superseded?
-                          (epoch-state/claim-and-publish-delayed-silence!
-                            id cb g (epoch-state/current-terminal-silence-seq)
+                          (rf.epoch.state/claim-and-publish-delayed-silence!
+                            id cb g (rf.epoch.state/current-terminal-silence-seq)
                             (fn [] nil)))
                   (throw (ex-info "delivery failed" {})))))
             "our publish still throws contained")
@@ -281,7 +281,7 @@
             "the successor reserved and published while we held no lock")
         (is (pos? (total-marks))
             "our failed publish compare-and-pruned only its OWN seq — the fresher mark stands")
-        (is (nil? (epoch-state/claim-and-publish-delayed-silence! id cb g 0 (fn [] nil)))
+        (is (nil? (rf.epoch.state/claim-and-publish-delayed-silence! id cb g 0 (fn [] nil)))
             "and that fresher mark still refuses a claim at the original baseline"))
       (finally
         (rf/unregister-listener! :epoch cb)))))
@@ -306,10 +306,10 @@
       (dotimes [i n]
         (let [id    (keyword "vxgfnd285-bounded" (str i))
               token (Object.)]
-          (epoch-state/claim-frame-owner! id token)
-          (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
-          (epoch.listeners/on-frame-destroyed! id token
-            (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
+          (rf.epoch.state/claim-frame-owner! id token)
+          (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+          (rf.epoch.listeners/on-frame-destroyed! id token
+            (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
           (is (<= (total-marks) 1)
               "at most one frame's marks are ever retained at once")))
       (is (= n @silencings) "each unique destroy silenced the persistent cb once")
@@ -337,31 +337,31 @@
           (swap! silencings conj ev))))
     (try
       ;; A observes F-a and snapshots (opening F-a's window) but does NOT publish.
-      (epoch-state/claim-frame-owner! f-a token-a)
-      (epoch.listeners/notify-listeners! {:frame f-a :epoch-id 1})
-      (let [a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! f-a nil nil nil)]
+      (rf.epoch.state/claim-frame-owner! f-a token-a)
+      (rf.epoch.listeners/notify-listeners! {:frame f-a :epoch-id 1})
+      (let [a-ev (rf.epoch.listeners/snapshot-terminal-destroy-evidence! f-a nil nil nil)]
         ;; Successor B of F-a re-arms cb, then retires — firing the one silence and
         ;; leaving a (F-a, cb) mark above A's baseline.
-        (epoch-state/claim-frame-owner! f-a token-b)
-        (epoch.listeners/notify-listeners! {:frame f-a :epoch-id 2})
-        (epoch.listeners/on-frame-destroyed! f-a token-b
-          (epoch.listeners/snapshot-terminal-destroy-evidence! f-a nil nil nil))
+        (rf.epoch.state/claim-frame-owner! f-a token-b)
+        (rf.epoch.listeners/notify-listeners! {:frame f-a :epoch-id 2})
+        (rf.epoch.listeners/on-frame-destroyed! f-a token-b
+          (rf.epoch.listeners/snapshot-terminal-destroy-evidence! f-a nil nil nil))
         (is (= 1 (silences-for-frame silencings cb f-a)) "B fired the one truthful F-a silence")
         (is (= 1 (total-marks)) "exactly F-a's mark is retained while A is held")
         ;; Destroy many UNRELATED frames synchronously — they must not accrete.
         (dotimes [i 500]
           (let [id    (keyword "vxgfnd285-held-other" (str i))
                 token (Object.)]
-            (epoch-state/claim-frame-owner! id token)
-            (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
-            (epoch.listeners/on-frame-destroyed! id token
-              (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))))
+            (rf.epoch.state/claim-frame-owner! id token)
+            (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+            (rf.epoch.listeners/on-frame-destroyed! id token
+              (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))))
         (is (= 1 (total-marks))
             "held A keeps ONLY F-a's mark — unrelated frames self-clean")
-        (is (= #{cb} (set (keys (get (epoch-state/terminal-silence-marks-snapshot) f-a))))
+        (is (= #{cb} (set (keys (get (rf.epoch.state/terminal-silence-marks-snapshot) f-a))))
             "the retained mark is exactly the one A could still consume")
         ;; A resumes: it must NOT re-emit (B's mark is above A's baseline)…
-        (epoch.listeners/on-frame-destroyed! f-a token-a a-ev)
+        (rf.epoch.listeners/on-frame-destroyed! f-a token-a a-ev)
         (is (= 1 (silences-for-frame silencings cb f-a))
             "late A adds no F-a silence — the retired successor already fired it")
         (is (zero? (total-marks))
@@ -378,11 +378,11 @@
     (rf/register-listener! :epoch cb (fn [_] nil))
     ;; A destroyed predecessor left a terminal-silence mark that `reset-listeners!`
     ;; must clear (cb is owed — not a live observer — so the claim reserves it).
-    (epoch-state/open-silence-lineage! id)
-    (epoch-state/claim-and-publish-delayed-silence! id cb (cb-generation cb) 0
+    (rf.epoch.state/open-silence-lineage! id)
+    (rf.epoch.state/claim-and-publish-delayed-silence! id cb (cb-generation cb) 0
                                                     (fn [] nil))
     (is (pos? (total-marks)) "a terminal-silence mark is present")
-    (epoch-state/reset-listeners!)
+    (rf.epoch.state/reset-listeners!)
     (is (zero? (total-marks))
         "reset-listeners! clears the terminal-silence lineage, not just the registry")))
 
@@ -393,12 +393,12 @@
   ;; successor already fired. The seq only ever climbs.
   (let [;; An outstanding predecessor's baseline, taken after the domain has moved
         ;; well above zero.
-        _        (dotimes [_ 5] (epoch-state/next-terminal-silence-seq))
-        baseline (epoch-state/current-terminal-silence-seq)]
+        _        (dotimes [_ 5] (rf.epoch.state/next-terminal-silence-seq))
+        baseline (rf.epoch.state/current-terminal-silence-seq)]
     (is (pos? baseline) "the comparison domain has advanced above zero")
-    (epoch-state/reset-frame-silences!)
+    (rf.epoch.state/reset-frame-silences!)
     (is (zero? (total-marks)) "reset cleared the marks")
-    (let [after (epoch-state/next-terminal-silence-seq)]
+    (let [after (rf.epoch.state/next-terminal-silence-seq)]
       (is (> after baseline)
           "a post-reset mark is stamped ABOVE an outstanding baseline — the domain never recycles"))))
 
@@ -423,15 +423,15 @@
     (let [churner (future
                     (while (not @stop?)
                       (rf/register-listener! :epoch cb (fn [_] nil))
-                      (epoch-state/record-observation! cb (cb-generation cb) id)))]
+                      (rf.epoch.state/record-observation! cb (cb-generation cb) id)))]
       (try
         (dotimes [_ rounds]
           (reset! silencings [])
           (let [token (Object.)]
-            (epoch-state/claim-frame-owner! id token)
-            (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
-            (epoch.listeners/on-frame-destroyed! id token
-              (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)))
+            (rf.epoch.state/claim-frame-owner! id token)
+            (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+            (rf.epoch.listeners/on-frame-destroyed! id token
+              (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)))
           (is (<= (silences-for silencings cb) 1)
               "no destroy double-signals the cb under concurrent generation churn"))
         (finally

--- a/implementation/epoch/test/re_frame/epoch_silencing_lineage_aba_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silencing_lineage_aba_test.clj
@@ -33,23 +33,23 @@
             [re-frame.core :as rf]
             ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
             [re-frame.epoch]
-            [re-frame.epoch.listeners :as epoch.listeners]
-            [re-frame.epoch.state :as epoch-state]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.epoch.listeners :as rf.epoch.listeners]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- executor-barrier!
   "Wait until work already submitted through `interop/next-tick` has run."
   []
   (let [latch (CountDownLatch. 1)]
-    (interop/next-tick #(.countDown latch))
+    (rf.interop/next-tick #(.countDown latch))
     (is (.await latch 5 TimeUnit/SECONDS)
         "the executor reached the deterministic barrier")))
 
@@ -75,11 +75,11 @@
         release-a      (CountDownLatch. 1)
         first-epoch?   (atom true)
         silencings     (atom [])
-        original-epoch (late-bind/get-fn :epoch/on-frame-destroyed)]
+        original-epoch (rf.late-bind/get-fn :epoch/on-frame-destroyed)]
     (rf/reg-event :vxgfnd265/claim-idle-settle
       (fn [{:keys [db]} _] {:db (assoc db :a true)}))
     (rf/reg-event :vxgfnd265/claim-idle-destroy
-      (fn [_ _] (frame/destroy-frame! id) {:db {:owner :a-tail}}))
+      (fn [_ _] (rf.frame/destroy-frame! id) {:db {:owner :a-tail}}))
     (rf/make-frame {:id id})
     (rf/register-listener! :epoch cb (fn [_] nil))
     (rf/dispatch-sync [:vxgfnd265/claim-idle-settle] {:frame id})
@@ -88,7 +88,7 @@
         (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
           (swap! silencings conj ev))))
     (try
-      (late-bind/set-fn! :epoch/on-frame-destroyed
+      (rf.late-bind/set-fn! :epoch/on-frame-destroyed
         (fn [& args]
           (when (and (= id (first args))
                      (compare-and-set! first-epoch? true false))
@@ -103,8 +103,8 @@
         ;; Same-id B claims the id-keyed stores (models the pre-first-epoch
         ;; render/backfill claim) but never settles → cb never observes B.
         (rf/make-frame {:id id})
-        (epoch-state/claim-frame-owner! id (frame/frame-incarnation-token id))
-        (is (nil? (get-in (epoch-state/observations-snapshot) [cb id]))
+        (rf.epoch.state/claim-frame-owner! id (rf.frame/frame-incarnation-token id))
+        (is (nil? (get-in (rf.epoch.state/observations-snapshot) [cb id]))
             "B's claim dropped cb's observation; B delivered nothing to re-arm it")
         (.countDown release-a)
         (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
@@ -117,8 +117,8 @@
         (.countDown release-a)
         (rf/unregister-listener! :epoch cb)
         (rf/unregister-listener! :trace ::vxgfnd265-claim-idle-silencing)
-        (when (frame/frame id) (frame/destroy-frame! id))
-        (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
+        (when (rf.frame/frame id) (rf.frame/destroy-frame! id))
+        (rf.late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
 
 (deftest predecessor-silences-after-successor-claims-then-retires-without-delivery
   ;; Mode 1 `retires` variant, composed at the epoch-state seam. cb observes A;
@@ -138,17 +138,17 @@
           (swap! silencings conj ev))))
     (try
       ;; A: claim + cb observes A.
-      (epoch-state/claim-frame-owner! id token-a)
-      (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
-      (let [a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+      (rf.epoch.state/claim-frame-owner! id token-a)
+      (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+      (let [a-ev (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
         ;; B claims (dropping cb's observation) but never delivers, then retires.
-        (epoch-state/claim-frame-owner! id token-b)
-        (epoch.listeners/on-frame-destroyed! id token-b
-          (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
+        (rf.epoch.state/claim-frame-owner! id token-b)
+        (rf.epoch.listeners/on-frame-destroyed! id token-b
+          (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil))
         (is (zero? (silences-for silencings cb))
             "B's retire silences nothing — B never delivered to cb")
         ;; A resumes: still owes the one silence.
-        (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+        (rf.epoch.listeners/on-frame-destroyed! id token-a a-ev)
         (is (= 1 (silences-for silencings cb))
             "A emits its one owed silence after B claimed-then-retired without delivery"))
       (finally
@@ -172,11 +172,11 @@
         first-epoch?   (atom true)
         received       (atom [])
         silencings     (atom [])
-        original-epoch (late-bind/get-fn :epoch/on-frame-destroyed)]
+        original-epoch (rf.late-bind/get-fn :epoch/on-frame-destroyed)]
     (rf/reg-event :vxgfnd265/aba-settle
       (fn [{:keys [db]} _] {:db (assoc db :a true)}))
     (rf/reg-event :vxgfnd265/aba-destroy
-      (fn [_ _] (frame/destroy-frame! id) {:db {:owner :a-tail}}))
+      (fn [_ _] (rf.frame/destroy-frame! id) {:db {:owner :a-tail}}))
     (rf/reg-event :vxgfnd265/aba-b-settle
       (fn [{:keys [db]} _] {:db (assoc db :owner :b)}))
     (rf/make-frame {:id id})
@@ -187,7 +187,7 @@
         (when (= :rf.epoch.cb/silenced-on-frame-destroy (:operation ev))
           (swap! silencings conj ev))))
     (try
-      (late-bind/set-fn! :epoch/on-frame-destroyed
+      (rf.late-bind/set-fn! :epoch/on-frame-destroyed
         (fn [& args]
           (when (and (= id (first args))
                      (compare-and-set! first-epoch? true false))
@@ -204,9 +204,9 @@
         (rf/dispatch-sync [:vxgfnd265/aba-b-settle] {:frame id})
         (is (= 2 (count @received))
             "cb received A's settle and B's settle — re-armed for the reused id")
-        (let [token-b (frame/frame-incarnation-token id)]
-          (epoch.listeners/on-frame-destroyed! id token-b
-            (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)))
+        (let [token-b (rf.frame/frame-incarnation-token id)]
+          (rf.epoch.listeners/on-frame-destroyed! id token-b
+            (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)))
         (is (= 1 (silences-for silencings cb))
             "B's retire fired exactly one truthful silence for cb")
         ;; A resumes: must add NO further silence for cb (ABA prevented).
@@ -220,8 +220,8 @@
         (.countDown release-a)
         (rf/unregister-listener! :epoch cb)
         (rf/unregister-listener! :trace ::vxgfnd265-aba-silencing)
-        (when (frame/frame id) (frame/destroy-frame! id))
-        (late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
+        (when (rf.frame/frame id) (rf.frame/destroy-frame! id))
+        (rf.late-bind/set-fn! :epoch/on-frame-destroyed original-epoch)))))
 
 ;; ---- Mode 3: mixed identities decided independently -----------------------
 
@@ -250,22 +250,22 @@
           (swap! silencings conj ev))))
     (try
       ;; A claims and fans one record → U, V, W all observe A.
-      (epoch-state/claim-frame-owner! id token-a)
-      (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
-      (is (= #{u v w} (set (epoch-state/cbs-observing-frame id)))
+      (rf.epoch.state/claim-frame-owner! id token-a)
+      (rf.epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+      (is (= #{u v w} (set (rf.epoch.state/cbs-observing-frame id)))
           "U, V, W all observed A")
-      (let [u-gen (:generation (get (epoch-state/listeners-snapshot) u))
-            a-ev  (epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
+      (let [u-gen (:generation (get (rf.epoch.state/listeners-snapshot) u))
+            a-ev  (rf.epoch.listeners/snapshot-terminal-destroy-evidence! id nil nil nil)]
         ;; Successor B claims (dropping every observation) and stays LIVE. It
         ;; re-arms ONLY U; V is left un-rearmed; W is re-registered to a fresh
         ;; generation that never observed the frame.
-        (epoch-state/claim-frame-owner! id token-b)
-        (epoch-state/record-observation! u u-gen id)     ; U live on B
+        (rf.epoch.state/claim-frame-owner! id token-b)
+        (rf.epoch.state/record-observation! u u-gen id)     ; U live on B
         (rf/register-listener! :epoch w (fn [_] nil))     ; W → fresh generation
-        (is (= [u] (epoch-state/cbs-observing-frame id))
+        (is (= [u] (rf.epoch.state/cbs-observing-frame id))
             "only U is a live observer of the reused id under the successor")
         ;; A resumes with its stale snapshot (token-a is no longer the owner).
-        (epoch.listeners/on-frame-destroyed! id token-a a-ev)
+        (rf.epoch.listeners/on-frame-destroyed! id token-a a-ev)
         (is (= 1 (silences-for silencings v))
             "V — A-only identity — is silenced")
         (is (zero? (silences-for silencings u))

--- a/implementation/epoch/test/re_frame/epoch_silencing_same_generation_rearm_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silencing_same_generation_rearm_test.clj
@@ -48,14 +48,14 @@
             [re-frame.core :as rf]
             ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
             [re-frame.epoch]
-            [re-frame.epoch.listeners :as epoch.listeners]
-            [re-frame.epoch.state :as epoch-state]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.epoch.listeners :as rf.epoch.listeners]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- silence-current?
   "The SUPPORTED receiver decision, expressed exactly as the spec states it and
@@ -69,14 +69,14 @@
   it — the generation alone can only recompose the torn two-read decision);
   artefact-internal tests read the registry snapshot directly."
   [cb]
-  (get-in (epoch-state/listeners-snapshot) [cb :generation]))
+  (get-in (rf.epoch.state/listeners-snapshot) [cb :generation]))
 
 (defn- observing?
   "Whether `cb`'s CURRENT registration observes `frame` — the observation-
   continuum fact the decision weighs, read here from the state ns for assertions
   that need to name it separately."
   [cb frame]
-  (let [token (get-in (epoch-state/observations-snapshot) [cb frame] ::absent)]
+  (let [token (get-in (rf.epoch.state/observations-snapshot) [cb frame] ::absent)]
     (and (not= token ::absent)
          (= token (cb-generation cb)))))
 
@@ -98,8 +98,8 @@
   so the frame's destroy snapshot owes it a silence under its live generation."
   [frame token cb]
   (rf/register-listener! :epoch cb (fn [_] nil))
-  (epoch-state/claim-frame-owner! frame token)
-  (epoch.listeners/notify-listeners! {:frame frame :epoch-id 1}))
+  (rf.epoch.state/claim-frame-owner! frame token)
+  (rf.epoch.listeners/notify-listeners! {:frame frame :epoch-id 1}))
 
 ;; ---- THE BEAD CASE: same-generation re-arm inside the emit window -----------
 
@@ -125,13 +125,13 @@
     (park-silence-emit! silence-key cb captured reached-emit rearmed)
     (try
       (let [g    (cb-generation cb)
-            a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! frame nil nil nil)
+            a-ev (rf.epoch.listeners/snapshot-terminal-destroy-evidence! frame nil nil nil)
             ;; The successor's delivery, landing strictly INSIDE the lock-free
             ;; emit window, under the UNCHANGED generation G.
             rearmer   (future (.await reached-emit 5 TimeUnit/SECONDS)
-                              (epoch-state/record-observation! cb g frame)
+                              (rf.epoch.state/record-observation! cb g frame)
                               (.countDown rearmed))
-            destroyer (future (epoch.listeners/on-frame-destroyed! frame token a-ev))]
+            destroyer (future (rf.epoch.listeners/on-frame-destroyed! frame token a-ev))]
         (is (not= ::timeout (deref rearmer 5000 ::timeout))
             "the re-arm completed — it was NOT blocked by the emit (no ledger lock is held)")
         (is (not= ::timeout (deref destroyer 5000 ::timeout)) "the destroy/emit completed")
@@ -179,10 +179,10 @@
     (park-silence-emit! silence-key cb captured reached-emit resume)
     (try
       (let [g    (cb-generation cb)
-            a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! frame nil nil nil)
+            a-ev (rf.epoch.listeners/snapshot-terminal-destroy-evidence! frame nil nil nil)
             idle (future (.await reached-emit 5 TimeUnit/SECONDS)
                          (.countDown resume))
-            destroyer (future (epoch.listeners/on-frame-destroyed! frame token a-ev))]
+            destroyer (future (rf.epoch.listeners/on-frame-destroyed! frame token a-ev))]
         (is (not= ::timeout (deref idle 5000 ::timeout)) "the emit window opened and closed")
         (is (not= ::timeout (deref destroyer 5000 ::timeout)) "the destroy/emit completed")
         (is (= 1 (count @captured)) "exactly one silence fired for cb")
@@ -213,16 +213,16 @@
         captured     (atom [])
         silence-key  ::qg98y-scoped-silencing]
     (observe! frame token cb)
-    (epoch-state/claim-frame-owner! other-frame other-token)
+    (rf.epoch.state/claim-frame-owner! other-frame other-token)
     (park-silence-emit! silence-key cb captured reached-emit rearmed)
     (try
       (let [g    (cb-generation cb)
-            a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! frame nil nil nil)
+            a-ev (rf.epoch.listeners/snapshot-terminal-destroy-evidence! frame nil nil nil)
             rearmer   (future (.await reached-emit 5 TimeUnit/SECONDS)
                               ;; A delivery from the OTHER frame, same generation.
-                              (epoch-state/record-observation! cb g other-frame)
+                              (rf.epoch.state/record-observation! cb g other-frame)
                               (.countDown rearmed))
-            destroyer (future (epoch.listeners/on-frame-destroyed! frame token a-ev))]
+            destroyer (future (rf.epoch.listeners/on-frame-destroyed! frame token a-ev))]
         (is (not= ::timeout (deref rearmer 5000 ::timeout)) "the other-frame re-arm completed")
         (is (not= ::timeout (deref destroyer 5000 ::timeout)) "the destroy/emit completed")
         (is (= 1 (count @captured)) "exactly one silence fired for cb")
@@ -256,12 +256,12 @@
     (park-silence-emit! silence-key cb captured reached-emit mutated)
     (try
       (let [g    (cb-generation cb)
-            a-ev (epoch.listeners/snapshot-terminal-destroy-evidence! frame nil nil nil)
+            a-ev (rf.epoch.listeners/snapshot-terminal-destroy-evidence! frame nil nil nil)
             mutator   (future (.await reached-emit 5 TimeUnit/SECONDS)
-                              (epoch-state/record-observation! cb g frame)
+                              (rf.epoch.state/record-observation! cb g frame)
                               (rf/register-listener! :epoch cb (fn [_] nil)) ; G → H
                               (.countDown mutated))
-            destroyer (future (epoch.listeners/on-frame-destroyed! frame token a-ev))]
+            destroyer (future (rf.epoch.listeners/on-frame-destroyed! frame token a-ev))]
         (is (not= ::timeout (deref mutator 5000 ::timeout)) "re-arm + replacement completed")
         (is (not= ::timeout (deref destroyer 5000 ::timeout)) "the destroy/emit completed")
         (is (= 1 (count @captured)) "exactly one silence fired for cb")
@@ -290,8 +290,8 @@
     (try
       (is (false? (observing? cb frame))
           "a registered listener that has consumed no record observes nothing")
-      (epoch-state/claim-frame-owner! frame token)
-      (epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
+      (rf.epoch.state/claim-frame-owner! frame token)
+      (rf.epoch.listeners/notify-listeners! {:frame frame :epoch-id 1})
       (is (true? (observing? cb frame))
           "after consuming a record it observes the frame")
       (is (false? (observing? cb :qg98y/boundary-unseen))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -26,7 +26,7 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             ;; Side-effect require: flows publishes the `:flows/reg-flow`
             ;; late-bind hook at ns-load. Several restore-* tests register
             ;; flows via `rf/reg-flow` in their bodies; without this load
@@ -42,9 +42,9 @@
             ;; clock read at assembly time. Both `now-ms` (elapsed clock) and
             ;; `epoch-now-ms` (wall-clock, the surface the router stamps fresh
             ;; tokens from — rf2-n1rh0f / EP-0010 §Time) are pinned.
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
             ;; rf2-eig68k — require the schemas FAÇADE, not the `.malli`
             ;; validator adapter. The dependency runs ONE way:
             ;; `re-frame.schemas` `:require`s `re-frame.schemas.malli`
@@ -59,22 +59,22 @@
             ;; need AND the Malli validate hook the runtime-db
             ;; schema-mismatch precondition (rf2-szbzei) drives a real
             ;; failure through. Side-effect require — alias unused.
-            [re-frame.schemas :as schemas]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]
-            [re-frame.epoch :as epoch]
-            [re-frame.epoch.assembly :as assembly]
-            [re-frame.epoch.capture :as capture]
-            [re-frame.epoch.listeners :as epoch.listeners]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.epoch.assembly :as rf.epoch.assembly]
+            [re-frame.epoch.capture :as rf.epoch.capture]
+            [re-frame.epoch.listeners :as rf.epoch.listeners]
             ;; `state` is used in test BODIES for the deep private-impl
             ;; unit tests (the `@#'state/value-changed-epoch-for` scan
             ;; against a hand-built `@#'state/histories` ring, and the
             ;; shipped-default accessor probe) — NOT for fixture config
             ;; reset, which now flows through the public `configure!`
             ;; boundary + the `:epoch/reset-config!` reset hook.
-            [re-frame.epoch.state :as state]
-            [re-frame.epoch.tool-pair :as tool-pair]
+            [re-frame.epoch.state :as rf.epoch.state]
+            [re-frame.epoch.tool-pair :as rf.epoch.tool-pair]
             ;; Side-effect require: routing publishes its `:routing/*`
             ;; late-bind hooks (incl. the `rf/reg-route` registrar kind)
             ;; at ns-load. Several tests call `rf/reg-route` in their
@@ -93,7 +93,7 @@
             ;; rf2-u5kmf8 — read the machine `:after` host-clock timer table
             ;; directly to prove an end-to-end restore releases the restored
             ;; frame's armed timer handles (the orphaned async host work).
-            [re-frame.machines.timer :as machine-timer]))
+            [re-frame.machines.timer :as rf.machines.timer]))
 
 ;; ---- fixtures --------------------------------------------------------------
 ;;
@@ -114,8 +114,8 @@
 ;; `:init-fn` runs AFTER the post-dispose reset hooks, so the override
 ;; lands on top of the freshly-reset default.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
@@ -310,8 +310,8 @@
       ;; fills :time-ms when absent), so the token time below rides through;
       ;; pinning both clocks makes a regression that re-reads either ambient
       ;; surface at assembly time stamp the sentinel and fail loudly.
-      (with-redefs [interop/now-ms       (constantly clock-time)
-                    interop/epoch-now-ms (constantly clock-time)]
+      (with-redefs [rf.interop/now-ms       (constantly clock-time)
+                    rf.interop/epoch-now-ms (constantly clock-time)]
         (rf/dispatch-sync [:seed] {:frame            :test/main
                                    :rf.cofx {:rf/time-ms token-time}}))
       (let [r (last (rf/epoch-history :test/main))]
@@ -334,12 +334,12 @@
       ;; Pin BOTH clock surfaces (elapsed `now-ms` + wall-clock
       ;; `epoch-now-ms`, rf2-n1rh0f) so neither ambient read can leak into
       ;; :committed-at across the drift.
-      (with-redefs [interop/now-ms       (constantly 100)
-                    interop/epoch-now-ms (constantly 100)]
+      (with-redefs [rf.interop/now-ms       (constantly 100)
+                    rf.interop/epoch-now-ms (constantly 100)]
         (rf/dispatch-sync [:seed] {:frame            :test/main
                                    :rf.cofx {:rf/time-ms token-time}}))
-      (with-redefs [interop/now-ms       (constantly 8888888888888)
-                    interop/epoch-now-ms (constantly 8888888888888)]
+      (with-redefs [rf.interop/now-ms       (constantly 8888888888888)
+                    rf.interop/epoch-now-ms (constantly 8888888888888)]
         (rf/dispatch-sync [:inc]  {:frame            :test/main
                                    :rf.cofx {:rf/time-ms token-time}}))
       (let [history (rf/epoch-history :test/main)]
@@ -372,7 +372,7 @@
           ;; CLJS). Pinned to this sentinel by the redef below.
           child-clock 5550000000000]
       (rf/dispatch-sync [:seed] {:frame :test/main})
-      (with-redefs [interop/epoch-now-ms (constantly child-clock)]
+      (with-redefs [rf.interop/epoch-now-ms (constantly child-clock)]
         (rf/dispatch-sync [:parent] {:frame            :test/main
                                      :rf.cofx {:rf/time-ms parent-time}}))
       (let [history    (rf/epoch-history :test/main)
@@ -748,8 +748,8 @@
       ;; send a post-settle render at a record that no longer exists, so
       ;; the splice would silently drop the render instead of attributing
       ;; it to the live cascade.
-      (state/record-mount-epoch! :test/main [:view/probe "t1"] retired-id)
-      (is (= retired-id (state/mount-epoch-for :test/main [:view/probe "t1"]))
+      (rf.epoch.state/record-mount-epoch! :test/main [:view/probe "t1"] retired-id)
+      (is (= retired-id (rf.epoch.state/mount-epoch-for :test/main [:view/probe "t1"]))
           "precondition: the mount anchor names the epoch about to retire")
 
       (rf/configure! {:epoch-history {:depth 0}})
@@ -757,9 +757,9 @@
 
       (is (= [] (rf/epoch-history :test/main))
           "re-enabling does not resurrect the pre-disable records")
-      (is (nil? (state/last-settled-epoch-id :test/main))
+      (is (nil? (rf.epoch.state/last-settled-epoch-id :test/main))
           "the post-settle back-fill anchor no longer names a retired epoch")
-      (is (nil? (state/mount-epoch-for :test/main [:view/probe "t1"]))
+      (is (nil? (rf.epoch.state/mount-epoch-for :test/main [:view/probe "t1"]))
           "nor does the per-render-key mount anchor")
 
       (rf/dispatch-sync [:inc] {:frame :test/main})
@@ -837,7 +837,7 @@
     (rf/make-frame {:id :test/main})
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
 
-    (let [observed (deref #'state/observed-frames-by-cb)
+    (let [observed (deref #'rf.epoch.state/observed-frames-by-cb)
           recorded (record-trace!)
           a        (atom 0)
           b        (atom 0)
@@ -856,20 +856,20 @@
         (is (contains? (get snap ::w2) :test/main)
             "::w2 observed :test/main")
         ;; each ledger stamps the frame with the cb's own live generation
-        (is (= (:generation (get (state/listeners-snapshot) ::w1))
+        (is (= (:generation (get (rf.epoch.state/listeners-snapshot) ::w1))
                (get-in snap [::w1 :test/main]))
             "::w1's observation carries ::w1's generation token")
-        (is (= (:generation (get (state/listeners-snapshot) ::w2))
+        (is (= (:generation (get (rf.epoch.state/listeners-snapshot) ::w2))
                (get-in snap [::w2 :test/main]))
             "::w2's observation carries ::w2's generation token")
-        (is (= #{::w1 ::w2} (set (state/cbs-observing-frame :test/main)))
+        (is (= #{::w1 ::w2} (set (rf.epoch.state/cbs-observing-frame :test/main)))
             "both cbs are live-generation observers of :test/main"))
 
       ;; Re-register ::w1 under a different fn — mints a fresh generation. Its
       ;; ledger entry for :test/main still carries the OLD generation token
       ;; (not cleared), but that token is no longer live.
       (rf/register-listener! :epoch ::w1 (fn [_] (swap! c inc)))
-      (is (= [::w2] (state/cbs-observing-frame :test/main))
+      (is (= [::w2] (rf.epoch.state/cbs-observing-frame :test/main))
           "immediately after re-register, only ::w2 (live gen) observes
            :test/main — ::w1's retired generation is skipped, not silenced")
       (is (contains? (get @observed ::w2) :test/main)
@@ -881,7 +881,7 @@
       (is (= 1 @a) "the original ::w1 fn does not fire — it was replaced")
       (is (= 1 @c) "the replacement ::w1 fn fires once")
       (is (= 2 @b) "::w2 keeps firing across both cascades")
-      (is (= (:generation (get (state/listeners-snapshot) ::w1))
+      (is (= (:generation (get (rf.epoch.state/listeners-snapshot) ::w1))
              (get-in @observed [::w1 :test/main]))
           "::w1's ledger re-stamped :test/main under the NEW generation")
 
@@ -1093,7 +1093,7 @@
             partition + frame-id to the :resources/reconcile-on-restore hook and
             returns the frame-state with the hook's reconciled runtime-db installed."
     (let [hook-key :resources/reconcile-on-restore
-          original (late-bind/get-fn hook-key)
+          original (rf.late-bind/get-fn hook-key)
           seen     (atom nil)]
       (try
         ;; Stub a reconcile that records its inputs and rewrites the runtime-db
@@ -1101,13 +1101,13 @@
         ;; rf2-obi8rr — the hook is now consulted with a third `opts` arg
         ;; (`{:defer-traces? true}`) so its success traces ride back deferred;
         ;; the stub records it to pin that the seam passes the opts through.
-        (late-bind/set-fn! hook-key
+        (rf.late-bind/set-fn! hook-key
                            (fn [rdb frame-id opts]
                              (reset! seen {:rdb rdb :frame-id frame-id :opts opts})
                              (assoc rdb :rf.runtime/reconciled? true)))
         (let [fs {:rf.db/app     {:n 1}
                   :rf.db/runtime {:rf.runtime/resources {:entries {}}}}
-              out (tool-pair/reconcile-runtime-db-on-restore :test/x fs)]
+              out (rf.epoch.tool-pair/reconcile-runtime-db-on-restore :test/x fs)]
           (is (= {:rf.runtime/resources {:entries {}}} (:rdb @seen))
               "the hook receives the runtime-db PARTITION value")
           (is (= :test/x (:frame-id @seen)) "the hook receives the carried frame-id")
@@ -1117,37 +1117,37 @@
               "the hook's reconciled runtime-db is installed back into the frame-state")
           (is (= {:n 1} (:rf.db/app out)) "the app-db partition is untouched"))
         (finally
-          (late-bind/set-fn! hook-key original))))))
+          (rf.late-bind/set-fn! hook-key original))))))
 
 (deftest reconcile-runtime-db-on-restore-noop-without-hook
   (testing "rf2-7r5mc2 — absent the :resources/reconcile-on-restore hook (no
             resources artefact), the frame-state installs verbatim (the
             pre-rf2-7r5mc2 behaviour)."
     (let [hook-key :resources/reconcile-on-restore
-          original (late-bind/get-fn hook-key)]
+          original (rf.late-bind/get-fn hook-key)]
       (try
-        (late-bind/set-fn! hook-key nil)
+        (rf.late-bind/set-fn! hook-key nil)
         (let [fs {:rf.db/app {:n 1} :rf.db/runtime {:rf.runtime/resources {:entries {:k :v}}}}]
-          (is (= fs (tool-pair/reconcile-runtime-db-on-restore :test/x fs))
+          (is (= fs (rf.epoch.tool-pair/reconcile-runtime-db-on-restore :test/x fs))
               "no hook → frame-state passes through unchanged"))
         (finally
-          (late-bind/set-fn! hook-key original))))))
+          (rf.late-bind/set-fn! hook-key original))))))
 
 (deftest reconcile-runtime-db-on-restore-noop-on-app-db-only-record
   (testing "rf2-7r5mc2 — a frame-state with only the app-db partition (no
             :rf.db/runtime key) passes through unchanged even when the hook
             is present (nothing to reconcile)."
     (let [hook-key :resources/reconcile-on-restore
-          original (late-bind/get-fn hook-key)
+          original (rf.late-bind/get-fn hook-key)
           called?  (atom false)]
       (try
-        (late-bind/set-fn! hook-key (fn [rdb _] (reset! called? true) rdb))
+        (rf.late-bind/set-fn! hook-key (fn [rdb _] (reset! called? true) rdb))
         (let [fs {:rf.db/app {:n 1}}]
-          (is (= fs (tool-pair/reconcile-runtime-db-on-restore :test/x fs))
+          (is (= fs (rf.epoch.tool-pair/reconcile-runtime-db-on-restore :test/x fs))
               "app-db-only frame-state is unchanged")
           (is (false? @called?) "the hook is not consulted when there is no runtime-db partition"))
         (finally
-          (late-bind/set-fn! hook-key original))))))
+          (rf.late-bind/set-fn! hook-key original))))))
 
 (deftest perform-restore!-reconciles-installed-runtime-db
   (testing "rf2-7r5mc2 — end-to-end: perform-restore! runs the
@@ -1164,13 +1164,13 @@
     (rf/reg-event :clear (fn [{:keys [db]} _] {:db {:phase :cleared}}))
 
     (let [hook-key :resources/reconcile-on-restore
-          original (late-bind/get-fn hook-key)]
+          original (rf.late-bind/get-fn hook-key)]
       (try
         ;; Stub the reconcile: settle the mid-flight entry (loading → loaded-ish)
         ;; + clear current-work, standing in for the resources artefact's real
         ;; reconcile so the epoch wiring is exercised without a resources dep.
         ;; rf2-obi8rr — accept the third `opts` arg (`{:defer-traces? true}`).
-        (late-bind/set-fn! hook-key
+        (rf.late-bind/set-fn! hook-key
                            (fn [rdb _frame-id _opts]
                              (-> rdb
                                  (assoc-in [:rf.runtime/resources :entries :k :status] :idle)
@@ -1189,7 +1189,7 @@
             (is (nil? (get-in rdb [:rf.runtime/resources :entries :k :current-work]))
                 "the vanished current-work pointer was cleared during the reconcile")))
         (finally
-          (late-bind/set-fn! hook-key original))))))
+          (rf.late-bind/set-fn! hook-key original))))))
 
 (deftest perform-restore!-threads-restored-epoch-causal-time-as-restore-time-ms
   (testing "rf2-wshzsp — perform-restore! threads the RESTORED epoch's causal
@@ -1209,12 +1209,12 @@
     (rf/reg-event :clear (fn [{:keys [db]} _] {:db {:phase :cleared}}))
 
     (let [hook-key   :resources/reconcile-on-restore
-          original   (late-bind/get-fn hook-key)
+          original   (rf.late-bind/get-fn hook-key)
           seen-opts  (atom nil)
           token-time 1781078400777          ; the causal token time of the mid-flight commit
           clock-time 9999999999999]         ; the (wrong) ambient install-clock sentinel
       (try
-        (late-bind/set-fn! hook-key
+        (rf.late-bind/set-fn! hook-key
                            (fn [rdb _frame-id opts]
                              (reset! seen-opts opts)
                              rdb))
@@ -1229,8 +1229,8 @@
           (rf/dispatch-sync [:clear] {:frame :test/main})
           ;; Restore UNDER a wrong ambient install clock — a regression that
           ;; sourced :restore-time-ms from now-ms would stamp the sentinel here.
-          (with-redefs [interop/now-ms       (constantly clock-time)
-                        interop/epoch-now-ms (constantly clock-time)]
+          (with-redefs [rf.interop/now-ms       (constantly clock-time)
+                        rf.interop/epoch-now-ms (constantly clock-time)]
             (is (true? (rf/restore-epoch! :test/main mid-epoch))
                 "restore to the mid-flight epoch succeeded"))
           (is (= token-time (:restore-time-ms @seen-opts))
@@ -1238,7 +1238,7 @@
           (is (not= clock-time (:restore-time-ms @seen-opts))
               ":restore-time-ms is NOT the live ambient install clock"))
         (finally
-          (late-bind/set-fn! hook-key original))))))
+          (rf.late-bind/set-fn! hook-key original))))))
 
 ;; ---- restore-time host-transient quiesce (rf2-u5kmf8) ----------------------
 ;;
@@ -1272,12 +1272,12 @@
     (rf/reg-event :step2 (fn [{:keys [db]} _] {:db (assoc db :n 2)}))
     (let [machines-key :machines/on-frame-restored!
           http-key     :http/abort-in-flight-for-frame!
-          orig-mach    (late-bind/get-fn machines-key)
-          orig-http    (late-bind/get-fn http-key)
+          orig-mach    (rf.late-bind/get-fn machines-key)
+          orig-http    (rf.late-bind/get-fn http-key)
           seen         (atom [])]
       (try
-        (late-bind/set-fn! machines-key (fn [frame-id] (swap! seen conj [:machines frame-id])))
-        (late-bind/set-fn! http-key     (fn [frame-id] (swap! seen conj [:http frame-id])))
+        (rf.late-bind/set-fn! machines-key (fn [frame-id] (swap! seen conj [:machines frame-id])))
+        (rf.late-bind/set-fn! http-key     (fn [frame-id] (swap! seen conj [:http frame-id])))
         (rf/dispatch-sync [:step] {:frame :test/main})
         (let [target (:epoch-id (last (rf/epoch-history :test/main)))]
           (rf/dispatch-sync [:step2] {:frame :test/main})
@@ -1288,8 +1288,8 @@
           (is (some #{[:http :test/main]} @seen)
               ":http/abort-in-flight-for-frame! fired for the restored frame"))
         (finally
-          (late-bind/set-fn! machines-key orig-mach)
-          (late-bind/set-fn! http-key orig-http))))))
+          (rf.late-bind/set-fn! machines-key orig-mach)
+          (rf.late-bind/set-fn! http-key orig-http))))))
 
 (deftest perform-restore!-quiesce-noop-without-hooks
   (testing "rf2-u5kmf8 — absent the machines / http artefacts (hooks nil) the
@@ -1300,19 +1300,19 @@
     (rf/reg-event :step2 (fn [{:keys [db]} _] {:db (assoc db :n 2)}))
     (let [machines-key :machines/on-frame-restored!
           http-key     :http/abort-in-flight-for-frame!
-          orig-mach    (late-bind/get-fn machines-key)
-          orig-http    (late-bind/get-fn http-key)]
+          orig-mach    (rf.late-bind/get-fn machines-key)
+          orig-http    (rf.late-bind/get-fn http-key)]
       (try
-        (late-bind/set-fn! machines-key nil)
-        (late-bind/set-fn! http-key nil)
+        (rf.late-bind/set-fn! machines-key nil)
+        (rf.late-bind/set-fn! http-key nil)
         (rf/dispatch-sync [:step] {:frame :test/main})
         (let [target (:epoch-id (last (rf/epoch-history :test/main)))]
           (rf/dispatch-sync [:step2] {:frame :test/main})
           (is (true? (rf/restore-epoch! :test/main target))
               "restore succeeds with no quiesce hooks registered"))
         (finally
-          (late-bind/set-fn! machines-key orig-mach)
-          (late-bind/set-fn! http-key orig-http))))))
+          (rf.late-bind/set-fn! machines-key orig-mach)
+          (rf.late-bind/set-fn! http-key orig-http))))))
 
 (deftest perform-restore!-does-not-quiesce-on-failed-install
   (testing "rf2-u5kmf8 — a destroyed-frame install (perform-restore! returns
@@ -1323,10 +1323,10 @@
     (rf/make-frame {:id :test/main})
     (rf/reg-event :step (fn [{:keys [db]} _] {:db (assoc db :n 1)}))
     (let [machines-key :machines/on-frame-restored!
-          orig-mach    (late-bind/get-fn machines-key)
+          orig-mach    (rf.late-bind/get-fn machines-key)
           fired?       (atom false)]
       (try
-        (late-bind/set-fn! machines-key (fn [_frame-id] (reset! fired? true)))
+        (rf.late-bind/set-fn! machines-key (fn [_frame-id] (reset! fired? true)))
         (rf/dispatch-sync [:step] {:frame :test/main})
         (let [target-record (last (rf/epoch-history :test/main))
               ;; Capture the incarnation token while the frame is still live (as
@@ -1335,14 +1335,14 @@
               ;; (the validate-then-destroy / destroyed-frame branch): the
               ;; write-boundary incarnation gate refuses and perform-restore!
               ;; bails with false BEFORE the success telemetry / quiesce chain.
-              token (frame/frame-incarnation-token :test/main)
+              token (rf.frame/frame-incarnation-token :test/main)
               _ (rf/destroy-frame! :test/main)
-              result (tool-pair/perform-restore! :test/main token target-record)]
+              result (rf.epoch.tool-pair/perform-restore! :test/main token target-record)]
           (is (false? result) "perform-restore! returns false for the destroyed frame")
           (is (false? @fired?)
               "the quiesce chain did NOT fire for a restore that wrote nothing"))
         (finally
-          (late-bind/set-fn! machines-key orig-mach))))))
+          (rf.late-bind/set-fn! machines-key orig-mach))))))
 
 (deftest restore-releases-armed-machine-after-timer-end-to-end
   (testing "rf2-u5kmf8 — ADVERSARIAL end-to-end through the REAL machines
@@ -1369,12 +1369,12 @@
     (let [idle-epoch (:epoch-id (last (rf/epoch-history :test/main)))]
       ;; epoch 2: :fetch → :loading arms the :after host-clock timer.
       (rf/dispatch-sync [:rest/m [:fetch]] {:frame :test/main})
-      (is (seq (get @machine-timer/after-timers :test/main))
+      (is (seq (get @rf.machines.timer/after-timers :test/main))
           "precondition: the :loading state armed an :after host-clock timer")
       ;; Restore to the :idle epoch — the snapshot rewinds out of :loading.
       (is (true? (rf/restore-epoch! :test/main idle-epoch))
           "restore to the pre-:loading epoch succeeded")
-      (is (empty? (get @machine-timer/after-timers :test/main))
+      (is (empty? (get @rf.machines.timer/after-timers :test/main))
           "the orphaned :after host-clock handle was RELEASED by the restore — no leaked wall-clock timer from the unwound epoch"))))
 
 ;; ---- restore failure modes -------------------------------------------------
@@ -1504,7 +1504,7 @@
       (is (string? (:schema-digest r))
           "the record carries a :schema-digest string")
       (is (= (:schema-digest r)
-             (schemas/app-schemas-digest :test/digest))
+             (rf.schemas/app-schemas-digest :test/digest))
           "record's stamp matches the live digest at record time"))))
 
 (deftest restore-failure-missing-handler-route
@@ -1525,7 +1525,7 @@
     ;; whose :frame-state-after references :route/users.
     (let [target (last (rf/epoch-history :test/main))]
       ;; Now blow away the route registration.
-      (registrar/unregister! :route :route/users)
+      (rf.registrar/unregister! :route :route/users)
 
       (let [recorded (record-trace!)
             pre      (rf/app-db-value :test/main)
@@ -1569,7 +1569,7 @@
           "snapshot recorded in the runtime-db partition")
 
       ;; Unregister the machine so the recorded snapshot's id no longer resolves.
-      (registrar/unregister! :event :machine/tl)
+      (rf.registrar/unregister! :event :machine/tl)
 
       (let [recorded (record-trace!)
             pre      (rf/app-db-value :test/main)
@@ -1735,7 +1735,7 @@
             walk and `re-frame.epoch.listeners`'s post-settle back-fill."
     (testing "tag PRESENT on a sub run inside an in-flight cascade →
               row carries :cause-event-id"
-      (let [row (capture/sub-run-row
+      (let [row (rf.epoch.capture/sub-run-row
                   {:op-type   :rf.sub
                    :operation :rf.sub/run
                    :tags      {:rf.sub/id             :counter/value
@@ -1753,7 +1753,7 @@
     (testing "tag OMITTED (post-settle reactive flush outside a cascade,
               or `re-frame.epoch` artefact absent) → row slot is ABSENT,
               parity with the OMIT-vs-nil semantics of the trace tag"
-      (let [row (capture/sub-run-row
+      (let [row (rf.epoch.capture/sub-run-row
                   {:op-type   :rf.sub
                    :operation :rf.sub/run
                    :tags      {:rf.sub/id             :counter/value
@@ -1778,7 +1778,7 @@
             Direct unit test against `capture/sub-run-row`."
     (testing ":large? tag PRESENT → row carries :large? true, value intact
               (the projection, not the row builder, does the substitution)"
-      (let [row (capture/sub-run-row
+      (let [row (rf.epoch.capture/sub-run-row
                   {:op-type   :rf.sub
                    :operation :rf.sub/run
                    :tags      {:rf.sub/id             :big/value
@@ -1794,7 +1794,7 @@
         (is (= "BIG" (:value row))
             "the raw value stays on the row — on-box ring keeps exact state")))
     (testing ":large? tag ABSENT (non-large sub) → row omits the flag"
-      (let [row (capture/sub-run-row
+      (let [row (rf.epoch.capture/sub-run-row
                   {:op-type   :rf.sub
                    :operation :rf.sub/run
                    :tags      {:rf.sub/id             :small/value
@@ -2052,13 +2052,13 @@
             facing tier per rf2-18g1w / rf2-jppad (the rationale lives
             in `re-frame.epoch.assembly/outcome->consumer-facing`)"
     (testing ":ok → :ok (the cascade settled cleanly)"
-      (is (= :ok (assembly/outcome->consumer-facing :ok))))
+      (is (= :ok (rf.epoch.assembly/outcome->consumer-facing :ok))))
     (testing ":halted-depth → :blocked (drain hit the depth limit)"
-      (is (= :blocked (assembly/outcome->consumer-facing :halted-depth))))
+      (is (= :blocked (rf.epoch.assembly/outcome->consumer-facing :halted-depth))))
     (testing ":halted-destroy → :blocked (frame destroyed mid-drain)"
-      (is (= :blocked (assembly/outcome->consumer-facing :halted-destroy))))
+      (is (= :blocked (rf.epoch.assembly/outcome->consumer-facing :halted-destroy))))
     (testing ":halted-handler-exception → :error (schema-reserved)"
-      (is (= :error (assembly/outcome->consumer-facing :halted-handler-exception))))))
+      (is (= :error (rf.epoch.assembly/outcome->consumer-facing :halted-handler-exception))))))
 
 (deftest rf-epoch-outcome-emits-on-ok-cascade
   (testing "every :ok cascade emits a paired :rf.epoch/outcome trace
@@ -2155,7 +2155,7 @@
       ;; Stub the ambient clock to a sentinel; supply the destroying event's
       ;; causal token time. A regression that re-read now-ms at assembly
       ;; would stamp the sentinel.
-      (with-redefs [interop/now-ms (constantly clock-time)]
+      (with-redefs [rf.interop/now-ms (constantly clock-time)]
         (rf/dispatch-sync [:self-destruct]
                           {:frame            :test/short-lived
                            :rf.cofx {:rf/time-ms token-time}}))
@@ -2350,13 +2350,13 @@
     ;; context. (`make-frame` emits a :rf.frame/created trace that
     ;; capture-event! would buffer; reset so the buffer is genuinely
     ;; empty, mirroring the empty-buffer abort case.)
-    (reset! @#'state/capture-buffers {})
+    (reset! @#'rf.epoch.state/capture-buffers {})
 
     ;; settle! fires at the abort boundary with no buffered cascade
     ;; context — the empty-buffer skip suppresses the commit. (rf2-bh56rc:
     ;; the clean arity now takes committed-at; nil here — nothing commits,
     ;; so the value is unused.)
-    (epoch/settle! :test/main {} {} nil)
+    (rf.epoch/settle! :test/main {} {} nil)
 
     (is (empty? (rf/epoch-history :test/main))
         "no epoch record committed for an empty-buffer drain boundary —
@@ -2444,25 +2444,25 @@
           ;; An orphan (nil dispatch-id) — must be dropped (self-cleaning).
           orphan  {:op-type :rf.frame :operation :rf.frame/created
                    :tags {:frame frame}}]
-      (state/buffer-event! frame own-err)
-      (state/buffer-event! frame child)
-      (state/buffer-event! frame orphan)
-      (let [returned (state/harvest-buffer-for-event! frame :S)]
+      (rf.epoch.state/buffer-event! frame own-err)
+      (rf.epoch.state/buffer-event! frame child)
+      (rf.epoch.state/buffer-event! frame orphan)
+      (let [returned (rf.epoch.state/harvest-buffer-for-event! frame :S)]
         (is (= [] returned)
             "no cascade ran — nothing returned, so settle! commits no fake epoch")
-        (is (= [child] (state/buffer-for frame))
+        (is (= [child] (rf.epoch.state/buffer-for frame))
             "the unrelated child marker is RETAINED; the settling dispatch's own
              error trace + the orphan are dropped"))
-      (state/drop-frame-buffer! frame))))
+      (rf.epoch.state/drop-frame-buffer! frame))))
 
 ;; ---- recording is gated on debug-enabled? ---------------------------------
 
 (deftest configure-roundtrip
   (testing "(rf/configure! {:epoch-history {:depth N}}) updates the depth"
     (rf/configure! {:epoch-history {:depth 7}})
-    (is (= 7 (:depth (epoch/current-config))))
+    (is (= 7 (:depth (rf.epoch/current-config))))
     (rf/configure! {:epoch-history {:depth 12}})
-    (is (= 12 (:depth (epoch/current-config))))))
+    (is (= 12 (:depth (rf.epoch/current-config))))))
 
 ;; ---- rf2-iegsz / rf2-mrsck: :trace-events elision policy -----------------
 ;;
@@ -2536,7 +2536,7 @@
 
     ;; Fixture-configured cap (NOT the shipped default of 50). Reset-runtime
     ;; forces :trace-events-keep 5 so this elision path is exercised cheaply.
-    (is (= 5 (:trace-events-keep (epoch/current-config)))
+    (is (= 5 (:trace-events-keep (rf.epoch/current-config)))
         "fixture-configured :trace-events-keep is 5 (the shipped default is 50)")
 
     (rf/dispatch-sync [:seed] {:frame :test/main})
@@ -2640,13 +2640,13 @@
                             (vc-record frame-id :e2 render-key)]       ;; idx 2 ← target
                            (map #(plain-record frame-id (keyword (str "e" %)))
                                 (range 3 8)))]                          ;; idx 3..7
-      (reset! @#'state/histories {frame-id history})
+      (reset! @#'rf.epoch.state/histories {frame-id history})
       ;; new-keep = 3 → the index bound would be lo = (- 8 3) = 5, skipping
       ;; idx 2 even though it still carries :trace-events.
-      (reset! @#'state/config {:depth 50 :trace-events-keep 3 :redact-fn nil})
+      (reset! @#'rf.epoch.state/config {:depth 50 :trace-events-keep 3 :redact-fn nil})
       ;; Anchor at the ring-newest epoch (:e7) so the scan runs the full
       ;; newest-first walk — the anchor bound (rf2-arzb9o) is a no-op here.
-      (is (= :e2 (@#'state/value-changed-epoch-for frame-id render-key :e7))
+      (is (= :e2 (@#'rf.epoch.state/value-changed-epoch-for frame-id render-key :e7))
           "the scan reaches the still-trace-bearing value-change at idx 2,
            below (- n new-keep) = 5 — the post-reduction transient gap"))))
 
@@ -2666,10 +2666,10 @@
                       (plain-record frame-id :e3)      ;; idx 3
                       (plain-record frame-id :e4)]     ;; idx 4
           ]
-      (reset! @#'state/histories {frame-id history})
-      (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
+      (reset! @#'rf.epoch.state/histories {frame-id history})
+      (reset! @#'rf.epoch.state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
       ;; Anchor at the ring-newest epoch (:e4) — full newest-first scan.
-      (is (nil? (@#'state/value-changed-epoch-for frame-id render-key :e4))
+      (is (nil? (@#'rf.epoch.state/value-changed-epoch-for frame-id render-key :e4))
           "the elided record carries no evidence the attribution scan can match"))))
 
 ;; ---- restore-epoch! reactive surfaces -------------------------------------
@@ -3138,7 +3138,7 @@
     ;; Pre-condition: depth 0 retains no history (the existing documented
     ;; behaviour) and no anchor has been set by the seed dispatch.
     (is (= [] (rf/epoch-history :test/main)) "depth 0 retains no ring history")
-    (is (nil? (state/last-settled-epoch-id :test/main))
+    (is (nil? (rf.epoch.state/last-settled-epoch-id :test/main))
         "no last-settled anchor under depth 0 (companion phantom-anchor gate)")
 
     (let [recorded (record-trace!)
@@ -3149,7 +3149,7 @@
           "app-db unchanged — the rejected injection is a no-op")
       (is (= [] (rf/epoch-history :test/main))
           "still no ring history — nothing force-appended")
-      (is (nil? (state/last-settled-epoch-id :test/main))
+      (is (nil? (rf.epoch.state/last-settled-epoch-id :test/main))
           "NO phantom anchor left behind (would have named a non-ring epoch-id
            and broken later back-fill or undo attribution)")
       (let [ev (some (fn [ev]
@@ -3178,7 +3178,7 @@
         "replace-frame-state! rejected")
     (is (= {:n 0} (rf/app-db-value :test/main))
         "app-db untouched by any of the four rejected injections")
-    (is (nil? (state/last-settled-epoch-id :test/main))
+    (is (nil? (rf.epoch.state/last-settled-epoch-id :test/main))
         "no phantom anchor from any of the four")))
 
 (deftest replace-frame-state-app-only-positive-depth-still-records-undo-anchor
@@ -3197,7 +3197,7 @@
           head    (last history)]
       (is (= :rf.epoch/db-replaced (:event-id head))
           "the synthetic undo-anchor landed in the ring")
-      (is (= (:epoch-id head) (state/last-settled-epoch-id :test/main))
+      (is (= (:epoch-id head) (rf.epoch.state/last-settled-epoch-id :test/main))
           "last-settled anchors to a REAL ring epoch (no phantom)")
       ;; restore-epoch! of the seed epoch rewinds PAST the injection — undo works.
       (let [seed-epoch (some #(when (= :seed (:event-id %)) %) history)]
@@ -3425,9 +3425,9 @@
   (testing "rf/replace-frame-state! raises :rf.error/epoch-artefact-missing
             when the :epoch/replace-frame-state! late-bind hook is nil"
     (let [hook-key :epoch/replace-frame-state!
-          original (late-bind/get-fn hook-key)]
+          original (rf.late-bind/get-fn hook-key)]
       (try
-        (late-bind/set-fn! hook-key nil)
+        (rf.late-bind/set-fn! hook-key nil)
         (let [thrown (try (rf/replace-frame-state! :any/frame {:rf.db/app {} :rf.db/runtime {}})
                           nil
                           (catch clojure.lang.ExceptionInfo e e))]
@@ -3443,7 +3443,7 @@
             (is (= :no-recovery (:recovery data)))
             (is (string? (:reason data)))))
         (finally
-          (late-bind/set-fn! hook-key original))))))
+          (rf.late-bind/set-fn! hook-key original))))))
 
 (deftest replace-frame-state!-failure-runtime-schema-mismatch
   (testing "replace-frame-state! rejects an injection whose runtime-db
@@ -3664,7 +3664,7 @@
                            ;; lest it accrete into the next cascade's record.
                            :rf.warning/epoch-redact-fn-exception
                            :rf.warning/restore-quiesce-hook-exception}
-          skip-ops       @#'capture/skip-ops]
+          skip-ops       @#'rf.epoch.capture/skip-ops]
       ;; Anti-vacuity guard: an empty scanned set would make the SUPERSET
       ;; assertion trivially true (the exact trap the old test fell into).
       ;; A zero-match regex or a broken source path fails HERE.
@@ -4071,8 +4071,8 @@
     ;; exact incarnation ownership plus rf2-bh56rc
     ;; added the causal :time-ms; this seam tests the ring-drop with no
     ;; in-flight cascade, so nil snapshots + nil committed-at apply.)
-    (epoch.listeners/on-frame-destroyed!
-      :test/other (frame/frame-incarnation-token :test/other) nil nil nil)
+    (rf.epoch.listeners/on-frame-destroyed!
+      :test/other (rf.frame/frame-incarnation-token :test/other) nil nil nil)
 
     ;; The frame's ring is gone.
     (is (= [] (rf/epoch-history :test/other))
@@ -4080,7 +4080,7 @@
 
     ;; The frame record itself is still queryable — on-frame-destroyed! is
     ;; scoped to epoch-internal state.
-    (is (some? (frame/frame :test/other))
+    (is (some? (rf.frame/frame :test/other))
         "the frame is still registered (we did NOT call destroy-frame!)")))
 
 (deftest on-frame-destroyed-idempotent-on-repeat
@@ -4094,12 +4094,12 @@
     ;; First call — clears the buffer. (rf2-9neiq / rf2-bh56rc: hook arity
     ;; is (frame-id owner-token db-before db-after committed-at); nil snapshots + nil
     ;; committed-at for this ring-drop pin.)
-    (let [owner-token (frame/frame-incarnation-token :test/repeat)]
-      (epoch.listeners/on-frame-destroyed! :test/repeat owner-token nil nil nil)
+    (let [owner-token (rf.frame/frame-incarnation-token :test/repeat)]
+      (rf.epoch.listeners/on-frame-destroyed! :test/repeat owner-token nil nil nil)
     (is (= [] (rf/epoch-history :test/repeat)))
 
     ;; Second call — no-op.
-      (epoch.listeners/on-frame-destroyed! :test/repeat owner-token nil nil nil))
+      (rf.epoch.listeners/on-frame-destroyed! :test/repeat owner-token nil nil nil))
     (is (= [] (rf/epoch-history :test/repeat))
         "ring stays empty across repeated calls")))
 
@@ -4111,7 +4111,7 @@
     ;; The observable contract is "no throw, no side effects on
     ;; unrelated state".
     (let [traces (record-trace!)]
-      (epoch.listeners/on-frame-destroyed! :test/no-such-frame nil nil nil nil)
+      (rf.epoch.listeners/on-frame-destroyed! :test/no-such-frame nil nil nil nil)
       (is (empty? @traces)
           "no traces emitted — nothing observed to silence"))))
 
@@ -4146,17 +4146,17 @@
       (rf/register-listener! :epoch cb (fn [r] (swap! records conj r)))
       (rf/dispatch-sync [:seed] {:frame id})
       (reset! records [])                       ; drop the :seed :ok record
-      (let [token (frame/frame-incarnation-token id)]
+      (let [token (rf.frame/frame-incarnation-token id)]
         ;; The 3-arity nil-bundle seam: exactly what `notify-epoch-listeners!`
         ;; threads when `snapshot-epoch-terminal-evidence!` returned nil (threw).
-        (epoch.listeners/on-frame-destroyed! id token nil))
+        (rf.epoch.listeners/on-frame-destroyed! id token nil))
       (is (empty? (filterv (fn [r] (= :halted-destroy (:outcome r))) @records))
           "no :halted-destroy record is fabricated from the nil bundle")
       (is (empty? (filterv #(= :rf.epoch.cb/silenced-on-frame-destroy
                                 (:operation %))
                            @traces))
           "no silencing fires — the snapshot that would have owed it produced nothing")
-      (is (zero? (reduce + 0 (map count (vals (state/terminal-silence-marks-snapshot)))))
+      (is (zero? (reduce + 0 (map count (vals (rf.epoch.state/terminal-silence-marks-snapshot)))))
           "a nil bundle opens no deferred-silence window — no mark accreted (bounded)"))))
 
 ;; ---- rf2-hclxos — nil terminal-evidence STILL cleans the exact-owner stores ----
@@ -4193,7 +4193,7 @@
           render-key    ::nil-evidence-view   ; mount-attribution key for store #5
           records       (atom [])
           traces        (record-trace!)
-          original-snap (late-bind/get-fn :epoch/snapshot-frame-destroyed)]
+          original-snap (rf.late-bind/get-fn :epoch/snapshot-frame-destroyed)]
       (rf/make-frame {:id id})
       (rf/reg-event :seed (fn [_ _] {:db {:audit/seed :from-A}}))
       ;; cb OBSERVES A: delivery of the settled :seed record stamps its observation
@@ -4202,7 +4202,7 @@
       (rf/register-listener! :epoch cb (fn [r] (swap! records conj r)))
       (rf/dispatch-sync [:seed] {:frame id})
       (reset! records [])                          ; drop the :seed :ok record
-      (let [a-token   (frame/frame-incarnation-token id)
+      (let [a-token   (rf.frame/frame-incarnation-token id)
             a-epoch-id (:epoch-id (first (rf/epoch-history id)))]
         ;; A settled one epoch: the cascade already seeded three of the five stores
         ;; — history (the [:audit/seed] record), last-settled-epoch (the settle
@@ -4211,21 +4211,21 @@
         ;; two: the in-flight capture buffer is harvested empty at settle, and there
         ;; is no React commit to record mount attribution. SEED those two directly so
         ;; every one of the five exact-owner stores holds A's state before destroy.
-        (state/buffer-event! id {:operation :rf.event/run-start
+        (rf.epoch.state/buffer-event! id {:operation :rf.event/run-start
                                  :tags {:rf.trace/dispatch-id ::seed-dispatch}})
-        (state/record-mount-epoch! id render-key a-epoch-id)
-        (state/record-render-deps! id render-key ::a-sub)
+        (rf.epoch.state/record-mount-epoch! id render-key a-epoch-id)
+        (rf.epoch.state/record-render-deps! id render-key ::a-sub)
 
         ;; PRE-DESTROY: all five exact-owner stores are non-empty for A's id.
-        (is (contains? (set (state/cbs-observing-frame id)) cb)
+        (is (contains? (set (rf.epoch.state/cbs-observing-frame id)) cb)
             "observation stamp seeded — cb observed A's settled record")
-        (is (= 1 (count (state/history-for id)))
+        (is (= 1 (count (rf.epoch.state/history-for id)))
             "history seeded — A settled one epoch")
-        (is (seq (state/buffer-for id))
+        (is (seq (rf.epoch.state/buffer-for id))
             "capture buffer seeded — an in-flight event is buffered")
-        (is (some? (state/last-settled-epoch-id id))
+        (is (some? (rf.epoch.state/last-settled-epoch-id id))
             "last-settled epoch seeded — A's settle anchored it")
-        (is (some? (state/mount-epoch-for id render-key))
+        (is (some? (rf.epoch.state/mount-epoch-for id render-key))
             "mount attribution seeded — render-key anchored to A's epoch")
         (is (= :from-A (get-in (first (rf/epoch-history id)) [:db-after :audit/seed]))
             "A's settled record carries [:audit/seed] :from-A")
@@ -4234,7 +4234,7 @@
           ;; destroy-frame! converts the throw to nil terminal-evidence and threads
           ;; it to on-frame-destroyed! (#5939). Teardown is best-effort — it does
           ;; NOT abort — so destroy-frame! returns normally.
-          (late-bind/set-fn! :epoch/snapshot-frame-destroyed
+          (rf.late-bind/set-fn! :epoch/snapshot-frame-destroyed
             (fn [& args]
               (if (= id (first args))
                 (throw (ex-info "snapshot blew" {:why :test}))
@@ -4245,23 +4245,23 @@
           ;;     FIVE id-keyed stores the cleanup-fn drops is asserted directly, so
           ;;     re-nesting cleanup under the evidence guard — or removing ANY single
           ;;     drop call — fails exactly the matching assertion (rf2-oh1y8).
-          (is (empty? (state/cbs-observing-frame id))
+          (is (empty? (rf.epoch.state/cbs-observing-frame id))
               "observation stamps dropped (drop-frame-observation!)")
-          (is (= [] (state/history-for id))
+          (is (= [] (rf.epoch.state/history-for id))
               "history dropped (drop-frame-history!)")
-          (is (empty? (state/buffer-for id))
+          (is (empty? (rf.epoch.state/buffer-for id))
               "capture buffer dropped (drop-frame-buffer!)")
-          (is (nil? (state/last-settled-epoch-id id))
+          (is (nil? (rf.epoch.state/last-settled-epoch-id id))
               "last-settled epoch dropped (drop-last-settled-epoch!)")
-          (is (nil? (state/mount-epoch-for id render-key))
+          (is (nil? (rf.epoch.state/mount-epoch-for id render-key))
               "mount attribution dropped (drop-frame-mount-attribution!)")
-          (is (nil? (state/render-deps-for id render-key))
+          (is (nil? (rf.epoch.state/render-deps-for id render-key))
               "mount attribution read-set dropped with the frame's entry")
           ;; The public projection agrees with the raw store, and the incarnation
           ;; is gone.
           (is (= [] (rf/epoch-history id))
               "destroyed id's epoch-history is [] even though the snapshot threw")
-          (is (nil? (frame/frame-incarnation-token id))
+          (is (nil? (rf.frame/frame-incarnation-token id))
               "A is fully destroyed — no live incarnation owns the id")
 
           ;; (2) #5939 NON-FABRICATION still holds: the nil bundle publishes nothing.
@@ -4272,12 +4272,12 @@
                                @traces))
               "no silencing fires — the snapshot that would have owed it produced nothing")
           (is (zero? (reduce + 0 (map count
-                                      (vals (state/terminal-silence-marks-snapshot)))))
+                                      (vals (rf.epoch.state/terminal-silence-marks-snapshot)))))
               "a nil bundle opens no deferred-silence window — no mark accreted (bounded)")
 
           ;; (3) SAME-ID SUCCESSOR B, BEFORE its first epoch, inherits nothing.
           (rf/make-frame {:id id})
-          (let [b-token (frame/frame-incarnation-token id)]
+          (let [b-token (rf.frame/frame-incarnation-token id)]
             (is (some? b-token) "same-id B is live after A's destroy")
             (is (not= a-token b-token)
                 "B is a FRESH incarnation — distinct token from destroyed A")
@@ -4287,8 +4287,8 @@
                           (rf/epoch-history id))
                 "B carries none of A's [:audit/seed] records"))
           (finally
-            (late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)
-            (when (frame/frame id) (rf/destroy-frame! id))
+            (rf.late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)
+            (when (rf.frame/frame id) (rf/destroy-frame! id))
             (rf/unregister-listener! :epoch cb)))))))
 
 ;; ---- capture-buffer cross-contamination from out-of-drain emits -----------
@@ -4372,7 +4372,7 @@
     ;; capture-event! buffers since the tag carries `:frame`. Reset
     ;; explicitly so the test starts from a known-empty buffer
     ;; rather than relying on the make-frame side-effect.)
-    (let [buffers-atom @#'state/capture-buffers]
+    (let [buffers-atom @#'rf.epoch.state/capture-buffers]
       (reset! buffers-atom {})
 
       (swap! buffers-atom assoc :test/main
@@ -4394,8 +4394,8 @@
       ;; committed-at are fine (the synthetic run-start carries no
       ;; :event-id, so no halted record commits — and this test does not
       ;; assert one).
-      (epoch.listeners/on-frame-destroyed!
-        :test/main (frame/frame-incarnation-token :test/main) nil nil nil)
+      (rf.epoch.listeners/on-frame-destroyed!
+        :test/main (rf.frame/frame-incarnation-token :test/main) nil nil nil)
 
       (is (nil? (get @buffers-atom :test/main))
           "the capture-buffer entry was dropped on destroy — no
@@ -4448,7 +4448,7 @@
       ;; REAL and non-nil, which is the contract (Spec-Schemas §Outcomes).
       (rf/reg-event :destroy-self
                        (fn [_ _]
-                         (frame/destroy-frame! :test/main)
+                         (rf.frame/destroy-frame! :test/main)
                          {}))
       (try (rf/dispatch-sync [:destroy-self] {:frame :test/main})
            (catch Throwable _ nil))
@@ -4490,7 +4490,7 @@
         ;; frame per the rf2-d656 read-empty contract). This part of the
         ;; contract is UNCHANGED by rf2-9neiq.
         (is (empty? (filter (fn [r] (= :halted-destroy (:outcome r)))
-                            (epoch/epoch-history :test/main)))
+                            (rf.epoch/epoch-history :test/main)))
             "the :halted-destroy record never lands in the ring buffer
              (it is delivered to listeners only; epoch-history is
              read-empty post-destroy per rf2-d656)")))))
@@ -4516,7 +4516,7 @@
       ;; {:phase :parent-done} write committed (per-event epoch boundary).
       (rf/reg-event :child-destroy
                        (fn [_ _]
-                         (frame/destroy-frame! :test/main)
+                         (rf.frame/destroy-frame! :test/main)
                          {}))
       ;; Parent: commits a db write, then fx-dispatches the child. The
       ;; child runs as a SEPARATE dequeued event in the same drain.
@@ -4579,7 +4579,7 @@
                             :operation :rf.event/run-start
                             :tags      {:frame          :test/main
                                         :rf.trace/phase :run-start}}]
-          record          (#'assembly/build-record
+          record          (#'rf.epoch.assembly/build-record
                             :test/main nil nil tag-less-events
                             1700000000000  ; rf2-bh56rc: committed-at (token :time-ms)
                             :halted-destroy
@@ -4610,7 +4610,7 @@
                                :rf.trace/phase    :run-start
                                :rf.trace/event-id :seed
                                :rf.event/v        [:seed 1 2 3]}}]
-          record (#'assembly/build-record :test/main {} {:n 0} events 1700000000000)]
+          record (#'rf.epoch.assembly/build-record :test/main {} {:n 0} events 1700000000000)]
       (is (= :seed (:event-id record))
           ":event-id is the resolved event keyword")
       (is (= [:seed 1 2 3] (:trigger-event record))
@@ -4641,7 +4641,7 @@
                               :operation :rf.event
                               :tags      {:frame             :test/main
                                           :rf.trace/event-id :foo}}]
-          trigger           (#'capture/find-trigger-event tag-less-fallback)]
+          trigger           (#'rf.epoch.capture/find-trigger-event tag-less-fallback)]
       (is (= :foo (:event-id trigger))
           ":event-id is recovered from the fallback arm")
       (is (nil? (:event trigger))
@@ -4656,7 +4656,7 @@
                             :operation :rf.event
                             :tags      {:frame             :test/main
                                         :rf.trace/event-id :foo}}]
-          record          (#'assembly/build-record
+          record          (#'rf.epoch.assembly/build-record
                             :test/main nil nil tag-less-events
                             1700000000000  ; rf2-bh56rc: committed-at (token :time-ms)
                             :halted-destroy
@@ -4677,7 +4677,7 @@
                     :tags      {:frame             :test/main
                                 :rf.trace/event-id :foo
                                 :rf.event/v        [:foo "bar" 42]}}]
-          trigger (#'capture/find-trigger-event events)]
+          trigger (#'rf.epoch.capture/find-trigger-event events)]
       (is (= :foo (:event-id trigger)))
       (is (= [:foo "bar" 42] (:event trigger))
           "the full event vector survives — payload is preserved"))))
@@ -4704,7 +4704,7 @@
                               :tags      {:frame                :test/main
                                           :rf.trace/event-id    :foo
                                           :rf.trace/dispatch-id 99}}]
-          trigger           (#'capture/find-trigger-event fallback-with-did)]
+          trigger           (#'rf.epoch.capture/find-trigger-event fallback-with-did)]
       (is (= :foo (:event-id trigger))
           ":event-id is recovered from the fallback arm")
       (is (nil? (:dispatch-id trigger))
@@ -4718,7 +4718,7 @@
                    :tags      {:frame                :test/main
                                :rf.trace/event-id    :foo
                                :rf.trace/dispatch-id 99}}]
-          record (#'assembly/build-record
+          record (#'rf.epoch.assembly/build-record
                   :test/main nil nil events
                   1700000000000  ; rf2-bh56rc: committed-at (token :time-ms)
                   :halted-destroy
@@ -4738,7 +4738,7 @@
                                 :rf.trace/event-id    :foo
                                 :rf.event/v           [:foo]
                                 :rf.trace/dispatch-id 7}}]
-          trigger (#'capture/find-trigger-event events)]
+          trigger (#'rf.epoch.capture/find-trigger-event events)]
       (is (= 7 (:dispatch-id trigger))
           "the run-start arm pins :dispatch-id from the canonical
            :event/run-start trace"))))
@@ -4765,7 +4765,7 @@
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 
-    (let [observed-atom @#'state/observed-frames-by-cb
+    (let [observed-atom @#'rf.epoch.state/observed-frames-by-cb
           swap-count    (atom 0)]
       (add-watch observed-atom ::swap-counter
                  (fn [_ _ _ _] (swap! swap-count inc)))
@@ -4814,41 +4814,41 @@
   (testing "(rf/configure! {:epoch-history {:depth nil}}) is a no-op; the
             previously-stored depth survives"
     (rf/configure! {:epoch-history {:depth 7}})
-    (is (= 7 (:depth (epoch/current-config))))
+    (is (= 7 (:depth (rf.epoch/current-config))))
 
     (rf/configure! {:epoch-history {:depth nil}})
-    (is (= 7 (:depth (epoch/current-config)))
+    (is (= 7 (:depth (rf.epoch/current-config)))
         ":depth nil silently dropped — prior 7 survives")))
 
 (deftest configure-rejects-non-numeric-depth
   (testing "(rf/configure! {:epoch-history {:depth \"five\"}) is a no-op"
     (rf/configure! {:epoch-history {:depth 7}})
     (rf/configure! {:epoch-history {:depth "five"}})
-    (is (= 7 (:depth (epoch/current-config)))
+    (is (= 7 (:depth (rf.epoch/current-config)))
         ":depth non-numeric silently dropped")))
 
 (deftest configure-rejects-negative-depth
   (testing "(rf/configure! {:epoch-history {:depth -1}}) is a no-op"
     (rf/configure! {:epoch-history {:depth 7}})
     (rf/configure! {:epoch-history {:depth -1}})
-    (is (= 7 (:depth (epoch/current-config)))
+    (is (= 7 (:depth (rf.epoch/current-config)))
         ":depth negative silently dropped")))
 
 (deftest configure-rejects-invalid-trace-events-keep
   (testing "(rf/configure! {:epoch-history {:trace-events-keep <bad>}}) is a no-op"
     (rf/configure! {:epoch-history {:trace-events-keep 3}})
-    (is (= 3 (:trace-events-keep (epoch/current-config))))
+    (is (= 3 (:trace-events-keep (rf.epoch/current-config))))
 
     (rf/configure! {:epoch-history {:trace-events-keep nil}})
-    (is (= 3 (:trace-events-keep (epoch/current-config)))
+    (is (= 3 (:trace-events-keep (rf.epoch/current-config)))
         ":trace-events-keep nil silently dropped")
 
     (rf/configure! {:epoch-history {:trace-events-keep "no"}})
-    (is (= 3 (:trace-events-keep (epoch/current-config)))
+    (is (= 3 (:trace-events-keep (rf.epoch/current-config)))
         ":trace-events-keep non-numeric silently dropped")
 
     (rf/configure! {:epoch-history {:trace-events-keep -5}})
-    (is (= 3 (:trace-events-keep (epoch/current-config)))
+    (is (= 3 (:trace-events-keep (rf.epoch/current-config)))
         ":trace-events-keep negative silently dropped")))
 
 (deftest configure-accepts-zero
@@ -4857,10 +4857,10 @@
             disables recording; :trace-events-keep 0 drops every
             record's :trace-events)"
     (rf/configure! {:epoch-history {:depth 0}})
-    (is (= 0 (:depth (epoch/current-config))))
+    (is (= 0 (:depth (rf.epoch/current-config))))
 
     (rf/configure! {:epoch-history {:trace-events-keep 0}})
-    (is (= 0 (:trace-events-keep (epoch/current-config))))))
+    (is (= 0 (:trace-events-keep (rf.epoch/current-config))))))
 
 (deftest configure-partial-update-rejects-bad-key-only
   (testing "a configure call carrying one valid and one invalid key
@@ -4868,7 +4868,7 @@
             in one key never poisons another"
     (rf/configure! {:epoch-history {:depth 7 :trace-events-keep 4}})
     (rf/configure! {:epoch-history {:depth 11 :trace-events-keep nil}})
-    (let [cfg (epoch/current-config)]
+    (let [cfg (rf.epoch/current-config)]
       (is (= 11 (:depth cfg))
           "the valid :depth update was applied")
       (is (= 4 (:trace-events-keep cfg))
@@ -5039,7 +5039,7 @@
             private `default-trace-events-keep` var, bypassing the
             fixture's keep<depth override. Pins the default consistently
             with docs/core/api/01-core.md and `re-frame.epoch.state`."
-    (is (= 50 @#'state/default-trace-events-keep)
+    (is (= 50 @#'rf.epoch.state/default-trace-events-keep)
         "the source-of-truth default var ships 50")
     ;; The accessor is wired to fall back to that var when the slot is
     ;; absent from the live config map (the shape a fresh process / a
@@ -5053,10 +5053,10 @@
     ;; exercise the accessor's fallback). Only a raw `reset!` of the
     ;; private `config` can build that shape — the shared fixture's
     ;; reset-to-default always carries the slot.
-    (reset! @#'state/config {:depth 50 :redact-fn nil})
-    (is (= 50 (state/trace-events-keep))
+    (reset! @#'rf.epoch.state/config {:depth 50 :redact-fn nil})
+    (is (= 50 (rf.epoch.state/trace-events-keep))
         "trace-events-keep accessor falls back to the shipped 50 default")
-    (is (= 50 (:trace-events-keep (epoch/current-config) 50))
+    (is (= 50 (:trace-events-keep (rf.epoch/current-config) 50))
         "current-config's :trace-events-keep resolves to the shipped 50")))
 
 ;; ============================================================================
@@ -5096,7 +5096,7 @@
           ;; (1) Validate against the LIVE frame — passes, yields the epoch and
           ;; the exact incarnation token the checks resolved against.
           {:keys [outcome epoch incarnation-token]}
-          (tool-pair/check-restore-preconditions! :test/short-lived target-id)]
+          (rf.epoch.tool-pair/check-restore-preconditions! :test/short-lived target-id)]
       (is (= :ok outcome) "precondition validation passed against the live frame")
 
       ;; (2) The race: the frame is destroyed in the validate→write window.
@@ -5104,7 +5104,7 @@
 
       ;; (3) Perform the write at the boundary — the resolved incarnation is gone.
       (let [recorded (record-trace!)
-            result   (tool-pair/perform-restore! :test/short-lived incarnation-token epoch)]
+            result   (rf.epoch.tool-pair/perform-restore! :test/short-lived incarnation-token epoch)]
         (is (false? result)
             "perform-restore! reports HONEST failure (false) — NOT a synthetic
              success — when the frame disappeared between validate and write")
@@ -5127,12 +5127,12 @@
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
 
     (let [target-id (-> (rf/epoch-history :test/short-lived) first :epoch-id)
-          real-check tool-pair/check-restore-preconditions!
+          real-check rf.epoch.tool-pair/check-restore-preconditions!
           recorded   (record-trace!)]
       ;; Inject the destroy into the validate→write window: run the REAL
       ;; (live) precondition check, then destroy the frame before the
       ;; orchestrator reaches perform-restore!.
-      (with-redefs [tool-pair/check-restore-preconditions!
+      (with-redefs [rf.epoch.tool-pair/check-restore-preconditions!
                     (fn [frame-id epoch-id]
                       (let [r (real-check frame-id epoch-id)]
                         (rf/destroy-frame! frame-id)
@@ -5159,7 +5159,7 @@
     ;; (1) Validate against the LIVE frame — passes, yields the exact
     ;; incarnation token the checks resolved against (rf2-gj2bo).
     (let [{:keys [outcome incarnation-token]}
-          (tool-pair/check-replace-frame-state-preconditions!
+          (rf.epoch.tool-pair/check-replace-frame-state-preconditions!
             :test/short-lived {:rf.db/app {:n 999}})]
       (is (= :ok outcome) "precondition validation passed against the live frame")
       (is (some? incarnation-token) "the :ok ticket carries the incarnation token")
@@ -5178,7 +5178,7 @@
 
         ;; (3) Perform the reset at the boundary — the resolved incarnation is gone.
         (let [recorded (record-trace!)
-              result   (#'epoch/perform-replace-frame-state!
+              result   (#'rf.epoch/perform-replace-frame-state!
                          :test/short-lived incarnation-token {:rf.db/app {:n 999}})]
           (is (false? result)
               "perform-replace-frame-state! reports HONEST failure (false) — NOT a
@@ -5205,9 +5205,9 @@
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
 
-    (let [real-check tool-pair/check-replace-frame-state-preconditions!
+    (let [real-check rf.epoch.tool-pair/check-replace-frame-state-preconditions!
           recorded   (record-trace!)]
-      (with-redefs [tool-pair/check-replace-frame-state-preconditions!
+      (with-redefs [rf.epoch.tool-pair/check-replace-frame-state-preconditions!
                     (fn [frame-id new-frame-state]
                       (let [r (real-check frame-id new-frame-state)]
                         (rf/destroy-frame! frame-id)
@@ -5259,21 +5259,21 @@
 
     (let [target-id (-> (rf/epoch-history :test/short-lived) first :epoch-id)
           {:keys [outcome epoch incarnation-token]}
-          (tool-pair/check-restore-preconditions! :test/short-lived target-id)]
+          (rf.epoch.tool-pair/check-restore-preconditions! :test/short-lived target-id)]
       (is (= :ok outcome) "precondition validation passed against the live frame")
 
-      (let [real-write frame/replace-frame-state!
+      (let [real-write rf.frame/replace-frame-state!
             recorded   (record-trace!)
             ;; The post-liveness window: the write-boundary incarnation gate
             ;; (inside perform-restore!) passes against the LIVE incarnation, THEN
             ;; this redef'd exact-incarnation write destroys the frame and
             ;; delegates to the real 3-arity write, which now returns nil against
             ;; the destroyed incarnation.
-            result     (with-redefs [frame/replace-frame-state!
+            result     (with-redefs [rf.frame/replace-frame-state!
                                      (fn [frame-id token fs]
                                        (rf/destroy-frame! frame-id)
                                        (real-write frame-id token fs))]
-                         (tool-pair/perform-restore! :test/short-lived incarnation-token epoch))]
+                         (rf.epoch.tool-pair/perform-restore! :test/short-lived incarnation-token epoch))]
         (is (false? result)
             "perform-restore! reports HONEST failure (false) — the nil write
              return is checked, not ignored")
@@ -5317,7 +5317,7 @@
           ;; (1) Resolve preconditions against LIVE incarnation A — yields the
           ;; target epoch AND A's exact incarnation token.
           {:keys [outcome epoch incarnation-token]}
-          (tool-pair/check-restore-preconditions! :test/succ a-target-id)]
+          (rf.epoch.tool-pair/check-restore-preconditions! :test/succ a-target-id)]
       (is (some? a-target-id) "seeded an A epoch whose db-after is {:owner :A :n 1}")
       (is (= :ok outcome) "preconditions passed against live incarnation A")
 
@@ -5332,7 +5332,7 @@
       ;; (3) Drive the write with A's now-stale token + epoch.
       (let [recorded    (record-trace!)
             b-db-before (rf/app-db-value :test/succ)
-            result      (tool-pair/perform-restore! :test/succ incarnation-token epoch)
+            result      (rf.epoch.tool-pair/perform-restore! :test/succ incarnation-token epoch)
             b-db-after  (rf/app-db-value :test/succ)]
         (is (false? result)
             (str "the stale cross-incarnation restore must be REJECTED; got "
@@ -5361,11 +5361,11 @@
     (let [target-id (some (fn [r] (when (= {:n 1} (:db-after r)) (:epoch-id r)))
                           (rf/epoch-history :test/ctl))
           {:keys [outcome epoch incarnation-token]}
-          (tool-pair/check-restore-preconditions! :test/ctl target-id)]
+          (rf.epoch.tool-pair/check-restore-preconditions! :test/ctl target-id)]
       (is (= :ok outcome) "preconditions passed against the live frame")
       (is (= {:n 2} (rf/app-db-value :test/ctl)) "current state is {:n 2} before restore")
       (let [recorded (record-trace!)
-            result   (tool-pair/perform-restore! :test/ctl incarnation-token epoch)]
+            result   (rf.epoch.tool-pair/perform-restore! :test/ctl incarnation-token epoch)]
         (is (true? result) "an ordinary within-incarnation restore still succeeds")
         (is (= {:n 1} (rf/app-db-value :test/ctl)) "app-db rewound to the target epoch")
         (is (some #(= :rf.epoch/restored (:operation %)) @recorded)
@@ -5400,11 +5400,11 @@
     (rf/dispatch-sync [:set-owner :A 2] {:frame :test/seam1})
     (let [a-target-id (some (fn [r] (when (= {:owner :A :n 1} (:db-after r)) (:epoch-id r)))
                             (rf/epoch-history :test/seam1))
-          a-token     (frame/frame-incarnation-token :test/seam1)
-          real-hist   state/history-for
+          a-token     (rf.frame/frame-incarnation-token :test/seam1)
+          real-hist   rf.epoch.state/history-for
           churned?    (atom false)]
       (is (some? a-target-id) "seeded an A epoch whose db-after is {:owner :A :n 1}")
-      (let [result (with-redefs [state/history-for
+      (let [result (with-redefs [rf.epoch.state/history-for
                                  (fn [fid]
                                    ;; Interpose the churn on the bare-id history
                                    ;; re-resolve the checks perform: capture A's
@@ -5419,7 +5419,7 @@
                                        (rf/dispatch-sync [:set-owner :B 99] {:frame :test/seam1})
                                        a-hist)
                                      (real-hist fid)))]
-                     (tool-pair/check-restore-preconditions! :test/seam1 a-target-id))]
+                     (rf.epoch.tool-pair/check-restore-preconditions! :test/seam1 a-target-id))]
         (is (true? @churned?) "the successor was interposed during sampling")
         (is (= :fail (:outcome result))
             "the checks refuse rather than pair A's epoch against the seated successor")
@@ -5428,7 +5428,7 @@
         (is (= :frame (:kind (:tags result))) "the typed failure carries :kind :frame")
         (is (nil? (:incarnation-token result))
             "no :ok ticket — so no A epoch is ever paired with the successor's token")
-        (is (not (identical? a-token (frame/frame-incarnation-token :test/seam1)))
+        (is (not (identical? a-token (rf.frame/frame-incarnation-token :test/seam1)))
             "successor B is a fresh incarnation (distinct token)")
         (is (= {:owner :B :n 99} (rf/app-db-value :test/seam1))
             "successor B is byte-for-byte unchanged")))))
@@ -5453,15 +5453,15 @@
     (let [a-target-id (some (fn [r] (when (= {:owner :A :n 1} (:db-after r)) (:epoch-id r)))
                             (rf/epoch-history :test/seam2))
           {:keys [outcome epoch incarnation-token]}
-          (tool-pair/check-restore-preconditions! :test/seam2 a-target-id)
+          (rf.epoch.tool-pair/check-restore-preconditions! :test/seam2 a-target-id)
           seen-token (atom :unseen)
           b-effect?  (atom false)
           rk         :resources/reconcile-on-restore
-          r0         (late-bind/get-fn rk)]
+          r0         (rf.late-bind/get-fn rk)]
       (is (= :ok outcome) "preconditions passed against live incarnation A")
       (is (some? a-target-id) "seeded an A epoch")
       (try
-        (late-bind/set-fn! rk
+        (rf.late-bind/set-fn! rk
           (fn [rdb frame-id {:keys [owner-token]}]
             (reset! seen-token owner-token)
             ;; churn A -> same-id successor B mid-reconcile
@@ -5472,10 +5472,10 @@
             ;; id; fence it on the threaded token exactly as ssr.cljc now does. A
             ;; true here would mean a bare-id host-table touch landing on B.
             (when (and frame-id (or (nil? owner-token)
-                                    (frame/frame-incarnation-live? frame-id owner-token)))
+                                    (rf.frame/frame-incarnation-live? frame-id owner-token)))
               (reset! b-effect? true))
             rdb))
-        (let [result (tool-pair/perform-restore! :test/seam2 incarnation-token epoch)]
+        (let [result (rf.epoch.tool-pair/perform-restore! :test/seam2 incarnation-token epoch)]
           (is (identical? incarnation-token @seen-token)
               "the reconcile received the EXACT incarnation token (was absent before the fix)")
           (is (false? @b-effect?)
@@ -5483,7 +5483,7 @@
           (is (false? result) "the exact write rejects the lost incarnation")
           (is (= {:owner :B :n 99} (rf/app-db-value :test/seam2))
               "successor B is byte-for-byte unchanged"))
-        (finally (late-bind/set-fn! rk r0))))))
+        (finally (rf.late-bind/set-fn! rk r0))))))
 
 (deftest restore-tail-anchoring-fenced-to-exact-incarnation
   (testing "rf2-qfrh4 seam 3 — after the exact install commits, a synchronous
@@ -5500,7 +5500,7 @@
     (let [a-target-id (some (fn [r] (when (= {:owner :A :n 1} (:db-after r)) (:epoch-id r)))
                             (rf/epoch-history :test/seam3))
           {:keys [outcome epoch incarnation-token]}
-          (tool-pair/check-restore-preconditions! :test/seam3 a-target-id)
+          (rf.epoch.tool-pair/check-restore-preconditions! :test/seam3 a-target-id)
           fired? (atom false)
           lk     ::seam3-churn]
       (is (= :ok outcome) "preconditions passed against live incarnation A")
@@ -5513,11 +5513,11 @@
             (rf/make-frame {:id :test/seam3})
             (rf/dispatch-sync [:set-owner3 :B 99] {:frame :test/seam3}))))
       (try
-        (let [result (tool-pair/perform-restore! :test/seam3 incarnation-token epoch)]
+        (let [result (rf.epoch.tool-pair/perform-restore! :test/seam3 incarnation-token epoch)]
           (is (true? @fired?) "the :rf.epoch/restored listener churned A to B")
           (is (true? result)
               "the install committed on the exact incarnation A, so the public result stays TRUE")
-          (is (not= a-target-id (state/last-settled-epoch-id :test/seam3))
+          (is (not= a-target-id (rf.epoch.state/last-settled-epoch-id :test/seam3))
               "the post-write anchor was NOT retargeted onto successor B")
           (is (= {:owner :B :n 99} (rf/app-db-value :test/seam3))
               "successor B's app-db is untouched by the restore tail"))
@@ -5540,29 +5540,29 @@
     (let [target-id (some (fn [r] (when (= {:n 1} (:db-after r)) (:epoch-id r)))
                           (rf/epoch-history :test/allfences))
           {:keys [outcome epoch incarnation-token]}
-          (tool-pair/check-restore-preconditions! :test/allfences target-id)
+          (rf.epoch.tool-pair/check-restore-preconditions! :test/allfences target-id)
           token-live? (atom nil)
           rk          :resources/reconcile-on-restore
-          r0          (late-bind/get-fn rk)]
+          r0          (rf.late-bind/get-fn rk)]
       (is (= :ok outcome) "preconditions passed against the live frame")
-      (is (identical? incarnation-token (frame/frame-incarnation-token :test/allfences))
+      (is (identical? incarnation-token (rf.frame/frame-incarnation-token :test/allfences))
           "the :ok ticket's token is the live incarnation's own drain-lock (record-derived)")
       (try
-        (late-bind/set-fn! rk
+        (rf.late-bind/set-fn! rk
           (fn [rdb frame-id {:keys [owner-token]}]
             (reset! token-live? (and (some? owner-token)
-                                     (frame/frame-incarnation-live? frame-id owner-token)))
+                                     (rf.frame/frame-incarnation-live? frame-id owner-token)))
             rdb))
         (let [recorded (record-trace!)
-              result   (tool-pair/perform-restore! :test/allfences incarnation-token epoch)]
+              result   (rf.epoch.tool-pair/perform-restore! :test/allfences incarnation-token epoch)]
           (is (true? @token-live?) "the reconcile saw the threaded token LIVE (no churn)")
           (is (true? result) "an ordinary within-incarnation restore still succeeds")
           (is (= {:n 1} (rf/app-db-value :test/allfences)) "app-db rewound to the target epoch")
-          (is (= target-id (state/last-settled-epoch-id :test/allfences))
+          (is (= target-id (rf.epoch.state/last-settled-epoch-id :test/allfences))
               "the tail anchored last-settled to the restored epoch")
           (is (some #(= :rf.epoch/restored (:operation %)) @recorded)
               ":rf.epoch/restored success trace fired"))
-        (finally (late-bind/set-fn! rk r0))))))
+        (finally (rf.late-bind/set-fn! rk r0))))))
 
 ;; ---- rf2-gj2bo — state INJECTION is the same exact-incarnation transaction -
 ;;
@@ -5598,14 +5598,14 @@
     (rf/reg-event :set-owner-inj (fn [_ [_ o]] {:db {:owner o}}))
     (rf/dispatch-sync [:set-owner-inj :A] {:frame :test/inj})
 
-    (let [real-check   tool-pair/check-replace-frame-state-preconditions!
-          a-token      (frame/frame-incarnation-token :test/inj)
+    (let [real-check   rf.epoch.tool-pair/check-replace-frame-state-preconditions!
+          a-token      (rf.frame/frame-incarnation-token :test/inj)
           check-result (atom nil)
           b-baseline   (atom nil)
           fanned       (atom [])
           recorded     (record-trace!)]
       (rf/register-listener! :epoch ::inj-fan (fn [r] (swap! fanned conj r)))
-      (with-redefs [tool-pair/check-replace-frame-state-preconditions!
+      (with-redefs [rf.epoch.tool-pair/check-replace-frame-state-preconditions!
                     (fn [frame-id new-frame-state]
                       (let [r (real-check frame-id new-frame-state)]
                         (reset! check-result r)
@@ -5626,7 +5626,7 @@
               "the REAL precondition check passed against live incarnation A")
           (is (identical? a-token (:incarnation-token @check-result))
               "the :ok ticket carries A's exact record-derived token")
-          (is (not (identical? a-token (frame/frame-incarnation-token :test/inj)))
+          (is (not (identical? a-token (rf.frame/frame-incarnation-token :test/inj)))
               "successor B is a fresh incarnation (A/B tokens distinct)")
           (is (false? result)
               (str "the stale cross-incarnation injection must be REJECTED; got "
@@ -5658,10 +5658,10 @@
          :rf.db/runtime (assoc (or rt {}) :rf.runtime/routing {:current {:route-id :start}})}))
     (rf/dispatch-sync [:seed-inj2 :A] {:frame :test/inj2})
 
-    (let [real-check tool-pair/check-replace-frame-state-preconditions!
+    (let [real-check rf.epoch.tool-pair/check-replace-frame-state-preconditions!
           b-baseline (atom nil)
           recorded   (record-trace!)]
-      (with-redefs [tool-pair/check-replace-frame-state-preconditions!
+      (with-redefs [rf.epoch.tool-pair/check-replace-frame-state-preconditions!
                     (fn [frame-id new-frame-state]
                       (let [r (real-check frame-id new-frame-state)]
                         (rf/destroy-frame! frame-id)
@@ -5697,12 +5697,12 @@
     (rf/reg-event :set-owner-inj3 (fn [_ [_ o]] {:db {:owner o}}))
     (rf/dispatch-sync [:set-owner-inj3 :A] {:frame :test/inj3})
 
-    (let [real-write frame/replace-frame-state!
+    (let [real-write rf.frame/replace-frame-state!
           a-changed  (atom ::unset)
           fanned     (atom [])
           recorded   (record-trace!)]
       (rf/register-listener! :epoch ::inj3-fan (fn [r] (swap! fanned conj r)))
-      (let [result (with-redefs [frame/replace-frame-state!
+      (let [result (with-redefs [rf.frame/replace-frame-state!
                                  (fn [frame-id token fs]
                                    ;; The exact A write runs FIRST and its
                                    ;; changed-key-set is captured — then the
@@ -5725,7 +5725,7 @@
         (is (not-any? #(= :rf.epoch/db-replaced (:event-id %)) b-history)
             "A's synthetic :rf.epoch/db-replaced record was NOT spliced into B's ring")
         (is (some? b-seed) "B's own seed epoch is in B's ring")
-        (is (= (:epoch-id b-seed) (state/last-settled-epoch-id :test/inj3))
+        (is (= (:epoch-id b-seed) (rf.epoch.state/last-settled-epoch-id :test/inj3))
             "B's last-settled anchor is B's own epoch — NOT retargeted to A's synthetic id")
         (is (not-any? #(= :rf.epoch/db-replaced (:operation %)) @recorded)
             "no :rf.epoch/db-replaced trace fired after the churn")
@@ -5748,10 +5748,10 @@
 
     ;; The :ok ticket pairs the live incarnation's own record-derived token.
     (let [{:keys [outcome incarnation-token]}
-          (tool-pair/check-replace-frame-state-preconditions!
+          (rf.epoch.tool-pair/check-replace-frame-state-preconditions!
             :test/inj-ctl {:rf.db/app {:owner :INJECTED}})]
       (is (= :ok outcome) "preconditions pass against the live frame")
-      (is (identical? incarnation-token (frame/frame-incarnation-token :test/inj-ctl))
+      (is (identical? incarnation-token (rf.frame/frame-incarnation-token :test/inj-ctl))
           "the :ok ticket's token is the live incarnation's own drain-lock"))
 
     (let [fanned   (atom [])
@@ -5774,7 +5774,7 @@
             "the synthetic record's before-state matches the pre-injection app-db")
         (is (= {:owner :INJECTED} (get-in synthetic [:frame-state-after :rf.db/app]))
             "the synthetic record's after-state matches the installed app-db")
-        (is (= (:epoch-id synthetic) (state/last-settled-epoch-id :test/inj-ctl))
+        (is (= (:epoch-id synthetic) (rf.epoch.state/last-settled-epoch-id :test/inj-ctl))
             "the synthetic epoch anchors last-settled")
         (is (some #(= :rf.epoch/db-replaced (:operation %)) @recorded)
             ":rf.epoch/db-replaced success trace fired")
@@ -5799,15 +5799,15 @@
   [machines-fn http-fn f]
   (let [mk :machines/on-frame-restored!
         hk :http/abort-in-flight-for-frame!
-        m0 (late-bind/get-fn mk)
-        h0 (late-bind/get-fn hk)]
+        m0 (rf.late-bind/get-fn mk)
+        h0 (rf.late-bind/get-fn hk)]
     (try
-      (late-bind/set-fn! mk machines-fn)
-      (late-bind/set-fn! hk http-fn)
+      (rf.late-bind/set-fn! mk machines-fn)
+      (rf.late-bind/set-fn! hk http-fn)
       (f)
       (finally
-        (late-bind/set-fn! mk m0)
-        (late-bind/set-fn! hk h0)))))
+        (rf.late-bind/set-fn! mk m0)
+        (rf.late-bind/set-fn! hk h0)))))
 
 (deftest restore-quiesce-chain-fenced-per-hook
   (testing "rf2-sdeae — the host-work quiesce CHAIN is a callback fan-out. The
@@ -5823,7 +5823,7 @@
     (let [target-id (some (fn [r] (when (= {:owner :A :n 1} (:db-after r)) (:epoch-id r)))
                           (rf/epoch-history :test/sdeae-quiesce))
           {:keys [outcome epoch incarnation-token]}
-          (tool-pair/check-restore-preconditions! :test/sdeae-quiesce target-id)
+          (rf.epoch.tool-pair/check-restore-preconditions! :test/sdeae-quiesce target-id)
           machines-saw (atom [])
           http-saw     (atom [])]
       (is (= :ok outcome) "preconditions passed against live incarnation A")
@@ -5836,7 +5836,7 @@
           (rf/dispatch-sync [:set-q :B 99] {:frame fid}))
         (fn [fid] (swap! http-saw conj fid))
         (fn []
-          (let [result (tool-pair/perform-restore! :test/sdeae-quiesce incarnation-token epoch)]
+          (let [result (rf.epoch.tool-pair/perform-restore! :test/sdeae-quiesce incarnation-token epoch)]
             (is (true? result)
                 "the exact-incarnation install committed, so the public result stays TRUE")
             (is (= [:test/sdeae-quiesce] @machines-saw)
@@ -5898,7 +5898,7 @@
     (let [target-id (some (fn [r] (when (= {:owner :A :n 1} (:db-after r)) (:epoch-id r)))
                           (rf/epoch-history :test/vy2hj-quiesce))
           {:keys [outcome epoch incarnation-token]}
-          (tool-pair/check-restore-preconditions! :test/vy2hj-quiesce target-id)
+          (rf.epoch.tool-pair/check-restore-preconditions! :test/vy2hj-quiesce target-id)
           machines-saw (atom [])
           http-saw     (atom [])]
       (is (= :ok outcome) "preconditions passed against live incarnation A")
@@ -5915,7 +5915,7 @@
               (throw (ex-info "quiesce hook failed after seating B" {})))
             (fn [fid] (swap! http-saw conj fid))
             (fn []
-              (let [result (tool-pair/perform-restore! :test/vy2hj-quiesce incarnation-token epoch)]
+              (let [result (rf.epoch.tool-pair/perform-restore! :test/vy2hj-quiesce incarnation-token epoch)]
                 (is (true? result)
                     "the already-committed exact-incarnation install keeps its
                      documented TRUE return — the throwing tail is best-effort")
@@ -5979,7 +5979,7 @@
           round (fn [warnings churn?]
                   (let [before (count @warnings)]
                     (rf/make-frame {:id fid})
-                    (let [token (frame/frame-incarnation-token fid)]
+                    (let [token (rf.frame/frame-incarnation-token fid)]
                       (with-quiesce-hook-stubs
                         (fn [f]
                           (when churn?
@@ -5988,7 +5988,7 @@
                           (throw (ex-info "hook failed" {})))
                         (fn [_f] nil)
                         (fn []
-                          (tool-pair/quiesce-orphaned-async-host-work! fid token))))
+                          (rf.epoch.tool-pair/quiesce-orphaned-async-host-work! fid token))))
                     (- (count @warnings) before)))]
       (with-quiesce-warning-capture
         (fn [warnings]
@@ -6014,21 +6014,21 @@
     (let [target-id (some (fn [r] (when (= {:n 1} (:db-after r)) (:epoch-id r)))
                           (rf/epoch-history :test/sdeae-commit))
           {:keys [outcome epoch incarnation-token]}
-          (tool-pair/check-restore-preconditions! :test/sdeae-commit target-id)
+          (rf.epoch.tool-pair/check-restore-preconditions! :test/sdeae-commit target-id)
           ck   :resources/commit-restore-reconcile!
-          c0   (late-bind/get-fn ck)
+          c0   (rf.late-bind/get-fn ck)
           seen (atom nil)]
       (is (= :ok outcome) "preconditions passed against the live frame")
       (try
-        (late-bind/set-fn! ck (fn [_rdb frame-id opts] (reset! seen [frame-id opts])))
-        (is (true? (tool-pair/perform-restore! :test/sdeae-commit incarnation-token epoch))
+        (rf.late-bind/set-fn! ck (fn [_rdb frame-id opts] (reset! seen [frame-id opts])))
+        (is (true? (rf.epoch.tool-pair/perform-restore! :test/sdeae-commit incarnation-token epoch))
             "the restore committed")
         (is (= :test/sdeae-commit (first @seen))
             "the commit hook is told WHICH frame the intents belong to")
         (is (identical? incarnation-token (:owner-token (second @seen)))
             "ACCEPTANCE — the EXACT captured incarnation token is carried into the
              commit fan-out so it can revalidate at every intent boundary")
-        (finally (late-bind/set-fn! ck c0))))))
+        (finally (rf.late-bind/set-fn! ck c0))))))
 
 ;; rf2-obi8rr — the resources restore-reconcile success rows
 ;; (:rf.resource/restored / :rf.resource/owner-released) must NOT leak when the
@@ -6052,10 +6052,10 @@
   [f]
   (let [rk :resources/reconcile-on-restore
         ck :resources/commit-restore-reconcile!
-        r0 (late-bind/get-fn rk)
-        c0 (late-bind/get-fn ck)]
+        r0 (rf.late-bind/get-fn rk)
+        c0 (rf.late-bind/get-fn ck)]
     (try
-      (late-bind/set-fn! rk
+      (rf.late-bind/set-fn! rk
                          (fn [rdb frame-id {:keys [defer-traces?]}]
                            (let [intents [{:level :rf.epoch
                                            :op    :rf.resource/restored
@@ -6068,23 +6068,23 @@
                              (if defer-traces?
                                (vary-meta rdb assoc rf2-obi8rr-deferred-key intents)
                                (do (doseq [{:keys [level op tags]} intents]
-                                     (trace/emit! level op tags))
+                                     (rf.trace/emit! level op tags))
                                    rdb)))))
       ;; 3-arity, mirroring the real ssr.cljc body since rf2-sdeae: the commit is
       ;; a per-intent callback fan-out, so it takes the frame-id + the restore's
       ;; captured `:owner-token` and revalidates exact ownership at every intent.
-      (late-bind/set-fn! ck
+      (rf.late-bind/set-fn! ck
                          (fn [rdb frame-id {:keys [owner-token]}]
                            (doseq [{:keys [level op tags]} (-> rdb meta (get rf2-obi8rr-deferred-key))
                                    :while (or (nil? frame-id)
                                               (nil? owner-token)
-                                              (frame/frame-incarnation-live? frame-id owner-token))]
-                             (trace/emit! level op tags))
+                                              (rf.frame/frame-incarnation-live? frame-id owner-token))]
+                             (rf.trace/emit! level op tags))
                            nil))
       (f)
       (finally
-        (late-bind/set-fn! rk r0)
-        (late-bind/set-fn! ck c0)))))
+        (rf.late-bind/set-fn! rk r0)
+        (rf.late-bind/set-fn! ck c0)))))
 
 (deftest restore-failed-install-emits-no-resource-success-traces
   (testing "rf2-obi8rr ACCEPTANCE — a restore whose frame-state install FAILS
@@ -6107,15 +6107,15 @@
         (let [target-id (-> (rf/epoch-history :test/obi8rr-fail) last :epoch-id)]
           (rf/dispatch-sync [:clear-res] {:frame :test/obi8rr-fail})
           (let [{:keys [outcome epoch incarnation-token]}
-                (tool-pair/check-restore-preconditions! :test/obi8rr-fail target-id)]
+                (rf.epoch.tool-pair/check-restore-preconditions! :test/obi8rr-fail target-id)]
             (is (= :ok outcome) "precondition validation passed against the live frame")
-            (let [real-write frame/replace-frame-state!
+            (let [real-write rf.frame/replace-frame-state!
                   recorded   (record-trace!)
-                  result     (with-redefs [frame/replace-frame-state!
+                  result     (with-redefs [rf.frame/replace-frame-state!
                                            (fn [fid token fs]
                                              (rf/destroy-frame! fid)
                                              (real-write fid token fs))]
-                               (tool-pair/perform-restore! :test/obi8rr-fail incarnation-token epoch))]
+                               (rf.epoch.tool-pair/perform-restore! :test/obi8rr-fail incarnation-token epoch))]
               (is (false? result) "perform-restore! reports honest failure for the nil-write teardown")
               (is (not-any? #(= :rf.epoch/restored (:operation %)) @recorded)
                   "no :rf.epoch/restored (the install never landed)")
@@ -6169,14 +6169,14 @@
       (rf/dispatch-sync [:seed] {:frame :test/short-lived})
       (reset! fanned [])
 
-      (let [real-write frame/replace-frame-state!
-            a-token    (frame/frame-incarnation-token :test/short-lived)
+      (let [real-write rf.frame/replace-frame-state!
+            a-token    (rf.frame/frame-incarnation-token :test/short-lived)
             recorded   (record-trace!)
-            result     (with-redefs [frame/replace-frame-state!
+            result     (with-redefs [rf.frame/replace-frame-state!
                                      (fn [frame-id token fs]
                                        (rf/destroy-frame! frame-id)
                                        (real-write frame-id token fs))]
-                         (#'epoch/perform-replace-frame-state!
+                         (#'rf.epoch/perform-replace-frame-state!
                            :test/short-lived a-token {:rf.db/app {:n 999}}))]
         (is (false? result)
             "perform-replace-frame-state! reports HONEST failure (false) for the
@@ -6209,14 +6209,14 @@
       (rf/dispatch-sync [:seed] {:frame :test/short-lived})
       (reset! fanned [])
 
-      (let [real-write frame/replace-frame-state!
-            a-token    (frame/frame-incarnation-token :test/short-lived)
+      (let [real-write rf.frame/replace-frame-state!
+            a-token    (rf.frame/frame-incarnation-token :test/short-lived)
             recorded   (record-trace!)
-            result     (with-redefs [frame/replace-frame-state!
+            result     (with-redefs [rf.frame/replace-frame-state!
                                      (fn [frame-id token fs]
                                        (rf/destroy-frame! frame-id)
                                        (real-write frame-id token fs))]
-                         (#'epoch/perform-replace-frame-state!
+                         (#'rf.epoch/perform-replace-frame-state!
                            :test/short-lived a-token
                            {:rf.db/runtime {:rf.runtime/routing {:current {:route-id :home}}}}))]
         (is (false? result)
@@ -6249,15 +6249,15 @@
       (rf/dispatch-sync [:seed] {:frame :test/short-lived})
       (reset! fanned [])
 
-      (let [real-write frame/replace-frame-state!
-            a-token    (frame/frame-incarnation-token :test/short-lived)
+      (let [real-write rf.frame/replace-frame-state!
+            a-token    (rf.frame/frame-incarnation-token :test/short-lived)
             recorded   (record-trace!)
             new-fs     {:rf.db/app {:n 999} :rf.db/runtime {:rf.runtime/routing {:current {:route-id :home}}}}
-            result     (with-redefs [frame/replace-frame-state!
+            result     (with-redefs [rf.frame/replace-frame-state!
                                      (fn [frame-id token fs]
                                        (rf/destroy-frame! frame-id)
                                        (real-write frame-id token fs))]
-                         (#'epoch/perform-replace-frame-state!
+                         (#'rf.epoch/perform-replace-frame-state!
                            :test/short-lived a-token new-fs))]
         (is (false? result)
             "perform-replace-frame-state! reports HONEST failure (false) for the
@@ -6292,8 +6292,8 @@
     (let [recorded (record-trace!)
           ;; Inject the IDENTICAL value — a genuine no-op write against a live
           ;; frame. commit-frame-transition! returns #{} (empty, non-nil).
-          result   (#'epoch/perform-replace-frame-state!
-                     :test/main (frame/frame-incarnation-token :test/main)
+          result   (#'rf.epoch/perform-replace-frame-state!
+                     :test/main (rf.frame/frame-incarnation-token :test/main)
                      {:rf.db/app {:n 7}})]
       (is (true? result)
           "a live-frame no-op write stays successful (empty-set ≠ nil)")
@@ -6330,17 +6330,17 @@
     ;; Register a cb, capture its generation (as a fan-out snapshot would),
     ;; then unregister — it is GONE from the listener registry.
     (rf/register-listener! :epoch ::ghost (fn [_] nil))
-    (let [ghost-gen (:generation (get (state/listeners-snapshot) ::ghost))]
+    (let [ghost-gen (:generation (get (rf.epoch.state/listeners-snapshot) ::ghost))]
       (rf/unregister-listener! :epoch ::ghost)
-      (is (not (contains? (state/listeners-snapshot) ::ghost))
+      (is (not (contains? (rf.epoch.state/listeners-snapshot) ::ghost))
           "::ghost is no longer a registered listener")
 
       ;; Simulate the racing fan-out: record-observation! is called for the
       ;; now-stale ::ghost id + its snapshotted generation (as notify-listeners!
       ;; would for a snapshot taken before the unregister).
-      (state/record-observation! ::ghost ghost-gen :test/main)
+      (rf.epoch.state/record-observation! ::ghost ghost-gen :test/main)
 
-      (is (not (contains? (state/observations-snapshot) ::ghost))
+      (is (not (contains? (rf.epoch.state/observations-snapshot) ::ghost))
           "no stale observed-frames-by-cb entry for the unregistered cb —
            record-observation! refused to re-introduce bookkeeping for a dead cb"))))
 
@@ -6366,7 +6366,7 @@
       (rf/register-listener! :epoch ::victim (fn [_] nil))
       (let [;; (1) notify-listeners! takes the snapshot (includes ::victim +
             ;;     its generation token).
-            snapshot (state/listeners-snapshot)]
+            snapshot (rf.epoch.state/listeners-snapshot)]
         (is (contains? snapshot ::victim)
             "::victim is in the fan-out snapshot")
 
@@ -6377,11 +6377,11 @@
         ;; calls record-observation! for it with the snapshotted generation
         ;; (the loop iterates the stale snapshot). Replay that single step.
         (doseq [[id {:keys [generation]}] snapshot]
-          (state/record-observation! id generation :test/main)))
+          (rf.epoch.state/record-observation! id generation :test/main)))
 
-      (is (not (contains? (state/listeners-snapshot) ::victim))
+      (is (not (contains? (rf.epoch.state/listeners-snapshot) ::victim))
           "::victim was unregistered during fan-out")
-      (is (not (contains? (state/observations-snapshot) ::victim))
+      (is (not (contains? (rf.epoch.state/observations-snapshot) ::victim))
           "::victim carries NO stale observed-frames-by-cb entry after the
            snapshot-then-unregister-then-record interleaving")
 
@@ -6426,7 +6426,7 @@
           published      (promise)
           release        (java.util.concurrent.CountDownLatch. 1)
           armed?         (atom false)
-          listeners-atom (deref #'state/listeners)]
+          listeners-atom (deref #'rf.epoch.state/listeners)]
       ;; Register the OLD callback; it never observes :j538/race.
       (rf/register-listener! :epoch ::probe (fn [_] nil))
       ;; Park the NEXT listeners swap (the replacement's publish) until the main
@@ -6447,9 +6447,9 @@
               "replacement published the new callback and parked")
           ;; Fan out a record for :j538/race while the replacement is parked —
           ;; the NEW callback runs and its observation must be recorded.
-          (epoch.listeners/notify-listeners! {:frame :j538/race :epoch-id 1})
+          (rf.epoch.listeners/notify-listeners! {:frame :j538/race :epoch-id 1})
           (is (= 1 @fired) "the new callback ran during the fan-out")
-          (is (contains? (get (state/observations-snapshot) ::probe) :j538/race)
+          (is (contains? (get (rf.epoch.state/observations-snapshot) ::probe) :j538/race)
               "the new callback's observation was recorded during the pause")
           (finally
             (.countDown release)
@@ -6458,7 +6458,7 @@
             (remove-watch listeners-atom ::barrier))))
       ;; After the replacement completes, the observation must SURVIVE — the
       ;; pre-fix second swap erased it here.
-      (is (contains? (get (state/observations-snapshot) ::probe) :j538/race)
+      (is (contains? (get (rf.epoch.state/observations-snapshot) ::probe) :j538/race)
           "the new callback's observation survived the completed replacement")
       (rf/destroy-frame! :j538/race)
       (let [silenced (filter #(and (= :rf.epoch.cb/silenced-on-frame-destroy
@@ -6480,17 +6480,17 @@
     (rf/make-frame {:id :j538/mirror})
     (let [recorded (record-trace!)]
       (rf/register-listener! :epoch ::probe (fn [_] nil))
-      (let [stale-gen (:generation (get (state/listeners-snapshot) ::probe))]
+      (let [stale-gen (:generation (get (rf.epoch.state/listeners-snapshot) ::probe))]
         ;; Same-id replacement mints a new generation.
         (rf/register-listener! :epoch ::probe (fn [_] nil))
-        (is (not= stale-gen (:generation (get (state/listeners-snapshot) ::probe)))
+        (is (not= stale-gen (:generation (get (rf.epoch.state/listeners-snapshot) ::probe)))
             "same-id replacement minted a fresh generation")
         ;; The stale fan-out records against the OLD generation — must be refused.
-        (state/record-observation! ::probe stale-gen :j538/mirror)
-        (is (not (contains? (get (state/observations-snapshot) ::probe) :j538/mirror))
+        (rf.epoch.state/record-observation! ::probe stale-gen :j538/mirror)
+        (is (not (contains? (get (rf.epoch.state/observations-snapshot) ::probe) :j538/mirror))
             "the stale old-generation observation was refused — the new
              registration did not inherit it")
-        (is (empty? (state/cbs-observing-frame :j538/mirror))
+        (is (empty? (rf.epoch.state/cbs-observing-frame :j538/mirror))
             "no live-generation observer of the frame")
         (rf/destroy-frame! :j538/mirror)
         (let [silenced (filter #(and (= :rf.epoch.cb/silenced-on-frame-destroy
@@ -6517,15 +6517,15 @@
                                      @recorded)))]
       (rf/register-listener! :epoch ::probe (fn [_] nil))
       ;; Old generation observes frame-a.
-      (epoch.listeners/notify-listeners! {:frame :j538/frame-a :epoch-id 1})
-      (is (= [::probe] (state/cbs-observing-frame :j538/frame-a))
+      (rf.epoch.listeners/notify-listeners! {:frame :j538/frame-a :epoch-id 1})
+      (is (= [::probe] (rf.epoch.state/cbs-observing-frame :j538/frame-a))
           "old generation is the live observer of frame-a")
       ;; Same-id replacement mints a new generation, which observes frame-b.
       (rf/register-listener! :epoch ::probe (fn [_] nil))
-      (epoch.listeners/notify-listeners! {:frame :j538/frame-b :epoch-id 2})
-      (is (empty? (state/cbs-observing-frame :j538/frame-a))
+      (rf.epoch.listeners/notify-listeners! {:frame :j538/frame-b :epoch-id 2})
+      (is (empty? (rf.epoch.state/cbs-observing-frame :j538/frame-a))
           "frame-a's stale old-generation observation is no longer live")
-      (is (= [::probe] (state/cbs-observing-frame :j538/frame-b))
+      (is (= [::probe] (rf.epoch.state/cbs-observing-frame :j538/frame-b))
           "the new generation's frame-b observation survives and is live")
       ;; Destroy frame-a — the new callback never consumed it → no silence.
       (rf/destroy-frame! :j538/frame-a)
@@ -6537,8 +6537,8 @@
           "frame-b destroy silences the live generation exactly once — true positive")
       ;; Same-key recreation re-arms: recreate frame-b, observe, destroy → silence.
       (rf/make-frame {:id :j538/frame-b})
-      (epoch.listeners/notify-listeners! {:frame :j538/frame-b :epoch-id 3})
-      (is (= [::probe] (state/cbs-observing-frame :j538/frame-b))
+      (rf.epoch.listeners/notify-listeners! {:frame :j538/frame-b :epoch-id 3})
+      (is (= [::probe] (rf.epoch.state/cbs-observing-frame :j538/frame-b))
           "same-key frame recreation re-arms the observation")
       (rf/destroy-frame! :j538/frame-b)
       (is (= 2 (silences :j538/frame-b))

--- a/implementation/epoch/test/re_frame/join_strict_mint_epoch_replay_test.clj
+++ b/implementation/epoch/test/re_frame/join_strict_mint_epoch_replay_test.clj
@@ -46,9 +46,9 @@
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.epoch :as epoch]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; Side-effect require — loads the machines late-bind hooks
             ;; (`:machines/reg-machine`, the `:rf.machine/spawn` fx, the join
             ;; lifecycle fx) and the `install-runtime!` hook the reset fixture
@@ -61,11 +61,11 @@
 ;; plain-atom substrate and ensures + binds the ambient `:rf/default` frame, so
 ;; bare `dispatch-sync` lands there. Clear the epoch ring/listeners per test.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn []
-                (epoch/clear-history!)
-                (epoch/clear-epoch-listeners!))}))
+                (rf.epoch/clear-history!)
+                (rf.epoch/clear-epoch-listeners!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; probes over the `:rf/default` frame the fixture seats

--- a/implementation/epoch/test/re_frame/machine_minted_cofx_replay_token_test.clj
+++ b/implementation/epoch/test/re_frame/machine_minted_cofx_replay_token_test.clj
@@ -11,20 +11,20 @@
   decision without another host read."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.epoch :as epoch]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             ;; Side-effect require — loads the machines late-bind hooks
             ;; (`:machines/reg-machine`, etc.). The capture/restore fixture
             ;; preserves these ns-load-time registrations across each test.
             [re-frame.machines]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter
      :init-fn (fn []
-                (epoch/clear-history!)
-                (epoch/clear-epoch-listeners!))}))
+                (rf.epoch/clear-history!)
+                (rf.epoch/clear-epoch-listeners!))}))
 
 (defn- machine-state [machine-id]
   (-> (:rf.db/runtime (rf/frame-state-value :test/main))

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -11,17 +11,17 @@
   This namespace is the public facade for the optional
   `day8/re-frame2-flows` artefact. It publishes its core integration points
   through `re-frame.late-bind`."
-  (:require [re-frame.elision :as elision]
-            [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.flows.registry :as registry]
-            [re-frame.flows.topo :as topo]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.trace :as trace]
+  (:require [re-frame.elision :as rf.elision]
+            [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.flows.registry :as rf.flows.registry]
+            [re-frame.flows.topo :as rf.flows.topo]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.trace :as rf.trace]
             ;; Keep tooling unreachable from the CLJS facade so Closure can
             ;; remove it when no tool requires the sibling namespace.
-            #?@(:clj [[re-frame.flows.tooling :as flows-tooling]])))
+            #?@(:clj [[re-frame.flows.tooling :as rf.flows.tooling]])))
 
 (def ^:no-doc stale-incarnation
   "Internal return marker: the exact frame owner vanished during a flow pass."
@@ -30,29 +30,29 @@
 (defn- owner-live?
   [frame-id owner-token exact-owner?]
   (or (not exact-owner?)
-      (frame/event-continuation-live? frame-id owner-token)))
+      (rf.frame/event-continuation-live? frame-id owner-token)))
 
 ;; ---- public-surface re-exports -------------------------------------------
 ;;
 ;; `last-inputs-snapshot` exposes raw cached values for tests and rollback. It
 ;; is not a tooling or egress surface; trace payloads use the elided path.
 
-(def flows-snapshot       registry/flows-snapshot)
-(def ^:no-doc last-inputs-snapshot registry/last-inputs-snapshot)
+(def flows-snapshot       rf.flows.registry/flows-snapshot)
+(def ^:no-doc last-inputs-snapshot rf.flows.registry/last-inputs-snapshot)
 
 ;; Flow metadata is frame-scoped and therefore cannot use the frame-blind
 ;; registrar metadata slot.
-(def flow-meta-at       registry/flow-meta-at)
+(def flow-meta-at       rf.flows.registry/flow-meta-at)
 
-(def reg-flow           registry/reg-flow)
-(def clear-flow         registry/clear-flow)
-(def reset-flows!       registry/reset-flows!)
-(def reset-last-inputs! registry/reset-last-inputs!)
+(def reg-flow           rf.flows.registry/reg-flow)
+(def clear-flow         rf.flows.registry/clear-flow)
+(def reset-flows!       rf.flows.registry/reset-flows!)
+(def reset-last-inputs! rf.flows.registry/reset-last-inputs!)
 
 ;; JVM tools get a convenience alias. CLJS tools require the bundle-isolated
 ;; sibling directly.
 #?(:clj
-   (def flow-algebra-view flows-tooling/flow-algebra-view))
+   (def flow-algebra-view rf.flows.tooling/flow-algebra-view))
 
 ;; ---- partition-qualified input resolution -------------------------------
 ;;
@@ -66,8 +66,8 @@
 (defn- resolve-input
   "Read a bare input from app-db or a qualified input from runtime-db."
   [db runtime-db path]
-  (if (registry/runtime-input? path)
-    (get-in runtime-db (registry/partition-relative-input-path path))
+  (if (rf.flows.registry/runtime-input? path)
+    (get-in runtime-db (rf.flows.registry/partition-relative-input-path path))
     (get-in db path)))
 
 (defn- read-inputs
@@ -83,9 +83,9 @@
   inside a `debug-enabled?` branch so Closure can remove the walk."
   [frame-id flow input-values]
   (mapv (fn [input-path v]
-          (elision/elide-wire-value
+          (rf.elision/elide-wire-value
             v {:frame frame-id
-               :path  (registry/partition-relative-input-path input-path)}))
+               :path  (rf.flows.registry/partition-relative-input-path input-path)}))
         (:inputs flow)
         input-values))
 
@@ -105,7 +105,7 @@
       ;; means no declaration.
       (not (contains? flow :schema)) true
       :else
-      (if-let [validate (late-bind/get-fn-cached
+      (if-let [validate (rf.late-bind/get-fn-cached
                           :schemas/validate-with-registered-fn)]
         (let [valid? (validate schema new-output)]
           ;; Registered schema functions are authored callback boundaries.
@@ -114,12 +114,12 @@
             (not (live?)) false
             valid? true
             :else
-            (let [explain     (late-bind/get-fn-cached
+            (let [explain     (rf.late-bind/get-fn-cached
                                 :schemas/explain-with-registered-fn)
                   explanation (when explain (explain schema new-output))]
               (if-not (live?)
                 false
-                (let [redact (late-bind/get-fn-cached
+                (let [redact (rf.late-bind/get-fn-cached
                                :schemas/redact-validation-tags)
                       tags   {:category   :rf.error/schema-validation-failure
                               :where      :flow-output
@@ -127,7 +127,7 @@
                               :failing-id (:id flow)
                               :schema-id  (:id flow)
                               :path       (:output-path flow)
-                              :value      (elision/elide-wire-value
+                              :value      (rf.elision/elide-wire-value
                                             new-output
                                             {:frame frame-id
                                              :path (:output-path flow)})
@@ -141,7 +141,7 @@
                   (if-not (live?)
                     false
                     (do
-                      (trace/emit-error!
+                      (rf.trace/emit-error!
                         :rf.error/schema-validation-failure tags)
                       (live?))))))))
         true))))
@@ -235,8 +235,8 @@
     stale-incarnation
     (let [flow-id     (:id flow)
           output-path (:output-path flow)]
-      (when interop/debug-enabled?
-        (trace/emit! :flow :rf.flow/failed
+      (when rf.interop/debug-enabled?
+        (rf.trace/emit! :flow :rf.flow/failed
                      {:flow-id           flow-id
                       :phase             phase
                       :path              output-path
@@ -247,7 +247,7 @@
                       :frame             frame-id}))
       (if-not (owner-live? frame-id owner-token exact-owner?)
         stale-incarnation
-        (error/throw-error!
+        (rf.error/throw-error!
           :rf.error/flow-eval-exception
           'rf/run-flows-on-db
           (if (= :derive phase)
@@ -295,11 +295,11 @@
           new-inputs (read-inputs db runtime-db flow)
           ;; Read and write the captured A-owned cell, never a bare-id lookup
           ;; that could resolve to replacement B after a callback.
-          old-inputs (registry/pass-flow-last-inputs pass flow-id)]
+          old-inputs (rf.flows.registry/pass-flow-last-inputs pass flow-id)]
       (if (= new-inputs old-inputs)
         (do
-          (when interop/debug-enabled?
-            (trace/emit! :flow :rf.flow/skip
+          (when rf.interop/debug-enabled?
+            (rf.trace/emit! :flow :rf.flow/skip
                          {:flow-id               flow-id
                           :reason                :inputs-value-equal
                           :input-paths-unchanged (:inputs flow)
@@ -313,7 +313,7 @@
         ;; declared `:output-path` into the pending app-db is structurally
         ;; unreachable from the derive handler, so it can never be reported as
         ;; the programmer's `:derive` fn throwing (rf2-gpj9r).
-        (let [started-at-ms  (when interop/debug-enabled? (interop/now-ms))
+        (let [started-at-ms  (when rf.interop/debug-enabled? (rf.interop/now-ms))
               derive-outcome (try
                                {::output (apply (:derive flow) new-inputs)}
                                (catch #?(:clj Throwable :cljs :default) e
@@ -328,23 +328,23 @@
               stale-incarnation
               (try
                 (let [new-output      (::output derive-outcome)
-                      flow-elapsed-ms (when interop/debug-enabled?
-                                        (- (interop/now-ms) started-at-ms))
-                      old-output      (when interop/debug-enabled?
+                      flow-elapsed-ms (when rf.interop/debug-enabled?
+                                        (- (rf.interop/now-ms) started-at-ms))
+                      old-output      (when rf.interop/debug-enabled?
                                         (get-in db (:output-path flow)))
                       new-db          (assoc-in db (:output-path flow)
                                                 new-output)]
-                  (registry/pass-set-flow-last-inputs!
+                  (rf.flows.registry/pass-set-flow-last-inputs!
                     pass flow-id new-inputs)
-                  (when interop/debug-enabled?
-                    (trace/emit! :flow :rf.flow/computed
+                  (when rf.interop/debug-enabled?
+                    (rf.trace/emit! :flow :rf.flow/computed
                                  {:flow-id      flow-id
                                   :input-values (elide-inputs frame-id flow new-inputs)
-                                  :before       (elision/elide-wire-value
+                                  :before       (rf.elision/elide-wire-value
                                                   old-output
                                                   {:frame frame-id
                                                    :path (:output-path flow)})
-                                  :result       (elision/elide-wire-value
+                                  :result       (rf.elision/elide-wire-value
                                                   new-output
                                                   {:frame frame-id
                                                    :path (:output-path flow)})
@@ -353,7 +353,7 @@
                                   :frame        frame-id}))
                   (if-not (owner-live? frame-id owner-token exact-owner?)
                     stale-incarnation
-                    (if (or (not interop/debug-enabled?)
+                    (if (or (not rf.interop/debug-enabled?)
                             (validate-output! frame-id owner-token exact-owner?
                                               flow new-output))
                       new-db
@@ -367,21 +367,21 @@
   (if-not (owner-live? frame-id owner-token exact-owner?)
     stale-incarnation
     (let [pass (if exact-owner?
-                 (registry/capture-flow-pass-state frame-id owner-token)
-                 (registry/legacy-flow-pass-state frame-id))]
+                 (rf.flows.registry/capture-flow-pass-state frame-id owner-token)
+                 (rf.flows.registry/legacy-flow-pass-state frame-id))]
       (if-not pass
         stale-incarnation
         (let [flow-map          (:flow-map pass)
-              abandoned-before (registry/pass-abandoned-paths-snapshot pass)
-              abandoned-paths  (registry/pass-drain-abandoned-paths! pass)
-              db               (reduce registry/vacate-path-in-db
+              abandoned-before (rf.flows.registry/pass-abandoned-paths-snapshot pass)
+              abandoned-paths  (rf.flows.registry/pass-drain-abandoned-paths! pass)
+              db               (reduce rf.flows.registry/vacate-path-in-db
                                        db abandoned-paths)]
           (if-not (owner-live? frame-id owner-token exact-owner?)
             stale-incarnation
             (if-not (seq flow-map)
               db
-              (let [ordered            (topo/topo-sort flow-map)
-                    last-inputs-before (registry/pass-last-inputs-snapshot pass)]
+              (let [ordered            (rf.flows.topo/topo-sort flow-map)
+                    last-inputs-before (rf.flows.registry/pass-last-inputs-snapshot pass)]
                 (try
                   (loop [remaining ordered
                          db        db]
@@ -408,9 +408,9 @@
                     (if-not (owner-live? frame-id owner-token exact-owner?)
                       stale-incarnation
                       (do
-                        (registry/pass-reset-last-inputs!
+                        (rf.flows.registry/pass-reset-last-inputs!
                           pass last-inputs-before)
-                        (registry/pass-restore-abandoned-paths!
+                        (rf.flows.registry/pass-restore-abandoned-paths!
                           pass abandoned-before)
                         (throw e)))))))))))))
 
@@ -427,7 +427,7 @@
    ;; Preserve the established three-argument late-bind contract. Inside an
    ;; event, core's private owner binding supplies the exact A token; direct
    ;; callers have no token and retain the legacy frame-id-scoped behaviour.
-   (if-let [owner-token (frame/current-event-owner-token)]
+   (if-let [owner-token (rf.frame/current-event-owner-token)]
      (run-flows-on-db* frame-id db runtime-db owner-token true)
      (run-flows-on-db* frame-id db runtime-db nil false)))
   ([frame-id db runtime-db {:keys [exact-owner-token]}]
@@ -464,34 +464,34 @@
   `registry/clear-flow` calls this through the seam it publishes; the
   `:require` runs the other way."
   [frame-id owner-token]
-  (when-let [db (frame/frame-app-db-value frame-id)]
-    (let [runtime-db (frame/frame-runtime-db-value frame-id)
+  (when-let [db (rf.frame/frame-app-db-value frame-id)]
+    (let [runtime-db (rf.frame/frame-runtime-db-value frame-id)
           settled    (binding [*pass-caller* :direct-clear]
                        (run-flows-on-db frame-id db runtime-db
                                         {:exact-owner-token owner-token}))]
       (when-not (or (= stale-incarnation settled)
                     (identical? settled db))
-        (frame/swap-frame-db-exact! frame-id owner-token (constantly settled)))))
+        (rf.frame/swap-frame-db-exact! frame-id owner-token (constantly settled)))))
   nil)
 
-(registry/set-settle-fn! settle-frame-flows!)
+(rf.flows.registry/set-settle-fn! settle-frame-flows!)
 
 ;; ---- late-bind hook registration ----------------------------------------
 ;;
 ;; Core cannot statically require this optional artefact. Keep each publication
 ;; as a literal call so the late-bind drift gate can discover it.
 
-(late-bind/set-fn! :flows/reg-flow           reg-flow)
-(late-bind/set-fn! :flows/clear-flow         clear-flow)
-(late-bind/set-fn! :flows/run-flows-on-db    run-flows-on-db)
-(late-bind/set-fn! :flows/reset-flows!       reset-flows!)
+(rf.late-bind/set-fn! :flows/reg-flow           reg-flow)
+(rf.late-bind/set-fn! :flows/clear-flow         clear-flow)
+(rf.late-bind/set-fn! :flows/run-flows-on-db    run-flows-on-db)
+(rf.late-bind/set-fn! :flows/reset-flows!       reset-flows!)
 ;; The router owns post-transform commit rollback. These pairs let it restore
 ;; the eager dirty-check advances and consumed path vacations that this
 ;; artefact cannot otherwise observe after returning.
-(late-bind/set-fn! :flows/snapshot-last-inputs registry/frame-last-inputs-snapshot)
-(late-bind/set-fn! :flows/restore-last-inputs!  registry/reset-frame-last-inputs-to!)
-(late-bind/set-fn! :flows/snapshot-abandoned-paths registry/abandoned-output-paths-snapshot)
-(late-bind/set-fn! :flows/restore-abandoned-paths!  registry/restore-abandoned-output-paths!)
+(rf.late-bind/set-fn! :flows/snapshot-last-inputs rf.flows.registry/frame-last-inputs-snapshot)
+(rf.late-bind/set-fn! :flows/restore-last-inputs!  rf.flows.registry/reset-frame-last-inputs-to!)
+(rf.late-bind/set-fn! :flows/snapshot-abandoned-paths rf.flows.registry/abandoned-output-paths-snapshot)
+(rf.late-bind/set-fn! :flows/restore-abandoned-paths!  rf.flows.registry/restore-abandoned-output-paths!)
 ;; Frame destruction must release registry rows and caches owned by that frame.
-(late-bind/set-fn! :flows/teardown-on-frame-destroy!
-                   registry/teardown-on-frame-destroy!)
+(rf.late-bind/set-fn! :flows/teardown-on-frame-destroy!
+                   rf.flows.registry/teardown-on-frame-destroy!)

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -6,14 +6,14 @@
   output-path vacations also use per-frame containers so drain rollback cannot
   interfere with a sibling frame. External consumers use the snapshot and
   lifecycle functions rather than the private atoms."
-  (:require [re-frame.elision :as elision]
-            [re-frame.error :as error]
-            [re-frame.flows.topo :as topo]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.path :as path]
-            [re-frame.source-coords :as source-coords]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.elision :as rf.elision]
+            [re-frame.error :as rf.error]
+            [re-frame.flows.topo :as rf.flows.topo]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.path :as rf.path]
+            [re-frame.source-coords :as rf.source-coords]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- state ---------------------------------------------------------------
 ;;
@@ -61,7 +61,7 @@
   (cond
     (nil? opts-or-frame-target) {}
     (or (keyword? opts-or-frame-target)
-        (frame/frame-value? opts-or-frame-target)) {:frame opts-or-frame-target}
+        (rf.frame/frame-value? opts-or-frame-target)) {:frame opts-or-frame-target}
     (map? opts-or-frame-target) opts-or-frame-target
     :else {:frame opts-or-frame-target}))
 
@@ -70,8 +70,8 @@
   [opts]
   (let [override (:frame opts)]
     (if (some? override)
-      (frame/frame-target->id override)
-      (frame/require-current-frame!
+      (rf.frame/frame-target->id override)
+      (rf.frame/require-current-frame!
         :flow-meta-at {:where 'rf/flow-meta-at}))))
 
 (defn flow-meta-at
@@ -110,7 +110,7 @@
      @a
      {}))
   ([frame-id owner-token]
-   (when (frame/event-continuation-live? frame-id owner-token)
+   (when (rf.frame/event-continuation-live? frame-id owner-token)
      (frame-last-inputs-snapshot frame-id))))
 
 (defn ^:no-doc get-frame-flow-last-inputs
@@ -127,7 +127,7 @@
 (defn ^:no-doc reset-frame-last-inputs-to!
   "Restore one frame's dirty-check cache from a prior snapshot."
   [frame-id owner-token prior]
-  (when (frame/event-continuation-live? frame-id owner-token)
+  (when (rf.frame/event-continuation-live? frame-id owner-token)
     (when-let [a (get @frame-last-inputs frame-id)]
       (reset! a prior))))
 
@@ -167,13 +167,13 @@
      @a
      #{}))
   ([frame-id owner-token]
-   (when (frame/event-continuation-live? frame-id owner-token)
+   (when (rf.frame/event-continuation-live? frame-id owner-token)
      (abandoned-output-paths-snapshot frame-id))))
 
 (defn ^:no-doc restore-abandoned-output-paths!
   "Restore one frame's pending output-path vacations from a prior snapshot."
   [frame-id owner-token prior]
-  (when (frame/event-continuation-live? frame-id owner-token)
+  (when (rf.frame/event-continuation-live? frame-id owner-token)
     (when-let [a (get @frame-abandoned-output-paths frame-id)]
       (reset! a (set prior)))))
 
@@ -188,11 +188,11 @@
   neither advance nor restore B's dirty-check/vacation state.  Returns nil
   when `owner-token` no longer names the live incarnation."
   [frame-id owner-token]
-  (when (frame/event-continuation-live? frame-id owner-token)
+  (when (rf.frame/event-continuation-live? frame-id owner-token)
     (let [state {:flow-map        (get @flows frame-id)
                  :last-inputs     (ensure-frame-last-inputs-atom! frame-id)
                  :abandoned-paths (ensure-frame-abandoned-paths-atom! frame-id)}]
-      (when (frame/event-continuation-live? frame-id owner-token)
+      (when (rf.frame/event-continuation-live? frame-id owner-token)
         state))))
 
 (defn ^:no-doc legacy-flow-pass-state
@@ -246,7 +246,7 @@
 (defn- valid-path-element?
   "True when `x` belongs to the shared concrete path-segment domain."
   [x]
-  (path/segment? x))
+  (rf.path/segment? x))
 
 (defn- valid-path?
   "True for a non-empty vector of valid path segments."
@@ -262,7 +262,7 @@
   "Build a flow registration error with optional diagnostic data."
   ([error-kw reason flow] (flow-error error-kw reason flow nil))
   ([error-kw reason flow extras]
-   (error/thrown-ex-info
+   (rf.error/thrown-ex-info
      error-kw 'rf/reg-flow reason
      {:recovery :fix-registration
       :extra    (merge {:flow flow} extras)})))
@@ -448,8 +448,8 @@
   (let [owner (flow-owner (:id flow))
         [explicit-s explicit-l] (explicit-flow-output-mark-paths flow)]
     (-> (or reg {})
-        (elision/replace-owner-claims :sensitive-declarations owner explicit-s)
-        (elision/replace-owner-claims :declarations owner explicit-l))))
+        (rf.elision/replace-owner-claims :sensitive-declarations owner explicit-s)
+        (rf.elision/replace-owner-claims :declarations owner explicit-l))))
 
 (defn- write-flow-output-marks!
   "Install or refresh one flow's output declarations in its frame.
@@ -458,7 +458,7 @@
   elision write so a synchronous container watch that destroys A mid-write
   cannot bump same-id B's commit epoch or write B's runtime-db."
   [frame-id owner-token flow]
-  (elision/swap-elision-slot! frame-id owner-token
+  (rf.elision/swap-elision-slot! frame-id owner-token
                               (fn [reg] (fold-flow-declarations reg flow))))
 
 (defn- clear-flow-output-marks!
@@ -474,12 +474,12 @@
   cannot bump same-id B's commit epoch or write B's runtime-db."
   [frame-id owner-token flow-id]
   (let [owner (flow-owner flow-id)]
-    (elision/swap-elision-slot!
+    (rf.elision/swap-elision-slot!
       frame-id owner-token
       (fn [reg]
         (-> (or reg {})
-            (elision/remove-owner :sensitive-declarations owner)
-            (elision/remove-owner :declarations owner))))))
+            (rf.elision/remove-owner :sensitive-declarations owner)
+            (rf.elision/remove-owner :declarations owner))))))
 
 ;; ---- registration --------------------------------------------------------
 
@@ -494,7 +494,7 @@
   [flow-id metadata derive-fn]
   ;; Validate before using map operations so callers receive a typed error.
   (when-not (map? metadata)
-    (throw (error/thrown-ex-info
+    (throw (rf.error/thrown-ex-info
              :rf.error/invalid-flow-metadata
              'rf/reg-flow
              (str "flow " flow-id "'s metadata (the MIDDLE slot) must be a map, "
@@ -505,7 +505,7 @@
              {:recovery :fix-registration
               :extra    {:id flow-id :value metadata}})))
   (when (contains? metadata :derive)
-    (throw (error/thrown-ex-info
+    (throw (rf.error/thrown-ex-info
              :rf.error/invalid-flow-metadata
              'rf/reg-flow
              (str "flow " flow-id " declares :derive inside its metadata map — "
@@ -557,15 +557,15 @@
    (let [[flow frame] (reconstruct-flow flow-id metadata derive-fn)]
    (validate-flow flow)
    (let [;; Normalize frame values before liveness checks and registry access.
-         frame-id (or (some-> frame frame/frame-target->id)
-                      (frame/require-current-frame!
+         frame-id (or (some-> frame rf.frame/frame-target->id)
+                      (rf.frame/require-current-frame!
                         :reg-flow
                         {:where    'rf/reg-flow
                          :event-id (:id flow)}))
          flow-id  (:id flow)
          ;; Store coordinates with the frame-scoped definition so tooling reads
          ;; them from the same authoritative value.
-         flow     (source-coords/merge-coords flow)]
+         flow     (rf.source-coords/merge-coords flow)]
      ;; PIN the incarnation this call selected. The serialization helper below
      ;; intentionally tolerates absent frames (so `clear-flow` stays idempotent
      ;; and mid-drain effects run reentrantly), so a bare pre-serializer
@@ -582,9 +582,9 @@
      ;; (no ghost row); a registration that wins publishes its row, which the
      ;; destroy's flows-teardown hook then removes. See
      ;; re-frame.frame/frame-incarnation-token.
-     (let [pinned-incarnation (frame/frame-incarnation-token frame-id)]
+     (let [pinned-incarnation (rf.frame/frame-incarnation-token frame-id)]
        (when (nil? pinned-incarnation)
-         (error/throw-error!
+         (rf.error/throw-error!
            :rf.error/flow-frame-not-live
            'rf/reg-flow
            (str "cannot register a flow against frame "
@@ -603,7 +603,7 @@
        ;; serialized with the frame drain. The registry swap keeps topology
        ;; validation inside the CAS retry, preventing concurrent registrations
        ;; from jointly admitting a cycle or output overlap.
-       (frame/call-serialized-with-drain!
+       (rf.frame/call-serialized-with-drain!
          frame-id
          (fn []
            ;; LINEARIZATION GATE. Admit this mutation ONLY while the pinned
@@ -617,8 +617,8 @@
            ;; re-registered NEW incarnation's slot; identity of the pinned token
            ;; is what rejects that.
            (when-not (identical? pinned-incarnation
-                                 (frame/frame-incarnation-token frame-id))
-             (error/throw-error!
+                                 (rf.frame/frame-incarnation-token frame-id))
+             (rf.error/throw-error!
                :rf.error/flow-frame-not-live
                'rf/reg-flow
                (str "cannot register a flow against frame "
@@ -638,8 +638,8 @@
                             (assoc prior-frame-flows flow-id flow)]
                         ;; Prefer the specific output-overlap diagnostic before
                         ;; the dependency-cycle check.
-                        (topo/detect-output-path-overlap! prospective-frame-flows)
-                        (topo/topo-sort prospective-frame-flows)
+                        (rf.flows.topo/detect-output-path-overlap! prospective-frame-flows)
+                        (rf.flows.topo/topo-sort prospective-frame-flows)
                         (assoc flows-by-frame frame-id prospective-frame-flows)))))
            ;; A moved output must vacate the old path. Queue the vacation during
            ;; a drain so it is applied to the pending db; otherwise write now.
@@ -649,7 +649,7 @@
            (when-let [prior @prior-frame-flow]
              (let [old-path (:output-path prior)]
                (when (not= old-path (:output-path flow))
-                 (if (frame/in-drain? frame-id)
+                 (if (rf.frame/in-drain? frame-id)
                    (record-abandoned-output-path! frame-id old-path)
                    (vacate-output-path! frame-id pinned-incarnation old-path)))))
            ;; rf2-rxsldx: the output-mark write below is itself exact-
@@ -671,7 +671,7 @@
            ;; container write: if a synchronous container watch destroyed A and
            ;; published a same-id B, abort before any bare-id dirty-cache drop,
            ;; registry mutation, or dedup-and-trace pipeline reaches B.
-           (when (frame/event-continuation-live? frame-id pinned-incarnation)
+           (when (rf.frame/event-continuation-live? frame-id pinned-incarnation)
              ;; A replacement invalidates the cache even when inputs are equal.
              ;; Hot-reload trace dedup compares the prior and new stored flow
              ;; shapes of THIS frame slot (`flow-reload-shape`, rf2-soyqfn).
@@ -697,9 +697,9 @@
                ;; already-entered delivery may stand once, every later framework-
                ;; owned trace stage is fenced. AND-composes with any parent (router)
                ;; predicate.
-               (when interop/debug-enabled?
-                 (trace/call-with-continuation-predicate
-                   #(frame/event-continuation-live? frame-id pinned-incarnation)
+               (when rf.interop/debug-enabled?
+                 (rf.trace/call-with-continuation-predicate
+                   #(rf.frame/event-continuation-live? frame-id pinned-incarnation)
                    (fn []
                      (let [prior              @prior-frame-flow
                            derive-fn-changed? (not= (:derive prior) (:derive flow))
@@ -721,7 +721,7 @@
                            shape-changed? (not= (flow-reload-shape prior)
                                                 (flow-reload-shape flow))]
                         (when shape-changed?
-                          (trace/emit! :rf.registry :rf.registry/handler-replaced
+                          (rf.trace/emit! :rf.registry :rf.registry/handler-replaced
                                       {:kind          :flow
                                        :id            flow-id
                                        :frame         frame-id
@@ -752,11 +752,11 @@
              ;; starts after A's exact ownership is lost. AND-composes with any parent
              ;; predicate, so the reserved-effect route's router predicate is
              ;; preserved.
-             (when (and interop/debug-enabled? (nil? @prior-frame-flow))
-               (trace/call-with-continuation-predicate
-                 #(frame/event-continuation-live? frame-id pinned-incarnation)
+             (when (and rf.interop/debug-enabled? (nil? @prior-frame-flow))
+               (rf.trace/call-with-continuation-predicate
+                 #(rf.frame/event-continuation-live? frame-id pinned-incarnation)
                  (fn []
-                   (trace/emit! :flow :rf.flow/registered
+                   (rf.trace/emit! :flow :rf.flow/registered
                                 {:flow-id flow-id
                                  :inputs  (:inputs flow)
                                  :path    (:output-path flow)
@@ -802,10 +802,10 @@
   app-db write so a synchronous container watch that destroys A mid-vacation
   cannot bump same-id B's commit epoch or write B's app-db."
   [frame-id owner-token path]
-  (when-let [db (frame/frame-app-db-value frame-id)]
+  (when-let [db (rf.frame/frame-app-db-value frame-id)]
     (let [new-db (vacate-path-in-db db path)]
       (when-not (identical? new-db db)
-        (frame/swap-frame-db-exact! frame-id owner-token (constantly new-db))))))
+        (rf.frame/swap-frame-db-exact! frame-id owner-token (constantly new-db))))))
 
 ;; ---- direct-clear settle seam --------------------------------------------
 ;;
@@ -846,8 +846,8 @@
   ([id] (clear-flow id {}))
   ([id {:keys [frame] :as _opts}]
    (let [;; Normalize frame values before registry access.
-         frame-id (or (some-> frame frame/frame-target->id)
-                      (frame/require-current-frame!
+         frame-id (or (some-> frame rf.frame/frame-target->id)
+                      (rf.frame/require-current-frame!
                         :clear-flow
                         {:where    'rf/clear-flow
                          :event-id id}))]
@@ -857,7 +857,7 @@
      ;; trace is initiated while the pinned incarnation is still authoritative
      ;; (previously it emitted after the serialized section released, carrying no
      ;; token). A no-op clear (no flow / lost owner) emits nothing.
-     (frame/call-serialized-with-drain!
+     (rf.frame/call-serialized-with-drain!
        frame-id
        (fn []
          (when-let [flow (get-in @flows [frame-id id])]
@@ -869,14 +869,14 @@
            ;; linearized before that loss stands, and every later registry /
            ;; cache / trace action is fenced by the exact-owner postcheck /
            ;; continuation below.
-           (let [pinned    (frame/frame-incarnation-token frame-id)
+           (let [pinned    (rf.frame/frame-incarnation-token frame-id)
                  path      (:output-path flow)
                  ;; ONE reading of the drain marker for BOTH the vacation
                  ;; branch and the settle below, so the two halves of one
                  ;; lifecycle boundary can never disagree about which pass owns
                  ;; the repair. It is a thread marker for this frame and this
                  ;; thread, so it cannot change across the serialized body.
-                 in-drain? (frame/in-drain? frame-id)]
+                 in-drain? (rf.frame/in-drain? frame-id)]
              ;; In-drain vacation must modify the pending db, not the live
              ;; app-db that the deferred commit will replace.
              (if in-drain?
@@ -896,7 +896,7 @@
              ;; Exact-owner postcheck after the (callback-bearing) output-mark
              ;; container write: if the watch lost A, abort before the bare-id
              ;; flow-row dissoc, dirty-cache drop, and clear-trace pipeline reach B.
-             (when (frame/event-continuation-live? frame-id pinned)
+             (when (rf.frame/event-continuation-live? frame-id pinned)
                ;; Prune an empty frame row rather than expose `{frame-id {}}`.
                (swap! flows (fn [m]
                               (let [m' (update m frame-id dissoc id)]
@@ -917,11 +917,11 @@
                ;; (rf2-pwum1g): already-entered delivery may stand once, every
                ;; later framework-owned trace stage is fenced. AND-composes with
                ;; any parent (router) predicate.
-               (when interop/debug-enabled?
-                 (trace/call-with-continuation-predicate
-                   #(frame/event-continuation-live? frame-id pinned)
+               (when rf.interop/debug-enabled?
+                 (rf.trace/call-with-continuation-predicate
+                   #(rf.frame/event-continuation-live? frame-id pinned)
                    (fn []
-                     (trace/emit! :flow :rf.flow/cleared
+                     (rf.trace/emit! :flow :rf.flow/cleared
                                   {:flow-id id
                                    :path    path
                                    :frame   frame-id}))))

--- a/implementation/flows/src/re_frame/flows/tooling.cljc
+++ b/implementation/flows/src/re_frame/flows/tooling.cljc
@@ -4,8 +4,8 @@
   Kept separate from `re-frame.flows` so CLJS applications that attach no tool
   can eliminate this namespace. JVM consumers receive a facade alias; CLJS
   tools require this sibling directly."
-  (:require [re-frame.derivation.node :as node]
-            [re-frame.flows.registry :as registry]))
+  (:require [re-frame.derivation.node :as rf.derivation.node]
+            [re-frame.flows.registry :as rf.flows.registry]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -21,9 +21,9 @@
 (defn- declared-input
   "Lower a flow input to `[:db path]` or `[:runtime path]`."
   [path]
-  (if (registry/runtime-input? path)
-    [:runtime (registry/partition-relative-input-path path)]
-    [:db (registry/partition-relative-input-path path)]))
+  (if (rf.flows.registry/runtime-input? path)
+    [:runtime (rf.flows.registry/partition-relative-input-path path)]
+    [:db (rf.flows.registry/partition-relative-input-path path)]))
 
 (defn- declared-inputs
   "Project inputs in the positional order expected by `:derive`."
@@ -33,7 +33,7 @@
 (defn- flow-source-coords
   "Return a flow's source-coordinate map, or nil when absent."
   [flow]
-  (let [source (node/source-coords flow)]
+  (let [source (rf.derivation.node/source-coords flow)]
     (when (seq source) source)))
 
 (defn- with-metadata
@@ -50,7 +50,7 @@
   "Build one frame-owned, app-db-materialized derivation node."
   [frame-id flow]
   (let [flow-id (:id flow)]
-    (-> (node/node-base flow-id [:db (vec (:output-path flow))]
+    (-> (rf.derivation.node/node-base flow-id [:db (vec (:output-path flow))]
                         {:kind          :derivation
                          :storage       :app-db
                          :evaluation    :after-event
@@ -69,7 +69,7 @@
   frame's `{flow-id derivation-node}` map. The projection is read-only and
   preserves frame ownership for ids registered in more than one frame."
   ([]
-   (let [snapshot (registry/flows-snapshot)]
+   (let [snapshot (rf.flows.registry/flows-snapshot)]
      (reduce-kv
        (fn [acc frame-id flow-map]
          (assoc acc frame-id
@@ -81,7 +81,7 @@
        {}
        snapshot)))
   ([frame-id]
-   (let [flow-map (get (registry/flows-snapshot) frame-id)]
+   (let [flow-map (get (rf.flows.registry/flows-snapshot) frame-id)]
      (reduce-kv
        (fn [m flow-id flow]
          (assoc m flow-id (node-for frame-id flow)))

--- a/implementation/flows/src/re_frame/flows/topo.cljc
+++ b/implementation/flows/src/re_frame/flows/topo.cljc
@@ -6,8 +6,8 @@
   closing-repeat path for tools. Registration separately rejects overlapping
   output paths because output/output overlap creates no dependency edge and
   would otherwise leave write order undefined."
-  (:require [re-frame.error :as error]
-            [re-frame.path :as path]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.path :as rf.path]))
 
 (defn depends-on?
   "True when B reads a path overlapping A's output path."
@@ -15,14 +15,14 @@
   (let [a-path (:output-path a-flow)]
     (boolean
       (some (fn [b-input]
-              (or (path/prefix? a-path b-input)
-                  (path/prefix? b-input a-path)))
+              (or (rf.path/prefix? a-path b-input)
+                  (rf.path/prefix? b-input a-path)))
             (:inputs b-flow)))))
 
 (defn output-paths-overlap?
   "True when two output paths are equal or one is a prefix of the other."
   [a-path b-path]
-  (path/overlap? a-path b-path))
+  (rf.path/overlap? a-path b-path))
 
 (defn- first-overlapping-pair
   "Return a stable description of the first overlapping output pair, or nil.
@@ -57,7 +57,7 @@
   last-write order depend on map iteration. Returns `flow-map` when valid."
   [flow-map]
   (when-let [overlap (first-overlapping-pair flow-map)]
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/flow-path-overlap 'rf/reg-flow
       "Two flows in the same frame have overlapping output :output-paths (one is a prefix of the other, identical included). Their relative evaluation order is undefined — the topo-sort dependency rule compares :output-path against :inputs, never :output-path against :output-path, so no edge orders them and the shared slot would be written last-write-wins in map-iteration order (per Spec 013 §Disjoint output paths). Give each flow a disjoint :output-path."
       {:recovery :fix-registration
@@ -83,7 +83,7 @@
         (cond
           (nil? next-dependency-id)
           ;; Every unpeeled node must have an unpeeled dependency.
-          (error/throw-error!
+          (rf.error/throw-error!
             :rf.error/flow-cycle-extract-invariant 'rf/reg-flow
             "Cycle-path extraction reached a dead end: a stuck node found no stuck dependency to follow. Internal topo invariant violated — report with the :node / :stack / :seen / :remaining payload."
             {:extra {:node      node-id
@@ -159,7 +159,7 @@
             (if (seq remaining)
               ;; Registration validates the prospective map before mutation,
               ;; so callers can correct the graph and retry.
-              (error/throw-error!
+              (rf.error/throw-error!
                 :rf.error/flow-cycle 'rf/reg-flow
                 "Cyclic flow dependency — either two-or-more flows' :output-path / :inputs overlap mutually, or one flow's :inputs overlap its own :output-path (a self-cycle) (per Spec 013 §Dependency rule). The closing-repeat :cycle vector names the offending chain; a self-cycle repeats one id, e.g. [id id]."
                 {:recovery :fix-registration

--- a/implementation/flows/test/re_frame/flow_algebra_view_test.clj
+++ b/implementation/flows/test/re_frame/flow_algebra_view_test.clj
@@ -24,10 +24,10 @@
   `re-frame.core/flow-algebra-view` public facade export."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.flows.tooling :as flows-tooling]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.tooling :as rf.flows.tooling]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.trace]))
 
 ;; The standard runtime reset (registrar baseline + frames + flows/schemas +
@@ -37,7 +37,7 @@
 ;; (EP-0002 — reg-flow is context-required frame-local).
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; The five fixed classifications EVERY flow algebra node carries
 ;; (Derivations §Worked equivalence — the flow column: the canonical
@@ -56,17 +56,17 @@
 
 (deftest empty-registry-returns-empty-map
   (testing "(flow-algebra-view) returns {} (not nil) when no flows are registered"
-    (flows/reset-flows!)
-    (is (= {} (flows-tooling/flow-algebra-view)))
-    (is (map? (flows-tooling/flow-algebra-view))))
+    (rf.flows/reset-flows!)
+    (is (= {} (rf.flows.tooling/flow-algebra-view)))
+    (is (map? (rf.flows.tooling/flow-algebra-view))))
   (testing "(flow-algebra-view frame-id) returns {} for a frame with no flows"
-    (is (= {} (flows-tooling/flow-algebra-view :rf/default)))))
+    (is (= {} (rf.flows.tooling/flow-algebra-view :rf/default)))))
 
 (deftest jvm-alias-mirrors-the-tooling-fn
   (testing "the JVM `re-frame.flows/flow-algebra-view` alias is the tooling fn"
     (rf/reg-flow :area {:inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* (or w 0) (or h 0))))
-    (is (= (flows-tooling/flow-algebra-view)
-           (flows/flow-algebra-view))
+    (is (= (rf.flows.tooling/flow-algebra-view)
+           (rf.flows/flow-algebra-view))
         "the JVM convenience alias projects identically to the tooling sibling")))
 
 ;; ---- a registered flow exposes its algebra view --------------------------
@@ -74,7 +74,7 @@
 (deftest flow-exposes-its-full-algebra-view
   (testing "a reg-flow exposes the full materialized / after-event / frame node"
     (rf/reg-flow :cart/materialized-total {:inputs [[:cart :items] [:pricing :discounts]] :output-path [:cart :total]} (fn [items discounts] [items discounts]))
-    (let [node (get-in (flows-tooling/flow-algebra-view)
+    (let [node (get-in (rf.flows.tooling/flow-algebra-view)
                        [:rf/default :cart/materialized-total])]
       (is (some? node) "the flow is present under its owning frame's slot")
       (is (has-fixed-classifications? node)
@@ -93,9 +93,9 @@
 (deftest single-frame-arity-returns-that-frames-flows
   (testing "(flow-algebra-view frame-id) returns {flow-id node} for one frame"
     (rf/reg-flow :area {:inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* (or w 0) (or h 0))))
-    (let [per-frame (flows-tooling/flow-algebra-view :rf/default)]
+    (let [per-frame (rf.flows.tooling/flow-algebra-view :rf/default)]
       (is (= #{:area} (set (keys per-frame))))
-      (is (= (get-in (flows-tooling/flow-algebra-view) [:rf/default :area])
+      (is (= (get-in (rf.flows.tooling/flow-algebra-view) [:rf/default :area])
              (get per-frame :area))
           "the one-frame form equals that frame's entry in the all-flows map"))))
 
@@ -107,7 +107,7 @@
     ;; partition-qualified input; only the write side is reserved.
     (rf/reg-flow :route/derived {:inputs [[:rf.db/runtime :rf.runtime/routing :current :route-id]
                            [:local :seed]] :output-path [:derived :slug]} (fn [route-id seed] [route-id seed]))
-    (let [node (get-in (flows-tooling/flow-algebra-view)
+    (let [node (get-in (rf.flows.tooling/flow-algebra-view)
                        [:rf/default :route/derived])]
       (is (has-fixed-classifications? node))
       (is (= [[:runtime [:rf.runtime/routing :current :route-id]]
@@ -121,7 +121,7 @@
   (testing "every registered flow on a frame projects to its own node"
     (rf/reg-flow :a {:inputs [[:w]] :output-path [:out :a]} (fn [w] w))
     (rf/reg-flow :b {:inputs [[:h]] :output-path [:out :b]} (fn [h] h))
-    (let [per-frame (flows-tooling/flow-algebra-view :rf/default)]
+    (let [per-frame (rf.flows.tooling/flow-algebra-view :rf/default)]
       (is (= #{:a :b} (set (keys per-frame))))
       (is (every? has-fixed-classifications? (vals per-frame)))
       (is (= [:db [:out :a]] (:output (:a per-frame))))
@@ -134,7 +134,7 @@
     (rf/make-frame {:id :other :doc "second frame for the frame-scoped view test"})
     (rf/reg-flow :shared {:frame :rf/default :inputs [[:a]] :output-path [:out :default]} (fn [a] a))
     (rf/reg-flow :shared {:frame :other :inputs [[:b]] :output-path [:out :other]} (fn [b] b))
-    (let [view (flows-tooling/flow-algebra-view)]
+    (let [view (rf.flows.tooling/flow-algebra-view)]
       (is (= [:db [:out :default]] (get-in view [:rf/default :shared :output])))
       (is (= [:db [:out :other]]   (get-in view [:other :shared :output])))
       (is (= [:frame :rf/default]  (get-in view [:rf/default :shared :owner])))
@@ -146,7 +146,7 @@
 (deftest source-coords-surface-in-the-node
   (testing ":ns / :line / :file captured by reg-flow surface under :source"
     (rf/reg-flow :area {:inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* (or w 0) (or h 0))))
-    (let [node   (get-in (flows-tooling/flow-algebra-view) [:rf/default :area])
+    (let [node   (get-in (rf.flows.tooling/flow-algebra-view) [:rf/default :area])
           source (:source node)]
       (is (some? source) ":source map is present when the registration carried coords")
       (is (some? (:ns source))     ":ns captured at the call site")
@@ -156,7 +156,7 @@
 (deftest schema-and-doc-pass-through
   (testing ":schema and :doc supplied on the flow map surface in the node"
     (rf/reg-flow :priced {:doc "a priced total" :schema :app.money/amount :inputs [[:price]] :output-path [:cart :total]} (fn [p] p))
-    (let [node (get-in (flows-tooling/flow-algebra-view) [:rf/default :priced])]
+    (let [node (get-in (rf.flows.tooling/flow-algebra-view) [:rf/default :priced])]
       (is (= :app.money/amount (:schema node))
           "the declared output :schema surfaces as a node fact")
       (is (= "a priced total" (:doc node))))))
@@ -164,7 +164,7 @@
 (deftest no-schema-or-doc-when-absent
   (testing ":schema / :doc are absent when the registration didn't supply them"
     (rf/reg-flow :area {:inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* (or w 0) (or h 0))))
-    (let [node (get-in (flows-tooling/flow-algebra-view) [:rf/default :area])]
+    (let [node (get-in (rf.flows.tooling/flow-algebra-view) [:rf/default :area])]
       (is (not (contains? node :schema)))
       (is (not (contains? node :doc))))))
 
@@ -174,8 +174,8 @@
   (testing "(clear-flow id) removes the flow from the algebra view"
     (rf/reg-flow :a {:inputs [[:w]] :output-path [:out :a]} (fn [w] w))
     (rf/reg-flow :b {:inputs [[:h]] :output-path [:out :b]} (fn [h] h))
-    (is (contains? (flows-tooling/flow-algebra-view :rf/default) :a))
-    (flows/clear-flow :a)
-    (let [per-frame (flows-tooling/flow-algebra-view :rf/default)]
+    (is (contains? (rf.flows.tooling/flow-algebra-view :rf/default) :a))
+    (rf.flows/clear-flow :a)
+    (let [per-frame (rf.flows.tooling/flow-algebra-view :rf/default)]
       (is (not (contains? per-frame :a)))
       (is (contains? per-frame :b)))))

--- a/implementation/flows/test/re_frame/flows_clear_reg_watch_incarnation_test.clj
+++ b/implementation/flows/test/re_frame/flows_clear_reg_watch_incarnation_test.clj
@@ -24,16 +24,16 @@
   fire exactly once, during the lifecycle op under test."
   (:require [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.flows :as flows]
-            [re-frame.flows.registry :as registry]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.elision :as rf.elision]
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.registry :as rf.flows.registry]
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- install-watching-adapter!
   "Install a plain-atom-backed adapter whose `replace-container!` runs `on-write`
@@ -41,11 +41,11 @@
   `armed?` holds true. The physical write always lands FIRST so A's write that
   linearized before the loss stands."
   [armed? on-write]
-  (let [base-replace (:replace-container! plain-atom/adapter)]
-    (adapter/dispose-adapter!)
-    (reset! frame/frames {})
-    (adapter/install-adapter!
-      (assoc plain-atom/adapter
+  (let [base-replace (:replace-container! rf.substrate.plain-atom/adapter)]
+    (rf.substrate.adapter/dispose-adapter!)
+    (reset! rf.frame/frames {})
+    (rf.substrate.adapter/install-adapter!
+      (assoc rf.substrate.plain-atom/adapter
              :kind :custom
              :replace-container!
              (fn [container value]
@@ -54,9 +54,9 @@
                  (on-write)))))))
 
 (defn- restore-plain-adapter! []
-  (reset! frame/frames {})
-  (adapter/dispose-adapter!)
-  (adapter/install-adapter! plain-atom/adapter))
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/dispose-adapter!)
+  (rf.substrate.adapter/install-adapter! rf.substrate.plain-atom/adapter))
 
 ;; ---------------------------------------------------------------------------
 ;; clear-flow — the output-mark write's watch loses A; the stale tail must not
@@ -82,18 +82,18 @@
       (fn []
         ;; The mark-write watch: destroy A, publish same-id B with its own flow
         ;; state, and snapshot B's stores for the byte-identical assertions.
-        (frame/destroy-frame! id)
+        (rf.frame/destroy-frame! id)
         (rf/make-frame {:id id})
         (rf/reg-flow :flow.incarnation/f
           {:frame id :inputs [[:bn]] :output-path [:bout] :sensitive [[:bout]]}
           (fn [n] (or n 0)))
-        (registry/set-frame-flow-last-inputs! id :flow.incarnation/f [::b-input])
-        (reset! b-token (frame/frame-incarnation-token id))
-        (reset! b-flow-row (get-in (registry/flows-snapshot)
+        (rf.flows.registry/set-frame-flow-last-inputs! id :flow.incarnation/f [::b-input])
+        (reset! b-token (rf.frame/frame-incarnation-token id))
+        (reset! b-flow-row (get-in (rf.flows.registry/flows-snapshot)
                                    [id :flow.incarnation/f]))
-        (reset! b-dirty (registry/get-frame-flow-last-inputs id :flow.incarnation/f))
-        (reset! b-commit (frame/frame-commit-epoch id))
-        (reset! b-sensitive (elision/sensitive-declarations id))))
+        (reset! b-dirty (rf.flows.registry/get-frame-flow-last-inputs id :flow.incarnation/f))
+        (reset! b-commit (rf.frame/frame-commit-epoch id))
+        (reset! b-sensitive (rf.elision/sensitive-declarations id))))
     (try
       (rf/make-frame {:id id})
       ;; A's flow declares an output classification so clearing it produces a
@@ -102,20 +102,20 @@
         {:frame id :inputs [[:n]] :output-path [:out] :sensitive [[:out]]}
         (fn [n] (or n 0)))
       (reset! armed? true)
-      (is (nil? (flows/clear-flow :flow.incarnation/f {:frame id}))
+      (is (nil? (rf.flows/clear-flow :flow.incarnation/f {:frame id}))
           "clear-flow returns nil; its stale tail is aborted after the watch")
       (let [token-b @b-token]
         (is (some? token-b) "the mark-write watch published a same-id B")
-        (is (identical? token-b (frame/frame-incarnation-token id))
+        (is (identical? token-b (rf.frame/frame-incarnation-token id))
             "B remains the live incarnation")
-        (is (= @b-flow-row (get-in (registry/flows-snapshot) [id :flow.incarnation/f]))
+        (is (= @b-flow-row (get-in (rf.flows.registry/flows-snapshot) [id :flow.incarnation/f]))
             "A's stale clear-flow tail never dissociates B's flow row")
         (is (= @b-dirty
-               (registry/get-frame-flow-last-inputs id :flow.incarnation/f))
+               (rf.flows.registry/get-frame-flow-last-inputs id :flow.incarnation/f))
             "A's stale clear-flow tail never drops B's dirty-check cache")
-        (is (= @b-commit (frame/frame-commit-epoch id))
+        (is (= @b-commit (rf.frame/frame-commit-epoch id))
             "A's stale mark write never bumps B's commit epoch")
-        (is (= @b-sensitive (elision/sensitive-declarations id))
+        (is (= @b-sensitive (rf.elision/sensitive-declarations id))
             "A's stale clear-flow tail never rewrites B's output-mark declaration"))
       (finally
         (restore-plain-adapter!)))))
@@ -142,17 +142,17 @@
     (install-watching-adapter!
       armed?
       (fn []
-        (frame/destroy-frame! id)
+        (rf.frame/destroy-frame! id)
         (rf/make-frame {:id id})
         (rf/reg-flow :flow.incarnation/g
           {:frame id :inputs [[:bn]] :output-path [:bout] :sensitive [[:bout]]}
           (fn [n] (or n 0)))
-        (registry/set-frame-flow-last-inputs! id :flow.incarnation/g [::b-input])
-        (reset! b-token (frame/frame-incarnation-token id))
-        (reset! b-flow-row (get-in (registry/flows-snapshot)
+        (rf.flows.registry/set-frame-flow-last-inputs! id :flow.incarnation/g [::b-input])
+        (reset! b-token (rf.frame/frame-incarnation-token id))
+        (reset! b-flow-row (get-in (rf.flows.registry/flows-snapshot)
                                    [id :flow.incarnation/g]))
-        (reset! b-dirty (registry/get-frame-flow-last-inputs id :flow.incarnation/g))
-        (reset! b-commit (frame/frame-commit-epoch id))))
+        (reset! b-dirty (rf.flows.registry/get-frame-flow-last-inputs id :flow.incarnation/g))
+        (reset! b-commit (rf.frame/frame-commit-epoch id))))
     (try
       (rf/make-frame {:id id})
       (rf/reg-flow :flow.incarnation/g
@@ -161,7 +161,7 @@
       ;; Prime a dirty-check row for A so the (unfixed) stale
       ;; drop-frame-flow-last-inputs!
       ;; would have something to drop off the successor.
-      (registry/set-frame-flow-last-inputs! id :flow.incarnation/g [::a-input])
+      (rf.flows.registry/set-frame-flow-last-inputs! id :flow.incarnation/g [::a-input])
       (reset! armed? true)
       ;; Replacement registration: refreshes marks (the watch seam), then runs
       ;; the post-mark dirty-cache + dedup tail.
@@ -170,14 +170,14 @@
         (fn [n] (* 2 (or n 0))))
       (let [token-b @b-token]
         (is (some? token-b) "the mark-refresh watch published a same-id B")
-        (is (identical? token-b (frame/frame-incarnation-token id))
+        (is (identical? token-b (rf.frame/frame-incarnation-token id))
             "B remains the live incarnation")
-        (is (= @b-flow-row (get-in (registry/flows-snapshot) [id :flow.incarnation/g]))
+        (is (= @b-flow-row (get-in (rf.flows.registry/flows-snapshot) [id :flow.incarnation/g]))
             "A's stale reg-flow tail never rewrites B's flow row")
         (is (= @b-dirty
-               (registry/get-frame-flow-last-inputs id :flow.incarnation/g))
+               (rf.flows.registry/get-frame-flow-last-inputs id :flow.incarnation/g))
             "A's stale post-mark tail never drops B's dirty-check cache")
-        (is (= @b-commit (frame/frame-commit-epoch id))
+        (is (= @b-commit (rf.frame/frame-commit-epoch id))
             "A's stale mark write never bumps B's commit epoch"))
       (finally
         (restore-plain-adapter!)))))
@@ -204,19 +204,19 @@
       (rf/reg-flow :flow.incarnation/h
         {:frame id :inputs [[:n]] :output-path [:out] :sensitive [[:out]]}
         (fn [n] (or n 0)))
-      (registry/set-frame-flow-last-inputs! id :flow.incarnation/h [::a-input])
-      (let [epoch-before (frame/frame-commit-epoch id)]
+      (rf.flows.registry/set-frame-flow-last-inputs! id :flow.incarnation/h [::a-input])
+      (let [epoch-before (rf.frame/frame-commit-epoch id)]
         (reset! armed? true)
-        (is (nil? (flows/clear-flow :flow.incarnation/h {:frame id}))
+        (is (nil? (rf.flows/clear-flow :flow.incarnation/h {:frame id}))
             "clear-flow completes normally against the live owner")
         (is (= 1 @watch-runs) "the container watch fired on the mark write")
-        (is (nil? (get-in (registry/flows-snapshot) [id :flow.incarnation/h]))
+        (is (nil? (get-in (rf.flows.registry/flows-snapshot) [id :flow.incarnation/h]))
             "the flow row is removed for the live owner")
-        (is (nil? (registry/get-frame-flow-last-inputs id :flow.incarnation/h))
+        (is (nil? (rf.flows.registry/get-frame-flow-last-inputs id :flow.incarnation/h))
             "the dirty-check cache row is dropped for the live owner")
-        (is (empty? (elision/sensitive-declarations id))
+        (is (empty? (rf.elision/sensitive-declarations id))
             "the flow's output-mark declaration is cleared for the live owner")
-        (is (> (frame/frame-commit-epoch id) epoch-before)
+        (is (> (rf.frame/frame-commit-epoch id) epoch-before)
             "the mark write advanced the live owner's commit epoch"))
       (finally
         (restore-plain-adapter!)))))
@@ -249,7 +249,7 @@
   value — only the projection reactions are disposed — so the vacation A wrote
   before losing ownership is observable HERE, isolated from B's fresh container."
   [container]
-  (get (adapter/read-container container) frame/app-partition-key))
+  (get (rf.substrate.adapter/read-container container) rf.frame/app-partition-key))
 
 ;; ---------------------------------------------------------------------------
 ;; clear-flow — the app-db path-VACATION write's watch loses A; the stale tail
@@ -280,20 +280,20 @@
       (fn []
         ;; The vacation-write watch: destroy A, publish same-id B with its own
         ;; materialized output leaf + flow state, and snapshot B's stores.
-        (frame/destroy-frame! id)
+        (rf.frame/destroy-frame! id)
         (rf/make-frame {:id id})
-        (frame/swap-frame-db! id assoc :bout ::b-sentinel)
+        (rf.frame/swap-frame-db! id assoc :bout ::b-sentinel)
         (rf/reg-flow :flow.incarnation/f
           {:frame id :inputs [[:bn]] :output-path [:bout] :sensitive [[:bout]]}
           (fn [n] (or n 0)))
-        (registry/set-frame-flow-last-inputs! id :flow.incarnation/f [::b-input])
-        (reset! b-token (frame/frame-incarnation-token id))
-        (reset! b-flow-row (get-in (registry/flows-snapshot)
+        (rf.flows.registry/set-frame-flow-last-inputs! id :flow.incarnation/f [::b-input])
+        (reset! b-token (rf.frame/frame-incarnation-token id))
+        (reset! b-flow-row (get-in (rf.flows.registry/flows-snapshot)
                                    [id :flow.incarnation/f]))
-        (reset! b-dirty (registry/get-frame-flow-last-inputs id :flow.incarnation/f))
-        (reset! b-commit (frame/frame-commit-epoch id))
-        (reset! b-app-db (frame/frame-app-db-value id))
-        (reset! b-sensitive (elision/sensitive-declarations id))))
+        (reset! b-dirty (rf.flows.registry/get-frame-flow-last-inputs id :flow.incarnation/f))
+        (reset! b-commit (rf.frame/frame-commit-epoch id))
+        (reset! b-app-db (rf.frame/frame-app-db-value id))
+        (reset! b-sensitive (rf.elision/sensitive-declarations id))))
     (try
       (rf/make-frame {:id id})
       (rf/reg-flow :flow.incarnation/f
@@ -302,30 +302,30 @@
       ;; Materialize A's output leaf so clearing it is a REAL app-db path
       ;; vacation (not the no-op the unmaterialized loss fixtures hit) — the
       ;; watch then fires on `swap-frame-db-exact!`, before the mark write.
-      (frame/swap-frame-db! id assoc :out ::a-output)
+      (rf.frame/swap-frame-db! id assoc :out ::a-output)
       ;; Capture A's physical container to prove the vacation linearized HERE.
-      (reset! a-container (:frame-state (frame/frame id)))
+      (reset! a-container (:frame-state (rf.frame/frame id)))
       (reset! armed? true)
-      (is (nil? (flows/clear-flow :flow.incarnation/f {:frame id}))
+      (is (nil? (rf.flows/clear-flow :flow.incarnation/f {:frame id}))
           "clear-flow returns nil; its stale tail is aborted after the vacation watch")
       (let [token-b @b-token]
         (is (some? token-b) "the app-db-vacation watch published a same-id B")
-        (is (identical? token-b (frame/frame-incarnation-token id))
+        (is (identical? token-b (rf.frame/frame-incarnation-token id))
             "B remains the live incarnation")
         (is (not (contains? (a-detached-app-db @a-container) :out))
             "A's vacation physically linearized into A's own detached container")
-        (is (= @b-app-db (frame/frame-app-db-value id))
+        (is (= @b-app-db (rf.frame/frame-app-db-value id))
             "A's exact-incarnation vacation never touches B's app-db")
-        (is (= ::b-sentinel (get (frame/frame-app-db-value id) :bout))
+        (is (= ::b-sentinel (get (rf.frame/frame-app-db-value id) :bout))
             "B's own materialized output leaf stands untouched")
-        (is (= @b-flow-row (get-in (registry/flows-snapshot) [id :flow.incarnation/f]))
+        (is (= @b-flow-row (get-in (rf.flows.registry/flows-snapshot) [id :flow.incarnation/f]))
             "A's stale clear-flow tail never dissociates B's flow row")
         (is (= @b-dirty
-               (registry/get-frame-flow-last-inputs id :flow.incarnation/f))
+               (rf.flows.registry/get-frame-flow-last-inputs id :flow.incarnation/f))
             "A's stale clear-flow tail never drops B's dirty-check cache")
-        (is (= @b-commit (frame/frame-commit-epoch id))
+        (is (= @b-commit (rf.frame/frame-commit-epoch id))
             "A's fenced exact vacation never bumps B's commit epoch")
-        (is (= @b-sensitive (elision/sensitive-declarations id))
+        (is (= @b-sensitive (rf.elision/sensitive-declarations id))
             "A's stale clear-flow tail never rewrites B's output-mark declaration"))
       (finally
         (restore-plain-adapter!)))))
@@ -355,28 +355,28 @@
     (install-watching-adapter!
       armed?
       (fn []
-        (frame/destroy-frame! id)
+        (rf.frame/destroy-frame! id)
         (rf/make-frame {:id id})
-        (frame/swap-frame-db! id assoc :bout ::b-sentinel)
+        (rf.frame/swap-frame-db! id assoc :bout ::b-sentinel)
         (rf/reg-flow :flow.incarnation/g
           {:frame id :inputs [[:bn]] :output-path [:bout] :sensitive [[:bout]]}
           (fn [n] (or n 0)))
-        (registry/set-frame-flow-last-inputs! id :flow.incarnation/g [::b-input])
-        (reset! b-token (frame/frame-incarnation-token id))
-        (reset! b-flow-row (get-in (registry/flows-snapshot)
+        (rf.flows.registry/set-frame-flow-last-inputs! id :flow.incarnation/g [::b-input])
+        (reset! b-token (rf.frame/frame-incarnation-token id))
+        (reset! b-flow-row (get-in (rf.flows.registry/flows-snapshot)
                                    [id :flow.incarnation/g]))
-        (reset! b-dirty (registry/get-frame-flow-last-inputs id :flow.incarnation/g))
-        (reset! b-commit (frame/frame-commit-epoch id))
-        (reset! b-app-db (frame/frame-app-db-value id))))
+        (reset! b-dirty (rf.flows.registry/get-frame-flow-last-inputs id :flow.incarnation/g))
+        (reset! b-commit (rf.frame/frame-commit-epoch id))
+        (reset! b-app-db (rf.frame/frame-app-db-value id))))
     (try
       (rf/make-frame {:id id})
       (rf/reg-flow :flow.incarnation/g
         {:frame id :inputs [[:n]] :output-path [:out] :sensitive [[:out]]}
         (fn [n] (or n 0)))
       ;; Materialize A's OLD output leaf so the path move actually vacates it.
-      (frame/swap-frame-db! id assoc :out ::a-output)
-      (registry/set-frame-flow-last-inputs! id :flow.incarnation/g [::a-input])
-      (reset! a-container (:frame-state (frame/frame id)))
+      (rf.frame/swap-frame-db! id assoc :out ::a-output)
+      (rf.flows.registry/set-frame-flow-last-inputs! id :flow.incarnation/g [::a-input])
+      (reset! a-container (:frame-state (rf.frame/frame id)))
       (reset! armed? true)
       ;; Replacement with a MOVED output-path: the old-path vacation is the watch
       ;; seam, then the post-vacation dirty-cache drop + dedup trace tail.
@@ -385,20 +385,20 @@
         (fn [n] (* 2 (or n 0))))
       (let [token-b @b-token]
         (is (some? token-b) "the path-move vacation watch published a same-id B")
-        (is (identical? token-b (frame/frame-incarnation-token id))
+        (is (identical? token-b (rf.frame/frame-incarnation-token id))
             "B remains the live incarnation")
         (is (not (contains? (a-detached-app-db @a-container) :out))
             "A's old-path vacation physically linearized into A's own detached container")
-        (is (= @b-app-db (frame/frame-app-db-value id))
+        (is (= @b-app-db (rf.frame/frame-app-db-value id))
             "A's exact-incarnation vacation never touches B's app-db")
-        (is (= ::b-sentinel (get (frame/frame-app-db-value id) :bout))
+        (is (= ::b-sentinel (get (rf.frame/frame-app-db-value id) :bout))
             "B's own materialized output leaf stands untouched")
-        (is (= @b-flow-row (get-in (registry/flows-snapshot) [id :flow.incarnation/g]))
+        (is (= @b-flow-row (get-in (rf.flows.registry/flows-snapshot) [id :flow.incarnation/g]))
             "A's stale reg-flow tail never rewrites B's flow row")
         (is (= @b-dirty
-               (registry/get-frame-flow-last-inputs id :flow.incarnation/g))
+               (rf.flows.registry/get-frame-flow-last-inputs id :flow.incarnation/g))
             "A's stale post-vacation tail never drops B's dirty-check cache")
-        (is (= @b-commit (frame/frame-commit-epoch id))
+        (is (= @b-commit (rf.frame/frame-commit-epoch id))
             "A's fenced exact vacation never bumps B's commit epoch"))
       (finally
         (restore-plain-adapter!)))))
@@ -424,17 +424,17 @@
       (rf/reg-flow :flow.incarnation/k
         {:frame id :inputs [[:n]] :output-path [:out] :sensitive [[:out]]}
         (fn [n] (or n 0)))
-      (frame/swap-frame-db! id assoc :out ::a-output)
-      (let [epoch-before (frame/frame-commit-epoch id)]
+      (rf.frame/swap-frame-db! id assoc :out ::a-output)
+      (let [epoch-before (rf.frame/frame-commit-epoch id)]
         (reset! armed? true)
-        (is (nil? (flows/clear-flow :flow.incarnation/k {:frame id}))
+        (is (nil? (rf.flows/clear-flow :flow.incarnation/k {:frame id}))
             "clear-flow completes normally against the live owner")
         (is (= 1 @watch-runs) "the container watch fired on the app-db vacation write")
-        (is (not (contains? (frame/frame-app-db-value id) :out))
+        (is (not (contains? (rf.frame/frame-app-db-value id) :out))
             "the materialized output leaf is vacated from the live owner's app-db")
-        (is (> (frame/frame-commit-epoch id) epoch-before)
+        (is (> (rf.frame/frame-commit-epoch id) epoch-before)
             "the exact-incarnation vacation advanced the live owner's commit epoch")
-        (is (nil? (get-in (registry/flows-snapshot) [id :flow.incarnation/k]))
+        (is (nil? (get-in (rf.flows.registry/flows-snapshot) [id :flow.incarnation/k]))
             "the flow row is removed for the live owner"))
       (finally
         (restore-plain-adapter!)))))

--- a/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
+++ b/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
@@ -89,10 +89,10 @@
   JVM-only by design."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.flows :as rf.flows]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicLong]))
 
@@ -105,7 +105,7 @@
 ;; `:rf/default` as the ambient scope (EP-0002) for the bodies below.
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; Per-thread iteration count. The standard 5000 keeps CI under ~60s
 ;; wall-clock with the default thread count. Operators dial up via the
@@ -232,10 +232,10 @@
                           ;; the leak invariant can pass. (`:cyc-b`
                           ;; never registered because the cycle
                           ;; throw rolled it back.)
-                          (flows/clear-flow cyc-a {:frame frame-id})
+                          (rf.flows/clear-flow cyc-a {:frame frame-id})
                           ;; Clear the main flow so the leak
                           ;; invariant can pass.
-                          (flows/clear-flow flow-id {:frame frame-id})
+                          (rf.flows/clear-flow flow-id {:frame frame-id})
                           ;; Surface the thread idx for diagnostics
                           ;; if a future hangs.
                           idx)))]
@@ -303,8 +303,8 @@
         ;; Each per-thread frame had ALL its flows cleared, so clearing the
         ;; last one prunes the frame-id key entirely — the slot is strictly
         ;; `nil`, never a `{frame-id {}}` empty husk.
-        (let [flows-snapshot       (flows/flows-snapshot)
-              last-inputs-snapshot (flows/last-inputs-snapshot)]
+        (let [flows-snapshot       (rf.flows/flows-snapshot)
+              last-inputs-snapshot (rf.flows/last-inputs-snapshot)]
           (doseq [{:keys [frame-id flow-id cyc-a cyc-b]} per-thread]
             (let [per-frame-slot (get flows-snapshot frame-id)]
               (is (nil? per-frame-slot)
@@ -331,9 +331,9 @@
             ;; RESERVED-but-empty — never written — so it is `nil` throughout,
             ;; not "vacated on last release". The per-frame store check above is
             ;; the real cleanup assertion.
-            (is (nil? (registrar/lookup :flow flow-id))
+            (is (nil? (rf.registrar/lookup :flow flow-id))
                 (str ":flow registrar slot for " flow-id
                      " is RESERVED-but-empty (rf2-en00bk)"))
-            (is (nil? (registrar/lookup :flow cyc-a))
+            (is (nil? (rf.registrar/lookup :flow cyc-a))
                 (str ":flow registrar slot for cycle-probe " cyc-a
                      " is RESERVED-but-empty (rf2-en00bk)"))))))))

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -103,17 +103,17 @@
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [re-frame.conformance :as conformance]
+            [re-frame.conformance :as rf.conformance]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.flows :as flows]
-            [re-frame.flows.topo :as topo]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.subs :as subs]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.topo :as rf.flows.topo]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.subs :as rf.subs]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- runtime reset --------------------------------------------------------
 ;;
@@ -141,12 +141,12 @@
 ;; `run-flows-conformance-corpus` to reset between the fixtures it iterates
 ;; inside a single deftest.
 (def ^:private reset-runtime-fixture
-  (let [standard (test-support/make-reset-runtime-fixture
-                   {:adapter       plain-atom/adapter
+  (let [standard (rf.test-support/make-reset-runtime-fixture
+                   {:adapter       rf.substrate.plain-atom/adapter
                     :ambient-frame nil})]
     (fn [test-fn]
       (standard (fn []
-                  (error-emit/clear-error-listeners!)
+                  (rf.error-emit/clear-error-listeners!)
                   (test-fn))))))
 
 (use-fixtures :each reset-runtime-fixture)
@@ -291,11 +291,11 @@
   to the frame's app-db via the substrate adapter and to the dispatch
   surface. Mirrors core's runner shape."
   []
-  {:read-db!  (fn [frame-id] (frame/frame-app-db-value frame-id))
+  {:read-db!  (fn [frame-id] (rf.frame/frame-app-db-value frame-id))
    ;; EP-0001: write the app-db PARTITION via swap-frame-db! — app-db-container
    ;; is a read-only projection over the one physical frame-state container.
    :write-db! (fn [frame-id new-db]
-                (frame/swap-frame-db! frame-id (constantly new-db)))
+                (rf.frame/swap-frame-db! frame-id (constantly new-db)))
    :dispatch! (fn [event frame-id] (rf/dispatch event {:frame frame-id}))})
 
 (defn- realise-event-sub-fx-handlers
@@ -317,7 +317,7 @@
         helpers       (adapter-helpers)]
     ;; ---- events --------------------------------------------------------
     (doseq [[id steps] (:event hmap)]
-      (let [[kind handler] (conformance/realise-event-handler steps)
+      (let [[kind handler] (rf.conformance/realise-event-handler steps)
             meta           (get event-meta id {})]
         (case kind
           ;; EP-0018 Slice Z: one public `reg-event` (cofx-in, effects-map-out).
@@ -333,14 +333,14 @@
                 (rf/reg-event id handler)))))
     ;; ---- subs ----------------------------------------------------------
     (doseq [[id steps] (:sub hmap)]
-      (let [{:keys [kind inputs body]} (conformance/realise-sub steps)
+      (let [{:keys [kind inputs body]} (rf.conformance/realise-sub steps)
             meta                       (get sub-meta id {})]
         (case kind
           :layer-1 (if (seq meta) (rf/reg-sub id meta body) (rf/reg-sub id body))
           ;; Use the fn-form `subs/reg-sub` — the public `rf/reg-sub`
           ;; is a JVM macro (Spec 001 §Source-coordinate capture); a
           ;; macro var isn't `apply`-able.
-          :layer-2 (apply subs/reg-sub id
+          :layer-2 (apply rf.subs/reg-sub id
                           (concat (when (seq meta) [meta])
                                   (interleave (repeat :<-) inputs)
                                   [body])))))
@@ -356,7 +356,7 @@
       (doseq [id custom-ids]
         (let [body    (get fx-bodies id [[:noop]])
               meta    (get fx-registry id {})
-              handler (conformance/realise-fx-handler id body helpers)]
+              handler (rf.conformance/realise-fx-handler id body helpers)]
           (rf/reg-fx id (assoc meta :handler-fn handler) handler))))))
 
 (defn- realise-flows!
@@ -373,7 +373,7 @@
         flow-bodies   (or (:fixture/flow-bodies fixture) {})]
     (doseq [[flow-id flow-meta] flow-registry]
       (when-let [body (get flow-bodies flow-id)]
-        (let [output-fn (conformance/realise-flow-output-fn body)]
+        (let [output-fn (rf.conformance/realise-flow-output-fn body)]
           ;; rf2-bqstzr — the 3-slot grammar: `(reg-flow flow-id metadata
           ;; derive-fn)`. The fixture `flow-meta` carries the reflection keys
           ;; (`:inputs` / `:output-path` / …) as the metadata middle slot; the
@@ -387,7 +387,7 @@
   accumulates every captured trace event."
   [fixture-id]
   (let [traces (atom [])]
-    (trace/register-listener! [fixture-id]
+    (rf.trace/register-listener! [fixture-id]
                               (fn [ev] (swap! traces conj ev)))
     traces))
 
@@ -408,7 +408,7 @@
   returns the captured-records atom."
   [fixture-id]
   (let [records (atom [])]
-    (error-emit/register-error-listener!
+    (rf.error-emit/register-error-listener!
       [::flows-conformance fixture-id]
       (fn [r] (swap! records conj r)))
     records))
@@ -510,7 +510,7 @@
   flows. Fixtures that register on a non-default frame would extend
   this; today's flow-*.edn fixtures all target `:rf/default`."
   []
-  (let [registry (get (flows/flows-snapshot) :rf/default {})]
+  (let [registry (get (rf.flows/flows-snapshot) :rf/default {})]
     (into {}
           (for [[id flow] registry]
             [id (into #{}
@@ -519,7 +519,7 @@
                             ;; `topo/depends-on?` takes `(b-flow a-flow)`
                             ;; — "b depends on a". We want "this-flow
                             ;; depends on other-flow", so b=flow, a=other.
-                            :when (topo/depends-on? flow other-flow)]
+                            :when (rf.flows.topo/depends-on? flow other-flow)]
                         other-id))]))))
 
 (defn- flow-registry-ids
@@ -529,7 +529,7 @@
   fixtures (per Spec 013 §Frame-scoping)."
   ([] (flow-registry-ids :rf/default))
   ([frame-id]
-   (into #{} (keys (get (flows/flows-snapshot) frame-id {})))))
+   (into #{} (keys (get (rf.flows/flows-snapshot) frame-id {})))))
 
 (defn- last-inputs-frame-set
   "Per-flow set of frame-ids currently present in `last-inputs[flow-id]`.
@@ -537,7 +537,7 @@
   destroyed frame's row in every `last-inputs[flow-id]` MUST be dropped;
   the whole flow-id key drops when no other frame still holds an entry."
   [flow-id]
-  (into #{} (keys (get (flows/last-inputs-snapshot) flow-id {}))))
+  (into #{} (keys (get (rf.flows/last-inputs-snapshot) flow-id {}))))
 
 (defn- registrar-flow-slot-ids
   "The id set of the REAL `:flow` registrar slot, read from the authoritative
@@ -560,7 +560,7 @@
   `re-frame.flows-destroy-frame-teardown-test` reads the registrar the same way
   (`registrar/lookup :flow …`)."
   []
-  (registrar/ids :flow))
+  (rf.registrar/ids :flow))
 
 ;; ---- single-fixture execution -------------------------------------------
 
@@ -614,7 +614,7 @@
       ;; no-explicit-frame calls below. Multi-frame fixtures
       ;; pass explicit `{:frame …}` envelopes (the override), which win over
       ;; this ambient binding.
-      (binding [frame/*current-frame* :rf/default]
+      (binding [rf.frame/*current-frame* :rf/default]
        (realise-flows! fixture)
       ;; Dispatches may be:
       ;;   - a bare event vector (single-frame default)
@@ -630,7 +630,7 @@
           (map? ev)
           (cond
             (contains? ev :destroy-frame)
-            (frame/destroy-frame! (:destroy-frame ev))
+            (rf.frame/destroy-frame! (:destroy-frame ev))
 
             :else
             (let [{event :event :as opts} ev]
@@ -727,8 +727,8 @@
             expected-err     (:error-emit-records expect)
             err-failures     (when expected-err
                                (check-trace-stream @err-records expected-err))]
-        (trace/clear-listeners!)
-        (error-emit/clear-error-listeners!)
+        (rf.trace/clear-listeners!)
+        (rf.error-emit/clear-error-listeners!)
         {:fixture-id        fid
          :passed?           (and (or (nil? expected-db)  (submap? expected-db final-db))
                                  (or (nil? expected-dbs) (every? (fn [[fid db]] (submap? db (get final-dbs fid)))
@@ -940,7 +940,7 @@
     ;; and the pre-fix matcher could not observe.
     (reset-runtime-fixture
       (fn []
-        (registrar/register! :flow :rf.test/forbidden-registrar-row
+        (rf.registrar/register! :flow :rf.test/forbidden-registrar-row
                              {:doc "rf2-3neiv pollution control — teardown must not leave this behind"})
         (let [result (run-fixture destroy-fixture)]
           (is (not (:passed? result))

--- a/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
+++ b/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
@@ -18,17 +18,17 @@
   artefact publishes for `frame/destroy-frame!`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.flows :as flows]
+            [re-frame.elision :as rf.elision]
+            [re-frame.flows :as rf.flows]
             ;; Loading `re-frame.flows` registers the late-bind hook
             ;; (`:flows/teardown-on-frame-destroy!`) the tests exercise —
             ;; keep the require even when the test ns doesn't reach
             ;; `flows/...` directly through a public fn.
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---- per-test reset ------------------------------------------------------
 ;;
@@ -38,13 +38,13 @@
 ;; ambient `reg-flow` calls in the bodies below carry a frame stamp.
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---- hook publication ----------------------------------------------------
 
 (deftest flows-publishes-teardown-hook
   (testing ":flows/teardown-on-frame-destroy! is published when re-frame.flows is loaded"
-    (is (fn? (late-bind/get-fn :flows/teardown-on-frame-destroy!))
+    (is (fn? (rf.late-bind/get-fn :flows/teardown-on-frame-destroy!))
         "the hook is callable after the flows artefact ns-loads")))
 
 ;; ---- per-frame registry slot cleared on destroy --------------------------
@@ -53,10 +53,10 @@
   (testing "destroying a frame drops its slot from re-frame.flows.registry/flows"
     (rf/make-frame {:id :fc/scratch :doc "scratch frame for destroy teardown test"})
     (rf/reg-flow :area {:frame :fc/scratch :inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* (or w 0) (or h 0))))
-    (is (contains? (flows/flows-snapshot) :fc/scratch)
+    (is (contains? (rf.flows/flows-snapshot) :fc/scratch)
         "precondition: the flow registered under the scratch frame's slot")
-    (frame/destroy-frame! :fc/scratch)
-    (is (not (contains? (flows/flows-snapshot) :fc/scratch))
+    (rf.frame/destroy-frame! :fc/scratch)
+    (is (not (contains? (rf.flows/flows-snapshot) :fc/scratch))
         "post-destroy: the destroyed frame's slot is gone")))
 
 ;; ---- last-inputs rows cleared on destroy --------------------------------
@@ -70,12 +70,12 @@
     ;; `last-inputs[:area][:fc/scratch]`.
     (rf/dispatch-sync [:fc/seed] {:frame :fc/scratch})
     (is (= [3 4]
-           (get-in (flows/last-inputs-snapshot) [:area :fc/scratch]))
+           (get-in (rf.flows/last-inputs-snapshot) [:area :fc/scratch]))
         "precondition: last-inputs recorded the scratch frame's inputs")
-    (frame/destroy-frame! :fc/scratch)
-    (is (not (contains? (get (flows/last-inputs-snapshot) :area) :fc/scratch))
+    (rf.frame/destroy-frame! :fc/scratch)
+    (is (not (contains? (get (rf.flows/last-inputs-snapshot) :area) :fc/scratch))
         "post-destroy: the destroyed frame's last-inputs entry is gone")
-    (is (not (contains? (flows/last-inputs-snapshot) :area))
+    (is (not (contains? (rf.flows/last-inputs-snapshot) :area))
         "and the whole flow-id row is dropped (no other frame still held an entry)")))
 
 ;; ---- last-inputs rows from sibling frames are preserved -----------------
@@ -90,12 +90,12 @@
     (rf/reg-flow :area {:frame :fc/b :inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* w h)))
     (rf/dispatch-sync [:fc/seed-a] {:frame :fc/a})
     (rf/dispatch-sync [:fc/seed-b] {:frame :fc/b})
-    (is (= [2 5] (get-in (flows/last-inputs-snapshot) [:area :fc/a])))
-    (is (= [7 9] (get-in (flows/last-inputs-snapshot) [:area :fc/b])))
-    (frame/destroy-frame! :fc/a)
-    (is (not (contains? (get (flows/last-inputs-snapshot) :area) :fc/a))
+    (is (= [2 5] (get-in (rf.flows/last-inputs-snapshot) [:area :fc/a])))
+    (is (= [7 9] (get-in (rf.flows/last-inputs-snapshot) [:area :fc/b])))
+    (rf.frame/destroy-frame! :fc/a)
+    (is (not (contains? (get (rf.flows/last-inputs-snapshot) :area) :fc/a))
         "destroyed-frame A's last-inputs row is gone")
-    (is (= [7 9] (get-in (flows/last-inputs-snapshot) [:area :fc/b]))
+    (is (= [7 9] (get-in (rf.flows/last-inputs-snapshot) [:area :fc/b]))
         "sibling frame B's last-inputs row is preserved")))
 
 ;; ---- per-frame entry dropped when destroyed frame was last owner --------
@@ -104,14 +104,14 @@
   (testing "destroying the only frame that owned a flow id drops its per-frame entry (rf2-en00bk: no registrar slot to prune)"
     (rf/make-frame {:id :fc/scratch :doc "scratch frame"})
     (rf/reg-flow :sole-area {:frame :fc/scratch :inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* (or w 0) (or h 0))))
-    (is (some? (flows/flow-meta-at :sole-area {:frame :fc/scratch}))
+    (is (some? (rf.flows/flow-meta-at :sole-area {:frame :fc/scratch}))
         "precondition: the per-frame store carries the flow")
-    (is (nil? (registrar/lookup :flow :sole-area))
+    (is (nil? (rf.registrar/lookup :flow :sole-area))
         "the :flow registrar slot is RESERVED-but-empty even while the flow is live")
-    (frame/destroy-frame! :fc/scratch)
-    (is (nil? (flows/flow-meta-at :sole-area {:frame :fc/scratch}))
+    (rf.frame/destroy-frame! :fc/scratch)
+    (is (nil? (rf.flows/flow-meta-at :sole-area {:frame :fc/scratch}))
         "post-destroy: the per-frame entry is gone — no leaked entry")
-    (is (nil? (registrar/lookup :flow :sole-area))
+    (is (nil? (rf.registrar/lookup :flow :sole-area))
         "registrar slot stays empty (rf2-en00bk)")))
 
 ;; ---- sibling frame keeps its OWN authoritative entry on destroy ---------
@@ -125,12 +125,12 @@
       (rf/reg-flow :shared {:frame :fc/a :inputs [[:w] [:h]] :output-path [:rect :area]} f-a)
       (rf/reg-flow :shared {:frame :fc/b :inputs [[:w] [:h]] :output-path [:rect :area]} f-b)
       ;; Destroy :fc/a. :fc/b still holds :shared with its OWN divergent body.
-      (frame/destroy-frame! :fc/a)
-      (is (nil? (flows/flow-meta-at :shared {:frame :fc/a}))
+      (rf.frame/destroy-frame! :fc/a)
+      (is (nil? (rf.flows/flow-meta-at :shared {:frame :fc/a}))
           ":fc/a's entry is gone")
-      (is (= f-b (:derive (flows/flow-meta-at :shared {:frame :fc/b})))
+      (is (= f-b (:derive (rf.flows/flow-meta-at :shared {:frame :fc/b})))
           ":fc/b's entry is intact and authoritative IN PLACE — no realignment needed (rf2-en00bk)")
-      (is (nil? (registrar/lookup :flow :shared))
+      (is (nil? (rf.registrar/lookup :flow :shared))
           "registrar :flow slot stays empty throughout (rf2-en00bk)"))))
 
 (deftest destroy-frame-non-owner-leaves-owner-entry-intact
@@ -139,8 +139,8 @@
     (rf/make-frame {:id :fc/b :doc "frame B"})
     (rf/reg-flow :shared {:frame :fc/b :inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] h))
     ;; Destroy :fc/a — it never registered :shared.
-    (frame/destroy-frame! :fc/a)
-    (is (some? (flows/flow-meta-at :shared {:frame :fc/b}))
+    (rf.frame/destroy-frame! :fc/a)
+    (is (some? (rf.flows/flow-meta-at :shared {:frame :fc/b}))
         ":fc/b's entry survives — destroying :fc/a could not touch it")))
 
 ;; ---- SSR-style per-request frame churn stays bounded --------------------
@@ -154,12 +154,12 @@
           (rf/reg-flow :churn {:frame frame-id :inputs [[:n]] :output-path [:result]} (fn [n] (or n 0)))
           (rf/reg-event :fc/seed-churn (fn [{:keys [db]} [_ v]] {:db {:n v}}))
           (rf/dispatch-sync [:fc/seed-churn i] {:frame frame-id})
-          (frame/destroy-frame! frame-id)))
-      (is (empty? (flows/flows-snapshot))
+          (rf.frame/destroy-frame! frame-id)))
+      (is (empty? (rf.flows/flows-snapshot))
           "per-frame flow registry is empty after N destroy cycles")
-      (is (empty? (flows/last-inputs-snapshot))
+      (is (empty? (rf.flows/last-inputs-snapshot))
           "last-inputs is empty after N destroy cycles")
-      (is (nil? (registrar/lookup :flow :churn))
+      (is (nil? (rf.registrar/lookup :flow :churn))
           "registrar :flow slot is RESERVED-but-empty throughout (rf2-en00bk single-store)"))))
 
 ;; ---- frame-id reuse: new make-frame starts clean -------------------------
@@ -170,15 +170,15 @@
     (rf/reg-event :fc/seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow :area {:frame :fc/scratch :inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* (or w 0) (or h 0))))
     (rf/dispatch-sync [:fc/seed] {:frame :fc/scratch})
-    (frame/destroy-frame! :fc/scratch)
+    (rf.frame/destroy-frame! :fc/scratch)
     (rf/make-frame {:id :fc/scratch :doc "second incarnation"})
-    (is (not (contains? (flows/flows-snapshot) :fc/scratch))
+    (is (not (contains? (rf.flows/flows-snapshot) :fc/scratch))
         "the new frame has no inherited flow-registry slot")
-    (is (not (contains? (get (flows/last-inputs-snapshot) :area) :fc/scratch))
+    (is (not (contains? (get (rf.flows/last-inputs-snapshot) :area) :fc/scratch))
         "the new frame has no inherited last-inputs row")
-    (is (nil? (flows/flow-meta-at :area {:frame :fc/scratch}))
+    (is (nil? (rf.flows/flow-meta-at :area {:frame :fc/scratch}))
         "the new frame has no inherited per-frame flow entry")
-    (is (nil? (registrar/lookup :flow :area))
+    (is (nil? (rf.registrar/lookup :flow :area))
         "registrar :flow slot is RESERVED-but-empty throughout (rf2-en00bk)")))
 
 ;; ---- flow-output elision marks ride the frame-record drop ----------------
@@ -204,19 +204,19 @@
     ;; frame's elision registry (the same surface flows_output_marks_test
     ;; reads). The sensitive subpath roots at :output-path ++ [:secret]; the large
     ;; whole-output mark roots at :output-path.
-    (is (contains? (elision/sensitive-declarations :fc/scratch) [:derived :creds :secret])
+    (is (contains? (rf.elision/sensitive-declarations :fc/scratch) [:derived :creds :secret])
         "precondition: the :sensitive flow declaration is installed")
-    (is (contains? (elision/declarations :fc/scratch) [:derived :blob])
+    (is (contains? (rf.elision/declarations :fc/scratch) [:derived :blob])
         "precondition: the :large flow declaration is installed")
-    (frame/destroy-frame! :fc/scratch)
+    (rf.frame/destroy-frame! :fc/scratch)
     ;; Post-destroy: `registry-of` reads the destroyed frame's container,
     ;; which `dissoc-frame!` removed, so both reader fns return {} — the
     ;; flow-sourced declarations are unobservable, no explicit scrub needed.
-    (is (nil? (frame/frame :fc/scratch))
+    (is (nil? (rf.frame/frame :fc/scratch))
         "the frame record is gone after destroy-frame!")
-    (is (= {} (elision/sensitive-declarations :fc/scratch))
+    (is (= {} (rf.elision/sensitive-declarations :fc/scratch))
         "the destroyed frame exposes no flow-sourced sensitive declarations")
-    (is (= {} (elision/declarations :fc/scratch))
+    (is (= {} (rf.elision/declarations :fc/scratch))
         "the destroyed frame exposes no flow-sourced large declarations")))
 
 (deftest make-frame-after-destroy-observes-no-stale-flow-output-marks
@@ -233,16 +233,16 @@
     ;; propagation claim's replacement.
     (rf/make-frame {:id :fc/scratch :doc "first incarnation"})
     (rf/reg-flow :token {:frame :fc/scratch :inputs [[:n]] :output-path [:auth :token] :sensitive [[]]} (fn [n] {:jwt n}))
-    (is (contains? (elision/sensitive-declarations :fc/scratch) [:auth :token])
+    (is (contains? (rf.elision/sensitive-declarations :fc/scratch) [:auth :token])
         "precondition: the first incarnation installed a whole-output sensitive mark")
-    (frame/destroy-frame! :fc/scratch)
+    (rf.frame/destroy-frame! :fc/scratch)
     ;; Second incarnation under the SAME id — a brand-new frame-state container.
     (rf/make-frame {:id :fc/scratch :doc "second incarnation"})
-    (is (= {} (elision/sensitive-declarations :fc/scratch))
+    (is (= {} (rf.elision/sensitive-declarations :fc/scratch))
         "the reused frame inherited no sensitive flow-sourced declaration")
-    (is (= {} (elision/declarations :fc/scratch))
+    (is (= {} (rf.elision/declarations :fc/scratch))
         "the reused frame inherited no large flow-sourced declaration")
-    (is (not (contains? (elision/sensitive-declarations :fc/scratch) [:auth :token]))
+    (is (not (contains? (rf.elision/sensitive-declarations :fc/scratch) [:auth :token]))
         "specifically: the first incarnation's [:auth :token] mark did not survive")))
 
 ;; ---- reg-flow must not resurrect stale flows on a dead frame -------------
@@ -262,13 +262,13 @@
             structured error and leaves flows / last-inputs / the :flow
             registrar untouched (no dormant state for the dead frame)"
     (rf/make-frame {:id :fc/scratch :doc "scratch frame, then destroyed"})
-    (frame/destroy-frame! :fc/scratch)
-    (is (nil? (frame/frame :fc/scratch))
+    (rf.frame/destroy-frame! :fc/scratch)
+    (is (nil? (rf.frame/frame :fc/scratch))
         "precondition: the frame is non-live after destroy-frame!")
     ;; Snapshot the three mutation surfaces BEFORE the rejected call.
-    (let [flows-before    (flows/flows-snapshot)
-          inputs-before   (flows/last-inputs-snapshot)
-          registrar-before (registrar/lookup :flow :leak/probe)
+    (let [flows-before    (rf.flows/flows-snapshot)
+          inputs-before   (rf.flows/last-inputs-snapshot)
+          registrar-before (rf.registrar/lookup :flow :leak/probe)
           thrown          (atom nil)]
       (try
         (rf/reg-flow :leak/probe {:frame :fc/scratch :inputs [[:n]] :output-path [:out]} (fn [n] (* (or n 0) 10)))
@@ -278,22 +278,22 @@
           "rejected with the stable :rf.error/flow-frame-not-live discriminator")
       (is (= :fc/scratch (:frame @thrown))
           "the error names the offending frame id")
-      (is (= flows-before (flows/flows-snapshot))
+      (is (= flows-before (rf.flows/flows-snapshot))
           "flows registry is unchanged — no resurrected flow row")
-      (is (= inputs-before (flows/last-inputs-snapshot))
+      (is (= inputs-before (rf.flows/last-inputs-snapshot))
           "last-inputs is unchanged")
-      (is (= registrar-before (registrar/lookup :flow :leak/probe))
+      (is (= registrar-before (rf.registrar/lookup :flow :leak/probe))
           "the shared :flow registrar slot is unchanged (no dead-frame stamp)")
-      (is (nil? (registrar/lookup :flow :leak/probe))
+      (is (nil? (rf.registrar/lookup :flow :leak/probe))
           "specifically: no :flow registrar slot was installed"))))
 
 (deftest reg-flow-against-never-registered-frame-rejects
   (testing "Per rf2-zbxvqj: reg-flow against a NEVER-registered (typo'd) frame
             id is rejected the same way as a destroyed one — no dormant state"
-    (is (nil? (frame/frame :fc/never))
+    (is (nil? (rf.frame/frame :fc/never))
         "precondition: the frame id was never registered")
-    (let [flows-before     (flows/flows-snapshot)
-          registrar-before (registrar/lookup :flow :typo/flow)
+    (let [flows-before     (rf.flows/flows-snapshot)
+          registrar-before (rf.registrar/lookup :flow :typo/flow)
           thrown           (atom nil)]
       (try
         (rf/reg-flow :typo/flow {:frame :fc/never :inputs [[:n]] :output-path [:out]} (fn [n] (or n 0)))
@@ -301,11 +301,11 @@
           (reset! thrown (ex-data e))))
       (is (= :rf.error/flow-frame-not-live (:rf.error/id @thrown))
           "rejected with the same stable discriminator as the destroyed-frame case")
-      (is (= flows-before (flows/flows-snapshot))
+      (is (= flows-before (rf.flows/flows-snapshot))
           "flows registry is unchanged")
-      (is (nil? (registrar/lookup :flow :typo/flow))
+      (is (nil? (rf.registrar/lookup :flow :typo/flow))
           "no :flow registrar slot was installed")
-      (is (= registrar-before (registrar/lookup :flow :typo/flow))
+      (is (= registrar-before (rf.registrar/lookup :flow :typo/flow))
           "the :flow registrar slot is unchanged"))))
 
 (deftest reg-flow-after-destroy-then-make-frame-reuse-starts-without-resurrected-flow
@@ -313,7 +313,7 @@
             followed by re-registering that frame id, leaves the fresh frame
             with NO inherited flow — the resurrection path is closed"
     (rf/make-frame {:id :fc/scratch :doc "first incarnation"})
-    (frame/destroy-frame! :fc/scratch)
+    (rf.frame/destroy-frame! :fc/scratch)
     ;; The resurrection attempt — rejected, mutates nothing.
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #"rf.error/flow-frame-not-live"
@@ -323,9 +323,9 @@
     (rf/make-frame {:id :fc/scratch :doc "second incarnation"})
     (rf/reg-event :fc/set-n (fn [{:keys [db]} [_ v]] {:db {:n v}}))
     (rf/dispatch-sync [:fc/set-n 7] {:frame :fc/scratch})
-    (is (not (contains? (flows/flows-snapshot) :fc/scratch))
+    (is (not (contains? (rf.flows/flows-snapshot) :fc/scratch))
         "the re-registered frame inherited no flow-registry slot")
-    (is (nil? (registrar/lookup :flow :leak/probe))
+    (is (nil? (rf.registrar/lookup :flow :leak/probe))
         "no resurrected :flow registrar slot survived into the new frame")
-    (is (nil? (get (frame/frame-app-db-value :fc/scratch) :out))
+    (is (nil? (get (rf.frame/frame-app-db-value :fc/scratch) :out))
         "the stale flow did not run — no [:out] write in the fresh frame's app-db")))

--- a/implementation/flows/test/re_frame/flows_first_registration_trace_incarnation_test.clj
+++ b/implementation/flows/test/re_frame/flows_first_registration_trace_incarnation_test.clj
@@ -41,16 +41,16 @@
   already-entered delivery and the observer is the SUBSEQUENT one."
   (:require [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.flows :as flows]
-            [re-frame.flows.registry :as registry]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.elision :as rf.elision]
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.registry :as rf.flows.registry]
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; The trace-internal boundary: A's first-registration emit reaches ordered
@@ -85,24 +85,24 @@
     ;; and publishes same-id B, exactly once (one-shot CAS), then snapshots B's
     ;; stores for the byte-identical assertions. This is the trace-internal loss
     ;; the ytpeqf mark-write seam cannot reach.
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::destroyer
       (fn [ev]
         (when (and (= :rf.flow/registered (:operation ev))
                    (= id (get-in ev [:tags :frame]))
                    (compare-and-set! armed? true false))
           (swap! destroyer-hits inc)
-          (frame/destroy-frame! id)
+          (rf.frame/destroy-frame! id)
           (rf/make-frame {:id id})
-          (reset! b-token (frame/frame-incarnation-token id))
-          (reset! b-flow-registry (get (registry/flows-snapshot) id ::none))
-          (reset! b-commit (frame/frame-commit-epoch id))
-          (reset! b-sensitive (elision/sensitive-declarations id))
-          (reset! b-trace-disabled (trace/frame-trace-disabled? id)))))
+          (reset! b-token (rf.frame/frame-incarnation-token id))
+          (reset! b-flow-registry (get (rf.flows.registry/flows-snapshot) id ::none))
+          (reset! b-commit (rf.frame/frame-commit-epoch id))
+          (reset! b-sensitive (rf.elision/sensitive-declarations id))
+          (reset! b-trace-disabled (rf.trace/frame-trace-disabled? id)))))
     ;; Listener 2 (registered SECOND → fans out AFTER the destroyer): the
     ;; SUBSEQUENT observer. Absent the fence it receives A's stale
     ;; :rf.flow/registered after B owns the bare id; the fence suppresses it.
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::observer
       (fn [ev]
         (when (= :rf.flow/registered (:operation ev))
@@ -124,7 +124,7 @@
           "the destroyer listener received A's :rf.flow/registered once — the
            already-entered delivery stands")
       (is (some? @b-token) "the destroyer published a same-id B")
-      (is (identical? @b-token (frame/frame-incarnation-token id))
+      (is (identical? @b-token (rf.frame/frame-incarnation-token id))
           "B remains the live incarnation")
       ;; THE TOOTH: the subsequent listener never receives A's stale event.
       (is (empty? @observer-a-regs)
@@ -135,13 +135,13 @@
       ;; B is never observed by A's tail: B's stores are byte-identical to the
       ;; clean slate the destroy handed it; no A work consulted or mutated B.
       (is (= ::none @b-flow-registry) "B started with an empty flow registry")
-      (is (= ::none (get (registry/flows-snapshot) id ::none))
+      (is (= ::none (get (rf.flows.registry/flows-snapshot) id ::none))
           "A's stale first-registration tail never wrote a flow row onto B")
-      (is (= @b-commit (frame/frame-commit-epoch id))
+      (is (= @b-commit (rf.frame/frame-commit-epoch id))
           "A's stale tail never bumped B's commit epoch")
-      (is (= @b-sensitive (elision/sensitive-declarations id))
+      (is (= @b-sensitive (rf.elision/sensitive-declarations id))
           "A's stale tail never wrote B's output-mark declaration")
-      (is (= @b-trace-disabled (trace/frame-trace-disabled? id))
+      (is (= @b-trace-disabled (rf.trace/frame-trace-disabled? id))
           "A's stale tail never changed B's trace policy")
       ;; The fence does not POISON the successor: a later independent
       ;; registration owned by B (outside A's continuation scope) emits
@@ -157,8 +157,8 @@
       (is (= b-flow-id (get-in (first @observer-regs) [:tags :flow-id]))
           "the sole post-loss registration observed is B's own")
       (finally
-        (trace/unregister-listener! ::destroyer)
-        (trace/unregister-listener! ::observer)))))
+        (rf.trace/unregister-listener! ::destroyer)
+        (rf.trace/unregister-listener! ::observer)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Green control / over-fence tooth — when A retains ownership through a
@@ -177,12 +177,12 @@
         touched  (atom 0)
         observed (atom [])]
     (rf/make-frame {:id id})
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::live-touch
       (fn [ev]
         (when (= :rf.flow/registered (:operation ev))
           (swap! touched inc))))          ;; observe only — A stays live
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::live-observer
       (fn [ev]
         (when (= :rf.flow/registered (:operation ev))
@@ -200,8 +200,8 @@
         (is (= [:out]  (:path tags))    "A's own :output-path")
         (is (= id      (:frame tags))   "A's own frame"))
       (finally
-        (trace/unregister-listener! ::live-touch)
-        (trace/unregister-listener! ::live-observer)))))
+        (rf.trace/unregister-listener! ::live-touch)
+        (rf.trace/unregister-listener! ::live-observer)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The reserved-effect `:rf.fx/reg-flow` route already runs the first-

--- a/implementation/flows/test/re_frame/flows_first_registration_watch_incarnation_test.clj
+++ b/implementation/flows/test/re_frame/flows_first_registration_watch_incarnation_test.clj
@@ -27,17 +27,17 @@
   exactly once, during the first-time mark write under test."
   (:require [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.flows :as flows]
-            [re-frame.flows.registry :as registry]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.elision :as rf.elision]
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.registry :as rf.flows.registry]
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- install-watching-adapter!
   "Install a plain-atom-backed adapter whose `replace-container!` runs `on-write`
@@ -45,11 +45,11 @@
   `armed?` holds true. The physical write always lands FIRST so A's write that
   linearized before the loss stands."
   [armed? on-write]
-  (let [base-replace (:replace-container! plain-atom/adapter)]
-    (adapter/dispose-adapter!)
-    (reset! frame/frames {})
-    (adapter/install-adapter!
-      (assoc plain-atom/adapter
+  (let [base-replace (:replace-container! rf.substrate.plain-atom/adapter)]
+    (rf.substrate.adapter/dispose-adapter!)
+    (reset! rf.frame/frames {})
+    (rf.substrate.adapter/install-adapter!
+      (assoc rf.substrate.plain-atom/adapter
              :kind :custom
              :replace-container!
              (fn [container value]
@@ -58,9 +58,9 @@
                  (on-write)))))))
 
 (defn- restore-plain-adapter! []
-  (reset! frame/frames {})
-  (adapter/dispose-adapter!)
-  (adapter/install-adapter! plain-atom/adapter))
+  (reset! rf.frame/frames {})
+  (rf.substrate.adapter/dispose-adapter!)
+  (rf.substrate.adapter/install-adapter! rf.substrate.plain-atom/adapter))
 
 (defn- registered-events
   "The captured `:rf.flow/registered` events, in emission order."
@@ -94,21 +94,21 @@
         ;; The mark-write watch: destroy A, publish same-id B with its own
         ;; first-time flow state (B's reg-flow emits B's own :rf.flow/registered),
         ;; and snapshot B's stores for the byte-identical assertions.
-        (frame/destroy-frame! id)
+        (rf.frame/destroy-frame! id)
         (rf/make-frame {:id id})
         (rf/reg-flow :flow.incarnation/f
           {:frame id :inputs [[:bn]] :output-path [:bout] :sensitive [[:bout]]}
           (fn [n] (or n 0)))
-        (registry/set-frame-flow-last-inputs! id :flow.incarnation/f [::b-input])
-        (reset! b-token (frame/frame-incarnation-token id))
-        (reset! b-flow-row (get-in (registry/flows-snapshot)
+        (rf.flows.registry/set-frame-flow-last-inputs! id :flow.incarnation/f [::b-input])
+        (reset! b-token (rf.frame/frame-incarnation-token id))
+        (reset! b-flow-row (get-in (rf.flows.registry/flows-snapshot)
                                    [id :flow.incarnation/f]))
-        (reset! b-dirty (registry/get-frame-flow-last-inputs id :flow.incarnation/f))
-        (reset! b-commit (frame/frame-commit-epoch id))
-        (reset! b-sensitive (elision/sensitive-declarations id))))
+        (reset! b-dirty (rf.flows.registry/get-frame-flow-last-inputs id :flow.incarnation/f))
+        (reset! b-commit (rf.frame/frame-commit-epoch id))
+        (reset! b-sensitive (rf.elision/sensitive-declarations id))))
     (try
       (rf/make-frame {:id id})
-      (trace/register-listener!
+      (rf.trace/register-listener!
         ::first-registration-recorder
         (fn [ev]
           (when (= :flow (:op-type ev))
@@ -125,7 +125,7 @@
       (let [token-b @b-token
             regs    (registered-events captured)]
         (is (some? token-b) "the mark-write watch published a same-id B")
-        (is (identical? token-b (frame/frame-incarnation-token id))
+        (is (identical? token-b (rf.frame/frame-incarnation-token id))
             "B remains the live incarnation")
         ;; The core assertion: zero A :rf.flow/registered deliveries after loss.
         (is (= 1 (count regs))
@@ -138,17 +138,17 @@
             "the sole delivered registration is B's (:bout), emitted by B's own
              reg-flow inside the watch")
         ;; B's evidence stays byte-identical — A's stale tail touches nothing.
-        (is (= @b-flow-row (get-in (registry/flows-snapshot) [id :flow.incarnation/f]))
+        (is (= @b-flow-row (get-in (rf.flows.registry/flows-snapshot) [id :flow.incarnation/f]))
             "A's stale first-registration tail never rewrites B's flow row")
         (is (= @b-dirty
-               (registry/get-frame-flow-last-inputs id :flow.incarnation/f))
+               (rf.flows.registry/get-frame-flow-last-inputs id :flow.incarnation/f))
             "A's stale tail never drops B's dirty-check cache")
-        (is (= @b-commit (frame/frame-commit-epoch id))
+        (is (= @b-commit (rf.frame/frame-commit-epoch id))
             "A's stale mark write never bumps B's commit epoch")
-        (is (= @b-sensitive (elision/sensitive-declarations id))
+        (is (= @b-sensitive (rf.elision/sensitive-declarations id))
             "A's stale tail never rewrites B's output-mark declaration"))
       (finally
-        (trace/unregister-listener! ::first-registration-recorder)
+        (rf.trace/unregister-listener! ::first-registration-recorder)
         (restore-plain-adapter!)))))
 
 ;; ---------------------------------------------------------------------------
@@ -170,7 +170,7 @@
       (fn [] (swap! watch-runs inc)))          ; observe only — A stays live
     (try
       (rf/make-frame {:id id})
-      (trace/register-listener!
+      (rf.trace/register-listener!
         ::first-registration-live-recorder
         (fn [ev]
           (when (= :flow (:op-type ev))
@@ -188,5 +188,5 @@
           (is (= [:out] (:path tags))                 "A's own :output-path")
           (is (= id (:frame tags))                    "A's own frame")))
       (finally
-        (trace/unregister-listener! ::first-registration-live-recorder)
+        (rf.trace/unregister-listener! ::first-registration-live-recorder)
         (restore-plain-adapter!)))))

--- a/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
+++ b/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
@@ -46,11 +46,11 @@
   CLJS is single-threaded; this race is JVM-only by construction."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.flows.registry :as registry]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.registry :as rf.flows.registry]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
 ;; ---- per-test reset -------------------------------------------------------
@@ -61,7 +61,7 @@
 ;; ambient `reg-flow` calls in the bodies below carry a frame stamp.
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- await! [^CountDownLatch latch where]
   (is (.await latch 30 TimeUnit/SECONDS)
@@ -119,7 +119,7 @@
       (try
         (let [clearer
               (future
-                (flows/clear-flow :doubled {:frame :rf/default}))
+                (rf.flows/clear-flow :doubled {:frame :rf/default}))
               ;; Thread B: once clear-flow has vacated (and is parked under
               ;; the drain-lock), fire an input-changing event. It
               ;; spin-CAS-waits on the drain-lock until clear-flow finishes,
@@ -151,15 +151,15 @@
           (alter-var-root vacate-var (constantly orig-vacate))))
 
       ;; --- The load-bearing post-conditions (bead acceptance) -----------
-      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :doubled))
+      (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :doubled))
           "registry row gone: clear-flow removed :doubled from the per-frame registry")
-      (is (not (contains? (flows/last-inputs-snapshot) :doubled))
+      (is (not (contains? (rf.flows/last-inputs-snapshot) :doubled))
           "last-inputs row gone: clear-flow dropped the dirty-check row")
       (is (not (contains? (rf/app-db-value :rf/default) :out))
           (str "output path ABSENT after clear-flow returned — the racing "
                "drain did NOT re-commit the vacated :out. Pre-fix it would "
                "hold the stale value " (:out (rf/app-db-value :rf/default))))
-      (is (nil? (registrar/lookup :flow :doubled))
+      (is (nil? (rf.registrar/lookup :flow :doubled))
           "the :flow registrar slot is RESERVED-but-empty throughout (rf2-en00bk single-store)"))))
 
 ;; ---------------------------------------------------------------------------
@@ -187,7 +187,7 @@
   ;; here — the original `reg-flow` is a first-time registration and the seed
   ;; dispatch advances the row directly, neither routing through this fn.)
   (testing "an unrelated dispatch racing the invalidate window still gets a fresh recompute"
-    (let [orig-drop @#'registry/drop-frame-flow-last-inputs!
+    (let [orig-drop @#'rf.flows.registry/drop-frame-flow-last-inputs!
           published     (CountDownLatch. 1)
           raced         (CountDownLatch. 1)
           release       (CountDownLatch. 1)]
@@ -199,7 +199,7 @@
       (is (= 10 (:out (rf/app-db-value :rf/default)))
           "precondition: the original flow materialised :out = 2 × :n = 10")
 
-      (with-redefs [registry/drop-frame-flow-last-inputs!
+      (with-redefs [rf.flows.registry/drop-frame-flow-last-inputs!
                     (fn [frame-id flow-id]
                       ;; The new flow is ALREADY published into `flows` by
                       ;; reg-flow's swap! before this call; parking here opens
@@ -323,7 +323,7 @@
         ;; Thread B: clear :scaled. A pre-lock read would capture the OLD
         ;; `[:out-a]` now (A hasn't swapped yet); B then blocks on the
         ;; drain-lock A's drain holds.
-        (let [clearer (future (flows/clear-flow :scaled {:frame :rf/default}))]
+        (let [clearer (future (rf.flows/clear-flow :scaled {:frame :rf/default}))]
           ;; B must NOT complete while A holds the lock — it's blocked on the
           ;; drain-lock (bounded wait; B's pre-lock read, if any, is a few
           ;; instructions before the blocking acquire).
@@ -339,11 +339,11 @@
               "clear-flow completed within 30s")))
 
       ;; --- The load-bearing post-conditions (bead acceptance) -----------
-      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :scaled))
+      (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :scaled))
           "registry row gone: clear-flow removed :scaled")
-      (is (not (contains? (flows/last-inputs-snapshot) :scaled))
+      (is (not (contains? (rf.flows/last-inputs-snapshot) :scaled))
           "last-inputs row gone")
-      (is (nil? (registrar/lookup :flow :scaled))
+      (is (nil? (rf.registrar/lookup :flow :scaled))
           "the :flow registrar slot is RESERVED-but-empty throughout (rf2-en00bk single-store)")
       ;; THE LOAD-BEARING ASSERT: clear-flow vacated the REPLACEMENT's live
       ;; path (:out-b), not the stale pre-lock :out-a. A stale pre-lock read
@@ -405,7 +405,7 @@
                "as " (:out-a db) "."))
       (is (= 500 (:out-b db))
           ":out-b = 100 × :n = 500 — the moved flow materialised on its new path")
-      (is (= [:out-b] (:output-path (get-in (flows/flows-snapshot) [:rf/default :scaled])))
+      (is (= [:out-b] (:output-path (get-in (rf.flows/flows-snapshot) [:rf/default :scaled])))
           "the live registry points :scaled at its new path [:out-b]"))))
 
 (deftest reg-flow-path-move-out-of-drain-vacates-directly
@@ -472,7 +472,7 @@
     ;; A handler that, mid-drain, clears :scaled and returns its db UNCHANGED.
     (rf/reg-event :clear-scaled
                   (fn [{:keys [db]} _]
-                    (flows/clear-flow :scaled {:frame :rf/default})
+                    (rf.flows/clear-flow :scaled {:frame :rf/default})
                     {:db db}))
     (rf/dispatch-sync [:clear-scaled] {:frame :rf/default})
 
@@ -484,9 +484,9 @@
                "and :out-a resurrected as " (:out-a db) "."))
       (is (= 35 (:out-kept db))
           ":out-kept (the sibling flow, never cleared) is untouched")
-      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :scaled))
+      (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :scaled))
           "registry row gone: clear-flow removed :scaled")
-      (is (contains? (get (flows/flows-snapshot) :rf/default) :kept)
+      (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :kept)
           "the sibling flow's registry row survives"))))
 
 (deftest clear-flow-in-drain-last-flow-on-frame-does-not-resurrect-cleared-output
@@ -507,7 +507,7 @@
     ;; returns its db UNCHANGED.
     (rf/reg-event :clear-solo
                   (fn [{:keys [db]} _]
-                    (flows/clear-flow :solo {:frame :rf/default})
+                    (rf.flows/clear-flow :solo {:frame :rf/default})
                     {:db db}))
     (rf/dispatch-sync [:clear-solo] {:frame :rf/default})
 
@@ -517,7 +517,7 @@
                "LAST flow still vacated through the deferred commit (the "
                "empty-flow-map drain BEFORE the early return). Pre-fix it "
                "resurrected as " (:out-solo db) "."))
-      (is (not (contains? (flows/flows-snapshot) :rf/default))
+      (is (not (contains? (rf.flows/flows-snapshot) :rf/default))
           "the per-frame flows entry is pruned entirely — clearing the last flow drops the frame key")
-      (is (empty? (registry/abandoned-output-paths-snapshot :rf/default))
+      (is (empty? (rf.flows.registry/abandoned-output-paths-snapshot :rf/default))
           "the abandoned-path bookkeeping was drained, not left pending forever"))))

--- a/implementation/flows/test/re_frame/flows_output_write_attribution_cljs_test.cljc
+++ b/implementation/flows/test/re_frame/flows_output_write_attribution_cljs_test.cljc
@@ -28,13 +28,13 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.trace :as trace]
-   [re-frame.test-support :as test-support]
+   [re-frame.trace :as rf.trace]
+   [re-frame.test-support :as rf.test-support]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter substrate/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter substrate/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; Recorders.  The reset fixture clears both registries between tests, so each
@@ -44,7 +44,7 @@
 (defn- record-flow-traces!
   "Capture every `:flow`-op-type trace event into `sink`."
   [sink]
-  (trace/register-listener!
+  (rf.trace/register-listener!
     ::flow-trace-recorder
     (fn [ev]
       (when (= :flow (:op-type ev))

--- a/implementation/flows/test/re_frame/flows_path_cljs_test.cljc
+++ b/implementation/flows/test/re_frame/flows_path_cljs_test.cljc
@@ -21,14 +21,14 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
-   [re-frame.flows :as flows]
-   [re-frame.flows.topo :as topo]
-   [re-frame.test-support :as test-support]
+   [re-frame.flows :as rf.flows]
+   [re-frame.flows.topo :as rf.flows.topo]
+   [re-frame.test-support :as rf.test-support]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter substrate/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter substrate/adapter}))
 
 (defn- error-id [ex]
   (:rf.error/id (ex-data ex)))
@@ -50,11 +50,11 @@
 (deftest output-paths-overlap-on-cljs
   (testing "the shared prefix-in-either-direction relation (Spec 013
             §Disjoint output paths) computes identically on this host"
-    (is (true?  (topo/output-paths-overlap? [:x] [:x]))       "identical paths overlap")
-    (is (true?  (topo/output-paths-overlap? [:x] [:x :y]))    "parent/child overlap")
-    (is (true?  (topo/output-paths-overlap? [:x :y] [:x]))    "symmetric parent/child")
-    (is (false? (topo/output-paths-overlap? [:x :y] [:x :z])) "siblings are disjoint")
-    (is (false? (topo/output-paths-overlap? [:a] [:b]))       "unrelated are disjoint")))
+    (is (true?  (rf.flows.topo/output-paths-overlap? [:x] [:x]))       "identical paths overlap")
+    (is (true?  (rf.flows.topo/output-paths-overlap? [:x] [:x :y]))    "parent/child overlap")
+    (is (true?  (rf.flows.topo/output-paths-overlap? [:x :y] [:x]))    "symmetric parent/child")
+    (is (false? (rf.flows.topo/output-paths-overlap? [:x :y] [:x :z])) "siblings are disjoint")
+    (is (false? (rf.flows.topo/output-paths-overlap? [:a] [:b]))       "unrelated are disjoint")))
 
 ;; ===========================================================================
 ;; 1b. topo-sort self-cycle rejection (pure data, host-portable) — rf2-j538f7.6
@@ -72,7 +72,7 @@
   "Run `topo/topo-sort` and return the thrown ExceptionInfo (or nil)."
   [flow-map]
   (try
-    (topo/topo-sort flow-map)
+    (rf.flows.topo/topo-sort flow-map)
     nil
     (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e e)))
 
@@ -112,7 +112,7 @@
             with A first and D last — no false-positive self/cycle rejection"
     ;; A: source, writes [:a]. B,C: read [:a], write [:b]/[:c]. D: reads [:b]
     ;; and [:c], writes [:d]. No self-overlap anywhere.
-    (let [order (topo/topo-sort
+    (let [order (rf.flows.topo/topo-sort
                   {:a {:id :a :inputs [[:src]]      :derive identity :output-path [:a]}
                    :b {:id :b :inputs [[:a]]        :derive identity :output-path [:b]}
                    :c {:id :c :inputs [[:a]]        :derive identity :output-path [:c]}
@@ -134,7 +134,7 @@
     (let [ex (reg-flow-throws {:id :probe/self :inputs [[:x]] :derive inc :output-path [:x]})]
       (is (some? ex) "the self-cyclic registration throws")
       (is (= :rf.error/flow-cycle (error-id ex)) "structured :rf.error/flow-cycle")
-      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :probe/self))
+      (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :probe/self))
           "the rejected self-cyclic flow is absent from the registry"))))
 
 (deftest reg-flow-runtime-input-overlapping-app-db-output-is-not-a-self-cycle-on-this-host
@@ -143,7 +143,7 @@
             not a self-cycle — it registers cleanly (rf2-j538f7.6, Spec 013)"
     (is (some? (rf/reg-flow :probe/runtime {:inputs [[:rf.db/runtime :x]] :output-path [:x]} identity))
         "the runtime-input flow registers (its input reads runtime-db, its output writes app-db)")
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :probe/runtime)
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :probe/runtime)
         "the flow row is present after clean registration")))
 
 ;; ===========================================================================
@@ -167,7 +167,7 @@
       (let [flow-id (keyword "elt" (name label))]
         (is (some? (rf/reg-flow flow-id {:inputs [[:root elt]] :output-path [:out elt]} identity))
             (str "shared-domain segment " (pr-str elt) " is accepted on this host"))
-        (flows/clear-flow flow-id)))))
+        (rf.flows/clear-flow flow-id)))))
 
 ;; ===========================================================================
 ;; 3. reg-flow REJECTS host / composite segments (CLJS host — the gap)

--- a/implementation/flows/test/re_frame/flows_path_overlap_test.clj
+++ b/implementation/flows/test/re_frame/flows_path_overlap_test.clj
@@ -28,10 +28,10 @@
   explicit guard that the scan terminates on any frame with ≥2 disjoint flows."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.flows.topo :as topo]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.topo :as rf.flows.topo]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---- per-test reset -------------------------------------------------------
 ;;
@@ -41,7 +41,7 @@
 ;; ambient `reg-flow` calls in the bodies below carry a frame stamp.
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. topo/output-paths-overlap? — the prefix-relation predicate
@@ -49,25 +49,25 @@
 
 (deftest output-paths-overlap?-identical-paths
   (testing "identical :paths overlap (a vector is a prefix of itself)"
-    (is (true? (topo/output-paths-overlap? [:x] [:x])))
-    (is (true? (topo/output-paths-overlap? [:a :b] [:a :b])))))
+    (is (true? (rf.flows.topo/output-paths-overlap? [:x] [:x])))
+    (is (true? (rf.flows.topo/output-paths-overlap? [:a :b] [:a :b])))))
 
 (deftest output-paths-overlap?-prefix-in-either-direction
   (testing "parent/child overlap — one :output-path is a prefix of the other (Spec 013 §Disjoint output paths)"
-    (is (true? (topo/output-paths-overlap? [:x] [:x :y]))
+    (is (true? (rf.flows.topo/output-paths-overlap? [:x] [:x :y]))
         "[:x] is a prefix of [:x :y] — writing [:x] clobbers the child")
-    (is (true? (topo/output-paths-overlap? [:x :y] [:x]))
+    (is (true? (rf.flows.topo/output-paths-overlap? [:x :y] [:x]))
         "symmetric: [:x] is still a prefix of [:x :y] with args flipped")))
 
 (deftest output-paths-overlap?-disjoint-siblings
   (testing "sibling leaves under a shared parent do NOT overlap — neither is a prefix of the other"
-    (is (false? (topo/output-paths-overlap? [:x :y] [:x :z]))
+    (is (false? (rf.flows.topo/output-paths-overlap? [:x :y] [:x :z]))
         "[:x :y] and [:x :z] are disjoint (each owns its own leaf)")
-    (is (false? (topo/output-paths-overlap? [:a] [:b]))
+    (is (false? (rf.flows.topo/output-paths-overlap? [:a] [:b]))
         "wholly unrelated single-key paths are disjoint")
-    (is (false? (topo/output-paths-overlap? [:a :b :c] [:a :b :d]))
+    (is (false? (rf.flows.topo/output-paths-overlap? [:a :b :c] [:a :b :d]))
         "deeper sibling leaves [:a :b :c] / [:a :b :d] are disjoint too")
-    (is (true? (topo/output-paths-overlap? [:a :b] [:a :b :c :d]))
+    (is (true? (rf.flows.topo/output-paths-overlap? [:a :b] [:a :b :c :d]))
         "but a deep child [:a :b :c :d] DOES overlap its ancestor [:a :b]")))
 
 (deftest output-paths-overlap?-shared-non-prefix-element
@@ -75,7 +75,7 @@
     ;; [:x :y] vs [:y :x] share both elements but neither is a prefix of
     ;; the other → disjoint. Mirrors depends-on?'s prefix-not-membership
     ;; rule (flows_topo_test.clj depends-on?-false-when-...share-element).
-    (is (false? (topo/output-paths-overlap? [:x :y] [:y :x])))))
+    (is (false? (rf.flows.topo/output-paths-overlap? [:x :y] [:y :x])))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. topo/detect-output-path-overlap! — the prospective-map scanner
@@ -88,14 +88,14 @@
     (let [flow-map {:a {:id :a :inputs [[:w]] :derive identity :output-path [:x :a]}
                     :b {:id :b :inputs [[:h]] :derive identity :output-path [:x :b]}
                     :c {:id :c :inputs [[:q]] :derive identity :output-path [:y]}}]
-      (is (= flow-map (topo/detect-output-path-overlap! flow-map))
+      (is (= flow-map (rf.flows.topo/detect-output-path-overlap! flow-map))
           "disjoint outputs: no throw, threads the map through"))))
 
 (deftest detect-output-path-overlap!-throws-on-identical-paths
   (testing "two flows with identical output :paths throw :rf.error/flow-path-overlap with the canonical thrown-error shape"
     (let [flow-map {:a {:id :a :inputs [[:w]] :derive identity :output-path [:x]}
                     :b {:id :b :inputs [[:h]] :derive identity :output-path [:x]}}
-          thrown   (try (topo/detect-output-path-overlap! flow-map)
+          thrown   (try (rf.flows.topo/detect-output-path-overlap! flow-map)
                         nil
                         (catch clojure.lang.ExceptionInfo e e))]
       (is (some? thrown) "overlapping outputs raise")
@@ -125,7 +125,7 @@
   (testing "two flows where one :output-path is a PREFIX of the other throw :rf.error/flow-path-overlap"
     (let [flow-map {:parent {:id :parent :inputs [[:w]] :derive identity :output-path [:x]}
                     :child  {:id :child  :inputs [[:h]] :derive identity :output-path [:x :y]}}
-          thrown   (try (topo/detect-output-path-overlap! flow-map)
+          thrown   (try (rf.flows.topo/detect-output-path-overlap! flow-map)
                         nil
                         (catch clojure.lang.ExceptionInfo e e))]
       (is (some? thrown) "prefix-related outputs raise")
@@ -138,7 +138,7 @@
   (testing "the reported :overlap pair is stable across runs (sort-by hash, not iteration order)"
     (let [flow-map {:a {:id :a :inputs [[:w]] :derive identity :output-path [:x]}
                     :b {:id :b :inputs [[:h]] :derive identity :output-path [:x]}}
-          overlap-of (fn [] (-> (try (topo/detect-output-path-overlap! flow-map)
+          overlap-of (fn [] (-> (try (rf.flows.topo/detect-output-path-overlap! flow-map)
                                      (catch clojure.lang.ExceptionInfo e (ex-data e)))
                                 :overlap))]
       (is (= (overlap-of) (overlap-of) (overlap-of))
@@ -157,7 +157,7 @@
   (testing "the reported pair is invariant to flow-map iteration order"
     (let [flow-a {:id :a :inputs [[:w]] :derive identity :output-path [:x]}
           flow-b {:id :b :inputs [[:h]] :derive identity :output-path [:x]}
-          overlap-of (fn [m] (-> (try (topo/detect-output-path-overlap! m)
+          overlap-of (fn [m] (-> (try (rf.flows.topo/detect-output-path-overlap! m)
                                       (catch clojure.lang.ExceptionInfo e (ex-data e)))
                                  :overlap))
           a-first (overlap-of (array-map :a flow-a :b flow-b))
@@ -178,7 +178,7 @@
           "precondition: the two ids genuinely collide on hash")
       (let [flow-lo {:id id-lo :inputs [[:w]] :derive identity :output-path [:x]}
             flow-hi {:id id-hi :inputs [[:h]] :derive identity :output-path [:x]}
-            overlap-of (fn [m] (-> (try (topo/detect-output-path-overlap! m)
+            overlap-of (fn [m] (-> (try (rf.flows.topo/detect-output-path-overlap! m)
                                         (catch clojure.lang.ExceptionInfo e (ex-data e)))
                                    :overlap))
             lo-first (overlap-of (array-map id-lo flow-lo id-hi flow-hi))
@@ -213,9 +213,9 @@
           "the offending pair is named in :overlap"))
     ;; The rejected REPLACEMENT must not have vacated / disturbed the
     ;; prior registration (symmetric with the cycle-check atomicity).
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :a)
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :a)
         "the prior flow :a survives the rejected registration")
-    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :b))
+    (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :b))
         "the rejected flow :b never lands in the committed registry")))
 
 (deftest reg-flow-allows-disjoint-sibling-output-paths
@@ -224,7 +224,7 @@
     ;; this reg-flow call must complete, not hang the suite.
     (rf/reg-flow :w {:inputs [[:in-w]] :output-path [:rect :w]} identity)
     (rf/reg-flow :h {:inputs [[:in-h]] :output-path [:rect :h]} identity)
-    (let [committed (get (flows/flows-snapshot) :rf/default)]
+    (let [committed (get (rf.flows/flows-snapshot) :rf/default)]
       (is (contains? committed :w) "the [:rect :w] flow registered")
       (is (contains? committed :h) "the [:rect :h] flow registered — no false-positive overlap"))))
 
@@ -236,9 +236,9 @@
     ;; their writes land in different app-dbs, so no collision.
     (rf/reg-flow :x {:frame :frame-a :inputs [[:in]] :output-path [:dest]} identity)
     (rf/reg-flow :x {:frame :frame-b :inputs [[:in]] :output-path [:dest]} identity)
-    (is (contains? (get (flows/flows-snapshot) :frame-a) :x)
+    (is (contains? (get (rf.flows/flows-snapshot) :frame-a) :x)
         "frame-a holds its :x flow")
-    (is (contains? (get (flows/flows-snapshot) :frame-b) :x)
+    (is (contains? (get (rf.flows/flows-snapshot) :frame-b) :x)
         "frame-b holds its own :x flow — overlap detection is per-frame, not cross-frame")))
 
 (deftest reg-flow-re-registration-does-not-self-overlap
@@ -255,7 +255,7 @@
                 nil
                 (catch clojure.lang.ExceptionInfo e e)))
         "re-registering :a with the same :output-path must not throw :rf.error/flow-path-overlap")
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :a)
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :a)
         "the re-registered flow :a is committed")))
 
 (deftest reg-flow-still-rejects-cycles-and-passes-clean-topologies
@@ -264,7 +264,7 @@
     ;; topo-sorts cleanly — disjoint OUTPUTS, a genuine input edge.
     (rf/reg-flow :a {:inputs [[:seed]] :output-path [:a-out]} identity)
     (rf/reg-flow :b {:inputs [[:a-out]] :output-path [:b-out]} identity)
-    (is (= #{:a :b} (set (keys (get (flows/flows-snapshot) :rf/default))))
+    (is (= #{:a :b} (set (keys (get (rf.flows/flows-snapshot) :rf/default))))
         "a clean dependency topology (disjoint outputs, real edge) registers both flows")
     ;; Cycle check still fires: C reads B's output [:b-out]; re-registering
     ;; B to read C's output [:c-out] closes the cycle b → c → b.

--- a/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
+++ b/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
@@ -26,11 +26,11 @@
   This namespace is JVM-only (`.clj`)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.flows.registry :as registry]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace])
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.registry :as rf.flows.registry]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace])
   (:import [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicLong]))
 
@@ -44,7 +44,7 @@
 ;; listeners (the reset clears every listener first).
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. Deterministic unit-level repro — the rollback must touch ONLY the
@@ -68,20 +68,20 @@
     (rf/reg-flow :flow-x {:frame :b :inputs [[:n]] :output-path [:out]} (fn [n] (* 2 (or n 0))))
 
     ;; Simulate B having drained to completion: its dirty-check row is V2.
-    (registry/set-frame-flow-last-inputs! :b :flow-x [42])
-    (is (= [42] (registry/get-frame-flow-last-inputs :b :flow-x))
+    (rf.flows.registry/set-frame-flow-last-inputs! :b :flow-x [42])
+    (is (= [42] (rf.flows.registry/get-frame-flow-last-inputs :b :flow-x))
         "precondition: B's row is seeded to V2 = [42]")
 
     ;; Drive frame A's drain directly. A's flow throws, so run-flows-on-db
     ;; rolls back A's OWN container. The throw propagates — catch it.
     (is (thrown? Throwable
-                 (flows/run-flows-on-db :a {:n 7} nil))
+                 (rf.flows/run-flows-on-db :a {:n 7} nil))
         "A's flow throw propagates out of run-flows-on-db")
 
     ;; THE ASSERTION: B's row is untouched by A's rollback.
-    (is (= [42] (registry/get-frame-flow-last-inputs :b :flow-x))
+    (is (= [42] (rf.flows.registry/get-frame-flow-last-inputs :b :flow-x))
         "B's last-inputs row survives A's throwing-flow rollback (rf2-94ol5)")
-    (is (= [42] (get-in (flows/last-inputs-snapshot) [:flow-x :b]))
+    (is (= [42] (get-in (rf.flows/last-inputs-snapshot) [:flow-x :b]))
         "the aggregated snapshot still shows B's row")))
 
 ;; ---------------------------------------------------------------------------
@@ -104,11 +104,11 @@
       ;; throws — so :A's advance must be rolled back.
       (rf/reg-flow :A {:frame :solo :inputs [[:n]] :output-path [:a-out]} (fn [n] (* 10 (or n 0))))
       (rf/reg-flow :B {:frame :solo :inputs [[:a-out]] :output-path [:b-out]} (fn [_] (throw (ex-info "boom-B" {}))))
-      (is (thrown? Throwable (flows/run-flows-on-db :solo {:n 5} nil)))
-      (reset! a-row-before (registry/get-frame-flow-last-inputs :solo :A))
+      (is (thrown? Throwable (rf.flows/run-flows-on-db :solo {:n 5} nil)))
+      (reset! a-row-before (rf.flows.registry/get-frame-flow-last-inputs :solo :A))
       (is (nil? @a-row-before)
           ":A's last-inputs advance was rolled back (single-frame atomicity intact)")
-      (is (nil? (registry/get-frame-flow-last-inputs :solo :B))
+      (is (nil? (rf.flows.registry/get-frame-flow-last-inputs :solo :B))
           ":B never advanced (it threw)"))))
 
 ;; ---------------------------------------------------------------------------
@@ -158,7 +158,7 @@
 
       ;; Count B's :rf.flow/computed traces (the spurious-recompute symptom).
       (let [b-computed (AtomicLong. 0)]
-        (trace/register-listener!
+        (rf.trace/register-listener!
           ::b-computed-watch
           (fn [ev]
             (when (and (= :rf.flow/computed (:operation ev))
@@ -196,7 +196,7 @@
           (is (not= ::timeout (deref fut-b 120000 ::timeout))
               "thread B completed within 120s")
 
-          (trace/unregister-listener! ::b-computed-watch)
+          (rf.trace/unregister-listener! ::b-computed-watch)
 
           ;; THE INVARIANT: B's :derive fired exactly once. A concurrent
           ;; rollback clobbering B's row would push this above 1.
@@ -219,6 +219,6 @@
               "B's flow output is correct (2 × 7)")
 
           ;; B's last-inputs row survives intact at [7].
-          (is (= [7] (registry/get-frame-flow-last-inputs :rf2-94ol5/b
+          (is (= [7] (rf.flows.registry/get-frame-flow-last-inputs :rf2-94ol5/b
                                                           :rf2-94ol5/doubles))
               "B's last-inputs row is intact at [7] after the stress"))))))

--- a/implementation/flows/test/re_frame/flows_reg_flow_destroy_linearization_test.clj
+++ b/implementation/flows/test/re_frame/flows_reg_flow_destroy_linearization_test.clj
@@ -50,19 +50,19 @@
   CLJS is single-threaded; this race is JVM-only by construction."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.flows :as flows]
-            [re-frame.flows.registry :as registry]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.elision :as rf.elision]
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.registry :as rf.flows.registry]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
 ;; ---- per-test reset -------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- await! [^CountDownLatch latch where]
   (is (.await latch 30 TimeUnit/SECONDS)
@@ -87,7 +87,7 @@
 
 (deftest reg-flow-losing-to-destroy-in-the-mutation-window-refuses-no-ghost
   (testing "destroy between reg-flow's pin and its serialized mutation -> refuse, no ghost row"
-    (let [orig-token frame/frame-incarnation-token
+    (let [orig-token rf.frame/frame-incarnation-token
           calls      (atom 0)
           entered    (CountDownLatch. 1) ;; reg-flow captured its pin, is parked before the mutation
           release    (CountDownLatch. 1)] ;; let reg-flow resume into the mutation
@@ -100,7 +100,7 @@
       ;; itself now routes its liveness flip through `call-serialized-with-drain!`,
       ;; so the pause seam MUST NOT be that helper (it would park destroy too);
       ;; `frame-incarnation-token` is called only by reg-flow here.
-      (with-redefs [frame/frame-incarnation-token
+      (with-redefs [rf.frame/frame-incarnation-token
                     (fn [id]
                       (let [tok (orig-token id)]
                         (when (= 1 (swap! calls inc)) ;; #1 = reg-flow's outer pin
@@ -120,23 +120,23 @@
                                     (fn [n] (* 2 (or n 0))))))]
           (await! entered "reg-flow parked past its pin")
           ;; Destroy completes FULLY while reg-flow is parked past its pin.
-          (frame/destroy-frame! :fc/scratch)
-          (is (nil? (frame/frame :fc/scratch))
+          (rf.frame/destroy-frame! :fc/scratch)
+          (is (nil? (rf.frame/frame :fc/scratch))
               "precondition: destroy fully torn the frame down before reg-flow resumes")
           (.countDown release)
           (is (= :rf.error/flow-frame-not-live (deref reg 30000 ::timeout))
               "reg-flow that lost the race to destroy refuses with the stable discriminator")))
 
       ;; --- The load-bearing post-conditions (no ghost on ANY surface) ------
-      (is (not (contains? (flows/flows-snapshot) :fc/scratch))
+      (is (not (contains? (rf.flows/flows-snapshot) :fc/scratch))
           "flows-snapshot: no ghost flow row survives the destroyed frame")
-      (is (not (contains? (flows/last-inputs-snapshot) :ghost))
+      (is (not (contains? (rf.flows/last-inputs-snapshot) :ghost))
           "last-inputs-snapshot: no dirty-check row for the ghost flow")
-      (is (empty? (registry/abandoned-output-paths-snapshot :fc/scratch))
+      (is (empty? (rf.flows.registry/abandoned-output-paths-snapshot :fc/scratch))
           "no pending abandoned output paths for the destroyed frame")
-      (is (empty? (elision/sensitive-declarations :fc/scratch))
+      (is (empty? (rf.elision/sensitive-declarations :fc/scratch))
           "no flow-sourced :sensitive declaration survives")
-      (is (nil? (registrar/lookup :flow :ghost))
+      (is (nil? (rf.registrar/lookup :flow :ghost))
           "the :flow registrar slot is RESERVED-but-empty throughout (rf2-en00bk single-store)"))))
 
 ;; ---------------------------------------------------------------------------
@@ -147,7 +147,7 @@
 
 (deftest stale-reg-flow-does-not-clobber-a-re-registered-new-incarnation
   (testing "reg-flow pinned to incarnation X refuses when X is destroyed and the id is re-registered to X+1"
-    (let [orig-token frame/frame-incarnation-token
+    (let [orig-token rf.frame/frame-incarnation-token
           calls      (atom 0)
           entered    (CountDownLatch. 1)
           release    (CountDownLatch. 1)]
@@ -156,7 +156,7 @@
       ;; Park reg-flow right after its outer pin (captures incarnation X's token)
       ;; via `frame-incarnation-token` — NOT `call-serialized-with-drain!`, which
       ;; `destroy-frame!` now also uses.
-      (with-redefs [frame/frame-incarnation-token
+      (with-redefs [rf.frame/frame-incarnation-token
                     (fn [id]
                       (let [tok (orig-token id)]
                         (when (= 1 (swap! calls inc)) ;; #1 = reg-flow's outer pin
@@ -172,9 +172,9 @@
           (await! entered "stale reg-flow parked past its pin")
           ;; X is destroyed, then the SAME id is re-registered as a FRESH
           ;; incarnation X+1 (new :drain-lock -> new incarnation token).
-          (frame/destroy-frame! :fc/reused)
+          (rf.frame/destroy-frame! :fc/reused)
           (rf/make-frame {:id :fc/reused :doc "incarnation X+1"})
-          (is (some? (frame/frame :fc/reused))
+          (is (some? (rf.frame/frame :fc/reused))
               "precondition: a NEW incarnation is live under the reused id")
           (.countDown release)
           ;; The stale reg-flow's revalidation sees a DIFFERENT incarnation
@@ -185,10 +185,10 @@
               "the stale reg-flow refuses rather than clobbering incarnation X+1")))
 
       ;; The fresh incarnation inherited NO flow; a drive proves nothing runs.
-      (is (not (contains? (flows/flows-snapshot) :fc/reused))
+      (is (not (contains? (rf.flows/flows-snapshot) :fc/reused))
           "the re-registered incarnation has no inherited flow-registry slot")
       (rf/dispatch-sync [:fc/set-n 5] {:frame :fc/reused})
-      (is (nil? (get (frame/frame-app-db-value :fc/reused) :out))
+      (is (nil? (get (rf.frame/frame-app-db-value :fc/reused) :out))
           "the stale flow did not run — no [:out] write in the new incarnation's app-db"))))
 
 ;; ---------------------------------------------------------------------------
@@ -199,7 +199,7 @@
 
 (deftest reg-flow-holding-the-gate-blocks-destroy-then-teardown-removes-the-row
   (testing "reg-flow committing under the lock succeeds; a racing destroy blocks, then tears the row down"
-    (let [orig-token frame/frame-incarnation-token
+    (let [orig-token rf.frame/frame-incarnation-token
           in-thunk   (CountDownLatch. 1) ;; reg-flow is inside its serialized thunk, holding :drain-lock
           release    (CountDownLatch. 1) ;; let reg-flow finish the thunk
           calls      (atom 0)]
@@ -208,7 +208,7 @@
       ;; the revalidation read. The FIRST token read is reg-flow's outer pin
       ;; (before the lock); the SECOND is the revalidation (under the lock) —
       ;; park on the second so destroy blocks on the lock reg-flow holds.
-      (with-redefs [frame/frame-incarnation-token
+      (with-redefs [rf.frame/frame-incarnation-token
                     (fn [id]
                       (let [n (swap! calls inc)]
                         (when (= n 2)
@@ -224,7 +224,7 @@
           ;; Destroy on this thread must BLOCK on the drain-lock reg-flow holds
           ;; (its mark-frame-destroyed! now takes the same lock). Prove it can't
           ;; complete while reg-flow is parked.
-          (let [destroyer (future (frame/destroy-frame! :fc/winner))]
+          (let [destroyer (future (rf.frame/destroy-frame! :fc/winner))]
             (is (= ::still-blocked (deref destroyer 1000 ::still-blocked))
                 "destroy is blocked on the :drain-lock reg-flow holds")
             (.countDown release)
@@ -234,9 +234,9 @@
                 "destroy completed once reg-flow released the lock"))))
 
       ;; reg-flow's row was published, then the destroy's teardown removed it.
-      (is (nil? (frame/frame :fc/winner))
+      (is (nil? (rf.frame/frame :fc/winner))
           "the frame is destroyed")
-      (is (not (contains? (flows/flows-snapshot) :fc/winner))
+      (is (not (contains? (rf.flows/flows-snapshot) :fc/winner))
           "no leftover flow row — the destroy's flows-teardown removed the committed row"))))
 
 ;; ---------------------------------------------------------------------------
@@ -260,7 +260,7 @@
                                         (fn [n] (* 2 (or n 0))))))
               destroy (future
                         (.await start 5 TimeUnit/SECONDS)
-                        (frame/destroy-frame! fid))]
+                        (rf.frame/destroy-frame! fid))]
           (.countDown start)
           (let [reg-result     (deref reg 30000 ::timeout)
                 destroy-result (deref destroy 30000 ::timeout)]
@@ -273,7 +273,7 @@
                      i " (got " reg-result ")"))))
         ;; The load-bearing invariant: whoever won, the destroyed frame carries
         ;; NO flow row (registration refused, or registered-then-torn-down).
-        (is (not (contains? (flows/flows-snapshot) fid))
+        (is (not (contains? (rf.flows/flows-snapshot) fid))
             (str "no ghost flow row for the destroyed frame on iteration " i))))))
 
 ;; ---------------------------------------------------------------------------
@@ -297,9 +297,9 @@
                     {:db db}))
     (rf/dispatch-sync [:fc/seed] {:frame :fc/live})
     (rf/dispatch-sync [:fc/install-flow] {:frame :fc/live})
-    (is (contains? (get (flows/flows-snapshot) :fc/live) :mid)
+    (is (contains? (get (rf.flows/flows-snapshot) :fc/live) :mid)
         "the mid-drain reg-flow registered its row")
-    (is (= 15 (:out (frame/frame-app-db-value :fc/live)))
+    (is (= 15 (:out (rf.frame/frame-app-db-value :fc/live)))
         "the mid-drain flow materialised its output (3 × 5 = 15) on the same drain")))
 
 ;; ---------------------------------------------------------------------------
@@ -310,10 +310,10 @@
 (deftest clear-flow-idempotent-for-absent-frame
   (testing "clear-flow against a destroyed / never-registered frame is a silent no-op"
     (rf/make-frame {:id :fc/gone :doc "frame to destroy"})
-    (frame/destroy-frame! :fc/gone)
-    (is (nil? (flows/clear-flow :whatever {:frame :fc/gone}))
+    (rf.frame/destroy-frame! :fc/gone)
+    (is (nil? (rf.flows/clear-flow :whatever {:frame :fc/gone}))
         "clear-flow on a DESTROYED frame returns nil (idempotent no-op)")
-    (is (nil? (flows/clear-flow :whatever {:frame :fc/never-existed}))
+    (is (nil? (rf.flows/clear-flow :whatever {:frame :fc/never-existed}))
         "clear-flow on a NEVER-registered frame returns nil (idempotent no-op)")))
 
 ;; ---------------------------------------------------------------------------
@@ -335,13 +335,13 @@
     (let [;; A cold serialized critical section (no active drain) whose body
           ;; calls destroy-frame! on the SAME frame — the Tool-Pair write shape.
           done (future
-                 (frame/call-serialized-with-drain! :fc/nested
+                 (rf.frame/call-serialized-with-drain! :fc/nested
                    (fn []
-                     (frame/destroy-frame! :fc/nested)
+                     (rf.frame/destroy-frame! :fc/nested)
                      :ok)))]
       (is (= :ok (deref done 30000 ::timeout))
           "the nested destroy ran reentrantly and the serialized write returned (pre-fix: deadlock)"))
-    (is (nil? (frame/frame :fc/nested))
+    (is (nil? (rf.frame/frame :fc/nested))
         "the frame was destroyed")
-    (is (not (contains? (flows/flows-snapshot) :fc/nested))
+    (is (not (contains? (rf.flows/flows-snapshot) :fc/nested))
         "its flow row was torn down by destroy — no leak")))

--- a/implementation/flows/test/re_frame/flows_reg_flow_toctou_test.clj
+++ b/implementation/flows/test/re_frame/flows_reg_flow_toctou_test.clj
@@ -26,10 +26,10 @@
   `RF2_QXWIB_TOCTOU_ROUNDS`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.flows.topo :as topo]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.topo :as rf.flows.topo]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support])
   (:import [java.util.concurrent CyclicBarrier]
            [java.util.concurrent.atomic AtomicLong]))
 
@@ -41,7 +41,7 @@
 ;; ambient `reg-flow` calls in the bodies below carry a frame stamp.
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; Round count. Each round opens a fresh interleaving window on the
 ;; shared frame; the race needs only ONE round where both threads read
@@ -129,9 +129,9 @@
           ;; THE load-bearing assertion: the committed registry for the
           ;; shared frame is acyclic. topo-sort throws :rf.error/flow-cycle
           ;; iff a cycle was admitted.
-          (let [committed (get (flows/flows-snapshot) frame-id)]
+          (let [committed (get (rf.flows/flows-snapshot) frame-id)]
             (try
-              (topo/topo-sort committed)
+              (rf.flows.topo/topo-sort committed)
               (catch Throwable t
                 (when (nil? @first-bad)
                   (reset! first-bad {:round    round
@@ -141,8 +141,8 @@
           ;; each round starts from the frame's pre-cycle state (the
           ;; window the race needs). clear-flow no-ops cleanly on the id
           ;; that was rejected / never committed.
-          (flows/clear-flow a-id {:frame frame-id})
-          (flows/clear-flow b-id {:frame frame-id})))
+          (rf.flows/clear-flow a-id {:frame frame-id})
+          (rf.flows/clear-flow b-id {:frame frame-id})))
 
       ;; --- Invariant 1: no round ever admitted a cycle. ---------------
       (is (nil? @first-bad)

--- a/implementation/flows/test/re_frame/flows_replace_clear_trace_incarnation_cljs_test.cljc
+++ b/implementation/flows/test/re_frame/flows_replace_clear_trace_incarnation_cljs_test.cljc
@@ -59,15 +59,15 @@
   (:require #?(:clj  [clojure.test :refer [deftest is use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.flows.registry :as registry]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.registry :as rf.flows.registry]
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ===========================================================================
 ;; REPLACEMENT — `:rf.registry/handler-replaced`
@@ -108,22 +108,22 @@
     ;; Listener 1 (registered FIRST → fans out FIRST): the DESTROYER. On A's own
     ;; :rf.registry/handler-replaced — the already-entered delivery — it destroys
     ;; A and publishes same-id B exactly once, then snapshots B's stores.
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::destroyer
       (fn [ev]
         (when (and (= :rf.registry/handler-replaced (:operation ev))
                    (= flow-id (get-in ev [:tags :id]))
                    (compare-and-set! armed? true false))
           (swap! destroyer-hits inc)
-          (frame/destroy-frame! id)
+          (rf.frame/destroy-frame! id)
           (rf/make-frame {:id id})
-          (reset! b-token (frame/frame-incarnation-token id))
-          (reset! b-flow-registry (get (registry/flows-snapshot) id ::none))
-          (reset! b-commit (frame/frame-commit-epoch id)))))
+          (reset! b-token (rf.frame/frame-incarnation-token id))
+          (reset! b-flow-registry (get (rf.flows.registry/flows-snapshot) id ::none))
+          (reset! b-commit (rf.frame/frame-commit-epoch id)))))
     ;; Listener 2 (registered SECOND → fans out AFTER the destroyer): the
     ;; SUBSEQUENT observer. Absent the fence it receives A's stale replaced event
     ;; after B owns the bare id; the fence suppresses it.
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::observer
       (fn [ev]
         (when (= :rf.registry/handler-replaced (:operation ev))
@@ -141,7 +141,7 @@
           "the destroyer received A's :rf.registry/handler-replaced once — the
            already-entered delivery stands")
       (is (some? @b-token) "the destroyer published a same-id B")
-      (is (identical? @b-token (frame/frame-incarnation-token id))
+      (is (identical? @b-token (rf.frame/frame-incarnation-token id))
           "B remains the live incarnation")
       ;; THE TOOTH: the subsequent listener never receives A's stale event.
       (is (empty? @observer-a-repl)
@@ -151,9 +151,9 @@
            wrapper makes this fail)")
       ;; B is never observed / mutated by A's stale tail.
       (is (= ::none @b-flow-registry) "B started with an empty flow registry")
-      (is (= ::none (get (registry/flows-snapshot) id ::none))
+      (is (= ::none (get (rf.flows.registry/flows-snapshot) id ::none))
           "A's stale replacement tail never wrote a flow row onto B")
-      (is (= @b-commit (frame/frame-commit-epoch id))
+      (is (= @b-commit (rf.frame/frame-commit-epoch id))
           "A's stale tail never bumped B's commit epoch")
       ;; The fence does not POISON the successor: B's OWN later replacement emits
       ;; :rf.registry/handler-replaced exactly once, observed.
@@ -170,8 +170,8 @@
       (is (= b-flow-id (get-in (first @observer-repl) [:tags :id]))
           "the sole post-loss replacement observed is B's own")
       (finally
-        (trace/unregister-listener! ::destroyer)
-        (trace/unregister-listener! ::observer)))))
+        (rf.trace/unregister-listener! ::destroyer)
+        (rf.trace/unregister-listener! ::observer)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Green control / over-fence tooth — when A retains ownership through a
@@ -193,12 +193,12 @@
     (rf/reg-flow flow-id
       {:frame id :inputs [[:n]] :output-path [:out]}
       (fn [n] (or n 0)))
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::live-touch
       (fn [ev]
         (when (= :rf.registry/handler-replaced (:operation ev))
           (swap! touched inc))))          ;; observe only — A stays live
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::live-observer
       (fn [ev]
         (when (= :rf.registry/handler-replaced (:operation ev))
@@ -213,8 +213,8 @@
            is not over-fenced")
       (is (= flow-id (get-in (first @observed) [:tags :id])) "A's own flow id")
       (finally
-        (trace/unregister-listener! ::live-touch)
-        (trace/unregister-listener! ::live-observer)))))
+        (rf.trace/unregister-listener! ::live-touch)
+        (rf.trace/unregister-listener! ::live-observer)))))
 
 ;; ===========================================================================
 ;; CLEAR — `:rf.flow/cleared`
@@ -250,7 +250,7 @@
       (fn [n] (or n 0)))
     ;; Listener 1 (registered FIRST): the DESTROYER. On A's own :rf.flow/cleared
     ;; it destroys A and publishes same-id B exactly once, then snapshots B.
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::destroyer
       (fn [ev]
         (when (and (= :rf.flow/cleared (:operation ev))
@@ -258,13 +258,13 @@
                    (= id (get-in ev [:tags :frame]))
                    (compare-and-set! armed? true false))
           (swap! destroyer-hits inc)
-          (frame/destroy-frame! id)
+          (rf.frame/destroy-frame! id)
           (rf/make-frame {:id id})
-          (reset! b-token (frame/frame-incarnation-token id))
-          (reset! b-flow-registry (get (registry/flows-snapshot) id ::none))
-          (reset! b-commit (frame/frame-commit-epoch id)))))
+          (reset! b-token (rf.frame/frame-incarnation-token id))
+          (reset! b-flow-registry (get (rf.flows.registry/flows-snapshot) id ::none))
+          (reset! b-commit (rf.frame/frame-commit-epoch id)))))
     ;; Listener 2 (registered SECOND): the SUBSEQUENT observer.
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::observer
       (fn [ev]
         (when (= :rf.flow/cleared (:operation ev))
@@ -272,13 +272,13 @@
           (when (= flow-id (get-in ev [:tags :flow-id]))
             (swap! observer-a-clr conj ev)))))
     (try
-      (is (nil? (flows/clear-flow flow-id {:frame id}))
+      (is (nil? (rf.flows/clear-flow flow-id {:frame id}))
           "clear-flow returns nil even though A's owner was lost mid-emit")
       (is (= 1 @destroyer-hits)
           "the destroyer received A's :rf.flow/cleared once — the already-entered
            delivery stands")
       (is (some? @b-token) "the destroyer published a same-id B")
-      (is (identical? @b-token (frame/frame-incarnation-token id))
+      (is (identical? @b-token (rf.frame/frame-incarnation-token id))
           "B remains the live incarnation")
       ;; THE TOOTH: the subsequent listener never receives A's stale event.
       (is (empty? @observer-a-clr)
@@ -288,7 +288,7 @@
            serialization, makes this fail)")
       ;; B is never observed / mutated by A's stale tail.
       (is (= ::none @b-flow-registry) "B started with an empty flow registry")
-      (is (= @b-commit (frame/frame-commit-epoch id))
+      (is (= @b-commit (rf.frame/frame-commit-epoch id))
           "A's stale clear tail never bumped B's commit epoch")
       ;; The fence does not POISON the successor: B's OWN later clear emits
       ;; :rf.flow/cleared exactly once, observed.
@@ -296,15 +296,15 @@
       (rf/reg-flow b-flow-id
         {:frame id :inputs [[:bn]] :output-path [:bout]}
         (fn [n] (or n 0)))
-      (is (nil? (flows/clear-flow b-flow-id {:frame id})))
+      (is (nil? (rf.flows/clear-flow b-flow-id {:frame id})))
       (is (= 1 (count @observer-clr))
           "B's own later clear emits :rf.flow/cleared exactly once — the fence did
            not poison the successor")
       (is (= b-flow-id (get-in (first @observer-clr) [:tags :flow-id]))
           "the sole post-loss clear observed is B's own")
       (finally
-        (trace/unregister-listener! ::destroyer)
-        (trace/unregister-listener! ::observer)))))
+        (rf.trace/unregister-listener! ::destroyer)
+        (rf.trace/unregister-listener! ::observer)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Green control / over-fence tooth — when A retains ownership through a
@@ -324,18 +324,18 @@
     (rf/reg-flow flow-id
       {:frame id :inputs [[:n]] :output-path [:out]}
       (fn [n] (or n 0)))
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::live-touch
       (fn [ev]
         (when (= :rf.flow/cleared (:operation ev))
           (swap! touched inc))))          ;; observe only — A stays live
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::live-observer
       (fn [ev]
         (when (= :rf.flow/cleared (:operation ev))
           (swap! observed conj ev))))
     (try
-      (is (nil? (flows/clear-flow flow-id {:frame id})))
+      (is (nil? (rf.flows/clear-flow flow-id {:frame id})))
       (is (= 1 @touched) "the first listener saw A's cleared event")
       (is (= 1 (count @observed))
           "the SUBSEQUENT listener also received it — the live-owner clear is not
@@ -345,8 +345,8 @@
         (is (= [:out]  (:path tags))    "A's own :output-path")
         (is (= id      (:frame tags))   "A's own frame"))
       (finally
-        (trace/unregister-listener! ::live-touch)
-        (trace/unregister-listener! ::live-observer)))))
+        (rf.trace/unregister-listener! ::live-touch)
+        (rf.trace/unregister-listener! ::live-observer)))))
 
 ;; ===========================================================================
 ;; PER-FRAME REPLACEMENT EVIDENCE (rf2-soyqfn) — CROSS-HOST (CLJ + CLJS)
@@ -371,7 +371,7 @@
   (let [captured (atom [])
         f1       (fn [n] (* 2 (or n 0)))
         f2       (fn [n] (* 3 (or n 0)))]
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::repl-recorder
       (fn [ev]
         (when (= :rf.registry/handler-replaced (:operation ev))
@@ -397,7 +397,7 @@
       (is (empty? @captured)
           "identical reloads suppress independently within each frame")
       (finally
-        (trace/unregister-listener! ::repl-recorder)))))
+        (rf.trace/unregister-listener! ::repl-recorder)))))
 
 (deftest fx-reg-flow-replacement-evidence-is-per-frame-cross-host
   ;; RESERVED-EFFECT :rf.fx/reg-flow. The dispatching frame threads through as the
@@ -407,7 +407,7 @@
   (let [captured (atom [])
         f1       (fn [n] (* 2 (or n 0)))
         f2       (fn [n] (* 3 (or n 0)))]
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::repl-recorder
       (fn [ev]
         (when (= :rf.registry/handler-replaced (:operation ev))
@@ -431,7 +431,7 @@
              (set (map #(get-in % [:tags :frame]) @captured)))
           "the reserved-effect evidence is attributable to its frame")
       (finally
-        (trace/unregister-listener! ::repl-recorder)))))
+        (rf.trace/unregister-listener! ::repl-recorder)))))
 
 (deftest reg-flow-replacement-reincarnation-does-not-inherit-cross-host
   ;; Destroy + recreate a frame under the SAME id; the new incarnation's genuine
@@ -440,7 +440,7 @@
   (let [captured (atom [])
         f1       (fn [n] (* 2 (or n 0)))
         f2       (fn [n] (* 3 (or n 0)))]
-    (trace/register-listener!
+    (rf.trace/register-listener!
       ::repl-recorder
       (fn [ev]
         (when (= :rf.registry/handler-replaced (:operation ev))
@@ -451,7 +451,7 @@
       (rf/reg-flow :shared {:frame :host :inputs [[:n]] :output-path [:out]} f2)
       (is (= 1 (count @captured)) "incarnation A's real replacement emitted once")
       (reset! captured [])
-      (frame/destroy-frame! :host)
+      (rf.frame/destroy-frame! :host)
       (rf/make-frame {:id :host})
       (rf/reg-flow :shared {:frame :host :inputs [[:n]] :output-path [:out]} f1)
       (rf/reg-flow :shared {:frame :host :inputs [[:n]] :output-path [:out]} f2)
@@ -460,4 +460,4 @@
       (is (= :host (get-in (first @captured) [:tags :frame]))
           "attributed to the reincarnated :host frame")
       (finally
-        (trace/unregister-listener! ::repl-recorder)))))
+        (rf.trace/unregister-listener! ::repl-recorder)))))

--- a/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
+++ b/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
@@ -29,11 +29,11 @@
   rejection path without pulling Malli onto the classpath."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
-            [re-frame.flows.registry :as registry]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.registry :as rf.flows.registry]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---- per-test reset / schema-validator seam ------------------------------
 ;;
@@ -46,14 +46,14 @@
 
 (defn- with-schema-validator-reset
   [test-fn]
-  (schemas/reset-schema-validator!)
+  (rf.schemas/reset-schema-validator!)
   (try
     (test-fn)
     (finally
-      (schemas/reset-schema-validator!))))
+      (rf.schemas/reset-schema-validator!))))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
   with-schema-validator-reset)
 
 ;; A pluggable predicate validator: a registered "schema" here is a 1-arg
@@ -61,7 +61,7 @@
 ;; the `:schemas/validate-with-registered-fn` seam without Malli (Spec 010
 ;; §Non-Malli validators).
 (defn- install-predicate-validator! []
-  (schemas/set-schema-fns!
+  (rf.schemas/set-schema-fns!
     {:validate (fn [schema value] (boolean (schema value)))
      :explain  (fn [schema value] (when-not (schema value) {:failed value}))}))
 
@@ -115,12 +115,12 @@
       ;; THE LOAD-BEARING ASSERT: the flow's dirty-check row was rolled back
       ;; in lock-step. A surviving advanced row would leave the flow looking
       ;; up-to-date despite its output never reaching app-db.
-      (is (not (contains? (flows/last-inputs-snapshot) :double))
+      (is (not (contains? (rf.flows/last-inputs-snapshot) :double))
           (str "flow :double's last-inputs row was rolled back with the "
                "rejected candidate (pre-fix it stayed advanced to "
                "{:double {:rf/default [1]}}, permanently suppressing the "
                "flow). Got "
-               (pr-str (flows/last-inputs-snapshot))))
+               (pr-str (rf.flows/last-inputs-snapshot))))
 
       ;; Flip the validator to accept, then drive a CLEAN drain whose event
       ;; does NOT change :n (the flow's only input). The rolled-back
@@ -137,7 +137,7 @@
                (pr-str (rf/app-db-value :rf/default))))
       (is (:other (rf/app-db-value :rf/default))
           "the no-op event's own write also landed")
-      (is (= [1] (get-in (flows/last-inputs-snapshot) [:double :rf/default]))
+      (is (= [1] (get-in (rf.flows/last-inputs-snapshot) [:double :rf/default]))
           "after the successful recompute the dirty-check row is advanced to [1]"))))
 
 ;; ---------------------------------------------------------------------------
@@ -156,7 +156,7 @@
     (rf/dispatch-sync [:seed])
     (is (= 6 (:out (rf/app-db-value :rf/default)))
         "the flow output committed durably")
-    (is (= [3] (get-in (flows/last-inputs-snapshot) [:double :rf/default]))
+    (is (= [3] (get-in (rf.flows/last-inputs-snapshot) [:double :rf/default]))
         "last-inputs advanced normally on a durable commit (no over-restore)")))
 
 ;; ===========================================================================
@@ -184,10 +184,10 @@
 
     ;; The aborting event. Its flows :after must NOT advance :derived's row.
     (rf/dispatch-sync [:boom])
-    (is (not (contains? (flows/last-inputs-snapshot) :derived))
+    (is (not (contains? (rf.flows/last-inputs-snapshot) :derived))
         (str "the errored event did NOT advance :derived's dirty-check row "
              "(pre-fix it stayed advanced to [1], suppressing the flow). Got "
-             (pr-str (flows/last-inputs-snapshot))))
+             (pr-str (rf.flows/last-inputs-snapshot))))
     (is (nil? (:out (rf/app-db-value :rf/default)))
         ":out was not committed by the aborted event")
 
@@ -216,7 +216,7 @@
                   (fn [{:keys [db]} _] {:db (assoc db :touched true)}))
     (rf/dispatch-sync [:with-bad-after])
 
-    (is (not (contains? (flows/last-inputs-snapshot) :derived))
+    (is (not (contains? (rf.flows/last-inputs-snapshot) :derived))
         ":derived's dirty-check row was NOT advanced by the user-:after-throw abort")
     (is (nil? (:out (rf/app-db-value :rf/default)))
         ":out not committed (the whole event aborted)")
@@ -242,8 +242,8 @@
     (is (= 99 (:stale    (rf/app-db-value :rf/default))) "precondition: :stale present")
     (is (= 35 (:out-keep (rf/app-db-value :rf/default))) "precondition: :out-keep = 35")
 
-    (registry/record-abandoned-output-path! :rf/default [:stale])
-    (is (= #{[:stale]} (registry/abandoned-output-paths-snapshot :rf/default))
+    (rf.flows.registry/record-abandoned-output-path! :rf/default [:stale])
+    (is (= #{[:stale]} (rf.flows.registry/abandoned-output-paths-snapshot :rf/default))
         "[:stale] is queued for vacation on the next drain")
 
     ;; An errored event. Pre-fix its flows :after drains-and-clears the queued
@@ -252,10 +252,10 @@
     ;; stranded). The guard leaves the queue intact for the next drain.
     (rf/reg-event :boom (fn [_ _] (throw (ex-info "boom" {:src :test}))))
     (rf/dispatch-sync [:boom])
-    (is (= #{[:stale]} (registry/abandoned-output-paths-snapshot :rf/default))
+    (is (= #{[:stale]} (rf.flows.registry/abandoned-output-paths-snapshot :rf/default))
         (str "the queued [:stale] vacation was NOT consumed by the aborted "
              "event (pre-fix it was drained-and-lost). Got "
-             (pr-str (registry/abandoned-output-paths-snapshot :rf/default))))
+             (pr-str (rf.flows.registry/abandoned-output-paths-snapshot :rf/default))))
     (is (= 99 (:stale (rf/app-db-value :rf/default)))
         ":stale not yet vacated (the aborted event committed nothing)")
 
@@ -264,7 +264,7 @@
     (rf/dispatch-sync [:touch])
     (is (not (contains? (rf/app-db-value :rf/default) :stale))
         ":stale finally vacated on the next clean drain (the move re-attempted)")
-    (is (empty? (registry/abandoned-output-paths-snapshot :rf/default))
+    (is (empty? (rf.flows.registry/abandoned-output-paths-snapshot :rf/default))
         "the queue is drained after the successful vacation")
     (is (= 35 (:out-keep (rf/app-db-value :rf/default)))
         ":out-keep (the live sibling flow) is untouched")))
@@ -309,10 +309,10 @@
                   (fn [{:keys [db]} _] {:db db}))
     (rf/dispatch-sync [:legacy])
 
-    (is (not (contains? (flows/last-inputs-snapshot) :derived))
+    (is (not (contains? (rf.flows/last-inputs-snapshot) :derived))
         (str "the in-band legacy-root abort restored :derived's dirty-check "
              "row (pre-fix#2 it stayed advanced to [4]). Got "
-             (pr-str (flows/last-inputs-snapshot))))
+             (pr-str (rf.flows/last-inputs-snapshot))))
     (is (nil? (:out (rf/app-db-value :rf/default)))
         ":out not committed (the whole event aborted, no partial commit)")
 

--- a/implementation/flows/test/re_frame/flows_runtime_partition_input_test.clj
+++ b/implementation/flows/test/re_frame/flows_runtime_partition_input_test.clj
@@ -37,12 +37,12 @@
   explicitly."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.elision :as rf.elision]
+            [re-frame.flows :as rf.flows]
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- per-test reset / trace recorder -------------------------------------
 ;;
@@ -61,7 +61,7 @@
   [test-fn]
   (let [captured (atom [])]
     (binding [*captured* captured]
-      (trace/register-listener!
+      (rf.trace/register-listener!
         ::flow-trace-recorder
         (fn [ev]
           (when (= :flow (:op-type ev))
@@ -69,10 +69,10 @@
       (try
         (test-fn)
         (finally
-          (trace/unregister-listener! ::flow-trace-recorder))))))
+          (rf.trace/unregister-listener! ::flow-trace-recorder))))))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
   with-flow-trace-recorder)
 
 (defn- by-op
@@ -86,8 +86,8 @@
   The declared paths are stored in the frame's runtime-db elision registry, so
   `elide-wire-value` (frame-scoped) matches a value at the declared path."
   [frame-id & paths]
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt {:large (mapv vec paths)}))))
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt {:large (mapv vec paths)}))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. resolve-input's runtime branch — reads the VALUE from runtime-db at the
@@ -115,7 +115,7 @@
                       ;; a resolver that read app-db verbatim would read this
                       :rf.db/runtime      {:rf.runtime/routing {:current {:route-id :APP-DECOY-raw}}}}
           runtime-db {:rf.runtime/routing {:current {:route-id :the-real-runtime-value}}}
-          out        (flows/run-flows-on-db :rf/default app-db runtime-db)]
+          out        (rf.flows/run-flows-on-db :rf/default app-db runtime-db)]
       (is (= :the-real-runtime-value (get-in out [:out]))
           (str "resolve-input must read runtime-db at the STRIPPED path "
                "[:rf.runtime/routing :current :route-id]; got "
@@ -146,12 +146,12 @@
             app-db {:unrelated 1}
             rt-v1  {:rf.runtime/routing {:current {:route-id :home}}}
             rt-v2  {:rf.runtime/routing {:current {:route-id :about}}}
-            db1    (flows/run-flows-on-db :rf/default app-db rt-v1)
+            db1    (rf.flows/run-flows-on-db :rf/default app-db rt-v1)
             _      (reset! *captured* [])
-            db2    (flows/run-flows-on-db :rf/default app-db rt-v2)
+            db2    (rf.flows/run-flows-on-db :rf/default app-db rt-v2)
             computed-2 (by-op :rf.flow/computed)
             _      (reset! *captured* [])
-            db3    (flows/run-flows-on-db :rf/default app-db rt-v2)
+            db3    (rf.flows/run-flows-on-db :rf/default app-db rt-v2)
             skip-3 (by-op :rf.flow/skip)]
         (is (= :home (get-in db1 [:derived :slug]))
             "drain 1 computed the flow onto the runtime-db value V1")
@@ -195,7 +195,7 @@
       (fn [a rt b] [a rt b]))
     (let [app-db     {:app-first :A :app-last :B}
           runtime-db {:rt {:mid :R}}
-          out        (flows/run-flows-on-db :rf/default app-db runtime-db)]
+          out        (rf.flows/run-flows-on-db :rf/default app-db runtime-db)]
       (is (= [:A :R :B] (get-in out [:combined]))
           (str "read-inputs resolves each input against its declared partition "
                "IN DECLARATION ORDER: app-db :app-first (:A), runtime-db :rt/:mid "
@@ -227,17 +227,17 @@
     ;; Drive with a runtime-db that carries BOTH the elision registry (from
     ;; install-large!) and the actual value at the stripped path — the realistic
     ;; single-partition shape a real drain would present.
-    (let [runtime-db (assoc-in (frame/frame-runtime-db-value :rf/default)
+    (let [runtime-db (assoc-in (rf.frame/frame-runtime-db-value :rf/default)
                                [:rt :val] {:big "payload"})]
       (reset! *captured* [])
-      (flows/run-flows-on-db :rf/default {} runtime-db)
+      (rf.flows/run-flows-on-db :rf/default {} runtime-db)
       (let [ev            (last (by-op :rf.flow/computed))
             input-values  (:input-values (:tags ev))
             [first-input] input-values]
         (is (some? ev) ":rf.flow/computed fired")
         (is (vector? input-values)
             ":input-values preserves the per-input slot shape")
-        (is (elision/marker? first-input)
+        (is (rf.elision/marker? first-input)
             (str "the runtime-qualified input value is replaced by the wire "
                  "marker — proving the declaration at the stripped path matched. "
                  "Got " (pr-str first-input) " (a raw {:big \"payload\"} means "

--- a/implementation/flows/test/re_frame/flows_schema_validation_test.clj
+++ b/implementation/flows/test/re_frame/flows_schema_validation_test.clj
@@ -27,15 +27,15 @@
       silent (the whole surface DCEs in prod CLJS)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.schemas :as schemas]
+            [re-frame.interop :as rf.interop]
+            [re-frame.schemas :as rf.schemas]
             ;; Loading `re-frame.flows` wires the flow late-bind hooks the
             ;; `rf/reg-flow` bodies below drive (the flow-output validation
             ;; path this suite pins).
             [re-frame.flows]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- per-test reset / schema-violation recorder --------------------------
 ;;
@@ -54,10 +54,10 @@
   the recorder and reset the validator again afterwards so no validator
   leaks into a sibling suite."
   [test-fn]
-  (schemas/reset-schema-validator!)
+  (rf.schemas/reset-schema-validator!)
   (let [captured (atom [])]
     (binding [*captured* captured]
-      (trace/register-listener!
+      (rf.trace/register-listener!
         ::schema-violation-recorder
         (fn [ev]
           (when (= :rf.error/schema-validation-failure (:operation ev))
@@ -65,18 +65,18 @@
       (try
         (test-fn)
         (finally
-          (trace/unregister-listener! ::schema-violation-recorder)
-          (schemas/reset-schema-validator!))))))
+          (rf.trace/unregister-listener! ::schema-violation-recorder)
+          (rf.schemas/reset-schema-validator!))))))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
   with-schema-violation-recorder)
 
 ;; A trivial pluggable validator: a schema here is a 1-arg predicate fn.
 ;; This exercises the `:schemas/validate-with-registered-fn` seam without
 ;; pulling Malli onto the test classpath (Spec 010 §Non-Malli validators).
 (defn- install-predicate-validator! []
-  (schemas/set-schema-fns!
+  (rf.schemas/set-schema-fns!
     {:validate (fn [schema value] (boolean (schema value)))
      :explain  (fn [schema value]
                  (when-not (schema value)
@@ -158,7 +158,7 @@
 (deftest absent-schema-skips-validation
   (testing "a flow without :schema never consults the validator (no violation even on a 'bad' value)"
     (let [validator-calls (atom 0)]
-      (schemas/set-schema-fns!
+      (rf.schemas/set-schema-fns!
         {:validate (fn [_ _] (swap! validator-calls inc) false)})
       (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
       (rf/reg-flow :area {:inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* w h)))
@@ -176,7 +176,7 @@
   (testing "with the validator set to nil, a :schema flow soft-passes (no violation)"
     ;; nil validator => the `:schemas/validate-with-registered-fn` seam
     ;; treats 'no validator' as 'no validation' (Spec 010 soft-pass).
-    (schemas/set-schema-validator! nil)
+    (rf.schemas/set-schema-validator! nil)
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow :area {:inputs [[:w] [:h]] :output-path [:rect :area] :schema (fn [_] false)} (fn [w h] (* w h))) ;; would reject everything IF consulted
     (rf/dispatch-sync [:seed])
@@ -194,7 +194,7 @@
     (install-predicate-validator!)
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
     (rf/reg-flow :area {:inputs [[:w] [:h]] :output-path [:rect :area] :schema (fn [_] false)} (fn [w h] (* w h))) ;; would reject IF the gate let it run
-    (with-redefs [interop/debug-enabled? false]
+    (with-redefs [rf.interop/debug-enabled? false]
       (rf/dispatch-sync [:seed]))
     (is (= 12 (get-in (rf/app-db-value :rf/default) [:rect :area]))
         "value written even with validation elided")
@@ -242,7 +242,7 @@
   (testing "an explicit {:schema nil} flow declaration reaches the validator
             verbatim; the false verdict emits :where :flow-output"
     (let [seen (atom [])]
-      (schemas/set-schema-fns!
+      (rf.schemas/set-schema-fns!
         {:validate (fn [schema _value] (swap! seen conj schema) false)})
       (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
       (rf/reg-flow :area

--- a/implementation/flows/test/re_frame/flows_settle_on_dispatch_test.clj
+++ b/implementation/flows/test/re_frame/flows_settle_on_dispatch_test.clj
@@ -26,12 +26,12 @@
   lagging runtime and green against the settling one."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.flows :as rf.flows]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (def ^:private sum-flow
   [:step-2/computed
@@ -52,7 +52,7 @@
 
     (rf/dispatch-sync [:enter])
 
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :step-2/computed)
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :step-2/computed)
         "the registry carries the flow after the registering dispatch")
     ;; THE CONTROL, register arm. Red under the one-event lag: the flow
     ;; transform for :enter ran before `:fx` registered the flow, so nothing
@@ -74,7 +74,7 @@
 
     (rf/dispatch-sync [:leave])
 
-    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :step-2/computed))
+    (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :step-2/computed))
         "the registry row is gone — this half was never lagged")
     ;; THE CONTROL, clear arm. Red under the one-event lag: the vacation was
     ;; recorded as a pending abandoned path and only dissoc'd from the pending

--- a/implementation/flows/test/re_frame/flows_settle_ordering_test.clj
+++ b/implementation/flows/test/re_frame/flows_settle_ordering_test.clj
@@ -27,11 +27,11 @@
             ;; lagging runtime — every assertion below goes red for the wrong
             ;; reason. Required for effect, not for a var.
             [re-frame.flows]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (def ^:private sum-flow
   "1 + 2 = 3 at `[:derived]` — the audit probe's own shape."

--- a/implementation/flows/test/re_frame/flows_t2_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_t2_trace_test.clj
@@ -28,8 +28,8 @@
             ;; late-bind hook this test exercises (the post-flow t2 path);
             ;; the tests register flows via the `rf/reg-flow` facade.
             [re-frame.flows]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; The standard runtime reset (registrar baseline + frames + flows/schemas +
 ;; plain-atom adapter + ambient `:rf/default` scope) is owned by
@@ -38,7 +38,7 @@
 ;; frame stamp.
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (defn- collect-traces!
   [id]

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -20,14 +20,14 @@
     - clear-all / lifecycle interaction with the per-frame registry"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
-            [re-frame.flows.registry :as registry]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            [re-frame.elision :as rf.elision]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.flows :as rf.flows]
+            [re-frame.flows.registry :as rf.flows.registry]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
             [re-frame.trace])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
@@ -46,7 +46,7 @@
 ;; below carry a frame stamp (EP-0002).
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 (deftest exact-owner-loss-in-first-derive-stops-the-flow-tail
   ;; Mutation teeth: removing the post-derive owner check publishes :killer's
@@ -60,7 +60,7 @@
     (rf/reg-flow :killer
       {:frame id :inputs [[:seed]] :output-path [:derived]}
       (fn [_]
-        (frame/destroy-frame! id)
+        (rf.frame/destroy-frame! id)
         (.countDown destroyed)
         (.await release 10 TimeUnit/SECONDS)
         (throw (ex-info "obsolete derive failure" {}))))
@@ -79,7 +79,7 @@
       (is (nil? (deref dispatch-a 5000 ::timeout))
           "destroy+throw in A's derive is inert after exact-owner loss"))
     (is (zero? @later-runs) "no later flow callback runs")
-    (is (= {} (frame/frame-app-db-value id))
+    (is (= {} (rf.frame/frame-app-db-value id))
         "A's pending handler/flow transition never commits into B")))
 
 ;; ---------------------------------------------------------------------------
@@ -89,14 +89,14 @@
 (deftest reg-flow-populates-registry
   (testing "reg-flow stores the flow under [frame-id flow-id] in the per-frame registry"
     (rf/reg-flow :area {:inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* (or w 0) (or h 0))))
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :area)
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :area)
         "the flow lives under :rf/default's slot of the per-frame registry")
     ;; Per rf2-en00bk the per-frame `flows` store is the SOLE store — the flow
     ;; is introspectable via the frame-scoped `flow-meta-at`, NOT a frame-blind
     ;; registrar `:flow` slot (which is RESERVED-but-empty).
-    (is (some? (flows/flow-meta-at :area {:frame :rf/default}))
+    (is (some? (rf.flows/flow-meta-at :area {:frame :rf/default}))
         "the flow is discoverable via the frame-scoped flow-meta-at")
-    (is (nil? (registrar/lookup :flow :area))
+    (is (nil? (rf.registrar/lookup :flow :area))
         "the :flow registrar kind is RESERVED-but-empty — no slot is written (rf2-en00bk)")))
 
 (deftest clear-flow-removes-from-registry-and-vacates-output-slot
@@ -109,13 +109,13 @@
     (rf/dispatch-sync [:seed])
     (is (= 12 (get-in (rf/app-db-value :rf/default) [:rect :area]))
         "flow ran on the drain after :seed and materialised :rect/:area")
-    (flows/clear-flow :area)
-    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :area))
+    (rf.flows/clear-flow :area)
+    (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :area))
         "the per-frame registry no longer carries :area")
     (is (not (contains? (get (rf/app-db-value :rf/default) :rect) :area))
         "clear-flow dissoc'd the leaf at the flow's :output-path"))
   (testing "calling clear-flow on an unknown id is a no-op (does not throw)"
-    (flows/clear-flow :no-such-flow)))
+    (rf.flows/clear-flow :no-such-flow)))
 
 (deftest clear-flow-prunes-empty-frame-slot-from-registry
   ;; Clearing the LAST flow on a frame dissocs the frame-id key from the
@@ -125,10 +125,10 @@
   ;; `teardown-on-frame-destroy!`'s `(swap! flows dissoc frame-id)`.
   (testing "clearing the sole flow on a frame removes the frame-id key from flows-snapshot"
     (rf/reg-flow :area {:inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* (or w 0) (or h 0))))
-    (is (contains? (flows/flows-snapshot) :rf/default)
+    (is (contains? (rf.flows/flows-snapshot) :rf/default)
         "precondition: the frame slot exists while a flow is registered")
-    (flows/clear-flow :area)
-    (is (not (contains? (flows/flows-snapshot) :rf/default))
+    (rf.flows/clear-flow :area)
+    (is (not (contains? (rf.flows/flows-snapshot) :rf/default))
         "the frame-id key is GONE from @flows — no {frame-id {}} husk remains")))
 
 (deftest clear-flow-vacates-leaf-only-leaving-empty-parent-husk
@@ -148,7 +148,7 @@
     (rf/dispatch-sync [:touch-wizard])
     (is (= 42 (get-in (rf/app-db-value :rf/default) [:wizard :result]))
         "flow materialised its output at the leaf")
-    (flows/clear-flow :wizard/result)
+    (rf.flows/clear-flow :wizard/result)
     (let [db (rf/app-db-value :rf/default)]
       (is (not (contains? (get db :wizard) :result))
           "the leaf value is fully vacated")
@@ -168,7 +168,7 @@
   (testing "clear-flow on nested-path flow before first compute leaves app-db unchanged"
     (rf/reg-flow :pending {:inputs [[:n]] :output-path [:step-2 :result]} (fn [_] "never-runs"))
     (let [db-before (rf/app-db-value :rf/default)]
-      (flows/clear-flow :pending)
+      (rf.flows/clear-flow :pending)
       (let [db-after (rf/app-db-value :rf/default)]
         (is (= db-before db-after)
             "app-db is unchanged when clearing a never-materialised nested-path flow")
@@ -197,7 +197,7 @@
     (rf/dispatch-sync [:seed])
     (rf/reg-flow :pending {:inputs [[:n]] :output-path [:step-2 :result]} (fn [_] "never-runs"))
     (let [db-ref-before (rf/app-db-value :rf/default)]
-      (flows/clear-flow :pending)
+      (rf.flows/clear-flow :pending)
       (let [db-ref-after (rf/app-db-value :rf/default)]
         (is (identical? db-ref-before db-ref-after)
             "the app-db container reference is UNCHANGED — clear-flow skipped replace-container! for the no-op dissoc (rf2-2vpac)"))))
@@ -209,7 +209,7 @@
     (rf/dispatch-sync [:seed2])
     (rf/reg-flow :absent-top {:inputs [[:n]] :output-path [:never-written]} (fn [_] "never-runs")) ;; single-element path, never materialised
     (let [db-ref-before (rf/app-db-value :rf/default)]
-      (flows/clear-flow :absent-top)
+      (rf.flows/clear-flow :absent-top)
       (is (identical? db-ref-before (rf/app-db-value :rf/default))
           "single-element absent key: container reference unchanged (no rewrite)")))
   (testing "POSITIVE control — clearing a MATERIALISED slot DOES rewrite the container (guard must not over-suppress real clears)"
@@ -223,7 +223,7 @@
     (is (= 12 (get-in (rf/app-db-value :rf/default) [:rect :area]))
         "precondition: the flow materialised [:rect :area]")
     (let [db-ref-before (rf/app-db-value :rf/default)]
-      (flows/clear-flow :area3)
+      (rf.flows/clear-flow :area3)
       (let [db-ref-after (rf/app-db-value :rf/default)]
         (is (not (identical? db-ref-before db-ref-after))
             "the container WAS rewritten — a real dissoc installs a fresh reference")
@@ -252,7 +252,7 @@
     ;; entry to clear; its `:output-path` [:step-2 :result] never materialised.
     (rf/reg-flow :pending {:inputs [[:foo]] :output-path [:step-2 :result]} (fn [_] "never-stored"))
     ;; Clear must NOT throw, and must leave the scalar parent intact.
-    (is (nil? (flows/clear-flow :pending))
+    (is (nil? (rf.flows/clear-flow :pending))
         "clear-flow returns nil (no throw) when the intermediate is a non-map")
     (is (= 1 (:step-2 (rf/app-db-value :rf/default)))
         ":step-2 is preserved as its scalar value — clear-flow did not corrupt it")
@@ -271,7 +271,7 @@
     (rf/dispatch-sync [:seed])
     (is (= 12 (get (rf/app-db-value :rf/default) :area))
         "flow ran on the drain after :seed and materialised :area")
-    (flows/clear-flow :area)
+    (rf.flows/clear-flow :area)
     (let [db (rf/app-db-value :rf/default)]
       (is (not (contains? db :area))
           "single-element :output-path is dissoc'd cleanly")
@@ -425,8 +425,8 @@
       (is (= :fix-registration (:recovery data)) ":recovery names the disposition")
       (is (string? (:reason data)) ":reason is a human-readable sentence")))
   (testing "flow cycle throw stamps :rf.error/id"
-    (flows/reset-flows!)
-    (flows/reset-last-inputs!)
+    (rf.flows/reset-flows!)
+    (rf.flows/reset-last-inputs!)
     (rf/reg-flow :a {:inputs [[:b]] :output-path [:a]} identity)
     (let [ex (try
                (rf/reg-flow :b {:inputs [[:a]] :output-path [:b]} identity)
@@ -517,20 +517,20 @@
   ;; the registration was accepted; the rule rejects it at the API boundary.
   (testing "a multi-segment :rf.db/runtime-rooted :output-path is rejected"
     (let [ex (try
-               (rf/reg-flow :bad {:inputs [[:n]] :output-path [registry/runtime-partition-key :cur]} identity)
+               (rf/reg-flow :bad {:inputs [[:n]] :output-path [rf.flows.registry/runtime-partition-key :cur]} identity)
                (catch Throwable t t))]
       (is (some? ex) "registration threw")
       (is (flow-reserved-output-path? ex)
           "error id is :rf.error/flow-reserved-output-path (distinct from the flow-bad-path shape family)")
       (is (= 'rf/reg-flow (:where (ex-data ex))) ":where names the user-facing surface")
       (is (= :fix-registration (:recovery (ex-data ex))) ":recovery names the disposition")
-      (is (= [registry/runtime-partition-key] (:bad-elements (ex-data ex)))
+      (is (= [rf.flows.registry/runtime-partition-key] (:bad-elements (ex-data ex)))
           "ex-data names the offending leading segment")
       (is (re-find #":rf\.db/runtime" (:reason (ex-data ex)))
           ":reason names the reserved partition key")))
   (testing "a single-segment [:rf.db/runtime] :output-path is likewise rejected"
     (let [ex (try
-               (rf/reg-flow :bad2 {:inputs [[:n]] :output-path [registry/runtime-partition-key]} identity)
+               (rf/reg-flow :bad2 {:inputs [[:n]] :output-path [rf.flows.registry/runtime-partition-key]} identity)
                (catch Throwable t t))]
       (is (flow-reserved-output-path? ex)
           "a bare [:rf.db/runtime] output-path is rejected too")))
@@ -539,9 +539,9 @@
     ;; The reservation is positional: only a LEADING :rf.db/runtime confuses
     ;; the topo/dirty-check partition logic. A :rf.db/runtime key nested under
     ;; a real app-db root is just an ordinary keyword key and must still pass.
-    (is (some? (rf/reg-flow :deep {:inputs [[:n]] :output-path [:app registry/runtime-partition-key]} identity))
+    (is (some? (rf/reg-flow :deep {:inputs [[:n]] :output-path [:app rf.flows.registry/runtime-partition-key]} identity))
         "a non-leading :rf.db/runtime segment registers cleanly")
-    (flows/clear-flow :deep)))
+    (rf.flows/clear-flow :deep)))
 
 (deftest reg-flow-accepts-shared-domain-path-elements
   (testing "path elements across the SHARED EP-0012 segment domain all pass
@@ -566,7 +566,7 @@
       (let [flow-id (keyword "elt" (name label))]
         (is (some? (rf/reg-flow flow-id {:inputs [[:root elt]] :output-path [:out elt]} identity))
             (str "shared-domain path segment " (pr-str elt) " is accepted"))
-        (flows/clear-flow flow-id)))))
+        (rf.flows/clear-flow flow-id)))))
 
 (deftest reg-flow-accepts-empty-inputs-vector
   (testing ":inputs [] is allowed (one-shot flow with no app-db dependencies)"
@@ -744,9 +744,9 @@
     ;; swap! that writes the flows row and before write-flow-output-marks!
     ;; folds the classification declarations into the frame elision registry.
     ;; So a rejected registration must leave all three surfaces untouched.
-    (let [flows-before     (flows/flows-snapshot)
-          sensitive-before (elision/sensitive-declarations :rf/default)
-          large-before     (elision/declarations :rf/default)
+    (let [flows-before     (rf.flows/flows-snapshot)
+          sensitive-before (rf.elision/sensitive-declarations :rf/default)
+          large-before     (rf.elision/declarations :rf/default)
           ex (reg-flow-throwing {:id          :bad/no-leak
                                  :inputs      [[:n]]
                                  :derive      identity
@@ -758,14 +758,14 @@
                                  :large       :not-a-vector})]
       (is (some? ex) "registration threw")
       (is (flow-bad-marks? ex) "error id is :rf.error/flow-bad-marks")
-      (is (= flows-before (flows/flows-snapshot))
+      (is (= flows-before (rf.flows/flows-snapshot))
           "no flow row was installed — the per-frame flows registry is unchanged")
-      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :bad/no-leak))
+      (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :bad/no-leak))
           "specifically: the rejected flow id is absent from the registry")
-      (is (= sensitive-before (elision/sensitive-declarations :rf/default))
+      (is (= sensitive-before (rf.elision/sensitive-declarations :rf/default))
           "no :sensitive elision declaration was installed (the well-formed
            [:secret] mark did not leak past the malformed :large rejection)")
-      (is (= large-before (elision/declarations :rf/default))
+      (is (= large-before (rf.elision/declarations :rf/default))
           "no :large elision declaration was installed"))))
 
 (deftest reg-flow-detects-cycles-at-registration
@@ -774,7 +774,7 @@
     (is (thrown? Throwable
                  (rf/reg-flow :b {:inputs [[:a]] :output-path [:b]} identity))
         "the cyclic registration unwinds and throws :rf.error/flow-cycle")
-    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :b))
+    (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :b))
         "cycle-detection rolls back the partial registration of :b")))
 
 (deftest reg-flow-cycle-error-carries-ordered-cycle-path
@@ -810,8 +810,8 @@
     ;; Reset and build a longer chain. The reg-flow ordering matters
     ;; because the cycle is detected on the registration that closes
     ;; it — register :a, :b first (no cycle yet), then :c closes.
-    (flows/reset-flows!)
-    (flows/reset-last-inputs!)
+    (rf.flows/reset-flows!)
+    (rf.flows/reset-last-inputs!)
     (rf/reg-flow :a {:inputs [[:b]] :output-path [:a]} identity)
     (rf/reg-flow :b {:inputs [[:c]] :output-path [:b]} identity)
     (let [ex (try
@@ -845,7 +845,7 @@
     ;; 1. :a reads [:b], writes [:a]. Currently no cycle because :b is
     ;;    not yet registered.
     (rf/reg-flow :a {:inputs [[:b]] :output-path [:a]} (fn [b] (str "A-from-B-" b)))
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :a)
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :a)
         "initial :a registers cleanly")
 
     ;; 2. :b reads an unrelated path [:source], writes [:b]. Graph is
@@ -856,7 +856,7 @@
     ;;    its replacement is what would close the cycle.
     (let [original-b-output (fn [src] (str "B-of-" src))]
       (rf/reg-flow :b {:inputs [[:source]] :output-path [:b]} original-b-output)
-      (is (contains? (get (flows/flows-snapshot) :rf/default) :b)
+      (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :b)
           "initial :b registers cleanly (reads [:source]; no cycle)")
 
       ;; 3. RE-register :b with :inputs [[:a]]. :a already reads [:b],
@@ -874,16 +874,16 @@
       ;;    this: cycle/overlap detection runs on the prospective map
       ;;    inside the swap! update fn and never commits on rejection,
       ;;    so the prior registration is left untouched.
-      (is (contains? (get (flows/flows-snapshot) :rf/default) :b)
+      (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :b)
           "after a failed cyclic replacement, the prior :b registration is preserved")
-      (let [b-after (get-in (flows/flows-snapshot) [:rf/default :b])]
+      (let [b-after (get-in (rf.flows/flows-snapshot) [:rf/default :b])]
         (is (= [[:source]] (:inputs b-after))
             "prior :b's :inputs are intact ([[:source]], not the rejected [[:a]])")
         (is (identical? original-b-output (:derive b-after))
             "prior :b's :derive fn has the SAME identity (not the rejected new fn)"))
       ;; And the per-frame store — the single source of truth (rf2-en00bk) —
       ;; must still resolve the prior :b for this frame.
-      (is (some? (flows/flow-meta-at :b {:frame :rf/default}))
+      (is (some? (rf.flows/flow-meta-at :b {:frame :rf/default}))
           "the per-frame flow store for :b is still populated"))))
 
 ;; ---------------------------------------------------------------------------
@@ -905,7 +905,7 @@
   (testing "a singleton flow whose bare input EQUALS its own :output-path is a
             self-cycle → :rf.error/flow-cycle, closing-repeat [id id], nothing
             registered"
-    (let [before (flows/flows-snapshot)
+    (let [before (rf.flows/flows-snapshot)
           ex     (reg-flow-throwing {:id :probe/self :inputs [[:x]] :derive inc :output-path [:x]})]
       (is (some? ex) "the self-cyclic registration throws")
       (is (flow-cycle? ex) "structured :rf.error/flow-cycle")
@@ -913,9 +913,9 @@
           ":cycle is the closing-repeat single-node path [id id]")
       (is (= :fix-registration (:recovery (ex-data ex)))
           ":recovery :fix-registration — the cycle is caller-fixable")
-      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :probe/self))
+      (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :probe/self))
           "the rejected flow is absent from the registry")
-      (is (= before (flows/flows-snapshot))
+      (is (= before (rf.flows/flows-snapshot))
           "registration mutated no flow state (rejected before commit)")))
 
   (testing "prefix self-overlap in BOTH directions is also a self-cycle"
@@ -936,11 +936,11 @@
       (is (flow-cycle? ex) "the self-cycle is detected alongside acyclic siblings")
       (is (= [:probe/self :probe/self] (:cycle (ex-data ex)))
           ":cycle names only the offending self-cyclic id"))
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :keep/a)
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :keep/a)
         "the prior acyclic :keep/a survives the rejected registration")
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :keep/b)
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :keep/b)
         "the prior acyclic :keep/b survives the rejected registration")
-    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :probe/self))
+    (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :probe/self))
         "the rejected self-cyclic flow is absent")))
 
 (deftest reg-flow-self-cycle-replacement-preserves-prior-registration-and-output
@@ -956,7 +956,7 @@
       (rf/dispatch-sync [:init])
       (is (= 10 (get-in (rf/app-db-value :rf/default) [:derived :doubled]))
           "the valid flow materialized its output")
-      (is (some? (registry/get-frame-flow-last-inputs :rf/default :double))
+      (is (some? (rf.flows.registry/get-frame-flow-last-inputs :rf/default :double))
           "the valid flow seeded a dirty-check row")
       ;; Re-register :double so its INPUT now overlaps its OWN output — a
       ;; self-cycle. The replacement must be rejected.
@@ -967,12 +967,12 @@
         (is (flow-cycle? ex) "the self-cyclic replacement is rejected"))
       ;; The prior working definition, its dirty-check row, and its output
       ;; must all survive — the rejection happened before any mutation.
-      (let [after (get-in (flows/flows-snapshot) [:rf/default :double])]
+      (let [after (get-in (rf.flows/flows-snapshot) [:rf/default :double])]
         (is (= [[:n]] (:inputs after))
             "prior :double's :inputs are intact ([[:n]], not the rejected self-input)")
         (is (identical? original-derive (:derive after))
             "prior :double's :derive fn has the SAME identity"))
-      (is (some? (registry/get-frame-flow-last-inputs :rf/default :double))
+      (is (some? (rf.flows.registry/get-frame-flow-last-inputs :rf/default :double))
           "the prior dirty-check row is preserved")
       (is (= 10 (get-in (rf/app-db-value :rf/default) [:derived :doubled]))
           "the prior materialized output is untouched"))))
@@ -1160,7 +1160,7 @@
     ;; walk settles the frame's flows before this dispatch returns, so the
     ;; initial output is present immediately.
     (rf/dispatch-sync [:enter])
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :step-2/computed)
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :step-2/computed)
         "registry now carries :step-2/computed")
     (is (= 7 (get-in (rf/app-db-value :rf/default) [:wizard :result]))
         "and its initial output 3 + 4 = 7 settled on the registering dispatch")
@@ -1173,7 +1173,7 @@
     ;; dispatch, so the registry row and the value it owned disappear
     ;; together rather than one drain apart.
     (rf/dispatch-sync [:leave])
-    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :step-2/computed))
+    (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :step-2/computed))
         "registry slot removed")
     (is (not (contains? (get (rf/app-db-value :rf/default) :wizard) :result))
         "and :rf.fx/clear-flow's dissoc-in landed on the same dispatch")))
@@ -1204,7 +1204,7 @@
   (testing "a bare mid-event reg-flow settles on its own dispatch"
     (rf/dispatch-sync [:init])
     (rf/dispatch-sync [:enter-bare])
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :step-2/computed)
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :step-2/computed)
         "flow IS registered after :enter-bare")
     (is (= 7 (get-in (rf/app-db-value :rf/default) [:wizard :result]))
         "and :result carries 3 + 4 = 7 with no follow-up event"))
@@ -1225,16 +1225,16 @@
     (rf/reg-flow :one {:inputs [[:a]] :output-path [:slots :one]} identity)
     (rf/reg-flow :two {:inputs [[:a]] :output-path [:slots :two]} identity)
     ;; The flows live in the per-frame store, introspectable via flow-meta-at.
-    (is (some? (flows/flow-meta-at :one {:frame :rf/default})))
-    (is (some? (flows/flow-meta-at :two {:frame :rf/default})))
+    (is (some? (rf.flows/flow-meta-at :one {:frame :rf/default})))
+    (is (some? (rf.flows/flow-meta-at :two {:frame :rf/default})))
     ;; The registrar `:flow` slot is RESERVED-but-empty — never written.
-    (is (nil? (registrar/lookup :flow :one))
+    (is (nil? (rf.registrar/lookup :flow :one))
         ":flow registrar slot is empty — flows own their per-frame store (rf2-en00bk)")
-    (is (nil? (registrar/lookup :flow :two)))
+    (is (nil? (rf.registrar/lookup :flow :two)))
     ;; `reset-flows!` (NOT registrar/clear-all!) is what clears the flow store.
-    (flows/reset-flows!)
-    (is (nil? (flows/flow-meta-at :one {:frame :rf/default})))
-    (is (nil? (flows/flow-meta-at :two {:frame :rf/default})))))
+    (rf.flows/reset-flows!)
+    (is (nil? (rf.flows/flow-meta-at :one {:frame :rf/default})))
+    (is (nil? (rf.flows/flow-meta-at :two {:frame :rf/default})))))
 
 (deftest reset-flows-clears-both-flows-and-last-inputs
   ;; `reset-flows!` resets BOTH the flow registry AND the dirty-check
@@ -1248,12 +1248,12 @@
     (rf/dispatch-sync [:init])
     (is (= 10 (:doubled (rf/app-db-value :rf/default)))
         "flow evaluated; last-inputs row populated for [:double :rf/default]")
-    (is (some? (get-in (flows/last-inputs-snapshot) [:double :rf/default]))
+    (is (some? (get-in (rf.flows/last-inputs-snapshot) [:double :rf/default]))
         "last-inputs has the dirty-check entry before reset")
-    (flows/reset-flows!)
-    (is (empty? (flows/flows-snapshot))
+    (rf.flows/reset-flows!)
+    (is (empty? (rf.flows/flows-snapshot))
         "flow registry is empty after reset-flows!")
-    (is (empty? (flows/last-inputs-snapshot))
+    (is (empty? (rf.flows/last-inputs-snapshot))
         "last-inputs is ALSO empty after reset-flows! (rf2-mb65w)")))
 
 (deftest reset-flows-allows-re-registration-without-stale-skip
@@ -1271,7 +1271,7 @@
       (is (= 1 @calls) "flow body ran on the first drain")
       ;; Reset BOTH atoms via the public reset-flows! — then re-register
       ;; the IDENTICAL flow against the IDENTICAL inputs.
-      (flows/reset-flows!)
+      (rf.flows/reset-flows!)
       (rf/reg-flow :double {:inputs [[:n]] :output-path [:doubled]} (fn [n] (swap! calls inc) (* 2 n)))
       (rf/dispatch-sync [:init])
       (is (= 2 @calls)
@@ -1280,13 +1280,13 @@
 (deftest reset-flows-clears-per-frame-state
   (testing "(flows/reset-flows!) clears the per-frame registry; reg-flow repopulates fresh"
     (rf/reg-flow :one {:inputs [[:a]] :output-path [:slots :one]} identity)
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :one))
-    (flows/reset-flows!)
-    (schemas/clear-schemas-by-frame!)
-    (is (empty? (get (flows/flows-snapshot) :rf/default))
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :one))
+    (rf.flows/reset-flows!)
+    (rf.schemas/clear-schemas-by-frame!)
+    (is (empty? (get (rf.flows/flows-snapshot) :rf/default))
         "per-frame map is empty after reset")
     (rf/reg-flow :one {:inputs [[:a]] :output-path [:slots :one]} identity)
-    (is (contains? (get (flows/flows-snapshot) :rf/default) :one)
+    (is (contains? (get (rf.flows/flows-snapshot) :rf/default) :one)
         "re-registration after reset works without raising")))
 
 ;; ---------------------------------------------------------------------------
@@ -1328,17 +1328,17 @@
         "left frame's :compute used the 2x formula (5 * 2)")
     (is (= 500 (:result (rf/app-db-value :right)))
         "right frame's :compute used the 100x formula (5 * 100)")
-    (is (contains? (get (flows/flows-snapshot) :left)  :compute)
+    (is (contains? (get (rf.flows/flows-snapshot) :left)  :compute)
         ":left's per-frame registry slot carries :compute")
-    (is (contains? (get (flows/flows-snapshot) :right) :compute)
+    (is (contains? (get (rf.flows/flows-snapshot) :right) :compute)
         ":right's per-frame registry slot carries :compute"))
 
   (testing "clear-flow on one frame leaves the sibling frame's registry slot intact"
     ;; Branch 1: per-frame registry routing.
-    (flows/clear-flow :compute {:frame :left})
-    (is (not (contains? (get (flows/flows-snapshot) :left)  :compute))
+    (rf.flows/clear-flow :compute {:frame :left})
+    (is (not (contains? (get (rf.flows/flows-snapshot) :left)  :compute))
         ":left's slot was removed")
-    (is (contains? (get (flows/flows-snapshot) :right) :compute)
+    (is (contains? (get (rf.flows/flows-snapshot) :right) :compute)
         ":right's slot is untouched — flow STILL registered against :right"))
 
   (testing ":left's app-db output path is dissoc'd; :right's app-db is unchanged"
@@ -1365,20 +1365,20 @@
     ;; Under the per-frame single store, :right's entry is authoritative in
     ;; place — there is no shared registrar `:flow` slot to keep aligned. Per-
     ;; frame introspection shows :left cleared, :right still owning the id.
-    (is (nil? (flows/flow-meta-at :compute {:frame :left}))
+    (is (nil? (rf.flows/flow-meta-at :compute {:frame :left}))
         ":left's per-frame flow entry is gone after the clear")
-    (is (some? (flows/flow-meta-at :compute {:frame :right}))
+    (is (some? (rf.flows/flow-meta-at :compute {:frame :right}))
         ":right's per-frame flow entry is intact — it still registers the id")
-    (is (nil? (registrar/lookup :flow :compute))
+    (is (nil? (rf.registrar/lookup :flow :compute))
         "the :flow registrar slot is RESERVED-but-empty throughout (rf2-en00bk)"))
 
   (testing "clearing from the second (last) frame drops the final per-frame entry"
-    (flows/clear-flow :compute {:frame :right})
-    (is (not (contains? (get (flows/flows-snapshot) :right) :compute))
+    (rf.flows/clear-flow :compute {:frame :right})
+    (is (not (contains? (get (rf.flows/flows-snapshot) :right) :compute))
         ":right's slot is now gone")
-    (is (nil? (flows/flow-meta-at :compute {:frame :right}))
+    (is (nil? (rf.flows/flow-meta-at :compute {:frame :right}))
         ":right's per-frame flow entry is gone")
-    (is (nil? (registrar/lookup :flow :compute))
+    (is (nil? (rf.registrar/lookup :flow :compute))
         "the :flow registrar slot stays empty — single-store, nothing to unregister (rf2-en00bk)")))
 
 ;; ---------------------------------------------------------------------------
@@ -1400,7 +1400,7 @@
             (does NOT report the live frame as not-live), and flow-meta-at
             observes the SAME flow whether keyed by id or by value"
     (let [frame-val (rf/make-frame {:id :fv/host})]
-      (is (frame/frame-value? frame-val)
+      (is (rf.frame/frame-value? frame-val)
           "make-frame returns a frame VALUE, not a bare keyword")
       ;; Pre-fix this THREW :rf.error/flow-frame-not-live because the raw
       ;; value keyed the `frame/frame` liveness probe (which keys `@frames`
@@ -1413,28 +1413,28 @@
                           (fn [w h] (* (or w 0) (or h 0)))))
           "reg-flow against a frame VALUE succeeds (frame normalized to its id)")
       ;; Read by id AND by value resolve the same registered flow.
-      (is (some? (flows/flow-meta-at :area {:frame :fv/host}))
+      (is (some? (rf.flows/flow-meta-at :area {:frame :fv/host}))
           "flow-meta-at by frame-id finds the flow registered via the value")
-      (is (some? (flows/flow-meta-at :area {:frame frame-val}))
+      (is (some? (rf.flows/flow-meta-at :area {:frame frame-val}))
           "flow-meta-at by frame VALUE finds the same flow")
-      (is (= (flows/flow-meta-at :area {:frame :fv/host})
-             (flows/flow-meta-at :area {:frame frame-val}))
+      (is (= (rf.flows/flow-meta-at :area {:frame :fv/host})
+             (rf.flows/flow-meta-at :area {:frame frame-val}))
           "by-id and by-value observe the IDENTICAL flow meta")
       ;; The store is keyed by the normalized id, not the raw value map.
-      (is (contains? (get (flows/flows-snapshot) :fv/host) :area)
+      (is (contains? (get (rf.flows/flows-snapshot) :fv/host) :area)
           "the per-frame store is keyed by the normalized frame-id")
-      (is (not (contains? (flows/flows-snapshot) frame-val))
+      (is (not (contains? (rf.flows/flows-snapshot) frame-val))
           "the store is NOT keyed by the raw frame-value map"))
 
     (testing "clear-flow with an explicit FRAME-VALUE `:frame` clears the flow
               registered under the frame-id (does not silently miss it)"
       (let [frame-val (rf/make-frame {:id :fv/host})]  ; idempotent re-make; same id
-        (flows/clear-flow :area {:frame frame-val})
-        (is (nil? (flows/flow-meta-at :area {:frame :fv/host}))
+        (rf.flows/clear-flow :area {:frame frame-val})
+        (is (nil? (rf.flows/flow-meta-at :area {:frame :fv/host}))
             "clear-by-value removed the flow observed by id")
-        (is (nil? (flows/flow-meta-at :area {:frame frame-val}))
+        (is (nil? (rf.flows/flow-meta-at :area {:frame frame-val}))
             "clear-by-value removed the flow observed by value")
-        (is (not (contains? (get (flows/flows-snapshot) :fv/host) :area))
+        (is (not (contains? (get (rf.flows/flows-snapshot) :fv/host) :area))
             "the per-frame store slot is gone after the value-keyed clear")))))
 
 ;; ---------------------------------------------------------------------------
@@ -1478,7 +1478,7 @@
     ;; Drive a drain on each frame so both have last-inputs rows.
     (rf/dispatch-sync [:seed 5] {:frame :left})
     (rf/dispatch-sync [:seed 5] {:frame :right})
-    (let [li (flows/last-inputs-snapshot)]
+    (let [li (rf.flows/last-inputs-snapshot)]
       (is (some? (get-in li [:shared :left]))
           "before re-registration: :left's last-inputs row is populated")
       (is (some? (get-in li [:shared :right]))
@@ -1486,7 +1486,7 @@
     ;; Re-register :shared on :left with a NEW body — should invalidate
     ;; :left's row ONLY.
     (rf/reg-flow :shared {:frame :left :inputs [[:n]] :output-path [:result]} (fn [n] (* 7 (or n 0))))
-    (let [li (flows/last-inputs-snapshot)]
+    (let [li (rf.flows/last-inputs-snapshot)]
       (is (nil? (get-in li [:shared :left]))
           "after re-registration on :left: :left's last-inputs row was dropped (re-evaluate on next drain)")
       (is (some? (get-in li [:shared :right]))
@@ -1521,14 +1521,14 @@
       (rf/reg-flow :shared {:frame :right :inputs [[:m]] :output-path [:result-right]} f-right)
       ;; Each frame's flow-meta-at returns its OWN divergent definition — the
       ;; very thing a frame-blind slot could never represent.
-      (is (= f-left  (:derive (flows/flow-meta-at :shared {:frame :left})))
+      (is (= f-left  (:derive (rf.flows/flow-meta-at :shared {:frame :left})))
           ":left's flow-meta-at carries :left's :derive")
-      (is (= f-right (:derive (flows/flow-meta-at :shared {:frame :right})))
+      (is (= f-right (:derive (rf.flows/flow-meta-at :shared {:frame :right})))
           ":right's flow-meta-at carries :right's :derive (divergent, not overwritten)")
-      (is (= [:result-left]  (:output-path (flows/flow-meta-at :shared {:frame :left}))))
-      (is (= [:result-right] (:output-path (flows/flow-meta-at :shared {:frame :right}))))
+      (is (= [:result-left]  (:output-path (rf.flows/flow-meta-at :shared {:frame :left}))))
+      (is (= [:result-right] (:output-path (rf.flows/flow-meta-at :shared {:frame :right}))))
       ;; The registrar `:flow` slot is RESERVED-but-empty throughout.
-      (is (nil? (registrar/lookup :flow :shared))
+      (is (nil? (rf.registrar/lookup :flow :shared))
           "no frame-blind registrar :flow slot is written (rf2-en00bk)"))))
 
 (deftest clear-flow-of-one-frame-leaves-sibling-authoritative-in-place
@@ -1540,12 +1540,12 @@
       (rf/reg-flow :shared {:frame :left :inputs [[:n]] :output-path [:result]} f-left)
       (rf/reg-flow :shared {:frame :right :inputs [[:n]] :output-path [:result]} f-right)
       ;; Clear :right. :left still holds :shared — its entry is unchanged.
-      (flows/clear-flow :shared {:frame :right})
-      (is (nil? (flows/flow-meta-at :shared {:frame :right}))
+      (rf.flows/clear-flow :shared {:frame :right})
+      (is (nil? (rf.flows/flow-meta-at :shared {:frame :right}))
           ":right's per-frame entry is gone")
-      (is (= f-left (:derive (flows/flow-meta-at :shared {:frame :left})))
+      (is (= f-left (:derive (rf.flows/flow-meta-at :shared {:frame :left})))
           ":left's entry is intact and authoritative IN PLACE — no realignment needed")
-      (is (nil? (registrar/lookup :flow :shared))
+      (is (nil? (rf.registrar/lookup :flow :shared))
           "registrar :flow slot stays empty (rf2-en00bk)"))))
 
 (deftest clear-flow-non-owner-frame-leaves-owner-intact
@@ -1555,22 +1555,22 @@
     (rf/reg-flow :shared {:frame :right :inputs [[:n]] :output-path [:result]} (fn [n] n))
     ;; :left never registered :shared — clearing it is a frame-local no-op for
     ;; :right's entry.
-    (flows/clear-flow :shared {:frame :left})
-    (is (some? (flows/flow-meta-at :shared {:frame :right}))
+    (rf.flows/clear-flow :shared {:frame :left})
+    (is (some? (rf.flows/flow-meta-at :shared {:frame :right}))
         ":right's entry survives — the clear on :left could not touch it")
-    (is (nil? (flows/flow-meta-at :shared {:frame :left}))
+    (is (nil? (rf.flows/flow-meta-at :shared {:frame :left}))
         ":left never held :shared")))
 
 (deftest clear-flow-last-frame-drops-the-final-per-frame-entry
   (testing "clearing the only registering frame drops the final per-frame entry; the registrar slot was empty all along (rf2-en00bk)"
     (rf/reg-flow :solo {:inputs [[:n]] :output-path [:result]} (fn [n] n))
-    (is (some? (flows/flow-meta-at :solo {:frame :rf/default})))
-    (is (nil? (registrar/lookup :flow :solo))
+    (is (some? (rf.flows/flow-meta-at :solo {:frame :rf/default})))
+    (is (nil? (rf.registrar/lookup :flow :solo))
         "registrar :flow slot is RESERVED-but-empty even while the flow is live")
-    (flows/clear-flow :solo)
-    (is (nil? (flows/flow-meta-at :solo {:frame :rf/default}))
+    (rf.flows/clear-flow :solo)
+    (is (nil? (rf.flows/flow-meta-at :solo {:frame :rf/default}))
         "the per-frame entry is gone after the clear")
-    (is (nil? (registrar/lookup :flow :solo))
+    (is (nil? (rf.registrar/lookup :flow :solo))
         "registrar :flow slot remains empty — nothing to unregister (rf2-en00bk)")))
 
 ;; ---------------------------------------------------------------------------
@@ -1788,7 +1788,7 @@
         (reset! captured [])
         ;; Destroy and recreate under the SAME id — a fresh incarnation with an
         ;; empty per-frame flow registry.
-        (frame/destroy-frame! :host)
+        (rf.frame/destroy-frame! :host)
         (rf/make-frame {:id :host :doc "host reincarnated"})
         ;; The new incarnation registers f1 first-time (:rf.flow/registered), then
         ;; genuinely replaces it with f2.

--- a/implementation/flows/test/re_frame/flows_topo_test.clj
+++ b/implementation/flows/test/re_frame/flows_topo_test.clj
@@ -16,7 +16,7 @@
   Per audit `ai/findings/flows-slice-audit-2026-05-15.md` §T2 (prior
   round) + audit-r2 carried forward."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.flows.topo :as topo]))
+            [re-frame.flows.topo :as rf.flows.topo]))
 
 ;; ---------------------------------------------------------------------------
 ;; extract-cycle-path defensive throw
@@ -44,7 +44,7 @@
     (let [graph     {:a #{}}
           remaining #{:a}
           thrown    (try
-                      (#'topo/extract-cycle-path graph remaining)
+                      (#'rf.flows.topo/extract-cycle-path graph remaining)
                       nil
                       (catch clojure.lang.ExceptionInfo e e))]
       (is (some? thrown)
@@ -76,16 +76,16 @@
 
 (deftest topo-sort-empty-and-singleton
   (testing "empty flow-map yields empty order"
-    (is (= [] (topo/topo-sort {}))))
+    (is (= [] (rf.flows.topo/topo-sort {}))))
   (testing "single flow yields itself in order"
     (is (= [:a]
-           (topo/topo-sort {:a {:id :a :inputs [[:n]] :derive identity :output-path [:a]}})))))
+           (rf.flows.topo/topo-sort {:a {:id :a :inputs [[:n]] :derive identity :output-path [:a]}})))))
 
 (deftest topo-sort-detects-cycle
   (testing "two flows forming a cycle raise :rf.error/flow-cycle with the canonical thrown-error shape (per Spec 009 §The thrown-error shape)"
     (let [flow-map {:a {:id :a :inputs [[:b]] :derive identity :output-path [:a]}
                     :b {:id :b :inputs [[:a]] :derive identity :output-path [:b]}}
-          thrown   (try (topo/topo-sort flow-map)
+          thrown   (try (rf.flows.topo/topo-sort flow-map)
                         nil
                         (catch clojure.lang.ExceptionInfo e e))]
       (is (some? thrown) "cycle raises")
@@ -134,7 +134,7 @@
             A writes)"
     (let [a {:id :a :output-path [:foo]   :inputs [[:other]]}
           b {:id :b :output-path [:bar]   :inputs [[:foo]]}]
-      (is (true? (topo/depends-on? b a))
+      (is (true? (rf.flows.topo/depends-on? b a))
           "B's :inputs include A's :output-path exactly → B depends on A"))))
 
 (deftest depends-on?-true-when-input-is-prefix-of-output-path
@@ -143,7 +143,7 @@
             writes — Spec 013 'prefix in either direction')"
     (let [a {:id :a :output-path [:foo :bar :baz] :inputs []}
           b {:id :b :output-path [:other]         :inputs [[:foo]]}]
-      (is (true? (topo/depends-on? b a))
+      (is (true? (rf.flows.topo/depends-on? b a))
           "B reads :foo (a prefix of A's :output-path [:foo :bar :baz])"))))
 
 (deftest depends-on?-true-when-output-path-is-prefix-of-input
@@ -152,7 +152,7 @@
             writes — also covered by 'prefix in either direction')"
     (let [a {:id :a :output-path [:foo]              :inputs []}
           b {:id :b :output-path [:other]            :inputs [[:foo :bar :baz]]}]
-      (is (true? (topo/depends-on? b a))
+      (is (true? (rf.flows.topo/depends-on? b a))
           "A writes [:foo] which is a prefix of B's input [:foo :bar :baz]"))))
 
 (deftest depends-on?-self-edge-via-overlapping-path
@@ -163,7 +163,7 @@
             derivation of independently-owned facts, not a recurrence over its
             own prior output — Spec 013 §Dependency rule)."
     (let [a {:id :a :output-path [:foo] :inputs [[:foo]]}]
-      (is (true? (topo/depends-on? a a))
+      (is (true? (rf.flows.topo/depends-on? a a))
           "A's own :inputs include A's own :output-path → depends-on? returns
            true; topo-sort retains this self-edge to reject the self-cycle"))))
 
@@ -172,7 +172,7 @@
             a prefix with A's :output-path in either direction"
     (let [a {:id :a :output-path [:foo :bar] :inputs []}
           b {:id :b :output-path [:other]    :inputs [[:unrelated] [:other-thing]]}]
-      (is (false? (topo/depends-on? b a))
+      (is (false? (rf.flows.topo/depends-on? b a))
           "B's inputs are disjoint from A's :output-path tree → no dependency"))))
 
 (deftest depends-on?-false-when-paths-share-no-prefix-but-share-element
@@ -183,7 +183,7 @@
           ;; B's input [:bar :foo] shares both elements with A's :output-path
           ;; but neither is a prefix of the other → no dependency.
           b {:id :b :output-path [:other]    :inputs [[:bar :foo]]}]
-      (is (false? (topo/depends-on? b a))
+      (is (false? (rf.flows.topo/depends-on? b a))
           "shared elements without a prefix relationship → false"))))
 
 (deftest depends-on?-empty-inputs
@@ -191,7 +191,7 @@
             (cannot depend on anything if it reads nothing)"
     (let [a {:id :a :output-path [:foo] :inputs []}
           b {:id :b :output-path [:bar] :inputs []}]
-      (is (false? (topo/depends-on? b a))
+      (is (false? (rf.flows.topo/depends-on? b a))
           "B has no :inputs → cannot depend on A (or anything else)"))))
 
 (deftest depends-on?-multiple-inputs-any-match-wins
@@ -200,6 +200,6 @@
             dependency edge"
     (let [a {:id :a :output-path [:foo] :inputs []}
           b {:id :b :output-path [:bar] :inputs [[:unrelated] [:foo] [:other]]}]
-      (is (true? (topo/depends-on? b a))
+      (is (true? (rf.flows.topo/depends-on? b a))
           "B's second input matches A's :output-path → dependency established
            despite the surrounding non-matching inputs"))))

--- a/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
+++ b/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
@@ -37,23 +37,23 @@
   `re-frame.flow-eval-exception-elision-prod-test`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support]
             ;; Require flows directly so its ns body — including every
             ;; gated trace/emit! call site — sits in the reachability
             ;; graph for the closure compiler.
-            [re-frame.flows :as flows]
+            [re-frame.flows :as rf.flows]
             [re-frame.flows.registry]
             ;; Require schemas so a registered validator IS available —
             ;; the prod test must prove the validation surface elides even
             ;; when the seam is wired, not merely when it is absent.
-            [re-frame.schemas :as schemas]
+            [re-frame.schemas :as rf.schemas]
             ;; The listener surface lives in `re-frame.trace.tooling`.
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -64,14 +64,14 @@
   [body-fn]
   (let [captured-traces (atom [])
         listener-id     (keyword (str "elision-prod-" (gensym)))]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       listener-id
       (fn [event] (swap! captured-traces conj event)))
     (try
       (body-fn)
       @captured-traces
       (finally
-        (trace-tooling/unregister-listener! listener-id)))))
+        (rf.trace.tooling/unregister-listener! listener-id)))))
 
 ;; ---- :rf.flow/registered elides under prod --------------------------------
 
@@ -94,7 +94,7 @@
     ;; registry (read via `flows/flows-snapshot`) is keyed
     ;; `{frame-id {flow-id flow}}`; the flow registers under
     ;; `:rf/default` by default.
-    (is (some? (get-in (flows/flows-snapshot) [:rf/default :prod-elision/area]))
+    (is (some? (get-in (rf.flows/flows-snapshot) [:rf/default :prod-elision/area]))
         "flow registered in the per-frame index — only trace surface elided")))
 
 ;; ---- :rf.flow/computed elides under prod ----------------------------------
@@ -185,10 +185,10 @@
       (fn [w] (or w 0)))
     (let [traces (capture-traces
                  (fn []
-                   (flows/clear-flow :prod-elision/clearable)))]
+                   (rf.flows/clear-flow :prod-elision/clearable)))]
       (is (empty? traces)
           "no :rf.flow/cleared trace under prod"))
-    (is (nil? (get-in (flows/flows-snapshot) [:rf/default :prod-elision/clearable]))
+    (is (nil? (get-in (rf.flows/flows-snapshot) [:rf/default :prod-elision/clearable]))
         "flow removed from per-frame index — only trace surface elided")))
 
 ;; ---- :schema output validation elides under prod --------------------------
@@ -204,7 +204,7 @@
             written (recompute is never gated)."
     ;; Register a validator that REJECTS every value — if validation ran,
     ;; a violation would surface.
-    (schemas/set-schema-fns! {:validate (fn [_ _] false)})
+    (rf.schemas/set-schema-fns! {:validate (fn [_ _] false)})
     (rf/reg-event :prod-elision/seed-validate
       (fn [{:keys [db]} _] {:db (assoc db :w 3 :h 4)}))
     (rf/reg-flow :prod-elision/validated

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -12,13 +12,13 @@
   re-frame-10x v2's flow panel."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.frame :as frame]
-            [re-frame.privacy :as privacy]
-            [re-frame.flows :as flows]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.elision :as rf.elision]
+            [re-frame.frame :as rf.frame]
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.flows :as rf.flows]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- per-test reset / trace recorder -------------------------------------
 ;;
@@ -37,7 +37,7 @@
   [test-fn]
   (let [captured (atom [])]
     (binding [*captured* captured]
-      (trace/register-listener!
+      (rf.trace/register-listener!
         ::flow-trace-recorder
         (fn [ev]
           ;; Filter to flow op-type only — keeps assertions tight.
@@ -46,10 +46,10 @@
       (try
         (test-fn)
         (finally
-          (trace/unregister-listener! ::flow-trace-recorder))))))
+          (rf.trace/unregister-listener! ::flow-trace-recorder))))))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})
   with-flow-trace-recorder)
 
 (defn- by-op
@@ -71,8 +71,8 @@
   "Seed the frame's large app-db classification via the commit-plane effect
   path (`:source :effect`). Marker `:reason` for these paths is `:effect`."
   [frame-id & paths]
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt {:large (mapv vec paths)}))))
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt {:large (mapv vec paths)}))))
 
 (defn- install-sensitive!
   "Seed the frame's sensitive app-db classification via the commit-plane
@@ -80,17 +80,17 @@
   stamp + on-wire redaction, the same way schema-sensitive slots formerly
   did."
   [frame-id & paths]
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt {:sensitive (mapv vec paths)}))))
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt {:sensitive (mapv vec paths)}))))
 
 (defn- record-all-traces
   "Capture every emitted trace event (not just `:op-type :flow`) for the
   ordered-stream tests. The `*captured*` fixture recorder is flow-only."
   [body-fn]
   (let [seen (atom [])]
-    (trace/register-listener! ::all-trace-recorder (fn [ev] (swap! seen conj ev)))
+    (rf.trace/register-listener! ::all-trace-recorder (fn [ev] (swap! seen conj ev)))
     (try (body-fn)
-         (finally (trace/unregister-listener! ::all-trace-recorder)))
+         (finally (rf.trace/unregister-listener! ::all-trace-recorder)))
     @seen))
 
 ;; ---------------------------------------------------------------------------
@@ -425,7 +425,7 @@
     (rf/reg-flow :area {:inputs [[:rect :w] [:rect :h]] :output-path [:rect :area]} (fn [w h] (* w h)))
     (rf/dispatch-sync [:seed])
     (reset! *captured* [])
-    (flows/clear-flow :area)
+    (rf.flows/clear-flow :area)
     (let [evs (by-op :rf.flow/cleared)]
       (is (= 1 (count evs)))
       (let [tags (:tags (first evs))]
@@ -435,7 +435,7 @@
 
 (deftest clear-flow-on-unknown-id-emits-nothing
   (testing "clear-flow on an unregistered id is a no-op and emits no trace"
-    (flows/clear-flow :no-such-flow)
+    (rf.flows/clear-flow :no-such-flow)
     (is (zero? (count (by-op :rf.flow/cleared))))))
 
 ;; ---------------------------------------------------------------------------
@@ -661,7 +661,7 @@
       (rf/register-listener! :errors
         :test/recorder
         (fn [record] (reset! listener-saw record)))
-      (trace/register-listener!
+      (rf.trace/register-listener!
         ::flow-eval-trace-recorder
         (fn [ev]
           (when (= :rf.error/flow-eval-exception (:operation ev))
@@ -676,7 +676,7 @@
             "corpus-wide listener saw the record — always-on substrate path fired")
         (is (= :rf.error/flow-eval-exception (:error @listener-saw)))
         (finally
-          (trace/unregister-listener! ::flow-eval-trace-recorder))))))
+          (rf.trace/unregister-listener! ::flow-eval-trace-recorder))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6. End-to-end sample: all five events fire across a typical lifecycle
@@ -690,7 +690,7 @@
     (rf/dispatch-sync [:init])
     (rf/dispatch-sync [:replace-n 3])     ;; same → skip
     (rf/dispatch-sync [:replace-n 4])     ;; change → compute
-    (flows/clear-flow :double)
+    (rf.flows/clear-flow :double)
     (is (= 1 (count (by-op :rf.flow/registered))))
     (is (pos?  (count (by-op :rf.flow/computed))))
     (is (= 1 (count (by-op :rf.flow/skip))))
@@ -728,7 +728,7 @@
     (let [ev   (last (by-op :rf.flow/computed))
           tags (:tags ev)]
       (is (some? ev) ":rf.flow/computed fired")
-      (is (elision/marker? (:result tags))
+      (is (rf.elision/marker? (:result tags))
           ":result is replaced by the `:rf.size/large-elided` marker")
       (let [marker (:rf.size/large-elided (:result tags))]
         (is (= [:derived :blob] (:path marker))
@@ -751,7 +751,7 @@
       (is (some? ev) ":rf.flow/failed fired")
       (is (vector? (:inputs tags))
           ":inputs vector preserves the per-input slot shape")
-      (is (elision/marker? first-input)
+      (is (rf.elision/marker? first-input)
           "the elided input-value is substituted with the wire marker"))))
 
 ;; ---------------------------------------------------------------------------
@@ -1086,9 +1086,9 @@
           last-ev  (last computes)
           tags     (:tags last-ev)]
       (is (some? last-ev) ":rf.flow/computed fired on the recompute")
-      (is (elision/marker? (:before tags))
+      (is (rf.elision/marker? (:before tags))
           ":before is replaced by the `:rf.size/large-elided` marker — the slot is frame-large")
-      (is (elision/marker? (:result tags))
+      (is (rf.elision/marker? (:result tags))
           ":result is similarly elided (sanity)")
       (let [marker (:rf.size/large-elided (:before tags))]
         (is (= [:derived :blob] (:path marker))
@@ -1138,7 +1138,7 @@
     (rf/reg-flow :payload {:inputs [[:n]] :output-path [:derived :blob] :large? true} (fn [_] {:bytes "BIG"}))
     ;; Precondition: the flow's own registration installed the :source :flow
     ;; declaration (not a helper, not an effect).
-    (is (some #(= :flow (:source %)) (get (elision/declarations :rf/default) [:derived :blob]))
+    (is (some #(= :flow (:source %)) (get (rf.elision/declarations :rf/default) [:derived :blob]))
         "precondition: the reg-flow :large? mark stands as a :source :flow owner")
     (reset! *captured* [])
     (rf/dispatch-sync [:init])
@@ -1146,7 +1146,7 @@
     (let [ev     (last (by-op :rf.flow/computed))
           result (:result (:tags ev))]
       (is (some? ev) ":rf.flow/computed fired")
-      (is (elision/marker? result)
+      (is (rf.elision/marker? result)
           ":result is replaced by the :rf.size/large-elided marker")
       (let [marker (:rf.size/large-elided result)]
         (is (= [:derived :blob] (:path marker))
@@ -1156,9 +1156,9 @@
              declaration, NOT the :reason :effect of the install-large! helper path")))
     ;; (b) the app-db destination channel — the slot at :output-path projects
     ;; the marker through the SAME per-frame elision registry.
-    (let [wire (elision/elide-wire-value (frame/frame-app-db-value :rf/default))
+    (let [wire (rf.elision/elide-wire-value (rf.frame/frame-app-db-value :rf/default))
           slot (get-in wire [:derived :blob])]
-      (is (elision/marker? slot)
+      (is (rf.elision/marker? slot)
           "the app-db destination slot egresses as the large marker")
       (is (= :flow (:reason (:rf.size/large-elided slot)))
           "the app-db-slot marker is also :reason :flow (same flow-sourced declaration)"))))
@@ -1173,7 +1173,7 @@
     (rf/reg-flow :creds {:inputs [[:n]] :output-path [:auth :creds] :sensitive [[:secret]]} (fn [n] {:secret (str "Bearer-" n)}))
     ;; Precondition: the sensitive sub-slot roots at :output-path ++ [:secret]
     ;; and is a :source :flow declaration.
-    (is (some #(= :flow (:source %)) (get (elision/sensitive-declarations :rf/default)
+    (is (some #(= :flow (:source %)) (get (rf.elision/sensitive-declarations :rf/default)
                                           [:auth :creds :secret]))
         "precondition: the reg-flow :sensitive mark stands as a :source :flow owner")
     (reset! *captured* [])
@@ -1183,12 +1183,12 @@
     (let [ev     (last (by-op :rf.flow/computed))
           result (:result (:tags ev))]
       (is (some? ev) ":rf.flow/computed fired")
-      (is (= privacy/redacted-sentinel (:secret result))
+      (is (= rf.privacy/redacted-sentinel (:secret result))
           ":result's sensitive sub-slot is redacted to :rf/redacted on the trace bus"))
     ;; (b) the app-db destination channel — the destination sub-slot projects
     ;; :rf/redacted through the SAME per-frame elision registry.
-    (let [wire (elision/elide-wire-value (frame/frame-app-db-value :rf/default))]
-      (is (= privacy/redacted-sentinel (get-in wire [:auth :creds :secret]))
+    (let [wire (rf.elision/elide-wire-value (rf.frame/frame-app-db-value :rf/default))]
+      (is (= rf.privacy/redacted-sentinel (get-in wire [:auth :creds :secret]))
           "the app-db destination sub-slot egresses as :rf/redacted (flow-sourced)"))))
 
 ;; ---------------------------------------------------------------------------
@@ -1304,7 +1304,7 @@
       ;; The ex-data is redacted wholesale — the sensitive frame handles
       ;; secrets, so the framework cannot prove the author-keyed ex-data map
       ;; is secret-free (mirrors project-machine-error-tags).
-      (is (= privacy/redacted-sentinel (:exception-data tags))
+      (is (= rf.privacy/redacted-sentinel (:exception-data tags))
           ":exception-data is redacted to the sentinel for a sensitive frame")
       ;; The raw token must NOT appear anywhere in the delivered tags.
       (is (not (contains? (set (tree-seq coll? seq tags)) "TOP-SECRET"))
@@ -1537,7 +1537,7 @@
             leaves the effect claim. The path stays classified while any owner
             claims it."
     (let [p      [:auth :creds :secret]
-          owners #(get (elision/sensitive-declarations :rf/default) p)]
+          owners #(get (rf.elision/sensitive-declarations :rf/default) p)]
       ;; a flow classifies its own output sub-slot :sensitive at registration
       (rf/reg-flow :creds {:inputs [[:n]] :output-path [:auth :creds] :sensitive [[:secret]]}
                    (fn [n] {:secret (str "Bearer-" n)}))
@@ -1554,6 +1554,6 @@
       (is (some #(= :flow (:source %)) (owners)) "the flow claim SURVIVES the effect clear")
       ;; re-add the effect, then clear-flow — the effect survives the flow teardown
       (rf/dispatch-sync [:flow-union/classify])
-      (flows/clear-flow :creds {:frame :rf/default})
+      (rf.flows/clear-flow :creds {:frame :rf/default})
       (is (contains? (owners) {:source :effect}) "the effect claim SURVIVES clear-flow")
       (is (not (some #(= :flow (:source %)) (owners))) "the flow owner is dropped by clear-flow"))))

--- a/implementation/flows/test/re_frame/flows_vector_parent_vacation_test.clj
+++ b/implementation/flows/test/re_frame/flows_vector_parent_vacation_test.clj
@@ -16,12 +16,12 @@
   mirroring `re-frame.path/container-for`'s vector-index semantics."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.flows :as rf.flows]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; clear-flow vacates a vector-index output leaf (the repro).
@@ -37,7 +37,7 @@
     (is (= [10 20 30 99] (:cells (rf/app-db-value :rf/default)))
         "precondition: the flow wrote its derived value into vector index 3")
 
-    (flows/clear-flow :cell3)
+    (rf.flows/clear-flow :cell3)
     (let [cells (:cells (rf/app-db-value :rf/default))]
       (is (nil? (get cells 3))
           (str "index 3 was vacated (assoc'd nil) — the stranded derived value "
@@ -46,7 +46,7 @@
           "the sibling vector entries are untouched (no dissoc/shift)")
       (is (= 4 (count cells))
           "vacation is local: the vector keeps its length (nil at the index, not a shift)"))
-    (is (not (contains? (get (flows/flows-snapshot) :rf/default) :cell3))
+    (is (not (contains? (get (rf.flows/flows-snapshot) :rf/default) :cell3))
         "the flow's registry row is gone")))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -19,26 +19,26 @@
   `re-frame.core`."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Loading flows registers its late-bind hooks. The
             ;; `with-hook-as-nil` helper below re-establishes the absent
             ;; state by flipping the hook value at runtime; restoration
             ;; in `finally` keeps cross-test isolation intact.
             [re-frame.flows]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 (defn- with-hook-as-nil
   "Run `f` with the named late-bind hook set to nil. Restores the
   original value after `f` returns or throws."
   [hook-key f]
-  (let [original (late-bind/get-fn hook-key)]
+  (let [original (rf.late-bind/get-fn hook-key)]
     (try
-      (late-bind/set-fn! hook-key nil)
+      (rf.late-bind/set-fn! hook-key nil)
       (f)
       (finally
-        (late-bind/set-fn! hook-key original)))))
+        (rf.late-bind/set-fn! hook-key original)))))
 
 ;; `clear-flow` is not on the `re-frame.core` façade — it is reached through
 ;; `re-frame.flows/clear-flow`, so the façade artefact-missing contract does
@@ -104,14 +104,14 @@
     ;; no-op and the drain completes.
     (with-hook-as-nil :flows/run-flows-on-db
       (fn []
-        (rf/init! plain-atom/adapter)
+        (rf/init! rf.substrate.plain-atom/adapter)
         ;; EP-0002: `init!` does not create `:rf/default`, and a bare
         ;; `dispatch-sync` under no established scope raises
         ;; `:rf.error/no-frame-context`. Register `:rf/default` and pin it
         ;; as the established scope so this absent-flows-artefact drain test
         ;; carries a frame stamp (the carried invariant).
-        (frame/ensure-default-frame!)
-        (binding [frame/*current-frame* :rf/default]
+        (rf.frame/ensure-default-frame!)
+        (binding [rf.frame/*current-frame* :rf/default]
           (rf/reg-event :flows-absent/init (fn [{:keys [db]} _] {:db {:probe :ok}}))
           (is (do (rf/dispatch-sync [:flows-absent/init]) :ok)
               "dispatch completes without throwing when the run-flows! hook is absent")
@@ -129,7 +129,7 @@
     (with-hook-as-nil :flows/reset-flows!
       (fn []
         (let [ran? (atom false)
-              fix  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})]
+              fix  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter})]
           (fix (fn [] (reset! ran? true)))
           (is @ran? "fixture invoked the test-fn without throwing on the absent hook"))))))
 
@@ -141,11 +141,11 @@
     ;; short-circuits.
     (with-hook-as-nil :flows/teardown-on-frame-destroy!
       (fn []
-        (rf/init! plain-atom/adapter)
+        (rf/init! rf.substrate.plain-atom/adapter)
         (rf/make-frame {:id :late-bind-missing/scratch :doc "scratch frame for teardown probe"})
-        (is (some? (get @frame/frames :late-bind-missing/scratch))
+        (is (some? (get @rf.frame/frames :late-bind-missing/scratch))
             "frame registered")
-        (is (do (frame/destroy-frame! :late-bind-missing/scratch) :ok)
+        (is (do (rf.frame/destroy-frame! :late-bind-missing/scratch) :ok)
             "destroy-frame! completes without throwing when the flows-teardown hook is absent")
-        (is (nil? (get @frame/frames :late-bind-missing/scratch))
+        (is (nil? (get @rf.frame/frames :late-bind-missing/scratch))
             "frame was destroyed despite the absent teardown hook")))))

--- a/implementation/hicasso/lint-fixtures/macro_shapes.cljs
+++ b/implementation/hicasso/lint-fixtures/macro_shapes.cljs
@@ -12,7 +12,7 @@
   requires exactly that one `:unused-binding` finding. It is the proof that
   kondo's ordinary analysis actually ran over the rewritten forms — a gate
   that expected pure silence would stay green while linting nothing at all."
-  (:require [re-frame.hicasso :as h]))
+  (:require [re-frame.hicasso :as rf.hicasso]))
 
 ;; A stand-in for a foreign React component, so `defhost` has something to
 ;; wrap.
@@ -20,37 +20,37 @@
 
 ;; `defview`, docstring + destructuring: the name defines a var, the props
 ;; bind, and the body's uses resolve.
-(h/defview greeting
+(rf.hicasso/defview greeting
   "One paragraph, both props read."
   [{:keys [salutation subject]}]
   [:p.greeting salutation ", " subject])
 
 ;; `defview`, no docstring, whole-map prop.
-(h/defview badge [props]
+(rf.hicasso/defview badge [props]
   [:span.badge (:label props)])
 
 ;; `defhost`, docstring + opts: the component and opts expressions are
 ;; analysed as ordinary code, so `foreign-widget` is a use, not a mystery.
-(h/defhost fancy-widget
+(rf.hicasso/defhost fancy-widget
   "The interop door, fully dressed."
   foreign-widget
   {:fallback [:div "loading"]})
 
 ;; `defhost`, bare: no docstring, no opts.
-(h/defhost plain-widget foreign-widget)
+(rf.hicasso/defhost plain-widget foreign-widget)
 
 ;; `event` is `fn`-shaped: its argument binds and its body's use resolves —
 ;; and every view and host above is referenced here, so a rewrite that stops
 ;; defining one reds this body too.
-(h/defview page [_]
+(rf.hicasso/defview page [_]
   [:main
    [greeting {:salutation "Hello" :subject "world"}]
    [badge {:label "new"}]
    [fancy-widget]
    [plain-widget]
-   [:button {:on-click (h/event [payload] payload)} "echo"]])
+   [:button {:on-click (rf.hicasso/event [payload] payload)} "echo"]])
 
 ;; THE SENTINEL — `unread` is deliberately never used. The gate pins the
 ;; `:unused-binding` finding this row produces; see the ns docstring.
-(h/defview sentinel [{:keys [shown unread]}]
+(rf.hicasso/defview sentinel [{:keys [shown unread]}]
   [:p shown])

--- a/implementation/hicasso/scripts/check_bundle_isolation.cjs
+++ b/implementation/hicasso/scripts/check_bundle_isolation.cjs
@@ -298,7 +298,7 @@ const SENTINELS = [
     surface: 'forms module — the view the chapter documents (rf2-sh56)',
     sentinel: 're-frame.hicasso.forms/buffered-field',
     source: 'src/re_frame/hicasso/forms.cljs',
-    premise: '(h/defview buffered-field',
+    premise: '(rf.hicasso/defview buffered-field',
     why:
       'The view NAME `h/defview` computes and `mint-view!` stamps as the ' +
       'boundary\'s `displayName`, unconditionally — the same idiom the ' +
@@ -415,7 +415,7 @@ const CONTROLS = [
   {
     control: 're-frame.hicasso.consumer-app/app',
     source: 'test/re_frame/hicasso/consumer_app.cljs',
-    premise: '(h/defview app',
+    premise: '(rf.hicasso/defview app',
     proves:
       'the release entry\'s `h/defview` really compiled — `mint-view!` stamps ' +
       'this name as the boundary\'s `displayName`, unconditionally. Without ' +

--- a/implementation/hicasso/scripts/check_production_erasure.cjs
+++ b/implementation/hicasso/scripts/check_production_erasure.cjs
@@ -257,7 +257,7 @@ const CONTROLS = [
   {
     control: 're-frame.hicasso.consumer-app/app',
     source: 'test/re_frame/hicasso/consumer_app.cljs',
-    premise: '(h/defview app',
+    premise: '(rf.hicasso/defview app',
     proves:
       'the release entry\'s `h/defview` really compiled — `mint-view!` stamps ' +
       'this name as the boundary\'s `displayName` and as its `:render` measure ' +

--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -55,16 +55,16 @@
   ;; `"NO_SOURCE_PATH"` sentinel into every declaration; core solved that
   ;; once, absolutises the classpath-relative path while it is there, and
   ;; is already this package's only dependency.
-  #?(:clj (:require [re-frame.source-coords :as source-coords]))
+  #?(:clj (:require [re-frame.source-coords :as rf.source-coords]))
   #?(:cljs
-     (:require [re-frame.hicasso.impl.boundary :as impl-boundary]
-               [re-frame.hicasso.impl.codec :as impl-codec]
-               [re-frame.hicasso.impl.collector :as impl-collector]
+     (:require [re-frame.hicasso.impl.boundary :as rf.hicasso.impl.boundary]
+               [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+               [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
                [re-frame.hicasso.impl.intent]
-               [re-frame.hicasso.impl.mount :as impl-mount]
-               [re-frame.hicasso.impl.portal :as impl-portal]
-               [re-frame.hicasso.impl.route-link :as impl-route-link]
-               [re-frame.hicasso.impl.state :as impl-state]))
+               [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+               [re-frame.hicasso.impl.portal :as rf.hicasso.impl.portal]
+               [re-frame.hicasso.impl.route-link :as rf.hicasso.impl.route-link]
+               [re-frame.hicasso.impl.state :as rf.hicasso.impl.state]))
   #?(:cljs (:require-macros [re-frame.hicasso :refer [defview defhost event]])))
 
 ;; ---------------------------------------------------------------------------
@@ -242,7 +242,7 @@
            ;; substrates spell one convention. No `^{:rf/id …}` override
            ;; here: a `defview` has exactly one name and this is it.
            view-id   (keyword (str (ns-name *ns*)) (str sym))
-           coord     (source-coords/coords-form (meta &form) *file* (ns-name *ns*))
+           coord     (rf.source-coords/coords-form (meta &form) *file* (ns-name *ns*))
            ;; The registration slot IS the coordinate map — `reg-view`
            ;; merges its coords into the slot's top level and tools read
            ;; them back from there — plus the author's `:doc`, without
@@ -400,7 +400,7 @@
            ;; the refusal carries the declaration's coordinate.
            extra       (seq (drop 2 forms))
            host-name   (str (ns-name *ns*) "/" sym)
-           coord       (source-coords/coords-form (meta &form) *file* (ns-name *ns*))]
+           coord       (rf.source-coords/coords-form (meta &form) *file* (ns-name *ns*))]
        `(def ~(if doc (vary-meta sym assoc :doc doc) sym)
           (do
             (when re-frame.interop/debug-enabled?
@@ -426,7 +426,7 @@
   inlined helper. The edge is recorded where the read happens, so a branch
   not taken contributes no edge.
   `re-frame.hicasso.impl.collector/sub`."}
-       sub impl-collector/sub)
+       sub rf.hicasso.impl.collector/sub)
 
      (def ^{:doc "`h/error-boundary` — the runtime's own error boundary
   (HD-020(c)); takes `:fallback`, `:reset-key` and `:on-error`.
@@ -435,12 +435,12 @@
   rules (row 12). A bare `boundary` would be the wrong word twice over: every minted `defview` is already *a boundary* here,
   and React has a second kind — the Suspense boundary — that this one is
   not. `re-frame.hicasso.impl.boundary/boundary`."}
-       error-boundary impl-boundary/boundary)
+       error-boundary rf.hicasso.impl.boundary/boundary)
 
      (def ^{:doc "`h/reg-state` — the instance-key sugar (HD-009). Mints one
   parametric subscription and one setter event under `[:ui ::concern ikey]`,
   and nothing else. `re-frame.hicasso.impl.state/reg-state`."}
-       reg-state impl-state/reg-state)
+       reg-state rf.hicasso.impl.state/reg-state)
 
      (def ^{:doc "`h/portal` — **hiccup into `createPortal`**.
   A legal hiccup head taking `:target`, the DOM container the subtree
@@ -468,13 +468,13 @@
   The raw mechanism, for containers the application does not own.
   Anchoring, dismissal and focus conduct are the overlay module's.
   `re-frame.hicasso.impl.portal/portal`."}
-       portal impl-portal/portal)
+       portal rf.hicasso.impl.portal/portal)
 
      (def ^{:doc "One real anchor, as data — href and click decision taken
   whole from routing's late-bound seams. A plain function, not a boundary:
   it mints no boundary and adds no hook.
   `re-frame.hicasso.impl.route-link/route-link`."}
-       route-link impl-route-link/route-link)
+       route-link rf.hicasso.impl.route-link/route-link)
 
      (def ^{:doc "`h/as-element` — **the one explicit hiccup→ReactNode
   conversion**. Answers the React element a hiccup form
@@ -517,7 +517,7 @@
   and an intent written in that markup stays the loud
   `:rf.error/hicasso-intent-outside-boundary` it is everywhere else.
   `re-frame.hicasso.impl.codec/as-element`."}
-       as-element impl-codec/as-element)
+       as-element rf.hicasso.impl.codec/as-element)
 
      (def ^{:doc "`h/as-component` — **the outward bridge**.
   Answers a real React component for a hiccup head, so a React parent —
@@ -537,7 +537,7 @@
   parent must not have to require the native namespace — and therefore
   ship it — to cross inward.
   `re-frame.hicasso.impl.codec/as-component`."}
-       as-component impl-codec/as-component)
+       as-component rf.hicasso.impl.codec/as-component)
 
      ;; ---- the root lifecycle: mount, re-render, tear down ----------------
      ;;
@@ -605,7 +605,7 @@
        ;; `hydrate!` below already has: impl reads the keys it owns and a
        ;; config key added later needs no edit here.
        (fn mount! [container config hiccup]
-         (impl-mount/root! container (:frame config) hiccup config)))
+         (rf.hicasso.impl.mount/root! container (:frame config) hiccup config)))
 
      (def ^{:doc "`h/hydrate!` — **adopt a container's existing
   server-rendered DOM** rather than replacing it; `mount!`'s hydrating
@@ -658,7 +658,7 @@
        ;; than re-built from `:identifier-prefix` — impl reads the keys
        ;; it owns and a config key added later needs no edit here.
        (fn hydrate! [container config hiccup]
-         (impl-mount/hydrate-root! container (:frame config) hiccup config)))
+         (rf.hicasso.impl.mount/hydrate-root! container (:frame config) hiccup config)))
 
      (def ^{:doc "Re-render a mounted root in place, synchronously, and
   answer its handle — **the hot-reload door**:
@@ -671,11 +671,11 @@
   `createRoot` a second time and replace the tree instead, discarding
   every node, subscription and scrap of component state.
   `re-frame.hicasso.impl.mount/render!`."}
-       render! impl-mount/render!)
+       render! rf.hicasso.impl.mount/render!)
 
      (def ^{:doc "Take THIS root down — `mount!`'s inverse, and
   idempotent. Unmounts the root and leaves everything else exactly where
   it was: the sibling roots' subscriptions and frames, and the container
   you handed `mount!`, which React empties but does not remove.
   `re-frame.hicasso.impl.mount/unmount!`."}
-       unmount! impl-mount/unmount!)))
+       unmount! rf.hicasso.impl.mount/unmount!)))

--- a/implementation/hicasso/src/re_frame/hicasso/forms.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/forms.cljs
@@ -35,14 +35,14 @@
   is written on, and the validation and submit orchestration it
   deliberately leaves to them, are
   `docs/design/hicasso/product/forms-recipes.md`."
-  (:require [re-frame.events :as events]
+  (:require [re-frame.events :as rf.events]
             ;; Side-effecting: registers `:dispatch`, which the commit and
             ;; cancel handlers emit. Named here so the module is correct
             ;; standing alone rather than through `re-frame.core`.
             [re-frame.fx]
-            [re-frame.hicasso :as h]
+            [re-frame.hicasso :as rf.hicasso]
             ;; For `ui-root` alone — see `draft-path`.
-            [re-frame.hicasso.impl.state :as impl-state]))
+            [re-frame.hicasso.impl.state :as rf.hicasso.impl.state]))
 
 ;; ---------------------------------------------------------------------------
 ;; The draft's home
@@ -66,7 +66,7 @@
   release bundle for this exact string; a namespace rename would move a
   `::drafts` keyword while the scan went on matching nothing
   (`forms-cljs-test/the-concern-is-what-the-bundle-gate-pins`)."
-  (h/reg-state :re-frame.hicasso.forms/drafts {:default nil}))
+  (rf.hicasso/reg-state :re-frame.hicasso.forms/drafts {:default nil}))
 
 (defn- draft-path
   "`reg-state`'s `[:ui <concern> <ikey>]` layout for `control`. The
@@ -76,7 +76,7 @@
   shows a field whose session has ended and whose draft has not. The `:ui`
   tier is app-space by `reg-state`'s own contract."
   [control]
-  [impl-state/ui-root drafts control])
+  [rf.hicasso.impl.state/ui-root drafts control])
 
 (defn- record-of [db control] (get-in db (draft-path control)))
 
@@ -108,7 +108,7 @@
 ;; the field by hand.
 ;; ---------------------------------------------------------------------------
 
-(events/reg-event ::edit
+(rf.events/reg-event ::edit
   {:doc "`[::edit control revision text]` — the keystroke event, on
          `:on-input`. Write `{:revision revision :draft text}` at `control`, replacing
          whole whatever was there: a record a reset made ineligible is
@@ -118,7 +118,7 @@
   (fn [{:keys [db]} [_ control revision text]]
     {:db (assoc-in db (draft-path control) {:revision revision :draft text})}))
 
-(events/reg-event ::commit
+(rf.events/reg-event ::commit
   {:doc "`[::commit control revision on-commit]` — Enter and blur alike,
          since D016 makes them one operation.
          End the session at `control` and hand the caller its candidate:
@@ -145,7 +145,7 @@
           (seq on-commit)
           (assoc :fx [[:dispatch (conj (vec on-commit) (:draft record))]]))))))
 
-(events/reg-event ::cancel
+(rf.events/reg-event ::cancel
   {:doc "`[::cancel control revision on-cancel]` — Escape.
          Abandon the session at `control`: when the record is live under
          `revision`, remove it and dispatch `on-cancel` if one was given;
@@ -168,9 +168,9 @@
   "The props `buffered-field` consumes rather than forwards to the
   `<input>`; `:key` is here because it would be actively wrong on a DOM
   node."
-  [:control :value :on-commit :on-cancel :key ::h/revision])
+  [:control :value :on-commit :on-cancel :key ::rf.hicasso/revision])
 
-(h/defview buffered-field
+(rf.hicasso/defview buffered-field
   "A controlled `<input>` with an app-db draft in front of the committed
   value. Takes a stable `:control` address, the committed `:value`, its
   `::h/revision`, and the `:on-commit` event that receives a candidate:
@@ -216,14 +216,14 @@
   grid where that is too much, use an uncontrolled input or a native
   island. Chapter: `docs/core/hicasso/05-forms.md`."
   [{:keys [control value on-commit on-cancel] :as props}]
-  (let [revision (::h/revision props)
-        record   (h/sub [drafts control])]
+  (let [revision (::rf.hicasso/revision props)
+        record   (rf.hicasso/sub [drafts control])]
     [:input
      (merge {:type "text"}
             (apply dissoc props module-props)
             {:value       (if (live? record revision) (:draft record) value)
-             ::h/revision revision
-             :on-input    [::edit control revision ::h/value]
+             ::rf.hicasso/revision revision
+             :on-input    [::edit control revision ::rf.hicasso/value]
              :on-blur     [::commit control revision on-commit]
              ;; The key MAP rather than a callback reading `.key`: the
              ;; substrate's composition gate answers a key event there, so

--- a/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
@@ -187,11 +187,11 @@
   browser calls outside React's own work loop — an intent handler that
   throws lands in the browser's error channel, not here. That is React's
   boundary, not this runtime's, and the runtime inherits it exactly."
-  (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
+  (:require [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
             [re-frame.hicasso.impl.error :refer [fail!]]
-            [re-frame.hicasso.impl.intent :as intent]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
             ["react" :as react]))
 
 (defn- props-of
@@ -281,7 +281,7 @@
 (defn- frame-of
   "The frame this boundary is mounted under, read through `contextType`."
   [^js this]
-  (adapter-context/context-value->current-frame (.-context this)))
+  (rf.adapter.context/context-value->current-frame (.-context this)))
 
 (defn- report!
   "Fire `:on-error` for the failure React just caught. A vector is an
@@ -307,7 +307,7 @@
   [^js this error]
   (let [on-error (:on-error (props-of this))]
     (cond
-      (vector? on-error) (collector/dispatch! (frame-of this) (conj on-error error))
+      (vector? on-error) (rf.hicasso.impl.collector/dispatch! (frame-of this) (conj on-error error))
       (fn? on-error)     (on-error error)
       :else              nil))
   nil)
@@ -336,7 +336,7 @@
     (set! (.-prototype ^js ctor) proto)
     (set! (.-constructor proto) ctor)
     (set! (.-displayName ^js ctor) "hicasso/boundary")
-    (set! (.-contextType ^js ctor) adapter-context/frame-context)
+    (set! (.-contextType ^js ctor) rf.adapter.context/frame-context)
     ;; React 19 requires the static marker for the boundary to catch at
     ;; all. It cannot reach the instance, so it only flips the render
     ;; marker; everything with a side effect is the commit's.
@@ -379,9 +379,9 @@
                 ;; binding is unconditional so the branch does not exist, and
                 ;; an intent written under a frameless boundary still lands on
                 ;; the existing loud error naming the intent.
-                (intent/with-frame frame-kw (when frame-kw (collector/frame-dispatch frame-kw))
+                (rf.hicasso.impl.intent/with-frame frame-kw (when frame-kw (rf.hicasso.impl.collector/frame-dispatch frame-kw))
                   (fn []
                     (if (some? error)
-                      (codec/as-element (if (fn? fallback) (fallback error) fallback))
-                      (codec/as-element (into [:<>] children)))))))))
-    (codec/mark-boundary! ctor)))
+                      (rf.hicasso.impl.codec/as-element (if (fn? fallback) (fallback error) fallback))
+                      (rf.hicasso.impl.codec/as-element (into [:<>] children)))))))))
+    (rf.hicasso.impl.codec/mark-boundary! ctor)))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
@@ -52,12 +52,12 @@
   docs/design/hicasso/studio/our-walk-against-reagents.md and
   docs/design/hicasso/studio/the-interpreter-walk-profiled-and-cheapened.md."
   (:require [clojure.string :as str]
-            [re-frame.hicasso.impl.controlled :as controlled]
+            [re-frame.hicasso.impl.controlled :as rf.hicasso.impl.controlled]
             [re-frame.hicasso.impl.error :refer [fail!]]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.impl.slot :as slot]
-            [re-frame.interop :as interop]
-            [re-frame.trace :as trace]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.impl.slot :as rf.hicasso.impl.slot]
+            [re-frame.interop :as rf.interop]
+            [re-frame.trace :as rf.trace]
             ["react" :as react]))
 
 (declare as-element)
@@ -145,10 +145,10 @@
 (defn- mint-slot
   "The `PropSlot` for a keyword or symbol prop literal whose name is `n`."
   [k n]
-  (let [js-name (slot/prop-name k)]
+  (let [js-name (rf.hicasso.impl.slot/prop-name k)]
     (->PropSlot js-name
                 (reserved-name? js-name)
-                (intent/event-prop? n)
+                (rf.hicasso.impl.intent/event-prop? n)
                 (identical? "ref" js-name)
                 (identical? "className" js-name))))
 
@@ -160,9 +160,9 @@
   cannot leave the cache holding a different spelling from a cold build's."
   [cache]
   (doto cache
-    (unchecked-set "class" (->PropSlot (slot/prop-name :class) false false false true))
-    (unchecked-set "for" (->PropSlot (slot/prop-name :for) false false false false))
-    (unchecked-set "charset" (->PropSlot (slot/prop-name :charset) false false false false))))
+    (unchecked-set "class" (->PropSlot (rf.hicasso.impl.slot/prop-name :class) false false false true))
+    (unchecked-set "for" (->PropSlot (rf.hicasso.impl.slot/prop-name :for) false false false false))
+    (unchecked-set "charset" (->PropSlot (rf.hicasso.impl.slot/prop-name :charset) false false false false))))
 
 (def ^:private prop-cache (seed-prop-cache! (empty-cache)))
 
@@ -191,7 +191,7 @@
   (docs/design/hicasso/decisions.md HD-023 (c′))."
   [k]
   (if-not (or (keyword? k) (symbol? k))
-    (if (string? k) (slot/prop-name k) k)
+    (if (string? k) (rf.hicasso.impl.slot/prop-name k) k)
     (let [^PropSlot s (prop-slot k (name k))]
       (.-js-name s))))
 
@@ -404,12 +404,12 @@
 
                            (and (.-event? s) (keyword? k))
                            (if (or (vector? v) (map? v) (fn? v))
-                             (intent/lower-prop k v)
+                             (rf.hicasso.impl.intent/lower-prop k v)
                              v)
 
                            :else
-                           (if (intent/callback? v)
-                             (intent/lower-prop k v)
+                           (if (rf.hicasso.impl.intent/callback? v)
+                             (rf.hicasso.impl.intent/lower-prop k v)
                              v)))))
       o)
 
@@ -420,7 +420,7 @@
                             (cond
                               (identical? ref-slot n)   v
                               (identical? class-slot n) (class-names (unchecked-get o class-slot) v)
-                              :else                     (intent/lower-prop k v)))))
+                              :else                     (rf.hicasso.impl.intent/lower-prop k v)))))
       o)))
 
 (defn convert-props
@@ -623,7 +623,7 @@
   fire — silently, since a trace that does not fire looks like a page with
   no crossing on it."
   []
-  (when interop/debug-enabled? #js {:armed false :announced false}))
+  (when rf.interop/debug-enabled? #js {:armed false :announced false}))
 
 (defn- note-unadopted!
   "Arm the crossing: this gate has rendered its placeholder, so the next
@@ -641,7 +641,7 @@
              (unchecked-get crossing "armed")
              (not (unchecked-get crossing "announced")))
     (unchecked-set crossing "announced" true)
-    (trace/emit! :info :rf.ssr/host-adopted
+    (rf.trace/emit! :info :rf.ssr/host-adopted
                  {:host  host-name
                   :where 're-frame.hicasso.impl.codec/mint-host-gate!})))
 
@@ -1279,8 +1279,8 @@
         ;; direct lane.
         js-props    (convert-props props parsed)
         _           (when-some [r (get props revision-key)]
-                      (unchecked-set js-props controlled/revision-slot r))
-        component   (controlled/install! (.-tag parsed) js-props)]
+                      (unchecked-set js-props rf.hicasso.impl.controlled/revision-slot r))
+        component   (rf.hicasso.impl.controlled/install! (.-tag parsed) js-props)]
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     (make-element component js-props argv (if has-props? 2 1))))
 
@@ -1399,10 +1399,10 @@
             ;; not claim — a vector at `:render` — crosses as data
             ;; exactly as it would at an inferred position.
             (contains? declared slot)
-            (host-prop-value slot (intent/lower-declared-prop k v (get declared slot)))
+            (host-prop-value slot (rf.hicasso.impl.intent/lower-declared-prop k v (get declared slot)))
 
             (contains? slots slot)
-            (do (when (intent/callback? v)
+            (do (when (rf.hicasso.impl.intent/callback? v)
                   (refuse-unclaimed-host-callback! head k))
                 (as-element v))
 
@@ -1414,7 +1414,7 @@
             ;; written against where the value lands. The KEY for the
             ;; classifier, because the spelling is what it reads.
             :else
-            (host-prop-value slot (intent/lower-prop k v)))))
+            (host-prop-value slot (rf.hicasso.impl.intent/lower-prop k v)))))
       o)))
 
 (defn- host-element
@@ -1718,7 +1718,7 @@
   dispatch is what makes an intent vector legal, and an intent outside a
   boundary stays the loud `:rf.error/hicasso-intent-outside-boundary`."
   [frame-kw hiccup]
-  (binding [intent/*frame* frame-kw]
+  (binding [rf.hicasso.impl.intent/*frame* frame-kw]
     (as-element hiccup)))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -27,18 +27,18 @@
   cold read is priced in docs/design/hicasso/studio/the-cold-read-mount-term.md;
   every module-level owner here has its row on
   docs/design/hicasso/product/globals.md."
-  (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.error :as error :refer [fail!]]
-            [re-frame.hicasso.impl.frames :as frames]
-            [re-frame.hicasso.impl.generation :as generation]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.live-frame :as live-frame]
-            [re-frame.performance :as performance :include-macros true]
-            [re-frame.registrar :as registrar]
-            [re-frame.subs :as subs]
+  (:require [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.error :as rf.hicasso.impl.error :refer [fail!]]
+            [re-frame.hicasso.impl.frames :as rf.hicasso.impl.frames]
+            [re-frame.hicasso.impl.generation :as rf.hicasso.impl.generation]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.performance :as rf.performance :include-macros true]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.subs :as rf.subs]
             ["react" :as react]))
 
 ;; ---------------------------------------------------------------------------
@@ -103,7 +103,7 @@
   closure factory, so every caller reads the same row and the bundle can
   never describe a different incarnation than the closure that calls it."
   [frame-kw]
-  (frames/frame-row frame-kw mint-frame-dispatch))
+  (rf.hicasso.impl.frames/frame-row frame-kw mint-frame-dispatch))
 
 (defn frame-dispatch
   "The ambient dispatch a boundary binds for its render's dynamic extent
@@ -163,7 +163,7 @@
     (set! (.-disposed cell) true)
     (when-some [r (.-reaction cell)] (remove-watch r cell-watch-key))
     (swap! !cells dissoc (.-subKey cell))
-    (subs/unsubscribe (.-frameKw cell) (.-queryV cell)))
+    (rf.subs/unsubscribe (.-frameKw cell) (.-queryV cell)))
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -286,16 +286,16 @@
   [^js cell]
   (let [frame-kw (.-frameKw cell)
         query-v  (.-queryV cell)
-        reaction (subs/subscribe query-v {:frame frame-kw})]
+        reaction (rf.subs/subscribe query-v {:frame frame-kw})]
     (set! (.-reaction cell) reaction)
     (when (some? reaction)
       ;; On the substrate's PUSH path, before anything observes or watches it.
-      (interop/activate-derived-value! reaction)
+      (rf.interop/activate-derived-value! reaction)
       ;; ONE baseline deref, before the watch — see `acquire-cell!`.
       @reaction
       (add-watch reaction cell-watch-key
                  (fn [_ _ old nu] (when-not (= old nu) (mark-dirty! cell))))
-      (interop/add-on-dispose! reaction (fn [] (invalidate-cell! cell))))
+      (rf.interop/add-on-dispose! reaction (fn [] (invalidate-cell! cell))))
     cell))
 
 (defn- invalidate-cell!
@@ -325,7 +325,7 @@
         ;; second `add-on-dispose!` hook, so the next disposal would
         ;; invalidate twice, wire twice and compound.
         (when (and (not (.-disposed cell)) (nil? (.-reaction cell)))
-          (if (nil? (frame/frame-incarnation-token (.-frameKw cell)))
+          (if (nil? (rf.frame/frame-incarnation-token (.-frameKw cell)))
             (dispose-cell! cell)
             (do (wire-cell! cell)
                 ;; Re-stamp and notify: a boundary that painted before the
@@ -374,7 +374,7 @@
   before the registration it is about to read against."
   [{:keys [kind] :as registration}]
   (when (= :sub kind)
-    (generation/bump-registry-epoch!)
+    (rf.hicasso.impl.generation/bump-registry-epoch!)
     (first-registration! registration))
   nil)
 
@@ -383,7 +383,7 @@
 ;; keyword compare per registration and the scan only on a first-time `:sub`.
 #_:clj-kondo/ignore
 (defonce ^:private first-registration-armed
-  (do (registrar/add-registration-hook! sub-registered!) true))
+  (do (rf.registrar/add-registration-hook! sub-registered!) true))
 
 (defn- acquire-cell!
   "Commit-phase only. Take (building if necessary) the durable reference
@@ -406,7 +406,7 @@
                                      ;; contributes the CURRENT basis to
                                      ;; `getSnapshot`, so a cell born at
                                      ;; the same basis reads the same.
-                                     "epoch"    (generation/commit-basis frame-kw)
+                                     "epoch"    (rf.hicasso.impl.generation/commit-basis frame-kw)
                                      ;; The key's reverse edge AND its
                                      ;; reference count, in one array —
                                      ;; see the section header.
@@ -473,7 +473,7 @@
   (let [dirty @!dirty]
     (when (seq dirty)
       (vreset! !dirty #{})
-      (generation/bump-generation!)
+      (rf.hicasso.impl.generation/bump-generation!)
       ;; Re-STAMP rather than increment, so a cell's epoch stays a
       ;; `commit-basis` reading comparable with a staged key's — floored
       ;; at one above the stamp it carried, because across a same-id frame
@@ -485,7 +485,7 @@
       ;; `reincarnation-paint-dom-cljs-test`).
       (doseq [^js cell dirty]
         (set! (.-epoch cell) (max (inc (.-epoch cell))
-                                  (generation/commit-basis (.-frameKw cell)))))
+                                  (rf.hicasso.impl.generation/commit-basis (.-frameKw cell)))))
       (let [boundaries (dirty-readers dirty)]
         (if (rendering?)
           (do (vswap! !deferred into boundaries)
@@ -542,32 +542,32 @@
   on the acceptance shape (2.75 vs 1.42 µs/read;
   docs/design/hicasso/studio/the-cold-read-mount-term.md)."
   [frame-kw query-v]
-  (let [frame-record (frame/frame frame-kw)]
+  (let [frame-record (rf.frame/frame frame-kw)]
     (if (nil? frame-record)
-      (subs/subscribe-once query-v {:frame frame-kw})
-      (live-frame/call-with-frame-resolution
+      (rf.subs/subscribe-once query-v {:frame frame-kw})
+      (rf.live-frame/call-with-frame-resolution
         frame-kw
         (fn []
           (if-some [reaction (:reaction (get @(:sub-cache frame-record) query-v))]
             @reaction
             (let [^js probe (or (.-probe rstate)
-                                (when-some [frame-state (frame/frame-state-value frame-kw)]
+                                (when-some [frame-state (rf.frame/frame-state-value frame-kw)]
                                   (let [^js fresh #js {"fs" frame-state "vals" {}}]
                                  (set! (.-probe rstate) fresh)
                                  fresh)))]
               (if (nil? probe)
                 ;; The frame died between the record resolve and the
                 ;; state read — recover exactly as rung 3 does.
-                (subs/subscribe-once query-v {:frame frame-kw})
+                (rf.subs/subscribe-once query-v {:frame frame-kw})
                 ;; `find`, not `get`: a memoised nil (an unregistered
                 ;; query's recovery) is a HIT, and the one emission per
                 ;; distinct unknown key per run rides on that.
                 (if-some [cached-value (find (unchecked-get probe "vals") query-v)]
                   (val cached-value)
-                  (let [value (subs/compute-sub-with-memo
+                  (let [value (rf.subs/compute-sub-with-memo
                                 query-v
                                 (unchecked-get probe "fs")
-                                (atom {subs/observation-opts-key
+                                (atom {rf.subs/observation-opts-key
                                        {:frame frame-kw}}))]
                     (unchecked-set probe "vals"
                                    (assoc (unchecked-get probe "vals") query-v value))
@@ -753,7 +753,7 @@
                    (if-some [^js cell (get cells read-key)]
                      (+ epoch-sum (.-epoch cell))
                      (+ epoch-sum
-                        (generation/commit-basis (nth read-key 0)))))))))))
+                        (rf.hicasso.impl.generation/commit-basis (nth read-key 0)))))))))))
 
 (defn- make-subscribe
   "React's `subscribe`, a pure function of the read set — the only
@@ -889,9 +889,9 @@
   registration that bypassed the macro path."
   [view-name]
   (let [view-id (keyword view-name)]
-    {:data-rf2-source-coord (adapter-context/format-source-coord
-                              view-id (error/source-of view-name))
-     :data-rf-view          (adapter-context/format-view-id view-id)}))
+    {:data-rf2-source-coord (rf.adapter.context/format-source-coord
+                              view-id (rf.hicasso.impl.error/source-of view-name))
+     :data-rf-view          (rf.adapter.context/format-view-id view-id)}))
 
 (defn- author-owns-slot?
   "Does `authored` already write the React prop slot `slot`, in ANY of the
@@ -900,7 +900,7 @@
   emitter itself uses — so this cannot answer differently from what
   `convert-props` will do with the map."
   [authored slot]
-  (reduce-kv (fn [_ k _] (if (= slot (codec/canonical-slot k)) (reduced true) false))
+  (reduce-kv (fn [_ k _] (if (= slot (rf.hicasso.impl.codec/canonical-slot k)) (reduced true) false))
              false
              authored))
 
@@ -922,7 +922,7 @@
   the codec was about to walk anyway."
   [attrs authored]
   (reduce-kv (fn [acc k _]
-               (if (author-owns-slot? authored (codec/canonical-slot k))
+               (if (author-owns-slot? authored (rf.hicasso.impl.codec/canonical-slot k))
                  (dissoc acc k)
                  acc))
              attrs
@@ -966,7 +966,7 @@
   [hiccup attrs]
   (if (and (vector? hiccup)
            (pos? (count hiccup))
-           (= :tag (codec/head-kind (nth hiccup 0))))
+           (= :tag (rf.hicasso.impl.codec/head-kind (nth hiccup 0))))
     (let [maybe-attrs (nth hiccup 1 nil)]
       (if (map? maybe-attrs)
         (assoc hiccup 1 (merge (without-authored-slots attrs maybe-attrs) maybe-attrs))
@@ -995,9 +995,9 @@
   ;; render, and a real count is the one that says so.
   (set! (.-bodyRuns rstate) (inc (.-bodyRuns rstate)))
   (try
-    (intent/with-frame frame-kw (frame-dispatch frame-kw)
+    (rf.hicasso.impl.intent/with-frame frame-kw (frame-dispatch frame-kw)
       (fn []
-        (codec/as-element
+        (rf.hicasso.impl.codec/as-element
           (let [out (body-fn props)]
             (if ^boolean js/goog.DEBUG
               (if-some [attrs (unchecked-get body-fn view-attrs-slot)]
@@ -1071,10 +1071,10 @@
   (docs/design/hicasso/architecture.md, section The collector)."
   [frame-kw body-fn props]
   (loop [attempt 0]
-    (let [basis-before (generation/commit-basis frame-kw)
+    (let [basis-before (rf.hicasso.impl.generation/commit-basis frame-kw)
           element      (run-once frame-kw body-fn props)]
       (cond
-        (= basis-before (generation/commit-basis frame-kw))
+        (= basis-before (rf.hicasso.impl.generation/commit-basis frame-kw))
         (let [entry (entry-for scratch)]
           (set! (.-entry rstate) entry)
           (when ^boolean js/goog.DEBUG
@@ -1094,7 +1094,7 @@
                     (inc max-fence-retries) " consecutive runs. A body that "
                     "writes on every render cannot be fenced; move the write "
                     "out of the render.")
-               {:frame frame-kw :generation (generation/generation)})))))
+               {:frame frame-kw :generation (rf.hicasso.impl.generation/generation)})))))
 
 (defn last-reads
   "The read-set entry the most recent `render-body` resolved — what a
@@ -1121,7 +1121,7 @@
   tier can only answer for a different render than the one asking
   (docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md §3.2)."
   [frame-kw where]
-  (if (or (nil? frame-kw) (= adapter-context/no-provider-sentinel frame-kw))
+  (if (or (nil? frame-kw) (= rf.adapter.context/no-provider-sentinel frame-kw))
     (fail! :rf.error/no-frame-context
            where
            (str "A Hicasso boundary rendered with no frame in scope. Mount the "
@@ -1139,7 +1139,7 @@
   view at React's commit; in production the branch folds away and the
   entry's own is all there is."
   [body-fn js-props]
-  (let [frame-kw (resolve-frame! (react/useContext adapter-context/frame-context)
+  (let [frame-kw (resolve-frame! (react/useContext rf.adapter.context/frame-context)
                                  're-frame.hicasso.impl.collector/shell)
         props    (or (unchecked-get js-props "rfProps") {})
         element  (render-body frame-kw body-fn props)
@@ -1179,21 +1179,21 @@
     ;; as a parameter every mint would have to thread.
     (unchecked-set body-fn view-attrs-slot (view-annotations view-name)))
   (let [component (fn hicasso-boundary [js-props]
-                    (performance/mark-and-measure :render view-name
+                    (rf.performance/mark-and-measure :render view-name
                       (shell body-fn js-props)))
         ;; Dev only: the origin a refusal below names. `interop/debug-enabled?`
         ;; is `^boolean goog.DEBUG`, so under `:advanced` this `if` folds to
         ;; `component` and React calls the fn above, unchanged.
-        component (if interop/debug-enabled?
-                    (error/traced-boundary view-name component)
+        component (if rf.interop/debug-enabled?
+                    (rf.hicasso.impl.error/traced-boundary view-name component)
                     component)]
     (unchecked-set component "displayName" view-name)
-    (let [head (codec/memoize-boundary! (codec/mark-boundary! component))]
+    (let [head (rf.hicasso.impl.codec/memoize-boundary! (rf.hicasso.impl.codec/mark-boundary! component))]
       ;; The body, kept ON the head for the test kit's L2 walk alone, which
       ;; mounts nothing and would otherwise have no route back to it. One
       ;; own property; under `goog.DEBUG=false` it folds away with
       ;; `codec/retain-body!` (`view-body-retention-elision-prod-test`).
-      (when ^boolean js/goog.DEBUG (codec/retain-body! head body-fn))
+      (when ^boolean js/goog.DEBUG (rf.hicasso.impl.codec/retain-body! head body-fn))
       head)))
 
 ;; ---------------------------------------------------------------------------
@@ -1224,7 +1224,7 @@
   (`error-source-coord-elision-prod-test`). The argument:
   docs/design/hicasso/architecture.md, section The collector."
   [view-id slot head]
-  (registrar/register! :view view-id (assoc slot
+  (rf.registrar/register! :view view-id (assoc slot
                                        :hicasso/component head
                                        :executable-key    :hicasso/component))
   view-id)
@@ -1252,7 +1252,7 @@
   (vreset! !batching false)
   (reset-reapers! cell-reapers)
   (reset-reapers! entry-reapers)
-  (generation/reset-basis!)
+  (rf.hicasso.impl.generation/reset-basis!)
   (set! (.-entry rstate) nil)
   (set! (.-subscribe rstate) nil)
   (set! (.-frame rstate) nil)
@@ -1262,5 +1262,5 @@
   ;; across the thing they measure, and a teardown door that zeroed the
   ;; counter would let a reading taken on the wrong side of a reset look
   ;; like a reading. The kit's `reset-body-runs!` is the explicit zero.
-  (frames/forget-frame-ops!)
+  (rf.hicasso.impl.frames/forget-frame-ops!)
   nil)

--- a/implementation/hicasso/src/re_frame/hicasso/impl/error.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/error.cljc
@@ -16,8 +16,8 @@
   One constructor rather than one per lane, so a field of the shape is
   added in one place. Argument: docs/design/hicasso/product/specification.md
   §3.6 (Loud, stable failure)."
-  (:require [re-frame.error :as error]
-            [re-frame.interop :as interop]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.interop :as rf.interop]))
 
 ;; ---------------------------------------------------------------------------
 ;; The declaration ledger — dev only
@@ -141,7 +141,7 @@
   is what makes that emptiness show up as an ABSENT field rather than a
   nil one."
   [m]
-  (if interop/debug-enabled?
+  (if rf.interop/debug-enabled?
     (if-some [view @!origin]
       (let [coord (source-of view)]
         (cond-> (assoc m :view view)
@@ -167,7 +167,7 @@
   throw the runtime does not recover from; the fix lives in `:reason`.
   Argument: docs/design/hicasso/product/specification.md §3.6."
   [id where reason extra]
-  (throw (error/ex-info-from-data
+  (throw (rf.error/ex-info-from-data
            (merge (apply dissoc extra ambient)
                   (with-origin {:rf.error/id id :where where
                                 :reason reason :recovery :no-recovery})))))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/frames.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/frames.cljs
@@ -71,8 +71,8 @@
   closure that calls it can never describe different incarnations: the
   coupling is structural, not a rule somebody has to keep."
   (:require [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]))
 
 ;; frame-kw -> {:incarnation <token or nil>   the exact incarnation this row
 ;;                                            was minted under
@@ -126,7 +126,7 @@
   superseded); this table's only job is to hand out a bundle that was captured
   while the frame it names was alive."
   [frame-kw mint-dispatch]
-  (let [incarnation (frame/frame-incarnation-token frame-kw)
+  (let [incarnation (rf.frame/frame-incarnation-token frame-kw)
         row         (get @!frame-ops frame-kw)]
     (cond
       (nil? incarnation)
@@ -166,4 +166,4 @@
   [frame-kw]
   (forget-frame-ops! frame-kw))
 
-(late-bind/set-fn! :hicasso/on-frame-destroyed! on-frame-destroyed!)
+(rf.late-bind/set-fn! :hicasso/on-frame-destroyed! on-frame-destroyed!)

--- a/implementation/hicasso/src/re_frame/hicasso/impl/generation.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/generation.cljs
@@ -8,7 +8,7 @@
   writers, because a counter anything can increment is a counter nothing
   can reason about. Why the basis has three terms and what each one sees
   is docs/design/hicasso/architecture.md, section The collector."
-  (:require [re-frame.frame :as frame]))
+  (:require [re-frame.frame :as rf.frame]))
 
 (defonce ^:private !generation (volatile! 0))
 (defonce ^:private !registry-epoch (volatile! 0))
@@ -69,7 +69,7 @@
   `:node-key` axis, not this number's. Full argument:
   docs/design/hicasso/architecture.md, section The collector."
   [frame-kw]
-  (+ @!generation (frame/frame-commit-epoch frame-kw) @!registry-epoch))
+  (+ @!generation (rf.frame/frame-commit-epoch frame-kw) @!registry-epoch))
 
 (defn reset-basis!
   "Zero both terms this namespace owns: the teardown half of the

--- a/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
@@ -39,9 +39,9 @@
   Design record: docs/design/hicasso/decisions.md HD-020, HD-024, HD-026
   and HD-027; the authoring surface in docs/design/hicasso/authoring.md
   §Event intent as data."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.frame :as rf.frame]
             [re-frame.hicasso.impl.error :refer [fail!]]
-            [re-frame.late-bind :as late-bind]))
+            [re-frame.late-bind :as rf.late-bind]))
 
 ;; ---------------------------------------------------------------------------
 ;; The ambient frame (HD-020(a))
@@ -117,7 +117,7 @@
   ([frame-kw dispatch body-fn]
    (binding [*frame*                       frame-kw
              *dispatch*                    dispatch
-             frame/*ambient-frame-refusal* (cond-> ambient-frame-refusal
+             rf.frame/*ambient-frame-refusal* (cond-> ambient-frame-refusal
                                              frame-kw (assoc :extent-frame frame-kw))]
      (body-fn))))
 
@@ -227,11 +227,11 @@
   [_k f]
   (let [owner-dispatch *dispatch*
         owner-frame    *frame*
-        owner-refusal  frame/*ambient-frame-refusal*]
+        owner-refusal  rf.frame/*ambient-frame-refusal*]
     (fn hicasso-render-callback [& args]
       (binding [*frame*                       owner-frame
                 *dispatch*                    owner-dispatch
-                frame/*ambient-frame-refusal* owner-refusal]
+                rf.frame/*ambient-frame-refusal* owner-refusal]
         (apply f args)))))
 
 ;; ---------------------------------------------------------------------------
@@ -489,7 +489,7 @@
   (let [{:keys [frame payload native? veto]} (unwrap-navigate k v)
         veto-fn (lower-veto k veto)]
     (fn hicasso-navigate [e]
-      (if-some [activate (late-bind/get-fn :routing/activate-link!)]
+      (if-some [activate (rf.late-bind/get-fn :routing/activate-link!)]
         (activate e veto-fn frame payload native?)
         (when veto-fn (veto-fn e)))
       nil)))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
@@ -17,14 +17,14 @@
   business, so it returns before the tree is adopted and a witness waits
   for the adoption window to close. The mechanism record is
   docs/design/hicasso/architecture.md, section The root."
-  (:require [re-frame.adapter.context :as adapter-context]
+  (:require [re-frame.adapter.context :as rf.adapter.context]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.roots :as roots]
-            [re-frame.interop :as interop]
-            [re-frame.trace :as trace]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.roots :as rf.hicasso.impl.roots]
+            [re-frame.interop :as rf.interop]
+            [re-frame.trace :as rf.trace]
             ["react" :as react]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]))
@@ -36,7 +36,7 @@
   Renders no DOM of its own, so it cannot move a canonical-DOM parity
   comparison."
   [frame-kw child]
-  (react/createElement (.-Provider adapter-context/frame-context)
+  (react/createElement (.-Provider rf.adapter.context/frame-context)
                        #js {:value frame-kw}
                        child))
 
@@ -73,12 +73,12 @@
   witnesses in docs/design/hicasso/architecture.md, section The root)."
   [handle hiccup]
   (let [app (provider (:frame handle)
-                      (codec/root-element (:frame handle) hiccup))]
+                      (rf.hicasso.impl.codec/root-element (:frame handle) hiccup))]
     (if-some [window (:adoption handle)]
       (react/createElement (.-Fragment react) nil
                            (react/createElement adoption-window-closer
                                                 #js {:rfWindow window})
-                           (roots/with-adoption window app))
+                           (rf.hicasso.impl.roots/with-adoption window app))
       app)))
 
 (defn render!
@@ -131,7 +131,7 @@
   returns, so the first paint is the seeded one
   (docs/design/hicasso/architecture.md, section The root)."
   [frame-kw initial-events]
-  (when (nil? (frame/frame-incarnation-token frame-kw))
+  (when (nil? (rf.frame/frame-incarnation-token frame-kw))
     (rf/make-frame (cond-> {:id frame-kw}
                      (seq initial-events) (assoc :initial-events initial-events))))
   frame-kw)
@@ -175,7 +175,7 @@
   (docs/design/hicasso/architecture.md, section The root)."
   [^js props]
   (react/useEffect (fn close-window []
-                     (roots/close-adoption-window! (.-rfWindow props))
+                     (rf.hicasso.impl.roots/close-adoption-window! (.-rfWindow props))
                      js/undefined)
                    #js [])
   nil)
@@ -203,7 +203,7 @@
   an event and mints no epoch: it fires from a root-error callback,
   outside any dispatch scope."
   [error]
-  (trace/emit! :warning :rf.ssr/hydration-mismatch
+  (rf.trace/emit! :warning :rf.ssr/hydration-mismatch
                {:error    (some-> error .-message)
                 :where    're-frame.hicasso.impl.mount/hydrate-root!
                 :recovery :warned-and-replaced}))
@@ -229,7 +229,7 @@
   boundary."
   [^js window]
   (fn on-recoverable [error _error-info]
-    (when (roots/adopting? window)
+    (when (rf.hicasso.impl.roots/adopting? window)
       (emit-hydration-mismatch! error))
     (report-recoverable-default! error)))
 
@@ -242,7 +242,7 @@
   hydrate every server `useId` into a mismatch."
   [window opts]
   (root-options (:identifier-prefix opts)
-                (when interop/debug-enabled? (hydration-reporter window))))
+                (when rf.interop/debug-enabled? (hydration-reporter window))))
 
 (defn hydrate-root!
   "Associate `container`'s existing server-rendered DOM with `frame-kw`
@@ -277,7 +277,7 @@
   witnesses: docs/design/hicasso/architecture.md, section The root."
   ([container frame-kw hiccup] (hydrate-root! container frame-kw hiccup nil))
   ([container frame-kw hiccup opts]
-   (let [window  (roots/open-adoption-window!)
+   (let [window  (rf.hicasso.impl.roots/open-adoption-window!)
          handle  {:frame frame-kw :container container :adoption window}
          element (tree handle hiccup)
          ropts   (hydrate-root-options window opts)]
@@ -302,7 +302,7 @@
   `release!`'s (docs/design/hicasso/product/globals.md, the
   `reset-runtime!` paragraph)."
   [handle]
-  (roots/close-adoption-window! (:adoption handle))
+  (rf.hicasso.impl.roots/close-adoption-window! (:adoption handle))
   (when-some [r (:root handle)]
     (react-dom/flushSync (fn [] (.unmount r))))
   nil)
@@ -319,7 +319,7 @@
   (unmount! handle)
   (when-some [c (:container handle)]
     (when-some [p (.-parentNode c)] (.removeChild p c)))
-  (collector/reset-runtime!)
+  (rf.hicasso.impl.collector/reset-runtime!)
   nil)
 
 (defn dispatch!
@@ -327,7 +327,7 @@
   The witness door; an intent written in a view reaches
   `collector/dispatch!` on its own."
   [handle event]
-  (collector/dispatch! (:frame handle) event)
+  (rf.hicasso.impl.collector/dispatch! (:frame handle) event)
   (settle!)
   nil)
 

--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -34,11 +34,11 @@
   `:rf.error/hicasso-intent-outside-boundary`, because an element that
   invites a dismissal nothing can route is exactly the second owner
   (HD-020's frameless ruling)."
-  (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
+  (:require [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
             [re-frame.hicasso.impl.error :refer [fail!]]
-            [re-frame.hicasso.impl.intent :as intent]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
             ["react" :as react]))
 
 ;; ---------------------------------------------------------------------------
@@ -414,8 +414,8 @@
         ;; Hook 1 — the frame, through the shared reader so a no-provider
         ;; sentinel resolves to nil ("no scope") rather than being mistaken
         ;; for a frame keyword.
-        frame-kw (adapter-context/context-value->current-frame
-                   (react/useContext adapter-context/frame-context))
+        frame-kw (rf.adapter.context/context-value->current-frame
+                   (react/useContext rf.adapter.context/frame-context))
         ;; Hook 2 — the instance cell, filled lazily rather than through
         ;; `useRef`'s argument, which is evaluated on EVERY render and would
         ;; burn the counter once per render.
@@ -427,7 +427,7 @@
       ;; Zero cost when closed: no element, so no top-layer entry, no
       ;; listener, no anchor claim and no children rendered.
       (when (:open? props)
-        (let [dispatch (when frame-kw (collector/frame-dispatch frame-kw))
+        (let [dispatch (when frame-kw (rf.hicasso.impl.collector/frame-dispatch frame-kw))
               area     (position-area (:placement props))
               extra    (cond-> (assoc (dismissal-attrs props)
                                       :ref   (unchecked-get cell "ref")
@@ -449,9 +449,9 @@
           ;; the parent's body and are walked HERE, so the ambient frame the
           ;; codec's intent lowering reads is re-established around this
           ;; call and nowhere else.
-          (intent/with-frame frame-kw dispatch
+          (rf.hicasso.impl.intent/with-frame frame-kw dispatch
             (fn []
-              (codec/as-element
+              (rf.hicasso.impl.codec/as-element
                 (into [tag (element-attrs props extra)] (:children props))))))))))
 
 (defn- modal-dismissal-attrs
@@ -474,12 +474,12 @@
 
 (def modal
   "See `re-frame.hicasso.overlay/modal`."
-  (codec/mark-boundary!
+  (rf.hicasso.impl.codec/mark-boundary!
     (doto (fn hicasso-modal [js-props] (body modal-ops modal-dismissal-attrs js-props))
       (unchecked-set "displayName" "hicasso/modal"))))
 
 (def popover
   "See `re-frame.hicasso.overlay/popover`."
-  (codec/mark-boundary!
+  (rf.hicasso.impl.codec/mark-boundary!
     (doto (fn hicasso-popover [js-props] (body popover-ops popover-dismissal-attrs js-props))
       (unchecked-set "displayName" "hicasso/popover"))))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/portal.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/portal.cljs
@@ -30,7 +30,7 @@
   in front of it is what keeps the caller's `:fallback` reachable.
   Anchoring, dismissal and focus are `re-frame.hicasso.overlay`'s.
   Design record: docs/design/hicasso/decisions.md, HD-011."
-  (:require [re-frame.hicasso.impl.codec :as codec]
+  (:require [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
             ["react-dom" :as react-dom]))
 
 (defn- portal-body
@@ -41,7 +41,7 @@
   pass with no fallback flash. The target is read only on the adopted
   branch, because a server render legitimately has no container."
   [^js props]
-  (if (codec/adopted?)
+  (if (rf.hicasso.impl.codec/adopted?)
     (react-dom/createPortal (.-children props) (.-target props))
     (.-fallback props)))
 
@@ -57,6 +57,6 @@
   ReactNode position so hiccup there lowers under that same frame, and
   `:target` crosses by identity as ordinary data. A misspelled option is
   an absent one — two options is not a roster."
-  (codec/mint-host! "hicasso/portal" portal-body
+  (rf.hicasso.impl.codec/mint-host! "hicasso/portal" portal-body
                     {:slots  #{:fallback}
                      :server :render}))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/presence.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/presence.cljs
@@ -73,7 +73,7 @@
   spend an effect on it. Deadlines are absolute instants stored when a
   key starts exiting, so a timer re-armed for an unrelated reason cannot
   extend a child's retention past its terminal bound."
-  (:require [re-frame.hicasso.impl.codec :as codec]
+  (:require [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
             [re-frame.hicasso.impl.error :refer [fail!]]))
 
 ;; ---------------------------------------------------------------------------
@@ -89,12 +89,12 @@
 (def mounting-key
   "`::motion/mounting` — the attribute overrides applied while a child is
   entering."
-  codec/mounting-key)
+  rf.hicasso.impl.codec/mounting-key)
 
 (def unmounting-key
   "`::motion/unmounting` — the attribute overrides applied while a child
   is being retained on its way out."
-  codec/unmounting-key)
+  rf.hicasso.impl.codec/unmounting-key)
 
 (def override-keys #{mounting-key unmounting-key})
 
@@ -174,7 +174,7 @@
         base     (when props (apply dissoc props override-keys))]
     (cond
       (map? override)
-      (with-props child (merge base (codec/without-structural override)))
+      (with-props child (merge base (rf.hicasso.impl.codec/without-structural override)))
 
       ;; Nothing to strip and nothing to merge: the child is already
       ;; exactly what it should render as, so it comes back untouched

--- a/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
@@ -87,29 +87,29 @@
   was adopting for as long as any root anywhere was hydrating, and the
   tray would skip its enter transition for a hydration it had nothing to
   do with. The window this reads can only be its own root's."
-  (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.impl.presence :as presence]
-            [re-frame.hicasso.impl.roots :as roots]
+  (:require [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.impl.presence :as rf.hicasso.impl.presence]
+            [re-frame.hicasso.impl.roots :as rf.hicasso.impl.roots]
             ["react" :as react]))
 
 (defn- now [] (js/Date.now))
 
 (defn- presence-body [js-props]
   (let [props      (or (unchecked-get js-props "rfProps") {})
-        timeout-ms (presence/check-timeout! (:timeout-ms props))
+        timeout-ms (rf.hicasso.impl.presence/check-timeout! (:timeout-ms props))
         children   (:children props)
         ;; The frame hook. Classified through the shared reader the whole
         ;; substrate uses, so the no-provider sentinel resolves to nil
         ;; ("no scope") rather than being mistaken for a frame keyword.
-        frame-kw   (adapter-context/context-value->current-frame
-                     (react/useContext adapter-context/frame-context))
-        hook       (react/useState presence/initial)
+        frame-kw   (rf.adapter.context/context-value->current-frame
+                     (react/useContext rf.adapter.context/frame-context))
+        hook       (react/useState rf.hicasso.impl.presence/initial)
         state      (aget hook 0)
         set-state  (aget hook 1)
-        stepped    (presence/step state children (now) timeout-ms)
+        stepped    (rf.hicasso.impl.presence/step state children (now) timeout-ms)
         ;; BORN PRESENT UNDER ADOPTION. A child a render
         ;; meets for the first time is `:mounting`, which is right for a
         ;; child that is genuinely appearing and wrong for one that is
@@ -150,27 +150,27 @@
         ;; paths are measured in
         ;; `re-frame.hicasso.presence-ssr-seam-dom-cljs-test`: §1 the
         ;; windowless one, §5 the product door.
-        next       (if (roots/adopting-here?) (presence/settle stepped) stepped)]
+        next       (if (rf.hicasso.impl.roots/adopting-here?) (rf.hicasso.impl.presence/settle stepped) stepped)]
     ;; Adjusting state while rendering — React's own answer to "a value
     ;; derived from props that must persist". `step` is idempotent, so the
     ;; equality test converges rather than looping.
     (when-not (= next state) (set-state next))
     (react/useEffect
       (fn []
-        (let [expiry (when-some [d (presence/next-deadline next)]
+        (let [expiry (when-some [d (rf.hicasso.impl.presence/next-deadline next)]
                        (js/setTimeout
-                         (fn [] (set-state (fn [s] (presence/expire s (now)))))
+                         (fn [] (set-state (fn [s] (rf.hicasso.impl.presence/expire s (now)))))
                          (max 0 (- d (now)))))
               ;; The enter flip lands on a macrotask rather than a layout
               ;; effect: a class flip that beats the browser's first paint
               ;; of the mounting styles animates nothing, and this is the
               ;; weak half the guide teaches around.
-              enter  (when (presence/mounting? next)
-                       (js/setTimeout (fn [] (set-state presence/settle)) 0))]
+              enter  (when (rf.hicasso.impl.presence/mounting? next)
+                       (js/setTimeout (fn [] (set-state rf.hicasso.impl.presence/settle)) 0))]
           (fn []
             (when expiry (js/clearTimeout expiry))
             (when enter (js/clearTimeout enter)))))
-      #js [(presence/pending-signature next)])
+      #js [(rf.hicasso.impl.presence/pending-signature next)])
     ;; THE LOWERING, inside the frame. These children were
     ;; written in the parent's body and are walked here, so the ambient
     ;; frame the codec's intent lowering reads has to be re-established
@@ -178,8 +178,8 @@
     ;; the tray — the binding is unconditional so the branch does not
     ;; exist, and an intent written under a frameless tray still lands on
     ;; the existing loud error naming the intent.
-    (intent/with-frame frame-kw (when frame-kw (collector/frame-dispatch frame-kw))
-      (fn [] (codec/as-element (into [:<>] (presence/render next)))))))
+    (rf.hicasso.impl.intent/with-frame frame-kw (when frame-kw (rf.hicasso.impl.collector/frame-dispatch frame-kw))
+      (fn [] (rf.hicasso.impl.codec/as-element (into [:<>] (rf.hicasso.impl.presence/render next)))))))
 
 (def presence
   "`h/presence` — a boundary that retains exiting keyed children for
@@ -199,4 +199,4 @@
   subscription and holds no cell. It inserts no wrapper node and stamps
   no `data-*`; every child it renders is the author's own node with the
   author's own attributes merged."
-  (codec/mark-boundary! (doto presence-body (aset "displayName" "hicasso/presence"))))
+  (rf.hicasso.impl.codec/mark-boundary! (doto presence-body (aset "displayName" "hicasso/presence"))))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/route_link.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/route_link.cljs
@@ -74,8 +74,8 @@
   cancelled it. See intent.cljs §The navigate head for the click-time
   half."
   (:require [re-frame.hicasso.impl.error :refer [fail!]]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.late-bind :as late-bind]))
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.late-bind :as rf.late-bind]))
 
 (def ^:private routing-artefact
   "The optional-artefact identity the fail-loud missing-hook error
@@ -113,23 +113,23 @@
   — the route-click one-intent law."
   [on-click]
   (when-not (or (nil? on-click)
-                (intent/prevent-head? on-click)
-                (intent/callback? on-click)
+                (rf.hicasso.impl.intent/prevent-head? on-click)
+                (rf.hicasso.impl.intent/callback? on-click)
                 (fn? on-click))
     (fail! :rf.error/hicasso-route-link-bad-on-click
            're-frame.hicasso.impl.route-link/route-link
            (str "route-link's :on-click is the pre-navigation veto; it takes nil, "
-                "[" (pr-str intent/prevent-head) " [:my-event …]] (cancel the "
+                "[" (pr-str rf.hicasso.impl.intent/prevent-head) " [:my-event …]] (cancel the "
                 "navigation and dispatch this instead), h/event, or a plain function — "
                 "never " (pr-str on-click) ". A bare intent vector is refused "
                 "because the click already produces the one routing intent; an "
                 "application reaction belongs behind the routing event, or inside "
-                (pr-str intent/prevent-head) " if it replaces the navigation.")
+                (pr-str rf.hicasso.impl.intent/prevent-head) " if it replaces the navigation.")
            {:on-click on-click}))
   on-click)
 
 (defn- require-frame! [to]
-  (or intent/*frame*
+  (or rf.hicasso.impl.intent/*frame*
       (fail! :rf.error/hicasso-route-link-outside-boundary
              're-frame.hicasso.impl.route-link/route-link
              (str "route-link {:to " (pr-str to) "} was rendered with no ambient "
@@ -153,14 +153,14 @@
   (let [frame-kw (require-frame! to)
         _        (on-click-roster! on-click)
         {:keys [href payload native?]}
-        ((late-bind/require-fn! :routing/link-model
+        ((rf.late-bind/require-fn! :routing/link-model
                                 'route-link
                                 routing-artefact
                                 {:to to})
          (dissoc props :on-click) frame-kw)
         attrs    (-> (apply dissoc props control-keys)
                      (assoc :href href
-                            :on-click [intent/navigate-head
+                            :on-click [rf.hicasso.impl.intent/navigate-head
                                        {:frame    frame-kw
                                         :payload  payload
                                         :native?  native?

--- a/implementation/hicasso/src/re_frame/hicasso/impl/state.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/state.cljc
@@ -81,9 +81,9 @@
   is a fail-silent hazard of exactly the class this namespace exists to
   delete, so there is no sentinel here and no \"convenience\" arity that
   accepts one."
-  (:require [re-frame.events :as events]
+  (:require [re-frame.events :as rf.events]
             [re-frame.hicasso.impl.error :refer [fail!]]
-            [re-frame.subs :as subs]))
+            [re-frame.subs :as rf.subs]))
 
 ;; ---------------------------------------------------------------------------
 ;; The spellings
@@ -181,7 +181,7 @@
   "Register `[::h/clear ::concern ikey]`. Idempotent — one handler serves
   every concern, and re-registration replaces it with an identical one."
   []
-  (events/reg-event clear-event-id
+  (rf.events/reg-event clear-event-id
     (fn clear-handler [{:keys [db]} [_ concern ikey]]
       (check-key! concern ikey :clear)
       {:db (clear-entry db concern ikey)})))
@@ -243,11 +243,11 @@
                    "believes is in force.")
               {:concern concern :unknown (vec (sort-by str unknown))})))
    (let [default (:default opts)]
-     (subs/reg-sub concern
+     (rf.subs/reg-sub concern
        (fn read-state [db query-v]
          (let [ikey (check-key! concern (nth query-v 1 nil) :read)]
            (get-in db [ui-root concern ikey] default))))
-     (events/reg-event concern
+     (rf.events/reg-event concern
        (fn write-state [{:keys [db]} [_ ikey v]]
          (check-key! concern ikey :write)
          {:db (assoc-in db [ui-root concern ikey] v)}))

--- a/implementation/hicasso/src/re_frame/hicasso/motion.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/motion.cljs
@@ -86,7 +86,7 @@
   its props (docs/design/hicasso/decisions.md HD-030). Naming-ledger row
   31 ruled the respelling from the prototype's `::h/…` (operator,
   2026-08-11), and the vocabulary now matches the row (rf2-hg3q)."
-  (:require [re-frame.hicasso.impl.presence-react :as impl-presence-react]))
+  (:require [re-frame.hicasso.impl.presence-react :as rf.hicasso.impl.presence-react]))
 
 (def ^{:doc "`motion/presence` — retain exiting keyed children for
   `:timeout-ms`, merging each child's own `::motion/mounting` /
@@ -98,4 +98,4 @@
   merged. `:timeout-ms` is mandatory — it is the retention length and
   the hard terminal bound at once, so a child leaves on time whether or
   not any CSS ran. `re-frame.hicasso.impl.presence-react/presence`."}
-  presence impl-presence-react/presence)
+  presence rf.hicasso.impl.presence-react/presence)

--- a/implementation/hicasso/src/re_frame/hicasso/native.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/native.cljc
@@ -11,8 +11,8 @@
 
   docs/design/hicasso/product/lanes/design-laws.md, Native boundary."
   #?(:cljs (:require ["react" :as react]
-                     [re-frame.adapter.context :as adapter-context]
-                     [re-frame.hicasso.impl.collector :as collector])))
+                     [re-frame.adapter.context :as rf.adapter.context]
+                     [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector])))
 
 #?(:cljs
    (do
@@ -38,10 +38,10 @@
 
   docs/design/hicasso/product/lanes/design-laws.md, Native boundary."
        []
-       (let [frame-kw (collector/resolve-frame!
-                        (react/useContext adapter-context/frame-context)
+       (let [frame-kw (rf.hicasso.impl.collector/resolve-frame!
+                        (react/useContext rf.adapter.context/frame-context)
                         're-frame.hicasso.native/use-frame)]
-         (:ops (collector/frame-row frame-kw))))
+         (:ops (rf.hicasso.impl.collector/frame-row frame-kw))))
 
      (defn use-sub
        "The current value of the subscription `query-v` names, read under
@@ -65,18 +65,18 @@
 
   docs/design/hicasso/product/lanes/design-laws.md, Native boundary."
        [query-v]
-       (let [frame-kw  (collector/resolve-frame!
-                         (react/useContext adapter-context/frame-context)
+       (let [frame-kw  (rf.hicasso.impl.collector/resolve-frame!
+                         (react/useContext rf.adapter.context/frame-context)
                          're-frame.hicasso.native/use-sub)
              ;; The refusal sits BEFORE the store hook: a render that throws
              ;; never reaches React's hook reconciliation, so no hook count
              ;; can disagree with a previous render's.
              sub-key   [frame-kw query-v]
-             ^js entry (collector/hook-entry sub-key)]
+             ^js entry (rf.hicasso.impl.collector/hook-entry sub-key)]
          ;; The snapshot is an epoch, not the value: one monotone number
          ;; React compares with `Object.is`, and the value is read after it
          ;; from the same synchronous instant. The third argument is the
          ;; same closure for the same reason.
          (react/useSyncExternalStore (.-subscribe entry) (.-snapshot entry)
                                      (.-snapshot entry))
-         (collector/hook-read sub-key)))))
+         (rf.hicasso.impl.collector/hook-read sub-key)))))

--- a/implementation/hicasso/src/re_frame/hicasso/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/overlay.cljs
@@ -186,7 +186,7 @@
   terminal bound and a witness. Composing the two is worth doing and is
   not this module's; a second retention clock inside it would be the
   duplicate `motion` exists to prevent."
-  (:require [re-frame.hicasso.impl.overlay :as impl-overlay]))
+  (:require [re-frame.hicasso.impl.overlay :as rf.hicasso.impl.overlay]))
 
 (def ^{:doc "`overlay/popover` — an anchored, light-dismissable panel on
   the browser's own top layer.
@@ -209,7 +209,7 @@
   without one it is `popover=\"manual\"` and dismisses for nothing, because
   a dismissal with nowhere to go is how an open flag acquires a second
   owner. `re-frame.hicasso.impl.overlay/popover`."}
-  popover impl-overlay/popover)
+  popover rf.hicasso.impl.overlay/popover)
 
 (def ^{:doc "`overlay/modal` — a blocking dialog on the browser's own top
   layer, opened with `showModal`.
@@ -234,4 +234,4 @@
   `:light-dismiss? true`, because a destructive confirmation must not go
   away on a stray click. Without `:on-dismiss` the dialog honours no close
   request at all. `re-frame.hicasso.impl.overlay/modal`."}
-  modal impl-overlay/modal)
+  modal rf.hicasso.impl.overlay/modal)

--- a/implementation/hicasso/src/re_frame/hicasso/server.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/server.cljs
@@ -46,13 +46,13 @@
   (`docs/design/hicasso/studio/ssr-spike-witness.md`). It is not a
   production HTTP host: the response contract is `re-frame.ssr.ring`'s."
   (:require [re-frame.core :as rf]
-            [re-frame.error :as error]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.roots :as roots]
-            [re-frame.ssr.constants :as ssr-constants]
-            [re-frame.ssr.html-helpers :as ssr-html]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.render-state :as render-state]
+            [re-frame.error :as rf.error]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.roots :as rf.hicasso.impl.roots]
+            [re-frame.ssr.constants :as rf.ssr.constants]
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.ssr.render-state :as rf.ssr.render-state]
             ["react-dom/server" :as rdom-server]))
 
 ;; ---------------------------------------------------------------------------
@@ -99,8 +99,8 @@
   breakout. That shell namespace is JVM-only, so the three lines are
   re-spelled here on the two shared constants rather than required."
   [payload-edn]
-  (str "<script id=\"" ssr-constants/payload-script-id "\" type=\"application/edn\">"
-       (ssr-html/escape-edn-script-body payload-edn)
+  (str "<script id=\"" rf.ssr.constants/payload-script-id "\" type=\"application/edn\">"
+       (rf.ssr.html-helpers/escape-edn-script-body payload-edn)
        "</script>"))
 
 (defn document
@@ -116,14 +116,14 @@
   (str "<!DOCTYPE html>"
        "<html lang=\"en\">"
        "<head><meta charset=\"utf-8\"><title>"
-       (ssr-html/escape-html (or title "Hicasso SSR")) "</title></head>"
+       (rf.ssr.html-helpers/escape-html (or title "Hicasso SSR")) "</title></head>"
        "<body>"
-       "<div id=\"" (ssr-html/escape-attr (or app-element-id "app")) "\">"
+       "<div id=\"" (rf.ssr.html-helpers/escape-attr (or app-element-id "app")) "\">"
        html
        "</div>"
        script
        (when script-src
-         (str "<script src=\"" (ssr-html/escape-attr script-src) "\"></script>"))
+         (str "<script src=\"" (rf.ssr.html-helpers/escape-attr script-src) "\"></script>"))
        "</body></html>"))
 
 ;; ---------------------------------------------------------------------------
@@ -237,7 +237,7 @@
   Hicasso's: it is the framework's render-failure category, raised from
   the hosts that have to raise it by hand."
   [where frame-id {:keys [error] :as record} recorded]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/ssr-render-failed
     where
     (str "the render completed but the runtime recorded " recorded
@@ -352,7 +352,7 @@
         ;; Per REQUEST and reachable from nothing else — never a
         ;; module-level flag, which would let one request's throw leave
         ;; every later request born-present.
-        window    (roots/open-adoption-window!)
+        window    (rf.hicasso.impl.roots/open-adoption-window!)
         ;; Keyed on THIS invocation's frame, so a re-entrant `render`
         ;; cannot unregister the outer one's listener — see `listener-key`.
         listener  (listener-key render-listener-tag frame-id)
@@ -384,7 +384,7 @@
             ;; door calls: `:adoption` is what it branches on, so this is
             ;; the Fragment-plus-closer tree `hydrate-root!` will adopt,
             ;; position for position.
-            element (mount/tree {:frame frame-id :adoption window} hiccup)
+            element (rf.hicasso.impl.mount/tree {:frame frame-id :adoption window} hiccup)
             ropts   (render-options identifier-prefix)
             html    (if ropts
                       (rdom-server/renderToString element ropts)
@@ -401,12 +401,12 @@
                             (some? client-frame-id) (assoc :client-frame-id client-frame-id)
                             (some? version)         (assoc :version version)
                             (some? schema-digest)   (assoc :schema-digest schema-digest))
-              payload-map (payload-policy/build-payload
+              payload-map (rf.ssr.payload-policy/build-payload
                             ;; WIRE id — the caller's stable one or nil.
                             ;; NEVER `frame-id`.
                             (:client-frame-id policy-opts)
-                            (payload-policy/project-app-db-egress
-                              (payload-policy/apply-policy (rf/app-db-value frame-id) policy-opts)
+                            (rf.ssr.payload-policy/project-app-db-egress
+                              (rf.ssr.payload-policy/apply-policy (rf/app-db-value frame-id) policy-opts)
                               ;; PROJECTION frame — the real per-request one.
                               frame-id)
                             ;; NO RENDER HASH — nil, and `build-payload`
@@ -433,7 +433,7 @@
         (rf/unregister-listener! :errors listener)
         ;; The window before the frame — `destroy-frame!` may itself throw,
         ;; and the window must already be shut when it runs.
-        (roots/close-adoption-window! window)
+        (rf.hicasso.impl.roots/close-adoption-window! window)
         (rf/destroy-frame! frame-id)))))
 
 ;; ---------------------------------------------------------------------------
@@ -496,7 +496,7 @@
   more than one that returned."
   [{:keys [hiccup render-state identifier-prefix frame-opts]}]
   (let [frame-id  (fresh-frame-id)
-        window    (roots/open-adoption-window!)
+        window    (rf.hicasso.impl.roots/open-adoption-window!)
         ;; Keyed on THIS invocation's frame — see `listener-key`.
         listener  (listener-key render-body-listener-tag frame-id)
         ;; Armed BEFORE the frame is made, so a fault in construction or in
@@ -511,8 +511,8 @@
                             ;; This module's, and not overridable — see the
                             ;; docstring's first bullet.
                             :initial-events []))
-      (render-state/restore! frame-id render-state)
-      (let [element (mount/tree {:frame frame-id :adoption window} hiccup)
+      (rf.ssr.render-state/restore! frame-id render-state)
+      (let [element (rf.hicasso.impl.mount/tree {:frame frame-id :adoption window} hiccup)
             ropts   (render-options identifier-prefix)
             html    (if ropts
                       (rdom-server/renderToString element ropts)
@@ -530,5 +530,5 @@
         (rf/unregister-listener! :errors listener)
         ;; The window before the frame — `destroy-frame!` may itself throw,
         ;; and the window must already be shut when it runs.
-        (roots/close-adoption-window! window)
+        (rf.hicasso.impl.roots/close-adoption-window! window)
         (rf/destroy-frame! frame-id)))))

--- a/implementation/hicasso/src/re_frame/hicasso/substrate.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/substrate.cljs
@@ -74,10 +74,10 @@
   [`spec/006-ReactiveSubstrate.md`](../../../../../spec/006-ReactiveSubstrate.md)
   §The adapter API contract."
   (:require ["react" :as react]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.spine :as spine]
-            [re-frame.views.frame-boundary :as boundary]))
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.spine :as rf.substrate.spine]
+            [re-frame.views.frame-boundary :as rf.views.frame-boundary]))
 
 ;; ---------------------------------------------------------------------------
 ;; The spine
@@ -92,7 +92,7 @@
   fn object, which is what catches a cross-wired spine key. None of it is
   application API — Hicasso publishes `adapter` and reads subscriptions
   through `h/sub`."
-  (spine/make-react-spine
+  (rf.substrate.spine/make-react-spine
     {:substrate-name        "Hicasso"
      :gensym-prefix-sub     "rf-hic-sub-"
      :gensym-prefix-derived "rf-hic-derived-"
@@ -121,14 +121,14 @@
   here — the props arrive as React hands them over — so there is nothing for a
   wrapper to preserve and no reason to depend on one."
   [^js props]
-  (let [frame-kw (frame/require-frame-provider-target!
+  (let [frame-kw (rf.frame/require-frame-provider-target!
                    (.-frame props)
                    're-frame.hicasso.substrate/frame-provider)]
-    (boundary/require-live-frame-for-scope!
+    (rf.views.frame-boundary/require-live-frame-for-scope!
       frame-kw 're-frame.hicasso.substrate/frame-provider)
-    (apply adapter-context/provider-element
+    (apply rf.adapter.context/provider-element
            frame-kw
-           (adapter-context/normalize-children (.-children props)))))
+           (rf.adapter.context/normalize-children (.-children props)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The adapter Var
@@ -154,6 +154,6 @@
   two chained installs (the warn-once clear and the SSR hiccup emitter). The
   frame-provider stays here because the spine carries no substrate's own
   element machinery."
-  (spine/make-react-adapter spine-fns
+  (rf.substrate.spine/make-react-adapter spine-fns
                             {:kind           :rf.adapter/hicasso
                              :frame-provider frame-provider}))

--- a/implementation/hicasso/src/re_frame/hicasso/tool.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/tool.cljs
@@ -29,14 +29,14 @@
   shapes drift, and a roster that could be emitted without its loss
   eventually is. The contract is
   docs/design/hicasso/product/lanes/testing-xray.md §Evidence contract."
-  (:require [re-frame.elision :as elision]
-            [re-frame.hicasso.evidence :as evidence]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.error :as error]
-            [re-frame.hicasso.impl.frames :as frames]
-            [re-frame.hicasso.impl.generation :as generation]
-            [re-frame.interop :as interop]
-            [re-frame.trace.tooling :as trace-tooling]))
+  (:require [re-frame.elision :as rf.elision]
+            [re-frame.hicasso.evidence :as rf.hicasso.evidence]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.error :as rf.hicasso.impl.error]
+            [re-frame.hicasso.impl.frames :as rf.hicasso.impl.frames]
+            [re-frame.hicasso.impl.generation :as rf.hicasso.impl.generation]
+            [re-frame.interop :as rf.interop]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; ---------------------------------------------------------------------------
 ;; Deterministic order — the precondition of a byte-for-byte contract
@@ -76,7 +76,7 @@
   absolute declarations match the bare query, exactly as the Pair MCP
   direct reads do."
   [frame-id query-v]
-  (elision/elide-wire-value query-v {:frame frame-id :query-v query-v}))
+  (rf.elision/elide-wire-value query-v {:frame frame-id :query-v query-v}))
 
 (defn- sub-id-of
   "The registration id a query names.
@@ -89,7 +89,7 @@
   [query-v]
   (cond (keyword? query-v)                    query-v
         (and (vector? query-v) (seq query-v)) (nth query-v 0)
-        :else                                 evidence/unknown))
+        :else                                 rf.hicasso.evidence/unknown))
 
 (defn- read-identity
   "One read edge's EXPORTED identity: `[frame-id sub-id projected-query]`.
@@ -144,9 +144,9 @@
     {:sub-id   (sub-id-of query-v)
      :query    (projected-query frame-id query-v)
      :frame-id frame-id
-     :epoch    (if-some [^js cell (get @collector/!cells sub-key)]
+     :epoch    (if-some [^js cell (get @rf.hicasso.impl.collector/!cells sub-key)]
                  (.-epoch cell)
-                 evidence/unknown)}))
+                 rf.hicasso.evidence/unknown)}))
 
 ;; ---------------------------------------------------------------------------
 ;; The view names — the dev-only stamp, resolved to a coordinate
@@ -163,9 +163,9 @@
   (if (seq names)
     (mapv (fn [view-name]
             {:view view-name
-             :source (or (error/source-of view-name) evidence/unknown)})
+             :source (or (rf.hicasso.impl.error/source-of view-name) rf.hicasso.evidence/unknown)})
           (sort names))
-    evidence/unknown))
+    rf.hicasso.evidence/unknown))
 
 (defn- views-by-read-set
   "A `js/Map` from each entry's key SET — the object a registration's
@@ -174,11 +174,11 @@
   through a second registry."
   []
   (let [views-by-read-set-map (js/Map.)]
-    (doseq [[_ bucket] @collector/!entries
+    (doseq [[_ bucket] @rf.hicasso.impl.collector/!entries
             ^js entry  bucket]
       (.set views-by-read-set-map
             (.-set entry)
-            (view-rows (collector/entry-views entry))))
+            (view-rows (rf.hicasso.impl.collector/entry-views entry))))
     views-by-read-set-map))
 
 ;; ---------------------------------------------------------------------------
@@ -200,7 +200,7 @@
   entries, which the same subscribe/cleanup pair that moves `refs`
   keeps."
   []
-  (let [live-entries (for [[_ bucket] @collector/!entries
+  (let [live-entries (for [[_ bucket] @rf.hicasso.impl.collector/!entries
                            ^js entry  bucket
                            :when      (pos? (.-refs entry))]
                        entry)]
@@ -217,7 +217,7 @@
                                                (seq (.-set entry))))
                                      entries))]
                   {:boundary    {:parent nil :key projected-boundary-key}
-                   :views       (view-rows (into #{} (mapcat collector/entry-views) entries))
+                   :views       (view-rows (into #{} (mapcat rf.hicasso.impl.collector/entry-views) entries))
                    :instances   (reduce + 0 (map (fn [^js entry]
                                                   (.-refs entry))
                                                 entries))
@@ -228,7 +228,7 @@
                                             projected-boundary-key)]
                                   (if (= 1 (count frame-ids))
                                     (first frame-ids)
-                                    evidence/unknown))
+                                    rf.hicasso.evidence/unknown))
                    :reads       (mapv read-row raw-read-keys)})))
          (ordered (comp :key :boundary)))))
 
@@ -262,10 +262,10 @@
   subscribed and stays listed. React DevTools is the authority on
   visibility."
   []
-  (when interop/debug-enabled?
-    (evidence/envelope :mounted-boundaries true nil
+  (when rf.interop/debug-enabled?
+    (rf.hicasso.evidence/envelope :mounted-boundaries true nil
                        {:boundaries (entry-rows)
-                        :generation (generation/generation)})))
+                        :generation (rf.hicasso.impl.generation/generation)})))
 
 ;; ---------------------------------------------------------------------------
 ;; Read 2 — read attribution (sub → boundary)
@@ -293,7 +293,7 @@
                                       :key    (boundary-key (.-reads registration))
                                       :views  (or (.get views-by-read-set-map
                                                         (.-reads registration))
-                                                  evidence/unknown)}))
+                                                  rf.hicasso.evidence/unknown)}))
                               readers))}))
 
 (defn read-read-attribution
@@ -315,16 +315,16 @@
   nothing holds has no cell and is absent — it is not a subscription with
   zero readers, it is one this runtime is not holding."
   []
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (let [views-by-read-set-map (views-by-read-set)]
-      (evidence/envelope :read-attribution true nil
+      (rf.hicasso.evidence/envelope :read-attribution true nil
                          ;; Ordered by SUB-KEY before the row is built, never
                          ;; by a field on the row: the sub-key carries the raw
                          ;; query vector, and a sort key that rode on the row
                          ;; would be a second egress path for its arguments.
                          {:edges (mapv (fn [[sub-key cell]]
                                         (edge-row views-by-read-set-map sub-key cell))
-                                       (ordered key @collector/!cells))}))))
+                                       (ordered key @rf.hicasso.impl.collector/!cells))}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Read 3 — the intent stream
@@ -334,7 +334,7 @@
   "The frames this runtime dispatches through — the frame-ops table's
   keys, which is where every Hicasso intent's dispatch was captured."
   []
-  (vec (sort-by pr-str (keys @frames/!frame-ops))))
+  (vec (sort-by pr-str (keys @rf.hicasso.impl.frames/!frame-ops))))
 
 (defn- intent-row
   "One retained run, as an intent row: WHICH event, and how many arguments
@@ -368,8 +368,8 @@
   (let [event (:event bundle)]
     {:frames      #{frame-id}
      :dispatch-id (:dispatch-id bundle)
-     :event-id    (if (vector? event) (nth event 0) evidence/unknown)
-     :arg-count   (if (vector? event) (dec (count event)) evidence/unknown)
+     :event-id    (if (vector? event) (nth event 0) rf.hicasso.evidence/unknown)
+     :arg-count   (if (vector? event) (dec (count event)) rf.hicasso.evidence/unknown)
      :sub-ids     (into #{} (keep #(get-in % [:tags :rf.sub/id])) (:subs bundle))}))
 
 (defn- merge-fragments
@@ -426,7 +426,7 @@
                  (-> row
                      (update :frames #(vec (sort-by pr-str %)))
                      (update :sub-ids #(vec (sort-by pr-str %)))
-                     (update :dispatch-id #(if (number? %) % evidence/unknown))))))))
+                     (update :dispatch-id #(if (number? %) % rf.hicasso.evidence/unknown))))))))
 
 (defn read-intents
   "What was dispatched inside Spec 009's retained window, oldest first,
@@ -452,10 +452,10 @@
   at markup or at a timer is not recorded by the ring and is not claimed
   here."
   []
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (let [frame-ids (hicasso-frames)
-          windows   (into {} (map (fn [fid] [fid (trace-tooling/trace-buffer fid)])) frame-ids)]
-      (evidence/envelope :intents false {:reason :cap :dropped evidence/unknown}
+          windows   (into {} (map (fn [fid] [fid (rf.trace.tooling/trace-buffer fid)])) frame-ids)]
+      (rf.hicasso.evidence/envelope :intents false {:reason :cap :dropped rf.hicasso.evidence/unknown}
                          {:frames  frame-ids
                           :intents (intent-rows windows frame-ids)}))))
 
@@ -505,8 +505,8 @@
      :instances    (:instances boundary-row)
      :window       {:frames (vec (sort-by pr-str frame-ids))
                     :retained-runs retained-runs}
-     :snapshot     (if (seq epochs) (reduce + epochs) evidence/unknown)
-     :peak-epoch   (or peak-epoch evidence/unknown)
+     :snapshot     (if (seq epochs) (reduce + epochs) rf.hicasso.evidence/unknown)
+     :peak-epoch   (or peak-epoch rf.hicasso.evidence/unknown)
      ;; The READ IDENTITY, not the bare sub-id: `[:row 1]` and `[:row 2]`
      ;; are one sub-id and two different reads, and a Why view that
      ;; collapsed them would answer "`:row` moved" to a developer looking
@@ -517,11 +517,11 @@
                            (comp (filter #(= peak-epoch (:epoch %)))
                                  (map #(select-keys % [:sub-id :query :frame-id])))
                            boundary-reads)
-                     evidence/unknown)
+                     rf.hicasso.evidence/unknown)
      :loss         (if searched-window?
-                     {:reason :uncorrelated :dropped evidence/unknown}
-                     {:reason :cap :dropped evidence/unknown})
-     :candidates   (if searched-window? candidate-leads evidence/unknown)}))
+                     {:reason :uncorrelated :dropped rf.hicasso.evidence/unknown}
+                     {:reason :cap :dropped rf.hicasso.evidence/unknown})
+     :candidates   (if searched-window? candidate-leads rf.hicasso.evidence/unknown)}))
 
 (defn explain-render
   "Which reads changed, and which boundaries hold them — the honest half
@@ -548,7 +548,7 @@
   RAN is React's to know: a notification delivered is not a render
   performed."
   []
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (let [rows      (entry-rows)
           ;; Every frame that could hold a lead for one of these rows: the
           ;; frames this runtime dispatches through, PLUS any frame a
@@ -562,7 +562,7 @@
                                         rows)))
           windows   (into {}
                           (map (fn [frame-id]
-                                 [frame-id (trace-tooling/trace-buffer frame-id)]))
+                                 [frame-id (rf.trace.tooling/trace-buffer frame-id)]))
                           frame-ids)
           runs      (reduce + 0 (map count (vals windows)))
           ;; Keyed by [frame-id sub-id]: a run that recomputed `:todo` in
@@ -583,6 +583,6 @@
                     (update candidates candidate-key (fnil conj #{}) lead))
                   {}
                   leads)]
-      (evidence/envelope :explain-render false {:reason :uncorrelated :dropped evidence/unknown}
+      (rf.hicasso.evidence/envelope :explain-render false {:reason :uncorrelated :dropped rf.hicasso.evidence/unknown}
                          {:explanations (mapv #(explanation windows by-frame-sub %) rows)
                           :window       {:frames frame-ids :retained-runs runs}}))))

--- a/implementation/hicasso/test/re_frame/hicasso/activity_suspense_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/activity_suspense_cljs_test.cljs
@@ -101,15 +101,15 @@
   horizon — and never a `setTimeout` of this file's choosing."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [clojure.set :as set]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.frames :as frames]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.frames :as rf.hicasso.impl.frames]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::activity-suspense)
 
@@ -142,13 +142,13 @@
 ;; ambient scope the instant it returns. `:ambient-frame nil` because this
 ;; suite seats its own top-level frame.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
      :init-fn       (fn []
-                      (collector/reset-runtime!)
-                      (error-emit/clear-error-listeners!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!)
+                      (rf.error-emit/clear-error-listeners!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The exercised population — a MEASUREMENT, not a claim
@@ -187,8 +187,8 @@
   tree's helper, which the freeze gate forbids this package to require."
   []
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-  (when (frame/frame-incarnation-token frame-id) (rf/destroy-frame! frame-id))
-  (frames/forget-frame-ops! frame-id)
+  (when (rf.frame/frame-incarnation-token frame-id) (rf/destroy-frame! frame-id))
+  (rf.hicasso.impl.frames/forget-frame-ops! frame-id)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id
     (rf/dispatch-sync [:acs/seed {:which :a :a 1 :b 100}]))
@@ -205,12 +205,12 @@
   render-phase CACHE, not ownership, so the rows that care about it name
   it separately."
   []
-  (dissoc (runtime/residue) :entries))
+  (dissoc (rf.hicasso.test.runtime/residue) :entries))
 
 (defn- readers
   "The registrations currently reading `query-v`, as a snapshot vector."
   [query-v]
-  (runtime/cell-readers (sub-key query-v)))
+  (rf.hicasso.test.runtime/cell-readers (sub-key query-v)))
 
 (defn- reader-count
   "How many registrations read `query-v`.
@@ -266,7 +266,7 @@
 (defn- panel-body
   "One unconditional read."
   [_]
-  [:p (str "a=" (h/sub [:acs/a]))])
+  [:p (str "a=" (rf.hicasso/sub [:acs/a]))])
 
 (defn- conditional-body
   "A read set that MOVES. The selector is itself a read, so the boundary
@@ -275,9 +275,9 @@
   through the ambient collector, so a branch not taken contributes no
   edge."
   [_]
-  (let [which (h/sub [:acs/which])]
+  (let [which (rf.hicasso/sub [:acs/which])]
     [:p (str (name which) "="
-             (if (= :a which) (h/sub [:acs/a]) (h/sub [:acs/b])))]))
+             (if (= :a which) (rf.hicasso/sub [:acs/a]) (rf.hicasso/sub [:acs/b])))]))
 
 (defn- render!
   "Run ONE body under the real generation fence — the same call
@@ -285,8 +285,8 @@
   and answer the read-set entry the render resolved. Commits nothing:
   `subscribe` is React's to call, and nothing here calls it."
   [body-fn]
-  (collector/render-body frame-id body-fn {})
-  (collector/last-reads))
+  (rf.hicasso.impl.collector/render-body frame-id body-fn {})
+  (rf.hicasso.impl.collector/last-reads))
 
 (defn- commit!
   "React's commit: call the entry's own `subscribe` and keep the cleanup.
@@ -294,7 +294,7 @@
   `onStoreChange` calls the registration has received."
   [entry]
   (let [!notified (atom 0)]
-    {:cleanup   (collector/commit-boundary! entry (fn [] (swap! !notified inc)))
+    {:cleanup   (rf.hicasso.impl.collector/commit-boundary! entry (fn [] (swap! !notified inc)))
      :notified  !notified}))
 
 (defn- hide!
@@ -314,15 +314,15 @@
     (let [entry     (render! panel-body)
           committed (commit! entry)
           visible   (sole-reader [:acs/a])
-          token     (frame/frame-incarnation-token frame-id)]
+          token     (rf.frame/frame-incarnation-token frame-id)]
 
       (testing "VISIBLE-CONNECTED — the commit acquired exactly the read
                 set, and the registration holding it is the one this
                 commit minted"
-        (is (= #{(sub-key [:acs/a])} (runtime/reads-of entry)))
+        (is (= #{(sub-key [:acs/a])} (rf.hicasso.test.runtime/reads-of entry)))
         (is (some? visible))
         (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
-        (is (= #{(sub-key [:acs/a])} (runtime/boundary-reads visible))
+        (is (= #{(sub-key [:acs/a])} (rf.hicasso.test.runtime/boundary-reads visible))
             "and its forward edge is the entry's own key set"))
 
       (testing "it is LIVE, not merely present — a write to its key
@@ -351,7 +351,7 @@
                 incarnation, its app-db is intact, and the write above
                 landed in it — a hide releases this arm's ownership and
                 touches nothing the substrate owns"
-        (is (true? (identical? token (frame/frame-incarnation-token frame-id)))
+        (is (true? (identical? token (rf.frame/frame-incarnation-token frame-id)))
             "same incarnation — a hide is not a teardown")
         (is (= 3 (:a (app-db)))
             "seeded 1, bumped twice, and the second bump landed AFTER the
@@ -360,13 +360,13 @@
 
       (exercised! :activity/hide-releases)
 
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "and at the runtime's own horizon the hidden
                          boundary's residue is exactly zero — a hide that
                          retained a cell would show here"
                  (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                        (runtime/residue))))
+                        (rf.hicasso.test.runtime/residue))))
                (done))))))
 
 ;; ---------------------------------------------------------------------------
@@ -426,7 +426,7 @@
 
       (exercised! :activity/hide-inside-a-deferred-notification-window)
 
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "and the deferred notification is not delivered to
                          it. React has torn this subscription down; calling
@@ -453,7 +453,7 @@
                           (rf/with-frame frame-id (rf/dispatch-sync [:acs/bump :a]))
                           [:p "writer"])
           data          (try
-                          (collector/render-body frame-id always-writer {})
+                          (rf.hicasso.impl.collector/render-body frame-id always-writer {})
                           ::returned-without-refusing
                           (catch :default e (ex-data e)))]
       (is (= :rf.error/hicasso-generation-fence-exhausted (:rf.error/id data)))
@@ -471,18 +471,18 @@
     (let [committed (commit! (render! panel-body))]
       (hide! committed)
 
-      (let [before (runtime/body-runs)
+      (let [before (rf.hicasso.test.runtime/body-runs)
             ;; React renders hidden children at lower priority. Three runs,
             ;; because a leak of one membership per hidden render is
             ;; invisible in a single one.
             entries (doall (repeatedly 3 #(render! conditional-body)))
-            delta   (- (runtime/body-runs) before)]
+            delta   (- (rf.hicasso.test.runtime/body-runs) before)]
 
         (testing "the premise: the bodies genuinely RAN. Without this the
                   zeros below are the zeros of a render that never
                   happened, which is the cheapest possible false green"
           (is (= 3 delta))
-          (is (every? #(= #{(sub-key [:acs/which]) (sub-key [:acs/a])} (runtime/reads-of %))
+          (is (every? #(= #{(sub-key [:acs/which]) (sub-key [:acs/a])} (rf.hicasso.test.runtime/reads-of %))
                       entries)
               "and each one resolved a real, non-empty read set"))
 
@@ -501,7 +501,7 @@
                   thing a probing render leaves, and calling it out is what
                   keeps the zeros above honest — but not one of them is
                   CLAIMED"
-          (is (pos? (:entries (runtime/residue))))
+          (is (pos? (:entries (rf.hicasso.test.runtime/residue))))
           (is (every? #(zero? (entry-refs %)) entries)
               "zero refs on every hidden render's entry: React never called
                `subscribe`, so nothing above counted a claim that was
@@ -509,12 +509,12 @@
 
       (exercised! :activity/hidden-render-publishes-nothing)
 
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "and the speculative cache evaporates at the
                          runtime's own horizon"
                  (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                        (runtime/residue))))
+                        (rf.hicasso.test.runtime/residue))))
                (done))))))
 
 ;; ---------------------------------------------------------------------------
@@ -567,10 +567,10 @@
 
       (exercised! :activity/reveal-reacquires)
 
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                      (runtime/residue))
+                      (rf.hicasso.test.runtime/residue))
                    "teardown after a hide/reveal/hide cycle is exact")
                (done))))))
 
@@ -610,8 +610,8 @@
       (testing "the premise: the read set really did MOVE across the hidden
                 window. Without this the row is a hide/reveal of one
                 unchanged set, which section 3 already covers"
-        (is (= #{(sub-key [:acs/which]) (sub-key [:acs/a])} (runtime/reads-of entry-a)))
-        (is (= #{(sub-key [:acs/which]) (sub-key [:acs/b])} (runtime/reads-of entry-b)))
+        (is (= #{(sub-key [:acs/which]) (sub-key [:acs/a])} (rf.hicasso.test.runtime/reads-of entry-a)))
+        (is (= #{(sub-key [:acs/which]) (sub-key [:acs/b])} (rf.hicasso.test.runtime/reads-of entry-b)))
         (is (some? pre-hide)))
 
       (testing "THE ROW. `:acs/a` was read before the hide and is not read
@@ -630,7 +630,7 @@
             "one registration per boundary, holding both its keys — not two
              registrations holding one each")
         (is (= #{(sub-key [:acs/which]) (sub-key [:acs/b])}
-               (runtime/boundary-reads reveal-reg))))
+               (rf.hicasso.test.runtime/boundary-reads reveal-reg))))
 
       (testing "so the census is the reveal's read set and nothing else.
                 `:cells` is 3 because `:acs/a`'s cell is still inside its
@@ -651,13 +651,13 @@
       (hide! revealed)
       (exercised! :activity/conditional-read-moved-while-hidden)
 
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "and the dropped key's cell is gone at the horizon,
                          so nothing survives the transition on `:acs/a`'s
                          behalf"
                  (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                        (runtime/residue))))
+                        (rf.hicasso.test.runtime/residue))))
                (done))))))
 
 (deftest NEGATIVE-CONTROL-skipping-the-release-on-hide-resurrects-the-stale-membership
@@ -703,9 +703,9 @@
       ;; Release the visible one only. The leak is the point of the row, so
       ;; it is left for quiescence to fail to collect.
       (hide! revealed)
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
-               (is (pos? (:cell-refs (runtime/residue)))
+               (is (pos? (:cell-refs (rf.hicasso.test.runtime/residue)))
                    "and the leak OUTLIVES quiescence — a reaper cannot
                     collect a cell that still has a reader, which is
                     precisely why the release is the invariant")
@@ -755,10 +755,10 @@
   [thunk]
   (let [seen (atom [])
         key  (keyword "rf2-hic-014" (name (gensym "refusal")))]
-    (error-emit/register-error-listener!
+    (rf.error-emit/register-error-listener!
       key (fn [r] (when (= :rf.error/frame-destroyed (:error r)) (swap! seen conj r))))
     (try {:result (thunk) :refusals @seen}
-         (finally (error-emit/unregister-error-listener! key)))))
+         (finally (rf.error-emit/unregister-error-listener! key)))))
 
 (deftest an-intent-retained-across-a-hidden-window-obeys-the-incarnation-rule
   ;; The Activity form of the reincarnation rule. A hidden subtree keeps its
@@ -771,7 +771,7 @@
   (let [committed (commit! (render! panel-body))
         ;; The ambient dispatch this render bound — exactly what every
         ;; callback the body lowered retains.
-        retained  (collector/frame-dispatch frame-id)]
+        retained  (rf.hicasso.impl.collector/frame-dispatch frame-id)]
     (hide! committed)
 
     ;; The reincarnation, inside the hidden window: same public id, new
@@ -803,7 +803,7 @@
     (testing "LIVENESS — the reveal lowers a fresh callback, and it routes
               into the incarnation that is live now"
       (let [revealed  (commit! (render! panel-body))
-            on-reveal (collector/frame-dispatch frame-id)
+            on-reveal (rf.hicasso.impl.collector/frame-dispatch frame-id)
             {:keys [refusals]} (with-refusals #(on-reveal [:acs/mark :revealed]))]
         (is (= :revealed (:marked (app-db)))
             "the revealed subtree's own control writes its own app-db")
@@ -865,12 +865,12 @@
 
       (exercised! :activity/repeated-hide-reveal-cycles)
 
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "and the census after four full cycles is the census
                          after none: exact ownership does not accumulate"
                  (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                        (runtime/residue))))
+                        (rf.hicasso.test.runtime/residue))))
                (done))))))
 
 ;; ---------------------------------------------------------------------------
@@ -892,7 +892,7 @@
                 lists, its forward edge answers its read set, and the
                 entry it was minted from is CLAIMED"
         (is (some? connected))
-        (is (= #{(sub-key [:acs/a])} (runtime/boundary-reads connected)))
+        (is (= #{(sub-key [:acs/a])} (rf.hicasso.test.runtime/boundary-reads connected)))
         (is (= 1 (entry-refs entry))))
 
       (hide! committed)
@@ -903,7 +903,7 @@
                 `subscribe` is what a reveal calls"
         (is (zero? (reader-count [:acs/a])))
         (is (= 0 (entry-refs entry)))
-        (is (= #{(sub-key [:acs/a])} (runtime/boundary-reads connected))
+        (is (= #{(sub-key [:acs/a])} (rf.hicasso.test.runtime/boundary-reads connected))
             "the released registration still answers its read set — the
              forward edge is the entry's key set, shared by reference and
              never cleared, so a projection can still say WHAT a hidden
@@ -919,12 +919,12 @@
 
       (exercised! :lifecycle/three-states-distinguished)
 
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "UNMOUNTED — every table is empty, and the entry has
                          been evicted from the cache"
                  (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                        (runtime/residue))))
+                        (rf.hicasso.test.runtime/residue))))
 
                (testing "THE FINDING, stated where a reader of this file will
                          meet it. Between the hide above and the quiescence

--- a/implementation/hicasso/test/re_frame/hicasso/activity_suspense_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/activity_suspense_dom_cljs_test.cljs
@@ -61,15 +61,15 @@
   `npm run test:browser`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [clojure.set :as set]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]))
@@ -83,11 +83,11 @@
 (rf/reg-event :acsd/bump (fn [{:keys [db]} [_ key]] {:db (update db key inc)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The exercised population — a MEASUREMENT, not a claim
@@ -118,7 +118,7 @@
 
 (defn- seeded!
   []
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:acsd/seed {:a 1 :b 100}]))
   frame-id)
@@ -129,7 +129,7 @@
   "The census with the entry cache projected out. A read-set entry is a
   render-phase cache, not ownership."
   []
-  (dissoc (runtime/residue) :entries))
+  (dissoc (rf.hicasso.test.runtime/residue) :entries))
 
 (defn- reader-count
   "How many registrations read `query-v`.
@@ -139,16 +139,16 @@
   cycle and dies on the vector. The seam file's `reader-count` carries
   the full note."
   [query-v]
-  (count (runtime/cell-readers (sub-key query-v))))
+  (count (rf.hicasso.test.runtime/cell-readers (sub-key query-v))))
 
 (defn- sole-reader
   [query-v]
-  (let [rs (runtime/cell-readers (sub-key query-v))]
+  (let [rs (rf.hicasso.test.runtime/cell-readers (sub-key query-v))]
     (when (= 1 (count rs)) (first rs))))
 
 (defn- poll
   [pred label]
-  (test-support/poll-until pred {:label label :timeout-ms 4000}))
+  (rf.test-support/poll-until pred {:label label :timeout-ms 4000}))
 
 (defn- mount-concurrent!
   "A concurrent root, rendered WITHOUT `flushSync`.
@@ -185,13 +185,13 @@
 
 (defn- teardown-census!
   [handle]
-  (mount/unmount! handle)
-  (.then (runtime/quiesced!)
+  (rf.hicasso.impl.mount/unmount! handle)
+  (.then (rf.hicasso.test.runtime/quiesced!)
          (fn [_]
            (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                  (runtime/residue))
+                  (rf.hicasso.test.runtime/residue))
                "teardown is exact: zero residue after quiescence")
-           (mount/release! handle)
+           (rf.hicasso.impl.mount/release! handle)
            nil)))
 
 (defn- report-failure!
@@ -218,14 +218,14 @@
     (is false (str label " — " (.-message e)
                    " | DOM was " (pr-str (when handle (text handle)))
                    " | ownership " (pr-str (ownership))))
-    (when handle (mount/release! handle))
+    (when handle (rf.hicasso.impl.mount/release! handle))
     nil))
 
 ;; ---------------------------------------------------------------------------
 ;; The tree
 ;; ---------------------------------------------------------------------------
 
-(h/defview panel
+(rf.hicasso/defview panel
   "The boundary under Activity. Its read set is a function of a PROP, not
   of a subscription, and that is deliberate: while the subtree is hidden
   it holds no subscription, so an app-db change cannot reach it — the
@@ -234,7 +234,7 @@
   *conditional reads changed while hidden* names."
   [{:keys [which]}]
   [:p {:id "panel"}
-   (str (name which) "=" (if (= :a which) (h/sub [:acsd/a]) (h/sub [:acsd/b])))])
+   (str (name which) "=" (if (= :a which) (rf.hicasso/sub [:acsd/a]) (rf.hicasso/sub [:acsd/b])))])
 
 (def ^:private !bump-count (atom nil))
 
@@ -270,14 +270,14 @@
     (react/createElement
       (.-Activity react) #js {:mode mode}
       (react/createElement (.-Fragment react) nil
-                           (codec/root-element frame-id [panel {:which which}])
+                           (rf.hicasso.impl.codec/root-element frame-id [panel {:which which}])
                            (react/createElement host-state nil)))))
 
 (unchecked-set activity-host "displayName" "acsd/activity-host")
 
 (defn- activity-tree
   []
-  (mount/provider frame-id (react/createElement activity-host nil)))
+  (rf.hicasso.impl.mount/provider frame-id (react/createElement activity-host nil)))
 
 (defn- act!
   "Drive a React state setter and let its commit land. `flushSync`
@@ -296,10 +296,10 @@
 
 (deftest an-activity-hide-releases-ownership-and-its-reveal-reacquires-the-current-read-set
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (let [_      (seeded!)
-            handle (mount-concurrent! (mount/fresh-container!) (activity-tree))
+            handle (mount-concurrent! (rf.hicasso.impl.mount/fresh-container!) (activity-tree))
             !state (atom {})]
         (-> (poll #(and (= 1 (reader-count [:acsd/a])) (some? @!set-mode))
                   "the visible Activity commits and its boundary subscribes")
@@ -359,17 +359,17 @@
                 ;; A WRITE while hidden, and a PROP change while hidden.
                 ;; The write is what the reveal will have to correct for;
                 ;; the prop change is what moves the hidden read set.
-                (mount/dispatch! handle [:acsd/bump :a])
-                (swap! !state assoc :runs-before (runtime/body-runs))
+                (rf.hicasso.impl.mount/dispatch! handle [:acsd/bump :a])
+                (swap! !state assoc :runs-before (rf.hicasso.test.runtime/body-runs))
                 (act! (fn [] (@!set-which :b)))
-                (poll #(> (runtime/body-runs) (:runs-before @!state))
+                (poll #(> (rf.hicasso.test.runtime/body-runs) (:runs-before @!state))
                       "React renders the hidden child against its new prop")))
             (.then
               (fn [_]
                 (testing "the premise: React really did run the hidden
                           body. Without this the zeros below are the zeros
                           of a render that never happened"
-                  (is (pos? (- (runtime/body-runs) (:runs-before @!state)))))
+                  (is (pos? (- (rf.hicasso.test.runtime/body-runs) (:runs-before @!state)))))
 
                 (testing "and the hidden render published nothing — no
                           durable ownership on the key it just read, none
@@ -414,7 +414,7 @@
 
                 (testing "and the revealed boundary is LIVE — a write to
                           the key it now reads repaints it"
-                  (mount/dispatch! handle [:acsd/bump :b])
+                  (rf.hicasso.impl.mount/dispatch! handle [:acsd/bump :b])
                   (poll #(= "b=101" (painted handle "panel"))
                         "the revealed boundary repaints"))))
             (.then
@@ -481,10 +481,10 @@
   ;; end of the row carries the analysis and the reason it is React's
   ;; scheduling rather than this runtime's.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (let [_      (seeded!)
-            handle (mount-concurrent! (mount/fresh-container!) (activity-tree))]
+            handle (mount-concurrent! (rf.hicasso.impl.mount/fresh-container!) (activity-tree))]
         (-> (poll #(and (= 1 (reader-count [:acsd/a])) (some? @!set-mode))
                   "the visible Activity commits and its boundary subscribes")
             (.then
@@ -496,7 +496,7 @@
             (.then
               (fn [_]
                 ;; Four writes the hidden subtree cannot hear.
-                (dotimes [_ 4] (mount/dispatch! handle [:acsd/bump :a]))
+                (dotimes [_ 4] (rf.hicasso.impl.mount/dispatch! handle [:acsd/bump :a]))
 
                 (testing "the premise, and it is the whole row: app-db moved
                           four times while the subtree was hidden, and the
@@ -531,7 +531,7 @@
                       "React releases the subscription a second time")))
             (.then
               (fn [_]
-                (dotimes [_ 3] (mount/dispatch! handle [:acsd/bump :a]))
+                (dotimes [_ 3] (rf.hicasso.impl.mount/dispatch! handle [:acsd/bump :a]))
                 (is (= 8 (:a (rf/app-db-value frame-id))))
                 (is (= "a=5" (.-textContent ^js (node handle "panel")))
                     "the premise for reading 2: stale again, by three")
@@ -626,8 +626,8 @@
   (react/createElement
     (.-Suspense react) #js {:fallback (react/createElement "p" #js {:id "fb"} "waiting")}
     (react/createElement (.-Fragment react) nil
-                         (mount/provider frame-id
-                                         (codec/root-element frame-id [panel {:which :a}]))
+                         (rf.hicasso.impl.mount/provider frame-id
+                                         (rf.hicasso.impl.codec/root-element frame-id [panel {:which :a}]))
                          (react/createElement gate nil))))
 
 (deftest a-post-commit-suspension-retains-the-subscription-and-the-retry-leaves-exact-ownership
@@ -656,11 +656,11 @@
   ;; OWNERSHIP across the cycle: the count never leaves 1, the identity
   ;; never changes, and the retry adds nothing. That is what is asserted.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (let [_       (seeded!)
             _       (reset! !gate-promise (js/Promise. (fn [res] (reset! !gate-resolve res))))
-            handle  (mount-concurrent! (mount/fresh-container!) (suspense-tree))
+            handle  (mount-concurrent! (rf.hicasso.impl.mount/fresh-container!) (suspense-tree))
             !state  (atom {})]
         (-> (poll #(and (= 1 (reader-count [:acsd/a])) (some? @!set-gate))
                   "the primary tree commits and its boundary subscribes")
@@ -702,7 +702,7 @@
 
                 ;; A write DURING the suspension. Because the subscription
                 ;; survived, the hidden primary tree hears it.
-                (mount/dispatch! handle [:acsd/bump :a])
+                (rf.hicasso.impl.mount/dispatch! handle [:acsd/bump :a])
 
                 ;; The retry.
                 (act! (fn [] (@!set-gate false)))
@@ -727,7 +727,7 @@
                   (is (= "a=2" (painted handle "panel"))))
 
                 (testing "still live after the retry"
-                  (mount/dispatch! handle [:acsd/bump :a])
+                  (rf.hicasso.impl.mount/dispatch! handle [:acsd/bump :a])
                   (poll #(= "a=3" (painted handle "panel"))
                         "the retried boundary repaints"))))
             (.then
@@ -743,7 +743,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-declared-population-was-actually-exercised
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test runs none of the mechanisms above")
     (is (= declared-population @!exercised)
         (str "every declared Activity/Suspense mechanism must be reached at

--- a/implementation/hicasso/test/re_frame/hicasso/boundary_intent_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/boundary_intent_dom_cljs_test.cljs
@@ -95,18 +95,18 @@
   React DOM; under `:node-test` every DOM claim degrades to a stated
   skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.hicasso.impl.boundary :refer [boundary]]
-            [re-frame.hicasso.hook-probe :as probe]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.hicasso.hook-probe :as rf.hicasso.hook-probe]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]))
@@ -149,21 +149,21 @@
                 {:db (update db :attempt inc)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; `:ambient-frame nil` is load-bearing. The fixture's default leaves a
      ;; dynamic-var frame stamp in scope, and a boundary that resolved its
      ;; frame through that tier instead of through React context would look
      ;; correct here for the wrong reason. With no ambient stamp, the only
      ;; thing that can name a frame is the provider above the tree.
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- skip! [why]
   (is true (str "an intent-on-a-boundary claim needs a real React DOM — " why)))
 
 (defn- fresh! [frame-kw]
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-kw})
   (rf/with-frame frame-kw (rf/dispatch-sync [:hicasso.bdy/seed]))
   frame-kw)
@@ -179,8 +179,8 @@
   ;; which clears the caught error with a `setState` of its own — a second
   ;; commit, from a lifecycle rather than from the event. Row 1 reads the DOM
   ;; after both.
-  (mount/settle!)
-  (mount/settle!))
+  (rf.hicasso.impl.mount/settle!)
+  (rf.hicasso.impl.mount/settle!))
 
 ;; ---------------------------------------------------------------------------
 ;; The instrument — a boundary that records what escaped the subject
@@ -195,7 +195,7 @@
   fails the way the subject fails measures nothing."
   [frame-kw hiccup]
   (reset! !caught nil)
-  (mount/root! (mount/fresh-container!) frame-kw
+  (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-kw
                [boundary {:fallback [:p.escaped "the subject refused to render"]
                           :on-error (fn [e] (reset! !caught e))}
                 hiccup]))
@@ -215,15 +215,15 @@
 ;; The screens
 ;; ---------------------------------------------------------------------------
 
-(h/defview risky
+(rf.hicasso/defview risky
   "Throws from the render phase while the model says so — which is where a
   React error boundary is the only thing that can catch."
   [_]
-  (when (collector/sub [:hicasso.bdy/boom?])
+  (when (rf.hicasso.impl.collector/sub [:hicasso.bdy/boom?])
     (throw (ex-info "the child threw" {:planted true})))
   [:p.ok "recovered"])
 
-(h/defview retry-screen
+(rf.hicasso/defview retry-screen
   "HD-020(c)'s ADVERTISED CASE, and the reason this bead is P2: a fallback
   whose whole point is a retry control, beside the `:reset-key` that makes
   the retry the caller's to schedule rather than the boundary's to guess."
@@ -231,10 +231,10 @@
   [boundary {:fallback  [:div.fb
                          [:p "that did not work"]
                          [:button.retry {:on-click [:hicasso.bdy/retry]} "try again"]]
-             :reset-key (collector/sub [:hicasso.bdy/attempt])}
+             :reset-key (rf.hicasso.impl.collector/sub [:hicasso.bdy/attempt])}
    [risky {}]])
 
-(h/defview note-fallback-screen
+(rf.hicasso/defview note-fallback-screen
   "The FUNCTION fallback, carrying **only** the one callback form. Two
   things at once: `h/event` is the second row of the position table, and the
   closure reads the error the fallback was handed — so this is also the
@@ -245,7 +245,7 @@
                          [:div.fb
                           [:button.note
                            {:data-role "note"
-                            :on-click  (h/event [e]
+                            :on-click  (rf.hicasso/event [e]
                                          ;; A live event read, and ONE
                                          ;; intent returned — the event
                                          ;; contract the position imposes.
@@ -254,7 +254,7 @@
                            "note"]])}
    [risky {}]])
 
-(h/defview child-intent-screen
+(rf.hicasso/defview child-intent-screen
   "The CHILDREN half. Nothing throws here: these are ordinary native
   children of `h/error-boundary`, written in this body and lowered one
   render later inside the class's."
@@ -263,14 +263,14 @@
    [:div.body
     [:button.dismiss {:on-click [:hicasso.bdy/dismissed 1]} "dismiss"]]])
 
-(h/defview child-callback-screen
+(rf.hicasso/defview child-callback-screen
   "The children half, carrying **only** the callback form — the same
   separation rows 1 and 2 keep, for the same reason."
   [_]
   [boundary {:fallback [:p.fb "unused — nothing throws on this screen"]}
    [:button.note
     {:data-role "note"
-     :on-click  (h/event [e]
+     :on-click  (rf.hicasso/event [e]
                   (when (= "note" (.. e -target -dataset -role))
                     [:hicasso.bdy/noted "child"]))}
     "note"]])
@@ -280,7 +280,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-fallbacks-retry-button-dispatches-and-the-reset-key-retries
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id)
@@ -306,14 +306,14 @@
                  failure and the child rendered")
             (is (nil? (query handle ".fb"))
                 "with the fallback gone"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — the one callback form on a function fallback
 ;; ---------------------------------------------------------------------------
 
 (deftest a-callback-on-the-fallback-dispatches-what-it-returned
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id)
@@ -331,14 +331,14 @@
               "at invocation the h/event read the real event, closed over the error
                the fallback was handed, and the vector it RETURNED drained
                through the arm's synchronous door")
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — a bare intent vector on a native child of h/error-boundary
 ;; ---------------------------------------------------------------------------
 
 (deftest a-native-child-of-a-boundary-dispatches-its-inline-intent
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id)
@@ -357,14 +357,14 @@
           (click! (query handle ".dismiss"))
           (is (= [1 1] (:dismissed (db frame-id)))
               "and again, so this is a live handler and not a one-shot")
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — the one callback form on a native child
 ;; ---------------------------------------------------------------------------
 
 (deftest a-callback-on-a-native-child-dispatches-what-it-returned
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id)
@@ -374,20 +374,20 @@
           (click! (query handle ".note"))
           (is (= ["child"] (:noted (db frame-id)))
               "the callback path, at a child position, on its own subject")
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5 — the frame is the BOUNDARY's, proved against a second live frame
 ;; ---------------------------------------------------------------------------
 
 (deftest a-fallbacks-intent-lands-in-the-frame-the-boundary-was-mounted-under
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id)
       (fresh! other-frame-id)
       (let [a (watched-root! frame-id [retry-screen {}])
-            b (mount/root! (mount/fresh-container!) other-frame-id
+            b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) other-frame-id
                            [retry-screen {}])]
         (try
           (click! (query a ".retry"))
@@ -400,7 +400,7 @@
           (is (= 1 (:attempt (db other-frame-id))))
           (is (= 1 (:attempt (db frame-id)))
               "and symmetrically the other way")
-          (finally (mount/release! a) (mount/release! b)))))))
+          (finally (rf.hicasso.impl.mount/release! a) (rf.hicasso.impl.mount/release! b)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6 — a frameless boundary is legal; an intent under one is still the loud error
@@ -415,16 +415,16 @@
   different question."
   [hiccup]
   (reset! !caught nil)
-  (mount/root! (mount/fresh-container!) adapter-context/no-provider-sentinel
+  (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) rf.adapter.context/no-provider-sentinel
                [boundary {:fallback [:p.escaped "the subject refused to render"]
                           :on-error (fn [e] (reset! !caught e))}
                 hiccup]))
 
 (deftest a-frameless-boundary-is-legal-until-something-below-writes-an-intent
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
-      (support/leave-act-environment!)
+      (rf.hicasso.checkpoint-support/leave-act-environment!)
       (testing "a boundary with no frame above it and no intent below it
                 renders. The class reads no subscription, so requiring a frame
                 it does not need would refuse a legal page — the binding is
@@ -435,7 +435,7 @@
           (try
             (is (some? (query handle ".body")))
             (is (nil? @!caught) (str "nothing was raised. Escaped: " (pr-str (escaped))))
-            (finally (mount/release! handle)))))
+            (finally (rf.hicasso.impl.mount/release! handle)))))
       (testing "and an intent under one is the loud error, NAMED — the
                 diagnostic points at the intent rather than at the boundary"
         (let [handle (frameless-root!
@@ -448,17 +448,17 @@
                    (:rf.error/id (ex-data @!caught)))
                 (str "and it named the intent: " (pr-str (ex-data @!caught))))
             (is (= [:hicasso.bdy/dismissed 1] (:intent (ex-data @!caught))))
-            (finally (mount/release! handle))))))))
+            (finally (rf.hicasso.impl.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6b — and the boundary's OWN `:on-error` vector is one of those intents
 ;; ---------------------------------------------------------------------------
 
 (deftest a-frameless-boundarys-own-on-error-vector-is-refused-at-first-render
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
-      (support/leave-act-environment!)
+      (rf.hicasso.checkpoint-support/leave-act-environment!)
       (testing "a vector `:on-error` is an INTENT, and a boundary with no frame
                 above it has nothing that could dispatch it. Accepting the
                 declaration and finding that out in `componentDidCatch` costs
@@ -488,7 +488,7 @@
                       boundary already raises, named at the position and
                       carrying the intent, so the recovery is readable off the
                       refusal itself. Escaped: " (pr-str (ex-data @!caught))))
-            (finally (mount/release! handle)))))
+            (finally (rf.hicasso.impl.mount/release! handle)))))
       (testing "THE NEAR MISS, on the axis this guard was one step from
                 over-reaching: a FUNCTION `:on-error` needs no frame, so the
                 same frameless boundary takes one, catches a deliberate
@@ -508,7 +508,7 @@
             (is (= ["the foreign child threw"] @!fired)
                 (str "and the function fired ONCE, with the error. Got: "
                      (pr-str @!fired)))
-            (finally (mount/release! handle))))))))
+            (finally (rf.hicasso.impl.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 7 — the fence: the class still spends no hook, in its error state too
@@ -522,9 +522,9 @@
            is invisible at React's dispatcher. Counted on the page where the
            new binding actually runs — a boundary in its ERROR state,
            rendering the fallback"
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (skip! ":node-test has no DOM")
-      (if-not (probe/install!)
+      (if-not (rf.hicasso.hook-probe/install!)
         (is false (str "React's internals slot was not found, so this claim is "
                        "UNWITNESSED on this build. A gate nobody has watched "
                        "fire is not evidence — fix "
@@ -533,7 +533,7 @@
         (do
           (fresh! frame-id)
           (let [handle (volatile! nil)
-                names  (probe/record!
+                names  (rf.hicasso.hook-probe/record!
                          (fn [] (vreset! handle
                                          (watched-root! frame-id
                                                         [retry-screen {}]))))]
@@ -547,21 +547,21 @@
                        "declares. Two `h/error-boundary` classes are in this "
                        "tree (the watcher and the subject) and between them they "
                        "contributed none. Raw: " (pr-str names)))
-              (is (= 2 (count runtime/shell-hook-ledger) (count (distinct names)))
+              (is (= 2 (count rf.hicasso.test.runtime/shell-hook-ledger) (count (distinct names)))
                   "and the declared shell ledger is the measured roster")
               (is (empty? (filter #{"useRef" "useMemo" "useCallback" "useState"
                                     "useEffect"}
                                   names))
                   "no useRef, no memo, no state and no effect — the class is
                    still a class")
-              (finally (mount/release! @handle)))))))))
+              (finally (rf.hicasso.impl.mount/release! @handle)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 8 — the roster is closed: a misspelled prop is refused, not dropped
 ;; ---------------------------------------------------------------------------
 
 (deftest a-prop-outside-the-roster-is-refused-and-the-right-spelling-still-reports
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id)
@@ -586,7 +586,7 @@
             (is (nil? (query handle ".body"))
                 "and the subject did not render — a refusal that let the page up
                  anyway would be a warning wearing a throw's clothes")
-            (finally (mount/release! handle)))))
+            (finally (rf.hicasso.impl.mount/release! handle)))))
       (testing "THE NEAR MISS. One character away, `:on-error` is the real key
                 and still reports — beside `:fallback`, `:reset-key` and the
                 trailing children, so the whole legal roster is exercised by the
@@ -601,18 +601,18 @@
                 (str "nothing escaped the subject. Escaped: " (pr-str (escaped))))
             (is (some? (query handle ".fb"))
                 "the child threw and the fallback is on screen")
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (= ["spelled right"] (:noted (db frame-id)))
                 "and the report reached the frame — the guard refuses the
                  misspelling without touching the spelling it exists to protect")
-            (finally (mount/release! handle))))))))
+            (finally (rf.hicasso.impl.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 9 — the shape is closed too: an `:on-error` nothing can fire is refused
 ;; ---------------------------------------------------------------------------
 
 (deftest an-on-error-nothing-can-fire-is-refused-and-a-wrapped-intent-still-is-not
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id)
@@ -637,7 +637,7 @@
                 "and — the point of raising in `render` rather than in `report!`
                  — the refusal arrived with no error caught at all, so it cost
                  no application error path to find")
-            (finally (mount/release! handle)))))
+            (finally (rf.hicasso.impl.mount/release! handle)))))
       (testing "THE NEAR MISS. The same keyword inside brackets is the real
                 thing, and reports"
         (let [handle (watched-root! frame-id
@@ -647,10 +647,10 @@
           (try
             (is (nil? @!caught)
                 (str "nothing escaped. Escaped: " (pr-str (escaped))))
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (= ["wrapped"] (:noted (db frame-id)))
                 "one bracket apart from the refused form, and it fires")
-            (finally (mount/release! handle)))))
+            (finally (rf.hicasso.impl.mount/release! handle)))))
       (testing "THE OTHER NEAR MISS. An explicit `nil` says no reporting was
                 asked for, which is the one value `report!`'s last arm still
                 means. A guard that refused it would refuse a legal page"
@@ -666,7 +666,7 @@
                 "the boundary caught, rendered its fallback, and reported
                  nowhere — quietly, because that is what was declared")
             (is (nil? (:noted (db frame-id))))
-            (finally (mount/release! handle))))))))
+            (finally (rf.hicasso.impl.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 10 — once per FAILURE, measured where React re-runs renders: StrictMode
@@ -684,13 +684,13 @@
 ;; in: a reset the caller schedules with the cause still in place is a NEW
 ;; failure, so it reports exactly once more.
 
-(h/defview strict-guarded
+(rf.hicasso/defview strict-guarded
   "The retry shape under test, with `:on-error` wired: reads `:attempt` as
   its `:reset-key` so a `:rearm` dispatch retries the child, and records
   every report so ONCE is a count rather than a flag."
   [_]
   [boundary {:fallback  [:p.fb "caught"]
-             :reset-key (collector/sub [:hicasso.bdy/attempt])
+             :reset-key (rf.hicasso.impl.collector/sub [:hicasso.bdy/attempt])
              :on-error  [:hicasso.bdy/record-error]}
    [risky {}]])
 
@@ -704,7 +704,7 @@
     (react-dom/flushSync
       (fn [] (.render root (react/createElement
                              react/StrictMode nil
-                             (mount/provider frame-kw (codec/as-element hiccup))))))
+                             (rf.hicasso.impl.mount/provider frame-kw (rf.hicasso.impl.codec/as-element hiccup))))))
     {:root root :frame frame-kw :container container}))
 
 (deftest the-boundary-reports-once-per-failure-under-strictmode
@@ -712,13 +712,13 @@
   ;; once per failure — the render, in StrictMode, is the visible case.
   ;; The instance-flag alternative is argued away in `impl.boundary`'s
   ;; docstring; this row is the measurement that argument leans on.
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id)
-      (let [handle (strict-root! (mount/fresh-container!) frame-id [strict-guarded {}])]
+      (let [handle (strict-root! (rf.hicasso.impl.mount/fresh-container!) frame-id [strict-guarded {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (is (some? (query handle ".fb")) "the throw was caught")
           (is (= ["the child threw"] (:errors (db frame-id)))
               (str "ONE report, however many times StrictMode invoked the "
@@ -734,9 +734,9 @@
             ;; first settle; the moved `:reset-key` is then read by
             ;; `componentDidUpdate`, whose own `setState` is a second
             ;; commit, and the re-thrown child's report follows it.
-            (mount/settle!)
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (some? (query handle ".fb")) "it threw again; the fallback stands")
             (is (= ["the child threw" "the child threw"] (:errors (db frame-id)))
                 (str "Got: " (pr-str (:errors (db frame-id))))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/callback_form_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/callback_form_dom_cljs_test.cljs
@@ -30,20 +30,20 @@
   React DOM; under `:node-test` every DOM claim degrades to a stated
   skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.todo-support :as todo]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.todo-support :as rf.hicasso.todo-support]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (def ^:private frame-id ::callback-form)
 
@@ -53,25 +53,25 @@
 
 (defn- fresh! []
   (reset! !ran 0)
-  (support/leave-act-environment!)
-  (todo/make-frame! frame-id 3)
-  (todo/reseed! frame-id 3)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
+  (rf.hicasso.todo-support/make-frame! frame-id 3)
+  (rf.hicasso.todo-support/reseed! frame-id 3)
   frame-id)
 
 ;; ---------------------------------------------------------------------------
 ;; The screen — one form at one position, three times
 ;; ---------------------------------------------------------------------------
 
-(h/defview toggle-row
+(rf.hicasso/defview toggle-row
   "The row a real click lands on. `event` is the ONE form; `:on-click` is
   the position; the returned vector is the contract that position
   imposes. Nothing here names a form: the author wrote a function and
   returned data."
   [{:keys [id]}]
-  (let [done? (collector/sub [:hicasso.todo/done? id])]
+  (let [done? (rf.hicasso.impl.collector/sub [:hicasso.todo/done? id])]
     [:li.row {:data-id id :data-done (str done?)}
      [:button.toggle
-      {:on-click (h/event [e]
+      {:on-click (rf.hicasso/event [e]
                    (swap! !ran inc)
                    ;; A live event: the same form the predecessor would
                    ;; need `v/event` for, reading the DOM event and
@@ -83,7 +83,7 @@
      [:button.silent
       ;; The same form, same position, whose body returns something that
       ;; is not a vector. The predecessor spells this `v/handler`.
-      {:on-click (h/event [_] (swap! !ran inc) :nothing-to-dispatch)}
+      {:on-click (rf.hicasso/event [_] (swap! !ran inc) :nothing-to-dispatch)}
       "silent"]]))
 
 (defn- query [handle sel] (.querySelector (:container handle) sel))
@@ -93,44 +93,44 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-real-click-on-the-one-form-dispatches-what-it-returned
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [toggle-row {:id 1}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [toggle-row {:id 1}])]
         (try
           (is (= "false" (.getAttribute (query handle ".row") "data-done")))
           (.click (query handle ".toggle"))
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (is (= 1 @!ran) "React routed the click to the closure the runtime minted")
           (is (= "true" (.getAttribute (query handle ".row") "data-done"))
               "and the intent it RETURNED drained through the synchronous
                door, so the echo is on screen in the same turn")
           (.click (query handle ".toggle"))
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (is (= "false" (.getAttribute (query handle ".row") "data-done"))
               "and again, so this is a working handler and not a one-shot")
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — event position: a return that is not a vector dispatches nothing
 ;; ---------------------------------------------------------------------------
 
 (deftest the-same-form-at-the-same-position-can-return-nothing
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [toggle-row {:id 1}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [toggle-row {:id 1}])]
         (try
           (.click (query handle ".silent"))
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (is (= 1 @!ran) "the body ran")
           (is (= "false" (.getAttribute (query handle ".row") "data-done"))
               "and nothing was dispatched — in the predecessor this is a
                different FORM with a different contract; here it is the same
                form, and the return value is the whole of the difference")
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — outside every walked position, it is a function
@@ -144,12 +144,12 @@
             expression it tripped on and naming nothing the author wrote.
             The one form is a function everywhere, so a position Hicasso
             never walks costs the CONTRACT and nothing else."
-    (let [cb       (h/event [x] (swap! !ran inc) [:would-have-dispatched x])
+    (let [cb       (rf.hicasso/event [x] (swap! !ran inc) [:would-have-dispatched x])
           js-props #js {:onPing cb}]
       (reset! !ran 0)
       (is (fn? (.-onPing js-props)))
       (is (= [:would-have-dispatched 3] ((.-onPing js-props) 3)))
       (is (= 1 @!ran))
-      (is (true? (intent/callback? cb))
+      (is (true? (rf.hicasso.impl.intent/callback? cb))
           "and it is still the marked form, so a position that DOES walk it
            would impose that position's contract on the same value"))))

--- a/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
@@ -97,17 +97,17 @@
   `react-dom/server` render and none of them touches a document, so the
   browser lane would add cost and decide nothing. `:node-test` runs it."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.forms :as forms]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.overlay :as overlay]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.forms :as rf.hicasso.forms]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.overlay :as rf.hicasso.overlay]
             [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
-            [re-frame.hicasso.test.forms :as tf]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso.test.forms :as rf.hicasso.test.forms]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/server" :as react-dom-server]))
 
@@ -130,10 +130,10 @@
   (fn [_ [_ open?]] {:db {:title "milk" :revision 3 :open? open?}}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- fresh!
   "A frame seeded to one immutable request snapshot.
@@ -144,7 +144,7 @@
   documents."
   [open?]
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-  (h/reg-state :re-frame.hicasso.forms/drafts {:default nil})
+  (rf.hicasso/reg-state :re-frame.hicasso.forms/drafts {:default nil})
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:hicasso.arms/seed open?]))
   frame-id)
@@ -167,100 +167,100 @@
   [hiccup]
   (rf.hicasso.roots-frames-support/without-view-annotations
     (react-dom-server/renderToString
-      (mount/provider frame-id (codec/root-element frame-id hiccup)))))
+      (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The subjects — one surface per view, so a red row names a surface
 ;; ---------------------------------------------------------------------------
 
-(h/defview field-page
+(rf.hicasso/defview field-page
   "HS-31's subject: the optional forms module's one view."
   []
   [:div.owner
-   [forms/buffered-field
+   [rf.hicasso.forms/buffered-field
     {:control     control
-     :value       (h/sub [:hicasso.arms/title])
-     ::h/revision (h/sub [:hicasso.arms/revision])
+     :value       (rf.hicasso/sub [:hicasso.arms/title])
+     ::rf.hicasso/revision (rf.hicasso/sub [:hicasso.arms/revision])
      :on-commit   [:todo/committed 7]
      :placeholder "What needs doing?"}]])
 
-(h/defview anchored-popover-page
+(rf.hicasso/defview anchored-popover-page
   "HS-32's subject with an `:anchor`, which is the arm that bakes a
   generated CSS anchor name into the `style` attribute."
   []
   [:div.owner
    [:button {:id "trigger"} "Filter"]
-   [overlay/popover {:open?      (h/sub [:hicasso.arms/open?])
+   [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [:hicasso.arms/open?])
                      :on-dismiss [:menu/dismissed]
                      :anchor     "trigger"
                      :placement  :bottom-start}
     [:ul {:role "menu"} [:li.choice "Unread"]]]])
 
-(h/defview unanchored-popover-page
+(rf.hicasso/defview unanchored-popover-page
   "The same surface with no `:anchor` — the control that keeps §5 a fact
   about the anchor ident rather than about popovers."
   []
   [:div.owner
-   [overlay/popover {:open?      (h/sub [:hicasso.arms/open?])
+   [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [:hicasso.arms/open?])
                      :on-dismiss [:menu/dismissed]}
     [:ul {:role "menu"} [:li.choice "Unread"]]]])
 
-(h/defview modal-page
+(rf.hicasso/defview modal-page
   "HS-32's other door. A modal takes no `:anchor`, so it mints no ident."
   []
   [:div.owner
-   [overlay/modal {:open?      (h/sub [:hicasso.arms/open?])
+   [rf.hicasso.overlay/modal {:open?      (rf.hicasso/sub [:hicasso.arms/open?])
                    :on-dismiss [:invoice/cancelled]
                    :label      "Confirm deletion"}
     [:h2.title "Delete this invoice?"]
     [:button.confirm "Delete"]]])
 
-(h/defview undismissable-modal-page
+(rf.hicasso/defview undismissable-modal-page
   "The `closedby` ladder's no-dismissal arm: with no `:on-dismiss` there
   is nowhere to route a close request, so the dialog is told to honour
   none and the open flag cannot acquire a second owner."
   []
   [:div.owner
-   [overlay/modal {:open? (h/sub [:hicasso.arms/open?])
+   [rf.hicasso.overlay/modal {:open? (rf.hicasso/sub [:hicasso.arms/open?])
                    :label "Processing"}
     [:p.wait "Do not close this tab."]]])
 
-(h/defview light-dismiss-modal-page
+(rf.hicasso/defview light-dismiss-modal-page
   "The ladder's opt-in arm: `:light-dismiss?` widens `closedby` to the
   platform's `any`, so a backdrop click can dismiss."
   []
   [:div.owner
-   [overlay/modal {:open?          (h/sub [:hicasso.arms/open?])
+   [rf.hicasso.overlay/modal {:open?          (rf.hicasso/sub [:hicasso.arms/open?])
                    :on-dismiss     [:invoice/cancelled]
                    :light-dismiss? true
                    :label          "Quick filter"}
     [:p.hint "Click anywhere outside to dismiss."]]])
 
-(h/defview manual-popover-page
+(rf.hicasso/defview manual-popover-page
   "The popover half of the same choice: no `:on-dismiss` means `manual` —
   in the top layer, dismissing for nothing."
   []
   [:div.owner
-   [overlay/popover {:open? (h/sub [:hicasso.arms/open?])}
+   [rf.hicasso.overlay/popover {:open? (rf.hicasso/sub [:hicasso.arms/open?])}
     [:ul {:role "menu"} [:li.choice "Unread"]]]])
 
-(h/defview author-placed-popover-page
+(rf.hicasso/defview author-placed-popover-page
   "An author's `:style {:position-area …}` written beside the
   `:placement` that also produces one — `element-attrs`' documented
   precedence subject."
   []
   [:div.owner
-   [overlay/popover {:open?      (h/sub [:hicasso.arms/open?])
+   [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [:hicasso.arms/open?])
                      :on-dismiss [:menu/dismissed]
                      :placement  :bottom-start
                      :style      {:position-area "block-start"}}
     [:ul {:role "menu"} [:li.choice "Unread"]]]])
 
-(h/defview island
+(rf.hicasso/defview island
   "The Hicasso boundary that sits UNDER the Activity host, so that a row
   measuring bytes is measuring a real read rather than a literal."
   []
-  [:p.inner (str "title=" (h/sub [:hicasso.arms/title]))])
+  [:p.inner (str "title=" (rf.hicasso/sub [:hicasso.arms/title]))])
 
 (def ^:private Activity
   "React 19.2's own `<Activity>`, reached by interop. It is a symbol
@@ -268,15 +268,15 @@
   which door it goes through."
   (.-Activity react))
 
-(h/defhost activity-bare Activity)
+(rf.hicasso/defhost activity-bare Activity)
 
-(h/defhost activity-with-fallback Activity
+(rf.hicasso/defhost activity-with-fallback Activity
   {:fallback [:div.activity-skeleton "loading"]})
 
-(h/defhost activity-render Activity
+(rf.hicasso/defhost activity-render Activity
   {:server :render})
 
-(h/defview activity-host-page
+(rf.hicasso/defview activity-host-page
   "HS-23 through `h/defhost` — the third of the three routes the lane
   note names, and the only one that carries a server policy at all."
   [{:keys [head mode]}]
@@ -284,7 +284,7 @@
    [head {:mode mode}
     [island {}]]])
 
-(h/defview activity-native-page
+(rf.hicasso/defview activity-native-page
   "HS-23 through raw React construction, which the lane note recommends
   first and which the client witness uses: a boundary body returning the
   `<Activity>` element itself, with the hosted subtree crossed through
@@ -292,7 +292,7 @@
   [{:keys [mode]}]
   [:div.owner
    (react/createElement Activity #js {:mode mode}
-                        (codec/as-element [island {}]))])
+                        (rf.hicasso.impl.codec/as-element [island {}]))])
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — HS-31, the optional forms module
@@ -343,7 +343,7 @@
             the protocol and not this file's idea of it"
     (fresh! true)
     (rf/with-frame frame-id
-      (rf/dispatch-sync [tf/edit-id control 3 "half-typed"]))
+      (rf/dispatch-sync [rf.hicasso.test.forms/edit-id control 3 "half-typed"]))
     (let [html (server-html [field-page {}])]
       (is (re-find #"<input[^>]*value=\"half-typed\"" html)
           (str "the draft, not the committed value: " html))
@@ -354,7 +354,7 @@
             commit a no-op, answered while producing bytes"
     (fresh! true)
     (rf/with-frame frame-id
-      (rf/dispatch-sync [tf/edit-id control 2 "stale"]))
+      (rf/dispatch-sync [rf.hicasso.test.forms/edit-id control 2 "stale"]))
     (let [html (server-html [field-page {}])]
       (is (re-find #"<input[^>]*value=\"milk\"" html)
           (str "the committed value, because revision 2 is not 3: " html)))))

--- a/implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/codec_cljs_test.cljs
@@ -8,13 +8,13 @@
   layers that have their own opinions. What React then does with these
   elements is the arms' browser witness set, not this file's."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.impl.slot :as slot]
-            [re-frame.hicasso.slot-corpus :as slot-corpus]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.impl.slot :as rf.hicasso.impl.slot]
+            [re-frame.hicasso.slot-corpus :as rf.hicasso.slot-corpus]
             ["react" :as react]))
 
-(use-fixtures :each {:before (fn [] (codec/reset-caches!))})
+(use-fixtures :each {:before (fn [] (rf.hicasso.impl.codec/reset-caches!))})
 
 ;; ---------------------------------------------------------------------------
 ;; Reading an element
@@ -32,46 +32,46 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-bare-tag-becomes-an-element-of-that-type
-  (let [e (codec/as-element [:div])]
+  (let [e (rf.hicasso.impl.codec/as-element [:div])]
     (is (= "div" (el-type e)))
     (is (= [] (prop-names e)))))
 
 (deftest the-id-and-class-shorthand-is-parsed-and-folded-into-the-props
   (testing "id alone"
-    (is (= "main" (prop (codec/as-element [:div#main]) "id"))))
+    (is (= "main" (prop (rf.hicasso.impl.codec/as-element [:div#main]) "id"))))
   (testing "classes alone, dot-separated"
-    (is (= "wide tall" (prop (codec/as-element [:div.wide.tall]) "className"))))
+    (is (= "wide tall" (prop (rf.hicasso.impl.codec/as-element [:div.wide.tall]) "className"))))
   (testing "id then classes, in the one spelling the donor supports"
-    (let [e (codec/as-element [:section#main.wide.tall])]
+    (let [e (rf.hicasso.impl.codec/as-element [:section#main.wide.tall])]
       (is (= "section" (el-type e)))
       (is (= "main" (prop e "id")))
       (is (= "wide tall" (prop e "className")))))
   (testing "an explicit :id wins over the shorthand"
-    (is (= "explicit" (prop (codec/as-element [:div#short {:id "explicit"}]) "id"))))
+    (is (= "explicit" (prop (rf.hicasso.impl.codec/as-element [:div#short {:id "explicit"}]) "id"))))
   (testing "the shorthand class is prepended to an explicit one"
-    (is (= "short explicit" (prop (codec/as-element [:div.short {:class "explicit"}]) "className"))))
+    (is (= "short explicit" (prop (rf.hicasso.impl.codec/as-element [:div.short {:class "explicit"}]) "className"))))
   (testing "a collection class value joins, dropping nils"
-    (is (= "a b" (prop (codec/as-element [:div {:class ["a" nil :b]}]) "className")))))
+    (is (= "a b" (prop (rf.hicasso.impl.codec/as-element [:div {:class ["a" nil :b]}]) "className")))))
 
 (deftest the-tag-cache-holds-one-entry-per-distinct-literal
-  (is (= 0 (:tags (codec/cache-sizes))))
-  (codec/as-element [:div.row])
-  (codec/as-element [:div.row])
-  (codec/as-element [:div.row])
-  (is (= 1 (:tags (codec/cache-sizes))) "three renders of one literal, one entry")
-  (codec/as-element [:span])
-  (is (= 2 (:tags (codec/cache-sizes))))
+  (is (= 0 (:tags (rf.hicasso.impl.codec/cache-sizes))))
+  (rf.hicasso.impl.codec/as-element [:div.row])
+  (rf.hicasso.impl.codec/as-element [:div.row])
+  (rf.hicasso.impl.codec/as-element [:div.row])
+  (is (= 1 (:tags (rf.hicasso.impl.codec/cache-sizes))) "three renders of one literal, one entry")
+  (rf.hicasso.impl.codec/as-element [:span])
+  (is (= 2 (:tags (rf.hicasso.impl.codec/cache-sizes))))
   (testing "a cached parse produces the same element a fresh parse does"
-    (is (= "row" (prop (codec/as-element [:div.row]) "className")))))
+    (is (= "row" (prop (rf.hicasso.impl.codec/as-element [:div.row]) "className")))))
 
 (deftest the-caches-refuse-the-prototype-poisoning-keys
   (testing "a tag named __proto__ parses without being cached"
-    (is (= "__proto__" (el-type (codec/as-element [:__proto__]))))
-    (is (= 0 (:tags (codec/cache-sizes)))))
+    (is (= "__proto__" (el-type (rf.hicasso.impl.codec/as-element [:__proto__]))))
+    (is (= 0 (:tags (rf.hicasso.impl.codec/cache-sizes)))))
   (testing "a prop named __proto__ is neither cached nor set"
-    (let [e (codec/as-element [:div {:__proto__ "nope"}])]
+    (let [e (rf.hicasso.impl.codec/as-element [:div {:__proto__ "nope"}])]
       (is (= [] (prop-names e))))
-    (is (= 3 (:props (codec/cache-sizes)))
+    (is (= 3 (:props (rf.hicasso.impl.codec/cache-sizes)))
         "the three seeded entries and nothing else — the refusal is on the write")))
 
 (deftest a-literal-named-after-an-inherited-property-cannot-be-served-one
@@ -85,44 +85,44 @@
   ;; construction answers it now, so it is witnessed rather than assumed.
   (testing "a TAG named after an Object.prototype member parses as itself"
     (doseq [n ["toString" "valueOf" "hasOwnProperty" "isPrototypeOf" "constructor"]]
-      (is (= n (el-type (codec/as-element [(keyword n)])))
+      (is (= n (el-type (rf.hicasso.impl.codec/as-element [(keyword n)])))
           (str "tag " n " must render as itself"))))
   (testing "and the second render of one reads its own cached entry"
-    (codec/reset-caches!)
-    (codec/as-element [:toString])
-    (is (= 1 (:tags (codec/cache-sizes))))
-    (is (= "toString" (el-type (codec/as-element [:toString]))))
-    (is (= 1 (:tags (codec/cache-sizes)))))
+    (rf.hicasso.impl.codec/reset-caches!)
+    (rf.hicasso.impl.codec/as-element [:toString])
+    (is (= 1 (:tags (rf.hicasso.impl.codec/cache-sizes))))
+    (is (= "toString" (el-type (rf.hicasso.impl.codec/as-element [:toString]))))
+    (is (= 1 (:tags (rf.hicasso.impl.codec/cache-sizes)))))
   (testing "a PROP named after an Object.prototype member converts as itself"
-    (codec/reset-caches!)
-    (let [e (codec/as-element [:div {:toString "a" :valueOf "b" :hasOwnProperty "c"}])]
+    (rf.hicasso.impl.codec/reset-caches!)
+    (let [e (rf.hicasso.impl.codec/as-element [:div {:toString "a" :valueOf "b" :hasOwnProperty "c"}])]
       (is (= ["hasOwnProperty" "toString" "valueOf"] (prop-names e)))
       (is (= "a" (prop e "toString")))
       (is (= "b" (prop e "valueOf")))
       (is (= "c" (prop e "hasOwnProperty"))))
     (testing "and the second element reads the cached slots"
-      (is (= "d" (prop (codec/as-element [:div {:toString "d"}]) "toString"))))))
+      (is (= "d" (prop (rf.hicasso.impl.codec/as-element [:div {:toString "d"}]) "toString"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Prop names
 ;; ---------------------------------------------------------------------------
 
 (deftest prop-names-follow-the-donors-kebab-to-camel-rule
-  (is (= "onClick" (slot/prop-name :on-click)))
-  (is (= "tabIndex" (slot/prop-name :tab-index)))
-  (is (= "className" (codec/cached-prop-name :class)))
-  (is (= "htmlFor" (codec/cached-prop-name :for)))
-  (is (= "charSet" (codec/cached-prop-name :charset)))
+  (is (= "onClick" (rf.hicasso.impl.slot/prop-name :on-click)))
+  (is (= "tabIndex" (rf.hicasso.impl.slot/prop-name :tab-index)))
+  (is (= "className" (rf.hicasso.impl.codec/cached-prop-name :class)))
+  (is (= "htmlFor" (rf.hicasso.impl.codec/cached-prop-name :for)))
+  (is (= "charSet" (rf.hicasso.impl.codec/cached-prop-name :charset)))
   (testing "aria and data are HTML attribute names in React too"
-    (is (= "aria-label" (slot/prop-name :aria-label)))
-    (is (= "data-index" (slot/prop-name :data-index))))
+    (is (= "aria-label" (rf.hicasso.impl.slot/prop-name :aria-label)))
+    (is (= "data-index" (rf.hicasso.impl.slot/prop-name :data-index))))
   (testing "a CSS custom property is preserved verbatim"
-    (is (= "--gap" (slot/prop-name :--gap))))
+    (is (= "--gap" (rf.hicasso.impl.slot/prop-name :--gap))))
   (testing "the three seeded entries are the rule, not a memo of one"
-    (is (= 3 (:props (codec/cache-sizes))))
-    (codec/cached-prop-name :on-click)
-    (codec/cached-prop-name :on-click)
-    (is (= 4 (:props (codec/cache-sizes))))))
+    (is (= 3 (:props (rf.hicasso.impl.codec/cache-sizes))))
+    (rf.hicasso.impl.codec/cached-prop-name :on-click)
+    (rf.hicasso.impl.codec/cached-prop-name :on-click)
+    (is (= 4 (:props (rf.hicasso.impl.codec/cache-sizes))))))
 
 (deftest the-codecs-cached-slot-is-the-shared-rules-answer
   (testing "THE OTHER HALF OF THE EQUIVALENCE PIN (rf2-ani6y). The rule
@@ -136,13 +136,13 @@
             So the codec's own doors are asked the same corpus: whatever
             the rule answers, `cached-prop-name` and `canonical-slot`
             answer, for every spelling the codec accepts."
-    (doseq [[k expected] slot-corpus/corpus]
-      (is (= expected (codec/cached-prop-name k) (codec/canonical-slot k))
+    (doseq [[k expected] rf.hicasso.slot-corpus/corpus]
+      (is (= expected (rf.hicasso.impl.codec/cached-prop-name k) (rf.hicasso.impl.codec/canonical-slot k))
           (str "codec slot for " (pr-str k)))))
   (testing "and again warm, because the first ask is the one that writes
             the cache and the second is the one that reads it"
-    (doseq [[k expected] slot-corpus/corpus]
-      (is (= expected (codec/cached-prop-name k))
+    (doseq [[k expected] rf.hicasso.slot-corpus/corpus]
+      (is (= expected (rf.hicasso.impl.codec/cached-prop-name k))
           (str "warm codec slot for " (pr-str k))))))
 
 (deftest the-slot-is-a-pure-function-of-the-key-and-a-string-cannot-poison-it
@@ -153,19 +153,19 @@
             keyword — emitting every handler written the taught way into a
             slot React ignores, and making the canonical slot depend on what
             the page happened to render first."
-    (is (= "on-input" (codec/cached-prop-name "on-input")))
-    (is (= "onInput" (codec/cached-prop-name :on-input))
+    (is (= "on-input" (rf.hicasso.impl.codec/cached-prop-name "on-input")))
+    (is (= "onInput" (rf.hicasso.impl.codec/cached-prop-name :on-input))
         "the keyword still camelCases, whatever was asked before it")
-    (is (= "on-input" (codec/cached-prop-name "on-input"))
+    (is (= "on-input" (rf.hicasso.impl.codec/cached-prop-name "on-input"))
         "and the string is still itself, whatever was asked before IT"))
   (testing "the other way round, from a cold cache"
-    (codec/reset-caches!)
-    (is (= "onInput" (codec/cached-prop-name :on-input)))
-    (is (= "on-input" (codec/cached-prop-name "on-input"))))
+    (rf.hicasso.impl.codec/reset-caches!)
+    (is (= "onInput" (rf.hicasso.impl.codec/cached-prop-name :on-input)))
+    (is (= "on-input" (rf.hicasso.impl.codec/cached-prop-name "on-input"))))
   (testing "the three React renames are the rule, so they hold for every
             spelling of the one attribute"
     (doseq [k [:class :className "class" :x/class 'class]]
-      (is (= "className" (codec/canonical-slot k)) (str "spelled " (pr-str k))))))
+      (is (= "className" (rf.hicasso.impl.codec/canonical-slot k)) (str "spelled " (pr-str k))))))
 
 (deftest the-cached-classification-is-spelling-aware-and-no-spelling-poisons-another
   ;; The prop cache's entries carry the POSITION CLASSIFICATION
@@ -177,18 +177,18 @@
   ;; exactly the order dependence the string/keyword law above exists to
   ;; remove. Both directions, both from a cold cache.
   (testing "a symbol minted FIRST does not cost the keyword its event lowering"
-    (codec/reset-caches!)
-    (codec/cached-prop-name 'on-click)
+    (rf.hicasso.impl.codec/reset-caches!)
+    (rf.hicasso.impl.codec/cached-prop-name 'on-click)
     (let [!seen (atom [])
-          e     (intent/with-frame (fn [ev] (swap! !seen conj ev))
-                                   (fn [] (codec/as-element [:button {:on-click [:go]}])))]
+          e     (rf.hicasso.impl.intent/with-frame (fn [ev] (swap! !seen conj ev))
+                                   (fn [] (rf.hicasso.impl.codec/as-element [:button {:on-click [:go]}])))]
       (is (fn? (prop e "onClick")) "the keyword position still lowers to a handler")
       ((prop e "onClick") #js {:target #js {}})
       (is (= [[:go]] @!seen))))
   (testing "a keyword minted FIRST does not make the symbol an event position"
-    (codec/reset-caches!)
-    (codec/cached-prop-name :on-click)
-    (let [e (codec/as-element [:div {'on-click [:go]}])]
+    (rf.hicasso.impl.codec/reset-caches!)
+    (rf.hicasso.impl.codec/cached-prop-name :on-click)
+    (let [e (rf.hicasso.impl.codec/as-element [:div {'on-click [:go]}])]
       (is (array? (prop e "onClick"))
           "a symbol key is never an event position (event-prop? says so), so
            the vector is a plain prop value and converts through clj->js —
@@ -207,21 +207,21 @@
   ;; and `[:div.a {:x/class "b"}]` pins at "a".
   (testing "a namespaced class spelling composes with the shorthand rather
             than losing to it"
-    (is (= "a b" (prop (codec/as-element [:div.a {:x/class "b"}]) "className"))))
+    (is (= "a b" (prop (rf.hicasso.impl.codec/as-element [:div.a {:x/class "b"}]) "className"))))
   (testing "and so does every other spelling the codec accepts"
     (doseq [k [:class :className "class" "className" 'class :x/class :class-name]]
-      (is (= "a b" (prop (codec/as-element [:div.a {k "b"}]) "className"))
+      (is (= "a b" (prop (rf.hicasso.impl.codec/as-element [:div.a {k "b"}]) "className"))
           (str "spelled " (pr-str k)))))
   (testing "the class value is coerced at the slot, so a collection joins
             whatever key carried it — the coercion used to live in the map
             surgery, where only `:class` and `:className` reached it"
     (doseq [k [:class "className" :x/class]]
-      (is (= "a x y" (prop (codec/as-element [:div.a {k ["x" nil :y]}]) "className"))
+      (is (= "a x y" (prop (rf.hicasso.impl.codec/as-element [:div.a {k ["x" nil :y]}]) "className"))
           (str "spelled " (pr-str k)))))
   (testing "two spellings of the one slot COMPOSE rather than the last write
             silently winning — a dropped class is the failure class the
             ruling exists to delete"
-    (is (= "a b c" (prop (codec/as-element [:div.a {:class "b" :x/class "c"}]) "className")))))
+    (is (= "a b c" (prop (rf.hicasso.impl.codec/as-element [:div.a {:class "b" :x/class "c"}]) "className")))))
 
 (deftest the-shorthand-id-loses-to-an-explicit-one-however-it-is-spelled
   ;; The other half of the spelling-aware rule. `#tag` is the weakest
@@ -231,12 +231,12 @@
   ;; which one survives to the order the props map happens to iterate in.
   (testing "written on the element"
     (doseq [k [:id "id" 'id :x/id]]
-      (is (= "explicit" (prop (codec/as-element [:div#tag {k "explicit"}]) "id"))
+      (is (= "explicit" (prop (rf.hicasso.impl.codec/as-element [:div#tag {k "explicit"}]) "id"))
           (str "spelled " (pr-str k)))))
   (testing "and the shorthand still lands when nothing claims the slot"
-    (is (= "tag" (prop (codec/as-element [:div#tag {:title "t"}]) "id"))))
+    (is (= "tag" (prop (rf.hicasso.impl.codec/as-element [:div#tag {:title "t"}]) "id"))))
   (testing "a near miss is not the id slot and keeps its own name"
-    (let [e (codec/as-element [:div#tag {:data-id "d" :ids "many"}])]
+    (let [e (rf.hicasso.impl.codec/as-element [:div#tag {:data-id "d" :ids "many"}])]
       (is (= "tag" (prop e "id")))
       (is (= "d" (prop e "data-id")))
       (is (= "many" (prop e "ids"))))))
@@ -250,37 +250,37 @@
   (let [expected {"id" "caller" "className" "foo bar"}
         emitted  (fn [e] {"id" (prop e "id") "className" (prop e "className")})]
     (testing "the audit's own witness, both ways round"
-      (is (= expected (emitted (codec/as-element
+      (is (= expected (emitted (rf.hicasso.impl.codec/as-element
                                 [:div#tag.foo {"id" "caller" "className" "bar"}]))))
-      (is (= expected (emitted (codec/as-element
+      (is (= expected (emitted (rf.hicasso.impl.codec/as-element
                                 [:div#tag.foo {"className" "bar" "id" "caller"}])))))
     (testing "and out of a hash map, whose iteration order is neither"
       (let [caller (into {} (map (fn [i] [(keyword (str "data-" i)) i])) (range 12))]
-        (is (= expected (emitted (codec/as-element
+        (is (= expected (emitted (rf.hicasso.impl.codec/as-element
                                   [:div#tag.foo (assoc caller "id" "caller" :x/class "bar")]))))))
     (testing "renders are independent of what the caches were asked first"
-      (codec/reset-caches!)
-      (codec/cached-prop-name "class")
-      (codec/cached-prop-name :x/id)
-      (is (= expected (emitted (codec/as-element
+      (rf.hicasso.impl.codec/reset-caches!)
+      (rf.hicasso.impl.codec/cached-prop-name "class")
+      (rf.hicasso.impl.codec/cached-prop-name :x/id)
+      (is (= expected (emitted (rf.hicasso.impl.codec/as-element
                                 [:div#tag.foo {"id" "caller" "className" "bar"}])))))))
 
 (deftest prop-values-are-converted-in-the-shapes-react-wants
   (testing "a style map becomes a JS object with camelCased keys"
-    (let [style (prop (codec/as-element [:div {:style {:font-size "12px" :color :red}}]) "style")]
+    (let [style (prop (rf.hicasso.impl.codec/as-element [:div {:style {:font-size "12px" :color :red}}]) "style")]
       (is (= "12px" (aget style "fontSize")))
       (is (= "red" (aget style "color")) "a keyword value stringifies")))
   (testing "a CSS custom property survives inside style"
-    (let [style (prop (codec/as-element [:div {:style {:--gap "4px"}}]) "style")]
+    (let [style (prop (rf.hicasso.impl.codec/as-element [:div {:style {:--gap "4px"}}]) "style")]
       (is (= "4px" (aget style "--gap")))))
   (testing "a function passes through BY IDENTITY, so downstream bail-outs still work"
     (let [f (fn [_])]
-      (is (identical? f (prop (codec/as-element [:div {:on-click f}]) "onClick")))))
+      (is (identical? f (prop (rf.hicasso.impl.codec/as-element [:div {:on-click f}]) "onClick")))))
   (testing "a ref is an ordinary prop — callback refs are legal on native tags"
     (let [r (fn [_node])]
-      (is (identical? r (prop (codec/as-element [:div {:ref r}]) "ref")))))
+      (is (identical? r (prop (rf.hicasso.impl.codec/as-element [:div {:ref r}]) "ref")))))
   (testing "scalars are left alone"
-    (let [e (codec/as-element [:input {:value "x" :disabled true :tab-index 3}])]
+    (let [e (rf.hicasso.impl.codec/as-element [:input {:value "x" :disabled true :tab-index 3}])]
       (is (= "x" (prop e "value")))
       (is (= true (prop e "disabled")))
       (is (= 3 (prop e "tabIndex"))))))
@@ -290,7 +290,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-native-elements-key-is-key-in-the-props-map-and-is-not-an-attribute
-  (let [e (codec/as-element [:li {:key 7 :class "row"}])]
+  (let [e (rf.hicasso.impl.codec/as-element [:li {:key 7 :class "row"}])]
     (is (= "7" (el-key e)) "React stringifies keys")
     (is (= ["className"] (prop-names e)) ":key never reaches the DOM props")))
 
@@ -300,13 +300,13 @@
 
 (deftest children-are-realized-once-and-flattened-one-level
   (testing "one child arrives as the single child, not an array"
-    (let [e (codec/as-element [:p "text"])]
+    (let [e (rf.hicasso.impl.codec/as-element [:p "text"])]
       (is (= "text" (children e)))))
   (testing "several children arrive in order"
-    (let [e (codec/as-element [:p "a" "b" "c"])]
+    (let [e (rf.hicasso.impl.codec/as-element [:p "a" "b" "c"])]
       (is (= ["a" "b" "c"] (child-vec e)))))
   (testing "a seq is expanded, and an interior nil does NOT truncate it"
-    (let [e (codec/as-element [:ul (for [i (range 4)] (when (odd? i) [:li {:key i} i]))])
+    (let [e (rf.hicasso.impl.codec/as-element [:ul (for [i (range 4)] (when (odd? i) [:li {:key i} i]))])
           expanded (vec (children e))]
       (is (= 4 (count expanded)) "all four slots survive the single pass")
       (is (nil? (nth expanded 0)))
@@ -314,39 +314,39 @@
       (is (nil? (nth expanded 2)))
       (is (= "li" (el-type (nth expanded 3))))))
   (testing "nil and false render nothing"
-    (is (nil? (codec/as-element nil)))
-    (is (nil? (codec/as-element false)))
-    (is (= [nil nil "x"] (child-vec (codec/as-element [:p nil false "x"])))))
+    (is (nil? (rf.hicasso.impl.codec/as-element nil)))
+    (is (nil? (rf.hicasso.impl.codec/as-element false)))
+    (is (= [nil nil "x"] (child-vec (rf.hicasso.impl.codec/as-element [:p nil false "x"])))))
   (testing "true is an error"
-    (is (thrown-with-msg? js/Error #"true is an error" (codec/as-element true)))
+    (is (thrown-with-msg? js/Error #"true is an error" (rf.hicasso.impl.codec/as-element true)))
     (try
-      (codec/as-element true)
+      (rf.hicasso.impl.codec/as-element true)
       (is false "should have thrown")
       (catch :default e
         (is (= :rf.error/hicasso-true-child (:rf.error/id (ex-data e)))))))
   (testing "an existing React element is a legal child anywhere"
     (let [foreign (react/createElement "b" nil "bold")
-          e       (codec/as-element [:p foreign])]
+          e       (rf.hicasso.impl.codec/as-element [:p foreign])]
       (is (identical? foreign (children e))))))
 
 (deftest a-map-in-the-first-slot-is-props-and-anything-else-is-a-child
   (testing "a map is props"
-    (is (= "row" (prop (codec/as-element [:div {:class "row"}]) "className"))))
+    (is (= "row" (prop (rf.hicasso.impl.codec/as-element [:div {:class "row"}]) "className"))))
   (testing "a string in the first slot is a child, not props"
-    (is (= "hello" (children (codec/as-element [:div "hello"])))))
+    (is (= "hello" (children (rf.hicasso.impl.codec/as-element [:div "hello"])))))
   (testing "a vector in the first slot is a child"
-    (is (= "b" (el-type (children (codec/as-element [:div [:b]])))))))
+    (is (= "b" (el-type (children (rf.hicasso.impl.codec/as-element [:div [:b]])))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Fragments
 ;; ---------------------------------------------------------------------------
 
 (deftest the-fragment-spelling-is-a-fragment
-  (let [e (codec/as-element [:<> [:li "a"] [:li "b"]])]
+  (let [e (rf.hicasso.impl.codec/as-element [:<> [:li "a"] [:li "b"]])]
     (is (identical? (.-Fragment react) (el-type e)))
     (is (= 2 (count (child-vec e)))))
   (testing "a keyed fragment carries its key"
-    (is (= "k" (el-key (codec/as-element [:<> {:key "k"} [:li "a"]]))))))
+    (is (= "k" (el-key (rf.hicasso.impl.codec/as-element [:<> {:key "k"} [:li "a"]]))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Boundaries — the HD-016 head rules
@@ -359,36 +359,36 @@
   [_js-props]
   nil)
 
-(codec/mark-boundary! a-view)
+(rf.hicasso.impl.codec/mark-boundary! a-view)
 
 (deftest a-marked-view-in-head-position-is-a-boundary-child
-  (let [e (codec/as-element [a-view {:id 7}])]
+  (let [e (rf.hicasso.impl.codec/as-element [a-view {:id 7}])]
     (is (identical? a-view (el-type e)))
     (is (= {:id 7} (prop e "rfProps")) "the body receives one CLJS props map")))
 
 (deftest a-boundarys-key-is-extracted-before-the-body-sees-props
-  (let [e (codec/as-element [a-view {:key 3 :id 7}])]
+  (let [e (rf.hicasso.impl.codec/as-element [a-view {:key 3 :id 7}])]
     (is (= "3" (el-key e)))
     (is (= {:id 7} (prop e "rfProps")) ":key is React's contract, not the body's")))
 
 (deftest a-boundarys-children-arrive-as-a-realized-vector-of-hiccup
   (testing "trailing forms become (:children props)"
-    (let [e (codec/as-element [a-view {:id 7} [:li "a"] [:li "b"]])]
+    (let [e (rf.hicasso.impl.codec/as-element [a-view {:id 7} [:li "a"] [:li "b"]])]
       (is (= {:id 7 :children [[:li "a"] [:li "b"]]} (prop e "rfProps")))))
   (testing "a seq child is realized once and flattened exactly one level"
-    (let [e (codec/as-element [a-view {} (for [i (range 2)] [:li i])])]
+    (let [e (rf.hicasso.impl.codec/as-element [a-view {} (for [i (range 2)] [:li i])])]
       (is (= [[:li 0] [:li 1]] (:children (prop e "rfProps"))))))
   (testing "with no trailing forms there is no :children key at all"
-    (is (= {:id 7} (prop (codec/as-element [a-view {:id 7}]) "rfProps"))))
+    (is (= {:id 7} (prop (rf.hicasso.impl.codec/as-element [a-view {:id 7}]) "rfProps"))))
   (testing "a boundary with no props map still works"
-    (is (= {} (prop (codec/as-element [a-view]) "rfProps")))))
+    (is (= {} (prop (rf.hicasso.impl.codec/as-element [a-view]) "rfProps")))))
 
 (deftest a-plain-function-in-head-position-is-a-loud-error
   (let [helper (fn [_] [:div])]
-    (is (false? (codec/boundary-head? helper)))
-    (is (thrown-with-msg? js/Error #"never a silent" (codec/as-element [helper {}])))
+    (is (false? (rf.hicasso.impl.codec/boundary-head? helper)))
+    (is (thrown-with-msg? js/Error #"never a silent" (rf.hicasso.impl.codec/as-element [helper {}])))
     (try
-      (codec/as-element [helper {}])
+      (rf.hicasso.impl.codec/as-element [helper {}])
       (is false "should have thrown")
       (catch :default e
         (is (= :rf.error/hicasso-bad-head (:rf.error/id (ex-data e))))))))
@@ -397,13 +397,13 @@
   ;; The prose is the CATALOGUED prose (the package's refusals are minted
   ;; by `impl.error/fail!` under `check_complaint_catalogue.py`),
   ;; so each row pins the id — the stable contract — beside the wording.
-  (is (thrown-with-msg? js/Error #"must have a head" (codec/as-element [])))
+  (is (thrown-with-msg? js/Error #"must have a head" (rf.hicasso.impl.codec/as-element [])))
   (is (= :rf.error/hicasso-empty-vector
-         (try (codec/as-element []) nil (catch :default e (:rf.error/id (ex-data e))))))
+         (try (rf.hicasso.impl.codec/as-element []) nil (catch :default e (:rf.error/id (ex-data e))))))
   (is (thrown-with-msg? js/Error #"Hiccup head must be a tag keyword"
-                        (codec/as-element [42 {}])))
+                        (rf.hicasso.impl.codec/as-element [42 {}])))
   (is (= :rf.error/hicasso-bad-head
-         (try (codec/as-element [42 {}]) nil (catch :default e (:rf.error/id (ex-data e)))))))
+         (try (rf.hicasso.impl.codec/as-element [42 {}]) nil (catch :default e (:rf.error/id (ex-data e)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The canonical structural-slot filter
@@ -416,18 +416,18 @@
             namespaced keyword, and a rule that names `#{:key :ref}` sees
             exactly one of the four."
     (doseq [k [:key "key" 'key :x/key :re-frame.hicasso/key]]
-      (is (true? (codec/structural-slot? k)) (str "key, spelled " (pr-str k))))
+      (is (true? (rf.hicasso.impl.codec/structural-slot? k)) (str "key, spelled " (pr-str k))))
     (doseq [k [:ref "ref" 'ref :x/ref]]
-      (is (true? (codec/structural-slot? k)) (str "ref, spelled " (pr-str k))))
+      (is (true? (rf.hicasso.impl.codec/structural-slot? k)) (str "ref, spelled " (pr-str k))))
     (doseq [k [:id :class :on-click :data-key "aria-ref" :keyboard]]
-      (is (false? (codec/structural-slot? k))
+      (is (false? (rf.hicasso.impl.codec/structural-slot? k))
           (str "and nothing else is structural: " (pr-str k)))))
   (testing "the filter drops every one of them and returns the map by
             identity when there is nothing to drop"
-    (is (= {:class "x"} (codec/without-structural
+    (is (= {:class "x"} (rf.hicasso.impl.codec/without-structural
                           {:class "x" :key 1 "key" 2 :x/key 3 :ref (fn [_]) "ref" 4 :x/ref 5})))
     (let [clean {:class "x" :id "y"}]
-      (is (identical? clean (codec/without-structural clean))))))
+      (is (identical? clean (rf.hicasso.impl.codec/without-structural clean))))))
 
 ;; ---------------------------------------------------------------------------
 ;; `:ref` — React's own slot, forwarded untouched
@@ -438,7 +438,7 @@
             function at :ref arrives at React as the same function object —
             rewrapping it would detach and reattach the node every render."
     (let [f (fn [_node] nil)
-          e (codec/as-element [:div {:ref f}])]
+          e (rf.hicasso.impl.codec/as-element [:div {:ref f}])]
       (is (identical? f (prop e "ref"))))))
 
 (deftest a-ref-crosses-by-identity-however-it-is-spelled
@@ -447,18 +447,18 @@
             ref slot by identity too — wrapping would both forbid a dispatch
             that is legitimate there and change the identity React uses to
             decide whether to re-attach the node"
-    (let [f (intent/callback (fn [_node]))]
-      (is (identical? f (prop (codec/as-element [:div {"ref" f}]) "ref")))
-      (is (identical? f (prop (codec/as-element [:div {:x/ref f}]) "ref")))))
+    (let [f (rf.hicasso.impl.intent/callback (fn [_node]))]
+      (is (identical? f (prop (rf.hicasso.impl.codec/as-element [:div {"ref" f}]) "ref")))
+      (is (identical? f (prop (rf.hicasso.impl.codec/as-element [:div {:x/ref f}]) "ref")))))
   (testing "every :ref value passes through the ordinary conversion — the
             codec claims nothing about the slot's value-space"
-    (is (nil? (prop (codec/as-element [:div {:ref nil}]) "ref")))
-    (is (= "legacy" (prop (codec/as-element [:div {:ref "legacy"}]) "ref")))
-    (is (some? (prop (codec/as-element [:div {:ref {:a 1}}]) "ref")))
-    (is (some? (prop (codec/as-element [:div {:ref [::autosize {:max-rows 8}]}]) "ref"))
+    (is (nil? (prop (rf.hicasso.impl.codec/as-element [:div {:ref nil}]) "ref")))
+    (is (= "legacy" (prop (rf.hicasso.impl.codec/as-element [:div {:ref "legacy"}]) "ref")))
+    (is (some? (prop (rf.hicasso.impl.codec/as-element [:div {:ref {:a 1}}]) "ref")))
+    (is (some? (prop (rf.hicasso.impl.codec/as-element [:div {:ref [::autosize {:max-rows 8}]}]) "ref"))
         "a vector converts as any collection does; nothing is reserved"))
   (testing "and :ref is not an event position, so intent lowering never sees it"
-    (is (false? (intent/event-prop? :ref)))))
+    (is (false? (rf.hicasso.impl.intent/event-prop? :ref)))))
 
 ;; ---------------------------------------------------------------------------
 ;; A presence override no tray reached
@@ -480,19 +480,19 @@
 
 (deftest an-override-outside-a-trays-direct-child-is-skipped-rather-than-emitted
   (testing "a native node: the key is dropped and no attribute reaches the page"
-    (let [e (codec/as-element [:div {:re-frame.hicasso.motion/mounting {:class "in"} :id "x"}])]
+    (let [e (rf.hicasso.impl.codec/as-element [:div {:re-frame.hicasso.motion/mounting {:class "in"} :id "x"}])]
       (is (= ["id"] (vec (js/Object.keys (.-props e)))))))
   (testing "both keys, and at any depth — a tray walks its direct children and
             nothing below them, so a grandchild is as unreachable as an
             element with no tray above it at all"
-    (let [e     (codec/as-element [:section [:div {:re-frame.hicasso.motion/unmounting {:class "out"}}]])
+    (let [e     (rf.hicasso.impl.codec/as-element [:section [:div {:re-frame.hicasso.motion/unmounting {:class "out"}}]])
           child (aget (.-props e) "children")]
       (is (= [] (vec (js/Object.keys (.-props child)))))))
   (testing "the crossing skips it at the same position — a [:>] head that IS a
             tray's direct child has its overrides stripped and merged exactly
             as a native node does, so one arriving here is misplaced for the
             identical reason"
-    (let [e (codec/as-element [:> an-override-crossing
+    (let [e (rf.hicasso.impl.codec/as-element [:> an-override-crossing
                                {:re-frame.hicasso.motion/mounting {:class "in"} :size 1}])]
       (is (= ["size"] (vec (js/Object.keys (raw-props e))))))))
 
@@ -501,12 +501,12 @@
             under its own name; the skip is on the EXACT keyword and not on
             the canonical slot, because these two are Hicasso's own private
             keys where `ref` and `className` are React's positions"
-    (is (= "x" (prop (codec/as-element [:div {:mounting "x"}]) "mounting")))
-    (is (= "x" (prop (codec/as-element [:div {:unmounting "x"}]) "unmounting")))
+    (is (= "x" (prop (rf.hicasso.impl.codec/as-element [:div {:mounting "x"}]) "mounting")))
+    (is (= "x" (prop (rf.hicasso.impl.codec/as-element [:div {:unmounting "x"}]) "unmounting")))
     (doseq [spelling [:mounting "mounting" 'mounting :x/mounting :data-mounting]]
-      (is (= "x" (prop (codec/as-element [:div {spelling "x"}]) (name spelling)))
+      (is (= "x" (prop (rf.hicasso.impl.codec/as-element [:div {spelling "x"}]) (name spelling)))
           (str "emitted, spelled " (pr-str spelling))))
-    (is (= "x" (aget (raw-props (codec/as-element [:> an-override-crossing {:mounting "x"}])) "mounting"))
+    (is (= "x" (aget (raw-props (rf.hicasso.impl.codec/as-element [:> an-override-crossing {:mounting "x"}])) "mounting"))
         "and the same at the crossing, where a foreign ABI may genuinely
          name a prop `mounting`")))
 
@@ -516,8 +516,8 @@
 
 (deftest event-vectors-in-attributes-lower-during-prop-conversion
   (let [!seen (atom [])
-        e     (intent/with-frame (fn [ev] (swap! !seen conj ev))
-                                 (fn [] (codec/as-element
+        e     (rf.hicasso.impl.intent/with-frame (fn [ev] (swap! !seen conj ev))
+                                 (fn [] (rf.hicasso.impl.codec/as-element
                                          [:button {:on-click [:todo/toggle 7] :class "btn"}
                                           "done"])))]
     (is (= "btn" (prop e "className")))
@@ -528,8 +528,8 @@
 
 (deftest a-controlled-field-lowers-its-marker-through-the-codec
   (let [!seen (atom [])
-        e     (intent/with-frame (fn [ev] (swap! !seen conj ev))
-                                 (fn [] (codec/as-element
+        e     (rf.hicasso.impl.intent/with-frame (fn [ev] (swap! !seen conj ev))
+                                 (fn [] (rf.hicasso.impl.codec/as-element
                                          [:input {:value "milk"
                                                   :on-input [:todo.ui/edit 7 :re-frame.hicasso/value]}])))]
     (is (= "milk" (prop e "value")))
@@ -547,14 +547,14 @@
   [_js-props]
   nil)
 
-(def ^:private a-host (codec/mint-host! "AHost" a-foreign-component))
+(def ^:private a-host (rf.hicasso.impl.codec/mint-host! "AHost" a-foreign-component))
 
 (defn- host-prop
   "The value the codec emitted at `slot` for a one-prop host crossing.
   Reads the GATE element's props, which are the props object the foreign
   component receives — the gate forwards it verbatim."
   [k v slot]
-  (prop (codec/as-element [a-host {k v}]) slot))
+  (prop (rf.hicasso.impl.codec/as-element [a-host {k v}]) slot))
 
 (deftest a-namespaced-keyword-keeps-its-namespace-at-a-host-prop
   (testing "the shape rf2-vrvv9 names. `(name :theme/dark)` is \"dark\", so
@@ -595,7 +595,7 @@
   (testing "the namespace drop survives ONLY here, and it is the same answer
             the native walk gives at the same name"
     (is (= "dark" (host-prop :class :theme/dark "className")))
-    (is (= "dark" (prop (codec/as-element [:div {:class :theme/dark}]) "className"))
+    (is (= "dark" (prop (rf.hicasso.impl.codec/as-element [:div {:class :theme/dark}]) "className"))
         "the native crossing, unchanged")))
 
 ;; ---------------------------------------------------------------------------
@@ -611,7 +611,7 @@
             the DOM as \"a,,b\" wherever the component passes it on: nothing
             threw and the styling was simply wrong."
     (let [crossed (host-prop :class ["a" nil :b] "className")
-          native  (prop (codec/as-element [:div {:class ["a" nil :b]}]) "className")]
+          native  (prop (rf.hicasso.impl.codec/as-element [:div {:class ["a" nil :b]}]) "className")]
       (is (string? crossed)
           "a class string, not the JS array clj->js used to build here")
       (is (= "a b" crossed))
@@ -633,13 +633,13 @@
             two spellings of one element's class are two map keys and one
             React slot, so letting the last write win would drop a class
             silently"
-    (let [e (codec/as-element [a-host {:class "a" :x/class ["b" :c]}])]
+    (let [e (rf.hicasso.impl.codec/as-element [a-host {:class "a" :x/class ["b" :c]}])]
       (is (= "a b c" (prop e "className"))))
     ;; the crossing rule as a worked case — the guide states it as a rule
     ;; (docs/core/hicasso/09-interop.md §Crossing rules) and no longer carries
     ;; the example this once quoted verbatim
     (is (= "btn on wide"
-           (prop (codec/as-element [a-host {:class ["btn" nil :on] :className "wide"}])
+           (prop (rf.hicasso.impl.codec/as-element [a-host {:class ["btn" nil :on] :className "wide"}])
                  "className"))))
   (testing "nothing else at the slot moves. A string is verbatim, a keyword
             still stringifies (rf2-vrvv9's rule, unchanged), and a
@@ -652,7 +652,7 @@
             hand a collection to `clj->js` at BOTH positions, so there is
             nothing to reconcile there and nothing here that changed them"
     (is (array? (host-prop :id ["a" "b"] "id")))
-    (is (array? (prop (codec/as-element [:div {:id ["a" "b"]}]) "id"))
+    (is (array? (prop (rf.hicasso.impl.codec/as-element [:div {:id ["a" "b"]}]) "id"))
         "the native walk's own answer, quoted so the claim is not asserted
          about a function nobody ran")))
 
@@ -665,9 +665,9 @@
             the value that tells the two orders apart, because
             `class-names` would quietly answer it \"a b\" where a `:render`
             override leaves it a value that crosses as DATA."
-    (let [declared (codec/mint-host! "ClassContractHost" a-foreign-component
+    (let [declared (rf.hicasso.impl.codec/mint-host! "ClassContractHost" a-foreign-component
                                      {:callbacks {:class :render}})]
-      (is (array? (prop (codec/as-element [declared {:class ["a" "b"]}]) "className"))
+      (is (array? (prop (rf.hicasso.impl.codec/as-element [declared {:class ["a" "b"]}]) "className"))
           "the declaration decided, not the slot")))
   (testing "and an undeclared host is unaffected — the same value at the
             same slot is an ordinary class collection"
@@ -681,17 +681,17 @@
         d     (fn [ev] (swap! !seen conj ev))]
     (testing "an on*-spelled prop is an EVENT position with no declaration
               at all: an h/event there dispatches its return"
-      (let [f (intent/with-frame d (fn [] (host-prop :on-pick (intent/callback (fn [x] [:row/pick x])) "onPick")))]
+      (let [f (rf.hicasso.impl.intent/with-frame d (fn [] (host-prop :on-pick (rf.hicasso.impl.intent/callback (fn [x] [:row/pick x])) "onPick")))]
         (f 1)
         (is (= [[:row/pick 1]] @!seen))))
     (testing "and so are the vector and key-map spellings, exactly as at a
               native tag"
       (reset! !seen [])
-      (let [f (intent/with-frame d (fn [] (host-prop :on-close [:dialog/cancel] "onClose")))]
+      (let [f (rf.hicasso.impl.intent/with-frame d (fn [] (host-prop :on-close [:dialog/cancel] "onClose")))]
         (f #js {:target #js {}})
         (is (= [[:dialog/cancel]] @!seen)))
       (reset! !seen [])
-      (let [f (intent/with-frame d (fn [] (host-prop :on-key-down {"Enter" [:go]} "onKeyDown")))]
+      (let [f (rf.hicasso.impl.intent/with-frame d (fn [] (host-prop :on-key-down {"Enter" [:go]} "onKeyDown")))]
         (f #js {:key "Enter" :isComposing false :target #js {}})
         (is (= [[:go]] @!seen))))
     (testing "any other prop is a RENDER position: the h/event takes the
@@ -700,13 +700,13 @@
               into that frame when clicked — after the render extent has
               unwound"
       (reset! !seen [])
-      (let [render-row (intent/with-frame d
+      (let [render-row (rf.hicasso.impl.intent/with-frame d
                          (fn [] (host-prop :render-row
-                                           (intent/callback
-                                             (fn [i] (codec/as-element [:li {:on-click [:row/pick i]}])))
+                                           (rf.hicasso.impl.intent/callback
+                                             (fn [i] (rf.hicasso.impl.codec/as-element [:li {:on-click [:row/pick i]}])))
                                            "renderRow")))
             row        (render-row 9)]
-        (is (nil? intent/*dispatch*) "precondition: no ambient dispatch here")
+        (is (nil? rf.hicasso.impl.intent/*dispatch*) "precondition: no ambient dispatch here")
         (is (= "li" (.-type row)))
         ((aget (.-props row) "onClick") #js {:target #js {}})
         (is (= [[:row/pick 9]] @!seen))))
@@ -717,13 +717,13 @@
               is the render output (an event wrapper returns nil) and it
               still dispatches on click"
       (reset! !seen [])
-      (let [fluent    (codec/mint-host! "FluentList" a-foreign-component
+      (let [fluent    (rf.hicasso.impl.codec/mint-host! "FluentList" a-foreign-component
                                         {:callbacks {:on-render-item :render}})
-            render-fn (intent/with-frame d
-                        (fn [] (prop (codec/as-element
+            render-fn (rf.hicasso.impl.intent/with-frame d
+                        (fn [] (prop (rf.hicasso.impl.codec/as-element
                                        [fluent {:on-render-item
-                                                (intent/callback
-                                                  (fn [item] (codec/as-element [:li {:on-click [:row/pick item]}])))}])
+                                                (rf.hicasso.impl.intent/callback
+                                                  (fn [item] (rf.hicasso.impl.codec/as-element [:li {:on-click [:row/pick item]}])))}])
                                      "onRenderItem")))
             row       (render-fn "x")]
         (is (= "li" (.-type row)) "the render output came back")
@@ -733,8 +733,8 @@
               render, and the vector spelling then lowers as at a native
               event position"
       (reset! !seen [])
-      (let [h (codec/mint-host! "PickHost" a-foreign-component {:callbacks {:pick :event}})
-            f (intent/with-frame d (fn [] (prop (codec/as-element [h {:pick [:row/pick 2]}]) "pick")))]
+      (let [h (rf.hicasso.impl.codec/mint-host! "PickHost" a-foreign-component {:callbacks {:pick :event}})
+            f (rf.hicasso.impl.intent/with-frame d (fn [] (prop (rf.hicasso.impl.codec/as-element [h {:pick [:row/pick 2]}]) "pick")))]
         (f #js {:target #js {}})
         (is (= [[:row/pick 2]] @!seen))))
     (testing "a PLAIN function crosses by identity at an event position and
@@ -746,11 +746,11 @@
     (testing "a vector at an inferred render position crosses as DATA, as
               at a native tag; so does one at a declared :render override"
       (is (array? (host-prop :columns ["a" "b"] "columns")))
-      (let [h (codec/mint-host! "ColumnsHost" a-foreign-component {:callbacks {:render-row :render}})]
-        (is (array? (prop (codec/as-element [h {:render-row ["a" "b"]}]) "renderRow")))))
+      (let [h (rf.hicasso.impl.codec/mint-host! "ColumnsHost" a-foreign-component {:callbacks {:render-row :render}})]
+        (is (array? (prop (rf.hicasso.impl.codec/as-element [h {:render-row ["a" "b"]}]) "renderRow")))))
     (testing "and a contract outside the two is a bad declaration, refused
               at mint where the author's stack is the declaration"
-      (let [data (try (codec/mint-host! "HandlerHost" a-foreign-component
+      (let [data (try (rf.hicasso.impl.codec/mint-host! "HandlerHost" a-foreign-component
                                         {:callbacks {:on-pick :handler}})
                       nil
                       (catch :default e (ex-data e)))]
@@ -791,7 +791,7 @@
             oversight: a later refusal cannot land silently, because it has
             to delete these rows first."
     (let [r (react/createRef)]
-      (is (identical? r (prop (codec/as-element [:div {:ref r}]) "ref"))
+      (is (identical? r (prop (rf.hicasso.impl.codec/as-element [:div {:ref r}]) "ref"))
           "a native tag")
       (is (identical? r (host-prop :ref r "ref"))
           "and a defhost crossing — HD-011's conversion parity, which is
@@ -800,12 +800,12 @@
   (testing "and it is one rule at one slot, so an alternate spelling of the
             ref position answers the same way"
     (let [r (react/createRef)]
-      (is (identical? r (prop (codec/as-element [:div {"ref" r}]) "ref")))
+      (is (identical? r (prop (rf.hicasso.impl.codec/as-element [:div {"ref" r}]) "ref")))
       (is (identical? r (host-prop :x/ref r "ref")))))
   (testing "and a VECTOR crosses at both as the author wrote it — nothing
             about the slot's value-space is reserved"
     (let [v [::autosize {:max-rows 8}]]
-      (is (some? (prop (codec/as-element [:div {:ref v}]) "ref")))
+      (is (some? (prop (rf.hicasso.impl.codec/as-element [:div {:ref v}]) "ref")))
       (is (= v (host-prop :ref v "ref"))))))
 
 ;; ---------------------------------------------------------------------------
@@ -837,7 +837,7 @@
   "The value the escape emitted at `slot` for a one-prop crossing —
   [[host-prop]]'s twin, so the two can be read against each other."
   [k v slot]
-  (aget (raw-props (codec/as-element [:> a-foreign-component {k v}])) slot))
+  (aget (raw-props (rf.hicasso.impl.codec/as-element [:> a-foreign-component {k v}])) slot))
 
 (defn- crossed-same?
   "Did the two crossings answer the same thing? Functions by identity —
@@ -855,7 +855,7 @@
             `hiccup-tag?` accepted any keyword that is not `:<>`, so
             `[:> Foo {}]` routed to the native path and asked React for
             an element literally named `<>`"
-    (let [e (codec/as-element [:> a-foreign-component {}])]
+    (let [e (rf.hicasso.impl.codec/as-element [:> a-foreign-component {}])]
       (is (not= ">" (el-type e)) "not a native tag any more")
       (is (fn? (el-type e)) "a component — the shared gate")
       (is (= "[:>]" (.-displayName (el-type e)))
@@ -874,11 +874,11 @@
       (is (not (identical? :> computed))
           "precondition: the row is only meaningful because these are two
            objects")
-      (is (= "[:>]" (.-displayName (el-type (codec/as-element [computed a-foreign-component {}])))))))
+      (is (= "[:>]" (.-displayName (el-type (rf.hicasso.impl.codec/as-element [computed a-foreign-component {}])))))))
   (testing "and the arms either side of the new one are untouched"
-    (is (= (.-Fragment react) (el-type (codec/as-element [:<> "x"]))))
-    (is (= "div" (el-type (codec/as-element [:div]))))
-    (is (= "toString" (el-type (codec/as-element [:toString])))
+    (is (= (.-Fragment react) (el-type (rf.hicasso.impl.codec/as-element [:<> "x"]))))
+    (is (= "div" (el-type (rf.hicasso.impl.codec/as-element [:div]))))
+    (is (= "toString" (el-type (rf.hicasso.impl.codec/as-element [:toString])))
         "the redundant second fragment test that paid for this arm is
          gone; a native tag still parses as itself")))
 
@@ -906,8 +906,8 @@
                    :count      7
                    :open       true
                    :ref        ref-fn}
-          door    (.-props (codec/as-element [a-host corpus]))
-          raw     (raw-props (codec/as-element [:> a-foreign-component corpus]))]
+          door    (.-props (rf.hicasso.impl.codec/as-element [a-host corpus]))
+          raw     (raw-props (rf.hicasso.impl.codec/as-element [:> a-foreign-component corpus]))]
       (is (= (vec (sort (js/Object.keys door))) (vec (sort (js/Object.keys raw))))
           "prop for prop, the same emitted slots")
       (doseq [k (js/Object.keys door)]
@@ -922,7 +922,7 @@
         "and NOT at an ordinary slot: the keyword crosses whole"))
   (testing "the class slot composes across spellings here too, because the
             rule is on the SLOT and the walk is the door's"
-    (let [e (codec/as-element [:> a-foreign-component {:class "a" :x/class ["b" :c]}])]
+    (let [e (rf.hicasso.impl.codec/as-element [:> a-foreign-component {:class "a" :x/class ["b" :c]}])]
       (is (= "a b c" (aget (raw-props e) "className"))))))
 
 (deftest the-carrier-never-leaks-and-key-rides-the-outer-element
@@ -931,17 +931,17 @@
             stripping it inside would cost a shallow copy per crossing
             per render and leave the key one bug away from React; two
             slots make the leak unrepresentable instead"
-    (let [p (raw-props (codec/as-element [:> a-foreign-component {:label "x"}]))]
+    (let [p (raw-props (rf.hicasso.impl.codec/as-element [:> a-foreign-component {:label "x"}]))]
       (is (= ["label"] (vec (sort (js/Object.keys p)))))))
   (testing "and the carrier itself holds exactly the two slots, plus
             children when there are any"
-    (is (= ["c" "p"] (vec (sort (js/Object.keys (raw-carrier (codec/as-element [:> a-foreign-component {}])))))))
+    (is (= ["c" "p"] (vec (sort (js/Object.keys (raw-carrier (rf.hicasso.impl.codec/as-element [:> a-foreign-component {}])))))))
     (is (= ["c" "children" "p"]
-           (vec (sort (js/Object.keys (raw-carrier (codec/as-element [:> a-foreign-component {} [:span]]))))))))
+           (vec (sort (js/Object.keys (raw-carrier (rf.hicasso.impl.codec/as-element [:> a-foreign-component {} [:span]]))))))))
   (testing "`:key` is React's contract on the crossing's own element, not
             an attribute and not a carrier slot — the door's rule,
             unchanged"
-    (let [e (codec/as-element [:> a-foreign-component {:key "k7" :label "x"}])]
+    (let [e (rf.hicasso.impl.codec/as-element [:> a-foreign-component {:key "k7" :label "x"}])]
       (is (= "k7" (el-key e)))
       ;; `Object.keys` rather than a read of `.key`: React 19 defines a
       ;; DEV warning getter at that name on any props object it built
@@ -955,7 +955,7 @@
   (testing "a childless crossing does not write `children` onto the props
             the component receives — which is what makes the parity row
             above a claim about the object rather than about our walk"
-    (is (not (contains? (set (js/Object.keys (raw-props (codec/as-element [:> a-foreign-component {}]))))
+    (is (not (contains? (set (js/Object.keys (raw-props (rf.hicasso.impl.codec/as-element [:> a-foreign-component {}]))))
                         "children")))))
 
 (deftest the-escape-infers-every-contract-exactly-as-the-door-does
@@ -967,14 +967,14 @@
     (testing "an intent vector at an event-SPELLED slot lowers to a
               dispatching handler, exactly as at a native tag"
       (let [!seen (atom [])
-            f     (intent/with-frame (fn [ev] (swap! !seen conj ev))
+            f     (rf.hicasso.impl.intent/with-frame (fn [ev] (swap! !seen conj ev))
                                      (fn [] (raw-prop :on-pick [:row/pick 7] "onPick")))]
         (is (fn? f))
         (f #js {:target #js {}})
         (is (= [[:row/pick 7]] @!seen))))
     (testing "and so does an event-spelled key-map"
       (let [!seen (atom [])
-            f     (intent/with-frame (fn [ev] (swap! !seen conj ev))
+            f     (rf.hicasso.impl.intent/with-frame (fn [ev] (swap! !seen conj ev))
                                      (fn [] (raw-prop :on-key-down {"Enter" [:go]} "onKeyDown")))]
         (f #js {:key "Enter" :isComposing false :target #js {}})
         (is (= [[:go]] @!seen))))
@@ -984,9 +984,9 @@
               the spelling selects the contract, never a declaration"
       (let [!seen  (atom [])
             d      (fn [ev] (swap! !seen conj ev))
-            marked (intent/callback (fn [x] [:row/pick x]))
-            on     (intent/with-frame d (fn [] (raw-prop :on-value-change marked "onValueChange")))
-            row    (intent/with-frame d (fn [] (raw-prop :row-formatter marked "rowFormatter")))]
+            marked (rf.hicasso.impl.intent/callback (fn [x] [:row/pick x]))
+            on     (rf.hicasso.impl.intent/with-frame d (fn [] (raw-prop :on-value-change marked "onValueChange")))
+            row    (rf.hicasso.impl.intent/with-frame d (fn [] (raw-prop :row-formatter marked "rowFormatter")))]
         (on 3)
         (is (= [[:row/pick 3]] @!seen) "the event wrapper dispatched")
         (is (= [:row/pick 4] (row 4)) "the render wrapper returned the value")
@@ -1011,26 +1011,26 @@
             existing three arms — so an intent closure in a child
             captures the owner's frame-locked dispatch at LOWERING time
             (the two-frame proof of that is the DOM witness)"
-    (let [one (raw-carrier (codec/as-element [:> a-foreign-component {} [:span "x"]]))]
+    (let [one (raw-carrier (rf.hicasso.impl.codec/as-element [:> a-foreign-component {} [:span "x"]]))]
       (is (= "span" (.-type (aget one "children")))
           "one child: an element, not hiccup"))
-    (let [many (raw-carrier (codec/as-element [:> a-foreign-component {} [:span "a"] [:b "c"]]))
+    (let [many (raw-carrier (rf.hicasso.impl.codec/as-element [:> a-foreign-component {} [:span "a"] [:b "c"]]))
           kids (aget many "children")]
       (is (array? kids))
       (is (= ["span" "b"] (mapv #(.-type %) (vec kids))))))
   (testing "the attribute map is optional, and the indices shift by one
             from the door's: component at 1, props at 2 when it is a map,
             children from 3 or from 2"
-    (let [e (codec/as-element [:> a-foreign-component [:span "no props"]])]
+    (let [e (rf.hicasso.impl.codec/as-element [:> a-foreign-component [:span "no props"]])]
       (is (= "span" (.-type (aget (raw-carrier e) "children"))))
       (is (= [] (vec (sort (js/Object.keys (raw-props e)))))))
-    (is (some? (codec/as-element [:> a-foreign-component]))
+    (is (some? (rf.hicasso.impl.codec/as-element [:> a-foreign-component]))
         "[:> Component] with neither props nor children is legal"))
   (testing "a lowered intent inside a `[:>]` child is the ordinary
             frame-locked one — the crossing is transparent to it"
     (let [!seen (atom [])
-          e     (intent/with-frame (fn [ev] (swap! !seen conj ev))
-                                   (fn [] (codec/as-element
+          e     (rf.hicasso.impl.intent/with-frame (fn [ev] (swap! !seen conj ev))
+                                   (fn [] (rf.hicasso.impl.codec/as-element
                                             [:> a-foreign-component {}
                                              [:button {:on-click [:go]}]])))
           child (aget (raw-carrier e) "children")]
@@ -1047,7 +1047,7 @@
 ;; that each category crosses, and the refusals assert the id AND the
 ;; discriminating reason rather than merely "it threw".
 
-(defn- accepts? [c] (identical? c (raw-component-of (codec/as-element [:> c {}]))))
+(defn- accepts? [c] (identical? c (raw-component-of (rf.hicasso.impl.codec/as-element [:> c {}]))))
 
 (deftest every-category-react-mints-a-fiber-for-crosses
   (testing "functions and classes"
@@ -1072,7 +1072,7 @@
             a Suspense ancestor, and HD-011 names that pairing as a reason
             the escape exists, so a roster that took one and not the other
             would be unsound"
-    (is (some? (codec/as-element [:> (.-Suspense react) {}
+    (is (some? (rf.hicasso.impl.codec/as-element [:> (.-Suspense react) {}
                                   [:> (react/lazy (fn [] (js/Promise.resolve #js {:default a-foreign-component}))) {}]])))))
 
 (deftest the-three-values-react-would-accept-or-misreport-are-refused-at-the-crossing
@@ -1080,29 +1080,29 @@
             rather than by React — whose own refusal is minted at fiber
             creation, post-adoption and client-only"
     (testing "nil, and the bare form: the broken-import diagnosis"
-      (let [d (ex-data (try (codec/as-element [:> nil {}]) nil (catch :default e e)))]
+      (let [d (ex-data (try (rf.hicasso.impl.codec/as-element [:> nil {}]) nil (catch :default e e)))]
         (is (= :rf.error/hicasso-raw-not-a-component (:rf.error/id d)))
         (is (= 3 (:argv-count d)))
         (is (re-find #"no default export" (:reason d))))
-      (is (= :rf.error/hicasso-raw-not-a-component (error-id #(codec/as-element [:>])))))
+      (is (= :rf.error/hicasso-raw-not-a-component (error-id #(rf.hicasso.impl.codec/as-element [:>])))))
     (testing "a defview head, which React WOULD accept — it is fn?-true,
               so a bare 'is it a function' test mounts the shell raw, the
               body reads rfProps, gets undefined, and receives nil props"
-      (let [d (ex-data (try (codec/as-element [:> a-view {}]) nil (catch :default e e)))]
+      (let [d (ex-data (try (rf.hicasso.impl.codec/as-element [:> a-view {}]) nil (catch :default e e)))]
         (is (= :rf.error/hicasso-raw-not-a-component (:rf.error/id d)))
         (is (identical? a-view (:component d)))
         (is (re-find #"a defview product" (:reason d)))
         (is (re-find #"\[my-view" (:reason d)))))
     (testing "a defhost head — the escape is for what a declaration cannot
               express, and this one already IS a declaration"
-      (let [d (ex-data (try (codec/as-element [:> a-host {}]) nil (catch :default e e)))]
+      (let [d (ex-data (try (rf.hicasso.impl.codec/as-element [:> a-host {}]) nil (catch :default e e)))]
         (is (= :rf.error/hicasso-raw-not-a-component (:rf.error/id d)))
         (is (re-find #"a defhost product" (:reason d)))))
     (testing "everything else is React's to judge — a keyword, a map or a
               React element crosses, and React reports it at fiber creation
               with its own 'Element type is invalid'"
-      (doseq [c [:div {:a 1} (codec/as-element [:div])]]
-        (is (identical? c (raw-component-of (codec/as-element [:> c {}])))
+      (doseq [c [:div {:a 1} (rf.hicasso.impl.codec/as-element [:div])]]
+        (is (identical? c (raw-component-of (rf.hicasso.impl.codec/as-element [:> c {}])))
             (str "crosses: " (pr-str c)))))))
 
 ;; ---------------------------------------------------------------------------
@@ -1112,15 +1112,15 @@
 (deftest the-codec-mints-a-fresh-props-object-per-element-and-memoizes-no-element
   (testing "two renders of the same hiccup are two elements with two props objects"
     (let [hiccup [:div {:class "row"} "x"]
-          a      (codec/as-element hiccup)
-          b      (codec/as-element hiccup)]
+          a      (rf.hicasso.impl.codec/as-element hiccup)
+          b      (rf.hicasso.impl.codec/as-element hiccup)]
       (is (not (identical? a b)) "no element memoization — HD-006 stands")
       (is (not (identical? (.-props a) (.-props b))) "no props-object cache")
       (is (= (prop-names a) (prop-names b)))))
   (testing "only the two codec-work caches grow — tags and prop names (HD-004)"
-    (codec/reset-caches!)
-    (dotimes [i 20] (codec/as-element [:div.row {:class (str "c" i)} i]))
-    (is (= {:tags 1 :props 3} (codec/cache-sizes))
+    (rf.hicasso.impl.codec/reset-caches!)
+    (dotimes [i 20] (rf.hicasso.impl.codec/as-element [:div.row {:class (str "c" i)} i]))
+    (is (= {:tags 1 :props 3} (rf.hicasso.impl.codec/cache-sizes))
         "one tag literal; `:class` is one of the three seeded prop names, so
          twenty renders with twenty distinct class VALUES add nothing")))
 
@@ -1140,7 +1140,7 @@
   [nm]
   (let [f (fn [_js-props] nil)]
     (unchecked-set f "displayName" nm)
-    (codec/mark-boundary! f)))
+    (rf.hicasso.impl.codec/mark-boundary! f)))
 
 (defn- warnings-during
   "Everything the codec said on `console.warn` while `f` ran. The channel
@@ -1156,17 +1156,17 @@
 (deftest an-unkeyed-boundary-seq-is-reacts-to-warn-about-and-the-codec-is-silent
   (let [row (named-view "w1.ns/row")]
     (is (= [] (warnings-during
-                #(codec/as-element [:ul (for [i (range 3)] [row {:id i}])])))
+                #(rf.hicasso.impl.codec/as-element [:ul (for [i (range 3)] [row {:id i}])])))
         "React already warns about a missing key; the codec adds nothing")
     (is (= [] (warnings-during
-                #(codec/as-element [:ul (list [row {:key nil :id 1}])])))
+                #(rf.hicasso.impl.codec/as-element [:ul (list [row {:key nil :id 1}])])))
         "and `:key nil` is the same absent key")))
 
 (deftest a-keyed-boundary-seq-is-silent-and-so-is-every-legitimate-key-shape
   (testing "the canonical keyed list says nothing at all"
     (let [row (named-view "w2.ns/row")]
       (is (= [] (warnings-during
-                  #(codec/as-element [:ul (for [i (range 300)] [row {:key i}])]))))))
+                  #(rf.hicasso.impl.codec/as-element [:ul (for [i (range 300)] [row {:key i}])]))))))
   (testing "each primitive key shape individually — a warning that fired on
             valid code would be worse than no warning"
     (doseq [[label k] [["number" 1] ["string" "a"] ["keyword" :a]
@@ -1174,14 +1174,14 @@
                        ["zero" 0] ["empty-string" ""]]]
       (let [row (named-view (str "w2b.ns/" label))]
         (is (= [] (warnings-during
-                    #(codec/as-element [:ul (list [row {:key k}])])))
+                    #(rf.hicasso.impl.codec/as-element [:ul (list [row {:key k}])])))
             (str "a " label " key is a legitimate key"))))))
 
 (deftest the-site-warns-exactly-once-however-many-renders-it-takes
   (let [row     (named-view "w3.ns/row")
         hiccup  [:ul (list [row {:key {:id 1}}] [row {:key {:id 2}}])]
-        first-r (warnings-during #(codec/as-element hiccup))
-        again   (warnings-during #(codec/as-element hiccup))]
+        first-r (warnings-during #(rf.hicasso.impl.codec/as-element hiccup))
+        again   (warnings-during #(rf.hicasso.impl.codec/as-element hiccup))]
     (is (= 1 (count first-r)) "two entity-keyed members of one head are one site")
     (is (= [] again) "a second render of the same site re-fires nothing")))
 
@@ -1190,18 +1190,18 @@
     (let [a   (named-view "w4.ns/a")
           b   (named-view "w4.ns/b")
           out (warnings-during
-                #(codec/as-element [:ul (list [a {:key {:id 1}}] [b {:key {:id 2}}])]))]
+                #(rf.hicasso.impl.codec/as-element [:ul (list [a {:key {:id 1}}] [b {:key {:id 2}}])]))]
       (is (= 2 (count out)) "scanning past the first offender is what finds the second")))
   (testing "one member head, two hazards — two sites"
     (let [row (named-view "w5.ns/row")
           out (warnings-during
-                #(codec/as-element [:ul (list [row {:key {:id 1}}] [row {:key [1 2]}])]))]
+                #(rf.hicasso.impl.codec/as-element [:ul (list [row {:key {:id 1}}] [row {:key [1 2]}])]))]
       (is (= 2 (count out))))))
 
 (deftest a-mixed-seq-names-the-first-entity-keyed-member
   (let [row (named-view "w8.ns/row")
         out (warnings-during
-              #(codec/as-element
+              #(rf.hicasso.impl.codec/as-element
                  [:ul (list [row {:key 0}] [row {:key 1}]
                             [row {:key {:id 2}}] [row {:key 3}])]))]
     (is (= 1 (count out)))
@@ -1213,7 +1213,7 @@
             its own CONTENT and an edit silently remounts the row"
     (let [row  (named-view "w9.ns/row")
           out  (warnings-during
-                 #(codec/as-element [:ul (list [row {:key {:id 1 :label "a"}}])]))
+                 #(rf.hicasso.impl.codec/as-element [:ul (list [row {:key {:id 1 :label "a"}}])]))
           line (first out)]
       (is (= 1 (count out)))
       (is (re-find #"^\[hicasso\] Entity-valued :key" line)
@@ -1228,7 +1228,7 @@
   (testing "a vector and a set are the same hazard, and two distinct sites"
     (let [row (named-view "w10.ns/row")
           out (warnings-during
-                #(codec/as-element [:ul (list [row {:key [1 2]}] [row {:key #{1}}])]))]
+                #(rf.hicasso.impl.codec/as-element [:ul (list [row {:key [1 2]}] [row {:key #{1}}])]))]
       (is (= 2 (count out)))
       (is (re-find #"carries a vector at :key" (first out)))
       (is (re-find #"carries a set at :key" (second out))))))
@@ -1253,7 +1253,7 @@
           seen (atom nil)]
       (warnings-during
         #(reset! seen (child-vec
-                        (codec/as-element
+                        (rf.hicasso.impl.codec/as-element
                           [:ul (list [row {:key #js {:id 1}}]
                                      [row {:key #js {:id 2}}])]))))
       (is (= 2 (count @seen)))
@@ -1264,7 +1264,7 @@
   (testing "and it warns, naming the shape without ever printing the value"
     (let [row  (named-view "w25.ns/row")
           out  (warnings-during
-                 #(codec/as-element [:ul (list [row {:key #js {:secret "s3cr3t"}}])]))
+                 #(rf.hicasso.impl.codec/as-element [:ul (list [row {:key #js {:secret "s3cr3t"}}])]))
           line (first out)]
       (is (= 1 (count out)))
       (is (re-find #"w25\.ns/row" line) "the member head")
@@ -1282,7 +1282,7 @@
           cyclic (js-obj "id" 1)]
       (unchecked-set cyclic "self" cyclic)
       (let [out (warnings-during
-                  #(codec/as-element [:ul (list [row {:key cyclic}])]))]
+                  #(rf.hicasso.impl.codec/as-element [:ul (list [row {:key cyclic}])]))]
         (is (= 1 (count out)))
         (is (re-find #"carries a foreign object at :key" (first out)))))))
 
@@ -1295,7 +1295,7 @@
              ["js-array" #js [1 2]    #"carries a foreign object at :key"]]]
       (let [row (named-view (str "w27.ns/" label))
             out (warnings-during
-                  #(codec/as-element [:ul (list [row {:key k}])]))]
+                  #(rf.hicasso.impl.codec/as-element [:ul (list [row {:key k}])]))]
         (is (= 1 (count out)) (str "a " label " key must not fall through"))
         (is (re-find pattern (first out)) (str "a " label " key is named"))))))
 
@@ -1310,7 +1310,7 @@
       (is (= [] (warnings-during
                   #(reset! seen
                            (child-vec
-                             (codec/as-element
+                             (rf.hicasso.impl.codec/as-element
                                [:ul (for [id ids] [row {:key id}])]))))))
       (is (= "00000000-0000-0000-0000-000000000001" (el-key (first @seen)))
           "the coercion is the identity itself — this is WHY it is classified safe")
@@ -1320,37 +1320,37 @@
             `plain-key?` already admits does"
     (let [row (named-view "w29.ns/row")]
       (is (= [] (warnings-during
-                  #(codec/as-element [:ul (list [row {:key 'a}] [row {:key 'ns/b}])])))))))
+                  #(rf.hicasso.impl.codec/as-element [:ul (list [row {:key 'a}] [row {:key 'ns/b}])])))))))
 
 (deftest the-scope-line-holds-in-both-directions
   (testing "native-tag members are React's beat — there is no boundary head to name"
     (is (= [] (warnings-during
-                #(codec/as-element [:ul (for [i (range 3)] [:li {:key {:id i}} i])])))))
+                #(rf.hicasso.impl.codec/as-element [:ul (for [i (range 3)] [:li {:key {:id i}} i])])))))
   (testing "host-headed members are silent"
     (is (= [] (warnings-during
-                #(codec/as-element [:ul (list [a-host {:key {:id 1}}])])))))
+                #(rf.hicasso.impl.codec/as-element [:ul (list [a-host {:key {:id 1}}])])))))
   (testing "strings, numbers and nils in a seq are not elements"
     (is (= [] (warnings-during
-                #(codec/as-element [:ul (list "a" 1 nil false)])))))
+                #(rf.hicasso.impl.codec/as-element [:ul (list "a" 1 nil false)])))))
   (testing "a headless vector is somebody else's refusal — the check tolerates
             it silently and leaves `vec->element`'s loud error to speak"
     (is (= [] (warnings-during
-                #(try (codec/as-element [:ul (list [])])
+                #(try (rf.hicasso.impl.codec/as-element [:ul (list [])])
                       (catch :default _ nil)))))))
 
 (deftest every-parent-class-reaches-the-check-through-the-one-site
   (testing "a fragment parent"
     (let [row (named-view "w15.ns/row")]
       (is (= 1 (count (warnings-during
-                        #(codec/as-element [:<> (list [row {:key {:id 1}}])])))))))
+                        #(rf.hicasso.impl.codec/as-element [:<> (list [row {:key {:id 1}}])])))))))
   (testing "a host parent — this is what the [:>] crossing will inherit"
     (let [row (named-view "w16.ns/row")]
       (is (= 1 (count (warnings-during
-                        #(codec/as-element [a-host {} (list [row {:key {:id 1}}])])))))))
+                        #(rf.hicasso.impl.codec/as-element [a-host {} (list [row {:key {:id 1}}])])))))))
   (testing "a nested seq is checked at its own level, one level at a time"
     (let [row (named-view "w17.ns/row")]
       (is (= 1 (count (warnings-during
-                        #(codec/as-element [:ul (list (list [row {:key {:id 1}}]))]))))))))
+                        #(rf.hicasso.impl.codec/as-element [:ul (list (list [row {:key {:id 1}}]))]))))))))
 
 (deftest the-crossing-into-a-boundary-warns-where-nothing-else-can
   (testing "`[a-view {} (for …)]` — realize-children flattens the seq into
@@ -1359,20 +1359,20 @@
     (let [outer (named-view "w18.ns/outer")
           row   (named-view "w18.ns/row")
           out   (warnings-during
-                  #(codec/as-element [outer {} (for [i (range 3)] [row {:key {:id i}}])]))]
+                  #(rf.hicasso.impl.codec/as-element [outer {} (for [i (range 3)] [row {:key {:id i}}])]))]
       (is (= 1 (count out)))
       (is (re-find #"w18\.ns/row" (first out)))))
   (testing "a keyed crossing seq is silent"
     (let [outer (named-view "w19.ns/outer")
           row   (named-view "w19.ns/row")]
       (is (= [] (warnings-during
-                  #(codec/as-element [outer {} (for [i (range 3)] [row {:key i}])]))))))
+                  #(rf.hicasso.impl.codec/as-element [outer {} (for [i (range 3)] [row {:key i}])]))))))
   (testing "a crossing seq of native members is silent — the presence fixture's
             own shape, and every `[presence {…} (for … [:div.toast {:key id}])]`
             the guide teaches"
     (let [tray (named-view "w20.ns/tray")]
       (is (= [] (warnings-during
-                  #(codec/as-element
+                  #(rf.hicasso.impl.codec/as-element
                      [tray {:timeout-ms 300}
                       (for [i (range 3)]
                         [:div.toast {:key i} "x"])])))))))

--- a/implementation/hicasso/test/re_frame/hicasso/cold_probe_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/cold_probe_cljs_test.cljs
@@ -80,15 +80,15 @@
   keeps the claim and changes the condition: a frame running an EXPLICIT
   image, where a selection is a thing a read can get wrong."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.interop :as interop]
-            [re-frame.subs :as subs]
-            [re-frame.test-support :as test-support]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.interop :as rf.interop]
+            [re-frame.subs :as rf.subs]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::cold-probe)
 
@@ -104,10 +104,10 @@
 (rf/reg-event :coldprobe/seed (fn [_ [_ db]] {:db db}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!) (vreset! !runs 0))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!) (vreset! !runs 0))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -130,9 +130,9 @@
   about."
   [fid f]
   (let [!seen (volatile! [])]
-    (collector/render-body
+    (rf.hicasso.impl.collector/render-body
       fid
-      (fn [_] (f (fn [query-v] (vswap! !seen conj (collector/sub query-v)))) [:p])
+      (fn [_] (f (fn [query-v] (vswap! !seen conj (rf.hicasso.impl.collector/sub query-v)))) [:p])
       {})
     @!seen))
 
@@ -159,7 +159,7 @@
   [fid selected-ns]
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
   (rf/make-frame {:id fid :images [(rf/image {:select-ns {:include [selected-ns]}})]})
-  (frame/replace-app-db! fid {:v 7})
+  (rf.frame/replace-app-db! fid {:v 7})
   (vreset! !runs 0)
   fid)
 
@@ -167,16 +167,16 @@
   "The frame's own sub-cache slot for `query-v`, or nil. The probe
   promises not to create one; `subs/subscribe` is what does."
   [query-v]
-  (get @(:sub-cache (frame/frame frame-id)) query-v))
+  (get @(:sub-cache (rf.frame/frame frame-id)) query-v))
 
 (defn- errors-during
   "Run `thunk` with the always-on error listener attached; answer the
   records it emitted."
   [thunk]
   (let [!records (volatile! [])]
-    (error-emit/register-error-listener! ::cold-probe (fn [r] (vswap! !records conj r)))
+    (rf.error-emit/register-error-listener! ::cold-probe (fn [r] (vswap! !records conj r)))
     (try (thunk)
-         (finally (error-emit/unregister-error-listener! ::cold-probe)))
+         (finally (rf.error-emit/unregister-error-listener! ::cold-probe)))
     @!records))
 
 ;; ---------------------------------------------------------------------------
@@ -192,25 +192,25 @@
             reverse edge and no watch; no sub-cache slot, so no reaction
             and no ref-count. An abandoned render pays for its reads and
             keeps none of them"
-    (is (nil? (get @collector/!cells (sub-key [:coldprobe/plain]))))
+    (is (nil? (get @rf.hicasso.impl.collector/!cells (sub-key [:coldprobe/plain]))))
     (is (nil? (sub-cache-entry [:coldprobe/plain])))
-    (is (= [] (runtime/cell-readers (sub-key [:coldprobe/plain]))))
+    (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:coldprobe/plain]))))
     (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0}
-           (dissoc (runtime/residue) :entries))))
+           (dissoc (rf.hicasso.test.runtime/residue) :entries))))
 
   ;; THE CONTROL, and the reason the four nils above mean anything. Both
   ;; tables are perfectly capable of holding this key; what decides is
   ;; whether React committed the render.
-  (let [entry   (do (collector/render-body
-                      frame-id (fn [_] (collector/sub [:coldprobe/plain]) [:p]) {})
-                    (collector/last-reads))
-        release (collector/commit-boundary! entry (fn []))]
+  (let [entry   (do (rf.hicasso.impl.collector/render-body
+                      frame-id (fn [_] (rf.hicasso.impl.collector/sub [:coldprobe/plain]) [:p]) {})
+                    (rf.hicasso.impl.collector/last-reads))
+        release (rf.hicasso.impl.collector/commit-boundary! entry (fn []))]
     (testing "committing the very same read fills both tables — so the
               emptiness above is the probe's promise, not an instrument
               that cannot see"
-      (is (some? (get @collector/!cells (sub-key [:coldprobe/plain]))))
+      (is (some? (get @rf.hicasso.impl.collector/!cells (sub-key [:coldprobe/plain]))))
       (is (some? (sub-cache-entry [:coldprobe/plain])))
-      (is (= 1 (count (runtime/cell-readers (sub-key [:coldprobe/plain]))))))
+      (is (= 1 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:coldprobe/plain]))))))
     (release)))
 
 (deftest a-cold-read-answers-what-the-committed-path-answers
@@ -219,15 +219,15 @@
   ;; probe's pure compute and the reactive build share the input grammar,
   ;; so a value must not depend on which rung answered it.
   (let [cold (first (run-body! (fn [read] (read [:coldprobe/plain]))))]
-    (let [entry   (do (collector/render-body
-                        frame-id (fn [_] (collector/sub [:coldprobe/plain]) [:p]) {})
-                      (collector/last-reads))
-          release (collector/commit-boundary! entry (fn []))
+    (let [entry   (do (rf.hicasso.impl.collector/render-body
+                        frame-id (fn [_] (rf.hicasso.impl.collector/sub [:coldprobe/plain]) [:p]) {})
+                      (rf.hicasso.impl.collector/last-reads))
+          release (rf.hicasso.impl.collector/commit-boundary! entry (fn []))
           warm    (first (run-body! (fn [read] (read [:coldprobe/plain]))))]
       (testing "the warm read really is warm — a committed cell now holds
                 the key, so this second read is a pure deref and not a
                 second cold one"
-        (is (some? (get @collector/!cells (sub-key [:coldprobe/plain])))))
+        (is (some? (get @rf.hicasso.impl.collector/!cells (sub-key [:coldprobe/plain])))))
       (is (= cold warm))
       (is (= 7 warm))
       (release))))
@@ -255,7 +255,7 @@
             scratch's sub-keys are values: a repeated read is a repeated
             entry in the sequence and one member of the set"
     (is (= #{(sub-key [:coldprobe/counted])}
-           (runtime/reads-of (collector/last-reads)))))
+           (rf.hicasso.test.runtime/reads-of (rf.hicasso.impl.collector/last-reads)))))
 
   ;; THE OTHER HALF, and it is the half a global memo would break. The box
   ;; is reset by every body run, so a LATER render computes again rather
@@ -312,8 +312,8 @@
   ;; only through a capturing deref, and an unactivated container
   ;; recomputes on every deref, which would make the count below say
   ;; nothing.
-  (let [reaction (subs/subscribe [:coldprobe/counted] {:frame frame-id})]
-    (interop/activate-derived-value! reaction)
+  (let [reaction (rf.subs/subscribe [:coldprobe/counted] {:frame frame-id})]
+    (rf.interop/activate-derived-value! reaction)
     @reaction
     (vreset! !runs 0)
 
@@ -321,7 +321,7 @@
               cell holds the key, so this read is cold by the runtime's
               own definition and rung 1 is the rung it must take"
       (is (some? (sub-cache-entry [:coldprobe/counted])))
-      (is (nil? (get @collector/!cells (sub-key [:coldprobe/counted])))))
+      (is (nil? (get @rf.hicasso.impl.collector/!cells (sub-key [:coldprobe/counted])))))
 
     (testing "the read answers the reaction's own value"
       (is (= [7] (run-body! (fn [read] (read [:coldprobe/counted]))))))
@@ -331,7 +331,7 @@
               rung 1 buys over the pure compute beneath it"
       (is (= 0 @!runs)))
 
-    (subs/unsubscribe frame-id [:coldprobe/counted]))
+    (rf.subs/unsubscribe frame-id [:coldprobe/counted]))
 
   ;; THE CONTROL. Same key, same body, same value — with the warm reaction
   ;; released, so rung 1 has nothing to find and the read falls to the

--- a/implementation/hicasso/test/re_frame/hicasso/combobox_keyboard_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/combobox_keyboard_dom_cljs_test.cljs
@@ -75,13 +75,13 @@
   async row under a positional fixture aborts the whole run)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.overlay :as overlay]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.overlay :as rf.hicasso.overlay]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The model — the guide's, with a COMMITTED value beside the active one
@@ -137,7 +137,7 @@
 ;; The view — the guide's example with the audit's repair
 ;; ---------------------------------------------------------------------------
 
-(h/defview select-dropdown
+(rf.hicasso/defview select-dropdown
   "The guide's *Build a dropdown from a popover*, repaired.
 
   Four changes, and each is one clause of the audit:
@@ -162,9 +162,9 @@
      are two different options for as long as the user is looking
      around, and collapsing them announces a choice nobody has made."
   [_]
-  (let [open?  (h/sub [::open?])
-        active (h/sub [::active])
-        value  (h/sub [::value])
+  (let [open?  (rf.hicasso/sub [::open?])
+        active (rf.hicasso/sub [::active])
+        value  (rf.hicasso/sub [::value])
         label  (some #(when (= value (:value %)) (:label %)) items)]
     [:div.combo
      [:span {:id label-id} "Language"]
@@ -178,11 +178,11 @@
        :aria-controls         (when open? listbox-id)
        :aria-activedescendant (when (and open? active) (option-id active))
        :on-click              [::toggled]
-       :on-key-down           {"ArrowDown" [::h/prevent [::moved 1]]
-                               "ArrowUp"   [::h/prevent [::moved -1]]
-                               "Enter"     [::h/prevent [::committed]]}}
+       :on-key-down           {"ArrowDown" [::rf.hicasso/prevent [::moved 1]]
+                               "ArrowUp"   [::rf.hicasso/prevent [::moved -1]]
+                               "Enter"     [::rf.hicasso/prevent [::committed]]}}
       label]
-     [overlay/popover {:open?      open?
+     [rf.hicasso.overlay/popover {:open?      open?
                        :on-dismiss [::dismissed]
                        :anchor     trigger-id
                        :placement  :bottom-start}
@@ -195,7 +195,7 @@
                :on-click      [::selected v]}
           l])]]]))
 
-(h/defview the-guides-dropdown-as-written
+(rf.hicasso/defview the-guides-dropdown-as-written
   "THE POSITIVE CONTROL — the same dropdown with the repair taken back
   out, which is the shape the guide ships today.
 
@@ -207,9 +207,9 @@
   click-driven test, or in a structural sweep that only asks whether
   every control has a name."
   [_]
-  (let [open?  (h/sub [::open?])
-        active (h/sub [::active])
-        value  (h/sub [::value])
+  (let [open?  (rf.hicasso/sub [::open?])
+        active (rf.hicasso/sub [::active])
+        value  (rf.hicasso/sub [::value])
         label  (some #(when (= value (:value %)) (:label %)) items)]
     [:div.combo
      [:span {:id label-id} "Language"]
@@ -221,11 +221,11 @@
        :aria-expanded         open?
        :aria-activedescendant (when (and open? active) (option-id active))
        :on-click              [::toggled]
-       :on-key-down           {"ArrowDown" [::h/prevent [::moved 1]]
-                               "ArrowUp"   [::h/prevent [::moved -1]]
-                               "Enter"     [::h/prevent [::committed]]}}
+       :on-key-down           {"ArrowDown" [::rf.hicasso/prevent [::moved 1]]
+                               "ArrowUp"   [::rf.hicasso/prevent [::moved -1]]
+                               "Enter"     [::rf.hicasso/prevent [::committed]]}}
       label]
-     [overlay/popover {:open?      open?
+     [rf.hicasso.overlay/popover {:open?      open?
                        :on-dismiss [::dismissed]
                        :anchor     trigger-id
                        :placement  :bottom-start}
@@ -240,8 +240,8 @@
           l])]]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 ;; ---------------------------------------------------------------------------
@@ -257,7 +257,7 @@
   #{"combobox" "textbox" "searchbox" "listbox" "menu" "menubar" "tree"
     "treegrid" "grid" "radiogroup" "group" "toolbar" "application"})
 
-(defn- attr [node k] (get (ht/attrs node) k))
+(defn- attr [node k] (get (rf.hicasso.test/attrs node) k))
 
 (defn- ids-of [s] (remove str/blank? (str/split (or s "") #"\s+")))
 
@@ -279,7 +279,7 @@
   | `:activedescendant-outside-the-owned-subtree` | resolves it outside what the combobox controls |"
   [tree]
   (let [by-id (into {} (map (juxt #(attr % :id) identity))
-                    (ht/find-all tree #(some? (attr % :id))))]
+                    (rf.hicasso.test/find-all tree #(some? (attr % :id))))]
     (into []
           (mapcat
             (fn [node]
@@ -289,7 +289,7 @@
                     owner  (some by-id owned)
                     referent (get by-id target)]
                 (cond-> []
-                  (not (contains? activedescendant-roles (name (or (ht/role node) :none))))
+                  (not (contains? activedescendant-roles (name (or (rf.hicasso.test/role node) :none))))
                   (conj :role-may-not-carry-activedescendant)
 
                   (empty? owned)
@@ -300,25 +300,25 @@
 
                   (and (some? referent) (some? owner)
                        (not (some #(identical? referent %)
-                                  (ht/find-all owner (constantly true)))))
+                                  (rf.hicasso.test/find-all owner (constantly true)))))
                   (conj :activedescendant-outside-the-owned-subtree)))))
-          (ht/find-all tree #(some? (attr % :aria-activedescendant))))))
+          (rf.hicasso.test/find-all tree #(some? (attr % :aria-activedescendant))))))
 
 (defn- selected-options
   "The values of the options carrying `aria-selected=\"true\"`, in
   document order."
   [tree]
   (into []
-        (comp (filter #(= :option (ht/role %)))
+        (comp (filter #(= :option (rf.hicasso.test/role %)))
               (filter #(true? (attr % :aria-selected)))
               (map #(attr % :id)))
-        (ht/find-all tree (constantly true))))
+        (rf.hicasso.test/find-all tree (constantly true))))
 
 (defn- open-tree
   "The named view, rendered with the list open and the keyboard resting
   on `active` while `value` is committed."
   [view {:keys [active value]}]
-  (ht/tree [view {}]
+  (rf.hicasso.test/tree [view {}]
            {:subs {[::open?] true
                    [::active] active
                    [::value] (or value "en")}}))
@@ -336,7 +336,7 @@
          *3 of 3, 日本語* at all")
 
     (testing "and the pieces, named, so a failure above says which"
-      (let [trigger (ht/find t #(= :combobox (ht/role %)))]
+      (let [trigger (rf.hicasso.test/find t #(= :combobox (rf.hicasso.test/role %)))]
         (is (= trigger-id (attr trigger :id)))
         (is (= listbox-id (attr trigger :aria-controls)))
         (is (= (option-id "ja") (attr trigger :aria-activedescendant)))
@@ -358,8 +358,8 @@
 
     (testing "and the trigger reads as an ordinary button, which is
               precisely the problem: everything about it is legal markup"
-      (let [trigger (ht/find t #(some? (attr % :aria-activedescendant)))]
-        (is (= :button (ht/role trigger)))
+      (let [trigger (rf.hicasso.test/find t #(some? (attr % :aria-activedescendant)))]
+        (is (= :button (rf.hicasso.test/role trigger)))
         (is (nil? (attr trigger :aria-controls)))))))
 
 (deftest aria-selected-follows-the-commitment-and-not-the-keyboard
@@ -414,13 +414,13 @@
   [m k]
   (.dispatchEvent (query-node m (str "#" trigger-id))
                   (js/KeyboardEvent. "keydown" #js {:key k :bubbles true}))
-  (hm/settle! m)
+  (rf.hicasso.test.mounted/settle! m)
   nil)
 
 (deftest the-arrow-keys-move-the-active-option-and-nothing-else
   (if-not (browser?)
     (skip! "the arrow keys")
-    (let [m (hm/mount! [select-dropdown {}])]
+    (let [m (rf.hicasso.test.mounted/mount! [select-dropdown {}])]
       (try
         (.focus (query-node m (str "#" trigger-id)))
         (testing "premise: shut, with no pointer and nothing to point at"
@@ -464,12 +464,12 @@
                   instead of moving focus into the list"
           (is (identical? (query-node m (str "#" trigger-id)) (active-el))))
 
-        (finally (hm/unmount! m))))))
+        (finally (rf.hicasso.test.mounted/unmount! m))))))
 
 (deftest enter-commits-the-active-option-and-shuts-the-list
   (if-not (browser?)
     (skip! "the commit")
-    (let [m (hm/mount! [select-dropdown {}])]
+    (let [m (rf.hicasso.test.mounted/mount! [select-dropdown {}])]
       (try
         (.focus (query-node m (str "#" trigger-id)))
         (key! m "ArrowDown")
@@ -494,4 +494,4 @@
             "and focus is still on the trigger — nothing had to be
              restored, because nothing ever moved")
 
-        (finally (hm/unmount! m))))))
+        (finally (rf.hicasso.test.mounted/unmount! m))))))

--- a/implementation/hicasso/test/re_frame/hicasso/consumer_app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/consumer_app.cljs
@@ -71,9 +71,9 @@
   `hicasso/testbed/hmr` under `test:hicasso-hmr`, which drives a real
   shadow-cljs watch and a real reload; inventing a second gate here would
   add machinery without adding a witness."
-  (:require [re-frame.adapter.uix :as uix-adapter]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]))
+            [re-frame.hicasso :as rf.hicasso]))
 
 (def ^:private frame-id ::frame)
 
@@ -95,7 +95,7 @@
 ;; The view — one boundary, one read, one intent, one controlled field
 ;; ---------------------------------------------------------------------------
 
-(h/defview app
+(rf.hicasso/defview app
   "The whole application.
 
   The field is controlled in the substrate's own sense: `:value` is the
@@ -113,9 +113,9 @@
    [:h1 "Hicasso"]
    [:label {:for "greeting"} "Greeting"]
    [:input#greeting {:type     "text"
-                     :value    (h/sub [::greeting])
-                     :on-input [::typed ::h/value]}]
-   [:p.echo "Committed: " (h/sub [::greeting])]])
+                     :value    (rf.hicasso/sub [::greeting])
+                     :on-input [::typed ::rf.hicasso/value]}]
+   [:p.echo "Committed: " (rf.hicasso/sub [::greeting])]])
 
 ;; ---------------------------------------------------------------------------
 ;; The mount, and the reload
@@ -136,7 +136,7 @@
   view code is different."
   []
   (when-some [root @!root]
-    (h/render! root [app {}])))
+    (rf.hicasso/render! root [app {}])))
 
 (defn ^:export -main
   "The `:hicasso-release` build's `:init-fn`, and the three lines that
@@ -156,7 +156,7 @@
   handle is what [[reload!]] re-renders — the one reason a mount-once
   application keeps hold of it."
   []
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (rf/make-frame {:id frame-id :initial-events [[::seed]]})
-  (reset! !root (h/mount! (js/document.getElementById "app") {:frame frame-id} [app {}]))
+  (reset! !root (rf.hicasso/mount! (js/document.getElementById "app") {:frame frame-id} [app {}]))
   nil)

--- a/implementation/hicasso/test/re_frame/hicasso/controlled_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/controlled_dom_cljs_test.cljs
@@ -34,8 +34,8 @@
   The guard rows need no DOM and run on both targets; the rest degrade
   to a stated skip under `:node-test`."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.controlled :as controlled]))
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.controlled :as rf.hicasso.impl.controlled]))
 
 (defn- browser? []
   (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
@@ -110,11 +110,11 @@
           (is (= {:value "abXcd" :caret [3 3]} (reading node))
               "the browser got there first, as it always does")
           (committed! node "abXcd")
-          (is (= "abXcd" (controlled/last-rendered node))
+          (is (= "abXcd" (rf.hicasso.impl.controlled/last-rendered node))
               "and the commit moved the record with it")
           (testing "the naive form — the handler's own closure value"
             (.setSelectionRange node 3 3)
-            (controlled/converge-to! node "abXcd" 3 "abcd")
+            (rf.hicasso.impl.controlled/converge-to! node "abXcd" 3 "abcd")
             (is (= "abcd" (.-value node))
                 "the accepted keystroke is GONE. This is the regression,
                  measured rather than assumed")
@@ -125,7 +125,7 @@
           (testing "the same call, one argument different — the record"
             (committed! node "abXcd")
             (.setSelectionRange node 3 3)
-            (controlled/converge-to! node "abXcd" 3 (controlled/last-rendered node))
+            (rf.hicasso.impl.controlled/converge-to! node "abXcd" 3 (rf.hicasso.impl.controlled/last-rendered node))
             (is (= {:value "abXcd" :caret [3 3]} (reading node))
                 "nothing moved, which is the whole of what a keystroke
                  the model took verbatim is owed"))
@@ -151,9 +151,9 @@
               "the field still shows what was typed — nothing re-rendered")
           (is (= "abXcd" (.-value accepted))
               "and so does this one — because that IS what was rendered")
-          (is (not= (controlled/last-rendered refused) (.-value refused))
+          (is (not= (rf.hicasso.impl.controlled/last-rendered refused) (.-value refused))
               "the record is the only thing that tells them apart")
-          (is (= (controlled/last-rendered accepted) (.-value accepted)))
+          (is (= (rf.hicasso.impl.controlled/last-rendered accepted) (.-value accepted)))
           (finally (drop! refused) (drop! accepted)))))))
 
 ;; ---------------------------------------------------------------------------
@@ -173,7 +173,7 @@
           (typed! node "5" 5)
           (is (= {:value "1,2345" :caret [6 6]} (reading node)))
           (committed! node "12,345")
-          (controlled/converge-to! node "1,2345" 6 "12,345")
+          (rf.hicasso.impl.controlled/converge-to! node "1,2345" 6 "12,345")
           (is (= {:value "12,345" :caret [6 6]} (reading node))
               "0 from the end of a six-character string and 0 from the
                end of a seven-character one are the same caret")
@@ -186,7 +186,7 @@
         (try
           (typed! node "z" 2)
           (is (= {:value "12z345" :caret [3 3]} (reading node)))
-          (controlled/converge-to! node "12z345" 3 (controlled/last-rendered node))
+          (rf.hicasso.impl.controlled/converge-to! node "12z345" 3 (rf.hicasso.impl.controlled/last-rendered node))
           (is (= {:value "12345" :caret [2 2]} (reading node))
               "3 from the end of \"12z345\" is 2 from the end of
                \"12345\" — the position before the refused character")
@@ -203,7 +203,7 @@
   event target, and read the node afterwards — so a row says whether a
   converge ran without knowing how it was installed."
   [hiccup name' node]
-  ((slot (codec/as-element hiccup) name') #js {:target node})
+  ((slot (rf.hicasso.impl.codec/as-element hiccup) name') #js {:target node})
   (reading node))
 
 (deftest a-controlled-field-converges-through-the-handler-the-codec-emitted
@@ -234,7 +234,7 @@
       (let [node (field! "12345")]
         (try
           (typed! node "z" 2)
-          (let [e (codec/as-element [:input {:value     "12345"
+          (let [e (rf.hicasso.impl.codec/as-element [:input {:value     "12345"
                                              :on-input  (fn [_e])
                                              :on-change (fn [_e])}])]
             ((slot e "onInput") #js {:target node})
@@ -277,7 +277,7 @@
       (skip! ":node-test has no DOM")
       (let [!ran (atom 0)
             hiccup [:input {:value "12345" :on-input (fn [_e] (swap! !ran inc))}]
-            handler (fn [] (slot (codec/as-element hiccup) "onInput"))]
+            handler (fn [] (slot (rf.hicasso.impl.codec/as-element hiccup) "onInput"))]
         (testing "not composing — the converge runs"
           (let [node (field! "12345")]
             (try
@@ -302,11 +302,11 @@
            `isComposing` off it would be dead. A synthetic target from a
            node-side row carries no native event at all, which is why
            every row written before the carve-out reads as it did"
-    (is (false? (controlled/composing-input? #js {:target #js {}})))
-    (is (false? (controlled/composing-input? #js {})))
-    (is (false? (controlled/composing-input? #js {:nativeEvent #js {}})))
-    (is (false? (controlled/composing-input? #js {:nativeEvent #js {:isComposing false}})))
-    (is (true? (controlled/composing-input? #js {:nativeEvent #js {:isComposing true}})))))
+    (is (false? (rf.hicasso.impl.controlled/composing-input? #js {:target #js {}})))
+    (is (false? (rf.hicasso.impl.controlled/composing-input? #js {})))
+    (is (false? (rf.hicasso.impl.controlled/composing-input? #js {:nativeEvent #js {}})))
+    (is (false? (rf.hicasso.impl.controlled/composing-input? #js {:nativeEvent #js {:isComposing false}})))
+    (is (true? (rf.hicasso.impl.controlled/composing-input? #js {:nativeEvent #js {:isComposing true}})))))
 
 (deftest the-element-type-does-not-move-when-the-input-type-does
   (testing "why the shadow's component is chosen without reading `:type`.
@@ -319,7 +319,7 @@
            reads the type — one render later, where a wrong answer costs
            nothing"
     (let [f   (fn [_e])
-          typ (fn [props] (.-type (codec/as-element [:input props])))
+          typ (fn [props] (.-type (rf.hicasso.impl.codec/as-element [:input props])))
           controlled-as (fn [t] (typ (cond-> {:value "1" :on-input f}
                                        (some? t) (assoc :type t))))]
       (is (identical? (controlled-as "text") (controlled-as "number"))
@@ -335,7 +335,7 @@
            so an element-tree reader asks for the TAG rather than the
            type. Everything else answers itself"
     (let [f (fn [_e])
-          tag-of (fn [hiccup] (controlled/element-tag (codec/as-element hiccup)))]
+          tag-of (fn [hiccup] (rf.hicasso.impl.controlled/element-tag (rf.hicasso.impl.codec/as-element hiccup)))]
       (is (= "input" (tag-of [:input {:value "x" :on-input f}])))
       (is (= "textarea" (tag-of [:textarea {:value "x" :on-input f}])))
       (is (= "input" (tag-of [:input {:on-input f}]))
@@ -354,7 +354,7 @@
            function to React by identity, so `identical?` is exactly the
            question \"was anything installed here?\""
     (let [f (fn [_e])
-          emitted (fn [hiccup] (slot (codec/as-element hiccup) "onInput"))]
+          emitted (fn [hiccup] (slot (rf.hicasso.impl.codec/as-element hiccup) "onInput"))]
       (is (not (identical? f (emitted [:input {:value "x" :on-input f}])))
           "the control: a controlled text field IS wrapped")
       (is (identical? f (emitted [:input {:on-input f}]))
@@ -420,7 +420,7 @@
 
 (deftest every-spelling-of-a-caret-type-is-the-same-control
   (let [f       (fn [_e])
-        emitted (fn [hiccup] (slot (codec/as-element hiccup) "onInput"))
+        emitted (fn [hiccup] (slot (rf.hicasso.impl.codec/as-element hiccup) "onInput"))
         wrapped? (fn [hiccup] (not (identical? f (emitted hiccup))))]
     (testing "every caret-bearing type, shouted — each of these IS a text
              entry control to the engine, and each used to walk past the
@@ -524,7 +524,7 @@
            after, which is what makes it a statement about the design
            rather than about the repair."
     (let [f   (fn [_e])
-          typ (fn [t] (.-type (codec/as-element
+          typ (fn [t] (.-type (rf.hicasso.impl.codec/as-element
                                [:input (cond-> {:value "1" :on-input f}
                                          (some? t) (assoc :type t))])))]
       (is (identical? (typ "text") (typ "TEXT")))
@@ -535,7 +535,7 @@
 (deftest a-controlled-field-with-no-change-handler-has-nothing-wrapped
   (testing "there is no slot to install into, and the codec does not mint
            one — an element with no handler comes out with no handler"
-    (let [e (codec/as-element [:input {:value "12345"}])]
+    (let [e (rf.hicasso.impl.codec/as-element [:input {:value "12345"}])]
       (is (nil? (slot e "onInput")))
       (is (nil? (slot e "onChange")))
       (is (= "12345" (slot e "value"))))))
@@ -547,15 +547,15 @@
            synthetic `#js {:target #js {…}}`, and none of them may throw
            or flush anything."
     (let [!seen (atom [])
-          e     (codec/as-element
+          e     (rf.hicasso.impl.codec/as-element
                  [:input {:value    "12345"
                           :on-input (fn [ev] (swap! !seen conj (.. ev -target -value)))}])]
       ((slot e "onInput") #js {:target #js {:value "typed"}})
       (is (= ["typed"] @!seen) "the author's handler ran and saw the event")
-      (is (nil? (controlled/last-rendered #js {:value "typed"}))
+      (is (nil? (rf.hicasso.impl.controlled/last-rendered #js {:value "typed"}))
           "and there was no record to converge to")))
   (testing "an event with no target at all"
     (let [!ran (atom 0)
-          e    (codec/as-element [:input {:value "x" :on-input (fn [_e] (swap! !ran inc))}])]
+          e    (rf.hicasso.impl.codec/as-element [:input {:value "x" :on-input (fn [_e] (swap! !ran inc))}])]
       ((slot e "onInput") #js {})
       (is (= 1 @!ran)))))

--- a/implementation/hicasso/test/re_frame/hicasso/coord_sentinel_source.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/coord_sentinel_source.cljs
@@ -26,9 +26,9 @@
   `defview`'s authoring-time alias rides the same
   `debug-enabled?` gate as the coordinate, so the registrar entry is one
   more thing this build is asserted not to have."
-  (:require [re-frame.hicasso :as h]))
+  (:require [re-frame.hicasso :as rf.hicasso]))
 
-(h/defview sentinel-row
+(rf.hicasso/defview sentinel-row
   "Declared for its coordinate. Under a dev build the macro registers this
   file's absolute path, line and column against [[view-name]]; under
   `:advanced` + `goog.DEBUG=false` it registers nothing and the path
@@ -36,7 +36,7 @@
   [_]
   [:li "sentinel"])
 
-(h/defhost sentinel-host
+(rf.hicasso/defhost sentinel-host
   "The declaration channel's half of the same proof — `defhost` opens the
   same extent under the same gate."
   (fn CoordSentinel [_props] nil)

--- a/implementation/hicasso/test/re_frame/hicasso/core_view_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/core_view_ssr_dom_cljs_test.cljs
@@ -42,14 +42,14 @@
   node lane is the one that decides the server claims** — a green
   browser lane says nothing about `renderToString`."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom/server" :as react-dom-server]))
 
 (def ^:private frame-id ::core-ssr)
@@ -84,13 +84,13 @@
 (rf/reg-event :hicasso.core-ssr/edit (fn [{:keys [db]} _] {:db db}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; the hydration rows wait on a real clock, and `cljs.test`
      ;; hard-errors on a fn-form fixture in a suite with an async test.
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- skip! [why]
   (is true (str "a hydration claim needs a real React DOM — " why)))
@@ -110,7 +110,7 @@
 ;; The views — one surface per view, so a red row names a surface
 ;; ---------------------------------------------------------------------------
 
-(h/defview article
+(rf.hicasso/defview article
   "HS-01 and HS-02. A boundary whose whole content is subscription
   reads, one of them behind a `when` — because §2.4's snapshot clause is
   about *conditional* reads as much as unconditional ones, and a page
@@ -118,11 +118,11 @@
   taken contributes nothing."
   [_]
   [:article.article
-   [:h1.title (h/sub [:hicasso.core-ssr/title])]
-   (when (h/sub [:hicasso.core-ssr/done?])
-     [:span.badge (h/sub [:hicasso.core-ssr/badge])])])
+   [:h1.title (rf.hicasso/sub [:hicasso.core-ssr/title])]
+   (when (rf.hicasso/sub [:hicasso.core-ssr/done?])
+     [:span.badge (rf.hicasso/sub [:hicasso.core-ssr/badge])])])
 
-(h/defview chrome
+(rf.hicasso/defview chrome
   "HS-04 and HS-05. The intrinsic head in its three shapes — an HTML
   element, an SVG subtree, and a custom element — under a fragment head
   that must contribute no wrapper of its own. The two bare strings are
@@ -137,7 +137,7 @@
     [:path {:d "M0 0 L10 10" :stroke-width 2 :stroke "currentColor"}]]
    [:my-widget {:data-kind "custom" :aria-label "widget"} "inside"]])
 
-(h/defview slots
+(rf.hicasso/defview slots
   "HS-06 and HS-15. One canonical slot per value however the key was
   written — kebab keyword, camel keyword and string all name the same
   React prop — and the caller's attributes forwarded with an ordinary
@@ -152,7 +152,7 @@
                    :defaultValue "typed"})]
    [:span {:style {:font-weight 700 :margin-top 4}} "styled"]])
 
-(h/defview intents
+(rf.hicasso/defview intents
   "HS-03 and HS-07. Every intent spelling the grammar has — a literal
   vector, the `::h/prevent` decorator head, and the `::h/value` and
   `::h/checked` placeholders — plus `::h/revision`, the controlled
@@ -161,7 +161,7 @@
   lowering that let any of these through would ship the application's
   event vocabulary to the browser as markup."
   [_]
-  [:form.intents {:on-submit [::h/prevent [:hicasso.core-ssr/edit]]}
+  [:form.intents {:on-submit [::rf.hicasso/prevent [:hicasso.core-ssr/edit]]}
    ;; CONTROLLED, and it has to be: `::h/revision` re-baselines a
    ;; controlled field to its model, so `impl.controlled/install!`
    ;; refuses it on a field with no `:value` to re-baseline TO. Measured
@@ -169,15 +169,15 @@
    ;; [[a-revision-on-an-uncontrolled-field-is-refused-at-source]] is
    ;; that refusal kept as a row rather than merely designed around.
    [:input.text {:type        "text"
-                 :value       (h/sub [:hicasso.core-ssr/draft])
-                 :on-change   [:hicasso.core-ssr/edit ::h/value]
-                 ::h/revision 7}]
+                 :value       (rf.hicasso/sub [:hicasso.core-ssr/draft])
+                 :on-change   [:hicasso.core-ssr/edit ::rf.hicasso/value]
+                 ::rf.hicasso/revision 7}]
    [:input.check {:type "checkbox" :defaultChecked true
-                  :on-change [:hicasso.core-ssr/edit ::h/checked]}]
-   [:a.link {:href "#x" :on-click [::h/prevent [:hicasso.core-ssr/finish]]} "veto"]
+                  :on-change [:hicasso.core-ssr/edit ::rf.hicasso/checked]}]
+   [:a.link {:href "#x" :on-click [::rf.hicasso/prevent [:hicasso.core-ssr/finish]]} "veto"]
    [:button.go {:on-click [:hicasso.core-ssr/finish]} "go"]])
 
-(h/defview bad-revision
+(rf.hicasso/defview bad-revision
   "`::h/revision` on an UNCONTROLLED field — `:defaultValue`, so there is
   no model to re-baseline to. The refusal this shape draws is HS-07's
   own, and it fires during the SERVER render, which is the half worth
@@ -185,9 +185,9 @@
   ship this page and fail at adoption."
   [_]
   [:div.bad
-   [:input {:type "text" :defaultValue "x" ::h/revision 7}]])
+   [:input {:type "text" :defaultValue "x" ::rf.hicasso/revision 7}]])
 
-(h/defview controls
+(rf.hicasso/defview controls
   "HS-08 as a class. Section 2.3 dispositions each control type for the
   controlled-field law; this row is the *server* half §2.1 owns — the
   value a control carries has to be IN the bytes, or the page paints
@@ -195,26 +195,26 @@
   contract exists to prevent."
   [_]
   [:div.controls
-   [:input.c-text {:type "text" :value (h/sub [:hicasso.core-ssr/draft])
-                   :on-change [:hicasso.core-ssr/edit ::h/value]}]
+   [:input.c-text {:type "text" :value (rf.hicasso/sub [:hicasso.core-ssr/draft])
+                   :on-change [:hicasso.core-ssr/edit ::rf.hicasso/value]}]
    [:input.c-check {:type "checkbox" :checked true
-                    :on-change [:hicasso.core-ssr/edit ::h/checked]}]
+                    :on-change [:hicasso.core-ssr/edit ::rf.hicasso/checked]}]
    [:textarea.c-area {:value "area-text"
-                      :on-change [:hicasso.core-ssr/edit ::h/value]}]
-   [:select.c-select {:value "b" :on-change [:hicasso.core-ssr/edit ::h/value]}
+                      :on-change [:hicasso.core-ssr/edit ::rf.hicasso/value]}]
+   [:select.c-select {:value "b" :on-change [:hicasso.core-ssr/edit ::rf.hicasso/value]}
     [:option {:value "a"} "A"]
     [:option {:value "b"} "B"]]])
 
-(h/defview guarded
+(rf.hicasso/defview guarded
   "HS-09, the succeeding arm: `h/error-boundary` around a child that
   does not throw contributes its child's output and no wrapper element
   of its own."
   [_]
   [:div.guarded
-   [h/error-boundary {:fallback [:p.fellback "fell back"]}
-    [:p.kid (h/sub [:hicasso.core-ssr/title])]]])
+   [rf.hicasso/error-boundary {:fallback [:p.fellback "fell back"]}
+    [:p.kid (rf.hicasso/sub [:hicasso.core-ssr/title])]]])
 
-(h/defview exploding
+(rf.hicasso/defview exploding
   "HS-09, the throwing arm. React is explicit that a CLIENT error
   boundary does not catch a SERVER rendering error, so the declared
   `:fallback` is not what stands in the bytes — the render fails. A row
@@ -222,10 +222,10 @@
   does not exist."
   [_]
   [:div.guarded
-   [h/error-boundary {:fallback [:p.fellback "fell back"]}
+   [rf.hicasso/error-boundary {:fallback [:p.fellback "fell back"]}
     [:p.kid (throw (js/Error. "server render exploded"))]]])
 
-(h/defview page
+(rf.hicasso/defview page
   "The hydration rows' page: the reading boundary, the intrinsic chrome
   and the intent grammar in one tree, so ONE adoption covers HS-01 to
   HS-07 rather than leaving most of them witnessed on the server side
@@ -246,7 +246,7 @@
   ([hiccup] (server-html frame-id hiccup))
   ([kw hiccup]
    (react-dom-server/renderToString
-     (mount/provider kw (codec/root-element kw hiccup)))))
+     (rf.hicasso.impl.mount/provider kw (rf.hicasso.impl.codec/root-element kw hiccup)))))
 
 (defn- page-bytes
   "`server-html` with Spec 006's dev-mode view annotations taken out — for
@@ -258,7 +258,7 @@
   they baked, and a client render annotates too, so stripping one side
   would manufacture the mismatch those rows exist to rule out."
   [hiccup]
-  (sup/without-view-annotations (server-html hiccup)))
+  (rf.hicasso.roots-frames-support/without-view-annotations (server-html hiccup)))
 
 (defn- query-node [root selector] (.querySelector root selector))
 
@@ -284,17 +284,17 @@
   [hiccup done after]
   (fresh!)
   (let [html      (server-html hiccup)
-        container (sup/stamp-server-nodes! (sup/server-dom! html))
-        {:keys [seen stop!]} (sup/watch-mismatches!)
-        handle    (mount/hydrate-root! container frame-id hiccup)]
+        container (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+        {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)
+        handle    (rf.hicasso.impl.mount/hydrate-root! container frame-id hiccup)]
     (js/setTimeout
       (fn []
         (stop!)
         (try
           (after container @seen html)
           (finally
-            (mount/release! handle)
-            (collector/reset-runtime!)
+            (rf.hicasso.impl.mount/release! handle)
+            (rf.hicasso.impl.collector/reset-runtime!)
             (done))))
       200)))
 
@@ -565,7 +565,7 @@
 
 (deftest the-page-adopts-the-servers-own-nodes
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (hydration-row
         [page {}]
@@ -579,36 +579,36 @@
               (str "**REACT FOUND NOTHING TO RECONCILE.** The client's
                     first pass rendered what the server did, so the two
                     agreed by construction: " (pr-str seen)))
-          (is (sup/every-server-node? container ".title")
+          (is (rf.hicasso.roots-frames-support/every-server-node? container ".title")
               "and the title is the SERVER'S node, still carrying the
                expando — adoption, not a re-render that looks the same")
-          (is (sup/every-server-node? container ".adjacent")
+          (is (rf.hicasso.roots-frames-support/every-server-node? container ".adjacent")
               "as is the adjacent-text paragraph, which is the node the
                comment separator exists for")
-          (is (sup/every-server-node? container "my-widget")
+          (is (rf.hicasso.roots-frames-support/every-server-node? container "my-widget")
               "and the custom element, whose head React does not know")
           (is (= "quarterly" (.-textContent (query-node container ".title")))
               "carrying the request's value"))))))
 
 (deftest a-deliberate-mismatch-is-attributed-to-the-root-that-owns-it
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
         (let [html      (server-html [page {}])
-              container (sup/server-dom! html)
-              {:keys [seen stop!]} (sup/watch-mismatches!)
+              container (rf.hicasso.roots-frames-support/server-dom! html)
+              {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)
               ;; MANUFACTURED here and asserted on here — the only shape
               ;; of call site at which swallowing an uncaught error is
               ;; not the fail-open the pageerror rule forbids.
-              {:keys [captured close!]} (sup/open-console-capture!
+              {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture!
                                           {:swallow-uncaught? true})]
           ;; The request the client renders is not the request the server
           ;; rendered — the divergence a stale cache or a clock produces.
           (rf/with-frame frame-id
             (rf/dispatch-sync [:hicasso.core-ssr/retitle "annual"]))
-          (let [handle (mount/hydrate-root! container frame-id [page {}])]
+          (let [handle (rf.hicasso.impl.mount/hydrate-root! container frame-id [page {}])]
             (js/setTimeout
               (fn []
                 (close!)
@@ -629,37 +629,37 @@
                     (is (= 1 (count @seen))
                         (str "the framework's Spec 011 diagnostic fired
                               exactly once, for this one root; got "
-                             (pr-str (mapv (comp :error sup/tags-of) @seen))))
+                             (pr-str (mapv (comp :error rf.hicasso.roots-frames-support/tags-of) @seen))))
                     (is (= 're-frame.hicasso.impl.mount/hydrate-root!
-                           (:where (sup/tags-of (first @seen))))
+                           (:where (rf.hicasso.roots-frames-support/tags-of (first @seen))))
                         "attributed to the door that owns the adoption")
                     (is (= :warned-and-replaced
-                           (:recovery (sup/tags-of (first @seen))))
+                           (:recovery (rf.hicasso.roots-frames-support/tags-of (first @seen))))
                         "with the recovery React had already performed")
                     (is (= "annual" (.-textContent (query-node container ".title")))
                         "and the repaired DOM carries the CLIENT's value,
                          which is what 'warned and replaced' means"))
                   (finally
-                    (mount/release! handle)
-                    (collector/reset-runtime!)
+                    (rf.hicasso.impl.mount/release! handle)
+                    (rf.hicasso.impl.collector/reset-runtime!)
                     (done))))
               300)))))))
 
 (deftest two-overlapping-roots-adopt-under-distinct-prefixes
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh! frame-id "quarterly")
         (fresh! other-frame-id "annual")
         (let [html-a (server-html frame-id [page {}])
               html-b (server-html other-frame-id [page {}])
-              ca     (sup/stamp-server-nodes! (sup/server-dom! html-a))
-              cb     (sup/stamp-server-nodes! (sup/server-dom! html-b))
-              {:keys [seen stop!]} (sup/watch-mismatches!)
-              ha     (mount/hydrate-root! ca frame-id [page {}]
+              ca     (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-a))
+              cb     (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-b))
+              {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)
+              ha     (rf.hicasso.impl.mount/hydrate-root! ca frame-id [page {}]
                                           {:identifier-prefix "pfx-a-"})
-              hb     (mount/hydrate-root! cb other-frame-id [page {}]
+              hb     (rf.hicasso.impl.mount/hydrate-root! cb other-frame-id [page {}]
                                           {:identifier-prefix "pfx-b-"})]
           (js/setTimeout
             (fn []
@@ -683,14 +683,14 @@
                       "root A settled on its own request")
                   (is (= "annual" (.-textContent (query-node cb ".title")))
                       "root B on its own")
-                  (is (sup/every-server-node? ca ".title")
+                  (is (rf.hicasso.roots-frames-support/every-server-node? ca ".title")
                       "root A adopted the server's nodes")
-                  (is (sup/every-server-node? cb ".title")
+                  (is (rf.hicasso.roots-frames-support/every-server-node? cb ".title")
                       "and so did root B, concurrently"))
                 (finally
-                  (mount/release! ha)
-                  (mount/release! hb)
-                  (collector/reset-runtime!)
+                  (rf.hicasso.impl.mount/release! ha)
+                  (rf.hicasso.impl.mount/release! hb)
+                  (rf.hicasso.impl.collector/reset-runtime!)
                   (done))))
             300))))))
 
@@ -700,42 +700,42 @@
 
 (deftest a-server-render-acquires-no-reader-and-an-adoption-acquires-one
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (hydration-row
         [page {}]
         done
         (fn [_container _seen _html]
-          (is (= 1 (sup/readers-of [frame-id [:hicasso.core-ssr/title]]))
+          (is (= 1 (rf.hicasso.roots-frames-support/readers-of [frame-id [:hicasso.core-ssr/title]]))
               (str "exactly ONE reader after adoption. The server render
                     ran the same body and registered NONE — there is no
                     subscription to release on a server, and a tier that
                     acquired one there would leak a cell per request —
                     so a count of two would mean both halves acquired
                     and the server's was never released; cells: "
-                   (pr-str (sup/cell-keys))))
-          (is (zero? (sup/readers-of [frame-id [:hicasso.core-ssr/badge]]))
+                   (pr-str (rf.hicasso.roots-frames-support/cell-keys))))
+          (is (zero? (rf.hicasso.roots-frames-support/readers-of [frame-id [:hicasso.core-ssr/badge]]))
               (str "and the key only the untaken branch reads has no
                     reader at all, on either side: "
-                   (pr-str (sup/cell-keys)))))))))
+                   (pr-str (rf.hicasso.roots-frames-support/cell-keys)))))))))
 
 (deftest an-adopted-page-releases-exactly-what-it-acquired
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (collector/reset-runtime!)
+      (rf.hicasso.impl.collector/reset-runtime!)
       (testing "§2.4's last clause: exact cleanup. Narrowing caught:
                 a teardown that empties the runtime's tables rather than
                 releasing the subscriptions — it answers zero whether it
                 released anything or not, which is a gate that cannot go
                 red (`impl.mount/unmount!`, rf2-2rtt6.48)"
-        (let [h (mount/root! (mount/fresh-container!) frame-id [page {}])]
-          (is (= 1 (sup/readers-of [frame-id [:hicasso.core-ssr/title]]))
+        (let [h (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [page {}])]
+          (is (= 1 (rf.hicasso.roots-frames-support/readers-of [frame-id [:hicasso.core-ssr/title]]))
               (str "one reader while mounted; cells: "
-                   (pr-str (sup/cell-keys))))
-          (mount/unmount! h)
-          (is (zero? (sup/readers-of [frame-id [:hicasso.core-ssr/title]]))
+                   (pr-str (rf.hicasso.roots-frames-support/cell-keys))))
+          (rf.hicasso.impl.mount/unmount! h)
+          (is (zero? (rf.hicasso.roots-frames-support/readers-of [frame-id [:hicasso.core-ssr/title]]))
               (str "and none after the PUBLIC teardown door, which
                     touches nothing the runtime holds; cells: "
-                   (pr-str (sup/cell-keys)))))))))
+                   (pr-str (rf.hicasso.roots-frames-support/cell-keys)))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/direct_return_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/direct_return_cljs_test.cljs
@@ -145,20 +145,20 @@
   lane is not, and `hook-budget-cljs-test` takes the same view for the
   same reason."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.hook-probe :as hook-probe]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.controlled :as controlled]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.hook-probe :as rf.hicasso.hook-probe]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.controlled :as rf.hicasso.impl.controlled]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
             [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]
             [uix.core :as uix]
             ["react" :as react]
             ["react-dom/server" :as react-dom-server]))
@@ -174,10 +174,10 @@
   {:labels {1 "quarterly"} :tags {1 ["clj" "react"]}})
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The pair — one page, written twice
@@ -199,11 +199,11 @@
   a callback slot, and a controlled field — one member of each
   population the four probes below count."
   [{:keys [id]}]
-  (let [label (h/sub [:dr/label id])
-        n     (count (h/sub [:dr/tags id]))]
+  (let [label (rf.hicasso/sub [:dr/label id])
+        n     (count (rf.hicasso/sub [:dr/tags id]))]
     [:div {:class "row" :on-click [:dr/picked id]}
      [:span {:class "label"} (str label " " n)]
-     [:input {:class "field" :value label :on-input [:dr/edited id ::h/value]}]]))
+     [:input {:class "field" :value label :on-input [:dr/edited id ::rf.hicasso/value]}]]))
 
 (defn direct-body
   "The Rung 3 spelling of the same page. The reads are the boundary's,
@@ -215,8 +215,8 @@
   the field's echo is the author's to write. Both are the escape's price
   and both are visible in this source."
   [{:keys [id]}]
-  (let [label (h/sub [:dr/label id])
-        n     (count (h/sub [:dr/tags id]))]
+  (let [label (rf.hicasso/sub [:dr/label id])
+        n     (count (rf.hicasso/sub [:dr/tags id]))]
     (react/createElement "div" #js {:className "row" :onClick (fn [_] nil)}
       (react/createElement "span" #js {:className "label"} (str label " " n))
       (react/createElement "input" #js {:className "field" :value label :onChange (fn [_] nil)}))))
@@ -226,8 +226,8 @@
   element, so the escape sees it exactly as it sees [[direct-body]]'s —
   which the probes below read rather than assume."
   [{:keys [id]}]
-  (let [label (h/sub [:dr/label id])
-        n     (count (h/sub [:dr/tags id]))]
+  (let [label (rf.hicasso/sub [:dr/label id])
+        n     (count (rf.hicasso/sub [:dr/tags id]))]
     (uix/$ :div {:class "row" :on-click (fn [_] nil)}
            (uix/$ :span {:class "label"} (str label " " n))
            (uix/$ :input {:class "field" :value label :on-change (fn [_] nil)}))))
@@ -239,10 +239,10 @@
   [_]
   nil)
 
-(h/defview hiccup-arm [props] (hiccup-body props))
-(h/defview direct-arm [props] (direct-body props))
-(h/defview uix-arm    [props] (uix-body props))
-(h/defview floor-arm  [props] (floor-body props))
+(rf.hicasso/defview hiccup-arm [props] (hiccup-body props))
+(rf.hicasso/defview direct-arm [props] (direct-body props))
+(rf.hicasso/defview uix-arm    [props] (uix-body props))
+(rf.hicasso/defview floor-arm  [props] (floor-body props))
 
 ;; ---------------------------------------------------------------------------
 ;; The key pair — a seq of boundary members, which is the population the
@@ -257,7 +257,7 @@
 ;; without meaning anything. The members are boundaries, and their React
 ;; counterpart is an ordinary function component rendering the same span.
 
-(h/defview tag-row  [{:keys [label]}] [:span {:class "tag"} label])
+(rf.hicasso/defview tag-row  [{:keys [label]}] [:span {:class "tag"} label])
 
 (defn- react-tag-row
   "The same span as a raw React component. The arms compare a key
@@ -265,16 +265,16 @@
   [^js props]
   (react/createElement "span" #js {:className "tag"} (.-label props)))
 
-(h/defview key-hiccup-arm
+(rf.hicasso/defview key-hiccup-arm
   [{:keys [id]}]
   [:div {:class "tags"}
-   (for [t (h/sub [:dr/tags id])] [tag-row {:key {:tag t} :label t}])])
+   (for [t (rf.hicasso/sub [:dr/tags id])] [tag-row {:key {:tag t} :label t}])])
 
-(h/defview key-direct-arm
+(rf.hicasso/defview key-direct-arm
   [{:keys [id]}]
   (react/createElement "div" #js {:className "tags"}
     (into-array (map (fn [t] (react/createElement react-tag-row #js {:key #js {:tag t} :label t}))
-                     (h/sub [:dr/tags id])))))
+                     (rf.hicasso/sub [:dr/tags id])))))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -283,7 +283,7 @@
 (defn- seeded!
   ([] (seeded! seed-db))
   ([db]
-   (support/leave-act-environment!)
+   (rf.hicasso.checkpoint-support/leave-act-environment!)
    (rf/make-frame {:id frame-id})
    (rf/with-frame frame-id (rf/dispatch-sync [:dr/seed db]))
    frame-id))
@@ -302,7 +302,7 @@
   [view]
   (rf.hicasso.roots-frames-support/without-view-annotations
     (react-dom-server/renderToStaticMarkup
-      (mount/provider frame-id (codec/root-element frame-id [view {:id 1}])))))
+      (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id [view {:id 1}])))))
 
 (defn- probe
   "Entries into the shipping var `install!` wraps, while `view` renders.
@@ -385,39 +385,39 @@
 
 (deftest a-direct-return-does-not-enter-the-hiccup-walk
   (seeded!)
-  (let [real codec/vec->element]
+  (let [real rf.hicasso.impl.codec/vec->element]
     (walks-past
       "the hiccup walk (codec/vec->element)"
-      (probes (fn [n] (set! codec/vec->element
+      (probes (fn [n] (set! rf.hicasso.impl.codec/vec->element
                             (fn [form] (swap! n inc) (real form))))
-              (fn [] (set! codec/vec->element real))))))
+              (fn [] (set! rf.hicasso.impl.codec/vec->element real))))))
 
 (deftest a-direct-return-does-not-enter-the-prop-pipeline
   (seeded!)
-  (let [real codec/convert-props]
+  (let [real rf.hicasso.impl.codec/convert-props]
     (walks-past
       "the prop pipeline (codec/convert-props)"
-      (probes (fn [n] (set! codec/convert-props
+      (probes (fn [n] (set! rf.hicasso.impl.codec/convert-props
                             (fn [& args] (swap! n inc) (apply real args))))
-              (fn [] (set! codec/convert-props real))))))
+              (fn [] (set! rf.hicasso.impl.codec/convert-props real))))))
 
 (deftest a-direct-return-does-not-enter-event-lowering
   (seeded!)
-  (let [real intent/lower-prop]
+  (let [real rf.hicasso.impl.intent/lower-prop]
     (walks-past
       "event lowering (intent/lower-prop)"
-      (probes (fn [n] (set! intent/lower-prop
+      (probes (fn [n] (set! rf.hicasso.impl.intent/lower-prop
                             (fn [& args] (swap! n inc) (apply real args))))
-              (fn [] (set! intent/lower-prop real))))))
+              (fn [] (set! rf.hicasso.impl.intent/lower-prop real))))))
 
 (deftest a-direct-return-does-not-enter-controlled-repair
   (seeded!)
-  (let [real controlled/install!]
+  (let [real rf.hicasso.impl.controlled/install!]
     (walks-past
       "controlled repair (controlled/install!)"
-      (probes (fn [n] (set! controlled/install!
+      (probes (fn [n] (set! rf.hicasso.impl.controlled/install!
                             (fn [& args] (swap! n inc) (apply real args))))
-              (fn [] (set! controlled/install! real))))))
+              (fn [] (set! rf.hicasso.impl.controlled/install! real))))))
 
 (deftest a-direct-return-is-not-inspected-by-the-key-diagnostic
   (seeded!)
@@ -457,10 +457,10 @@
 
 (deftest a-boundary-that-returns-an-element-still-costs-exactly-two-hooks
   (seeded!)
-  (is (true? (hook-probe/install!))
+  (is (true? (rf.hicasso.hook-probe/install!))
       "React's client-internals dispatcher slot was not found — the hook
        budget is UNWITNESSED, not satisfied")
-  (let [hooks-of (fn [view] (hook-probe/record! (fn [] (render! view))))
+  (let [hooks-of (fn [view] (rf.hicasso.hook-probe/record! (fn [] (render! view))))
         hiccup   (hooks-of hiccup-arm)
         direct   (hooks-of direct-arm)]
 
@@ -468,7 +468,7 @@
               subscription/epoch hook, in the order the ledger declares
               them, with the body between"
       (is (= ["useContext" "useSyncExternalStore"] (vec direct)))
-      (is (= (count runtime/shell-hook-ledger) (count direct))))
+      (is (= (count rf.hicasso.test.runtime/shell-hook-ledger) (count direct))))
 
     (testing "the boundary pays the same two on either arm: Rung 3 is an
               escape from the codec, not from the boundary. A third hook
@@ -498,18 +498,18 @@
 (deftest l2-refuses-a-direct-return-as-opaque
   (testing "CONTROL — the hiccup arm's body is exactly what L2 is for, and
             it answers a tree"
-    (is (= :div (:tag (ht/tree [hiccup-body {:id 1}] l2-fixtures)))))
+    (is (= :div (:tag (rf.hicasso.test/tree [hiccup-body {:id 1}] l2-fixtures)))))
 
   (testing "the direct arm's body answers a value only React can
             interpret, so L2 refuses it and points at L3. This is the
             escape's OTHER price and the one an author meets first: a
             boundary moved to Rung 3 leaves the assertion tier that runs
             without a browser"
-    (let [{:keys [refused]} (outcome #(ht/tree [direct-body {:id 1}] l2-fixtures))]
+    (let [{:keys [refused]} (outcome #(rf.hicasso.test/tree [direct-body {:id 1}] l2-fixtures))]
       (is (= :rf.error/hicasso-test-react-is-opaque (:rf.error/id refused)))))
 
   (testing "and it refuses at the DIRECT-RETURN position specifically —
             the body answered the element itself, with no tree around it
             for the refusal to have come from"
-    (let [{:keys [refused]} (outcome #(ht/tree [(fn [_] (react/createElement "b" nil "x"))] {}))]
+    (let [{:keys [refused]} (outcome #(rf.hicasso.test/tree [(fn [_] (react/createElement "b" nil "x"))] {}))]
       (is (= :rf.error/hicasso-test-react-is-opaque (:rf.error/id refused))))))

--- a/implementation/hicasso/test/re_frame/hicasso/erasure_sentinels_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/erasure_sentinels_cljs_test.cljs
@@ -41,11 +41,11 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.evidence :as evidence]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test :as ht]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.evidence :as rf.hicasso.evidence]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test :as rf.hicasso.test]))
 
 (def sentinels
   "The eight strings the release-bundle scan requires to be ABSENT, spelled
@@ -64,7 +64,7 @@
   {:boundary-marker "hicassoBoundary"
    :shipped-refusal "rf.error/hicasso-empty-vector"})
 
-(h/defview probe
+(rf.hicasso/defview probe
   "A declared boundary, minted at namespace load, for its head alone."
   [_]
   [:p "the erasure roster's probe"])
@@ -83,7 +83,7 @@
     (is (some? (unchecked-get probe (:body-slot sentinels)))
         "the mint writes the body under this exact property name")
     (is (= (unchecked-get probe (:body-slot sentinels))
-           (codec/retained-body probe))
+           (rf.hicasso.impl.codec/retained-body probe))
         "and `retained-body` reads that same slot — the kit's only route
          from a minted head back to the body its author wrote")))
 
@@ -91,21 +91,21 @@
   (testing "`hicassoViews` is the own property a dev build keeps on the read-set entry"
     (rf/make-frame {:id ::erasure-views})
     (try
-      (collector/render-body ::erasure-views (codec/retained-body probe) {})
-      (let [^js entry (collector/last-reads)]
+      (rf.hicasso.impl.collector/render-body ::erasure-views (rf.hicasso.impl.codec/retained-body probe) {})
+      (let [^js entry (rf.hicasso.impl.collector/last-reads)]
         (is (some? (unchecked-get entry (:views-slot sentinels)))
             "the render minted the slot under this exact property name — the
              named `subscribe` React is about to be handed lives there")
-        (is (nil? (collector/entry-views entry))
+        (is (nil? (rf.hicasso.impl.collector/entry-views entry))
             "but a render alone names nothing: the name is counted at the commit")
-        (let [release (collector/commit-boundary! entry (fn []))]
+        (let [release (rf.hicasso.impl.collector/commit-boundary! entry (fn []))]
           (is (= #{"re-frame.hicasso.erasure-sentinels-cljs-test/probe"}
-                 (collector/entry-views entry))
+                 (rf.hicasso.impl.collector/entry-views entry))
               "the commit counts the declared view's name, and `entry-views`
                reads it off that same slot — the tool tier's only route from
                an edge set back to a view name")
           (release)
-          (is (nil? (collector/entry-views entry))
+          (is (nil? (rf.hicasso.impl.collector/entry-views entry))
               "and the cleanup uncounts it")))
       (finally
         (rf/destroy-frame! ::erasure-views)))))
@@ -113,7 +113,7 @@
 (deftest the-spec-006-annotations-write-the-slot-and-the-keys-the-scan-names
   (testing "`hicassoViewAttrs` is the own property a dev-built body carries,
             and the two attribute names are the keys inside it"
-    (let [body  (codec/retained-body probe)
+    (let [body  (rf.hicasso.impl.codec/retained-body probe)
           attrs (unchecked-get body (:view-attrs-slot sentinels))]
       (is (some? attrs)
           "the mint writes Spec 006's attrs map under this exact property name")
@@ -137,14 +137,14 @@
 
 (deftest the-test-kits-refusal-ids-carry-the-family-the-scan-names
   (testing "`rf.error/hicasso-test-` prefixes the ids the kit mints"
-    (let [id (:rf.error/id (refusal #(ht/tree [42 {}])))]
+    (let [id (:rf.error/id (refusal #(rf.hicasso.test/tree [42 {}])))]
       (is (= :rf.error/hicasso-test-not-a-body id))
       (is (str/includes? (str id) (:test-kit-refusal sentinels))))))
 
 (deftest the-evidence-schema-pin-is-the-slug-the-scan-names
   (testing "`re-frame.hicasso.evidence` is the projection's identity slug"
-    (is (= :re-frame.hicasso.evidence/v3 evidence/schema))
-    (is (= (:evidence-schema sentinels) (namespace evidence/schema))
+    (is (= :re-frame.hicasso.evidence/v3 rf.hicasso.evidence/schema))
+    (is (= (:evidence-schema sentinels) (namespace rf.hicasso.evidence/schema))
         "every envelope carries it, so a projection in a consumer bundle
          cannot hide")))
 
@@ -154,10 +154,10 @@
           original (.-warn js/console)
           row      (fn [_js-props] nil)]
       (unchecked-set row "displayName" "erasure/row")
-      (codec/mark-boundary! row)
+      (rf.hicasso.impl.codec/mark-boundary! row)
       (try
         (set! (.-warn js/console) (fn [& args] (swap! said conj (str/join " " args))))
-        (codec/as-element [:ul (list [row {:key {:id 1}}])])
+        (rf.hicasso.impl.codec/as-element [:ul (list [row {:key {:id 1}}])])
         (finally
           (set! (.-warn js/console) original)))
       (is (some #(str/starts-with? % (:console-prefix sentinels)) @said)
@@ -180,6 +180,6 @@
 
 (deftest a-shipped-refusal-id-is-minted-on-the-path-every-build-keeps
   (testing "`rf.error/hicasso-empty-vector` comes out of `fail!` ungated"
-    (let [data (refusal #(codec/vector-kind []))]
+    (let [data (refusal #(rf.hicasso.impl.codec/vector-kind []))]
       (is (= :rf.error/hicasso-empty-vector (:rf.error/id data)))
       (is (str/includes? (str (:rf.error/id data)) (:shipped-refusal controls))))))

--- a/implementation/hicasso/test/re_frame/hicasso/error_shape_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/error_shape_cljs_test.cljs
@@ -13,14 +13,14 @@
   IDENTITY, and a `(thrown? …)` stays green for a throw from any layer
   with any id. Every row asserts the ex-data as a map."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.error :as error]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.error :as rf.hicasso.impl.error]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom/server" :as react-dom-server]))
 
 (def ^:private frame-id ::error-shape)
@@ -28,17 +28,17 @@
 (rf/reg-sub :error-shape/anything (fn [db _] (:anything db)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The consumer's source file — declared through the public door, so the
 ;; coordinates below are the macro's own and not a fixture's
 ;; ---------------------------------------------------------------------------
 
-(h/defview refusing-row
+(rf.hicasso/defview refusing-row
   "A boundary whose body writes a plain function in head position — the
   ordinary authoring mistake HD-016 makes loud. The refusal is raised by
   `codec/vec->element`, which knows nothing about this view; everything
@@ -46,7 +46,7 @@
   [_]
   [:li [(fn a-plain-function [] [:span "not a head"])]])
 
-(h/defhost date-picker
+(rf.hicasso/defhost date-picker
   "A well-formed crossing, declared so the DECLARATION channel has a real
   macro-captured coordinate to assert on rather than a fabricated one."
   (fn DatePicker [_props] nil)
@@ -64,7 +64,7 @@
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
   (rf/make-frame {:id frame-id})
   (react-dom-server/renderToString
-    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+    (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup))))
 
 (defn- refusal
   "Run `f`, and answer the ex-data of the refusal it raised — or a marker
@@ -95,7 +95,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest fail-builds-the-canonical-map-and-the-bracketed-id-message
-  (let [throw! #(error/fail! :rf.error/hicasso-state-bad-argument
+  (let [throw! #(rf.hicasso.impl.error/fail! :rf.error/hicasso-state-bad-argument
                              're-frame.hicasso.impl.state/reg-state
                              "reg-state options must be a map."
                              {:options :not-a-map})]
@@ -116,9 +116,9 @@
   (testing "the four canonical fields and the two ambient ones belong to the
             CONSTRUCTOR: an `extra` that spells any of them loses, and the
             class's own slots ride alongside untouched"
-    (error/declaring! "app.pickers/calendar" {:ns 'app.pickers :file "app/pickers.cljs"
+    (rf.hicasso.impl.error/declaring! "app.pickers/calendar" {:ns 'app.pickers :file "app/pickers.cljs"
                                               :line 12 :column 3})
-    (let [data (refusal #(error/fail! :rf.error/hicasso-state-bad-argument
+    (let [data (refusal #(rf.hicasso.impl.error/fail! :rf.error/hicasso-state-bad-argument
                                       're-frame.hicasso.impl.state/reg-state
                                       "reg-state options must be a map."
                                       {:rf.error/id :rf.error/hicasso-true-child
@@ -128,7 +128,7 @@
                                        :view        "app.impostor/not-this-one"
                                        :source      {:ns 'app.impostor}
                                        :options     :not-a-map}))]
-      (error/declared!)
+      (rf.hicasso.impl.error/declared!)
       (is (= {:rf.error/id :rf.error/hicasso-state-bad-argument
               :where       're-frame.hicasso.impl.state/reg-state
               :reason      "reg-state options must be a map."
@@ -148,7 +148,7 @@
   (testing "outside every extent a forged `:view` and `:source` are DROPPED,
             not overwritten — a catch site reading `:view` gets absence
             rather than a file name the call site made up"
-    (let [data (refusal #(error/fail! :rf.error/hicasso-state-bad-argument
+    (let [data (refusal #(rf.hicasso.impl.error/fail! :rf.error/hicasso-state-bad-argument
                                       're-frame.hicasso.impl.state/reg-state
                                       "reg-state options must be a map."
                                       {:view    "app.impostor/not-a-view"
@@ -202,7 +202,7 @@
 (deftest defhost-registers-its-macro-captured-coordinate
   (testing "the coordinate is keyed by the same `<ns>/<sym>` string the
             macro stamps as `displayName`, and it is the declaration's own"
-    (let [coord (error/source-of "re-frame.hicasso.error-shape-cljs-test/date-picker")]
+    (let [coord (rf.hicasso.impl.error/source-of "re-frame.hicasso.error-shape-cljs-test/date-picker")]
       (is (some? coord) "defhost registered a coordinate")
       (is (= 're-frame.hicasso.error-shape-cljs-test (:ns coord)))
       (is (string? (:file coord)))
@@ -213,13 +213,13 @@
   (testing "this is the extent `defhost` opens around `mint-host!`, driven
             directly because a declaration that refuses cannot be written
             at the top of a file that must load"
-    (error/declaring! "app.pickers/calendar" {:ns 'app.pickers :file "app/pickers.cljs"
+    (rf.hicasso.impl.error/declaring! "app.pickers/calendar" {:ns 'app.pickers :file "app/pickers.cljs"
                                               :line 12 :column 3})
-    (let [data (refusal #(error/fail! :rf.error/hicasso-bad-host-declaration
+    (let [data (refusal #(rf.hicasso.impl.error/fail! :rf.error/hicasso-bad-host-declaration
                                       're-frame.hicasso.impl.codec/mint-host!
                                       "defhost was given an option it does not know."
                                       {:option :nope}))]
-      (error/declared!)
+      (rf.hicasso.impl.error/declared!)
       (is (= {:rf.error/id :rf.error/hicasso-bad-host-declaration
               :where       're-frame.hicasso.impl.codec/mint-host!
               :recovery    :no-recovery
@@ -229,7 +229,7 @@
              (dissoc data :reason)))))
 
   (testing "and the extent closes, so the next refusal is not attributed to it"
-    (is (nil? (:view (refusal #(error/fail! :rf.error/hicasso-state-bad-argument
+    (is (nil? (:view (refusal #(rf.hicasso.impl.error/fail! :rf.error/hicasso-state-bad-argument
                                             're-frame.hicasso.impl.state/reg-state
                                             "reg-state options must be a map."
                                             {})))))))
@@ -241,7 +241,7 @@
   ;; loading. Inside a `deftest` the same expansion runs with a catch
   ;; around it — which is not a contrivance but the case itself. An HMR
   ;; runtime catches exactly this and leaves the mounted page rendering.
-  (let [data (refusal (fn [] (h/defhost refusing-declaration
+  (let [data (refusal (fn [] (rf.hicasso/defhost refusing-declaration
                                (fn Refusing [_props] nil)
                                {:not-an-option true})))]
 
@@ -258,14 +258,14 @@
     (testing "and the extent is CLOSED, so a later refusal — from an event
               handler, a timer, any code with no boundary on the stack —
               does not inherit the dead declaration's `:view` and `:source`"
-      (let [later (refusal #(h/sub [:error-shape/anything]))]
+      (let [later (refusal #(rf.hicasso/sub [:error-shape/anything]))]
         (is (= :rf.error/hicasso-sub-outside-render (:rf.error/id later))
             "the later refusal is the ordinary outside-extent one")
         (is (not (contains? later :view)))
         (is (not (contains? later :source)))))))
 
 (deftest a-refusal-outside-every-extent-omits-the-ambient-pair
-  (let [data (refusal #(h/sub [:error-shape/anything]))]
+  (let [data (refusal #(rf.hicasso/sub [:error-shape/anything]))]
 
     (testing "the identity, whole"
       (is (= {:rf.error/id :rf.error/hicasso-sub-outside-render

--- a/implementation/hicasso/test/re_frame/hicasso/error_source_coord_elision_prod_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/error_source_coord_elision_prod_test.cljs
@@ -50,10 +50,10 @@
   the only thing that can put its file name in an artefact is the
   coordinate this bead erases."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.hicasso.coord-sentinel-source :as sentinel]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.error :as error]
-            [re-frame.registrar :as registrar]))
+            [re-frame.hicasso.coord-sentinel-source :as rf.hicasso.coord-sentinel-source]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.error :as rf.hicasso.impl.error]
+            [re-frame.registrar :as rf.registrar]))
 
 ;; ---------------------------------------------------------------------------
 ;; The ledger was never written
@@ -63,11 +63,11 @@
   (testing "the `(when debug-enabled? (declaring! …))` the `defview`
             expansion emits DCEs whole, so the ledger has no entry and the
             absolute file path the macro read never reached the bundle"
-    (is (nil? (error/source-of sentinel/view-name)))))
+    (is (nil? (rf.hicasso.impl.error/source-of rf.hicasso.coord-sentinel-source/view-name)))))
 
 (deftest no-coordinate-is-registered-for-a-host-declared-under-prod
   (testing "`defhost` opens the same extent under the same gate"
-    (is (nil? (error/source-of sentinel/host-name)))))
+    (is (nil? (rf.hicasso.impl.error/source-of rf.hicasso.coord-sentinel-source/host-name)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Nor was the authoring-time alias
@@ -79,12 +79,12 @@
             bundle publishes no entry and Hicasso's *no registry at runtime*
             stance holds where it is claimed. The entry serves tools; there
             are none here"
-    (is (nil? (registrar/lookup :view sentinel/view-id))))
+    (is (nil? (rf.registrar/lookup :view rf.hicasso.coord-sentinel-source/view-id))))
 
   (testing "and NO entry anywhere in the `:view` kind carries the alias's
             slot — a build-wide absence rather than one id's"
     (is (empty? (filter :hicasso/component
-                        (vals (registrar/registrations :view)))))))
+                        (vals (rf.registrar/registrations :view)))))))
 
 (deftest the-view-kind-is-populated-under-prod-so-the-absence-above-is-real
   ;; The positive control the row above needs. This build compiles every
@@ -93,7 +93,7 @@
   ;; answering non-empty is what proves the nil above is the DECLARATION's
   ;; absence and not a registrar that answers nothing for anyone.
   (testing "other substrates' views are registered here"
-    (is (seq (registrar/registrations :view)))))
+    (is (seq (rf.registrar/registrations :view)))))
 
 ;; ---------------------------------------------------------------------------
 ;; A refusal carries neither ambient field
@@ -101,7 +101,7 @@
 
 (deftest a-refusal-under-prod-carries-no-view-and-no-source
   (let [data (try
-               (error/fail! :rf.error/hicasso-empty-vector
+               (rf.hicasso.impl.error/fail! :rf.error/hicasso-empty-vector
                             're-frame.hicasso.impl.codec/vec->element
                             "A hiccup vector must have a head."
                             {})
@@ -135,7 +135,7 @@
   ;; `goog.DEBUG=false`, so there was no ambient value to overwrite it with
   ;; and the forgery merged through untouched.
   (let [data (try
-               (error/fail! :rf.error/hicasso-empty-vector
+               (rf.hicasso.impl.error/fail! :rf.error/hicasso-empty-vector
                             're-frame.hicasso.impl.codec/vec->element
                             "A hiccup vector must have a head."
                             {:view   "app.impostor/not-a-view"
@@ -165,8 +165,8 @@
 (deftest the-boundary-and-the-host-are-still-minted-under-prod
   (testing "a positive control, and the reason this file cannot pass by the
             macros having compiled to nothing at all"
-    (is (true? (codec/boundary-head? sentinel/sentinel-row)))
-    (is (true? (codec/host-head? sentinel/sentinel-host)))
-    (is (= sentinel/view-name (.-displayName sentinel/sentinel-row))
+    (is (true? (rf.hicasso.impl.codec/boundary-head? rf.hicasso.coord-sentinel-source/sentinel-row)))
+    (is (true? (rf.hicasso.impl.codec/host-head? rf.hicasso.coord-sentinel-source/sentinel-host)))
+    (is (= rf.hicasso.coord-sentinel-source/view-name (.-displayName rf.hicasso.coord-sentinel-source/sentinel-row))
         "the view name is NOT elided — it is the measure id and the
          React DevTools label, and it is a name rather than a coordinate")))

--- a/implementation/hicasso/test/re_frame/hicasso/evidence_schema_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/evidence_schema_cljs_test.cljs
@@ -10,7 +10,7 @@
   is the check firing and not the door being broken for everything."
   (:require [cljs.test :refer [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.hicasso.evidence :as evidence]))
+            [re-frame.hicasso.evidence :as rf.hicasso.evidence]))
 
 (defn- outcome
   "`{:emitted v}` when the door let it through, `{:refused <ex-data>
@@ -33,9 +33,9 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-coherent-envelope-is-stamped-over-its-body
-  (let [e (evidence/envelope :mounted-boundaries true nil {:boundaries [] :generation 3})]
-    (is (= evidence/schema (:schema e)) "the version pin rides on every envelope")
-    (is (= evidence/producer (:producer e)))
+  (let [e (rf.hicasso.evidence/envelope :mounted-boundaries true nil {:boundaries [] :generation 3})]
+    (is (= rf.hicasso.evidence/schema (:schema e)) "the version pin rides on every envelope")
+    (is (= rf.hicasso.evidence/producer (:producer e)))
     (is (= :mounted-boundaries (:read e)))
     (is (true? (:complete? e)))
     (is (nil? (:loss e)))
@@ -43,11 +43,11 @@
     (is (= 3 (:generation e)))))
 
 (deftest a-capped-envelope-carries-its-loss
-  (let [e (evidence/envelope :intents false {:reason :cap :dropped evidence/unknown} {:intents []})]
+  (let [e (rf.hicasso.evidence/envelope :intents false {:reason :cap :dropped rf.hicasso.evidence/unknown} {:intents []})]
     (is (false? (:complete? e)))
-    (is (= {:reason :cap :dropped evidence/unknown} (:loss e)))
+    (is (= {:reason :cap :dropped rf.hicasso.evidence/unknown} (:loss e)))
     (testing "and a counted drop is legal too"
-      (is (contains? (outcome #(evidence/envelope :intents false {:reason :cap :dropped 4} {}))
+      (is (contains? (outcome #(rf.hicasso.evidence/envelope :intents false {:reason :cap :dropped 4} {}))
                      :emitted)))))
 
 ;; ---------------------------------------------------------------------------
@@ -55,29 +55,29 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-read-outside-the-vocabulary-is-refused
-  (let [o (outcome #(evidence/envelope :whatever true nil {}))]
+  (let [o (outcome #(rf.hicasso.evidence/envelope :whatever true nil {}))]
     (is (refused-with o ":read :whatever") (str (:message o)))))
 
 (deftest a-loss-must-name-a-reason-and-size-its-drop
   (testing "an absent :dropped is the shape in which unknown looks like none"
-    (is (refused-with (outcome #(evidence/envelope :intents false {:reason :cap} {}))
+    (is (refused-with (outcome #(rf.hicasso.evidence/envelope :intents false {:reason :cap} {}))
                       "absent :dropped")))
   (testing "a reason outside the closed vocabulary"
-    (is (refused-with (outcome #(evidence/envelope :intents false {:reason :probably :dropped 3} {}))
+    (is (refused-with (outcome #(rf.hicasso.evidence/envelope :intents false {:reason :probably :dropped 3} {}))
                       ":loss")))
   (testing "a loss that is not a map"
-    (is (refused-with (outcome #(evidence/envelope :intents false :cap {})) ":loss"))))
+    (is (refused-with (outcome #(rf.hicasso.evidence/envelope :intents false :cap {})) ":loss"))))
 
 (deftest completeness-and-loss-cannot-both-be-claimed
-  (let [o (outcome #(evidence/envelope :mounted-boundaries true {:reason :cap :dropped 4} {}))]
+  (let [o (outcome #(rf.hicasso.evidence/envelope :mounted-boundaries true {:reason :cap :dropped 4} {}))]
     (is (refused-with o "claims completeness and also reports loss") (str (:message o)))))
 
 (deftest completeness-is-a-boolean
-  (is (refused-with (outcome #(evidence/envelope :mounted-boundaries nil nil {})) ":complete?"))
-  (is (refused-with (outcome #(evidence/envelope :mounted-boundaries :yes nil {})) ":complete?")))
+  (is (refused-with (outcome #(rf.hicasso.evidence/envelope :mounted-boundaries nil nil {})) ":complete?"))
+  (is (refused-with (outcome #(rf.hicasso.evidence/envelope :mounted-boundaries :yes nil {})) ":complete?")))
 
 (deftest a-refusal-names-every-problem-at-once
-  (let [o (outcome #(evidence/envelope :nope true {:reason :cap} {}))]
+  (let [o (outcome #(rf.hicasso.evidence/envelope :nope true {:reason :cap} {}))]
     (is (= 3 (count (:problems (:refused o))))
         "the read, the loss's missing :dropped and the completeness clash are all named")))
 
@@ -86,8 +86,8 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-vocabulary-is-closed
-  (is (= :unknown evidence/unknown))
-  (is (= #{:cap :opaque :host-opaque :uncorrelated} evidence/loss-reasons))
-  (is (= #{:mounted-boundaries :read-attribution :intents :explain-render} evidence/reads))
-  (is (= :re-frame.hicasso.evidence/v3 evidence/schema)
+  (is (= :unknown rf.hicasso.evidence/unknown))
+  (is (= #{:cap :opaque :host-opaque :uncorrelated} rf.hicasso.evidence/loss-reasons))
+  (is (= #{:mounted-boundaries :read-attribution :intents :explain-render} rf.hicasso.evidence/reads))
+  (is (= :re-frame.hicasso.evidence/v3 rf.hicasso.evidence/schema)
       "the wire shape and the stamp move together, or the pin is nominal"))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/app.cljs
@@ -34,11 +34,11 @@
   matters. Serving it needs a `:dev-http` entry in
   `implementation/shadow-cljs.edn`, which is a hot-zone file; the
   measurement lane that wants one adds it with the build it needs."
-  (:require [re-frame.adapter.uix :as uix-adapter]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.editor.events :as events]
-            [re-frame.hicasso.examples.editor.views :as views]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.editor.events :as rf.hicasso.examples.editor.events]
+            [re-frame.hicasso.examples.editor.views :as rf.hicasso.examples.editor.views]))
 
 (def frame-id
   "This application's frame. Namespaced, so two applications in one
@@ -49,7 +49,7 @@
   "What seeds a fresh frame. Public because every test that mounts this
   application seeds it the same way, and a witness that seeded itself
   differently from the application would be evidence about the witness."
-  [[::events/seed]])
+  [[::rf.hicasso.examples.editor.events/seed]])
 
 (defonce ^:private !root
   ;; `defonce`, because a reload re-evaluates this namespace and a plain
@@ -62,7 +62,7 @@
   caret survive."
   []
   (when-some [root @!root]
-    (h/render! root [views/editor {}])))
+    (rf.hicasso/render! root [rf.hicasso.examples.editor.views/editor {}])))
 
 (defn ^:export -main
   "Mount the editor on `#app`.
@@ -73,8 +73,8 @@
   adapter will not do — its derived value is not `IWatchable` and a
   moving subscription under it would notify nothing."
   []
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (rf/make-frame {:id frame-id :initial-events initial-events})
-  (reset! !root (h/mount! (js/document.getElementById "app") {:frame frame-id}
-                          [views/editor {}]))
+  (reset! !root (rf.hicasso/mount! (js/document.getElementById "app") {:frame frame-id}
+                          [rf.hicasso.examples.editor.views/editor {}]))
   nil)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs
@@ -50,19 +50,19 @@
   stands in front of it. A `dispatch-sync` of the same intent would prove
   the model and nothing about the glass."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.editor.app :as app]
-            [re-frame.hicasso.examples.editor.events :as events]
-            [re-frame.hicasso.examples.editor.subs :as subs]
-            [re-frame.hicasso.examples.editor.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.editor.app :as rf.hicasso.examples.editor.app]
+            [re-frame.hicasso.examples.editor.events :as rf.hicasso.examples.editor.events]
+            [re-frame.hicasso.examples.editor.subs :as rf.hicasso.examples.editor.subs]
+            [re-frame.hicasso.examples.editor.views :as rf.hicasso.examples.editor.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 (defn- browser? []
@@ -76,7 +76,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- mount-editor! []
-  (hm/mount! [views/editor {}] {:initial-events app/initial-events}))
+  (rf.hicasso.test.mounted/mount! [rf.hicasso.examples.editor.views/editor {}] {:initial-events rf.hicasso.examples.editor.app/initial-events}))
 
 (defn- node [m selector] (.querySelector (:container m) selector))
 
@@ -86,7 +86,7 @@
   (.-textContent (node m (str "[data-committed='" (name field) "']"))))
 
 (defn- model [m field]
-  (rf/with-frame (:frame m) (deref (rf/subscribe [::subs/field field]))))
+  (rf/with-frame (:frame m) (deref (rf/subscribe [::rf.hicasso.examples.editor.subs/field field]))))
 
 (defn- set-native-value!
   "Write `v` through the element prototype's OWN `value` setter, bypassing
@@ -120,13 +120,13 @@
     (let [m (mount-editor!)
           n (field-node m :title)]
       (type-into! n "!")
-      (hm/settle! m)
+      (rf.hicasso.test.mounted/settle! m)
       (is (= "Intents are data!" (.-value n))
           "the character the model TOOK is on the glass. This is the
            converge's own trap: writing the change handler's stale closure
            value back here would wipe the character just typed")
       (is (= "Intents are data!" (model m :title)))
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 (deftest a-normalised-keystroke-echoes-the-COMMITTED-value
   (if-not (browser?)
@@ -135,14 +135,14 @@
           n (field-node m :slug)]
       (set-native-value! n "")
       (type-into! n "Hello,   World")
-      (hm/settle! m)
+      (rf.hicasso.test.mounted/settle! m)
       (is (= "hello-world" (model m :slug))
           "the model normalised")
       (is (= "hello-world" (.-value n))
           "AND THE FIELD SHOWS THE MODEL, not what was typed — at a length
            the typing did not have. A field that echoed nothing would be
            green on a length-preserving normalisation and red here")
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 (deftest the-checkbox-writes-a-boolean-through-a-real-click
   (if-not (browser?)
@@ -151,25 +151,25 @@
           n (field-node m :published)]
       (is (false? (.-checked n)))
       (click! n)
-      (hm/settle! m)
+      (rf.hicasso.test.mounted/settle! m)
       (is (true? (.-checked n)))
       (is (true? (model m :published?)))
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 (deftest the-readout-holds-still-while-you-type-and-moves-when-you-save
   (if-not (browser?)
     (skip! "the committed readout")
     (let [m (mount-editor!)]
       (type-into! (field-node m :title) "!")
-      (hm/settle! m)
+      (rf.hicasso.test.mounted/settle! m)
       (is (= "Intents are data" (committed-text m :title))
           "\"echoes only committed state\", readable off the page: the
            readout subscribes to `::subs/committed` and a keystroke moves
            the draft, so the readout is not notified at all")
       (click! (node m "#save"))
-      (hm/settle! m)
+      (rf.hicasso.test.mounted/settle! m)
       (is (= "Intents are data!" (committed-text m :title)))
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 ;; ---------------------------------------------------------------------------
 ;; The reset — the slice authoring report's finding 5, measured
@@ -187,14 +187,14 @@
       (type-into! slug "-x")
       (type-into! body " More.")
       (click! box)
-      (hm/settle! m)
-      (is (= 0 (rf/with-frame (:frame m) (deref (rf/subscribe [::subs/revision]))))
+      (rf.hicasso.test.mounted/settle! m)
+      (is (= 0 (rf/with-frame (:frame m) (deref (rf/subscribe [::rf.hicasso.examples.editor.subs/revision]))))
           "nothing has reset yet")
 
       (click! (node m "#discard"))
-      (hm/settle! m)
+      (rf.hicasso.test.mounted/settle! m)
 
-      (is (= 1 (rf/with-frame (:frame m) (deref (rf/subscribe [::subs/revision]))))
+      (is (= 1 (rf/with-frame (:frame m) (deref (rf/subscribe [::rf.hicasso.examples.editor.subs/revision]))))
           "ONE, from an `app-db` that had no `:revision` key — the
            `(fnil inc 0)` nothing on the door asks an author to write")
       (is (= "Intents are data" (.-value title)))
@@ -202,9 +202,9 @@
       (is (= false (.-checked box))
           "the checkbox restores WITHOUT a revision, which is why
            `published-box` carries none")
-      (is (= (get-in events/seed [:article :body]) (.-value body))
+      (is (= (get-in rf.hicasso.examples.editor.events/seed [:article :body]) (.-value body))
           "and the textarea restores on the same law as the inputs")
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 (deftest what-the-revision-bump-is-actually-load-bearing-FOR
   ;; The slice authoring report's finding 5 says the bump is needed
@@ -258,8 +258,8 @@
           title (field-node m :title)
           slug  (field-node m :slug)]
       (type-into! title "!")
-      (hm/settle! m)
-      (is (true? (rf/with-frame (:frame m) (deref (rf/subscribe [::subs/dirty?]))))
+      (rf.hicasso.test.mounted/settle! m)
+      (is (true? (rf/with-frame (:frame m) (deref (rf/subscribe [::rf.hicasso.examples.editor.subs/dirty?]))))
           "dirtied from the OTHER field, so `#discard` is live and the
            slug's own address is not among what the discard will move")
 
@@ -274,7 +274,7 @@
            keystroke's divergence never saw it")
 
       (click! (node m "#discard"))
-      (hm/settle! m)
+      (rf.hicasso.test.mounted/settle! m)
       (is (= "intents-are-data" (.-value slug))
           "re-baselined, and the counter is the only thing that could have
            done it. `:draft :slug` never moved, so of this boundary's two
@@ -286,9 +286,9 @@
            the field still showing `typed-by-nobody` — measured, and that
            is why the counter cannot be dropped as bookkeeping nobody can
            see a reason for")
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
-(h/defview bad-revision-box
+(rf.hicasso/defview bad-revision-box
   "A DELIBERATE DEFECT, and the only one in this bead's two applications.
 
   It lives in a test namespace and not in either witness, because a
@@ -296,7 +296,7 @@
   gate red. `published-box`'s docstring claims the door refuses a
   revision here; this is the view that asks it to."
   [_]
-  [:input {:type "checkbox" :checked false ::h/revision 1}])
+  [:input {:type "checkbox" :checked false ::rf.hicasso/revision 1}])
 
 (deftest a-revision-on-a-value-less-checkbox-is-refused-at-the-element
   ;; The L3 half of `l2-cljs-test`'s stated limit: `ht/controlled?` builds
@@ -308,7 +308,7 @@
   ;; anti-pattern belongs in the control that has to be able to go red.
   (if-not (browser?)
     (skip! "an element is only created on a real root")
-    (let [data (try (hm/mount! [bad-revision-box {}] {}) nil
+    (let [data (try (rf.hicasso.test.mounted/mount! [bad-revision-box {}] {}) nil
                     (catch :default e (ex-data e)))]
       (is (= {:rf.error/id :rf.error/hicasso-revision-not-controlled}
              (select-keys data [:rf.error/id]))
@@ -329,14 +329,14 @@
       ;; The FIRST keystroke of an editing session moves `::subs/dirty?`
       ;; too, so the button row runs with the field. That is the ordinary
       ;; second body run and it is named rather than tuned away.
-      (let [first-burst (hm/bodies-run #(do (type-into! n "a") (hm/settle! m)))]
+      (let [first-burst (rf.hicasso.test.mounted/bodies-run #(do (type-into! n "a") (rf.hicasso.test.mounted/settle! m)))]
         (is (= 2 first-burst)
             "the field and the button row — `::subs/dirty?` goes false to
              true exactly once per session"))
 
       (testing "and every keystroke after it runs ONE body"
         (doseq [ch ["b" "c" "d"]]
-          (is (= 1 (hm/bodies-run #(do (type-into! n ch) (hm/settle! m))))
+          (is (= 1 (rf.hicasso.test.mounted/bodies-run #(do (type-into! n ch) (rf.hicasso.test.mounted/settle! m))))
               (str "typing " ch " ran a body that was not the title
                     field's. Four controls are on this page and three of
                     them read addresses this keystroke did not move; the
@@ -345,12 +345,12 @@
 
       (testing "including the field that normalises — a policy is not a cost"
         (let [slug (field-node m :slug)]
-          (is (= 1 (hm/bodies-run #(do (type-into! slug "z") (hm/settle! m)))))))
+          (is (= 1 (rf.hicasso.test.mounted/bodies-run #(do (type-into! slug "z") (rf.hicasso.test.mounted/settle! m)))))))
 
       (testing "the count is a property of the TOPOLOGY, not of the form's size"
         ;; The editor has four controls. `grid.scaling-dom-cljs-test`
         ;; runs the same measurement over a hundred, and gets the same
         ;; answer — which is the sentence specification §6 asks for.
-        (is (= 1 (hm/bodies-run #(do (type-into! n "e") (hm/settle! m))))))
+        (is (= 1 (rf.hicasso.test.mounted/bodies-run #(do (type-into! n "e") (rf.hicasso.test.mounted/settle! m))))))
 
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
@@ -30,16 +30,16 @@
   controlled keystroke describes. It is asserted here rather than there
   because it is a property of the model and needs no React to be true."
   (:require [cljs.test :refer-macros [deftest is use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.editor.app :as app]
-            [re-frame.hicasso.examples.editor.events :as events]
-            [re-frame.hicasso.examples.editor.subs :as subs]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.editor.app :as rf.hicasso.examples.editor.app]
+            [re-frame.hicasso.examples.editor.events :as rf.hicasso.examples.editor.events]
+            [re-frame.hicasso.examples.editor.subs :as rf.hicasso.examples.editor.subs]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 (defn- with-app
@@ -47,26 +47,26 @@
   itself — `app/initial-events`, not a hand-written `:rf/set-db`, so
   these rows exercise the boot the application actually has."
   [f]
-  (rf/with-new-frame [frame (rf/make-frame {:initial-events app/initial-events})]
+  (rf/with-new-frame [frame (rf/make-frame {:initial-events rf.hicasso.examples.editor.app/initial-events})]
     (f frame)))
 
 (defn- read-sub [frame query-v] (rf/subscribe-once query-v {:frame frame}))
 
 (defn- type! [frame field text]
-  (rf/dispatch-sync [::events/edit field text] {:frame frame}))
+  (rf/dispatch-sync [::rf.hicasso.examples.editor.events/edit field text] {:frame frame}))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure — the policies
 ;; ---------------------------------------------------------------------------
 
 (deftest slugify-lower-cases-and-collapses
-  (is (= "hello-world" (events/slugify "Hello, World")))
-  (is (= "a-b" (events/slugify "A   B"))
+  (is (= "hello-world" (rf.hicasso.examples.editor.events/slugify "Hello, World")))
+  (is (= "a-b" (rf.hicasso.examples.editor.events/slugify "A   B"))
       "a RUN of non-alphanumerics collapses to one dash, so this
        normalisation changes the length — which is what makes the slug
        field's echo row distinguishable from a field that echoed nothing")
-  (is (= "" (events/slugify "")))
-  (is (= "-" (events/slugify "!!!"))
+  (is (= "" (rf.hicasso.examples.editor.events/slugify "")))
+  (is (= "-" (rf.hicasso.examples.editor.events/slugify "!!!"))
       "recorded rather than defended: a leading or trailing dash is what
        this policy produces mid-typing, and trimming it would make the
        field fight the user's next keystroke"))
@@ -75,17 +75,17 @@
   ;; `editable-fields` is derived from `field-policy`, so a field added
   ;; without a policy would answer nil and take nothing. This is the row
   ;; that says so rather than leaving it to be discovered on screen.
-  (is (= (set events/editable-fields) (set (keys events/field-policy))))
-  (doseq [field events/editable-fields]
-    (is (ifn? (get events/field-policy field))
+  (is (= (set rf.hicasso.examples.editor.events/editable-fields) (set (keys rf.hicasso.examples.editor.events/field-policy))))
+  (doseq [field rf.hicasso.examples.editor.events/editable-fields]
+    (is (ifn? (get rf.hicasso.examples.editor.events/field-policy field))
         (str "field " field " has no policy function"))))
 
 (deftest the-seed-carries-no-revision-key
   ;; The premise of the `fnil` below, stated where a reader meets the
   ;; seed. A consumer copying a starting `app-db` from a guide would not
   ;; put a counter in it either.
-  (is (not (contains? events/seed :revision)))
-  (is (= (:article events/seed) (:draft events/seed))
+  (is (not (contains? rf.hicasso.examples.editor.events/seed :revision)))
+  (is (= (:article rf.hicasso.examples.editor.events/seed) (:draft rf.hicasso.examples.editor.events/seed))
       "draft and article begin equal; the distance between them is what
        `echoes only committed state` is a claim about"))
 
@@ -97,14 +97,14 @@
   (with-app
     (fn [frame]
       (type! frame :title "Intents, revisited")
-      (is (= "Intents, revisited" (read-sub frame [::subs/field :title])))
-      (is (true? (read-sub frame [::subs/dirty?]))))))
+      (is (= "Intents, revisited" (read-sub frame [::rf.hicasso.examples.editor.subs/field :title])))
+      (is (true? (read-sub frame [::rf.hicasso.examples.editor.subs/dirty?]))))))
 
 (deftest a-normalising-field-commits-the-normalised-value
   (with-app
     (fn [frame]
       (type! frame :slug "Hello, World")
-      (is (= "hello-world" (read-sub frame [::subs/field :slug]))
+      (is (= "hello-world" (read-sub frame [::rf.hicasso.examples.editor.subs/field :slug]))
           "the MODEL holds the normalised value, which is what the field
            will be handed back and therefore what it echoes — the
            controlled law's `a normalised value echoes as the committed
@@ -114,10 +114,10 @@
 (deftest the-checkbox-commits-a-boolean-and-not-a-truthy
   (with-app
     (fn [frame]
-      (rf/dispatch-sync [::events/set-published true] {:frame frame})
-      (is (true? (read-sub frame [::subs/field :published?])))
-      (rf/dispatch-sync [::events/set-published nil] {:frame frame})
-      (is (false? (read-sub frame [::subs/field :published?]))
+      (rf/dispatch-sync [::rf.hicasso.examples.editor.events/set-published true] {:frame frame})
+      (is (true? (read-sub frame [::rf.hicasso.examples.editor.subs/field :published?])))
+      (rf/dispatch-sync [::rf.hicasso.examples.editor.events/set-published nil] {:frame frame})
+      (is (false? (read-sub frame [::rf.hicasso.examples.editor.subs/field :published?]))
           "`nil` coerces to false rather than being stored. An owned
            `:checked` wins by PRESENCE and not by truthiness, so a model
            holding nil would leave the control uncontrolled"))))
@@ -141,34 +141,34 @@
   (with-app
     (fn [frame]
       (type! frame :title "Committed")
-      (is (= "Intents are data" (read-sub frame [::subs/committed :title]))
+      (is (= "Intents are data" (read-sub frame [::rf.hicasso.examples.editor.subs/committed :title]))
           "typing does not move the article")
-      (rf/dispatch-sync [::events/save] {:frame frame})
-      (is (= "Committed" (read-sub frame [::subs/committed :title])))
-      (is (= "Committed" (read-sub frame [::subs/field :title]))
+      (rf/dispatch-sync [::rf.hicasso.examples.editor.events/save] {:frame frame})
+      (is (= "Committed" (read-sub frame [::rf.hicasso.examples.editor.subs/committed :title])))
+      (is (= "Committed" (read-sub frame [::rf.hicasso.examples.editor.subs/field :title]))
           "and the draft still holds it — a save is not a reset")
-      (is (false? (read-sub frame [::subs/dirty?]))))))
+      (is (false? (read-sub frame [::rf.hicasso.examples.editor.subs/dirty?]))))))
 
 (deftest discarding-restores-the-draft-and-bumps-the-revision-from-absent
   (with-app
     (fn [frame]
       (type! frame :title "typed")
       (type! frame :slug "Typed Slug")
-      (is (= 0 (read-sub frame [::subs/revision]))
+      (is (= 0 (read-sub frame [::rf.hicasso.examples.editor.subs/revision]))
           "the subscription's own default answers 0 for the absent key, so
            the fields have a revision to render before any discard")
-      (rf/dispatch-sync [::events/discard] {:frame frame})
-      (is (= (get-in events/seed [:article :title])
-             (read-sub frame [::subs/field :title]))
+      (rf/dispatch-sync [::rf.hicasso.examples.editor.events/discard] {:frame frame})
+      (is (= (get-in rf.hicasso.examples.editor.events/seed [:article :title])
+             (read-sub frame [::rf.hicasso.examples.editor.subs/field :title]))
           "the model is back")
-      (is (= "intents-are-data" (read-sub frame [::subs/field :slug])))
-      (is (false? (read-sub frame [::subs/dirty?])))
-      (is (= 1 (read-sub frame [::subs/revision]))
+      (is (= "intents-are-data" (read-sub frame [::rf.hicasso.examples.editor.subs/field :slug])))
+      (is (false? (read-sub frame [::rf.hicasso.examples.editor.subs/dirty?])))
+      (is (= 1 (read-sub frame [::rf.hicasso.examples.editor.subs/revision]))
           "ONE, from a key that did not exist. `(fnil inc 0)` is what makes
            the FIRST discard a reset rather than a nil arithmetic error,
            and nothing on the public door says an application needs a
            counter at all — rf2-hic-025 finding 5, confirmed")
-      (rf/dispatch-sync [::events/discard] {:frame frame})
-      (is (= 2 (read-sub frame [::subs/revision]))
+      (rf/dispatch-sync [::rf.hicasso.examples.editor.events/discard] {:frame frame})
+      (is (= 2 (read-sub frame [::rf.hicasso.examples.editor.subs/revision]))
           "and a second discard bumps again, so two resets in a row are two
            distinct triggers rather than one repeated value"))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/l2_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/l2_cljs_test.cljs
@@ -30,42 +30,42 @@
   browser path runs, and the finding is CONFIRMED by measurement from a
   second application rather than repeated."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.editor.events :as events]
-            [re-frame.hicasso.examples.editor.subs :as subs]
-            [re-frame.hicasso.examples.editor.views :as views]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.editor.events :as rf.hicasso.examples.editor.events]
+            [re-frame.hicasso.examples.editor.subs :as rf.hicasso.examples.editor.subs]
+            [re-frame.hicasso.examples.editor.views :as rf.hicasso.examples.editor.views]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
-(defn- tagged [tree tag] (ht/find tree #(= tag (:tag %))))
+(defn- tagged [tree tag] (rf.hicasso.test/find tree #(= tag (:tag %))))
 
 (defn- field-tree
   "The title or slug field's tree, under the two reads it makes and no
   others."
   [field {:keys [value revision]}]
-  (ht/tree [views/text-field {:field field :label "L"}]
-           {:subs {[::subs/field field] value
-                   [::subs/revision]    revision}}))
+  (rf.hicasso.test/tree [rf.hicasso.examples.editor.views/text-field {:field field :label "L"}]
+           {:subs {[::rf.hicasso.examples.editor.subs/field field] value
+                   [::rf.hicasso.examples.editor.subs/revision]    revision}}))
 
 ;; ---------------------------------------------------------------------------
 ;; THE MARKER LAW — the slice report's finding 1, confirmed from a second app
 ;; ---------------------------------------------------------------------------
 
 (deftest the-positional-intent-substitutes-what-was-typed
-  (is (= [::events/edit :title "typed"]
-         (ht/materialize [::events/edit :title ::h/value] {:value "typed"}))
+  (is (= [::rf.hicasso.examples.editor.events/edit :title "typed"]
+         (rf.hicasso.test/materialize [::rf.hicasso.examples.editor.events/edit :title ::rf.hicasso/value] {:value "typed"}))
       "the spelling every controlled field in this application uses")
-  (is (= [::events/set-published true]
-         (ht/materialize [::events/set-published ::h/checked] {:checked true}))
+  (is (= [::rf.hicasso.examples.editor.events/set-published true]
+         (rf.hicasso.test/materialize [::rf.hicasso.examples.editor.events/set-published ::rf.hicasso/checked] {:checked true}))
       "and the checkbox's")
-  (is (= [::events/edit 3 4 "7"]
-         (ht/materialize [::events/edit 3 4 ::h/value] {:value "7"}))
+  (is (= [::rf.hicasso.examples.editor.events/edit 3 4 "7"]
+         (rf.hicasso.test/materialize [::rf.hicasso.examples.editor.events/edit 3 4 ::rf.hicasso/value] {:value "7"}))
       "the grid's three-argument shape substitutes the same way — the
        marker's position in the vector is immaterial, only its DEPTH is"))
 
@@ -75,9 +75,9 @@
   ;; new code toward it. `materialize` maps over the intent's TOP LEVEL,
   ;; deliberately and for a stated cost reason, so the shape the
   ;; convention asks for cannot carry a marker.
-  (let [written    [::events/edit {:field :title :value ::h/value}]
-        dispatched (ht/materialize written {:value "typed"})]
-    (is (= [::events/edit {:field :title :value :re-frame.hicasso/value}]
+  (let [written    [::rf.hicasso.examples.editor.events/edit {:field :title :value ::rf.hicasso/value}]
+        dispatched (rf.hicasso.test/materialize written {:value "typed"})]
+    (is (= [::rf.hicasso.examples.editor.events/edit {:field :title :value :re-frame.hicasso/value}]
            dispatched)
         "NOT substituted, NOT refused, and not linted: the marker KEYWORD
          is what reaches the handler, lands in app-db and renders as text.
@@ -108,12 +108,12 @@
     ;; not an error, so the build completes and the page throws at
     ;; render. The naming gap itself is acknowledged in `h/defview`'s
     ;; docstring.
-    (let [cb (h/event [e] [::events/edit {:field :title
+    (let [cb (rf.hicasso/event [e] [::rf.hicasso.examples.editor.events/edit {:field :title
                                         :value (.. e -target -value)}])]
-      (is (ht/callback? cb)
+      (is (rf.hicasso.test/callback? cb)
           "it is the one callback form, so a position expecting an intent
            vector will not silently take it as data")
-      (is (= [::events/edit {:field :title :value "typed"}]
+      (is (= [::rf.hicasso.examples.editor.events/edit {:field :title :value "typed"}]
              (cb #js {"target" #js {"value" "typed"}}))
           "and it does produce the canonical shape — the choice is real,
            and it is between a linted shape with a closure and an
@@ -126,15 +126,15 @@
 (deftest every-text-control-is-controlled-and-carries-a-revision
   (doseq [[label form] {"input"    [:input {:type "text"
                                             :value "v"
-                                            ::h/revision 3
-                                            :on-input [::events/edit :title ::h/value]}]
+                                            ::rf.hicasso/revision 3
+                                            :on-input [::rf.hicasso.examples.editor.events/edit :title ::rf.hicasso/value]}]
                         "textarea" [:textarea {:value "v"
-                                               ::h/revision 3
-                                               :on-input [::events/edit :body ::h/value]}]}]
-    (is (true? (ht/controlled? form))
+                                               ::rf.hicasso/revision 3
+                                               :on-input [::rf.hicasso.examples.editor.events/edit :body ::rf.hicasso/value]}]}]
+    (is (true? (rf.hicasso.test/controlled? form))
         (str "the " label " does not install the controlled shadow — the
               runtime's own decision, not a re-derivation of it"))
-    (is (= 3 (ht/revision form))
+    (is (= 3 (rf.hicasso.test/revision form))
         (str "the " label " does not carry the reset trigger")))
 
   (testing "the checkbox carries no revision, and could not"
@@ -148,13 +148,13 @@
     ;; controls it, and there is no draft between the click and the
     ;; dispatch for a shadow to hold.
     (let [box [:input {:type "checkbox" :checked false
-                       :on-change [::events/set-published ::h/checked]}]]
-      (is (false? (ht/controlled? box))
+                       :on-change [::rf.hicasso.examples.editor.events/set-published ::rf.hicasso/checked]}]]
+      (is (false? (rf.hicasso.test/controlled? box))
           "a value-less checkbox is not a CONVERGING control, and this row
            says so rather than leaving `examples.editor.views` asserting
            it from taste")
-      (is (nil? (ht/revision box)))
-      (is (true? (contains? (ht/element-props box) "checked"))
+      (is (nil? (rf.hicasso.test/revision box)))
+      (is (true? (contains? (rf.hicasso.test/element-props box) "checked"))
           "`false` reaches the element as a slot — an owned `:checked`
            wins by PRESENCE, not truthiness, and a truthiness test in the
            codec would leave an unchecked box uncontrolled")))
@@ -173,19 +173,19 @@
     ;; EMITS, and no L1 door reports what the runtime would say about the
     ;; pair. The refusal is asserted in `flow-dom-cljs-test`, where an
     ;; element is really created.
-    (is (false? (ht/controlled? [:input {:type "checkbox" :checked false
-                                         ::h/revision 1
-                                         :on-change [::events/set-published
-                                                     ::h/checked]}]))
+    (is (false? (rf.hicasso.test/controlled? [:input {:type "checkbox" :checked false
+                                         ::rf.hicasso/revision 1
+                                         :on-change [::rf.hicasso.examples.editor.events/set-published
+                                                     ::rf.hicasso/checked]}]))
         "recorded as measured conduct and not as approval — a tier that
          answered `true` here would be worse, but a tier that answers at
          all is stating something the runtime does not agree with")))
 
 (deftest the-revision-is-a-trigger-and-not-an-emitted-slot
-  (let [form  [:input {:type "text" :value "v" ::h/revision 7}]
-        slots (ht/element-props form)]
+  (let [form  [:input {:type "text" :value "v" ::rf.hicasso/revision 7}]
+        slots (rf.hicasso.test/element-props form)]
     (is (contains? slots "value"))
-    (is (= 7 (ht/revision form))
+    (is (= 7 (rf.hicasso.test/revision form))
         "the author's own attribute map carries it — `ht/revision` reads
          it pre-merge, which is where the codec reads it")
     (is (= #{"type" "value"} (set (keys slots)))
@@ -205,14 +205,14 @@
 
 (deftest a-text-field-reads-its-own-address-and-the-counter
   (let [input (tagged (field-tree :title {:value "Title" :revision 0}) :input)
-        attrs (ht/attrs input)]
+        attrs (rf.hicasso.test/attrs input)]
     (is (= "Title" (:value attrs)))
-    (is (= [::events/edit :title ::h/value] (:on-input attrs))
+    (is (= [::rf.hicasso.examples.editor.events/edit :title ::rf.hicasso/value] (:on-input attrs))
         "the intent is DATA — a vector `=` can compare, which is what
          makes two renders of one field's handler equal and what keeps a
          closure off the props map")
     (is (= "title" (:id attrs)))
-    (is (= "title" (:for (ht/attrs (tagged (field-tree :title {:value "T" :revision 0})
+    (is (= "title" (:for (rf.hicasso.test/attrs (tagged (field-tree :title {:value "T" :revision 0})
                                            :label))))
         "and the label points at it, so the control has an accessible
          name")))
@@ -222,34 +222,34 @@
   ;; else. A parametric subscription is keyed by its whole query vector,
   ;; so title and slug are separate cells with separate equality gates —
   ;; which is the property the per-keystroke budget rests on.
-  (let [attrs (ht/attrs (tagged (field-tree :slug {:value "a-slug" :revision 0}) :input))]
+  (let [attrs (rf.hicasso.test/attrs (tagged (field-tree :slug {:value "a-slug" :revision 0}) :input))]
     (is (= "a-slug" (:value attrs)))
-    (is (= [::events/edit :slug ::h/value] (:on-input attrs)))))
+    (is (= [::rf.hicasso.examples.editor.events/edit :slug ::rf.hicasso/value] (:on-input attrs)))))
 
 (deftest the-checkbox-body-reads-one-address-and-writes-one-marker
-  (let [tree  (ht/tree [views/published-box {:label "Published"}]
-                       {:subs {[::subs/field :published?] true}})
-        attrs (ht/attrs (tagged tree :input))]
+  (let [tree  (rf.hicasso.test/tree [rf.hicasso.examples.editor.views/published-box {:label "Published"}]
+                       {:subs {[::rf.hicasso.examples.editor.subs/field :published?] true}})
+        attrs (rf.hicasso.test/attrs (tagged tree :input))]
     (is (true? (:checked attrs)))
-    (is (= [::events/set-published ::h/checked] (:on-change attrs)))
+    (is (= [::rf.hicasso.examples.editor.events/set-published ::rf.hicasso/checked] (:on-change attrs)))
     (is (= "checkbox" (:type attrs)))))
 
 (deftest the-buttons-read-one-value-between-them
   (testing "clean: both disabled"
-    (let [tree (ht/tree [views/buttons {}] {:subs {[::subs/dirty?] false}})
-          btns (ht/find-all tree #(= :button (:tag %)))]
+    (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.editor.views/buttons {}] {:subs {[::rf.hicasso.examples.editor.subs/dirty?] false}})
+          btns (rf.hicasso.test/find-all tree #(= :button (:tag %)))]
       (is (= 2 (count btns)))
-      (is (= [true true] (mapv (comp :disabled ht/attrs) btns)))))
+      (is (= [true true] (mapv (comp :disabled rf.hicasso.test/attrs) btns)))))
 
   (testing "dirty: both live, and the discard says nothing about which field"
-    (let [tree (ht/tree [views/buttons {}] {:subs {[::subs/dirty?] true}})
-          btns (ht/find-all tree #(= :button (:tag %)))]
-      (is (= [false false] (mapv (comp :disabled ht/attrs) btns))
+    (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.editor.views/buttons {}] {:subs {[::rf.hicasso.examples.editor.subs/dirty?] true}})
+          btns (rf.hicasso.test/find-all tree #(= :button (:tag %)))]
+      (is (= [false false] (mapv (comp :disabled rf.hicasso.test/attrs) btns))
           "`false` and not nil — per 004B a false attribute is RECORDED
            and a nil one is dropped, so `(is (nil? …))` here would be
            green against a button that had no disabled slot at all")
-      (is (= [[::events/save] [::events/discard]]
-             (mapv (comp :on-click ht/attrs) btns))
+      (is (= [[::rf.hicasso.examples.editor.events/save] [::rf.hicasso.examples.editor.events/discard]]
+             (mapv (comp :on-click rf.hicasso.test/attrs) btns))
           "no payload, and no marker either. Both COULD take the canonical
            `[<id> {<k> <v>}]` map — which is the whole shape of the
            collision above: the map is available to every intent that needs
@@ -261,34 +261,34 @@
   ;; not one `::subs/field`. A keystroke moves the draft, so it does not
   ;; notify this body at all — which is what makes "echoes only committed
   ;; state" readable off the page rather than merely true.
-  (let [tree (ht/tree [views/readout {}]
-                      {:subs {[::subs/committed :title]      "T"
-                              [::subs/committed :slug]       "s"
-                              [::subs/committed :body]       "B"
-                              [::subs/committed :published?] false}})]
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.editor.views/readout {}]
+                      {:subs {[::rf.hicasso.examples.editor.subs/committed :title]      "T"
+                              [::rf.hicasso.examples.editor.subs/committed :slug]       "s"
+                              [::rf.hicasso.examples.editor.subs/committed :body]       "B"
+                              [::rf.hicasso.examples.editor.subs/committed :published?] false}})]
     (is (= ["T" "s" "B" "false"]
-           (mapv ht/text (ht/find-all tree #(= :dd (:tag %))))))))
+           (mapv rf.hicasso.test/text (rf.hicasso.test/find-all tree #(= :dd (:tag %))))))))
 
 (deftest the-form-body-reads-nothing
   ;; An EMPTY fixture map, and the kit refuses any read. This is the row
   ;; that keeps the parent off the typing path: every value on the page
   ;; comes from a child's own body, so this body runs at mount and then
   ;; only if its own props change.
-  (let [tree (ht/tree [views/editor {}] {:subs {}})]
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.editor.views/editor {}] {:subs {}})]
     (is (some? tree)
         "the form body made a read. Every value on this page belongs to a
          child's own body; a read here puts the form, and a props compare
          over six children, on every keystroke's path")
 
     (testing "and it calls the four controls with the props they need"
-      (let [calls (ht/find-all tree #(some? (:view-id %)))]
+      (let [calls (rf.hicasso.test/find-all tree #(some? (:view-id %)))]
         (is (= 6 (count calls))
             "four controls, the buttons and the readout — L2 records a
              child boundary as a CALL and does not run its body")
         (is (= [:title :slug nil nil nil nil]
-               (mapv (comp :field ht/attrs) calls)))
+               (mapv (comp :field rf.hicasso.test/attrs) calls)))
         (is (= ["Title" "Slug" "Body" "Published" nil nil]
-               (mapv (comp :label ht/attrs) calls))
+               (mapv (comp :label rf.hicasso.test/attrs) calls))
             "the labels are ordinary data handed down, not a subsystem —
              §7's whole i18n answer at this size")))))
 
@@ -297,8 +297,8 @@
   ;; VECTOR; a site carrying a function contributes nothing. So an empty
   ;; answer here would mean the fields had grown closures.
   (let [tree    (field-tree :title {:value "T" :revision 0})
-        offered (ht/intents tree)]
-    (is (= [[::events/edit :title ::h/value]] offered)
+        offered (rf.hicasso.test/intents tree)]
+    (is (= [[::rf.hicasso.examples.editor.events/edit :title ::rf.hicasso/value]] offered)
         "one site, one vector. This application needed `h/event` nowhere —
          every intent said what it meant as data, which is rf2-hic-025's
          observation about `event` confirmed from a form of four controls")))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
@@ -42,9 +42,9 @@
   (a wrapper, a second argument, a metadata carrier) all cost more than
   the ambiguity does, and the marker keywords already read
   `:re-frame.hicasso/…` in every other position."
-  (:require [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.editor.events :as events]
-            [re-frame.hicasso.examples.editor.subs :as subs]))
+  (:require [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.editor.events :as rf.hicasso.examples.editor.events]
+            [re-frame.hicasso.examples.editor.subs :as rf.hicasso.examples.editor.subs]))
 
 (def field-labels
   "The four accessible names, as data.
@@ -64,7 +64,7 @@
 ;; The controls
 ;; ---------------------------------------------------------------------------
 
-(h/defview text-field
+(rf.hicasso/defview text-field
   "One controlled `<input type=text>`: the title and the slug.
 
   Two reads, both its own — the field's value and the reset counter. The
@@ -78,11 +78,11 @@
      [:input {:id          id
               :type        "text"
               :data-field  id
-              ::h/revision (h/sub [::subs/revision])
-              :value       (h/sub [::subs/field field])
-              :on-input    [::events/edit field ::h/value]}]]))
+              ::rf.hicasso/revision (rf.hicasso/sub [::rf.hicasso.examples.editor.subs/revision])
+              :value       (rf.hicasso/sub [::rf.hicasso.examples.editor.subs/field field])
+              :on-input    [::rf.hicasso.examples.editor.events/edit field ::rf.hicasso/value]}]]))
 
-(h/defview body-field
+(rf.hicasso/defview body-field
   "The same law on the other convergeable tag. Identical in every respect
   a reader would care about, which is the claim — `<textarea>` is not a
   second controlled-input story."
@@ -91,11 +91,11 @@
    [:label {:for "body"} label]
    [:textarea {:id          "body"
                :data-field  "body"
-               ::h/revision (h/sub [::subs/revision])
-               :value       (h/sub [::subs/field :body])
-               :on-input    [::events/edit :body ::h/value]}]])
+               ::rf.hicasso/revision (rf.hicasso/sub [::rf.hicasso.examples.editor.subs/revision])
+               :value       (rf.hicasso/sub [::rf.hicasso.examples.editor.subs/field :body])
+               :on-input    [::rf.hicasso.examples.editor.events/edit :body ::rf.hicasso/value]}]])
 
-(h/defview published-box
+(rf.hicasso/defview published-box
   "The owned `::h/checked` pair.
 
   It carries NO `::h/revision`, and the omission is not a choice: a
@@ -113,14 +113,14 @@
    [:input {:id         "published"
             :type       "checkbox"
             :data-field "published"
-            :checked    (h/sub [::subs/field :published?])
-            :on-change  [::events/set-published ::h/checked]}]])
+            :checked    (rf.hicasso/sub [::rf.hicasso.examples.editor.subs/field :published?])
+            :on-change  [::rf.hicasso.examples.editor.events/set-published ::rf.hicasso/checked]}]])
 
 ;; ---------------------------------------------------------------------------
 ;; The form's other two boundaries
 ;; ---------------------------------------------------------------------------
 
-(h/defview buttons
+(rf.hicasso/defview buttons
   "Save and Discard, in their own boundary reading their own one value.
 
   Separate from the fields on purpose: `::subs/dirty?` moves on the
@@ -129,20 +129,20 @@
   buttons in with a field would have put that read on the field's edge
   set and re-run the field on every change to it."
   [_]
-  (let [dirty? (h/sub [::subs/dirty?])]
+  (let [dirty? (rf.hicasso/sub [::rf.hicasso.examples.editor.subs/dirty?])]
     [:p.buttons
      [:button {:id       "save"
                :type     "button"
                :disabled (not dirty?)
-               :on-click [::events/save]}
+               :on-click [::rf.hicasso.examples.editor.events/save]}
       "Save"]
      [:button {:id       "discard"
                :type     "button"
                :disabled (not dirty?)
-               :on-click [::events/discard]}
+               :on-click [::rf.hicasso.examples.editor.events/discard]}
       "Discard"]]))
 
-(h/defview readout
+(rf.hicasso/defview readout
   "The COMMITTED article, on the page.
 
   Its own boundary reading the committed addresses, so a keystroke — which
@@ -151,17 +151,17 @@
   not move while you type, and moves when you save."
   [_]
   [:dl.committed
-   [:dt "title"] [:dd {:data-committed "title"} (h/sub [::subs/committed :title])]
-   [:dt "slug"] [:dd {:data-committed "slug"} (h/sub [::subs/committed :slug])]
-   [:dt "body"] [:dd {:data-committed "body"} (h/sub [::subs/committed :body])]
+   [:dt "title"] [:dd {:data-committed "title"} (rf.hicasso/sub [::rf.hicasso.examples.editor.subs/committed :title])]
+   [:dt "slug"] [:dd {:data-committed "slug"} (rf.hicasso/sub [::rf.hicasso.examples.editor.subs/committed :slug])]
+   [:dt "body"] [:dd {:data-committed "body"} (rf.hicasso/sub [::rf.hicasso.examples.editor.subs/committed :body])]
    [:dt "published"] [:dd {:data-committed "published"}
-                      (str (boolean (h/sub [::subs/committed :published?])))]])
+                      (str (boolean (rf.hicasso/sub [::rf.hicasso.examples.editor.subs/committed :published?])))]])
 
 ;; ---------------------------------------------------------------------------
 ;; The form
 ;; ---------------------------------------------------------------------------
 
-(h/defview editor
+(rf.hicasso/defview editor
   "The whole application, and it reads nothing.
 
   Every value on this page comes from a child's own body, so this body

--- a/implementation/hicasso/test/re_frame/hicasso/examples/fence_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/fence_cljs_test.cljs
@@ -196,9 +196,9 @@
   ;; the public door, through the same reader and predicates the live row
   ;; uses. Both plants are named by package; the door is not.
   (let [form  '(ns re-frame.hicasso.examples.planted.views
-                 (:require [re-frame.hicasso :as h]
-                           [re-frame.hicasso.impl.collector :as collector])
-                 (:require-macros [re-frame.hicasso.test.mounted :as hm]))
+                 (:require [re-frame.hicasso :as rf.hicasso]
+                           [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector])
+                 (:require-macros [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]))
         found (breaches {"planted" {"planted/views.cljs" (dependencies form)}})]
     (is (= #{"re-frame.hicasso.impl.collector" "re-frame.hicasso.test.mounted"}
            (into #{} (map #(nth % 2)) found)))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/forms/db.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/forms/db.cljs
@@ -35,7 +35,7 @@
   application does not pay for it — and the reason is written down
   because *which of the two* is the question a reader arrives with."
   (:require [clojure.string :as str]
-            [re-frame.hicasso :as h]))
+            [re-frame.hicasso :as rf.hicasso]))
 
 ;; ---------------------------------------------------------------------------
 ;; The shape
@@ -81,7 +81,7 @@
   `h/reg-state`'s own stated reason: a fixed `[:ui :subject-draft]` would
   be ONE draft shared by every ticket on the page, opening them all
   together with nothing on screen to say so."
-  (h/reg-state ::subject-draft {:default nil}))
+  (rf.hicasso/reg-state ::subject-draft {:default nil}))
 
 (defn draft-path
   "`h/reg-state`'s documented `app-db` layout for [[subject-draft]] — the

--- a/implementation/hicasso/test/re_frame/hicasso/examples/forms/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/forms/events.cljs
@@ -60,7 +60,7 @@
             ;; Side-effecting: registers the `:rf.mutation/*` events and the
             ;; passive `:rf/mutation` subscription this form reads.
             [re-frame.resources]
-            [re-frame.hicasso.examples.forms.db :as db]))
+            [re-frame.hicasso.examples.forms.db :as rf.hicasso.examples.forms.db]))
 
 ;; ---------------------------------------------------------------------------
 ;; Boot
@@ -68,7 +68,7 @@
 
 (rf/reg-event ::seed
   {:doc "Install the starting app-db. The frame's `:initial-events` step."}
-  (fn [_ _] {:db (db/seed)}))
+  (fn [_ _] {:db (rf.hicasso.examples.forms.db/seed)}))
 
 ;; ---------------------------------------------------------------------------
 ;; Recipe 1 — the buffered subject field
@@ -86,7 +86,7 @@
   that debt comes due."
   [db ikey]
   (-> db
-      (update-in (pop (db/draft-path ikey)) dissoc ikey)
+      (update-in (pop (rf.hicasso.examples.forms.db/draft-path ikey)) dissoc ikey)
       (update-in [:subject-revision ikey] (fnil inc 0))))
 
 (rf/reg-event ::commit-subject
@@ -101,7 +101,7 @@
          or a blur arriving after Escape all find no session the second
          time and do nothing."}
   (fn [{:keys [db]} [_ ikey]]
-    (if-some [typed (get-in db (db/draft-path ikey))]
+    (if-some [typed (get-in db (rf.hicasso.examples.forms.db/draft-path ikey))]
       (let [candidate (str/trim typed)]
         (if (str/blank? candidate)
           ;; REFUSE. The subject does not move, so nothing the field reads
@@ -122,7 +122,7 @@
          *cancel must beat the late blur*, answered by the model rather
          than by ordering."}
   (fn [{:keys [db]} [_ ikey]]
-    (if (contains? (get-in db (pop (db/draft-path ikey))) ikey)
+    (if (contains? (get-in db (pop (rf.hicasso.examples.forms.db/draft-path ikey))) ikey)
       {:db (end-session db ikey)}
       {})))
 
@@ -191,7 +191,7 @@
          accepted branch executes the write."}
   (fn [{:keys [db]} _]
     (let [attempted (assoc-in db [:form :attempted?] true)]
-      (if-not (db/can-submit? db)
+      (if-not (rf.hicasso.examples.forms.db/can-submit? db)
         {:db attempted}
         {:db attempted
          :fx [[:dispatch [:rf.mutation/execute
@@ -212,5 +212,5 @@
     (if (= :ok status)
       {:db (-> db
                (update :ticket merge (get-in db [:form :draft]))
-               (assoc :form db/blank-form))}
+               (assoc :form rf.hicasso.examples.forms.db/blank-form))}
       {})))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/forms/flow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/forms/flow_dom_cljs_test.cljs
@@ -49,16 +49,16 @@
   and each row degrades there to a STATED skip rather than a false
   green."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.forms.events :as events]
-            [re-frame.hicasso.examples.forms.subs :as subs]
-            [re-frame.hicasso.examples.forms.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
+            [re-frame.fx :as rf.fx]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.forms.events :as rf.hicasso.examples.forms.events]
+            [re-frame.hicasso.examples.forms.subs :as rf.hicasso.examples.forms.subs]
+            [re-frame.hicasso.examples.forms.views :as rf.hicasso.examples.forms.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
             [re-frame.http.managed]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The lane
@@ -70,8 +70,8 @@
   (is true (str "a mounted form needs a real React DOM — " why)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The MAP shape, because every row is `async`: `cljs.test` refuses an
      ;; async test under a fn-form fixture and aborts the namespace.
@@ -85,7 +85,7 @@
                       ;; ns-load registration is not still there when a row
                       ;; runs. `events/register-save!` says what that costs
                       ;; when it is forgotten.
-                      (events/register-save!))}))
+                      (rf.hicasso.examples.forms.events/register-save!))}))
 
 (def ^:private ticket 7)
 (def ^:private committed "Login page hangs on submit")
@@ -112,7 +112,7 @@
   (let [d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
     (.call (.-set d) n v)
     (.dispatchEvent n (js/InputEvent. "input" #js {:bubbles true}))
-    (hm/settle! m)))
+    (rf.hicasso.test.mounted/settle! m)))
 
 (defn- drift!
   "Move the field's value WITHOUT telling React — the foreign write an
@@ -130,24 +130,24 @@
   real one."
   [m n key]
   (.dispatchEvent n (js/KeyboardEvent. "keydown" #js {:key key :bubbles true}))
-  (hm/settle! m))
+  (rf.hicasso.test.mounted/settle! m))
 
 (defn- blur!
   "Take focus off `n` for real, which is what fires React's `onBlur`."
   [m n]
   (.blur n)
-  (hm/settle! m))
+  (rf.hicasso.test.mounted/settle! m))
 
 (defn- read-sub [m query-v] (rf/subscribe-once query-v {:frame (:frame m)}))
 
 (defn- mount-screen!
-  ([] (mount-screen! [views/screen {:ikey ticket}]))
-  ([form] (hm/mount! form {:initial-events [[::events/seed]]})))
+  ([] (mount-screen! [rf.hicasso.examples.forms.views/screen {:ikey ticket}]))
+  ([form] (rf.hicasso.test.mounted/mount! form {:initial-events [[::rf.hicasso.examples.forms.events/seed]]})))
 
 (defn- finish
   "Tear down, assert this mount left nothing behind, and end the row."
   [m done]
-  (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))
+  (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!) (.then done)))
 
 (defn- report-rejection!
   "The default reporter: a rejected wait is this row's failure, said in
@@ -226,7 +226,7 @@
             "the trailing blur found no session and committed nothing —
              cancel beats the late blur through the model, not through
              ordering")
-        (is (= 1 (read-sub m [::subs/subject-revision ticket]))
+        (is (= 1 (read-sub m [::rf.hicasso.examples.forms.subs/subject-revision ticket]))
             "and it moved the revision exactly once: the cancel's. A blur
              that ran would have moved it a second time, which is the
              narrower thing this line is watching for")
@@ -266,10 +266,10 @@
         ;; reach no handler and open no session at all.
         (type-into! m n "Login page hangs on submi")
         (type-into! m n committed)
-        (is (= committed (read-sub m [::subs/subject-shown ticket]))
+        (is (= committed (read-sub m [::rf.hicasso.examples.forms.subs/subject-shown ticket]))
             "so the value the field reads is what it was before the session
              opened, and ending the session will not move it")
-        (is (true? (read-sub m [::subs/editing? ticket])))
+        (is (true? (read-sub m [::rf.hicasso.examples.forms.subs/editing? ticket])))
         ;; The drift: a write React never saw and no handler ran for.
         (drift! n "autofilled@example.com")
         (is (= "autofilled@example.com" (.-value n)))
@@ -290,9 +290,9 @@
       (let [m (mount-screen!)]
         (.focus (subject-node m))
         (type-into! m (subject-node m) "half typed")
-        (hm/rerender! m [views/details-form {}])
+        (rf.hicasso.test.mounted/rerender! m [rf.hicasso.examples.forms.views/details-form {}])
         (is (nil? (subject-node m)) "the field is off the page")
-        (hm/rerender! m [views/screen {:ikey ticket}])
+        (rf.hicasso.test.mounted/rerender! m [rf.hicasso.examples.forms.views/screen {:ikey ticket}])
         (is (= "half typed" (.-value (subject-node m)))
             "and it comes back holding the draft — which lives at an address
              in app-db, not in a fiber that was just thrown away")
@@ -301,15 +301,15 @@
              neither a commit nor a cancel")
         (finish m done)))))
 
-(h/defview two-tickets
+(rf.hicasso/defview two-tickets
   "Two of the same field on one page, on different instance keys — the
   arrangement `h/reg-state` exists for. The seed holds one ticket, so
   both fields start from the same committed text, which makes a
   collision harder to miss rather than easier."
   [_]
   [:div.two-tickets
-   [views/subject-field {:ikey 7}]
-   [views/subject-field {:ikey 9}]])
+   [rf.hicasso.examples.forms.views/subject-field {:ikey 7}]
+   [rf.hicasso.examples.forms.views/subject-field {:ikey 9}]])
 
 (deftest two-tickets-edit-independently-on-one-page
   (async done
@@ -326,7 +326,7 @@
             "a hand-picked `[:ui :subject-draft]` path would have moved both,
              and nothing on screen would have said so")
         (press! m n7 "Escape")
-        (is (= 0 (read-sub m [::subs/subject-revision 9]))
+        (is (= 0 (read-sub m [::rf.hicasso.examples.forms.subs/subject-revision 9]))
             "and the cancel moved one revision, not two — a reset is per
              instance")
         (finish m done)))))
@@ -339,7 +339,7 @@
 
 (defn- capture-transport! []
   (reset! !requests [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! !requests conj args) nil)))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! !requests conj args) nil)))
 
 (deftest a-refused-submission-reveals-the-problem-it-has-and-no-other
   (async done
@@ -349,7 +349,7 @@
             m (mount-screen!)]
         (is (nil? (node m ".field-problem")) "a blank form reports nothing")
         (.requestSubmit (node m "form.details"))
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (is (= 1 (.-length (.querySelectorAll (:container m) ".field-problem")))
             "one problem — the blank assignee. The note is empty and empty is
              legal, so a gate that revealed both would be reporting a
@@ -374,9 +374,9 @@
         ;; recorder on the next line reads it before that turn. So a marker
         ;; goes through the same queue and the assertion waits behind it —
         ;; anything the submission enqueued has run by then.
-        (rf/dispatch [::events/edit :notes "marker"] {:frame (:frame m)})
-        (-> (test-support/poll-until
-              #(= "marker" (read-sub m [::subs/field :notes]))
+        (rf/dispatch [::rf.hicasso.examples.forms.events/edit :notes "marker"] {:frame (:frame m)})
+        (-> (rf.test-support/poll-until
+              #(= "marker" (read-sub m [::rf.hicasso.examples.forms.subs/field :notes]))
               {:label "the dispatch queue to reach a marker enqueued after the submit"})
             (.then (fn [_]
                      (is (= [] @!requests)
@@ -407,16 +407,16 @@
         ;; dispatch is synchronous, but the `:fx [[:dispatch …]]` a handler
         ;; returns is a turn of its own. `hm/settle!` is a React flush and
         ;; cannot help, because nothing is scheduled in React yet.
-        (-> (test-support/poll-until #(seq @!requests)
+        (-> (rf.test-support/poll-until #(seq @!requests)
                                      {:label "the write to reach the transport"})
             (.then
               (fn [_]
-                (hm/settle! m)
+                (rf.hicasso.test.mounted/settle! m)
                 (is (= 1 (count @!requests)))
                 (is (true? (.-disabled button)) "busy — from the instance")
                 (is (true? (.-disabled (node m "#ticket-assignee")))
                     "and so are the fields, off the same read")
-                (hm/dispatch-and-settle! m (conj (:on-success (last @!requests))
+                (rf.hicasso.test.mounted/dispatch-and-settle! m (conj (:on-success (last @!requests))
                                                  {:status :ok :value {:ok true}}))
                 (is (false? (.-disabled button)))
                 (is (= "" (.-value (node m "#ticket-assignee")))
@@ -444,11 +444,11 @@
   (async done
     (if-not (browser?)
       (do (skip! "a real mount to strand") (done))
-      (let [before    (hm/census)
+      (let [before    (rf.hicasso.test.mounted/census)
             m         (mount-screen!)
             !reported (atom nil)]
-        (is (not= before (hm/census)) "the mount is up and the page shows it")
-        (-> (test-support/poll-until
+        (is (not= before (rf.hicasso.test.mounted/census)) "the mount is up and the page shows it")
+        (-> (rf.test-support/poll-until
               (constantly false)
               {:label "a condition arranged never to hold" :timeout-ms 50 :interval-ms 5})
             (finish-after
@@ -470,7 +470,7 @@
                 (is (true? (:clean? report)))
                 (is (zero? (:standing report))
                     "and no facade mount is left standing")
-                (is (= before (hm/census))
+                (is (= before (rf.hicasso.test.mounted/census))
                     "so the page a following row opens on is the page this
                      row found — nothing retained, no residue to be charged
                      to whoever runs next")

--- a/implementation/hicasso/test/re_frame/hicasso/examples/forms/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/forms/l0_cljs_test.cljs
@@ -25,22 +25,22 @@
   nothing, so each row below is written to state what it would take to
   make it red."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.hicasso.examples.forms.db :as db]
-            [re-frame.hicasso.examples.forms.events :as events]
-            [re-frame.hicasso.examples.forms.subs :as subs]
+            [re-frame.fx :as rf.fx]
+            [re-frame.hicasso.examples.forms.db :as rf.hicasso.examples.forms.db]
+            [re-frame.hicasso.examples.forms.events :as rf.hicasso.examples.forms.events]
+            [re-frame.hicasso.examples.forms.subs :as rf.hicasso.examples.forms.subs]
             ;; The production managed-HTTP fx surface, so the mutation's
             ;; transport probe resolves. The fetch itself never happens —
             ;; `capture-transport!` below replaces the effect with a
             ;; recorder and the rows replay the transport's own reply shape.
             [re-frame.http.managed]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The reset restores the registrar to a baseline and the resources
      ;; artefact clears the mutation kind, so the ns-load registration may
@@ -48,7 +48,7 @@
      ;; not in the browser one, which is exactly the kind of luck a
      ;; witness should not be standing on — see `events/register-save!`
      ;; for what its absence costs.
-     :init-fn       (fn [] (events/register-save!))}))
+     :init-fn       (fn [] (rf.hicasso.examples.forms.events/register-save!))}))
 
 (def ^:private ticket 7)
 
@@ -56,7 +56,7 @@
   "Run `f` against a fresh frame booted with the application's own seed
   event, and destroy it afterwards."
   [f]
-  (rf/with-new-frame [frame (rf/make-frame {:initial-events [[::events/seed]]})]
+  (rf/with-new-frame [frame (rf/make-frame {:initial-events [[::rf.hicasso.examples.forms.events/seed]]})]
     (f frame)))
 
 (defn- read-sub [frame query-v] (rf/subscribe-once query-v {:frame frame}))
@@ -67,39 +67,39 @@
   "Type `text` into the buffered subject field — `h/reg-state`'s own
   setter event, which is what `:on-input` dispatches."
   [frame text]
-  (send! frame [db/subject-draft ticket text]))
+  (send! frame [rf.hicasso.examples.forms.db/subject-draft ticket text]))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure — the rules, with no runtime anywhere
 ;; ---------------------------------------------------------------------------
 
 (deftest the-rules-are-a-function-of-the-draft-alone
-  (is (= {} (db/problems {:assignee "ada" :notes ""})))
-  (is (= {:assignee :problem/assignee-blank} (db/problems {:assignee "  " :notes ""})))
+  (is (= {} (rf.hicasso.examples.forms.db/problems {:assignee "ada" :notes ""})))
+  (is (= {:assignee :problem/assignee-blank} (rf.hicasso.examples.forms.db/problems {:assignee "  " :notes ""})))
   (is (= {:notes :problem/notes-too-long}
-         (db/problems {:assignee "ada" :notes (apply str (repeat (inc db/notes-limit) "x"))})))
+         (rf.hicasso.examples.forms.db/problems {:assignee "ada" :notes (apply str (repeat (inc rf.hicasso.examples.forms.db/notes-limit) "x"))})))
   (testing "exactly at the limit is legal — the near-miss the guard must not catch"
-    (is (= {} (db/problems {:assignee "ada" :notes (apply str (repeat db/notes-limit "x"))}))))
+    (is (= {} (rf.hicasso.examples.forms.db/problems {:assignee "ada" :notes (apply str (repeat rf.hicasso.examples.forms.db/notes-limit "x"))}))))
   (testing "both at once, because a submit attempt reveals every one of them"
     (is (= #{:assignee :notes}
-           (set (keys (db/problems {:assignee "" :notes (apply str (repeat 200 "x"))})))))))
+           (set (keys (rf.hicasso.examples.forms.db/problems {:assignee "" :notes (apply str (repeat 200 "x"))})))))))
 
 (deftest a-problem-is-not-shown-until-it-is-earned
   (let [form {:draft {:assignee "" :notes ""} :touched #{} :attempted? false}]
     (testing "R-A5 — a blank form on first paint reports nothing"
-      (is (nil? (db/shown-problem form :assignee))
+      (is (nil? (rf.hicasso.examples.forms.db/shown-problem form :assignee))
           "the problem EXISTS; showing it before the user has been near the
            field is the defect this gate deletes"))
     (testing "touching the field it belongs to reveals it"
       (is (= :problem/assignee-blank
-             (db/shown-problem (assoc form :touched #{:assignee}) :assignee))))
+             (rf.hicasso.examples.forms.db/shown-problem (assoc form :touched #{:assignee}) :assignee))))
     (testing "and touching its NEIGHBOUR does not — the gate is per field"
-      (is (nil? (db/shown-problem (assoc form :touched #{:notes}) :assignee))))
+      (is (nil? (rf.hicasso.examples.forms.db/shown-problem (assoc form :touched #{:notes}) :assignee))))
     (testing "a submit attempt reveals every field at once"
       (is (= :problem/assignee-blank
-             (db/shown-problem (assoc form :attempted? true) :assignee))))
+             (rf.hicasso.examples.forms.db/shown-problem (assoc form :attempted? true) :assignee))))
     (testing "and reveals nothing that is not a problem"
-      (is (nil? (db/shown-problem (-> form
+      (is (nil? (rf.hicasso.examples.forms.db/shown-problem (-> form
                                       (assoc :attempted? true)
                                       (assoc-in [:draft :assignee] "ada"))
                                   :assignee))
@@ -112,10 +112,10 @@
 (deftest the-field-is-populated-before-anybody-types
   (with-app
     (fn [frame]
-      (is (= "Login page hangs on submit" (read-sub frame [::subs/subject-shown ticket]))
+      (is (= "Login page hangs on submit" (read-sub frame [::rf.hicasso.examples.forms.subs/subject-shown ticket]))
           "no draft, so the committed subject is what the field shows —
            there is no load-the-form step to forget")
-      (is (false? (read-sub frame [::subs/editing? ticket]))
+      (is (false? (read-sub frame [::rf.hicasso.examples.forms.subs/editing? ticket]))
           "and reading is not editing"))))
 
 (deftest a-keystroke-opens-the-session-and-nothing-else-moves
@@ -124,8 +124,8 @@
       (let [before (app-db-of frame)]
         (type-subject! frame "Login page hangs")
         (let [after (app-db-of frame)]
-          (is (= "Login page hangs" (read-sub frame [::subs/subject-shown ticket])))
-          (is (true? (read-sub frame [::subs/editing? ticket])))
+          (is (= "Login page hangs" (read-sub frame [::rf.hicasso.examples.forms.subs/subject-shown ticket])))
+          (is (true? (read-sub frame [::rf.hicasso.examples.forms.subs/editing? ticket])))
           (is (= (:ticket before) (:ticket after))
               "the committed subject has not moved — that is what BUFFERED means")
           (is (= (:subject-revision before) (:subject-revision after))
@@ -135,11 +135,11 @@
   (with-app
     (fn [frame]
       (type-subject! frame "  Login times out  ")
-      (send! frame [::events/commit-subject ticket])
+      (send! frame [::rf.hicasso.examples.forms.events/commit-subject ticket])
       (is (= "Login times out" (get-in (app-db-of frame) [:ticket :subject])))
-      (is (false? (read-sub frame [::subs/editing? ticket]))
+      (is (false? (read-sub frame [::rf.hicasso.examples.forms.subs/editing? ticket]))
           "the session is over — the draft is gone, not merely equal")
-      (is (= 1 (read-sub frame [::subs/subject-revision ticket]))
+      (is (= 1 (read-sub frame [::rf.hicasso.examples.forms.subs/subject-revision ticket]))
           "and the revision moved, which is what re-baselines a field that
            is still mounted"))))
 
@@ -150,15 +150,15 @@
   (with-app
     (fn [frame]
       (type-subject! frame "   ")
-      (send! frame [::events/commit-subject ticket])
+      (send! frame [::rf.hicasso.examples.forms.events/commit-subject ticket])
       (is (= "Login page hangs on submit" (get-in (app-db-of frame) [:ticket :subject]))
           "blank is refused — the committed subject does NOT move")
-      (is (= 1 (read-sub frame [::subs/subject-revision ticket]))
+      (is (= 1 (read-sub frame [::rf.hicasso.examples.forms.subs/subject-revision ticket]))
           "and the revision moves ANYWAY. Delete the revision bump from the
            refusing branch of `events/end-session` and this line reds; it is
            the only signal a refusal has, because value equality is blind to
            it by construction")
-      (is (false? (read-sub frame [::subs/editing? ticket]))
+      (is (false? (read-sub frame [::rf.hicasso.examples.forms.subs/editing? ticket]))
           "a refusal ends the session too — the user is shown the committed
            value back, not left holding text nothing will accept"))))
 
@@ -168,12 +168,12 @@
   (with-app
     (fn [frame]
       (type-subject! frame "half-typed nonsense")
-      (send! frame [::events/cancel-subject ticket])
-      (is (= "Login page hangs on submit" (read-sub frame [::subs/subject-shown ticket])))
-      (is (= 1 (read-sub frame [::subs/subject-revision ticket])))
+      (send! frame [::rf.hicasso.examples.forms.events/cancel-subject ticket])
+      (is (= "Login page hangs on submit" (read-sub frame [::rf.hicasso.examples.forms.subs/subject-shown ticket])))
+      (is (= 1 (read-sub frame [::rf.hicasso.examples.forms.subs/subject-revision ticket])))
       (testing "the blur that follows finds no session and commits nothing"
         (let [before (app-db-of frame)]
-          (send! frame [::events/commit-subject ticket])
+          (send! frame [::rf.hicasso.examples.forms.events/commit-subject ticket])
           (is (= before (app-db-of frame))
               "not merely 'the subject is unchanged' — NOTHING is, including
                the revision. A commit that ran and happened to write the same
@@ -184,9 +184,9 @@
   (with-app
     (fn [frame]
       (type-subject! frame "Login times out")
-      (send! frame [::events/commit-subject ticket])
+      (send! frame [::rf.hicasso.examples.forms.events/commit-subject ticket])
       (let [after-first (app-db-of frame)]
-        (send! frame [::events/commit-subject ticket])
+        (send! frame [::rf.hicasso.examples.forms.events/commit-subject ticket])
         (is (= after-first (app-db-of frame))
             "Enter then blur, or double Enter: the second finds no session")))))
 
@@ -195,14 +195,14 @@
   ;; `[:ui :subject-draft]` path would be ONE draft for the whole page.
   (with-app
     (fn [frame]
-      (send! frame [db/subject-draft 7 "seven"])
-      (send! frame [db/subject-draft 9 "nine"])
-      (is (= "seven" (read-sub frame [::subs/subject-shown 7])))
-      (is (= "nine" (read-sub frame [::subs/subject-shown 9])))
+      (send! frame [rf.hicasso.examples.forms.db/subject-draft 7 "seven"])
+      (send! frame [rf.hicasso.examples.forms.db/subject-draft 9 "nine"])
+      (is (= "seven" (read-sub frame [::rf.hicasso.examples.forms.subs/subject-shown 7])))
+      (is (= "nine" (read-sub frame [::rf.hicasso.examples.forms.subs/subject-shown 9])))
       (testing "and ending one session leaves the other's alone"
-        (send! frame [::events/cancel-subject 7])
-        (is (= "nine" (read-sub frame [::subs/subject-shown 9])))
-        (is (= 0 (read-sub frame [::subs/subject-revision 9]))
+        (send! frame [::rf.hicasso.examples.forms.events/cancel-subject 7])
+        (is (= "nine" (read-sub frame [::rf.hicasso.examples.forms.subs/subject-shown 9])))
+        (is (= 0 (read-sub frame [::rf.hicasso.examples.forms.subs/subject-revision 9]))
             "including its revision — a reset is per instance")))))
 
 ;; ---------------------------------------------------------------------------
@@ -212,12 +212,12 @@
 (deftest a-refused-submission-reveals-every-problem-and-asks-for-nothing
   (with-app
     (fn [frame]
-      (is (nil? (read-sub frame [::subs/shown-problem :assignee]))
+      (is (nil? (read-sub frame [::rf.hicasso.examples.forms.subs/shown-problem :assignee]))
           "before the attempt")
-      (send! frame [::events/submit])
-      (is (= :problem/assignee-blank (read-sub frame [::subs/shown-problem :assignee]))
+      (send! frame [::rf.hicasso.examples.forms.events/submit])
+      (is (= :problem/assignee-blank (read-sub frame [::rf.hicasso.examples.forms.subs/shown-problem :assignee]))
           "after it")
-      (is (false? (read-sub frame [::subs/can-submit?]))
+      (is (false? (read-sub frame [::rf.hicasso.examples.forms.subs/can-submit?]))
           "and the gate the button reads still says no"))))
 
 (deftest the-button-and-the-handler-read-one-definition
@@ -227,18 +227,18 @@
   (with-app
     (fn [frame]
       (doseq [text ["" "  " "ada" ""]]
-        (send! frame [::events/edit :assignee text])
-        (is (= (db/can-submit? (app-db-of frame))
-               (read-sub frame [::subs/can-submit?]))
+        (send! frame [::rf.hicasso.examples.forms.events/edit :assignee text])
+        (is (= (rf.hicasso.examples.forms.db/can-submit? (app-db-of frame))
+               (read-sub frame [::rf.hicasso.examples.forms.subs/can-submit?]))
             (str "gate agreement after typing " (pr-str text)))))))
 
 (deftest a-problem-clears-as-soon-as-the-field-is-repaired
   (with-app
     (fn [frame]
-      (send! frame [::events/touch {:field :assignee}])
-      (is (some? (read-sub frame [::subs/shown-problem :assignee])))
-      (send! frame [::events/edit :assignee "ada"])
-      (is (nil? (read-sub frame [::subs/shown-problem :assignee]))
+      (send! frame [::rf.hicasso.examples.forms.events/touch {:field :assignee}])
+      (is (some? (read-sub frame [::rf.hicasso.examples.forms.subs/shown-problem :assignee])))
+      (send! frame [::rf.hicasso.examples.forms.events/edit :assignee "ada"])
+      (is (nil? (read-sub frame [::rf.hicasso.examples.forms.subs/shown-problem :assignee]))
           "the problem is derived from the current draft, so repairing the
            field clears it without a second event to remember"))))
 
@@ -259,7 +259,7 @@
   transport would have produced."
   []
   (reset! !requests [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! !requests conj args) nil)))
+  (rf.fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! !requests conj args) nil)))
 
 (defn- reply-ok! [frame args value]
   (send! frame (conj (:on-success args) {:status :ok :value value})))
@@ -268,17 +268,17 @@
   (send! frame (conj (:on-failure args) {:status :error :error error})))
 
 (defn- fill-valid! [frame]
-  (send! frame [::events/edit :assignee "ada"])
-  (send! frame [::events/edit :notes "reproduced on staging"]))
+  (send! frame [::rf.hicasso.examples.forms.events/edit :assignee "ada"])
+  (send! frame [::rf.hicasso.examples.forms.events/edit :notes "reproduced on staging"]))
 
 (defn- status [frame]
-  (read-sub frame [:rf/mutation {:instance events/save-instance}]))
+  (read-sub frame [:rf/mutation {:instance rf.hicasso.examples.forms.events/save-instance}]))
 
 (deftest a-refused-submission-asks-the-server-for-nothing
   (capture-transport!)
   (with-app
     (fn [frame]
-      (send! frame [::events/submit])
+      (send! frame [::rf.hicasso.examples.forms.events/submit])
       (is (= [] @!requests)
           "the gate refused, so no write was executed at all")
       (is (false? (:pending? (status frame)))
@@ -293,7 +293,7 @@
   (with-app
     (fn [frame]
       (fill-valid! frame)
-      (send! frame [::events/submit])
+      (send! frame [::rf.hicasso.examples.forms.events/submit])
       (is (= 1 (count @!requests)))
       (is (true? (:pending? (status frame)))
           "pending comes from the instance; this application writes no
@@ -303,14 +303,14 @@
       (is (true? (:success? (status frame))))
       (testing "and the reply landed at the named event, which reset the form"
         (is (= "ada" (get-in (app-db-of frame) [:ticket :assignee])))
-        (is (= db/blank-form (:form (app-db-of frame))))))))
+        (is (= rf.hicasso.examples.forms.db/blank-form (:form (app-db-of frame))))))))
 
 (deftest a-failed-write-leaves-the-draft-alone-and-says-so-once
   (capture-transport!)
   (with-app
     (fn [frame]
       (fill-valid! frame)
-      (send! frame [::events/submit])
+      (send! frame [::rf.hicasso.examples.forms.events/submit])
       (reply-error! frame (last @!requests) {:message "boom"})
       (is (true? (:error? (status frame))))
       (is (false? (:pending? (status frame)))
@@ -326,10 +326,10 @@
   (with-app
     (fn [frame]
       (fill-valid! frame)
-      (send! frame [::events/submit])
+      (send! frame [::rf.hicasso.examples.forms.events/submit])
       (let [first-args (last @!requests)]
-        (send! frame [::events/edit :assignee "grace"])
-        (send! frame [::events/submit])
+        (send! frame [::rf.hicasso.examples.forms.events/edit :assignee "grace"])
+        (send! frame [::rf.hicasso.examples.forms.events/submit])
         (let [second-args (last @!requests)]
           (is (= 2 (count @!requests)) "two writes under one instance")
           (is (not= (:on-success first-args) (:on-success second-args))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/forms/l2_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/forms/l2_cljs_test.cljs
@@ -28,24 +28,24 @@
   re-renders, and on a form every one of those decisions is paid per
   keystroke."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.forms.db :as db]
-            [re-frame.hicasso.examples.forms.events :as events]
-            [re-frame.hicasso.examples.forms.subs :as subs]
-            [re-frame.hicasso.examples.forms.views :as views]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.forms.db :as rf.hicasso.examples.forms.db]
+            [re-frame.hicasso.examples.forms.events :as rf.hicasso.examples.forms.events]
+            [re-frame.hicasso.examples.forms.subs :as rf.hicasso.examples.forms.subs]
+            [re-frame.hicasso.examples.forms.views :as rf.hicasso.examples.forms.views]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 (def ^:private ticket 7)
 
-(defn- tagged [tree tag] (ht/find tree #(= tag (:tag %))))
-(defn- classed [tree class] (ht/find tree #(= class (:class (ht/attrs %)))))
+(defn- tagged [tree tag] (rf.hicasso.test/find tree #(= tag (:tag %))))
+(defn- classed [tree class] (rf.hicasso.test/find tree #(= class (:class (rf.hicasso.test/attrs %)))))
 
 (def ^:private idle
   "A mutation instance nobody has executed — the shape `:rf/mutation`
@@ -58,21 +58,21 @@
   closing does not re-render the field — see `views/subject-hint` on why
   that separation is what keeps `::h/revision` load-bearing."
   [{:keys [shown revision]}]
-  (ht/tree [views/subject-field {:ikey ticket}]
-           {:subs {[::subs/subject-shown ticket]    shown
-                   [::subs/subject-revision ticket] revision}}))
+  (rf.hicasso.test/tree [rf.hicasso.examples.forms.views/subject-field {:ikey ticket}]
+           {:subs {[::rf.hicasso.examples.forms.subs/subject-shown ticket]    shown
+                   [::rf.hicasso.examples.forms.subs/subject-revision ticket] revision}}))
 
 (defn- hint-tree [editing?]
-  (ht/tree [views/subject-hint {:ikey ticket}]
-           {:subs {[::subs/editing? ticket] (boolean editing?)}}))
+  (rf.hicasso.test/tree [rf.hicasso.examples.forms.views/subject-hint {:ikey ticket}]
+           {:subs {[::rf.hicasso.examples.forms.subs/editing? ticket] (boolean editing?)}}))
 
 (defn- field-tree
   [{:keys [field label multiline? text problem save]}]
-  (ht/tree [views/field-row (cond-> {:field field :label label}
+  (rf.hicasso.test/tree [rf.hicasso.examples.forms.views/field-row (cond-> {:field field :label label}
                               multiline? (assoc :multiline? true))]
-           {:subs {[::subs/field field]                              text
-                   [::subs/shown-problem field]                      problem
-                   [:rf/mutation {:instance events/save-instance}]   (or save idle)}}))
+           {:subs {[::rf.hicasso.examples.forms.subs/field field]                              text
+                   [::rf.hicasso.examples.forms.subs/shown-problem field]                      problem
+                   [:rf/mutation {:instance rf.hicasso.examples.forms.events/save-instance}]   (or save idle)}}))
 
 ;; ---------------------------------------------------------------------------
 ;; Recipe 1 — the buffered field's markup
@@ -80,15 +80,15 @@
 
 (deftest the-subject-field-is-value-revision-and-three-intents
   (let [tree  (subject-tree {:shown "Login page hangs" :revision 2})
-        attrs (ht/attrs (tagged tree :input))]
+        attrs (rf.hicasso.test/attrs (tagged tree :input))]
     (is (= "Login page hangs" (:value attrs)))
-    (is (= [db/subject-draft ticket ::h/value] (:on-input attrs))
+    (is (= [rf.hicasso.examples.forms.db/subject-draft ticket ::rf.hicasso/value] (:on-input attrs))
         "typing writes h/reg-state's own setter, keyed by the ticket —
          POSITIONAL, because a marker inside a payload map is substituted
          nowhere and arrives as the keyword itself")
-    (is (= [::events/commit-subject ticket] (:on-blur attrs)))
-    (is (= {"Enter"  [::events/commit-subject ticket]
-            "Escape" [::events/cancel-subject ticket]}
+    (is (= [::rf.hicasso.examples.forms.events/commit-subject ticket] (:on-blur attrs)))
+    (is (= {"Enter"  [::rf.hicasso.examples.forms.events/commit-subject ticket]
+            "Escape" [::rf.hicasso.examples.forms.events/cancel-subject ticket]}
            (:on-key-down attrs))
         "the key MAP, not a callback reading `.key` — which is what keeps
          the composition gate, and why this file finds no function")))
@@ -99,7 +99,7 @@
   (testing "and the FIELD does not read it — an empty fixture entry here
             would red, because `tree` refuses a read it was not given"
     (is (= "re-frame.hicasso.examples.forms.views/subject-hint"
-           (:view-id (ht/find (subject-tree {:shown "s" :revision 0}) :view-id)))
+           (:view-id (rf.hicasso.test/find (subject-tree {:shown "s" :revision 0}) :view-id)))
         "the hint is a CALL from inside the field's markup, so its read
          belongs to its own body and not to the field's")))
 
@@ -108,10 +108,10 @@
   ;; so this is the substrate's own answer rather than a re-reading of
   ;; what the author wrote.
   (let [form [:input {:type "text" :value "s"
-                      ::h/revision 2
-                      :on-input [db/subject-draft ticket ::h/value]}]]
-    (is (true? (ht/controlled? form)))
-    (is (= 2 (ht/revision form))
+                      ::rf.hicasso/revision 2
+                      :on-input [rf.hicasso.examples.forms.db/subject-draft ticket ::rf.hicasso/value]}]]
+    (is (true? (rf.hicasso.test/controlled? form)))
+    (is (= 2 (rf.hicasso.test/revision form))
         "the trigger is read pre-merge, off the author's own map — it is
          never a DOM attribute and a remainder cannot arm it")))
 
@@ -121,11 +121,11 @@
   ;; nothing — so its absence is part of the recipe rather than an
   ;; oversight.
   (doseq [form [[:input {:type "text" :value "ada"
-                         :on-input [::events/edit :assignee ::h/value]}]
+                         :on-input [::rf.hicasso.examples.forms.events/edit :assignee ::rf.hicasso/value]}]
                 [:textarea {:value "note"
-                            :on-input [::events/edit :notes ::h/value]}]]]
-    (is (true? (ht/controlled? form)))
-    (is (nil? (ht/revision form)))))
+                            :on-input [::rf.hicasso.examples.forms.events/edit :notes ::rf.hicasso/value]}]]]
+    (is (true? (rf.hicasso.test/controlled? form)))
+    (is (nil? (rf.hicasso.test/revision form)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Recipe 2 — the gate, as an absence and a presence
@@ -133,25 +133,25 @@
 
 (deftest a-field-with-no-shown-problem-renders-no-problem-region
   (let [tree  (field-tree {:field :assignee :label "Assignee" :text "" :problem nil})
-        attrs (ht/attrs (tagged tree :input))]
+        attrs (rf.hicasso.test/attrs (tagged tree :input))]
     (is (nil? (classed tree "field-problem"))
         "ABSENT rather than empty — an empty region is still a node, and
          `aria-describedby` pointing at one is a name that says nothing")
     (is (= "false" (:aria-invalid attrs)))
     (is (nil? (:aria-describedby attrs)))
-    (is (= [::events/touch {:field :assignee}] (:on-blur attrs))
+    (is (= [::rf.hicasso.examples.forms.events/touch {:field :assignee}] (:on-blur attrs))
         "blur is the touch mark, and it names ONE field")))
 
 (deftest a-shown-problem-is-rendered-announced-and-pointed-at
   (let [tree    (field-tree {:field :assignee :label "Assignee" :text ""
                              :problem :problem/assignee-blank})
-        input   (ht/attrs (tagged tree :input))
+        input   (rf.hicasso.test/attrs (tagged tree :input))
         problem (classed tree "field-problem")]
-    (is (= "An assignee is required." (ht/text problem)))
-    (is (= :alert (ht/role problem))
+    (is (= "An assignee is required." (rf.hicasso.test/text problem)))
+    (is (= :alert (rf.hicasso.test/role problem))
         "the message announces itself when it appears")
     (is (= "true" (:aria-invalid input)))
-    (is (= (:id (ht/attrs problem)) (:aria-describedby input))
+    (is (= (:id (rf.hicasso.test/attrs problem)) (:aria-describedby input))
         "and the control points at THAT node — the two ids are written
          from one expression, so they cannot drift apart")))
 
@@ -160,7 +160,7 @@
                           :text "reproduced" :problem nil})]
     (is (some? (tagged tree :textarea)))
     (is (nil? (tagged tree :input)))
-    (is (= [::events/edit :notes ::h/value] (:on-input (ht/attrs (tagged tree :textarea))))
+    (is (= [::rf.hicasso.examples.forms.events/edit :notes ::rf.hicasso/value] (:on-input (rf.hicasso.test/attrs (tagged tree :textarea))))
         "one props map serves both spellings, so a change to the contract
          cannot reach one field and miss the other")))
 
@@ -174,11 +174,11 @@
   `:subs` refuses a read it cannot answer, so the day this button reaches
   for the gate again, this file reds and says so."
   [{:keys [save]}]
-  (ht/tree [views/save-button {}]
-           {:subs {[:rf/mutation {:instance events/save-instance}] (or save idle)}}))
+  (rf.hicasso.test/tree [rf.hicasso.examples.forms.views/save-button {}]
+           {:subs {[:rf/mutation {:instance rf.hicasso.examples.forms.events/save-instance}] (or save idle)}}))
 
 (deftest an-invalid-form-leaves-the-button-operable-and-claims-nothing
-  (let [attrs (ht/attrs (button-tree {}))]
+  (let [attrs (rf.hicasso.test/attrs (button-tree {}))]
     (is (false? (:disabled attrs))
         "operable — a disabled submit is out of the tab order and explains
          nothing, and it is also what would make `:attempted?` unreachable
@@ -192,51 +192,51 @@
          screen reader user that the one instruction they have does not
          work. This row is the semantic-coherence half; an attribute pin
          alone could not see it")
-    (is (= "Save ticket" (ht/text (button-tree {}))))))
+    (is (= "Save ticket" (rf.hicasso.test/text (button-tree {}))))))
 
 (deftest validity-reaches-the-user-through-the-fields-instead
   (testing "what the button gave up, the field carries — and carries
             better, because it names WHICH value is wrong"
     (let [tree    (field-tree {:field :assignee :label "Assignee"
                                :text "" :problem :problem/assignee-blank})
-          input   (ht/attrs (tagged tree :input))
+          input   (rf.hicasso.test/attrs (tagged tree :input))
           problem (classed tree "field-problem")]
       (is (= "true" (:aria-invalid input)))
-      (is (= :alert (ht/role problem))
+      (is (= :alert (rf.hicasso.test/role problem))
           "a live region, so a refused submission is heard rather than
            found")
-      (is (= (:id (ht/attrs problem)) (:aria-describedby input))))))
+      (is (= (:id (rf.hicasso.test/attrs problem)) (:aria-describedby input))))))
 
 (deftest a-write-in-flight-disables-the-button-from-the-writes-own-status
-  (let [attrs (ht/attrs (button-tree {:save (assoc idle :pending? true)}))]
+  (let [attrs (rf.hicasso.test/attrs (button-tree {:save (assoc idle :pending? true)}))]
     (is (true? (:disabled attrs))
         "busy is a projection of the instance. There is no `:saving?` key
          in this application's app-db for a failure branch to forget")
-    (is (= "Saving…" (ht/text (button-tree {:save (assoc idle :pending? true)}))))))
+    (is (= "Saving…" (rf.hicasso.test/text (button-tree {:save (assoc idle :pending? true)}))))))
 
 (deftest a-field-in-flight-is-disabled-and-recovers-on-failure
-  (is (true? (:disabled (ht/attrs (tagged (field-tree {:field :assignee :label "Assignee"
+  (is (true? (:disabled (rf.hicasso.test/attrs (tagged (field-tree {:field :assignee :label "Assignee"
                                                        :text "ada" :problem nil
                                                        :save (assoc idle :pending? true)})
                                           :input)))))
   (testing "and a settled failure re-enables it — the trap a hand-kept flag
             falls into is exactly this branch"
-    (is (false? (:disabled (ht/attrs (tagged (field-tree {:field :assignee :label "Assignee"
+    (is (false? (:disabled (rf.hicasso.test/attrs (tagged (field-tree {:field :assignee :label "Assignee"
                                                           :text "ada" :problem nil
                                                           :save (assoc idle :error? true
                                                                             :settled? true)})
                                              :input)))))))
 
 (deftest the-failure-region-is-present-only-while-the-instance-says-so
-  (is (nil? (classed (ht/tree [views/save-failure {}]
-                              {:subs {[:rf/mutation {:instance events/save-instance}] idle}})
+  (is (nil? (classed (rf.hicasso.test/tree [rf.hicasso.examples.forms.views/save-failure {}]
+                              {:subs {[:rf/mutation {:instance rf.hicasso.examples.forms.events/save-instance}] idle}})
                      "save-failure"))
       "no write has failed, so the region is not in the tree at all")
-  (let [tree (ht/tree [views/save-failure {}]
-                      {:subs {[:rf/mutation {:instance events/save-instance}]
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.forms.views/save-failure {}]
+                      {:subs {[:rf/mutation {:instance rf.hicasso.examples.forms.events/save-instance}]
                               (assoc idle :error? true :settled? true)}})]
-    (is (= :alert (ht/role tree)))
-    (is (= "Saving failed. Nothing was lost — try again." (ht/text tree)))))
+    (is (= :alert (rf.hicasso.test/role tree)))
+    (is (= "Saving failed. Nothing was lost — try again." (rf.hicasso.test/text tree)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The shells — what they read, which is nothing
@@ -247,9 +247,9 @@
   ;; LOAD-BEARING empty: `tree` refuses any read no fixture answers, so a
   ;; sub added to this body reds here before it can reach a keystroke's
   ;; path.
-  (let [tree (ht/tree [views/details-form {}] {})
-        kids (ht/find-all tree :view-id)]
-    (is (= [::events/submit] (:on-submit (ht/attrs tree)))
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.forms.views/details-form {}] {})
+        kids (rf.hicasso.test/find-all tree :view-id)]
+    (is (= [::rf.hicasso.examples.forms.events/submit] (:on-submit (rf.hicasso.test/attrs tree)))
         "and submit is a plain intent — `:on-submit` auto-prevents, so
          there is no `.preventDefault` in the application at all")
     (is (= ["re-frame.hicasso.examples.forms.views/field-row"
@@ -261,8 +261,8 @@
          their reads are not on this fixture map")))
 
 (deftest the-screen-reads-nothing-either
-  (let [tree (ht/tree [views/screen {:ikey ticket}] {})]
-    (is (= ticket (:ikey (ht/attrs (ht/find tree #(= "re-frame.hicasso.examples.forms.views/subject-field"
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.forms.views/screen {:ikey ticket}] {})]
+    (is (= ticket (:ikey (rf.hicasso.test/attrs (rf.hicasso.test/find tree #(= "re-frame.hicasso.examples.forms.views/subject-field"
                                                      (:view-id %))))))
         "the screen hands the instance key down and reads nothing itself")))
 
@@ -283,11 +283,11 @@
      (field-tree {:field :notes :label "Notes" :multiline? true
                   :text "note" :problem nil})
      (button-tree {})
-     (ht/tree [views/save-failure {}]
-              {:subs {[:rf/mutation {:instance events/save-instance}]
+     (rf.hicasso.test/tree [rf.hicasso.examples.forms.views/save-failure {}]
+              {:subs {[:rf/mutation {:instance rf.hicasso.examples.forms.events/save-instance}]
                       (assoc idle :error? true :settled? true)}})
-     (ht/tree [views/details-form {}] {})
-     (ht/tree [views/screen {:ikey ticket}] {})]))
+     (rf.hicasso.test/tree [rf.hicasso.examples.forms.views/details-form {}] {})
+     (rf.hicasso.test/tree [rf.hicasso.examples.forms.views/screen {:ikey ticket}] {})]))
 
 (deftest every-handler-site-is-data
   ;; TRAP: the arity-sniffed done-fn, and the `onChange` closure a
@@ -295,8 +295,8 @@
   ;; the opaque marker, so one anywhere in the application would show up
   ;; here by name.
   (let [opaque (for [tree (every-tree)
-                     node (ht/find-all tree map?)
-                     [k v] (ht/attrs node)
+                     node (rf.hicasso.test/find-all tree map?)
+                     [k v] (rf.hicasso.test/attrs node)
                      :when (= {:rf.ui/opaque :fn} v)]
                  [(:tag node) k])]
     (is (= [] (vec opaque))
@@ -306,12 +306,12 @@
 
 (deftest every-control-has-an-accessible-name
   (doseq [tree (every-tree)]
-    (is (= [] (ht/unnamed-controls tree))
+    (is (= [] (rf.hicasso.test/unnamed-controls tree))
         "the a11y projection ranges over what a user can OPERATE — the
          three fields and the button — and each is named by its own
          `<label for=…>` or by its text")))
 
-(h/defview counter-example
+(rf.hicasso/defview counter-example
   "NOT part of the application, and never rendered by it: a body written
   the two ways the recipes say not to write one, so the two rows above
   are shown to BITE rather than merely to be green.
@@ -326,19 +326,19 @@
    [:input#hand-rolled
     {:type     "text"
      :value    "x"
-     :on-input (h/event [e] [::events/edit :assignee (.. e -target -value)])}]
-   [:button.unnamed {:type "button" :on-click [::events/submit]}]])
+     :on-input (rf.hicasso/event [e] [::rf.hicasso.examples.forms.events/edit :assignee (.. e -target -value)])}]
+   [:button.unnamed {:type "button" :on-click [::rf.hicasso.examples.forms.events/submit]}]])
 
 (deftest the-two-structural-rows-catch-what-they-claim-to-and-no-more
-  (let [tree (ht/tree [counter-example {}] {})]
+  (let [tree (rf.hicasso.test/tree [counter-example {}] {})]
     (is (= [[:input :on-input]]
-           (vec (for [node  (ht/find-all tree map?)
-                      [k v] (ht/attrs node)
+           (vec (for [node  (rf.hicasso.test/find-all tree map?)
+                      [k v] (rf.hicasso.test/attrs node)
                       :when (= {:rf.ui/opaque :fn} v)]
                   [(:tag node) k])))
         "the opaque-marker walk finds the hand-rolled callback, and finds
          the ordinary `[::events/submit]` beside it acceptable")
-    (is (= [:button] (mapv :tag (ht/unnamed-controls tree)))
+    (is (= [:button] (mapv :tag (rf.hicasso.test/unnamed-controls tree)))
         "and the a11y projection reports the unnamed button and NOT the
          labelled field — the direction an over-eager guard gets wrong,
          and the one nothing else here would catch")))
@@ -346,9 +346,9 @@
 (deftest the-fields-are-named-by-their-labels-and-not-by-a-placeholder
   (let [tree  (subject-tree {:shown "s" :revision 0})
         input (tagged tree :input)]
-    (is (= "Subject" (ht/accessible-name tree input))
+    (is (= "Subject" (rf.hicasso.test/accessible-name tree input))
         "from the `<label for=…>` beside it — a name that survives the
          first keystroke, which a placeholder does not"))
   (let [tree (field-tree {:field :notes :label "Notes" :multiline? true
                           :text "" :problem nil})]
-    (is (= "Notes" (ht/accessible-name tree (tagged tree :textarea))))))
+    (is (= "Notes" (rf.hicasso.test/accessible-name tree (tagged tree :textarea))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/forms/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/forms/subs.cljs
@@ -23,7 +23,7 @@
   notify every field's error region at once — which is exactly what it is
   for."
   (:require [re-frame.core :as rf]
-            [re-frame.hicasso.examples.forms.db :as db]))
+            [re-frame.hicasso.examples.forms.db :as rf.hicasso.examples.forms.db]))
 
 ;; ---------------------------------------------------------------------------
 ;; Recipe 1 — the buffered field
@@ -32,7 +32,7 @@
 (rf/reg-sub ::subject-shown
   {:doc "What the subject field shows — the draft while a session is open,
          the committed subject otherwise."}
-  (fn [db [_ ikey]] (db/subject-shown db ikey)))
+  (fn [db [_ ikey]] (rf.hicasso.examples.forms.db/subject-shown db ikey)))
 
 (rf/reg-sub ::subject-revision
   {:doc "The subject field's reset trigger. A COUNTER, not a value: the
@@ -47,7 +47,7 @@
   {:doc "Is a subject session open for `ikey`? Read by the region that
          explains Enter and Escape, so the hint is absent until it
          applies."}
-  (fn [db [_ ikey]] (some? (get-in db (db/draft-path ikey)))))
+  (fn [db [_ ikey]] (some? (get-in db (rf.hicasso.examples.forms.db/draft-path ikey)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Recipe 2 — the ordinary fields and the gate
@@ -60,11 +60,11 @@
 (rf/reg-sub ::shown-problem
   {:doc "The problem to DISPLAY for `field`, gated by touch and submit
          attempt — nil until the user has earned it."}
-  (fn [db [_ field]] (db/shown-problem (:form db) field)))
+  (fn [db [_ field]] (rf.hicasso.examples.forms.db/shown-problem (:form db) field)))
 
 (rf/reg-sub ::can-submit?
   {:doc "The submit gate, as a read. Calls the same `db/can-submit?` the
          submit handler calls, so no reader can disagree with the
          refusal. The save button deliberately does NOT read it — see
          the views namespace."}
-  (fn [db _] (db/can-submit? db)))
+  (fn [db _] (rf.hicasso.examples.forms.db/can-submit? db)))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/forms/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/forms/views.cljs
@@ -54,24 +54,24 @@
   save moves their draft to a value they are not already showing, which
   React's own re-assert handles — and a revision that never has to fire
   is a prop a reader has to reason about for nothing."
-  (:require [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.forms.db :as db]
-            [re-frame.hicasso.examples.forms.events :as events]
-            [re-frame.hicasso.examples.forms.subs :as subs]))
+  (:require [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.forms.db :as rf.hicasso.examples.forms.db]
+            [re-frame.hicasso.examples.forms.events :as rf.hicasso.examples.forms.events]
+            [re-frame.hicasso.examples.forms.subs :as rf.hicasso.examples.forms.subs]))
 
 (def ^:private problem-text
   "Problem keyword → the sentence shown. The rules live in `db` as
   keywords; turning one into English is a rendering decision and belongs
   here, where the rest of the strings are."
   {:problem/assignee-blank "An assignee is required."
-   :problem/notes-too-long (str "Notes must be " db/notes-limit
+   :problem/notes-too-long (str "Notes must be " rf.hicasso.examples.forms.db/notes-limit
                                 " characters or fewer.")})
 
 ;; ---------------------------------------------------------------------------
 ;; Recipe 1 — the buffered subject field
 ;; ---------------------------------------------------------------------------
 
-(h/defview subject-hint
+(rf.hicasso/defview subject-hint
   "*Enter commits, Escape reverts* — present only while a session is open.
 
   Its own boundary, and that is not tidiness. It is the ONLY body that
@@ -83,10 +83,10 @@
   would make `::h/revision` inert, and a reset that only works because
   something else happened to re-render is not a reset."
   [{:keys [ikey]}]
-  (when (h/sub [::subs/editing? ikey])
+  (when (rf.hicasso/sub [::rf.hicasso.examples.forms.subs/editing? ikey])
     [:p.subject-hint "Enter commits, Escape reverts."]))
 
-(h/defview subject-field
+(rf.hicasso/defview subject-field
   "The ticket's subject, edited in place behind a draft.
 
   The whole commit protocol is three props and no callback: Enter and
@@ -112,19 +112,19 @@
       {:id          id
        :class       "subject"
        :type        "text"
-       :value       (h/sub [::subs/subject-shown ikey])
-       ::h/revision (h/sub [::subs/subject-revision ikey])
-       :on-input    [db/subject-draft ikey ::h/value]
-       :on-blur     [::events/commit-subject ikey]
-       :on-key-down {"Enter"  [::events/commit-subject ikey]
-                     "Escape" [::events/cancel-subject ikey]}}]
+       :value       (rf.hicasso/sub [::rf.hicasso.examples.forms.subs/subject-shown ikey])
+       ::rf.hicasso/revision (rf.hicasso/sub [::rf.hicasso.examples.forms.subs/subject-revision ikey])
+       :on-input    [rf.hicasso.examples.forms.db/subject-draft ikey ::rf.hicasso/value]
+       :on-blur     [::rf.hicasso.examples.forms.events/commit-subject ikey]
+       :on-key-down {"Enter"  [::rf.hicasso.examples.forms.events/commit-subject ikey]
+                     "Escape" [::rf.hicasso.examples.forms.events/cancel-subject ikey]}}]
      [subject-hint {:ikey ikey}]]))
 
 ;; ---------------------------------------------------------------------------
 ;; Recipe 2 — an ordinary field, its touch mark and its gated problem
 ;; ---------------------------------------------------------------------------
 
-(h/defview field-row
+(rf.hicasso/defview field-row
   "One label, one control, and — once the user has earned it — one
   problem.
 
@@ -134,16 +134,16 @@
   shut, so `aria-describedby` never points at a node that is not there."
   [{:keys [field label multiline?]}]
   (let [id      (str "ticket-" (name field))
-        problem (h/sub [::subs/shown-problem field])
-        busy?   (:pending? (h/sub [:rf/mutation {:instance events/save-instance}]))
+        problem (rf.hicasso/sub [::rf.hicasso.examples.forms.subs/shown-problem field])
+        busy?   (:pending? (rf.hicasso/sub [:rf/mutation {:instance rf.hicasso.examples.forms.events/save-instance}]))
         props   {:id                id
                  :class             (name field)
-                 :value             (h/sub [::subs/field field])
+                 :value             (rf.hicasso/sub [::rf.hicasso.examples.forms.subs/field field])
                  :disabled          busy?
                  :aria-invalid      (if problem "true" "false")
                  :aria-describedby  (when problem (str id "-problem"))
-                 :on-input          [::events/edit field ::h/value]
-                 :on-blur           [::events/touch {:field field}]}]
+                 :on-input          [::rf.hicasso.examples.forms.events/edit field ::rf.hicasso/value]
+                 :on-blur           [::rf.hicasso.examples.forms.events/touch {:field field}]}]
     [:div.field-row
      [:label {:for id} label]
      (if multiline?
@@ -157,15 +157,15 @@
 ;; Recipe 3 — the write's status, read from the write
 ;; ---------------------------------------------------------------------------
 
-(h/defview save-failure
+(rf.hicasso/defview save-failure
   "The error region. Present only while the instance says the last
   attempt failed, and gone the moment a retry starts — because it is a
   projection of the write rather than a copy of it."
   [_]
-  (when (:error? (h/sub [:rf/mutation {:instance events/save-instance}]))
+  (when (:error? (rf.hicasso/sub [:rf/mutation {:instance rf.hicasso.examples.forms.events/save-instance}]))
     [:p.save-failure {:role "alert"} "Saving failed. Nothing was lost — try again."]))
 
-(h/defview save-button
+(rf.hicasso/defview save-button
   "Submit. Disabled while the write is in flight and carrying nothing at
   all while the form is invalid — see the namespace docstring on why
   those are not two grades of the same thing.
@@ -177,7 +177,7 @@
   the submit handler and exposed at `::subs/can-submit?` for anything
   that needs the answer; `l0` pins those two agreeing."
   [_]
-  (let [busy? (:pending? (h/sub [:rf/mutation {:instance events/save-instance}]))]
+  (let [busy? (:pending? (rf.hicasso/sub [:rf/mutation {:instance rf.hicasso.examples.forms.events/save-instance}]))]
     [:button.save
      {:type     "submit"
       :disabled busy?}
@@ -187,7 +187,7 @@
 ;; The screen
 ;; ---------------------------------------------------------------------------
 
-(h/defview details-form
+(rf.hicasso/defview details-form
   "The form shell. It reads NOTHING, so a keystroke in either field
   re-renders that field's row and stops there.
 
@@ -195,13 +195,13 @@
   form and the browser does not navigate — with no `.preventDefault`
   anywhere in this file."
   [_]
-  [:form.details {:on-submit [::events/submit]}
+  [:form.details {:on-submit [::rf.hicasso.examples.forms.events/submit]}
    [field-row {:field :assignee :label "Assignee"}]
    [field-row {:field :notes :label "Notes" :multiline? true}]
    [save-failure {}]
    [save-button {}]])
 
-(h/defview screen
+(rf.hicasso/defview screen
   "The whole page: the buffered subject above, the ordinary form below."
   [{:keys [ikey]}]
   [:main.ticket-screen

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/app.cljs
@@ -6,11 +6,11 @@
   scaling witness moves. Everything else — the namespaced frame keyword,
   the reload handle, the absence of any registered route — is
   `examples.editor.app`'s, and its docstring carries the reasoning."
-  (:require [re-frame.adapter.uix :as uix-adapter]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.grid.events :as events]
-            [re-frame.hicasso.examples.grid.views :as views]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.grid.events :as rf.hicasso.examples.grid.events]
+            [re-frame.hicasso.examples.grid.views :as rf.hicasso.examples.grid.views]))
 
 (def frame-id
   "This application's frame. Namespaced, so two applications in one
@@ -24,8 +24,8 @@
   variable of `grid.scaling-dom-cljs-test`: the suite mounts the same
   application twice and the only difference between the two mounts is
   what this returns."
-  ([] (initial-events events/default-dimensions))
-  ([dimensions] [[::events/seed dimensions]]))
+  ([] (initial-events rf.hicasso.examples.grid.events/default-dimensions))
+  ([dimensions] [[::rf.hicasso.examples.grid.events/seed dimensions]]))
 
 (defonce ^:private !root (atom nil))
 
@@ -33,13 +33,13 @@
   "Re-render the mounted root after a hot reload."
   []
   (when-some [root @!root]
-    (h/render! root [views/grid {}])))
+    (rf.hicasso/render! root [rf.hicasso.examples.grid.views/grid {}])))
 
 (defn ^:export -main
   "Mount the 100-cell grid on `#app`."
   []
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (rf/make-frame {:id frame-id :initial-events (initial-events)})
-  (reset! !root (h/mount! (js/document.getElementById "app") {:frame frame-id}
-                          [views/grid {}]))
+  (reset! !root (rf.hicasso/mount! (js/document.getElementById "app") {:frame frame-id}
+                          [rf.hicasso.examples.grid.views/grid {}]))
   nil)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/l0_cljs_test.cljs
@@ -12,56 +12,56 @@
   first number of the per-keystroke walk, asserted over a hundred
   addresses rather than four."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.grid.app :as app]
-            [re-frame.hicasso.examples.grid.events :as events]
-            [re-frame.hicasso.examples.grid.subs :as subs]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.grid.app :as rf.hicasso.examples.grid.app]
+            [re-frame.hicasso.examples.grid.events :as rf.hicasso.examples.grid.events]
+            [re-frame.hicasso.examples.grid.subs :as rf.hicasso.examples.grid.subs]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 (defn- with-grid
   "Run `f` against a fresh frame holding a grid of `dimensions`, seeded
   exactly as the application seeds itself."
-  ([f] (with-grid events/default-dimensions f))
+  ([f] (with-grid rf.hicasso.examples.grid.events/default-dimensions f))
   ([dimensions f]
    (rf/with-new-frame [frame (rf/make-frame
-                               {:initial-events (app/initial-events dimensions)})]
+                               {:initial-events (rf.hicasso.examples.grid.app/initial-events dimensions)})]
      (f frame))))
 
 (defn- read-sub [frame query-v] (rf/subscribe-once query-v {:frame frame}))
 
 (defn- type! [frame row col text]
-  (rf/dispatch-sync [::events/edit row col text] {:frame frame}))
+  (rf/dispatch-sync [::rf.hicasso.examples.grid.events/edit row col text] {:frame frame}))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure
 ;; ---------------------------------------------------------------------------
 
 (deftest the-default-grid-is-a-hundred-cells
-  (is (= {:rows 10 :cols 10} events/default-dimensions))
-  (is (= 100 (count (events/seed-cells events/default-dimensions))))
-  (is (= "0" (get (events/seed-cells events/default-dimensions) [0 0])))
-  (is (= "99" (get (events/seed-cells events/default-dimensions) [9 9]))
+  (is (= {:rows 10 :cols 10} rf.hicasso.examples.grid.events/default-dimensions))
+  (is (= 100 (count (rf.hicasso.examples.grid.events/seed-cells rf.hicasso.examples.grid.events/default-dimensions))))
+  (is (= "0" (get (rf.hicasso.examples.grid.events/seed-cells rf.hicasso.examples.grid.events/default-dimensions) [0 0])))
+  (is (= "99" (get (rf.hicasso.examples.grid.events/seed-cells rf.hicasso.examples.grid.events/default-dimensions) [9 9]))
       "each cell seeds to a distinct digit string, so a witness reading
        one cell can tell it apart from its neighbours"))
 
 (deftest the-policy-refuses-anything-that-is-not-a-digit-string
-  (is (= "12" (events/digits-only "9" "12")) "accepted")
-  (is (= "" (events/digits-only "9" "")) "an empty field is a legal state")
-  (is (= "9" (events/digits-only "9" "1a")) "refused — the model does not move")
-  (is (= "9" (events/digits-only "9" "-1")))
-  (is (= "9" (events/digits-only "9" " ")))
+  (is (= "12" (rf.hicasso.examples.grid.events/digits-only "9" "12")) "accepted")
+  (is (= "" (rf.hicasso.examples.grid.events/digits-only "9" "")) "an empty field is a legal state")
+  (is (= "9" (rf.hicasso.examples.grid.events/digits-only "9" "1a")) "refused — the model does not move")
+  (is (= "9" (rf.hicasso.examples.grid.events/digits-only "9" "-1")))
+  (is (= "9" (rf.hicasso.examples.grid.events/digits-only "9" " ")))
   (testing "a refusal answers the COMMITTED value by identity"
     ;; Not merely `=`. The value the field is handed back has to be the
     ;; one it was handed before, or a refusal would look to every
     ;; equality gate above it like a change.
     (let [old "9"]
-      (is (identical? old (events/digits-only old "x"))))))
+      (is (identical? old (rf.hicasso.examples.grid.events/digits-only old "x"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Transitions
@@ -71,16 +71,16 @@
   (with-grid
     (fn [frame]
       (type! frame 3 4 "77")
-      (is (= "77" (read-sub frame [::subs/cell 3 4])))
-      (is (= "35" (read-sub frame [::subs/cell 3 5]))
+      (is (= "77" (read-sub frame [::rf.hicasso.examples.grid.subs/cell 3 4])))
+      (is (= "35" (read-sub frame [::rf.hicasso.examples.grid.subs/cell 3 5]))
           "and its neighbour is untouched — the seed's own value, still"))))
 
 (deftest a-refused-keystroke-leaves-the-model-where-it-was
   (with-grid
     (fn [frame]
-      (let [before (read-sub frame [::subs/cell 3 4])]
+      (let [before (read-sub frame [::rf.hicasso.examples.grid.subs/cell 3 4])]
         (type! frame 3 4 "34x")
-        (is (= before (read-sub frame [::subs/cell 3 4]))
+        (is (= before (read-sub frame [::rf.hicasso.examples.grid.subs/cell 3 4]))
             "THE REFUSAL HALF OF THE CONTROLLED LAW, at the model tier: the
              field will be handed back the committed value, which is what
              makes the echo in `scaling-dom-cljs-test` a snap-back rather
@@ -101,11 +101,11 @@
 (deftest a-row-total-is-the-sum-of-its-row
   (with-grid {:rows 2 :cols 3}
     (fn [frame]
-      (is (= (+ 0 1 2) (read-sub frame [::subs/row-total 0])))
-      (is (= (+ 3 4 5) (read-sub frame [::subs/row-total 1])))
+      (is (= (+ 0 1 2) (read-sub frame [::rf.hicasso.examples.grid.subs/row-total 0])))
+      (is (= (+ 3 4 5) (read-sub frame [::rf.hicasso.examples.grid.subs/row-total 1])))
       (type! frame 1 1 "40")
-      (is (= (+ 3 40 5) (read-sub frame [::subs/row-total 1])))
-      (is (= (+ 0 1 2) (read-sub frame [::subs/row-total 0]))
+      (is (= (+ 3 40 5) (read-sub frame [::rf.hicasso.examples.grid.subs/row-total 1])))
+      (is (= (+ 0 1 2) (read-sub frame [::rf.hicasso.examples.grid.subs/row-total 0]))
           "the other row's total did not move, which is what makes it a
            per-row edge rather than a whole-grid one")))
 
@@ -113,15 +113,15 @@
     (with-grid {:rows 1 :cols 2}
       (fn [frame]
         (type! frame 0 0 "")
-        (is (= 1 (read-sub frame [::subs/row-total 0])))))))
+        (is (= 1 (read-sub frame [::rf.hicasso.examples.grid.subs/row-total 0])))))))
 
 (deftest clearing-a-row-moves-that-row-and-no-other
   (with-grid {:rows 3 :cols 4}
     (fn [frame]
-      (rf/dispatch-sync [::events/clear-row {:row 1}] {:frame frame})
-      (is (= ["" "" "" ""] (mapv #(read-sub frame [::subs/cell 1 %]) (range 4))))
-      (is (= 0 (read-sub frame [::subs/row-total 1])))
-      (is (= ["0" "1" "2" "3"] (mapv #(read-sub frame [::subs/cell 0 %]) (range 4)))
+      (rf/dispatch-sync [::rf.hicasso.examples.grid.events/clear-row {:row 1}] {:frame frame})
+      (is (= ["" "" "" ""] (mapv #(read-sub frame [::rf.hicasso.examples.grid.subs/cell 1 %]) (range 4))))
+      (is (= 0 (read-sub frame [::rf.hicasso.examples.grid.subs/row-total 1])))
+      (is (= ["0" "1" "2" "3"] (mapv #(read-sub frame [::rf.hicasso.examples.grid.subs/cell 0 %]) (range 4)))
           "a BROAD update is still scoped to what changed. `scaling-dom`
            counts the bodies this runs, so the narrow number has something
            to be narrow compared to"))))
@@ -131,5 +131,5 @@
   ;; mounted at two sizes, differing in nothing but this.
   (with-grid {:rows 5 :cols 5}
     (fn [frame]
-      (is (= {:rows 5 :cols 5} (read-sub frame [::subs/dimensions])))
+      (is (= {:rows 5 :cols 5} (read-sub frame [::rf.hicasso.examples.grid.subs/dimensions])))
       (is (= 25 (count (:cells (rf/app-db-value frame))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/l2_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/l2_cljs_test.cljs
@@ -22,31 +22,31 @@
   A body that grew a read reds this file before anything is mounted,
   which is the earliest a topology regression can be caught."
   (:require [cljs.test :refer-macros [deftest is use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.grid.events :as events]
-            [re-frame.hicasso.examples.grid.subs :as subs]
-            [re-frame.hicasso.examples.grid.views :as views]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.grid.events :as rf.hicasso.examples.grid.events]
+            [re-frame.hicasso.examples.grid.subs :as rf.hicasso.examples.grid.subs]
+            [re-frame.hicasso.examples.grid.views :as rf.hicasso.examples.grid.views]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
-(defn- tagged [tree tag] (ht/find tree #(= tag (:tag %))))
+(defn- tagged [tree tag] (rf.hicasso.test/find tree #(= tag (:tag %))))
 
 ;; ---------------------------------------------------------------------------
 ;; The cell — the whole of the typing surface
 ;; ---------------------------------------------------------------------------
 
 (deftest a-cell-reads-one-address-and-writes-one-intent
-  (let [tree  (ht/tree [views/cell {:row 3 :col 4}]
-                       {:subs {[::subs/cell 3 4] "34"}})
-        attrs (ht/attrs (tagged tree :input))]
+  (let [tree  (rf.hicasso.test/tree [rf.hicasso.examples.grid.views/cell {:row 3 :col 4}]
+                       {:subs {[::rf.hicasso.examples.grid.subs/cell 3 4] "34"}})
+        attrs (rf.hicasso.test/attrs (tagged tree :input))]
     (is (= "34" (:value attrs)))
-    (is (= [::events/edit 3 4 ::h/value] (:on-input attrs))
+    (is (= [::rf.hicasso.examples.grid.events/edit 3 4 ::rf.hicasso/value] (:on-input attrs))
         "a THREE-argument positional intent. It is positional for the
          reason the editor's two-argument ones are — a marker below the
          top level of an intent vector is not substituted — and the
@@ -65,40 +65,40 @@
   ;; subscription and an intent vector at `:on-input`, and the difference
   ;; between one field and a hundred is the loop that writes them.
   (let [form [:input {:type "text" :value "34"
-                      :on-input [::events/edit 3 4 ::h/value]}]]
-    (is (true? (ht/controlled? form))
+                      :on-input [::rf.hicasso.examples.grid.events/edit 3 4 ::rf.hicasso/value]}]]
+    (is (true? (rf.hicasso.test/controlled? form))
         "the hundredth cell installs the same converge shadow as the
          first, and there is no second way of writing a field for when
          there are a hundred of them")
-    (is (nil? (ht/revision form))
+    (is (nil? (rf.hicasso.test/revision form))
         "and the grid carries no reset trigger anywhere — it has no
          discard, so `::h/revision` never appears in this application")))
 
 (deftest the-row-total-reads-its-own-row-and-nothing-else
-  (let [tree (ht/tree [views/row-total {:row 2}]
-                      {:subs {[::subs/row-total 2] 42}})]
-    (is (= "42" (ht/text tree)))
-    (is (= "2" (:data-total (ht/attrs tree))))))
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.grid.views/row-total {:row 2}]
+                      {:subs {[::rf.hicasso.examples.grid.subs/row-total 2] 42}})]
+    (is (= "42" (rf.hicasso.test/text tree)))
+    (is (= "2" (:data-total (rf.hicasso.test/attrs tree))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The layout bodies — the half of the topology that is an ABSENCE
 ;; ---------------------------------------------------------------------------
 
 (deftest a-row-body-reads-the-dimensions-and-no-cell
-  (let [tree  (ht/tree [views/grid-row {:row 2}]
-                       {:subs {[::subs/dimensions] {:rows 10 :cols 4}}})
-        cells (ht/find-all tree #(= "re-frame.hicasso.examples.grid.views/cell"
+  (let [tree  (rf.hicasso.test/tree [rf.hicasso.examples.grid.views/grid-row {:row 2}]
+                       {:subs {[::rf.hicasso.examples.grid.subs/dimensions] {:rows 10 :cols 4}}})
+        cells (rf.hicasso.test/find-all tree #(= "re-frame.hicasso.examples.grid.views/cell"
                                     (:view-id %)))]
     (is (= 4 (count cells))
         "one call per column — and a CALL, so the child's body did not run
          and its read is not on this fixture map")
     (is (= [[2 0] [2 1] [2 2] [2 3]]
-           (mapv (fn [c] [(:row (ht/attrs c)) (:col (ht/attrs c))]) cells)))
+           (mapv (fn [c] [(:row (rf.hicasso.test/attrs c)) (:col (rf.hicasso.test/attrs c))]) cells)))
     (is (= ["0" "1" "2" "3"] (mapv :key cells))
         "keyed by column. A list keyed by anything that moves reuses the
          wrong element the moment the order changes, and on a page of
          controlled fields that is a caret landing in another cell")
-    (is (= 1 (count (ht/find-all tree #(= "re-frame.hicasso.examples.grid.views/row-total"
+    (is (= 1 (count (rf.hicasso.test/find-all tree #(= "re-frame.hicasso.examples.grid.views/row-total"
                                           (:view-id %)))))
         "and one total, at the end of the row")))
 
@@ -108,12 +108,12 @@
   ;; keystroke cannot reach this body. A `[::subs/all-cells]` here — the
   ;; guide's named anti-shape — would put the parent, and a props compare
   ;; over every row, on every keystroke's path.
-  (let [tree (ht/tree [views/grid {}]
-                      {:subs {[::subs/dimensions] {:rows 3 :cols 3}}})
-        rows (ht/find-all tree #(= "re-frame.hicasso.examples.grid.views/grid-row"
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.grid.views/grid {}]
+                      {:subs {[::rf.hicasso.examples.grid.subs/dimensions] {:rows 3 :cols 3}}})
+        rows (rf.hicasso.test/find-all tree #(= "re-frame.hicasso.examples.grid.views/grid-row"
                                    (:view-id %)))]
     (is (= 3 (count rows)))
-    (is (= [0 1 2] (mapv (comp :row ht/attrs) rows)))
+    (is (= [0 1 2] (mapv (comp :row rf.hicasso.test/attrs) rows)))
     (is (= ["0" "1" "2"] (mapv :key rows)))
     (is (some? (tagged tree :table)))))
 
@@ -130,14 +130,14 @@
         rows  (range (:rows dims))
         cells (into []
                     (mapcat (fn [row]
-                              (let [tree (ht/tree [views/grid-row {:row row}]
-                                                  {:subs {[::subs/dimensions] dims}})]
-                                (->> (ht/find-all
+                              (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.grid.views/grid-row {:row row}]
+                                                  {:subs {[::rf.hicasso.examples.grid.subs/dimensions] dims}})]
+                                (->> (rf.hicasso.test/find-all
                                        tree
                                        #(= "re-frame.hicasso.examples.grid.views/cell"
                                            (:view-id %)))
-                                     (mapv (fn [c] [(:row (ht/attrs c))
-                                                    (:col (ht/attrs c))]))))))
+                                     (mapv (fn [c] [(:row (rf.hicasso.test/attrs c))
+                                                    (:col (rf.hicasso.test/attrs c))]))))))
                     rows)]
     (is (= 100 (count cells)))
     (is (= 100 (count (set cells))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/row_total_layer2_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/row_total_layer2_dom_cljs_test.cljs
@@ -67,16 +67,16 @@
   what is counted is BODY RUNS, and the `cols` `parseInt`s inside one body
   are read off the body rather than counted by anything."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.grid.app :as app]
-            [re-frame.hicasso.examples.grid.events :as events]
-            [re-frame.hicasso.examples.grid.subs :as subs]
-            [re-frame.hicasso.examples.grid.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.registrar :as registrar]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.grid.app :as rf.hicasso.examples.grid.app]
+            [re-frame.hicasso.examples.grid.events :as rf.hicasso.examples.grid.events]
+            [re-frame.hicasso.examples.grid.subs :as rf.hicasso.examples.grid.subs]
+            [re-frame.hicasso.examples.grid.views :as rf.hicasso.examples.grid.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The contrast arm — the SAME arithmetic, stated over its own inputs
@@ -98,7 +98,7 @@
   `app-db`, so the row's width has to be told to it."}
   ;; input-fn — pure `query-v -> [query-vector*]`, run once per cache entry.
   (fn [[_ row cols]]
-    (mapv (fn [col] [::subs/cell row col]) (range cols)))
+    (mapv (fn [col] [::rf.hicasso.examples.grid.subs/cell row col]) (range cols)))
   ;; computation fn — a parametric sub is handed a VECTOR of input values.
   (fn [cell-values _]
     (transduce (map (fn [s] (if (seq s) (js/parseInt s 10) 0)))
@@ -106,30 +106,30 @@
                0
                cell-values)))
 
-(h/defview row-total-l2
+(rf.hicasso/defview row-total-l2
   "`views/row-total` with its subscription restated. Same markup, same
   `.total` class, same `data-total` — so the same selector reads it and
   the arms differ in exactly one expression."
   [{:keys [row cols]}]
-  [:td.total {:data-total (str row)} (str (h/sub [::row-total-l2 row cols]))])
+  [:td.total {:data-total (str row)} (str (rf.hicasso/sub [::row-total-l2 row cols]))])
 
-(h/defview grid-row-l2
+(rf.hicasso/defview grid-row-l2
   "`views/grid-row` with [[row-total-l2]] in place of `views/row-total`.
 
   The cells are the APPLICATION's `views/cell`, required and used
   unchanged: the contrast is one subscription's spelling, and a re-typed
   cell would put a second difference into a two-arm measurement."
   [{:keys [row]}]
-  (let [{:keys [cols]} (h/sub [::subs/dimensions])]
+  (let [{:keys [cols]} (rf.hicasso/sub [::rf.hicasso.examples.grid.subs/dimensions])]
     [:tr {:data-row (str row)}
      (for [col (range cols)]
-       [views/cell {:key (str col) :row row :col col}])
+       [rf.hicasso.examples.grid.views/cell {:key (str col) :row row :col col}])
      [row-total-l2 {:key "total" :row row :cols cols}]]))
 
-(h/defview grid-l2
+(rf.hicasso/defview grid-l2
   "`views/grid` over [[grid-row-l2]]."
   [_]
-  (let [{:keys [rows]} (h/sub [::subs/dimensions])]
+  (let [{:keys [rows]} (rf.hicasso/sub [::rf.hicasso.examples.grid.subs/dimensions])]
     [:main#hundred-cell-grid
      [:h1 "Grid"]
      [:table
@@ -142,8 +142,8 @@
 ;; file would strand `::row-total-l2` and every layer-2 mount would refuse.
 ;; Same reason `grid.scaling-dom-cljs-test` puts its own here.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 ;; ---------------------------------------------------------------------------
@@ -176,12 +176,12 @@
   with its own arity, and this counter has no opinion about which."
   [sub-ids f]
   (let [!counts   (atom {})
-        originals (reduce (fn [m id] (assoc m id (registrar/lookup :sub id)))
+        originals (reduce (fn [m id] (assoc m id (rf.registrar/lookup :sub id)))
                           {}
                           sub-ids)]
     (doseq [[id meta] originals]
       (let [orig (:handler-fn meta)]
-        (registrar/register! :sub id
+        (rf.registrar/register! :sub id
           (assoc meta :handler-fn
                  (fn [& args]
                    (swap! !counts update id (fnil inc 0))
@@ -190,7 +190,7 @@
       (f (fn [] @!counts) (fn [] (reset! !counts {})))
       (finally
         (doseq [[id meta] originals]
-          (registrar/register! :sub id meta))))))
+          (rf.registrar/register! :sub id meta))))))
 
 (defn- total
   "The census's one number, summed over the per-sub attribution."
@@ -200,10 +200,10 @@
 (def ^:private counted-sub-ids
   "Both arms count the same four ids, so an arm that never ran its own
   total shows up as an ABSENT key rather than as a smaller sum."
-  [::subs/cell ::subs/dimensions ::subs/row-total ::row-total-l2])
+  [::rf.hicasso.examples.grid.subs/cell ::rf.hicasso.examples.grid.subs/dimensions ::rf.hicasso.examples.grid.subs/row-total ::row-total-l2])
 
 (defn- grid-node [m row col]
-  (.querySelector (:container m) (str "#" (events/cell-id row col))))
+  (.querySelector (:container m) (str "#" (rf.hicasso.examples.grid.events/cell-id row col))))
 
 (defn- total-text [m row]
   (.-textContent (.querySelector (:container m) (str "[data-total='" row "']"))))
@@ -229,12 +229,12 @@
   [form dimensions]
   (with-counted-subs counted-sub-ids
     (fn [sub-runs reset-subs!]
-      (let [m (hm/mount! form {:initial-events (app/initial-events dimensions)})
+      (let [m (rf.hicasso.test.mounted/mount! form {:initial-events (rf.hicasso.examples.grid.app/initial-events dimensions)})
             n (grid-node m 3 4)]
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (let [before (total-text m 3)]
           (reset-subs!)
-          (let [bodies (hm/bodies-run (fn [] (type-into! n "1") (hm/settle! m)))
+          (let [bodies (rf.hicasso.test.mounted/bodies-run (fn [] (type-into! n "1") (rf.hicasso.test.mounted/settle! m)))
                 runs   (sub-runs)]
             (try
               {:sub-runs     (total runs)
@@ -243,7 +243,7 @@
                :total-before before
                :total-after  (total-text m 3)
                :cell-value   (.-value (grid-node m 3 4))}
-              (finally (hm/unmount! m)))))))))
+              (finally (rf.hicasso.test.mounted/unmount! m)))))))))
 
 (def ^:private small {:rows 5 :cols 5})
 (def ^:private full {:rows 10 :cols 10})
@@ -258,16 +258,16 @@
   ;; measuring the wrong thing.
   (if-not (browser?)
     (skip! "the faithfulness premise")
-    (let [l1 (hm/mount! [views/grid {}] {:initial-events (app/initial-events full)})
-          l2 (hm/mount! [grid-l2 {}] {:initial-events (app/initial-events full)})]
+    (let [l1 (rf.hicasso.test.mounted/mount! [rf.hicasso.examples.grid.views/grid {}] {:initial-events (rf.hicasso.examples.grid.app/initial-events full)})
+          l2 (rf.hicasso.test.mounted/mount! [grid-l2 {}] {:initial-events (rf.hicasso.examples.grid.app/initial-events full)})]
       (is (= (mapv #(total-text l1 %) (range 10))
              (mapv #(total-text l2 %) (range 10)))
           "every row's total, both spellings, at 10x10")
       (is (= "345" (total-text l1 3))
           "and the value is the seeded row's real sum (30+31+…+39), so the
            row above is not two spellings agreeing on nil")
-      (hm/unmount! l1)
-      (hm/unmount! l2))))
+      (rf.hicasso.test.mounted/unmount! l1)
+      (rf.hicasso.test.mounted/unmount! l2))))
 
 ;; ---------------------------------------------------------------------------
 ;; The contrast
@@ -276,9 +276,9 @@
 (deftest the-layer-2-row-total-recomputes-once-where-the-layer-1-one-recomputes-per-row
   (if-not (browser?)
     (skip! "the contrast")
-    (let [l1-100 (census-of [views/grid {}] full)
+    (let [l1-100 (census-of [rf.hicasso.examples.grid.views/grid {}] full)
           l2-100 (census-of [grid-l2 {}] full)
-          l1-25  (census-of [views/grid {}] small)
+          l1-25  (census-of [rf.hicasso.examples.grid.views/grid {}] small)
           l2-25  (census-of [grid-l2 {}] small)]
 
       (testing "the arm is live — the one run produced the new number"
@@ -305,7 +305,7 @@
              recomputation saving below meaningless."))
 
       (testing "the layer-1 arm — the census's own figures, re-read here"
-        (is (= {::subs/cell 100 ::subs/row-total 10 ::subs/dimensions 1}
+        (is (= {::rf.hicasso.examples.grid.subs/cell 100 ::rf.hicasso.examples.grid.subs/row-total 10 ::rf.hicasso.examples.grid.subs/dimensions 1}
                (:by-sub l1-100))
             "10x10: every mounted cell, every row total, and the
              dimensions cell that nothing moved. Identical to the
@@ -313,12 +313,12 @@
              same counter — so this file's subtraction is between two
              readings it took itself")
         (is (= 111 (:sub-runs l1-100)))
-        (is (= {::subs/cell 25 ::subs/row-total 5 ::subs/dimensions 1}
+        (is (= {::rf.hicasso.examples.grid.subs/cell 25 ::rf.hicasso.examples.grid.subs/row-total 5 ::rf.hicasso.examples.grid.subs/dimensions 1}
                (:by-sub l1-25)))
         (is (= 31 (:sub-runs l1-25))))
 
       (testing "the layer-2 arm — the row-total term collapses to ONE"
-        (is (= {::subs/cell 100 ::row-total-l2 1 ::subs/dimensions 1}
+        (is (= {::rf.hicasso.examples.grid.subs/cell 100 ::row-total-l2 1 ::rf.hicasso.examples.grid.subs/dimensions 1}
                (:by-sub l2-100))
             "10x10: ONE row-total body where the layer-1 spelling ran ten.
              The nine that did not run are the nine rows whose cells did
@@ -326,22 +326,22 @@
              and finds them `=`, where the layer-1 memo compares the whole
              of `app-db` and finds it moved")
         (is (= 102 (:sub-runs l2-100)))
-        (is (= {::subs/cell 25 ::row-total-l2 1 ::subs/dimensions 1}
+        (is (= {::rf.hicasso.examples.grid.subs/cell 25 ::row-total-l2 1 ::rf.hicasso.examples.grid.subs/dimensions 1}
                (:by-sub l2-25))
             "and at 5x5 the same ONE — the term is flat in the grid, where
              the layer-1 spelling's was linear in `rows`")
         (is (= 27 (:sub-runs l2-25))))
 
       (testing "the contrast, stated as the two shapes"
-        (is (= [10 5] [(::subs/row-total (:by-sub l1-100))
-                       (::subs/row-total (:by-sub l1-25))])
+        (is (= [10 5] [(::rf.hicasso.examples.grid.subs/row-total (:by-sub l1-100))
+                       (::rf.hicasso.examples.grid.subs/row-total (:by-sub l1-25))])
             "layer-1 row-total runs = rows: 10 at 10x10, 5 at 5x5 — it
              GROWS with the page")
         (is (= [1 1] [(::row-total-l2 (:by-sub l2-100))
                       (::row-total-l2 (:by-sub l2-25))])
             "layer-2 row-total runs = 1 at both sizes — it does NOT")
 
-        (is (= 100 (::subs/cell (:by-sub l1-100)) (::subs/cell (:by-sub l2-100)))
+        (is (= 100 (::rf.hicasso.examples.grid.subs/cell (:by-sub l1-100)) (::rf.hicasso.examples.grid.subs/cell (:by-sub l2-100)))
             "AND THE LINEAR TERM SURVIVES, which is the half of this
              measurement a reader is likeliest to misread. `::cell` is a
              layer-1 reader in BOTH arms and there are a hundred of them

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs
@@ -56,15 +56,15 @@
   minted in this namespace too — a cell in the application cannot be
   written coarsely without somebody adding one."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.grid.app :as app]
-            [re-frame.hicasso.examples.grid.events :as events]
-            [re-frame.hicasso.examples.grid.subs :as subs]
-            [re-frame.hicasso.examples.grid.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.grid.app :as rf.hicasso.examples.grid.app]
+            [re-frame.hicasso.examples.grid.events :as rf.hicasso.examples.grid.events]
+            [re-frame.hicasso.examples.grid.subs :as rf.hicasso.examples.grid.subs]
+            [re-frame.hicasso.examples.grid.views :as rf.hicasso.examples.grid.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The two coarse shapes — the guide's named anti-patterns, as controls
@@ -77,14 +77,14 @@
   the shapes below coarse."}
   (fn [db _] (:cells db)))
 
-(h/defview coarse-cell
+(rf.hicasso/defview coarse-cell
   "A cell rendered FROM PROPS. Reads nothing; its value arrives from a
   parent that read the whole grid."
   [{:keys [row col value]}]
   [:td [:input {:type "text" :value value
-                :on-input [::events/edit row col ::h/value]}]])
+                :on-input [::rf.hicasso.examples.grid.events/edit row col ::rf.hicasso/value]}]])
 
-(h/defview coarse-closure-cell
+(rf.hicasso/defview coarse-closure-cell
   "The same, plus the thing the guide names as the case where nothing
   bails: a callback minted in the parent's render.
 
@@ -96,12 +96,12 @@
   [:td [:input {:type "text" :value value :data-row (str row) :data-col (str col)
                 :on-input on-edit}]])
 
-(h/defview coarse-grid
+(rf.hicasso/defview coarse-grid
   "The guide's `;; Don't` shape: one whole-grid read at the top, cells
   rendered from props."
   [{:keys [closures?]}]
-  (let [cells (h/sub [::all-cells])
-        {:keys [rows cols]} (h/sub [::subs/dimensions])]
+  (let [cells (rf.hicasso/sub [::all-cells])
+        {:keys [rows cols]} (rf.hicasso/sub [::rf.hicasso.examples.grid.subs/dimensions])]
     [:table
      [:tbody
       (for [row (range rows)]
@@ -116,7 +116,7 @@
                ;; A FRESH closure per cell per render. Written with the
                ;; one callback form, which is the spelling an author
                ;; reaches for when they want the event itself.
-               :on-edit (h/event [e] [::events/edit row col (.. e -target -value)])}]
+               :on-edit (rf.hicasso/event [e] [::rf.hicasso.examples.grid.events/edit row col (.. e -target -value)])}]
              [coarse-cell {:key   (str col)
                            :row   row
                            :col   col
@@ -127,8 +127,8 @@
 ;; at the top of the file would strand `::all-cells` and every coarse
 ;; mount would refuse.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 ;; ---------------------------------------------------------------------------
@@ -145,12 +145,12 @@
 (def ^:private full {:rows 10 :cols 10})
 
 (defn- mount-grid!
-  ([dimensions] (mount-grid! dimensions [views/grid {}]))
+  ([dimensions] (mount-grid! dimensions [rf.hicasso.examples.grid.views/grid {}]))
   ([dimensions form]
-   (hm/mount! form {:initial-events (app/initial-events dimensions)})))
+   (rf.hicasso.test.mounted/mount! form {:initial-events (rf.hicasso.examples.grid.app/initial-events dimensions)})))
 
 (defn- cell-node [m row col]
-  (.querySelector (:container m) (str "#" (events/cell-id row col))))
+  (.querySelector (:container m) (str "#" (rf.hicasso.examples.grid.events/cell-id row col))))
 
 (defn- set-native-value! [n v]
   (let [d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
@@ -172,8 +172,8 @@
               (nth (array-seq (.querySelectorAll (:container m) "input"))
                    (+ (* row (:cols dimensions)) col)))]
     (try
-      (hm/bodies-run #(do (type-into! n "1") (hm/settle! m)))
-      (finally (hm/unmount! m)))))
+      (rf.hicasso.test.mounted/bodies-run #(do (type-into! n "1") (rf.hicasso.test.mounted/settle! m)))
+      (finally (rf.hicasso.test.mounted/unmount! m)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The application scales
@@ -188,13 +188,13 @@
       (is (= 100 (.-length (.querySelectorAll (:container m) "input"))))
       (is (= 10 (.-length (.querySelectorAll (:container m) ".total"))))
       (is (= "34" (.-value (cell-node m 3 4))))
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 (deftest a-keystroke-costs-the-same-at-25-cells-and-at-100
   (if-not (browser?)
     (skip! "the scaling claim")
-    (let [at-25  (amplification small [views/grid {}] 3 4)
-          at-100 (amplification full [views/grid {}] 3 4)]
+    (let [at-25  (amplification small [rf.hicasso.examples.grid.views/grid {}] 3 4)
+          at-100 (amplification full [rf.hicasso.examples.grid.views/grid {}] 3 4)]
       (is (= 2 at-25 at-100)
           "THE ACCEPTANCE. Two bodies — the cell that was typed into and
            its row's total, which genuinely depends on it — at both sizes.
@@ -214,23 +214,23 @@
         ;; dispatch rather than on every changed READ would answer 2 here.
         (let [m (mount-grid! full)
               n (cell-node m 3 4)]
-          (is (= 0 (hm/bodies-run #(do (type-into! n "x") (hm/settle! m))))
+          (is (= 0 (rf.hicasso.test.mounted/bodies-run #(do (type-into! n "x") (rf.hicasso.test.mounted/settle! m))))
               "a refusal notifies nothing, because the subscription's
                equality gate stops a value that did not move")
           (is (= "34" (.-value n))
               "and the field echoes the COMMITTED value — the refusal half
                of the controlled law, on the glass")
-          (hm/unmount! m)))))
+          (rf.hicasso.test.mounted/unmount! m)))))
 
   (testing "a BROAD update costs what it changed, and not more"
     (if-not (browser?)
       (skip! "the broad contrast")
       (let [m (mount-grid! full)]
-        (is (= 11 (hm/bodies-run #(hm/dispatch-and-settle! m [::events/clear-row {:row 2}])))
+        (is (= 11 (rf.hicasso.test.mounted/bodies-run #(rf.hicasso.test.mounted/dispatch-and-settle! m [::rf.hicasso.examples.grid.events/clear-row {:row 2}])))
             "ten cells and one total. The narrow number has something to
              be narrow COMPARED TO, and the same topology produces both —
              work follows the data, in either direction")
-        (hm/unmount! m)))))
+        (rf.hicasso.test.mounted/unmount! m)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The sabotage — a coarse read makes it red

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/views.cljs
@@ -38,28 +38,28 @@
   reset), no `h/event` (every intent is a vector, including the
   three-argument one), and nothing at all from the optional modules or
   the native tier — the `:require` below is the whole of it."
-  (:require [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.grid.events :as events]
-            [re-frame.hicasso.examples.grid.subs :as subs]))
+  (:require [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.grid.events :as rf.hicasso.examples.grid.events]
+            [re-frame.hicasso.examples.grid.subs :as rf.hicasso.examples.grid.subs]))
 
-(h/defview cell
+(rf.hicasso/defview cell
   "One controlled cell. Two props, one read, one intent.
 
   The intent carries THREE arguments — the row, the column and the
   marker — and is therefore positional. See `grid.events` §`::h/value` is
   positional here too."
   [{:keys [row col]}]
-  (let [id (events/cell-id row col)]
+  (let [id (rf.hicasso.examples.grid.events/cell-id row col)]
     [:td
      [:input {:id           id
               :type         "text"
               :size         4
-              :aria-label   (events/cell-label row col)
+              :aria-label   (rf.hicasso.examples.grid.events/cell-label row col)
               :data-cell    id
-              :value        (h/sub [::subs/cell row col])
-              :on-input     [::events/edit row col ::h/value]}]]))
+              :value        (rf.hicasso/sub [::rf.hicasso.examples.grid.subs/cell row col])
+              :on-input     [::rf.hicasso.examples.grid.events/edit row col ::rf.hicasso/value]}]]))
 
-(h/defview row-total
+(rf.hicasso/defview row-total
   "One row's sum.
 
   Its own boundary, reading its own row's derived value. Fold it into
@@ -67,24 +67,24 @@
   layout body and props-compare ten cells; here it re-runs one body that
   renders one number."
   [{:keys [row]}]
-  [:td.total {:data-total (str row)} (str (h/sub [::subs/row-total row]))])
+  [:td.total {:data-total (str row)} (str (rf.hicasso/sub [::rf.hicasso.examples.grid.subs/row-total row]))])
 
-(h/defview grid-row
+(rf.hicasso/defview grid-row
   "One row: its cells and its total.
 
   Reads the dimensions, which do not move while anybody is typing, so
   this body runs at mount and not again."
   [{:keys [row]}]
-  (let [{:keys [cols]} (h/sub [::subs/dimensions])]
+  (let [{:keys [cols]} (rf.hicasso/sub [::rf.hicasso.examples.grid.subs/dimensions])]
     [:tr {:data-row (str row)}
      (for [col (range cols)]
        [cell {:key (str col) :row row :col col}])
      [row-total {:key "total" :row row}]]))
 
-(h/defview grid
+(rf.hicasso/defview grid
   "The whole application."
   [_]
-  (let [{:keys [rows]} (h/sub [::subs/dimensions])]
+  (let [{:keys [rows]} (rf.hicasso/sub [::rf.hicasso.examples.grid.subs/dimensions])]
     [:main#hundred-cell-grid
      [:h1 "Grid"]
      [:table

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/a11y_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/a11y_cljs_test.cljs
@@ -30,16 +30,16 @@
   state all live — and the row is the piece that repeats ten thousand
   times, so it is the piece worth holding to one assertion per rendering."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso.examples.ledger.events :as events]
-            [re-frame.hicasso.examples.ledger.subs :as subs]
-            [re-frame.hicasso.examples.ledger.views :as views]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso.examples.ledger.events :as rf.hicasso.examples.ledger.events]
+            [re-frame.hicasso.examples.ledger.subs :as rf.hicasso.examples.ledger.subs]
+            [re-frame.hicasso.examples.ledger.views :as rf.hicasso.examples.ledger.views]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 ;; ---------------------------------------------------------------------------
@@ -55,18 +55,18 @@
   "The row at model index `i`, in the state the options describe."
   ([i] (row-tree i {}))
   ([i {:keys [note flagged?] :or {note "" flagged? false}}]
-   (ht/tree [views/ledger-row {:index i :offset (* i views/row-height)}]
-            {:subs {[::subs/record i]   (events/record i)
-                    [::subs/note i]     note
-                    [::subs/flagged? i] flagged?}})))
+   (rf.hicasso.test/tree [rf.hicasso.examples.ledger.views/ledger-row {:index i :offset (* i rf.hicasso.examples.ledger.views/row-height)}]
+            {:subs {[::rf.hicasso.examples.ledger.subs/record i]   (rf.hicasso.examples.ledger.events/record i)
+                    [::rf.hicasso.examples.ledger.subs/note i]     note
+                    [::rf.hicasso.examples.ledger.subs/flagged? i] flagged?}})))
 
 (defn- status-tree [window total]
-  (ht/tree [views/status-line {}]
-           {:subs {[::subs/window] window
-                   [::subs/total]  total}}))
+  (rf.hicasso.test/tree [rf.hicasso.examples.ledger.views/status-line {}]
+           {:subs {[::rf.hicasso.examples.ledger.subs/window] window
+                   [::rf.hicasso.examples.ledger.subs/total]  total}}))
 
-(defn- classed [tree class] (ht/find tree #(= class (:class (ht/attrs %)))))
-(defn- named [tree node] (ht/accessible-name tree node))
+(defn- classed [tree class] (rf.hicasso.test/find tree #(= class (:class (rf.hicasso.test/attrs %)))))
+(defn- named [tree node] (rf.hicasso.test/accessible-name tree node))
 
 (defn- rewrite
   "`tree` with every node matching `pred` replaced by `(f node)`.
@@ -98,7 +98,7 @@
 (deftest a-rows-announced-position-is-its-place-in-the-MODEL
   (testing "row 4,137 of ten thousand, from a row that will be rendered
             somewhere around the fourth of twenty-six mounted siblings"
-    (is (= "4137" (:aria-rowindex (ht/attrs (row-tree 4136))))
+    (is (= "4137" (:aria-rowindex (rf.hicasso.test/attrs (row-tree 4136))))
         "`aria-rowindex` is one-based, and it is the MODEL index plus one.
          A window-relative implementation would write `4` here — a value
          that is correct about the document, wrong about the data, and
@@ -108,24 +108,24 @@
 
   (testing "and the first row of the model still says 1, so the rule is a
             rule rather than a constant offset that happens to fit"
-    (is (= "1" (:aria-rowindex (ht/attrs (row-tree 0))))))
+    (is (= "1" (:aria-rowindex (rf.hicasso.test/attrs (row-tree 0))))))
 
   (testing "the columns are announced too — three cells, in order"
-    (let [cells (ht/find-all (row-tree 4136) #(= :gridcell (ht/role %)))]
+    (let [cells (rf.hicasso.test/find-all (row-tree 4136) #(= :gridcell (rf.hicasso.test/role %)))]
       (is (= 3 (count cells)))
-      (is (= ["1" "2" "3"] (mapv #(:aria-colindex (ht/attrs %)) cells))))))
+      (is (= ["1" "2" "3"] (mapv #(:aria-colindex (rf.hicasso.test/attrs %)) cells))))))
 
 (deftest a-row-is-a-row-and-its-cells-are-cells
   (let [tree (row-tree 4136)]
-    (is (= :row (ht/role tree))
+    (is (= :row (rf.hicasso.test/role tree))
         "the row's own role, written by hand: the virtualizer contributes
          two `role=\"presentation\"` wrappers between the grid and this
          node and knows nothing about tables, so the grid's semantics are
          the application's to write")
-    (is (= :textbox (ht/role (note-node tree)))
+    (is (= :textbox (rf.hicasso.test/role (note-node tree)))
         "an `<input type=\"text\">`, resolved through the implicit table
          rather than asserted as a tag")
-    (is (= :button (ht/role (flag-node tree))))))
+    (is (= :button (rf.hicasso.test/role (flag-node tree))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Names — resolved, and following the record rather than the row
@@ -158,7 +158,7 @@
                         (row-tree 4136 {:note "chase" :flagged? true})]
                        ["the first row" (row-tree 0)]
                        ["the last row" (row-tree 9999)]]]
-    (is (= [] (ht/unnamed-controls tree))
+    (is (= [] (rf.hicasso.test/unnamed-controls tree))
         (str what " — every field and button a user can operate must carry
              an accessible name, and this is the whole row asked at once"))))
 
@@ -170,11 +170,11 @@
             — nothing else changes, and the sweep must find exactly one
             offender"
     (let [sabotaged (rewrite (row-tree 4136)
-                             #(= "ledger-note" (:class (ht/attrs %)))
+                             #(= "ledger-note" (:class (rf.hicasso.test/attrs %)))
                              #(update % :attrs dissoc :aria-label))
-          found     (ht/unnamed-controls sabotaged)]
+          found     (rf.hicasso.test/unnamed-controls sabotaged)]
       (is (= 1 (count found)))
-      (is (= (events/note-id 4136) (:id (ht/attrs (first found))))
+      (is (= (rf.hicasso.examples.ledger.events/note-id 4136) (:id (rf.hicasso.test/attrs (first found))))
           "and it names the field, by the id the application gave it")))
 
   (testing "and the button, which is named by an attribute rather than by
@@ -182,12 +182,12 @@
             them, so content naming would be a name that identifies
             nothing"
     (let [sabotaged (rewrite (row-tree 4136)
-                             #(= "ledger-flag" (:class (ht/attrs %)))
+                             #(= "ledger-flag" (:class (rf.hicasso.test/attrs %)))
                              #(update % :attrs dissoc :aria-label))]
       (is (= "Flag" (named sabotaged (flag-node sabotaged)))
           "it falls back to its content, which is why the row above
            asserts the VALUE of the name and not merely that one exists")
-      (is (= [] (ht/unnamed-controls sabotaged))
+      (is (= [] (rf.hicasso.test/unnamed-controls sabotaged))
           "so this sabotage does NOT show up in the sweep, and saying so
            is the honest limit of a sweep: it catches an absent name, not
            an unhelpful one"))))
@@ -200,8 +200,8 @@
   (let [off (row-tree 4136)
         on  (row-tree 4136 {:flagged? true})]
     (testing "the state, both ways"
-      (is (= "false" (:aria-pressed (ht/attrs (flag-node off)))))
-      (is (= "true" (:aria-pressed (ht/attrs (flag-node on))))))
+      (is (= "false" (:aria-pressed (rf.hicasso.test/attrs (flag-node off)))))
+      (is (= "true" (:aria-pressed (rf.hicasso.test/attrs (flag-node on))))))
     (testing "and the NAME, unchanged across the toggle — a control that
               renames itself as its state changes is a control a
               screen-reader user has to re-find, and these two halves are
@@ -211,8 +211,8 @@
       (is (= "Flag Record 4136" (named on (flag-node on)))))))
 
 (deftest the-note-field-echoes-the-committed-value
-  (is (= "chase" (:value (ht/attrs (note-node (row-tree 4136 {:note "chase"}))))))
-  (is (= "" (:value (ht/attrs (note-node (row-tree 4136)))))
+  (is (= "chase" (:value (rf.hicasso.test/attrs (note-node (row-tree 4136 {:note "chase"}))))))
+  (is (= "" (:value (rf.hicasso.test/attrs (note-node (row-tree 4136)))))
       "and an untouched field is EMPTY rather than absent — a `nil` here
        is React's uncontrolled-input warning, not an empty field"))
 
@@ -222,13 +222,13 @@
 
 (deftest the-status-line-is-a-status-and-counts-the-model
   (let [tree (status-tree {:from 40 :to 66} 10000)]
-    (is (= :status (ht/role tree))
+    (is (= :status (rf.hicasso.test/role tree))
         "a STATUS and not an ALERT: the window moving is not an
          interruption, and the two roles are different promises about how
          urgently a screen reader speaks")
-    (is (= "Showing rows 41–67 of 10000" (ht/text tree))
+    (is (= "Showing rows 41–67 of 10000" (rf.hicasso.test/text tree))
         "one-based, and the denominator is the MODEL's count — the number
          the document cannot supply")
-    (is (nil? (ht/accessible-name tree tree))
+    (is (nil? (rf.hicasso.test/accessible-name tree tree))
         "a live region takes no name from its own text: it is announced
          BECAUSE it changed")))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/app.cljs
@@ -9,11 +9,11 @@
 
   One root, one frame, no route — `examples.editor.app` says why an
   application in this tree registers none."
-  (:require [re-frame.adapter.uix :as uix-adapter]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.ledger.events :as events]
-            [re-frame.hicasso.examples.ledger.views :as views]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.ledger.events :as rf.hicasso.examples.ledger.events]
+            [re-frame.hicasso.examples.ledger.views :as rf.hicasso.examples.ledger.views]))
 
 (def frame-id
   "This application's frame. Namespaced, so two applications in one
@@ -22,8 +22,8 @@
 
 (defn initial-events
   "What seeds a fresh frame holding `total` records."
-  ([] (initial-events events/default-total))
-  ([total] [[::events/seed {:total total}]]))
+  ([] (initial-events rf.hicasso.examples.ledger.events/default-total))
+  ([total] [[::rf.hicasso.examples.ledger.events/seed {:total total}]]))
 
 (defonce ^:private !root (atom nil))
 
@@ -31,13 +31,13 @@
   "Re-render the mounted root after a hot reload."
   []
   (when-some [root @!root]
-    (h/render! root [views/ledger {}])))
+    (rf.hicasso/render! root [rf.hicasso.examples.ledger.views/ledger {}])))
 
 (defn ^:export -main
   "Mount the ten-thousand-row ledger on `#app`."
   []
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (rf/make-frame {:id frame-id :initial-events (initial-events)})
-  (reset! !root (h/mount! (js/document.getElementById "app") {:frame frame-id}
-                          [views/ledger {}]))
+  (reset! !root (rf.hicasso/mount! (js/document.getElementById "app") {:frame frame-id}
+                          [rf.hicasso.examples.ledger.views/ledger {}]))
   nil)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/keyboard_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/keyboard_dom_cljs_test.cljs
@@ -85,22 +85,22 @@
   `test:browser` run, every later namespace and the closing summary
   included."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.ledger.app :as app]
-            [re-frame.hicasso.examples.ledger.events :as events]
-            [re-frame.hicasso.examples.ledger.vendor :as vendor]
-            [re-frame.hicasso.examples.ledger.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.hicasso.trusted-input-support :as trusted]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.ledger.app :as rf.hicasso.examples.ledger.app]
+            [re-frame.hicasso.examples.ledger.events :as rf.hicasso.examples.ledger.events]
+            [re-frame.hicasso.examples.ledger.vendor :as rf.hicasso.examples.ledger.vendor]
+            [re-frame.hicasso.examples.ledger.views :as rf.hicasso.examples.ledger.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.hicasso.trusted-input-support :as rf.hicasso.trusted-input-support]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom" :as react-dom]))
 
 ;; ---------------------------------------------------------------------------
 ;; The control page — the two defects this file's instruments must catch
 ;; ---------------------------------------------------------------------------
 
-(h/defview a-page-of-near-misses
+(rf.hicasso/defview a-page-of-near-misses
   "Three controls that all LOOK operable, and one of them is.
 
   It is a page rather than a ledger variant on purpose: what the two
@@ -131,8 +131,8 @@
 ;; and `:async? true` is the opt-in, so the file was one async row away
 ;; from the trap it believed it had avoided.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true}))
 
@@ -155,7 +155,7 @@
   (array-seq (.querySelectorAll (:container mount) selector)))
 
 (defn- viewport-in [m] (query-node m ".ledger-viewport"))
-(defn- note-node [m i] (query-node m (str "#" (events/note-id i))))
+(defn- note-node [m i] (query-node m (str "#" (rf.hicasso.examples.ledger.events/note-id i))))
 (defn- active [] (.-activeElement js/document))
 (defn- record-of [^js node] (some-> node (.getAttribute "data-record")))
 
@@ -247,18 +247,18 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- mount-ledger!
-  ([] (mount-ledger! events/default-total))
-  ([total] (hm/mount! [views/ledger {}] {:initial-events (app/initial-events total)})))
+  ([] (mount-ledger! rf.hicasso.examples.ledger.events/default-total))
+  ([total] (rf.hicasso.test.mounted/mount! [rf.hicasso.examples.ledger.views/ledger {}] {:initial-events (rf.hicasso.examples.ledger.app/initial-events total)})))
 
 (defn- window-at
   "The window `views/ledger`'s geometry puts on screen at scroll offset
   `top`, derived rather than typed — `ledger.l0-cljs-test` is where the
   arithmetic itself is held."
   [top total]
-  (vendor/window-from top
-                      {:row-height      views/row-height
-                       :viewport-height views/viewport-height
-                       :overscan        views/overscan
+  (rf.hicasso.examples.ledger.vendor/window-from top
+                      {:row-height      rf.hicasso.examples.ledger.views/row-height
+                       :viewport-height rf.hicasso.examples.ledger.views/viewport-height
+                       :overscan        rf.hicasso.examples.ledger.views/overscan
                        :total           total}))
 
 (defn- tell-the-vendor-it-scrolled!
@@ -277,8 +277,8 @@
   (let [^js vp (viewport-in m)]
     (react-dom/flushSync
       (fn [] (.dispatchEvent vp (js/Event. "scroll" #js {:bubbles true}))))
-    (hm/settle! m)
-    (hm/settle! m)
+    (rf.hicasso.test.mounted/settle! m)
+    (rf.hicasso.test.mounted/settle! m)
     m))
 
 (defn- controls-of-rows
@@ -290,7 +290,7 @@
   here and a row rendered there cannot disagree about the spelling."
   [from to]
   (into []
-        (mapcat (fn [i] [(events/note-id i) "ledger-flag"]))
+        (mapcat (fn [i] [(rf.hicasso.examples.ledger.events/note-id i) "ledger-flag"]))
         (range from (inc to))))
 
 ;; ---------------------------------------------------------------------------
@@ -303,7 +303,7 @@
   ;; would satisfy all of them at once.
   (if-not (browser?)
     (skip! "the instruments")
-    (let [m (hm/mount! [a-page-of-near-misses {}])]
+    (let [m (rf.hicasso.test.mounted/mount! [a-page-of-near-misses {}])]
       (testing "focusability is the ENGINE's answer and it goes both ways"
         (is (true? (focusable? (query-node m "#real"))))
         (is (true? (focusable? (query-node m "#half")))
@@ -323,7 +323,7 @@
             "and the real button is NOT among them, so the sweep is
              discriminating rather than reporting every element it
              ranges over"))
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 (deftest the-ledgers-controls-are-reachable-and-its-chrome-is-not
   (if-not (browser?)
@@ -364,7 +364,7 @@
         (is (false? (focusable? (query-node m "[role='grid']"))))
         (is (false? (focusable? (query-node m "[role='gridcell']")))))
 
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 ;; ---------------------------------------------------------------------------
 ;; A REAL Tab — and the synthetic one it has to be told apart from
@@ -383,11 +383,11 @@
   ;; of virtualizer would only make it slower to read.
   (if-not (browser?)
     (skip! "a real key press")
-    (if-not (trusted/bridge?)
-      (trusted/unwitnessed! "sequential navigation on this screen")
+    (if-not (rf.hicasso.trusted-input-support/bridge?)
+      (rf.hicasso.trusted-input-support/unwitnessed! "sequential navigation on this screen")
       (async done
-        (let [m      (hm/mount! [a-page-of-near-misses {}])
-              finish (fn [] (hm/unmount! m) (done))]
+        (let [m      (rf.hicasso.test.mounted/mount! [a-page-of-near-misses {}])
+              finish (fn [] (rf.hicasso.test.mounted/unmount! m) (done))]
           (try
             (let [real (query-node m "#real")]
               (.focus real)
@@ -410,7 +410,7 @@
                       "and focus has not moved: a `pressed Tab` row built this
                        way would be measuring its own dispatcher")))
 
-              (trusted/press-once!
+              (rf.hicasso.trusted-input-support/press-once!
                 "Tab"
                 (fn []
                   (try
@@ -443,21 +443,21 @@
   ;; differs on the first step or not at all.
   (if-not (browser?)
     (skip! "the traversal")
-    (if-not (trusted/bridge?)
-      (trusted/unwitnessed! "the traversal")
+    (if-not (rf.hicasso.trusted-input-support/bridge?)
+      (rf.hicasso.trusted-input-support/unwitnessed! "the traversal")
       (async done
         (let [m      (mount-ledger!)
-              finish (fn [] (hm/unmount! m) (done))
+              finish (fn [] (rf.hicasso.test.mounted/unmount! m) (done))
               steps  5]
           (try
             (let [order (keyboard-order m)
                   start (note-node m 0)]
-              (is (= (first order) (events/note-id 0))
+              (is (= (first order) (rf.hicasso.examples.ledger.events/note-id 0))
                   "premise: the instrument puts row 0's note field first")
               (.focus start)
               (is (identical? start (active)) "premise: the walk starts there")
 
-              (trusted/walk!
+              (rf.hicasso.trusted-input-support/walk!
                 "Tab" steps
                 (fn [] (some-> (active) label-of))
                 (fn [landings]
@@ -482,7 +482,7 @@
   (if-not (browser?)
     (skip! "the order")
     (let [m         (mount-ledger!)
-          [from to] (window-at 0 events/default-total)]
+          [from to] (window-at 0 rf.hicasso.examples.ledger.events/default-total)]
       (is (= (controls-of-rows from to) (keyboard-order m))
           "THE COMPLETE SEQUENCE rather than a membership test — a
            control that joined the order, left it, or moved within it is
@@ -497,14 +497,14 @@
                        (filterv #(pos? (.-tabIndex ^js %)))
                        (mapv label-of)))))
 
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 (deftest the-keyboard-reachable-set-is-the-window-and-not-the-model
   (if-not (browser?)
     (skip! "the bound")
     (let [small   (mount-ledger! 100)
           n-100   (count (keyboard-order small))
-          _       (hm/unmount! small)
+          _       (rf.hicasso.test.mounted/unmount! small)
           big     (mount-ledger! 10000)
           n-10k   (count (keyboard-order big))]
       (is (= n-100 n-10k)
@@ -525,7 +525,7 @@
         (is (nil? (note-node big 9999)))
         (is (= "10000" (.getAttribute (query-node big "[role='grid']") "aria-rowcount"))))
 
-      (hm/unmount! big))))
+      (rf.hicasso.test.mounted/unmount! big))))
 
 ;; ---------------------------------------------------------------------------
 ;; Traversal drives the virtualizer — which is what makes the model reachable
@@ -534,7 +534,7 @@
 (deftest traversing-to-the-window-edge-scrolls-and-extends-the-reachable-set
   (if-not (browser?)
     (skip! "the mitigation")
-    (let [total     events/default-total
+    (let [total     rf.hicasso.examples.ledger.events/default-total
           m         (mount-ledger! total)
           [_ to]    (window-at 0 total)
           ^js vp    (viewport-in m)
@@ -545,7 +545,7 @@
                 pixel viewport"
         (is (zero? (.-scrollTop vp)))
         (is (some? edge))
-        (is (> (* to views/row-height) views/viewport-height)))
+        (is (> (* to rf.hicasso.examples.ledger.views/row-height) rf.hicasso.examples.ledger.views/viewport-height)))
 
       (.focus edge)
 
@@ -585,7 +585,7 @@
                 "the far edge advanced past where the first window
                  ended"))))
 
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 (deftest the-field-a-user-was-typing-in-stays-reachable-after-any-scroll
   ;; The keyboard half of Rule 3. `virtualized-dom-cljs-test` shows the
@@ -594,14 +594,14 @@
   ;; then tabs away — whether they can ever get back.
   (if-not (browser?)
     (skip! "the pin's keyboard consequence")
-    (let [total     events/default-total
+    (let [total     rf.hicasso.examples.ledger.events/default-total
           m         (mount-ledger! total)
           ^js vp    (viewport-in m)
           field     (note-node m 5)
-          top       (* 500 views/row-height)
+          top       (* 500 rf.hicasso.examples.ledger.views/row-height)
           [from to] (window-at top total)]
       (.focus field)
-      (hm/settle! m)
+      (rf.hicasso.test.mounted/settle! m)
       (set! (.-scrollTop vp) top)
       (tell-the-vendor-it-scrolled! m)
 
@@ -610,7 +610,7 @@
            ninety-five rows after the window left it")
 
       (let [order (keyboard-order m)]
-        (is (= (events/note-id 5) (last (butlast order)))
+        (is (= (rf.hicasso.examples.ledger.events/note-id 5) (last (butlast order)))
             "THE PIN'S PLACE IN THE ORDER. The vendor appends the pinned
              row after the window's rows, so the field the user was
              typing in is the second-to-last stop rather than the first
@@ -627,7 +627,7 @@
              constant would be asserting about whichever offset it was
              written at"))
 
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 ;; ---------------------------------------------------------------------------
 ;; Activation — bought by the tag, not by a handler
@@ -655,4 +655,4 @@
                (into #{} (map #(.getAttribute ^js % "role"))
                      (query-nodes m "[role]")))))
 
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/l0_cljs_test.cljs
@@ -18,18 +18,18 @@
   arithmetic rather than typed in. Getting it wrong here would make the
   DOM suite agree with a wrong number rather than fail."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.ledger.app :as app]
-            [re-frame.hicasso.examples.ledger.events :as events]
-            [re-frame.hicasso.examples.ledger.subs :as subs]
-            [re-frame.hicasso.examples.ledger.vendor :as vendor]
-            [re-frame.hicasso.examples.ledger.views :as views]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.ledger.app :as rf.hicasso.examples.ledger.app]
+            [re-frame.hicasso.examples.ledger.events :as rf.hicasso.examples.ledger.events]
+            [re-frame.hicasso.examples.ledger.subs :as rf.hicasso.examples.ledger.subs]
+            [re-frame.hicasso.examples.ledger.vendor :as rf.hicasso.examples.ledger.vendor]
+            [re-frame.hicasso.examples.ledger.views :as rf.hicasso.examples.ledger.views]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 (defn- with-ledger
@@ -38,7 +38,7 @@
   ([f] (with-ledger 200 f))
   ([total f]
    (rf/with-new-frame [frame (rf/make-frame
-                               {:initial-events (app/initial-events total)})]
+                               {:initial-events (rf.hicasso.examples.ledger.app/initial-events total)})]
      (f frame))))
 
 (defn- read-sub [frame query-v] (rf/subscribe-once query-v {:frame frame}))
@@ -49,19 +49,19 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-records-id-is-not-its-index
-  (is (= {:id "rec-100000" :name "Record 0"} (events/record 0)))
-  (is (= {:id "rec-104136" :name "Record 4136"} (events/record 4136)))
+  (is (= {:id "rec-100000" :name "Record 0"} (rf.hicasso.examples.ledger.events/record 0)))
+  (is (= {:id "rec-104136" :name "Record 4136"} (rf.hicasso.examples.ledger.events/record 4136)))
   (testing "which is what makes a focus assertion an assertion about the
             RECORD — an id that read `5` would be equally satisfied by
             focus having stayed on the fifth row of the window, and the
             fifth row of the window is exactly what a slot-keyed
             virtualizer leaves it on"
-    (is (not= (str 5) (:id (events/record 5))))))
+    (is (not= (str 5) (:id (rf.hicasso.examples.ledger.events/record 5))))))
 
 (deftest the-default-ledger-is-ten-thousand-records
-  (is (= 10000 events/default-total)
+  (is (= 10000 rf.hicasso.examples.ledger.events/default-total)
       "specification §7's `10K-row behavior`, as a number the witnesses read")
-  (let [db (events/seed 10000)]
+  (let [db (rf.hicasso.examples.ledger.events/seed 10000)]
     (is (= 10000 (count (:records db))))
     (is (= {} (:notes db)) "an untouched record costs no entry")
     (is (= -1 (:focused db)) "nothing is pinned before anything has focus")))
@@ -73,24 +73,24 @@
 (deftest one-keystroke-moves-exactly-one-address
   (with-ledger 10000
     (fn [frame]
-      (send! frame [::events/note 4136 "chase"])
-      (is (= "chase" (read-sub frame [::subs/note 4136])))
-      (is (= "" (read-sub frame [::subs/note 4135])))
-      (is (= "" (read-sub frame [::subs/note 4137]))
+      (send! frame [::rf.hicasso.examples.ledger.events/note 4136 "chase"])
+      (is (= "chase" (read-sub frame [::rf.hicasso.examples.ledger.subs/note 4136])))
+      (is (= "" (read-sub frame [::rf.hicasso.examples.ledger.subs/note 4135])))
+      (is (= "" (read-sub frame [::rf.hicasso.examples.ledger.subs/note 4137]))
           "the neighbours, because a map keyed by index is only worth
            having if a write reaches one key of it")
       (testing "and the records are untouched — the note is a second
                 address and not a field of the record, so a keystroke
                 cannot move what a row displays as its name"
         (is (= {:id "rec-104136" :name "Record 4136"}
-               (read-sub frame [::subs/record 4136])))))))
+               (read-sub frame [::rf.hicasso.examples.ledger.subs/record 4136])))))))
 
 (deftest a-record-is-read-by-index-and-answers-by-identity
   (with-ledger
     (fn [frame]
-      (let [before (read-sub frame [::subs/record 7])]
-        (send! frame [::events/note 7 "x"])
-        (is (identical? before (read-sub frame [::subs/record 7]))
+      (let [before (read-sub frame [::rf.hicasso.examples.ledger.subs/record 7])]
+        (send! frame [::rf.hicasso.examples.ledger.events/note 7 "x"])
+        (is (identical? before (read-sub frame [::rf.hicasso.examples.ledger.subs/record 7]))
             "IDENTICAL, not merely `=`. A note write must not mint a fresh
              record map, because the row's record read is what a
              keystroke must NOT notify — and a subscription's equality
@@ -100,34 +100,34 @@
 (deftest the-flag-toggles-and-nothing-else-does
   (with-ledger
     (fn [frame]
-      (is (false? (read-sub frame [::subs/flagged? 3])))
-      (send! frame [::events/flag {:index 3}])
-      (is (true? (read-sub frame [::subs/flagged? 3])))
-      (is (false? (read-sub frame [::subs/flagged? 4])))
-      (send! frame [::events/flag {:index 3}])
-      (is (false? (read-sub frame [::subs/flagged? 3])) "and back"))))
+      (is (false? (read-sub frame [::rf.hicasso.examples.ledger.subs/flagged? 3])))
+      (send! frame [::rf.hicasso.examples.ledger.events/flag {:index 3}])
+      (is (true? (read-sub frame [::rf.hicasso.examples.ledger.subs/flagged? 3])))
+      (is (false? (read-sub frame [::rf.hicasso.examples.ledger.subs/flagged? 4])))
+      (send! frame [::rf.hicasso.examples.ledger.events/flag {:index 3}])
+      (is (false? (read-sub frame [::rf.hicasso.examples.ledger.subs/flagged? 3])) "and back"))))
 
 (deftest focus-is-recorded-as-an-index-and-read-back-as-the-pin
   (with-ledger
     (fn [frame]
-      (is (= -1 (read-sub frame [::subs/pinned-index]))
+      (is (= -1 (read-sub frame [::rf.hicasso.examples.ledger.subs/pinned-index]))
           "`-1` and not `nil`: the value goes to a foreign component as a
            number, and `nil` there would be a prop the vendor has to
            special-case")
-      (send! frame [::events/row-focused {:index 12}])
-      (is (= 12 (read-sub frame [::subs/pinned-index])))
+      (send! frame [::rf.hicasso.examples.ledger.events/row-focused {:index 12}])
+      (is (= 12 (read-sub frame [::rf.hicasso.examples.ledger.subs/pinned-index])))
       (testing "the next focus replaces it — one pin, and it is released
                 by the next focus and by nothing else, because a `:on-blur`
                 companion would unmount the row while the platform is
                 still moving focus through it"
-        (send! frame [::events/row-focused {:index 13}])
-        (is (= 13 (read-sub frame [::subs/pinned-index])))))))
+        (send! frame [::rf.hicasso.examples.ledger.events/row-focused {:index 13}])
+        (is (= 13 (read-sub frame [::rf.hicasso.examples.ledger.subs/pinned-index])))))))
 
 (deftest the-window-the-vendor-reports-is-ordinary-data
   (with-ledger
     (fn [frame]
-      (send! frame [::events/window-shown {:from 40 :to 66}])
-      (is (= {:from 40 :to 66} (read-sub frame [::subs/window]))))))
+      (send! frame [::rf.hicasso.examples.ledger.events/window-shown {:from 40 :to 66}])
+      (is (= {:from 40 :to 66} (read-sub frame [::rf.hicasso.examples.ledger.subs/window]))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The window function
@@ -137,12 +137,12 @@
   "The screen's own geometry, read from the view rather than typed, so
   this file and the DOM suite cannot disagree about the numbers the
   screen actually uses."
-  {:row-height      views/row-height
-   :viewport-height views/viewport-height
-   :overscan        views/overscan
+  {:row-height      rf.hicasso.examples.ledger.views/row-height
+   :viewport-height rf.hicasso.examples.ledger.views/viewport-height
+   :overscan        rf.hicasso.examples.ledger.views/overscan
    :total           10000})
 
-(defn- window [scroll-top] (vendor/window-from scroll-top geometry))
+(defn- window [scroll-top] (rf.hicasso.examples.ledger.vendor/window-from scroll-top geometry))
 
 (deftest the-window-is-the-viewport-plus-the-overscan
   (testing "at the top, where the overscan above the viewport is clamped away"
@@ -151,18 +151,18 @@
          nothing above — twenty-four rows of DOM for a ten-thousand-row
          model"))
   (testing "in the middle, where both edges get their overscan"
-    (is (= [7 33] (window (* 10 views/row-height)))
+    (is (= [7 33] (window (* 10 rf.hicasso.examples.ledger.views/row-height)))
         "scrolled to row 10: three above, twenty visible, three below")
-    (is (= [497 523] (window (* 500 views/row-height)))))
+    (is (= [497 523] (window (* 500 rf.hicasso.examples.ledger.views/row-height)))))
   (testing "at the bottom, where the model clamps the far edge"
-    (is (= [9974 9999] (window (* 9977 views/row-height))))))
+    (is (= [9974 9999] (window (* 9977 rf.hicasso.examples.ledger.views/row-height))))))
 
 (deftest the-window-does-not-grow-with-the-model
   ;; The virtualizer half of the screen's scaling claim, stated where it
   ;; is arithmetic. The DOM suite measures the same thing on a real
   ;; engine; this row is what makes that measurement's expected value a
   ;; derivation rather than a constant somebody typed.
-  (let [at-100   (vendor/window-from 0 (assoc geometry :total 100))
+  (let [at-100   (rf.hicasso.examples.ledger.vendor/window-from 0 (assoc geometry :total 100))
         at-10000 (window 0)]
     (is (= at-100 at-10000)
         "a hundred records and ten thousand produce the same window at the
@@ -170,14 +170,14 @@
          collection`, before any DOM is involved")
     (is (= [0 23] at-10000)))
   (testing "and a model SMALLER than one window is clamped, not padded"
-    (is (= [0 9] (vendor/window-from 0 (assoc geometry :total 10))))))
+    (is (= [0 9] (rf.hicasso.examples.ledger.vendor/window-from 0 (assoc geometry :total 10))))))
 
 (deftest a-scroll-of-n-rows-moves-the-window-by-n
   ;; The premise the DOM suite's `a scroll costs the rows that entered`
   ;; row rests on: if a three-row scroll moved the window by more than
   ;; three, the body count it measures would be about the vendor's
   ;; arithmetic rather than about the screen's topology.
-  (let [[from-a to-a] (window (* 100 views/row-height))
-        [from-b to-b] (window (* 103 views/row-height))]
+  (let [[from-a to-a] (window (* 100 rf.hicasso.examples.ledger.views/row-height))
+        [from-b to-b] (window (* 103 rf.hicasso.examples.ledger.views/row-height))]
     (is (= 3 (- from-b from-a)))
     (is (= 3 (- to-b to-a)))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/views.cljs
@@ -90,10 +90,10 @@
   is not needed here, because a virtualizer is an ordinary
   React component and the door for an ordinary React component is the
   declaration."
-  (:require [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.ledger.events :as events]
-            [re-frame.hicasso.examples.ledger.subs :as subs]
-            [re-frame.hicasso.examples.ledger.vendor :as vendor]))
+  (:require [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.ledger.events :as rf.hicasso.examples.ledger.events]
+            [re-frame.hicasso.examples.ledger.subs :as rf.hicasso.examples.ledger.subs]
+            [re-frame.hicasso.examples.ledger.vendor :as rf.hicasso.examples.ledger.vendor]))
 
 ;; ---------------------------------------------------------------------------
 ;; Geometry
@@ -119,7 +119,7 @@
 ;; The crossing
 ;; ---------------------------------------------------------------------------
 
-(h/defhost rows
+(rf.hicasso/defhost rows
   "The declared door onto the virtualizer.
 
   `:render-row` carries the `:render` contract, so what the callback
@@ -134,13 +134,13 @@
   offset)`, `onWindow(from, to)` — so there is no event at argument one
   and nothing for a vector's markers to read. The one callback form
   receives the library's own arguments, in order (HD-024)."
-  vendor/virtual-rows)
+  rf.hicasso.examples.ledger.vendor/virtual-rows)
 
 ;; ---------------------------------------------------------------------------
 ;; The screen
 ;; ---------------------------------------------------------------------------
 
-(h/defview ledger-row
+(rf.hicasso/defview ledger-row
   "One record's row: its name, its note and its flag.
 
   Three reads, all parametric on the model index, and every one of them
@@ -154,7 +154,7 @@
   contributes two `role=\"presentation\"` wrappers and knows nothing
   about tables."
   [{:keys [index offset]}]
-  (let [{:keys [id name]} (h/sub [::subs/record index])]
+  (let [{:keys [id name]} (rf.hicasso/sub [::rf.hicasso.examples.ledger.subs/record index])]
     [:div {:role          "row"
            :class         "ledger-row"
            :aria-rowindex (str (inc index))
@@ -167,22 +167,22 @@
                            :height   row-height}}
      [:div {:role "gridcell" :aria-colindex "1" :class "ledger-name"} name]
      [:div {:role "gridcell" :aria-colindex "2"}
-      [:input {:id          (events/note-id index)
+      [:input {:id          (rf.hicasso.examples.ledger.events/note-id index)
                :class       "ledger-note"
                :type        "text"
-               :aria-label  (events/note-label index)
+               :aria-label  (rf.hicasso.examples.ledger.events/note-label index)
                :data-record id
-               :value       (h/sub [::subs/note index])
-               :on-focus    [::events/row-focused {:index index}]
-               :on-input    [::events/note index ::h/value]}]]
+               :value       (rf.hicasso/sub [::rf.hicasso.examples.ledger.subs/note index])
+               :on-focus    [::rf.hicasso.examples.ledger.events/row-focused {:index index}]
+               :on-input    [::rf.hicasso.examples.ledger.events/note index ::rf.hicasso/value]}]]
      [:div {:role "gridcell" :aria-colindex "3"}
       [:button {:class        "ledger-flag"
-                :aria-label   (events/flag-label index)
-                :aria-pressed (str (h/sub [::subs/flagged? index]))
-                :on-click     [::events/flag {:index index}]}
+                :aria-label   (rf.hicasso.examples.ledger.events/flag-label index)
+                :aria-pressed (str (rf.hicasso/sub [::rf.hicasso.examples.ledger.subs/flagged? index]))
+                :on-click     [::rf.hicasso.examples.ledger.events/flag {:index index}]}
        "Flag"]]]))
 
-(h/defview status-line
+(rf.hicasso/defview status-line
   "*Showing rows 41–66 of 10,000.*
 
   Its own boundary, and that is the whole reason it exists as one: it is
@@ -191,12 +191,12 @@
   re-run the screen, re-mint the render callback and re-create the whole
   window's worth of elements."
   [_]
-  (let [{:keys [from to]} (h/sub [::subs/window])
-        total             (h/sub [::subs/total])]
+  (let [{:keys [from to]} (rf.hicasso/sub [::rf.hicasso.examples.ledger.subs/window])
+        total             (rf.hicasso/sub [::rf.hicasso.examples.ledger.subs/total])]
     [:p.ledger-status {:role "status"}
      (str "Showing rows " (inc from) "–" (inc to) " of " total)]))
 
-(h/defview ledger
+(rf.hicasso/defview ledger
   "The whole application.
 
   Reads the total, which nothing writes after the seed, and the pinned
@@ -204,8 +204,8 @@
   or by a keystroke, so this body runs at mount and on a focus change and
   at no other time."
   [_]
-  (let [total  (h/sub [::subs/total])
-        pinned (h/sub [::subs/pinned-index])]
+  (let [total  (rf.hicasso/sub [::rf.hicasso.examples.ledger.subs/total])
+        pinned (rf.hicasso/sub [::rf.hicasso.examples.ledger.subs/pinned-index])]
     [:section#ledger
      [:h1 "Ledger"]
      [status-line {}]
@@ -221,10 +221,10 @@
              :viewport-height viewport-height
              :overscan        overscan
              :pinned-index    pinned
-             :render-row      (h/event [i offset]
-                                (h/as-element
+             :render-row      (rf.hicasso/event [i offset]
+                                (rf.hicasso/as-element
                                   [ledger-row {:key    (row-key i)
                                                :index  i
                                                :offset offset}]))
-             :on-window       (h/event [from to]
-                                [::events/window-shown {:from from :to to}])}]]]))
+             :on-window       (rf.hicasso/event [from to]
+                                [::rf.hicasso.examples.ledger.events/window-shown {:from from :to to}])}]]]))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/virtualized_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/virtualized_dom_cljs_test.cljs
@@ -63,23 +63,23 @@
   than to a false green — the posture every other `*-dom` suite here
   keeps."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.ledger.app :as app]
-            [re-frame.hicasso.examples.ledger.events :as events]
-            [re-frame.hicasso.examples.ledger.subs :as subs]
-            [re-frame.hicasso.examples.ledger.vendor :as vendor]
-            [re-frame.hicasso.examples.ledger.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.ledger.app :as rf.hicasso.examples.ledger.app]
+            [re-frame.hicasso.examples.ledger.events :as rf.hicasso.examples.ledger.events]
+            [re-frame.hicasso.examples.ledger.subs :as rf.hicasso.examples.ledger.subs]
+            [re-frame.hicasso.examples.ledger.vendor :as rf.hicasso.examples.ledger.vendor]
+            [re-frame.hicasso.examples.ledger.views :as rf.hicasso.examples.ledger.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom" :as react-dom]))
 
 ;; ---------------------------------------------------------------------------
 ;; The controls — the recipe with one rule removed each
 ;; ---------------------------------------------------------------------------
 
-(h/defview unkeyed-ledger
+(rf.hicasso/defview unkeyed-ledger
   "**Rule 1 removed.** Identical to `views/ledger` except that the row
   written in the render callback carries no `:key`.
 
@@ -88,37 +88,37 @@
   three rows hands every DOM node to the record three places further
   down, silently, while the page keeps looking right."
   [_]
-  (let [total  (h/sub [::subs/total])
-        pinned (h/sub [::subs/pinned-index])]
+  (let [total  (rf.hicasso/sub [::rf.hicasso.examples.ledger.subs/total])
+        pinned (rf.hicasso/sub [::rf.hicasso.examples.ledger.subs/pinned-index])]
     [:div {:role "grid" :aria-rowcount (str total)}
-     [views/rows {:count           total
-                  :row-height      views/row-height
-                  :viewport-height views/viewport-height
-                  :overscan        views/overscan
+     [rf.hicasso.examples.ledger.views/rows {:count           total
+                  :row-height      rf.hicasso.examples.ledger.views/row-height
+                  :viewport-height rf.hicasso.examples.ledger.views/viewport-height
+                  :overscan        rf.hicasso.examples.ledger.views/overscan
                   :pinned-index    pinned
-                  :render-row      (h/event [i offset]
-                                     (h/as-element
-                                       [views/ledger-row {:index i :offset offset}]))}]]))
+                  :render-row      (rf.hicasso/event [i offset]
+                                     (rf.hicasso/as-element
+                                       [rf.hicasso.examples.ledger.views/ledger-row {:index i :offset offset}]))}]]))
 
-(h/defview unpinned-ledger
+(rf.hicasso/defview unpinned-ledger
   "**Rule 3 removed.** Identical to `views/ledger` except that the
   virtualizer is never told which row the platform's focus is in, so it
   unmounts that row like any other the moment the window leaves it."
   [_]
-  (let [total (h/sub [::subs/total])]
+  (let [total (rf.hicasso/sub [::rf.hicasso.examples.ledger.subs/total])]
     [:div {:role "grid" :aria-rowcount (str total)}
-     [views/rows {:count           total
-                  :row-height      views/row-height
-                  :viewport-height views/viewport-height
-                  :overscan        views/overscan
+     [rf.hicasso.examples.ledger.views/rows {:count           total
+                  :row-height      rf.hicasso.examples.ledger.views/row-height
+                  :viewport-height rf.hicasso.examples.ledger.views/viewport-height
+                  :overscan        rf.hicasso.examples.ledger.views/overscan
                   :pinned-index    -1
-                  :render-row      (h/event [i offset]
-                                     (h/as-element
-                                       [views/ledger-row {:key    (views/row-key i)
+                  :render-row      (rf.hicasso/event [i offset]
+                                     (rf.hicasso/as-element
+                                       [rf.hicasso.examples.ledger.views/ledger-row {:key    (rf.hicasso.examples.ledger.views/row-key i)
                                                           :index  i
                                                           :offset offset}]))}]]))
 
-(h/defview plain-list
+(rf.hicasso/defview plain-list
   "The same rows with no virtualizer at all — the contrast that makes
   *the document holds a window* a measurement rather than a reading of
   one number.
@@ -127,22 +127,22 @@
   is not an anti-pattern: for a hundred rows it is the right shape, and
   saying so is half of what a virtualizer recipe is for."
   [_]
-  (let [total (h/sub [::subs/total])]
+  (let [total (rf.hicasso/sub [::rf.hicasso.examples.ledger.subs/total])]
     [:div {:role "grid" :aria-rowcount (str total)}
      (for [i (range total)]
-       [views/ledger-row {:key    (views/row-key i)
+       [rf.hicasso.examples.ledger.views/ledger-row {:key    (rf.hicasso.examples.ledger.views/row-key i)
                           :index  i
-                          :offset (* i views/row-height)}])]))
+                          :offset (* i rf.hicasso.examples.ledger.views/row-height)}])]))
 
 ;; The fixture snapshots the registrar when THIS form is evaluated, so it
 ;; sits below the three views above.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     ;; The MAP shape, because [[the-screen-leaves-nothing-behind]] is
     ;; `async` and `cljs.test` aborts the WHOLE RUN — every namespace
     ;; after this one included — on an async row under a positional
     ;; fixture. Observed: one line of `Testing aborted.` and no summary.
-    {:adapter       uix-adapter/adapter
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true}))
 
@@ -158,8 +158,8 @@
                  subject — " why)))
 
 (defn- mount-ledger!
-  ([total] (mount-ledger! total [views/ledger {}]))
-  ([total form] (hm/mount! form {:initial-events (app/initial-events total)})))
+  ([total] (mount-ledger! total [rf.hicasso.examples.ledger.views/ledger {}]))
+  ([total form] (rf.hicasso.test.mounted/mount! form {:initial-events (rf.hicasso.examples.ledger.app/initial-events total)})))
 
 (defn- query-node [mount selector] (.querySelector (:container mount) selector))
 (defn- query-nodes [mount selector]
@@ -173,7 +173,7 @@
   "The note field of the row showing model index `i`, or nil when that
   row is not in the document."
   [m i]
-  (query-node m (str "#" (events/note-id i))))
+  (query-node m (str "#" (rf.hicasso.examples.ledger.events/note-id i))))
 
 (defn- record-of
   "The record id the node BELONGS TO, read off the DOM. The whole of the
@@ -189,10 +189,10 @@
   derived rather than typed — see `ledger.l0-cljs-test`, which is where
   the arithmetic itself is held."
   [i total]
-  (vendor/window-from (* i views/row-height)
-                      {:row-height      views/row-height
-                       :viewport-height views/viewport-height
-                       :overscan        views/overscan
+  (rf.hicasso.examples.ledger.vendor/window-from (* i rf.hicasso.examples.ledger.views/row-height)
+                      {:row-height      rf.hicasso.examples.ledger.views/row-height
+                       :viewport-height rf.hicasso.examples.ledger.views/viewport-height
+                       :overscan        rf.hicasso.examples.ledger.views/overscan
                        :total           total}))
 
 (defn- window-size [i total]
@@ -225,14 +225,14 @@
      line's body run outside the measurement it belongs to."
   [m i]
   (let [^js vp (viewport-in m)
-        want   (* i views/row-height)]
+        want   (* i rf.hicasso.examples.ledger.views/row-height)]
     (set! (.-scrollTop vp) want)
     (is (= want (.-scrollTop vp))
         "the viewport did not scroll — the instrument, not the screen")
     (react-dom/flushSync
       (fn [] (.dispatchEvent vp (js/Event. "scroll" #js {:bubbles true}))))
-    (hm/settle! m)
-    (hm/settle! m)
+    (rf.hicasso.test.mounted/settle! m)
+    (rf.hicasso.test.mounted/settle! m)
     ;; 4. And assert the WINDOW moved, not merely the offset. Steps 1 and
     ;;    2 can both succeed while the window stands still — that is
     ;;    exactly what the first two runs of this file did — and the
@@ -252,12 +252,12 @@
 (defn- type-into! [m ^js n text]
   (set-native-value! n (str (.-value n) text))
   (.dispatchEvent n (js/Event. "input" #js {:bubbles true}))
-  (hm/settle! m)
+  (rf.hicasso.test.mounted/settle! m)
   nil)
 
 (defn- focus! [m ^js n]
   (.focus n)
-  (hm/settle! m)
+  (rf.hicasso.test.mounted/settle! m)
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -283,7 +283,7 @@
       (testing "and each carries a real, operable field"
         (is (some? (note-node m 0)))
         (is (= "Note for Record 0" (.getAttribute (note-node m 0) "aria-label"))))
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 (deftest the-vendors-own-wrappers-are-presentational
   ;; A `role="grid"` owns `role="row"`, and a virtualizer puts two divs
@@ -297,9 +297,9 @@
       (is (= "presentation" (.getAttribute (query-node m ".ledger-spacer") "role")))
       (testing "and the spacer is the MODEL's full height, which is what
                 makes the scrollbar honest"
-        (is (= (str (* 10000 views/row-height) "px")
+        (is (= (str (* 10000 rf.hicasso.examples.ledger.views/row-height) "px")
                (.. ^js (query-node m ".ledger-spacer") -style -height))))
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 ;; ---------------------------------------------------------------------------
 ;; Windowing bounds the mounted rows
@@ -310,7 +310,7 @@
     (skip! "the windowing claim")
     (let [small (mount-ledger! 100)
           n-100 (count (rows-in small))
-          _     (hm/unmount! small)
+          _     (rf.hicasso.test.mounted/unmount! small)
           big   (mount-ledger! 10000)
           n-10k (count (rows-in big))]
       (is (= n-100 n-10k)
@@ -319,7 +319,7 @@
            hundred changed nothing about the page, which is what
            `10K-row behavior` means before any timing is involved")
       (is (= 24 n-10k))
-      (hm/unmount! big)))
+      (rf.hicasso.test.mounted/unmount! big)))
 
   (testing "and the unwindowed shape GROWS, which is what says the number
             above is a measurement"
@@ -333,8 +333,8 @@
              document is the model. For a hundred rows that is the right
              shape; the ledger's claim is about the shape that is still
              right at ten thousand")
-        (hm/unmount! a)
-        (hm/unmount! b)))))
+        (rf.hicasso.test.mounted/unmount! a)
+        (rf.hicasso.test.mounted/unmount! b)))))
 
 (deftest the-announced-position-follows-the-model-across-a-scroll
   (if-not (browser?)
@@ -355,7 +355,7 @@
            on screen")
       (is (= (str "rec-" (+ 100000 from)) (record-of (first (rows-in m))))
           "and it is the record the position claims it is")
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 ;; ---------------------------------------------------------------------------
 ;; Keyed identity across a scroll — the finding
@@ -399,7 +399,7 @@
       (is (= 2 (.-selectionStart ^js (active)))
           "with the caret still between the two letters the user left it
            between — the fact a node-identity claim exists to buy")
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 (deftest a-slot-keyed-window-moves-focus-to-another-record
   ;; THE POSITIVE CONTROL, and the finding this screen publishes. Without
@@ -427,7 +427,7 @@
         (is (= "rec-100043" (record-of (active)))
             "the correct screen answers `rec-100040` at this exact point;
              the two variants differ in nothing else"))
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 ;; ---------------------------------------------------------------------------
 ;; Focus continuity — the pin
@@ -456,9 +456,9 @@
       (testing "and the application never touched focus to achieve it —
                 the pin only stops React deleting the node the platform's
                 focus is already in"
-        (is (= 40 (rf/subscribe-once [::subs/pinned-index] {:frame (:frame m)}))
+        (is (= 40 (rf/subscribe-once [::rf.hicasso.examples.ledger.subs/pinned-index] {:frame (:frame m)}))
             "the one thing the application knows about focus: an index"))
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 (deftest without-the-pin-a-scroll-destroys-the-focused-node
   ;; THE POSITIVE CONTROL for the row above.
@@ -475,7 +475,7 @@
           "and focus fell to the document body. The user was typing; now
            they are typing nowhere, and no keystroke will reach the field
            they were in")
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 ;; ---------------------------------------------------------------------------
 ;; Work follows the data
@@ -487,13 +487,13 @@
     (letfn [(keystroke-cost [total]
               (let [m (mount-ledger! total)
                     n (note-node m 0)]
-                (try (hm/bodies-run #(type-into! m n "a"))
-                     (finally (hm/unmount! m)))))
+                (try (rf.hicasso.test.mounted/bodies-run #(type-into! m n "a"))
+                     (finally (rf.hicasso.test.mounted/unmount! m)))))
             (scroll-cost [total]
               (let [m (mount-ledger! total)]
                 (scroll-to! m 40)
-                (try (hm/bodies-run #(scroll-to! m 43))
-                     (finally (hm/unmount! m)))))]
+                (try (rf.hicasso.test.mounted/bodies-run #(scroll-to! m 43))
+                     (finally (rf.hicasso.test.mounted/unmount! m)))))]
       (testing "a keystroke costs one body, and the model's size is not in it"
         (let [at-100 (keystroke-cost 100)
               at-10k (keystroke-cost 10000)]
@@ -526,13 +526,13 @@
     (skip! "the pin's price")
     (let [m (mount-ledger! 10000)
           n (note-node m 5)]
-      (is (= 1 (hm/bodies-run #(focus! m n)))
+      (is (= 1 (rf.hicasso.test.mounted/bodies-run #(focus! m n)))
           "ONE: the screen's own body, because `:pinned-index` moved. The
            twenty-four mounted rows ran nothing — the render callback
            re-created their elements with identical props and every one
            of them bailed out. That is what makes the pin affordable, and
            it is a fact about the row's props being two numbers")
-      (hm/unmount! m))))
+      (rf.hicasso.test.mounted/unmount! m))))
 
 ;; ---------------------------------------------------------------------------
 ;; Teardown
@@ -551,6 +551,6 @@
         (scroll-to! m 500)
         (focus! m (note-node m 500))
         (type-into! m (note-node m 500) "x")
-        (-> (hm/unmount! m)
-            (hm/assert-clean!)
+        (-> (rf.hicasso.test.mounted/unmount! m)
+            (rf.hicasso.test.mounted/assert-clean!)
             (.then (fn [_] (done))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/conduct_dom_cljs_test.cljs
@@ -83,16 +83,16 @@
   a naming-ledger question that is still open (row 36 — *keep as taught*,
   status open), not this bead's to settle."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.navigation.events :as events]
-            [re-frame.hicasso.examples.navigation.routes :as routes]
-            [re-frame.hicasso.examples.navigation.subs :as subs]
-            [re-frame.hicasso.examples.navigation.views :as views]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.routing :as routing]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.navigation.events :as rf.hicasso.examples.navigation.events]
+            [re-frame.hicasso.examples.navigation.routes :as rf.hicasso.examples.navigation.routes]
+            [re-frame.hicasso.examples.navigation.subs :as rf.hicasso.examples.navigation.subs]
+            [re-frame.hicasso.examples.navigation.views :as rf.hicasso.examples.navigation.views]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.routing :as rf.routing]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The lane
@@ -104,8 +104,8 @@
   (is true (str "a navigation-conduct witness needs a real browser — " why)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
      :init-fn       (fn []
@@ -115,8 +115,8 @@
                       ;; position saved by one row would still be there for
                       ;; the next — which is precisely what the
                       ;; never-visited-URL row is written to rule out.
-                      (routing/reset-scroll-cache!)
-                      (routes/register!))}))
+                      (rf.routing/reset-scroll-cache!)
+                      (rf.hicasso.examples.navigation.routes/register!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Reading the page
@@ -171,8 +171,8 @@
   link, and the shape every other row starts from."
   ([route] (at! route nil))
   ([route params]
-   (hm/mount! [views/app {}]
-              {:initial-events [[::events/seed]
+   (rf.hicasso.test.mounted/mount! [rf.hicasso.examples.navigation.views/app {}]
+              {:initial-events [[::rf.hicasso.examples.navigation.events/seed]
                                 [:rf.route/navigate (cond-> {:to route}
                                                       params (assoc :params params))]]})))
 
@@ -183,7 +183,7 @@
   ([m done] (finish m nil done))
   ([m extra-nodes done]
    (doseq [n extra-nodes] (try (.remove n) (catch :default _ nil)))
-   (-> (hm/unmount! m) (hm/assert-clean!) (.then done))))
+   (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!) (.then done))))
 
 (defn- finish-after
   "End the row when `p` settles, reporting a rejection as a failure rather
@@ -232,7 +232,7 @@
   a recipe that focused somebody else's heading, which is precisely the
   document-scoped defect the decoy row exists to catch."
   [m label]
-  (-> (test-support/poll-until
+  (-> (rf.test-support/poll-until
         #(let [h (heading m)]
            (and (some? h) (identical? h (active))))
         {:label label})
@@ -265,50 +265,50 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-element-the-recipe-focuses-is-a-heading-with-the-panes-name
-  (let [tree (ht/tree [views/feed-page {}]
-                      {:subs {[::subs/feed] [{:slug "deep-space" :title "Deep space"}]}})
-        marked (ht/find tree #(= "true" (:data-route-heading (ht/attrs %))))]
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.navigation.views/feed-page {}]
+                      {:subs {[::rf.hicasso.examples.navigation.subs/feed] [{:slug "deep-space" :title "Deep space"}]}})
+        marked (rf.hicasso.test/find tree #(= "true" (:data-route-heading (rf.hicasso.test/attrs %))))]
     (testing "the marker the focus effect selects on exists, exactly once,
               and is on a real heading"
       (is (some? marked)
           "no element carries :data-route-heading — the recipe would focus
            nothing, and every browser row below would be asserting that a
            nil selector match is a no-op")
-      (is (= 1 (count (ht/find-all tree #(= "true" (:data-route-heading (ht/attrs %))))))
+      (is (= 1 (count (rf.hicasso.test/find-all tree #(= "true" (:data-route-heading (rf.hicasso.test/attrs %))))))
           "exactly one: `querySelector` takes the first match in document
            order, so a second marker is a focus target chosen by accident
            of markup order")
-      (is (= :heading (ht/role marked))
+      (is (= :heading (rf.hicasso.test/role marked))
           "a heading, per `ht/role` — landing focus on an unlabelled
            `<div>` announces nothing, which is the version of this recipe
            that passes a browser row and helps nobody"))
 
     (testing "and it carries the pane's own accessible name, so arriving
               there says WHERE the user arrived"
-      (is (= "Articles" (ht/accessible-name tree marked))))
+      (is (= "Articles" (rf.hicasso.test/accessible-name tree marked))))
 
     (testing "it is programmatically focusable and NOT a new Tab stop"
-      (is (= -1 (:tab-index (ht/attrs marked)))
+      (is (= -1 (:tab-index (rf.hicasso.test/attrs marked)))
           "-1, not 0: the heading is a focus TARGET, not a stop on the Tab
            order. Without any tabindex the engine refuses focus outright
            and `.focus()` is a silent no-op; with 0 the recipe buys itself
            an extra Tab press for every keyboard user on every page"))))
 
 (deftest the-recipe-names-a-root-and-not-the-document
-  (let [fx           (:fx (events/pane-shown {} [::events/pane-shown]))
+  (let [fx           (:fx (rf.hicasso.examples.navigation.events/pane-shown {} [::rf.hicasso.examples.navigation.events/pane-shown]))
         [fx-id args] (first fx)]
     (testing "`:on-match` asks for exactly one effect, and it is the focus one"
       (is (= 1 (count fx)))
-      (is (= ::events/focus-heading fx-id)))
+      (is (= ::rf.hicasso.examples.navigation.events/focus-heading fx-id)))
 
     (testing "the effect carries a ROOT scope alongside the selector"
-      (is (= events/root-selector (:root args))
+      (is (= rf.hicasso.examples.navigation.events/root-selector (:root args))
           "without `:root` the effect resolves its selector against the whole
            document and focuses the first marked heading on the page, whoever
            it belongs to — the defect
            [[a-deep-link-focuses-inside-the-applications-own-root]] mounts a
            decoy to catch")
-      (is (= events/heading-selector (:selector args))))
+      (is (= rf.hicasso.examples.navigation.events/heading-selector (:selector args))))
 
     (testing "and the shell RENDERS that root, so the scope names an element
               rather than nothing"
@@ -316,11 +316,11 @@
       ;; cannot state: a recipe scoped to an id no view writes resolves to
       ;; nil and focuses nothing at all — a no-op that looks exactly like a
       ;; working recipe on a page where nothing else competes for the marker.
-      (let [tree (ht/tree [views/app {}] {:subs {[:rf.route/id] routes/feed}})
-            root (ht/find tree #(= events/root-id (:id (ht/attrs %))))]
+      (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.navigation.views/app {}] {:subs {[:rf.route/id] rf.hicasso.examples.navigation.routes/feed}})
+            root (rf.hicasso.test/find tree #(= rf.hicasso.examples.navigation.events/root-id (:id (rf.hicasso.test/attrs %))))]
         (is (some? root)
             (str "no element in the shell carries the id "
-                 (pr-str events/root-id) " that " (pr-str events/root-selector)
+                 (pr-str rf.hicasso.examples.navigation.events/root-id) " that " (pr-str rf.hicasso.examples.navigation.events/root-selector)
                  " names"))
         (is (= :main (:tag root))
             "and it is the application's own root element")))))
@@ -333,7 +333,7 @@
   (if-not (browser?)
     (skip! ":node-test has no focus model")
     (async done
-      (let [m (at! routes/article {:slug (:slug first-article)})]
+      (let [m (at! rf.hicasso.examples.navigation.routes/article {:slug (:slug first-article)})]
         (-> (focused-heading m "the deep link's landing focus")
             (.then (fn [h]
                      (is (identical? h (active))
@@ -356,20 +356,20 @@
       ;; application's container in document order and a document-wide
       ;; lookup reaches it first. Binding order is the whole mechanism.
       (let [decoy (decoy!)
-            m     (at! routes/article {:slug (:slug first-article)})]
+            m     (at! rf.hicasso.examples.navigation.routes/article {:slug (:slug first-article)})]
         (-> (js/Promise.resolve
               (testing "the near-miss is LIVE — a document-wide lookup does NOT
                         answer this application's heading"
                 (is (some? (heading m))
                     "precondition: the pane rendered a marked heading of its own")
-                (is (some? (.querySelector js/document events/root-selector))
+                (is (some? (.querySelector js/document rf.hicasso.examples.navigation.events/root-selector))
                     (str "precondition: the shell rendered "
-                         (pr-str events/root-selector) ", the root the recipe
+                         (pr-str rf.hicasso.examples.navigation.events/root-selector) ", the root the recipe
                          scopes to. A scope that resolves to nothing focuses
                          nothing, which on a page with no decoy is
                          indistinguishable from a recipe that works"))
                 (is (not (identical? (heading m)
-                                     (.querySelector js/document events/heading-selector)))
+                                     (.querySelector js/document rf.hicasso.examples.navigation.events/heading-selector)))
                     "the decoy precedes the application in document order, so
                      `document.querySelector` over the shared marker answers
                      something that is not this application's heading. The
@@ -397,7 +397,7 @@
   (if-not (browser?)
     (skip! ":node-test has no focus model")
     (async done
-      (let [m (at! routes/article {:slug (:slug first-article)})]
+      (let [m (at! rf.hicasso.examples.navigation.routes/article {:slug (:slug first-article)})]
         (-> (focused-heading m "the deep link's landing focus")
             (.then (fn [_]
                      ;; The Back button, as the framework sees it: one
@@ -406,10 +406,10 @@
                      ;; because this mount's frame is not URL-bound — what
                      ;; is under test is the conduct the door produces, not
                      ;; the listener that opens it.
-                     (hm/dispatch-and-settle!
+                     (rf.hicasso.test.mounted/dispatch-and-settle!
                        m [:rf.route/handle-url-change "/navigation"
                           {:rf.route/cause :popstate}])
-                     (is (= routes/feed (read-sub m [:rf.route/id]))
+                     (is (= rf.hicasso.examples.navigation.routes/feed (read-sub m [:rf.route/id]))
                          "the Back really landed, so the row below is not green
                           for want of anything happening")
                      (focused-heading m "the Back navigation's landing focus")))
@@ -430,15 +430,15 @@
   (if-not (browser?)
     (skip! ":node-test has no focus model")
     (async done
-      (let [m (at! routes/article {:slug (:slug first-article)})]
+      (let [m (at! rf.hicasso.examples.navigation.routes/article {:slug (:slug first-article)})]
         (-> (focused-heading m "the deep link's landing focus")
             (.then (fn [_]
                      ;; Put focus where a user would have it — in the field
                      ;; they are typing in — and then re-render underneath
                      ;; them.
                      (.focus (node m "#navigation-title"))
-                     (hm/dispatch-and-settle!
-                       m [::events/edit (:slug first-article) "Deep space, revisited"])
+                     (rf.hicasso.test.mounted/dispatch-and-settle!
+                       m [::rf.hicasso.examples.navigation.events/edit (:slug first-article) "Deep space, revisited"])
                      (is (= "Deep space, revisited" (.-value (node m "#navigation-title")))
                          "the re-render really happened")
                      (two-frames)))
@@ -455,19 +455,19 @@
   (if-not (browser?)
     (skip! ":node-test has no focus model")
     (async done
-      (let [m    (at! routes/article {:slug (:slug first-article)})
+      (let [m    (at! rf.hicasso.examples.navigation.routes/article {:slug (:slug first-article)})
             slug (:slug first-article)]
         (-> (focused-heading m "the deep link's landing focus")
             (.then (fn [_]
                      ;; The pending mutation: a typed, unsaved title. The
                      ;; article route's `:can-leave` guard reads it.
-                     (hm/dispatch-and-settle! m [::events/edit slug "Half a title"])
+                     (rf.hicasso.test.mounted/dispatch-and-settle! m [::rf.hicasso.examples.navigation.events/edit slug "Half a title"])
                      (.focus (node m "#navigation-title"))
 
-                     (hm/dispatch-and-settle! m [:rf.route/navigate {:to routes/feed}])
+                     (rf.hicasso.test.mounted/dispatch-and-settle! m [:rf.route/navigate {:to rf.hicasso.examples.navigation.routes/feed}])
 
                      (testing "the leave is REFUSED, and parked rather than dropped"
-                       (is (= routes/article (read-sub m [:rf.route/id]))
+                       (is (= rf.hicasso.examples.navigation.routes/article (read-sub m [:rf.route/id]))
                            "the route did not move")
                        (is (some? (read-sub m [:rf/pending-navigation]))
                            "and the refusal is resumable — routing wrote one
@@ -489,8 +489,8 @@
                      ;; Resume through the application's own wiring point,
                      ;; not through a hand-written event id.
                      (.click (node m ".leave-anyway"))
-                     (hm/settle! m)
-                     (is (= routes/feed (read-sub m [:rf.route/id]))
+                     (rf.hicasso.test.mounted/settle! m)
+                     (is (= rf.hicasso.examples.navigation.routes/feed (read-sub m [:rf.route/id]))
                          "the parked navigation resumed on confirmation")
                      (focused-heading m "the resumed navigation's landing focus")))
             (.then (fn [h]
@@ -514,15 +514,15 @@
     (skip! ":node-test has no scroll model")
     (async done
       (scroll-to! 0)
-      (let [m (at! routes/feed)]
+      (let [m (at! rf.hicasso.examples.navigation.routes/feed)]
         (-> (focused-heading m "the list's landing focus")
             (.then (fn [_]
                      (scrolled-to! deep-offset)
 
-                     (hm/dispatch-and-settle!
-                       m [:rf.route/navigate {:to routes/article
+                     (rf.hicasso.test.mounted/dispatch-and-settle!
+                       m [:rf.route/navigate {:to rf.hicasso.examples.navigation.routes/article
                                               :params {:slug (:slug first-article)}}])
-                     (is (= routes/article (read-sub m [:rf.route/id])))
+                     (is (= rf.hicasso.examples.navigation.routes/article (read-sub m [:rf.route/id])))
                      (is (= 0 (scroll-y))
                          (str "a forward navigation lands at the top and this one
                               is at " (scroll-y) ". Arriving at a new page
@@ -533,10 +533,10 @@
                      ;; `:restore`, and the position it looks up is the one
                      ;; `:rf.nav/capture-scroll` saved for `/navigation`
                      ;; when the navigation above left it.
-                     (hm/dispatch-and-settle!
+                     (rf.hicasso.test.mounted/dispatch-and-settle!
                        m [:rf.route/handle-url-change "/navigation"
                           {:rf.route/cause :popstate}])
-                     (is (= routes/feed (read-sub m [:rf.route/id])))
+                     (is (= rf.hicasso.examples.navigation.routes/feed (read-sub m [:rf.route/id])))
                      (is (= deep-offset (scroll-y))
                          (str "Back restored " (scroll-y) " rather than "
                               deep-offset ". The list is where the user was
@@ -569,16 +569,16 @@
     (skip! ":node-test has no scroll model")
     (async done
       (scroll-to! 0)
-      (let [m (at! routes/feed)]
+      (let [m (at! rf.hicasso.examples.navigation.routes/feed)]
         (-> (focused-heading m "the list's landing focus")
             (.then (fn [_]
                      (scrolled-to! 700)
 
-                     (hm/dispatch-and-settle!
-                       m [:rf.route/navigate {:to     routes/article
+                     (rf.hicasso.test.mounted/dispatch-and-settle!
+                       m [:rf.route/navigate {:to     rf.hicasso.examples.navigation.routes/article
                                               :params {:slug (:slug first-article)}
                                               :scroll false}])
-                     (is (= routes/article (read-sub m [:rf.route/id]))
+                     (is (= rf.hicasso.examples.navigation.routes/article (read-sub m [:rf.route/id]))
                          "the navigation happened, so the row is not green for
                           want of one")
                      (is (= 700 (scroll-y))
@@ -600,22 +600,22 @@
     (skip! ":node-test has no scroll model")
     (async done
       (scroll-to! 0)
-      (let [m (at! routes/feed)]
+      (let [m (at! rf.hicasso.examples.navigation.routes/feed)]
         (-> (focused-heading m "the list's landing focus")
             (.then (fn [_]
                      ;; Leave `/navigation` at a distinctive offset, so the
                      ;; cache holds exactly one position and it is one no
                      ;; other URL is entitled to.
                      (scrolled-to! deep-offset)
-                     (hm/dispatch-and-settle!
-                       m [:rf.route/navigate {:to routes/article
+                     (rf.hicasso.test.mounted/dispatch-and-settle!
+                       m [:rf.route/navigate {:to rf.hicasso.examples.navigation.routes/article
                                               :params {:slug (:slug first-article)}}])
                      (is (= 0 (scroll-y)))
                      (scrolled-to! 300)
 
                      ;; A Back to a URL this session has never left — so the
                      ;; cache has nothing keyed under it.
-                     (hm/dispatch-and-settle!
+                     (rf.hicasso.test.mounted/dispatch-and-settle!
                        m [:rf.route/handle-url-change "/navigation/article/shallow-water"
                           {:rf.route/cause :popstate}])
                      (is (= "shallow-water" (:slug (read-sub m [:rf.route/params])))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/routes.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/routes.cljs
@@ -49,9 +49,9 @@
   `deftest` runs. A consumer never meets this; a test does, on its first
   row. `reg-route` is idempotent for an unchanged registration, so
   calling both costs nothing."
-  (:require [re-frame.hicasso.examples.navigation.events :as events]
-            [re-frame.hicasso.examples.navigation.subs :as subs]
-            [re-frame.routing :as routing]))
+  (:require [re-frame.hicasso.examples.navigation.events :as rf.hicasso.examples.navigation.events]
+            [re-frame.hicasso.examples.navigation.subs :as rf.hicasso.examples.navigation.subs]
+            [re-frame.routing :as rf.routing]))
 
 (def feed
   "The list page. `/navigation`."
@@ -65,17 +65,17 @@
   "Register the witness's routes. Idempotent; see the namespace docstring
   on why it is a function as well as a load-time effect."
   []
-  (routing/reg-route feed
+  (rf.routing/reg-route feed
     {:doc      "The article list."
-     :on-match [[::events/pane-shown]]}
+     :on-match [[::rf.hicasso.examples.navigation.events/pane-shown]]}
     "/navigation")
-  (routing/reg-route article
+  (rf.routing/reg-route article
     {:doc "One article, with its title editor."
      ;; The guard is on the route being LEFT, which is the article: a
      ;; typed-and-unsaved title is what must not be walked away from. The
      ;; feed carries none — there is nothing on it to lose.
-     :can-leave [::subs/may-leave?]
-     :on-match  [[::events/pane-shown]]}
+     :can-leave [::rf.hicasso.examples.navigation.subs/may-leave?]
+     :on-match  [[::rf.hicasso.examples.navigation.events/pane-shown]]}
     "/navigation/article/:slug")
   nil)
 

--- a/implementation/hicasso/test/re_frame/hicasso/examples/navigation/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/navigation/views.cljs
@@ -36,20 +36,20 @@
   whether the mechanism works or not. The height is on the SHELL rather
   than on a pane, so both routes are equally tall and a restored offset
   cannot be silently clamped away by arriving at a shorter page."
-  (:require [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.navigation.events :as events]
-            [re-frame.hicasso.examples.navigation.routes :as routes]
-            [re-frame.hicasso.examples.navigation.subs :as subs]))
+  (:require [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.navigation.events :as rf.hicasso.examples.navigation.events]
+            [re-frame.hicasso.examples.navigation.routes :as rf.hicasso.examples.navigation.routes]
+            [re-frame.hicasso.examples.navigation.subs :as rf.hicasso.examples.navigation.subs]))
 
 ;; ---------------------------------------------------------------------------
 ;; The feed
 ;; ---------------------------------------------------------------------------
 
-(h/defview feed-page
+(rf.hicasso/defview feed-page
   "The list. Keyed by slug, because a keyed list whose key is its index
   reuses the wrong row the moment the order changes."
   [_]
-  (let [rows (h/sub [::subs/feed])]
+  (let [rows (rf.hicasso/sub [::rf.hicasso.examples.navigation.subs/feed])]
     [:section.feed
      [:h2.pane-heading {:tab-index -1 :data-route-heading "true"} "Articles"]
      [:ul.article-list
@@ -59,39 +59,39 @@
          ;; function, because a link is not a unit of re-render. The href
          ;; and the click decision come whole from routing; this body
          ;; never sees a URL.
-         (h/route-link {:to routes/article :params {:slug slug} :class "article-link"}
+         (rf.hicasso/route-link {:to rf.hicasso.examples.navigation.routes/article :params {:slug slug} :class "article-link"}
                        title)])]]))
 
 ;; ---------------------------------------------------------------------------
 ;; The article
 ;; ---------------------------------------------------------------------------
 
-(h/defview article-page
+(rf.hicasso/defview article-page
   "One article and its title editor. The slug comes from the URL through
   routing's own subscription, so the address bar and the page cannot
   disagree."
   [_]
-  (let [slug    (:slug (h/sub [:rf.route/params]))
-        article (h/sub [::subs/article slug])]
+  (let [slug    (:slug (rf.hicasso/sub [:rf.route/params]))
+        article (rf.hicasso/sub [::rf.hicasso.examples.navigation.subs/article slug])]
     [:section.article
      [:h2.pane-heading {:tab-index -1 :data-route-heading "true"}
       (if article (:title article) "No such article")]
-     (h/route-link {:to routes/feed :class "back"} "Back to the list")
+     (rf.hicasso/route-link {:to rf.hicasso.examples.navigation.routes/feed :class "back"} "Back to the list")
      (when article
-       [:form.editor {:on-submit [::events/save {:slug slug}]}
+       [:form.editor {:on-submit [::rf.hicasso.examples.navigation.events/save {:slug slug}]}
         [:label {:for "navigation-title"} "Title"]
         [:input#navigation-title.field-title
          {:type     "text"
-          :value    (h/sub [::subs/title slug])
-          :on-input [::events/edit slug ::h/value]}]
-        [:button.save {:type "submit" :disabled (not (h/sub [::subs/dirty?]))}
+          :value    (rf.hicasso/sub [::rf.hicasso.examples.navigation.subs/title slug])
+          :on-input [::rf.hicasso.examples.navigation.events/edit slug ::rf.hicasso/value]}]
+        [:button.save {:type "submit" :disabled (not (rf.hicasso/sub [::rf.hicasso.examples.navigation.subs/dirty?]))}
          "Save"]])]))
 
 ;; ---------------------------------------------------------------------------
 ;; The blocked-navigation region — the dirty-leave WIRING POINT
 ;; ---------------------------------------------------------------------------
 
-(h/defview leave-prompt
+(rf.hicasso/defview leave-prompt
   "What a refused leave looks like on screen.
 
   A `:can-leave` guard that answers false does not cancel the
@@ -107,7 +107,7 @@
   where
   the pending value is read, and which event resumes it."
   [_]
-  (when-let [pending (h/sub [:rf/pending-navigation])]
+  (when-let [pending (rf.hicasso/sub [:rf/pending-navigation])]
     [:div.leave-prompt {:role "alert"}
      "You have unsaved changes."
      [:button.leave-anyway
@@ -118,7 +118,7 @@
 ;; The shell
 ;; ---------------------------------------------------------------------------
 
-(h/defview app
+(rf.hicasso/defview app
   "The whole application: whichever pane the route selects, plus the
   blocked-leave region. See the namespace docstring on the height and on
   the root id.
@@ -127,11 +127,11 @@
   element the shell names and the element the focus recipe looks for are
   the two halves of one fact — see `events/root-selector`."
   [_]
-  (let [route (h/sub [:rf.route/id])]
-    [:main.navigation {:id    events/root-id
+  (let [route (rf.hicasso/sub [:rf.route/id])]
+    [:main.navigation {:id    rf.hicasso.examples.navigation.events/root-id
                        :style {:min-height "4000px"}}
      [leave-prompt {}]
-     (if (= route routes/article)
+     (if (= route rf.hicasso.examples.navigation.routes/article)
        [article-page {}]
        ;; Before the first navigation resolves there is no route at all,
        ;; and a page that rendered nothing there would be a blank screen

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/a11y_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/a11y_cljs_test.cljs
@@ -43,17 +43,17 @@
   added tomorrow without a name reds it, and no row has to be written for
   it."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso.examples.slice.i18n :as i18n]
-            [re-frame.hicasso.examples.slice.routes :as routes]
-            [re-frame.hicasso.examples.slice.subs :as subs]
-            [re-frame.hicasso.examples.slice.views :as views]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso.examples.slice.i18n :as rf.hicasso.examples.slice.i18n]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.subs :as rf.hicasso.examples.slice.subs]
+            [re-frame.hicasso.examples.slice.views :as rf.hicasso.examples.slice.views]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 ;; ---------------------------------------------------------------------------
@@ -67,13 +67,13 @@
 ;; literals — that is where the claim lives.
 
 (defn- t* [locale ks]
-  (into {} (map (fn [k] [[::subs/t k] (i18n/t locale k)])) ks))
+  (into {} (map (fn [k] [[::rf.hicasso.examples.slice.subs/t k] (rf.hicasso.examples.slice.i18n/t locale k)])) ks))
 
-(defn- classed [tree class] (ht/find tree #(= class (:class (ht/attrs %)))))
+(defn- classed [tree class] (rf.hicasso.test/find tree #(= class (:class (rf.hicasso.test/attrs %)))))
 
-(defn- named [tree class] (ht/accessible-name tree (classed tree class)))
+(defn- named [tree class] (rf.hicasso.test/accessible-name tree (classed tree class)))
 
-(defn- by-id [tree id] (ht/find tree #(= id (:id (ht/attrs %)))))
+(defn- by-id [tree id] (rf.hicasso.test/find tree #(= id (:id (rf.hicasso.test/attrs %)))))
 
 (defn- theme-buttons
   "The chrome's two theme choices, in menu order. Reached through the
@@ -86,9 +86,9 @@
 ;; --- chrome ----------------------------------------------------------------
 
 (defn- chrome-tree [locale]
-  (ht/tree [views/chrome {}]
-           {:subs (merge {[::subs/locale] locale
-                          [::subs/theme]  :light}
+  (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/chrome {}]
+           {:subs (merge {[::rf.hicasso.examples.slice.subs/locale] locale
+                          [::rf.hicasso.examples.slice.subs/theme]  :light}
                          (t* locale [:app/title :app/locale :app/theme
                                      :theme/light :theme/dark]))}))
 
@@ -98,15 +98,15 @@
   {:slug "intents" :title "Intents are data" :published? true :tags ["intents" "data"]})
 
 (defn- row-tree [locale open?]
-  (ht/tree [views/article-row row-props]
-           {:subs (merge {[::subs/tags-open? "intents"] open?}
+  (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/article-row row-props]
+           {:subs (merge {[::rf.hicasso.examples.slice.subs/tags-open? "intents"] open?}
                          (t* locale [:feed/tags]))}))
 
 ;; --- the feed page ---------------------------------------------------------
 
 (defn- feed-tree [locale rows]
-  (ht/tree [views/feed-page {}]
-           {:subs (merge {[::subs/feed] rows}
+  (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/feed-page {}]
+           {:subs (merge {[::rf.hicasso.examples.slice.subs/feed] rows}
                          (t* locale [:feed/heading :feed/empty]))}))
 
 ;; --- the pager -------------------------------------------------------------
@@ -117,21 +117,21 @@
   which is inert markup this tier reads as data rather than a node the
   sweep can walk."
   [locale page]
-  (ht/tree [views/pager {}]
-           {:subs (merge {[::subs/current-page] page
-                          [::subs/page-count]   3}
+  (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/pager {}]
+           {:subs (merge {[::rf.hicasso.examples.slice.subs/current-page] page
+                          [::rf.hicasso.examples.slice.subs/page-count]   3}
                          (t* locale [:feed/pagination :feed/previous :feed/next]))}))
 
 ;; --- the editor ------------------------------------------------------------
 
 (defn- editor-tree
   [locale save]
-  (ht/tree [views/editor {:slug "intents"}]
-           {:subs (merge {[::subs/draft "intents"]      {:title "T" :body "B"
+  (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/editor {:slug "intents"}]
+           {:subs (merge {[::rf.hicasso.examples.slice.subs/draft "intents"]      {:title "T" :body "B"
                                                          :published? true}
-                          [::subs/dirty? "intents"]     false
-                          [::subs/save-state "intents"] save
-                          [::subs/token :danger]        "rgb(176, 32, 32)"}
+                          [::rf.hicasso.examples.slice.subs/dirty? "intents"]     false
+                          [::rf.hicasso.examples.slice.subs/save-state "intents"] save
+                          [::rf.hicasso.examples.slice.subs/token :danger]        "rgb(176, 32, 32)"}
                          (t* locale [:editor/heading :editor/title :editor/body
                                      :editor/published :editor/save :editor/saving
                                      :editor/discard :editor/saved :editor/retry
@@ -140,16 +140,16 @@
 ;; --- the article page and the shell ----------------------------------------
 
 (defn- article-tree [locale article]
-  (ht/tree [views/article-page {}]
+  (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/article-page {}]
            {:subs (merge {[:rf.route/params]         {:slug "intents"}
-                          [::subs/article "intents"] article}
+                          [::rf.hicasso.examples.slice.subs/article "intents"] article}
                          (t* locale [:article/back :article/missing]))}))
 
 (defn- shell-tree [locale route]
-  (ht/tree [views/app {}]
+  (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/app {}]
            {:subs (merge {[:rf.route/id]          route
-                          [::subs/token :surface] "rgb(255, 255, 255)"
-                          [::subs/token :ink]     "rgb(26, 26, 26)"}
+                          [::rf.hicasso.examples.slice.subs/token :surface] "rgb(255, 255, 255)"
+                          [::rf.hicasso.examples.slice.subs/token :ink]     "rgb(26, 26, 26)"}
                          (t* locale [:app/pane-error]))}))
 
 ;; ---------------------------------------------------------------------------
@@ -158,33 +158,33 @@
 
 (deftest every-field-in-the-editor-is-named-by-the-label-that-points-at-it
   (let [tree (editor-tree :en {:status :idle :problem nil})]
-    (is (= "Title" (ht/accessible-name tree (by-id tree "slice-title")))
+    (is (= "Title" (rf.hicasso.test/accessible-name tree (by-id tree "slice-title")))
         "the `<label for=\"slice-title\">` and the `<input id=\"slice-title\">`
          are two elements and one pairing, and only the resolved name can
          tell a correct pairing from two attributes that happen to sit in
          the same form")
-    (is (= "Body" (ht/accessible-name tree (by-id tree "slice-body")))
+    (is (= "Body" (rf.hicasso.test/accessible-name tree (by-id tree "slice-body")))
         "and a textarea is labelled the same way")
-    (is (= "Published" (ht/accessible-name tree (by-id tree "slice-published")))
+    (is (= "Published" (rf.hicasso.test/accessible-name tree (by-id tree "slice-published")))
         "the checkbox is inside its label AND carries the `for` — the two
          mechanisms at once, and the name is the label's text once rather
          than twice")))
 
 (deftest the-locale-select-is-named-by-the-chromes-own-label
   (let [tree (chrome-tree :en)]
-    (is (= :combobox (ht/role (by-id tree "slice-locale"))))
-    (is (= "Language" (ht/accessible-name tree (by-id tree "slice-locale"))))))
+    (is (= :combobox (rf.hicasso.test/role (by-id tree "slice-locale"))))
+    (is (= "Language" (rf.hicasso.test/accessible-name tree (by-id tree "slice-locale"))))))
 
 (deftest a-name-follows-the-string-table-into-the-other-language
   (testing "the same three fields, the same three pairings, one locale
             later — which is what says the name is READ from the label
             rather than baked beside the control"
     (let [tree (editor-tree :fr {:status :idle :problem nil})]
-      (is (= "Titre" (ht/accessible-name tree (by-id tree "slice-title"))))
-      (is (= "Corps" (ht/accessible-name tree (by-id tree "slice-body"))))
-      (is (= "Publié" (ht/accessible-name tree (by-id tree "slice-published"))))))
+      (is (= "Titre" (rf.hicasso.test/accessible-name tree (by-id tree "slice-title"))))
+      (is (= "Corps" (rf.hicasso.test/accessible-name tree (by-id tree "slice-body"))))
+      (is (= "Publié" (rf.hicasso.test/accessible-name tree (by-id tree "slice-published"))))))
   (is (= "Langue" (let [tree (chrome-tree :fr)]
-                    (ht/accessible-name tree (by-id tree "slice-locale"))))))
+                    (rf.hicasso.test/accessible-name tree (by-id tree "slice-locale"))))))
 
 (deftest the-buttons-are-named-by-what-they-say
   (let [tree (editor-tree :en {:status :idle :problem nil})]
@@ -197,18 +197,18 @@
             anywhere — content is their whole name and the row proves the
             content path is live"
     (let [tree (chrome-tree :en)]
-      (is (= ["Light" "Dark"] (mapv #(ht/accessible-name tree %) (theme-buttons tree)))))
+      (is (= ["Light" "Dark"] (mapv #(rf.hicasso.test/accessible-name tree %) (theme-buttons tree)))))
     (let [tree (chrome-tree :fr)]
-      (is (= ["Clair" "Sombre"] (mapv #(ht/accessible-name tree %) (theme-buttons tree)))))))
+      (is (= ["Clair" "Sombre"] (mapv #(rf.hicasso.test/accessible-name tree %) (theme-buttons tree)))))))
 
 (deftest the-article-link-is-a-link-because-routing-gave-it-an-href
   (let [tree (row-tree :en false)
-        link (ht/find tree #(= :a (:tag %)))]
-    (is (= :link (ht/role link))
+        link (rf.hicasso.test/find tree #(= :a (:tag %)))]
+    (is (= :link (rf.hicasso.test/role link))
         "an `<a>` with no href is not a link, and this one's href is the
          routing artefact's synthesis rather than a string the view
          wrote — so the role is evidence that the crossing happened")
-    (is (= "Intents are data" (ht/accessible-name tree link))
+    (is (= "Intents are data" (rf.hicasso.test/accessible-name tree link))
         "named by the article's own title, which is CONTENT and is
          therefore not translated")))
 
@@ -220,8 +220,8 @@
   (let [closed (row-tree :en false)
         open   (row-tree :en true)]
     (testing "the state, both ways"
-      (is (= "false" (:aria-expanded (ht/attrs (classed closed "tags-toggle")))))
-      (is (= "true" (:aria-expanded (ht/attrs (classed open "tags-toggle"))))))
+      (is (= "false" (:aria-expanded (rf.hicasso.test/attrs (classed closed "tags-toggle")))))
+      (is (= "true" (:aria-expanded (rf.hicasso.test/attrs (classed open "tags-toggle"))))))
     (testing "and the NAME, unchanged across the flip — a control that
               renames itself as its state changes is a control a
               screen-reader user has to re-find, and the two halves of
@@ -242,7 +242,7 @@
 
   (testing "failed: an ALERT, which interrupts"
     (let [tree (editor-tree :en {:status :failed :problem :problem/title-taken})]
-      (is (= :alert (ht/role (classed tree "save-problem"))))
+      (is (= :alert (rf.hicasso.test/role (classed tree "save-problem"))))
       (is (nil? (classed tree "save-ok")))))
 
   (testing "saved: a STATUS, which does not — the two roles are different
@@ -250,14 +250,14 @@
             row asserting only that `a role is present` could not tell
             them apart"
     (let [tree (editor-tree :en {:status :saved :problem nil})]
-      (is (= :status (ht/role (classed tree "save-ok"))))
+      (is (= :status (rf.hicasso.test/role (classed tree "save-ok"))))
       (is (nil? (classed tree "save-problem")))))
 
   (testing "and a live region takes no name from its own text: it is
             announced BECAUSE it appeared, and naming it would be this
             kit inventing something the platform does not give"
     (let [tree (editor-tree :en {:status :failed :problem :problem/title-taken})]
-      (is (nil? (ht/accessible-name tree (classed tree "save-problem")))))))
+      (is (nil? (rf.hicasso.test/accessible-name tree (classed tree "save-problem")))))))
 
 (deftest the-save-button-renames-itself-while-it-is-working
   (testing "the one control in the application whose NAME is supposed to
@@ -270,14 +270,14 @@
 (deftest the-retry-appears-with-the-failure-and-is-named
   (let [tree (editor-tree :en {:status :failed :problem :problem/title-taken})]
     (is (= "Try again" (named tree "retry")))
-    (is (= :button (ht/role (classed tree "retry")))))
+    (is (= :button (rf.hicasso.test/role (classed tree "retry")))))
   (is (nil? (classed (editor-tree :en {:status :idle :problem nil}) "retry"))))
 
 (deftest the-shell-is-a-main-landmark-and-the-feed-is-a-list
-  (is (= :main (ht/role (shell-tree :en routes/feed))))
+  (is (= :main (rf.hicasso.test/role (shell-tree :en rf.hicasso.examples.slice.routes/feed))))
   (let [tree (feed-tree :en [{:slug "a" :title "A" :published? true :tags []}])]
-    (is (= :list (ht/role (ht/find tree #(= :ul (:tag %))))))
-    (is (= :heading (ht/role (ht/find tree #(= :h2 (:tag %))))))))
+    (is (= :list (rf.hicasso.test/role (rf.hicasso.test/find tree #(= :ul (:tag %))))))
+    (is (= :heading (rf.hicasso.test/role (rf.hicasso.test/find tree #(= :h2 (:tag %))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The sweep — the bead's acceptance, as one assertion per rendering
@@ -296,14 +296,14 @@
      ["a feed row, closed" (row-tree locale false)]
      ["a feed row, open" (row-tree locale true)]
      ["a feed row, unpublished"
-      (ht/tree [views/article-row (assoc row-props :published? false)]
-               {:subs (merge {[::subs/tags-open? "intents"] false}
+      (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/article-row (assoc row-props :published? false)]
+               {:subs (merge {[::rf.hicasso.examples.slice.subs/tags-open? "intents"] false}
                              (t* locale [:feed/tags]))})]
      ;; Both reads sit at the top of the row's `let`, so they run whether
      ;; or not the row has tags, and a tagless row owes both fixtures too.
      ["a feed row with no tags"
-      (ht/tree [views/article-row (assoc row-props :tags [])]
-               {:subs (merge {[::subs/tags-open? "intents"] false}
+      (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/article-row (assoc row-props :tags [])]
+               {:subs (merge {[::rf.hicasso.examples.slice.subs/tags-open? "intents"] false}
                              (t* locale [:feed/tags]))})]
      ["the feed, populated" (feed-tree locale [{:slug "a" :title "A"
                                                 :published? true :tags []}])]
@@ -311,8 +311,8 @@
      ["the article page" (article-tree locale {:slug "intents"
                                                :title "Intents are data"})]
      ["the article page, no such article" (article-tree locale nil)]
-     ["the shell, on the feed" (shell-tree locale routes/feed)]
-     ["the shell, on an article" (shell-tree locale routes/article)]
+     ["the shell, on the feed" (shell-tree locale rf.hicasso.examples.slice.routes/feed)]
+     ["the shell, on an article" (shell-tree locale rf.hicasso.examples.slice.routes/article)]
      ["the shell, before the first navigation" (shell-tree locale nil)]]
     (for [save [{:status :idle :problem nil}
                 {:status :saving :problem nil}
@@ -321,9 +321,9 @@
       [(str "the editor, " (name (:status save))) (editor-tree locale save)])))
 
 (deftest every-operable-control-in-the-application-has-a-name
-  (doseq [locale i18n/locales
+  (doseq [locale rf.hicasso.examples.slice.i18n/locales
           [what tree] (states locale)]
-    (is (= [] (ht/unnamed-controls tree))
+    (is (= [] (rf.hicasso.test/unnamed-controls tree))
         (str what ", in " (name locale)
              " — every button, link, field and select a user can operate "
              "must carry an accessible name, and this is the whole "
@@ -338,13 +338,13 @@
             equally consistent with `unnamed-controls` never finding
             anything at all"
     (let [tree     (editor-tree :en {:status :idle :problem nil})
-          detached (ht/find tree #(and (= :label (:tag %))
-                                       (= "slice-title" (:for (ht/attrs %)))))
+          detached (rf.hicasso.test/find tree #(and (= :label (:tag %))
+                                       (= "slice-title" (:for (rf.hicasso.test/attrs %)))))
           sabotaged (update tree :children
                             (fn [cs] (mapv #(if (identical? % detached)
                                               (assoc % :attrs {:for "elsewhere"})
                                               %)
                                            cs)))
-          found     (ht/unnamed-controls sabotaged)]
+          found     (rf.hicasso.test/unnamed-controls sabotaged)]
       (is (= 1 (count found)))
-      (is (= "slice-title" (:id (ht/attrs (first found))))))))
+      (is (= "slice-title" (:id (rf.hicasso.test/attrs (first found))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/a11y_focus_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/a11y_focus_dom_cljs_test.cljs
@@ -44,14 +44,14 @@
   than to a false green — the skip is honest, and it is not a
   measurement."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.slice.events :as events]
-            [re-frame.hicasso.examples.slice.routes :as routes]
-            [re-frame.hicasso.examples.slice.subs :as subs]
-            [re-frame.hicasso.examples.slice.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.slice.events :as rf.hicasso.examples.slice.events]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.subs :as rf.hicasso.examples.slice.subs]
+            [re-frame.hicasso.examples.slice.views :as rf.hicasso.examples.slice.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The lane
@@ -63,13 +63,13 @@
   (is true (str "a focus witness needs a real browser — " why)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
      :init-fn       (fn []
                       (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-                      (routes/register!))}))
+                      (rf.hicasso.examples.slice.routes/register!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Reading the page
@@ -79,13 +79,13 @@
 
 (defn- at-article!
   [slug]
-  (hm/mount! [views/app {}]
-             {:initial-events [[::events/seed]
-                               [:rf.route/navigate {:to routes/article
+  (rf.hicasso.test.mounted/mount! [rf.hicasso.examples.slice.views/app {}]
+             {:initial-events [[::rf.hicasso.examples.slice.events/seed]
+                               [:rf.route/navigate {:to rf.hicasso.examples.slice.routes/article
                                                     :params {:slug slug}}]]}))
 
 (defn- finish [m done]
-  (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))
+  (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!) (.then done)))
 
 (defn- read-sub [m query-v] (rf/subscribe-once query-v {:frame (:frame m)}))
 
@@ -146,7 +146,7 @@
         d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
     (.call (.-set d) n s)
     (.dispatchEvent n (js/InputEvent. "input" #js {:bubbles true}))
-    (hm/settle! m)))
+    (rf.hicasso.test.mounted/settle! m)))
 
 ;; ---------------------------------------------------------------------------
 ;; The label associations, as the engine computes them
@@ -263,7 +263,7 @@
       (let [m (at-article! "intents")]
         (type-into! m "#slice-title" "A new title")
         (.click (node m ".save"))
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
 
         (testing "the save is in flight, the button is disabled, and it is
                   out of the order — the other direction of the same
@@ -278,9 +278,9 @@
         ;; wait for the region to leave `:saving`, then assert the button
         ;; came BACK, which is what makes the row above about a transition
         ;; rather than about a button that is simply always disabled.
-        (-> (hm/settle-until!
+        (-> (rf.hicasso.test.mounted/settle-until!
               m
-              #(not= :saving (:status (read-sub m [::subs/save-state "intents"])))
+              #(not= :saving (:status (read-sub m [::rf.hicasso.examples.slice.subs/save-state "intents"])))
               {:label "the stand-in server's reply for intents"})
             (.then (fn [_]
                      (is (false? (.-disabled (node m ".save"))))
@@ -304,7 +304,7 @@
           ;; clicking the `<select>` would move focus itself, and what is
           ;; under test is what the RE-RENDER does to focus, not what a
           ;; click does.
-          (hm/dispatch-and-settle! m [::events/set-locale "fr"])
+          (rf.hicasso.test.mounted/dispatch-and-settle! m [::rf.hicasso.examples.slice.events/set-locale "fr"])
 
           (is (identical? field (.-activeElement js/document))
               "the SAME element still holds focus after every label on the
@@ -338,7 +338,7 @@
           ;; Dispatched rather than clicked: clicking `.save` would move
           ;; focus to the button, and what is under test is what the
           ;; ALERT's arrival does to focus.
-          (hm/dispatch-and-settle! m [::events/save {:slug "intents"}])
+          (rf.hicasso.test.mounted/dispatch-and-settle! m [::rf.hicasso.examples.slice.events/save {:slug "intents"}])
 
           (is (= "alert" (.getAttribute (node m ".save-problem") "role"))
               "the region really did arrive, so the row below is not green

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/app.cljs
@@ -39,12 +39,12 @@
   already has, so the reloaded view code meets its own DOM; a second
   `h/mount!` would `createRoot` again and discard every node, subscription
   and scrap of component state."
-  (:require [re-frame.adapter.uix :as uix-adapter]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.slice.events :as events]
-            [re-frame.hicasso.examples.slice.routes :as routes]
-            [re-frame.hicasso.examples.slice.views :as views]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.slice.events :as rf.hicasso.examples.slice.events]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.views :as rf.hicasso.examples.slice.views]))
 
 (def frame-id
   "This application's frame. One root, one frame; a page holding a second
@@ -62,10 +62,10 @@
   and takes `:initial-events`, so the two steps below are the value a
   witness passes it. A consumer calls it once, here."
   []
-  (routes/register!)
+  (rf.hicasso.examples.slice.routes/register!)
   (rf/make-frame {:id             frame-id
-                  :initial-events [[::events/seed]
-                                   [:rf.route/navigate {:to routes/feed}]]}))
+                  :initial-events [[::rf.hicasso.examples.slice.events/seed]
+                                   [:rf.route/navigate {:to rf.hicasso.examples.slice.routes/feed}]]}))
 
 (defn ^:dev/after-load reload!
   "Re-render the mounted root after a hot reload. React reconciles the new
@@ -74,12 +74,12 @@
   code is different."
   []
   (when-some [root @!root]
-    (h/render! root [views/app {}])))
+    (rf.hicasso/render! root [rf.hicasso.examples.slice.views/app {}])))
 
 (defn ^:export -main
   "Start the application."
   []
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (make-frame!)
-  (reset! !root (h/mount! (js/document.getElementById "app") {:frame frame-id} [views/app {}]))
+  (reset! !root (rf.hicasso/mount! (js/document.getElementById "app") {:frame frame-id} [rf.hicasso.examples.slice.views/app {}]))
   nil)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/events.cljs
@@ -72,7 +72,7 @@
   problem, and leaving it out would have made the slice evidence for an
   API that had never met one."
   (:require [re-frame.core :as rf]
-            [re-frame.hicasso.examples.slice.db :as db]))
+            [re-frame.hicasso.examples.slice.db :as rf.hicasso.examples.slice.db]))
 
 ;; ---------------------------------------------------------------------------
 ;; Boot
@@ -80,7 +80,7 @@
 
 (rf/reg-event ::seed
   {:doc "Install the starting app-db. The frame's `:initial-events` step."}
-  (fn [_ _] {:db db/seed}))
+  (fn [_ _] {:db rf.hicasso.examples.slice.db/seed}))
 
 ;; ---------------------------------------------------------------------------
 ;; Editing — the controlled fields write straight into the draft
@@ -98,13 +98,13 @@
     ;; draft yet, so the article's own fields are what the edit lands on
     ;; top of. Without it the first character would arrive into an empty
     ;; map and the other fields would blank themselves.
-    {:db (assoc-in db [:drafts slug] (assoc (db/draft-for db slug) field value))}))
+    {:db (assoc-in db [:drafts slug] (assoc (rf.hicasso.examples.slice.db/draft-for db slug) field value))}))
 
 (rf/reg-event ::toggle-published
   {:doc "Take the checkbox's state. Positional because it carries `::h/checked`."}
   (fn [{:keys [db]} [_ slug published?]]
     {:db (assoc-in db [:drafts slug]
-                   (assoc (db/draft-for db slug) :published? (boolean published?)))}))
+                   (assoc (rf.hicasso.examples.slice.db/draft-for db slug) :published? (boolean published?)))}))
 
 (rf/reg-event ::discard
   {:doc "Throw a draft away — the reset, and it is one move."}
@@ -132,8 +132,8 @@
 (rf/reg-event ::save
   {:doc "Validate a draft locally; if it passes, ask the server."}
   (fn [{:keys [db]} [_ {:keys [slug]}]]
-    (let [draft    (db/draft-for db slug)
-          problems (db/problems draft)]
+    (let [draft    (rf.hicasso.examples.slice.db/draft-for db slug)
+          problems (rf.hicasso.examples.slice.db/problems draft)]
       (if (seq problems)
         ;; The local half. No request is made, so there is nothing in
         ;; flight and nothing to arrive late: the status goes straight to
@@ -143,7 +143,7 @@
         {:db (assoc db :save {:status :saving :slug slug})
          :fx [[::persist {:slug    slug
                           :draft   draft
-                          :taken?  (db/title-taken? db slug (:title draft))
+                          :taken?  (rf.hicasso.examples.slice.db/title-taken? db slug (:title draft))
                           :delay   save-delay-ms
                           :on-ok   ::saved
                           :on-fail ::save-failed}]]}))))
@@ -152,7 +152,7 @@
   {:doc "The server accepted a draft. Fold it in."}
   (fn [{:keys [db]} [_ {:keys [slug draft]}]]
     (if (= slug (get-in db [:save :slug]))
-      {:db (-> (db/commit db slug draft)
+      {:db (-> (rf.hicasso.examples.slice.db/commit db slug draft)
                (assoc :save {:status :saved :slug slug}))}
       ;; A reply for an article this frame is no longer saving. Dropping
       ;; it is the whole of stale-reply suppression at this size, and it
@@ -233,7 +233,7 @@
   (fn [ctx {:keys [delay on-ok]}]
     (js/setTimeout
       (fn []
-        (rf/dispatch [on-ok {:blocks db/digest}] {:frame (:frame ctx)}))
+        (rf/dispatch [on-ok {:blocks rf.hicasso.examples.slice.db/digest}] {:frame (:frame ctx)}))
       delay)))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/extension_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/extension_dom_cljs_test.cljs
@@ -35,15 +35,15 @@
   and each row degrades there to a STATED skip rather than to a false
   green."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.slice.db :as db]
-            [re-frame.hicasso.examples.slice.events :as events]
-            [re-frame.hicasso.examples.slice.routes :as routes]
-            [re-frame.hicasso.examples.slice.subs :as subs]
-            [re-frame.hicasso.examples.slice.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.slice.db :as rf.hicasso.examples.slice.db]
+            [re-frame.hicasso.examples.slice.events :as rf.hicasso.examples.slice.events]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.subs :as rf.hicasso.examples.slice.subs]
+            [re-frame.hicasso.examples.slice.views :as rf.hicasso.examples.slice.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The lane
@@ -55,8 +55,8 @@
   (is true (str "a mounted page needs a real React DOM — " why)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The MAP shape, because rows here are `async`: `cljs.test` refuses
      ;; an async test under a fn-form fixture and aborts the NAMESPACE —
@@ -67,7 +67,7 @@
                       ;; The reset restores the registrar to a baseline
                       ;; captured before `routes` finished loading. See
                       ;; that namespace on why `register!` is exposed.
-                      (routes/register!))}))
+                      (rf.hicasso.examples.slice.routes/register!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Reading and driving the page
@@ -84,7 +84,7 @@
   dispatch is synchronous, so the settle is all that is owed."
   [m sel]
   (.click (node m sel))
-  (hm/settle! m))
+  (rf.hicasso.test.mounted/settle! m))
 
 (defn- read-sub [m query-v] (rf/subscribe-once query-v {:frame (:frame m)}))
 
@@ -93,10 +93,10 @@
   URL carries; `nil` is a bare `/slice`, which is what a first visit is."
   ([] (at-page! nil))
   ([n]
-   (hm/mount! [views/app {}]
-              {:initial-events [[::events/seed]
+   (rf.hicasso.test.mounted/mount! [rf.hicasso.examples.slice.views/app {}]
+              {:initial-events [[::rf.hicasso.examples.slice.events/seed]
                                 [:rf.route/navigate
-                                 (cond-> {:to routes/feed}
+                                 (cond-> {:to rf.hicasso.examples.slice.routes/feed}
                                    (some? n) (assoc :query {:page n}))]]})))
 
 (defn- go-to-page!
@@ -104,12 +104,12 @@
   SYNCHRONOUS door, which is what Back and Forward ultimately reach
   through the history listener a real application installs."
   [m n]
-  (hm/dispatch-and-settle! m [:rf.route/navigate {:to routes/feed :query {:page n}}]))
+  (rf.hicasso.test.mounted/dispatch-and-settle! m [:rf.route/navigate {:to rf.hicasso.examples.slice.routes/feed :query {:page n}}]))
 
 (defn- finish
   "Tear down, assert this mount left nothing behind, and end the row."
   [m done]
-  (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))
+  (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!) (.then done)))
 
 (defn- finish-after
   "End the row when `p` settles, reporting a rejected `p` as a failure
@@ -167,7 +167,7 @@
         ;; own `activate-link!` deciding. Nothing here calls preventDefault
         ;; — if the click were not claimed, this page would navigate away.
         (.click (node m ".pager-next"))
-        (-> (hm/settle-until! m
+        (-> (rf.hicasso.test.mounted/settle-until! m
                               #(= 2 (:page (read-sub m [:rf.route/query])))
                               {:label "the page link's navigate to drain"})
             (.then (fn [_]
@@ -298,8 +298,8 @@
         ;; A payload that arrived cut short — the list block without its
         ;; items — installed through the application's OWN arrival event,
         ;; because that is the door a real truncated response comes in by.
-        (hm/dispatch-and-settle! m [::events/digest-arrived
-                                    {:blocks db/digest-truncated}])
+        (rf.hicasso.test.mounted/dispatch-and-settle! m [::rf.hicasso.examples.slice.events/digest-arrived
+                                    {:blocks rf.hicasso.examples.slice.db/digest-truncated}])
 
         (testing "the region's own boundary caught it"
           (is (some? (node m ".digest-error")))
@@ -342,8 +342,8 @@
     (skip! ":node-test has no React DOM")
     (async done
       (let [m (at-page!)]
-        (hm/dispatch-and-settle! m [::events/digest-arrived
-                                    {:blocks db/digest-truncated}])
+        (rf.hicasso.test.mounted/dispatch-and-settle! m [::rf.hicasso.examples.slice.events/digest-arrived
+                                    {:blocks rf.hicasso.examples.slice.db/digest-truncated}])
         (is (some? (node m ".digest-retry")) "the fallback carries the retry")
 
         (click! m ".digest-retry")
@@ -354,8 +354,8 @@
           (is (true? (.-disabled (node m ".digest-retry")))
               "so a second click cannot queue a second request"))
 
-        (-> (hm/settle-until! m
-                              #(= db/digest (read-sub m [::subs/digest-blocks]))
+        (-> (rf.hicasso.test.mounted/settle-until! m
+                              #(= rf.hicasso.examples.slice.db/digest (read-sub m [::rf.hicasso.examples.slice.subs/digest-blocks]))
                               {:label "the stand-in content server's reply"})
             (.then
               (fn [_]

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/flow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/flow_dom_cljs_test.cljs
@@ -67,15 +67,15 @@
   and each row degrades there to a STATED skip rather than to a false
   green."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.slice.db :as db]
-            [re-frame.hicasso.examples.slice.events :as events]
-            [re-frame.hicasso.examples.slice.routes :as routes]
-            [re-frame.hicasso.examples.slice.subs :as subs]
-            [re-frame.hicasso.examples.slice.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.slice.db :as rf.hicasso.examples.slice.db]
+            [re-frame.hicasso.examples.slice.events :as rf.hicasso.examples.slice.events]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.subs :as rf.hicasso.examples.slice.subs]
+            [re-frame.hicasso.examples.slice.views :as rf.hicasso.examples.slice.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The lane, and the two lines this file writes rather than imports
@@ -87,8 +87,8 @@
   (is true (str "a mounted flow needs a real React DOM — " why)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The MAP shape, because every row is `async`: `cljs.test` refuses an
      ;; async test under a fn-form fixture and aborts the namespace.
@@ -101,7 +101,7 @@
                       ;; captured when this form was EVALUATED, which is
                       ;; before `routes` finished loading. See that
                       ;; namespace on why `register!` is exposed at all.
-                      (routes/register!))}))
+                      (rf.hicasso.examples.slice.routes/register!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Reading and driving the page
@@ -117,7 +117,7 @@
   dispatch is synchronous, so the settle is all that is owed."
   [m sel]
   (.click (node m sel))
-  (hm/settle! m))
+  (rf.hicasso.test.mounted/settle! m))
 
 (defn- type-into!
   "Type `v` into the field at `sel` — a foreign write followed by a real
@@ -135,7 +135,7 @@
         d     (js/Object.getOwnPropertyDescriptor proto "value")]
     (.call (.-set d) n v)
     (.dispatchEvent n (js/InputEvent. "input" #js {:bubbles true}))
-    (hm/settle! m)))
+    (rf.hicasso.test.mounted/settle! m)))
 
 (defn- read-sub [m query-v] (rf/subscribe-once query-v {:frame (:frame m)}))
 
@@ -145,19 +145,19 @@
   "The whole application, on its own root and its own frame, seeded and
   pointed at a route. `:initial-events` drain to fixed point before the
   first render, so the page a row opens on is already the seeded one."
-  ([] (mount-app! [:rf.route/navigate {:to routes/feed}]))
+  ([] (mount-app! [:rf.route/navigate {:to rf.hicasso.examples.slice.routes/feed}]))
   ([nav-event]
-   (hm/mount! [views/app {}] {:initial-events [[::events/seed] nav-event]})))
+   (rf.hicasso.test.mounted/mount! [rf.hicasso.examples.slice.views/app {}] {:initial-events [[::rf.hicasso.examples.slice.events/seed] nav-event]})))
 
 (defn- at-article!
   "Mounted, with the article route already resolved."
   [slug]
-  (mount-app! [:rf.route/navigate {:to routes/article :params {:slug slug}}]))
+  (mount-app! [:rf.route/navigate {:to rf.hicasso.examples.slice.routes/article :params {:slug slug}}]))
 
 (defn- finish
   "Tear down, assert this mount left nothing behind, and end the row."
   [m done]
-  (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))
+  (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!) (.then done)))
 
 (defn- finish-after
   "End the row when `p` settles, reporting a rejected `p` as a failure
@@ -202,8 +202,8 @@
         ;; own `activate-link!` deciding. Nothing here calls preventDefault
         ;; — if the click were not claimed, this page would navigate away.
         (.click (node m ".article-list li:nth-child(2) .article-link"))
-        (-> (hm/settle-until! m
-                              #(= routes/article (read-sub m [:rf.route/id]))
+        (-> (rf.hicasso.test.mounted/settle-until! m
+                              #(= rf.hicasso.examples.slice.routes/article (read-sub m [:rf.route/id]))
                               {:label "the route-link's navigate to drain"})
             (.then (fn [_]
                      (is (= {:slug "intents"} (read-sub m [:rf.route/params])))
@@ -236,7 +236,7 @@
         (is (= "A click carries a vector, and two renders are equal."
                (.-value (node m ".field-body"))))
         (is (true? (.-checked (node m "#slice-published"))))
-        (is (false? (read-sub m [::subs/dirty? "intents"]))
+        (is (false? (read-sub m [::rf.hicasso.examples.slice.subs/dirty? "intents"]))
             "opening an article is not editing it; `:drafts` is still empty")
         (finish m done)))))
 
@@ -248,13 +248,13 @@
         (type-into! m ".field-title" "Intents, revisited")
         (is (= "Intents, revisited" (.-value (node m ".field-title")))
             "the glass")
-        (is (= "Intents, revisited" (:title (read-sub m [::subs/draft "intents"])))
+        (is (= "Intents, revisited" (:title (read-sub m [::rf.hicasso.examples.slice.subs/draft "intents"])))
             "and the model — one place, not two")
         (is (= "A click carries a vector, and two renders are equal."
                (.-value (node m ".field-body")))
             "the field nobody touched is untouched: the first keystroke
              edited on top of the article rather than into an empty map")
-        (is (= "Intents are data" (:title (db/article (app-db m) "intents")))
+        (is (= "Intents are data" (:title (rf.hicasso.examples.slice.db/article (app-db m) "intents")))
             "and the ARTICLE has not moved — a draft is not a save")
         (finish m done)))))
 
@@ -265,7 +265,7 @@
       (let [m (at-article! "controls")]
         (is (false? (.-checked (node m "#slice-published"))))
         (click! m "#slice-published")
-        (is (true? (:published? (read-sub m [::subs/draft "controls"])))
+        (is (true? (:published? (read-sub m [::rf.hicasso.examples.slice.subs/draft "controls"])))
             "a Hicasso intent dispatches SYNCHRONOUSLY — no drain, no poll,
              the next line reads the moved model")
         (is (true? (.-checked (node m "#slice-published"))))
@@ -278,8 +278,8 @@
 (defn- replied
   "Wait for the save region of `slug` to leave `:saving`."
   [m slug]
-  (hm/settle-until! m
-                    #(not= :saving (:status (read-sub m [::subs/save-state slug])))
+  (rf.hicasso.test.mounted/settle-until! m
+                    #(not= :saving (:status (read-sub m [::rf.hicasso.examples.slice.subs/save-state slug])))
                     {:label (str "the stand-in server's reply for " slug)}))
 
 (deftest a-save-the-server-refuses-shows-its-reason-and-keeps-the-draft
@@ -313,7 +313,7 @@
                      typed because the server disagreed is the cruellest
                      failure mode")
                 (is (= "Controlled, synchronously"
-                       (:title (db/article (app-db m) "controls")))
+                       (:title (rf.hicasso.examples.slice.db/article (app-db m) "controls")))
                     "and the article did not move")))
             (finish-after m done))))))
 
@@ -334,12 +334,12 @@
                      (is (nil? (node m ".save-problem")))
                      (is (= "Saved." (text m ".save-ok")))
                      (is (= "Controlled, revisited"
-                            (:title (db/article (app-db m) "controls")))
+                            (:title (rf.hicasso.examples.slice.db/article (app-db m) "controls")))
                          "the article moved")
-                     (is (false? (read-sub m [::subs/dirty? "controls"]))
+                     (is (false? (read-sub m [::rf.hicasso.examples.slice.subs/dirty? "controls"]))
                          "and the draft was cleared by the commit")
 
-                     (hm/dispatch-and-settle! m [:rf.route/navigate {:to routes/feed}])
+                     (rf.hicasso.test.mounted/dispatch-and-settle! m [:rf.route/navigate {:to rf.hicasso.examples.slice.routes/feed}])
                      (is (some #{"Controlled, revisited"}
                                (mapv #(.-textContent %) (nodes m ".article-link")))
                          "the feed shows the new title, because it reads the
@@ -361,7 +361,7 @@
         ;; not the request was skipped.
         (is (= "A title is required. Try again" (text m ".save-problem")))
         (is (nil? (node m ".save-ok")))
-        (is (= :failed (:status (read-sub m [::subs/save-state "intents"]))))
+        (is (= :failed (:status (read-sub m [::rf.hicasso.examples.slice.subs/save-state "intents"]))))
         (finish m done)))))
 
 ;; ---------------------------------------------------------------------------
@@ -405,7 +405,7 @@
               "and it is the SAME element: re-baselined, not remounted, so
                focus, selection and scroll position survive a discard"))
 
-        (is (false? (read-sub m [::subs/dirty? "intents"])))
+        (is (false? (read-sub m [::rf.hicasso.examples.slice.subs/dirty? "intents"])))
         (is (true? (.-disabled (node m ".discard"))))
         (finish m done)))))
 
@@ -435,7 +435,7 @@
           (.call (.-set d) n "pasted by something else"))
         (is (= "pasted by something else" (.-value (node m ".field-title")))
             "the drift landed, and nothing in the application knows")
-        (is (= "Intents are data" (:title (read-sub m [::subs/draft "intents"])))
+        (is (= "Intents are data" (:title (read-sub m [::rf.hicasso.examples.slice.subs/draft "intents"])))
             "the model is exactly where it was — this is the state a reset
              trigger would exist for")
 
@@ -479,10 +479,10 @@
                 ;; are in it — `::h/value` and `::h/checked` are
                 ;; substituted before the handler ever runs, so this is
                 ;; what a handler actually received.
-                (is (= [[::events/edit "controls" :title "Ready"]
-                        [::events/toggle-published "controls" true]
-                        [::events/save {:slug "controls"}]
-                        [::events/saved
+                (is (= [[::rf.hicasso.examples.slice.events/edit "controls" :title "Ready"]
+                        [::rf.hicasso.examples.slice.events/toggle-published "controls" true]
+                        [::rf.hicasso.examples.slice.events/save {:slug "controls"}]
+                        [::rf.hicasso.examples.slice.events/saved
                          {:slug  "controls"
                           :draft {:title      "Ready"
                                   :body       "The model is the only place the text lives."
@@ -512,8 +512,8 @@
         ;; reading — so unmounting `a` and asserting it while `b` is still
         ;; up reports `b`'s live subscriptions as `a`'s leak. The facade
         ;; says so in the failure it raises, which is how this was found.
-        (hm/unmount! a)
-        (hm/unmount! b)
-        (-> (hm/assert-clean! a)
-            (.then (fn [_] (hm/assert-clean! b)))
+        (rf.hicasso.test.mounted/unmount! a)
+        (rf.hicasso.test.mounted/unmount! b)
+        (-> (rf.hicasso.test.mounted/assert-clean! a)
+            (.then (fn [_] (rf.hicasso.test.mounted/assert-clean! b)))
             (.then done))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/i18n_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/i18n_dom_cljs_test.cljs
@@ -44,15 +44,15 @@
   compiles this namespace too, and each row degrades there to a STATED
   skip rather than to a false green."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.slice.events :as events]
-            [re-frame.hicasso.examples.slice.i18n :as i18n]
-            [re-frame.hicasso.examples.slice.routes :as routes]
-            [re-frame.hicasso.examples.slice.subs :as subs]
-            [re-frame.hicasso.examples.slice.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.slice.events :as rf.hicasso.examples.slice.events]
+            [re-frame.hicasso.examples.slice.i18n :as rf.hicasso.examples.slice.i18n]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.subs :as rf.hicasso.examples.slice.subs]
+            [re-frame.hicasso.examples.slice.views :as rf.hicasso.examples.slice.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]))
 
 (defn- browser? [] (exists? js/document))
 
@@ -60,22 +60,22 @@
   (is true (str "a runtime switch needs a real React DOM — " why)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
      :init-fn       (fn []
                       (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-                      (routes/register!))}))
+                      (rf.hicasso.examples.slice.routes/register!))}))
 
 (defn- node [m sel] (.querySelector (:container m) sel))
 (defn- text [m sel] (some-> (node m sel) .-textContent))
 
 (defn- at-article!
   [slug]
-  (hm/mount! [views/app {}]
-             {:initial-events [[::events/seed]
-                               [:rf.route/navigate {:to routes/article
+  (rf.hicasso.test.mounted/mount! [rf.hicasso.examples.slice.views/app {}]
+             {:initial-events [[::rf.hicasso.examples.slice.events/seed]
+                               [:rf.route/navigate {:to rf.hicasso.examples.slice.routes/article
                                                     :params {:slug slug}}]]}))
 
 (defn- choose-locale!
@@ -87,7 +87,7 @@
         d (js/Object.getOwnPropertyDescriptor js/HTMLSelectElement.prototype "value")]
     (.call (.-set d) n (name locale))
     (.dispatchEvent n (js/Event. "change" #js {:bubbles true}))
-    (hm/settle! m)))
+    (rf.hicasso.test.mounted/settle! m)))
 
 (defn- click-theme!
   "Click the theme button by its VISIBLE LABEL in the page's current
@@ -96,19 +96,19 @@
   reordered them is one of the things this file is watching for."
   [m theme]
   (let [buttons (array-seq (.querySelectorAll (:container m) ".theme-choice"))
-        locale  (rf/subscribe-once [::subs/locale] {:frame (:frame m)})
-        want    (i18n/t locale (keyword "theme" (name theme)))
+        locale  (rf/subscribe-once [::rf.hicasso.examples.slice.subs/locale] {:frame (:frame m)})
+        want    (rf.hicasso.examples.slice.i18n/t locale (keyword "theme" (name theme)))
         button  (first (filter #(= want (.-textContent %)) buttons))]
     (is (some? button)
         (str "no theme button reads " (pr-str want) " in " (pr-str locale)
              "; the page offers " (pr-str (mapv #(.-textContent %) buttons))))
     (.click button)
-    (hm/settle! m)))
+    (rf.hicasso.test.mounted/settle! m)))
 
 (defn- surface-of [m] (.. (node m ".slice") -style -background))
 
 (defn- finish [m done]
-  (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))
+  (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!) (.then done)))
 
 ;; ---------------------------------------------------------------------------
 ;; Locale
@@ -174,7 +174,7 @@
             d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
         (.call (.-set d) n "à moitié écrit")
         (.dispatchEvent n (js/InputEvent. "input" #js {:bubbles true}))
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (choose-locale! m :fr)
         (is (= "à moitié écrit" (.-value (node m ".field-title")))
             "the re-render did not reach past the labels into the model")
@@ -218,9 +218,9 @@
         ;; and no clock.
         (.call (.-set d) n "   ")
         (.dispatchEvent n (js/InputEvent. "input" #js {:bubbles true}))
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (.click (node m ".save"))
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
 
         (is (= "rgb(176, 32, 32)" (.. (node m ".save-problem") -style -color)))
         (click-theme! m :dark)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/l0_cljs_test.cljs
@@ -20,25 +20,25 @@
   interceptor chain has run — a test that called the handler function by
   hand would be green for a registration that never happened."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.slice.db :as db]
-            [re-frame.hicasso.examples.slice.events :as events]
-            [re-frame.hicasso.examples.slice.i18n :as i18n]
-            [re-frame.hicasso.examples.slice.routes :as routes]
-            [re-frame.hicasso.examples.slice.subs :as subs]
-            [re-frame.routing :as routing]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.slice.db :as rf.hicasso.examples.slice.db]
+            [re-frame.hicasso.examples.slice.events :as rf.hicasso.examples.slice.events]
+            [re-frame.hicasso.examples.slice.i18n :as rf.hicasso.examples.slice.i18n]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.subs :as rf.hicasso.examples.slice.subs]
+            [re-frame.routing :as rf.routing]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The reset restores the registrar to a baseline captured when this
      ;; form was EVALUATED, which is before `routes` finished loading — so
      ;; the URL rows below would meet an empty route registry. See that
      ;; namespace on why `register!` is exposed at all.
-     :init-fn       (fn [] (routes/register!))}))
+     :init-fn       (fn [] (rf.hicasso.examples.slice.routes/register!))}))
 
 (defn- with-app
   "Run `f` against a fresh frame seeded with the slice's own starting
@@ -47,7 +47,7 @@
   The seed is `[::events/seed]` rather than `[:rf/set-db db/seed]` so the
   rows below exercise the handler the application actually boots with."
   [f]
-  (rf/with-new-frame [frame (rf/make-frame {:initial-events [[::events/seed]]})]
+  (rf/with-new-frame [frame (rf/make-frame {:initial-events [[::rf.hicasso.examples.slice.events/seed]]})]
     (f frame)))
 
 (defn- read-sub
@@ -66,31 +66,31 @@
     (is (= {:title "Intents are data"
             :body  "A click carries a vector, and two renders are equal."
             :published? true}
-           (db/draft-for db/seed "intents")))
-    (is (false? (db/dirty? db/seed "intents"))
+           (rf.hicasso.examples.slice.db/draft-for rf.hicasso.examples.slice.db/seed "intents")))
+    (is (false? (rf.hicasso.examples.slice.db/dirty? rf.hicasso.examples.slice.db/seed "intents"))
         "reading the article is not editing it"))
 
   (testing "a slug the URL invented has no draft and no article"
-    (is (nil? (db/draft-for db/seed "nonsense")))
-    (is (nil? (db/article db/seed "nonsense")))))
+    (is (nil? (rf.hicasso.examples.slice.db/draft-for rf.hicasso.examples.slice.db/seed "nonsense")))
+    (is (nil? (rf.hicasso.examples.slice.db/article rf.hicasso.examples.slice.db/seed "nonsense")))))
 
 (deftest the-feed-takes-its-order-from-order
   (is (= ["hicasso" "intents" "controls" "keys" "boundaries" "revision" "pages"]
-         (mapv :slug (db/listed db/seed))))
+         (mapv :slug (rf.hicasso.examples.slice.db/listed rf.hicasso.examples.slice.db/seed))))
   (testing "an article missing from :articles is skipped rather than nil-padded"
-    (is (= ["intents"] (mapv :slug (db/listed (assoc db/seed :order ["gone" "intents"])))))))
+    (is (= ["intents"] (mapv :slug (rf.hicasso.examples.slice.db/listed (assoc rf.hicasso.examples.slice.db/seed :order ["gone" "intents"])))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Pagination — arithmetic, and a page number nobody may trust
 ;; ---------------------------------------------------------------------------
 
-(def ^:private slugs (mapv :slug (db/listed db/seed)))
+(def ^:private slugs (mapv :slug (rf.hicasso.examples.slice.db/listed rf.hicasso.examples.slice.db/seed)))
 
-(defn- page-slugs [n] (mapv :slug (db/page-rows (db/listed db/seed) n)))
+(defn- page-slugs [n] (mapv :slug (rf.hicasso.examples.slice.db/page-rows (rf.hicasso.examples.slice.db/listed rf.hicasso.examples.slice.db/seed) n)))
 
 (deftest pages-are-cut-from-the-order-and-the-last-one-is-short
   (is (= 7 (count slugs)) "the seed's roster, which the sizes below are read against")
-  (is (= 3 (db/page-count (db/listed db/seed)))
+  (is (= 3 (rf.hicasso.examples.slice.db/page-count (rf.hicasso.examples.slice.db/listed rf.hicasso.examples.slice.db/seed)))
       "seven articles at a page size of three")
   (is (= ["hicasso" "intents" "controls"] (page-slugs 1)))
   (is (= ["keys" "boundaries" "revision"] (page-slugs 2)))
@@ -102,22 +102,22 @@
        none is on none"))
 
 (deftest an-empty-feed-is-one-empty-page-rather-than-zero-pages
-  (let [empty-db (assoc db/seed :order [])]
-    (is (= 1 (db/page-count (db/listed empty-db)))
+  (let [empty-db (assoc rf.hicasso.examples.slice.db/seed :order [])]
+    (is (= 1 (rf.hicasso.examples.slice.db/page-count (rf.hicasso.examples.slice.db/listed empty-db)))
         "zero pages would make `page 1` a question with no answer, and the
          pager would have no number to call the page the user is on")
-    (is (= [] (db/page-rows (db/listed empty-db) 1)))))
+    (is (= [] (rf.hicasso.examples.slice.db/page-rows (rf.hicasso.examples.slice.db/listed empty-db) 1)))))
 
 (deftest a-page-number-off-the-url-is-clamped-rather-than-trusted
-  (let [rows (db/listed db/seed)]
-    (is (= 1 (db/clamp-page rows nil)) "no ?page= at all is the first page")
-    (is (= 1 (db/clamp-page rows 1)))
-    (is (= 3 (db/clamp-page rows 3)))
+  (let [rows (rf.hicasso.examples.slice.db/listed rf.hicasso.examples.slice.db/seed)]
+    (is (= 1 (rf.hicasso.examples.slice.db/clamp-page rows nil)) "no ?page= at all is the first page")
+    (is (= 1 (rf.hicasso.examples.slice.db/clamp-page rows 1)))
+    (is (= 3 (rf.hicasso.examples.slice.db/clamp-page rows 3)))
     (testing "a number outside the range is a PAGE, not an error — a URL is
               user input and `/slice?page=900` is something anybody can type"
-      (is (= 1 (db/clamp-page rows 0)))
-      (is (= 1 (db/clamp-page rows -3)))
-      (is (= 3 (db/clamp-page rows 900)))
+      (is (= 1 (rf.hicasso.examples.slice.db/clamp-page rows 0)))
+      (is (= 1 (rf.hicasso.examples.slice.db/clamp-page rows -3)))
+      (is (= 3 (rf.hicasso.examples.slice.db/clamp-page rows 900)))
       (is (= ["pages"] (page-slugs 900))
           "and the rows follow the clamp, so the page renders the nearest
            thing that exists rather than nothing at all"))))
@@ -135,11 +135,11 @@
   ;; navigation event of the application's own is involved, and there is
   ;; none in this slice to involve.
   (testing "the pager's own destination becomes a URL that carries the page"
-    (is (= "/slice?page=2" (routing/route-url {:to routes/feed :query {:page 2}}))))
+    (is (= "/slice?page=2" (rf.routing/route-url {:to rf.hicasso.examples.slice.routes/feed :query {:page 2}}))))
 
   (testing "and the URL comes back as the same page, as a NUMBER"
-    (let [match (routing/match-url "/slice?page=2")]
-      (is (= routes/feed (:route-id match)))
+    (let [match (rf.routing/match-url "/slice?page=2")]
+      (is (= rf.hicasso.examples.slice.routes/feed (:route-id match)))
       (is (= {:page 2} (:query match))
           "`:int` coercion is what makes this a 2 rather than a \"2\" — the
            subscription that reads it does arithmetic, and a string would
@@ -147,31 +147,31 @@
 
   (testing "a bare /slice is page one, because :query-defaults says so
             rather than because a view remembered to"
-    (is (= {:page 1} (:query (routing/match-url "/slice")))))
+    (is (= {:page 1} (:query (rf.routing/match-url "/slice")))))
 
   (testing "the article route is untouched by any of it"
-    (is (= routes/article (:route-id (routing/match-url "/slice/article/intents"))))))
+    (is (= rf.hicasso.examples.slice.routes/article (:route-id (rf.routing/match-url "/slice/article/intents"))))))
 
 (deftest validation-answers-keywords-in-a-stable-order
-  (is (= [] (db/problems {:title "t" :body "b"})))
-  (is (= [:problem/title-blank] (db/problems {:title "  " :body "b"})))
-  (is (= [:problem/body-blank] (db/problems {:title "t" :body nil})))
-  (is (= [:problem/title-blank :problem/body-blank] (db/problems {}))
+  (is (= [] (rf.hicasso.examples.slice.db/problems {:title "t" :body "b"})))
+  (is (= [:problem/title-blank] (rf.hicasso.examples.slice.db/problems {:title "  " :body "b"})))
+  (is (= [:problem/body-blank] (rf.hicasso.examples.slice.db/problems {:title "t" :body nil})))
+  (is (= [:problem/title-blank :problem/body-blank] (rf.hicasso.examples.slice.db/problems {}))
       "title first, always — the editor shows the first problem and a set
        would make which one it shows depend on hashing"))
 
 (deftest a-title-is-taken-only-by-another-article
-  (is (true? (db/title-taken? db/seed "controls" "Intents are data")))
-  (is (false? (db/title-taken? db/seed "intents" "Intents are data"))
+  (is (true? (rf.hicasso.examples.slice.db/title-taken? rf.hicasso.examples.slice.db/seed "controls" "Intents are data")))
+  (is (false? (rf.hicasso.examples.slice.db/title-taken? rf.hicasso.examples.slice.db/seed "intents" "Intents are data"))
       "an article does not collide with itself, or no article could ever
        be saved without renaming it")
-  (is (true? (db/title-taken? db/seed "controls" "  intents ARE data  "))
+  (is (true? (rf.hicasso.examples.slice.db/title-taken? rf.hicasso.examples.slice.db/seed "controls" "  intents ARE data  "))
       "case and surrounding space are not what makes two titles different"))
 
 (deftest commit-folds-the-draft-and-clears-it
-  (let [db' (db/commit db/seed "intents" {:title "Renamed" :body "New body" :published? false})]
-    (is (= "Renamed" (:title (db/article db' "intents"))))
-    (is (false? (db/dirty? db' "intents")))
+  (let [db' (rf.hicasso.examples.slice.db/commit rf.hicasso.examples.slice.db/seed "intents" {:title "Renamed" :body "New body" :published? false})]
+    (is (= "Renamed" (:title (rf.hicasso.examples.slice.db/article db' "intents"))))
+    (is (false? (rf.hicasso.examples.slice.db/dirty? db' "intents")))
     (is (= #{:articles :order :drafts :save :digest :locale :theme}
            (set (keys db')))
         "a commit moves two keys and mints none — in particular no
@@ -183,23 +183,23 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-missing-translation-shows-itself
-  (is (= "Articles" (i18n/t :en :feed/heading)))
-  (is (= "Rien de publié pour l'instant." (i18n/t :fr :feed/empty)))
-  (is (= "‹feed/heading›" (i18n/t :de :feed/heading))
+  (is (= "Articles" (rf.hicasso.examples.slice.i18n/t :en :feed/heading)))
+  (is (= "Rien de publié pour l'instant." (rf.hicasso.examples.slice.i18n/t :fr :feed/empty)))
+  (is (= "‹feed/heading›" (rf.hicasso.examples.slice.i18n/t :de :feed/heading))
       "an unknown locale answers the sentinel rather than falling back to
        English, because a silent fallback makes a hole and a translation
        look identical on screen and in a test")
-  (is (= "‹app/nonexistent›" (i18n/t :en :app/nonexistent))))
+  (is (= "‹app/nonexistent›" (rf.hicasso.examples.slice.i18n/t :en :app/nonexistent))))
 
 (deftest every-locale-carries-every-key
-  (let [ks (set (keys (:en i18n/strings)))]
-    (doseq [locale i18n/locales]
-      (is (= ks (set (keys (get i18n/strings locale))))
+  (let [ks (set (keys (:en rf.hicasso.examples.slice.i18n/strings)))]
+    (doseq [locale rf.hicasso.examples.slice.i18n/locales]
+      (is (= ks (set (keys (get rf.hicasso.examples.slice.i18n/strings locale))))
           (str "locale " locale " and :en disagree about which strings exist")))))
 
 (deftest every-theme-carries-every-token
-  (let [ks (set (keys (:light i18n/themes)))]
-    (doseq [[theme tokens] i18n/themes]
+  (let [ks (set (keys (:light rf.hicasso.examples.slice.i18n/themes)))]
+    (doseq [[theme tokens] rf.hicasso.examples.slice.i18n/themes]
       (is (= ks (set (keys tokens)))
           (str "theme " theme " and :light disagree about which tokens exist")))))
 
@@ -210,49 +210,49 @@
 (deftest the-first-keystroke-edits-on-top-of-the-article
   (with-app
     (fn [frame]
-      (rf/dispatch-sync [::events/edit "intents" :title "Intents, revisited"] {:frame frame})
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/edit "intents" :title "Intents, revisited"] {:frame frame})
       (is (= {:title "Intents, revisited"
               :body  "A click carries a vector, and two renders are equal."
               :published? true}
-             (read-sub frame [::subs/draft "intents"]))
+             (read-sub frame [::rf.hicasso.examples.slice.subs/draft "intents"]))
           "the body and the published flag survive an edit that named
            neither — without db/draft-for underneath, the first character
            would land in an empty map and blank them")
-      (is (true? (read-sub frame [::subs/dirty? "intents"]))))))
+      (is (true? (read-sub frame [::rf.hicasso.examples.slice.subs/dirty? "intents"]))))))
 
 (deftest discarding-restores-the-article
   (with-app
     (fn [frame]
-      (rf/dispatch-sync [::events/edit "intents" :title "typed"] {:frame frame})
-      (is (true? (read-sub frame [::subs/dirty? "intents"])))
-      (rf/dispatch-sync [::events/discard {:slug "intents"}] {:frame frame})
-      (is (= "Intents are data" (:title (read-sub frame [::subs/draft "intents"])))
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/edit "intents" :title "typed"] {:frame frame})
+      (is (true? (read-sub frame [::rf.hicasso.examples.slice.subs/dirty? "intents"])))
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/discard {:slug "intents"}] {:frame frame})
+      (is (= "Intents are data" (:title (read-sub frame [::rf.hicasso.examples.slice.subs/draft "intents"])))
           "the MODEL moved, which is the whole of the reset here — the
            counter this handler used to bump beside it was measured inert
            and removed (rf2-36bd)")
-      (is (false? (read-sub frame [::subs/dirty? "intents"]))))))
+      (is (false? (read-sub frame [::rf.hicasso.examples.slice.subs/dirty? "intents"]))))))
 
 (deftest a-local-problem-never-reaches-the-server
   (with-app
     (fn [frame]
-      (rf/dispatch-sync [::events/edit "intents" :title "   "] {:frame frame})
-      (rf/dispatch-sync [::events/save {:slug "intents"}] {:frame frame})
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/edit "intents" :title "   "] {:frame frame})
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/save {:slug "intents"}] {:frame frame})
       (is (= {:status :failed :problem :problem/title-blank}
-             (read-sub frame [::subs/save-state "intents"]))
+             (read-sub frame [::rf.hicasso.examples.slice.subs/save-state "intents"]))
           "no request is made, so the status goes straight to :failed —
            there is nothing in flight and nothing that can arrive late")
-      (is (true? (read-sub frame [::subs/dirty? "intents"]))
+      (is (true? (read-sub frame [::rf.hicasso.examples.slice.subs/dirty? "intents"]))
           "a refused save keeps the draft; losing what the user typed
            because it was invalid is the cruellest form of validation"))))
 
 (deftest a-save-that-passes-validation-goes-in-flight
   (with-app
     (fn [frame]
-      (rf/dispatch-sync [::events/edit "intents" :title "Fine"] {:frame frame})
-      (rf/dispatch-sync [::events/save {:slug "intents"}] {:frame frame})
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/edit "intents" :title "Fine"] {:frame frame})
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/save {:slug "intents"}] {:frame frame})
       (is (= {:status :saving :problem nil}
-             (read-sub frame [::subs/save-state "intents"])))
-      (is (true? (read-sub frame [::subs/dirty? "intents"]))
+             (read-sub frame [::rf.hicasso.examples.slice.subs/save-state "intents"])))
+      (is (true? (read-sub frame [::rf.hicasso.examples.slice.subs/dirty? "intents"]))
           "the draft is kept until the reply lands, so a failure has
            something to fail back to"))))
 
@@ -260,36 +260,36 @@
   (testing "a reply for the article this frame is saving is folded in"
     (with-app
       (fn [frame]
-        (rf/dispatch-sync [::events/edit "intents" :title "Fine"] {:frame frame})
-        (rf/dispatch-sync [::events/save {:slug "intents"}] {:frame frame})
-        (rf/dispatch-sync [::events/saved {:slug "intents" :draft {:title "Fine"}}]
+        (rf/dispatch-sync [::rf.hicasso.examples.slice.events/edit "intents" :title "Fine"] {:frame frame})
+        (rf/dispatch-sync [::rf.hicasso.examples.slice.events/save {:slug "intents"}] {:frame frame})
+        (rf/dispatch-sync [::rf.hicasso.examples.slice.events/saved {:slug "intents" :draft {:title "Fine"}}]
                           {:frame frame})
-        (is (= "Fine" (:title (db/article (app-db-of frame) "intents"))))
-        (is (= :saved (:status (read-sub frame [::subs/save-state "intents"])))))))
+        (is (= "Fine" (:title (rf.hicasso.examples.slice.db/article (app-db-of frame) "intents"))))
+        (is (= :saved (:status (read-sub frame [::rf.hicasso.examples.slice.subs/save-state "intents"])))))))
 
   (testing "a reply for an article it is no longer saving is DROPPED"
     (with-app
       (fn [frame]
-        (rf/dispatch-sync [::events/edit "intents" :title "Fine"] {:frame frame})
-        (rf/dispatch-sync [::events/save {:slug "intents"}] {:frame frame})
+        (rf/dispatch-sync [::rf.hicasso.examples.slice.events/edit "intents" :title "Fine"] {:frame frame})
+        (rf/dispatch-sync [::rf.hicasso.examples.slice.events/save {:slug "intents"}] {:frame frame})
         ;; The user moved on and started saving a different article.
-        (rf/dispatch-sync [::events/edit "controls" :title "Also fine"] {:frame frame})
-        (rf/dispatch-sync [::events/save {:slug "controls"}] {:frame frame})
+        (rf/dispatch-sync [::rf.hicasso.examples.slice.events/edit "controls" :title "Also fine"] {:frame frame})
+        (rf/dispatch-sync [::rf.hicasso.examples.slice.events/save {:slug "controls"}] {:frame frame})
         ;; …and now the first request's reply lands.
-        (rf/dispatch-sync [::events/saved {:slug "intents" :draft {:title "Fine"}}]
+        (rf/dispatch-sync [::rf.hicasso.examples.slice.events/saved {:slug "intents" :draft {:title "Fine"}}]
                           {:frame frame})
-        (is (= "Intents are data" (:title (db/article (app-db-of frame) "intents")))
+        (is (= "Intents are data" (:title (rf.hicasso.examples.slice.db/article (app-db-of frame) "intents")))
             "the stale reply moved nothing")
-        (is (= :saving (:status (read-sub frame [::subs/save-state "controls"])))
+        (is (= :saving (:status (read-sub frame [::rf.hicasso.examples.slice.subs/save-state "controls"])))
             "and did not disturb the save that is actually in flight")))))
 
 (deftest the-save-region-is-projected-per-article
   (with-app
     (fn [frame]
-      (rf/dispatch-sync [::events/edit "intents" :title "Fine"] {:frame frame})
-      (rf/dispatch-sync [::events/save {:slug "intents"}] {:frame frame})
-      (is (= {:status :saving :problem nil} (read-sub frame [::subs/save-state "intents"])))
-      (is (= {:status :idle :problem nil} (read-sub frame [::subs/save-state "controls"]))
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/edit "intents" :title "Fine"] {:frame frame})
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/save {:slug "intents"}] {:frame frame})
+      (is (= {:status :saving :problem nil} (read-sub frame [::rf.hicasso.examples.slice.subs/save-state "intents"])))
+      (is (= {:status :idle :problem nil} (read-sub frame [::rf.hicasso.examples.slice.subs/save-state "controls"]))
           "the projection is what keeps the stale-reply rule out of the
            view: an editor asks one question, not two"))))
 
@@ -300,18 +300,18 @@
 (deftest switching-the-locale-moves-every-string
   (with-app
     (fn [frame]
-      (is (= "Articles" (read-sub frame [::subs/t :feed/heading])))
-      (rf/dispatch-sync [::events/set-locale "fr"] {:frame frame})
-      (is (= :fr (read-sub frame [::subs/locale]))
+      (is (= "Articles" (read-sub frame [::rf.hicasso.examples.slice.subs/t :feed/heading])))
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/set-locale "fr"] {:frame frame})
+      (is (= :fr (read-sub frame [::rf.hicasso.examples.slice.subs/locale]))
           "the handler keywords the string a <select> hands it")
-      (is (= "Modifier" (read-sub frame [::subs/t :editor/heading]))))))
+      (is (= "Modifier" (read-sub frame [::rf.hicasso.examples.slice.subs/t :editor/heading]))))))
 
 (deftest switching-the-theme-moves-every-token
   (with-app
     (fn [frame]
-      (is (= "rgb(255, 255, 255)" (read-sub frame [::subs/token :surface])))
-      (rf/dispatch-sync [::events/set-theme {:theme :dark}] {:frame frame})
-      (is (= "rgb(18, 21, 26)" (read-sub frame [::subs/token :surface]))))))
+      (is (= "rgb(255, 255, 255)" (read-sub frame [::rf.hicasso.examples.slice.subs/token :surface])))
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/set-theme {:theme :dark}] {:frame frame})
+      (is (= "rgb(18, 21, 26)" (read-sub frame [::rf.hicasso.examples.slice.subs/token :surface]))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Pagination and the digest, through the frame
@@ -323,9 +323,9 @@
   [n f]
   (rf/with-new-frame
     [frame (rf/make-frame
-             {:initial-events [[::events/seed]
+             {:initial-events [[::rf.hicasso.examples.slice.events/seed]
                                [:rf.route/navigate
-                                (cond-> {:to routes/feed}
+                                (cond-> {:to rf.hicasso.examples.slice.routes/feed}
                                   (some? n) (assoc :query {:page n}))]]})]
     (f frame)))
 
@@ -333,18 +333,18 @@
   (testing "a bare /slice"
     (at-page nil
       (fn [frame]
-        (is (= 1 (read-sub frame [::subs/current-page])))
-        (is (= 3 (read-sub frame [::subs/page-count])))
+        (is (= 1 (read-sub frame [::rf.hicasso.examples.slice.subs/current-page])))
+        (is (= 3 (read-sub frame [::rf.hicasso.examples.slice.subs/page-count])))
         (is (= ["hicasso" "intents" "controls"]
-               (mapv :slug (read-sub frame [::subs/feed])))))))
+               (mapv :slug (read-sub frame [::rf.hicasso.examples.slice.subs/feed])))))))
 
   (testing "?page=2 moves the list and nothing else"
     (at-page 2
       (fn [frame]
-        (is (= 2 (read-sub frame [::subs/current-page])))
+        (is (= 2 (read-sub frame [::rf.hicasso.examples.slice.subs/current-page])))
         (is (= ["keys" "boundaries" "revision"]
-               (mapv :slug (read-sub frame [::subs/feed]))))
-        (is (= 7 (count (read-sub frame [::subs/listed])))
+               (mapv :slug (read-sub frame [::rf.hicasso.examples.slice.subs/feed]))))
+        (is (= 7 (count (read-sub frame [::rf.hicasso.examples.slice.subs/listed])))
             "the whole list is still the whole list — pagination is a
              projection over it, not a filter applied to `app-db`")
         (is (nil? (:page (app-db-of frame)))
@@ -356,35 +356,35 @@
   (testing "?page=900 clamps, and the RAW ask stays visible beside it"
     (at-page 900
       (fn [frame]
-        (is (= 900 (read-sub frame [::subs/page])) "what the URL asked for")
-        (is (= 3 (read-sub frame [::subs/current-page])) "what exists")
-        (is (= ["pages"] (mapv :slug (read-sub frame [::subs/feed]))))))))
+        (is (= 900 (read-sub frame [::rf.hicasso.examples.slice.subs/page])) "what the URL asked for")
+        (is (= 3 (read-sub frame [::rf.hicasso.examples.slice.subs/current-page])) "what exists")
+        (is (= ["pages"] (mapv :slug (read-sub frame [::rf.hicasso.examples.slice.subs/feed]))))))))
 
 (deftest the-digest-is-seeded-whole-and-a-partial-delivery-is-taken-as-it-came
   (with-app
     (fn [frame]
-      (is (= db/digest (read-sub frame [::subs/digest-blocks]))
+      (is (= rf.hicasso.examples.slice.db/digest (read-sub frame [::rf.hicasso.examples.slice.subs/digest-blocks]))
           "the application opens with content; the digest ships with the page")
-      (is (false? (read-sub frame [::subs/digest-loading?])))
+      (is (false? (read-sub frame [::rf.hicasso.examples.slice.subs/digest-loading?])))
 
       (testing "a delivery that arrived cut short is stored UNINSPECTED —
                 the client validates no block, and the region's own error
                 boundary is why it does not have to"
-        (rf/dispatch-sync [::events/digest-arrived {:blocks db/digest-truncated}]
+        (rf/dispatch-sync [::rf.hicasso.examples.slice.events/digest-arrived {:blocks rf.hicasso.examples.slice.db/digest-truncated}]
                           {:frame frame})
-        (is (= db/digest-truncated (read-sub frame [::subs/digest-blocks])))
-        (is (nil? (:block/items (second (read-sub frame [::subs/digest-blocks]))))
+        (is (= rf.hicasso.examples.slice.db/digest-truncated (read-sub frame [::rf.hicasso.examples.slice.subs/digest-blocks])))
+        (is (nil? (:block/items (second (read-sub frame [::rf.hicasso.examples.slice.subs/digest-blocks]))))
             "the list block lost its items, which is the shape a renderer
              refuses")))))
 
 (deftest reloading-the-digest-goes-in-flight-and-keeps-what-is-on-screen
   (with-app
     (fn [frame]
-      (rf/dispatch-sync [::events/digest-arrived {:blocks db/digest-truncated}]
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/digest-arrived {:blocks rf.hicasso.examples.slice.db/digest-truncated}]
                         {:frame frame})
-      (rf/dispatch-sync [::events/reload-digest] {:frame frame})
-      (is (true? (read-sub frame [::subs/digest-loading?])))
-      (is (= db/digest-truncated (read-sub frame [::subs/digest-blocks]))
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.events/reload-digest] {:frame frame})
+      (is (true? (read-sub frame [::rf.hicasso.examples.slice.subs/digest-loading?])))
+      (is (= rf.hicasso.examples.slice.db/digest-truncated (read-sub frame [::rf.hicasso.examples.slice.subs/digest-blocks]))
           "the blocks did not move. Emptying them would clear the region's
            error boundary — its reset key is the CONTENT — so a failed
            region would blink through an empty success on its way back, and
@@ -398,13 +398,13 @@
 (deftest per-row-disclosure-state-is-per-row
   (with-app
     (fn [frame]
-      (is (false? (read-sub frame [::subs/tags-open? "intents"]))
+      (is (false? (read-sub frame [::rf.hicasso.examples.slice.subs/tags-open? "intents"]))
           "the registered :default, with nothing in app-db")
-      (rf/dispatch-sync [::subs/tags-open? "intents" true] {:frame frame})
-      (is (true? (read-sub frame [::subs/tags-open? "intents"])))
-      (is (false? (read-sub frame [::subs/tags-open? "hicasso"]))
+      (rf/dispatch-sync [::rf.hicasso.examples.slice.subs/tags-open? "intents" true] {:frame frame})
+      (is (true? (read-sub frame [::rf.hicasso.examples.slice.subs/tags-open? "intents"])))
+      (is (false? (read-sub frame [::rf.hicasso.examples.slice.subs/tags-open? "hicasso"]))
           "the bug h/reg-state deletes: a hand-rolled [:ui :tags-open?]
            path would have opened every row on the page at once")
-      (is (= {"intents" true} (get-in (app-db-of frame) [:ui ::subs/tags-open?]))
+      (is (= {"intents" true} (get-in (app-db-of frame) [:ui ::rf.hicasso.examples.slice.subs/tags-open?]))
           "and it lives in app-space at [:ui ::concern ikey], readable by
            an ordinary handler and dumpable in a tool"))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/l2_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/l2_cljs_test.cljs
@@ -25,32 +25,32 @@
   running the editor's own body. That is the ladder's definition of the
   tier rather than a limitation worked around."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso.examples.slice.db :as db]
-            [re-frame.hicasso.examples.slice.events :as events]
-            [re-frame.hicasso.examples.slice.routes :as routes]
-            [re-frame.hicasso.examples.slice.subs :as subs]
-            [re-frame.hicasso.examples.slice.views :as views]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso.examples.slice.db :as rf.hicasso.examples.slice.db]
+            [re-frame.hicasso.examples.slice.events :as rf.hicasso.examples.slice.events]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.subs :as rf.hicasso.examples.slice.subs]
+            [re-frame.hicasso.examples.slice.views :as rf.hicasso.examples.slice.views]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 (defn- tagged
   "The first node in `tree` with tag `tag`."
   [tree tag]
-  (ht/find tree #(= tag (:tag %))))
+  (rf.hicasso.test/find tree #(= tag (:tag %))))
 
 (defn- classed
   "The first node in `tree` carrying `class` — the slice's own hook for
   finding a region, and the same hook the mounted suite uses, so the two
   tiers talk about the same parts of the page."
   [tree class]
-  (ht/find tree #(= class (:class (ht/attrs %)))))
+  (rf.hicasso.test/find tree #(= class (:class (rf.hicasso.test/attrs %)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The feed row — a link, a badge, a disclosure
@@ -60,33 +60,33 @@
   {:slug "intents" :title "Intents are data" :published? true :tags ["intents" "data"]})
 
 (defn- row-tree [{:keys [open?]}]
-  (ht/tree [views/article-row row-props]
-           {:subs {[::subs/tags-open? "intents"] (boolean open?)
-                   [::subs/t :feed/tags]         "Tags"}}))
+  (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/article-row row-props]
+           {:subs {[::rf.hicasso.examples.slice.subs/tags-open? "intents"] (boolean open?)
+                   [::rf.hicasso.examples.slice.subs/t :feed/tags]         "Tags"}}))
 
 (deftest a-feed-row-links-through-routing-and-never-builds-a-url
   (let [a (tagged (row-tree {}) :a)]
-    (is (= "/slice/article/intents" (:href (ht/attrs a)))
+    (is (= "/slice/article/intents" (:href (rf.hicasso.test/attrs a)))
         "the href is the routing artefact's own synthesis — `views` names
          no URL anywhere, and this is the assertion that says so")
-    (is (= "Intents are data" (ht/text a)))
-    (is (intent/navigate-head? (:on-click (ht/attrs a)))
+    (is (= "Intents are data" (rf.hicasso.test/text a)))
+    (is (rf.hicasso.impl.intent/navigate-head? (:on-click (rf.hicasso.test/attrs a)))
         "the click decision is DATA — a vector headed by the intent
          namespace's own keyword, which `=` can see and which is what
          makes two renders of one link equal")))
 
 (deftest a-published-row-carries-no-draft-badge
   (is (nil? (classed (row-tree {}) "draft-badge")))
-  (is (some? (classed (ht/tree [views/article-row (assoc row-props :published? false)]
-                               {:subs {[::subs/tags-open? "intents"] false
-                                       [::subs/t :feed/tags]         "Tags"}})
+  (is (some? (classed (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/article-row (assoc row-props :published? false)]
+                               {:subs {[::rf.hicasso.examples.slice.subs/tags-open? "intents"] false
+                                       [::rf.hicasso.examples.slice.subs/t :feed/tags]         "Tags"}})
                       "draft-badge"))))
 
 (deftest the-disclosure-carries-its-own-instance-key
   (testing "closed: the toggle asks to open THIS row"
     (let [toggle (classed (row-tree {:open? false}) "tags-toggle")]
-      (is (= "false" (:aria-expanded (ht/attrs toggle))))
-      (is (= [::subs/tags-open? "intents" true] (:on-click (ht/attrs toggle)))
+      (is (= "false" (:aria-expanded (rf.hicasso.test/attrs toggle))))
+      (is (= [::rf.hicasso.examples.slice.subs/tags-open? "intents" true] (:on-click (rf.hicasso.test/attrs toggle)))
           "the slug is the instance key, so the intent names the row it
            came from — the whole of what h/reg-state buys")
       (is (nil? (classed (row-tree {:open? false}) "tag-list"))
@@ -95,12 +95,12 @@
   (testing "open: the toggle asks to close, and the tags are there"
     (let [tree   (row-tree {:open? true})
           toggle (classed tree "tags-toggle")]
-      (is (= "true" (:aria-expanded (ht/attrs toggle))))
-      (is (= [::subs/tags-open? "intents" false] (:on-click (ht/attrs toggle))))
+      (is (= "true" (:aria-expanded (rf.hicasso.test/attrs toggle))))
+      (is (= [::rf.hicasso.examples.slice.subs/tags-open? "intents" false] (:on-click (rf.hicasso.test/attrs toggle))))
       (let [tags (:children (classed tree "tag-list"))]
         (is (= ["intents" "data"] (mapv :key tags))
             "keyed by the tag itself")
-        (is (= ["intents" "data"] (mapv ht/text tags)))))))
+        (is (= ["intents" "data"] (mapv rf.hicasso.test/text tags)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The feed page — a keyed list, and the empty case
@@ -109,9 +109,9 @@
 (deftest the-list-keys-every-row-by-its-slug
   (let [rows [{:slug "a" :title "A" :published? true :tags []}
               {:slug "b" :title "B" :published? true :tags []}]
-        tree (ht/tree [views/feed-page {}]
-                      {:subs {[::subs/feed]           rows
-                              [::subs/t :feed/heading] "Articles"}})
+        tree (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/feed-page {}]
+                      {:subs {[::rf.hicasso.examples.slice.subs/feed]           rows
+                              [::rf.hicasso.examples.slice.subs/t :feed/heading] "Articles"}})
         kids (:children (tagged tree :ul))]
     (is (= ["a" "b"] (mapv :key kids))
         "the key is the domain id. A list keyed by its index reuses the
@@ -122,11 +122,11 @@
          and does not run the child's body")))
 
 (deftest an-empty-feed-reads-its-empty-string-and-nothing-else
-  (let [tree (ht/tree [views/feed-page {}]
-                      {:subs {[::subs/feed]            []
-                              [::subs/t :feed/heading] "Articles"
-                              [::subs/t :feed/empty]   "Nothing published yet."}})]
-    (is (= "Nothing published yet." (ht/text (classed tree "feed-empty"))))
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/feed-page {}]
+                      {:subs {[::rf.hicasso.examples.slice.subs/feed]            []
+                              [::rf.hicasso.examples.slice.subs/t :feed/heading] "Articles"
+                              [::rf.hicasso.examples.slice.subs/t :feed/empty]   "Nothing published yet."}})]
+    (is (= "Nothing published yet." (rf.hicasso.test/text (classed tree "feed-empty"))))
     (is (nil? (tagged tree :ul)))))
 
 (deftest a-populated-feed-does-not-read-the-empty-string
@@ -134,10 +134,10 @@
   ;; set, so LEAVING OUT `[::subs/t :feed/empty]` is an assertion that the
   ;; populated branch never reads it. If the string were hoisted out of
   ;; the `if`, this row would refuse.
-  (is (some? (ht/tree [views/feed-page {}]
-                      {:subs {[::subs/feed] [{:slug "a" :title "A"
+  (is (some? (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/feed-page {}]
+                      {:subs {[::rf.hicasso.examples.slice.subs/feed] [{:slug "a" :title "A"
                                               :published? true :tags []}]
-                              [::subs/t :feed/heading] "Articles"}}))
+                              [::rf.hicasso.examples.slice.subs/t :feed/heading] "Articles"}}))
       "a read inside a branch not taken contributes no edge"))
 
 ;; ---------------------------------------------------------------------------
@@ -150,12 +150,12 @@
   single-page row below an assertion rather than a rendering."
   ([page pages] (pager-tree page pages true))
   ([page pages labels?]
-   (ht/tree [views/pager {}]
-            {:subs (cond-> {[::subs/current-page] page
-                            [::subs/page-count]   pages}
-                     labels? (merge {[::subs/t :feed/pagination] "Pages"
-                                     [::subs/t :feed/previous]   "Previous"
-                                     [::subs/t :feed/next]       "Next"}))})))
+   (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/pager {}]
+            {:subs (cond-> {[::rf.hicasso.examples.slice.subs/current-page] page
+                            [::rf.hicasso.examples.slice.subs/page-count]   pages}
+                     labels? (merge {[::rf.hicasso.examples.slice.subs/t :feed/pagination] "Pages"
+                                     [::rf.hicasso.examples.slice.subs/t :feed/previous]   "Previous"
+                                     [::rf.hicasso.examples.slice.subs/t :feed/next]       "Next"}))})))
 
 (deftest one-page-renders-no-pager-and-reads-no-string
   ;; The fixture map is the assertion: no label entries at all, so a body
@@ -171,7 +171,7 @@
     (is (= [1 2 3] (mapv :key links))
         "one item per page, keyed by the page number")
     (is (= ["/slice" nil "/slice?page=3"]
-           (mapv #(:href (ht/attrs (first (:children %)))) links))
+           (mapv #(:href (rf.hicasso.test/attrs (first (:children %)))) links))
         "the hrefs are routing's own synthesis from `{:page n}` — `views`
          names no URL and no `?` anywhere. Two of the three answers are
          worth reading twice. The CURRENT page has no href at all, because
@@ -181,32 +181,32 @@
          `route-url` leaves it out and every page has exactly one URL.
          Two spellings of one page would be two history entries and two
          things to bookmark")
-    (is (= "page" (:aria-current (ht/attrs (classed tree "pager-current"))))
+    (is (= "page" (:aria-current (rf.hicasso.test/attrs (classed tree "pager-current"))))
         "and that span is what tells a screen reader where it is")))
 
 (deftest both-ends-stop-being-controls-at-the-end-they-guard
   (testing "page 1: Previous is text, Next is a link"
     (let [tree (pager-tree 1 3)]
       (is (= :span (:tag (classed tree "pager-prev"))))
-      (is (= "true" (:aria-disabled (ht/attrs (classed tree "pager-prev"))))
+      (is (= "true" (:aria-disabled (rf.hicasso.test/attrs (classed tree "pager-prev"))))
           "`aria-disabled` rather than an `<a>` with no href: `disabled` is
            not an anchor attribute, and a hrefless anchor is a focusable
            thing a screen-reader user is told to activate and nothing
            happens when they do")
       (is (= :a (:tag (classed tree "pager-next"))))
-      (is (= "/slice?page=2" (:href (ht/attrs (classed tree "pager-next")))))))
+      (is (= "/slice?page=2" (:href (rf.hicasso.test/attrs (classed tree "pager-next")))))))
 
   (testing "the last page: the other way round"
     (let [tree (pager-tree 3 3)]
       (is (= :a (:tag (classed tree "pager-prev"))))
-      (is (= "/slice?page=2" (:href (ht/attrs (classed tree "pager-prev")))))
+      (is (= "/slice?page=2" (:href (rf.hicasso.test/attrs (classed tree "pager-prev")))))
       (is (= :span (:tag (classed tree "pager-next"))))
-      (is (= "true" (:aria-disabled (ht/attrs (classed tree "pager-next")))))))
+      (is (= "true" (:aria-disabled (rf.hicasso.test/attrs (classed tree "pager-next")))))))
 
   (testing "in the middle, both are links"
     (let [tree (pager-tree 2 3)]
       (is (= ["/slice" "/slice?page=3"]
-             (mapv #(:href (ht/attrs (classed tree %))) ["pager-prev" "pager-next"]))
+             (mapv #(:href (rf.hicasso.test/attrs (classed tree %))) ["pager-prev" "pager-next"]))
           "and Previous from page two is the bare `/slice` — see above on
            why page one has exactly one URL"))))
 
@@ -215,7 +215,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- block-tree [block extra]
-  (ht/tree [(get views/block-views (:block/kind block) views/unsupported-block)
+  (rf.hicasso.test/tree [(get rf.hicasso.examples.slice.views/block-views (:block/kind block) rf.hicasso.examples.slice.views/unsupported-block)
             {:block block}]
            {:subs (or extra {})}))
 
@@ -224,8 +224,8 @@
   ;; `(get block-views kind …)` — a value out of a map, in head position,
   ;; with no registry under it — and this row runs the selection the
   ;; application itself runs.
-  (let [tree (ht/tree [views/digest-body {}]
-                      {:subs {[::subs/digest-blocks] db/digest}})
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/digest-body {}]
+                      {:subs {[::rf.hicasso.examples.slice.subs/digest-blocks] rf.hicasso.examples.slice.db/digest}})
         kids (:children tree)]
     (is (= ["intro" "reading" "url" "care" "ticker"] (mapv :key kids))
         "one child per block, keyed by the block's own id")
@@ -238,7 +238,7 @@
         "each block reached the renderer its own kind names, and the kind
          with no entry fell to `unsupported-block` — the DEFAULT ARGUMENT
          is the whole of the policy")
-    (is (= (mapv :block/id db/digest) (mapv (comp :block/id :block :props) kids))
+    (is (= (mapv :block/id rf.hicasso.examples.slice.db/digest) (mapv (comp :block/id :block :props) kids))
         "and each call carries its own block; L2 records the call and does
          not run the child's body")))
 
@@ -247,9 +247,9 @@
   ;; body. This is the EXPECTED one: content outlives the build that
   ;; renders it, so an unknown kind is an ordinary thing to be sent.
   (let [tree (block-tree {:block/id "t" :block/kind :block/ticker}
-                         {[::subs/t :digest/unsupported] "This build cannot show a block of kind"})]
+                         {[::rf.hicasso.examples.slice.subs/t :digest/unsupported] "This build cannot show a block of kind"})]
     (is (some? (classed tree "block-unsupported")))
-    (is (= ":block/ticker" (ht/text (classed tree "block-kind")))
+    (is (= ":block/ticker" (rf.hicasso.test/text (classed tree "block-kind")))
         "the kind is NAMED rather than swallowed — a silent hole is a hole
          nobody reports")))
 
@@ -259,13 +259,13 @@
   ;; nothing for it would put a silent hole where an editor put three
   ;; items. The region above it is what turns the throw into a page.
   (is (= ["Keys are domain ids" "Boundaries are components" "Revision is a counter"]
-         (mapv ht/text (:children (block-tree (second db/digest) nil))))
+         (mapv rf.hicasso.test/text (:children (block-tree (second rf.hicasso.examples.slice.db/digest) nil))))
       "the whole payload renders, keyed by the item itself")
   (is (empty? (:children (block-tree {:block/id "e" :block/kind :block/list
                                       :block/items []}
                                      nil)))
       "an EMPTY list is a list with nothing in it, and renders as one")
-  (is (thrown? js/Error (block-tree (second db/digest-truncated) nil))
+  (is (thrown? js/Error (block-tree (second rf.hicasso.examples.slice.db/digest-truncated) nil))
       "a list block whose items key is ABSENT refuses. The distinction is
        the whole of the row above: `[]` is content, and a missing key is a
        delivery that was cut short"))
@@ -273,39 +273,39 @@
 (deftest a-callout-picks-its-emphasis-TAG-and-its-token-from-its-tone
   (let [accent (block-tree {:block/id "a" :block/kind :block/callout
                             :block/tone :accent :block/text "quiet"}
-                           {[::subs/token :accent] "rgb(11, 107, 203)"})
+                           {[::rf.hicasso.examples.slice.subs/token :accent] "rgb(11, 107, 203)"})
         warn   (block-tree {:block/id "w" :block/kind :block/callout
                             :block/tone :warning :block/text "loud"}
-                           {[::subs/token :danger] "rgb(176, 32, 32)"})]
+                           {[::rf.hicasso.examples.slice.subs/token :danger] "rgb(176, 32, 32)"})]
     (is (= :em (:tag (classed accent "block-emphasis")))
         "a keyword in head position is a keyword in head position whether
          it was typed or computed")
     (is (= :strong (:tag (classed warn "block-emphasis"))))
-    (is (= "rgb(11, 107, 203)" (:color (:style (ht/attrs (tagged accent :aside))))))
-    (is (= "rgb(176, 32, 32)" (:color (:style (ht/attrs (tagged warn :aside))))))
+    (is (= "rgb(11, 107, 203)" (:color (:style (rf.hicasso.test/attrs (tagged accent :aside))))))
+    (is (= "rgb(176, 32, 32)" (:color (:style (rf.hicasso.test/attrs (tagged warn :aside))))))
     ;; The fixture maps are the second assertion: neither tone reads the
     ;; other's token, so the branch really is a branch.
     (is (thrown? js/Error
           (block-tree {:block/id "w" :block/kind :block/callout
                        :block/tone :warning :block/text "loud"}
-                      {[::subs/token :accent] "rgb(11, 107, 203)"}))
+                      {[::rf.hicasso.examples.slice.subs/token :accent] "rgb(11, 107, 203)"}))
         "a warning callout handed only the accent token refuses — an
          escaped read, which is how this tier proves a branch was taken")))
 
 (defn- digest-tree [blocks loading?]
-  (ht/tree [views/digest {}]
-           {:subs {[::subs/digest-blocks]   blocks
-                   [::subs/digest-loading?] loading?
-                   [::subs/t :digest/heading] "Editor's digest"
-                   [::subs/t :digest/problem] "This digest could not be displayed."
-                   [::subs/t (if loading? :digest/loading :digest/retry)]
+  (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/digest {}]
+           {:subs {[::rf.hicasso.examples.slice.subs/digest-blocks]   blocks
+                   [::rf.hicasso.examples.slice.subs/digest-loading?] loading?
+                   [::rf.hicasso.examples.slice.subs/t :digest/heading] "Editor's digest"
+                   [::rf.hicasso.examples.slice.subs/t :digest/problem] "This digest could not be displayed."
+                   [::rf.hicasso.examples.slice.subs/t (if loading? :digest/loading :digest/retry)]
                    (if loading? "Reloading…" "Reload the digest")}}))
 
 (deftest the-digest-region-carries-its-own-boundary-and-resets-on-its-CONTENT
-  (let [tree     (digest-tree db/digest false)
-        boundary (ht/find tree #(contains? (:props %) :reset-key))]
+  (let [tree     (digest-tree rf.hicasso.examples.slice.db/digest false)
+        boundary (rf.hicasso.test/find tree #(contains? (:props %) :reset-key))]
     (is (some? boundary) "the region has an error boundary of its own")
-    (is (= db/digest (:reset-key (ht/attrs boundary)))
+    (is (= rf.hicasso.examples.slice.db/digest (:reset-key (rf.hicasso.test/attrs boundary)))
         "the reset key is the CONTENT, compared with `=`. A counter would
          clear the caught failure whenever a retry happened — including
          one that brought the same broken payload back, which would throw
@@ -317,10 +317,10 @@
          caught HERE — inside the shell's boundary, not by it")
 
     (testing "the fallback is inert markup, with the retry intent on it"
-      (let [fallback (:fallback (ht/attrs boundary))
+      (let [fallback (:fallback (rf.hicasso.test/attrs boundary))
             button   (last fallback)]
         (is (= "alert" (:role (second fallback))))
-        (is (= [::events/reload-digest] (:on-click (second button))))
+        (is (= [::rf.hicasso.examples.slice.events/reload-digest] (:on-click (second button))))
         (is (false? (:disabled (second button)))
             "enabled while nothing is in flight")
         (is (= "Reload the digest" (last button))
@@ -330,9 +330,9 @@
              was given")))))
 
 (deftest a-reload-in-flight-renames-the-retry-and-disables-it
-  (let [boundary (ht/find (digest-tree db/digest-truncated true)
+  (let [boundary (rf.hicasso.test/find (digest-tree rf.hicasso.examples.slice.db/digest-truncated true)
                           #(contains? (:props %) :reset-key))
-        button   (last (:fallback (ht/attrs boundary)))]
+        button   (last (:fallback (rf.hicasso.test/attrs boundary)))]
     (is (true? (:disabled (second button)))
         "so a second click cannot queue a second request")
     (is (= "Reloading…" (last button)))))
@@ -342,35 +342,35 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private editor-base-subs
-  {[::subs/draft "intents"]      {:title "T" :body "B" :published? true}
-   [::subs/dirty? "intents"]     false
-   [::subs/t :editor/heading]    "Edit"
-   [::subs/t :editor/title]      "Title"
-   [::subs/t :editor/body]       "Body"
-   [::subs/t :editor/published]  "Published"
-   [::subs/t :editor/save]       "Save"
-   [::subs/t :editor/discard]    "Discard changes"})
+  {[::rf.hicasso.examples.slice.subs/draft "intents"]      {:title "T" :body "B" :published? true}
+   [::rf.hicasso.examples.slice.subs/dirty? "intents"]     false
+   [::rf.hicasso.examples.slice.subs/t :editor/heading]    "Edit"
+   [::rf.hicasso.examples.slice.subs/t :editor/title]      "Title"
+   [::rf.hicasso.examples.slice.subs/t :editor/body]       "Body"
+   [::rf.hicasso.examples.slice.subs/t :editor/published]  "Published"
+   [::rf.hicasso.examples.slice.subs/t :editor/save]       "Save"
+   [::rf.hicasso.examples.slice.subs/t :editor/discard]    "Discard changes"})
 
 (defn- editor-tree [save extra]
-  (ht/tree [views/editor {:slug "intents"}]
+  (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/editor {:slug "intents"}]
            {:subs (merge editor-base-subs
-                         {[::subs/save-state "intents"] save}
+                         {[::rf.hicasso.examples.slice.subs/save-state "intents"] save}
                          extra)}))
 
 (deftest the-text-fields-are-controlled-by-the-model-alone
   (let [tree  (editor-tree {:status :idle :problem nil} {})
         title (classed tree "field-title")
         body  (classed tree "field-body")]
-    (is (= "T" (:value (ht/attrs title))))
-    (is (= "B" (:value (ht/attrs body))))
-    (is (= [::events/edit "intents" :title :re-frame.hicasso/value]
-           (:on-input (ht/attrs title)))
+    (is (= "T" (:value (rf.hicasso.test/attrs title))))
+    (is (= "B" (:value (rf.hicasso.test/attrs body))))
+    (is (= [::rf.hicasso.examples.slice.events/edit "intents" :title :re-frame.hicasso/value]
+           (:on-input (rf.hicasso.test/attrs title)))
         "POSITIONAL, and it has to be: `::h/value` substitutes at the
          intent vector's top level only, so the canonical `[<id> {<k>
          <v>}]` payload shape would carry the marker keyword itself into
          app-db — silently. See the events namespace docstring.")
-    (is (= [::events/edit "intents" :body :re-frame.hicasso/value]
-           (:on-input (ht/attrs body))))))
+    (is (= [::rf.hicasso.examples.slice.events/edit "intents" :body :re-frame.hicasso/value]
+           (:on-input (rf.hicasso.test/attrs body))))))
 
 (deftest neither-text-field-carries-a-reset-trigger
   ;; The ABSENCE, pinned at the tier that can read a marker off an authored
@@ -378,34 +378,34 @@
   ;; re-adds. Deleting the counter's bump from `::discard` moves the
   ;; browser lane not at all: a discard already re-runs this body three
   ;; times over, and the commit re-asserts the model on its own.
-  (is (= 0 (ht/revision [:input {:value "T" :re-frame.hicasso/revision 0}]))
+  (is (= 0 (rf.hicasso.test/revision [:input {:value "T" :re-frame.hicasso/revision 0}]))
       "the kit CAN read a trigger off an authored form, which is what makes
        the two readings below a finding rather than a blind spot")
   (let [tree (editor-tree {:status :idle :problem nil} {})]
-    (is (= [nil nil] (mapv #(:re-frame.hicasso/revision (ht/attrs %))
+    (is (= [nil nil] (mapv #(:re-frame.hicasso/revision (rf.hicasso.test/attrs %))
                            [(classed tree "field-title") (classed tree "field-body")]))
         "and neither field authors one — see `views/editor` for the
          population that does need `::h/revision`")))
 
 (deftest the-checkbox-takes-the-checked-marker
-  (let [box (ht/find (editor-tree {:status :idle :problem nil} {})
-                     #(= "checkbox" (:type (ht/attrs %))))]
-    (is (true? (:checked (ht/attrs box))))
-    (is (= [::events/toggle-published "intents" :re-frame.hicasso/checked]
-           (:on-change (ht/attrs box))))))
+  (let [box (rf.hicasso.test/find (editor-tree {:status :idle :problem nil} {})
+                     #(= "checkbox" (:type (rf.hicasso.test/attrs %))))]
+    (is (true? (:checked (rf.hicasso.test/attrs box))))
+    (is (= [::rf.hicasso.examples.slice.events/toggle-published "intents" :re-frame.hicasso/checked]
+           (:on-change (rf.hicasso.test/attrs box))))))
 
 (deftest submitting-the-form-is-the-save-intent
   (let [form (tagged (editor-tree {:status :idle :problem nil} {}) :form)]
-    (is (= [::events/save {:slug "intents"}] (:on-submit (ht/attrs form)))
+    (is (= [::rf.hicasso.examples.slice.events/save {:slug "intents"}] (:on-submit (rf.hicasso.test/attrs form)))
         "`:on-submit` auto-prevents (authoring.md's census-weighted
          default), so the page does not navigate and the handler is the
          whole of what a submit means here")))
 
 (deftest discard-is-disabled-until-something-was-typed
-  (is (true? (:disabled (ht/attrs (classed (editor-tree {:status :idle :problem nil} {})
+  (is (true? (:disabled (rf.hicasso.test/attrs (classed (editor-tree {:status :idle :problem nil} {})
                                            "discard")))))
-  (is (false? (:disabled (ht/attrs (classed (editor-tree {:status :idle :problem nil}
-                                                         {[::subs/dirty? "intents"] true})
+  (is (false? (:disabled (rf.hicasso.test/attrs (classed (editor-tree {:status :idle :problem nil}
+                                                         {[::rf.hicasso.examples.slice.subs/dirty? "intents"] true})
                                             "discard"))))
       "`false` and not absent: 004B drops a nil attribute value and keeps a
        false one, so the enabled case is a value rather than a hole"))
@@ -418,54 +418,54 @@
 
   (testing "failed: the problem KEYWORD becomes a sentence here"
     (let [tree (editor-tree {:status :failed :problem :problem/title-taken}
-                            {[::subs/token :danger] "rgb(176, 32, 32)"
-                             [::subs/t :problem/title-taken] "That title is already used."
-                             [::subs/t :editor/retry] "Try again"})
+                            {[::rf.hicasso.examples.slice.subs/token :danger] "rgb(176, 32, 32)"
+                             [::rf.hicasso.examples.slice.subs/t :problem/title-taken] "That title is already used."
+                             [::rf.hicasso.examples.slice.subs/t :editor/retry] "Try again"})
           region (classed tree "save-problem")]
-      (is (= "alert" (:role (ht/attrs region)))
+      (is (= "alert" (:role (rf.hicasso.test/attrs region)))
           "an error region a screen reader is not told about is an error
            region a screen reader user does not get")
-      (is (= "rgb(176, 32, 32)" (:color (:style (ht/attrs region))))
+      (is (= "rgb(176, 32, 32)" (:color (:style (rf.hicasso.test/attrs region))))
           "the colour is a THEME TOKEN read through a sub, not a class
            name promising something about a stylesheet")
-      (is (= [::events/save {:slug "intents"}]
-             (:on-click (ht/attrs (classed tree "retry"))))
+      (is (= [::rf.hicasso.examples.slice.events/save {:slug "intents"}]
+             (:on-click (rf.hicasso.test/attrs (classed tree "retry"))))
           "retry is the same intent as save — a failed mutation needs no
            second event, and inventing one is how the two drift"))))
 
 (deftest saving-disables-the-button-and-renames-it
   (let [tree (editor-tree {:status :saving :problem nil}
-                          {[::subs/t :editor/saving] "Saving…"})
+                          {[::rf.hicasso.examples.slice.subs/t :editor/saving] "Saving…"})
         save (classed tree "save")]
-    (is (true? (:disabled (ht/attrs save))))
-    (is (= "Saving…" (ht/text save))))
+    (is (true? (:disabled (rf.hicasso.test/attrs save))))
+    (is (= "Saving…" (rf.hicasso.test/text save))))
   ;; And the idle fixture map carries `:editor/save` but NOT
   ;; `:editor/saving`, so the two branches are proved distinct by the
   ;; fixtures rather than by the strings.
-  (is (= "Save" (ht/text (classed (editor-tree {:status :idle :problem nil} {}) "save")))))
+  (is (= "Save" (rf.hicasso.test/text (classed (editor-tree {:status :idle :problem nil} {}) "save")))))
 
 ;; ---------------------------------------------------------------------------
 ;; The article page — the route's params reach the editor
 ;; ---------------------------------------------------------------------------
 
 (deftest the-page-hands-the-editor-the-slug-it-read-off-the-url
-  (let [tree (ht/tree [views/article-page {}]
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/article-page {}]
                       {:subs {[:rf.route/params]        {:slug "intents"}
-                              [::subs/article "intents"] {:slug "intents" :title "Intents are data"}
-                              [::subs/t :article/back]   "All articles"}})
-        call (ht/find tree #(some? (:view-id %)))]
+                              [::rf.hicasso.examples.slice.subs/article "intents"] {:slug "intents" :title "Intents are data"}
+                              [::rf.hicasso.examples.slice.subs/t :article/back]   "All articles"}})
+        call (rf.hicasso.test/find tree #(some? (:view-id %)))]
     (is (= "re-frame.hicasso.examples.slice.views/editor" (:view-id call)))
     (is (= {:slug "intents"} (:props call))
         "the call is recorded; the editor's body does not run here")))
 
 (deftest a-slug-nobody-published-is-a-page-rather-than-an-error
-  (let [tree (ht/tree [views/article-page {}]
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/article-page {}]
                       {:subs {[:rf.route/params]         {:slug "nonsense"}
-                              [::subs/article "nonsense"] nil
-                              [::subs/t :article/back]    "All articles"
-                              [::subs/t :article/missing] "No such article."}})]
-    (is (= "No such article." (ht/text (classed tree "article-missing"))))
-    (is (nil? (ht/find tree #(some? (:view-id %))))
+                              [::rf.hicasso.examples.slice.subs/article "nonsense"] nil
+                              [::rf.hicasso.examples.slice.subs/t :article/back]    "All articles"
+                              [::rf.hicasso.examples.slice.subs/t :article/missing] "No such article."}})]
+    (is (= "No such article." (rf.hicasso.test/text (classed tree "article-missing"))))
+    (is (nil? (rf.hicasso.test/find tree #(some? (:view-id %))))
         "and no editor is called for an article that does not exist")))
 
 ;; ---------------------------------------------------------------------------
@@ -473,29 +473,29 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- shell-tree [route]
-  (ht/tree [views/app {}]
+  (rf.hicasso.test/tree [rf.hicasso.examples.slice.views/app {}]
            {:subs {[:rf.route/id]              route
-                   [::subs/token :surface]     "rgb(18, 21, 26)"
-                   [::subs/token :ink]         "rgb(232, 234, 237)"
-                   [::subs/t :app/pane-error]  "This page could not be displayed."}}))
+                   [::rf.hicasso.examples.slice.subs/token :surface]     "rgb(18, 21, 26)"
+                   [::rf.hicasso.examples.slice.subs/token :ink]         "rgb(232, 234, 237)"
+                   [::rf.hicasso.examples.slice.subs/t :app/pane-error]  "This page could not be displayed."}}))
 
 (deftest the-shell-paints-from-tokens-and-routes-the-pane
-  (let [tree     (shell-tree routes/article)
-        boundary (ht/find tree #(contains? (:props %) :reset-key))]
+  (let [tree     (shell-tree rf.hicasso.examples.slice.routes/article)
+        boundary (rf.hicasso.test/find tree #(contains? (:props %) :reset-key))]
     (is (= {:background "rgb(18, 21, 26)" :color "rgb(232, 234, 237)"}
-           (:style (ht/attrs (tagged tree :main)))))
+           (:style (rf.hicasso.test/attrs (tagged tree :main)))))
 
     (testing "the routed pane sits under h/error-boundary"
       (is (some? boundary)
           "recorded as the CALL it is — h/error-boundary is a legal hiccup
            head and its own body does not run here")
-      (is (= routes/article (:reset-key (ht/attrs boundary)))
+      (is (= rf.hicasso.examples.slice.routes/article (:reset-key (rf.hicasso.test/attrs boundary)))
           "the reset key is the ROUTE, so navigating away from a pane that
            threw clears the caught failure — the retry is the
            application's, taken when the user does something different,
            rather than the boundary's to guess")
       (is (= [:p.pane-error {:role "alert"} "This page could not be displayed."]
-             (:fallback (ht/attrs boundary)))
+             (:fallback (rf.hicasso.test/attrs boundary)))
           "the fallback is INERT MARKUP, and asserting it as data is the
            only honest thing this tier can say about it: driving it needs
            something to throw, which a testbed does not carry. Its
@@ -508,6 +508,6 @@
              (:view-id (first (:children boundary)))))))
 
   (testing "an unresolved route falls back to the feed rather than blanking"
-    (let [boundary (ht/find (shell-tree nil) #(contains? (:props %) :reset-key))]
+    (let [boundary (rf.hicasso.test/find (shell-tree nil) #(contains? (:props %) :reset-key))]
       (is (= "re-frame.hicasso.examples.slice.views/feed-page"
              (:view-id (first (:children boundary))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/routes.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/routes.cljs
@@ -30,7 +30,7 @@
   guide (`reg-route` at the top level, once) does not survive the
   supported test fixture without a second door being exposed for the
   test's sake."
-  (:require [re-frame.routing :as routing]))
+  (:require [re-frame.routing :as rf.routing]))
 
 (def feed
   "The list page. `/slice`, optionally `/slice?page=N`."
@@ -92,12 +92,12 @@
   [[re-frame.hicasso.examples.slice.db/clamp-page]] brings it inside,
   because a URL is user input and a typo is a page rather than an error."
   []
-  (routing/reg-route feed
+  (rf.routing/reg-route feed
     {:doc            "The article list, one page at a time."
      :query          [:map [:page {:optional true} :int]]
      :query-defaults {:page 1}}
     "/slice")
-  (routing/reg-route article
+  (rf.routing/reg-route article
     {:doc "One article, with its editor."}
     "/slice/article/:slug")
   nil)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/subs.cljs
@@ -22,9 +22,9 @@
   `re-frame.core` subs above it know nothing about a view substrate."
   (:refer-clojure :exclude [t])
   (:require [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.slice.db :as db]
-            [re-frame.hicasso.examples.slice.i18n :as i18n]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.slice.db :as rf.hicasso.examples.slice.db]
+            [re-frame.hicasso.examples.slice.i18n :as rf.hicasso.examples.slice.i18n]))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 1 — the raw reads
@@ -43,7 +43,7 @@
   answers that can drift."}
   (fn [db _]
     (mapv (fn [a] (select-keys a [:slug :title :published? :tags]))
-          (db/listed db))))
+          (rf.hicasso.examples.slice.db/listed db))))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 2 — i18n and theming, as ordinary derived reads
@@ -52,12 +52,12 @@
 (rf/reg-sub ::t
   {:doc "The sentence for a string key, in the frame's current locale."}
   :<- [::locale]
-  (fn [locale [_ k]] (i18n/t locale k)))
+  (fn [locale [_ k]] (rf.hicasso.examples.slice.i18n/t locale k)))
 
 (rf/reg-sub ::token
   {:doc "The value of a theme token, under the frame's current theme."}
   :<- [::theme]
-  (fn [theme [_ k]] (i18n/token theme k)))
+  (fn [theme [_ k]] (rf.hicasso.examples.slice.i18n/token theme k)))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 2 — the feed and the article
@@ -79,7 +79,7 @@
 (rf/reg-sub ::page-count
   {:doc "How many pages the feed has."}
   :<- [::listed]
-  (fn [rows _] (db/page-count rows)))
+  (fn [rows _] (rf.hicasso.examples.slice.db/page-count rows)))
 
 (rf/reg-sub ::current-page
   {:doc "The page actually on screen — the URL's number brought inside the
@@ -87,7 +87,7 @@
   empty one, because a URL is user input."}
   :<- [::listed]
   :<- [::page]
-  (fn [[rows page] _] (db/clamp-page rows page)))
+  (fn [[rows page] _] (rf.hicasso.examples.slice.db/clamp-page rows page)))
 
 (rf/reg-sub ::feed
   {:doc "The rows THIS PAGE shows, in publication order. Each row is the
@@ -99,7 +99,7 @@
   and the list reads rows."}
   :<- [::listed]
   :<- [::current-page]
-  (fn [[rows page] _] (db/page-rows rows page)))
+  (fn [[rows page] _] (rf.hicasso.examples.slice.db/page-rows rows page)))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 2 — the digest, the runtime-selected content region
@@ -119,16 +119,16 @@
 
 (rf/reg-sub ::article
   {:doc "One article by slug, or nil for a slug the URL invented."}
-  (fn [db [_ slug]] (db/article db slug)))
+  (fn [db [_ slug]] (rf.hicasso.examples.slice.db/article db slug)))
 
 (rf/reg-sub ::draft
   {:doc "The editable value of one article — the draft, or the article's
   own fields when nobody has typed yet. See db/draft-for."}
-  (fn [db [_ slug]] (db/draft-for db slug)))
+  (fn [db [_ slug]] (rf.hicasso.examples.slice.db/draft-for db slug)))
 
 (rf/reg-sub ::dirty?
   {:doc "Has this article been edited since it was last saved or discarded?"}
-  (fn [db [_ slug]] (db/dirty? db slug)))
+  (fn [db [_ slug]] (rf.hicasso.examples.slice.db/dirty? db slug)))
 
 ;; ---------------------------------------------------------------------------
 ;; Layer 3 — the save region, projected for the view
@@ -166,4 +166,4 @@
   `[:ui :tags-open?]` flag and they all open at once. The instance key
   is the article's slug — a domain id, which is the rule the sugar
   teaches and does not police."
-  (h/reg-state ::tags-open? {:default false}))
+  (rf.hicasso/reg-state ::tags-open? {:default false}))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/slice/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/slice/views.cljs
@@ -39,17 +39,17 @@
   [[article-row]] and [[pager]] used to read through the grouped
   `h/use-subs` as the control; that door was removed (rf2-6c12m.15) and
   both bodies now read the same way as the rest."
-  (:require [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.slice.events :as events]
-            [re-frame.hicasso.examples.slice.i18n :as i18n]
-            [re-frame.hicasso.examples.slice.routes :as routes]
-            [re-frame.hicasso.examples.slice.subs :as subs]))
+  (:require [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.slice.events :as rf.hicasso.examples.slice.events]
+            [re-frame.hicasso.examples.slice.i18n :as rf.hicasso.examples.slice.i18n]
+            [re-frame.hicasso.examples.slice.routes :as rf.hicasso.examples.slice.routes]
+            [re-frame.hicasso.examples.slice.subs :as rf.hicasso.examples.slice.subs]))
 
 ;; ---------------------------------------------------------------------------
 ;; The chrome — locale and theme, switched at runtime
 ;; ---------------------------------------------------------------------------
 
-(h/defview chrome
+(rf.hicasso/defview chrome
   "The header: the application's name, a locale `<select>` and two theme
   buttons.
 
@@ -60,39 +60,39 @@
   switching either moves one key in `app-db`, and every boundary that
   read a string or a token re-renders because it read it."
   [_]
-  (let [locale-now (h/sub [::subs/locale])
-        theme-now  (h/sub [::subs/theme])]
+  (let [locale-now (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/locale])
+        theme-now  (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/theme])]
     [:header.slice-chrome
-     [:h1.slice-title (h/sub [::subs/t :app/title])]
+     [:h1.slice-title (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :app/title])]
 
-     [:label.locale-label {:for "slice-locale"} (h/sub [::subs/t :app/locale])]
+     [:label.locale-label {:for "slice-locale"} (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :app/locale])]
      [:select#slice-locale.locale
       {;; `::h/value` off a `<select>` is `.-value`, a string — the
        ;; handler keywords it. Positional, because the marker substitutes
        ;; at the intent's top level only; see `events`'s namespace
        ;; docstring.
        :value     (name locale-now)
-       :on-change [::events/set-locale ::h/value]}
+       :on-change [::rf.hicasso.examples.slice.events/set-locale ::rf.hicasso/value]}
       ;; The option roster never changes, so it is a module constant read
       ;; directly rather than a subscription over a literal.
-      (for [locale i18n/locales]
+      (for [locale rf.hicasso.examples.slice.i18n/locales]
         [:option {:key (name locale) :value (name locale)} (name locale)])]
 
      [:div.theme-switch
-      [:span.theme-label (h/sub [::subs/t :app/theme])]
+      [:span.theme-label (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :app/theme])]
       (for [[theme label-key] [[:light :theme/light] [:dark :theme/dark]]]
         [:button.theme-choice
          {:key      (name theme)
           :type     "button"
           :class    (when (= theme theme-now) "current")
-          :on-click [::events/set-theme {:theme theme}]}
-         (h/sub [::subs/t label-key])])]]))
+          :on-click [::rf.hicasso.examples.slice.events/set-theme {:theme theme}]}
+         (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t label-key])])]]))
 
 ;; ---------------------------------------------------------------------------
 ;; The feed — a keyed list
 ;; ---------------------------------------------------------------------------
 
-(h/defview article-row
+(rf.hicasso/defview article-row
   "One row of the feed: a link to the article, and a tag disclosure whose
   open flag is this row's own.
 
@@ -101,13 +101,13 @@
   :tags-open?]` path is the bug the sugar deletes: every row on the page
   would share one flag and they would all open together, silently."
   [{:keys [slug title published? tags]}]
-  (let [open?      (h/sub [::subs/tags-open? slug])
-        tags-label (h/sub [::subs/t :feed/tags])]
+  (let [open?      (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/tags-open? slug])
+        tags-label (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :feed/tags])]
     [:li.article-row
      ;; CALLED, not a head — see the namespace docstring. The href and the
      ;; click decision come whole from the routing artefact; this body
      ;; never sees a URL.
-     (h/route-link {:to routes/article :params {:slug slug} :class "article-link"}
+     (rf.hicasso/route-link {:to rf.hicasso.examples.slice.routes/article :params {:slug slug} :class "article-link"}
                    title)
      (when-not published?
        [:span.draft-badge "draft"])
@@ -116,7 +116,7 @@
         [:button.tags-toggle
          {:type          "button"
           :aria-expanded (str (boolean open?))
-          :on-click      [::subs/tags-open? slug (not open?)]}
+          :on-click      [::rf.hicasso.examples.slice.subs/tags-open? slug (not open?)]}
          tags-label]
         (when open?
           [:ul.tag-list
@@ -127,7 +127,7 @@
 ;; The pager — the page is a URL, so Back and Forward are routing's
 ;; ---------------------------------------------------------------------------
 
-(h/defview pager
+(rf.hicasso/defview pager
   "The feed's pager: an end-stop or a link at each end, and one link per
   page in between.
 
@@ -154,19 +154,19 @@
   shrinking with the branch, and `l2-cljs-test` asserts exactly that by
   handing this body a fixture map with no strings in it."
   [_]
-  (let [page  (h/sub [::subs/current-page])
-        pages (h/sub [::subs/page-count])]
+  (let [page  (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/current-page])
+        pages (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/page-count])]
     (when (< 1 pages)
       ;; Both labels are read OUTSIDE the branches that place them, so the
       ;; page a user is on never changes which strings this body reads.
       ;; An edge that appears on page 2 and not on page 1 is an edge whose
       ;; absence nobody would notice until a translation changed.
-      (let [previous (h/sub [::subs/t :feed/previous])
-            next     (h/sub [::subs/t :feed/next])]
-        [:nav.pager {:aria-label (h/sub [::subs/t :feed/pagination])}
+      (let [previous (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :feed/previous])
+            next     (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :feed/next])]
+        [:nav.pager {:aria-label (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :feed/pagination])}
          (if (= 1 page)
            [:span.pager-prev {:aria-disabled "true"} previous]
-           (h/route-link {:to routes/feed :query {:page (dec page)} :class "pager-prev"}
+           (rf.hicasso/route-link {:to rf.hicasso.examples.slice.routes/feed :query {:page (dec page)} :class "pager-prev"}
                          previous))
          [:ol.pager-pages
           (for [n (range 1 (inc pages))]
@@ -177,11 +177,11 @@
                ;; link because a link to the page you are on is a link
                ;; that does nothing.
                [:span.pager-current {:aria-current "page"} (str n)]
-               (h/route-link {:to routes/feed :query {:page n} :class "pager-link"}
+               (rf.hicasso/route-link {:to rf.hicasso.examples.slice.routes/feed :query {:page n} :class "pager-link"}
                              (str n)))])]
          (if (= page pages)
            [:span.pager-next {:aria-disabled "true"} next]
-           (h/route-link {:to routes/feed :query {:page (inc page)} :class "pager-next"}
+           (rf.hicasso/route-link {:to rf.hicasso.examples.slice.routes/feed :query {:page (inc page)} :class "pager-next"}
                          next))]))))
 
 ;; ---------------------------------------------------------------------------
@@ -194,12 +194,12 @@
 ;; picking one out of a map is picking a value out of a map.
 ;; ---------------------------------------------------------------------------
 
-(h/defview prose-block
+(rf.hicasso/defview prose-block
   "A paragraph."
   [{:keys [block]}]
   [:p.block-prose (:block/text block)])
 
-(h/defview list-block
+(rf.hicasso/defview list-block
   "A bulleted list — and the one renderer in this application that
   REFUSES its input.
 
@@ -224,7 +224,7 @@
           (map (fn [item] [:li.block-item {:key item} item]))
           items)))
 
-(h/defview callout-block
+(rf.hicasso/defview callout-block
   "An aside whose EMPHASIS TAG and colour are both chosen from the
   block's tone at render time.
 
@@ -235,10 +235,10 @@
   [{:keys [block]}]
   (let [warning? (= :warning (:block/tone block))]
     [:aside.block-callout
-     {:style {:color (h/sub [::subs/token (if warning? :danger :accent)])}}
+     {:style {:color (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/token (if warning? :danger :accent)])}}
      [(if warning? :strong :em) {:class "block-emphasis"} (:block/text block)]]))
 
-(h/defview unsupported-block
+(rf.hicasso/defview unsupported-block
   "A block of a kind this build has no renderer for.
 
   The EXPECTED failure, and it stays data. Content outlives the build
@@ -248,7 +248,7 @@
   swallowed, so the hole says what it is."
   [{:keys [block]}]
   [:p.block-unsupported
-   (h/sub [::subs/t :digest/unsupported])
+   (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :digest/unsupported])
    " "
    [:code.block-kind (str (:block/kind block))]])
 
@@ -259,7 +259,7 @@
    :block/list    list-block
    :block/callout callout-block})
 
-(h/defview digest-body
+(rf.hicasso/defview digest-body
   "The blocks, each rendered by whichever view its own kind names.
 
   `(get block-views kind unsupported-block)` in HEAD POSITION is the
@@ -268,13 +268,13 @@
   other. A kind with no entry falls to [[unsupported-block]] rather than
   to a refusal — the default argument is the policy."
   [_]
-  (let [blocks (h/sub [::subs/digest-blocks])]
+  (let [blocks (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/digest-blocks])]
     (into [:div.digest-body]
           (map (fn [{:block/keys [id kind] :as block}]
                  [(get block-views kind unsupported-block) {:key id :block block}]))
           blocks)))
 
-(h/defview digest
+(rf.hicasso/defview digest
   "The digest region, and the application's NESTED error region.
 
   `h/error-boundary` here sits inside the one
@@ -294,26 +294,26 @@
   fallback a second time after a visible flicker. Reading the content
   itself, a retry that changed nothing changes nothing on screen."
   [_]
-  (let [blocks   (h/sub [::subs/digest-blocks])
-        loading? (h/sub [::subs/digest-loading?])]
+  (let [blocks   (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/digest-blocks])
+        loading? (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/digest-loading?])]
     [:section.digest
-     [:h3.digest-heading (h/sub [::subs/t :digest/heading])]
-     [h/error-boundary
+     [:h3.digest-heading (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :digest/heading])]
+     [rf.hicasso/error-boundary
       {:reset-key blocks
        :fallback  [:div.digest-error {:role "alert"}
-                   [:p.digest-problem (h/sub [::subs/t :digest/problem])]
+                   [:p.digest-problem (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :digest/problem])]
                    [:button.digest-retry
                     {:type     "button"
                      :disabled loading?
-                     :on-click [::events/reload-digest]}
-                    (h/sub [::subs/t (if loading? :digest/loading :digest/retry)])]]}
+                     :on-click [::rf.hicasso.examples.slice.events/reload-digest]}
+                    (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t (if loading? :digest/loading :digest/retry)])]]}
       [digest-body {}]]]))
 
 ;; ---------------------------------------------------------------------------
 ;; The feed page
 ;; ---------------------------------------------------------------------------
 
-(h/defview feed-page
+(rf.hicasso/defview feed-page
   "The list. Keyed by slug, because a keyed list whose key is its index
   reuses the wrong row the moment the order changes — and with
   pagination there is a moment: every page flip replaces the whole list,
@@ -325,12 +325,12 @@
   this body still reads exactly the two things it read before pagination
   existed, so the page it renders is still *the rows, and a heading*."
   [_]
-  (let [rows (h/sub [::subs/feed])]
+  (let [rows (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/feed])]
     [:section.feed
-     [:h2 (h/sub [::subs/t :feed/heading])]
+     [:h2 (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :feed/heading])]
      [digest {}]
      (if (empty? rows)
-       [:p.feed-empty (h/sub [::subs/t :feed/empty])]
+       [:p.feed-empty (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :feed/empty])]
        [:ul.article-list
         (for [{:keys [slug] :as row} rows]
           [article-row (assoc row :key slug)])])
@@ -340,7 +340,7 @@
 ;; The editor — controlled fields, an async save, an error region, a reset
 ;; ---------------------------------------------------------------------------
 
-(h/defview editor
+(rf.hicasso/defview editor
   "The article's form.
 
   Both text fields are CONTROLLED in the substrate's sense: `:value` is a
@@ -363,38 +363,38 @@
   React never saw. This editor is neither, and
   `flow-dom-cljs-test`'s reset section witnesses both halves."
   [{:keys [slug]}]
-  (let [draft            (h/sub [::subs/draft slug])
-        dirty?           (h/sub [::subs/dirty? slug])
-        {:keys [status problem]} (h/sub [::subs/save-state slug])
+  (let [draft            (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/draft slug])
+        dirty?           (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/dirty? slug])
+        {:keys [status problem]} (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/save-state slug])
         saving?          (= :saving status)]
-    [:form.editor {:on-submit [::events/save {:slug slug}]}
-     [:h3 (h/sub [::subs/t :editor/heading])]
+    [:form.editor {:on-submit [::rf.hicasso.examples.slice.events/save {:slug slug}]}
+     [:h3 (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :editor/heading])]
 
-     [:label {:for "slice-title"} (h/sub [::subs/t :editor/title])]
+     [:label {:for "slice-title"} (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :editor/title])]
      [:input#slice-title.field-title
       {:type     "text"
        :value    (:title draft)
-       :on-input [::events/edit slug :title ::h/value]}]
+       :on-input [::rf.hicasso.examples.slice.events/edit slug :title ::rf.hicasso/value]}]
 
-     [:label {:for "slice-body"} (h/sub [::subs/t :editor/body])]
+     [:label {:for "slice-body"} (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :editor/body])]
      [:textarea#slice-body.field-body
       {:value    (:body draft)
-       :on-input [::events/edit slug :body ::h/value]}]
+       :on-input [::rf.hicasso.examples.slice.events/edit slug :body ::rf.hicasso/value]}]
 
      [:label.published {:for "slice-published"}
       [:input#slice-published
        {:type      "checkbox"
         :checked   (boolean (:published? draft))
-        :on-change [::events/toggle-published slug ::h/checked]}]
-      (h/sub [::subs/t :editor/published])]
+        :on-change [::rf.hicasso.examples.slice.events/toggle-published slug ::rf.hicasso/checked]}]
+      (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :editor/published])]
 
      [:div.editor-actions
       [:button.save {:type "submit" :disabled saving?}
-       (h/sub [::subs/t (if saving? :editor/saving :editor/save)])]
+       (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t (if saving? :editor/saving :editor/save)])]
       [:button.discard {:type     "button"
                         :disabled (not dirty?)
-                        :on-click [::events/discard {:slug slug}]}
-       (h/sub [::subs/t :editor/discard])]]
+                        :on-click [::rf.hicasso.examples.slice.events/discard {:slug slug}]}
+       (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :editor/discard])]]
 
      ;; The error region. A problem is a KEYWORD in `app-db` and a
      ;; sentence here, which is what makes a failed save translatable and
@@ -404,29 +404,29 @@
      ;; a message it is not showing.
      (when (= :failed status)
        [:p.save-problem {:role  "alert"
-                         :style {:color (h/sub [::subs/token :danger])}}
-        (h/sub [::subs/t problem])
+                         :style {:color (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/token :danger])}}
+        (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t problem])
         " "
-        [:button.retry {:type "button" :on-click [::events/save {:slug slug}]}
-         (h/sub [::subs/t :editor/retry])]])
+        [:button.retry {:type "button" :on-click [::rf.hicasso.examples.slice.events/save {:slug slug}]}
+         (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :editor/retry])]])
 
      (when (= :saved status)
-       [:p.save-ok {:role "status"} (h/sub [::subs/t :editor/saved])])]))
+       [:p.save-ok {:role "status"} (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :editor/saved])])]))
 
-(h/defview article-page
+(rf.hicasso/defview article-page
   "One article and its editor. The slug comes from the URL through
   routing's own subscription — the slice keeps no copy of the current
   route in `app-db`, so the address bar and the page cannot disagree."
   [_]
-  (let [slug    (:slug (h/sub [:rf.route/params]))
-        article (h/sub [::subs/article slug])]
+  (let [slug    (:slug (rf.hicasso/sub [:rf.route/params]))
+        article (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/article slug])]
     [:section.article
-     (h/route-link {:to routes/feed :class "back"}
-                   (h/sub [::subs/t :article/back]))
+     (rf.hicasso/route-link {:to rf.hicasso.examples.slice.routes/feed :class "back"}
+                   (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :article/back]))
      (if (nil? article)
        ;; A URL is user input, so a slug nobody published is a page rather
        ;; than an error.
-       [:p.article-missing (h/sub [::subs/t :article/missing])]
+       [:p.article-missing (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :article/missing])]
        [:<>
         [:h2.article-title (:title article)]
         [editor {:slug slug}]])]))
@@ -435,7 +435,7 @@
 ;; The shell
 ;; ---------------------------------------------------------------------------
 
-(h/defview app
+(rf.hicasso/defview app
   "The whole application: the chrome, then whichever pane the route
   selects, under one error boundary.
 
@@ -444,22 +444,22 @@
   application's, taken at the moment the user does something different,
   rather than the boundary's to guess."
   [_]
-  (let [route (h/sub [:rf.route/id])]
+  (let [route (rf.hicasso/sub [:rf.route/id])]
     [:main.slice
-     {:style {:background (h/sub [::subs/token :surface])
-              :color      (h/sub [::subs/token :ink])}}
+     {:style {:background (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/token :surface])
+              :color      (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/token :ink])}}
      [chrome {}]
      ;; The fallback is markup written HERE, in a body that rendered fine,
      ;; so its string is read the way every other string is. A hardcoded
      ;; English sentence would be the one place in the application a
      ;; French reader falls out of their own language, and it would do so
      ;; at the worst possible moment.
-     [h/error-boundary {:reset-key route
+     [rf.hicasso/error-boundary {:reset-key route
                         :fallback  [:p.pane-error {:role "alert"}
-                                    (h/sub [::subs/t :app/pane-error])]}
+                                    (rf.hicasso/sub [::rf.hicasso.examples.slice.subs/t :app/pane-error])]}
       (cond
-        (= route routes/article) [article-page {}]
-        (= route routes/feed)    [feed-page {}]
+        (= route rf.hicasso.examples.slice.routes/article) [article-page {}]
+        (= route rf.hicasso.examples.slice.routes/feed)    [feed-page {}]
         ;; Before the first navigation resolves there is no route at all,
         ;; and a page that rendered nothing there would be a blank screen
         ;; with no explanation. The feed is the honest default.

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/app.cljs
@@ -31,12 +31,12 @@
   boundary that read it must re-render, and the headless plain-atom
   adapter's derived value is not `IWatchable`, so a moving subscription
   under it notifies nothing at all."
-  (:require [re-frame.adapter.uix :as uix-adapter]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.todo.events :as events]
-            [re-frame.hicasso.examples.todo.routes :as routes]
-            [re-frame.hicasso.examples.todo.views :as views]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.todo.events :as rf.hicasso.examples.todo.events]
+            [re-frame.hicasso.examples.todo.routes :as rf.hicasso.examples.todo.routes]
+            [re-frame.hicasso.examples.todo.views :as rf.hicasso.examples.todo.views]))
 
 (def frame-id
   "This application's frame. One root, one frame; a page holding a second
@@ -60,10 +60,10 @@
   and takes `:initial-events`, so the two events below are the value a
   witness hands it."
   []
-  (routes/register!)
+  (rf.hicasso.examples.todo.routes/register!)
   (rf/make-frame {:id             frame-id
-                  :initial-events [[::events/seed sample-todos]
-                                   [:rf.route/navigate {:to routes/all}]]}))
+                  :initial-events [[::rf.hicasso.examples.todo.events/seed sample-todos]
+                                   [:rf.route/navigate {:to rf.hicasso.examples.todo.routes/all}]]}))
 
 (defn ^:dev/after-load reload!
   "Re-render the mounted root after a hot reload. React reconciles the
@@ -73,12 +73,12 @@
   discard all three."
   []
   (when-some [root @!root]
-    (h/render! root [views/app {}])))
+    (rf.hicasso/render! root [rf.hicasso.examples.todo.views/app {}])))
 
 (defn ^:export -main
   "Start the application."
   []
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (make-frame!)
-  (reset! !root (h/mount! (js/document.getElementById "app") {:frame frame-id} [views/app {}]))
+  (reset! !root (rf.hicasso/mount! (js/document.getElementById "app") {:frame frame-id} [rf.hicasso.examples.todo.views/app {}]))
   nil)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/db.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/db.cljs
@@ -27,7 +27,7 @@
   A `nil` draft means *this row is not being edited* — one representation
   of unset, which is why cancelling an edit is `[::h/clear ::draft id]`
   (removal, back to the default) rather than a write of `nil`."
-  (:require [re-frame.hicasso :as h]))
+  (:require [re-frame.hicasso :as rf.hicasso]))
 
 ;; ---------------------------------------------------------------------------
 ;; The shape
@@ -73,4 +73,4 @@
   A hand-rolled `[:ui :edit-draft]` path is the bug this deletes: every
   row on the page would share one draft, they would all open together,
   and nothing would complain."
-  (h/reg-state ::draft {:default nil}))
+  (rf.hicasso/reg-state ::draft {:default nil}))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/events.cljs
@@ -31,8 +31,8 @@
      it."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.todo.db :as db]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.todo.db :as rf.hicasso.examples.todo.db]))
 
 ;; ---------------------------------------------------------------------------
 ;; Boot
@@ -44,7 +44,7 @@
          on a seeded model rather than on a nil the views have to defend
          against."}
   (fn [_ [_ titles]]
-    {:db (db/seed (or titles []))}))
+    {:db (rf.hicasso.examples.todo.db/seed (or titles []))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The new-to-do box
@@ -125,10 +125,10 @@
     ;; `[:ui <concern> <ikey>]` is `h/reg-state`'s documented app-db layout
     ;; and an ordinary handler may read it. The `:ui` root has no name on
     ;; the door, so it is written out — see the namespace docstring.
-    (if-some [text (get-in db [:ui db/draft id])]
+    (if-some [text (get-in db [:ui rf.hicasso.examples.todo.db/draft id])]
       (let [title (str/trim text)]
         {:db (if (str/blank? title)
                (update db :todos dissoc id)
                (assoc-in db [:todos id :title] title))
-         :fx [[:dispatch [::h/clear db/draft id]]]})
+         :fx [[:dispatch [::rf.hicasso/clear rf.hicasso.examples.todo.db/draft id]]]})
       {})))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/flow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/flow_dom_cljs_test.cljs
@@ -58,16 +58,16 @@
   and each row degrades there to a STATED skip rather than a false
   green."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.todo.app :as app]
-            [re-frame.hicasso.examples.todo.db :as db]
-            [re-frame.hicasso.examples.todo.events :as events]
-            [re-frame.hicasso.examples.todo.routes :as routes]
-            [re-frame.hicasso.examples.todo.subs :as subs]
-            [re-frame.hicasso.examples.todo.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.todo.app :as rf.hicasso.examples.todo.app]
+            [re-frame.hicasso.examples.todo.db :as rf.hicasso.examples.todo.db]
+            [re-frame.hicasso.examples.todo.events :as rf.hicasso.examples.todo.events]
+            [re-frame.hicasso.examples.todo.routes :as rf.hicasso.examples.todo.routes]
+            [re-frame.hicasso.examples.todo.subs :as rf.hicasso.examples.todo.subs]
+            [re-frame.hicasso.examples.todo.views :as rf.hicasso.examples.todo.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The lane
@@ -79,8 +79,8 @@
   (is true (str "a mounted flow needs a real React DOM — " why)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The MAP shape, because every row is `async`: `cljs.test` refuses an
      ;; async test under a fn-form fixture and aborts the namespace.
@@ -93,7 +93,7 @@
                       ;; captured when this form was EVALUATED, which is
                       ;; before `routes` finished loading. See that
                       ;; namespace on why `register!` is exposed at all.
-                      (routes/register!))}))
+                      (rf.hicasso.examples.todo.routes/register!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Reading and driving the page
@@ -118,13 +118,13 @@
   dispatch is synchronous, so the settle is all that is owed."
   [m sel]
   (.click (node m sel))
-  (hm/settle! m))
+  (rf.hicasso.test.mounted/settle! m))
 
 (defn- double-click!
   "A real `dblclick`, which `.click()` cannot synthesise."
   [m sel]
   (.dispatchEvent (node m sel) (js/MouseEvent. "dblclick" #js {:bubbles true}))
-  (hm/settle! m))
+  (rf.hicasso.test.mounted/settle! m))
 
 (defn- press!
   "A real `keydown` carrying `key`, at `sel`. React's synthetic
@@ -132,7 +132,7 @@
   lookup is the real one."
   [m sel key]
   (.dispatchEvent (node m sel) (js/KeyboardEvent. "keydown" #js {:key key :bubbles true}))
-  (hm/settle! m))
+  (rf.hicasso.test.mounted/settle! m))
 
 (defn- submit!
   "Submit the form at `sel` the way the browser's own implicit
@@ -140,7 +140,7 @@
   and cannot drive."
   [m sel]
   (.requestSubmit (node m sel))
-  (hm/settle! m))
+  (rf.hicasso.test.mounted/settle! m))
 
 (defn- type-into!
   "Type `v` into the field at `sel` — a foreign write followed by a real
@@ -155,7 +155,7 @@
         d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
     (.call (.-set d) n v)
     (.dispatchEvent n (js/InputEvent. "input" #js {:bubbles true}))
-    (hm/settle! m)))
+    (rf.hicasso.test.mounted/settle! m)))
 
 (defn- read-sub [m query-v] (rf/subscribe-once query-v {:frame (:frame m)}))
 
@@ -167,23 +167,23 @@
                 (nodes m ".filters a"))]
     (is (some? a) (str "there is a tab labelled " (pr-str label)))
     (.click a)
-    (hm/settle-until! m
-                      #(= expected-filter (read-sub m [::subs/showing]))
+    (rf.hicasso.test.mounted/settle-until! m
+                      #(= expected-filter (read-sub m [::rf.hicasso.examples.todo.subs/showing]))
                       {:label (str "the " label " filter to land")})))
 
 (defn- mount-app!
   "The whole application, on its own root and its own frame, seeded and
   pointed at *All*. `:initial-events` drain to fixed point before the
   first render, so a row opens on the seeded page."
-  ([] (mount-app! [:rf.route/navigate {:to routes/all}]))
+  ([] (mount-app! [:rf.route/navigate {:to rf.hicasso.examples.todo.routes/all}]))
   ([nav-event]
-   (hm/mount! [views/app {}]
-              {:initial-events [[::events/seed app/sample-todos] nav-event]})))
+   (rf.hicasso.test.mounted/mount! [rf.hicasso.examples.todo.views/app {}]
+              {:initial-events [[::rf.hicasso.examples.todo.events/seed rf.hicasso.examples.todo.app/sample-todos] nav-event]})))
 
 (defn- finish
   "Tear down, assert this mount left nothing behind, and end the row."
   [m done]
-  (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))
+  (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!) (.then done)))
 
 (defn- finish-after
   "End the row when `p` settles, reporting a rejected `p` as a failure
@@ -207,16 +207,16 @@
     (skip! "the seeded page and a form submission")
     (async done
       (let [m (mount-app!)]
-        (is (= app/sample-todos (titles m))
+        (is (= rf.hicasso.examples.todo.app/sample-todos (titles m))
             "the frame's :initial-events drained before the first render")
         (is (= "3 items left" (text m ".todo-count")))
 
         (type-into! m "#new-todo" "buy milk")
-        (is (= "buy milk" (read-sub m [::subs/new-todo]))
+        (is (= "buy milk" (read-sub m [::rf.hicasso.examples.todo.subs/new-todo]))
             "controlled: the keystroke reached the model, not a local draft")
 
         (submit! m ".new-todo-form")
-        (is (= (conj app/sample-todos "buy milk") (titles m)))
+        (is (= (conj rf.hicasso.examples.todo.app/sample-todos "buy milk") (titles m)))
         (is (= "" (.-value (node m "#new-todo")))
             "and the box emptied itself, because its :value IS the model")
         (finish m done)))))
@@ -231,8 +231,8 @@
     (async done
       (let [m (mount-app!)]
         (.click (node m ".todo-row .toggle"))
-        (hm/settle! m)
-        (is (= 2 (read-sub m [::subs/active-count])))
+        (rf.hicasso.test.mounted/settle! m)
+        (is (= 2 (read-sub m [::rf.hicasso.examples.todo.subs/active-count])))
         (is (= "2 items left" (text m ".todo-count")))
         (is (true? (.-checked (node m ".todo-row .toggle")))
             "the box shows what the model says, which is the same fact it
@@ -277,7 +277,7 @@
           (press! m ".edit" "Enter")
           (is (= "Read the whole spec" (first (titles m))))
           (is (nil? (node m ".edit")) "and the editor closed")
-          (is (nil? (read-sub m [db/draft 1])) "leaving no draft behind"))
+          (is (nil? (read-sub m [rf.hicasso.examples.todo.db/draft 1])) "leaving no draft behind"))
 
         (testing "Escape reverts, and the blur that follows commits nothing"
           (double-click! m ".todo-row .todo-title")
@@ -300,14 +300,14 @@
         ;; name and `closest` — no test-only attribute on the application
         (.dispatchEvent (.querySelector (row-node m "Write the witness") ".todo-title")
                         (js/MouseEvent. "dblclick" #js {:bubbles true}))
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (is (= 1 (count (nodes m ".edit")))
             "one editor, because the draft is keyed by the to-do's id. A
              hand-rolled [:ui :edit-draft] path would have opened all
              three, silently")
         (is (= "Write the witness" (.-value (node m ".edit"))))
-        (is (nil? (read-sub m [db/draft 1])))
-        (is (= "Write the witness" (read-sub m [db/draft 2])))
+        (is (nil? (read-sub m [rf.hicasso.examples.todo.db/draft 1])))
+        (is (= "Write the witness" (read-sub m [rf.hicasso.examples.todo.db/draft 2])))
         (finish m done)))))
 
 ;; ---------------------------------------------------------------------------
@@ -320,7 +320,7 @@
     (async done
       (let [m (mount-app!)]
         (.click (node m ".todo-row .toggle"))          ;; "Read the spec" is done
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (let [before-witness (row-node m "Write the witness")
               before-spec    (row-node m "Read the spec")]
           (is (some? before-witness))
@@ -329,7 +329,7 @@
           (-> (follow-filter! m "Active" :active)
               (.then
                 (fn [_]
-                  (is (= routes/filtered (read-sub m [:rf.route/id]))
+                  (is (= rf.hicasso.examples.todo.routes/filtered (read-sub m [:rf.route/id]))
                       "a real click on a real anchor navigated the frame")
                   (is (= ["Write the witness" "Merge the PR"] (titles m))
                       "the completed row left the list")
@@ -385,11 +385,11 @@
       (let [m (mount-app!)]
         (.dispatchEvent (.querySelector (row-node m "Merge the PR") ".todo-title")
                         (js/MouseEvent. "dblclick" #js {:bubbles true}))
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (type-into! m ".edit" "Merge it")
         (let [field (node m ".edit")]
           (.click (.querySelector (row-node m "Read the spec") ".toggle"))
-          (hm/settle! m)
+          (rf.hicasso.test.mounted/settle! m)
           (is (identical? field (node m ".edit"))
               "the editor is the same element across a commit that moved a
                different row — keyed rows again, and the reason a caret

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/l0_cljs_test.cljs
@@ -24,19 +24,19 @@
   report's third finding, met here on this file's first row and confirmed
   unchanged."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.todo.db :as db]
-            [re-frame.hicasso.examples.todo.events :as events]
-            [re-frame.hicasso.examples.todo.routes :as routes]
-            [re-frame.hicasso.examples.todo.subs :as subs]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.todo.db :as rf.hicasso.examples.todo.db]
+            [re-frame.hicasso.examples.todo.events :as rf.hicasso.examples.todo.events]
+            [re-frame.hicasso.examples.todo.routes :as rf.hicasso.examples.todo.routes]
+            [re-frame.hicasso.examples.todo.subs :as rf.hicasso.examples.todo.subs]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       routes/register!}))
+     :init-fn       rf.hicasso.examples.todo.routes/register!}))
 
 (def ^:private titles ["milk" "bread" "jam"])
 
@@ -47,7 +47,7 @@
   Seeded through `[::events/seed …]` rather than `[:rf/set-db …]` so the
   rows exercise the handler the application actually boots with."
   [f]
-  (rf/with-new-frame [frame (rf/make-frame {:initial-events [[::events/seed titles]]})]
+  (rf/with-new-frame [frame (rf/make-frame {:initial-events [[::rf.hicasso.examples.todo.events/seed titles]]})]
     (f frame)))
 
 (defn- read-sub [frame query-v] (rf/subscribe-once query-v {:frame frame}))
@@ -61,7 +61,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest seeding-allocates-ids-that-are-not-positions
-  (let [seeded (db/seed titles)]
+  (let [seeded (rf.hicasso.examples.todo.db/seed titles)]
     (is (= [1 2 3] (keys (:todos seeded)))
         "ids come from the allocator, so they survive a delete — which is
          what makes them a legal React key and an index illegal")
@@ -72,8 +72,8 @@
     (is (= "" (:new-todo seeded)))))
 
 (deftest the-empty-shape-is-the-seed-of-nothing
-  (is (= db/empty-db (db/seed [])))
-  (is (= (sorted-map) (:todos db/empty-db))
+  (is (= rf.hicasso.examples.todo.db/empty-db (rf.hicasso.examples.todo.db/seed [])))
+  (is (= (sorted-map) (:todos rf.hicasso.examples.todo.db/empty-db))
       "a sorted map, so iteration order is insertion order without a
        second :order vector to keep in step with it"))
 
@@ -87,17 +87,17 @@
     (fn [frame]
       (rf/with-frame frame
         (testing "a blank submission is ignored rather than refused"
-          (rf/dispatch-sync [::events/typed "   "])
-          (rf/dispatch-sync [::events/add])
+          (rf/dispatch-sync [::rf.hicasso.examples.todo.events/typed "   "])
+          (rf/dispatch-sync [::rf.hicasso.examples.todo.events/add])
           (is (= 3 (count (todos-of frame))) "nothing was added")
-          (is (= "   " (read-sub frame [::subs/new-todo]))
+          (is (= "   " (read-sub frame [::rf.hicasso.examples.todo.subs/new-todo]))
               "and the box is left exactly as the user left it"))
 
         (testing "a real one is trimmed, appended and clears the box"
-          (rf/dispatch-sync [::events/typed "  eggs  "])
-          (rf/dispatch-sync [::events/add])
-          (is (= ["milk" "bread" "jam" "eggs"] (titles-of frame [::subs/todos])))
-          (is (= "" (read-sub frame [::subs/new-todo]))))))))
+          (rf/dispatch-sync [::rf.hicasso.examples.todo.events/typed "  eggs  "])
+          (rf/dispatch-sync [::rf.hicasso.examples.todo.events/add])
+          (is (= ["milk" "bread" "jam" "eggs"] (titles-of frame [::rf.hicasso.examples.todo.subs/todos])))
+          (is (= "" (read-sub frame [::rf.hicasso.examples.todo.subs/new-todo]))))))))
 
 (deftest toggling-takes-the-value-rather-than-negating
   (with-app
@@ -107,33 +107,33 @@
         ;; the same value twice is therefore idempotent, where a `not` would
         ;; have flipped it back — which is the whole reason the marker beats
         ;; a negation in the handler.
-        (rf/dispatch-sync [::events/toggle 2 true])
-        (rf/dispatch-sync [::events/toggle 2 true])
-        (is (= [false true false] (mapv :done? (read-sub frame [::subs/todos]))))
-        (is (= 2 (read-sub frame [::subs/active-count])))
-        (is (= 1 (read-sub frame [::subs/completed-count])))
-        (is (false? (read-sub frame [::subs/all-done?])))
+        (rf/dispatch-sync [::rf.hicasso.examples.todo.events/toggle 2 true])
+        (rf/dispatch-sync [::rf.hicasso.examples.todo.events/toggle 2 true])
+        (is (= [false true false] (mapv :done? (read-sub frame [::rf.hicasso.examples.todo.subs/todos]))))
+        (is (= 2 (read-sub frame [::rf.hicasso.examples.todo.subs/active-count])))
+        (is (= 1 (read-sub frame [::rf.hicasso.examples.todo.subs/completed-count])))
+        (is (false? (read-sub frame [::rf.hicasso.examples.todo.subs/all-done?])))
 
         (testing "toggle-all takes a value too"
-          (rf/dispatch-sync [::events/toggle-all true])
-          (is (true? (read-sub frame [::subs/all-done?])))
-          (rf/dispatch-sync [::events/toggle-all false])
-          (is (= 3 (read-sub frame [::subs/active-count]))))))))
+          (rf/dispatch-sync [::rf.hicasso.examples.todo.events/toggle-all true])
+          (is (true? (read-sub frame [::rf.hicasso.examples.todo.subs/all-done?])))
+          (rf/dispatch-sync [::rf.hicasso.examples.todo.events/toggle-all false])
+          (is (= 3 (read-sub frame [::rf.hicasso.examples.todo.subs/active-count]))))))))
 
 (deftest an-empty-list-is-not-all-done
-  (rf/with-new-frame [frame (rf/make-frame {:initial-events [[::events/seed []]]})]
-    (is (false? (read-sub frame [::subs/all-done?]))
+  (rf/with-new-frame [frame (rf/make-frame {:initial-events [[::rf.hicasso.examples.todo.events/seed []]]})]
+    (is (false? (read-sub frame [::rf.hicasso.examples.todo.subs/all-done?]))
         "otherwise the toggle-all box sits checked over nothing")
-    (is (false? (read-sub frame [::subs/any?])))))
+    (is (false? (read-sub frame [::rf.hicasso.examples.todo.subs/any?])))))
 
 (deftest clearing-completed-keeps-the-rest-in-order
   (with-app
     (fn [frame]
       (rf/with-frame frame
-        (rf/dispatch-sync [::events/toggle 1 true])
-        (rf/dispatch-sync [::events/toggle 3 true])
-        (rf/dispatch-sync [::events/clear-completed])
-        (is (= ["bread"] (titles-of frame [::subs/todos])))
+        (rf/dispatch-sync [::rf.hicasso.examples.todo.events/toggle 1 true])
+        (rf/dispatch-sync [::rf.hicasso.examples.todo.events/toggle 3 true])
+        (rf/dispatch-sync [::rf.hicasso.examples.todo.events/clear-completed])
+        (is (= ["bread"] (titles-of frame [::rf.hicasso.examples.todo.subs/todos])))
         (is (= [2] (keys (todos-of frame)))
             "the surviving row keeps its id, so its React key does not move")))))
 
@@ -141,8 +141,8 @@
   (with-app
     (fn [frame]
       (rf/with-frame frame
-        (rf/dispatch-sync [::events/destroy 2])
-        (is (= ["milk" "jam"] (titles-of frame [::subs/todos])))))))
+        (rf/dispatch-sync [::rf.hicasso.examples.todo.events/destroy 2])
+        (is (= ["milk" "jam"] (titles-of frame [::rf.hicasso.examples.todo.subs/todos])))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Edit in place — the reg-state pair, and the late-blur rule
@@ -152,30 +152,30 @@
   (with-app
     (fn [frame]
       (rf/with-frame frame
-        (is (nil? (read-sub frame [db/draft 2]))
+        (is (nil? (read-sub frame [rf.hicasso.examples.todo.db/draft 2]))
             "not editing — the concern's default, read because the entry
              is ABSENT rather than because a nil was written")
 
         (testing "opening the editor and filling it are ONE write"
-          (rf/dispatch-sync [db/draft 2 "bread"])
-          (is (= "bread" (read-sub frame [db/draft 2])))
-          (is (nil? (read-sub frame [db/draft 1]))
+          (rf/dispatch-sync [rf.hicasso.examples.todo.db/draft 2 "bread"])
+          (is (= "bread" (read-sub frame [rf.hicasso.examples.todo.db/draft 2])))
+          (is (nil? (read-sub frame [rf.hicasso.examples.todo.db/draft 1]))
               "and it opened exactly one row — the instance key is the
                to-do's id, which is the whole of what h/reg-state buys"))
 
         (testing "committing writes the trimmed draft and closes the editor"
-          (rf/dispatch-sync [db/draft 2 "  sourdough  "])
-          (rf/dispatch-sync [::events/commit-edit 2])
-          (is (= ["milk" "sourdough" "jam"] (titles-of frame [::subs/todos])))
-          (is (nil? (read-sub frame [db/draft 2]))))))))
+          (rf/dispatch-sync [rf.hicasso.examples.todo.db/draft 2 "  sourdough  "])
+          (rf/dispatch-sync [::rf.hicasso.examples.todo.events/commit-edit 2])
+          (is (= ["milk" "sourdough" "jam"] (titles-of frame [::rf.hicasso.examples.todo.subs/todos])))
+          (is (nil? (read-sub frame [rf.hicasso.examples.todo.db/draft 2]))))))))
 
 (deftest committing-a-blank-draft-destroys-the-row
   (with-app
     (fn [frame]
       (rf/with-frame frame
-        (rf/dispatch-sync [db/draft 2 "   "])
-        (rf/dispatch-sync [::events/commit-edit 2])
-        (is (= ["milk" "jam"] (titles-of frame [::subs/todos]))
+        (rf/dispatch-sync [rf.hicasso.examples.todo.db/draft 2 "   "])
+        (rf/dispatch-sync [::rf.hicasso.examples.todo.events/commit-edit 2])
+        (is (= ["milk" "jam"] (titles-of frame [::rf.hicasso.examples.todo.subs/todos]))
             "TodoMVC's own rule: editing a title away deletes the to-do")))))
 
 (deftest a-commit-with-no-draft-does-nothing
@@ -187,10 +187,10 @@
         ;; from `app-db` rather than off the DOM event is what makes the
         ;; second one a no-op — the ordering problem is solved by the
         ;; model rather than by ordering.
-        (rf/dispatch-sync [db/draft 2 "typed but cancelled"])
-        (rf/dispatch-sync [:re-frame.hicasso/clear db/draft 2])
-        (rf/dispatch-sync [::events/commit-edit 2])
-        (is (= ["milk" "bread" "jam"] (titles-of frame [::subs/todos]))
+        (rf/dispatch-sync [rf.hicasso.examples.todo.db/draft 2 "typed but cancelled"])
+        (rf/dispatch-sync [:re-frame.hicasso/clear rf.hicasso.examples.todo.db/draft 2])
+        (rf/dispatch-sync [::rf.hicasso.examples.todo.events/commit-edit 2])
+        (is (= ["milk" "bread" "jam"] (titles-of frame [::rf.hicasso.examples.todo.subs/todos]))
             "the cancelled text did not reach the model")
         (is (= 3 (count (todos-of frame)))
             "and the row was not destroyed by a blank commit either")))))
@@ -203,38 +203,38 @@
   "Seeded, with one done to-do, and navigated to `nav-event`."
   [nav-event f]
   (rf/with-new-frame [frame (rf/make-frame
-                              {:initial-events [[::events/seed titles]
-                                                [::events/toggle 2 true]
+                              {:initial-events [[::rf.hicasso.examples.todo.events/seed titles]
+                                                [::rf.hicasso.examples.todo.events/toggle 2 true]
                                                 nav-event]})]
     (f frame)))
 
 (deftest the-showing-filter-is-read-off-the-url
   (testing "the unparameterised route"
-    (with-app-at [:rf.route/navigate {:to routes/all}]
+    (with-app-at [:rf.route/navigate {:to rf.hicasso.examples.todo.routes/all}]
       (fn [frame]
-        (is (= :all (read-sub frame [::subs/showing])))
-        (is (= ["milk" "bread" "jam"] (titles-of frame [::subs/visible]))))))
+        (is (= :all (read-sub frame [::rf.hicasso.examples.todo.subs/showing])))
+        (is (= ["milk" "bread" "jam"] (titles-of frame [::rf.hicasso.examples.todo.subs/visible]))))))
 
   (testing "active"
-    (with-app-at [:rf.route/navigate {:to routes/filtered :params {:filter "active"}}]
+    (with-app-at [:rf.route/navigate {:to rf.hicasso.examples.todo.routes/filtered :params {:filter "active"}}]
       (fn [frame]
-        (is (= :active (read-sub frame [::subs/showing])))
-        (is (= ["milk" "jam"] (titles-of frame [::subs/visible]))))))
+        (is (= :active (read-sub frame [::rf.hicasso.examples.todo.subs/showing])))
+        (is (= ["milk" "jam"] (titles-of frame [::rf.hicasso.examples.todo.subs/visible]))))))
 
   (testing "completed"
-    (with-app-at [:rf.route/navigate {:to routes/filtered :params {:filter "completed"}}]
+    (with-app-at [:rf.route/navigate {:to rf.hicasso.examples.todo.routes/filtered :params {:filter "completed"}}]
       (fn [frame]
-        (is (= :completed (read-sub frame [::subs/showing])))
-        (is (= ["bread"] (titles-of frame [::subs/visible])))))))
+        (is (= :completed (read-sub frame [::rf.hicasso.examples.todo.subs/showing])))
+        (is (= ["bread"] (titles-of frame [::rf.hicasso.examples.todo.subs/visible])))))))
 
 (deftest a-filter-the-url-invented-shows-everything
   ;; A URL is user input. `/hicasso-todo/banana` matches the parameterised
   ;; route, so the coercion has to happen in the subscription that reads
   ;; the parameter rather than in the router that matched it.
-  (with-app-at [:rf.route/navigate {:to routes/filtered :params {:filter "banana"}}]
+  (with-app-at [:rf.route/navigate {:to rf.hicasso.examples.todo.routes/filtered :params {:filter "banana"}}]
     (fn [frame]
-      (is (= :all (read-sub frame [::subs/showing])))
-      (is (= 3 (count (read-sub frame [::subs/visible])))))))
+      (is (= :all (read-sub frame [::rf.hicasso.examples.todo.subs/showing])))
+      (is (= 3 (count (read-sub frame [::rf.hicasso.examples.todo.subs/visible])))))))
 
 (deftest no-route-at-all-shows-everything
   ;; This application registers no `:rf.route/not-found` — the id is
@@ -244,10 +244,10 @@
   (with-app
     (fn [frame]
       (is (nil? (read-sub frame [:rf.route/id])))
-      (is (= :all (read-sub frame [::subs/showing]))))))
+      (is (= :all (read-sub frame [::rf.hicasso.examples.todo.subs/showing]))))))
 
 (deftest the-application-never-stores-the-filter
-  (with-app-at [:rf.route/navigate {:to routes/filtered :params {:filter "completed"}}]
+  (with-app-at [:rf.route/navigate {:to rf.hicasso.examples.todo.routes/filtered :params {:filter "completed"}}]
     (fn [frame]
       (let [db (rf/app-db-value frame)]
         (is (= #{:todos :next-id :new-todo} (set (keys db)))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/l2_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/l2_cljs_test.cljs
@@ -24,46 +24,46 @@
   — and the row's own contents are asserted by running the row's own
   body."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso.examples.todo.db :as db]
-            [re-frame.hicasso.examples.todo.events :as events]
-            [re-frame.hicasso.examples.todo.routes :as routes]
-            [re-frame.hicasso.examples.todo.subs :as subs]
-            [re-frame.hicasso.examples.todo.views :as views]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso.examples.todo.db :as rf.hicasso.examples.todo.db]
+            [re-frame.hicasso.examples.todo.events :as rf.hicasso.examples.todo.events]
+            [re-frame.hicasso.examples.todo.routes :as rf.hicasso.examples.todo.routes]
+            [re-frame.hicasso.examples.todo.subs :as rf.hicasso.examples.todo.subs]
+            [re-frame.hicasso.examples.todo.views :as rf.hicasso.examples.todo.views]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       routes/register!}))
+     :init-fn       rf.hicasso.examples.todo.routes/register!}))
 
-(defn- tagged [tree tag] (ht/find tree #(= tag (:tag %))))
+(defn- tagged [tree tag] (rf.hicasso.test/find tree #(= tag (:tag %))))
 
 (defn- classed
   "The first node carrying exactly `class` — the same hook the mounted
   suite selects on, so the two tiers talk about the same parts of the
   page."
   [tree class]
-  (ht/find tree #(= class (:class (ht/attrs %)))))
+  (rf.hicasso.test/find tree #(= class (:class (rf.hicasso.test/attrs %)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The header — a form, and the whole of "Enter adds a to-do"
 ;; ---------------------------------------------------------------------------
 
 (deftest the-new-todo-box-commits-through-the-form
-  (let [tree  (ht/tree [views/new-todo-box {}] {:subs {[::subs/new-todo] "eg"}})
+  (let [tree  (rf.hicasso.test/tree [rf.hicasso.examples.todo.views/new-todo-box {}] {:subs {[::rf.hicasso.examples.todo.subs/new-todo] "eg"}})
         form  (tagged tree :form)
         field (tagged tree :input)]
-    (is (= [::events/add] (:on-submit (ht/attrs form)))
+    (is (= [::rf.hicasso.examples.todo.events/add] (:on-submit (rf.hicasso.test/attrs form)))
         "Enter in a text field submits its form, and :on-submit
          AUTO-PREVENTS — so there is no key test and no .preventDefault
          anywhere in this application's header")
-    (is (= "eg" (:value (ht/attrs field)))
+    (is (= "eg" (:value (rf.hicasso.test/attrs field)))
         "controlled: the text is the subscription's, not the element's")
-    (is (= [::events/typed :re-frame.hicasso/value] (:on-input (ht/attrs field)))
+    (is (= [::rf.hicasso.examples.todo.events/typed :re-frame.hicasso/value] (:on-input (rf.hicasso.test/attrs field)))
         "and the write is an intent vector with the marker at its TOP
          LEVEL — the only position the materializer substitutes at")))
 
@@ -74,17 +74,17 @@
 (def ^:private row-props {:id 7 :title "milk" :done? false})
 
 (defn- row-tree [props draft]
-  (ht/tree [views/todo-row props] {:subs {[db/draft (:id props)] draft}}))
+  (rf.hicasso.test/tree [rf.hicasso.examples.todo.views/todo-row props] {:subs {[rf.hicasso.examples.todo.db/draft (:id props)] draft}}))
 
 (deftest a-row-carries-its-three-intents-and-no-editor
   (let [tree (row-tree row-props nil)]
-    (is (= "milk" (ht/text (classed tree "todo-title"))))
-    (is (= [::events/toggle 7 :re-frame.hicasso/checked]
-           (:on-change (ht/attrs (classed tree "toggle"))))
+    (is (= "milk" (rf.hicasso.test/text (classed tree "todo-title"))))
+    (is (= [::rf.hicasso.examples.todo.events/toggle 7 :re-frame.hicasso/checked]
+           (:on-change (rf.hicasso.test/attrs (classed tree "toggle"))))
         "::h/checked hands the handler what the box IS, so the model and
          the checkbox cannot drift apart through a negation")
-    (is (= [::events/destroy 7] (:on-click (ht/attrs (classed tree "destroy")))))
-    (is (= [db/draft 7 "milk"] (:on-double-click (ht/attrs (classed tree "todo-title"))))
+    (is (= [::rf.hicasso.examples.todo.events/destroy 7] (:on-click (rf.hicasso.test/attrs (classed tree "destroy")))))
+    (is (= [rf.hicasso.examples.todo.db/draft 7 "milk"] (:on-double-click (rf.hicasso.test/attrs (classed tree "todo-title"))))
         "opening the editor and filling it are ONE write — h/reg-state's
          setter, with the row's own id as the instance key")
     (is (nil? (classed tree "edit"))
@@ -95,11 +95,11 @@
   ;; `:class` prop; L2 folds the two, in that order, because the author
   ;; cannot see the sugar otherwise. Everything after the first name is
   ;; this body's.
-  (is (= "todo-row" (:class (ht/attrs (row-tree row-props nil)))))
+  (is (= "todo-row" (:class (rf.hicasso.test/attrs (row-tree row-props nil)))))
   (is (= "todo-row completed"
-         (:class (ht/attrs (row-tree (assoc row-props :done? true) nil)))))
+         (:class (rf.hicasso.test/attrs (row-tree (assoc row-props :done? true) nil)))))
   (is (= "todo-row completed editing"
-         (:class (ht/attrs (row-tree (assoc row-props :done? true) "milk"))))
+         (:class (rf.hicasso.test/attrs (row-tree (assoc row-props :done? true) "milk"))))
       "a completed to-do can still be edited"))
 
 ;; ---------------------------------------------------------------------------
@@ -109,22 +109,22 @@
 (deftest the-editor-is-a-key-map-and-a-stable-ref
   (let [tree  (row-tree row-props "sourdough")
         field (classed tree "edit")
-        attrs (ht/attrs field)]
+        attrs (rf.hicasso.test/attrs field)]
     (is (some? field) "a draft, so the editor is on the page")
     (is (= "sourdough" (:value attrs)))
-    (is (= [db/draft 7 :re-frame.hicasso/value] (:on-input attrs))
+    (is (= [rf.hicasso.examples.todo.db/draft 7 :re-frame.hicasso/value] (:on-input attrs))
         "every keystroke writes h/reg-state's own slot; there is no
          bespoke typing event in this application")
 
     (testing "Enter and Escape are DATA — the map shape at an :on-* prop"
-      (is (= {"Enter"  [::events/commit-edit 7]
-              "Escape" [:re-frame.hicasso/clear db/draft 7]}
+      (is (= {"Enter"  [::rf.hicasso.examples.todo.events/commit-edit 7]
+              "Escape" [:re-frame.hicasso/clear rf.hicasso.examples.todo.db/draft 7]}
              (:on-key-down attrs))
           "one .key lookup per event, composition-gated centrally so an
            IME's Enter commits nothing — and no callback anywhere"))
 
     (testing "blur commits too, and is safe after Escape"
-      (is (= [::events/commit-edit 7] (:on-blur attrs))
+      (is (= [::rf.hicasso.examples.todo.events/commit-edit 7] (:on-blur attrs))
           "the same intent as Enter: the handler reads the draft from
            app-db, so a blur that lands after Escape finds nothing"))
 
@@ -137,19 +137,19 @@
 (deftest the-rows-intent-inventory-includes-both-key-branches
   ;; `ht/intents` unpacks a key-map into its branches, which is the one
   ;; place the tier knows the shape is not an ordinary vector.
-  (let [offered (set (ht/intents (row-tree row-props "sourdough")))]
-    (is (contains? offered [::events/commit-edit 7]))
-    (is (contains? offered [:re-frame.hicasso/clear db/draft 7]))
-    (is (contains? offered [::events/destroy 7]))))
+  (let [offered (set (rf.hicasso.test/intents (row-tree row-props "sourdough")))]
+    (is (contains? offered [::rf.hicasso.examples.todo.events/commit-edit 7]))
+    (is (contains? offered [:re-frame.hicasso/clear rf.hicasso.examples.todo.db/draft 7]))
+    (is (contains? offered [::rf.hicasso.examples.todo.events/destroy 7]))))
 
 ;; ---------------------------------------------------------------------------
 ;; The list — the keyed identity claim, at the tier where the key is data
 ;; ---------------------------------------------------------------------------
 
 (defn- list-tree [visible all-done?]
-  (ht/tree [views/todo-list {}]
-           {:subs {[::subs/visible]   visible
-                   [::subs/all-done?] all-done?}}))
+  (rf.hicasso.test/tree [rf.hicasso.examples.todo.views/todo-list {}]
+           {:subs {[::rf.hicasso.examples.todo.subs/visible]   visible
+                   [::rf.hicasso.examples.todo.subs/all-done?] all-done?}}))
 
 (def ^:private three
   [{:id 1 :title "milk" :done? false}
@@ -179,33 +179,33 @@
 
 (deftest toggle-all-reads-and-writes-the-same-fact
   (let [tree (list-tree three true)
-        box  (ht/attrs (classed tree "toggle-all"))]
+        box  (rf.hicasso.test/attrs (classed tree "toggle-all"))]
     (is (true? (:checked box)))
-    (is (= [::events/toggle-all :re-frame.hicasso/checked] (:on-change box)))))
+    (is (= [::rf.hicasso.examples.todo.events/toggle-all :re-frame.hicasso/checked] (:on-change box)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The footer — three routed tabs, a count, and conditional chrome
 ;; ---------------------------------------------------------------------------
 
 (defn- footer-tree [left done showing]
-  (ht/tree [views/footer {}]
-           {:subs {[::subs/active-count]    left
-                   [::subs/completed-count] done
-                   [::subs/showing]         showing}}))
+  (rf.hicasso.test/tree [rf.hicasso.examples.todo.views/footer {}]
+           {:subs {[::rf.hicasso.examples.todo.subs/active-count]    left
+                   [::rf.hicasso.examples.todo.subs/completed-count] done
+                   [::rf.hicasso.examples.todo.subs/showing]         showing}}))
 
 (deftest the-tabs-are-links-routing-built-and-this-file-names-no-url
   (let [tree (footer-tree 2 1 :active)
-        as   (ht/find-all tree #(= :a (:tag %)))]
+        as   (rf.hicasso.test/find-all tree #(= :a (:tag %)))]
     (is (= ["/hicasso-todo" "/hicasso-todo/active" "/hicasso-todo/completed"]
-           (mapv (comp :href ht/attrs) as))
+           (mapv (comp :href rf.hicasso.test/attrs) as))
         "the href is the routing artefact's own synthesis — `views` names
          no URL anywhere, and every path is under this application's own
          prefix because route paths are a PROCESS-GLOBAL registry")
-    (is (= ["All" "Active" "Completed"] (mapv ht/text as)))
-    (is (= [nil "selected" nil] (mapv (comp :class ht/attrs) as))
+    (is (= ["All" "Active" "Completed"] (mapv rf.hicasso.test/text as)))
+    (is (= [nil "selected" nil] (mapv (comp :class rf.hicasso.test/attrs) as))
         "the highlighted tab is derived from the URL, so it cannot
          disagree with the address bar")
-    (is (every? #(intent/navigate-head? (:on-click (ht/attrs %))) as)
+    (is (every? #(rf.hicasso.impl.intent/navigate-head? (:on-click (rf.hicasso.test/attrs %))) as)
         "the click decision is DATA — a vector headed by the intent
          namespace's own keyword, which `=` can see and which is what
          makes two renders of one link equal")))
@@ -213,24 +213,24 @@
 (deftest the-count-is-pluralised-and-the-clear-button-is-conditional
   (testing "one left"
     (let [tree (footer-tree 1 0 :all)]
-      (is (= "1 item left" (ht/text (classed tree "todo-count"))))
+      (is (= "1 item left" (rf.hicasso.test/text (classed tree "todo-count"))))
       (is (nil? (classed tree "clear-completed"))
           "nothing completed, so there is nothing to clear and no button
            to explain")))
 
   (testing "none left, two done"
     (let [tree (footer-tree 0 2 :all)]
-      (is (= "0 items left" (ht/text (classed tree "todo-count"))))
-      (is (= "Clear completed (2)" (ht/text (classed tree "clear-completed"))))
-      (is (= [::events/clear-completed]
-             (:on-click (ht/attrs (classed tree "clear-completed"))))))))
+      (is (= "0 items left" (rf.hicasso.test/text (classed tree "todo-count"))))
+      (is (= "Clear completed (2)" (rf.hicasso.test/text (classed tree "clear-completed"))))
+      (is (= [::rf.hicasso.examples.todo.events/clear-completed]
+             (:on-click (rf.hicasso.test/attrs (classed tree "clear-completed"))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The page — the conditional chrome
 ;; ---------------------------------------------------------------------------
 
 (deftest an-empty-page-is-the-header-and-nothing-else
-  (let [tree (ht/tree [views/app {}] {:subs {[::subs/any?] false}})
+  (let [tree (rf.hicasso.test/tree [rf.hicasso.examples.todo.views/app {}] {:subs {[::rf.hicasso.examples.todo.subs/any?] false}})
         kids (:children tree)]
     (is (= ["re-frame.hicasso.examples.todo.views/new-todo-box"]
            (into [] (comp (filter :view-id) (map :view-id)) kids))
@@ -238,7 +238,7 @@
          chrome, decided by one boolean read rather than by a count")))
 
 (deftest a-populated-page-carries-the-list-and-the-footer
-  (let [tree  (ht/tree [views/app {}] {:subs {[::subs/any?] true}})
+  (let [tree  (rf.hicasso.test/tree [rf.hicasso.examples.todo.views/app {}] {:subs {[::rf.hicasso.examples.todo.subs/any?] true}})
         views (into [] (comp (filter :view-id) (map :view-id))
                     (tree-seq map? :children tree))]
     (is (= ["re-frame.hicasso.examples.todo.views/new-todo-box"

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/routes.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/routes.cljs
@@ -46,7 +46,7 @@
   `deftest` runs. The slice authoring report found this and it reproduces
   here unchanged: `reg-sub` and `reg-event` survive, routes do not. A
   consumer never meets it; a test meets it on its first row."
-  (:require [re-frame.routing :as routing]))
+  (:require [re-frame.routing :as rf.routing]))
 
 (def all
   "Every to-do. `/hicasso-todo`."
@@ -62,10 +62,10 @@
   "Register both routes. Idempotent for an unchanged registration, so
   calling it from a test fixture as well as at load costs nothing."
   []
-  (routing/reg-route all
+  (rf.routing/reg-route all
     {:doc "Show every to-do."}
     "/hicasso-todo")
-  (routing/reg-route filtered
+  (rf.routing/reg-route filtered
     {:doc "Show the active or the completed to-dos."}
     "/hicasso-todo/:filter")
   nil)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/subs.cljs
@@ -22,7 +22,7 @@
   unmatched URL both coerce to `:all` rather than producing a filter
   nothing can render."
   (:require [re-frame.core :as rf]
-            [re-frame.hicasso.examples.todo.routes :as routes]))
+            [re-frame.hicasso.examples.todo.routes :as rf.hicasso.examples.todo.routes]))
 
 ;; ---------------------------------------------------------------------------
 ;; What is on the page
@@ -43,7 +43,7 @@
   :<- [:rf.route/id]
   :<- [:rf.route/params]
   (fn [[route-id params] _]
-    (if (= routes/filtered route-id)
+    (if (= rf.hicasso.examples.todo.routes/filtered route-id)
       (case (:filter params)
         "active"    :active
         "completed" :completed

--- a/implementation/hicasso/test/re_frame/hicasso/examples/todo/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/todo/views.cljs
@@ -52,11 +52,11 @@
   only place it lives. (The one `:ref` in this file touches focus and
   nothing else.)"
   (:require [clojure.string :as str]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.todo.db :as db]
-            [re-frame.hicasso.examples.todo.events :as events]
-            [re-frame.hicasso.examples.todo.routes :as routes]
-            [re-frame.hicasso.examples.todo.subs :as subs]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.todo.db :as rf.hicasso.examples.todo.db]
+            [re-frame.hicasso.examples.todo.events :as rf.hicasso.examples.todo.events]
+            [re-frame.hicasso.examples.todo.routes :as rf.hicasso.examples.todo.routes]
+            [re-frame.hicasso.examples.todo.subs :as rf.hicasso.examples.todo.subs]))
 
 (def ^:private focus-on-mount
   "React's own `:ref` contract: called in the commit phase with the node,
@@ -69,7 +69,7 @@
 ;; The header — one controlled box in a form
 ;; ---------------------------------------------------------------------------
 
-(h/defview new-todo-box
+(rf.hicasso/defview new-todo-box
   "The box you type a new to-do into.
 
   It is a `<form>`, and that is the whole of *Enter adds a to-do*: a text
@@ -77,19 +77,19 @@
   so the intent is `[::events/add]` with no key test, no callback and no
   `.preventDefault` anywhere in this file."
   [_]
-  [:form.new-todo-form {:on-submit [::events/add]}
+  [:form.new-todo-form {:on-submit [::rf.hicasso.examples.todo.events/add]}
    [:label {:for "new-todo"} "What needs to be done?"]
    [:input#new-todo.new-todo
     {:type        "text"
      :placeholder "What needs to be done?"
-     :value       (h/sub [::subs/new-todo])
-     :on-input    [::events/typed ::h/value]}]])
+     :value       (rf.hicasso/sub [::rf.hicasso.examples.todo.subs/new-todo])
+     :on-input    [::rf.hicasso.examples.todo.events/typed ::rf.hicasso/value]}]])
 
 ;; ---------------------------------------------------------------------------
 ;; One row — and the whole of edit-in-place
 ;; ---------------------------------------------------------------------------
 
-(h/defview todo-row
+(rf.hicasso/defview todo-row
   "One to-do: a checkbox, its title, a delete button, and — when this
   row's draft is set — an edit box in place of the title.
 
@@ -106,7 +106,7 @@
   the other side: the revision counter is what a reset needs when the field
   SURVIVES it."
   [{:keys [id title done?]}]
-  (let [draft (h/sub [db/draft id])]
+  (let [draft (rf.hicasso/sub [rf.hicasso.examples.todo.db/draft id])]
     [:li.todo-row {:class (str/join " " (cond-> []
                                           done?         (conj "completed")
                                           (some? draft) (conj "editing")))}
@@ -115,27 +115,27 @@
        {:type      "checkbox"
         :aria-label (str "Done: " title)
         :checked   done?
-        :on-change [::events/toggle id ::h/checked]}]
-      [:label.todo-title {:on-double-click [db/draft id title]} title]
+        :on-change [::rf.hicasso.examples.todo.events/toggle id ::rf.hicasso/checked]}]
+      [:label.todo-title {:on-double-click [rf.hicasso.examples.todo.db/draft id title]} title]
       [:button.destroy {:type       "button"
                         :aria-label (str "Delete " title)
-                        :on-click   [::events/destroy id]}]]
+                        :on-click   [::rf.hicasso.examples.todo.events/destroy id]}]]
      (when (some? draft)
        [:input.edit
         {:type        "text"
          :aria-label  "Edit to-do"
          :ref         focus-on-mount
          :value       draft
-         :on-input    [db/draft id ::h/value]
-         :on-blur     [::events/commit-edit id]
-         :on-key-down {"Enter"  [::events/commit-edit id]
-                       "Escape" [::h/clear db/draft id]}}])]))
+         :on-input    [rf.hicasso.examples.todo.db/draft id ::rf.hicasso/value]
+         :on-blur     [::rf.hicasso.examples.todo.events/commit-edit id]
+         :on-key-down {"Enter"  [::rf.hicasso.examples.todo.events/commit-edit id]
+                       "Escape" [::rf.hicasso/clear rf.hicasso.examples.todo.db/draft id]}}])]))
 
 ;; ---------------------------------------------------------------------------
 ;; The list
 ;; ---------------------------------------------------------------------------
 
-(h/defview todo-list
+(rf.hicasso/defview todo-list
   "The rows, keyed by the to-do's own id.
 
   The key is the domain id and never the position. A list keyed by its
@@ -148,11 +148,11 @@
   [:section.main
    [:input#toggle-all.toggle-all
     {:type      "checkbox"
-     :checked   (h/sub [::subs/all-done?])
-     :on-change [::events/toggle-all ::h/checked]}]
+     :checked   (rf.hicasso/sub [::rf.hicasso.examples.todo.subs/all-done?])
+     :on-change [::rf.hicasso.examples.todo.events/toggle-all ::rf.hicasso/checked]}]
    [:label {:for "toggle-all"} "Mark all as complete"]
    [:ul.todo-list
-    (for [{:keys [id] :as todo} (h/sub [::subs/visible])]
+    (for [{:keys [id] :as todo} (rf.hicasso/sub [::rf.hicasso.examples.todo.subs/visible])]
       [todo-row (assoc todo :key id)])]])
 
 ;; ---------------------------------------------------------------------------
@@ -162,17 +162,17 @@
 (def ^:private tabs
   "The three filter tabs, as data: the filter each one stands for, the
   route it links to, the params that route wants, and its label."
-  [{:kind :all       :to routes/all      :params nil                   :label "All"}
-   {:kind :active    :to routes/filtered :params {:filter "active"}    :label "Active"}
-   {:kind :completed :to routes/filtered :params {:filter "completed"} :label "Completed"}])
+  [{:kind :all       :to rf.hicasso.examples.todo.routes/all      :params nil                   :label "All"}
+   {:kind :active    :to rf.hicasso.examples.todo.routes/filtered :params {:filter "active"}    :label "Active"}
+   {:kind :completed :to rf.hicasso.examples.todo.routes/filtered :params {:filter "completed"} :label "Completed"}])
 
-(h/defview footer
+(rf.hicasso/defview footer
   "The count, the three tabs, and *Clear completed* — which is present
   only when there is something to clear."
   [_]
-  (let [left    (h/sub [::subs/active-count])
-        done    (h/sub [::subs/completed-count])
-        showing (h/sub [::subs/showing])]
+  (let [left    (rf.hicasso/sub [::rf.hicasso.examples.todo.subs/active-count])
+        done    (rf.hicasso/sub [::rf.hicasso.examples.todo.subs/completed-count])
+        showing (rf.hicasso/sub [::rf.hicasso.examples.todo.subs/showing])]
     [:footer.footer
      [:span.todo-count
       [:strong (str left)]
@@ -182,19 +182,19 @@
         [:li {:key (name kind)}
          ;; CALLED, not a head. The href is routing's own synthesis — no
          ;; URL is written anywhere in this application.
-         (h/route-link (cond-> {:to to :class (when (= kind showing) "selected")}
+         (rf.hicasso/route-link (cond-> {:to to :class (when (= kind showing) "selected")}
                          params (assoc :params params))
                        label)])]
      (when (pos? done)
        [:button.clear-completed {:type     "button"
-                                 :on-click [::events/clear-completed]}
+                                 :on-click [::rf.hicasso.examples.todo.events/clear-completed]}
         (str "Clear completed (" done ")")])]))
 
 ;; ---------------------------------------------------------------------------
 ;; The application
 ;; ---------------------------------------------------------------------------
 
-(h/defview app
+(rf.hicasso/defview app
   "The whole page.
 
   The list and the footer are ABSENT while there is nothing to show —
@@ -202,7 +202,7 @@
   decides it is `[::subs/any?]` rather than a count, so adding a
   hundredth to-do does not re-render this boundary."
   [_]
-  (let [any? (h/sub [::subs/any?])]
+  (let [any? (rf.hicasso/sub [::rf.hicasso.examples.todo.subs/any?])]
     [:main.todo-app
      [:h1 "todos"]
      [new-todo-box {}]

--- a/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/app.cljs
@@ -27,11 +27,11 @@
   are plain strings in a process-global registrar and the shared node
   bundle loads every application in the tree into one process. Nothing
   about a resource witness needs a URL."
-  (:require [re-frame.adapter.uix :as uix-adapter]
+  (:require [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.typeahead.events :as events]
-            [re-frame.hicasso.examples.typeahead.views :as views]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.typeahead.events :as rf.hicasso.examples.typeahead.events]
+            [re-frame.hicasso.examples.typeahead.views :as rf.hicasso.examples.typeahead.views]))
 
 (def frame-id
   "This application's frame. One root, one frame."
@@ -47,7 +47,7 @@
   and takes `:initial-events`, so the vector below is the value a witness
   hands it."
   []
-  (rf/make-frame {:id frame-id :initial-events [[::events/seed]]}))
+  (rf/make-frame {:id frame-id :initial-events [[::rf.hicasso.examples.typeahead.events/seed]]}))
 
 (defn ^:dev/after-load reload!
   "Re-render the mounted root after a hot reload. React reconciles the new
@@ -55,12 +55,12 @@
   every scrap of component state survive it."
   []
   (when-some [root @!root]
-    (h/render! root [views/screen {}])))
+    (rf.hicasso/render! root [rf.hicasso.examples.typeahead.views/screen {}])))
 
 (defn ^:export -main
   "Start the application."
   []
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (make-frame!)
-  (reset! !root (h/mount! (js/document.getElementById "app") {:frame frame-id} [views/screen {}]))
+  (reset! !root (rf.hicasso/mount! (js/document.getElementById "app") {:frame frame-id} [rf.hicasso.examples.typeahead.views/screen {}]))
   nil)

--- a/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/demand_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/demand_dom_cljs_test.cljs
@@ -51,14 +51,14 @@
   compiles this namespace too (`cljs-test$` matches `-dom-cljs-test`), and
   each row degrades there to a STATED skip rather than to a false green."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.typeahead.db :as db]
-            [re-frame.hicasso.examples.typeahead.events :as events]
-            [re-frame.hicasso.examples.typeahead.service :as service]
-            [re-frame.hicasso.examples.typeahead.views :as views]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso.examples.typeahead.db :as rf.hicasso.examples.typeahead.db]
+            [re-frame.hicasso.examples.typeahead.events :as rf.hicasso.examples.typeahead.events]
+            [re-frame.hicasso.examples.typeahead.service :as rf.hicasso.examples.typeahead.service]
+            [re-frame.hicasso.examples.typeahead.views :as rf.hicasso.examples.typeahead.views]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]))
 
 (defn- browser? [] (exists? js/document))
@@ -67,8 +67,8 @@
   (is true (str "a mounted resource witness needs a real React DOM — " why)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The MAP shape, because every row is `async`: `cljs.test` refuses an
      ;; async test under a fn-form fixture and aborts the namespace.
@@ -78,7 +78,7 @@
                       ;; scheduler, and every reading here is taken
                       ;; outside it.
                       (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-                      (service/reset-log!))}))
+                      (rf.hicasso.examples.typeahead.service/reset-log!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Reading and driving the page
@@ -101,22 +101,22 @@
         d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
     (.call (.-set d) n v)
     (.dispatchEvent n (js/InputEvent. "input" #js {:bubbles true}))
-    (hm/settle! m)))
+    (rf.hicasso.test.mounted/settle! m)))
 
 (defn- app-db [m] (rf/app-db-value (:frame m)))
 
-(defn- searches [] (filterv #(= :search (:kind %)) (service/requests)))
+(defn- searches [] (filterv #(= :search (:kind %)) (rf.hicasso.examples.typeahead.service/requests)))
 
 (defn- seeded
   "An `app-db` the application could have arrived at, handed to a mount so
   that the page opens in a named state. Core's own `[:rf/set-db …]`
   vocabulary, which is what `hm/mount!`'s `:initial-events` documents."
   [search]
-  [[:rf/set-db (update db/seed :search merge search)]])
+  [[:rf/set-db (update rf.hicasso.examples.typeahead.db/seed :search merge search)]])
 
 (defn- mount-screen!
-  ([] (mount-screen! [[::events/seed]]))
-  ([initial-events] (hm/mount! [views/screen {}] {:initial-events initial-events})))
+  ([] (mount-screen! [[::rf.hicasso.examples.typeahead.events/seed]]))
+  ([initial-events] (rf.hicasso.test.mounted/mount! [rf.hicasso.examples.typeahead.views/screen {}] {:initial-events initial-events})))
 
 (defn- mount-strict!
   "The same screen under `React.StrictMode`, which runs every body twice
@@ -124,9 +124,9 @@
   StrictMode is this file's variable: a consumer's own root would carry it
   in `app.cljs`, and a witness that baked it in could not measure with and
   without."
-  ([] (mount-strict! [[::events/seed]]))
+  ([] (mount-strict! [[::rf.hicasso.examples.typeahead.events/seed]]))
   ([initial-events]
-   (hm/mount! [:> react/StrictMode {} [views/screen {}]]
+   (rf.hicasso.test.mounted/mount! [:> react/StrictMode {} [rf.hicasso.examples.typeahead.views/screen {}]]
               {:initial-events initial-events})))
 
 ;; ---------------------------------------------------------------------------
@@ -143,21 +143,21 @@
       (let [m (mount-screen!)]
         (type-into! m "ca")
         (is (nil? (node m ".suggestion")) "nothing is on screen yet")
-        (-> (hm/settle-until! m #(node m ".suggestion")
+        (-> (rf.hicasso.test.mounted/settle-until! m #(node m ".suggestion")
                               {:label "the debounced search replies"})
             (.then (fn [_]
                      (is (= 1 (count (searches))) "one keystroke burst, one request")
                      (is (= 3 (count (nodes m ".suggestion")))
                          "three catalogue rows start with `ca`")
                      (.click (node m ".suggestion-choose"))
-                     (hm/settle! m)
+                     (rf.hicasso.test.mounted/settle! m)
                      (is (nil? (node m ".suggestion"))
                          "choosing closes the panel, so the suggestion read is gone")
-                     (hm/settle-until! m #(node m ".detail-name")
+                     (rf.hicasso.test.mounted/settle-until! m #(node m ".detail-name")
                                        {:label "the detail replies"})))
             (.then (fn [_]
                      (is (= "Cataract" (text m ".detail-name")))
-                     (-> (hm/unmount! m) (hm/assert-clean!))))
+                     (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!))))
             (.then done))))))
 
 ;; ---------------------------------------------------------------------------
@@ -185,12 +185,12 @@
         ;; The control: the same page, the same read, one intent. The
         ;; request appears — so the acquisition is real and it is the
         ;; INTENT that carries it, not the read.
-        (hm/dispatch-and-settle! m [::events/focus])
+        (rf.hicasso.test.mounted/dispatch-and-settle! m [::rf.hicasso.examples.typeahead.events/focus])
         (is (= 1 (count (searches)))
             "an intent acquires; a commit does not")
-        (-> (hm/settle-until! m #(node m ".suggestion")
+        (-> (rf.hicasso.test.mounted/settle-until! m #(node m ".suggestion")
                               {:label "the reply lands"})
-            (.then (fn [_] (-> (hm/unmount! m) (hm/assert-clean!))))
+            (.then (fn [_] (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!))))
             (.then done))))))
 
 ;; ---------------------------------------------------------------------------
@@ -219,10 +219,10 @@
       ;; keystroke on which a demand mechanism would have work to do, and
       ;; because three is a number with a reason rather than whatever a
       ;; steady-state keystroke happened to cost.
-      (let [keystroke (fn [m] (hm/bodies-run #(type-into! m "cc")))
+      (let [keystroke (fn [m] (rf.hicasso.test.mounted/bodies-run #(type-into! m "cc")))
             plain-m   (mount-screen! (seeded {:term "c" :open? true}))
             plain     (keystroke plain-m)]
-        (-> (hm/assert-clean! (hm/unmount! plain-m))
+        (-> (rf.hicasso.test.mounted/assert-clean! (rf.hicasso.test.mounted/unmount! plain-m))
             (.then
               (fn [_]
                 (let [strict-m (mount-strict! (seeded {:term "c" :open? true}))
@@ -236,7 +236,7 @@
                       "so the abandoned-render population on this witness
                        is non-empty and counted: `strict - plain` renders
                        ran and were discarded")
-                  (hm/assert-clean! (hm/unmount! strict-m)))))
+                  (rf.hicasso.test.mounted/assert-clean! (rf.hicasso.test.mounted/unmount! strict-m)))))
             (.then done))))))
 
 (deftest an-abandoned-render-asks-the-service-for-nothing
@@ -251,7 +251,7 @@
     (async done
       (let [m (mount-strict!)]
         (type-into! m "ca")
-        (-> (hm/settle-until! m #(node m ".suggestion")
+        (-> (rf.hicasso.test.mounted/settle-until! m #(node m ".suggestion")
                               {:label "the debounced search replies"})
             (.then (fn [_]
                      (is (= 1 (count (searches)))
@@ -259,7 +259,7 @@
                           twice and half of those renders were discarded")
                      (is (= 3 (count (nodes m ".suggestion")))
                          "and the page is the same page")
-                     (-> (hm/unmount! m) (hm/assert-clean!))))
+                     (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!))))
             (.then done))))))
 
 ;; ---------------------------------------------------------------------------
@@ -282,17 +282,17 @@
     (async done
       (let [released (mount-screen!)]
         (type-into! released "ca")
-        (hm/dispatch-and-settle! released [::events/dismiss])
-        (is (nil? (db/wanted (app-db released)))
+        (rf.hicasso.test.mounted/dispatch-and-settle! released [::rf.hicasso.examples.typeahead.events/dismiss])
+        (is (nil? (rf.hicasso.examples.typeahead.db/wanted (app-db released)))
             "the dismissal ended the read, and the model knows it")
-        (hm/unmount! released)
+        (rf.hicasso.test.mounted/unmount! released)
 
         (let [orphaned (mount-screen!)]
           (type-into! orphaned "ca")
-          (hm/unmount! orphaned)
+          (rf.hicasso.test.mounted/unmount! orphaned)
           (is (nil? (node orphaned ".typeahead-panel"))
               "the page is gone")
-          (-> (test-support/poll-until
+          (-> (rf.test-support/poll-until
                 #(some? (get-in (app-db orphaned) [:search :shown]))
                 {:label "the reply for the unmounted page lands"})
               (.then
@@ -305,8 +305,8 @@
                       "while the released arm, armed first and read last,
                        asked for nothing at all: its intent carried the
                        release the unmount could not")
-                  (-> (hm/assert-clean! orphaned)
-                      (.then (fn [_] (hm/assert-clean! released))))))
+                  (-> (rf.hicasso.test.mounted/assert-clean! orphaned)
+                      (.then (fn [_] (rf.hicasso.test.mounted/assert-clean! released))))))
               (.then done)))))))
 
 ;; ---------------------------------------------------------------------------
@@ -323,11 +323,11 @@
     (skip! "a retained-structure reading is only worth what built the page")
     (async done
       (let [m       (mount-screen! (seeded {:term "ca" :open? false}))
-            closed  (hm/census)
-            _       (hm/dispatch-and-settle! m [::events/focus])
-            open    (hm/census)
-            _       (hm/dispatch-and-settle! m [::events/dismiss])
-            again   (hm/census)]
+            closed  (rf.hicasso.test.mounted/census)
+            _       (rf.hicasso.test.mounted/dispatch-and-settle! m [::rf.hicasso.examples.typeahead.events/focus])
+            open    (rf.hicasso.test.mounted/census)
+            _       (rf.hicasso.test.mounted/dispatch-and-settle! m [::rf.hicasso.examples.typeahead.events/dismiss])
+            again   (rf.hicasso.test.mounted/census)]
         (is (some? (node m ".typeahead-field")) "the page is up")
 
         ;; The closed page is two boundaries and five reads, and every one
@@ -371,6 +371,6 @@
         ;; cells and the entry are released, just later than the
         ;; memberships were. A row that stopped at `again` would have
         ;; published a leak that is not one.
-        (-> (hm/unmount! m)
-            (hm/assert-clean!)
+        (-> (rf.hicasso.test.mounted/unmount! m)
+            (rf.hicasso.test.mounted/assert-clean!)
             (.then done))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/events.cljs
@@ -68,8 +68,8 @@
   level only. Everything else takes the canonical trailing map. This is
   the slice authoring report's first finding, met again here."
   (:require [re-frame.core :as rf]
-            [re-frame.hicasso.examples.typeahead.db :as db]
-            [re-frame.hicasso.examples.typeahead.service :as service]))
+            [re-frame.hicasso.examples.typeahead.db :as rf.hicasso.examples.typeahead.db]
+            [re-frame.hicasso.examples.typeahead.service :as rf.hicasso.examples.typeahead.service]))
 
 (def debounce-ms
   "How long the field waits for the typing to stop. Small, because the
@@ -96,7 +96,7 @@
 
 (rf/reg-event ::seed
   {:doc "Install the starting app-db. The frame's `:initial-events` step."}
-  (fn [_ _] {:db db/seed}))
+  (fn [_ _] {:db rf.hicasso.examples.typeahead.db/seed}))
 
 ;; ---------------------------------------------------------------------------
 ;; The one factored correlation
@@ -115,8 +115,8 @@
   one definition and three invocations — are counting."
   [db]
   ;; CENSUS O1 | OWNERSHIP | release | the definition: abandon the request the model believes is out
-  (when-some [{:keys [token]} (db/in-flight db)]
-    [[::service/abandon {:token token}]])
+  (when-some [{:keys [token]} (rf.hicasso.examples.typeahead.db/in-flight db)]
+    [[::rf.hicasso.examples.typeahead.service/abandon {:token token}]])
   ;; /CENSUS O1
   )
 
@@ -136,7 +136,7 @@
                      (assoc-in [:search :term] typed)
                      (assoc-in [:search :open?] true)
                      (update-in [:search :generation] inc))
-        term     (db/wanted db')
+        term     (rf.hicasso.examples.typeahead.db/wanted db')
         gen      (get-in db' [:search :generation])
         ;; CENSUS O2 | OWNERSHIP | release | the term moved, so the request out for the old one is work nobody reads
         release  (release-search db)
@@ -184,19 +184,19 @@
          already there."}
   (fn [{:keys [db]} _]
     (let [db'  (assoc-in db [:search :open?] true)
-          term (db/wanted db')
+          term (rf.hicasso.examples.typeahead.db/wanted db')
           gen  (get-in db' [:search :generation])
           ;; CENSUS O4 | OWNERSHIP | acquire | re-opening makes the read live again, so the resource has to be re-checked by hand
           fetch? (and (some? term)
-                      (not (db/satisfied? db' term))
-                      (nil? (db/in-flight db')))
+                      (not (rf.hicasso.examples.typeahead.db/satisfied? db' term))
+                      (nil? (rf.hicasso.examples.typeahead.db/in-flight db')))
           ;; /CENSUS O4
           ]
       (if fetch?
         {:db (-> db'
                  (assoc-in [:search :requested] {:token gen :term term})
                  (assoc-in [:search :status] (if (:shown (:search db')) :refreshing :loading)))
-         :fx [[::service/search {:token   gen
+         :fx [[::rf.hicasso.examples.typeahead.service/search {:token   gen
                                  :term    term
                                  :delay   service-delay-ms
                                  :on-ok   ::suggestions
@@ -218,7 +218,7 @@
         ;; /CENSUS O5
         ]
     {:db (-> db
-             (db/close-panel)
+             (rf.hicasso.examples.typeahead.db/close-panel)
              (assoc-in [:search :requested] nil)
              (assoc-in [:search :status] :idle))
      :fx (into [] cat [release])}))
@@ -238,13 +238,13 @@
          still want a term?"}
   (fn [{:keys [db]} [_ {:keys [token]}]]
     (let [;; CENSUS P2 | POLICY | debounce | a tick a newer keystroke superseded fires and does nothing
-          superseded? (not (db/current-generation? db token))
+          superseded? (not (rf.hicasso.examples.typeahead.db/current-generation? db token))
           ;; /CENSUS P2
-          term        (db/wanted db)
+          term        (rf.hicasso.examples.typeahead.db/wanted db)
           ;; CENSUS O6 | OWNERSHIP | acquire | issue only if a read is live and is not already answered
           acquire?    (and (some? term)
-                           (not (db/satisfied? db term))
-                           (nil? (db/in-flight db)))
+                           (not (rf.hicasso.examples.typeahead.db/satisfied? db term))
+                           (nil? (rf.hicasso.examples.typeahead.db/in-flight db)))
           ;; /CENSUS O6
           ]
       (if (or superseded? (not acquire?))
@@ -256,7 +256,7 @@
                  ;; keeps painting them. POLICY, and explicit under demand
                  ;; too.
                  (assoc-in [:search :status] (if (:shown (:search db)) :refreshing :loading)))
-         :fx [[::service/search {:token   token
+         :fx [[::rf.hicasso.examples.typeahead.service/search {:token   token
                                  :term    term
                                  :delay   service-delay-ms
                                  :on-ok   ::suggestions
@@ -267,8 +267,8 @@
          the model is still waiting for."}
   (fn [{:keys [db]} [_ {:keys [token] :as reply}]]
     ;; CENSUS P3 | POLICY | stale-reply-suppression | a reply for a request the model no longer awaits is dropped
-    (if (= token (:token (db/in-flight db)))
-      {:db (db/take-rows db reply)}
+    (if (= token (:token (rf.hicasso.examples.typeahead.db/in-flight db)))
+      {:db (rf.hicasso.examples.typeahead.db/take-rows db reply)}
       {})
     ;; /CENSUS P3
     ))
@@ -277,7 +277,7 @@
   {:doc "The service refused. Keep whatever is on screen; say why."}
   (fn [{:keys [db]} [_ {:keys [token problem]}]]
     ;; CENSUS P4 | POLICY | stale-reply-suppression | a failure for a request the model no longer awaits is dropped
-    (if (= token (:token (db/in-flight db)))
+    (if (= token (:token (rf.hicasso.examples.typeahead.db/in-flight db)))
       {:db (-> db
                (assoc-in [:search :requested] nil)
                (assoc-in [:search :status] :failed)
@@ -294,7 +294,7 @@
   "Ask the service for `id`'s detail. Used by the two sites that acquire
   one, so the request's shape is written once."
   [id]
-  [[::service/detail {:token (detail-token id)
+  [[::rf.hicasso.examples.typeahead.service/detail {:token (detail-token id)
                       :id    id
                       :delay service-delay-ms
                       :on-ok ::detail-ready}]])
@@ -313,14 +313,14 @@
           ;; /CENSUS O7
           ;; CENSUS O8 | OWNERSHIP | release | the detail pane's parameter moved, so the previous id's request is unread
           drop-detail (when stranded?
-                        [[::service/abandon {:token (detail-token previous)}]])
+                        [[::rf.hicasso.examples.typeahead.service/abandon {:token (detail-token previous)}]])
           ;; /CENSUS O8
           ;; CENSUS O9 | OWNERSHIP | acquire | the detail pane's read becomes live, unless the cache already answers it
           take-detail (when-not known? (detail-fx id))
           ;; /CENSUS O9
           ]
       {:db (cond-> (-> db
-                       (db/close-panel)
+                       (rf.hicasso.examples.typeahead.db/close-panel)
                        (assoc-in [:search :requested] nil)
                        (assoc-in [:search :status] :idle)
                        (assoc :chosen id))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/l0_cljs_test.cljs
@@ -65,13 +65,13 @@
   because `rf/dispatch-sync` runs the effects too. Nothing here waits on a
   duration and nothing here reports one."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.examples.typeahead.db :as db]
-            [re-frame.hicasso.examples.typeahead.events :as events]
-            [re-frame.hicasso.examples.typeahead.service :as service]
-            [re-frame.hicasso.examples.typeahead.subs :as subs]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.examples.typeahead.db :as rf.hicasso.examples.typeahead.db]
+            [re-frame.hicasso.examples.typeahead.events :as rf.hicasso.examples.typeahead.events]
+            [re-frame.hicasso.examples.typeahead.service :as rf.hicasso.examples.typeahead.service]
+            [re-frame.hicasso.examples.typeahead.subs :as rf.hicasso.examples.typeahead.subs]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The mutations — the application's own functions, one thing removed
@@ -89,13 +89,13 @@
          region deleted and nothing else. `db/take-rows` is the
          application's own fold, so this arm and the real one share every
          line but the `if`."}
-  (fn [{:keys [db]} [_ reply]] {:db (db/take-rows db reply)}))
+  (fn [{:keys [db]} [_ reply]] {:db (rf.hicasso.examples.typeahead.db/take-rows db reply)}))
 
 (rf/reg-event ::dismiss-without-release
   {:doc "`::events/dismiss` WITHOUT its release — the O5 region deleted
          and nothing else. The model half is the application's own
          function, called here and not copied."}
-  (fn [{:keys [db]} _] (dissoc (events/dismiss-fx db) :fx)))
+  (fn [{:keys [db]} _] (dissoc (rf.hicasso.examples.typeahead.events/dismiss-fx db) :fx)))
 
 (rf/reg-event ::typed-without-release
   {:doc "`::events/typed` WITHOUT its release — the O2 region deleted and
@@ -103,14 +103,14 @@
          `::service/abandon` entry filtered out, so the debounce it also
          emits is untouched and the mutation is exactly the release."}
   (fn [{:keys [db]} [_ typed]]
-    (update (events/typed-fx db typed) :fx
-            (fn [fx] (filterv #(not= ::service/abandon (first %)) fx)))))
+    (update (rf.hicasso.examples.typeahead.events/typed-fx db typed) :fx
+            (fn [fx] (filterv #(not= ::rf.hicasso.examples.typeahead.service/abandon (first %)) fx)))))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       service/reset-log!}))
+     :init-fn       rf.hicasso.examples.typeahead.service/reset-log!}))
 
 ;; ---------------------------------------------------------------------------
 ;; Driving
@@ -124,11 +124,11 @@
   row: `rf/with-new-frame` cancels the frame's own `:dispatch-later`
   timers on destroy, but the stand-in service's timers are the service's."
   [f]
-  (service/reset-log!)
+  (rf.hicasso.examples.typeahead.service/reset-log!)
   (try
-    (rf/with-new-frame [frame (rf/make-frame {:initial-events [[::events/seed]]})]
+    (rf/with-new-frame [frame (rf/make-frame {:initial-events [[::rf.hicasso.examples.typeahead.events/seed]]})]
       (f frame))
-    (finally (service/reset-log!))))
+    (finally (rf.hicasso.examples.typeahead.service/reset-log!))))
 
 (defn- read-sub [frame query-v] (rf/subscribe-once query-v {:frame frame}))
 
@@ -137,14 +137,14 @@
 (defn- searches
   "The terms the application asked the service for, in order."
   []
-  (mapv :param (filterv #(= :search (:kind %)) (service/requests))))
+  (mapv :param (filterv #(= :search (:kind %)) (rf.hicasso.examples.typeahead.service/requests))))
 
 (defn- detail-asks
   "The ids the application asked the service for, in order."
   []
-  (mapv :param (filterv #(= :detail (:kind %)) (service/requests))))
+  (mapv :param (filterv #(= :detail (:kind %)) (rf.hicasso.examples.typeahead.service/requests))))
 
-(defn- typed! [term] (rf/dispatch-sync [::events/typed term]))
+(defn- typed! [term] (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/typed term]))
 
 (defn- burst!
   "Type `term` one character at a time, all in this turn. The debounce
@@ -155,11 +155,11 @@
   (doseq [n (range 1 (inc (count term)))]
     (typed! (apply str (take n term)))))
 
-(defn- tick! [token] (rf/dispatch-sync [::events/search-due {:token token}]))
+(defn- tick! [token] (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/search-due {:token token}]))
 
 (defn- reply!
   [token term]
-  (rf/dispatch-sync [::events/suggestions
+  (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/suggestions
                      {:token token :term term
                       :rows  [{:id "row" :name "Row"}]}]))
 
@@ -217,9 +217,9 @@
           (reply! 1 "ca")
           (is (= "cat" (:term (:shown (:search (app-db frame)))))
               "the model still holds the rows for the term on screen")
-          (is (some? (read-sub frame [::subs/suggestions "cat"]))
+          (is (some? (read-sub frame [::rf.hicasso.examples.typeahead.subs/suggestions "cat"]))
               "and the live read still answers")
-          (is (nil? (read-sub frame [::subs/suggestions "ca"]))
+          (is (nil? (read-sub frame [::rf.hicasso.examples.typeahead.subs/suggestions "ca"]))
               "while the superseded term answers nothing"))))))
 
 (deftest without-the-guard-the-late-reply-clobbers
@@ -237,7 +237,7 @@
                            {:token 1 :term "ca" :rows [{:id "row" :name "Row"}]}])
         (is (= "ca" (:term (:shown (:search (app-db frame)))))
             "the stale rows landed")
-        (is (nil? (read-sub frame [::subs/suggestions "cat"]))
+        (is (nil? (read-sub frame [::rf.hicasso.examples.typeahead.subs/suggestions "cat"]))
             "and the live read now answers NOTHING for the term the field
              holds, so the panel paints rows for a term the user has
              already typed past")))))
@@ -252,11 +252,11 @@
       (rf/with-frame frame
         (typed! "ca")
         (tick! 1)
-        (is (= #{1} (service/outstanding)) "the request is out")
-        (rf/dispatch-sync [::events/dismiss])
-        (is (= #{} (service/outstanding))
+        (is (= #{1} (rf.hicasso.examples.typeahead.service/outstanding)) "the request is out")
+        (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/dismiss])
+        (is (= #{} (rf.hicasso.examples.typeahead.service/outstanding))
             "and the panel closing took it back down")
-        (is (false? (read-sub frame [::subs/open?])))))))
+        (is (false? (read-sub frame [::rf.hicasso.examples.typeahead.subs/open?])))))))
 
 (deftest without-the-release-site-the-request-survives-the-read
   ;; THE CONTROL, and C2's *missed release on a conditional-false read*.
@@ -268,8 +268,8 @@
         (typed! "ca")
         (tick! 1)
         (rf/dispatch-sync [::dismiss-without-release])
-        (is (false? (read-sub frame [::subs/open?])) "the read is gone")
-        (is (= #{1} (service/outstanding))
+        (is (false? (read-sub frame [::rf.hicasso.examples.typeahead.subs/open?])) "the read is gone")
+        (is (= #{1} (rf.hicasso.examples.typeahead.service/outstanding))
             "and its request is still armed — residue that outlives the
              read, produced by deleting one line from one of three
              intents that each have to remember it")))))
@@ -283,9 +283,9 @@
       (rf/with-frame frame
         (typed! "ca")
         (tick! 1)
-        (is (= #{1} (service/outstanding)))
+        (is (= #{1} (rf.hicasso.examples.typeahead.service/outstanding)))
         (typed! "cat")
-        (is (= #{} (service/outstanding))
+        (is (= #{} (rf.hicasso.examples.typeahead.service/outstanding))
             "the request for the term the user typed past is abandoned at
              the keystroke")))))
 
@@ -299,14 +299,14 @@
       (rf/with-frame frame
         (typed! "ca")
         (tick! 1)
-        (is (= #{1} (service/outstanding)))
+        (is (= #{1} (rf.hicasso.examples.typeahead.service/outstanding)))
         (rf/dispatch-sync [::typed-without-release "cat"])
-        (is (= #{1} (service/outstanding))
+        (is (= #{1} (rf.hicasso.examples.typeahead.service/outstanding))
             "the request for `ca` is still running, and nothing on screen
              will ever read its answer")
         (tick! 2)
         (is (= ["ca" "cat"] (searches)))
-        (is (= #{1 2} (service/outstanding))
+        (is (= #{1 2} (rf.hicasso.examples.typeahead.service/outstanding))
             "two requests in flight for one read — the waste this class
              names, produced by deleting one line")))))
 
@@ -316,15 +316,15 @@
       (rf/with-frame frame
         (typed! "ca")
         (tick! 1)
-        (let [revision (read-sub frame [::subs/revision])]
-          (rf/dispatch-sync [::events/clear])
-          (is (= #{} (service/outstanding)))
-          (is (= "" (read-sub frame [::subs/term])))
-          (is (= (inc revision) (read-sub frame [::subs/revision]))
+        (let [revision (read-sub frame [::rf.hicasso.examples.typeahead.subs/revision])]
+          (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/clear])
+          (is (= #{} (rf.hicasso.examples.typeahead.service/outstanding)))
+          (is (= "" (read-sub frame [::rf.hicasso.examples.typeahead.subs/term])))
+          (is (= (inc revision) (read-sub frame [::rf.hicasso.examples.typeahead.subs/revision]))
               "HD-019's reset: the field is handed an empty string it may
                already have been showing, so the revision is what makes it
                take it")
-          (is (= :idle (read-sub frame [::subs/status]))))))))
+          (is (= :idle (read-sub frame [::rf.hicasso.examples.typeahead.subs/status]))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Refresh-with-data, and the acquire site's two answers
@@ -337,15 +337,15 @@
         (typed! "ca")
         (tick! 1)
         (reply! 1 "ca")
-        (is (= :ready (read-sub frame [::subs/status])))
+        (is (= :ready (read-sub frame [::rf.hicasso.examples.typeahead.subs/status])))
 
         (typed! "cav")
         (tick! 2)
-        (is (= :refreshing (read-sub frame [::subs/status]))
+        (is (= :refreshing (read-sub frame [::rf.hicasso.examples.typeahead.subs/status]))
             "a request is out and rows are already on screen")
-        (is (nil? (read-sub frame [::subs/suggestions "cav"]))
+        (is (nil? (read-sub frame [::rf.hicasso.examples.typeahead.subs/suggestions "cav"]))
             "the live read is honest: nothing answers the NEW term yet")
-        (is (some? (read-sub frame [::subs/held-rows]))
+        (is (some? (read-sub frame [::rf.hicasso.examples.typeahead.subs/held-rows]))
             "and the held rows are what the panel keeps painting — the P5
              region in `views.cljs` is the decision between the two")))))
 
@@ -356,9 +356,9 @@
         (typed! "ca")
         (tick! 1)
         (reply! 1 "ca")
-        (rf/dispatch-sync [::events/dismiss])
-        (rf/dispatch-sync [::events/focus])
-        (is (true? (read-sub frame [::subs/open?])) "the read is live again")
+        (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/dismiss])
+        (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/focus])
+        (is (true? (read-sub frame [::rf.hicasso.examples.typeahead.subs/open?])) "the read is live again")
         (is (= ["ca"] (searches))
             "and the acquire site found the resource already answered, so
              it asked for nothing. THAT DECISION IS THE CEREMONY: the
@@ -373,9 +373,9 @@
       (rf/with-frame frame
         (typed! "ca")
         (tick! 1)
-        (rf/dispatch-sync [::events/dismiss])
-        (is (= #{} (service/outstanding)) "the dismissal released it")
-        (rf/dispatch-sync [::events/focus])
+        (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/dismiss])
+        (is (= #{} (rf.hicasso.examples.typeahead.service/outstanding)) "the dismissal released it")
+        (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/focus])
         (is (= ["ca" "ca"] (searches))
             "so re-opening has to ask again — the release and the
              re-acquire are two hand-written sites and the round trip is
@@ -391,13 +391,13 @@
       (rf/with-frame frame
         (typed! "ca")
         (tick! 1)
-        (is (= #{1} (service/outstanding)))
-        (rf/dispatch-sync [::events/choose {:id "canid"}])
-        (is (false? (read-sub frame [::subs/open?])))
+        (is (= #{1} (rf.hicasso.examples.typeahead.service/outstanding)))
+        (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/choose {:id "canid"}])
+        (is (false? (read-sub frame [::rf.hicasso.examples.typeahead.subs/open?])))
         (is (= ["canid"] (detail-asks)) "the detail read's resource was asked for")
-        (is (= #{(events/detail-token "canid")} (service/outstanding))
+        (is (= #{(rf.hicasso.examples.typeahead.events/detail-token "canid")} (rf.hicasso.examples.typeahead.service/outstanding))
             "and the suggestion request is gone while the detail's is out")
-        (is (= :pending (read-sub frame [::subs/detail "canid"])))))))
+        (is (= :pending (read-sub frame [::rf.hicasso.examples.typeahead.subs/detail "canid"])))))))
 
 (deftest choosing-again-releases-the-detail-the-parameter-left-behind
   (with-app
@@ -405,11 +405,11 @@
       (rf/with-frame frame
         (typed! "ca")
         (tick! 1)
-        (rf/dispatch-sync [::events/choose {:id "canid"}])
-        (rf/dispatch-sync [::events/choose {:id "cavil"}])
-        (is (= #{(events/detail-token "cavil")} (service/outstanding))
+        (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/choose {:id "canid"}])
+        (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/choose {:id "cavil"}])
+        (is (= #{(rf.hicasso.examples.typeahead.events/detail-token "cavil")} (rf.hicasso.examples.typeahead.service/outstanding))
             "the request for the id nobody reads any more was abandoned")
-        (is (nil? (read-sub frame [::subs/detail "canid"]))
+        (is (nil? (read-sub frame [::rf.hicasso.examples.typeahead.subs/detail "canid"]))
             "and its pending entry went with it, so a later choose asks
              again rather than waiting on an answer that was cancelled")))))
 
@@ -422,18 +422,18 @@
       (rf/with-frame frame
         (typed! "ca")
         (tick! 1)
-        (rf/dispatch-sync [::events/hover {:id "cavil"}])
+        (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/hover {:id "cavil"}])
         (is (= ["cavil"] (detail-asks)))
-        (is (nil? (read-sub frame [::subs/chosen]))
+        (is (nil? (read-sub frame [::rf.hicasso.examples.typeahead.subs/chosen]))
             "nothing is chosen, so no boundary reads [::subs/detail
              \"cavil\"] — the demand has no reader at all")
 
         (testing "hovering again asks nothing"
-          (rf/dispatch-sync [::events/hover {:id "cavil"}])
+          (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/hover {:id "cavil"}])
           (is (= ["cavil"] (detail-asks))))
 
         (testing "and choosing the warmed row asks nothing either"
-          (rf/dispatch-sync [::events/choose {:id "cavil"}])
+          (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/choose {:id "cavil"}])
           (is (= ["cavil"] (detail-asks))
               "which is what a prefetch buys, and the reason it cannot be
                given up to a mechanism that only knows about reads"))))))
@@ -448,17 +448,17 @@
       (rf/with-frame frame
         (typed! "zzz")
         (tick! 1)
-        (rf/dispatch-sync [::events/search-failed
+        (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/search-failed
                            {:token 1 :term "zzz" :problem :problem/service-down}])
-        (is (= :failed (read-sub frame [::subs/status])))
-        (is (= :problem/service-down (read-sub frame [::subs/problem])))
+        (is (= :failed (read-sub frame [::rf.hicasso.examples.typeahead.subs/status])))
+        (is (= :problem/service-down (read-sub frame [::rf.hicasso.examples.typeahead.subs/problem])))
 
         (testing "a refusal for a request nobody awaits is dropped"
           (typed! "ca")
           (tick! 2)
-          (rf/dispatch-sync [::events/search-failed
+          (rf/dispatch-sync [::rf.hicasso.examples.typeahead.events/search-failed
                              {:token 1 :term "zzz" :problem :problem/service-down}])
-          (is (not= :failed (read-sub frame [::subs/status]))
+          (is (not= :failed (read-sub frame [::rf.hicasso.examples.typeahead.subs/status]))
               "the stale refusal did not put the panel back into error"))))))
 
 ;; ---------------------------------------------------------------------------
@@ -469,14 +469,14 @@
   ;; `db/wanted` is the one expression the whole experiment is about: the
   ;; term a live read wants. Under demand it would be read off the
   ;; committed read set instead of computed here.
-  (is (nil? (db/wanted db/seed)) "a closed panel wants nothing")
-  (is (nil? (db/wanted (assoc-in db/seed [:search :open?] true)))
+  (is (nil? (rf.hicasso.examples.typeahead.db/wanted rf.hicasso.examples.typeahead.db/seed)) "a closed panel wants nothing")
+  (is (nil? (rf.hicasso.examples.typeahead.db/wanted (assoc-in rf.hicasso.examples.typeahead.db/seed [:search :open?] true)))
       "nor does an open one over an empty field")
-  (is (nil? (db/wanted (-> db/seed
+  (is (nil? (rf.hicasso.examples.typeahead.db/wanted (-> rf.hicasso.examples.typeahead.db/seed
                            (assoc-in [:search :open?] true)
                            (assoc-in [:search :term] "c"))))
       "nor over a term below the threshold")
-  (is (= "ca" (db/wanted (-> db/seed
+  (is (= "ca" (rf.hicasso.examples.typeahead.db/wanted (-> rf.hicasso.examples.typeahead.db/seed
                              (assoc-in [:search :open?] true)
                              (assoc-in [:search :term] "  ca "))))
       "and it is trimmed, because a field holding two spaces holds

--- a/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/subs.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/subs.cljs
@@ -28,7 +28,7 @@
   the term is read once by the field's own boundary and handed down as a
   prop."
   (:require [re-frame.core :as rf]
-            [re-frame.hicasso.examples.typeahead.db :as db]))
+            [re-frame.hicasso.examples.typeahead.db :as rf.hicasso.examples.typeahead.db]))
 
 ;; ---------------------------------------------------------------------------
 ;; The field
@@ -78,7 +78,7 @@
 (rf/reg-sub ::wanted
   {:doc "The term a live read wants, or `nil` — [[db/wanted]] as a
          subscription, so the shell can hand the panel its parameter."}
-  (fn [db _] (db/wanted db)))
+  (fn [db _] (rf.hicasso.examples.typeahead.db/wanted db)))
 
 (rf/reg-sub ::held-rows
   {:doc "Whatever rows are held, whichever term they answer. Read ONLY by
@@ -107,4 +107,4 @@
   {:doc "Has the user typed enough to be worth a request? The panel shows
          a hint rather than an empty list when they have not."}
   :<- [::term]
-  (fn [term _] (db/searchable? term)))
+  (fn [term _] (rf.hicasso.examples.typeahead.db/searchable? term)))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/views.cljs
@@ -37,15 +37,15 @@
   grammar declarative. Nothing about the resource story changes: a
   dismissal is an intent either way, and the census row is the release
   beside it."
-  (:require [re-frame.hicasso :as h]
-            [re-frame.hicasso.examples.typeahead.events :as events]
-            [re-frame.hicasso.examples.typeahead.subs :as subs]))
+  (:require [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.examples.typeahead.events :as rf.hicasso.examples.typeahead.events]
+            [re-frame.hicasso.examples.typeahead.subs :as rf.hicasso.examples.typeahead.subs]))
 
 ;; ---------------------------------------------------------------------------
 ;; The field
 ;; ---------------------------------------------------------------------------
 
-(h/defview field
+(rf.hicasso/defview field
   "The controlled search box, and the two buttons that end a read.
 
   `::h/revision` is what makes *clear* work: dropping the model's text
@@ -53,51 +53,51 @@
   showing an empty string React would see nothing to do. A changed
   revision re-baselines the field without remounting it (HD-019)."
   [_]
-  (let [term     (h/sub [::subs/term])
-        revision (h/sub [::subs/revision])]
+  (let [term     (rf.hicasso/sub [::rf.hicasso.examples.typeahead.subs/term])
+        revision (rf.hicasso/sub [::rf.hicasso.examples.typeahead.subs/revision])]
     [:div.typeahead-field
      [:label {:for "typeahead-term"} "Search"]
      [:input#typeahead-term.term
       {:type        "text"
        :value       term
-       ::h/revision revision
+       ::rf.hicasso/revision revision
        ;; Positional, because `::h/value` substitutes at the intent
        ;; vector's top level only.
-       :on-input    [::events/typed ::h/value]
-       :on-focus    [::events/focus {}]}]
-     [:button.clear {:type "button" :on-click [::events/clear {}]} "clear"]
-     [:button.dismiss {:type "button" :on-click [::events/dismiss {}]} "close"]]))
+       :on-input    [::rf.hicasso.examples.typeahead.events/typed ::rf.hicasso/value]
+       :on-focus    [::rf.hicasso.examples.typeahead.events/focus {}]}]
+     [:button.clear {:type "button" :on-click [::rf.hicasso.examples.typeahead.events/clear {}]} "clear"]
+     [:button.dismiss {:type "button" :on-click [::rf.hicasso.examples.typeahead.events/dismiss {}]} "close"]]))
 
 ;; ---------------------------------------------------------------------------
 ;; The suggestions
 ;; ---------------------------------------------------------------------------
 
-(h/defview suggestion-row
+(rf.hicasso/defview suggestion-row
   "One suggestion. Hovering it warms the row's detail — a demand no read
   expresses, and the reason C4 records prefetch as out of scope."
   [{:keys [id name]}]
   [:li.suggestion
    [:button.suggestion-choose
     {:type           "button"
-     :on-click       [::events/choose {:id id}]
-     :on-mouse-enter [::events/hover {:id id}]}
+     :on-click       [::rf.hicasso.examples.typeahead.events/choose {:id id}]
+     :on-mouse-enter [::rf.hicasso.examples.typeahead.events/hover {:id id}]}
     name]])
 
-(h/defview panel
+(rf.hicasso/defview panel
   "The suggestion list. Rendered only while a read wants a term, so its
   body's `[::subs/suggestions term]` is live exactly when the resource is
   wanted and not otherwise."
   [{:keys [term]}]
-  (let [rows   (h/sub [::subs/suggestions term])
-        status (h/sub [::subs/status])
+  (let [rows   (rf.hicasso/sub [::rf.hicasso.examples.typeahead.subs/suggestions term])
+        status (rf.hicasso/sub [::rf.hicasso.examples.typeahead.subs/status])
         ;; CENSUS P5 | POLICY | refresh-with-data | keep painting the rows held while a request for a NEW term is out
-        painted (or rows (h/sub [::subs/held-rows]))
+        painted (or rows (rf.hicasso/sub [::rf.hicasso.examples.typeahead.subs/held-rows]))
         ;; /CENSUS P5
         ]
     [:div.typeahead-panel
      (cond
        (= :failed status)
-       [:p.panel-problem {:role "alert"} (str (h/sub [::subs/problem]))]
+       [:p.panel-problem {:role "alert"} (str (rf.hicasso/sub [::rf.hicasso.examples.typeahead.subs/problem]))]
 
        (nil? painted)
        [:p.panel-loading "searching"]
@@ -117,11 +117,11 @@
 ;; The detail
 ;; ---------------------------------------------------------------------------
 
-(h/defview detail-pane
+(rf.hicasso/defview detail-pane
   "The chosen row. Its read is `[::subs/detail id]` — the second resource,
   parameterised by the id rather than by the term."
   [{:keys [id]}]
-  (let [detail (h/sub [::subs/detail id])]
+  (let [detail (rf.hicasso/sub [::rf.hicasso.examples.typeahead.subs/detail id])]
     [:section.typeahead-detail
      (cond
        (= :pending detail) [:p.detail-pending "loading"]
@@ -134,7 +134,7 @@
 ;; The shell
 ;; ---------------------------------------------------------------------------
 
-(h/defview screen
+(rf.hicasso/defview screen
   "The whole application.
 
   Two conditional children, and each one is a resource read appearing and
@@ -142,9 +142,9 @@
   something is chosen. Those two `when`s are the read liveness the census
   is trying to keep a request in step with."
   [_]
-  (let [term   (h/sub [::subs/wanted])
-        open?  (h/sub [::subs/open?])
-        chosen (h/sub [::subs/chosen])]
+  (let [term   (rf.hicasso/sub [::rf.hicasso.examples.typeahead.subs/wanted])
+        open?  (rf.hicasso/sub [::rf.hicasso.examples.typeahead.subs/open?])
+        chosen (rf.hicasso/sub [::rf.hicasso.examples.typeahead.subs/chosen])]
     [:main.typeahead
      [field {}]
      (cond

--- a/implementation/hicasso/test/re_frame/hicasso/facade_roster_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/facade_roster_ssr_dom_cljs_test.cljs
@@ -57,15 +57,15 @@
   lane is the one that decides the server claims** — a green browser lane
   says nothing about `renderToString`."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.routing :as routing]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.routing :as rf.routing]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom/server" :as react-dom-server]))
 
 (def ^:private frame-id ::roster)
@@ -93,13 +93,13 @@
               (fn [{:keys [db]} [_ a]] {:db (assoc db :author a)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; the hydration rows wait on a real clock, and `cljs.test`
      ;; hard-errors on a fn-form fixture in a suite with an async test.
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- fresh!
   "A frame seeded to a known request, with the route table and the state
@@ -112,8 +112,8 @@
   ([] (fresh! frame-id "jane"))
   ([kw author]
    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-   (routing/reg-route route-id {} "/profile/:username")
-   (h/reg-state panel-concern {:default false})
+   (rf.routing/reg-route route-id {} "/profile/:username")
+   (rf.hicasso/reg-state panel-concern {:default false})
    (rf/make-frame {:id kw})
    (rf/with-frame kw (rf/dispatch-sync [:hicasso.facade-roster/seed author]))
    kw))
@@ -122,19 +122,19 @@
 ;; The views — one surface per view, so a red row names a surface
 ;; ---------------------------------------------------------------------------
 
-(h/defview byline
+(rf.hicasso/defview byline
   "HS-40. One census route-link inside the boundary a link always lives
   in — the form is a plain CALL, not a hiccup head, because `route-link`
   mints no boundary and adds no hook. Its `:class` is an ordinary
   passthrough attribute, which is the control for the click-decision row:
   something on this props map does reach the bytes."
   [_]
-  (let [who (h/sub [:hicasso.facade-roster/author])]
+  (let [who (rf.hicasso/sub [:hicasso.facade-roster/author])]
     [:p.byline
-     (h/route-link {:to route-id :params {:username who} :class "author"}
+     (rf.hicasso/route-link {:to route-id :params {:username who} :class "author"}
                    who)]))
 
-(h/defview panel
+(rf.hicasso/defview panel
   "HS-42's read half. `reg-state` itself contributes nothing to a tree;
   what reaches a page is the parametric subscription it minted, read
   through the ordinary door. So the only server-observable fact about
@@ -143,9 +143,9 @@
   registered."
   [_]
   [:div.panel
-   [:span.p-state (str (h/sub [panel-concern "p1"]))]])
+   [:span.p-state (str (rf.hicasso/sub [panel-concern "p1"]))]])
 
-(h/defview page
+(rf.hicasso/defview page
   "The hydration rows' page: both surfaces in one tree, so ONE adoption
   covers HS-40 and HS-42 rather than leaving them witnessed on the server
   side alone."
@@ -168,7 +168,7 @@
   ([hiccup] (server-html frame-id hiccup))
   ([kw hiccup]
    (react-dom-server/renderToString
-     (mount/provider kw (codec/root-element kw hiccup)))))
+     (rf.hicasso.impl.mount/provider kw (rf.hicasso.impl.codec/root-element kw hiccup)))))
 
 (defn- query-node [root selector] (.querySelector root selector))
 
@@ -184,17 +184,17 @@
   [hiccup done after]
   (fresh!)
   (let [html      (server-html hiccup)
-        container (sup/stamp-server-nodes! (sup/server-dom! html))
-        {:keys [seen stop!]} (sup/watch-mismatches!)
-        handle    (mount/hydrate-root! container frame-id hiccup)]
+        container (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+        {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)
+        handle    (rf.hicasso.impl.mount/hydrate-root! container frame-id hiccup)]
     (js/setTimeout
       (fn []
         (stop!)
         (try
           (after container @seen html)
           (finally
-            (mount/release! handle)
-            (collector/reset-runtime!)
+            (rf.hicasso.impl.mount/release! handle)
+            (rf.hicasso.impl.collector/reset-runtime!)
             (done))))
       200)))
 
@@ -244,7 +244,7 @@
     ;; `data-rf2-source-coord` carries the declaring namespace on purpose,
     ;; so leaving it in would red this row on the framework obeying 006.
     ;; `sup/without-view-annotations` carries the argument in full.
-    (let [html (sup/without-view-annotations (server-html [byline {}]))]
+    (let [html (rf.hicasso.roots-frames-support/without-view-annotations (server-html [byline {}]))]
       (is (not (re-find #"onclick|onClick" html))
           (str "no DOM event attribute on the anchor: " html))
       (is (not (re-find #"re-frame\.hicasso" html))
@@ -302,8 +302,8 @@
 
 (deftest the-page-adopts-the-servers-own-nodes
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (hydration-row
         [page {}]
         done
@@ -318,10 +318,10 @@
                       not tell adoption from a fresh mount: " html))
             (is (empty? seen)
                 (str "**REACT FOUND NOTHING TO RECONCILE**: " (pr-str seen)))
-            (is (sup/every-server-node? container "a")
+            (is (rf.hicasso.roots-frames-support/every-server-node? container "a")
                 "the anchor is the SERVER'S node, still carrying the
                  expando — adoption, not a re-render that looks the same")
-            (is (sup/every-server-node? container ".p-state")
+            (is (rf.hicasso.roots-frames-support/every-server-node? container ".p-state")
                 "as is the reg-state panel's")
             (is (= "/profile/jane"
                    (.getAttribute (query-node container "a") "href"))
@@ -331,8 +331,8 @@
 
 (deftest an-adopted-read-is-acquired-exactly-once
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (hydration-row
         [page {}]
         done
@@ -341,23 +341,23 @@
                     read: one reader after adoption, not two, so the
                     server render registered NONE and only the adoption
                     acquired"
-            (is (= 1 (sup/readers-of [frame-id [:hicasso.facade-roster/author]]))
+            (is (= 1 (rf.hicasso.roots-frames-support/readers-of [frame-id [:hicasso.facade-roster/author]]))
                 (str "the link's read acquired exactly once; cells: "
-                     (pr-str (sup/cell-keys))))))))))
+                     (pr-str (rf.hicasso.roots-frames-support/cell-keys))))))))))
 
 (deftest a-deliberate-mismatch-is-attributed-to-the-root-that-owns-it
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
         (let [html      (server-html [page {}])
-              container (sup/server-dom! html)
-              {:keys [seen stop!]} (sup/watch-mismatches!)
+              container (rf.hicasso.roots-frames-support/server-dom! html)
+              {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)
               ;; MANUFACTURED here and asserted on here — the only shape
               ;; of call site at which swallowing an uncaught error is
               ;; not a fail-open.
-              {:keys [captured close!]} (sup/open-console-capture!
+              {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture!
                                           {:swallow-uncaught? true})]
           ;; The request the client renders is not the request the server
           ;; rendered, and the divergence lands on the LINK'S OWN
@@ -365,7 +365,7 @@
           ;; text-only mismatch check would miss.
           (rf/with-frame frame-id
             (rf/dispatch-sync [:hicasso.facade-roster/rename "mary"]))
-          (let [handle (mount/hydrate-root! container frame-id [page {}])]
+          (let [handle (rf.hicasso.impl.mount/hydrate-root! container frame-id [page {}])]
             (js/setTimeout
               (fn []
                 (close!)
@@ -386,38 +386,38 @@
                     (is (= 1 (count @seen))
                         (str "the framework's Spec 011 diagnostic fired
                               exactly once, for this one root; got "
-                             (pr-str (mapv (comp :error sup/tags-of) @seen))))
+                             (pr-str (mapv (comp :error rf.hicasso.roots-frames-support/tags-of) @seen))))
                     (is (= 're-frame.hicasso.impl.mount/hydrate-root!
-                           (:where (sup/tags-of (first @seen))))
+                           (:where (rf.hicasso.roots-frames-support/tags-of (first @seen))))
                         "attributed to the door that owns the adoption")
                     (is (= :warned-and-replaced
-                           (:recovery (sup/tags-of (first @seen))))
+                           (:recovery (rf.hicasso.roots-frames-support/tags-of (first @seen))))
                         "with the recovery React had already performed")
                     (is (= "/profile/mary"
                            (.getAttribute (query-node container "a") "href"))
                         "and the repaired DOM carries the CLIENT's href,
                          which is what 'warned and replaced' means"))
                   (finally
-                    (mount/release! handle)
-                    (collector/reset-runtime!)
+                    (rf.hicasso.impl.mount/release! handle)
+                    (rf.hicasso.impl.collector/reset-runtime!)
                     (done))))
               300)))))))
 
 (deftest two-overlapping-roots-adopt-under-distinct-prefixes
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (do
         (fresh! frame-id "jane")
         (fresh! other-frame-id "mary")
         (let [html-a (server-html frame-id [page {}])
               html-b (server-html other-frame-id [page {}])
-              ca     (sup/stamp-server-nodes! (sup/server-dom! html-a))
-              cb     (sup/stamp-server-nodes! (sup/server-dom! html-b))
-              {:keys [seen stop!]} (sup/watch-mismatches!)
-              ha     (mount/hydrate-root! ca frame-id [page {}]
+              ca     (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-a))
+              cb     (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-b))
+              {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)
+              ha     (rf.hicasso.impl.mount/hydrate-root! ca frame-id [page {}]
                                           {:identifier-prefix "roster-a-"})
-              hb     (mount/hydrate-root! cb other-frame-id [page {}]
+              hb     (rf.hicasso.impl.mount/hydrate-root! cb other-frame-id [page {}]
                                           {:identifier-prefix "roster-b-"})]
           (js/setTimeout
             (fn []
@@ -438,39 +438,39 @@
                       "root A's link settled on its own request")
                   (is (= "/profile/mary" (.getAttribute (query-node cb "a") "href"))
                       "root B's on its own")
-                  (is (sup/every-server-node? ca "a")
+                  (is (rf.hicasso.roots-frames-support/every-server-node? ca "a")
                       "root A adopted the server's anchor")
-                  (is (sup/every-server-node? cb "a")
+                  (is (rf.hicasso.roots-frames-support/every-server-node? cb "a")
                       "and so did root B, concurrently")
-                  (is (= 1 (sup/readers-of [frame-id [:hicasso.facade-roster/author]]))
+                  (is (= 1 (rf.hicasso.roots-frames-support/readers-of [frame-id [:hicasso.facade-roster/author]]))
                       (str "and each frame holds its own single edge
                             rather than one shared cell; cells: "
-                           (pr-str (sup/cell-keys))))
-                  (is (= 1 (sup/readers-of [other-frame-id [:hicasso.facade-roster/author]]))
+                           (pr-str (rf.hicasso.roots-frames-support/cell-keys))))
+                  (is (= 1 (rf.hicasso.roots-frames-support/readers-of [other-frame-id [:hicasso.facade-roster/author]]))
                       (str "one each, in both directions; cells: "
-                           (pr-str (sup/cell-keys)))))
+                           (pr-str (rf.hicasso.roots-frames-support/cell-keys)))))
                 (finally
-                  (mount/release! ha)
-                  (mount/release! hb)
-                  (collector/reset-runtime!)
+                  (rf.hicasso.impl.mount/release! ha)
+                  (rf.hicasso.impl.mount/release! hb)
+                  (rf.hicasso.impl.collector/reset-runtime!)
                   (done))))
             300))))))
 
 (deftest an-adopted-page-releases-exactly-what-it-acquired
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (collector/reset-runtime!)
+      (rf.hicasso.impl.collector/reset-runtime!)
       (testing "§2.4's last clause for these rows: exact cleanup.
                 Narrowing caught: a teardown that empties the runtime's
                 tables rather than releasing the subscriptions — it
                 answers zero whether it released anything or not"
-        (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
-          (is (= 1 (sup/readers-of [frame-id [:hicasso.facade-roster/author]]))
+        (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [page {}])]
+          (is (= 1 (rf.hicasso.roots-frames-support/readers-of [frame-id [:hicasso.facade-roster/author]]))
               (str "the link's edge is held while mounted; cells: "
-                   (pr-str (sup/cell-keys))))
-          (mount/unmount! handle)
-          (is (zero? (sup/readers-of [frame-id [:hicasso.facade-roster/author]]))
+                   (pr-str (rf.hicasso.roots-frames-support/cell-keys))))
+          (rf.hicasso.impl.mount/unmount! handle)
+          (is (zero? (rf.hicasso.roots-frames-support/readers-of [frame-id [:hicasso.facade-roster/author]]))
               (str "and it does not survive the PUBLIC teardown door; cells: "
-                   (pr-str (sup/cell-keys)))))))))
+                   (pr-str (rf.hicasso.roots-frames-support/cell-keys)))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/fallback_contents_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/fallback_contents_cljs_test.cljs
@@ -62,14 +62,14 @@
   Runtime: `-cljs-test`, not `-dom-`. Every claim is a declaration or a
   `renderToString`, so there is nothing here a DOM would add."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/server" :as react-dom-server]))
 
@@ -85,16 +85,16 @@
 (rf/reg-event :hicasso.fb/seed (fn [_ [_ title]] {:db {:title title}}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- fresh!
   "Two frames holding different values, because frame isolation is what
   the placeholder rows are read against."
   []
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-a})
   (rf/make-frame {:id frame-b})
   (rf/with-frame frame-a (rf/dispatch-sync [:hicasso.fb/seed "ALPHA"]))
@@ -111,15 +111,15 @@
   fallback and nothing else."
   (react/createContext "unset"))
 
-(h/defview fallback-view
+(rf.hicasso/defview fallback-view
   "A `defview` head written into a fallback — the whole question."
   [_]
-  [:section.fb-view [:h2.sub (collector/sub [:hicasso.fb/title])]])
+  [:section.fb-view [:h2.sub (rf.hicasso.impl.collector/sub [:hicasso.fb/title])]])
 
 (defn- inner-component [_props]
   (react/createElement "i" #js {:className "inner"} "INNER"))
 
-(h/defhost inner-host
+(rf.hicasso/defhost inner-host
   "A `defhost` head written into a fallback — a second deferring head, so
   the rule is not a `defview` fact."
   inner-component
@@ -139,12 +139,12 @@
   "One declaration, made HERE rather than at the top level, so a row that
   is about the declaration can put its own hiccup in it."
   [host-name fallback]
-  (codec/mint-host! host-name (.-Provider theme-context)
+  (rf.hicasso.impl.codec/mint-host! host-name (.-Provider theme-context)
                     {:fallback fallback}))
 
 (defn- server-html [frame hiccup]
   (react-dom-server/renderToString
-    (mount/provider frame (codec/root-element frame hiccup))))
+    (rf.hicasso.impl.mount/provider frame (rf.hicasso.impl.codec/root-element frame hiccup))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — what the mint-time WALK can see, it refuses (unchanged by the ruling)
@@ -166,7 +166,7 @@
             declaration is, which is outside any render"
     (is (= :rf.error/hicasso-sub-outside-render
            (error-id #(host-with-fallback "fb/sub"
-                                          [:div (collector/sub [:hicasso.fb/title])])))))
+                                          [:div (rf.hicasso.impl.collector/sub [:hicasso.fb/title])])))))
   (testing "and hiccup that is not hiccup, which is the property the walk
             was moved to the declaration FOR"
     (is (= :rf.error/hicasso-empty-vector

--- a/implementation/hicasso/test/re_frame/hicasso/file_input_value_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/file_input_value_dom_cljs_test.cljs
@@ -36,8 +36,8 @@
   document; the real-control rows are skipped there rather than faked,
   the same shape `controlled_dom_cljs_test` uses for its caret rows."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.intent :as intent]))
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]))
 
 (defn- browser? []
   (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
@@ -136,10 +136,10 @@
            model, and a file input with no :value at all is the supported
            path — uncontrolled, with the selection read off `.files` in an
            h/event. The codec lowers both without comment."
-    (is (nil? (thrown-by #(codec/as-element
+    (is (nil? (thrown-by #(rf.hicasso.impl.codec/as-element
                            [:input {:type :file :value ""
                                     :on-change noop-change}]))))
-    (is (nil? (thrown-by #(codec/as-element
+    (is (nil? (thrown-by #(rf.hicasso.impl.codec/as-element
                            [:input {:type :file :on-change noop-change}]))))))
 
 (deftest every-other-controlled-field-is-untouched
@@ -154,7 +154,7 @@
                      :on-change noop-change}]]
            ["a textarea" [:textarea {:value "x" :on-input noop-change}]]
            ["a select" [:select {:value "x" :on-change noop-change}]]]]
-    (is (nil? (thrown-by #(codec/as-element hiccup))) what)))
+    (is (nil? (thrown-by #(rf.hicasso.impl.codec/as-element hiccup))) what)))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — THE MARKER
@@ -168,7 +168,7 @@
           "the stand-in is the platform's rule written down")
       (is (= :rf.error/hicasso-file-input-value-marker
              (id-of (thrown-by
-                     #(intent/materialize [:app/upload :re-frame.hicasso/value]
+                     #(rf.hicasso.impl.intent/materialize [:app/upload :re-frame.hicasso/value]
                                           (ev target)))))
           "the marker used to lower to that string")))
   (testing "three files picked: it names the FIRST, and discards the rest"
@@ -176,7 +176,7 @@
       (is (= "C:\\fakepath\\a.csv" (.-value target)))
       (is (= :rf.error/hicasso-file-input-value-marker
              (id-of (thrown-by
-                     #(intent/materialize [:app/upload :re-frame.hicasso/value]
+                     #(rf.hicasso.impl.intent/materialize [:app/upload :re-frame.hicasso/value]
                                           (ev target))))))))
   (testing "nothing picked is refused too — the control is the wrong one
            for this marker whatever it currently holds, and a refusal that
@@ -186,7 +186,7 @@
       (is (= "" (.-value target)))
       (is (= :rf.error/hicasso-file-input-value-marker
              (id-of (thrown-by
-                     #(intent/materialize [:app/upload :re-frame.hicasso/value]
+                     #(rf.hicasso.impl.intent/materialize [:app/upload :re-frame.hicasso/value]
                                           (ev target)))))))))
 
 (deftest the-checked-marker-is-not-the-value-marker
@@ -194,7 +194,7 @@
            this reader and is not refused by it"
     (let [target #js {:files (array) :checked true}]
       (is (= [:app/pick true]
-             (intent/materialize [:app/pick :re-frame.hicasso/checked]
+             (rf.hicasso.impl.intent/materialize [:app/pick :re-frame.hicasso/checked]
                                  (ev target)))))))
 
 (deftest the-marker-is-untouched-on-every-other-control
@@ -213,7 +213,7 @@
               ["a" "c"]]
              ["a single <select>" #js {:value "urgent"} "urgent"]]]
       (is (= [:app/pick expected]
-             (intent/materialize [:app/pick :re-frame.hicasso/value]
+             (rf.hicasso.impl.intent/materialize [:app/pick :re-frame.hicasso/value]
                                  (ev target)))
           what))))
 
@@ -229,7 +229,7 @@
           (is (= 0 (.-length (.-files n))))
           (is (= :rf.error/hicasso-file-input-value-marker
                  (id-of (thrown-by
-                         #(intent/materialize
+                         #(rf.hicasso.impl.intent/materialize
                            [:app/upload :re-frame.hicasso/value] (ev n)))))))
         (testing "and with a file selected, the engine's own answer is the
                  fakepath fiction the spec mandates"
@@ -243,7 +243,7 @@
                    `.files`, which is what an h/event reads")
               (is (= :rf.error/hicasso-file-input-value-marker
                      (id-of (thrown-by
-                             #(intent/materialize
+                             #(rf.hicasso.impl.intent/materialize
                                [:app/upload :re-frame.hicasso/value]
                                (ev n)))))))))
         (finally (drop! n))))))
@@ -271,7 +271,7 @@
               "so the discriminator the marker reads is present, unshouted")
           (is (= :rf.error/hicasso-file-input-value-marker
                  (id-of (thrown-by
-                         #(intent/materialize
+                         #(rf.hicasso.impl.intent/materialize
                            [:app/upload :re-frame.hicasso/value] (ev n)))))
               "and the marker refusal fires at this spelling exactly as at
                the lowercase one — it always did")

--- a/implementation/hicasso/test/re_frame/hicasso/first_registration_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/first_registration_cljs_test.cljs
@@ -55,12 +55,12 @@
   writes thereafter. That is this file, and it is one row plus the control
   that makes the row attributable."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::first-registration)
 
@@ -71,17 +71,17 @@
 (rf/reg-event :firstreg/bump (fn [{:keys [db]} _] {:db (update db :late inc)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (def ^:private late-key [frame-id [:firstreg/late]])
 
 (defn- seeded!
   []
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:firstreg/seed {:late 5}]))
   frame-id)
@@ -90,8 +90,8 @@
   "One body run reading the late-registered key, and what it saw."
   []
   (let [!seen (volatile! ::unread)]
-    (collector/render-body frame-id
-                           (fn [_] (vreset! !seen (collector/sub [:firstreg/late])) [:p])
+    (rf.hicasso.impl.collector/render-body frame-id
+                           (fn [_] (vreset! !seen (rf.hicasso.impl.collector/sub [:firstreg/late])) [:p])
                            {})
     @!seen))
 
@@ -100,13 +100,13 @@
   late-registered key."
   []
   (let [!seen   (volatile! ::unread)
-        _       (collector/render-body
+        _       (rf.hicasso.impl.collector/render-body
                   frame-id
-                  (fn [_] (vreset! !seen (collector/sub [:firstreg/late])) [:p])
+                  (fn [_] (vreset! !seen (rf.hicasso.impl.collector/sub [:firstreg/late])) [:p])
                   {})
-        entry    (collector/last-reads)
+        entry    (rf.hicasso.impl.collector/last-reads)
         !notified (volatile! 0)
-        release  (collector/commit-boundary! entry (fn [] (vswap! !notified inc)))]
+        release  (rf.hicasso.impl.collector/commit-boundary! entry (fn [] (vswap! !notified inc)))]
     {:value @!seen :entry entry :notified !notified :release release}))
 
 (deftest a-cell-holding-an-unregistered-ids-recovery-is-repaired-by-the-first-registration
@@ -120,7 +120,7 @@
                 the substrate declined to cache, cached anyway, where
                 nothing evicts it"
         (is (nil? value))
-        (is (some? (runtime/cell-reaction late-key))))
+        (is (some? (rf.hicasso.test.runtime/cell-reaction late-key))))
 
       ;; NEGATIVE CONTROL, taken FIRST, so the drop measured below is
       ;; attributable to registering THIS id rather than to the mere fact
@@ -128,7 +128,7 @@
       ;; holding the id being registered, and this is the assertion that
       ;; makes that narrowing a measured property.
       (rf/reg-sub :firstreg/unrelated (fn [db _] (:late db)))
-      (is (some? (runtime/cell-reaction late-key))
+      (is (some? (rf.hicasso.test.runtime/cell-reaction late-key))
           "an unrelated first registration leaves this cell's reaction in place")
 
       (let [notified-before @notified]
@@ -140,7 +140,7 @@
 
         (testing "synchronously the held recovery is dropped — the repair's
                   first phase, which is all a correct READ needs"
-          (is (nil? (runtime/cell-reaction late-key))))
+          (is (nil? (rf.hicasso.test.runtime/cell-reaction late-key))))
 
         (testing "and a body run inside the window already answers with the
                   real handler, because a cell with no reaction takes the
@@ -148,8 +148,8 @@
                   is live now"
           (is (= 5 (read-late!))))
 
-        (support/at-the-checkpoint
-          #(some? (runtime/cell-reaction late-key))
+        (rf.hicasso.checkpoint-support/at-the-checkpoint
+          #(some? (rf.hicasso.test.runtime/cell-reaction late-key))
           "the first-registration repair"
           done
           (fn [_turns]
@@ -158,7 +158,7 @@
                       to correct itself — it painted nil, and a correction
                       that arrived in a later task could arrive after the
                       paint"
-              (is (some? (runtime/cell-reaction late-key)))
+              (is (some? (rf.hicasso.test.runtime/cell-reaction late-key)))
               (is (> @notified notified-before)))
 
             (testing "and the property the repair exists for: a LATER write
@@ -167,7 +167,7 @@
                       the mount, so the page rendered, painted, errored
                       nowhere, and never moved again"
               (let [before @notified]
-                (collector/dispatch! frame-id [:firstreg/bump])
+                (rf.hicasso.impl.collector/dispatch! frame-id [:firstreg/bump])
                 (is (= (inc before) @notified))))
 
             (testing "reading through the repaired cell answers the moved

--- a/implementation/hicasso/test/re_frame/hicasso/foreign_root_bridge_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/foreign_root_bridge_dom_cljs_test.cljs
@@ -68,16 +68,16 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [reagent.core :as r]
             [reagent.dom.client :as rdc]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.roots-frames-support :as support]
-            [re-frame.registrar :as rf-registrar]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.test-support :as rf.test-support]
             [uix.core :as uix :refer-macros [defui]]
             ["react" :as react]
             ["react-dom" :as react-dom]
@@ -92,7 +92,7 @@
 (rf/reg-sub ::counter (fn [db _] (or (:n db) 0)))
 (rf/reg-event ::bump (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
 
-(h/defview card
+(rf.hicasso/defview card
   "One ordinary boundary, reached by every route below. It reads a
   subscription, so the frame it resolved is observable on screen, and it
   bumps a counter, so a re-render is a NUMBER rather than an appearance —
@@ -100,12 +100,12 @@
   missing notification from a stale read."
   [props]
   (swap! !runs inc)
-  [:article {:data-test "card"} (str (:label props) "/" (h/sub [::counter]))])
+  [:article {:data-test "card"} (str (:label props) "/" (rf.hicasso/sub [::counter]))])
 
 (def ^:private bridged
   "THE OUTWARD BRIDGE, minted once at top level beside the view it
   bridges — the law, because it allocates a component."
-  (h/as-component card))
+  (rf.hicasso/as-component card))
 
 (def ^:private memo-bridged (react/memo bridged))
 
@@ -118,8 +118,8 @@
   (uix/$ :div (uix/$ bridged {:label label})))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil
      ;; §3 is an `(async done …)` row and `cljs.test` runs one only under a
      ;; MAP-form fixture. `:async? true` selects that shape; with
@@ -127,9 +127,9 @@
      ;; keep the behaviour they had under the fn-form.
      :async?        true
      :init-fn       (fn []
-                      (support/leave-act-environment!)
+                      (rf.hicasso.roots-frames-support/leave-act-environment!)
                       (reset! !runs 0)
-                      (collector/reset-runtime!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -155,14 +155,14 @@
   (some-> (.querySelector node "[data-test=\"card\"]") .-textContent))
 
 (defn- readers-of [frame-kw]
-  (count (runtime/cell-readers [frame-kw [::counter]])))
+  (count (rf.hicasso.test.runtime/cell-readers [frame-kw [::counter]])))
 
 (defn- wired?
   "Does this frame's cell hold a live reaction? The cell is the only thing
   a watch can hang off, so this is the commit-owned fact a repaint
   depends on — and it is readable before any DOM is."
   [frame-kw]
-  (some? (some-> ^js (get @collector/!cells [frame-kw [::counter]]) (.-reaction))))
+  (some? (some-> ^js (get @rf.hicasso.impl.collector/!cells [frame-kw [::counter]]) (.-reaction))))
 
 ;; ---------------------------------------------------------------------------
 ;; The five routes — one boundary, one subscription, one adapter, one drain
@@ -171,8 +171,8 @@
 (defn- hicasso-root
   "THE CONTROL. Hicasso's own root door, and no crossing at all."
   [node frame-kw]
-  (let [handle (h/mount! node {:frame frame-kw} [card {:label "ctl"}])]
-    (fn [] (try (h/unmount! handle) (catch :default _ nil)))))
+  (let [handle (rf.hicasso/mount! node {:frame frame-kw} [card {:label "ctl"}])]
+    (fn [] (try (rf.hicasso/unmount! handle) (catch :default _ nil)))))
 
 (defn- reagent-root-as-element
   "The bead's route 2: a REAGENT root, `rf/frame-provider` above, and the
@@ -183,7 +183,7 @@
       (fn []
         (rdc/render root
                     [rf/frame-provider {:frame frame-kw}
-                     [:div.reagent-parent (h/as-element [card {:label "alpha"}])]])))
+                     [:div.reagent-parent (rf.hicasso/as-element [card {:label "alpha"}])]])))
     (fn [] (try (.unmount root) (catch :default _ nil)))))
 
 (defn- reagent-root-as-component
@@ -208,10 +208,10 @@
   (let [root (react-dom-client/createRoot node)]
     (react-dom/flushSync
       (fn []
-        (.render root (mount/provider frame-kw
+        (.render root (rf.hicasso.impl.mount/provider frame-kw
                                       (react/createElement
                                         "div" nil
-                                        (h/as-element [card {:label "plain"}]))))))
+                                        (rf.hicasso/as-element [card {:label "plain"}]))))))
     (fn [] (try (.unmount root) (catch :default _ nil)))))
 
 (defn- uix-parent-plain-root
@@ -221,7 +221,7 @@
   (let [root (react-dom-client/createRoot node)]
     (react-dom/flushSync
       (fn []
-        (.render root (mount/provider frame-kw (uix/$ uix-parent {:label "uix"})))))
+        (.render root (rf.hicasso.impl.mount/provider frame-kw (uix/$ uix-parent {:label "uix"})))))
     (fn [] (try (.unmount root) (catch :default _ nil)))))
 
 (def ^:private routes
@@ -251,12 +251,12 @@
             was a missing NOTIFICATION rather than a stale read, so the
             reading that answers it is the one that says the body was
             invoked again."
-    (if-not (mount/browser?)
-      (support/skip! ":node-test has no DOM")
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM")
       (doseq [{:keys [route frame label mount]} routes]
         (testing (str route)
           (seat! frame 1)
-          (let [node (mount/fresh-container!)
+          (let [node (rf.hicasso.impl.mount/fresh-container!)
                 stop (mount node frame)]
             (try
               (is (= (str label "/1") (text-of node))
@@ -297,17 +297,17 @@
   window is genuinely open."
   [frame-kw mount-fn]
   (seat! frame-kw 1)
-  (let [node (mount/fresh-container!)
+  (let [node (rf.hicasso.impl.mount/fresh-container!)
         stop (mount-fn node frame-kw)]
     (stop))
   ;; A first-time `reg-sub` of a query a live cell holds. The registrar
   ;; clear is what makes it first-time; a fixture, a lazily loaded module
   ;; and a hot reload all reach the same hook.
-  (rf-registrar/clear-all!)
+  (rf.registrar/clear-all!)
   (rf/reg-sub ::counter (fn [db _] (or (:n db) 0)))
   (rf/reg-event ::bump (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
-  (reset! frame/frames {})
-  (frame/ensure-default-frame!)
+  (reset! rf.frame/frames {})
+  (rf.frame/ensure-default-frame!)
   (seat! frame-kw 1)
   nil)
 
@@ -331,21 +331,21 @@
             the cell at the microtask checkpoint, so a row that yielded
             first would be green either way and would be measuring the
             deferral rather than the acquire."
-    (if-not (mount/browser?)
-      (support/skip! ":node-test has no DOM")
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM")
       (doseq [[label frame mount-fn painted]
               [["h/mount!"         ::w1 hicasso-root           "ctl"]
                ["a Reagent parent" ::w2 reagent-root-as-element "alpha"]]]
         (testing label
           (open-the-window! frame mount-fn)
-          (is (contains? (support/cell-keys) [frame [::counter]])
+          (is (contains? (rf.hicasso.roots-frames-support/cell-keys) [frame [::counter]])
               "PRECONDITION: the cell is still in the table — its reaper is
                a macrotask and nothing has yielded")
           (is (not (wired? frame))
               "PRECONDITION: and its reaction has been dropped. Without
                this the row mounts against an ordinary live cell and
                proves nothing")
-          (let [node (mount/fresh-container!)
+          (let [node (rf.hicasso.impl.mount/fresh-container!)
                 stop (mount-fn node frame)]
             (try
               (is (wired? frame)
@@ -392,7 +392,7 @@
   it. `label` is a PROP, so a server/client divergence is a
   one-argument change rather than a second app."
   [frame-kw label]
-  (mount/provider frame-kw (react/createElement bridged #js {"label" label})))
+  (rf.hicasso.impl.mount/provider frame-kw (react/createElement bridged #js {"label" label})))
 
 (defn- consumer-server-bytes!
   "The markup a consumer's own server render would deliver for the bridged
@@ -400,7 +400,7 @@
   an ordinary root and unmounted, so nothing of that render survives into
   the reading."
   [frame-kw label]
-  (let [node (mount/fresh-container!)
+  (let [node (rf.hicasso.impl.mount/fresh-container!)
         root (react-dom-client/createRoot node)]
     (react-dom/flushSync (fn [] (.render root (consumer-element frame-kw label))))
     (let [html (.-innerHTML node)]
@@ -423,14 +423,14 @@
   (let [frame ::hydrate-consumer]
     (seat! frame 1)
     (let [html (consumer-server-bytes! frame "srv")]
-      (collector/reset-runtime!)
-      (let [node                      (support/server-dom! html)
-            {:keys [seen stop!]}      (support/watch-mismatches!)
-            {:keys [captured close!]} (support/open-console-capture!
+      (rf.hicasso.impl.collector/reset-runtime!)
+      (let [node                      (rf.hicasso.roots-frames-support/server-dom! html)
+            {:keys [seen stop!]}      (rf.hicasso.roots-frames-support/watch-mismatches!)
+            {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture!
                                         {:swallow-uncaught? true})
             root                      (react-dom-client/hydrateRoot
                                         node (consumer-element frame "cli"))]
-        (-> (support/wait-until! #(= "cli/1" (text-of node)))
+        (-> (rf.hicasso.roots-frames-support/wait-until! #(= "cli/1" (text-of node)))
             (.then
               (fn [recovered?]
                 (close!)
@@ -447,7 +447,7 @@
                           built this root, so no re-frame2 door set
                           `onRecoverableError` and Spec 011's diagnostic has
                           nowhere to fire from; got "
-                         (pr-str (mapv (comp :error support/tags-of) @seen))))
+                         (pr-str (mapv (comp :error rf.hicasso.roots-frames-support/tags-of) @seen))))
                 (try (.unmount root) (catch :default _ nil))
                 true)))))))
 
@@ -457,15 +457,15 @@
   []
   (let [frame ::hydrate-package]
     (seat! frame 1)
-    (let [html (support/server-html! frame [card {:label "own-srv"}])]
-      (collector/reset-runtime!)
-      (let [node                      (support/server-dom! html)
-            {:keys [seen stop!]}      (support/watch-mismatches!)
-            {:keys [captured close!]} (support/open-console-capture!
+    (let [html (rf.hicasso.roots-frames-support/server-html! frame [card {:label "own-srv"}])]
+      (rf.hicasso.impl.collector/reset-runtime!)
+      (let [node                      (rf.hicasso.roots-frames-support/server-dom! html)
+            {:keys [seen stop!]}      (rf.hicasso.roots-frames-support/watch-mismatches!)
+            {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture!
                                         {:swallow-uncaught? true})
-            handle                    (mount/hydrate-root!
+            handle                    (rf.hicasso.impl.mount/hydrate-root!
                                         node frame [card {:label "own-cli"}])]
-        (-> (support/adopted! handle)
+        (-> (rf.hicasso.roots-frames-support/adopted! handle)
             (.then
               (fn [adopted?]
                 (close!)
@@ -480,16 +480,16 @@
                      zero above is the absence of a REPORTER, not of a listener")
                 (doseq [ev @seen]
                   (is (= 're-frame.hicasso.impl.mount/hydrate-root!
-                         (:where (support/tags-of ev)))
+                         (:where (rf.hicasso.roots-frames-support/tags-of ev)))
                       "and what fired is tier-discriminated by the door that
                        opened the root"))
-                (mount/unmount! handle)
+                (rf.hicasso.impl.mount/unmount! handle)
                 true)))))))
 
 (deftest a-consumer-built-root-hydrates-a-bridged-subtree-with-no-framework-reporter
   (async done
-    (if-not (mount/browser?)
-      (do (support/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (-> (consumer-arm!)
           (.then (fn [_] (package-arm!)))
           (.then (fn [_] (done)))

--- a/implementation/hicasso/test/re_frame/hicasso/forms_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/forms_cljs_test.cljs
@@ -37,25 +37,25 @@
   would be green against a module that had stopped using it."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
+            [re-frame.error-emit :as rf.error-emit]
             ;; Side-effecting: the `:dispatch` fx a commit hands the
             ;; caller's event to. The module names it too; a suite that
             ;; relied on some other namespace having loaded it would be
             ;; asserting about the bundle rather than about the module.
             [re-frame.fx]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.forms :as forms]
-            [re-frame.hicasso.hook-probe :as probe]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.forms :as tf]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.forms :as rf.hicasso.forms]
+            [re-frame.hicasso.hook-probe :as rf.hicasso.hook-probe]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.forms :as rf.hicasso.test.forms]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom/server" :as react-dom-server]))
 
 ;; ---------------------------------------------------------------------------
@@ -125,25 +125,25 @@
 (rf/reg-event ::typed
   (fn [{:keys [db]} [_ v]] {:db (assoc-in db [:todo 7 :title] v)}))
 
-(h/defview hand-written-field
+(rf.hicasso/defview hand-written-field
   "A controlled field written BY HAND — the arrangement `buffered-field`
   replaces, minus the buffering. One boundary, one read, one controlled
   element."
   [_]
-  [:input {:type "text" :value (h/sub [::title]) :on-input [::typed ::h/value]}])
+  [:input {:type "text" :value (rf.hicasso/sub [::title]) :on-input [::typed ::rf.hicasso/value]}])
 
-(h/defview uncontrolled-field
+(rf.hicasso/defview uncontrolled-field
   "The same boundary and the same read over an UNCONTROLLED element, so
   §5's third hook can be shown to belong to the controlled element rather
   than to the shell."
   [_]
-  [:input {:type "text" :placeholder (h/sub [::title])}])
+  [:input {:type "text" :placeholder (rf.hicasso/sub [::title])}])
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Driving one, and reading what it would show
@@ -155,7 +155,7 @@
 
 (defn- db-of [frame] (rf/app-db-value frame))
 (defn- send! [frame event-v] (rf/dispatch-sync event-v {:frame frame}))
-(defn- draft-at [frame ctl] (rf/subscribe-once [forms/drafts ctl] {:frame frame}))
+(defn- draft-at [frame ctl] (rf/subscribe-once [rf.hicasso.forms/drafts ctl] {:frame frame}))
 (defn- record-of [frame] (draft-at frame control))
 (defn- title-of [frame] (get-in (db-of frame) [:todo 7 :title]))
 (defn- revision-of [frame] (get-in (db-of frame) [:todo 7 :title-revision]))
@@ -163,15 +163,15 @@
 (defn- cancelled-log [frame] (vec (:cancelled (db-of frame))))
 
 (defn- type! [frame revision text]
-  (send! frame [tf/edit-id control revision text]))
+  (send! frame [rf.hicasso.test.forms/edit-id control revision text]))
 
 (defn- commit! [frame revision]
-  (send! frame [tf/commit-id control revision [::title-committed 7]]))
+  (send! frame [rf.hicasso.test.forms/commit-id control revision [::title-committed 7]]))
 
 (defn- cancel!
   ([frame revision] (cancel! frame revision nil))
   ([frame revision on-cancel]
-   (send! frame [tf/cancel-id control revision on-cancel])))
+   (send! frame [rf.hicasso.test.forms/cancel-id control revision on-cancel])))
 
 (defn- field-tree
   "One `buffered-field` body, under its EXACT read set. `ht/tree` refuses
@@ -179,13 +179,13 @@
   out — and a body that grew a second read would red this file rather
   than quietly cost a re-render per keystroke."
   [props record]
-  (ht/tree [forms/buffered-field (merge {:control   control
+  (rf.hicasso.test/tree [rf.hicasso.forms/buffered-field (merge {:control   control
                                          :value     committed
                                          :on-commit [::title-committed 7]}
                                         props)]
-           {:subs {[forms/drafts control] record}}))
+           {:subs {[rf.hicasso.forms/drafts control] record}}))
 
-(defn- input-attrs [tree] (ht/attrs (ht/find tree #(= :input (:tag %)))))
+(defn- input-attrs [tree] (rf.hicasso.test/attrs (rf.hicasso.test/find tree #(= :input (:tag %)))))
 
 (defn- shown
   "What the field would DISPLAY for `record` under `revision`, against a
@@ -194,7 +194,7 @@
   leave this helper agreeing with it."
   ([record revision] (shown record revision committed))
   ([record revision value]
-   (:value (input-attrs (field-tree {::h/revision revision :value value} record)))))
+   (:value (input-attrs (field-tree {::rf.hicasso/revision revision :value value} record)))))
 
 (defn- shown-now
   "What the field shows against this frame's own record, revision and
@@ -212,10 +212,10 @@
   names that trap at length; this is its narrow form."
   [thunk]
   (let [records (volatile! [])]
-    (error-emit/register-error-listener! ::forms (fn [r] (vswap! records conj r)))
+    (rf.error-emit/register-error-listener! ::forms (fn [r] (vswap! records conj r)))
     (try
       (try (thunk) (catch :default _ nil))
-      (finally (error-emit/unregister-error-listener! ::forms)))
+      (finally (rf.error-emit/unregister-error-listener! ::forms)))
     (->> (concat (map (comp ex-data :exception) @records)
                  (map (comp ex-data ex-cause :exception) @records))
          (filter #(some-> % :rf.error/id namespace (= "rf.error")))
@@ -232,8 +232,8 @@
   ;; is the other end of the pin: the written spelling really is this
   ;; namespace's own `::drafts`, so a namespace rename cannot leave the
   ;; gate scanning for a string nobody emits any more.
-  (is (= ::forms/drafts forms/drafts))
-  (is (= "re-frame.hicasso.forms/drafts" (str (symbol forms/drafts)))))
+  (is (= ::rf.hicasso.forms/drafts rf.hicasso.forms/drafts))
+  (is (= "re-frame.hicasso.forms/drafts" (str (symbol rf.hicasso.forms/drafts)))))
 
 (deftest the-draft-does-not-live-at-the-control-address
   (with-app
@@ -241,7 +241,7 @@
       (type! frame 0 "Buy oat milk")
       (testing "the record is under the MODULE's key, addressed by the control"
         (is (= {:revision 0 :draft "Buy oat milk"}
-               (get-in (db-of frame) [:ui ::forms/drafts control]))
+               (get-in (db-of frame) [:ui ::rf.hicasso.forms/drafts control]))
             "the chapter's `app-db` promise, literally: the draft appears
              in snapshots, headless tests and Xray, at an address a reader
              can predict from the props it wrote"))
@@ -430,7 +430,7 @@
   (with-app
     (fn [frame]
       (type! frame 0 "Buy oat milk")
-      (send! frame [tf/commit-id control 0 nil])
+      (send! frame [rf.hicasso.test.forms/commit-id control 0 nil])
       (is (nil? (record-of frame)))
       (is (= [] (committed-log frame))
           "`:on-commit` is required by the chapter, and this module cannot
@@ -447,7 +447,7 @@
   (with-app
     (fn [frame]
       (type! frame 0 "abandoned on navigation")
-      (send! frame [:re-frame.hicasso/clear forms/drafts control])
+      (send! frame [:re-frame.hicasso/clear rf.hicasso.forms/drafts control])
       (is (nil? (record-of frame)))
       (is (= {} (:ui (db-of frame)))
           "and the concern map is pruned rather than left holding an empty
@@ -468,12 +468,12 @@
   ;; shares, and two rows open together with nothing on screen to say so.
   (with-app
     (fn [frame]
-      (send! frame [tf/edit-id [:todo 7 :title] 0 "seven"])
-      (send! frame [tf/edit-id [:todo 8 :title] 0 "eight"])
+      (send! frame [rf.hicasso.test.forms/edit-id [:todo 7 :title] 0 "seven"])
+      (send! frame [rf.hicasso.test.forms/edit-id [:todo 8 :title] 0 "eight"])
       (is (= "seven" (:draft (draft-at frame [:todo 7 :title]))))
       (is (= "eight" (:draft (draft-at frame [:todo 8 :title]))))
       (testing "and one field's commit does not end the other's session"
-        (send! frame [tf/commit-id [:todo 7 :title] 0 [::title-committed 7]])
+        (send! frame [rf.hicasso.test.forms/commit-id [:todo 7 :title] 0 [::title-committed 7]])
         (is (nil? (draft-at frame [:todo 7 :title])))
         (is (some? (draft-at frame [:todo 8 :title])))))))
 
@@ -488,7 +488,7 @@
         (is (some? d) "a nil control refuses rather than sharing a draft")
         (is (= :rf.error/hicasso-state-bad-argument (:rf.error/id d))
             "by an id that is already shipped and already catalogued")
-        (is (= ::forms/drafts (:concern d))
+        (is (= ::rf.hicasso.forms/drafts (:concern d))
             "and it names THIS module's concern, so the message points at
              the field the author wrote")))))
 
@@ -528,18 +528,18 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-field-renders-value-revision-and-three-intents
-  (let [attrs (input-attrs (field-tree {::h/revision 4} nil))]
+  (let [attrs (input-attrs (field-tree {::rf.hicasso/revision 4} nil))]
     (is (= committed (:value attrs)) "no record, so the committed value")
-    (is (= 4 (::h/revision attrs))
+    (is (= 4 (::rf.hicasso/revision attrs))
         "the caller's revision reaches the element — this module adds no
          reset vocabulary of its own and forwards the controlled law's")
-    (is (= [tf/edit-id control 4 ::h/value] (:on-input attrs))
+    (is (= [rf.hicasso.test.forms/edit-id control 4 ::rf.hicasso/value] (:on-input attrs))
         "the keystroke carries the address and the generation it was typed
          under — POSITIONAL, because a marker inside a payload map is
          substituted nowhere and would arrive as the keyword itself")
-    (is (= [tf/commit-id control 4 [::title-committed 7]] (:on-blur attrs)))
-    (is (= {"Enter"  [tf/commit-id control 4 [::title-committed 7]]
-            "Escape" [tf/cancel-id control 4 nil]}
+    (is (= [rf.hicasso.test.forms/commit-id control 4 [::title-committed 7]] (:on-blur attrs)))
+    (is (= {"Enter"  [rf.hicasso.test.forms/commit-id control 4 [::title-committed 7]]
+            "Escape" [rf.hicasso.test.forms/cancel-id control 4 nil]}
            (:on-key-down attrs))
         "the key MAP, not a callback reading `.key` — which is what keeps
          the substrate's own composition gate, and why this file finds no
@@ -558,13 +558,13 @@
   ;; `ht/controlled?` and `ht/revision` ask the RUNTIME which component
   ;; the codec installs and what it read pre-merge, so this is the
   ;; substrate's own answer rather than a re-reading of what was written.
-  (let [form [:input {:type "text" :value committed ::h/revision 4
-                      :on-input [tf/edit-id control 4 ::h/value]}]]
-    (is (true? (ht/controlled? form)))
-    (is (= 4 (ht/revision form)))))
+  (let [form [:input {:type "text" :value committed ::rf.hicasso/revision 4
+                      :on-input [rf.hicasso.test.forms/edit-id control 4 ::rf.hicasso/value]}]]
+    (is (true? (rf.hicasso.test/controlled? form)))
+    (is (= 4 (rf.hicasso.test/revision form)))))
 
 (deftest other-props-pass-through-and-the-owned-slots-do-not
-  (let [attrs (input-attrs (field-tree {::h/revision 0
+  (let [attrs (input-attrs (field-tree {::rf.hicasso/revision 0
                                         :on-cancel   [::title-cancelled 7]
                                         :placeholder "What needs doing?"
                                         :class       "title"
@@ -588,7 +588,7 @@
           "`:control` on a DOM node is a React warning at best and a
            serialized vector in the markup at worst"))
     (testing "`:on-cancel` reached the Escape branch instead"
-      (is (= [tf/cancel-id control 0 [::title-cancelled 7]]
+      (is (= [rf.hicasso.test.forms/cancel-id control 0 [::title-cancelled 7]]
              (get (:on-key-down attrs) "Escape"))))))
 
 (deftest the-owned-slots-win-a-collision
@@ -596,15 +596,15 @@
   ;; it. A caller who writes `:value` has misunderstood the field rather
   ;; than configured it, and the field's answer is to keep owning the slot
   ;; rather than to render a value nothing can update.
-  (let [attrs (input-attrs (field-tree {::h/revision 0
+  (let [attrs (input-attrs (field-tree {::rf.hicasso/revision 0
                                         :value       "written by the caller"
                                         :on-input    [:app/typed]
                                         :on-blur     [:app/blurred]
                                         :on-key-down {"Enter" [:app/entered]}}
                                        {:revision 0 :draft "half typed"}))]
     (is (= "half typed" (:value attrs)))
-    (is (= [tf/edit-id control 0 ::h/value] (:on-input attrs)))
-    (is (= [tf/commit-id control 0 [::title-committed 7]] (:on-blur attrs)))
+    (is (= [rf.hicasso.test.forms/edit-id control 0 ::rf.hicasso/value] (:on-input attrs)))
+    (is (= [rf.hicasso.test.forms/commit-id control 0 [::title-committed 7]] (:on-blur attrs)))
     (is (= #{"Enter" "Escape"} (set (keys (:on-key-down attrs)))))))
 
 (deftest trap-arity-sniffed-done-fn-every-handler-site-is-data
@@ -615,19 +615,19 @@
   ;; `ht/tree` installs no React dispatcher, so a body holding local state
   ;; would not have run — a statement by the instrument rather than by the
   ;; author.
-  (let [trees  [(field-tree {::h/revision 0} nil)
-                (field-tree {::h/revision 0 :on-cancel [::title-cancelled 7]}
+  (let [trees  [(field-tree {::rf.hicasso/revision 0} nil)
+                (field-tree {::rf.hicasso/revision 0 :on-cancel [::title-cancelled 7]}
                             {:revision 0 :draft "half typed"})]
         opaque (for [tree  trees
-                     node  (ht/find-all tree map?)
-                     [k v] (ht/attrs node)
+                     node  (rf.hicasso.test/find-all tree map?)
+                     [k v] (rf.hicasso.test/attrs node)
                      :when (= {:rf.ui/opaque :fn} v)]
                  [(:tag node) k])]
     (is (= [] (vec opaque))
         "not one function-valued prop. Give any slot a `(h/event …)` and this
          row names the tag and the prop it appeared on")
     (testing "and every intent the field offers is a vector of data"
-      (is (= 4 (count (ht/intents (first trees))))
+      (is (= 4 (count (rf.hicasso.test/intents (first trees))))
           "input, blur, Enter, Escape — four sites, four vectors, and the
            Escape one carries a `nil` `:on-cancel` rather than a closure"))))
 
@@ -655,19 +655,19 @@
 (def ^:private frame-id ::forms-hooks)
 
 (defn- server-render! [hiccup]
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [::seed]))
-  (is (true? (probe/install!))
+  (is (true? (rf.hicasso.hook-probe/install!))
       "React's client-internals dispatcher slot was not found — the hook
        budget is UNWITNESSED, not satisfied")
   (let [!html (volatile! nil)
-        hooks (probe/record!
+        hooks (rf.hicasso.hook-probe/record!
                 (fn []
                   (vreset! !html
                            (react-dom-server/renderToString
-                             (mount/provider frame-id
-                                             (codec/root-element frame-id hiccup))))))]
+                             (rf.hicasso.impl.mount/provider frame-id
+                                             (rf.hicasso.impl.codec/root-element frame-id hiccup))))))]
     {:html @!html :hooks hooks}))
 
 (deftest the-third-hook-belongs-to-the-controlled-element-not-to-the-shell
@@ -680,7 +680,7 @@
       (is (some? (re-find #"<input" (:html controlled)))))
     (testing "an uncontrolled element costs the shell's two and nothing"
       (is (= ["useContext" "useSyncExternalStore"] (:hooks bare)))
-      (is (= (count runtime/shell-hook-ledger) (count (:hooks bare)))))
+      (is (= (count rf.hicasso.test.runtime/shell-hook-ledger) (count (:hooks bare)))))
     (testing "a HAND-WRITTEN controlled field costs a third — the shadow
               `useState` the codec's controlled component holds, which
               every controlled field on any page pays and which I9 does
@@ -689,10 +689,10 @@
 
 (deftest the-field-costs-what-a-hand-written-controlled-field-costs
   (let [{:keys [html hooks]} (server-render!
-                               [forms/buffered-field
+                               [rf.hicasso.forms/buffered-field
                                 {:control     control
                                  :value       committed
-                                 ::h/revision 0
+                                 ::rf.hicasso/revision 0
                                  :on-commit   [::title-committed 7]}])]
     (testing "the premise: React really rendered the field"
       (is (some? (re-find #"<input" html))))
@@ -709,6 +709,6 @@
                     (count (:hooks (server-render! [hand-written-field {}])))))))
     (testing "and the shell's ledger did not move — no `useRef`, and the
               one `useState` is the element's rather than a boundary's"
-      (is (= 2 (count runtime/shell-hook-ledger)))
+      (is (= 2 (count rf.hicasso.test.runtime/shell-hook-ledger)))
       (is (= [] (filterv #{"useRef"} hooks)))
       (is (= 1 (count (filterv #{"useState"} hooks)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/forms_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/forms_dom_cljs_test.cljs
@@ -47,13 +47,13 @@
   each row degrades there to a STATED skip rather than a false green."
   (:require [cljs.test :refer-macros [deftest is use-fixtures async]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
             [re-frame.fx]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.forms :as forms]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.forms :as rf.hicasso.forms]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The screen — the chapter's own arrangement
@@ -101,20 +101,20 @@
 (rf/reg-event ::hide (fn [{:keys [db]} _] {:db (assoc db :showing? false)}))
 (rf/reg-event ::show (fn [{:keys [db]} _] {:db (assoc db :showing? true)}))
 
-(h/defview title-field
+(rf.hicasso/defview title-field
   "The chapter's own call site: a parent boundary reads the committed
   value and its revision and hands both down as props."
   [{:keys [id]}]
-  [forms/buffered-field
+  [rf.hicasso.forms/buffered-field
    {:control     [:todo id :title]
-    :value       (h/sub [::title id])
-    ::h/revision (h/sub [::title-revision id])
+    :value       (rf.hicasso/sub [::title id])
+    ::rf.hicasso/revision (rf.hicasso/sub [::title-revision id])
     :on-commit   [::title-committed id]
     :id          "todo-title"
     :class       "title"
     :placeholder "What needs doing?"}])
 
-(h/defview constant-field
+(rf.hicasso/defview constant-field
   "THE CONTROL ARM, and the whole reason the revision row below can fail.
 
   The chapter blesses a constant revision for a field that will never be
@@ -128,27 +128,27 @@
   its drift, the difference between them is the revision and cannot be
   anything else."
   [{:keys [id]}]
-  [forms/buffered-field
+  [rf.hicasso.forms/buffered-field
    {:control     [:todo id :constant]
-    :value       (h/sub [::title id])
-    ::h/revision 0
+    :value       (rf.hicasso/sub [::title id])
+    ::rf.hicasso/revision 0
     :on-commit   [::title-committed id]
     :id          "todo-constant"
     :class       "constant"}])
 
-(h/defview screen
+(rf.hicasso/defview screen
   "Both fields, and a switch that takes the first off the page. The switch
   is read HERE and nowhere else, so toggling it re-renders this body
   alone."
   [_]
   [:main.screen
-   (when (h/sub [::showing?])
+   (when (rf.hicasso/sub [::showing?])
      [title-field {:id todo}])
    [constant-field {:id todo}]])
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The MAP shape, because every row is `async`: `cljs.test` refuses an
      ;; async test under a fn-form fixture and aborts the namespace.
@@ -185,7 +185,7 @@
   [m n v]
   (.call (value-setter) n v)
   (.dispatchEvent n (js/InputEvent. "input" #js {:bubbles true}))
-  (hm/settle! m))
+  (rf.hicasso.test.mounted/settle! m))
 
 (defn- drift!
   "Move the field's value WITHOUT telling React — the foreign write an
@@ -198,19 +198,19 @@
 
 (defn- press! [m n key]
   (.dispatchEvent n (js/KeyboardEvent. "keydown" #js {:key key :bubbles true}))
-  (hm/settle! m))
+  (rf.hicasso.test.mounted/settle! m))
 
-(defn- blur! [m n] (.blur n) (hm/settle! m))
+(defn- blur! [m n] (.blur n) (rf.hicasso.test.mounted/settle! m))
 
 (defn- send! [m event-v] (rf/dispatch-sync event-v {:frame (:frame m)}))
 (defn- title-of [m] (get-in (rf/app-db-value (:frame m)) [:todo todo :title]))
 (defn- record-of [m]
-  (rf/subscribe-once [forms/drafts [:todo todo :title]] {:frame (:frame m)}))
+  (rf/subscribe-once [rf.hicasso.forms/drafts [:todo todo :title]] {:frame (:frame m)}))
 
-(defn- mount! [] (hm/mount! [screen {}] {:initial-events [[::seed]]}))
+(defn- mount! [] (rf.hicasso.test.mounted/mount! [screen {}] {:initial-events [[::seed]]}))
 
 (defn- finish [m done]
-  (-> (hm/unmount! m) (hm/assert-clean!) (.then done)))
+  (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!) (.then done)))
 
 ;; ---------------------------------------------------------------------------
 ;; The commit, on a real node
@@ -297,7 +297,7 @@
         (.focus n)
         (type-into! m n "half typed")
         (send! m [::settle todo "Buy almond milk"])
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (is (= "Buy almond milk" (.-value n))
             "the reset made the draft ineligible immediately — no
              render-time dispatch, and no turn in between showing the
@@ -347,13 +347,13 @@
         (drift! n "autofilled@example.com")
         (drift! c "autofilled@example.com")
         (is (nil? (record-of m)) "no session — neither box holds a draft")
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (is (= "autofilled@example.com" (.-value n))
             "settling alone repairs nothing: no subscription moved, so no
              boundary re-rendered")
         (is (= "autofilled@example.com" (.-value c)))
         (send! m [::bump-revision todo])
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (is (= committed (.-value n))
             "the revision is the only thing that changed, and it is what
              put the model back over the box")
@@ -381,14 +381,14 @@
         (.focus n)
         (type-into! m n "half typed")
         (send! m [::hide])
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (is (nil? (field m)) "the field really left the page")
         (is (= {:revision 0 :draft "half typed"} (record-of m))
             "and the draft is still where it was — unmount neither
              commits nor cancels")
         (is (= committed (title-of m)) "nothing was committed on the way out")
         (send! m [::show])
-        (hm/settle! m)
+        (rf.hicasso.test.mounted/settle! m)
         (let [n2 (field m)]
           (is (some? n2))
           (is (not (identical? n n2)) "a genuinely new node")

--- a/implementation/hicasso/test/re_frame/hicasso/frame_doors_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/frame_doors_cljs_test.cljs
@@ -29,34 +29,34 @@
   nil in the very extent where the door answers, and shows the same
   reader answering one line outside it."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.todo-support :as todo]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.todo-support :as rf.hicasso.todo-support]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; `:ambient-frame nil` for the reason the refusal suite gives: the
      ;; fixture's default leaves a dynamic-var stamp in scope, and tier 1
      ;; wins over everything — so a row claiming the door answered the
      ;; EXTENT's frame would pass for the wrong reason.
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (def ^:private frame-a ::doors-a)
 (def ^:private frame-b ::doors-b)
 
 (defn- frames! []
-  (todo/make-frame! frame-a 3)
-  (todo/make-frame! frame-b 3)
-  (todo/reseed! frame-a 3)
-  (todo/reseed! frame-b 3)
+  (rf.hicasso.todo-support/make-frame! frame-a 3)
+  (rf.hicasso.todo-support/make-frame! frame-b 3)
+  (rf.hicasso.todo-support/reseed! frame-a 3)
+  (rf.hicasso.todo-support/reseed! frame-b 3)
   nil)
 
 (defn- outcome
@@ -73,7 +73,7 @@
   here."
   [frame-kw body-fn]
   (let [seen (volatile! ::unset)]
-    (collector/render-body frame-kw (fn [_] (body-fn seen) [:li]) {})
+    (rf.hicasso.impl.collector/render-body frame-kw (fn [_] (body-fn seen) [:li]) {})
     @seen))
 
 (defn- with-context-frame
@@ -84,7 +84,7 @@
   nil inside a body *anyway*, and the row that needs it would be green
   against a tree with no refusal in it at all."
   [frame-kw thunk]
-  (let [^js ctx  adapter-context/frame-context
+  (let [^js ctx  rf.adapter.context/frame-context
         original (.-_currentValue ctx)]
     (set! (.-_currentValue ctx) frame-kw)
     (try (thunk)
@@ -144,17 +144,17 @@
                                     :read    (outcome #(rf/subscribe [:hicasso.todo/done? 0]))}))]
       ;; Lowered at a NON-event position inside frame-a's body, which is
       ;; what gives it the render contract.
-      (collector/render-body frame-a
+      (rf.hicasso.impl.collector/render-body frame-a
                              (fn [_]
                                (vreset! callback
-                                        (intent/lower-prop :render-row (intent/callback probe)))
+                                        (rf.hicasso.impl.intent/lower-prop :render-row (rf.hicasso.impl.intent/callback probe)))
                                [:li])
                              {})
       (is (some? @callback) "precondition: the render position lowered a wrapper")
 
       (testing "invoked from outside any extent at all — the foreign
                component's own render"
-        (is (not (collector/rendering?))
+        (is (not (rf.hicasso.impl.collector/rendering?))
             "the premise, asserted rather than described: the runtime's own
              render slot is EMPTY at the moment the callback runs")
         (@callback)
@@ -174,7 +174,7 @@
                so the supplying boundary is the only frame that can own
                this call"
         (vreset! seen ::unset)
-        (intent/with-frame frame-b (collector/frame-dispatch frame-b) (fn [] (@callback)))
+        (rf.hicasso.impl.intent/with-frame frame-b (rf.hicasso.impl.collector/frame-dispatch frame-b) (fn [] (@callback)))
         (is (= frame-a (:id @seen))
             "the invoker's frame must not colonise the owner's callback")
         (is (= frame-a (:capture @seen))))
@@ -200,23 +200,23 @@
            sub-key at all. Reads become edges because they are sub-KEYS;
            the frame is not one — it is render-constant per boundary and
            resolved once by the shell"
-    (collector/render-body frame-a (fn [_] [:li (str (rf/current-frame-id))]) {})
-    (is (= [] (vec (runtime/reads-of (collector/last-reads))))))
+    (rf.hicasso.impl.collector/render-body frame-a (fn [_] [:li (str (rf/current-frame-id))]) {})
+    (is (= [] (vec (rf.hicasso.test.runtime/reads-of (rf.hicasso.impl.collector/last-reads))))))
 
   (testing "and adding it to a READING body changes the read set not at
            all — same keys, same order. The control is the point: the
            first row alone would be green for a body that read nothing
            for any reason"
-    (collector/render-body frame-a
-                           (fn [_] [:li (str (collector/sub [:hicasso.todo/done? 0]))])
+    (rf.hicasso.impl.collector/render-body frame-a
+                           (fn [_] [:li (str (rf.hicasso.impl.collector/sub [:hicasso.todo/done? 0]))])
                            {})
-    (let [without (vec (runtime/reads-of (collector/last-reads)))]
-      (collector/render-body frame-a
+    (let [without (vec (rf.hicasso.test.runtime/reads-of (rf.hicasso.impl.collector/last-reads)))]
+      (rf.hicasso.impl.collector/render-body frame-a
                              (fn [_]
                                [:li (str (rf/current-frame-id))
-                                (str (collector/sub [:hicasso.todo/done? 0]))])
+                                (str (rf.hicasso.impl.collector/sub [:hicasso.todo/done? 0]))])
                              {})
-      (let [with (vec (runtime/reads-of (collector/last-reads)))]
+      (let [with (vec (rf.hicasso.test.runtime/reads-of (rf.hicasso.impl.collector/last-reads)))]
         (is (= 1 (count without)) "precondition: the control body read exactly one key")
         (is (= without with)
             (str "the identity read must contribute nothing to the collector: "
@@ -243,12 +243,12 @@
     (let [seen (volatile! ::unset)]
       (with-context-frame frame-a
         (fn []
-          (is (= frame-a (frame/resolve-current-frame))
+          (is (= frame-a (rf.frame/resolve-current-frame))
               "control: tier 2 is genuinely answering out here, so the nil
                below is the withdrawal and not an empty chain")
-          (collector/render-body frame-a
+          (rf.hicasso.impl.collector/render-body frame-a
                                  (fn [_]
-                                   (vreset! seen {:reader (frame/resolve-current-frame)
+                                   (vreset! seen {:reader (rf.frame/resolve-current-frame)
                                                   :door   (rf/current-frame-id)})
                                    [:li])
                                  {})))
@@ -272,7 +272,7 @@
            lands in the wrong place and this row says so"
     (let [carry (fn [frame-kw]
                   (let [held (volatile! nil)]
-                    (collector/render-body frame-kw
+                    (rf.hicasso.impl.collector/render-body frame-kw
                                            (fn [_]
                                              (vreset! held (rf/capture-frame))
                                              [:li])
@@ -285,7 +285,7 @@
 
       (testing "and each dispatches into ITS OWN frame, after the extent
                has gone"
-        (is (nil? intent/*frame*) "precondition: no render extent is live here")
+        (is (nil? rf.hicasso.impl.intent/*frame*) "precondition: no render extent is live here")
         ((:dispatch-sync a) [:hicasso.todo/toggle 0])
         (is (true? @(rf/subscribe [:hicasso.todo/done? 0] {:frame frame-a})))
         (is (false? @(rf/subscribe [:hicasso.todo/done? 0] {:frame frame-b}))
@@ -338,7 +338,7 @@
            is refused rather than silently repaired to its own frame"
     (let [seen (volatile! ::unset)]
       (rf/with-frame frame-b
-        (collector/render-body frame-a
+        (rf.hicasso.impl.collector/render-body frame-a
                                (fn [_]
                                  (vreset! seen {:capture  (outcome #(rf/capture-frame))
                                                 :id       (outcome #(rf/current-frame-id))
@@ -360,7 +360,7 @@
            there is no second frame and both doors answer it"
     (let [seen (volatile! ::unset)]
       (rf/with-frame frame-a
-        (collector/render-body frame-a
+        (rf.hicasso.impl.collector/render-body frame-a
                                (fn [_]
                                  (vreset! seen {:capture (:frame (rf/capture-frame))
                                                 :id      (rf/current-frame-id)})

--- a/implementation/hicasso/test/re_frame/hicasso/frame_doors_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/frame_doors_dom_cljs_test.cljs
@@ -47,25 +47,25 @@
   Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
   React DOM; under `:node-test` every claim degrades to a stated skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.hook-probe :as probe]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.todo-support :as todo]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.hook-probe :as rf.hicasso.hook-probe]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.todo-support :as rf.hicasso.todo-support]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; The hook-ledger fixture's reason, and it bites harder here: the
      ;; default leaves a dynamic-var frame stamp in scope, which tier 1
      ;; would answer — so an isolation miss could read as a rendering
@@ -78,7 +78,7 @@
      ;; be specified as maps. Testing aborted." — which aborts the WHOLE
      ;; browser run at this namespace, not just this file.
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (def ^:private frame-a ::doors-dom-a)
 (def ^:private frame-b ::doors-dom-b)
@@ -101,11 +101,11 @@
        (catch :default e (ex-data e))))
 
 (defn- frames! []
-  (support/leave-act-environment!)
-  (todo/make-frame! frame-a todos)
-  (todo/make-frame! frame-b todos)
-  (todo/reseed! frame-a todos)
-  (todo/reseed! frame-b todos)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
+  (rf.hicasso.todo-support/make-frame! frame-a todos)
+  (rf.hicasso.todo-support/make-frame! frame-b todos)
+  (rf.hicasso.todo-support/reseed! frame-a todos)
+  (rf.hicasso.todo-support/reseed! frame-b todos)
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -118,9 +118,9 @@
   rather than a degenerate one."
   [{:keys [id]}]
   [:span.row {:data-frame (str (rf/current-frame-id))
-              :data-done  (str (collector/sub [:hicasso.todo/done? id]))}])
+              :data-done  (str (rf.hicasso.impl.collector/sub [:hicasso.todo/done? id]))}])
 
-(h/defview context-row
+(rf.hicasso/defview context-row
   "The shell: the frame arrives through `useContext`."
   [props]
   (printing-body props))
@@ -133,30 +133,30 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-identity-door-answers-under-the-shell
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (frames!)
       (testing "the shell"
-        (let [handle (mount/root! (mount/fresh-container!) frame-a [context-row {:id 0}])]
+        (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-a [context-row {:id 0}])]
           (try (is (= (str frame-a) (frame-attr handle)))
-               (finally (mount/release! handle)))))
+               (finally (rf.hicasso.impl.mount/release! handle)))))
 
       (testing "and it FOLLOWS the frame — mounted under a second frame it
                answers the second. A constant would have passed the row
                above"
-        (let [handle (mount/root! (mount/fresh-container!) frame-b [context-row {:id 0}])]
+        (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-b [context-row {:id 0}])]
           (try (is (= (str frame-b) (frame-attr handle)))
-               (finally (mount/release! handle))))))))
+               (finally (rf.hicasso.impl.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The hook ledger does not move
 ;; ---------------------------------------------------------------------------
 
 (deftest the-identity-door-spends-no-hook
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.hicasso.hook-probe/install!)
       (unwitnessed!)
       (do
         (frames!)
@@ -167,14 +167,14 @@
                  boundary and already declared to core, so there is
                  nothing for a hook to hold"
           (let [handle (volatile! nil)
-                names  (probe/record!
+                names  (rf.hicasso.hook-probe/record!
                          (fn [] (vreset! handle
-                                         (mount/root! (mount/fresh-container!)
+                                         (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!)
                                                       frame-a [context-row {:id 0}]))))]
-            (mount/release! @handle)
+            (rf.hicasso.impl.mount/release! @handle)
             (is (= ["useContext" "useSyncExternalStore"] names)
                 (str "hooks React was asked for: " (pr-str names)))
-            (is (= (count runtime/shell-hook-ledger) (count names))
+            (is (= (count rf.hicasso.test.runtime/shell-hook-ledger) (count names))
                 "and the declared ledger is still the measured one")))))))
 
 ;; ---------------------------------------------------------------------------
@@ -188,7 +188,7 @@
   it ever gets to the dispatch."
   (atom {}))
 
-(h/defview reusable
+(rf.hicasso/defview reusable
   "ONE view, mounted under N frames — the case the seam exists for. It
   does not know its own frame id, which is exactly why neither
   `rf/with-frame` nor a `{:frame …}` opt can serve it: both presuppose
@@ -199,16 +199,16 @@
   (let [{:keys [frame] :as api} (rf/capture-frame)]
     (swap! !captures assoc frame api)
     [:span.row {:data-frame (str frame)
-                :data-done  (str (collector/sub [:hicasso.todo/done? id]))}]))
+                :data-done  (str (rf.hicasso.impl.collector/sub [:hicasso.todo/done? id]))}]))
 
 (deftest a-capture-built-in-a-body-fires-into-its-own-frame-after-the-render
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (frames!)
       (reset! !captures {})
-      (let [a (mount/root! (mount/fresh-container!) frame-a [reusable {:id 0}])
-            b (mount/root! (mount/fresh-container!) frame-b [reusable {:id 0}])]
+      (let [a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-a [reusable {:id 0}])
+            b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-b [reusable {:id 0}])]
         (is (= #{frame-a frame-b} (set (keys @!captures)))
             (str "two mounts of ONE view must have captured two different frames; got "
                  (pr-str (keys @!captures))))
@@ -220,10 +220,10 @@
         (js/setTimeout
           (fn []
             (try
-              (is (nil? intent/*frame*)
+              (is (nil? rf.hicasso.impl.intent/*frame*)
                   "precondition: no render extent is live inside the timeout")
               ((:dispatch-sync (get @!captures frame-a)) [:hicasso.todo/toggle 0])
-              (mount/settle!)
+              (rf.hicasso.impl.mount/settle!)
               (is (= "true" (.getAttribute (.querySelector (:container a) ".row") "data-done"))
                   "the closure dispatched into the frame its own boundary rendered under")
               (is (= "false" (.getAttribute (.querySelector (:container b) ".row") "data-done"))
@@ -231,8 +231,8 @@
                    contexts, and a capture that had resolved a process-wide
                    or a last-rendered frame would have moved both")
               (finally
-                (mount/release! a)
-                (mount/release! b)
+                (rf.hicasso.impl.mount/release! a)
+                (rf.hicasso.impl.mount/release! b)
                 (done))))
           0)))))
 
@@ -243,13 +243,13 @@
 (def ^:private !runs (atom 0))
 (def ^:private !seen (atom []))
 
-(h/defview strict-reader
+(rf.hicasso/defview strict-reader
   "Records the frame `rf/current-frame-id` answered on EVERY body run, so
   the double-invoke is a measured premise rather than an assumed one."
   [{:keys [id]}]
   (swap! !runs inc)
   (swap! !seen conj (rf/current-frame-id))
-  [:span.row {:data-done (str (collector/sub [:hicasso.todo/done? id]))}])
+  [:span.row {:data-done (str (rf.hicasso.impl.collector/sub [:hicasso.todo/done? id]))}])
 
 (defn- strict-root!
   "`mount/root!`, wrapped in `React.StrictMode`. Written here rather than
@@ -260,17 +260,17 @@
     (react-dom/flushSync
       (fn [] (.render root (react/createElement
                              react/StrictMode nil
-                             (mount/provider frame-kw (codec/as-element hiccup))))))
+                             (rf.hicasso.impl.mount/provider frame-kw (rf.hicasso.impl.codec/as-element hiccup))))))
     {:root root :frame frame-kw :container container}))
 
 (deftest strictmodes-double-invoke-reads-the-same-frame-and-adds-nothing
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (frames!)
       (reset! !runs 0)
       (reset! !seen [])
-      (let [handle (strict-root! (mount/fresh-container!) frame-a [strict-reader {:id 0}])]
+      (let [handle (strict-root! (rf.hicasso.impl.mount/fresh-container!) frame-a [strict-reader {:id 0}])]
         (try
           (testing "the premise: React really did invoke the body twice"
             (is (= 2 @!runs)
@@ -285,11 +285,11 @@
                    one boundary, one edge per read. The identity door
                    appends no sub-key, so a double-invoke cannot double
                    anything it contributes — because it contributes nothing"
-            (let [{:keys [entries boundaries edges]} (runtime/stats)]
+            (let [{:keys [entries boundaries edges]} (rf.hicasso.test.runtime/stats)]
               (is (= 1 entries))
               (is (= 1 boundaries))
               (is (= 1 edges) "the one real read, counted once")))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W7 — the `[:>]` value-first door, and the plain closure over the capture
@@ -335,7 +335,7 @@
       #js {:className "pick" :onClick (fn [_e] (on-pick))}
       "pick")))
 
-(h/defview escape-picker
+(rf.hicasso/defview escape-picker
   "`reusable`'s body at the foreign edge: ONE view, mounted under N
   frames, that does not know its own frame id — and now has to hand a
   dispatching closure to a caller it does not control.
@@ -349,7 +349,7 @@
         on-pick (fn [] (dispatch-sync [:hicasso.todo/toggle id]))]
     (swap! !built assoc (str frame) on-pick)
     [:span.row {:data-frame (str frame)
-                :data-done  (str (collector/sub [:hicasso.todo/done? id]))}
+                :data-done  (str (rf.hicasso.impl.collector/sub [:hicasso.todo/done? id]))}
      [:> foreign-picker {:label (str frame) :on-pick on-pick}]]))
 
 (defn- refusal-id [f]
@@ -360,11 +360,11 @@
 
 (defn- pick! [handle]
   (.click (.querySelector (:container handle) ".pick"))
-  (mount/settle!)
+  (rf.hicasso.impl.mount/settle!)
   nil)
 
 (deftest the-escapes-value-first-door-dispatches-through-a-plain-closure-over-the-capture
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (frames!)
@@ -378,21 +378,21 @@
                 three, and W7 measures that one on purpose, because it is
                 the door that carries no frame of its own"
         (is (= ::did-not-throw
-               (refusal-id #(intent/with-frame (fn [_] nil)
-                              (fn [] (codec/as-element
+               (refusal-id #(rf.hicasso.impl.intent/with-frame (fn [_] nil)
+                              (fn [] (rf.hicasso.impl.codec/as-element
                                        [:> foreign-picker {:on-pick [:hicasso.todo/toggle 0]}])))))
             "an intent vector at an event-spelled slot lowers rather than
              refusing — under a frame, as at a native tag; outside one it is
              the ordinary outside-boundary refusal, which is the same proof")
         (is (= ::did-not-throw
-               (refusal-id #(intent/with-frame (fn [_] nil)
-                              (fn [] (codec/as-element
+               (refusal-id #(rf.hicasso.impl.intent/with-frame (fn [_] nil)
+                              (fn [] (rf.hicasso.impl.codec/as-element
                                        [:> foreign-picker
-                                        {:on-pick (intent/callback (fn [] [:hicasso.todo/toggle 0]))}])))))
+                                        {:on-pick (rf.hicasso.impl.intent/callback (fn [] [:hicasso.todo/toggle 0]))}])))))
             "and so does a marked h/event, which takes the event wrapper"))
 
-      (let [a (mount/root! (mount/fresh-container!) frame-a [escape-picker {:id 0}])
-            b (mount/root! (mount/fresh-container!) frame-b [escape-picker {:id 0}])]
+      (let [a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-a [escape-picker {:id 0}])
+            b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-b [escape-picker {:id 0}])]
         (is (= #{(str frame-a) (str frame-b)} (set (keys @!handed)))
             (str "two mounts of ONE view crossed under two different frames; got "
                  (pr-str (keys @!handed))))
@@ -410,7 +410,7 @@
         (js/setTimeout
           (fn []
             (try
-              (is (nil? intent/*frame*)
+              (is (nil? rf.hicasso.impl.intent/*frame*)
                   "precondition: no render extent is live inside the timeout")
               (pick! a)
               (is (= "true" (done-attr a))
@@ -425,8 +425,8 @@
                    toggled that one frame twice and left this pair reading
                    false/false — which is why BOTH crossings are clicked")
               (finally
-                (mount/release! a)
-                (mount/release! b)
+                (rf.hicasso.impl.mount/release! a)
+                (rf.hicasso.impl.mount/release! b)
                 (done))))
           0)))))
 
@@ -453,27 +453,27 @@
   (let [render-row (.-renderRow props)]
     (react/createElement "ul" #js {:className "list"} (render-row 0))))
 
-(h/defview supplier
+(rf.hicasso/defview supplier
   "Supplies a render callback to a foreign component. Inside the callback
   it reads both doors and tries an ambient read, and records all three."
   [_]
   [:div.host
    [:> foreign-list
-    {:render-row (h/event [i]
+    {:render-row (rf.hicasso/event [i]
                    (let [id-seen (rf/current-frame-id)]
                      (swap! !callback-seen assoc id-seen
                             {:capture (:frame (rf/capture-frame))
                              :read    (outcome #(rf/subscribe [:hicasso.todo/done? i]))})
-                     (h/as-element [:li.row {:data-frame (str id-seen)} (str i)])))}]])
+                     (rf.hicasso/as-element [:li.row {:data-frame (str id-seen)} (str i)])))}]])
 
 (deftest a-render-callback-invoked-by-a-foreign-render-answers-the-supplying-boundary
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (frames!)
       (reset! !callback-seen {})
-      (let [a (mount/root! (mount/fresh-container!) frame-a [supplier {}])
-            b (mount/root! (mount/fresh-container!) frame-b [supplier {}])]
+      (let [a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-a [supplier {}])
+            b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-b [supplier {}])]
         (try
           (is (= #{frame-a frame-b} (set (keys @!callback-seen)))
               (str "two suppliers under two frames must have answered two
@@ -491,5 +491,5 @@
                         render happens to be under; got " (pr-str read)))
               (is (= f (:extent-frame read)) "naming the supplying boundary as the extent")))
           (finally
-            (mount/release! a)
-            (mount/release! b)))))))
+            (rf.hicasso.impl.mount/release! a)
+            (rf.hicasso.impl.mount/release! b)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/frame_doors_ssr_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/frame_doors_ssr_cljs_test.cljs
@@ -35,13 +35,13 @@
   where the rest of the entry's string-only rows run."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.server :as server]
-            [re-frame.hicasso.test.server :as ts]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.server :as rf.hicasso.server]
+            [re-frame.hicasso.test.server :as rf.hicasso.test.server]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; Registered ABOVE `use-fixtures`, for the sibling suites' reason: the
 ;; reset fixture captures its source-store baseline when the
@@ -51,8 +51,8 @@
 (rf/reg-sub ::remaining (fn [db _] (:remaining db)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; `:ambient-frame nil`, and here it is load-bearing rather than
      ;; tidiness. The default root-binds `frame/*current-frame*` to
      ;; `:rf/default`, which is a CARRIED tier-1 stamp naming a frame the
@@ -63,7 +63,7 @@
      ;; no scope and a host calls it at top of stack. Measuring the doors
      ;; against the fixture's own stamp would be measuring the fixture.
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (def ^:private !seen
   "Every frame id a server body read, newest last."
@@ -74,22 +74,22 @@
   of its refusal, or `::no-throw` with the value it produced."
   (atom ::unset))
 
-(h/defview discreet
+(rf.hicasso/defview discreet
   "Reads the request's frame and keeps it OUT of the markup — the
   documented correct shape. What it renders is a subscription value, so
   the boundary is an ordinary one."
   [_]
   (swap! !seen conj (rf/current-frame-id))
-  [:span.row (str (h/sub [::remaining]))])
+  [:span.row (str (rf.hicasso/sub [::remaining]))])
 
-(h/defview indiscreet
+(rf.hicasso/defview indiscreet
   "Renders the per-request id INTO the markup. This is the authorable
   hazard the guide warns about, written on purpose so the determinism
   check can be watched failing."
   [_]
   [:span.row {:data-frame (str (rf/current-frame-id))}])
 
-(h/defview carrying
+(rf.hicasso/defview carrying
   "Tries the AMBIENT carry — `(rf/capture-frame)`, 0-arity — inside a
   server body, and records what it got. It catches its own throw so the
   render completes and the row can read the markup rather than a
@@ -98,9 +98,9 @@
   (reset! !ambient
           (try [::no-throw (rf/capture-frame)]
                (catch :default e (ex-data e))))
-  [:span.row (str (h/sub [::remaining]))])
+  [:span.row (str (rf.hicasso/sub [::remaining]))])
 
-(h/defview reading
+(rf.hicasso/defview reading
   "Tries an AMBIENT read — `(rf/subscribe …)` — inside a server body, and
   records what it got, for the same reason `carrying` catches its own
   throw."
@@ -108,7 +108,7 @@
   (reset! !ambient
           (try [::no-throw @(rf/subscribe [::remaining])]
                (catch :default e (ex-data e))))
-  [:span.row (str (h/sub [::remaining]))])
+  [:span.row (str (rf.hicasso/sub [::remaining]))])
 
 (defn- request [hiccup]
   {:hiccup   hiccup
@@ -125,8 +125,8 @@
            different ones — which is what per-request isolation means when
            the id is the thing being read"
     (reset! !seen [])
-    (let [a (server/render (request [discreet {}]))
-          b (server/render (request [discreet {}]))]
+    (let [a (rf.hicasso.server/render (request [discreet {}]))
+          b (rf.hicasso.server/render (request [discreet {}]))]
       (is (= 2 (count @!seen)) "one read per request")
       (is (= [(:frame-id a) (:frame-id b)] @!seen)
           "each body read its OWN request's id, in order")
@@ -139,7 +139,7 @@
            documents are byte-identical anyway — because the value went
            into a read and not into the page"
     (let [{:keys [identical? differs-at] a :first b :second}
-          (ts/render-twice (request [discreet {}]))]
+          (rf.hicasso.test.server/render-twice (request [discreet {}]))]
       (is identical? (str "the two documents differ at index " differs-at))
       (is (not= (:frame-id a) (:frame-id b))
           "and they were different requests — this is the whole point")
@@ -152,7 +152,7 @@
            `ts/render-twice`'s byte comparison catches it. A claim about a
            check that has never been watched failing is not a check, so
            here it is failing"
-    (let [{:keys [identical? differs-at] a :first} (ts/render-twice (request [indiscreet {}]))]
+    (let [{:keys [identical? differs-at] a :first} (rf.hicasso.test.server/render-twice (request [indiscreet {}]))]
       (is (not identical?)
           "a document carrying the per-request gensym cannot be
            deterministic, and the determinism witness must say so")
@@ -171,7 +171,7 @@
            pure doors to the extent's declared frame, and the server
            render extent declares it exactly as the client's does"
     (reset! !ambient ::unset)
-    (let [{:keys [document frame-id]} (server/render (request [carrying {}]))
+    (let [{:keys [document frame-id]} (rf.hicasso.server/render (request [carrying {}]))
           data                        @!ambient]
       (is (vector? data)
           (str "expected the carry to be admitted; got " (pr-str data)))
@@ -197,7 +197,7 @@
     ;; the class of fault it exists to catch. The row's subject is untouched
     ;; — it still measures WHOSE refusal the read got, and it now also
     ;; measures that the door names that same refusal as its reason.
-    (let [thrown (try (server/render (request [reading {}]))
+    (let [thrown (try (rf.hicasso.server/render (request [reading {}]))
                       (catch :default e e))
           data   @!ambient]
       (is (= :rf.error/ambient-frame-refused (:rf.error/id data))

--- a/implementation/hicasso/test/re_frame/hicasso/frame_ops_retention_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/frame_ops_retention_cljs_test.cljs
@@ -43,14 +43,14 @@
   render or a direct table read, and none touches a document."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.frames :as frames]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.server :as server]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.frames :as rf.hicasso.impl.frames]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.server :as rf.hicasso.server]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; Registered ABOVE `use-fixtures` for the sibling suites' reason: the
 ;; reset fixture captures its source-store baseline when the
@@ -59,17 +59,17 @@
 
 (rf/reg-sub ::label (fn [db _] (:label db)))
 
-(h/defview page
+(rf.hicasso/defview page
   "One subscription read, so the render acquires a frame-keyed cell and
   the boundary body actually runs."
   [_]
-  [:div.page [:p.value (h/sub [::label])]])
+  [:div.page [:p.value (rf.hicasso/sub [::label])]])
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (def ^:private snapshot {:label "alpha"})
 
@@ -87,7 +87,7 @@
   this counts exactly the rows a request left behind and is blind to
   whatever else the bundle's other suites have in the table."
   []
-  (filter #(= "hicasso.ssr" (namespace %)) (keys @frames/!frame-ops)))
+  (filter #(= "hicasso.ssr" (namespace %)) (keys @rf.hicasso.impl.frames/!frame-ops)))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the general claim: the row dies with the incarnation
@@ -97,16 +97,16 @@
   (rf/make-frame {:id ::live :initial-events [[:rf/set-db snapshot]]})
 
   (testing "control — a body run under a live frame mints the row"
-    (is (nil? (get @frames/!frame-ops ::live))
+    (is (nil? (get @rf.hicasso.impl.frames/!frame-ops ::live))
         "nothing has rendered under this frame yet")
     ;; The exact lookup `run-once` makes around every boundary body.
-    (collector/frame-dispatch ::live)
-    (is (some? (get @frames/!frame-ops ::live))
+    (rf.hicasso.impl.collector/frame-dispatch ::live)
+    (is (some? (get @rf.hicasso.impl.frames/!frame-ops ::live))
         "a row exists — without this the assertion below is vacuous"))
 
   (testing "and `destroy-frame!` drops it"
     (rf/destroy-frame! ::live)
-    (is (nil? (get @frames/!frame-ops ::live))
+    (is (nil? (get @rf.hicasso.impl.frames/!frame-ops ::live))
         (str "the row is the destroyed incarnation's `capture-frame` bundle and "
              "the closure over it; no successor can ever look it up, so the "
              "destruction is the eviction"))))
@@ -119,18 +119,18 @@
   (is (empty? (ssr-rows))
       "baseline: no per-request rows before the first render")
 
-  (runtime/reset-body-runs!)
+  (rf.hicasso.test.runtime/reset-body-runs!)
 
   (testing "control — a render really runs this page's boundary body"
-    (is (str/includes? (:html (server/render (request))) "alpha")
+    (is (str/includes? (:html (rf.hicasso.server/render (request))) "alpha")
         "the seeded snapshot reaches the bytes")
-    (is (pos? (runtime/body-runs))
+    (is (pos? (rf.hicasso.test.runtime/body-runs))
         (str "a `render` that reached no boundary would leave the table "
-             "empty for the wrong reason; ran " (runtime/body-runs)
+             "empty for the wrong reason; ran " (rf.hicasso.test.runtime/body-runs)
              " bodies")))
 
   (let [after-1 (count (ssr-rows))]
-    (dotimes [_ 3] (server/render (request)))
+    (dotimes [_ 3] (rf.hicasso.server/render (request)))
     (let [after-4 (count (ssr-rows))]
 
       (testing "the table is BOUNDED in requests served, not linear in them"

--- a/implementation/hicasso/test/re_frame/hicasso/hmr_registry_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hmr_registry_cljs_test.cljs
@@ -45,14 +45,14 @@
   `checkIfSnapshotChanged` without a browser."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.generation :as generation]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.generation :as rf.hicasso.impl.generation]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::hmr-registry)
 
@@ -60,11 +60,11 @@
 (rf/reg-sub   :hmr-registry/label (fn [db _] (:label db)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -79,15 +79,15 @@
   (rf/with-frame frame-id (rf/dispatch-sync [:hmr-registry/seed label]))
   frame-id)
 
-(defn- label-body [_props] (collector/sub [:hmr-registry/label]))
+(defn- label-body [_props] (rf.hicasso.impl.collector/sub [:hmr-registry/label]))
 
 (defn- mount-boundary!
   "React's place at the commit seam, for a body of the caller's choosing."
   [body]
-  (let [value    (collector/render-body frame-id body {})
-        entry    (collector/last-reads)
+  (let [value    (rf.hicasso.impl.collector/render-body frame-id body {})
+        entry    (rf.hicasso.impl.collector/last-reads)
         notified (volatile! 0)
-        release  (collector/commit-boundary! entry (fn [] (vswap! notified inc)))]
+        release  (rf.hicasso.impl.collector/commit-boundary! entry (fn [] (vswap! notified inc)))]
     {:value value :entry entry :notified notified :release release}))
 
 (defn- same-object?
@@ -106,7 +106,7 @@
   timer this used to be is no longer a statement about anything — it was
   green for either scheduling. The sibling reincarnation suites wait the
   same way, on the same instrument, for the same reason."
-  support/at-the-checkpoint)
+  rf.hicasso.checkpoint-support/at-the-checkpoint)
 
 ;; ---------------------------------------------------------------------------
 ;; 1. The counter a reload moves
@@ -114,26 +114,26 @@
 
 (deftest a-save-moves-the-registry-epoch-once-per-sub-registration
   (seeded! "A")
-  (let [before (generation/registry-epoch)]
+  (let [before (rf.hicasso.impl.generation/registry-epoch)]
 
     ;; NEGATIVE CONTROL, taken FIRST. The epoch is the arm's count of `:sub`
     ;; registrations specifically, so a reload's OTHER top-level forms must
     ;; leave it alone. If this moved, every number below would be measuring
     ;; "a namespace loaded" rather than "a subscription was registered".
     (rf/reg-event :hmr-registry/other (fn [{:keys [db]} _] {:db db}))
-    (is (= before (generation/registry-epoch))
+    (is (= before (rf.hicasso.impl.generation/registry-epoch))
         "an event registration moves the registry epoch by zero")
 
     (testing "a reload's re-registration of an existing sub moves it by one —
               the replacement case, which is the case a save is"
       (rf/reg-sub :hmr-registry/label (fn [db _] (:label db)))
-      (is (= (inc before) (generation/registry-epoch))))
+      (is (= (inc before) (rf.hicasso.impl.generation/registry-epoch))))
 
     (testing "and a first-time registration moves it by one as well: the
               counter does not distinguish them, because in the render-commit
               gap they are the same defect"
       (rf/reg-sub :hmr-registry/fresh (fn [db _] (:label db)))
-      (is (= (+ 2 before) (generation/registry-epoch))))))
+      (is (= (+ 2 before) (rf.hicasso.impl.generation/registry-epoch))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. A save is not a re-render trigger
@@ -148,36 +148,36 @@
   ;; term in every key's live contribution and would render identically.
   (seeded! "A")
   (let [{:keys [entry notified release]} (mount-boundary! label-body)
-        snapshot-a (runtime/snapshot-of entry)]
+        snapshot-a (rf.hicasso.test.runtime/snapshot-of entry)]
 
     ;; NEGATIVE CONTROL, taken FIRST so the instrument is proven live before
     ;; it is asked to report a tie.
     (rf/with-frame frame-id (rf/dispatch-sync [:hmr-registry/seed "A2"]))
-    (is (> (runtime/snapshot-of entry) snapshot-a)
+    (is (> (rf.hicasso.test.runtime/snapshot-of entry) snapshot-a)
         "an ordinary write MOVES the number React re-reads — so a tie below
          is the save's property and not a dead instrument")
     (is (= 1 @notified) "and notifies the committed boundary exactly once")
 
-    (let [snapshot-before (runtime/snapshot-of entry)
+    (let [snapshot-before (rf.hicasso.test.runtime/snapshot-of entry)
           notified-before @notified
-          epoch-before    (generation/registry-epoch)]
+          epoch-before    (rf.hicasso.impl.generation/registry-epoch)]
 
       ;; The save: another namespace reloads and re-runs its registrations.
       (rf/reg-sub :hmr-registry/somewhere-else (fn [db _] (:label db)))
       (rf/reg-sub :hmr-registry/somewhere-else-2 (fn [db _] (:label db)))
 
       (testing "the registry epoch moved, so the save really happened"
-        (is (= (+ 2 epoch-before) (generation/registry-epoch))))
+        (is (= (+ 2 epoch-before) (rf.hicasso.impl.generation/registry-epoch))))
 
       (testing "and the mounted boundary's number did not move, so React
                 schedules nothing: a held key contributes its cell's frozen
                 stamp, which no registration touches"
-        (is (= snapshot-before (runtime/snapshot-of entry)))
+        (is (= snapshot-before (rf.hicasso.test.runtime/snapshot-of entry)))
         (is (= notified-before @notified)))
 
       (testing "nor was its cell disturbed — the first-registration scan
                 reaches only cells holding the id being registered"
-        (is (some? (runtime/cell-reaction label-key)))))
+        (is (some? (rf.hicasso.test.runtime/cell-reaction label-key)))))
     (release)))
 
 ;; ---------------------------------------------------------------------------
@@ -196,24 +196,24 @@
         held    (mount-boundary! label-body)
         ;; The in-flight boundary: rendered, not yet committed, on a key no
         ;; cell holds. This is the render-commit gap, held open.
-        _staged (collector/render-body frame-id
-                                       (fn [_] (collector/sub [:hmr-registry/staged]))
+        _staged (rf.hicasso.impl.collector/render-body frame-id
+                                       (fn [_] (rf.hicasso.impl.collector/sub [:hmr-registry/staged]))
                                        {})
-        staged-entry (collector/last-reads)
-        held-before   (runtime/snapshot-of (:entry held))
-        staged-before (runtime/snapshot-of staged-entry)]
+        staged-entry (rf.hicasso.impl.collector/last-reads)
+        held-before   (rf.hicasso.test.runtime/snapshot-of (:entry held))
+        staged-before (rf.hicasso.test.runtime/snapshot-of staged-entry)]
 
     (rf/reg-sub :hmr-registry/unrelated-to-both (fn [db _] (:label db)))
 
     (testing "the in-flight boundary's number MOVES — conservative in the
               safe direction, which is the only direction a monotone term
               added to a monotone sum can err in"
-      (is (> (runtime/snapshot-of staged-entry) staged-before)))
+      (is (> (rf.hicasso.test.runtime/snapshot-of staged-entry) staged-before)))
 
     (testing "and the mounted boundary's number TIES, on the very same
               registration — so the term's reach is exactly the set of keys
               inside a render-commit gap and not one key more"
-      (is (= held-before (runtime/snapshot-of (:entry held)))))
+      (is (= held-before (rf.hicasso.test.runtime/snapshot-of (:entry held)))))
 
     ((:release held))))
 
@@ -233,17 +233,17 @@
     (seeded! "hello")
     (let [{:keys [entry notified release value]} (mount-boundary! label-body)]
       (is (= "hello" value) "the boundary committed against the original sub")
-      (is (some? (runtime/cell-reaction label-key)) "holding a live reaction")
+      (is (some? (rf.hicasso.test.runtime/cell-reaction label-key)) "holding a live reaction")
 
       ;; NEGATIVE CONTROL, taken FIRST. Saving a file that registers OTHER
       ;; subscriptions must leave this cell's reaction in place — so the drop
       ;; measured below is caused by editing THIS subscription, and not by
       ;; the mere fact that a registration happened.
       (rf/reg-sub :hmr-registry/some-other-sub (fn [db _] (:label db)))
-      (is (some? (runtime/cell-reaction label-key))
+      (is (some? (rf.hicasso.test.runtime/cell-reaction label-key))
           "an unrelated registration leaves the held reaction intact")
 
-      (let [snapshot-before (runtime/snapshot-of entry)
+      (let [snapshot-before (rf.hicasso.test.runtime/snapshot-of entry)
             notified-before @notified]
 
         ;; THE SAVE: the same id, a changed computation. This is the edit.
@@ -252,12 +252,12 @@
         (testing "synchronously the held reference is gone — the replacement
                   reaches the arm as a disposal, and the repair's first phase
                   drops the reaction rather than deref a retired computation"
-          (is (nil? (runtime/cell-reaction label-key))))
+          (is (nil? (rf.hicasso.test.runtime/cell-reaction label-key))))
 
         (testing "yet React has been told nothing: the key is held, so its
                   contribution is the cell's frozen stamp and no registration
                   moves it"
-          (is (= snapshot-before (runtime/snapshot-of entry))
+          (is (= snapshot-before (rf.hicasso.test.runtime/snapshot-of entry))
               "the number React re-reads TIES across the save")
           (is (= notified-before @notified)
               "and no re-render is scheduled"))
@@ -267,10 +267,10 @@
                   the registration on the cold probe. This is exactly why a
                   rendered assertion is green on both sides of the window and
                   can see none of this"
-          (is (= "HELLO" (collector/render-body frame-id label-body {}))))
+          (is (= "HELLO" (rf.hicasso.impl.collector/render-body frame-id label-body {}))))
 
         (at-the-checkpoint
-          #(some? (runtime/cell-reaction label-key))
+          #(some? (rf.hicasso.test.runtime/cell-reaction label-key))
           "the edited-sub repair"
           done
           (fn [_turns]
@@ -279,9 +279,9 @@
                       the new registration, moved the number and delivered the
                       notification, so a boundary that painted before the save
                       is told to correct itself before the next paint"
-              (is (some? (runtime/cell-reaction label-key))
+              (is (some? (rf.hicasso.test.runtime/cell-reaction label-key))
                   "re-wired rather than left deaf")
-              (is (> (runtime/snapshot-of entry) snapshot-before)
+              (is (> (rf.hicasso.test.runtime/snapshot-of entry) snapshot-before)
                   "the number React re-reads has moved")
               (is (> @notified notified-before)
                   "the repair is delivered, not merely performed"))
@@ -299,7 +299,7 @@
   ;; preserved — hot-reload / Story-friendly". Witnessed here at the arm,
   ;; because what the arm cares about is whether the incarnation moved.
   (seeded! "A")
-  (let [token-before  (frame/frame-incarnation-token frame-id)
+  (let [token-before  (rf.frame/frame-incarnation-token frame-id)
         ;; Acquire the arm's frame row BEFORE the reload. Since the
         ;; incarnation is pinned into the row at mint time, a render acquires
         ;; the row rather than a first dispatch — so a count sampled while the
@@ -307,27 +307,27 @@
         ;; populated one and say nothing about the reload. Priming here is what
         ;; makes this row's own rationale — "a bundle captured before the
         ;; reload" — name something that exists.
-        row-before    (collector/frame-row frame-id)
-        frames-before (:frames (runtime/stats))]
+        row-before    (rf.hicasso.impl.collector/frame-row frame-id)
+        frames-before (:frames (rf.hicasso.test.runtime/stats))]
 
     (rf/make-frame {:id frame-id})
 
     (testing "re-running the constructor does NOT mint a new incarnation"
-      (is (true? (same-object? token-before (frame/frame-incarnation-token frame-id)))
+      (is (true? (same-object? token-before (rf.frame/frame-incarnation-token frame-id)))
           "the incarnation token is the same object"))
 
     (testing "durable state survives, so a reload does not empty app-db"
-      (is (= "A" (collector/render-body frame-id label-body {}))))
+      (is (= "A" (rf.hicasso.impl.collector/render-body frame-id label-body {}))))
 
     (testing "and the arm's frame-op memo is untouched, so a bundle captured
               before the reload still addresses the same incarnation"
-      (is (= frames-before (:frames (runtime/stats)))
+      (is (= frames-before (:frames (rf.hicasso.test.runtime/stats)))
           "the reload added no row")
-      (is (true? (same-object? row-before (collector/frame-row frame-id)))
+      (is (true? (same-object? row-before (rf.hicasso.impl.collector/frame-row frame-id)))
           "and it is the SAME row object — so the bundle captured before the
            reload is the one still in use, which is the claim this row makes
            and could not previously check")
-      (is (true? (same-object? token-before (:incarnation (collector/frame-row frame-id))))
+      (is (true? (same-object? token-before (:incarnation (rf.hicasso.impl.collector/frame-row frame-id))))
           "pinned to the pre-reload incarnation, by object identity"))
 
     ;; NEGATIVE CONTROL. The token reader is only worth anything if it can
@@ -343,5 +343,5 @@
               reload shapes"
       (rf/destroy-frame! frame-id)
       (rf/make-frame {:id frame-id})
-      (is (false? (same-object? token-before (frame/frame-incarnation-token frame-id)))
+      (is (false? (same-object? token-before (rf.frame/frame-incarnation-token frame-id)))
           "a new incarnation, under the same public id"))))

--- a/implementation/hicasso/test/re_frame/hicasso/hmr_remount_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hmr_remount_cljs_test.cljs
@@ -66,13 +66,13 @@
   runtime's to simulate. The DOM rows remain owed to a browser suite;
   the recorded contract says so rather than implying they were measured."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::hmr-remount)
 
@@ -83,11 +83,11 @@
 ;; containing an `(async done …)` test, and a residue baseline is only honest
 ;; past the runtime's own reap horizon (`runtime/quiesced!`).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The source file, as a consumer writes it
@@ -98,9 +98,9 @@
   a head around the same body — which is what an unrelated edit elsewhere
   in the file does."
   [{:keys [tag]}]
-  [:p {:class tag} (h/sub [:hmr-remount/label])])
+  [:p {:class tag} (rf.hicasso/sub [:hmr-remount/label])])
 
-(h/defview panel
+(rf.hicasso/defview panel
   "Declared through the public door, so what a reload re-mints is the real
   product of the real macro."
   [props]
@@ -137,7 +137,7 @@
   [body]
   (rf/reg-event :hmr-remount/seed (fn [_ [_ label]] {:db {:label label}}))
   (rf/reg-sub   :hmr-remount/label (fn [db _] (:label db)))
-  (collector/mint-view! view-name body))
+  (rf.hicasso.impl.collector/mint-view! view-name body))
 
 (defn- element-type-of
   "The React `type` of the element the codec creates for `head` — the
@@ -146,7 +146,7 @@
   rebuilt. Read off a real element rather than off the head's marker, so
   the witness sees what React sees."
   [head]
-  (.-type (codec/as-element [head {:tag "t"}])))
+  (.-type (rf.hicasso.impl.codec/as-element [head {:tag "t"}])))
 
 (defn- painted
   "The text the boundary's emitted element carries — its `<p>`'s only
@@ -163,17 +163,17 @@
   emitted element, the entry, the notification counter, this mount's
   registration object, and React's own cleanup."
   [body]
-  (let [value    (collector/render-body frame-id body {})
-        entry    (collector/last-reads)
+  (let [value    (rf.hicasso.impl.collector/render-body frame-id body {})
+        entry    (rf.hicasso.impl.collector/last-reads)
         notified (volatile! 0)
-        release  (collector/commit-boundary! entry (fn [] (vswap! notified inc)))]
+        release  (rf.hicasso.impl.collector/commit-boundary! entry (fn [] (vswap! notified inc)))]
     {:value    value
      :entry    entry
      :notified notified
      :release  release
      ;; The registration this commit just installed: the newest reader on
      ;; the key's cell. It is the object the hand-over is judged by.
-     :reg      (peek (runtime/cell-readers sub-key))}))
+     :reg      (peek (rf.hicasso.test.runtime/cell-readers sub-key))}))
 
 (defn- same-object?
   "`identical?`, answered as a plain boolean, and every identity assertion
@@ -195,18 +195,18 @@
   "Is `reg` among the registrations currently reading the label key?
   Answered as a boolean, for [[same-object?]]'s reason."
   [reg]
-  (boolean (some #(same-object? % reg) (runtime/cell-readers sub-key))))
+  (boolean (some #(same-object? % reg) (rf.hicasso.test.runtime/cell-readers sub-key))))
 
 (defn- settled
   "Run `f` once the runtime's own reapers have run — the only honest place
   to read a residue baseline."
   [f]
-  (.then (runtime/quiesced!) f))
+  (.then (rf.hicasso.test.runtime/quiesced!) f))
 
 (def ^:private one-boundary {:cells 1 :cell-refs 1 :boundaries 1 :edges 1})
 (def ^:private nothing      {:cells 0 :cell-refs 0 :boundaries 0 :edges 0})
 
-(defn- retention [] (dissoc (runtime/residue) :entries))
+(defn- retention [] (dissoc (rf.hicasso.test.runtime/residue) :entries))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. The head is re-minted, so the element type changes — the whole cause
@@ -250,8 +250,8 @@
   ;; `panel-body` is passed to both mints by name, so the "same body" premise
   ;; is carried by the code rather than by an assertion — asserting a var is
   ;; identical to itself would pass without exercising anything.
-  (let [g1 (collector/mint-view! view-name panel-body)
-        g2 (collector/mint-view! view-name panel-body)]
+  (let [g1 (rf.hicasso.impl.collector/mint-view! view-name panel-body)
+        g2 (rf.hicasso.impl.collector/mint-view! view-name panel-body)]
     (is (false? (same-object? g1 g2))
         "same name, same body, different head")
     (is (false? (same-object? (element-type-of g1) (element-type-of g2)))
@@ -266,9 +266,9 @@
   ;; and the recorded contract must be rewritten before the suite can pass.
   ;; That is the intended behaviour: the freeze is falsifiable.
   (let [reloaded (load-namespace! panel-body)]
-    (is (true? (codec/boundary-head? panel))
+    (is (true? (rf.hicasso.impl.codec/boundary-head? panel))
         "the macro's product is a marked boundary head")
-    (is (true? (codec/boundary-head? reloaded))
+    (is (true? (rf.hicasso.impl.codec/boundary-head? reloaded))
         "and so is the reload's, so the two are the same kind of object")
     (is (= (.-displayName ^js panel) (.-displayName ^js reloaded) view-name)
         "minted under the identical name — same address")
@@ -314,7 +314,7 @@
               (testing "and it is the SUCCESSOR's registration, by identity —
                         the assertion a count cannot make, and the one a
                         rendered-markup assertion cannot make at all"
-                (let [readers (runtime/cell-readers sub-key)]
+                (let [readers (rf.hicasso.test.runtime/cell-readers sub-key)]
                   (is (= 1 (count readers)))
                   (is (true? (same-object? reg2 (first readers)))
                       "the survivor is the generation that is mounted")
@@ -328,7 +328,7 @@
                             — zero residue after quiescence, invariant I5's
                             exact-teardown clause across a reload"
                     (is (= nothing (retention)))
-                    (is (= 0 (:entries (runtime/residue)))
+                    (is (= 0 (:entries (rf.hicasso.test.runtime/residue)))
                         "the shared read-set entry is reaped too"))
                   (done))))))))))
 
@@ -352,7 +352,7 @@
           (fn [_]
             (is (= one-boundary (retention))
                 "same terminal retention as destroy-then-create")
-            (is (true? (same-object? reg2 (first (runtime/cell-readers sub-key))))
+            (is (true? (same-object? reg2 (first (rf.hicasso.test.runtime/cell-readers sub-key))))
                 "and the successor still holds the key")
             ((:release m2))
             (settled (fn [_] (is (= nothing (retention))) (done)))))))))
@@ -392,7 +392,7 @@
 
             (testing "RED — and the identity assertion names the culprit,
                       which a count could not"
-              (let [readers (runtime/cell-readers sub-key)]
+              (let [readers (rf.hicasso.test.runtime/cell-readers sub-key)]
                 (is (= 2 (count readers)))
                 (is (true? (holds-key? reg1))
                     "the retired generation is still reading the key")
@@ -416,7 +416,7 @@
                           instrument reports the clean hand-over, so the red
                           above was the leak and not a broken witness"
                   (is (= one-boundary (retention)))
-                  (is (true? (same-object? reg2 (first (runtime/cell-readers sub-key))))))
+                  (is (true? (same-object? reg2 (first (rf.hicasso.test.runtime/cell-readers sub-key))))))
                 ((:release m2))
                 (settled (fn [_] (is (= nothing (retention))) (done)))))))))))
 
@@ -441,14 +441,14 @@
         (fn [_]
           (is (= one-boundary (retention))
               "three saves later, still exactly one cell, one reader, one edge")
-          (is (true? (same-object? (:reg @!live) (first (runtime/cell-readers sub-key))))
+          (is (true? (same-object? (:reg @!live) (first (rf.hicasso.test.runtime/cell-readers sub-key))))
               "and the holder is the newest generation")
-          (is (= 1 (:entries (runtime/residue)))
+          (is (= 1 (:entries (rf.hicasso.test.runtime/residue)))
               "one read-set entry, shared across every generation and handed
                from each to the next rather than re-minted per save")
           ((:release @!live))
           (settled
             (fn [_]
               (is (= nothing (retention)))
-              (is (= 0 (:entries (runtime/residue))))
+              (is (= 0 (:entries (rf.hicasso.test.runtime/residue))))
               (done))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/hook_budget_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hook_budget_cljs_test.cljs
@@ -55,16 +55,16 @@
   reach. `kernel_commit_owns_cljs_test` takes the same view for the same
   reason."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.hook-probe :as probe]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.hook-probe :as rf.hicasso.hook-probe]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/server" :as react-dom-server]))
 
@@ -75,10 +75,10 @@
 (rf/reg-event :hookbudget/seed (fn [_ [_ db]] {:db db}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -86,7 +86,7 @@
 
 (defn- seeded!
   []
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id
     (rf/dispatch-sync [:hookbudget/seed {:items (vec (range 20))}]))
@@ -97,7 +97,7 @@
   Every count in this file is worthless if this is not true, so it is
   asserted rather than branched on."
   []
-  (is (true? (probe/install!))
+  (is (true? (rf.hicasso.hook-probe/install!))
       "React's client-internals dispatcher slot was not found — the hook
        budget is UNWITNESSED, not satisfied"))
 
@@ -107,31 +107,31 @@
   while it ran, in call order."
   [hiccup]
   (let [!html (volatile! nil)
-        hooks (probe/record!
+        hooks (rf.hicasso.hook-probe/record!
                 (fn []
                   (vreset! !html
                            (react-dom-server/renderToString
-                             (mount/provider frame-id
-                                             (codec/root-element frame-id hiccup))))))]
+                             (rf.hicasso.impl.mount/provider frame-id
+                                             (rf.hicasso.impl.codec/root-element frame-id hiccup))))))]
     {:html @!html :hooks hooks}))
 
 ;; ---------------------------------------------------------------------------
 ;; The boundaries under the probe
 ;; ---------------------------------------------------------------------------
 
-(h/defview reader
+(rf.hicasso/defview reader
   "One boundary reading `n` subscriptions through the ambient collector.
   The reads sit in a `for` — which no hook-shaped read surface can do,
   and which is exactly why the count is interesting."
   [{:keys [n]}]
   [:ul.reads
    (for [i (range n)]
-     [:li.read {:key i} (str (h/sub [:hookbudget/item i]))])])
+     [:li.read {:key i} (str (rf.hicasso/sub [:hookbudget/item i]))])])
 
-(h/defview outer
+(rf.hicasso/defview outer
   "A boundary whose body mints another boundary's element."
   [_]
-  [:div.outer (str (h/sub [:hookbudget/item 0])) [reader {:n 1}]])
+  [:div.outer (str (rf.hicasso/sub [:hookbudget/item 0])) [reader {:n 1}]])
 
 (defn- three-hook-control
   "A plain React component calling three hooks, two of which HD-020(b)
@@ -162,25 +162,25 @@
   (react/useEffect (fn [] js/undefined) #js [])
   (react/createElement "p" #js {:className "hosted"} (.-label props)))
 
-(h/defhost gated-host
+(rf.hicasso/defhost gated-host
   "The RULED DEFAULT policy, `:client-only`, which mints a gate."
   hosted-widget)
 
-(h/defhost render-host
+(rf.hicasso/defhost render-host
   "The same component under `:server :render` — the policy that mints NO
   gate, so the head's slot carries the foreign component itself."
   hosted-widget
   {:server :render})
 
-(h/defview gated-page
+(rf.hicasso/defview gated-page
   "One boundary, one read, one gated crossing."
   [_]
-  [:div.page (str (h/sub [:hookbudget/item 0])) [gated-host {:label "hi"}]])
+  [:div.page (str (rf.hicasso/sub [:hookbudget/item 0])) [gated-host {:label "hi"}]])
 
-(h/defview render-page
+(rf.hicasso/defview render-page
   "The same page with the crossing's policy the only thing changed."
   [_]
-  [:div.page (str (h/sub [:hookbudget/item 0])) [render-host {:label "hi"}]])
+  [:div.page (str (rf.hicasso/sub [:hookbudget/item 0])) [render-host {:label "hi"}]])
 
 ;; ---------------------------------------------------------------------------
 ;; 1. The instrument can count, and can count past the budget
@@ -189,7 +189,7 @@
 (deftest the-probe-answers-what-react-was-asked-for-and-can-count-to-three
   (seeded!)
   (armed!)
-  (let [hooks (probe/record!
+  (let [hooks (rf.hicasso.hook-probe/record!
                 (fn [] (react-dom-server/renderToString
                          (react/createElement three-hook-control nil))))]
 
@@ -228,7 +228,7 @@
     (testing "and the ledger the shell declares agrees with what React was
               asked for — which is what makes the declaration a checked
               statement rather than a comment that can rot"
-      (is (= (count runtime/shell-hook-ledger) (count hooks))))
+      (is (= (count rf.hicasso.test.runtime/shell-hook-ledger) (count hooks))))
 
     (testing "neither is `useRef` and neither is `useState`: HD-020(b)'s
               two named prohibitions, stated as themselves rather than
@@ -327,7 +327,7 @@
 
     (testing "and the shell's ledger is what it was: the crossing added a
               fiber and a hook to the PAGE, not to the boundary"
-      (is (= 2 (count runtime/shell-hook-ledger))))))
+      (is (= 2 (count rf.hicasso.test.runtime/shell-hook-ledger))))))
 
 (deftest an-ssr-render-crossing-costs-no-hook-and-the-hosted-hooks-are-its-own
   (seeded!)
@@ -357,4 +357,4 @@
     (testing "and the budget is still the budget — the component brought
               three hooks through the door and the shell's ledger did not
               move"
-      (is (= 2 (count runtime/shell-hook-ledger))))))
+      (is (= 2 (count rf.hicasso.test.runtime/shell-hook-ledger))))))

--- a/implementation/hicasso/test/re_frame/hicasso/hooks_island_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hooks_island_cljs_test.cljs
@@ -38,17 +38,17 @@
   installs) or under nothing, and the crossing is measured where it
   costs something: the DOM lane."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.native :as n]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.native :as rf.hicasso.native]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]
             [uix.core :as uix :refer-macros [defui]]
             ["react" :as react]
             ["react-dom/server" :as react-dom-server])
-  (:require-macros [re-frame.hicasso.expansion-probe :as probe]))
+  (:require-macros [re-frame.hicasso.expansion-probe :as rf.hicasso.expansion-probe]))
 
 (def ^:private frame-id ::hooks-island)
 
@@ -60,10 +60,10 @@
 (rf/reg-event ::seed (fn [_ [_ prices]] {:db {:prices prices}}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The islands
@@ -78,12 +78,12 @@
 (defn- reader
   "Reads one subscription, and nothing else. Raw React."
   [^js props]
-  (react/createElement "span" nil (str (n/use-sub [::price (.-sym props)]))))
+  (react/createElement "span" nil (str (rf.hicasso.native/use-sub [::price (.-sym props)]))))
 
 (defn- framed
   "Takes the frame-locked ops and reports the frame it was locked to."
   [^js _props]
-  (let [ops (n/use-frame)]
+  (let [ops (rf.hicasso.native/use-frame)]
     (reset! !observed-ops ops)
     (react/createElement "span" nil (str (:frame ops)))))
 
@@ -91,7 +91,7 @@
   "The same read in a UIx `defui`: the hook does not know which dialect
   called it."
   [{:keys [sym]}]
-  (uix/$ :span (str (n/use-sub [::price sym]))))
+  (uix/$ :span (str (rf.hicasso.native/use-sub [::price sym]))))
 
 (defn- uix-arm
   "The plain React shim every crossing into UIx needs — UIx's ABI is a
@@ -117,7 +117,7 @@
   through a hand-built context wrapper this suite would then be pinning
   instead of the product."
   [element]
-  (react-dom-server/renderToStaticMarkup (mount/provider frame-id element)))
+  (react-dom-server/renderToStaticMarkup (rf.hicasso.impl.mount/provider frame-id element)))
 
 (defn- render-frameless!
   "Render `element` with NO provider above it. The island in a portal
@@ -141,7 +141,7 @@
   "The census with the entry cache projected out — the four counts a
   cold read must leave at zero."
   []
-  (dissoc (runtime/residue) :entries))
+  (dissoc (rf.hicasso.test.runtime/residue) :entries))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. The cold tier — a read before any commit
@@ -178,7 +178,7 @@
             render React discards leaves exactly the same one, and the
             hook seam mints through the same door precisely so there is
             one story"
-    (is (= 1 (:entries (runtime/residue)))))
+    (is (= 1 (:entries (rf.hicasso.test.runtime/residue)))))
 
   (testing "the UIx arm is the same hook and the same reading: the value
             is right, and nothing was committed"
@@ -244,7 +244,7 @@
               incarnation's bundle out forever. `hooks_island_dom_cljs_test`
               drives the reincarnation itself; this row is where the
               structural reason lives"
-      (is (identical? (:ops (collector/frame-row frame-id)) ops)))))
+      (is (identical? (:ops (rf.hicasso.impl.collector/frame-row frame-id)) ops)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4. The membership pin
@@ -254,7 +254,7 @@
   "Every public var name in `re-frame.hicasso.native`, read from the
   compiler at expansion — the analyser's public defs for the runtime
   half, the JVM namespace's public vars for the macro half."
-  (set (probe/public-vars re-frame.hicasso.native)))
+  (set (rf.hicasso.expansion-probe/public-vars re-frame.hicasso.native)))
 
 (deftest the-namespace-is-the-two-hooks
   (testing "the census is not vacuous: the probe really read a namespace.
@@ -266,8 +266,8 @@
   (testing "the two hooks are there, and they resolve"
     (is (contains? publics "use-sub"))
     (is (contains? publics "use-frame"))
-    (is (fn? n/use-sub))
-    (is (fn? n/use-frame)))
+    (is (fn? rf.hicasso.native/use-sub))
+    (is (fn? rf.hicasso.native/use-frame)))
 
   (testing "and they are the whole namespace — a third public var reds
             here at the diff that adds it (rf2-6c12m.3)"

--- a/implementation/hicasso/test/re_frame/hicasso/hooks_island_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hooks_island_dom_cljs_test.cljs
@@ -58,18 +58,18 @@
   What can be said without a fiber is said in `hooks_island_cljs_test`."
   (:require [clojure.set :as set]
             [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.native :as n]
-            [re-frame.hicasso.roots-frames-support :as support]
-            [re-frame.hicasso.tool :as tool]
-            [re-frame.test-support :as test-support]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.native :as rf.hicasso.native]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.hicasso.tool :as rf.hicasso.tool]
+            [re-frame.test-support :as rf.test-support]
             [uix.core :as uix :refer-macros [defui]]
             ["react" :as react]))
 
@@ -136,8 +136,8 @@
   [^js props]
   (swap! !island-runs inc)
   (let [sym               (.-sym props)
-        price             (n/use-sub [::price sym])
-        ops               (n/use-frame)
+        price             (rf.hicasso.native/use-sub [::price sym])
+        ops               (rf.hicasso.native/use-frame)
         [local set-local] (react/useState 0)]
     (reset! !last-ops ops)
     ;; The class on the ROOT node is what the rows read; the `.price`,
@@ -159,8 +159,8 @@
   same local state, the same DOM."
   [{:keys [sym]}]
   (swap! !island-runs inc)
-  (let [price             (n/use-sub [::price sym])
-        ops               (n/use-frame)
+  (let [price             (rf.hicasso.native/use-sub [::price sym])
+        ops               (rf.hicasso.native/use-frame)
         [local set-local] (uix/use-state 0)]
     (reset! !last-ops ops)
     (uix/$ :div {:class "island"}
@@ -183,8 +183,8 @@
   "An island reading TWO keys — the shape `n/use-sub`'s docstring prices
   at two cells, and the row below measures."
   [^js props]
-  (let [price (n/use-sub [::price (.-sym props)])
-        other (n/use-sub [::elsewhere])]
+  (let [price (rf.hicasso.native/use-sub [::price (.-sym props)])
+        other (rf.hicasso.native/use-sub [::elsewhere])]
     (react/createElement "div" #js {:className "two"}
       (react/createElement "b" #js {:className "price"} (str price))
       (react/createElement "i" #js {:className "other"} (str other)))))
@@ -193,12 +193,12 @@
 ;; on is the author's own function with nothing in between — the declared
 ;; arm the parity floor is stated over — and so the same tree is one tree
 ;; on every lane.
-(h/defhost ticker-host    ticker    {:server :render})
-(h/defhost uix-host-arm   uix-arm   {:server :render})
-(h/defhost two-reads-host two-reads {:server :render})
-(h/defhost strict-mode    react/StrictMode {:server :render})
+(rf.hicasso/defhost ticker-host    ticker    {:server :render})
+(rf.hicasso/defhost uix-host-arm   uix-arm   {:server :render})
+(rf.hicasso/defhost two-reads-host two-reads {:server :render})
+(rf.hicasso/defhost strict-mode    react/StrictMode {:server :render})
 
-(h/defview host
+(rf.hicasso/defview host
   "Rung 3's neighbour: an ordinary boundary body crossing into a raw
   React island through the named door. The island reaches the frame
   through the context this boundary's root installed, and through
@@ -206,36 +206,36 @@
   [{:keys [sym]}]
   [ticker-host {:sym sym}])
 
-(h/defview uix-host
+(rf.hicasso/defview uix-host
   "The same page with the UIx arm in the island's place."
   [{:keys [sym]}]
   [uix-host-arm {:sym sym}])
 
-(h/defview strict-host
+(rf.hicasso/defview strict-host
   "The raw island under React's own StrictMode, which double-invokes
   the body and runs mount/unmount/mount over every effect. StrictMode
   is a foreign component too, so it crosses through the same door."
   [{:keys [sym]}]
   [strict-mode [ticker-host {:sym sym}]])
 
-(h/defview two-reads-page
+(rf.hicasso/defview two-reads-page
   [{:keys [sym]}]
   [two-reads-host {:sym sym}])
 
-(h/defview boundary-reader
+(rf.hicasso/defview boundary-reader
   "A BOUNDARY reading the identical key the island reads — the control
   for the shared-entry claim."
   [{:keys [sym]}]
-  [:u.boundary (str (h/sub [::price sym]))])
+  [:u.boundary (str (rf.hicasso/sub [::price sym]))])
 
-(h/defview shared-host
+(rf.hicasso/defview shared-host
   "One boundary and one island, reading one key."
   [{:keys [sym]}]
   [:div [boundary-reader {:sym sym}] [ticker-host {:sym sym}]])
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; `nil` and not the default: a dynamic-var frame left in ambient scope
      ;; would let a hook that failed to resolve its own frame answer that one
      ;; instead, and the isolation row would read a rendering difference where
@@ -244,11 +244,11 @@
      ;; The MAP shape, because every row here is `async`.
      :async?        true
      :init-fn       (fn []
-                      (support/leave-act-environment!)
+                      (rf.hicasso.roots-frames-support/leave-act-environment!)
                       (reset! !island-runs 0)
                       (reset! !last-ops nil)
-                      (error-emit/clear-error-listeners!)
-                      (collector/reset-runtime!))}))
+                      (rf.error-emit/clear-error-listeners!)
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -262,7 +262,7 @@
   [frame-kw prices]
   (rf/make-frame {:id frame-kw})
   (rf/with-frame frame-kw (rf/dispatch-sync [::seed prices]))
-  (frame/frame-incarnation-token frame-kw))
+  (rf.frame/frame-incarnation-token frame-kw))
 
 (defn- query-node [handle selector]
   (.querySelector ^js (:container handle) selector))
@@ -270,10 +270,10 @@
   (some-> (query-node handle selector) .-textContent))
 (defn- click! [handle selector]
   (.click ^js (query-node handle selector))
-  (mount/settle!)
+  (rf.hicasso.impl.mount/settle!)
   nil)
 
-(defn- readers-of [sub-key] (runtime/cell-readers sub-key))
+(defn- readers-of [sub-key] (rf.hicasso.test.runtime/cell-readers sub-key))
 
 (defonce ^:private !minted
   ;; Every root a row has minted through `mount-live!`, oldest first.
@@ -292,7 +292,7 @@
   SYNCHRONOUSLY and hands it over only once the wait succeeds, so a
   rejection reaches the arm with a live root the arm has no name for."
   []
-  (run! mount/release! @!minted)
+  (run! rf.hicasso.impl.mount/release! @!minted)
   (reset! !minted [])
   nil)
 
@@ -312,15 +312,15 @@
   instant until [[release-minted!]] runs there is a live root on the page
   and this promise is the only thing that could ever name it."
   [frame-kw hiccup sub-key readers]
-  (let [container (mount/fresh-container!)
-        handle    (mount/root! container frame-kw hiccup)]
+  (let [container (rf.hicasso.impl.mount/fresh-container!)
+        handle    (rf.hicasso.impl.mount/root! container frame-kw hiccup)]
     (swap! !minted conj handle)
-    (-> (support/wait-until! #(= readers (count (readers-of sub-key))))
+    (-> (rf.hicasso.roots-frames-support/wait-until! #(= readers (count (readers-of sub-key))))
         (.then (fn [subscribed?]
                  (when-not subscribed?
                    (throw (ex-info (str "expected " readers
                                         " subscribed reader(s) on " (pr-str sub-key))
-                                   {:residue (runtime/residue)})))
+                                   {:residue (rf.hicasso.test.runtime/residue)})))
                  handle)))))
 
 (defn- skip! [why] (is true (str "a hook claim needs a real React DOM — " why)))
@@ -338,7 +338,7 @@
   [label]
   (fn [e]
     (is false (str label " — " (.-message e)
-                   " | residue " (pr-str (runtime/residue))))
+                   " | residue " (pr-str (rf.hicasso.test.runtime/residue))))
     nil))
 
 (defn- teardown!
@@ -348,7 +348,7 @@
   census taken after it reads zeros whether the teardown released
   anything or not."
   [handle]
-  (support/teardown-census! handle))
+  (rf.hicasso.roots-frames-support/teardown-census! handle))
 
 ;; ---------------------------------------------------------------------------
 ;; W1. The read is the runtime's own, and the tool tier can see it
@@ -356,7 +356,7 @@
 
 (deftest an-islands-read-is-the-runtimes-own-and-xray-sees-it
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (let [k (price-key alpha "AAPL")]
         (seat! alpha {"AAPL" 191})
@@ -374,7 +374,7 @@
                           hook that read through `subscribe-once` per render —
                           the paint above is identical under it and there would
                           be one reader here, or none"
-                  (is (= #{k} (support/cell-keys)))
+                  (is (= #{k} (rf.hicasso.roots-frames-support/cell-keys)))
                   (is (= 2 (count (readers-of k)))))
 
                 (testing "and TWO read-set entries exist, which is the honest
@@ -383,7 +383,7 @@
                           body that reads nothing still mints and claims an
                           entry, and that is what makes the tool tier's census
                           complete"
-                  (is (= 2 (:entries (runtime/residue)))))
+                  (is (= 2 (:entries (rf.hicasso.test.runtime/residue)))))
 
                 (testing "and `re-frame.hicasso.tool`'s mounted-boundary
                           projection — hic-023's, the one Xray consumes — NAMES
@@ -397,7 +397,7 @@
                           unchanged under it, because two entries with equal
                           key sets group into one row; what doubles is the
                           number of entries folded into that row"
-                  (let [projection (tool/read-mounted-boundaries)
+                  (let [projection (rf.hicasso.tool/read-mounted-boundaries)
                         row        (first (filter (fn [r]
                                                     (some #(= ::price (:sub-id %))
                                                           (:reads r)))
@@ -414,7 +414,7 @@
 
                 (exercised! :hooks/mounted-read)
                 (testing "teardown releases every membership the mount took"
-                  (is (= support/released (teardown! handle))))
+                  (is (= rf.hicasso.roots-frames-support/released (teardown! handle))))
                 nil))
             (.catch (report-failure! "W1 mounted read"))
             (.then (fn [_] (release-minted!) (done))))))))
@@ -425,7 +425,7 @@
 
 (deftest a-write-wakes-the-island-that-reads-it-and-nothing-else
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (let [k (price-key alpha "AAPL")]
         (seat! alpha {"AAPL" 191})
@@ -433,7 +433,7 @@
             (.then
               (fn [handle]
                 (testing "a write to the key the island reads repaints it"
-                  (mount/dispatch! handle [::set-price "AAPL" 204])
+                  (rf.hicasso.impl.mount/dispatch! handle [::set-price "AAPL" 204])
                   (is (= "204" (text-at handle ".price"))))
 
                 (let [runs (deref !island-runs)]
@@ -443,7 +443,7 @@
                             whole — it repaints correctly on the row above and
                             wakes on every write in the application here, which
                             is the cost the whole cell table exists to avoid"
-                    (mount/dispatch! handle [::touch-elsewhere])
+                    (rf.hicasso.impl.mount/dispatch! handle [::touch-elsewhere])
                     (is (= runs (deref !island-runs)))
                     (is (= "204" (text-at handle ".price")))))
 
@@ -457,7 +457,7 @@
                          (rf/with-frame alpha @(rf/subscribe [::price "AAPL"])))))
 
                 (exercised! :hooks/selective-wake)
-                (is (= support/released (teardown! handle)))
+                (is (= rf.hicasso.roots-frames-support/released (teardown! handle)))
                 nil))
             (.catch (report-failure! "W2 selective wake"))
             (.then (fn [_] (release-minted!) (done))))))))
@@ -484,7 +484,7 @@
           (fn [handle]
             (let [reg-at-mount (first (readers-of k))
                   runs         (deref !island-runs)
-                  residue      (runtime/residue)]
+                  residue      (rf.hicasso.test.runtime/residue)]
 
               (testing "three re-renders driven by the island's OWN React
                         state — a state bump behind a real click, which the
@@ -512,27 +512,27 @@
               (testing "so nothing was released and re-acquired: one cell,
                         one membership, one boundary, one edge, one entry —
                         the numbers the mount established, unmoved"
-                (is (= residue (runtime/residue))))
+                (is (= residue (rf.hicasso.test.runtime/residue))))
 
               (testing "the same holds across a re-render the RUNTIME
                         caused. A write moves the value, React re-renders
                         the island, and the read set is what it was — so
                         React is never handed a new `subscribe` and the
                         commit does no work"
-                (mount/dispatch! handle [::set-price "AAPL" 204])
+                (rf.hicasso.impl.mount/dispatch! handle [::set-price "AAPL" 204])
                 (is (= "204" (text-at handle ".price")))
                 (is (true? (identical? reg-at-mount (first (readers-of k))))
                     "React holds a DIFFERENT registration, so the
                      subscription was torn down and rebuilt")
-                (is (= residue (runtime/residue))))
+                (is (= residue (rf.hicasso.test.runtime/residue))))
 
               (exercised! mechanism)
-              (is (= support/released (teardown! handle)))
+              (is (= rf.hicasso.roots-frames-support/released (teardown! handle)))
               nil))))))
 
 (deftest a-re-render-that-changed-no-read-performs-no-re-subscribe
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (-> (no-resubscribe-row! host :hooks/no-resubscribe)
           (.catch (report-failure! "W3 no re-subscribe"))
@@ -540,7 +540,7 @@
 
 (deftest a-uix-island-re-rendered-for-its-own-reasons-performs-no-re-subscribe
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (-> (no-resubscribe-row! uix-host :hooks/no-resubscribe-uix)
           (.catch (report-failure! "W3 no re-subscribe, UIx arm"))
@@ -552,7 +552,7 @@
 
 (deftest strict-modes-double-mount-acquires-once-and-unmount-releases-exactly
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (let [k (price-key alpha "AAPL")]
         (seat! alpha {"AAPL" 191})
@@ -573,16 +573,16 @@
                           state machine's one prohibition — which under a
                           double-invoked render acquires twice and reads 2 here
                           while painting perfectly"
-                  (is (= #{k} (support/cell-keys)))
+                  (is (= #{k} (rf.hicasso.roots-frames-support/cell-keys)))
                   (is (= 1 (count (readers-of k))))
                   (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
-                         (dissoc (runtime/residue) :entries))))
+                         (dissoc (rf.hicasso.test.runtime/residue) :entries))))
 
                 (testing "the island is live, not merely tidy — a subscription
                           torn down by StrictMode's first cleanup and never
                           rebuilt would satisfy every count above and repaint
                           nothing"
-                  (mount/dispatch! handle [::set-price "AAPL" 204])
+                  (rf.hicasso.impl.mount/dispatch! handle [::set-price "AAPL" 204])
                   (is (= "204" (text-at handle ".price"))))
 
                 (testing "and unmount releases EXACTLY what mount acquired,
@@ -590,15 +590,15 @@
                           caught: a cleanup that released by key rather than by
                           the cells it acquired — after a reap and rebuild it
                           would release a successor's and leave its own"
-                  (is (= support/released (teardown! handle))))
+                  (is (= rf.hicasso.roots-frames-support/released (teardown! handle))))
 
                 (exercised! :hooks/strict-mode)
-                (-> (support/quiesced!)
+                (-> (rf.hicasso.roots-frames-support/quiesced!)
                     (.then (fn [_]
                              (testing "past the reapers the tables are empty"
                                (is (= {:cells 0 :cell-refs 0 :boundaries 0
                                        :edges 0 :entries 0}
-                                      (runtime/residue))))
+                                      (rf.hicasso.test.runtime/residue))))
                              nil)))))
             (.catch (report-failure! "W4 StrictMode"))
             (.then (fn [_] (release-minted!) (done))))))))
@@ -629,7 +629,7 @@
                         global, a dynamic var, a `:rf/default` floor —
                         every one of which produces ONE key here and two
                         visually plausible subtrees"
-                (is (= #{ka kb} (support/cell-keys)))
+                (is (= #{ka kb} (rf.hicasso.roots-frames-support/cell-keys)))
                 (is (= 1 (count (readers-of ka))))
                 (is (= 1 (count (readers-of kb)))))
 
@@ -640,19 +640,19 @@
               (testing "a write in one frame moves that frame's island and
                         leaves the other exactly where it was — the
                         isolation claim as a REPAINT rather than as a count"
-                (mount/dispatch! a [::set-price "AAPL" "alpha-moved"])
+                (rf.hicasso.impl.mount/dispatch! a [::set-price "AAPL" "alpha-moved"])
                 (is (= "alpha-moved" (text-at a ".price")))
                 (is (= "beta-price"  (text-at b ".price"))))
 
               (exercised! mechanism)
-              (mount/unmount! a)
-              (is (= support/released (teardown! b)))
-              (mount/release! (assoc a :root nil))
+              (rf.hicasso.impl.mount/unmount! a)
+              (is (= rf.hicasso.roots-frames-support/released (teardown! b)))
+              (rf.hicasso.impl.mount/release! (assoc a :root nil))
               nil))))))
 
 (deftest two-frames-are-two-cells-and-an-island-cannot-see-across
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (-> (isolation-row! host :hooks/frame-isolation)
           (.catch (report-failure! "W5 frame isolation"))
@@ -660,7 +660,7 @@
 
 (deftest a-uix-island-cannot-see-across-frames-either
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (-> (isolation-row! uix-host :hooks/frame-isolation-uix)
           (.catch (report-failure! "W5 frame isolation, UIx arm"))
@@ -672,7 +672,7 @@
 
 (deftest two-reads-in-one-island-are-two-cells
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (let [ka (price-key alpha "AAPL")
             ke [alpha [::elsewhere]]]
@@ -687,7 +687,7 @@
                           subscription is a hook, so `n` reads cost `n` of
                           them. Narrowing caught: a hook that folded a
                           component's reads into one entry and dropped one"
-                  (is (= #{ka ke} (support/cell-keys)))
+                  (is (= #{ka ke} (rf.hicasso.roots-frames-support/cell-keys)))
                   (is (= 1 (count (readers-of ka))))
                   (is (= 1 (count (readers-of ke))))
                   (is (= "191" (text-at handle ".price")))
@@ -695,16 +695,16 @@
 
                 (testing "and both are live: a write to either key repaints
                           the island through its own cell"
-                  (mount/dispatch! handle [::touch-elsewhere])
+                  (rf.hicasso.impl.mount/dispatch! handle [::touch-elsewhere])
                   (is (= "1" (text-at handle ".other")))
                   (is (= "191" (text-at handle ".price")))
-                  (mount/dispatch! handle [::set-price "AAPL" 204])
+                  (rf.hicasso.impl.mount/dispatch! handle [::set-price "AAPL" 204])
                   (is (= "204" (text-at handle ".price")))
                   (is (= 1 (count (readers-of ka))))
                   (is (= 1 (count (readers-of ke)))))
 
                 (exercised! :hooks/two-cells)
-                (is (= support/released (teardown! handle)))
+                (is (= rf.hicasso.roots-frames-support/released (teardown! handle)))
                 nil))
             (.catch (report-failure! "W5b two cells"))
             (.then (fn [_] (release-minted!) (done))))))))
@@ -720,14 +720,14 @@
   [thunk]
   (let [seen (atom [])
         k    ::destroyed-listener]
-    (error-emit/register-error-listener!
+    (rf.error-emit/register-error-listener!
       k (fn [r] (when (= :rf.error/frame-destroyed (:error r)) (swap! seen conj r))))
     (try (thunk) @seen
-         (finally (error-emit/unregister-error-listener! k)))))
+         (finally (rf.error-emit/unregister-error-listener! k)))))
 
 (deftest use-frame-is-stable-across-renders-and-retargets-across-a-reincarnation
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (let [k (price-key alpha "AAPL")]
         (seat! alpha {"AAPL" "predecessor"})
@@ -735,7 +735,7 @@
             (.then
               (fn [handle]
                 (let [ops-1   (deref !last-ops)
-                      token-1 (frame/frame-incarnation-token alpha)]
+                      token-1 (rf.frame/frame-incarnation-token alpha)]
 
                   (testing "reference stability: three re-renders that changed
                             no frame hand back the IDENTICAL map, which is what
@@ -755,7 +755,7 @@
                               public id"
                       (is (not (identical? token-1 token-2))))
 
-                    (-> (support/wait-until! #(= "successor" (text-at handle ".price")))
+                    (-> (rf.hicasso.roots-frames-support/wait-until! #(= "successor" (text-at handle ".price")))
                         (.then
                           (fn [corrected?]
                             (is (true? corrected?)
@@ -798,7 +798,7 @@
                                                   @(rf/subscribe [::price "AAPL"])))))))
 
                             (exercised! :hooks/incarnation)
-                            (is (= support/released (teardown! handle)))
+                            (is (= rf.hicasso.roots-frames-support/released (teardown! handle)))
                             nil))
                         ;; The inner chain finishes NOTHING and tears nothing
                         ;; down — it is returned into the outer one below.
@@ -819,7 +819,7 @@
   ;; fallback honestly rather than advertise transition-awareness. This is
   ;; the test half; `n/use-sub`'s docstring is the documented half.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (let [k (price-key alpha "AAPL")]
         (seat! alpha {"AAPL" 191})
@@ -827,8 +827,8 @@
             (.then
               (fn [handle]
                 (react/startTransition
-                  (fn [] (collector/dispatch! alpha [::set-price "AAPL" 204])))
-                (mount/settle!)
+                  (fn [] (rf.hicasso.impl.collector/dispatch! alpha [::set-price "AAPL" 204])))
+                (rf.hicasso.impl.mount/settle!)
                 (testing "the paint agrees with app-db — no tear. A hook that
                           returned a value captured independently of the epoch
                           `getSnapshot` reports could disagree here, and React
@@ -840,10 +840,10 @@
                           transition"
                   (is (= 1 (count (readers-of k))))
                   (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
-                         (dissoc (runtime/residue) :entries))))
+                         (dissoc (rf.hicasso.test.runtime/residue) :entries))))
 
                 (exercised! :hooks/transition)
-                (is (= support/released (teardown! handle)))
+                (is (= rf.hicasso.roots-frames-support/released (teardown! handle)))
                 nil))
             (.catch (report-failure! "W7 transition"))
             (.then (fn [_] (release-minted!) (done))))))))
@@ -853,7 +853,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-declared-population-was-actually-exercised
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test reaches none of the mechanisms")
     (is (= declared-population (deref !exercised))
         (str "declared but never reached: "

--- a/implementation/hicasso/test/re_frame/hicasso/host_adoption_trace_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/host_adoption_trace_dom_cljs_test.cljs
@@ -67,14 +67,14 @@
   takes the `-dom-cljs-test` suffix and that row skips in Node, in the
   shape the sibling `host-ssr-dom-cljs-test` established."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace :as rf.trace]
             ["react" :as react]
             ["react-dom/client" :as react-dom-client]
             ["react-dom/server" :as react-dom-server]))
@@ -84,17 +84,17 @@
 (rf/reg-event :hicasso.adoption/seed (fn [_ _] {:db {:title "quarterly"}}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- skip! [why]
   (is true (str "an adoption-trace DOM claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:hicasso.adoption/seed]))
   frame-id)
@@ -115,7 +115,7 @@
   "A declaration nobody else has touched — the same door `defhost`
   expands to. `n` keeps the `displayName` legible in a failure."
   [n]
-  (codec/mint-host! n chart {:fallback [:div.chart-skeleton "loading"]}))
+  (rf.hicasso.impl.codec/mint-host! n chart {:fallback [:div.chart-skeleton "loading"]}))
 
 ;; ---------------------------------------------------------------------------
 ;; Watching the instrumentation channel
@@ -128,14 +128,14 @@
   []
   (let [seen (atom [])
         lk   (keyword (gensym "rf.oaksj-adopt-"))]
-    (trace/register-listener!
+    (rf.trace/register-listener!
       lk (fn [ev] (when (= :rf.ssr/host-adopted (:operation ev))
                     (swap! seen conj ev))))
-    {:seen seen :stop (fn [] (trace/unregister-listener! lk))}))
+    {:seen seen :stop (fn [] (rf.trace/unregister-listener! lk))}))
 
 (defn- render-html [hiccup]
   (react-dom-server/renderToString
-    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+    (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup))))
 
 (defn- render-as
   "One render of `hiccup` with React's adoption answer FORCED — the whole
@@ -143,7 +143,7 @@
   not Hicasso's state. Everything downstream of it here — the gate
   closure, the crossing cell, the emit — is the shipping code."
   [adopted? hiccup]
-  (with-redefs [codec/adopted? (fn [] adopted?)]
+  (with-redefs [rf.hicasso.impl.codec/adopted? (fn [] adopted?)]
     (render-html hiccup)))
 
 (defn- query-node [root selector] (.querySelector root selector))
@@ -169,7 +169,7 @@
           (is (empty? @seen) (pr-str @seen))))
       (finally
         (stop)
-        (collector/reset-runtime!)))))
+        (rf.hicasso.impl.collector/reset-runtime!)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — a crossing announces ONCE, and carries the facts a tool reads
@@ -219,7 +219,7 @@
         (is (= 1 (count @seen)) (pr-str @seen)))
       (finally
         (stop)
-        (collector/reset-runtime!)))))
+        (rf.hicasso.impl.collector/reset-runtime!)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — nothing crossed, so nothing is announced
@@ -244,7 +244,7 @@
         (is (empty? @seen) (pr-str @seen)))
       (finally
         (stop)
-        (collector/reset-runtime!)))))
+        (rf.hicasso.impl.collector/reset-runtime!)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — the same claim, unstubbed, through a real hydration
@@ -252,19 +252,19 @@
 
 (deftest a-hydrated-crossing-announces-once
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
         (let [host      (mint! "hydrated-chart")
               page      [:div [host {:label "revenue"}] [host {:label "costs"}]]
               html      (render-html page)
-              container (mount/fresh-container!)
+              container (rf.hicasso.impl.mount/fresh-container!)
               {:keys [seen stop]} (watch-adoptions!)]
           (set! (.-innerHTML container) html)
           (let [root (react-dom-client/hydrateRoot
                        container
-                       (mount/provider frame-id (codec/root-element frame-id page)))]
+                       (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id page)))]
             (js/setTimeout
               (fn []
                 (try
@@ -282,6 +282,6 @@
                     (stop)
                     (.unmount root)
                     (when-some [p (.-parentNode container)] (.removeChild p container))
-                    (collector/reset-runtime!)
+                    (rf.hicasso.impl.collector/reset-runtime!)
                     (done))))
               150)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/host_slots_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/host_slots_dom_cljs_test.cljs
@@ -78,14 +78,14 @@
   React DOM. The declaration rows and the conversion rows need no DOM
   and run under `:node-test` too."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]))
 
 (def ^:private frame-id ::host-slots)
@@ -100,10 +100,10 @@
   (fn [{:keys [db]} [_ what]] {:db (assoc db :picked what)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The vendor family — a provider, two members, and the two prop KINDS
@@ -150,19 +150,19 @@
 ;; The declarations
 ;; ---------------------------------------------------------------------------
 
-(h/defhost panel-host panel {:slots #{:title :footer}})
+(rf.hicasso/defhost panel-host panel {:slots #{:title :footer}})
 
-(h/defhost bare-panel
+(rf.hicasso/defhost bare-panel
   "The SAME component, declared with no slots at all — the control the
   sabotage row needs."
   panel)
 
-(h/defhost rows-host row-list {:callbacks {:render-row :render}})
+(rf.hicasso/defhost rows-host row-list {:callbacks {:render-row :render}})
 
-(h/defhost themed (.-Provider theme-context) {:server :render})
-(h/defhost badge theme-badge {:server :render})
+(rf.hicasso/defhost themed (.-Provider theme-context) {:server :render})
+(rf.hicasso/defhost badge theme-badge {:server :render})
 
-(h/defhost suspense
+(rf.hicasso/defhost suspense
   "React's own compound, declared the way chapter 20 teaches it."
   react/Suspense
   {:slots #{:fallback}})
@@ -178,7 +178,7 @@
   (is true (str "a ReactNode-slot DOM claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:hicasso.slots/seed]))
   frame-id)
@@ -193,7 +193,7 @@
   and no render: the conversion is what is under test, so the assertion
   is taken where the conversion happens."
   [hiccup]
-  (.-props (codec/root-element frame-id hiccup)))
+  (.-props (rf.hicasso.impl.codec/root-element frame-id hiccup)))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the declaration (these rows run under :node-test too)
@@ -204,15 +204,15 @@
             normalised to its canonical slot at MINT — so `:on-empty` and
             a call site writing `:onEmpty` are the one position, which is
             the rule every other roster in this codec already keeps"
-    (is (some? (codec/mint-host! "slots/kebab" panel {:slots #{:on-empty}})))
-    (is (some? (codec/mint-host! "slots/camel" panel {:slots #{:onEmpty}})))
-    (is (some? (codec/mint-host! "slots/string" panel {:slots #{"title"}})))
-    (is (some? (codec/mint-host! "slots/near-reserved" panel
+    (is (some? (rf.hicasso.impl.codec/mint-host! "slots/kebab" panel {:slots #{:on-empty}})))
+    (is (some? (rf.hicasso.impl.codec/mint-host! "slots/camel" panel {:slots #{:onEmpty}})))
+    (is (some? (rf.hicasso.impl.codec/mint-host! "slots/string" panel {:slots #{"title"}})))
+    (is (some? (rf.hicasso.impl.codec/mint-host! "slots/near-reserved" panel
                                  {:slots #{:constructor-label :prototypes}}))
         "an ordinary prop that merely reads like a reserved emitted name
          mints; the crossing's reserved skip is on the WHOLE emitted slot"))
   (testing "and it composes with the two options that were already there"
-    (is (some? (codec/mint-host! "slots/all" panel
+    (is (some? (rf.hicasso.impl.codec/mint-host! "slots/all" panel
                                  {:callbacks {:on-close :event}
                                   :slots     #{:title}
                                   :server    :render})))))
@@ -221,45 +221,45 @@
   (testing "not a set. A vector or a map would each have to be read as
             something, and neither reading is one an author could hold"
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "slots/vec" panel {:slots [:title]}))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "slots/vec" panel {:slots [:title]}))))
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "slots/map" panel {:slots {:title true}}))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "slots/map" panel {:slots {:title true}}))))
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "slots/kw" panel {:slots :title}))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "slots/kw" panel {:slots :title}))))
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "slots/nil" panel {:slots nil})))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "slots/nil" panel {:slots nil})))
         "an explicit nil is a value and not an absence — the same rule
          `:server nil` takes, and for the same reason: inferring the default
          from nil is how a typo becomes a setting"))
   (testing "an entry that names no prop. Normalising a number into some
             slot nobody wrote is how a declaration comes to be inert"
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "slots/num" panel {:slots #{7}}))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "slots/num" panel {:slots #{7}}))))
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "slots/nested" panel {:slots #{[:title]}})))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "slots/nested" panel {:slots #{[:title]}})))))
   (testing "`key` and `ref` in every spelling. They are React's structural
             slots — an identity contract and a node handle — and neither
             carries markup, so a slot declared on one is a policy that can
             never apply"
     (doseq [k [:key :ref "ref" :x/ref]]
       (is (= :rf.error/hicasso-bad-host-declaration
-             (error-id #(codec/mint-host! (str "slots/" k) panel {:slots #{k}})))
+             (error-id #(rf.hicasso.impl.codec/mint-host! (str "slots/" k) panel {:slots #{k}})))
           (str (pr-str k) " must stay refused"))))
   (testing "two spellings of one slot. Whichever the fold reached second
             would silently be the same entry, so the set would carry one
             position the author wrote twice and could not see"
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "slots/dup" panel
+           (error-id #(rf.hicasso.impl.codec/mint-host! "slots/dup" panel
                                         {:slots #{:on-empty :onEmpty}})))))
   (testing "and a position declared BOTH a callback and a slot. `:render`
             invokes the value where a slot lowers it, and nothing decides
             which the author meant — so it is refused rather than ordered"
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "slots/both" panel
+           (error-id #(rf.hicasso.impl.codec/mint-host! "slots/both" panel
                                         {:callbacks {:title :render}
                                          :slots     #{:title}}))))
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "slots/both-spelled" panel
+           (error-id #(rf.hicasso.impl.codec/mint-host! "slots/both-spelled" panel
                                         {:callbacks {:on-empty :event}
                                          :slots     #{:onEmpty}})))
         "and across two spellings of it, because the collision is checked
@@ -269,14 +269,14 @@
   (testing "an override and a slot roster mint together, and the override
             is two-valued — `:render` where a vendor names a render prop
             `on*`, `:event` where it names an event prop something else"
-    (is (some? (codec/mint-host! "cb/ordinary" panel
+    (is (some? (rf.hicasso.impl.codec/mint-host! "cb/ordinary" panel
                                  {:callbacks {:on-render-row :render
                                               :pick          :event}
                                   :slots     #{:title}}))))
   (testing "and a third contract is refused at mint — :handler among them,
             since a plain function already crosses untouched everywhere"
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "cb/handler" panel
+           (error-id #(rf.hicasso.impl.codec/mint-host! "cb/handler" panel
                                         {:callbacks {:on-close :handler}}))))))
 
 ;; ---------------------------------------------------------------------------
@@ -321,7 +321,7 @@
             to delete"
     (is (= :rf.error/hicasso-host-unclaimed-callback
            (error-id #(crossing-props
-                        [panel-host {:title (h/event [] [:h2 "no"])}])))))
+                        [panel-host {:title (rf.hicasso/event [] [:h2 "no"])}])))))
   (testing "while a PLAIN function at the same prop of an undeclared
             crossing is untouched, because it never asked for anything"
     (is (fn? (.-title ^js (crossing-props [bare-panel {:title (fn [] nil)}]))))))
@@ -350,7 +350,7 @@
   (testing "and the per-site recovery is the explicit conversion, which
             crosses a real element through any prop of any crossing"
     (let [^js props (crossing-props
-                      [:> panel {:title (h/as-element [:h2.t "Tasks"])}])
+                      [:> panel {:title (rf.hicasso/as-element [:h2.t "Tasks"])}])
           ^js inner (.-p props)]
       (is (react/isValidElement (.-title inner)))
       (is (= "h2" (.-type (.-title inner)))))))
@@ -367,11 +367,11 @@
 ;; 3 — the compound library, mounted
 ;; ---------------------------------------------------------------------------
 
-(h/defview compound-screen
+(rf.hicasso/defview compound-screen
   "A provider, two members, two named slots and a render prop, in one
   tree — the family exercised the way an application would use it."
   [_]
-  (let [rows (h/sub [:hicasso.slots/rows])]
+  (let [rows (rf.hicasso/sub [:hicasso.slots/rows])]
     [themed {:value "dark"}
      [panel-host {:title  [:h2.t "Feed"]
                   :footer [:button.pick {:on-click [:hicasso.slots/pick "footer"]}
@@ -379,17 +379,17 @@
       [badge {}]
       [rows-host
        {:items      (into-array rows)
-        :render-row (h/event [item _i]
-                      (h/as-element
+        :render-row (rf.hicasso/event [item _i]
+                      (rf.hicasso/as-element
                         [:span.cell {:on-click [:hicasso.slots/pick item]}
                          item]))}]]]))
 
 (deftest the-compound-family-renders-through-one-declared-door
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                 [compound-screen {}])]
         (try
           (testing "the two declared slots reached the component as markup
@@ -407,14 +407,14 @@
                     explicit conversion"
             (is (= 2 (.-length (.querySelectorAll (:container handle) ".row"))))
             (is (= "alpha" (text handle ".rows .row .cell"))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 (deftest an-intent-inside-a-declared-slot-fires-into-the-declaring-frame
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                 [compound-screen {}])]
         (try
           (is (nil? (:picked (db))) "the premise")
@@ -423,39 +423,39 @@
                     boundary's — the same frame the crossing's children
                     get, and the same one an intent in the body gets"
             (.click (query handle ".panel-footer .pick"))
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (= "footer" (:picked (db)))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 (deftest a-render-prop-returns-markup-through-as-element
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                 [compound-screen {}])]
         (try
           (testing "the row was built during the LIBRARY's render, and its
                     intent fires later, on the user's click, into the frame
                     of the boundary that supplied the callback"
             (.click (query handle ".rows .row .cell"))
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (= "alpha" (:picked (db)))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — adversarial: StrictMode, remount, and a throw inside a slot
 ;; ---------------------------------------------------------------------------
 
-(h/defview strict-screen [_]
+(rf.hicasso/defview strict-screen [_]
   [:> react/StrictMode {} [compound-screen {}]])
 
 (deftest strict-mode-double-invocation-changes-nothing
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                 [strict-screen {}])]
         (try
           (testing "React renders every component twice under StrictMode.
@@ -468,20 +468,20 @@
           (testing "and the callbacks the double pass minted twice still
                     reach the one frame"
             (.click (query handle ".panel-footer .pick"))
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (= "footer" (:picked (db)))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 (deftest a-remount-rebuilds-the-slots-and-nothing-leaks
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [a (mount/root! (mount/fresh-container!) frame-id [compound-screen {}])]
+      (let [a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [compound-screen {}])]
         (is (= "Feed" (text a ".panel-title .t")))
-        (mount/release! a))
+        (rf.hicasso.impl.mount/release! a))
       (fresh!)
-      (let [b (mount/root! (mount/fresh-container!) frame-id [compound-screen {}])]
+      (let [b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [compound-screen {}])]
         (try
           (testing "a declaration is minted once and a slot is lowered per
                     crossing, so a second mount of the same declaration
@@ -489,11 +489,11 @@
                     first — including its frame"
             (is (= "Feed" (text b ".panel-title .t")))
             (.click (query b ".panel-footer .pick"))
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (= "footer" (:picked (db)))))
-          (finally (mount/release! b)))))))
+          (finally (rf.hicasso.impl.mount/release! b)))))))
 
-(h/defview thrown-slot-screen
+(rf.hicasso/defview thrown-slot-screen
   "A slot whose markup is malformed. The refusal is raised while the
   CROSSING is lowered, which is inside this boundary's own render — so a
   React error boundary above it is what catches, exactly as it would for
@@ -504,13 +504,13 @@
 (def ^:private !caught (atom nil))
 
 (deftest a-refusal-inside-a-slot-escapes-to-the-boundary-above
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (reset! !caught nil)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id
-                                [h/error-boundary
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
+                                [rf.hicasso/error-boundary
                                  {:fallback [:p.escaped "the slot refused"]
                                   :on-error (fn [e] (reset! !caught e))}
                                  [thrown-slot-screen {}]])]
@@ -522,4 +522,4 @@
             (is (some? (query handle ".escaped")))
             (is (= :rf.error/hicasso-empty-vector
                    (:rf.error/id (ex-data @!caught)))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/host_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/host_ssr_dom_cljs_test.cljs
@@ -101,14 +101,14 @@
   server renderer, and the point of using it here is that it is the
   same runtime the sibling Node entry drives."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/client" :as react-dom-client]
             ["react-dom/server" :as react-dom-server]))
@@ -124,18 +124,18 @@
 (rf/reg-event :hicasso.ssr/seed (fn [_ _] {:db {:title "quarterly"}}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; the hydration rows wait on a real clock, and `cljs.test`
      ;; hard-errors on a fn-form fixture in a suite with an async test.
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- skip! [why] (is true (str "an SSR-policy DOM claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:hicasso.ssr/seed]))
   frame-id)
@@ -166,13 +166,13 @@
       (react/createElement "span" #js {:className "chart-label"} (.-label props))
       (.-children props))))
 
-(h/defhost bare-chart
+(rf.hicasso/defhost bare-chart
   "No `:server` written at all — the default is what an author gets."
   chart)
 
-(h/defhost client-only-chart chart {:server :client-only})
+(rf.hicasso/defhost client-only-chart chart {:server :client-only})
 
-(h/defhost fallback-chart chart
+(rf.hicasso/defhost fallback-chart chart
   {:fallback [:div.chart-skeleton {:data-live "no"} "loading"]})
 
 ;; --- the `:render` fixtures: a provider, and something that reads it -------
@@ -207,18 +207,18 @@
   (react/useEffect (fn [] (swap! !child-mounts inc) js/undefined) #js [])
   (theme-reader props))
 
-(h/defhost themed
+(rf.hicasso/defhost themed
   "The guide's own provider example, declared the way the ruling says to
   declare it."
   (.-Provider theme-context)
   {:server :render})
 
-(h/defhost themed-client-only
+(rf.hicasso/defhost themed-client-only
   "The SAME provider under the default policy — the control that keeps
   the row below a fact about the policy rather than about the page."
   (.-Provider theme-context))
 
-(h/defhost reader-host theme-reader {:server :render})
+(rf.hicasso/defhost reader-host theme-reader {:server :render})
 
 ;; --- the FALSE assertion, and what it costs --------------------------------
 ;;
@@ -238,40 +238,40 @@
   [_props]
   (throw (js/ReferenceError. "window is not defined")))
 
-(h/defhost unsafe-render-host browser-only {:server :render})
+(rf.hicasso/defhost unsafe-render-host browser-only {:server :render})
 
-(h/defhost unsafe-client-only-host browser-only)
+(rf.hicasso/defhost unsafe-client-only-host browser-only)
 
-(h/defhost counted-reader-host counted-reader {:server :render})
+(rf.hicasso/defhost counted-reader-host counted-reader {:server :render})
 
 ;; ---------------------------------------------------------------------------
 ;; The pages
 ;; ---------------------------------------------------------------------------
 
-(h/defview client-only-page
+(rf.hicasso/defview client-only-page
   "A native sibling beside the host, so \"the host is absent\" is
   distinguishable from \"nothing rendered at all\"."
   [_]
   [:div.page
-   [:h1.title (collector/sub [:hicasso.ssr/title])]
-   [client-only-chart {:label (collector/sub [:hicasso.ssr/title])}]])
+   [:h1.title (rf.hicasso.impl.collector/sub [:hicasso.ssr/title])]
+   [client-only-chart {:label (rf.hicasso.impl.collector/sub [:hicasso.ssr/title])}]])
 
-(h/defview fallback-page
+(rf.hicasso/defview fallback-page
   [_]
   [:div.page
-   [:h1.title (collector/sub [:hicasso.ssr/title])]
-   [fallback-chart {:label (collector/sub [:hicasso.ssr/title])}]])
+   [:h1.title (rf.hicasso.impl.collector/sub [:hicasso.ssr/title])]
+   [fallback-chart {:label (rf.hicasso.impl.collector/sub [:hicasso.ssr/title])}]])
 
-(h/defview slotted-page
+(rf.hicasso/defview slotted-page
   "Children and props still cross the door — the gate forwards its own
   props object, so this is the regression guard for the crossing that
   the gate now sits in front of."
   [_]
   [:div.page
-   [fallback-chart {:label (collector/sub [:hicasso.ssr/title])}
+   [fallback-chart {:label (rf.hicasso.impl.collector/sub [:hicasso.ssr/title])}
     [:span.kid "slotted"]]])
 
-(h/defview provider-page
+(rf.hicasso/defview provider-page
   "THE PAGE THE DEFECT WAS FILED FROM, under the policy that answers it. A
   native sibling above the crossing so \"the subtree is absent\" stays
   distinguishable from \"nothing rendered\", markup inside it so the
@@ -279,50 +279,50 @@
   visible too."
   [_]
   [:div.page
-   [:h1.title (collector/sub [:hicasso.ssr/title])]
+   [:h1.title (rf.hicasso.impl.collector/sub [:hicasso.ssr/title])]
    [themed {:value "dark"}
     [:p.body "THE ENTIRE APPLICATION"]
     [reader-host {}]]])
 
-(h/defview provider-page-client-only
+(rf.hicasso/defview provider-page-client-only
   "The same page under the default policy — the defect, kept live."
   [_]
   [:div.page
-   [:h1.title (collector/sub [:hicasso.ssr/title])]
+   [:h1.title (rf.hicasso.impl.collector/sub [:hicasso.ssr/title])]
    [themed-client-only {:value "dark"}
     [:p.body "THE ENTIRE APPLICATION"]
     [reader-host {}]]])
 
-(h/defview unsafe-render-page
+(rf.hicasso/defview unsafe-render-page
   "A page whose one crossing declares `:render` over a component that is
   not server-safe."
   [_]
   [:div.page
-   [:h1.title (collector/sub [:hicasso.ssr/title])]
+   [:h1.title (rf.hicasso.impl.collector/sub [:hicasso.ssr/title])]
    [unsafe-render-host {}]])
 
-(h/defview unsafe-client-only-page
+(rf.hicasso/defview unsafe-client-only-page
   "The same component under the DEFAULT policy — the control that makes
   the row below a fact about the assertion rather than about the
   component."
   [_]
   [:div.page
-   [:h1.title (collector/sub [:hicasso.ssr/title])]
+   [:h1.title (rf.hicasso.impl.collector/sub [:hicasso.ssr/title])]
    [unsafe-client-only-host {}]])
 
-(h/defview unprovided-page
+(rf.hicasso/defview unprovided-page
   "The consumer with NO provider above it — what a policy that rendered
   the children alone would have emitted, so the `dark` below is a
   measured contrast and not an assumed one."
   [_]
   [:div.page [reader-host {}]])
 
-(h/defview counted-provider-page
+(rf.hicasso/defview counted-provider-page
   "[[provider-page]] with a mount-counting consumer, for the hydration
   row. Same shape, one extra effect."
   [_]
   [:div.page
-   [:h1.title (collector/sub [:hicasso.ssr/title])]
+   [:h1.title (rf.hicasso.impl.collector/sub [:hicasso.ssr/title])]
    [themed {:value "dark"}
     [:p.body "THE ENTIRE APPLICATION"]
     [counted-reader-host {}]]])
@@ -340,7 +340,7 @@
   to one call."
   [hiccup]
   (react-dom-server/renderToString
-    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+    (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup))))
 
 (defn- query-node [root selector] (.querySelector root selector))
 
@@ -382,32 +382,32 @@
             an author who writes it explicitly gets the same one — a
             foreign component is exactly the node whose render may reach
             for `window`, and the door does not guess"
-    (is (= :client-only (codec/host-server bare-chart)))
-    (is (= :client-only (codec/host-server client-only-chart))))
+    (is (= :client-only (rf.hicasso.impl.codec/host-server bare-chart)))
+    (is (= :client-only (rf.hicasso.impl.codec/host-server client-only-chart))))
   (testing "and a declared :fallback is MARKUP rather than a policy value
             (rf2-mo4o): the host is Client-only either way, which is what
             the two-policy matrix says and what the sibling native door
             already recorded"
-    (is (= :client-only (codec/host-server fallback-chart)))))
+    (is (= :client-only (rf.hicasso.impl.codec/host-server fallback-chart)))))
 
 (deftest the-other-policy-is-render-and-it-is-an-assertion
   (testing "rf2-l0wfx. `:render` is the second of the two — the author
             asserting that this component is safe to run on the server"
-    (is (= :render (codec/host-server themed)))
-    (is (= :render (codec/host-server reader-host))))
+    (is (= :render (rf.hicasso.impl.codec/host-server themed)))
+    (is (= :render (rf.hicasso.impl.codec/host-server reader-host))))
   (testing "and it reads back as data like the other policy, so a server
             walk that wants to state what it is honouring still can"
-    (is (= :client-only (codec/host-server themed-client-only)))
-    (is (some? (codec/mint-host! "server/render-plus-callbacks" chart
+    (is (= :client-only (rf.hicasso.impl.codec/host-server themed-client-only)))
+    (is (some? (rf.hicasso.impl.codec/mint-host! "server/render-plus-callbacks" chart
                                  {:callbacks {:on-pick :event} :server :render}))
         "and it composes with :callbacks, which is another option")))
 
 (deftest the-declaration-refuses-a-policy-it-cannot-honour
   (testing "a third value is refused at the declaration, naming the two"
     (is (= :rf.error/hicasso-host-bad-ssr-policy
-           (error-id #(codec/mint-host! "server/server" chart {:server :server}))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/server" chart {:server :server}))))
     (is (= :rf.error/hicasso-host-bad-ssr-policy
-           (error-id #(codec/mint-host! "server/true" chart {:server true})))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/true" chart {:server true})))))
   (testing "and the three spellings an author reaches for INSTEAD of
             `:render` stay refused, every one of them (rf2-l0wfx). They
             assert a structural property nobody can check — that the
@@ -416,36 +416,36 @@
             silent wrongness"
     (doseq [v [:children :transparent :passthrough]]
       (is (= :rf.error/hicasso-host-bad-ssr-policy
-             (error-id #(codec/mint-host! (str "server/" (name v)) chart {:server v})))
+             (error-id #(rf.hicasso.impl.codec/mint-host! (str "server/" (name v)) chart {:server v})))
           (str (pr-str v) " must stay refused"))))
   (testing "a map spelling of it is not a spelling of it either —
             `:render` is a bare keyword, and a policy that admitted both
             would be two ways to say one thing"
     (is (= :rf.error/hicasso-host-bad-ssr-policy
-           (error-id #(codec/mint-host! "server/render-map" chart
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/render-map" chart
                                         {:server {:render true}})))))
   (testing "an explicit nil is a value, not an absence — `:client-only` is
             the default of an ABSENT key, and inferring it from nil is how
             a typo becomes a policy"
     (is (= :rf.error/hicasso-host-bad-ssr-policy
-           (error-id #(codec/mint-host! "server/nil" chart {:server nil})))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/nil" chart {:server nil})))))
   (testing "a :fallback belongs to Client-only ALONE (rf2-mo4o). Under
             `:render` the component itself renders on the server, so there
             is nothing for a placeholder to stand in for, and a declaration
             carrying both says two incompatible things"
     (is (= :rf.error/hicasso-host-bad-ssr-policy
-           (error-id #(codec/mint-host! "server/render-plus-fallback" chart
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/render-plus-fallback" chart
                                         {:server :render :fallback [:div.s]})))))
   (testing "while an explicit nil fallback is a value here too — it is a
             placeholder that renders nothing, written by an author who
             believes they wrote one"
     (is (= :rf.error/hicasso-host-bad-ssr-policy
-           (error-id #(codec/mint-host! "server/nil-fb" chart {:fallback nil})))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/nil-fb" chart {:fallback nil})))))
   (testing "and a fallback that is not hiccup fails HERE, at the
             declaration, rather than one render into a server response —
             it is walked once at mint, where the author's stack is"
     (is (= :rf.error/hicasso-empty-vector
-           (error-id #(codec/mint-host! "server/bad-fb" chart {:fallback []})))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/bad-fb" chart {:fallback []})))))
   (testing "as does a `defview` head written into a fallback — a fallback
             is inert markup and that is enforced (rf2-nv07k). The full
             contract, both directions, is
@@ -453,7 +453,7 @@
             the two halves were ruled together and the refusal is one of
             this declaration's own"
     (is (= :rf.error/hicasso-host-fallback-boundary-head
-           (error-id #(codec/mint-host! "server/live-fb" chart
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/live-fb" chart
                                         {:fallback [client-only-page {}]}))))))
 
 (deftest the-declaration-refuses-an-option-it-does-not-know
@@ -462,25 +462,25 @@
             defect class as an intent crossing as inert data, and it gets
             the same refusal"
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "server/typo" chart {:sserver :client-only}))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/typo" chart {:sserver :client-only}))))
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "server/legacy" chart
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/legacy" chart
                                         {:callbacks {} :hydrate? true})))))
   (testing "AND THAT IS WHERE THE RETIRED `:ssr` SPELLING LANDS (rf2-mo4o).
             There is no alias and no deprecation path — this is pre-alpha,
             so a rename is a rename — and the option roster is what says
             so, in both of the shapes `:ssr` used to take"
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "server/retired-render" chart
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/retired-render" chart
                                         {:ssr :render}))))
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "server/retired-client-only" chart
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/retired-client-only" chart
                                         {:ssr :client-only}))))
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "server/retired-fallback" chart
+           (error-id #(rf.hicasso.impl.codec/mint-host! "server/retired-fallback" chart
                                         {:ssr {:fallback [:div.s]}})))))
   (testing "while the four it does know are accepted together"
-    (is (some? (codec/mint-host! "server/all" chart
+    (is (some? (rf.hicasso.impl.codec/mint-host! "server/all" chart
                                  {:callbacks {:on-pick :event}
                                   :slots     #{:title}
                                   :server    :client-only
@@ -607,44 +607,44 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-fresh-mount-renders-the-component-on-its-first-pass
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (testing "a `createRoot` mount never consults a server snapshot, so
                 neither policy costs a placeholder pass — asserted on the
                 line after `root!` returns, which is inside its flushSync"
-        (let [a (mount/root! (mount/fresh-container!) frame-id [client-only-page {}])]
+        (let [a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [client-only-page {}])]
           (try
             (is (some? (query-node (:container a) ".chart"))
                 ":client-only mounted its component immediately")
             (is (= "yes" (.getAttribute (query-node (:container a) ".chart") "data-live"))
                 "and it is the real one")
-            (finally (mount/release! a))))
-        (let [b (mount/root! (mount/fresh-container!) frame-id [fallback-page {}])]
+            (finally (rf.hicasso.impl.mount/release! a))))
+        (let [b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [fallback-page {}])]
           (try
             (is (some? (query-node (:container b) ".chart"))
                 "{:fallback …} mounted its component immediately too")
             (is (nil? (query-node (:container b) ".chart-skeleton"))
                 "and the placeholder never flashed — a fallback is for the
                  server's markup, not for a client that has none")
-            (finally (mount/release! b))))))))
+            (finally (rf.hicasso.impl.mount/release! b))))))))
 
 (deftest the-gate-forwards-props-and-children-untouched
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (testing "the gate hands its own props straight through, so the
                 crossing is the object `host-element` built — the door's
                 contract is unchanged by the policy sitting in front of it"
-        (let [h (mount/root! (mount/fresh-container!) frame-id [slotted-page {}])]
+        (let [h (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [slotted-page {}])]
           (try
             (is (= "quarterly" (.-textContent (query-node (:container h) ".chart-label")))
                 "a declared prop reached the foreign component")
             (is (some? (query-node (:container h) ".chart .kid"))
                 "and so did the children, in the component's own slot")
-            (finally (mount/release! h))))))))
+            (finally (rf.hicasso.impl.mount/release! h))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5 — hydration: the first client pass matches, and adoption swaps
@@ -671,11 +671,11 @@
   (fresh!)
   (reset! !renders 0)
   (let [html      (server-html hiccup)
-        container (mount/fresh-container!)
+        container (rf.hicasso.impl.mount/fresh-container!)
         {:keys [seen restore]} (watch-errors!)]
     (set! (.-innerHTML container) html)
     (let [root (hydrate! container
-                         (mount/provider frame-id (codec/root-element frame-id hiccup))
+                         (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup))
                          seen)]
       (js/setTimeout
         (fn []
@@ -685,13 +685,13 @@
               (restore)
               (.unmount root)
               (when-some [p (.-parentNode container)] (.removeChild p container))
-              (collector/reset-runtime!)
+              (rf.hicasso.impl.collector/reset-runtime!)
               (done))))
         150))))
 
 (deftest client-only-hydrates-with-nothing-there-and-mounts-after-adoption
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (hydration-row
         [client-only-page {}]
@@ -718,7 +718,7 @@
 
 (deftest a-fallback-hydrates-as-the-placeholder-and-is-swapped-after-adoption
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (hydration-row
         [fallback-page {}]
@@ -738,7 +738,7 @@
 
 (deftest a-render-crossing-hydrates-once-and-never-remounts
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (reset! !child-mounts 0)

--- a/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
@@ -109,15 +109,15 @@
   and run under `:node-test` too; the DOM rows say so and skip."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.roots :as roots]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.roots :as rf.hicasso.impl.roots]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/server" :as react-dom-server]))
 
@@ -136,13 +136,13 @@
 (rf/reg-event ::relabel (fn [{:keys [db]} [_ label]] {:db (assoc db :label label)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; the hydration rows wait on a real clock, and `cljs.test`
      ;; hard-errors on a fn-form fixture in a suite with an async test.
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The probe — a `useId` that reaches the server bytes
@@ -172,28 +172,28 @@
     (react/createElement "b" #js {:className "probe"} (react/useId))
     (react/createElement "i" #js {:className "label"} (.-label props))))
 
-(h/defhost id-host id-probe {:server :render})
+(rf.hicasso/defhost id-host id-probe {:server :render})
 
-(h/defview id-page
+(rf.hicasso/defview id-page
   "The page both sides render. One subscription read, so the root
   acquires a frame-keyed cell and its commit is observable at all; one
   island, so the page has an id in it."
   [_]
   [:div.page
-   [:p.value (h/sub label-q)]
-   [id-host {:label (h/sub label-q)}]])
+   [:p.value (rf.hicasso/sub label-q)]
+   [id-host {:label (rf.hicasso/sub label-q)}]])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
 ;; ---------------------------------------------------------------------------
 
 (defn- fresh! []
-  (sup/leave-act-environment!)
+  (rf.hicasso.roots-frames-support/leave-act-environment!)
   (rf/make-frame {:id frame-a})
   (rf/make-frame {:id frame-b})
   (rf/with-frame frame-a (rf/dispatch-sync [::seed "alpha"]))
   (rf/with-frame frame-b (rf/dispatch-sync [::seed "beta"]))
-  (collector/reset-runtime!)
+  (rf.hicasso.impl.collector/reset-runtime!)
   nil)
 
 (defn- server-html!
@@ -207,7 +207,7 @@
   other tree, and §3 pins the difference to that one fork."
   [frame-kw hiccup prefix]
   (react-dom-server/renderToString
-    (mount/provider frame-kw (codec/root-element frame-kw hiccup))
+    (rf.hicasso.impl.mount/provider frame-kw (rf.hicasso.impl.codec/root-element frame-kw hiccup))
     (when prefix #js {"identifierPrefix" prefix})))
 
 (defn- root-shaped-server-html!
@@ -232,13 +232,13 @@
   here is that this is not offered to any other suite and answers no
   question except *which structural difference moved the id*."
   [frame-kw hiccup prefix]
-  (let [window (roots/open-adoption-window!)
-        app    (mount/provider frame-kw (codec/root-element frame-kw hiccup))]
+  (let [window (rf.hicasso.impl.roots/open-adoption-window!)
+        app    (rf.hicasso.impl.mount/provider frame-kw (rf.hicasso.impl.codec/root-element frame-kw hiccup))]
     (react-dom-server/renderToString
       (react/createElement (.-Fragment react) nil
-                           (react/createElement mount/adoption-window-closer
+                           (react/createElement rf.hicasso.impl.mount/adoption-window-closer
                                                 #js {:rfWindow window})
-                           (roots/with-adoption window app))
+                           (rf.hicasso.impl.roots/with-adoption window app))
       (when prefix #js {"identifierPrefix" prefix}))))
 
 (defn- text-in [container sel]
@@ -267,7 +267,7 @@
   the reading on the next line is taken after a real client render."
   [frame-kw label]
   (rf/with-frame frame-kw (rf/dispatch-sync [::relabel label]))
-  (mount/settle!)
+  (rf.hicasso.impl.mount/settle!)
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -378,26 +378,26 @@
 
 (deftest the-bytes-a-consumer-can-bake-today-mismatch-on-position-not-on-prefix
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no React DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM") (done))
       (do
         (fresh!)
         (let [html      (server-html! frame-a [id-page {}] "pfx-a-")
               server-id (id-in-html html)
-              container (sup/stamp-server-nodes! (sup/server-dom! html))
-              {:keys [seen stop!]} (sup/watch-mismatches!)
+              container (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+              {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)
               ;; MANUFACTURED here and asserted on here — the only shape of
               ;; call site at which swallowing an uncaught error is not the
               ;; fail-open the pageerror rule forbids. React routes a hydration
               ;; failure to `reportError`, and the browser runner fails a
               ;; run on any uncaught pageerror.
-              {:keys [captured close!]} (sup/open-console-capture!
+              {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture!
                                           {:swallow-uncaught? true})]
           (is (some? server-id) "premise: the bytes carry an id")
-          (collector/reset-runtime!)
-          (let [handle (mount/hydrate-root! container frame-a [id-page {}]
+          (rf.hicasso.impl.collector/reset-runtime!)
+          (let [handle (rf.hicasso.impl.mount/hydrate-root! container frame-a [id-page {}]
                                             {:identifier-prefix "pfx-a-"})]
-            (-> (sup/adopted! handle)
+            (-> (rf.hicasso.roots-frames-support/adopted! handle)
                 (.then
                   (fn [ok]
                     ;; Closed HERE and named in `:release!` as well. Here,
@@ -418,7 +418,7 @@
                                              @captured))))
                       (is (seq @seen)
                           "the divergence must reach Spec 011's channel")
-                      (let [tags (sup/tags-of (first @seen))]
+                      (let [tags (rf.hicasso.roots-frames-support/tags-of (first @seen))]
                         (is (= 're-frame.hicasso.impl.mount/hydrate-root!
                                (:where tags))
                             (str "attributed to source; got " (pr-str (:where tags))))
@@ -445,13 +445,13 @@
                                "obstruction this row records; server "
                                (pr-str server-id) ", client "
                                (pr-str (probe-id container)))))))
-                (sup/settle-row!
+                (rf.hicasso.roots-frames-support/settle-row!
                   {:row      "§2 — the bytes a consumer can bake today"
                    :done     done
                    :release! (fn []
                                (close!)
                                (stop!)
-                               (mount/release! handle))}))))))))
+                               (rf.hicasso.impl.mount/release! handle))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — THE DIAGNOSIS: bytes of the root's own shape hydrate silently
@@ -459,18 +459,18 @@
 
 (deftest bytes-of-the-hydrating-root-s-own-shape-adopt-with-the-server-s-id
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no React DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM") (done))
       (do
         (fresh!)
         (let [html      (root-shaped-server-html! frame-a [id-page {}] "pfx-a-")
               server-id (id-in-html html)
-              container (sup/stamp-server-nodes! (sup/server-dom! html))
-              {:keys [seen stop!]} (sup/watch-mismatches!)]
-          (collector/reset-runtime!)
-          (let [handle (mount/hydrate-root! container frame-a [id-page {}]
+              container (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+              {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)]
+          (rf.hicasso.impl.collector/reset-runtime!)
+          (let [handle (rf.hicasso.impl.mount/hydrate-root! container frame-a [id-page {}]
                                             {:identifier-prefix "pfx-a-"})]
-            (-> (sup/adopted! handle)
+            (-> (rf.hicasso.roots-frames-support/adopted! handle)
                 (.then
                   (fn [ok]
                     (is (true? ok) "the root's own adoption window shut")
@@ -478,7 +478,7 @@
                     (testing "the adoption was real — these are the very nodes
                               the bytes produced, which no re-render could
                               reconstruct"
-                      (is (sup/every-server-node? container ".page, .value, .probe")
+                      (is (rf.hicasso.roots-frames-support/every-server-node? container ".page, .value, .probe")
                           "the server's nodes survived, probe included"))
 
                     (testing "and React had nothing to complain about, which is
@@ -487,7 +487,7 @@
                       (is (empty? @seen)
                           (str "matching shape and matching prefix must produce "
                                "no mismatch; got "
-                               (pr-str (mapv #(:error (sup/tags-of %)) @seen)))))
+                               (pr-str (mapv #(:error (rf.hicasso.roots-frames-support/tags-of %)) @seen)))))
 
                     (testing "the id agrees ACROSS A REAL CLIENT RENDER, which
                               is the only reading that separates *the client
@@ -500,12 +500,12 @@
                           (str "the client's own id must equal the server's; "
                                "server " (pr-str server-id) ", client "
                                (pr-str (probe-id container)))))))
-                (sup/settle-row!
+                (rf.hicasso.roots-frames-support/settle-row!
                   {:row      "§3 — bytes of the hydrating root's own shape"
                    :done     done
                    :release! (fn []
                                (stop!)
-                               (mount/release! handle))}))))))))
+                               (rf.hicasso.impl.mount/release! handle))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — §2.4's clause, as written: TWO SIMULTANEOUS hydrating roots
@@ -519,42 +519,42 @@
 
 (deftest two-simultaneous-hydrating-roots-keep-stable-and-distinct-prefixes
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no React DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM") (done))
       (do
         (fresh!)
         (let [html-a   (root-shaped-server-html! frame-a [id-page {}] "pfx-a-")
               html-b   (root-shaped-server-html! frame-b [id-page {}] "pfx-b-")
               server-a (id-in-html html-a)
               server-b (id-in-html html-b)
-              ca       (sup/stamp-server-nodes! (sup/server-dom! html-a))
-              cb       (sup/stamp-server-nodes! (sup/server-dom! html-b))
-              {:keys [seen stop!]} (sup/watch-mismatches!)]
+              ca       (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-a))
+              cb       (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-b))
+              {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)]
           (is (not= server-a server-b)
               (str "premise: two prefixes gave the server two ids; got "
                    (pr-str server-a) " and " (pr-str server-b)))
-          (collector/reset-runtime!)
-          (let [ha (mount/hydrate-root! ca frame-a [id-page {}]
+          (rf.hicasso.impl.collector/reset-runtime!)
+          (let [ha (rf.hicasso.impl.mount/hydrate-root! ca frame-a [id-page {}]
                                         {:identifier-prefix "pfx-a-"})
-                hb (mount/hydrate-root! cb frame-b [id-page {}]
+                hb (rf.hicasso.impl.mount/hydrate-root! cb frame-b [id-page {}]
                                         {:identifier-prefix "pfx-b-"})]
             ;; The overlap is a CONSTRUCTION and not a timing guess: both
             ;; roots were handed to React before either had adopted, and
             ;; each root's OWN window being open on this line says so.
-            (is (true? (roots/adopting? (:adoption ha)))
+            (is (true? (rf.hicasso.impl.roots/adopting? (:adoption ha)))
                 "root A is in flight — `hydrate-root!` returns before adoption")
-            (is (true? (roots/adopting? (:adoption hb)))
+            (is (true? (rf.hicasso.impl.roots/adopting? (:adoption hb)))
                 "and so is root B, in its own window")
-            (-> (sup/adopted! ha)
-                (.then (fn [_] (sup/adopted! hb)))
+            (-> (rf.hicasso.roots-frames-support/adopted! ha)
+                (.then (fn [_] (rf.hicasso.roots-frames-support/adopted! hb)))
                 (.then
                   (fn [ok]
                     (is (true? ok) "both roots adopted")
 
                     (testing "each root adopted its OWN server DOM"
-                      (is (sup/every-server-node? ca ".page, .value, .probe")
+                      (is (rf.hicasso.roots-frames-support/every-server-node? ca ".page, .value, .probe")
                           "root A kept the server's nodes")
-                      (is (sup/every-server-node? cb ".page, .value, .probe")
+                      (is (rf.hicasso.roots-frames-support/every-server-node? cb ".page, .value, .probe")
                           "root B kept the server's nodes"))
 
                     (testing "and neither adoption complained — two prefixes,
@@ -562,7 +562,7 @@
                       (is (empty? @seen)
                           (str "two matching prefixes must produce no mismatch; "
                                "got "
-                               (pr-str (mapv #(:error (sup/tags-of %)) @seen)))))
+                               (pr-str (mapv #(:error (rf.hicasso.roots-frames-support/tags-of %)) @seen)))))
 
                     (testing "the ids are DISTINCT and each is its own root's.
                               Read after a dispatch into each root, so both are
@@ -588,14 +588,14 @@
                               once both are down. Read before any `release!`,
                               because `release!` empties the tables by fiat and
                               a census after it cannot go red"
-                      (mount/unmount! ha)
-                      (is (not= sup/released (sup/census))
+                      (rf.hicasso.impl.mount/unmount! ha)
+                      (is (not= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/census))
                           "root B is still live, so the runtime is not empty")
-                      (mount/unmount! hb)
-                      (is (= sup/released (sup/census))
+                      (rf.hicasso.impl.mount/unmount! hb)
+                      (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/census))
                           (str "both roots down; residue was "
-                               (pr-str (sup/census)))))))
-                (sup/settle-row!
+                               (pr-str (rf.hicasso.roots-frames-support/census)))))))
+                (rf.hicasso.roots-frames-support/settle-row!
                   {:row      "§4 — two simultaneous hydrating roots"
                    :done     done
                    ;; The FULL handles, where the `finally` this replaced
@@ -615,8 +615,8 @@
                    ;; is the whole point.
                    :release! (fn []
                                (stop!)
-                               (mount/release! ha)
-                               (mount/release! hb))}))))))))
+                               (rf.hicasso.impl.mount/release! ha)
+                               (rf.hicasso.impl.mount/release! hb))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5 — the NEAR-MISS: a legal prefix that is the wrong one
@@ -632,21 +632,21 @@
 
 (deftest a-client-prefix-that-disagrees-with-the-bytes-is-caught-at-source
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no React DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM") (done))
       (do
         (fresh!)
         (let [html      (root-shaped-server-html! frame-a [id-page {}] "pfx-a-")
               server-id (id-in-html html)
-              container (sup/stamp-server-nodes! (sup/server-dom! html))
-              {:keys [seen stop!]} (sup/watch-mismatches!)
+              container (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+              {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)
               ;; Manufactured and asserted on here — see §2's note.
-              {:keys [captured close!]} (sup/open-console-capture!
+              {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture!
                                           {:swallow-uncaught? true})]
-          (collector/reset-runtime!)
-          (let [handle (mount/hydrate-root! container frame-a [id-page {}]
+          (rf.hicasso.impl.collector/reset-runtime!)
+          (let [handle (rf.hicasso.impl.mount/hydrate-root! container frame-a [id-page {}]
                                             {:identifier-prefix "pfx-b-"})]
-            (-> (sup/adopted! handle)
+            (-> (rf.hicasso.roots-frames-support/adopted! handle)
                 (.then
                   (fn [_]
                     ;; Closed here for §2's reason, and named in `:release!`
@@ -661,7 +661,7 @@
                                              @captured))))
                       (is (seq @seen)
                           "a prefix that disagrees with the bytes must complain")
-                      (let [tags (sup/tags-of (first @seen))]
+                      (let [tags (rf.hicasso.roots-frames-support/tags-of (first @seen))]
                         (is (= 're-frame.hicasso.impl.mount/hydrate-root!
                                (:where tags))
                             (str "attributed to source; got "
@@ -676,13 +676,13 @@
                       (is (str/includes? (probe-id container) "pfx-b-")
                           (str "and it is the client's prefix; got "
                                (pr-str (probe-id container)))))))
-                (sup/settle-row!
+                (rf.hicasso.roots-frames-support/settle-row!
                   {:row      "§5 — a client prefix that disagrees with the bytes"
                    :done     done
                    :release! (fn []
                                (close!)
                                (stop!)
-                               (mount/release! handle))}))))))))
+                               (rf.hicasso.impl.mount/release! handle))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6 — THE LEAK CONTROL: a rejected adoption still releases the page
@@ -707,36 +707,36 @@
 ;; merely slow.
 
 (deftest a-rejected-adoption-still-releases-the-root-console-and-watcher
-  (if-not (mount/browser?)
-    (sup/skip! "what a rejection can leak here is a real root and a real console")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! "what a rejection can leak here is a real root and a real console")
     (async done
       (fresh!)
       (let [html           (root-shaped-server-html! frame-a [id-page {}] "pfx-a-")
-            container      (sup/stamp-server-nodes! (sup/server-dom! html))
-            watch          (sup/watch-mismatches!)
+            container      (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+            watch          (rf.hicasso.roots-frames-support/watch-mismatches!)
             ;; NOT `:swallow-uncaught? true`: this row manufactures a
             ;; rejected PROMISE, which `sup/settle-row!` handles, and no
             ;; uncaught window error at all. Swallowing anywhere else is
             ;; the fail-open the browser runner's pageerror rule forbids.
             console-before (.-error js/console)
-            capture        (sup/open-console-capture!)
+            capture        (rf.hicasso.roots-frames-support/open-console-capture!)
             stops          (atom 0)
             finishes       (atom 0)
             reports        (atom [])]
-        (collector/reset-runtime!)
-        (let [handle (mount/hydrate-root! container frame-a [id-page {}]
+        (rf.hicasso.impl.collector/reset-runtime!)
+        (let [handle (rf.hicasso.impl.mount/hydrate-root! container frame-a [id-page {}]
                                           {:identifier-prefix "pfx-a-"})]
-          (-> (sup/adopted! handle)
+          (-> (rf.hicasso.roots-frames-support/adopted! handle)
               (.then
                 (fn [ok]
                   (is (true? ok) "premise: the root really did adopt")
-                  (is (not= sup/released (sup/census))
+                  (is (not= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/census))
                       (str "premise: the runtime is holding this root's cells "
                            "and edges, so the census taken after the rejection "
                            "is a RELEASE and not an empty page; got "
-                           (pr-str (sup/census))))
+                           (pr-str (rf.hicasso.roots-frames-support/census))))
                   (js/Promise.reject (js/Error. "adoption rejected on purpose"))))
-              (sup/settle-row!
+              (rf.hicasso.roots-frames-support/settle-row!
                 {:row      "the rejected-adoption control"
                  :done     (fn [] (swap! finishes inc))
                  :report!  (fn [e] (swap! reports conj e))
@@ -744,11 +744,11 @@
                              ((:close! capture))
                              (swap! stops inc)
                              ((:stop! watch))
-                             (mount/release! handle))})
+                             (rf.hicasso.impl.mount/release! handle))})
               ;; The cell reapers are armed at unmount and run past a bare
               ;; macrotask, so the tables are read at the runtime's own
               ;; horizon rather than one tick after the release.
-              (.then (fn [_] (sup/quiesced!)))
+              (.then (fn [_] (rf.hicasso.roots-frames-support/quiesced!)))
               (.then
                 (fn [_]
                   (testing "the rejection is REPORTED — which is the whole of
@@ -772,21 +772,21 @@
                             all the same, because a row that leans on the
                             fixture to stop its own watcher is measuring the
                             fixture)"
-                    (is (= sup/released (sup/census))
-                        (str "no root: residue was " (pr-str (sup/census))))
-                    (is (empty? (sup/cell-frames))
+                    (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/census))
+                        (str "no root: residue was " (pr-str (rf.hicasso.roots-frames-support/census))))
+                    (is (empty? (rf.hicasso.roots-frames-support/cell-frames))
                         (str "no frame: the cell table still mentions "
-                             (pr-str (sup/cell-frames))))
+                             (pr-str (rf.hicasso.roots-frames-support/cell-frames))))
                     (is (= 1 @stops)
                         (str "the mismatch watcher was stopped — `stop!` is what "
                              "unregisters the trace listener; it ran "
                              @stops " times"))
                     (is (identical? console-before (.-error js/console))
                         "`console.error` is the page's own again"))))
-              (sup/settle-row!
+              (rf.hicasso.roots-frames-support/settle-row!
                 {:row      "the rejected-adoption control's own settlement"
                  :done     done
                  :release! (fn []
                              ((:close! capture))
                              ((:stop! watch))
-                             (mount/release! handle))})))))))
+                             (rf.hicasso.impl.mount/release! handle))})))))))

--- a/implementation/hicasso/test/re_frame/hicasso/imperative_sdk_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/imperative_sdk_dom_cljs_test.cljs
@@ -109,15 +109,15 @@
   is the one row that needs no fiber and states so."
   (:require [clojure.set :as set]
             [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.roots-frames-support :as support]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/client" :as react-dom-client]))
 
@@ -308,7 +308,7 @@
 ;; THE CROSSINGS — one declaration each, and hiccup uses them as heads
 ;; ---------------------------------------------------------------------------
 
-(h/defhost spark
+(rf.hicasso/defhost spark
   "The declared host seam. `:on-pick` carries the `:event` contract, so an
   `h/event` written there sees the vendor's own arguments in order and a
   vector it returns dispatches under the frame of the boundary that wrote
@@ -335,25 +335,25 @@
 ;; is exactly what a positive control is for. A screen showing a count
 ;; beside its chart is also the more realistic screen.
 
-(h/defview screen
+(rf.hicasso/defview screen
   "One island, in one boundary. `:on-pick` is written FRESH on every
   render — the standing rule, and the reason the acquire effect may not
   depend on it."
   [{:keys [data]}]
   [:div
-   [:span.picks (str (h/sub [::picks]))]
-   [spark {:data data :on-pick (h/event [v] [::picked v])}]])
+   [:span.picks (str (rf.hicasso/sub [::picks]))]
+   [spark {:data data :on-pick (rf.hicasso/event [v] [::picked v])}]])
 
-(h/defview two-screen
+(rf.hicasso/defview two-screen
   "Two islands under one root — the positive control that says [[!live]]
   counts instances rather than answering a constant."
   [{:keys [data]}]
   [:div
-   [:span.picks (str (h/sub [::picks]))]
-   [spark {:data data :on-pick (h/event [v] [::picked v])}]
-   [spark {:data (str data "-b") :on-pick (h/event [v] [::picked v])}]])
+   [:span.picks (str (rf.hicasso/sub [::picks]))]
+   [spark {:data data :on-pick (rf.hicasso/event [v] [::picked v])}]
+   [spark {:data (str data "-b") :on-pick (rf.hicasso/event [v] [::picked v])}]])
 
-(h/defview toggle-screen
+(rf.hicasso/defview toggle-screen
   "The island behind a `when`, with its identity under the caller's
   control. Dropping it is an ordinary unmount; changing `:key` is a keyed
   remount — two exits, one screen.
@@ -366,11 +366,11 @@
   measures nothing — observed, on the first run of this file."
   [{:keys [data show? instance]}]
   [:div
-   [:span.picks (str (h/sub [::picks]))]
+   [:span.picks (str (rf.hicasso/sub [::picks]))]
    (when show?
-     [spark {:key instance :data data :on-pick (h/event [v] [::picked v])}])])
+     [spark {:key instance :data data :on-pick (rf.hicasso/event [v] [::picked v])}])])
 
-(h/defview detonator
+(rf.hicasso/defview detonator
   "A SIBLING of the island that throws during render once armed. A
   sibling and not the island itself, because a component that throws on
   its FIRST render never ran an effect and so has nothing to release —
@@ -383,13 +383,13 @@
     (throw (js/Error. "planted imperative-sdk throw"))
     [:span.armed "armed"]))
 
-(h/defview guarded-screen
+(rf.hicasso/defview guarded-screen
   [{:keys [data boom? attempt]}]
   [:div
-   [:span.picks (str (h/sub [::picks]))]
-   [h/error-boundary {:fallback [:p.fell "fell"] :reset-key attempt}
+   [:span.picks (str (rf.hicasso/sub [::picks]))]
+   [rf.hicasso/error-boundary {:fallback [:p.fell "fell"] :reset-key attempt}
     [:div
-     [spark {:data data :on-pick (h/event [v] [::picked v])}]
+     [spark {:data data :on-pick (rf.hicasso/event [v] [::picked v])}]
      [detonator {:boom? boom?}]]]])
 
 ;; ---------------------------------------------------------------------------
@@ -397,8 +397,8 @@
 ;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; `nil` and not the default: a dynamic-var frame left in ambient
      ;; scope would let a crossing that failed to resolve its own frame
      ;; answer from that one instead.
@@ -406,9 +406,9 @@
      ;; The MAP shape, because every row here is `async`.
      :async?        true
      :init-fn       (fn []
-                      (support/leave-act-environment!)
+                      (rf.hicasso.roots-frames-support/leave-act-environment!)
                       (force-release-all!)
-                      (collector/reset-runtime!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- seat! []
   (rf/make-frame {:id frame-id})
@@ -423,10 +423,10 @@
   condition and a synchronous flush would only be inventing a schedule
   for the one row where React deletes a subtree it is midway through."
   [hiccup]
-  (mount/provider frame-id (codec/root-element frame-id hiccup)))
+  (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup)))
 
 (defn- mount! [hiccup]
-  (let [container (mount/fresh-container!)
+  (let [container (rf.hicasso.impl.mount/fresh-container!)
         root      (react-dom-client/createRoot container)]
     (.render root (app-element hiccup))
     {:root root :container container :frame frame-id}))
@@ -436,7 +436,7 @@
   tree, which is where an application puts it and where this repo's other
   StrictMode witnesses put it (`kernel_commit_owns_dom_cljs_test`)."
   [hiccup]
-  (let [container (mount/fresh-container!)
+  (let [container (rf.hicasso.impl.mount/fresh-container!)
         root      (react-dom-client/createRoot container)]
     (.render root (react/createElement (.-StrictMode react) nil (app-element hiccup)))
     {:root root :container container :frame frame-id}))
@@ -446,7 +446,7 @@
   nil)
 
 (defn- poll [pred label]
-  (test-support/poll-until pred {:label label :timeout-ms 4000}))
+  (rf.test-support/poll-until pred {:label label :timeout-ms 4000}))
 
 (defn- wait-live!
   "Return once exactly `n` instances are live.
@@ -468,7 +468,7 @@
   [value]
   (.dispatchEvent js/window
                   (js/CustomEvent. external-event #js {"detail" #js {"value" value}}))
-  (mount/settle!)
+  (rf.hicasso.impl.mount/settle!)
   nil)
 
 (defn- picks [] (rf/with-frame frame-id @(rf/subscribe [::picks])))
@@ -509,7 +509,7 @@
     (is false (str label " — " (.-message e)
                    " | live " (pr-str (ids))
                    " acquired " @!acquired " released " @!released))
-    (when handle (mount/release! handle))
+    (when handle (rf.hicasso.impl.mount/release! handle))
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -524,7 +524,7 @@
   ;; census read after the reset that empties it. Each of the three is
   ;; driven here until it reads more than nothing.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (do
         (seat!)
@@ -565,9 +565,9 @@
                             it reads zeros whether the teardown released anything
                             or not; this is the reading that makes the zero below
                             it mean something"
-                    (let [before (support/census)]
+                    (let [before (rf.hicasso.roots-frames-support/census)]
                       (is (pos? (:boundaries before)))
-                      (is (= support/released (support/teardown-census! handle)))))
+                      (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/teardown-census! handle)))))
 
                   (testing "and the teardown released both instances — the
                             vendor's ledger and the runtime's agree"
@@ -596,7 +596,7 @@
   ;; care about — which is what the fresh-per-render intent callback
   ;; provides for free on every one of these renders.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (do
         (seat!)
@@ -647,7 +647,7 @@
 
                   (testing "and teardown releases exactly the one thing
                             the mount acquired"
-                    (is (= support/released (support/teardown-census! handle)))
+                    (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/teardown-census! handle)))
                     (is (= 0 (count @!live)))
                     (is (= 1 @!released))
                     (is (= 0 @!double-destroys))
@@ -671,7 +671,7 @@
   ;; imperative wrapper is most tempted to do, because the node is right
   ;; there — leaves two instances and one release, and paints identically.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (do
         (seat!)
@@ -708,7 +708,7 @@
 
                   (testing "and unmount releases exactly what the surviving
                             mount acquired"
-                    (is (= support/released (support/teardown-census! handle)))
+                    (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/teardown-census! handle)))
                     (is (= 0 (count @!live)))
                     (is (= 2 @!released))
                     (is (balanced?)))
@@ -724,7 +724,7 @@
 
 (deftest a-remount-releases-then-acquires-and-the-instance-is-a-new-one
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (do
         (seat!)
@@ -784,7 +784,7 @@
                     (fire-external! "keyed")
                     (is (= 1 (picks))))
 
-                  (is (= support/released (support/teardown-census! handle)))
+                  (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/teardown-census! handle)))
                   (is (= 0 (count @!live)))
                   (is (= 3 @!released))
                   (is (balanced?))
@@ -813,7 +813,7 @@
   ;; would be true of a mount that never happened — the exact shape of gate
   ;; that cannot go red.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (do
         (seat!)
@@ -886,7 +886,7 @@
 
                   (testing "and the ordinary teardown still balances after all
                             of it"
-                    (is (= support/released (support/teardown-census! handle)))
+                    (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/teardown-census! handle)))
                     (is (= 0 (count @!live)))
                     (is (= 2 @!released))
                     (is (= 0 @!double-destroys))
@@ -910,7 +910,7 @@
   ;; nothing to refuse. This row is what says the recipe reaches that
   ;; stronger statement and does not merely rely on the fence.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no React DOM") (done))
       (do
         (seat!)
@@ -923,7 +923,7 @@
                     (fire-external! "while-up")
                     (is (= 1 (picks))))
 
-                  (is (= support/released (support/teardown-census! handle)))
+                  (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/teardown-census! handle)))
 
                   (testing "and after the teardown the same event reaches
                             nothing — no intent, and no refusal either,
@@ -962,17 +962,17 @@
   ;; No fiber needed: the ledger is a declaration, read off the runtime.
   (testing "the shell still declares exactly its two hooks"
     (is (= [:use-context/frame :use-sync-external-store/subscription-epoch]
-           runtime/shell-hook-ledger))
-    (is (= 2 (count runtime/shell-hook-ledger))))
+           rf.hicasso.test.runtime/shell-hook-ledger))
+    (is (= 2 (count rf.hicasso.test.runtime/shell-hook-ledger))))
   (testing "and declares no ref or state hook — HD-020(b)"
-    (is (empty? (filter #(#{:use-ref :use-state} %) runtime/shell-hook-ledger)))))
+    (is (empty? (filter #(#{:use-ref :use-state} %) rf.hicasso.test.runtime/shell-hook-ledger)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 8. The roster
 ;; ---------------------------------------------------------------------------
 
 (deftest the-declared-population-was-actually-exercised
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test reaches none of the mechanisms")
     (testing "every mechanism this file claims to drive was driven"
       (is (= declared-population (set/intersection declared-population @!exercised))

--- a/implementation/hicasso/test/re_frame/hicasso/index_laws_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/index_laws_cljs_test.cljs
@@ -67,12 +67,12 @@
   copy of any of them would double the maintenance and the two would
   drift."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.generation :as generation]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.generation :as rf.hicasso.impl.generation]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::index-laws)
 
@@ -93,10 +93,10 @@
 ;; is `async`, because every law is a statement about one synchronous
 ;; commit and the one reaper window law 6 needs is entered, not waited on.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -123,7 +123,7 @@
   is the surface the laws are about: the edge is recorded WHERE THE READ
   HAPPENS."
   [query-vs]
-  (fn [_props] [:p (str (mapv collector/sub query-vs))]))
+  (fn [_props] [:p (str (mapv rf.hicasso.impl.collector/sub query-vs))]))
 
 (defn- mount!
   "Render a body and commit it, exactly as React does — `render-body`,
@@ -132,10 +132,10 @@
   and the cleanup React would hold."
   ([body] (mount! body {}))
   ([body props]
-   (collector/render-body frame-id body props)
-   (let [entry   (collector/last-reads)
+   (rf.hicasso.impl.collector/render-body frame-id body props)
+   (let [entry   (rf.hicasso.impl.collector/last-reads)
          !n      (volatile! 0)
-         release (collector/commit-boundary! entry (fn [] (vswap! !n inc)))]
+         release (rf.hicasso.impl.collector/commit-boundary! entry (fn [] (vswap! !n inc)))]
      {:entry entry :notified !n :release release})))
 
 (defn- woken
@@ -145,7 +145,7 @@
 
 (defn- release! [b] ((:release b)))
 
-(defn- readers-of [query-v] (count (runtime/cell-readers (sub-key query-v))))
+(defn- readers-of [query-v] (count (rf.hicasso.test.runtime/cell-readers (sub-key query-v))))
 
 ;; ---------------------------------------------------------------------------
 ;; Law 1 — a commit of that sub dirties that boundary ONLY
@@ -160,7 +160,7 @@
       (is (= 1 (readers-of [:idxlaw/a])))
       (is (= 1 (readers-of [:idxlaw/b]))))
 
-    (collector/dispatch! frame-id [:idxlaw/bump :a])
+    (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump :a])
 
     (testing "the reader of the moved sub is woken exactly once"
       (is (= 1 (woken reads-a))))
@@ -173,7 +173,7 @@
     ;; The mirror, on the same two counters, in the same test. Without it
     ;; the zero above is equally the zero of a runtime that notifies
     ;; nobody, and this file would be asserting silence.
-    (collector/dispatch! frame-id [:idxlaw/bump :b])
+    (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump :b])
 
     (testing "moving the OTHER sub wakes the other boundary and leaves the
               first where it was: both counters are live, and each moved
@@ -199,7 +199,7 @@
               edge — so a law about fan-out is a law about this list"
       (is (= 2 (readers-of [:idxlaw/a]))))
 
-    (collector/dispatch! frame-id [:idxlaw/bump :a])
+    (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump :a])
 
     (testing "both sharers are woken — the dirty set is the cell's readers,
               plural, and not the reader that got there first"
@@ -233,7 +233,7 @@
               untouched"
       (is (= 1 (readers-of [:idxlaw/a]))))
 
-    (collector/dispatch! frame-id [:idxlaw/bump :a])
+    (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump :a])
 
     (testing "so a later commit of that very sub reaches the survivor and
               not the departed. The PAIR is the law: a runtime that had
@@ -252,8 +252,8 @@
   performs the second read at all — which is what makes the dropped edge
   a consequence of control flow rather than of a declaration."
   [{:keys [wide?]}]
-  (let [a (collector/sub [:idxlaw/a])
-        b (when wide? (collector/sub [:idxlaw/b]))]
+  (let [a (rf.hicasso.impl.collector/sub [:idxlaw/a])
+        b (when wide? (rf.hicasso.impl.collector/sub [:idxlaw/b]))]
     [:p (str a "/" b)]))
 
 (deftest law-4-a-re-run-with-fewer-reads-drops-the-edge-it-stopped-holding
@@ -270,7 +270,7 @@
     (testing "the premise: the wide render read both keys, so `b` carries
               two memberships"
       (is (= #{(sub-key [:idxlaw/a]) (sub-key [:idxlaw/b])}
-             (runtime/reads-of (:entry wide))))
+             (rf.hicasso.test.runtime/reads-of (:entry wide))))
       (is (= 2 (readers-of [:idxlaw/b]))))
 
     ;; The re-run, with one read fewer. At the seam a read-set change is
@@ -281,13 +281,13 @@
       (release! wide)
 
       (testing "the narrow read set is the branch the body actually took"
-        (is (= #{(sub-key [:idxlaw/a])} (runtime/reads-of (:entry narrow)))))
+        (is (= #{(sub-key [:idxlaw/a])} (rf.hicasso.test.runtime/reads-of (:entry narrow)))))
 
       (testing "and `b` has lost the boundary that stopped reading it while
                 keeping the one that did not"
         (is (= 1 (readers-of [:idxlaw/b]))))
 
-      (collector/dispatch! frame-id [:idxlaw/bump :b])
+      (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump :b])
 
       (testing "so the sub the re-run dropped passes it by"
         (is (= 0 (woken narrow))))
@@ -297,7 +297,7 @@
                 nothing holds"
         (is (= 1 (woken keeper))))
 
-      (collector/dispatch! frame-id [:idxlaw/bump :a])
+      (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump :a])
 
       (testing "and the read the re-run kept still reaches it, so the
                 replacement dropped one edge rather than all of them"
@@ -316,19 +316,19 @@
   (let [only-a    (mount! (reading [[:idxlaw/a]]))
         reads-ab  (mount! (reading [[:idxlaw/a] [:idxlaw/b]]))
         only-c    (mount! (reading [[:idxlaw/c]]))
-        gen-before (generation/generation)]
+        gen-before (rf.hicasso.impl.generation/generation)]
 
     ;; ONE commit window moving TWO subs. `collector/dispatch!` is the
     ;; arm's own door and is `with-commit` applied, so the writes inside
     ;; it are collected and flushed once.
-    (collector/dispatch! frame-id [:idxlaw/bump-two :a :b])
+    (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump-two :a :b])
 
     (testing "the premise, and it is not decoration: `flush!` bumps the
               generation once per flush that found a dirty cell, so ONE
               here is the whole claim that this was one commit window. Two
               flushes would make `woken once` an accident of a second
               flush finding nothing rather than a union"
-      (is (= (inc gen-before) (generation/generation))))
+      (is (= (inc gen-before) (rf.hicasso.impl.generation/generation))))
 
     (testing "every reader of every dirty sub is in the set"
       (is (= 1 (woken only-a)))
@@ -343,7 +343,7 @@
       (is (= 0 (woken only-c))))
 
     ;; The mirror for `only-c`, so its zero is a live counter's zero.
-    (collector/dispatch! frame-id [:idxlaw/bump :c])
+    (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump :c])
     (testing "moving `c` wakes it and nobody else"
       (is (= 1 (woken only-c)))
       (is (= 1 (woken only-a)))
@@ -360,30 +360,30 @@
 (deftest law-6-a-sub-no-boundary-reads-becomes-no-commit-work-at-all
   (seeded!)
   (let [reader     (mount! (reading [[:idxlaw/a]]))
-        gen-before (generation/generation)]
+        gen-before (rf.hicasso.impl.generation/generation)]
 
-    (collector/dispatch! frame-id [:idxlaw/bump :unread])
+    (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump :unread])
 
     (testing "the write really happened — a body run reads the moved value
               back, so the silence below is the index's answer and not a
               dispatch that did nothing"
       (let [!seen (volatile! nil)]
-        (collector/render-body frame-id
-                               (fn [_] (vreset! !seen (collector/sub [:idxlaw/unread])) [:p])
+        (rf.hicasso.impl.collector/render-body frame-id
+                               (fn [_] (vreset! !seen (rf.hicasso.impl.collector/sub [:idxlaw/unread])) [:p])
                                {})
         (is (= 1 @!seen))))
 
     (testing "no cell holds the key, so it never enters the dirty set and
               the flush finds nothing to do"
-      (is (nil? (get @collector/!cells (sub-key [:idxlaw/unread]))))
-      (is (= gen-before (generation/generation))))
+      (is (nil? (get @rf.hicasso.impl.collector/!cells (sub-key [:idxlaw/unread]))))
+      (is (= gen-before (rf.hicasso.impl.generation/generation))))
 
     (testing "and no phantom boundary is conjured for it: the one committed
               boundary in the runtime is not woken"
       (is (= 0 (woken reader))))
 
     ;; The mirror, on that very counter.
-    (collector/dispatch! frame-id [:idxlaw/bump :a])
+    (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump :a])
     (testing "which it is, the moment a sub it actually reads moves"
       (is (= 1 (woken reader))))
 
@@ -407,16 +407,16 @@
 
     (testing "the premise: the cell survives its last reader, holding no
               readers at all"
-      (is (some? (get @collector/!cells (sub-key [:idxlaw/a]))))
+      (is (some? (get @rf.hicasso.impl.collector/!cells (sub-key [:idxlaw/a]))))
       (is (= 0 (readers-of [:idxlaw/a]))))
 
-    (let [gen-before (generation/generation)]
-      (collector/dispatch! frame-id [:idxlaw/bump :a])
+    (let [gen-before (rf.hicasso.impl.generation/generation)]
+      (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump :a])
 
       (testing "the cell really was dirtied — the generation moved, so a
                 flush found it. Without this the zeros below would be the
                 zeros of a commit that never reached the index"
-        (is (= (inc gen-before) (generation/generation))))
+        (is (= (inc gen-before) (rf.hicasso.impl.generation/generation))))
 
       (testing "and the union over that dirty cell is empty: the departed
                 boundary is not resurrected, and the live boundary reading
@@ -425,7 +425,7 @@
         (is (= 0 (woken elsewhere)))))
 
     ;; The mirror for `elsewhere`, so its zero is a live counter's zero.
-    (collector/dispatch! frame-id [:idxlaw/bump :c])
+    (rf.hicasso.impl.collector/dispatch! frame-id [:idxlaw/bump :c])
     (testing "the surviving boundary is woken by its own key"
       (is (= 1 (woken elsewhere))))
 

--- a/implementation/hicasso/test/re_frame/hicasso/instance_key_payload_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/instance_key_payload_ssr_dom_cljs_test.cljs
@@ -95,15 +95,15 @@
   React DOM. The payload-shape row needs no DOM and runs under
   `:node-test` too; every DOM claim degrades to a stated skip there."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.state :as impl-state]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.hicasso.server :as server]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.state :as rf.hicasso.impl.state]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.hicasso.server :as rf.hicasso.server]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private wire-frame ::instance-key-payload)
 
@@ -149,16 +149,16 @@
   documented tier. Spelled through `impl-state/ui-root` so the witness
   asserts on the same vector the sugar writes rather than on a
   hand-spelled copy of it."
-  [impl-state/ui-root open? open-key])
+  [rf.hicasso.impl.state/ui-root open? open-key])
 
 (rf/reg-sub ::panel-ids (fn [db _] (mapv :id (:panels db))))
 
 (rf/reg-sub ::panel-title
   (fn [db [_ id]] (some (fn [p] (when (= id (:id p)) (:title p))) (:panels db))))
 
-(h/reg-state open? {:default false})
+(rf.hicasso/reg-state open? {:default false})
 
-(h/defview panel
+(rf.hicasso/defview panel
   "A disclosure. It holds its own open flag under the instance key it was
   handed and knows nothing else about where it sits.
 
@@ -168,28 +168,28 @@
   be measuring React's SSR text-separator behaviour alongside the thing
   under test."
   [{:keys [ikey title]}]
-  (let [shown? (h/sub [open? ikey])]
+  (let [shown? (rf.hicasso/sub [open? ikey])]
     [:section.panel {:data-ikey ikey}
      [:button.panel-toggle {:on-click [open? ikey (not shown?)]} title]
      (when shown?
        [:div.panel-body "the details"])]))
 
-(h/defview screen
+(rf.hicasso/defview screen
   "The page. A heading, then one [[panel]] per roster entry, keyed by the
   same authored id it is instance-keyed by."
   [_]
   [:div.instance-key-page
    [:h1.title "instance state across the wire"]
    [:div.panels
-    (for [id (h/sub [::panel-ids])]
-      [panel {:key id :ikey id :title (h/sub [::panel-title id])}])]])
+    (for [id (rf.hicasso/sub [::panel-ids])]
+      [panel {:key id :ikey id :title (rf.hicasso/sub [::panel-title id])}])]])
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The two requests, differing by ONE allowlist entry
@@ -228,7 +228,7 @@
   so the seeding door is deliberately the least interesting part of the
   row."
   [payload]
-  (sup/leave-act-environment!)
+  (rf.hicasso.roots-frames-support/leave-act-environment!)
   (rf/make-frame {:id             wire-frame
                   :platform       :client
                   :initial-events [[:rf/set-db (:rf/app-db payload)]]})
@@ -246,12 +246,12 @@
   sets `:swallow-uncaught?` is the row that manufactures the fault and
   asserts on it."
   [html capture-opts]
-  (let [container                 (sup/stamp-server-nodes! (sup/server-dom! html))
-        {:keys [seen stop!]}      (sup/watch-mismatches!)
-        {:keys [captured close!]} (sup/open-console-capture! capture-opts)
+  (let [container                 (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+        {:keys [seen stop!]}      (rf.hicasso.roots-frames-support/watch-mismatches!)
+        {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture! capture-opts)
         before                    (some? (open-panel-in container))
-        handle                    (h/hydrate! container {:frame wire-frame} [screen {}])]
-    (-> (sup/adopted! handle)
+        handle                    (rf.hicasso/hydrate! container {:frame wire-frame} [screen {}])]
+    (-> (rf.hicasso.roots-frames-support/adopted! handle)
         (.then (fn [shut?]
                  (close!)
                  (stop!)
@@ -272,8 +272,8 @@
            identical; the allowlist is the only thing that moves. Without
            this row the two hydration rows below could be measuring any
            difference at all between two pages"
-    (let [green (server/render (request names-ui))
-          red   (server/render (request omits-ui))
+    (let [green (rf.hicasso.server/render (request names-ui))
+          red   (rf.hicasso.server/render (request omits-ui))
           gdb   (:rf/app-db (:payload green))
           rdb   (:rf/app-db (:payload red))]
       (is (= (:html green) (:html red))
@@ -325,10 +325,10 @@
            first render draws the same open panel, and React finds nothing
            to reconcile — asserted on the framework's own diagnostic AND on
            both channels React complains through"
-    (if-not (mount/browser?)
-      (sup/skip! "a payload-obligation hydration claim needs a real React DOM")
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (rf.hicasso.roots-frames-support/skip! "a payload-obligation hydration claim needs a real React DOM")
       (async done
-        (let [{:keys [html payload]} (server/render (request names-ui))]
+        (let [{:keys [html payload]} (rf.hicasso.server/render (request names-ui))]
           (client-frame! payload)
           (is (= true (get-in (rf/app-db-value wire-frame) state-path))
               "the client frame booted holding the instance state the server
@@ -355,19 +355,19 @@
                         "the panel is STILL open after adoption — open before,
                          open after, which is what \"hydrated\" means for a
                          page whose appearance is instance state")
-                    (is (sup/server-node? (open-panel-in container))
+                    (is (rf.hicasso.roots-frames-support/server-node? (open-panel-in container))
                         "and it is the SERVER'S own node. The stamp is an
                          expando and cannot survive re-serialisation, so React
                          reused the markup rather than building a replacement
                          that happens to look alike")
-                    (is (sup/every-server-node? container "*")
+                    (is (rf.hicasso.roots-frames-support/every-server-node? container "*")
                         "as is every element on the page — no partial adoption,
                          which is what a mismatch on one subtree would look
                          like")
                     (is (= 2 (panel-count container))
                         "both panels are there, so the row above is a claim
                          about a page and not about an empty container")
-                    (finally (h/unmount! handle)))))
+                    (finally (rf.hicasso/unmount! handle)))))
               ;; Reports and UNMOUNTS; it never finishes. `done` runs the whole
               ;; remainder of the run synchronously, so a `.catch` downstream of
               ;; it would claim a later namespace's throw as this row's and fire
@@ -394,10 +394,10 @@
            `:swallow-uncaught?` exists for. `rf2-mwx08` is not softened: the
            error is not unasserted here, it is the subject, and the row goes
            on to assert that the door reported it as well as emitting it"
-    (if-not (mount/browser?)
-      (sup/skip! "a payload-obligation hydration claim needs a real React DOM")
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (rf.hicasso.roots-frames-support/skip! "a payload-obligation hydration claim needs a real React DOM")
       (async done
-        (let [{:keys [html payload]} (server/render (request omits-ui))]
+        (let [{:keys [html payload]} (rf.hicasso.server/render (request omits-ui))]
           (client-frame! payload)
           (is (nil? (get-in (rf/app-db-value wire-frame) state-path))
               "the client frame booted WITHOUT the instance state — the entry
@@ -419,7 +419,7 @@
                               machinery, and this is that machinery answering.
                               Saw " (count mismatches) ": " (pr-str mismatches)))
                     (doseq [mm mismatches]
-                      (let [tags (sup/tags-of mm)]
+                      (let [tags (rf.hicasso.roots-frames-support/tags-of mm)]
                         (is (= :rf.ssr/hydration-mismatch (:operation mm)))
                         (is (= 're-frame.hicasso.impl.mount/hydrate-root! (:where tags))
                             "tier-discriminated by :where — this arm's hydrate
@@ -448,7 +448,7 @@
                     (is (= 2 (panel-count container))
                         "the rest of the page adopted normally — a stranded
                          partition is a wrong screen, not a blank one")
-                    (finally (h/unmount! handle)))))
+                    (finally (rf.hicasso/unmount! handle)))))
               ;; Reports and UNMOUNTS, as above.
               (.catch (fn [e] (is false (str "row 2 threw: " e)) nil))
               (.then (fn [_] (done)))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/intent_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/intent_cljs_test.cljs
@@ -9,7 +9,7 @@
   same closures is the arms' witness (validation.md's 100-cell grid), not
   this file's."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.hicasso.impl.intent :as intent]))
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]))
 
 ;; ---------------------------------------------------------------------------
 ;; A recording dispatch, and stand-in events
@@ -36,7 +36,7 @@
   below exercises a callback the browser invokes after the render's
   dynamic extent has unwound."
   [dispatch k v]
-  (intent/with-frame dispatch (fn [] (intent/lower-prop k v))))
+  (rf.hicasso.impl.intent/with-frame dispatch (fn [] (rf.hicasso.impl.intent/lower-prop k v))))
 
 ;; ---------------------------------------------------------------------------
 ;; Event vectors
@@ -67,17 +67,17 @@
             calls it long after the render unwound"
     (let [!seen (recorder)
           h     (lowered (dispatching !seen) :on-click [:ping])]
-      (is (nil? intent/*dispatch*))
+      (is (nil? rf.hicasso.impl.intent/*dispatch*))
       (h (ev {}))
       (is (= [[:ping]] @!seen)))))
 
 (deftest an-intent-lowered-outside-a-boundary-is-a-loud-error
-  (is (nil? intent/*dispatch*))
+  (is (nil? rf.hicasso.impl.intent/*dispatch*))
   (is (thrown-with-msg? js/Error #"no ambient frame"
-                        (intent/lower-prop :on-click [:ping])))
+                        (rf.hicasso.impl.intent/lower-prop :on-click [:ping])))
   (testing "the error carries its id"
     (try
-      (intent/lower-prop :on-click [:ping])
+      (rf.hicasso.impl.intent/lower-prop :on-click [:ping])
       (is false "should have thrown")
       (catch :default e
         (is (= :rf.error/hicasso-intent-outside-boundary (:rf.error/id (ex-data e))))))))
@@ -95,13 +95,13 @@
       (is (nil? (lowered d :on-click nil))))))
 
 (deftest both-event-prop-spellings-are-recognised-and-nothing-else-is
-  (is (true? (intent/event-prop? :on-click)))
-  (is (true? (intent/event-prop? :on-key-down)))
-  (is (true? (intent/event-prop? :onClick)))
-  (is (false? (intent/event-prop? :online)) "a kebab-less word starting with `on`")
-  (is (false? (intent/event-prop? :class)))
-  (is (false? (intent/event-prop? :data-on-click)))
-  (is (false? (intent/event-prop? nil))))
+  (is (true? (rf.hicasso.impl.intent/event-prop? :on-click)))
+  (is (true? (rf.hicasso.impl.intent/event-prop? :on-key-down)))
+  (is (true? (rf.hicasso.impl.intent/event-prop? :onClick)))
+  (is (false? (rf.hicasso.impl.intent/event-prop? :online)) "a kebab-less word starting with `on`")
+  (is (false? (rf.hicasso.impl.intent/event-prop? :class)))
+  (is (false? (rf.hicasso.impl.intent/event-prop? :data-on-click)))
+  (is (false? (rf.hicasso.impl.intent/event-prop? nil))))
 
 ;; ---------------------------------------------------------------------------
 ;; The value placeholder and the one pure materializer
@@ -128,18 +128,18 @@
   (testing "several markers in one intent all materialize"
     (let [e (ev {:value "v" :checked true})]
       (is (= [:e "v" true :tail]
-             (intent/materialize [:e :re-frame.hicasso/value :re-frame.hicasso/checked :tail] e)))))
+             (rf.hicasso.impl.intent/materialize [:e :re-frame.hicasso/value :re-frame.hicasso/checked :tail] e)))))
   (testing "an intent with no marker comes back with the same elements"
     (let [e (ev {:value "v"})]
-      (is (= [:e 1 "two"] (intent/materialize [:e 1 "two"] e)))))
+      (is (= [:e 1 "two"] (rf.hicasso.impl.intent/materialize [:e 1 "two"] e)))))
   (testing "markers are substituted at the top level only — the documented shape"
     (let [e (ev {:value "v"})]
       (is (= [:e {:v :re-frame.hicasso/value}]
-             (intent/materialize [:e {:v :re-frame.hicasso/value}] e)))))
+             (rf.hicasso.impl.intent/materialize [:e {:v :re-frame.hicasso/value}] e)))))
   (testing "the static/dynamic split is decidable before any event exists"
-    (is (true? (intent/markers? [:e :re-frame.hicasso/value])))
-    (is (true? (intent/markers? [:e :re-frame.hicasso/checked])))
-    (is (false? (intent/markers? [:e 1 "two"])))))
+    (is (true? (rf.hicasso.impl.intent/markers? [:e :re-frame.hicasso/value])))
+    (is (true? (rf.hicasso.impl.intent/markers? [:e :re-frame.hicasso/checked])))
+    (is (false? (rf.hicasso.impl.intent/markers? [:e 1 "two"])))))
 
 ;; ---------------------------------------------------------------------------
 ;; Submit auto-prevent, and the one reserved head that opts in elsewhere
@@ -239,9 +239,9 @@
           "and the difference is exactly the decorator, nothing else")))
   (testing "the predicate the classification uses is public, so a test can ask
             the same question the lowering asks"
-    (is (true? (intent/prevent-head? [:re-frame.hicasso/prevent [:x]])))
-    (is (false? (intent/prevent-head? [:conduit/show-your-feed])))
-    (is (false? (intent/prevent-head?
+    (is (true? (rf.hicasso.impl.intent/prevent-head? [:re-frame.hicasso/prevent [:x]])))
+    (is (false? (rf.hicasso.impl.intent/prevent-head? [:conduit/show-your-feed])))
+    (is (false? (rf.hicasso.impl.intent/prevent-head?
                   (with-meta [:conduit/show-your-feed]
                              {:re-frame.hicasso/prevent? true})))
         "the retired metadata is no longer a spelling of anything")))
@@ -297,8 +297,8 @@
     (testing "the refusal is taken at LOWERING time — before any event exists,
               so a malformed decorator cannot reach a user's click"
       (is (thrown? js/Error
-                   (intent/with-frame d
-                     (fn [] (intent/lower-props
+                   (rf.hicasso.impl.intent/with-frame d
+                     (fn [] (rf.hicasso.impl.intent/lower-props
                               {:on-click [:re-frame.hicasso/prevent :nope]}))))))
     (testing "and only at an event position: an intent travelling as data is
               not lowered, so it is not classified either"
@@ -389,10 +389,10 @@
       (is (true? @!called)))))
 
 (deftest the-composition-predicate-reads-both-signals
-  (is (true? (intent/composing? (ev {:composing? true}))))
-  (is (true? (intent/composing? (ev {:key-code 229}))))
-  (is (false? (intent/composing? (ev {:key-code 13}))))
-  (is (false? (intent/composing? (ev {})))))
+  (is (true? (rf.hicasso.impl.intent/composing? (ev {:composing? true}))))
+  (is (true? (rf.hicasso.impl.intent/composing? (ev {:key-code 229}))))
+  (is (false? (rf.hicasso.impl.intent/composing? (ev {:key-code 13}))))
+  (is (false? (rf.hicasso.impl.intent/composing? (ev {})))))
 
 ;; ---------------------------------------------------------------------------
 ;; The whole-map door
@@ -402,11 +402,11 @@
   (let [!seen (recorder)]
     (testing "a props map with nothing to lower comes back by identity"
       (let [props {:class "row" :data-index 3 :on-click (fn [_])}]
-        (is (identical? props (intent/with-frame (dispatching !seen)
-                                                 (fn [] (intent/lower-props props)))))))
+        (is (identical? props (rf.hicasso.impl.intent/with-frame (dispatching !seen)
+                                                 (fn [] (rf.hicasso.impl.intent/lower-props props)))))))
     (testing "a props map with an intent comes back lowered, everything else intact"
       (let [props    {:class "row" :data-index 3 :on-click [:touch 3]}
-            lowered' (intent/with-frame (dispatching !seen) (fn [] (intent/lower-props props)))]
+            lowered' (rf.hicasso.impl.intent/with-frame (dispatching !seen) (fn [] (rf.hicasso.impl.intent/lower-props props)))]
         (is (= "row" (:class lowered')))
         (is (= 3 (:data-index lowered')))
         (is (fn? (:on-click lowered')))
@@ -427,19 +427,19 @@
             gets the engine's own TypeError naming nothing they wrote. There
             is nothing here that can fail to be callable."
     (let [f  (fn [_] :ran)
-          cb (intent/callback f)]
+          cb (rf.hicasso.impl.intent/callback f)]
       (is (identical? f cb) "`callback` marks and returns the SAME function")
       (is (fn? cb))
-      (is (true? (intent/callback? cb)))
-      (is (false? (intent/callback? (fn [_]))) "an ordinary fn is not the form")
-      (is (false? (intent/callback? [:an :intent])))
-      (is (false? (intent/callback? "on-click"))))))
+      (is (true? (rf.hicasso.impl.intent/callback? cb)))
+      (is (false? (rf.hicasso.impl.intent/callback? (fn [_]))) "an ordinary fn is not the form")
+      (is (false? (rf.hicasso.impl.intent/callback? [:an :intent])))
+      (is (false? (rf.hicasso.impl.intent/callback? "on-click"))))))
 
 (deftest at-an-event-position-a-returned-vector-is-dispatched
   (testing "the contract the predecessor spells `v/event`"
     (let [!seen (recorder)
           h     (lowered (dispatching !seen) :on-change
-                         (intent/callback (fn [e] [:files/picked (.. e -target -value)])))]
+                         (rf.hicasso.impl.intent/callback (fn [e] [:files/picked (.. e -target -value)])))]
       (h (ev {:value "a.png"}))
       (is (= [[:files/picked "a.png"]] @!seen))))
   (testing "and a return that is not a vector is ignored — which is the
@@ -447,7 +447,7 @@
     (let [!seen (recorder)
           !ran  (atom 0)
           h     (lowered (dispatching !seen) :on-click
-                         (intent/callback (fn [_] (swap! !ran inc) :not-an-intent)))]
+                         (rf.hicasso.impl.intent/callback (fn [_] (swap! !ran inc) :not-an-intent)))]
       (h (ev {}))
       (is (= 1 @!ran) "the body ran")
       (is (= [] @!seen) "and nothing was dispatched")))
@@ -455,7 +455,7 @@
             an ordinary conditional returning nil"
     (let [!seen (recorder)
           h     (lowered (dispatching !seen) :on-click
-                         (intent/callback (fn [_] nil)))]
+                         (rf.hicasso.impl.intent/callback (fn [_] nil)))]
       (h (ev {}))
       (is (= [] @!seen)))))
 
@@ -477,7 +477,7 @@
         (reset! !seen [])
         (let [prevented (atom false)
               h (lowered (dispatching !seen) :on-submit
-                         (intent/callback (fn [_] [:signup/submit])))]
+                         (rf.hicasso.impl.intent/callback (fn [_] [:signup/submit])))]
           (h (ev {:prevented prevented}))
           (is (false? @prevented) "the runtime left the event alone")
           (is (= [[:signup/submit]] @!seen)))))))
@@ -489,7 +489,7 @@
             of the value cannot select the contract and the position must."
     (let [!seen (recorder)
           h     (lowered (dispatching !seen) :row-renderer
-                         (intent/callback (fn [row] [:li (:title row)])))]
+                         (rf.hicasso.impl.intent/callback (fn [row] [:li (:title row)])))]
       (is (= [:li "milk"] (h {:title "milk"}))
           "the hiccup came back to the caller and was NOT dispatched")
       (is (= [] @!seen)))))
@@ -506,22 +506,22 @@
           !row      (atom nil)
           !cb       (atom nil)
           !frame    (atom ::unread)
-          h (intent/with-frame ::supplier (dispatching !supplier)
-              (fn [] (intent/lower-prop
+          h (rf.hicasso.impl.intent/with-frame ::supplier (dispatching !supplier)
+              (fn [] (rf.hicasso.impl.intent/lower-prop
                        :row-renderer
-                       (intent/callback
+                       (rf.hicasso.impl.intent/callback
                          (fn [title]
-                           (reset! !frame intent/*frame*)
-                           (reset! !row (intent/lower-prop :on-click [:row/pick title]))
-                           (reset! !cb  (intent/lower-prop
+                           (reset! !frame rf.hicasso.impl.intent/*frame*)
+                           (reset! !row (rf.hicasso.impl.intent/lower-prop :on-click [:row/pick title]))
+                           (reset! !cb  (rf.hicasso.impl.intent/lower-prop
                                           :on-change
-                                          (intent/callback (fn [_] [:row/changed title]))))
+                                          (rf.hicasso.impl.intent/callback (fn [_] [:row/changed title]))))
                            [:li title])))))]
       (testing "the invocation runs under a DIFFERENT boundary — what a foreign
                 component nested below another one does — so neither claim
                 below can pass by accident"
         (is (= [:li "milk"]
-               (intent/with-frame ::other (dispatching !other)
+               (rf.hicasso.impl.intent/with-frame ::other (dispatching !other)
                  (fn [] (h "milk"))))
             "the return is still the render output")
         (is (= ::supplier @!frame)
@@ -530,7 +530,7 @@
         (is (= [] @!supplier) "the render itself dispatched nothing")
         (is (= [] @!other)))
       (testing "and then the browser's click, long after both extents unwound"
-        (is (nil? intent/*dispatch*))
+        (is (nil? rf.hicasso.impl.intent/*dispatch*))
         (@!row (ev {}))
         (@!cb (ev {}))
         (is (= [[:row/pick "milk"] [:row/changed "milk"]] @!supplier)
@@ -546,11 +546,11 @@
             a handler lowered inside it raises the ordinary outside-boundary
             error at lowering — the silently inert handler is the one outcome
             that is never available."
-    (is (nil? intent/*dispatch*))
-    (let [h (intent/lower-prop
+    (is (nil? rf.hicasso.impl.intent/*dispatch*))
+    (let [h (rf.hicasso.impl.intent/lower-prop
               :row-renderer
-              (intent/callback (fn [_]
-                                 (intent/lower-prop :on-click [:oops])
+              (rf.hicasso.impl.intent/callback (fn [_]
+                                 (rf.hicasso.impl.intent/lower-prop :on-click [:oops])
                                  [:li])))]
       (try
         (h {})
@@ -566,11 +566,11 @@
             prop with `:event` or `:render` — the same two wrappers — where
             a vendor's spelling infers the wrong one."
     (let [!seen (recorder)
-          cb    (intent/callback (fn [x] [:host/changed x]))]
+          cb    (rf.hicasso.impl.intent/callback (fn [x] [:host/changed x]))]
       (testing ":event dispatches the return even though :onValueChange is
                 not a position the attribute grammar would call an event"
-        (let [h (intent/with-frame (dispatching !seen)
-                                   (fn [] (intent/lower-declared-prop :onValueChange cb :event)))]
+        (let [h (rf.hicasso.impl.intent/with-frame (dispatching !seen)
+                                   (fn [] (rf.hicasso.impl.intent/lower-declared-prop :onValueChange cb :event)))]
           (h 7)
           (is (= [[:host/changed 7]] @!seen))))
       (testing "and it forwards EVERY argument the invoker passes. A native
@@ -582,9 +582,9 @@
                 silently drop everything after the first, or raise an arity
                 error naming nothing the author wrote."
         (reset! !seen [])
-        (let [pair (intent/callback (fn [value e] [:host/changed value (.-key e)]))
-              h    (intent/with-frame (dispatching !seen)
-                                      (fn [] (intent/lower-declared-prop :onValueChange pair :event)))]
+        (let [pair (rf.hicasso.impl.intent/callback (fn [value e] [:host/changed value (.-key e)]))
+              h    (rf.hicasso.impl.intent/with-frame (dispatching !seen)
+                                      (fn [] (rf.hicasso.impl.intent/lower-declared-prop :onValueChange pair :event)))]
           (h "typed" (ev {:key "Enter"}))
           (is (= [[:host/changed "typed" "Enter"]] @!seen))))
       (testing ":render at an on*-spelled prop is the override's whole
@@ -592,8 +592,8 @@
                 output, where the spelling would have selected the event
                 wrapper and returned nil"
         (reset! !seen [])
-        (let [h (intent/with-frame (dispatching !seen)
-                                   (fn [] (intent/lower-declared-prop :onRenderItem cb :render)))]
+        (let [h (rf.hicasso.impl.intent/with-frame (dispatching !seen)
+                                   (fn [] (rf.hicasso.impl.intent/lower-declared-prop :onRenderItem cb :render)))]
           (is (= [:host/changed 7] (h 7)) "the caller sees the return")
           (is (= [] @!seen) "and nothing was dispatched"))))))
 
@@ -604,14 +604,14 @@
             conveniences at :event only, because dispatching is exactly
             what that contract MEANS"
     (let [!seen (recorder)]
-      (let [h (intent/with-frame (dispatching !seen)
-                                 (fn [] (intent/lower-declared-prop
+      (let [h (rf.hicasso.impl.intent/with-frame (dispatching !seen)
+                                 (fn [] (rf.hicasso.impl.intent/lower-declared-prop
                                           :onValueChange [:host/changed 1] :event)))]
         (h (ev {}))
         (is (= [[:host/changed 1]] @!seen)))
       (reset! !seen [])
-      (let [h (intent/with-frame (dispatching !seen)
-                                 (fn [] (intent/lower-declared-prop
+      (let [h (rf.hicasso.impl.intent/with-frame (dispatching !seen)
+                                 (fn [] (rf.hicasso.impl.intent/lower-declared-prop
                                           :onValueChange {"Enter" [:host/changed 2]} :event)))]
         (h (ev {:key "Enter"}))
         (is (= [[:host/changed 2]] @!seen)))
@@ -619,13 +619,13 @@
                 untouched, to cross as DATA through the shallow conversion
                 exactly as it would at a native tag's render position"
         (doseq [carrier [[:host/changed 3] {"Enter" [:host/changed 3]}]]
-          (is (identical? carrier (intent/lower-declared-prop :onRenderRow carrier :render)))))
+          (is (identical? carrier (rf.hicasso.impl.intent/lower-declared-prop :onRenderRow carrier :render)))))
       (testing "an ordinary unmarked function crosses untouched at both — a
                 plain fn is claimed by no position, which is what the retired
                 :handler contract named"
         (let [f (fn [_] :whatever)]
           (doseq [contract [:event :render]]
-            (is (identical? f (intent/lower-declared-prop :onValueChange f contract))
+            (is (identical? f (rf.hicasso.impl.intent/lower-declared-prop :onValueChange f contract))
                 (str "at " contract))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -644,7 +644,7 @@
   (let [d (dispatching (recorder))]
     (testing "`::h/prevent` needs `preventDefault`, and says so when argument
               one has none"
-      (let [h (intent/with-frame d (fn [] (intent/lower-prop
+      (let [h (rf.hicasso.impl.intent/with-frame d (fn [] (rf.hicasso.impl.intent/lower-prop
                                             :on-pick [:re-frame.hicasso/prevent [:go]])))]
         (try
           (h "a-value")
@@ -659,11 +659,11 @@
               (is (re-find #"h/event" (ex-message e)) "and the spelling that works"))))))
     (testing "`:on-submit`'s auto-prevent is the same law, reached by the
               policy default rather than by the head"
-      (let [h (intent/with-frame d (fn [] (intent/lower-prop :on-submit [:go])))]
+      (let [h (rf.hicasso.impl.intent/with-frame d (fn [] (rf.hicasso.impl.intent/lower-prop :on-submit [:go])))]
         (is (= :rf.error/hicasso-intent-needs-the-event
                (try (h "a-value") ::no (catch :default e (:rf.error/id (ex-data e))))))))
     (testing "the markers need `target`, and the diagnostic says which"
-      (let [h (intent/with-frame d (fn [] (intent/lower-prop
+      (let [h (rf.hicasso.impl.intent/with-frame d (fn [] (rf.hicasso.impl.intent/lower-prop
                                             :on-pick [:set :re-frame.hicasso/value])))]
         (try
           (h 7)
@@ -672,21 +672,21 @@
             (is (= "target" (:needed (ex-data e))))))))
     (testing "a key-map needs `key` — and it is the sharpest of the three,
               because without the law it looks nothing up and does NOTHING"
-      (let [h (intent/with-frame d (fn [] (intent/lower-prop
+      (let [h (rf.hicasso.impl.intent/with-frame d (fn [] (rf.hicasso.impl.intent/lower-prop
                                             :on-pick {"Enter" [:go]})))]
         (is (= :rf.error/hicasso-intent-needs-the-event
                (try (h 7) ::no (catch :default e (:rf.error/id (ex-data e))))))))
     (testing "nil is refused the same way rather than raising the engine's own
               null dereference"
-      (let [h (intent/with-frame d (fn [] (intent/lower-prop :on-submit [:go])))]
+      (let [h (rf.hicasso.impl.intent/with-frame d (fn [] (rf.hicasso.impl.intent/lower-prop :on-submit [:go])))]
         (is (= :rf.error/hicasso-intent-needs-the-event
                (try (h nil) ::no (catch :default e (:rf.error/id (ex-data e))))))))
     (testing "while an intent with NEITHER a marker nor a prevent never reads
               its argument at all, so it costs no law and is correct under any
               invoker contract — the overwhelmingly common case"
       (let [!seen (recorder)
-            h     (intent/with-frame (dispatching !seen)
-                                     (fn [] (intent/lower-prop :on-pick [:go 1])))]
+            h     (rf.hicasso.impl.intent/with-frame (dispatching !seen)
+                                     (fn [] (rf.hicasso.impl.intent/lower-prop :on-pick [:go 1])))]
         (h "a-value")
         (h nil)
         (is (= [[:go 1] [:go 1]] @!seen))))))
@@ -699,7 +699,7 @@
             never anything but a function, so the position not being walked
             costs the contract and nothing else."
     (let [!ran     (atom 0)
-          cb       (intent/callback (fn [x] (swap! !ran inc) [:would-have-dispatched x]))
+          cb       (rf.hicasso.impl.intent/callback (fn [x] (swap! !ran inc) [:would-have-dispatched x]))
           js-props #js {:onPing cb}]
       (is (fn? (.-onPing js-props)))
       (is (= [:would-have-dispatched 3] ((.-onPing js-props) 3))
@@ -712,7 +712,7 @@
   (testing "the form is legal with no frame — a callback that never returns
             an intent has nothing to dispatch. Returning one there is the
             loud error, and it names the position rather than the form."
-    (let [h (intent/lower-prop :on-click (intent/callback (fn [_] [:too/late])))]
+    (let [h (rf.hicasso.impl.intent/lower-prop :on-click (rf.hicasso.impl.intent/callback (fn [_] [:too/late])))]
       (try
         (h (ev {}))
         (is false "should have thrown")
@@ -721,7 +721,7 @@
           (is (= :on-click (:position (ex-data e)))))))
     (testing "while the same callback returning nothing is fine"
       (let [!ran (atom 0)
-            h    (intent/lower-prop :on-click (intent/callback (fn [_] (swap! !ran inc) nil)))]
+            h    (rf.hicasso.impl.intent/lower-prop :on-click (rf.hicasso.impl.intent/callback (fn [_] (swap! !ran inc) nil)))]
         (h (ev {}))
         (is (= 1 @!ran))))))
 
@@ -731,12 +731,12 @@
             COMMIT phase with the node, and its return is the detach
             cleanup. Wrapping it would forbid a legitimate dispatch there and
             would change the identity React re-attaches on."
-    (is (= :ref (intent/position-contract :ref)))
-    (is (= :event (intent/position-contract :on-click)))
-    (is (= :render (intent/position-contract :row-renderer)))
-    (let [cb (intent/callback (fn [_node] :cleanup))]
-      (is (identical? cb (intent/lower-prop :ref cb)))
-      (is (identical? cb (intent/lower-prop "ref" cb))))))
+    (is (= :ref (rf.hicasso.impl.intent/position-contract :ref)))
+    (is (= :event (rf.hicasso.impl.intent/position-contract :on-click)))
+    (is (= :render (rf.hicasso.impl.intent/position-contract :row-renderer)))
+    (let [cb (rf.hicasso.impl.intent/callback (fn [_node] :cleanup))]
+      (is (identical? cb (rf.hicasso.impl.intent/lower-prop :ref cb)))
+      (is (identical? cb (rf.hicasso.impl.intent/lower-prop "ref" cb))))))
 
 (deftest an-ordinary-function-is-untouched-everywhere
   (testing "`raw-fn`'s identity passthrough is not v0 because it is already
@@ -745,6 +745,6 @@
             and every downstream bail-out that compares handler identity keep
             working. One fewer form for nothing given up."
     (let [f (fn [_] :whatever)]
-      (is (identical? f (intent/lower-prop :on-click f)))
-      (is (identical? f (intent/lower-prop :row-renderer f)))
-      (is (identical? f (intent/lower-prop :ref f))))))
+      (is (identical? f (rf.hicasso.impl.intent/lower-prop :on-click f)))
+      (is (identical? f (rf.hicasso.impl.intent/lower-prop :row-renderer f)))
+      (is (identical? f (rf.hicasso.impl.intent/lower-prop :ref f))))))

--- a/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_cljs_test.cljs
@@ -72,14 +72,14 @@
   making non-zero, which is the failure mode this repo has been bitten by
   twice."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom/server" :as react-dom-server]))
 
 (def ^:private frame-id ::kernel-commit-owns)
@@ -104,11 +104,11 @@
 ;; async body has resumed. `:ambient-frame nil` because this suite seats
 ;; its own top-level frame.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -140,7 +140,7 @@
 (defn- ownership
   "The census with the entry cache projected out."
   []
-  (dissoc (runtime/residue) :entries))
+  (dissoc (rf.hicasso.test.runtime/residue) :entries))
 
 (defn- probe!
   "Run ONE boundary body under the real generation fence — the same call
@@ -148,35 +148,35 @@
   and return the read-set entry the render resolved. Commits nothing:
   `subscribe` is React's to call, and nothing here calls it."
   [body-fn]
-  (collector/render-body frame-id body-fn {})
-  (collector/last-reads))
+  (rf.hicasso.impl.collector/render-body frame-id body-fn {})
+  (rf.hicasso.impl.collector/last-reads))
 
 ;; ---------------------------------------------------------------------------
 ;; A real React render that never commits
 ;; ---------------------------------------------------------------------------
 
-(h/defview left-line  [_] [:p.left (h/sub [:kco/left])])
-(h/defview right-line [_] [:p.right (h/sub [:kco/right])])
+(rf.hicasso/defview left-line  [_] [:p.left (rf.hicasso/sub [:kco/left])])
+(rf.hicasso/defview right-line [_] [:p.right (rf.hicasso/sub [:kco/right])])
 
-(h/defview both-lines
+(rf.hicasso/defview both-lines
   [_]
   [:div [left-line {}] [right-line {}]])
 
 (defn- server-html
   [hiccup]
   (react-dom-server/renderToString
-    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+    (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup))))
 
 (deftest a-server-render-runs-every-body-and-acquires-nothing-from-any-of-them
   (async done
     (seeded!)
-    (runtime/reset-body-runs!)
+    (rf.hicasso.test.runtime/reset-body-runs!)
     (let [markup (server-html [both-lines {}])]
 
       (testing "the premise: React really did run all three bodies. Without
                 this the zeros below would be the zeros of a render that
                 never happened"
-        (is (= 3 (runtime/body-runs)))
+        (is (= 3 (rf.hicasso.test.runtime/body-runs)))
         (is (re-find #"1" markup))
         (is (re-find #"2" markup)))
 
@@ -186,21 +186,21 @@
 
       (testing "the individually-named keys confirm it per key, which a
                 summed census could hide"
-        (is (= [] (runtime/cell-readers (sub-key [:kco/left]))))
-        (is (= [] (runtime/cell-readers (sub-key [:kco/right])))))
+        (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/left]))))
+        (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/right])))))
 
       (testing "the read-set entries ARE there — a render-phase cache is the
                 one thing a probing render leaves, and calling it out is
                 what keeps the zero above honest"
-        (is (pos? (:entries (runtime/residue)))))
+        (is (pos? (:entries (rf.hicasso.test.runtime/residue)))))
 
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "and the cache evaporates at the runtime's own
                          horizon: zero residue after quiescence, which is
                          I5's last clause"
                  (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                        (runtime/residue))))
+                        (rf.hicasso.test.runtime/residue))))
                (done))))))
 
 ;; ---------------------------------------------------------------------------
@@ -210,23 +210,23 @@
 (deftest the-commit-acquires-exactly-the-current-read-set
   (async done
     (seeded!)
-    (let [entry     (probe! (fn [_] [:p (h/sub [:kco/left])]))
+    (let [entry     (probe! (fn [_] [:p (rf.hicasso/sub [:kco/left])]))
           !notified (atom 0)]
 
       (testing "the render resolved the read set without owning it"
-        (is (= #{(sub-key [:kco/left])} (runtime/reads-of entry)))
+        (is (= #{(sub-key [:kco/left])} (rf.hicasso.test.runtime/reads-of entry)))
         (is (= nothing-owned (ownership))))
 
-      (let [cleanup (collector/commit-boundary! entry (fn [] (swap! !notified inc)))]
+      (let [cleanup (rf.hicasso.impl.collector/commit-boundary! entry (fn [] (swap! !notified inc)))]
 
         (testing "the commit takes exactly one cell, one reference, one edge"
           (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
-          (is (= 1 (count (runtime/cell-readers (sub-key [:kco/left]))))))
+          (is (= 1 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/left]))))))
 
         (testing "and NOTHING for a key this body did not read — the
                   acquisition is the read set, not the registrar"
-          (is (= [] (runtime/cell-readers (sub-key [:kco/right]))))
-          (is (nil? (runtime/cell-reaction (sub-key [:kco/right])))))
+          (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/right]))))
+          (is (nil? (rf.hicasso.test.runtime/cell-reaction (sub-key [:kco/right])))))
 
         (testing "the acquired boundary is a live reader: a write to its key
                   notifies it exactly once"
@@ -245,13 +245,13 @@
                   and the cell survives only until its reaper"
           (is (= {:cells 1 :cell-refs 0 :boundaries 0 :edges 0} (ownership)))))
 
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "and at the runtime's own horizon — which is strictly
                          past every reaper armed before it, the cell reapers
                          included — teardown is exact: total zero"
                  (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                        (runtime/residue))))
+                        (rf.hicasso.test.runtime/residue))))
                (done))))))
 
 (deftest a-branch-not-taken-contributes-no-edge
@@ -259,26 +259,26 @@
   ;; The ambient collector's whole claim: the edge is recorded WHERE THE
   ;; READ HAPPENS, so a boundary's edge set is a function of the control
   ;; flow the render actually took.
-  (let [body    (fn [_] [:p (when (h/sub [:kco/flag]) (h/sub [:kco/right]))])
+  (let [body    (fn [_] [:p (when (rf.hicasso/sub [:kco/flag]) (rf.hicasso/sub [:kco/right]))])
         cold    (probe! body)
-        cleanup (collector/commit-boundary! cold (fn []))]
+        cleanup (rf.hicasso.impl.collector/commit-boundary! cold (fn []))]
 
     (testing "flag is false, so the guarded read never ran and its key is
               not in the set"
-      (is (= #{(sub-key [:kco/flag])} (runtime/reads-of cold)))
+      (is (= #{(sub-key [:kco/flag])} (rf.hicasso.test.runtime/reads-of cold)))
       (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
-      (is (= [] (runtime/cell-readers (sub-key [:kco/right])))))
+      (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/right])))))
 
     (cleanup)
     (rf/with-frame frame-id (rf/dispatch-sync [:kco/raise]))
 
     (let [warm     (probe! body)
-          cleanup2 (collector/commit-boundary! warm (fn []))]
+          cleanup2 (rf.hicasso.impl.collector/commit-boundary! warm (fn []))]
       (testing "flag is true, so the same body reads two keys and the commit
                 acquires both — the edge set followed the branch"
         (is (= #{(sub-key [:kco/flag]) (sub-key [:kco/right])}
-               (runtime/reads-of warm)))
-        (is (= 1 (count (runtime/cell-readers (sub-key [:kco/right]))))))
+               (rf.hicasso.test.runtime/reads-of warm)))
+        (is (= 1 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/right]))))))
       (cleanup2))))
 
 ;; ---------------------------------------------------------------------------
@@ -290,11 +290,11 @@
   (let [before (ownership)]
 
     (is (thrown-with-msg? js/Error #"planted"
-          (collector/render-body
+          (rf.hicasso.impl.collector/render-body
             frame-id
             (fn [_]
-              (h/sub [:kco/left])
-              (h/sub [:kco/right])
+              (rf.hicasso/sub [:kco/left])
+              (rf.hicasso/sub [:kco/right])
               (throw (js/Error. "planted")))
             {}))
         "the body must actually throw — otherwise this row proves nothing")
@@ -309,19 +309,19 @@
     ;; every body; if a throwing run's reads survived into the next body,
     ;; the next boundary would commit edges it never read — correct on
     ;; screen, wrong forever after.
-    (let [entry   (probe! (fn [_] [:p (h/sub [:kco/flag])]))
-          cleanup (collector/commit-boundary! entry (fn []))]
+    (let [entry   (probe! (fn [_] [:p (rf.hicasso/sub [:kco/flag])]))
+          cleanup (rf.hicasso.impl.collector/commit-boundary! entry (fn []))]
 
       (testing "the next body's read set is ITS OWN, not the throwing run's
                 concatenated with it"
-        (is (= #{(sub-key [:kco/flag])} (runtime/reads-of entry)))
+        (is (= #{(sub-key [:kco/flag])} (rf.hicasso.test.runtime/reads-of entry)))
         (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership))))
 
       (testing "named per key, because `:cells 1` alone could be the right
                 count of the wrong keys"
-        (is (= 1 (count (runtime/cell-readers (sub-key [:kco/flag])))))
-        (is (= [] (runtime/cell-readers (sub-key [:kco/left]))))
-        (is (= [] (runtime/cell-readers (sub-key [:kco/right])))))
+        (is (= 1 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/flag])))))
+        (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/left]))))
+        (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/right])))))
 
       (cleanup))))
 
@@ -331,21 +331,21 @@
 
 (deftest a-re-render-before-the-commit-owns-the-second-read-set-and-only-that
   (seeded!)
-  (probe! (fn [_] [:p (h/sub [:kco/left]) (h/sub [:kco/right])]))
+  (probe! (fn [_] [:p (rf.hicasso/sub [:kco/left]) (rf.hicasso/sub [:kco/right])]))
 
   (testing "the first attempt owns nothing, so there is nothing for the
             second to undo"
     (is (= nothing-owned (ownership))))
 
-  (let [second-entry (probe! (fn [_] [:p (h/sub [:kco/flag])]))
-        cleanup      (collector/commit-boundary! second-entry (fn []))]
+  (let [second-entry (probe! (fn [_] [:p (rf.hicasso/sub [:kco/flag])]))
+        cleanup      (rf.hicasso.impl.collector/commit-boundary! second-entry (fn []))]
 
     (testing "React selected the second attempt, so the second attempt's set
               is what got acquired — in full and in isolation"
-      (is (= #{(sub-key [:kco/flag])} (runtime/reads-of second-entry)))
+      (is (= #{(sub-key [:kco/flag])} (rf.hicasso.test.runtime/reads-of second-entry)))
       (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership)))
-      (is (= [] (runtime/cell-readers (sub-key [:kco/left]))))
-      (is (= [] (runtime/cell-readers (sub-key [:kco/right])))))
+      (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/left]))))
+      (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/right])))))
 
     (cleanup)))
 
@@ -360,19 +360,19 @@
     ;; at the seam: one entry, two `subscribe` calls, two cleanups. The
     ;; REAL StrictMode witness is the DOM file's; this row states what the
     ;; seam owes it.
-    (let [entry (probe! (fn [_] [:p (h/sub [:kco/left])]))
-          c1    (collector/commit-boundary! entry (fn []))
-          c2    (collector/commit-boundary! entry (fn []))]
+    (let [entry (probe! (fn [_] [:p (rf.hicasso/sub [:kco/left])]))
+          c1    (rf.hicasso.impl.collector/commit-boundary! entry (fn []))
+          c2    (rf.hicasso.impl.collector/commit-boundary! entry (fn []))]
 
       (testing "two boundaries, two memberships, still ONE cell — the cell
                 is shared per unique key and the reader list is the count"
         (is (= {:cells 1 :cell-refs 2 :boundaries 2 :edges 2} (ownership)))
-        (is (= 2 (count (runtime/cell-readers (sub-key [:kco/left]))))))
+        (is (= 2 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/left]))))))
 
       (testing "and the two registrations are distinct objects: the
                 registration IS the boundary id, so a second subscribe
                 cannot be mistaken for the first"
-        (let [[a b] (runtime/cell-readers (sub-key [:kco/left]))]
+        (let [[a b] (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/left]))]
           (is (not (identical? a b)))))
 
       (c1)
@@ -380,11 +380,11 @@
         (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1} (ownership))))
 
       (c2)
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "and the pair leaves zero residue"
                  (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                        (runtime/residue))))
+                        (rf.hicasso.test.runtime/residue))))
                (done))))))
 
 ;; ---------------------------------------------------------------------------
@@ -395,10 +395,10 @@
   (seeded!)
   ;; The control for the row below, and the reason that row means anything:
   ;; if the number moved on every commit, a difference would prove nothing.
-  (let [entry     (probe! (fn [_] [:p (h/sub [:kco/left])]))
-        at-render (runtime/snapshot-of entry)
-        cleanup   (collector/commit-boundary! entry (fn []))
-        at-commit (runtime/snapshot-of entry)]
+  (let [entry     (probe! (fn [_] [:p (rf.hicasso/sub [:kco/left])]))
+        at-render (rf.hicasso.test.runtime/snapshot-of entry)
+        cleanup   (rf.hicasso.impl.collector/commit-boundary! entry (fn []))
+        at-commit (rf.hicasso.test.runtime/snapshot-of entry)]
     (testing "nothing landed in the gap, so React's post-subscribe re-read
               sees the number the fiber captured at render and schedules no
               correcting re-render"
@@ -410,17 +410,17 @@
   ;; A STAGED key — nothing holds `:kco/left`, so it has no cell, no watch
   ;; and no epoch, and the flush generation is structurally blind to it.
   ;; `commit-basis` is what is not blind, and this is the row that says so.
-  (let [entry     (probe! (fn [_] [:p (h/sub [:kco/left])]))
-        at-render (runtime/snapshot-of entry)]
+  (let [entry     (probe! (fn [_] [:p (rf.hicasso/sub [:kco/left])]))
+        at-render (rf.hicasso.test.runtime/snapshot-of entry)]
 
     (testing "the key really is staged: no cell holds it at render time"
-      (is (nil? (get @collector/!cells (sub-key [:kco/left])))))
+      (is (nil? (get @rf.hicasso.impl.collector/!cells (sub-key [:kco/left])))))
 
     ;; The write lands AFTER the body returned and BEFORE React acquires.
     (rf/with-frame frame-id (rf/dispatch-sync [:kco/bump-left]))
 
-    (let [cleanup   (collector/commit-boundary! entry (fn []))
-          at-commit (runtime/snapshot-of entry)]
+    (let [cleanup   (rf.hicasso.impl.collector/commit-boundary! entry (fn []))
+          at-commit (rf.hicasso.test.runtime/snapshot-of entry)]
       (testing "so the number React re-reads after `subscribe` differs from
                 the one the fiber captured at render, and the boundary is
                 corrected instead of painting a value that moved under it"
@@ -445,12 +445,12 @@
   ;; abandoned attempt.
   (async done
     (seeded!)
-    (let [entry (probe! (fn [_] [:p (h/sub [:kco/left])]))]
+    (let [entry (probe! (fn [_] [:p (rf.hicasso/sub [:kco/left])]))]
 
       (testing "the abandoned render, as every row above finds it"
         (is (= nothing-owned (ownership))))
 
-      (collector/commit-boundary! entry (fn []))
+      (rf.hicasso.impl.collector/commit-boundary! entry (fn []))
 
       (testing "one leaked registration, and the census says so — on the
                 summed counters"
@@ -459,12 +459,12 @@
 
       (testing "and on the per-key reader list, which is the observable the
                 acquisition rows actually assert on"
-        (is (= 1 (count (runtime/cell-readers (sub-key [:kco/left]))))))
+        (is (= 1 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/left]))))))
 
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "quiescence does NOT launder it: the reapers drop
                          what nothing holds, and this is held"
-                 (is (= 1 (count (runtime/cell-readers (sub-key [:kco/left])))))
-                 (is (not= 0 (:cell-refs (runtime/residue)))))
+                 (is (= 1 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:kco/left])))))
+                 (is (not= 0 (:cell-refs (rf.hicasso.test.runtime/residue)))))
                (done))))))

--- a/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/kernel_commit_owns_dom_cljs_test.cljs
@@ -84,14 +84,14 @@
   than to an assertion that passes because nothing ran."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [clojure.set :as set]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/client" :as react-dom-client]))
 
@@ -105,11 +105,11 @@
 (rf/reg-event :kcod/bump-right (fn [{:keys [db]} _] {:db (update db :right inc)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The exercised population — a MEASUREMENT, not a claim
@@ -149,14 +149,14 @@
 
 (def ^:private nothing-owned {:cells 0 :cell-refs 0 :boundaries 0 :edges 0})
 
-(defn- ownership [] (dissoc (runtime/residue) :entries))
+(defn- ownership [] (dissoc (rf.hicasso.test.runtime/residue) :entries))
 
-(defn- readers-of [query-v] (count (runtime/cell-readers (sub-key query-v))))
+(defn- readers-of [query-v] (count (rf.hicasso.test.runtime/cell-readers (sub-key query-v))))
 
 (defn- app
   "The hicasso subtree: the frame provider over a root element."
   [hiccup]
-  (mount/provider frame-id (codec/root-element frame-id hiccup)))
+  (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup)))
 
 (defn- mount-concurrent!
   "A concurrent root, rendered WITHOUT `flushSync`.
@@ -176,7 +176,7 @@
 
 (defn- poll
   [pred label]
-  (test-support/poll-until pred {:label label :timeout-ms 4000}))
+  (rf.test-support/poll-until pred {:label label :timeout-ms 4000}))
 
 (defn- prove-live!
   "Settle the commit's PASSIVE phase on a condition, never on a duration —
@@ -207,7 +207,7 @@
   quantity under test: the count is asserted afterwards, and a second
   reader changes the count without changing the text."
   [handle event expected label]
-  (mount/dispatch! handle event)
+  (rf.hicasso.impl.mount/dispatch! handle event)
   (poll #(= expected (text handle)) label))
 
 (defn- teardown-census!
@@ -215,13 +215,13 @@
   release. `mount/release!` resets the runtime, so a census taken after it
   cannot go red — see the namespace docstring."
   [handle]
-  (mount/unmount! handle)
-  (.then (runtime/quiesced!)
+  (rf.hicasso.impl.mount/unmount! handle)
+  (.then (rf.hicasso.test.runtime/quiesced!)
          (fn [_]
            (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                  (runtime/residue))
+                  (rf.hicasso.test.runtime/residue))
                "teardown is exact: zero residue after quiescence")
-           (mount/release! handle)
+           (rf.hicasso.impl.mount/release! handle)
            nil)))
 
 (defn- report-failure!
@@ -248,7 +248,7 @@
     (is false (str label " — " (.-message e)
                    " | DOM was " (pr-str (when handle (text handle)))
                    " | ownership " (pr-str (ownership))))
-    (when handle (mount/release! handle))
+    (when handle (rf.hicasso.impl.mount/release! handle))
     nil))
 
 (defn- make-gate
@@ -268,17 +268,17 @@
 ;; The views
 ;; ---------------------------------------------------------------------------
 
-(h/defview left-line  [_] [:p {:id "left"} (str "left=" (h/sub [:kcod/left]))])
-(h/defview right-line [_] [:p {:id "right"} (str "right=" (h/sub [:kcod/right]))])
+(rf.hicasso/defview left-line  [_] [:p {:id "left"} (str "left=" (rf.hicasso/sub [:kcod/left]))])
+(rf.hicasso/defview right-line [_] [:p {:id "right"} (str "right=" (rf.hicasso/sub [:kcod/right]))])
 
 (def ^:private !throw? (atom false))
 
-(h/defview thrower
+(rf.hicasso/defview thrower
   "Reads FIRST and throws SECOND — the bead's rollback shape. The reads are
   real reads, taken before the failure, so a runtime that acquired at
   render would have acquired them."
   [_]
-  (let [v (h/sub [:kcod/right])]
+  (let [v (rf.hicasso/sub [:kcod/right])]
     (when @!throw? (throw (js/Error. "planted kernel-commit-owns throw")))
     [:p {:id "right"} (str "right=" v)]))
 
@@ -288,13 +288,13 @@
 
 (deftest a-suspended-attempt-acquires-nothing-and-its-retry-acquires-exactly-once
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (let [_      (seeded!)
             gate   (make-gate)
-            before (runtime/body-runs)
+            before (rf.hicasso.test.runtime/body-runs)
             handle (mount-concurrent!
-                     (mount/fresh-container!)
+                     (rf.hicasso.impl.mount/fresh-container!)
                      (react/createElement
                        (.-Suspense react)
                        #js {:fallback (react/createElement "p" nil "waiting")}
@@ -307,7 +307,7 @@
                 (testing "the premise: React RAN the boundary body before it
                           threw the attempt away. Without this the zeros
                           below are the zeros of a render that never was"
-                  (is (pos? (- (runtime/body-runs) before))))
+                  (is (pos? (- (rf.hicasso.test.runtime/body-runs) before))))
 
                 (testing "and the attempt was genuinely abandoned — the
                           fallback is on the page, the boundary's markup is
@@ -359,7 +359,7 @@
 
 (deftest an-aborted-transition-acquires-nothing-and-its-completion-acquires-exactly-once
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (let [_    (seeded!)
             gate (make-gate)
@@ -367,7 +367,7 @@
                                       (app [right-line {}])
                                       (:element gate))
             handle (mount-concurrent!
-                     (mount/fresh-container!)
+                     (rf.hicasso.impl.mount/fresh-container!)
                      (react/createElement
                        (.-Suspense react)
                        #js {:fallback (react/createElement "p" nil "fallback")}
@@ -376,14 +376,14 @@
                   "the old tree commits")
             (.then
               (fn [_]
-                (let [before (runtime/body-runs)]
+                (let [before (rf.hicasso.test.runtime/body-runs)]
                   ;; A REAL transition. React renders the new tree at
                   ;; transition priority; it suspends; React keeps the
                   ;; committed UI and throws the new render away.
                   ((.-startTransition react) (fn [] (@!set-phase 1)))
                   ;; The poll condition IS the premise — the row cannot
                   ;; proceed until React has actually run the new body.
-                  (-> (poll #(> (runtime/body-runs) before)
+                  (-> (poll #(> (rf.hicasso.test.runtime/body-runs) before)
                             "the transition renders the new body")
                       (.then
                         (fn [_]
@@ -424,10 +424,10 @@
 
 (deftest strictmodes-double-invoke-is-not-additive
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (let [_      (seeded!)
-            before (runtime/body-runs)
+            before (rf.hicasso.test.runtime/body-runs)
             ;; TWO boundaries reading DIFFERENT keys, and that is the whole
             ;; design of this row rather than incidental scenery.
             ;;
@@ -442,7 +442,7 @@
             ;; this row is named for, and this is the smallest tree in which
             ;; it can be seen.
             handle (mount-concurrent!
-                     (mount/fresh-container!)
+                     (rf.hicasso.impl.mount/fresh-container!)
                      (react/createElement (.-StrictMode react) nil
                                           (app [:div
                                                 [left-line {}]
@@ -455,7 +455,7 @@
                           StrictMode really did run BOTH bodies twice. A green
                           here with a delta of 2 would be a green for a
                           StrictMode that never engaged"
-                  (is (= 4 (- (runtime/body-runs) before))))
+                  (is (= 4 (- (rf.hicasso.test.runtime/body-runs) before))))
                 (prove-live! handle [:kcod/bump-left] "left=2right=7"
                              "the strict boundaries are subscribed and live")))
             (.then
@@ -471,7 +471,7 @@
                   (is (= 1 (readers-of [:kcod/right])))
                   (is (= {:cells 2 :cell-refs 2 :boundaries 2 :edges 2}
                          (ownership)))
-                  (is (= 2 (:entries (runtime/residue)))))
+                  (is (= 2 (:entries (rf.hicasso.test.runtime/residue)))))
                 (exercised! :strict-mode/double-invoke)
                 (teardown-census! handle)))
             (.catch (report-failure! "strictmode witness" handle))
@@ -483,24 +483,24 @@
 
 (defn- guarded
   [reset-key]
-  (app [h/error-boundary {:fallback  [:p {:id "fb"} "caught"]
+  (app [rf.hicasso/error-boundary {:fallback  [:p {:id "fb"} "caught"]
                           :reset-key reset-key}
         [thrower {}]]))
 
 (deftest a-body-that-throws-after-its-reads-is-caught-and-the-retry-acquires-exactly-once
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (let [_      (seeded!)
             _      (reset! !throw? true)
-            before (runtime/body-runs)
-            handle (mount-concurrent! (mount/fresh-container!) (guarded 0))]
+            before (rf.hicasso.test.runtime/body-runs)
+            handle (mount-concurrent! (rf.hicasso.impl.mount/fresh-container!) (guarded 0))]
         (-> (poll #(= "caught" (text handle)) "the error boundary catches")
             (.then
               (fn [_]
                 (testing "the premise: the body RAN, took its read, and then
                           threw"
-                  (is (pos? (- (runtime/body-runs) before))))
+                  (is (pos? (- (rf.hicasso.test.runtime/body-runs) before))))
 
                 (testing "the throwing attempt is rolled back to nothing —
                           there is nothing to roll back, because a
@@ -544,7 +544,7 @@
   and this is a real write landing inside it."
   [_]
   (react/useLayoutEffect
-    (fn [] (collector/dispatch! frame-id [:kcod/bump-left]) js/undefined)
+    (fn [] (rf.hicasso.impl.collector/dispatch! frame-id [:kcod/bump-left]) js/undefined)
     #js [])
   nil)
 
@@ -552,11 +552,11 @@
 
 (deftest a-write-landing-in-the-render-to-commit-gap-heals-the-boundary
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (let [_      (seeded!)
             handle (mount-concurrent!
-                     (mount/fresh-container!)
+                     (rf.hicasso.impl.mount/fresh-container!)
                      (react/createElement (.-Fragment react) nil
                                           (app [left-line {}])
                                           (react/createElement gap-writer nil)))]
@@ -595,7 +595,7 @@
   ;; mechanism that stops being reached — a row deleted, a row that returns
   ;; early, a row whose poll silently degrades — fails here instead of
   ;; quietly shrinking what the suite covers.
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM, so no mechanism is exercised there")
     (is (= declared-population @!exercised)
         (str "every declared abandonment mechanism must be reached; missing: "

--- a/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
@@ -85,15 +85,15 @@
   gates."
   (:require [clojure.set :as set]
             [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
@@ -219,13 +219,13 @@
 
 ;; --- the Suspense hosts ----------------------------------------------------
 
-(h/defhost suspense-host
+(rf.hicasso/defhost suspense-host
   "The guide's declaration: `:fallback` is a ReactNode SLOT, so hiccup
   written there crosses to React as an element."
   (.-Suspense react)
   {:slots #{:fallback}})
 
-(h/defhost suspense-skeleton-host
+(rf.hicasso/defhost suspense-skeleton-host
   "The same crossing with a declared `:fallback` — `defhost`'s
   Client-only PLACEHOLDER, which is a different key with the same name
   and the only one of the two that can put bytes in a server response.
@@ -239,13 +239,13 @@
 
 (def ^:private paint-loader (deferred-loader))
 (def ^:private paint-head (lazy-head paint-loader))
-(h/defhost paint-host paint-head)
+(rf.hicasso/defhost paint-host paint-head)
 
 ;; --- scenario 3: the post-commit suspension --------------------------------
 
 (def ^:private own-loader (deferred-loader))
 (def ^:private own-head (lazy-head own-loader))
-(h/defhost own-host own-head)
+(rf.hicasso/defhost own-host own-head)
 
 ;; --- scenario 4: rejection, and the head that replaces it ------------------
 ;;
@@ -256,14 +256,14 @@
 (def ^:private reject-loader (deferred-loader))
 (def ^:private reject-head (lazy-head reject-loader))
 (def ^:private replacement-head (lazy-head reject-loader))
-(h/defhost reject-host reject-head)
-(h/defhost replacement-host replacement-head)
+(rf.hicasso/defhost reject-host reject-head)
+(rf.hicasso/defhost replacement-host replacement-head)
 
 ;; --- scenario 6: the server render -----------------------------------------
 
 (def ^:private ssr-loader (deferred-loader))
 (def ^:private ssr-head (lazy-head ssr-loader))
-(h/defhost ssr-host ssr-head)
+(rf.hicasso/defhost ssr-host ssr-head)
 
 ;; --- scenario 7: the UNSHADOWED server render ------------------------------
 ;;
@@ -274,7 +274,7 @@
 
 (def ^:private bare-loader (deferred-loader))
 (def ^:private bare-head (lazy-head bare-loader))
-(h/defhost bare-host bare-head)
+(rf.hicasso/defhost bare-host bare-head)
 
 ;; THE CONTROL, and the row is worthless without it. `renderToString` is
 ;; allowed to be inert — a renderer that never reached the region would
@@ -306,21 +306,21 @@
     (react/createElement "h1" #js {:id "title"} "metrics")
     (react/createElement (.-Suspense react)
       #js {:fallback (react/createElement "div" #js {:id "react-fallback"} "loading")}
-      (mount/provider frame-id (codec/root-element frame-id [host {:points [1 2 3]}])))))
+      (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id [host {:points [1 2 3]}])))))
 
 ;; ---------------------------------------------------------------------------
 ;; Views
 ;; ---------------------------------------------------------------------------
 
-(h/defview own-panel
+(rf.hicasso/defview own-panel
   "A committed boundary inside the Suspense region, and the subject of the
   ownership row: it holds a subscription before anything suspends."
   [_]
-  [:p {:id "panel"} (str "label=" (h/sub [:lzb/label]))])
+  [:p {:id "panel"} (str "label=" (rf.hicasso/sub [:lzb/label]))])
 
 (defonce ^:private !attempts (atom 0))
 
-(h/defview attempt-marker
+(rf.hicasso/defview attempt-marker
   "A sibling INSIDE the error boundary. Its render count is the retry
   row's premise: a `:reset-key` change that cleared the caught error and
   re-rendered the children moves it, and one that did nothing does not —
@@ -335,21 +335,21 @@
 ;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- skip! [why] (is true (str "a lazy-boundary DOM claim needs a real React DOM — " why)))
 
 (defn- seeded! []
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:lzb/seed]))
   frame-id)
 
-(defn- tree [hiccup] (mount/provider frame-id (codec/root-element frame-id hiccup)))
+(defn- tree [hiccup] (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup)))
 
 (defn- mount-concurrent!
   "A concurrent root rendered WITHOUT `flushSync`. Suspense's fallback and
@@ -379,31 +379,31 @@
   (when (visible? handle id) (.-textContent ^js (node handle id))))
 
 (defn- poll [pred label]
-  (test-support/poll-until pred {:label label :timeout-ms 4000}))
+  (rf.test-support/poll-until pred {:label label :timeout-ms 4000}))
 
 (defn- sub-key [query-v] [frame-id query-v])
 
-(defn- ownership [] (dissoc (runtime/residue) :entries))
+(defn- ownership [] (dissoc (rf.hicasso.test.runtime/residue) :entries))
 
 (defn- reader-count
   "A COUNT rather than the reader vector: a registration and the cells it
   acquired hold each other, so `cljs.test`'s failure printer walks a cycle
   and dies on the vector."
   [query-v]
-  (count (runtime/cell-readers (sub-key query-v))))
+  (count (rf.hicasso.test.runtime/cell-readers (sub-key query-v))))
 
 (defn- sole-reader [query-v]
-  (let [rs (runtime/cell-readers (sub-key query-v))]
+  (let [rs (rf.hicasso.test.runtime/cell-readers (sub-key query-v))]
     (when (= 1 (count rs)) (first rs))))
 
 (defn- teardown-census! [handle]
-  (mount/unmount! handle)
-  (.then (runtime/quiesced!)
+  (rf.hicasso.impl.mount/unmount! handle)
+  (.then (rf.hicasso.test.runtime/quiesced!)
          (fn [_]
            (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                  (runtime/residue))
+                  (rf.hicasso.test.runtime/residue))
                "teardown is exact: zero residue after quiescence")
-           (mount/release! handle)
+           (rf.hicasso.impl.mount/release! handle)
            nil)))
 
 (defn- report-failure!
@@ -417,7 +417,7 @@
     (is false (str label " — " (.-message e)
                    " | DOM was " (pr-str (when handle (.-textContent ^js (:container handle))))
                    " | ownership " (pr-str (ownership))))
-    (when handle (mount/release! handle))
+    (when handle (rf.hicasso.impl.mount/release! handle))
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -468,11 +468,11 @@
 
 (deftest a-lazy-boundary-paints-the-fallback-then-the-component-with-the-props-it-was-written-with
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (let [_      (seeded!)
             handle (mount-concurrent!
-                     (mount/fresh-container!)
+                     (rf.hicasso.impl.mount/fresh-container!)
                      (tree [suspense-host {:fallback [:p {:id "skel"} "loading"]}
                             [paint-host {:points [1 2 3]}
                              [:em {:id "kid"} "child"]]]))]
@@ -532,7 +532,7 @@
     ;; cascade that to descendants — a `<div>` in between would report the
     ;; panel visible throughout the suspension and the ownership rows
     ;; below would be measuring a premise that never held.
-    (codec/root-element
+    (rf.hicasso.impl.codec/root-element
       frame-id
       [suspense-host {:fallback [:p {:id "skel2"} "waiting"]}
        [own-panel {}]
@@ -559,12 +559,12 @@
   ;; measurement, particularly for the retry, which under a lazy head is
   ;; React re-reading a payload rather than re-running a component.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (let [_      (seeded!)
             _      (reset! !set-split nil)
-            handle (mount-concurrent! (mount/fresh-container!)
-                                      (mount/provider frame-id
+            handle (mount-concurrent! (rf.hicasso.impl.mount/fresh-container!)
+                                      (rf.hicasso.impl.mount/provider frame-id
                                                       (react/createElement split-host nil)))
             !state (atom {})]
         (-> (poll #(and (= 1 (reader-count [:lzb/label])) (some? @!set-split))
@@ -603,7 +603,7 @@
 
                 ;; A write DURING the suspension. Because the subscription
                 ;; survived, the hidden panel hears it.
-                (mount/dispatch! handle [:lzb/relabel "beta"])
+                (rf.hicasso.impl.mount/dispatch! handle [:lzb/relabel "beta"])
                 (settle! own-loader :resolve chart-cell)
                 (poll #(= "label=beta" (painted handle "panel"))
                       "the chunk lands and the boundary is revealed, up to date")))
@@ -624,7 +624,7 @@
                   (is (some? (node handle "chart"))))
 
                 (testing "still live after the arrival"
-                  (mount/dispatch! handle [:lzb/relabel "gamma"])
+                  (rf.hicasso.impl.mount/dispatch! handle [:lzb/relabel "gamma"])
                   (poll #(= "label=gamma" (painted handle "panel"))
                         "the revealed boundary repaints"))))
             (.then
@@ -641,7 +641,7 @@
 
 (defn- reject-tree
   [attempt host]
-  (tree [h/error-boundary {:fallback  [:p {:id "fb"} "caught"]
+  (tree [rf.hicasso/error-boundary {:fallback  [:p {:id "fb"} "caught"]
                            :reset-key attempt}
          [:div
           [attempt-marker {}]
@@ -656,11 +656,11 @@
   ;; the thing that remembers the rejection and neither this tier nor
   ;; React's public API can reset it.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (let [_      (seeded!)
             _      (reset! !attempts 0)
-            handle (mount-concurrent! (mount/fresh-container!) (reject-tree 0 reject-host))]
+            handle (mount-concurrent! (rf.hicasso.impl.mount/fresh-container!) (reject-tree 0 reject-host))]
         (-> (poll #(= "loading" (painted handle "skel3")) "the fallback takes the layout")
             (.then
               (fn [_]
@@ -739,7 +739,7 @@
 
 (defn- server-html [hiccup]
   (react-dom-server/renderToString
-    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+    (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup))))
 
 (deftest a-client-only-lazy-region-writes-nothing-and-a-declared-fallback-writes-the-skeleton
   (seeded!)
@@ -832,7 +832,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-declared-population-was-actually-exercised
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (is (set/subset? #{:gate/dedupe-and-retry :lazy/server-render :lazy/unshadowed-server-gate} @!exercised)
         (str "the two lane-independent rows must run everywhere; missing "
              (pr-str (set/difference #{:gate/dedupe-and-retry :lazy/server-render :lazy/unshadowed-server-gate} @!exercised))))

--- a/implementation/hicasso/test/re_frame/hicasso/login_server_crossing_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/login_server_crossing_ssr_dom_cljs_test.cljs
@@ -71,16 +71,16 @@
             [clojure.string :as str]
             [goog.object :as gobj]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.hicasso.substrate :as substrate]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.render-state :as render-state]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.hicasso.substrate :as rf.hicasso.substrate]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.ssr.render-state :as rf.ssr.render-state]
+            [re-frame.test-support :as rf.test-support]
             ;; The example, whole: views + SSR coordinates, the server module's
             ;; entry table, and the substrate-free model every `auth.login`
             ;; registration lives in.
@@ -103,16 +103,16 @@
   (fn [{:keys [db]} [_ k v]] {:db (assoc db k v)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     ;; The example's OWN adapter — `hicasso.login.core/run` installs this one.
-    {:adapter       substrate/adapter
+    {:adapter       rf.hicasso.substrate/adapter
      ;; The witness makes its own top-level frames, so the fixture's carried
      ;; `:rf/default` stamp would be a scope no request is rendering; and
      ;; `:initial-events` must drain synchronously rather than be treated as
      ;; a mid-cascade child-frame creation.
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The JVM half
@@ -147,14 +147,14 @@
   under `payload-policy-opts`, plus the durable runtime-db slice, exactly as
   `ssr-ring` assembles one. Anonymous server frame, so no `:rf/frame-id`."
   [frame-id]
-  (let [runtime (payload-policy/project-runtime-db
-                  (frame/frame-runtime-db-value frame-id) frame-id)
+  (let [runtime (rf.ssr.payload-policy/project-runtime-db
+                  (rf.frame/frame-runtime-db-value frame-id) frame-id)
         opts    (cond-> payload-policy-opts
                   (some? runtime) (assoc :runtime-db runtime))]
-    (payload-policy/build-payload
+    (rf.ssr.payload-policy/build-payload
       nil
-      (payload-policy/project-app-db-egress
-        (payload-policy/apply-policy (rf/app-db-value frame-id) opts) frame-id)
+      (rf.ssr.payload-policy/project-app-db-egress
+        (rf.ssr.payload-policy/apply-policy (rf/app-db-value frame-id) opts) frame-id)
       nil
       opts)))
 
@@ -222,8 +222,8 @@
   "The JVM half: project the settled frame under the host's `:render-state`
   policy and serialize both partitions to per-key EDN text."
   [frame-id]
-  (render-state/serialize
-    (render-state/project frame-id {:render-state app-policy/render-state-policy})))
+  (rf.ssr.render-state/serialize
+    (rf.ssr.render-state/project frame-id {:render-state app-policy/render-state-policy})))
 
 (defn- hand-to-module!
   "Hand the module the frozen call shape `worker.cjs` builds, and answer
@@ -300,7 +300,7 @@
   [f]
   (if (node-lane?)
     (f)
-    (sup/skip! "a crossing goes through the service's own validator, a CommonJS module off the CLJS classpath")))
+    (rf.hicasso.roots-frames-support/skip! "a crossing goes through the service's own validator, a CommonJS module off the CLJS classpath")))
 
 ;; ---------------------------------------------------------------------------
 ;; §1 - the module is one the sidecar will load
@@ -446,35 +446,35 @@
   clean adoption raises nothing to swallow, and arming the swallow there
   would hide a real regression."
   [html payload {:keys [swallow-uncaught?]}]
-  (let [container (sup/server-dom! html)
+  (let [container (rf.hicasso.roots-frames-support/server-dom! html)
         cfid      (keyword "rf.login-crossing" (str (gensym "client-")))
-        watch     (sup/watch-mismatches!)
-        console   (sup/open-console-capture! {:swallow-uncaught? swallow-uncaught?})]
+        watch     (rf.hicasso.roots-frames-support/watch-mismatches!)
+        console   (rf.hicasso.roots-frames-support/open-console-capture! {:swallow-uncaught? swallow-uncaught?})]
     (rf/make-frame (merge {:id cfid} model/frame-config))
-    (ssr/hydrate! {:frame cfid :payload payload})
-    (let [handle (h/hydrate! container
+    (rf.ssr/hydrate! {:frame cfid :payload payload})
+    (let [handle (rf.hicasso/hydrate! container
                              {:frame             cfid
                               :identifier-prefix views/identifier-prefix}
                              [views/root-view])]
-      (.then (sup/adopted! handle)
+      (.then (rf.hicasso.roots-frames-support/adopted! handle)
              (fn [_]
                (let [seen  ((:stop! watch))
                      shown (.-innerHTML container)]
                  ((:close! console))
-                 (h/unmount! handle)
+                 (rf.hicasso/unmount! handle)
                  (rf/destroy-frame! cfid)
                  {:seen seen :adopted-html shown}))))))
 
 (deftest the-client-adopts-the-server-bytes-with-no-recoverable-error
-  (if-not (mount/browser?)
-    (sup/skip! "adoption is React's own DOM business")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! "adoption is React's own DOM business")
     (async done
-      (sup/leave-act-environment!)
+      (rf.hicasso.roots-frames-support/leave-act-environment!)
       (let [fid     (server-frame! authed-events)
             html    (rendered! fid)
             payload (payload-of fid)]
         (rf/destroy-frame! fid)
-        (sup/settle-row!
+        (rf.hicasso.roots-frames-support/settle-row!
           (.then (hydrate-row! html payload {:swallow-uncaught? false})
                  (fn [{:keys [seen adopted-html]}]
                    (is (= [] seen)
@@ -486,10 +486,10 @@
 
 (deftest a-render-state-key-the-payload-omits-costs-one-recovered-adoption
   ;; §6's control, and the measurement the example's README turns into a rule.
-  (if-not (mount/browser?)
-    (sup/skip! "a recoverable error is React's own DOM business")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! "a recoverable error is React's own DOM business")
     (async done
-      (sup/leave-act-environment!)
+      (rf.hicasso.roots-frames-support/leave-act-environment!)
       (let [fid     (server-frame! authed-events server-only-db)
             html    (rendered! fid)
             payload (payload-of fid)]
@@ -497,7 +497,7 @@
         (is (str/includes? html notice) "the server rendered the notice")
         (is (not (str/includes? (pr-str payload) notice))
             "and the client will not be handed it")
-        (sup/settle-row!
+        (rf.hicasso.roots-frames-support/settle-row!
           (.then (hydrate-row! html payload {:swallow-uncaught? true})
                  (fn [{:keys [seen]}]
                    (is (seq seen)

--- a/implementation/hicasso/test/re_frame/hicasso/motion_presence_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/motion_presence_dom_cljs_test.cljs
@@ -76,14 +76,14 @@
     the teardown row with the retention timer named."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.set :as set]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.presence :as presence]
-            [re-frame.hicasso.motion :as motion]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.presence :as rf.hicasso.impl.presence]
+            [re-frame.hicasso.motion :as rf.hicasso.motion]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-kw ::frame)
 
@@ -98,10 +98,10 @@
 ;; no reactivity layer, so a subscription under it never notifies and the
 ;; DOM row's "the tray re-rendered" premise would pass by never firing.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The headless half — the machine, with no React and no clock
@@ -121,37 +121,37 @@
 (defn- painted
   "Two toasts, both settled — the state every headless row starts from."
   []
-  (presence/settle (presence/step presence/initial (toasts :a :b) 0 retention-ms)))
+  (rf.hicasso.impl.presence/settle (rf.hicasso.impl.presence/step rf.hicasso.impl.presence/initial (toasts :a :b) 0 retention-ms)))
 
 (deftest an-exit-interrupted-by-re-entry-cancels-on-the-node-it-already-had
   (let [start   (painted)
-        exiting (presence/step start (toasts :a) 1000 retention-ms)
-        back    (presence/step exiting (toasts :a :b) 1100 retention-ms)]
+        exiting (rf.hicasso.impl.presence/step start (toasts :a) 1000 retention-ms)
+        back    (rf.hicasso.impl.presence/step exiting (toasts :a :b) 1100 retention-ms)]
     (testing "premise: :b is genuinely mid-exit, on a deadline, before it returns"
-      (is (= {:a :present :b :unmounting} (presence/phases exiting)))
-      (is (= 1300 (presence/next-deadline exiting))))
+      (is (= {:a :present :b :unmounting} (rf.hicasso.impl.presence/phases exiting)))
+      (is (= 1300 (rf.hicasso.impl.presence/next-deadline exiting))))
 
     (testing "the claim: it returns to :present rather than finishing and remounting"
-      (is (= {:a :present :b :present} (presence/phases back)))
+      (is (= {:a :present :b :present} (rf.hicasso.impl.presence/phases back)))
       (is (nil? (:deadline (get (:entries back) :b)))
           "a cancelled exit leaves no deadline behind"))
 
     (testing "and it returns to the SAME node — the key never left, and order is frozen"
       (is (= [:a :b] (:order back))
           "first-appearance order is frozen, so an exiting child cannot jump slot")
-      (is (nil? (presence/next-deadline back))
+      (is (nil? (rf.hicasso.impl.presence/next-deadline back))
           "nothing is outstanding, so the React half's effect arms no timer at all"))))
 
 (deftest a-rapid-toggle-arms-one-deadline-per-exit-and-never-extends-a-live-one
   (let [start (painted)
         ;; out, back, out, and then two ordinary re-renders while the second
         ;; exit is in flight — the shape a user produces by clicking twice.
-        s1    (presence/step start (toasts :a)    1000 retention-ms)
-        s2    (presence/step s1    (toasts :a :b) 1050 retention-ms)
-        s3    (presence/step s2    (toasts :a)    1100 retention-ms)
-        s4    (presence/step s3    (toasts :a)    1150 retention-ms)
-        s5    (presence/step s4    (toasts :a)    1200 retention-ms)
-        seen  (mapv presence/next-deadline [s1 s2 s3 s4 s5])]
+        s1    (rf.hicasso.impl.presence/step start (toasts :a)    1000 retention-ms)
+        s2    (rf.hicasso.impl.presence/step s1    (toasts :a :b) 1050 retention-ms)
+        s3    (rf.hicasso.impl.presence/step s2    (toasts :a)    1100 retention-ms)
+        s4    (rf.hicasso.impl.presence/step s3    (toasts :a)    1150 retention-ms)
+        s5    (rf.hicasso.impl.presence/step s4    (toasts :a)    1200 retention-ms)
+        seen  (mapv rf.hicasso.impl.presence/next-deadline [s1 s2 s3 s4 s5])]
     (is (= [1300 nil 1400 1400 1400] seen)
         "one deadline per exit — and the second exit's is fixed at the instant it started")
     (is (= 2 (count (remove nil? (distinct seen))))
@@ -160,9 +160,9 @@
         "the deadline is the absolute instant :b started exiting, 50 ms of re-renders later")))
 
 (deftest re-deriving-mid-flight-is-a-no-op-on-every-frame-of-the-window
-  (let [exiting (presence/step (painted) (toasts :a) 1000 retention-ms)
+  (let [exiting (rf.hicasso.impl.presence/step (painted) (toasts :a) 1000 retention-ms)
         frames  (vec (range 1016 1300 16))
-        redone  (rest (reductions (fn [s now] (presence/step s (toasts :a) now retention-ms))
+        redone  (rest (reductions (fn [s now] (rf.hicasso.impl.presence/step s (toasts :a) now retention-ms))
                                   exiting
                                   frames))]
     (testing "premise: the window really is walked frame by frame at 60 Hz"
@@ -172,10 +172,10 @@
     (testing "THE FRAME BUDGET: every frame of the retention window costs nothing"
       (is (= #{exiting} (set redone))
           "the machine is idempotent, so re-deriving mid-flight changes no value")
-      (is (= #{(presence/pending-signature exiting)}
-             (set (map presence/pending-signature redone)))
+      (is (= #{(rf.hicasso.impl.presence/pending-signature exiting)}
+             (set (map rf.hicasso.impl.presence/pending-signature redone)))
           "the effect's own dependency never moves: no timer re-armed, no render forced")
-      (is (= #{1300} (set (map presence/next-deadline redone)))
+      (is (= #{1300} (set (map rf.hicasso.impl.presence/next-deadline redone)))
           "an absolute deadline cannot be pushed forward by the passage of frames"))))
 
 ;; ---------------------------------------------------------------------------
@@ -190,14 +190,14 @@
 
 (def ^:private retention-floor 1000)
 
-(h/defview tray
+(rf.hicasso/defview tray
   "A toast tray: presence over the keyed children a subscription supplies,
   each declaring its own exit appearance as data."
   [_]
-  [motion/presence {:timeout-ms dom-retention-ms}
-   (for [t (h/sub [::toasts])]
+  [rf.hicasso.motion/presence {:timeout-ms dom-retention-ms}
+   (for [t (rf.hicasso/sub [::toasts])]
      [:div.toast {:key            t
-                  ::motion/unmounting {:class       "toast toast--exit"
+                  ::rf.hicasso.motion/unmounting {:class       "toast toast--exit"
                                   :inert       true
                                   :aria-hidden true}}
       (name t)])])
@@ -269,23 +269,23 @@
 (defn- toast-nodes [container] (.querySelectorAll container ".toast"))
 
 (deftest an-unmount-mid-transition-clears-the-timer-it-armed
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM, so no effect runs and no timer is armed")
     (let [{:keys [log restore!]} (install-clock-ledger!)]
       (try
         (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
         (rf/make-frame {:id frame-kw})
         (rf/with-frame frame-kw (rf/dispatch-sync [::seed [:a :b]]))
-        (let [container (mount/fresh-container!)
-              handle    (mount/root! container frame-kw [tray])]
+        (let [container (rf.hicasso.impl.mount/fresh-container!)
+              handle    (rf.hicasso.impl.mount/root! container frame-kw [tray])]
           (try
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (= 2 (.-length (toast-nodes container)))
                 "premise: both toasts painted before anything leaves")
             (let [frames-before (select-keys @log [:rafs :intervals])]
 
               (rf/with-frame frame-kw (rf/dispatch-sync [::set [:a]]))
-              (mount/settle!)
+              (rf.hicasso.impl.mount/settle!)
 
               (testing "RETENTION: the node outlives the data, wearing the exit phase"
                 (is (= 2 (.-length (toast-nodes container)))
@@ -306,14 +306,14 @@
                 (is (= frames-before (select-keys @log [:rafs :intervals]))
                     "zero requestAnimationFrame and zero setInterval across the whole window"))
 
-              (mount/unmount! handle)
+              (rf.hicasso.impl.mount/unmount! handle)
 
               (testing "TEARDOWN: an unmount mid-transition leaves no timer behind"
                 (is (= #{} (orphans @log))
                     "every retention timer armed was cleared by the effect's own cleanup")
                 (is (= 0 (.-length (toast-nodes container)))
                     "and the retained node went with the root rather than outliving it")))
-            (finally (mount/release! handle))))
+            (finally (rf.hicasso.impl.mount/release! handle))))
         (finally (restore!))))))
 
 ;; ---------------------------------------------------------------------------
@@ -335,7 +335,7 @@
 ;; rather than an inference.
 
 (deftest an-override-no-tray-can-reach-never-becomes-an-attribute
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test sees the props object, not a painted attribute")
     (do
       (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
@@ -345,46 +345,46 @@
                 the page, so the namespaced key that shared its emitted
                 name really did leak. Without this row the refusal below
                 could be guarding a route that was never open"
-        (let [container (mount/fresh-container!)
-              handle    (mount/root! container frame-kw [:div.probe {:mounting "x"}])]
+        (let [container (rf.hicasso.impl.mount/fresh-container!)
+              handle    (rf.hicasso.impl.mount/root! container frame-kw [:div.probe {:mounting "x"}])]
           (try
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (let [node (.querySelector container ".probe")]
               (is (some? node))
               (is (= "x" (.getAttribute node "mounting"))
                   "an author's own `:mounting` attribute — untouched, and
                    painted, which is exactly the shape `::motion/mounting` took"))
-            (finally (mount/release! handle)))))
+            (finally (rf.hicasso.impl.mount/release! handle)))))
 
       (testing "and the override key itself is SKIPPED by the walk, so the
                 node paints and nothing carries the key to the DOM by that
                 route"
-        (let [container (mount/fresh-container!)
-              handle    (mount/root! container frame-kw
+        (let [container (rf.hicasso.impl.mount/fresh-container!)
+              handle    (rf.hicasso.impl.mount/root! container frame-kw
                                      [:div.probe {:re-frame.hicasso.motion/mounting {:class "in"}}])]
           (try
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (let [node (.querySelector container ".probe")]
               (is (some? node) "the element painted — nothing refused it")
               (is (nil? (.getAttribute node "mounting"))
                   "and the private key is not on it")
               (is (zero? (.-length (.querySelectorAll container "[mounting]")))))
-            (finally (mount/release! handle)))))
+            (finally (rf.hicasso.impl.mount/release! handle)))))
 
       (testing "while the LEGAL placement paints the override as appearance
                 and as nothing else: the merged class is on the node, and
                 neither key survives as an attribute"
         (rf/with-frame frame-kw (rf/dispatch-sync [::seed [:a :b]]))
-        (let [container (mount/fresh-container!)
-              handle    (mount/root! container frame-kw [tray])]
+        (let [container (rf.hicasso.impl.mount/fresh-container!)
+              handle    (rf.hicasso.impl.mount/root! container frame-kw [tray])]
           (try
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (rf/with-frame frame-kw (rf/dispatch-sync [::set [:a]]))
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (let [exiting (.querySelector container ".toast--exit")]
               (is (some? exiting) "premise: the exit phase is on the page")
               (is (zero? (.-length (.querySelectorAll container "[unmounting]")))
                   "the override arrived as `toast--exit`, never as an
                    `unmounting` attribute")
               (is (zero? (.-length (.querySelectorAll container "[mounting]")))))
-            (finally (mount/release! handle))))))))
+            (finally (rf.hicasso.impl.mount/release! handle))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
@@ -117,19 +117,19 @@
   nothing global, and the hook roster asserts the probe installed before
   it reads a count."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.hook-probe :as probe]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.overlay :as impl-overlay]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.overlay :as overlay]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.hicasso.trusted-input-support :as trusted]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.hook-probe :as rf.hicasso.hook-probe]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.overlay :as rf.hicasso.impl.overlay]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.overlay :as rf.hicasso.overlay]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.hicasso.trusted-input-support :as rf.hicasso.trusted-input-support]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::overlay)
 
@@ -165,11 +165,11 @@
 ;; `make-reset-runtime-fixture` returns the positional shape by DEFAULT,
 ;; so the MAP shape has to be asked for.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The headless half — the one part of this module that is a value
@@ -177,31 +177,31 @@
 
 (deftest a-compass-word-is-a-position-area-and-an-unknown-one-passes-through
   (testing "the taught compass words all resolve, and to distinct areas"
-    (is (= "block-end span-inline-end" (impl-overlay/position-area :bottom-start)))
-    (is (= "block-end span-inline-start" (impl-overlay/position-area :bottom-end)))
-    (is (= "block-start span-inline-end" (impl-overlay/position-area :top-start)))
-    (is (= "inline-end" (impl-overlay/position-area :right)))
-    (is (= (count impl-overlay/position-areas)
-           (count (set (vals impl-overlay/position-areas))))
+    (is (= "block-end span-inline-end" (rf.hicasso.impl.overlay/position-area :bottom-start)))
+    (is (= "block-end span-inline-start" (rf.hicasso.impl.overlay/position-area :bottom-end)))
+    (is (= "block-start span-inline-end" (rf.hicasso.impl.overlay/position-area :top-start)))
+    (is (= "inline-end" (rf.hicasso.impl.overlay/position-area :right)))
+    (is (= (count rf.hicasso.impl.overlay/position-areas)
+           (count (set (vals rf.hicasso.impl.overlay/position-areas))))
         "twelve words, twelve areas — a duplicate would be two names for one place"))
 
   (testing "no placement is no declaration, rather than a default one"
-    (is (nil? (impl-overlay/position-area nil))))
+    (is (nil? (rf.hicasso.impl.overlay/position-area nil))))
 
   (testing "the escape hatch: a raw `position-area` string is emitted verbatim"
     (is (= "block-end span-inline-start"
-           (impl-overlay/position-area "block-end span-inline-start"))))
+           (rf.hicasso.impl.overlay/position-area "block-end span-inline-start"))))
 
   (testing "and a misspelt compass word is emitted verbatim too — invalid CSS
             the engine drops, rather than a silent substitution of some
             other placement"
-    (is (= "botom-start" (impl-overlay/position-area :botom-start)))
-    (is (not (contains? (set (vals impl-overlay/position-areas)) "botom-start")))))
+    (is (= "botom-start" (rf.hicasso.impl.overlay/position-area :botom-start)))
+    (is (not (contains? (set (vals rf.hicasso.impl.overlay/position-areas)) "botom-start")))))
 
-(h/defview menu-page [_]
+(rf.hicasso/defview menu-page [_]
   [:div
    [:button#trigger {:aria-haspopup "menu"} "Filter"]
-   [overlay/popover {:open?      (h/sub [::open? :m])
+   [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [::open? :m])
                      :on-dismiss [::dismissed :m]
                      :anchor     "trigger"
                      :placement  :bottom-start}
@@ -209,9 +209,9 @@
      [:li [:button "Unread"]]
      [:li [:button "Flagged"]]]]])
 
-(h/defview unnamed-menu-page [_]
+(rf.hicasso/defview unnamed-menu-page [_]
   [:div
-   [overlay/popover {:open?      (h/sub [::open? :m])
+   [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [::open? :m])
                      :on-dismiss [::dismissed :m]}
     [:ul {:role "menu"}
      [:li [:button "Unread"]]
@@ -221,14 +221,14 @@
      [:li [:button.icon]]]]])
 
 (deftest an-overlays-contents-are-ordinary-markup-and-the-a11y-kit-reads-them
-  (let [t    (ht/tree [menu-page {}] {:subs {[::open? :m] true}})
-        menu (ht/find t #(= :menu (ht/role %)))]
+  (let [t    (rf.hicasso.test/tree [menu-page {}] {:subs {[::open? :m] true}})
+        menu (rf.hicasso.test/find t #(= :menu (rf.hicasso.test/role %)))]
     (testing "premise: an overlay is a BOUNDARY CALL in the L2 tree. Its body
               does not run — no hooks, no top layer, no refusal — so the kit
               sees the author's own children and claims nothing whatever about
               what the module renders around them"
       (is (some? menu) "the author's own menu list is in the tree")
-      (is (nil? (ht/role (ht/find t #(= "hicasso/popover" (:view-id %)))))
+      (is (nil? (rf.hicasso.test/role (rf.hicasso.test/find t #(= "hicasso/popover" (:view-id %)))))
           "and the overlay boundary itself has no role, because it is not an
            element — which is `role`'s own stated answer for a view-boundary"))
 
@@ -236,12 +236,12 @@
               decidable HEADLESS, on rf2-hic-043's projections, and needs none
               of this suite's browser lane"
       (is (= ["Filter" "Unread" "Flagged"]
-             (mapv #(ht/accessible-name t %)
-                   (ht/find-all t #(= :button (ht/role %)))))
+             (mapv #(rf.hicasso.test/accessible-name t %)
+                   (rf.hicasso.test/find-all t #(= :button (rf.hicasso.test/role %)))))
           "every control names itself from its own content — and the TRIGGER is
            in the same list as the panel's items, which is the other half of
            what the top layer buys: paint order changed, the tree did not")
-      (is (= [] (ht/unnamed-controls t))))
+      (is (= [] (rf.hicasso.test/unnamed-controls t))))
 
     (testing "and the instrument can say otherwise: the same panel with one
               icon-only button reports it. Without this arm the `[]` above is
@@ -249,10 +249,10 @@
               nothing at all — which it WAS, on the first draft, because
               `:menuitem` is outside `interactive-roles` and every control in
               the panel wore one"
-      (let [u     (ht/tree [unnamed-menu-page {}] {:subs {[::open? :m] true}})
-            found (ht/unnamed-controls u)]
+      (let [u     (rf.hicasso.test/tree [unnamed-menu-page {}] {:subs {[::open? :m] true}})
+            found (rf.hicasso.test/unnamed-controls u)]
         (is (= 1 (count found)) (str "expected one unnamed control, got " (pr-str found)))
-        (is (= :button (ht/role (first found))))))))
+        (is (= :button (rf.hicasso.test/role (first found))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The DOM half
@@ -271,7 +271,7 @@
 
 (defn- go! [event]
   (rf/with-frame frame-id (rf/dispatch-sync event))
-  (mount/settle!)
+  (rf.hicasso.impl.mount/settle!)
   nil)
 
 (defn- db [] (rf/app-db-value frame-id))
@@ -323,7 +323,7 @@
    :transform "translateZ(0)"
    :z-index   0})
 
-(h/defview clipped-page [_]
+(rf.hicasso/defview clipped-page [_]
   [:div
    [:button#outside {:type "button"} "Outside"]
    [:div#clip {:style clip-style}
@@ -332,20 +332,20 @@
     [:div#ladder {:style {:position "fixed" :top "300px" :left "0px"
                           :width "120px" :height "120px" :z-index 2147483647
                           :background "rgb(255 0 0)"}}]
-    [overlay/modal {:open?      (h/sub [::open? :m])
+    [rf.hicasso.overlay/modal {:open?      (rf.hicasso/sub [::open? :m])
                     :on-dismiss [::dismissed :m]
                     :label      "Confirm deletion"}
      [:p "in the top layer"]
      [:button#inside {:type "button"} "Inside"]]]])
 
 (deftest an-overlay-escapes-an-ancestor-that-clips-and-out-stacks-it
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no top layer, so nothing paints and nothing hit-tests")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [clipped-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [clipped-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (go! [::opened :m])
           (let [dialog ($ "dialog")
                 ladder ($ "#ladder")]
@@ -373,16 +373,16 @@
                     (str "its painted box is not contained by the 20px box that "
                          "clips it. dialog=[" (.-top d) "," (.-bottom d) "] "
                          "clip=[" (.-top c) "," (.-bottom c) "]")))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 (deftest a-modal-makes-the-document-behind-it-unfocusable
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no inertness, because it has no modal dialog")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [clipped-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [clipped-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (let [outside ($ "#outside")]
             (testing "premise: with no modal open the same control takes focus —
                       so the claim below is about the modal and not about the
@@ -406,27 +406,27 @@
               (go! [::closed :m])
               (.focus outside)
               (is (identical? outside (.-activeElement js/document)))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; --- focus restore ---------------------------------------------------------
 
-(h/defview trigger-page [_]
+(rf.hicasso/defview trigger-page [_]
   [:div
    [:button#trigger {:type "button" :on-click [::opened :m]} "Open"]
-   [overlay/modal {:open?      (h/sub [::open? :m])
+   [rf.hicasso.overlay/modal {:open?      (rf.hicasso/sub [::open? :m])
                    :on-dismiss [::dismissed :m]
                    :label      "Confirm"}
     [:button#first {:type "button"} "First"]
     [:button#chosen {:type "button" :auto-focus true} "Chosen"]]])
 
 (deftest closing-through-the-platform-door-returns-focus-to-the-trigger
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test restores nothing, because nothing was ever focused")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [trigger-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [trigger-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (let [trigger ($ "#trigger")]
             (.focus trigger)
             (is (identical? trigger (.-activeElement js/document))
@@ -445,16 +445,16 @@
               (is (identical? trigger (.-activeElement js/document))
                   "and focus is back on the trigger, with no restore handler
                    anywhere in the application")))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 (deftest the-focus-one-shot-is-the-platforms-focus-delegate-and-not-reacts-autofocus
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test runs no dialog focusing steps")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [trigger-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [trigger-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (go! [::opened :m])
           (testing "THE ONE-SHOT, as the engine actually performs it: opening
                     runs the platform's own dialog-focusing steps, which take
@@ -475,16 +475,16 @@
                      "`Invalid DOM property autofocus. Did you mean autoFocus?`, "
                      "and emits no attribute either. So NEITHER spelling reaches "
                      "the platform, and the recipe is tree order.")))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 (deftest a-close-request-on-a-modal-arrives-as-an-intent
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no dialog to make a close request of")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [trigger-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [trigger-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (go! [::opened :m])
           (let [dialog ($ "dialog")]
             (if-not (fn? (.-requestClose dialog))
@@ -497,7 +497,7 @@
                         author's own intent, which is what closes the overlay"
                 (is (zero? (get-in (db) [:dismissed :m] 0)) "premise: nothing yet")
                 (.requestClose dialog)
-                (mount/settle!)
+                (rf.hicasso.impl.mount/settle!)
                 (is (= 1 (get-in (db) [:dismissed :m]))
                     "the intent landed exactly once")
                 (is (false? (get-in (db) [:open :m]))
@@ -516,7 +516,7 @@
               (is (nil? ($ "dialog")))
               (is (= before (get-in (db) [:dismissed :m] 0))
                   "the count did not move")))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 (deftest a-real-escape-dismisses-the-modal-and-a-synthetic-one-does-nothing
   ;; BOTH ARMS, ON ONE MOUNT, IN ONE ROW — which is the only arrangement
@@ -531,16 +531,16 @@
   ;; Async because the press happens in another process. See
   ;; `re-frame.hicasso.trusted-input-support`, and the fixture note above
   ;; for why this file's fixtures are maps.
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no dialog, and no engine to press a key at")
-    (if-not (trusted/bridge?)
-      (trusted/unwitnessed! "the modal's conduct under a real Escape")
+    (if-not (rf.hicasso.trusted-input-support/bridge?)
+      (rf.hicasso.trusted-input-support/unwitnessed! "the modal's conduct under a real Escape")
       (async done
         (fresh!)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id [trigger-page {}])
-              finish (fn [] (mount/release! handle) (done))]
+        (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [trigger-page {}])
+              finish (fn [] (rf.hicasso.impl.mount/release! handle) (done))]
           (try
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (go! [::opened :m])
             (is (some? ($ "dialog")) "premise: the modal is open")
             (is (= 1 (.-length (.querySelectorAll js/document ":modal")))
@@ -561,7 +561,7 @@
                 (is (true? delivered)
                     "the event was dispatched and nothing called preventDefault")
                 (is (false? (.-isTrusted ev)) "and it is untrusted, by construction")
-                (mount/settle!)
+                (rf.hicasso.impl.mount/settle!)
                 (is (some? ($ "dialog")) "the dialog is still in the document")
                 (is (= 1 (.-length (.querySelectorAll js/document ":modal")))
                     "still modal, still in the top layer")
@@ -570,11 +570,11 @@
                      close request is a DEFAULT ACTION and a page may not
                      forge one")))
 
-            (trusted/press-once!
+            (rf.hicasso.trusted-input-support/press-once!
               "Escape"
               (fn []
                 (try
-                  (mount/settle!)
+                  (rf.hicasso.impl.mount/settle!)
                   (testing "TRUSTED: the same key, the same page, pressed by the
                             engine. It takes the platform's `cancel` path — the
                             one `[[a-close-request-on-a-modal-arrives-as-an-intent]]`
@@ -593,25 +593,25 @@
 
 ;; --- the stack -------------------------------------------------------------
 
-(h/defview two-modals-page [_]
+(rf.hicasso/defview two-modals-page [_]
   ;; Written SECOND-first in the DOM, so a row that passed on DOM order
   ;; would fail here.
   [:div
-   [overlay/modal {:open? (h/sub [::open? :b]) :on-dismiss [::dismissed :b]
+   [rf.hicasso.overlay/modal {:open? (rf.hicasso/sub [::open? :b]) :on-dismiss [::dismissed :b]
                    :label "B" :id "modal-b"}
     [:p "B"]]
-   [overlay/modal {:open? (h/sub [::open? :a]) :on-dismiss [::dismissed :a]
+   [rf.hicasso.overlay/modal {:open? (rf.hicasso/sub [::open? :a]) :on-dismiss [::dismissed :a]
                    :label "A" :id "modal-a"}
     [:p "A"]]])
 
 (deftest the-top-layer-stacks-last-in-first-out-not-in-dom-order
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no top layer to stack in")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [two-modals-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [two-modals-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (go! [::opened :a])
           (go! [::opened :b])
           (let [a ($ "#modal-a") b ($ "#modal-b")]
@@ -631,14 +631,14 @@
               (is (within? a (at-centre a))
                   "A is the top of the stack again — the stack popped rather
                    than collapsed")))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; --- the popover's LIFO dismissal, and the manual arm ----------------------
 
-(h/defview two-popovers-page [_]
+(rf.hicasso/defview two-popovers-page [_]
   [:div
    [:button#anchor-a {:type "button"} "A"]
-   [overlay/popover {:open?      (h/sub [::open? :pa])
+   [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [::open? :pa])
                      ;; NOTE: `::noted` does not clear the flag, so the
                      ;; element survives its own dismissal and the row below
                      ;; can attribute a SECOND dispatch to the teardown.
@@ -647,23 +647,23 @@
                      :placement  :bottom-start
                      :id         "pop-a"}
     [:ul {:role "menu"} [:li "one"]]]
-   [overlay/popover {:open?      (h/sub [::open? :pb])
+   [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [::open? :pb])
                      :on-dismiss [::dismissed :pb]
                      :id         "pop-b"}
     [:p "B"]]
    ;; The same panel with NO `:on-dismiss` — `popover="manual"`, and
    ;; therefore not a member of the auto stack at all.
-   [overlay/popover {:open? (h/sub [::open? :pm]) :id "pop-m"}
+   [rf.hicasso.overlay/popover {:open? (rf.hicasso/sub [::open? :pm]) :id "pop-m"}
     [:p "M"]]])
 
 (deftest an-unrelated-auto-popover-dismisses-the-open-one-and-a-manual-one-is-immune
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no popover API and no auto stack")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [two-popovers-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [two-popovers-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (go! [::opened :pa])
           (is (.matches ($ "#pop-a") ":popover-open")
               "premise: A is open and in the top layer")
@@ -672,7 +672,7 @@
                     dismisses the open one — the same engine path an outside
                     click takes, and the reason the module does not own one"
             (go! [::opened :pb])
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (.matches ($ "#pop-b") ":popover-open"))
             (is (not (.matches ($ "#pop-a") ":popover-open"))
                 "A was dismissed by the platform, not by this module")
@@ -694,16 +694,16 @@
             (is (.matches ($ "#pop-a") ":popover-open"))
             (is (.matches ($ "#pop-m") ":popover-open")
                 "the auto popover joining the stack did not disturb it"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 (deftest the-platform-dismissal-arrives-as-an-intent-and-the-teardown-does-not
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test dismisses nothing, because nothing opened")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [two-popovers-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [two-popovers-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (go! [::opened :pa])
           (go! [::opened :pb])
           (is (= 1 (get-in (db) [:dismissed :pa]))
@@ -739,7 +739,7 @@
             (is (zero? (get-in (db) [:dismissed :pb] 0))
                 "and no dismissal was reported for a close the application asked
                  for itself"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; --- a frameless overlay: legal until it carries `:on-dismiss` -------------
 ;;
@@ -758,10 +758,10 @@
   "A root whose provider carries the **no-provider sentinel** — the React
   context default, so exactly an overlay with no frame above it."
   [hiccup]
-  (mount/root! (mount/fresh-container!) adapter-context/no-provider-sentinel hiccup))
+  (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) rf.adapter.context/no-provider-sentinel hiccup))
 
 (deftest a-frameless-overlay-is-legal-until-it-carries-on-dismiss
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no top layer")
     (do
       (fresh!)
@@ -770,28 +770,28 @@
                 the flag that opened them is their only owner"
         (let [handle (frameless-root!
                        [:div
-                        [overlay/popover {:open? true :id "free-p"} [:p "quiet"]]
-                        [overlay/modal {:open? true :id "free-m"} [:p "quiet"]]])]
+                        [rf.hicasso.overlay/popover {:open? true :id "free-p"} [:p "quiet"]]
+                        [rf.hicasso.overlay/modal {:open? true :id "free-m"} [:p "quiet"]]])]
           (try
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (.matches ($ "#free-p") ":popover-open"))
             (is (= "manual" (.getAttribute ($ "#free-p") "popover")))
             (is (true? (.-open ($ "#free-m"))))
             (is (= "none" (.getAttribute ($ "#free-m") "closedby")))
-            (finally (mount/release! handle)))))
-      (doseq [[head tag] [[overlay/popover "popover"] [overlay/modal "modal"]]]
+            (finally (rf.hicasso.impl.mount/release! handle)))))
+      (doseq [[head tag] [[rf.hicasso.overlay/popover "popover"] [rf.hicasso.overlay/modal "modal"]]]
         (testing (str "REFUSAL: an open " tag " with `:on-dismiss` and no frame
                        is the existing loud error, naming the intent, rather
                        than an element the platform may dismiss with nothing
                        listening")
           (reset! !frameless-refusal nil)
           (let [handle (frameless-root!
-                         [h/error-boundary {:fallback [:p.frameless-refused "refused"]
+                         [rf.hicasso/error-boundary {:fallback [:p.frameless-refused "refused"]
                                             :on-error (fn [e] (reset! !frameless-refusal e))}
                           [head {:open? true :on-dismiss [::dismissed :x] :id "free-x"}
                            [:p "loud"]]])]
             (try
-              (mount/settle!)
+              (rf.hicasso.impl.mount/settle!)
               (is (some? ($ ".frameless-refused"))
                   "the overlay failed rather than rendering with a dead dismissal")
               (is (nil? ($ "#free-x")) "and no element reached the top layer")
@@ -800,11 +800,11 @@
                   (str "the existing id, no new vocabulary: " (pr-str (ex-data @!frameless-refusal))))
               (is (= [::dismissed :x] (:intent (ex-data @!frameless-refusal)))
                   "and it named the intent")
-              (finally (mount/release! handle)))))))))
+              (finally (rf.hicasso.impl.mount/release! handle)))))))))
 
 ;; --- the dismissal closure is the CURRENT render's --------------------------
 
-(h/defview swap-dismiss-page [_]
+(rf.hicasso/defview swap-dismiss-page [_]
   ;; The subject popover's `:on-dismiss` carries a tag read from app-db,
   ;; so a `::retag` dispatch re-renders it wired to a DIFFERENT intent
   ;; while it stays open. `pop-u` is the dismissal driver: an unrelated
@@ -814,11 +814,11 @@
   ;; identical event and the row above already proves THAT one routes
   ;; nowhere.
   [:div
-   [overlay/popover {:open?      (h/sub [::open? :ps])
-                     :on-dismiss [::dismissed (h/sub [::dismiss-tag])]
+   [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [::open? :ps])
+                     :on-dismiss [::dismissed (rf.hicasso/sub [::dismiss-tag])]
                      :id         "pop-s"}
     [:p "S"]]
-   [overlay/popover {:open?      (h/sub [::open? :pu])
+   [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [::open? :pu])
                      :on-dismiss [::noted :pu]
                      :id         "pop-u"}
     [:p "U"]]])
@@ -831,13 +831,13 @@
   ;; would cost a wrong event. That sentence had no witness: every other
   ;; row keeps one `:on-dismiss` for the life of its overlay, so a handler
   ;; cached on first render would pass all of them.
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no popover API and no auto stack")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [swap-dismiss-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [swap-dismiss-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (go! [::retag :old])
           (go! [::opened :ps])
           (is (.matches ($ "#pop-s") ":popover-open")
@@ -862,7 +862,7 @@
               "and the previous render's intent did not fire: a handler
                cached at first render — or a closure over the first
                render's props — would have dispatched :old here")
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; --- the census ------------------------------------------------------------
 
@@ -972,13 +972,13 @@
     (clear!)))
 
 (deftest an-open-overlay-adds-nothing-to-window-document-or-body
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test attaches nothing because it mounts nothing")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [two-popovers-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [two-popovers-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           ;; Instrumented AFTER the root exists, so React's own root-level
           ;; wiring is outside the window and the delta is the overlay's.
           (let [{:keys [log restore!] :as census} (install-census!)]
@@ -987,7 +987,7 @@
               (go! [::opened :pa])
               (.scrollTo js/window 0 40)
               (.dispatchEvent js/window (js/Event. "resize"))
-              (mount/settle!)
+              (rf.hicasso.impl.mount/settle!)
               (let [open-log @log]
                 (testing "premise: the instrument sees listeners at all —
                           React's own `beforetoggle`/`toggle` on the element"
@@ -1027,25 +1027,25 @@
                         (str "and still nothing global, on the way out either: "
                              (pr-str (:global closed-log)))))))
               (finally (restore!))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; --- zero cost when closed -------------------------------------------------
 
-(h/defview closed-page [_]
+(rf.hicasso/defview closed-page [_]
   [:div
-   [overlay/modal {:open? (h/sub [::open? :m]) :on-dismiss [::dismissed :m]}
-    [:p (str "body read: " (h/sub [::body-read]))]]
-   [overlay/popover {:open? (h/sub [::open? :p]) :on-dismiss [::dismissed :p]}
+   [rf.hicasso.overlay/modal {:open? (rf.hicasso/sub [::open? :m]) :on-dismiss [::dismissed :m]}
+    [:p (str "body read: " (rf.hicasso/sub [::body-read]))]]
+   [rf.hicasso.overlay/popover {:open? (rf.hicasso/sub [::open? :p]) :on-dismiss [::dismissed :p]}
     [:p "p"]]])
 
 (deftest a-closed-overlay-has-no-element-no-listener-and-no-rendered-body
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test cannot tell an absent element from an absent DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [closed-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [closed-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           ;; Instrumented AFTER the root, deliberately: creating a React root
           ;; attaches React's own `selectionchange` listener to the document,
           ;; and a census that had to whitelist it would be a census with an
@@ -1079,23 +1079,23 @@
                 (is (seq (filterv #{"cancel" "close" "toggle" "beforetoggle"}
                                   (:element @log)))))
               (finally (restore!))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; --- intents inside an overlay --------------------------------------------
 
-(h/defview intent-page [_]
+(rf.hicasso/defview intent-page [_]
   [:div
-   [overlay/modal {:open? (h/sub [::open? :m]) :on-dismiss [::dismissed :m]}
+   [rf.hicasso.overlay/modal {:open? (rf.hicasso/sub [::open? :m]) :on-dismiss [::dismissed :m]}
     [:button#act {:type "button" :on-click [::clicked :m]} "Act"]]])
 
 (deftest an-intent-on-an-overlay-child-dispatches-in-the-frame-above-it
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test cannot click a node it does not have")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [intent-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [intent-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (go! [::opened :m])
           (testing "an overlay's children are hiccup DATA lowered in the
                     overlay component's own render, one render after the body
@@ -1104,18 +1104,18 @@
                     at render rather than dispatching"
             (is (nil? (get-in (db) [:clicked :m])) "premise: nothing clicked yet")
             (.click ($ "#act"))
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (true? (get-in (db) [:clicked :m]))
                 "the intent landed, in the frame the overlay was mounted under"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; --- the anchor ------------------------------------------------------------
 
-(h/defview anchored-page [_]
+(rf.hicasso/defview anchored-page [_]
   [:div
    ;; An author-written `anchor-name` the module must hand back untouched.
    [:button#anchor-a {:type "button" :style {:anchor-name "--mine"}} "A"]
-   [overlay/popover {:open?      (h/sub [::open? :pa])
+   [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [::open? :pa])
                      :on-dismiss [::dismissed :pa]
                      :anchor     "anchor-a"
                      :placement  :bottom-start
@@ -1128,16 +1128,16 @@
    ;; route a dismissal. That is also what lets it be open at the same time
    ;; as the auto panel above: an auto popover joining the stack does not
    ;; disturb a manual one.
-   [overlay/popover {:open?     (h/sub [::open? :pt])
+   [rf.hicasso.overlay/popover {:open?     (rf.hicasso/sub [::open? :pt])
                      :anchor    "anchor-a"
                      :placement :top-start
                      :id        "pop-t"}
     [:p "tip"]]
    ;; The dangling `:anchor`, under a boundary that is BOTH how the refusal
    ;; is read and what keeps a deliberate one from reding the suite.
-   [h/error-boundary {:fallback [:p.anchor-refused "the overlay refused"]
+   [rf.hicasso/error-boundary {:fallback [:p.anchor-refused "the overlay refused"]
                       :on-error (fn [e] (reset! !anchor-refusal e))}
-    [overlay/popover {:open?      (h/sub [::open? :px])
+    [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [::open? :px])
                       :on-dismiss [::dismissed :px]
                       :anchor     "no-such-element"
                       :placement  :bottom-start
@@ -1153,13 +1153,13 @@
    [:div {:style {:height "1200px"}}]])
 
 (deftest the-anchor-is-claimed-while-open-and-handed-back-on-teardown
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test resolves no anchors, because it computes no style")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [anchored-page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [anchored-page {}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (let [trigger ($ "#anchor-a")]
             (is (= "--mine" (.. trigger -style -anchorName))
                 "premise: the trigger carries the author's own anchor name")
@@ -1272,27 +1272,27 @@
             ;; the top layer — an overlay cannot be both refused and open.
             (is (not (some-> ($ "#pop-x") (.matches ":popover-open")))
                 "and the panel never opened"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; --- the budget ------------------------------------------------------------
 
-(h/defview budget-page [_]
-  [overlay/modal {:open? (h/sub [::open? :m]) :on-dismiss [::dismissed :m]}
+(rf.hicasso/defview budget-page [_]
+  [rf.hicasso.overlay/modal {:open? (rf.hicasso/sub [::open? :m]) :on-dismiss [::dismissed :m]}
    [:p "cost"]])
 
 (deftest an-overlay-costs-two-hooks-and-the-shell-still-costs-two
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test does not run this suite's mount")
-    (if-not (probe/install!)
+    (if-not (rf.hicasso.hook-probe/install!)
       (unwitnessed! "React's internals slot was not found, so the hook counts
                      are UNWITNESSED on this build.")
       (do
         (fresh!)
         (let [handle (volatile! nil)
-              names  (probe/record!
+              names  (rf.hicasso.hook-probe/record!
                        (fn []
                          (vreset! handle
-                                  (mount/root! (mount/fresh-container!)
+                                  (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!)
                                                frame-id [budget-page {}]))))]
           (try
             (testing "premise: the instrument can report more than two — the
@@ -1300,7 +1300,7 @@
                       declares them"
               (is (= ["useContext" "useSyncExternalStore"] (vec (take 2 names)))
                   (str "raw: " (pr-str names)))
-              (is (= (count runtime/shell-hook-ledger) 2)
+              (is (= (count rf.hicasso.test.runtime/shell-hook-ledger) 2)
                   "and the declared shell ledger is still two"))
 
             (let [tail (vec (distinct (drop 2 names)))]
@@ -1316,4 +1316,4 @@
                                     tail))
                     "no effect, no state, no second store subscription — the
                      work happens in a ref callback, which is not a hook")))
-            (finally (when @handle (mount/release! @handle)))))))))
+            (finally (when @handle (rf.hicasso.impl.mount/release! @handle)))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
@@ -121,13 +121,13 @@
   is the MAP shape (an async row under a POSITIONAL fixture aborts the
   whole run)."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.overlay :as overlay]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.hicasso.trusted-input-support :as trusted]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.overlay :as rf.hicasso.overlay]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.hicasso.trusted-input-support :as rf.hicasso.trusted-input-support]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The application — one flag, and the two overlays over the same panel
@@ -149,11 +149,11 @@
 ;; The two pages differ in the OVERLAY and in nothing else: the same
 ;; three panel controls, the same three page controls, the same flag.
 
-(h/defview a-page-with-a-modal [_]
+(rf.hicasso/defview a-page-with-a-modal [_]
   [:div
    [:button#before {:type "button"} "Before"]
    [:button#trigger {:type "button" :on-click [::opened]} "Open"]
-   [overlay/modal {:open?      (h/sub [::open?])
+   [rf.hicasso.overlay/modal {:open?      (rf.hicasso/sub [::open?])
                    :on-dismiss [::dismissed]
                    :label      "Confirm deletion"}
     [:button#confirm {:type "button"} "Delete"]
@@ -161,11 +161,11 @@
     [:button#cancel {:type "button" :on-click [::closed]} "Cancel"]]
    [:button#after {:type "button"} "After"]])
 
-(h/defview a-page-with-a-popover [_]
+(rf.hicasso/defview a-page-with-a-popover [_]
   [:div
    [:button#before {:type "button"} "Before"]
    [:button#trigger {:type "button" :on-click [::opened]} "Open"]
-   [overlay/popover {:open?      (h/sub [::open?])
+   [rf.hicasso.overlay/popover {:open?      (rf.hicasso/sub [::open?])
                      :on-dismiss [::dismissed]
                      :anchor     "trigger"
                      :placement  :bottom-start}
@@ -183,7 +183,7 @@
 ;; would change what every one of them reads without making any of them
 ;; measure a wrap.
 
-(h/defview a-page-with-a-modal-holding-a-radio-group [_]
+(rf.hicasso/defview a-page-with-a-modal-holding-a-radio-group [_]
   ;; A RADIO GROUP IS THREE ELEMENTS AND ONE TAB STOP. Document order in
   ;; this panel is [small large ok reason]; sequential order is
   ;; [large ok reason], because `small` is an unchecked member of a group
@@ -193,7 +193,7 @@
   [:div
    [:button#before {:type "button"} "Before"]
    [:button#trigger {:type "button" :on-click [::opened]} "Open"]
-   [overlay/modal {:open?      (h/sub [::open?])
+   [rf.hicasso.overlay/modal {:open?      (rf.hicasso/sub [::open?])
                    :on-dismiss [::dismissed]
                    :label      "Pick a size"}
     [:input#small {:type "radio" :name "size" :aria-label "Small"}]
@@ -203,14 +203,14 @@
     [:input#reason {:type "text" :aria-label "Reason"}]]
    [:button#after {:type "button"} "After"]])
 
-(h/defview a-page-with-a-modal-ordered-by-tabindex [_]
+(rf.hicasso/defview a-page-with-a-modal-ordered-by-tabindex [_]
   ;; A POSITIVE `tabindex` SORTS AHEAD OF EVERY ZERO. Document order is
   ;; [second first third]; sequential order is [first second third],
   ;; because 1 precedes 2 and both precede the implicit 0.
   [:div
    [:button#before {:type "button"} "Before"]
    [:button#trigger {:type "button" :on-click [::opened]} "Open"]
-   [overlay/modal {:open?      (h/sub [::open?])
+   [rf.hicasso.overlay/modal {:open?      (rf.hicasso/sub [::open?])
                    :on-dismiss [::dismissed]
                    :label      "Ordered by tabindex"}
     [:button#second {:type "button" :tab-index 2} "Second"]
@@ -218,7 +218,7 @@
     [:button#third {:type "button"} "Third"]]
    [:button#after {:type "button"} "After"]])
 
-(h/defview a-page-with-a-modal-whose-last-control-is-hidden [_]
+(rf.hicasso/defview a-page-with-a-modal-whose-last-control-is-hidden [_]
   ;; A TRAILING `visibility:hidden` CONTROL, which is ordinary modal
   ;; markup — a final button hidden by a condition rather than removed.
   ;; Document order is [reason ok cancel ghost]; sequential order is
@@ -232,7 +232,7 @@
   [:div
    [:button#before {:type "button"} "Before"]
    [:button#trigger {:type "button" :on-click [::opened]} "Open"]
-   [overlay/modal {:open?      (h/sub [::open?])
+   [rf.hicasso.overlay/modal {:open?      (rf.hicasso/sub [::open?])
                    :on-dismiss [::dismissed]
                    :label      "Confirm"}
     [:input#reason {:type "text" :aria-label "Reason"}]
@@ -248,7 +248,7 @@
 ;; `checkVisibility` cannot reach them and the exclusion has to be asked
 ;; for another way.
 
-(h/defview a-page-with-a-modal-whose-last-control-is-inert [_]
+(rf.hicasso/defview a-page-with-a-modal-whose-last-control-is-inert [_]
   ;; A TRAILING `inert` REGION, which is ordinary modal markup: the step
   ;; of a wizard the user has not arrived at yet, painted but switched
   ;; off. Document order is [reason ok cancel ghost]; sequential order is
@@ -261,7 +261,7 @@
   [:div
    [:button#before {:type "button"} "Before"]
    [:button#trigger {:type "button" :on-click [::opened]} "Open"]
-   [overlay/modal {:open?      (h/sub [::open?])
+   [rf.hicasso.overlay/modal {:open?      (rf.hicasso/sub [::open?])
                    :on-dismiss [::dismissed]
                    :label      "Confirm"}
     [:input#reason {:type "text" :aria-label "Reason"}]
@@ -271,7 +271,7 @@
      [:button#ghost {:type "button"} "Ghost"]]]
    [:button#after {:type "button"} "After"]])
 
-(h/defview a-page-with-a-modal-whose-last-control-is-in-a-disabled-fieldset [_]
+(rf.hicasso/defview a-page-with-a-modal-whose-last-control-is-in-a-disabled-fieldset [_]
   ;; A TRAILING `disabled` `<fieldset>`, equally ordinary: a form section
   ;; switched off until an earlier choice enables it. Document order is
   ;; [reason ok cancel ghost]; sequential order is [reason ok cancel].
@@ -286,7 +286,7 @@
   [:div
    [:button#before {:type "button"} "Before"]
    [:button#trigger {:type "button" :on-click [::opened]} "Open"]
-   [overlay/modal {:open?      (h/sub [::open?])
+   [rf.hicasso.overlay/modal {:open?      (rf.hicasso/sub [::open?])
                    :on-dismiss [::dismissed]
                    :label      "Confirm"}
     [:input#reason {:type "text" :aria-label "Reason"}]
@@ -305,7 +305,7 @@
      [:button#ghost {:type "button"} "Ghost"]]]
    [:button#after {:type "button"} "After"]])
 
-(h/defview a-page-with-a-modal-whose-last-control-claims-tab [_]
+(rf.hicasso/defview a-page-with-a-modal-whose-last-control-claims-tab [_]
   ;; A LAST CONTROL THAT HANDLES Tab ITSELF, which is ordinary panel
   ;; markup: a grid, a combobox or an embedded editor claims the key for
   ;; its own internal focus movement and says so with `preventDefault`.
@@ -321,13 +321,13 @@
   [:div
    [:button#before {:type "button"} "Before"]
    [:button#trigger {:type "button" :on-click [::opened]} "Open"]
-   [overlay/modal {:open?      (h/sub [::open?])
+   [rf.hicasso.overlay/modal {:open?      (rf.hicasso/sub [::open?])
                    :on-dismiss [::dismissed]
                    :label      "Claimed Tab"}
     [:button#confirm {:type "button"} "Delete"]
     [:input#reason {:type "text" :aria-label "Reason"}]
     [:button#cancel {:type "button"
-                     :on-key-down {"Tab" [::h/prevent [::tab-claimed]]}}
+                     :on-key-down {"Tab" [::rf.hicasso/prevent [::tab-claimed]]}}
      "Cancel"]]
    [:button#after {:type "button"} "After"]])
 
@@ -336,8 +336,8 @@
 ;; POSITIONAL fn by default, and cljs.test throws a bare string that
 ;; unwinds the entire lane the moment an async body appears under one.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true}))
 
@@ -391,8 +391,8 @@
     (some-> (active) (.blur))
     order))
 
-(defn- open! [m] (hm/dispatch-and-settle! m [::opened]) m)
-(defn- close! [m] (hm/dispatch-and-settle! m [::closed]) m)
+(defn- open! [m] (rf.hicasso.test.mounted/dispatch-and-settle! m [::opened]) m)
+(defn- close! [m] (rf.hicasso.test.mounted/dispatch-and-settle! m [::closed]) m)
 
 (defn- $ [m sel] (.querySelector (:container m) sel))
 
@@ -427,7 +427,7 @@
   ;; behind must be measured STILL REACHABLE.
   (if-not (browser?)
     (skip! ":node-test has no <dialog>")
-    (let [m      (hm/mount! [a-page-with-a-modal {}])
+    (let [m      (rf.hicasso.test.mounted/mount! [a-page-with-a-modal {}])
           ^js d  (raw-dialog!)]
       (try
         (testing "premise: with nothing open, the page's own controls are
@@ -466,7 +466,7 @@
         (finally
           (when (.-open d) (.close d))
           (.remove d)
-          (hm/unmount! m))))))
+          (rf.hicasso.test.mounted/unmount! m))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The module's modal — the trap, complete
@@ -475,7 +475,7 @@
 (deftest an-open-modal-is-the-whole-of-what-a-keyboard-can-reach
   (if-not (browser?)
     (skip! ":node-test has no modality")
-    (let [m (hm/mount! [a-page-with-a-modal {}])]
+    (let [m (rf.hicasso.test.mounted/mount! [a-page-with-a-modal {}])]
       (try
         (testing "premise: closed, the page is its own three controls and
                   the panel is not in the document at all"
@@ -509,7 +509,7 @@
           (is (nil? ($ m "dialog")))
           (is (= ["before" "trigger" "after"] (reachable (:container m)))))
 
-        (finally (hm/unmount! m))))))
+        (finally (rf.hicasso.test.mounted/unmount! m))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The trap under a real keyboard
@@ -530,11 +530,11 @@
   ;; rather than a feature, and the exit is the platform's alone.
   (if-not (browser?)
     (skip! ":node-test has no modality, and no engine to press a key at")
-    (if-not (trusted/bridge?)
-      (trusted/unwitnessed! "the trap under real sequential navigation")
+    (if-not (rf.hicasso.trusted-input-support/bridge?)
+      (rf.hicasso.trusted-input-support/unwitnessed! "the trap under real sequential navigation")
       (async done
-        (let [m      (hm/mount! [a-page-with-a-modal {}])
-              finish (fn [] (hm/unmount! m) (done))]
+        (let [m      (rf.hicasso.test.mounted/mount! [a-page-with-a-modal {}])
+              finish (fn [] (rf.hicasso.test.mounted/unmount! m) (done))]
           (try
             (open! m)
             (is (.contains ($ m "dialog") (active))
@@ -546,7 +546,7 @@
             ;; FIVE, so the sequence closes: three presses is a wrap, five
             ;; is a CYCLE with its start repeated, and only the second
             ;; rules out a one-off excursion that happened to come back.
-            (trusted/walk!
+            (rf.hicasso.trusted-input-support/walk!
               "Tab" 5
               (fn [] (some-> (active) label-of))
               (fn [forward]
@@ -580,7 +580,7 @@
                   (is (= "confirm" (label-of (active)))
                       "premise: back on the panel's first control")
 
-                  (trusted/walk!
+                  (rf.hicasso.trusted-input-support/walk!
                     "Shift+Tab" 5
                     (fn [] (some-> (active) label-of))
                     (fn [backward]
@@ -597,11 +597,11 @@
                                  "more than the forward one does. Pressed: "
                                  (pr-str backward)))
 
-                        (trusted/press-once!
+                        (rf.hicasso.trusted-input-support/press-once!
                           "Escape"
                           (fn []
                             (try
-                              (hm/settle! m)
+                              (rf.hicasso.test.mounted/settle! m)
                               (testing "AND OUT: the platform's own dismissal,
                                         which is the only exit a trap has — and
                                         it still is, because the wrap answers
@@ -652,12 +652,12 @@
   Shift+Tab has to wrap at."
   [m start n k]
   (.focus ($ m start))
-  (trusted/walk!
+  (rf.hicasso.trusted-input-support/walk!
     "Tab" n
     (fn [] (some-> (active) label-of))
     (fn [forward]
       (.focus ($ m start))
-      (trusted/walk!
+      (rf.hicasso.trusted-input-support/walk!
         "Shift+Tab" n
         (fn [] (some-> (active) label-of))
         (fn [backward] (k forward backward))))))
@@ -665,11 +665,11 @@
 (deftest a-real-tab-wraps-at-the-radio-groups-edge-and-not-at-the-dom-s
   (if-not (browser?)
     (skip! ":node-test has no modality, and no engine to press a key at")
-    (if-not (trusted/bridge?)
-      (trusted/unwitnessed! "the trap over a panel holding a radio group")
+    (if-not (rf.hicasso.trusted-input-support/bridge?)
+      (rf.hicasso.trusted-input-support/unwitnessed! "the trap over a panel holding a radio group")
       (async done
-        (let [m      (hm/mount! [a-page-with-a-modal-holding-a-radio-group {}])
-              finish (fn [] (hm/unmount! m) (done))]
+        (let [m      (rf.hicasso.test.mounted/mount! [a-page-with-a-modal-holding-a-radio-group {}])
+              finish (fn [] (rf.hicasso.test.mounted/unmount! m) (done))]
           (try
             (open! m)
             (is (.contains ($ m "dialog") (active))
@@ -717,11 +717,11 @@
 (deftest a-real-tab-wraps-at-the-tabindex-ordered-edge
   (if-not (browser?)
     (skip! ":node-test has no modality, and no engine to press a key at")
-    (if-not (trusted/bridge?)
-      (trusted/unwitnessed! "the trap over a panel ordered by positive tabindex")
+    (if-not (rf.hicasso.trusted-input-support/bridge?)
+      (rf.hicasso.trusted-input-support/unwitnessed! "the trap over a panel ordered by positive tabindex")
       (async done
-        (let [m      (hm/mount! [a-page-with-a-modal-ordered-by-tabindex {}])
-              finish (fn [] (hm/unmount! m) (done))]
+        (let [m      (rf.hicasso.test.mounted/mount! [a-page-with-a-modal-ordered-by-tabindex {}])
+              finish (fn [] (rf.hicasso.test.mounted/unmount! m) (done))]
           (try
             (open! m)
             (is (.contains ($ m "dialog") (active))
@@ -782,11 +782,11 @@
 (deftest a-real-tab-wraps-past-a-trailing-hidden-control
   (if-not (browser?)
     (skip! ":node-test has no modality, and no engine to press a key at")
-    (if-not (trusted/bridge?)
-      (trusted/unwitnessed! "the trap over a panel whose last element is hidden")
+    (if-not (rf.hicasso.trusted-input-support/bridge?)
+      (rf.hicasso.trusted-input-support/unwitnessed! "the trap over a panel whose last element is hidden")
       (async done
-        (let [m      (hm/mount! [a-page-with-a-modal-whose-last-control-is-hidden {}])
-              finish (fn [] (hm/unmount! m) (done))]
+        (let [m      (rf.hicasso.test.mounted/mount! [a-page-with-a-modal-whose-last-control-is-hidden {}])
+              finish (fn [] (rf.hicasso.test.mounted/unmount! m) (done))]
           (try
             (open! m)
             (is (.contains ($ m "dialog") (active))
@@ -863,11 +863,11 @@
 (deftest a-real-tab-wraps-past-a-trailing-inert-region
   (if-not (browser?)
     (skip! ":node-test has no modality, and no engine to press a key at")
-    (if-not (trusted/bridge?)
-      (trusted/unwitnessed! "the trap over a panel ending in an inert region")
+    (if-not (rf.hicasso.trusted-input-support/bridge?)
+      (rf.hicasso.trusted-input-support/unwitnessed! "the trap over a panel ending in an inert region")
       (async done
-        (let [m      (hm/mount! [a-page-with-a-modal-whose-last-control-is-inert {}])
-              finish (fn [] (hm/unmount! m) (done))]
+        (let [m      (rf.hicasso.test.mounted/mount! [a-page-with-a-modal-whose-last-control-is-inert {}])
+              finish (fn [] (rf.hicasso.test.mounted/unmount! m) (done))]
           (try
             (open! m)
             (is (.contains ($ m "dialog") (active))
@@ -922,12 +922,12 @@
 (deftest a-real-tab-wraps-past-a-trailing-disabled-fieldset
   (if-not (browser?)
     (skip! ":node-test has no modality, and no engine to press a key at")
-    (if-not (trusted/bridge?)
-      (trusted/unwitnessed! "the trap over a panel ending in a disabled fieldset")
+    (if-not (rf.hicasso.trusted-input-support/bridge?)
+      (rf.hicasso.trusted-input-support/unwitnessed! "the trap over a panel ending in a disabled fieldset")
       (async done
-        (let [m      (hm/mount!
+        (let [m      (rf.hicasso.test.mounted/mount!
                        [a-page-with-a-modal-whose-last-control-is-in-a-disabled-fieldset {}])
-              finish (fn [] (hm/unmount! m) (done))]
+              finish (fn [] (rf.hicasso.test.mounted/unmount! m) (done))]
           (try
             (open! m)
             (is (.contains ($ m "dialog") (active))
@@ -1008,11 +1008,11 @@
   ;; popover rows have no wrap at all.
   (if-not (browser?)
     (skip! ":node-test has no modality, and no engine to press a key at")
-    (if-not (trusted/bridge?)
-      (trusted/unwitnessed! "the wrap's yield to a claimed press")
+    (if-not (rf.hicasso.trusted-input-support/bridge?)
+      (rf.hicasso.trusted-input-support/unwitnessed! "the wrap's yield to a claimed press")
       (async done
-        (let [m      (hm/mount! [a-page-with-a-modal-whose-last-control-claims-tab {}])
-              finish (fn [] (hm/unmount! m) (done))]
+        (let [m      (rf.hicasso.test.mounted/mount! [a-page-with-a-modal-whose-last-control-claims-tab {}])
+              finish (fn [] (rf.hicasso.test.mounted/unmount! m) (done))]
           (try
             (open! m)
             (.focus ($ m "#cancel"))
@@ -1020,11 +1020,11 @@
                 (str "premise: on the edge the wrap fires at. Active: "
                      (label-of (active))))
 
-            (trusted/press-once!
+            (rf.hicasso.trusted-input-support/press-once!
               "Tab"
               (fn []
                 (try
-                  (hm/settle! m)
+                  (rf.hicasso.test.mounted/settle! m)
                   (is (= 1 (:tab-claims (rf/app-db-value (:frame m))))
                       "premise: the press reached the control and its claim
                        dispatched, exactly once — so the reading below is of
@@ -1056,7 +1056,7 @@
   ;; claims and not what it does.
   (if-not (browser?)
     (skip! ":node-test has no popover")
-    (let [m (hm/mount! [a-page-with-a-popover {}])]
+    (let [m (rf.hicasso.test.mounted/mount! [a-page-with-a-popover {}])]
       (try
         (is (= ["before" "trigger" "after"] (reachable (:container m)))
             "premise: closed, the page is its own three controls")
@@ -1078,7 +1078,7 @@
         (close! m)
         (is (= ["before" "trigger" "after"] (reachable (:container m))))
 
-        (finally (hm/unmount! m))))))
+        (finally (rf.hicasso.test.mounted/unmount! m))))))
 
 (deftest a-real-tab-leaves-an-open-popover
   ;; THE FENCE ON THE MODAL'S WRAP, and the row above cannot stand in for
@@ -1094,11 +1094,11 @@
   ;; from the popover for exactly that reason.
   (if-not (browser?)
     (skip! ":node-test has no popover, and no engine to press a key at")
-    (if-not (trusted/bridge?)
-      (trusted/unwitnessed! "a popover's deliberate lack of a trap")
+    (if-not (rf.hicasso.trusted-input-support/bridge?)
+      (rf.hicasso.trusted-input-support/unwitnessed! "a popover's deliberate lack of a trap")
       (async done
-        (let [m      (hm/mount! [a-page-with-a-popover {}])
-              finish (fn [] (hm/unmount! m) (done))]
+        (let [m      (rf.hicasso.test.mounted/mount! [a-page-with-a-popover {}])
+              finish (fn [] (rf.hicasso.test.mounted/unmount! m) (done))]
           (try
             (open! m)
             (.focus ($ m "#cancel"))
@@ -1106,7 +1106,7 @@
                 (str "premise: on the panel's last control. Active: "
                      (label-of (active))))
 
-            (trusted/press-once!
+            (rf.hicasso.trusted-input-support/press-once!
               "Tab"
               (fn []
                 (try

--- a/implementation/hicasso/test/re_frame/hicasso/portal_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/portal_dom_cljs_test.cljs
@@ -69,14 +69,14 @@
   React DOM. The declaration rows and the `renderToString` rows need no
   DOM and run under `:node-test` too."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/client" :as react-dom-client]
             ["react-dom/server" :as react-dom-server]))
@@ -95,19 +95,19 @@
   (fn [{:keys [db]} [_ what]] {:db (update db :log conj what)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; the hydration row waits on a real clock, and `cljs.test` hard-errors
      ;; on a fn-form fixture in a suite with an async test.
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- skip! [why]
   (is true (str "a portal claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:hicasso.portal/seed]))
   frame-id)
@@ -131,8 +131,8 @@
 
 (defn- click! [node]
   (.click node)
-  (mount/settle!)
-  (mount/settle!))
+  (rf.hicasso.impl.mount/settle!)
+  (rf.hicasso.impl.mount/settle!))
 
 ;; ---------------------------------------------------------------------------
 ;; The pages
@@ -148,9 +148,9 @@
   (react/useEffect (fn [] (swap! !child-mounts inc) js/undefined) #js [])
   (react/createElement "span" #js {:className "counted"} "in the rack"))
 
-(h/defhost counted-host counted {:server :render})
+(rf.hicasso/defhost counted-host counted {:server :render})
 
-(h/defview toast-body
+(rf.hicasso/defview toast-body
   "A BOUNDARY inside the portal, and a second claim from the first one.
   An intent is lowered EAGERLY, in the writing window, and carries its
   frame-locked dispatch with it — so the intent row below would stay
@@ -160,9 +160,9 @@
   context. Context that did not reach here would be
   `:rf.error/no-frame-context` at the shell, before the body ran."
   [_]
-  [:p.deep (str (collector/sub [:hicasso.portal/message]))])
+  [:p.deep (str (rf.hicasso.impl.collector/sub [:hicasso.portal/message]))])
 
-(h/defview toast-page
+(rf.hicasso/defview toast-page
   "THE PAGE, used on both sides of the hydration row and on the client
   rows alike. `:target` arrives as a prop because a server pass has no
   container to name and the remount row needs to hand the same page a
@@ -170,26 +170,26 @@
   two sides render identically whatever is passed."
   [{:keys [target]}]
   [:div.owner {:on-click [:hicasso.portal/note "ancestor"]}
-   [:h1.title (str (collector/sub [:hicasso.portal/message]))]
-   [h/portal {:target   target
+   [:h1.title (str (rf.hicasso.impl.collector/sub [:hicasso.portal/message]))]
+   [rf.hicasso/portal {:target   target
               :fallback [:div.rack-placeholder "rack loading"]}
     [:button.toast {:on-click [:hicasso.portal/note "toast"]}
-     (str (collector/sub [:hicasso.portal/message]))]
+     (str (rf.hicasso.impl.collector/sub [:hicasso.portal/message]))]
     [toast-body {}]]])
 
-(h/defview bare-page
+(rf.hicasso/defview bare-page
   "No `:fallback` — the DEFAULT arm, and the shape most portals ship in:
   the tree position is genuinely empty in the response."
   [_]
   [:div.owner
-   [:h1.title (str (collector/sub [:hicasso.portal/message]))]
-   [h/portal {:target nil}
+   [:h1.title (str (rf.hicasso.impl.collector/sub [:hicasso.portal/message]))]
+   [rf.hicasso/portal {:target nil}
     [:button.toast "THE PORTALLED SUBTREE"]]])
 
-(h/defview counted-page
+(rf.hicasso/defview counted-page
   [{:keys [target]}]
   [:div.owner
-   [h/portal {:target target}
+   [rf.hicasso/portal {:target target}
     [counted-host {}]]])
 
 ;; ---------------------------------------------------------------------------
@@ -198,7 +198,7 @@
 
 (defn- server-html [hiccup]
   (react-dom-server/renderToString
-    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+    (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the declaration (runs under :node-test too)
@@ -211,13 +211,13 @@
             ReactNode slot, props by identity. There is no fifth element
             class here, and no new head kind for a reader or the test kit
             to learn"
-    (is (codec/host-head? h/portal)))
+    (is (rf.hicasso.impl.codec/host-head? rf.hicasso/portal)))
   (testing "and its declared policy reads `:render`, which is a claim about
             the head's COMPONENT — safe on the server, where it renders the
             caller's fallback and never reaches for a container. The
             SURFACE is Client-only, and §2 is where that is measured rather
             than declared"
-    (is (= :render (codec/host-server h/portal)))))
+    (is (= :render (rf.hicasso.impl.codec/host-server rf.hicasso/portal)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — the server render: Client-only, on both arms (no DOM needed)
@@ -259,12 +259,12 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-subtree-renders-into-the-target-and-not-into-the-root
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [rack (rack!)
-            h    (mount/root! (mount/fresh-container!) frame-id [toast-page {:target rack}])]
+            h    (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [toast-page {:target rack}])]
         (try
           (testing "a fresh `createRoot` mount consults no server snapshot, so
                     the portal is there on the first pass — asserted on the
@@ -300,21 +300,21 @@
                     live in somebody else's container, so nothing but React's
                     own cleanup can remove them — a portal that leaked here
                     would leave a page that grows one toast rack per mount"
-            (mount/unmount! h)
-            (mount/settle!)
+            (rf.hicasso.impl.mount/unmount! h)
+            (rf.hicasso.impl.mount/settle!)
             (is (nil? (query-node rack ".toast"))
                 "the target container is empty after unmount"))
           (finally
-            (mount/release! h)
+            (rf.hicasso.impl.mount/release! h)
             (drop-rack! rack)))))))
 
 (deftest an-intent-inside-a-portal-fires-into-the-owners-frame
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [rack (rack!)
-            h    (mount/root! (mount/fresh-container!) frame-id [toast-page {:target rack}])]
+            h    (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [toast-page {:target rack}])]
         (try
           (testing "THE FRAME IS PRESERVED. The children are lowered in the
                     render window of the boundary that wrote the crossing, so
@@ -327,16 +327,16 @@
             (is (some #{"toast"} (log))
                 (str "the intent reached the owner's frame: " (pr-str (log)))))
           (finally
-            (mount/release! h)
+            (rf.hicasso.impl.mount/release! h)
             (drop-rack! rack)))))))
 
 (deftest a-click-inside-the-portal-reaches-a-react-ancestor-that-is-no-dom-ancestor
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [rack (rack!)
-            h    (mount/root! (mount/fresh-container!) frame-id [toast-page {:target rack}])]
+            h    (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [toast-page {:target rack}])]
         (try
           (let [owner (query-node (:container h) ".owner")
                 toast (query-node rack ".toast")]
@@ -357,21 +357,21 @@
               (is (some #{"toast"} (log))
                   (str "and so did the clicked node's own: " (pr-str (log))))))
           (finally
-            (mount/release! h)
+            (rf.hicasso.impl.mount/release! h)
             (drop-rack! rack)))))))
 
 (deftest a-changed-target-is-a-remount
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (reset! !child-mounts 0)
       (let [rack-a (rack!)
             rack-b (rack!)
-            h      (mount/root! (mount/fresh-container!) frame-id
+            h      (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                 [counted-page {:target rack-a}])]
         (try
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (let [first-node (query-node rack-a ".counted")]
             (testing "one mount, in the first container"
               (is (some? first-node))
@@ -382,9 +382,9 @@
                       fiber and the whole subtree is destroyed and rebuilt with
                       its state and its effects. Keep the target stable rather
                       than computing one per render"
-              (mount/render! h [counted-page {:target rack-b}])
-              (mount/settle!)
-              (mount/settle!)
+              (rf.hicasso.impl.mount/render! h [counted-page {:target rack-b}])
+              (rf.hicasso.impl.mount/settle!)
+              (rf.hicasso.impl.mount/settle!)
               (is (nil? (query-node rack-a ".counted"))
                   "the subtree left the first container")
               (is (some? (query-node rack-b ".counted"))
@@ -396,7 +396,7 @@
                         computes a fresh target per render pays this on every
                         one. Read " @!child-mounts))))
           (finally
-            (mount/release! h)
+            (rf.hicasso.impl.mount/release! h)
             (drop-rack! rack-a)
             (drop-rack! rack-b)))))))
 
@@ -424,7 +424,7 @@
 
 (deftest a-fallback-hydrates-as-the-placeholder-and-the-portal-arrives-at-adoption
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
@@ -434,13 +434,13 @@
               ;; sides of the hydration are the SAME page rendering the same
               ;; markup, which is the only honest way to take this claim.
               html      (server-html [toast-page {:target nil}])
-              container (mount/fresh-container!)
+              container (rf.hicasso.impl.mount/fresh-container!)
               {:keys [seen restore]} (watch-errors!)]
           (set! (.-innerHTML container) html)
           (let [root (react-dom-client/hydrateRoot
                        container
-                       (mount/provider frame-id
-                                       (codec/root-element frame-id [toast-page {:target rack}]))
+                       (rf.hicasso.impl.mount/provider frame-id
+                                       (rf.hicasso.impl.codec/root-element frame-id [toast-page {:target rack}]))
                        #js {:onRecoverableError
                             (fn [err _info]
                               (swap! seen conj (str "onRecoverableError: " (ex-message err))))})]
@@ -467,6 +467,6 @@
                     (.unmount root)
                     (when-some [p (.-parentNode container)] (.removeChild p container))
                     (drop-rack! rack)
-                    (collector/reset-runtime!)
+                    (rf.hicasso.impl.collector/reset-runtime!)
                     (done))))
               150)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/presence_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_cljs_test.cljs
@@ -38,10 +38,10 @@
   taste rulings dressed as deletions — and this is the instrument that
   answers it for this one."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.presence :as presence]))
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.presence :as rf.hicasso.impl.presence]))
 
-(use-fixtures :each {:before (fn [] (codec/reset-caches!))})
+(use-fixtures :each {:before (fn [] (rf.hicasso.impl.codec/reset-caches!))})
 
 (def ^:private timeout-ms 300)
 
@@ -56,8 +56,8 @@
   "Fold a sequence of child-lists into the machine, one render per list,
   with an explicit clock."
   [renders]
-  (reduce (fn [s [children now]] (presence/step s children now timeout-ms))
-          presence/initial
+  (reduce (fn [s [children now]] (rf.hicasso.impl.presence/step s children now timeout-ms))
+          rf.hicasso.impl.presence/initial
           renders))
 
 ;; ---------------------------------------------------------------------------
@@ -65,37 +65,37 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-child-enters-mounting-then-settles-present
-  (let [s (presence/step presence/initial [(toast 1 "a")] 0 timeout-ms)]
-    (is (= {1 :mounting} (presence/phases s)))
-    (is (true? (presence/mounting? s)))
-    (let [s (presence/settle s)]
-      (is (= {1 :present} (presence/phases s)))
-      (is (false? (presence/mounting? s)))
+  (let [s (rf.hicasso.impl.presence/step rf.hicasso.impl.presence/initial [(toast 1 "a")] 0 timeout-ms)]
+    (is (= {1 :mounting} (rf.hicasso.impl.presence/phases s)))
+    (is (true? (rf.hicasso.impl.presence/mounting? s)))
+    (let [s (rf.hicasso.impl.presence/settle s)]
+      (is (= {1 :present} (rf.hicasso.impl.presence/phases s)))
+      (is (false? (rf.hicasso.impl.presence/mounting? s)))
       (testing "and a later render with the same child leaves it alone"
-        (is (= {1 :present} (presence/phases
-                              (presence/step s [(toast 1 "a")] 50 timeout-ms))))))))
+        (is (= {1 :present} (rf.hicasso.impl.presence/phases
+                              (rf.hicasso.impl.presence/step s [(toast 1 "a")] 50 timeout-ms))))))))
 
 (deftest a-child-that-leaves-the-source-is-retained-as-unmounting
   (let [s (-> (state-of [[[(toast 1 "a") (toast 2 "b")] 0]])
-              presence/settle
-              (presence/step [(toast 1 "a")] 100 timeout-ms))]
-    (is (= {1 :present 2 :unmounting} (presence/phases s))
+              rf.hicasso.impl.presence/settle
+              (rf.hicasso.impl.presence/step [(toast 1 "a")] 100 timeout-ms))]
+    (is (= {1 :present 2 :unmounting} (rf.hicasso.impl.presence/phases s))
         "the child is gone from the data and still on screen")
-    (is (= 400 (presence/next-deadline s)) "100 + :timeout-ms, as an instant")
+    (is (= 400 (rf.hicasso.impl.presence/next-deadline s)) "100 + :timeout-ms, as an instant")
     (testing "and it leaves exactly on time, not before"
-      (is (= {1 :present 2 :unmounting} (presence/phases (presence/expire s 399))))
-      (is (= {1 :present} (presence/phases (presence/expire s 400)))))))
+      (is (= {1 :present 2 :unmounting} (rf.hicasso.impl.presence/phases (rf.hicasso.impl.presence/expire s 399))))
+      (is (= {1 :present} (rf.hicasso.impl.presence/phases (rf.hicasso.impl.presence/expire s 400)))))))
 
 (deftest re-entry-cancels-exit
   (let [s (-> (state-of [[[(toast 1 "a")] 0]])
-              presence/settle
-              (presence/step [] 100 timeout-ms))]
-    (is (= {1 :unmounting} (presence/phases s)))
-    (let [back (presence/step s [(toast 1 "a")] 150 timeout-ms)]
-      (is (= {1 :present} (presence/phases back))
+              rf.hicasso.impl.presence/settle
+              (rf.hicasso.impl.presence/step [] 100 timeout-ms))]
+    (is (= {1 :unmounting} (rf.hicasso.impl.presence/phases s)))
+    (let [back (rf.hicasso.impl.presence/step s [(toast 1 "a")] 150 timeout-ms)]
+      (is (= {1 :present} (rf.hicasso.impl.presence/phases back))
           "the exit is cancelled rather than finished-and-remounted")
-      (is (nil? (presence/next-deadline back)) "and its deadline is gone with it")
-      (is (= "a" (nth (first (presence/render back)) 2))))))
+      (is (nil? (rf.hicasso.impl.presence/next-deadline back)) "and its deadline is gone with it")
+      (is (= "a" (nth (first (rf.hicasso.impl.presence/render back)) 2))))))
 
 (deftest the-deadline-is-a-terminal-bound-and-re-deriving-cannot-extend-it
   (testing "the property `:timeout-ms` is FOR. Deadlines are absolute
@@ -103,13 +103,13 @@
             neighbour arriving, a neighbour leaving, React re-running the
             body — leave a retained child leaving at the instant it was
             always going to."
-    (let [s (-> (state-of [[[(toast 1 "a")] 0]]) presence/settle
-                (presence/step [] 100 timeout-ms))]
-      (is (= 400 (presence/next-deadline s)))
+    (let [s (-> (state-of [[[(toast 1 "a")] 0]]) rf.hicasso.impl.presence/settle
+                (rf.hicasso.impl.presence/step [] 100 timeout-ms))]
+      (is (= 400 (rf.hicasso.impl.presence/next-deadline s)))
       (let [busy (-> s
-                     (presence/step [(toast 2 "b")] 150 timeout-ms)
-                     (presence/step [(toast 2 "b") (toast 3 "c")] 200 timeout-ms)
-                     (presence/step [(toast 3 "c")] 250 timeout-ms))]
+                     (rf.hicasso.impl.presence/step [(toast 2 "b")] 150 timeout-ms)
+                     (rf.hicasso.impl.presence/step [(toast 2 "b") (toast 3 "c")] 200 timeout-ms)
+                     (rf.hicasso.impl.presence/step [(toast 3 "c")] 250 timeout-ms))]
         (is (= 400 (:deadline (get (:entries busy) 1)))
             "still 400 — not 550, which is what re-deriving would give")))))
 
@@ -119,20 +119,20 @@
             so the component's `(when-not (= next state) (set-state next))`
             converges after one extra pass and cannot loop."
     (let [children [(toast 1 "a") (toast 2 "b")]
-          once     (presence/step presence/initial children 0 timeout-ms)
-          twice    (presence/step once children 99 timeout-ms)]
+          once     (rf.hicasso.impl.presence/step rf.hicasso.impl.presence/initial children 0 timeout-ms)
+          twice    (rf.hicasso.impl.presence/step once children 99 timeout-ms)]
       (is (= once twice)))
-    (let [s     (-> (state-of [[[(toast 1 "a")] 0]]) presence/settle)
-          once  (presence/step s [] 100 timeout-ms)
-          twice (presence/step once [] 500 timeout-ms)]
+    (let [s     (-> (state-of [[[(toast 1 "a")] 0]]) rf.hicasso.impl.presence/settle)
+          once  (rf.hicasso.impl.presence/step s [] 100 timeout-ms)
+          twice (rf.hicasso.impl.presence/step once [] 500 timeout-ms)]
       (is (= once twice) "including for a retained child, whose deadline holds"))))
 
 (deftest first-appearance-slots-are-frozen-so-an-exiting-child-does-not-jump
   (let [s (-> (state-of [[[(toast 1 "a") (toast 2 "b") (toast 3 "c")] 0]])
-              presence/settle
-              (presence/step [(toast 1 "a") (toast 3 "c")] 100 timeout-ms))]
+              rf.hicasso.impl.presence/settle
+              (rf.hicasso.impl.presence/step [(toast 1 "a") (toast 3 "c")] 100 timeout-ms))]
     (is (= [1 2 3] (:order s)) "the middle child holds its slot while it exits")
-    (let [s (presence/step s [(toast 1 "a") (toast 3 "c") (toast 4 "d")] 120 timeout-ms)]
+    (let [s (rf.hicasso.impl.presence/step s [(toast 1 "a") (toast 3 "c") (toast 4 "d")] 120 timeout-ms)]
       (is (= [1 2 3 4] (:order s)) "and a genuinely new child is appended"))))
 
 (defn- refusal-data
@@ -145,31 +145,31 @@
 
 (deftest nil-children-are-not-entries-and-unkeyed-children-are-a-loud-error
   (is (= {1 :mounting}
-         (presence/phases (presence/step presence/initial
+         (rf.hicasso.impl.presence/phases (rf.hicasso.impl.presence/step rf.hicasso.impl.presence/initial
                                          [(toast 1 "a") nil false]
                                          0 timeout-ms))))
   (is (thrown-with-msg? js/Error #"with a :key"
-                        (presence/step presence/initial [[:div.toast "x"]] 0 timeout-ms)))
+                        (rf.hicasso.impl.presence/step rf.hicasso.impl.presence/initial [[:div.toast "x"]] 0 timeout-ms)))
   (is (thrown-with-msg? js/Error #"with a :key"
-                        (presence/step presence/initial ["a string"] 0 timeout-ms)))
+                        (rf.hicasso.impl.presence/step rf.hicasso.impl.presence/initial ["a string"] 0 timeout-ms)))
   (testing "one id for both — presence cannot identify the child — carrying
             the offending child, which is what a tool branches on"
     (let [unkeyed (refusal-data
-                    #(presence/step presence/initial [[:div.toast "x"]] 0 timeout-ms))]
+                    #(rf.hicasso.impl.presence/step rf.hicasso.impl.presence/initial [[:div.toast "x"]] 0 timeout-ms))]
       (is (= :rf.error/hicasso-presence-child-unkeyed (:rf.error/id unkeyed)))
       (is (= [:div.toast "x"] (:child unkeyed))))
     (let [not-hiccup (refusal-data
-                       #(presence/step presence/initial ["a string"] 0 timeout-ms))]
+                       #(rf.hicasso.impl.presence/step rf.hicasso.impl.presence/initial ["a string"] 0 timeout-ms))]
       (is (= :rf.error/hicasso-presence-child-unkeyed (:rf.error/id not-hiccup)))
       (is (= "a string" (:child not-hiccup))))))
 
 (deftest timeout-ms-is-mandatory-and-positive
-  (is (= 300 (presence/check-timeout! 300)))
+  (is (= 300 (rf.hicasso.impl.presence/check-timeout! 300)))
   (doseq [bad [nil 0 -1 "300"]]
     (is (thrown-with-msg? js/Error #"positive :timeout-ms"
-                          (presence/check-timeout! bad))
+                          (rf.hicasso.impl.presence/check-timeout! bad))
         (str "refused: " (pr-str bad)))
-    (let [data (refusal-data #(presence/check-timeout! bad))]
+    (let [data (refusal-data #(rf.hicasso.impl.presence/check-timeout! bad))]
       (is (= :rf.error/hicasso-presence-timeout-required (:rf.error/id data))
           (str "with its own id, for " (pr-str bad)))
       (is (= bad (:timeout-ms data))
@@ -181,18 +181,18 @@
 
 (deftest a-native-child-takes-the-phases-override-map-and-nothing-else
   (testing ":present — the overrides are stripped and never reach the DOM"
-    (is (= [:div.toast {:key 1} "a"] (presence/with-phase (toast 1 "a") :present))))
+    (is (= [:div.toast {:key 1} "a"] (rf.hicasso.impl.presence/with-phase (toast 1 "a") :present))))
   (testing ":unmounting — the map is merged, and it WINS, because that is
             what an override is"
     (is (= [:div.toast {:key 1 :class "toast--exit" :inert true :aria-hidden true} "a"]
-           (presence/with-phase (toast 1 "a") :unmounting))))
+           (rf.hicasso.impl.presence/with-phase (toast 1 "a") :unmounting))))
   (testing ":mounting — the enter map is merged the same way. This is the
             arm the exit rows cannot witness: an `override-for` answering
             nil at :mounting still STRIPS the override keys, so every
             strip assertion in this file stays green while enter styling
             dies wholesale — the positive merge is the only pin"
     (is (= [:div.toast {:key 1 :class "toast--enter"} "a"]
-           (presence/with-phase
+           (rf.hicasso.impl.presence/with-phase
              [:div.toast {:key 1
                           :re-frame.hicasso.motion/mounting {:class "toast--enter"}}
               "a"]
@@ -205,7 +205,7 @@
                                :re-frame.hicasso.motion/unmounting
                                {:key "stolen" :ref (fn [_]) :class "x"}}]]
       (is (= [:div.toast {:key 1 :class "x"}]
-             (presence/with-phase hostile :unmounting)))))
+             (rf.hicasso.impl.presence/with-phase hostile :unmounting)))))
   (testing "and it cannot reach them under ANY spelling, which is the whole
             of the repair. `\"key\"` and `:x/key` survive a raw `#{:key
             :ref}` dissoc and canonicalise onto React's key — after the
@@ -217,10 +217,10 @@
       (let [hostile [:div.toast {:key 1
                                  :re-frame.hicasso.motion/unmounting
                                  {spelling "stolen" :class "x"}}]
-            out     (presence/with-phase hostile :unmounting)]
+            out     (rf.hicasso.impl.presence/with-phase hostile :unmounting)]
         (is (= [:div.toast {:key 1 :class "x"}] out)
             (str "key, spelled " (pr-str spelling)))
-        (is (= 1 (presence/child-key out))
+        (is (= 1 (rf.hicasso.impl.presence/child-key out))
             "the retained node's identity is the key the machine retains it
              under, and nothing in an override can move it")))
     (doseq [spelling ["ref" 'ref :x/ref]]
@@ -228,14 +228,14 @@
                                  :re-frame.hicasso.motion/unmounting
                                  {spelling (fn [_]) :class "x"}}]]
         (is (= [:div.toast {:key 1 :class "x"}]
-               (presence/with-phase hostile :unmounting))
+               (rf.hicasso.impl.presence/with-phase hostile :unmounting))
             (str "ref, spelled " (pr-str spelling))))))
   (testing "a child that carries no override comes back UNTOUCHED, by
             identity — the transform costs nothing on a node that does not
             use it"
     (let [plain [:div.toast {:key 1} "a"]]
-      (is (identical? plain (presence/with-phase plain :unmounting))))
-    (is (= [:div.toast] (presence/with-phase [:div.toast] :present))
+      (is (identical? plain (rf.hicasso.impl.presence/with-phase plain :unmounting))))
+    (is (= [:div.toast] (rf.hicasso.impl.presence/with-phase [:div.toast] :present))
         "including a node with no props map, which is not given one")))
 
 (deftest a-legal-override-reaches-the-element-as-appearance-and-never-as-an-attribute
@@ -249,8 +249,8 @@
                          :class "toast"
                          :re-frame.hicasso.motion/mounting   {:class "toast--enter"}
                          :re-frame.hicasso.motion/unmounting {:class "toast--exit"}}]
-            names (set (js/Object.keys (.-props (codec/as-element
-                                                  (presence/with-phase child phase)))))]
+            names (set (js/Object.keys (.-props (rf.hicasso.impl.codec/as-element
+                                                  (rf.hicasso.impl.presence/with-phase child phase)))))]
         (is (not (contains? names "mounting")) (str "at " phase))
         (is (not (contains? names "unmounting")) (str "at " phase)))))
 
@@ -258,14 +258,14 @@
             skipped by the codec's walk rather than emitted, which is the
             other half of the sentence: between the two there is no route
             to the DOM"
-    (let [names (set (js/Object.keys (.-props (codec/as-element
+    (let [names (set (js/Object.keys (.-props (rf.hicasso.impl.codec/as-element
                                                  [:div {:re-frame.hicasso.motion/mounting {:class "toast--enter"}}]))))]
       (is (not (contains? names "mounting"))))))
 
 (deftest a-boundary-child-takes-the-override-map-as-ordinary-props
-  (let [card (codec/mark-boundary! (fn [_] nil))]
+  (let [card (rf.hicasso.impl.codec/mark-boundary! (fn [_] nil))]
     (is (= [card {:key 1 :toast {:id 1} :exiting? true}]
-           (presence/with-phase [card {:key 1 :toast {:id 1}
+           (rf.hicasso.impl.presence/with-phase [card {:key 1 :toast {:id 1}
                                        :re-frame.hicasso.motion/unmounting {:exiting? true}}]
                                 :unmounting))
         "the same merge an element gets (HD-030): the phase's map lands in
@@ -275,16 +275,16 @@
               handed exactly what it was written with — no phase value, no
               reserved key"
       (is (= [card {:key 1 :toast {:id 1}}]
-             (presence/with-phase [card {:key 1 :toast {:id 1}
+             (rf.hicasso.impl.presence/with-phase [card {:key 1 :toast {:id 1}
                                          :re-frame.hicasso.motion/unmounting {:exiting? true}}]
                                   :present))))
     (testing "a view that declares no override comes back untouched, by
               identity, like an element"
       (let [plain [card {:key 1 :toast {:id 1}}]]
-        (is (identical? plain (presence/with-phase plain :unmounting)))))
+        (is (identical? plain (rf.hicasso.impl.presence/with-phase plain :unmounting)))))
     (testing "and an override on a view head cannot reach `:key` either"
       (is (= [card {:key 1 :exiting? true}]
-             (presence/with-phase [card {:key 1 :re-frame.hicasso.motion/unmounting
+             (rf.hicasso.impl.presence/with-phase [card {:key 1 :re-frame.hicasso.motion/unmounting
                                          {:key "stolen" :exiting? true}}]
                                   :unmounting))))))
 
@@ -305,7 +305,7 @@
                :aria-hidden (when exiting? true)}
    message])
 
-(def ^:private toast-card (codec/mark-boundary! toast-card-body))
+(def ^:private toast-card (rf.hicasso.impl.codec/mark-boundary! toast-card-body))
 
 (defn- child-view-tray
   "BEFORE — a keyed child view per toast, declaring the one prop it
@@ -340,17 +340,17 @@
   "Drive one tray through the machine to `phase`, then through the codec,
   and read the toast elements back."
   [tray toasts phase]
-  (let [seeded (presence/settle (presence/step presence/initial (tray toasts) 0 timeout-ms))
+  (let [seeded (rf.hicasso.impl.presence/settle (rf.hicasso.impl.presence/step rf.hicasso.impl.presence/initial (tray toasts) 0 timeout-ms))
         state  (if (= :unmounting phase)
-                 (presence/step seeded (tray []) 100 timeout-ms)
+                 (rf.hicasso.impl.presence/step seeded (tray []) 100 timeout-ms)
                  seeded)
-        hiccup (presence/render state)]
+        hiccup (rf.hicasso.impl.presence/render state)]
     ;; A boundary child renders through its body; a native child is already
     ;; the node. Both end at the codec, which is where the comparison is
     ;; taken, because that is the last point before React.
     (mapv (fn [child]
-            (codec/as-element
-              (if (codec/boundary-head? (nth child 0))
+            (rf.hicasso.impl.codec/as-element
+              (if (rf.hicasso.impl.codec/boundary-head? (nth child 0))
                 (toast-card-body (nth child 1))
                 child)))
           hiccup)))
@@ -370,27 +370,27 @@
 (deftest the-exit-attributes-arrive-while-unmounting-and-go-on-re-entry
   (testing "witness 1: a toast written INLINE — no child view — gets the exit
             attributes while unmounting, and loses them when it comes back."
-    (let [seeded (presence/settle
-                   (presence/step presence/initial (inline-tray toasts) 0 timeout-ms))
-          gone   (presence/step seeded (inline-tray [(first toasts)]) 100 timeout-ms)
-          back   (presence/step gone (inline-tray toasts) 150 timeout-ms)]
-      (is (= {1 :present 2 :unmounting} (presence/phases gone)))
-      (let [exiting (attrs (codec/as-element (second (presence/render gone))))]
+    (let [seeded (rf.hicasso.impl.presence/settle
+                   (rf.hicasso.impl.presence/step rf.hicasso.impl.presence/initial (inline-tray toasts) 0 timeout-ms))
+          gone   (rf.hicasso.impl.presence/step seeded (inline-tray [(first toasts)]) 100 timeout-ms)
+          back   (rf.hicasso.impl.presence/step gone (inline-tray toasts) 150 timeout-ms)]
+      (is (= {1 :present 2 :unmounting} (rf.hicasso.impl.presence/phases gone)))
+      (let [exiting (attrs (rf.hicasso.impl.codec/as-element (second (rf.hicasso.impl.presence/render gone))))]
         (is (= "toast toast--exit" (get exiting "className")))
         (is (true? (get exiting "inert")))
         (is (true? (get exiting "aria-hidden"))))
-      (is (= {1 :present 2 :present} (presence/phases back)))
-      (let [restored (attrs (codec/as-element (second (presence/render back))))]
+      (is (= {1 :present 2 :present} (rf.hicasso.impl.presence/phases back)))
+      (let [restored (attrs (rf.hicasso.impl.codec/as-element (second (rf.hicasso.impl.presence/render back))))]
         (is (= "toast" (get restored "className")))
         (is (nil? (get restored "inert")))
         (is (nil? (get restored "aria-hidden"))))))
   (testing "witness 3, headlessly: the child is gone after :timeout-ms and
             the machine retains nothing"
-    (let [seeded (presence/settle
-                   (presence/step presence/initial (inline-tray toasts) 0 timeout-ms))
-          gone   (presence/step seeded (inline-tray [(first toasts)]) 100 timeout-ms)
-          done   (presence/expire gone 400)]
-      (is (= {1 :present} (presence/phases done)))
+    (let [seeded (rf.hicasso.impl.presence/settle
+                   (rf.hicasso.impl.presence/step rf.hicasso.impl.presence/initial (inline-tray toasts) 0 timeout-ms))
+          gone   (rf.hicasso.impl.presence/step seeded (inline-tray [(first toasts)]) 100 timeout-ms)
+          done   (rf.hicasso.impl.presence/expire gone 400)]
+      (is (= {1 :present} (rf.hicasso.impl.presence/phases done)))
       (is (= [1] (:order done)))
       (is (= 1 (count (:entries done))))
-      (is (nil? (presence/next-deadline done))))))
+      (is (nil? (rf.hicasso.impl.presence/next-deadline done))))))

--- a/implementation/hicasso/test/re_frame/hicasso/presence_intent_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_intent_dom_cljs_test.cljs
@@ -65,18 +65,18 @@
   React DOM; under `:node-test` every DOM claim degrades to a stated
   skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.context :as rf.adapter.context]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.hicasso.impl.boundary :refer [boundary]]
-            [re-frame.hicasso.hook-probe :as probe]
-            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.hook-probe :as rf.hicasso.hook-probe]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
             [re-frame.hicasso.impl.presence-react :refer [presence]]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::presence-intent)
 (def ^:private other-frame-id ::presence-intent-other)
@@ -101,8 +101,8 @@
                 {:db (update db :noted (fnil conj []) id)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; `:ambient-frame nil` is load-bearing. The fixture's default leaves a
      ;; dynamic-var frame stamp in scope, and a tray that resolved the frame
      ;; through that tier instead of through React context would look correct
@@ -110,13 +110,13 @@
      ;; can name a frame is the provider above the tray.
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- skip! [why]
   (is true (str "an intent-on-a-presence-child claim needs a real React DOM — " why)))
 
 (defn- fresh! [frame-kw ts]
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-kw})
   (rf/with-frame frame-kw (rf/dispatch-sync [:hicasso.presence-intent/set ts]))
   frame-kw)
@@ -127,14 +127,14 @@
 ;; The screen — the tray HD-025 sells, with the button it could not carry
 ;; ---------------------------------------------------------------------------
 
-(h/defview toast-tray
+(rf.hicasso/defview toast-tray
   "The inline tray, with **no child view**, and now with controls on the
   toast. `:on-click` carries a bare intent vector on one button and the
   one callback form on the other, so both rows of the position table are
   written at the same position on the same child."
   [_]
   [presence {:timeout-ms timeout-ms}
-   (for [t (collector/sub [:hicasso.presence-intent/visible])]
+   (for [t (rf.hicasso.impl.collector/sub [:hicasso.presence-intent/visible])]
      [:div.toast {:key (:id t)
                   :data-id (:id t)
                   :re-frame.hicasso.motion/unmounting {:class "toast--exit"}}
@@ -143,7 +143,7 @@
                         :on-click [:hicasso.presence-intent/dismissed (:id t)]}
        "dismiss"]
       [:button.note {:data-id  (:id t)
-                     :on-click (h/event [e]
+                     :on-click (rf.hicasso/event [e]
                                  ;; A live event read, and ONE intent
                                  ;; returned — the event contract the
                                  ;; position imposes.
@@ -152,7 +152,7 @@
                      :data-role "note"}
        "note"]])])
 
-(h/defview note-only-tray
+(rf.hicasso/defview note-only-tray
   "The same tray carrying **only** the callback form, and it exists for
   what it proves when the frame binding is taken away. The two intent
   shapes fail at different MOMENTS: a bare vector is refused at LOWERING,
@@ -164,16 +164,16 @@
   own."
   [_]
   [presence {:timeout-ms timeout-ms}
-   (for [t (collector/sub [:hicasso.presence-intent/visible])]
+   (for [t (rf.hicasso.impl.collector/sub [:hicasso.presence-intent/visible])]
      [:div.toast {:key (:id t) :data-id (:id t)}
       [:button.note {:data-id   (:id t)
-                     :on-click  (h/event [e]
+                     :on-click  (rf.hicasso/event [e]
                                   (when (= "note" (.. e -target -dataset -role))
                                     [:hicasso.presence-intent/noted (:id t)]))
                      :data-role "note"}
        "note"]])])
 
-(h/defview toast-card
+(rf.hicasso/defview toast-card
   "A BOUNDARY child of presence. It resolves its own frame in its own
   shell and takes any override as ordinary props, so it is the control:
   presence's new binding must leave this path exactly as it was."
@@ -181,10 +181,10 @@
   [:div.card {:data-id id}
    [:button.card-dismiss {:on-click [:hicasso.presence-intent/dismissed id]} "dismiss"]])
 
-(h/defview card-tray
+(rf.hicasso/defview card-tray
   [_]
   [presence {:timeout-ms timeout-ms}
-   (for [t (collector/sub [:hicasso.presence-intent/visible])]
+   (for [t (rf.hicasso.impl.collector/sub [:hicasso.presence-intent/visible])]
      [toast-card {:key (:id t) :id (:id t)}])])
 
 (def ^:private two [{:id 1 :message "Saved"} {:id 2 :message "Copied"}])
@@ -198,18 +198,18 @@
 
 (defn- click! [node]
   (.click node)
-  (mount/settle!))
+  (rf.hicasso.impl.mount/settle!))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — a bare intent vector on a native presence child
 ;; ---------------------------------------------------------------------------
 
 (deftest a-native-presence-child-dispatches-its-inline-intent
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id two)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [toast-tray {}])]
         (try
           (is (some? (query handle ".toast"))
               "the tray rendered at all — before this repair the intent on the
@@ -223,21 +223,21 @@
           (click! (button handle ".dismiss" 1))
           (is (= [2 1] (:dismissed (db frame-id)))
               "and again, so this is a live handler and not a one-shot")
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — the one callback form at a presence child's event position
 ;; ---------------------------------------------------------------------------
 
 (deftest a-callback-at-a-presence-childs-event-position-dispatches-what-it-returned
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id two)
       ;; The callback-ONLY tray, deliberately: see its docstring. A bare
       ;; vector on the same child would fail earlier and louder with the
       ;; binding removed, and would take the credit for this row's red.
-      (let [handle (mount/root! (mount/fresh-container!) frame-id
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                 [note-only-tray {}])]
         (try
           (is (some? (button handle ".note" 1))
@@ -249,20 +249,20 @@
               "and at invocation the h/event read the real event and the vector it
                RETURNED drained through the arm's synchronous door — the second
                row of the position table, at a position presence lowered")
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — the unmounting window: retained, on screen, and still clickable
 ;; ---------------------------------------------------------------------------
 
 (deftest a-retained-child-dispatches-during-the-unmounting-window
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id two)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [toast-tray {}])]
         (try
-          (mount/dispatch! handle [:hicasso.presence-intent/set one])
+          (rf.hicasso.impl.mount/dispatch! handle [:hicasso.presence-intent/set one])
           (is (= 2 (.-length (.querySelectorAll (:container handle) ".toast")))
               "toast 2 is gone from app-db and RETAINED on screen")
           (is (.contains (.-classList (query handle ".toast[data-id=\"2\"]"))
@@ -278,20 +278,20 @@
             (click! (button handle ".note" 2))
             (is (= [2] (:noted (db frame-id)))
                 "both intent shapes, from the retained phase"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — the frame is the TRAY's, proved against a second live frame
 ;; ---------------------------------------------------------------------------
 
 (deftest a-presence-child-lands-in-the-frame-the-tray-was-mounted-under
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id two)
       (fresh! other-frame-id two)
-      (let [a (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])
-            b (mount/root! (mount/fresh-container!) other-frame-id [toast-tray {}])]
+      (let [a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [toast-tray {}])
+            b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) other-frame-id [toast-tray {}])]
         (try
           (click! (button a ".dismiss" 1))
           (is (= [1] (:dismissed (db frame-id))))
@@ -303,21 +303,21 @@
           (is (= [2] (:dismissed (db other-frame-id))))
           (is (= [1] (:dismissed (db frame-id)))
               "and symmetrically the other way")
-          (finally (mount/release! a) (mount/release! b)))))))
+          (finally (rf.hicasso.impl.mount/release! a) (rf.hicasso.impl.mount/release! b)))))))
 
 (deftest a-boundary-child-of-presence-still-lowers-in-its-own-render
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id two)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [card-tray {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [card-tray {}])]
         (try
           (click! (.querySelector (:container handle)
                                   ".card[data-id=\"2\"] .card-dismiss"))
           (is (= [2] (:dismissed (db frame-id)))
               "a boundary child resolves its own frame in its own shell, and
                presence's binding around the crossing left that path alone")
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5 — a frameless tray is legal; an intent under one is still the loud error
@@ -330,13 +330,13 @@
   the React-context default, so this is exactly a tray with no frame
   boundary above it, reached without a second door in `mount`."
   [hiccup]
-  (mount/root! (mount/fresh-container!) adapter-context/no-provider-sentinel hiccup))
+  (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) rf.adapter.context/no-provider-sentinel hiccup))
 
 (deftest a-frameless-tray-is-legal-until-a-child-writes-an-intent
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
-      (support/leave-act-environment!)
+      (rf.hicasso.checkpoint-support/leave-act-environment!)
       (testing "a tray with no frame above it and no intent below it renders.
                 Presence reads no subscription, so requiring a frame it does not
                 need would refuse a legal page"
@@ -345,7 +345,7 @@
                         [:div.toast {:key 1 :data-id 1} "quiet"]])]
           (try
             (is (some? (query handle ".toast")))
-            (finally (mount/release! handle)))))
+            (finally (rf.hicasso.impl.mount/release! handle)))))
       (testing "and an intent under one is the loud error, NAMED — the
                 diagnostic points at the intent rather than at the tray"
         (reset! !caught nil)
@@ -363,7 +363,7 @@
                    (:rf.error/id (ex-data @!caught)))
                 (str "and it named the intent: " (pr-str (ex-data @!caught))))
             (is (= [:hicasso.presence-intent/dismissed 1] (:intent (ex-data @!caught))))
-            (finally (mount/release! handle))))))))
+            (finally (rf.hicasso.impl.mount/release! handle))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5b — the mutation sentinel: a framed tray raises NOTHING, by name
@@ -378,12 +378,12 @@
 ;; somebody has to go and read.
 
 (deftest an-intent-under-a-framed-tray-raises-nothing
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id two)
       (reset! !caught nil)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                 [boundary {:fallback [:p.oops "the tray refused"]
                                            :on-error (fn [e] (reset! !caught e))}
                                  [toast-tray {}]])]
@@ -397,7 +397,7 @@
               "so the fallback did not take over")
           (is (= 2 (.-length (.querySelectorAll (:container handle) ".toast")))
               "and both toasts, controls and all, are on screen")
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6 — the hook budget, counted at React's own dispatcher
@@ -411,17 +411,17 @@
                  " rather than reading this as a pass.")))
 
 (deftest presence-costs-four-hooks-and-the-shell-still-costs-two
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
-    (if-not (probe/install!)
+    (if-not (rf.hicasso.hook-probe/install!)
       (unwitnessed!)
       (do
         (fresh! frame-id one)
         (let [handle (volatile! nil)
-              names  (probe/record!
+              names  (rf.hicasso.hook-probe/record!
                        (fn []
                          (vreset! handle
-                                  (mount/root! (mount/fresh-container!)
+                                  (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!)
                                                frame-id [toast-tray {}]))))
               tail   (vec (drop 2 names))
               freq   (frequencies tail)]
@@ -432,7 +432,7 @@
                      "whole of it — this repair added a hook to presence and "
                      "to nothing that HD-020(b)'s ≤2 budget governs. Raw: "
                      (pr-str names)))
-            (is (= (count runtime/shell-hook-ledger) (count (take 2 names)))
+            (is (= (count rf.hicasso.test.runtime/shell-hook-ledger) (count (take 2 names)))
                 "and the declared shell ledger is the measured one")
             (is (= ["useContext" "useState" "useEffect"] (vec (distinct tail)))
                 (str "presence's own roster, in call order: the frame hook, "
@@ -475,4 +475,4 @@
                    `distinct` and not by counting, and it is pinned here so a
                    React bump that changes it reds a test with an explanation
                    attached rather than a bare number"))
-            (finally (mount/release! @handle))))))))
+            (finally (rf.hicasso.impl.mount/release! @handle))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
@@ -188,18 +188,18 @@
   runs under `:node-test`; §2–§4 hydrate and state their skip there
   rather than reporting a false green."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.roots :as roots]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.motion :as motion]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.hicasso.server :as server]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.roots :as rf.hicasso.impl.roots]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.motion :as rf.hicasso.motion]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.hicasso.server :as rf.hicasso.server]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom/server" :as react-dom-server]))
 
 (def ^:private frame-id ::seam)
@@ -214,11 +214,11 @@
 (rf/reg-event ::seed (fn [_ [_ label]] {:db {:label label}}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The app
@@ -235,7 +235,7 @@
   ;; is the entire question on both sides of this seam.
   (atom {}))
 
-(h/defview phase-probe
+(rf.hicasso/defview phase-probe
   "A presence child that is a BOUNDARY, so the machine merges the phase's
   override map into its PROPS (`impl.presence/with-phase`, HD-030) rather
   than into a node's attributes. The tray below declares `{:phase …}`
@@ -252,35 +252,35 @@
   (swap! !phases update tag (fnil conj []) phase)
   [:span.probe (name phase)])
 
-(h/defview tray-screen
+(rf.hicasso/defview tray-screen
   "A screen with a presence tray in it — the surface this row is about."
   [{:keys [tag]}]
   [:div.screen
-   [:p.value (h/sub label-q)]
-   [motion/presence {:timeout-ms 50}
+   [:p.value (rf.hicasso/sub label-q)]
+   [rf.hicasso.motion/presence {:timeout-ms 50}
     [phase-probe {:key                 "one"
                   :tag                 tag
-                  ::motion/mounting    {:phase :mounting}
-                  ::motion/unmounting  {:phase :unmounting}}]]])
+                  ::rf.hicasso.motion/mounting    {:phase :mounting}
+                  ::rf.hicasso.motion/unmounting  {:phase :unmounting}}]]])
 
-(h/defview plain-screen
+(rf.hicasso/defview plain-screen
   "The same screen with the tray removed — §4's control. Identical in
   every other respect: same frame, same subscription read, same server
   door, same hydration."
   [_]
   [:div.screen
-   [:p.value (h/sub label-q)]])
+   [:p.value (rf.hicasso/sub label-q)]])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
 ;; ---------------------------------------------------------------------------
 
 (defn- fresh! []
-  (sup/leave-act-environment!)
+  (rf.hicasso.roots-frames-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [::seed "alpha"]))
-  (collector/reset-runtime!)
-  (runtime/reset-body-runs!)
+  (rf.hicasso.impl.collector/reset-runtime!)
+  (rf.hicasso.test.runtime/reset-body-runs!)
   nil)
 
 (defn- app-element
@@ -295,7 +295,7 @@
   hydrates. Any divergence the rows below find is therefore attributable
   to the window and to nothing else in the tree."
   [hiccup]
-  (mount/provider frame-id (codec/root-element frame-id hiccup)))
+  (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup)))
 
 (defn- server-bytes!
   "The bytes React's ACTUAL server renderer produces for `hiccup` — the
@@ -321,11 +321,11 @@
 
   When the product grows that door this fn is deleted, not promoted."
   [hiccup]
-  (let [window (roots/open-adoption-window!)]
+  (let [window (rf.hicasso.impl.roots/open-adoption-window!)]
     (try
       (react-dom-server/renderToString
-        (roots/with-adoption window (app-element hiccup)))
-      (finally (roots/close-adoption-window! window)))))
+        (rf.hicasso.impl.roots/with-adoption window (app-element hiccup)))
+      (finally (rf.hicasso.impl.roots/close-adoption-window! window)))))
 
 (defn- probe-text
   "The phase the markup says, read out of a STRING rather than a DOM —
@@ -477,17 +477,17 @@
 ;; findable.
 (deftest the-client-settled-bytes-and-the-real-server-bytes-differ
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM, and `settled-server-html!` mounts a client root") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM, and `settled-server-html!` mounts a client root") (done))
       (do
         (fresh!)
         (reset! !phases {})
-        (-> (sup/settled-server-html!
+        (-> (rf.hicasso.roots-frames-support/settled-server-html!
               frame-id [tray-screen {:tag :settled}]
               (fn [c] (= "present" (text-in c ".probe"))))
             (.then
               (fn [settled]
-                (collector/reset-runtime!)
+                (rf.hicasso.impl.collector/reset-runtime!)
                 (reset! !phases {})
                 (let [real (server-bytes! [tray-screen {:tag :server}])]
 
@@ -514,7 +514,7 @@
             ;; `settled-server-html!` releases the client root it used to
             ;; produce the settled bytes, and `server-bytes!` is a
             ;; `renderToString` with no DOM behind it.
-            (sup/settle-row!
+            (rf.hicasso.roots-frames-support/settle-row!
               {:row  "§2 — the client's settled bytes are not the server's"
                :done done}))))))
 
@@ -551,29 +551,29 @@
 ;; the only row in the file that catches it.
 (deftest hydrating-the-real-server-bytes-diverges-and-discards-the-adoption
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
         (reset! !phases {})
         (let [html (server-bytes! [tray-screen {:tag :server}])]
           (is (= "mounting" (probe-text html))
               (str "premise: these are the real server's bytes — " html))
-          (collector/reset-runtime!)
+          (rf.hicasso.impl.collector/reset-runtime!)
           (reset! !phases {})
-          (let [ca (sup/stamp-server-nodes! (sup/server-dom! html))
-                {:keys [seen stop!]} (sup/watch-mismatches!)
+          (let [ca (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+                {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)
                 ;; MANUFACTURED here and asserted on here — the only shape of
                 ;; call site at which swallowing an uncaught error is not the
                 ;; fail-open the pageerror rule forbids. The divergence is the
                 ;; subject of the row, not an accident inside it.
-                {:keys [captured close!]} (sup/open-console-capture! {:swallow-uncaught? true})
-                ha (mount/hydrate-root! ca frame-id [tray-screen {:tag :client}])]
-            (is (true? (roots/adopting? (:adoption ha)))
+                {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture! {:swallow-uncaught? true})
+                ha (rf.hicasso.impl.mount/hydrate-root! ca frame-id [tray-screen {:tag :client}])]
+            (is (true? (rf.hicasso.impl.roots/adopting? (:adoption ha)))
                 "premise: the client root DID mint a window — the client half
                  of the seam is present and working; it is the server half
                  that is missing")
-            (-> (sup/adopted! ha)
+            (-> (rf.hicasso.roots-frames-support/adopted! ha)
                 (.then
                   (fn [ok]
                     ;; Closed and stopped HERE, and named in `:release!` as
@@ -616,7 +616,7 @@
                             (str "React said " (count complaints)
                                  ", the framework said " (count @seen)))
                         (doseq [ev @seen]
-                          (let [tags (sup/tags-of ev)]
+                          (let [tags (rf.hicasso.roots-frames-support/tags-of ev)]
                             (is (= :rf.ssr/hydration-mismatch (:operation ev)))
                             (is (= 're-frame.hicasso.impl.mount/hydrate-root! (:where tags)))
                             (is (= :warned-and-replaced (:recovery tags)))
@@ -631,9 +631,9 @@
                       (is (some? (.querySelector ca ".probe"))
                           "premise: something is there to check, so the
                            negative below is not vacuous")
-                      (is (false? (sup/server-node? (.querySelector ca ".probe")))
+                      (is (false? (rf.hicasso.roots-frames-support/server-node? (.querySelector ca ".probe")))
                           "the probe node was re-created")
-                      (is (false? (sup/every-server-node? ca ".screen, .probe"))))
+                      (is (false? (rf.hicasso.roots-frames-support/every-server-node? ca ".screen, .probe"))))
 
                     (testing "while the FINAL DOM reads exactly what a healthy
                               adoption would have left — React's repair. This
@@ -642,13 +642,13 @@
                               file rests on it"
                       (is (= "present" (text-in ca ".probe")))
                       (is (= "alpha" (text-in ca ".value"))))))
-                (sup/settle-row!
+                (rf.hicasso.roots-frames-support/settle-row!
                   {:row      "§3 — hydrating the real server bytes diverges"
                    :done     done
                    :release! (fn []
                                (close!)
                                (stop!)
-                               (mount/release! ha))}))))))))
+                               (rf.hicasso.impl.mount/release! ha))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; §4 — the control: the same real server path, with no tray in the tree
@@ -668,19 +668,19 @@
 ;; has changed ordinary hydration, which is not what it was for.
 (deftest the-same-real-server-path-hydrates-a-tray-free-tree-with-no-divergence
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
         (let [html (server-bytes! [plain-screen {}])]
           (is (re-find #"alpha" html)
               (str "premise: the real server renderer produced this tree — " html))
-          (collector/reset-runtime!)
-          (let [ca (sup/stamp-server-nodes! (sup/server-dom! html))
-                {:keys [seen stop!]}      (sup/watch-mismatches!)
-                {:keys [captured close!]} (sup/open-console-capture!)
-                ha (mount/hydrate-root! ca frame-id [plain-screen {}])]
-            (-> (sup/adopted! ha)
+          (rf.hicasso.impl.collector/reset-runtime!)
+          (let [ca (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+                {:keys [seen stop!]}      (rf.hicasso.roots-frames-support/watch-mismatches!)
+                {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture!)
+                ha (rf.hicasso.impl.mount/hydrate-root! ca frame-id [plain-screen {}])]
+            (-> (rf.hicasso.roots-frames-support/adopted! ha)
                 (.then
                   (fn [ok]
                     ;; Closed and stopped here and named in `:release!` too,
@@ -696,18 +696,18 @@
                           (str "no complaint expected; captured " (pr-str @captured)))
                       (is (= 0 (count @seen))
                           (str "and no framework diagnostic; got "
-                               (pr-str (mapv (comp :error sup/tags-of) @seen)))))
+                               (pr-str (mapv (comp :error rf.hicasso.roots-frames-support/tags-of) @seen)))))
 
                     (testing "and kept the server's own nodes, which is what
                               adoption MEANS and what §3 lost"
-                      (is (sup/every-server-node? ca ".screen, .value")))))
-                (sup/settle-row!
+                      (is (rf.hicasso.roots-frames-support/every-server-node? ca ".screen, .value")))))
+                (rf.hicasso.roots-frames-support/settle-row!
                   {:row      "§4 — the same real server path with no tray"
                    :done     done
                    :release! (fn []
                                (close!)
                                (stop!)
-                               (mount/release! ha))}))))))))
+                               (rf.hicasso.impl.mount/release! ha))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; §5 — the PRODUCT server door, which does scope a window, and what that
@@ -737,7 +737,7 @@
 (deftest the-product-server-door-scopes-a-window-so-presence-is-present-in-its-bytes
   (fresh!)
   (reset! !phases {})
-  (let [{:keys [html]} (server/render {:hiccup   [tray-screen {:tag :product}]
+  (let [{:keys [html]} (rf.hicasso.server/render {:hiccup   [tray-screen {:tag :product}]
                                        :snapshot {:label "alpha"}
                                        :payload  [:label]})]
 
@@ -794,35 +794,35 @@
 ;; replaced for whatever runs next.
 
 (deftest a-rejected-adoption-still-releases-the-root-console-and-watcher
-  (if-not (mount/browser?)
-    (sup/skip! "what a rejection can leak here is a real root and a real console")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! "what a rejection can leak here is a real root and a real console")
     (async done
       (fresh!)
       (let [html           (server-bytes! [plain-screen {}])
-            ca             (sup/stamp-server-nodes! (sup/server-dom! html))
-            watch          (sup/watch-mismatches!)
+            ca             (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+            watch          (rf.hicasso.roots-frames-support/watch-mismatches!)
             ;; NOT `:swallow-uncaught? true`: this row manufactures a rejected
             ;; PROMISE, which `sup/settle-row!` handles, and no uncaught window
             ;; error at all. Swallowing anywhere else is the fail-open the
             ;; browser runner's pageerror rule forbids.
             console-before (.-error js/console)
-            capture        (sup/open-console-capture!)
+            capture        (rf.hicasso.roots-frames-support/open-console-capture!)
             stops          (atom 0)
             finishes       (atom 0)
             reports        (atom [])]
-        (collector/reset-runtime!)
-        (let [ha (mount/hydrate-root! ca frame-id [plain-screen {}])]
-          (-> (sup/adopted! ha)
+        (rf.hicasso.impl.collector/reset-runtime!)
+        (let [ha (rf.hicasso.impl.mount/hydrate-root! ca frame-id [plain-screen {}])]
+          (-> (rf.hicasso.roots-frames-support/adopted! ha)
               (.then
                 (fn [ok]
                   (is (true? ok) "premise: the root really did adopt")
-                  (is (not= sup/released (sup/census))
+                  (is (not= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/census))
                       (str "premise: the runtime is holding this root's cells "
                            "and edges, so the census taken after the rejection "
                            "is a RELEASE and not an empty page; got "
-                           (pr-str (sup/census))))
+                           (pr-str (rf.hicasso.roots-frames-support/census))))
                   (js/Promise.reject (js/Error. "adoption rejected on purpose"))))
-              (sup/settle-row!
+              (rf.hicasso.roots-frames-support/settle-row!
                 {:row      "the rejected-adoption control"
                  :done     (fn [] (swap! finishes inc))
                  :report!  (fn [e] (swap! reports conj e))
@@ -830,11 +830,11 @@
                              ((:close! capture))
                              (swap! stops inc)
                              ((:stop! watch))
-                             (mount/release! ha))})
+                             (rf.hicasso.impl.mount/release! ha))})
               ;; The cell reapers are armed at unmount and run past a bare
               ;; macrotask, so the tables are read at the runtime's own horizon
               ;; rather than one tick after the release.
-              (.then (fn [_] (sup/quiesced!)))
+              (.then (fn [_] (rf.hicasso.roots-frames-support/quiesced!)))
               (.then
                 (fn [_]
                   (testing "the rejection is REPORTED — which is the whole of
@@ -857,21 +857,21 @@
                             all the same, because a row that leans on the
                             fixture to stop its own watcher is measuring the
                             fixture)"
-                    (is (= sup/released (sup/census))
-                        (str "no root: residue was " (pr-str (sup/census))))
-                    (is (empty? (sup/cell-frames))
+                    (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/census))
+                        (str "no root: residue was " (pr-str (rf.hicasso.roots-frames-support/census))))
+                    (is (empty? (rf.hicasso.roots-frames-support/cell-frames))
                         (str "no frame: the cell table still mentions "
-                             (pr-str (sup/cell-frames))))
+                             (pr-str (rf.hicasso.roots-frames-support/cell-frames))))
                     (is (= 1 @stops)
                         (str "the mismatch watcher was stopped — `stop!` is what "
                              "unregisters the trace listener; it ran "
                              @stops " times"))
                     (is (identical? console-before (.-error js/console))
                         "`console.error` is the page's own again"))))
-              (sup/settle-row!
+              (rf.hicasso.roots-frames-support/settle-row!
                 {:row      "the rejected-adoption control's own settlement"
                  :done     done
                  :release! (fn []
                              ((:close! capture))
                              ((:stop! watch))
-                             (mount/release! ha))})))))))
+                             (rf.hicasso.impl.mount/release! ha))})))))))

--- a/implementation/hicasso/test/re_frame/hicasso/public_door_macros_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/public_door_macros_cljs_test.cljs
@@ -75,10 +75,10 @@
   when that lands, the sweep renames these witnesses with everything else."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
             ["react" :as react]
             ["react-dom/server" :as react-dom-server]))
 
@@ -89,7 +89,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest hfn-mints-an-ordinary-function-that-a-position-can-recognise
-  (let [picked (h/event [e] [:door/picked (.-value e)])]
+  (let [picked (rf.hicasso/event [e] [:door/picked (.-value e)])]
 
     (testing "the value is an ordinary function — no carrier object, nothing
               that can fail to be callable where Hicasso does not walk"
@@ -100,11 +100,11 @@
 
     (testing "the mark the expansion applies is on it, so a walked position
               can impose its contract"
-      (is (true? (intent/callback? picked))))
+      (is (true? (rf.hicasso.impl.intent/callback? picked))))
 
     (testing "and the witness discriminates rather than restating `fn?`: a
               plain `fn` written the same way is NOT the callback form"
-      (is (false? (intent/callback? (fn [e] [:door/picked (.-value e)])))))))
+      (is (false? (rf.hicasso.impl.intent/callback? (fn [e] [:door/picked (.-value e)])))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Witness B — `h/defhost`, the interop door
@@ -117,16 +117,16 @@
   [^js props]
   (react/createElement "b" #js {"className" "badge"} (.-label props)))
 
-(h/defhost badge badge-component {:server :render})
+(rf.hicasso/defhost badge badge-component {:server :render})
 
 (defn- html
   [hiccup]
-  (react-dom-server/renderToString (codec/root-element frame-id hiccup)))
+  (react-dom-server/renderToString (rf.hicasso.impl.codec/root-element frame-id hiccup)))
 
 (deftest defhost-mints-a-host-head-that-carries-the-option-it-was-declared-with
   (testing "the door hands back a minted host head, not the component the
             author named"
-    (is (true? (codec/host-head? badge)))
+    (is (true? (rf.hicasso.impl.codec/host-head? badge)))
     (is (not (identical? badge badge-component))))
 
   (testing "the `opts` argument reaches the declaration: the policy read back
@@ -134,7 +134,7 @@
             only reason the server render below produces anything at all —
             `:client-only`, the default a dropped argument would leave,
             renders no host region on the server"
-    (is (= :render (codec/host-server badge))))
+    (is (= :render (rf.hicasso.impl.codec/host-server badge))))
 
   (testing "and the minted var is a legal hiccup head inside an ordinary tree,
             with the crossing rendering the foreign component's own markup"
@@ -162,7 +162,7 @@
   [{:keys [id]}]
   [:li.ticket (str "ticket " id)])
 
-(h/defview ticket [props] (ticket-body props))
+(rf.hicasso/defview ticket [props] (ticket-body props))
 
 (defn- rendered
   "One boundary, server-rendered under a frame — React running the body
@@ -175,12 +175,12 @@
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
   (rf/make-frame {:id frame-id})
   (react-dom-server/renderToString
-    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+    (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup))))
 
 (deftest the-fn-defview-emits-binds-no-name-a-body-could-reach
   (testing "the door hands back a minted boundary, so what renders below is
             the expansion's own product"
-    (is (true? (codec/boundary-head? ticket))))
+    (is (true? (rf.hicasso.impl.codec/boundary-head? ticket))))
 
   (testing "a body that calls a helper named after its view resolves the
             AUTHOR's helper: React runs the body once and the markup is the
@@ -225,7 +225,7 @@
             DISCARDED, so the declaration is refused at the door rather than
             minting a head whose declared slots silently do not exist"
     (let [data (error-data
-                 #(h/defhost two-options-host badge-component
+                 #(rf.hicasso/defhost two-options-host badge-component
                     {:server :render}
                     {:slots #{:title}}))]
       (is (= :rf.error/hicasso-bad-host-declaration (:rf.error/id data))
@@ -241,9 +241,9 @@
             exact: the legal three-form shape — docstring, component, options
             — is one form longer than the refused two-form one and must still
             mint, keep its `opts`, and carry its docstring"
-    (is (true? (codec/host-head? badge))
+    (is (true? (rf.hicasso.impl.codec/host-head? badge))
         "the two-argument shape, declared at the top of this file")
-    (is (= :render (codec/host-server badge))
+    (is (= :render (rf.hicasso.impl.codec/host-server badge))
         "with its options intact")))
 
 (deftest defhost-refuses-options-that-are-not-a-map
@@ -252,7 +252,7 @@
             raised was not a declaration refusal. `h/reg-state` has had this
             guard since it was written; this is the same guard on the
             comparable surface"
-    (let [data (error-data #(codec/mint-host! "doc/in-the-wrong-place"
+    (let [data (error-data #(rf.hicasso.impl.codec/mint-host! "doc/in-the-wrong-place"
                                               badge-component
                                               "a docstring in the wrong place"))]
       (is (= :rf.error/hicasso-bad-host-declaration (:rf.error/id data))
@@ -263,18 +263,18 @@
 
   (testing "and every other non-map is refused the same way"
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "bad/vec" badge-component [:server :render]))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "bad/vec" badge-component [:server :render]))))
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "bad/kw" badge-component :render))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "bad/kw" badge-component :render))))
     (is (= :rf.error/hicasso-bad-host-declaration
-           (error-id #(codec/mint-host! "bad/set" badge-component #{:server})))))
+           (error-id #(rf.hicasso.impl.codec/mint-host! "bad/set" badge-component #{:server})))))
 
   (testing "THE NEAR MISS. `nil` is *no options*, which is exactly what the
             two-arity call means, so a guard that refused it would refuse the
             door's own commonest shape. All three legal spellings still mint"
-    (is (true? (codec/host-head? (codec/mint-host! "ok/nil" badge-component nil))))
-    (is (true? (codec/host-head? (codec/mint-host! "ok/empty" badge-component {}))))
-    (is (true? (codec/host-head? (codec/mint-host! "ok/arity2" badge-component))))
-    (is (= :render (codec/host-server (codec/mint-host! "ok/opts" badge-component
+    (is (true? (rf.hicasso.impl.codec/host-head? (rf.hicasso.impl.codec/mint-host! "ok/nil" badge-component nil))))
+    (is (true? (rf.hicasso.impl.codec/host-head? (rf.hicasso.impl.codec/mint-host! "ok/empty" badge-component {}))))
+    (is (true? (rf.hicasso.impl.codec/host-head? (rf.hicasso.impl.codec/mint-host! "ok/arity2" badge-component))))
+    (is (= :render (rf.hicasso.impl.codec/host-server (rf.hicasso.impl.codec/mint-host! "ok/opts" badge-component
                                                      {:server :render})))
         "and a real options map still reaches the declaration")))

--- a/implementation/hicasso/test/re_frame/hicasso/public_root_lifecycle_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/public_root_lifecycle_dom_cljs_test.cljs
@@ -42,14 +42,14 @@
   never touches the document, and the document is shared with every other
   browser suite."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-a ::frame-a)
 (def ^:private frame-b ::frame-b)
@@ -73,25 +73,25 @@
 (rf/reg-event ::relabel (fn [{:keys [db]} [_ label]] {:db (assoc db :label label)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; nil, not the default: a dynamic-var frame stamp left in ambient
      ;; scope would let a boundary that failed to resolve its own frame
      ;; answer that one instead, and an isolation miss would read as a
      ;; rendering difference rather than as the failure it is.
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The app — ONE view, mounted twice
 ;; ---------------------------------------------------------------------------
 
-(h/defview panel
+(rf.hicasso/defview panel
   "The whole app: one read, and a tag the caller supplies so a re-render
   with different props is legible in the markup."
   [{:keys [tag]}]
   [:div.panel {:data-tag tag}
-   [:span.label (h/sub label-q)]])
+   [:span.label (rf.hicasso/sub label-q)]])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -115,8 +115,8 @@
   (rf/make-frame {:id frame-b})
   (rf/with-frame frame-a (rf/dispatch-sync [::seed "alpha"]))
   (rf/with-frame frame-b (rf/dispatch-sync [::seed "beta"]))
-  (collector/reset-runtime!)
-  (runtime/reset-body-runs!)
+  (rf.hicasso.impl.collector/reset-runtime!)
+  (rf.hicasso.test.runtime/reset-body-runs!)
   nil)
 
 (defn- bare!
@@ -129,15 +129,15 @@
   make an ENSURE claim vacuous."
   []
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-  (collector/reset-runtime!)
-  (runtime/reset-body-runs!)
+  (rf.hicasso.impl.collector/reset-runtime!)
+  (rf.hicasso.test.runtime/reset-body-runs!)
   nil)
 
-(defn- live-frame? [frame-kw] (some? (frame/frame-incarnation-token frame-kw)))
+(defn- live-frame? [frame-kw] (some? (rf.frame/frame-incarnation-token frame-kw)))
 
-(defn- cell-keys [] (set (keys @collector/!cells)))
+(defn- cell-keys [] (set (keys @rf.hicasso.impl.collector/!cells)))
 
-(defn- readers-of [sub-key] (count (runtime/cell-readers sub-key)))
+(defn- readers-of [sub-key] (count (rf.hicasso.test.runtime/cell-readers sub-key)))
 
 (defn- node-at [handle sel] (.querySelector (:container handle) sel))
 
@@ -169,11 +169,11 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest tearing-one-root-down-leaves-the-other-root-live
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (let [_ (fresh!)
-          a (h/mount! (mount/fresh-container!) {:frame frame-a} [panel {:tag "a"}])
-          b (h/mount! (mount/fresh-container!) {:frame frame-b} [panel {:tag "b"}])]
+          a (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!) {:frame frame-a} [panel {:tag "a"}])
+          b (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!) {:frame frame-b} [panel {:tag "b"}])]
       (try
         (testing "premise: two roots, two frames, one cell each, both painted"
           (is (= #{[frame-a label-q] [frame-b label-q]} (cell-keys))
@@ -184,7 +184,7 @@
 
         ;; The act under test, and the ONLY thing that happens between the
         ;; premise above and the readings below.
-        (h/unmount! a)
+        (rf.hicasso/unmount! a)
 
         (testing "root B's runtime survives root A's teardown — its cell is
                   still in the table, and still read by its boundary"
@@ -199,7 +199,7 @@
                   the reading the DOM alone cannot give — the markup React
                   last committed stays on the page whether or not anything
                   is still wired to it"
-          (mount/dispatch! b [::relabel "beta-again"])
+          (rf.hicasso.impl.mount/dispatch! b [::relabel "beta-again"])
           (is (= "beta-again" (text-at b ".label"))
               "root B stopped repainting when root A was torn down"))
 
@@ -221,23 +221,23 @@
               "root A's boundary is still reading a cell after its teardown"))
 
         (finally
-          (h/unmount! b)
+          (rf.hicasso/unmount! b)
           (detach! a)
           (detach! b)
           (is (= [false false] [(connected? a) (connected? b)])
               "this witness left one of its own containers in the shared
                browser-test document")
-          (collector/reset-runtime!))))))
+          (rf.hicasso.impl.collector/reset-runtime!))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W2 — the door can re-render a mounted root
 ;; ---------------------------------------------------------------------------
 
 (deftest a-mounted-root-can-be-re-rendered-through-the-public-door
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (let [_ (fresh!)
-          a (h/mount! (mount/fresh-container!) {:frame frame-a} [panel {:tag "first"}])
+          a (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!) {:frame frame-a} [panel {:tag "first"}])
           node (node-at a ".panel")]
       (try
         (testing "premise: the root is mounted and painted"
@@ -247,10 +247,10 @@
 
         (testing "the door re-renders the EXISTING root — the new tree is on
                   the page and the boundary body ran again"
-          (runtime/reset-body-runs!)
-          (h/render! a [panel {:tag "second"}])
+          (rf.hicasso.test.runtime/reset-body-runs!)
+          (rf.hicasso/render! a [panel {:tag "second"}])
           (is (= "second" (attr-at a ".panel" "data-tag")))
-          (is (pos? (runtime/body-runs))
+          (is (pos? (rf.hicasso.test.runtime/body-runs))
               "the re-render did not run the boundary body"))
 
         (testing "and it is a RE-RENDER, not a remount: the very DOM node
@@ -263,16 +263,16 @@
 
         (testing "the root is still wired after the re-render — a dispatch
                   still reaches its paint"
-          (mount/dispatch! a [::relabel "alpha-again"])
+          (rf.hicasso.impl.mount/dispatch! a [::relabel "alpha-again"])
           (is (= "alpha-again" (text-at a ".label"))))
 
         (finally
-          (h/unmount! a)
+          (rf.hicasso/unmount! a)
           (detach! a)
           (is (false? (connected? a))
               "this witness left its own container in the shared
                browser-test document")
-          (collector/reset-runtime!))))))
+          (rf.hicasso.impl.collector/reset-runtime!))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W3 — THE EXECUTING SABOTAGE CONTROL for kernel risk row 2
@@ -296,7 +296,7 @@
   supposed to be able to do; total teardown is the one thing the public
   door must NOT be able to do, which is the whole of the narrowing."
   [handle]
-  (mount/release! handle))
+  (rf.hicasso.impl.mount/release! handle))
 
 ;; Kernel risk row 2 of `docs/design/hicasso/product/lanes/adversarial-risks.md`
 ;; — *independent roots and SSR requests cannot reset, adopt, dirty, or release
@@ -327,39 +327,39 @@
 ;; stopped moving. The armed half asserts all three — dead tables, a frozen
 ;; label, and a page that still looks perfectly well.
 (deftest a-page-wide-teardown-door-strands-the-sibling-root
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       ;; DISARMED — the shipped root-scoped door.
       (let [_ (fresh!)
-            a (h/mount! (mount/fresh-container!) {:frame frame-a} [panel {:tag "a"}])
-            b (h/mount! (mount/fresh-container!) {:frame frame-b} [panel {:tag "b"}])]
+            a (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!) {:frame frame-a} [panel {:tag "a"}])
+            b (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!) {:frame frame-b} [panel {:tag "b"}])]
         (try
           (is (= #{[frame-a label-q] [frame-b label-q]} (cell-keys))
               (str "premise: two roots, two frames, one cell each; got "
                    (pr-str (cell-keys))))
-          (h/unmount! a)
+          (rf.hicasso/unmount! a)
           (testing "DISARMED — root B keeps its cell, keeps its reader, and stays
                     LIVE across its sibling's teardown"
             (is (contains? (cell-keys) [frame-b label-q])
                 (str "got " (pr-str (cell-keys))))
             (is (= 1 (readers-of [frame-b label-q])))
-            (mount/dispatch! b [::relabel "beta-again"])
+            (rf.hicasso.impl.mount/dispatch! b [::relabel "beta-again"])
             (is (= "beta-again" (text-at b ".label"))
                 "root B stopped repainting when root A was torn down"))
           (finally
-            (h/unmount! b)
+            (rf.hicasso/unmount! b)
             (detach! a)
             (detach! b)
             (is (= [false false] [(connected? a) (connected? b)])
                 "this witness left one of its own containers in the shared
                  browser-test document")
-            (collector/reset-runtime!))))
+            (rf.hicasso.impl.collector/reset-runtime!))))
 
       ;; ARMED — the same construction, torn down through the page-wide door.
       (let [_ (fresh!)
-            a (h/mount! (mount/fresh-container!) {:frame frame-a} [panel {:tag "a"}])
-            b (h/mount! (mount/fresh-container!) {:frame frame-b} [panel {:tag "b"}])]
+            a (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!) {:frame frame-a} [panel {:tag "a"}])
+            b (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!) {:frame frame-b} [panel {:tag "b"}])]
         (try
           (is (= #{[frame-a label-q] [frame-b label-q]} (cell-keys))
               (str "premise: the same two roots as the disarmed half; got "
@@ -380,7 +380,7 @@
                     The only symptom is a screen that has stopped moving, which
                     is exactly why W1 reads the tables and the dispatch rather
                     than the DOM"
-            (mount/dispatch! b [::relabel "beta-again"])
+            (rf.hicasso.impl.mount/dispatch! b [::relabel "beta-again"])
             (is (= "beta" (text-at b ".label"))
                 (str "the page-wide door left root B repainting, so the dispatch
                       reading in W1 is not a discrimination either; got "
@@ -388,13 +388,13 @@
             (is (true? (connected? b))
                 "and the page still looks perfectly well"))
           (finally
-            (h/unmount! b)
+            (rf.hicasso/unmount! b)
             (detach! a)
             (detach! b)
             (is (= [false false] [(connected? a) (connected? b)])
                 "this witness left one of its own containers in the shared
                  browser-test document")
-            (collector/reset-runtime!)))))))
+            (rf.hicasso.impl.collector/reset-runtime!)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W4 — the door ENSURES its frame and seeds it BEFORE first paint
@@ -419,13 +419,13 @@
 ;; `:initial-events` nothing would seed it if it did.
 
 (deftest mounting-ensures-its-frame-and-seeds-it-before-the-first-paint
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (let [_ (bare!)
           _ (is (false? (live-frame? frame-ensured))
                 "premise: the frame this mount names must not exist yet, or the
                  ENSURE claim below is green against somebody else's frame")
-          a (h/mount! (mount/fresh-container!)
+          a (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!)
                       {:frame          frame-ensured
                        ;; TWO steps, because order is part of the contract:
                        ;; `::seed` installs a whole db and `::relabel` edits it,
@@ -453,16 +453,16 @@
 
         (testing "the root is ordinarily wired afterwards — the ensured frame is
                   a real frame, not a one-shot seeding trick"
-          (mount/dispatch! a [::relabel "third"])
+          (rf.hicasso.impl.mount/dispatch! a [::relabel "third"])
           (is (= "third" (text-at a ".label"))))
 
         (finally
-          (h/unmount! a)
+          (rf.hicasso/unmount! a)
           (detach! a)
           (is (false? (connected? a))
               "this witness left its own container in the shared
                browser-test document")
-          (collector/reset-runtime!))))))
+          (rf.hicasso.impl.collector/reset-runtime!))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W5 — a JOINING root does not replay `:initial-events`
@@ -481,17 +481,17 @@
 ;; carries a seed of its own precisely so that replaying would be visible.
 
 (deftest a-second-root-joining-one-frame-does-not-replay-initial-events
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (let [_ (bare!)
-          a (h/mount! (mount/fresh-container!)
+          a (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!)
                       {:frame          frame-ensured
                        :initial-events [[::seed "creator"]]}
                       [panel {:tag "a"}])
           ;; The joining root names its own `:initial-events`, and they must be
           ;; IGNORED. A door that replayed would leave "joiner" on both screens
           ;; and this row would be the only thing on the page to notice.
-          b (h/mount! (mount/fresh-container!)
+          b (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!)
                       {:frame          frame-ensured
                        :initial-events [[::seed "joiner"]]}
                       [panel {:tag "b"}])]
@@ -507,7 +507,7 @@
 
         (testing "and it really is ONE frame, not two that happen to agree: a
                   single dispatch moves both roots' paint"
-          (mount/dispatch! a [::relabel "shared"])
+          (rf.hicasso.impl.mount/dispatch! a [::relabel "shared"])
           (is (= ["shared" "shared"] [(text-at a ".label") (text-at b ".label")])
               "the two roots did not join one frame"))
 
@@ -518,11 +518,11 @@
               "both roots' boundaries must be reading the one cell"))
 
         (finally
-          (h/unmount! a)
-          (h/unmount! b)
+          (rf.hicasso/unmount! a)
+          (rf.hicasso/unmount! b)
           (detach! a)
           (detach! b)
           (is (= [false false] [(connected? a) (connected? b)])
               "this witness left one of its own containers in the shared
                browser-test document")
-          (collector/reset-runtime!))))))
+          (rf.hicasso.impl.collector/reset-runtime!))))))

--- a/implementation/hicasso/test/re_frame/hicasso/raw_escape_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/raw_escape_dom_cljs_test.cljs
@@ -50,15 +50,15 @@
   React DOM. The `renderToString` rows need no DOM and run under
   `:node-test` too."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.checkpoint-support :as support]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.test :as htest]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/client" :as react-dom-client]
             ["react-dom/server" :as react-dom-server]))
@@ -74,18 +74,18 @@
                 {:db (update db :picked (fnil conj []) what)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; the hydration row waits on a real clock, and `cljs.test`
      ;; hard-errors on a fn-form fixture in a suite with an async test.
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- skip! [why] (is true (str "a [:>] DOM claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:hicasso.raw/seed]))
   frame-id)
@@ -127,7 +127,7 @@
     (react/createElement "span" #js {:className "widget-label"} (.-label props))
     (.-children props)))
 
-(h/defhost declared-widget
+(rf.hicasso/defhost declared-widget
   "The DOOR, on the same component and under the same default policy —
   the control that makes every parity row below a fact about the
   crossing rather than about the page."
@@ -137,37 +137,37 @@
 ;; The pages
 ;; ---------------------------------------------------------------------------
 
-(h/defview escape-page
+(rf.hicasso/defview escape-page
   "A native sibling beside the crossing, so \"the escape rendered
   nothing\" stays distinguishable from \"nothing rendered at all\"."
   [_]
   [:div.page
-   [:h1.title (collector/sub [:hicasso.raw/title])]
-   [:> widget {:label (collector/sub [:hicasso.raw/title]) :variant "compact"}
+   [:h1.title (rf.hicasso.impl.collector/sub [:hicasso.raw/title])]
+   [:> widget {:label (rf.hicasso.impl.collector/sub [:hicasso.raw/title]) :variant "compact"}
     [:span.kid "slotted"]]])
 
-(h/defview door-page
+(rf.hicasso/defview door-page
   "[[escape-page]] through `defhost`, byte for byte the same authored
   shape."
   [_]
   [:div.page
-   [:h1.title (collector/sub [:hicasso.raw/title])]
-   [declared-widget {:label (collector/sub [:hicasso.raw/title]) :variant "compact"}
+   [:h1.title (rf.hicasso.impl.collector/sub [:hicasso.raw/title])]
+   [declared-widget {:label (rf.hicasso.impl.collector/sub [:hicasso.raw/title]) :variant "compact"}
     [:span.kid "slotted"]]])
 
-(h/defview childless-escape-page
+(rf.hicasso/defview childless-escape-page
   "A crossing with no children at all — the branch the gate takes when
   `props.children` is absent."
   [_]
   [:div.page [:> widget {:label "bare" :variant "solo"}]])
 
-(h/defview childless-door-page
+(rf.hicasso/defview childless-door-page
   "Its control at the door, so the parity claim is measured rather than
   assumed."
   [_]
   [:div.page [declared-widget {:label "bare" :variant "solo"}]])
 
-(h/defview intent-child-page
+(rf.hicasso/defview intent-child-page
   "A crossing whose CHILD carries an intent. The child's handler is
   lowered here, in this body's render window, and invoked much later —
   after every render extent has unwound — from the click."
@@ -185,7 +185,7 @@
   renderer."
   [hiccup]
   (react-dom-server/renderToString
-    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+    (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup))))
 
 (defn- query-node [root selector] (.querySelector root selector))
 
@@ -241,14 +241,14 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-fresh-mount-renders-the-component-on-its-first-pass
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (testing "a `createRoot` mount never consults a server snapshot, so
                 the gate costs no placeholder pass — asserted on the line
                 after `root!` returns, which is inside its flushSync"
-        (let [h (mount/root! (mount/fresh-container!) frame-id [escape-page {}])]
+        (let [h (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [escape-page {}])]
           (try
             (is (some? (query-node (:container h) ".widget"))
                 "the component mounted immediately")
@@ -261,10 +261,10 @@
             (is (some? (query-node (:container h) ".widget .kid"))
                 "and the children, in the component's own slot — forwarded
                  by the gate as createElement's third argument")
-            (finally (mount/release! h))))))))
+            (finally (rf.hicasso.impl.mount/release! h))))))))
 
 (deftest a-childless-crossing-hands-the-component-the-doors-own-props-object
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
@@ -273,12 +273,12 @@
                 write `children: undefined` onto a childless crossing —
                 a key the door never gives the component. Read off what
                 the component was actually handed, at both crossings"
-        (let [a (mount/root! (mount/fresh-container!) frame-id [childless-escape-page {}])
-              via-escape (do (mount/settle!) @!own-props)]
-          (mount/release! a)
-          (let [b (mount/root! (mount/fresh-container!) frame-id [childless-door-page {}])
-                via-door (do (mount/settle!) @!own-props)]
-            (mount/release! b)
+        (let [a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [childless-escape-page {}])
+              via-escape (do (rf.hicasso.impl.mount/settle!) @!own-props)]
+          (rf.hicasso.impl.mount/release! a)
+          (let [b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [childless-door-page {}])
+                via-door (do (rf.hicasso.impl.mount/settle!) @!own-props)]
+            (rf.hicasso.impl.mount/release! b)
             (is (= #{"label" "variant"} via-escape)
                 (str "no `children` key at the escape: " (pr-str via-escape)))
             (is (= via-door via-escape)
@@ -286,7 +286,7 @@
                      (pr-str via-escape) " / door: " (pr-str via-door)))))))))
 
 (deftest the-escape-and-the-door-produce-the-same-dom
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
@@ -298,23 +298,23 @@
                 its own, and `htest/canonical-dom` serialises element and text
                 nodes and ignores comments, so a nil-rendering gate is
                 invisible to it"
-        (let [a (mount/root! (mount/fresh-container!) frame-id [escape-page {}])
-              b (mount/root! (mount/fresh-container!) frame-id [door-page {}])]
+        (let [a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [escape-page {}])
+              b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [door-page {}])]
           (try
-            (let [via-escape (htest/canonical-dom (:container a))
-                  via-door   (htest/canonical-dom (:container b))]
+            (let [via-escape (rf.hicasso.test/canonical-dom (:container a))
+                  via-door   (rf.hicasso.test/canonical-dom (:container b))]
               (is (re-find #"class=\"widget\"" via-escape)
                   (str "precondition — the fixture renders something to
                         compare, so the row cannot pass on two empty
                         strings: " via-escape))
               (is (= via-door via-escape)
                   (str "BYTE-EQUAL. escape: " via-escape " / door: " via-door)))
-            (finally (mount/release! a) (mount/release! b)))))
+            (finally (rf.hicasso.impl.mount/release! a) (rf.hicasso.impl.mount/release! b)))))
       (testing "and the crossing's own fiber is named by the CONSTANT, not
                 by the component — one greppable frame naming the form the
                 author wrote, with the component naming itself one level
                 down at zero cost"
-        (let [e (codec/as-element [:> widget {}])]
+        (let [e (rf.hicasso.impl.codec/as-element [:> widget {}])]
           (is (= "[:>]" (.-displayName (.-type e)))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -323,19 +323,19 @@
 
 (deftest the-escape-hydrates-with-nothing-there-and-mounts-after-adoption
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
         (reset! !renders 0)
         (let [hiccup    [escape-page {}]
               html      (server-html hiccup)
-              container (mount/fresh-container!)
+              container (rf.hicasso.impl.mount/fresh-container!)
               {:keys [seen restore]} (watch-errors!)]
           (set! (.-innerHTML container) html)
           (let [root (react-dom-client/hydrateRoot
                        container
-                       (mount/provider frame-id (codec/root-element frame-id hiccup))
+                       (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup))
                        #js {:onRecoverableError
                             (fn [err _info]
                               (swap! seen conj (str "onRecoverableError: " (ex-message err))))})]
@@ -365,7 +365,7 @@
                     (restore)
                     (.unmount root)
                     (when-some [p (.-parentNode container)] (.removeChild p container))
-                    (collector/reset-runtime!)
+                    (rf.hicasso.impl.collector/reset-runtime!)
                     (done))))
               150)))))))
 
@@ -374,7 +374,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-child-intent-fires-into-the-frame-that-wrote-the-crossing
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (testing "children lower EAGERLY at the crossing, inside the render
@@ -388,17 +388,17 @@
           (fresh!)
           (rf/make-frame {:id other})
           (rf/with-frame other (rf/dispatch-sync [:hicasso.raw/seed]))
-          (let [h (mount/root! (mount/fresh-container!) frame-id [intent-child-page {}])]
+          (let [h (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [intent-child-page {}])]
             (try
-              (mount/settle!)
+              (rf.hicasso.impl.mount/settle!)
               (is (some? (query-node (:container h) ".widget .pick"))
                   "precondition: the child is mounted BENEATH the foreign
                    component, so its handler really did cross")
               (.click (query-node (:container h) ".pick"))
-              (mount/settle!)
+              (rf.hicasso.impl.mount/settle!)
               (is (= ["child"] (:picked (db)))
                   "the click dispatched into the frame that wrote the crossing")
               (is (nil? (:picked (rf/app-db-value other)))
                   "and nothing reached the other frame, which is what makes
                    the ownership assertion non-vacuous")
-              (finally (mount/release! h)))))))))
+              (finally (rf.hicasso.impl.mount/release! h)))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/read_extent_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/read_extent_cljs_test.cljs
@@ -92,12 +92,12 @@
   element the render emitted; what a browser would add there is the DOM's
   own dispatch, not the law."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::read-extent)
 
@@ -121,7 +121,7 @@
 ;; is what lets the namespace finish loading; the refusal itself is real.
 
 (defonce ^:private module-load-read
-  (try {:returned (h/sub [:re/left])}
+  (try {:returned (rf.hicasso/sub [:re/left])}
        (catch :default e {:refused (ex-data e) :message (ex-message e)})))
 
 ;; The UIx adapter rather than plain-atom, for the reason the package smoke
@@ -131,11 +131,11 @@
 ;; which the `(async done …)` rows require; `:ambient-frame nil` because
 ;; this suite seats its own.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -165,15 +165,15 @@
   [[re-frame.hicasso.impl.collector/shell]] makes between its two hooks —
   and return the read-set entry the render resolved. Commits nothing."
   [body-fn]
-  (collector/render-body frame-id body-fn {})
-  (collector/last-reads))
+  (rf.hicasso.impl.collector/render-body frame-id body-fn {})
+  (rf.hicasso.impl.collector/last-reads))
 
 (defn- element-of
   "The React element a body emitted, which is where the codec left every
   lowered callback. Reading a wrapper off here is how a Node witness gets
   hold of *the function React would call* rather than a stand-in for it."
   [body-fn]
-  (collector/render-body frame-id body-fn {}))
+  (rf.hicasso.impl.collector/render-body frame-id body-fn {}))
 
 (defn- outcome
   "**The suite's one discriminator.** Run `thunk` and report which of the
@@ -228,10 +228,10 @@
   any way — which is the point: the extent is the body's dynamic extent
   and a helper called from it is inside that extent."
   []
-  (h/sub [:re/right]))
+  (rf.hicasso/sub [:re/right]))
 
 (defn- helper-reads-through-another-helper []
-  (+ (helper-reads-right) (h/sub [:re/left])))
+  (+ (helper-reads-right) (rf.hicasso/sub [:re/left])))
 
 (deftest a-nested-helper-donates-its-reads-to-the-enclosing-boundary
   (seeded!)
@@ -240,13 +240,13 @@
     (testing "two helper frames deep, and both keys are the BOUNDARY's —
               there is no helper-level read set for them to belong to"
       (is (= #{(sub-key [:re/left]) (sub-key [:re/right])}
-             (runtime/reads-of entry))))
+             (rf.hicasso.test.runtime/reads-of entry))))
 
-    (let [cleanup (collector/commit-boundary! entry (fn []))]
+    (let [cleanup (rf.hicasso.impl.collector/commit-boundary! entry (fn []))]
       (testing "and the commit acquires both on the boundary's behalf: one
                 registration in each key's reader list, the same one"
-        (let [[a] (runtime/cell-readers (sub-key [:re/left]))
-              [b] (runtime/cell-readers (sub-key [:re/right]))]
+        (let [[a] (rf.hicasso.test.runtime/cell-readers (sub-key [:re/left]))
+              [b] (rf.hicasso.test.runtime/cell-readers (sub-key [:re/right]))]
           (is (some? a))
           (is (identical? a b))))
       (cleanup))))
@@ -257,15 +257,15 @@
   ;; The row here is the other direction and the one the matrix needs: BOTH arms
   ;; are legal, and which keys are recorded is a function of the control
   ;; flow the render actually took rather than of the text of the body.
-  (let [body (fn [_] [:p (if (h/sub [:re/flag])
-                           (h/sub [:re/right])
-                           (h/sub [:re/left]))])
+  (let [body (fn [_] [:p (if (rf.hicasso/sub [:re/flag])
+                           (rf.hicasso/sub [:re/right])
+                           (rf.hicasso/sub [:re/left]))])
         low  (probe! body)]
 
     (testing "flag false: the else arm ran, so the else arm's key is the
               one recorded and the then arm's is absent"
       (is (= #{(sub-key [:re/flag]) (sub-key [:re/left])}
-             (runtime/reads-of low))))
+             (rf.hicasso.test.runtime/reads-of low))))
 
     (rf/with-frame frame-id (rf/dispatch-sync [:re/raise]))
 
@@ -275,8 +275,8 @@
                 which is what a two-key assertion can see and a one-key
                 assertion cannot"
         (is (= #{(sub-key [:re/flag]) (sub-key [:re/right])}
-               (runtime/reads-of high)))
-        (is (not (contains? (runtime/reads-of high) (sub-key [:re/left]))))))))
+               (rf.hicasso.test.runtime/reads-of high)))
+        (is (not (contains? (rf.hicasso.test.runtime/reads-of high) (sub-key [:re/left]))))))))
 
 (deftest a-variable-length-loop-records-every-row-it-ran
   (seeded!)
@@ -285,25 +285,25 @@
   ;; return: a window that closed at the return would register no edge for
   ;; any row here, and would look perfectly correct on the first render.
   (let [body-of (fn [n] (fn [_] [:ul (for [i (range n)]
-                                       [:li {:key i} (h/sub [:re/row i])])]))
+                                       [:li {:key i} (rf.hicasso/sub [:re/row i])])]))
         two     (probe! (body-of 2))]
 
     (testing "every row of a two-row loop is in the set — the seq was forced
               inside the window by the same pass that made the elements"
       (is (= #{(sub-key [:re/row 0]) (sub-key [:re/row 1])}
-             (runtime/reads-of two))))
+             (rf.hicasso.test.runtime/reads-of two))))
 
     (let [four (probe! (body-of 4))]
       (testing "and the length is a render-time fact: four rows, four keys,
                 no ledger of what the previous render read"
         (is (= #{(sub-key [:re/row 0]) (sub-key [:re/row 1])
                  (sub-key [:re/row 2]) (sub-key [:re/row 3])}
-               (runtime/reads-of four)))))
+               (rf.hicasso.test.runtime/reads-of four)))))
 
     (let [one (probe! (body-of 1))]
       (testing "shrinking is symmetric: the read set is what THIS render
                 read, so three keys left it without anything being diffed"
-        (is (= #{(sub-key [:re/row 0])} (runtime/reads-of one)))))))
+        (is (= #{(sub-key [:re/row 0])} (rf.hicasso.test.runtime/reads-of one)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The reconciliation clause — appearing and disappearing reads land at the
@@ -319,54 +319,54 @@
     ;; the replacement IS the cleanup plus the new subscribe. What has to be
     ;; true is the OUTCOME: the key that stayed keeps exactly one reader, the
     ;; key that went keeps none, the key that arrived gains one.
-    (let [first-entry (probe! (fn [_] [:p (h/sub [:re/left]) (h/sub [:re/right])]))
-          release-1   (collector/commit-boundary! first-entry (fn []))]
+    (let [first-entry (probe! (fn [_] [:p (rf.hicasso/sub [:re/left]) (rf.hicasso/sub [:re/right])]))
+          release-1   (rf.hicasso.impl.collector/commit-boundary! first-entry (fn []))]
 
       (testing "the first commit owns exactly the first read set"
         (is (= #{(sub-key [:re/left]) (sub-key [:re/right])}
-               (runtime/reads-of first-entry)))
-        (is (= 1 (count (runtime/cell-readers (sub-key [:re/left])))))
-        (is (= 1 (count (runtime/cell-readers (sub-key [:re/right])))))
-        (is (= [] (runtime/cell-readers (sub-key [:re/flag])))))
+               (rf.hicasso.test.runtime/reads-of first-entry)))
+        (is (= 1 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:re/left])))))
+        (is (= 1 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:re/right])))))
+        (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:re/flag])))))
 
       ;; The re-render: `:re/right` disappears, `:re/flag` appears,
       ;; `:re/left` stays.
-      (let [second-entry (probe! (fn [_] [:p (h/sub [:re/left]) (h/sub [:re/flag])]))]
+      (let [second-entry (probe! (fn [_] [:p (rf.hicasso/sub [:re/left]) (rf.hicasso/sub [:re/flag])]))]
 
         (testing "the render alone changes no membership — render probes"
-          (is (= 1 (count (runtime/cell-readers (sub-key [:re/right])))))
-          (is (= [] (runtime/cell-readers (sub-key [:re/flag])))))
+          (is (= 1 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:re/right])))))
+          (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:re/flag])))))
 
-        (let [release-2 (collector/commit-boundary! second-entry (fn []))]
+        (let [release-2 (rf.hicasso.impl.collector/commit-boundary! second-entry (fn []))]
           ;; React's order at a changed subscription: subscribe the new,
           ;; then release the old. Doing it the other way round is the
           ;; variant `hmr_remount` pinned, and the outcome is the same.
           (release-1)
 
           (testing "the arrived key gained a reader"
-            (is (= 1 (count (runtime/cell-readers (sub-key [:re/flag]))))))
+            (is (= 1 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:re/flag]))))))
 
           (testing "the departed key lost its only one"
-            (is (= [] (runtime/cell-readers (sub-key [:re/right])))))
+            (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:re/right])))))
 
           (testing "and the key that stayed has exactly ONE reader, not two
                     — a runtime that acquired for the successor without
                     releasing the predecessor also paints correctly, and
                     this is the number that tells them apart"
-            (is (= 1 (count (runtime/cell-readers (sub-key [:re/left]))))))
+            (is (= 1 (count (rf.hicasso.test.runtime/cell-readers (sub-key [:re/left]))))))
 
           (testing "the surviving reader is the SUCCESSOR by identity, which
                     a count alone cannot say"
-            (let [[reader] (runtime/cell-readers (sub-key [:re/left]))]
+            (let [[reader] (rf.hicasso.test.runtime/cell-readers (sub-key [:re/left]))]
               (is (= #{(sub-key [:re/left]) (sub-key [:re/flag])}
-                     (runtime/boundary-reads reader)))))
+                     (rf.hicasso.test.runtime/boundary-reads reader)))))
 
           (release-2)
-          (.then (runtime/quiesced!)
+          (.then (rf.hicasso.test.runtime/quiesced!)
                  (fn [_]
                    (testing "and the pair leaves nothing behind"
                      (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                            (runtime/residue))))
+                            (rf.hicasso.test.runtime/residue))))
                    (done))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -381,9 +381,9 @@
   ;; and call it with a real event; the extent law does not depend on which.
   (let [!ran     (atom 0)
         element  (element-of
-                   (fn [_] [:button {:on-click (h/event [_]
+                   (fn [_] [:button {:on-click (rf.hicasso/event [_]
                                                  (swap! !ran inc)
-                                                 (h/sub [:re/right]))}
+                                                 (rf.hicasso/sub [:re/right]))}
                             "go"]))
         on-click (.. element -props -onClick)
         o        (outcome (fn [] (on-click #js {})))]
@@ -403,7 +403,7 @@
     ;; ambient dispatch is captured at lowering time on purpose.
     (let [before   (rf/with-frame frame-id @(rf/subscribe [:re/left]))
           element2 (element-of
-                     (fn [_] [:button {:on-click (h/event [_] [:re/bump])} "go"]))]
+                     (fn [_] [:button {:on-click (rf.hicasso/event [_] [:re/bump])} "go"]))]
       ((.. element2 -props -onClick) #js {})
       (testing "a callback may DISPATCH after the render — the extent law
                 fences reads, and the machinery is demonstrably alive at the
@@ -424,9 +424,9 @@
   ;; not guess which render owns the read.
   (let [!ran    (atom 0)
         element (element-of
-                  (fn [_] [:div {:render-row (h/event [_]
+                  (fn [_] [:div {:render-row (rf.hicasso/event [_]
                                                (swap! !ran inc)
-                                               (h/sub [:re/right]))}]))
+                                               (rf.hicasso/sub [:re/right]))}]))
         render-row (.. element -props -renderRow)
         o          (outcome (fn [] (render-row 7)))]
 
@@ -443,7 +443,7 @@
     (seeded!)
     (let [!ran (atom 0)
           !out (atom nil)]
-      (collector/render-body
+      (rf.hicasso.impl.collector/render-body
         frame-id
         (fn [_]
           ;; Scheduled from inside the body. The microtask runs after the
@@ -451,8 +451,8 @@
           (-> (js/Promise.resolve)
               (.then (fn []
                        (swap! !ran inc)
-                       (reset! !out (outcome (fn [] (h/sub [:re/right])))))))
-          [:p (h/sub [:re/left])])
+                       (reset! !out (outcome (fn [] (rf.hicasso/sub [:re/right])))))))
+          [:p (rf.hicasso/sub [:re/left])])
         {})
 
       (-> (js/Promise.resolve)
@@ -468,20 +468,20 @@
                    (testing "the body's OWN read is unaffected — the refusal
                              is the crossing's, not the query's"
                      (is (= #{(sub-key [:re/left])}
-                            (runtime/reads-of (collector/last-reads)))))
+                            (rf.hicasso.test.runtime/reads-of (rf.hicasso.impl.collector/last-reads)))))
                    (done)))))))
 
 (deftest a-timer-callback-refuses
   (async done
     (seeded!)
     (let [!ran (atom 0)]
-      (collector/render-body
+      (rf.hicasso.impl.collector/render-body
         frame-id
         (fn [_]
           (js/setTimeout
             (fn []
               (swap! !ran inc)
-              (let [o (outcome (fn [] (h/sub [:re/right])))]
+              (let [o (outcome (fn [] (rf.hicasso/sub [:re/right])))]
                 (testing "the premise: the timer fired"
                   (is (= 1 @!ran)))
                 (testing "and its read refused, with the stable shape"
@@ -501,13 +501,13 @@
                 (testing "and nothing was recorded: the next body's read set
                           is its own, with no trace of the refused key and
                           none of the render that deferred it"
-                  (let [entry (probe! (fn [_] [:p (h/sub [:re/flag])
-                                               (h/sub [:re/row 0])]))]
+                  (let [entry (probe! (fn [_] [:p (rf.hicasso/sub [:re/flag])
+                                               (rf.hicasso/sub [:re/row 0])]))]
                     (is (= #{(sub-key [:re/flag]) (sub-key [:re/row 0])}
-                           (runtime/reads-of entry)))))
+                           (rf.hicasso.test.runtime/reads-of entry)))))
                 (done)))
             0)
-          [:p (h/sub [:re/left])])
+          [:p (rf.hicasso/sub [:re/left])])
         {}))))
 
 (deftest an-escaped-lazy-sequence-refuses-where-an-in-window-one-is-legal
@@ -524,14 +524,14 @@
   (let [!escaped (atom nil)
         entry    (probe! (fn [_]
                            (reset! !escaped
-                                   (map (fn [i] (h/sub [:re/row i])) (range 3)))
+                                   (map (fn [i] (rf.hicasso/sub [:re/row i])) (range 3)))
                            ;; the LEGAL half, in the same body
                            [:ul (for [i (range 2)]
-                                  [:li {:key i} (h/sub [:re/row i])])]))]
+                                  [:li {:key i} (rf.hicasso/sub [:re/row i])])]))]
 
     (testing "the in-window loop's rows are edges of this boundary"
       (is (= #{(sub-key [:re/row 0]) (sub-key [:re/row 1])}
-             (runtime/reads-of entry))))
+             (rf.hicasso.test.runtime/reads-of entry))))
 
     (testing "the escaped seq really is unrealised — otherwise the row below
               would be measuring a value the body already computed"
@@ -559,7 +559,7 @@
 ;; The SECOND discriminator — the crossing walk, and the residue it declares
 ;; ---------------------------------------------------------------------------
 
-(h/defview crossing-child
+(rf.hicasso/defview crossing-child
   [{:keys [v]}]
   [:p (str v)])
 
@@ -573,9 +573,9 @@
   ;; rather than forcing it, because forcing an author's explicit deferral
   ;; would change what their program means.
   (let [o (outcome (fn []
-                     (collector/render-body
+                     (rf.hicasso.impl.collector/render-body
                        frame-id
-                       (fn [_] [:div [crossing-child {:v (delay (h/sub [:re/right]))}]])
+                       (fn [_] [:div [crossing-child {:v (delay (rf.hicasso/sub [:re/right]))}]])
                        {})))]
 
     (testing "refused at the crossing, with its own stable id and recovery —
@@ -600,12 +600,12 @@
   ;; freely, and its read belongs to the body that wrote it. Without this
   ;; row the one above could be "the walk refuses every delay".
   (let [entry (probe! (fn [_]
-                        (let [d (delay (h/sub [:re/right]))]
+                        (let [d (delay (rf.hicasso/sub [:re/right]))]
                           @d
                           [:div [crossing-child {:v @d}]])))]
     (testing "a delay forced in the writing body crosses, and its read is
               that body's own edge"
-      (is (= #{(sub-key [:re/right])} (runtime/reads-of entry))))))
+      (is (= #{(sub-key [:re/right])} (rf.hicasso.test.runtime/reads-of entry))))))
 
 (deftest an-escaped-deferral-forced-in-another-body-is-the-declared-limit
   (seeded!)
@@ -625,8 +625,8 @@
   ;; that goes red, and that is what it is for.
   (let [!parked (atom nil)]
     (probe! (fn [_]
-              (reset! !parked (fn [] (h/sub [:re/right])))
-              [:p (h/sub [:re/left])]))
+              (reset! !parked (fn [] (rf.hicasso/sub [:re/right])))
+              [:p (rf.hicasso/sub [:re/left])]))
 
     (testing "forced with no body on the stack it refuses, like every other
               escape"
@@ -635,12 +635,12 @@
 
     (let [victim (probe! (fn [_]
                            (@!parked)
-                           [:p (h/sub [:re/flag])]))]
+                           [:p (rf.hicasso/sub [:re/flag])]))]
       (testing "but forced inside a DIFFERENT body's render it does not
                 refuse — and the read is filed under that body, which never
                 wrote it. The page paints correctly and the edge is wrong"
         (is (= #{(sub-key [:re/flag]) (sub-key [:re/right])}
-               (runtime/reads-of victim)))))))
+               (rf.hicasso.test.runtime/reads-of victim)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The controls that make the matrix worth its greens
@@ -655,7 +655,7 @@
   ;; census guards against, in this file's own currency.
   (let [!seen (atom nil)]
     (probe! (fn [_]
-              (reset! !seen (outcome (fn [] (h/sub [:re/right]))))
+              (reset! !seen (outcome (fn [] (rf.hicasso/sub [:re/right]))))
               [:p "x"]))
 
     (testing "the IDENTICAL read, inside the window, is reported as allowed
@@ -690,22 +690,22 @@
     ;; a second copy of it.
     (let [!parked (atom nil)]
       (probe! (fn [_]
-                (reset! !parked (fn [] (h/sub [:re/right])))
-                [:p (h/sub [:re/left])]))
+                (reset! !parked (fn [] (rf.hicasso/sub [:re/right])))
+                [:p (rf.hicasso/sub [:re/left])]))
 
       (dotimes [_ 3] (outcome (fn [] (@!parked))))
 
       (testing "three refusals later the runtime owns exactly what the
                 probing render owned: nothing"
         (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0}
-               (dissoc (runtime/residue) :entries)))
-        (is (= [] (runtime/cell-readers (sub-key [:re/right]))))
-        (is (nil? (runtime/cell-reaction (sub-key [:re/right])))))
+               (dissoc (rf.hicasso.test.runtime/residue) :entries)))
+        (is (= [] (rf.hicasso.test.runtime/cell-readers (sub-key [:re/right]))))
+        (is (nil? (rf.hicasso.test.runtime/cell-reaction (sub-key [:re/right])))))
 
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "and the render-phase entry cache evaporates at the
                          runtime's own horizon, refusals included"
                  (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                        (runtime/residue))))
+                        (rf.hicasso.test.runtime/residue))))
                (done))))))

--- a/implementation/hicasso/test/re_frame/hicasso/read_extent_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/read_extent_dom_cljs_test.cljs
@@ -120,14 +120,14 @@
   controls that need no DOM run in both lanes."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [clojure.set :as set]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/client" :as react-dom-client]))
 
@@ -155,11 +155,11 @@
 ;; pass vacuously by never firing. `:ambient-frame nil` because this suite
 ;; seats its own.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The exercised population — a MEASUREMENT, not a claim
@@ -235,16 +235,16 @@
   [o]
   (dissoc (:refused o) :reason))
 
-(defn- readers-of [query-v] (count (runtime/cell-readers (sub-key query-v))))
+(defn- readers-of [query-v] (count (rf.hicasso.test.runtime/cell-readers (sub-key query-v))))
 
 (def ^:private nothing-owned {:cells 0 :cell-refs 0 :boundaries 0 :edges 0})
 
-(defn- ownership [] (dissoc (runtime/residue) :entries))
+(defn- ownership [] (dissoc (rf.hicasso.test.runtime/residue) :entries))
 
 (defn- app
   "The hicasso subtree: the frame provider over a root element."
   [hiccup]
-  (mount/provider frame-id (codec/root-element frame-id hiccup)))
+  (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup)))
 
 (defn- mount-concurrent!
   "A concurrent root, rendered WITHOUT `flushSync`.
@@ -269,7 +269,7 @@
 
 (defn- poll
   [pred label]
-  (test-support/poll-until pred {:label label :timeout-ms 4000}))
+  (rf.test-support/poll-until pred {:label label :timeout-ms 4000}))
 
 (defn- prove-live!
   "Settle the commit's PASSIVE phase on a condition, never on a duration,
@@ -290,7 +290,7 @@
   under test, since a second reader changes a count without changing any
   text."
   [handle expected label]
-  (collector/dispatch! frame-id [:red/bump])
+  (rf.hicasso.impl.collector/dispatch! frame-id [:red/bump])
   (poll #(= expected (text-at handle "#painted")) label))
 
 (defn- teardown-census!
@@ -299,13 +299,13 @@
   reads zeros whether teardown released anything or not — the shape of
   gate that cannot go red (`impl.mount/unmount!`)."
   [handle]
-  (mount/unmount! handle)
-  (.then (runtime/quiesced!)
+  (rf.hicasso.impl.mount/unmount! handle)
+  (.then (rf.hicasso.test.runtime/quiesced!)
          (fn [_]
            (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                  (runtime/residue))
+                  (rf.hicasso.test.runtime/residue))
                "teardown is exact: zero residue after quiescence")
-           (mount/release! handle)
+           (rf.hicasso.impl.mount/release! handle)
            nil)))
 
 (defn- report-failure!
@@ -331,14 +331,14 @@
   (fn [e]
     (is false (str label " — " (.-message e)
                    " | ownership " (pr-str (ownership))))
-    (when handle (mount/release! handle))
+    (when handle (rf.hicasso.impl.mount/release! handle))
     nil))
 
 ;; ---------------------------------------------------------------------------
 ;; The views
 ;; ---------------------------------------------------------------------------
 
-(h/defview sibling-line
+(rf.hicasso/defview sibling-line
   "A second boundary reading a DIFFERENT key, and it is load-bearing
   rather than scenery.
 
@@ -350,13 +350,13 @@
   nothing will ever release. That is a number, and it is the smallest tree
   in which it is one."
   [_]
-  [:p {:id "sibling"} (str "sibling=" (h/sub [:red/sibling]))])
+  [:p {:id "sibling"} (str "sibling=" (rf.hicasso/sub [:red/sibling]))])
 
 (def ^:private !effect-runs (atom 0))
 (def ^:private !layout-read (atom nil))
 (def ^:private !passive-read (atom nil))
 
-(h/defview effect-deferring-line
+(rf.hicasso/defview effect-deferring-line
   "A boundary that reads legally and then defers two reads into React's
   own post-body phases — the mutation phase (`useLayoutEffect`) and the
   passive phase (`useEffect`).
@@ -372,18 +372,18 @@
   about effects: the same escaped extent, the same instant, and the write
   goes through."
   [_]
-  (let [v (h/sub [:red/painted])]
+  (let [v (rf.hicasso/sub [:red/painted])]
     (react/useLayoutEffect
       (fn []
         (swap! !effect-runs inc)
-        (reset! !layout-read (outcome (fn [] (h/sub [:red/escaped-2]))))
+        (reset! !layout-read (outcome (fn [] (rf.hicasso/sub [:red/escaped-2]))))
         js/undefined)
       #js [])
     (react/useEffect
       (fn []
         (swap! !effect-runs inc)
-        (reset! !passive-read (outcome (fn [] (h/sub [:red/escaped]))))
-        (collector/dispatch! frame-id [:red/bump])
+        (reset! !passive-read (outcome (fn [] (rf.hicasso/sub [:red/escaped]))))
+        (rf.hicasso.impl.collector/dispatch! frame-id [:red/bump])
         js/undefined)
       #js [])
     [:p {:id "painted"} (str "painted=" v)]))
@@ -409,7 +409,7 @@
 
 (defn- release-gate! [] (reset! !released? true) (@!resolve-gate nil) nil)
 
-(h/defview suspending-line
+(rf.hicasso/defview suspending-line
   "A boundary that reads, defers a read onto the very thenable it is about
   to throw, and suspends.
 
@@ -425,7 +425,7 @@
   is what keeps the deferral single, so `1` is an assertable count rather
   than a schedule-dependent one."
   [_]
-  (let [v (h/sub [:red/painted])]
+  (let [v (rf.hicasso/sub [:red/painted])]
     (when-not @!released?
       (when-not @!attached?
         (reset! !attached? true)
@@ -433,7 +433,7 @@
             (.then (fn [_]
                      (swap! !resume-runs inc)
                      (reset! !resume-read
-                             (outcome (fn [] (h/sub [:red/escaped]))))))))
+                             (outcome (fn [] (rf.hicasso/sub [:red/escaped]))))))))
       (throw @!gate-promise))
     [:p {:id "painted"} (str "painted=" v)]))
 
@@ -441,15 +441,15 @@
 (def ^:private !activity-read (atom nil))
 (def ^:private !set-visible (atom nil))
 
-(h/defview activity-deferring-line
+(rf.hicasso/defview activity-deferring-line
   "A boundary inside an `Activity` subtree, deferring a read into the
   effect React withholds for as long as the subtree is hidden."
   [_]
-  (let [v (h/sub [:red/painted])]
+  (let [v (rf.hicasso/sub [:red/painted])]
     (react/useEffect
       (fn []
         (swap! !activity-runs inc)
-        (reset! !activity-read (outcome (fn [] (h/sub [:red/escaped]))))
+        (reset! !activity-read (outcome (fn [] (rf.hicasso/sub [:red/escaped]))))
         js/undefined)
       #js [])
     [:p {:id "painted"} (str "painted=" v)]))
@@ -474,7 +474,7 @@
 
 (deftest a-read-deferred-into-a-react-effect-refuses
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM, so React commits nothing and no effect runs")
           (done))
       (let [_ (seeded!)
@@ -482,7 +482,7 @@
                   (reset! !layout-read nil)
                   (reset! !passive-read nil))
             handle (mount-concurrent!
-                     (mount/fresh-container!)
+                     (rf.hicasso.impl.mount/fresh-container!)
                      (app [:div [effect-deferring-line {}] [sibling-line {}]]))]
         ;; The poll condition is three premises at once: the tree
         ;; committed, the passive effect ran to completion PAST its refused
@@ -518,7 +518,7 @@
                           of the mount"
                   (is (zero? (readers-of [:red/escaped])))
                   (is (zero? (readers-of [:red/escaped-2])))
-                  (is (nil? (runtime/cell-reaction (sub-key [:red/escaped])))))
+                  (is (nil? (rf.hicasso.test.runtime/cell-reaction (sub-key [:red/escaped])))))
 
                 (testing "while each body's own read is acquired exactly
                           once, and the runtime holds the two boundaries and
@@ -532,15 +532,15 @@
                 ;; and not about two queries that were broken anyway. The
                 ;; identical reads, inside a body's window, resolve to their
                 ;; values and record their edges.
-                (let [_     (collector/render-body
+                (let [_     (rf.hicasso.impl.collector/render-body
                               frame-id
-                              (fn [_] [:p (h/sub [:red/escaped])
-                                       (h/sub [:red/escaped-2])])
+                              (fn [_] [:p (rf.hicasso/sub [:red/escaped])
+                                       (rf.hicasso/sub [:red/escaped-2])])
                               {})
-                      entry (collector/last-reads)]
+                      entry (rf.hicasso.impl.collector/last-reads)]
                   (testing "the identical reads are legal in a window"
                     (is (= #{(sub-key [:red/escaped]) (sub-key [:red/escaped-2])}
-                           (runtime/reads-of entry)))))
+                           (rf.hicasso.test.runtime/reads-of entry)))))
 
                 (exercised! :effect/layout)
                 (exercised! :effect/passive)
@@ -554,14 +554,14 @@
 
 (deftest a-read-deferred-across-a-suspense-retry-refuses
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM, so nothing suspends and nothing retries")
           (done))
       (let [_      (seeded!)
             _      (arm-gate!)
-            before (runtime/body-runs)
+            before (rf.hicasso.test.runtime/body-runs)
             handle (mount-concurrent!
-                     (mount/fresh-container!)
+                     (rf.hicasso.impl.mount/fresh-container!)
                      (react/createElement
                        (.-Suspense react)
                        #js {:fallback (react/createElement
@@ -573,7 +573,7 @@
                 (testing "the premise: React RAN the body — it took its read
                           and then threw the thenable — and then threw the
                           attempt away"
-                  (is (pos? (- (runtime/body-runs) before)))
+                  (is (pos? (- (rf.hicasso.test.runtime/body-runs) before)))
                   (is (nil? (text-at handle "#painted"))))
 
                 (testing "and the abandoned attempt acquired nothing, so the
@@ -602,7 +602,7 @@
                 (testing "the refused key was not acquired by the retry that
                           followed it"
                   (is (zero? (readers-of [:red/escaped])))
-                  (is (nil? (runtime/cell-reaction (sub-key [:red/escaped])))))
+                  (is (nil? (rf.hicasso.test.runtime/cell-reaction (sub-key [:red/escaped])))))
 
                 (testing "and the retry acquired exactly its own read set:
                           one reader per key, with no second registration
@@ -623,7 +623,7 @@
 
 (deftest a-read-deferred-across-an-activity-reveal-refuses
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no DOM, so nothing is hidden and nothing is revealed")
           (done))
       (let [_ (seeded!)
@@ -631,7 +631,7 @@
                   (reset! !activity-read nil)
                   (reset! !set-visible nil))
             handle (mount-concurrent!
-                     (mount/fresh-container!)
+                     (rf.hicasso.impl.mount/fresh-container!)
                      (react/createElement
                        activity-host
                        #js {:child (app [:div
@@ -669,7 +669,7 @@
 
                 (testing "the refused key was not acquired at the reveal"
                   (is (zero? (readers-of [:red/escaped])))
-                  (is (nil? (runtime/cell-reaction (sub-key [:red/escaped])))))
+                  (is (nil? (rf.hicasso.test.runtime/cell-reaction (sub-key [:red/escaped])))))
 
                 (testing "while each revealed boundary holds exactly its own
                           read, once. Measured: with one boundary here this
@@ -701,10 +701,10 @@
   ;; runtime's conduct.
   (seeded!)
   (let [!seen (atom nil)]
-    (collector/render-body
+    (rf.hicasso.impl.collector/render-body
       frame-id
       (fn [_]
-        (reset! !seen (outcome (fn [] (h/sub [:red/escaped]))))
+        (reset! !seen (outcome (fn [] (rf.hicasso/sub [:red/escaped]))))
         [:p "x"])
       {})
 
@@ -723,7 +723,7 @@
 
 (deftest the-declared-population-was-actually-exercised
   ;; Declared LAST so every row above has run.
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM, so no carrier is driven there")
     (is (= declared-population @!exercised)
         (str "every declared deferral carrier must be reached; missing: "

--- a/implementation/hicasso/test/re_frame/hicasso/reaper_coalescing_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/reaper_coalescing_cljs_test.cljs
@@ -28,11 +28,11 @@
   Measured before the coalescing: 300 timers to mount, 600 to unmount.
   After: one and two."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::reaper-coalescing)
 
@@ -42,11 +42,11 @@
 (rf/reg-sub   :reap/row  (fn [db [_ i]] (get-in db [:rows i])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- counting-timers
   "Run `f` with every `setTimeout` counted and passed through to the real
@@ -67,8 +67,8 @@
   its own key. Answers the release fns."
   []
   (mapv (fn [i]
-          (collector/render-body frame-id (fn [_] (collector/sub [:reap/row i])) {})
-          (collector/commit-boundary! (collector/last-reads) (fn [])))
+          (rf.hicasso.impl.collector/render-body frame-id (fn [_] (rf.hicasso.impl.collector/sub [:reap/row i])) {})
+          (rf.hicasso.impl.collector/commit-boundary! (rf.hicasso.impl.collector/last-reads) (fn [])))
         (range rows)))
 
 (deftest a-cold-mount-of-300-distinct-read-boundaries-arms-one-timer-per-horizon
@@ -79,22 +79,22 @@
           armed     (counting-timers #(vreset! !releases (mount-rows!)))]
       (is (= 1 armed)
           (str "timers armed by mounting " rows " rows: " armed))
-      (.then (runtime/quiesced!)
+      (.then (rf.hicasso.test.runtime/quiesced!)
              (fn [_]
                (testing "past the horizon, the claimed entries and the held
                          cells are exactly what a mount retains"
                  (is (= {:cells rows :cell-refs rows :boundaries rows
                          :edges rows :entries rows}
-                        (runtime/residue))))
+                        (rf.hicasso.test.runtime/residue))))
                (let [armed (counting-timers #(doseq [release @!releases] (release)))]
                  (is (= 2 armed)
                      (str "timers armed by unmounting " rows " rows: " armed)))
-               (.then (runtime/quiesced!)
+               (.then (rf.hicasso.test.runtime/quiesced!)
                       (fn [_]
                         (testing "and past the horizon every cell, membership
                                   and entry has been reaped — the coalescing
                                   changed how many timers, never what runs"
                           (is (= {:cells 0 :cell-refs 0 :boundaries 0
                                   :edges 0 :entries 0}
-                                 (runtime/residue))))
+                                 (rf.hicasso.test.runtime/residue))))
                         (done))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/reincarnation_cells_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/reincarnation_cells_cljs_test.cljs
@@ -60,13 +60,13 @@
   hold. The cell table, the reader memberships and the deferred repair are
   the real ones."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::reincarnation-cells)
 
@@ -77,11 +77,11 @@
 ;; containing an `(async done …)` test, and the deferred repair under witness
 ;; here is only observable across a promise turn.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -93,19 +93,19 @@
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:reinc-cell/seed who]))
-  (frame/frame-incarnation-token frame-id))
+  (rf.frame/frame-incarnation-token frame-id))
 
-(defn- body [_props] (collector/sub [:reinc-cell/who]))
+(defn- body [_props] (rf.hicasso.impl.collector/sub [:reinc-cell/who]))
 
 (defn- render+commit!
   "Run the body under the generation fence and take React's place at the
   commit seam. Answers the entry, the notification counter and the
   release fn."
   []
-  (let [value    (collector/render-body frame-id body {})
-        entry    (collector/last-reads)
+  (let [value    (rf.hicasso.impl.collector/render-body frame-id body {})
+        entry    (rf.hicasso.impl.collector/last-reads)
         notified (volatile! 0)
-        release  (collector/commit-boundary! entry (fn [] (vswap! notified inc)))]
+        release  (rf.hicasso.impl.collector/commit-boundary! entry (fn [] (vswap! notified inc)))]
     {:value value :entry entry :notified notified :release release}))
 
 (def ^:private at-the-checkpoint
@@ -113,7 +113,7 @@
   [[re-frame.hicasso.checkpoint-support/at-the-checkpoint]] — it is the
   30 ms timer's replacement, and the reason for the replacement is that a
   duration was green for both schedulings."
-  support/at-the-checkpoint)
+  rf.hicasso.checkpoint-support/at-the-checkpoint)
 
 ;; ---------------------------------------------------------------------------
 ;; 1. React's own change-detection number ties across the transition
@@ -123,21 +123,21 @@
   (async done
     (incarnate! "A")
     (let [{:keys [value entry notified release]} (render+commit!)
-          snapshot-a (runtime/snapshot-of entry)]
+          snapshot-a (rf.hicasso.test.runtime/snapshot-of entry)]
       (is (= "A" value) "the committed boundary read the predecessor's value")
-      (is (some? (runtime/cell-reaction sub-key))
+      (is (some? (rf.hicasso.test.runtime/cell-reaction sub-key))
           "and it holds a live cell for the key")
 
       ;; NEGATIVE CONTROL, taken FIRST so the instrument is proven live before
       ;; it is asked to report a tie. An ordinary write inside the incarnation
       ;; must move the number and notify the boundary.
       (rf/with-frame frame-id (rf/dispatch-sync [:reinc-cell/seed "A2"]))
-      (is (> (runtime/snapshot-of entry) snapshot-a)
+      (is (> (rf.hicasso.test.runtime/snapshot-of entry) snapshot-a)
           "an ordinary in-incarnation write MOVES the snapshot — so a tie
            below is the transition's property, not a dead instrument")
       (is (= 1 @notified) "and notifies the committed boundary exactly once")
 
-      (let [snapshot-before (runtime/snapshot-of entry)
+      (let [snapshot-before (rf.hicasso.test.runtime/snapshot-of entry)
             notified-before @notified]
         (rf/destroy-frame! frame-id)
         (rf/make-frame {:id frame-id})
@@ -147,23 +147,23 @@
                   nothing — the number it re-reads is unchanged and no
                   notification has fired, so a committed boundary goes on
                   showing the predecessor's value"
-          (is (= snapshot-before (runtime/snapshot-of entry))
+          (is (= snapshot-before (rf.hicasso.test.runtime/snapshot-of entry))
               "the snapshot TIES across the reincarnation")
           (is (= notified-before @notified) "and no re-render was scheduled"))
 
         (testing "the cell's reaction reference was dropped synchronously by
                   the teardown, which is what makes the read fall back to the
                   cold probe rather than deref a retired computation"
-          (is (nil? (runtime/cell-reaction sub-key))))
+          (is (nil? (rf.hicasso.test.runtime/cell-reaction sub-key))))
 
         (testing "a body re-run right now already reads the SUCCESSOR — the
                   read path is address-directed on the public id, which is
                   precisely why rendered markup is a green instrument
                   throughout this window"
-          (is (= "B" (collector/render-body frame-id body {}))))
+          (is (= "B" (rf.hicasso.impl.collector/render-body frame-id body {}))))
 
         (at-the-checkpoint
-          #(some? (runtime/cell-reaction sub-key))
+          #(some? (rf.hicasso.test.runtime/cell-reaction sub-key))
           "the reincarnation repair"
           done
           (fn [_turns]
@@ -172,9 +172,9 @@
                       deferred repair has routed to the LIVE incarnation: the
                       attachment is rebuilt, the number moves, and the
                       boundary is notified so it can correct what it painted"
-              (is (some? (runtime/cell-reaction sub-key))
+              (is (some? (rf.hicasso.test.runtime/cell-reaction sub-key))
                   "the cell is re-wired rather than left deaf")
-              (is (> (runtime/snapshot-of entry) snapshot-before)
+              (is (> (rf.hicasso.test.runtime/snapshot-of entry) snapshot-before)
                   "and the number React re-reads has finally moved")
               (is (> @notified notified-before)
                   "the committed boundary is notified — the repair is
@@ -190,18 +190,18 @@
     (incarnate! "A")
     (let [{:keys [entry release]} (render+commit!)]
       (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
-             (dissoc (runtime/residue) :entries))
+             (dissoc (rf.hicasso.test.runtime/residue) :entries))
           "the commit acquired exactly one cell and one reader membership")
 
       (rf/destroy-frame! frame-id)
 
       (testing "synchronously the cell is still in the table, holding no
                 reaction — the repair's two phases, mid-flight"
-        (is (nil? (runtime/cell-reaction sub-key)))
-        (is (= 1 (:cells (runtime/residue)))))
+        (is (nil? (rf.hicasso.test.runtime/cell-reaction sub-key)))
+        (is (= 1 (:cells (rf.hicasso.test.runtime/residue)))))
 
       (at-the-checkpoint
-        #(zero? (:cells (runtime/residue)))
+        #(zero? (:cells (rf.hicasso.test.runtime/residue)))
         "the no-successor disposal"
         done
         (fn [_turns]
@@ -211,10 +211,10 @@
                     residue after quiescence, and the rescheduling in rf2-2l17
                     moved when that happens without changing what happens"
             (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0}
-                   (dissoc (runtime/residue) :entries))
+                   (dissoc (rf.hicasso.test.runtime/residue) :entries))
                 "no cell, no reader membership, no dependency edge survives a
                  frame that did not come back")
-            (is (nil? (runtime/cell-reaction sub-key))))
+            (is (nil? (rf.hicasso.test.runtime/cell-reaction sub-key))))
           (release))))))
 
 ;; ---------------------------------------------------------------------------
@@ -240,21 +240,21 @@
     (incarnate! "A")
     (let [{:keys [entry release]} (render+commit!)]
       (rf/destroy-frame! frame-id)
-      (is (nil? (runtime/cell-reaction sub-key))
+      (is (nil? (rf.hicasso.test.runtime/cell-reaction sub-key))
           "synchronous phase: reference dropped")
       ;; Seat the successor while the deferred phase is still pending.
       (rf/make-frame {:id frame-id})
       (rf/with-frame frame-id (rf/dispatch-sync [:reinc-cell/seed "B"]))
       (at-the-checkpoint
-        #(some? (runtime/cell-reaction sub-key))
+        #(some? (rf.hicasso.test.runtime/cell-reaction sub-key))
         "the liveness branch"
         done
         (fn [_turns]
           (testing "a successor seated INSIDE the deferral window flips the
                     branch from dispose to re-wire — so the two outcomes are
                     the frame's liveness, read when the deferred phase fires"
-            (is (some? (runtime/cell-reaction sub-key)))
-            (is (= 1 (:cells (runtime/residue)))))
+            (is (some? (rf.hicasso.test.runtime/cell-reaction sub-key)))
+            (is (= 1 (:cells (rf.hicasso.test.runtime/residue)))))
           (testing "and the re-wired cell answers for the SUCCESSOR"
-            (is (= "B" (collector/render-body frame-id body {}))))
+            (is (= "B" (rf.hicasso.impl.collector/render-body frame-id body {}))))
           (release))))))

--- a/implementation/hicasso/test/re_frame/hicasso/reincarnation_paint_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/reincarnation_paint_dom_cljs_test.cljs
@@ -67,16 +67,16 @@
   passes because nothing ran. The real run is `npm run test:browser`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [clojure.set :as set]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/client" :as react-dom-client]))
 
@@ -86,11 +86,11 @@
 (rf/reg-sub   :reinc-paint/who  (fn [db _] (:who db)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The exercised population — a MEASUREMENT, not a claim
@@ -116,7 +116,7 @@
   [why]
   (is true (str "a paint-order claim needs a real React DOM — " why)))
 
-(h/defview who-line [_] [:p {:id "who"} (h/sub [:reinc-paint/who])])
+(rf.hicasso/defview who-line [_] [:p {:id "who"} (rf.hicasso/sub [:reinc-paint/who])])
 
 (defn- seat!
   "Create the frame under `frame-id` and seed it. Called once to mount the
@@ -126,7 +126,7 @@
   [who]
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:reinc-paint/seed who]))
-  (frame/frame-incarnation-token frame-id))
+  (rf.frame/frame-incarnation-token frame-id))
 
 (defn- reincarnate!
   "Destroy and re-seat under the same public id, synchronously. Answers
@@ -140,7 +140,7 @@
 
 (defn- poll
   [pred label]
-  (test-support/poll-until pred {:label label :timeout-ms 4000}))
+  (rf.test-support/poll-until pred {:label label :timeout-ms 4000}))
 
 (defonce ^:private !minted
   ;; Every root a row has minted through `mount-live!`, oldest first.
@@ -164,7 +164,7 @@
   NEXT namespace to inherit, which is the very contamination this
   teardown exists to prevent, arriving by a second door."
   []
-  (run! mount/release! @!minted)
+  (run! rf.hicasso.impl.mount/release! @!minted)
   (reset! !minted [])
   nil)
 
@@ -184,12 +184,12 @@
   instant until [[release-minted!]] runs there is a live root on the page
   and this promise is the only thing that could ever name it."
   []
-  (let [container (mount/fresh-container!)
-        handle    (mount/root! container frame-id [who-line {}])]
+  (let [container (rf.hicasso.impl.mount/fresh-container!)
+        handle    (rf.hicasso.impl.mount/root! container frame-id [who-line {}])]
     (swap! !minted conj handle)
     (-> (poll #(= "A" (text handle)) "the predecessor's value is committed")
         (.then (fn [_]
-                 (mount/dispatch! handle [:reinc-paint/seed "A-live"])
+                 (rf.hicasso.impl.mount/dispatch! handle [:reinc-paint/seed "A-live"])
                  (poll #(= "A-live" (text handle))
                        "the boundary repaints, so its subscription is live")))
         (.then (fn [_] handle)))))
@@ -238,7 +238,7 @@
   (fn [e]
     (is false (str label " — " (.-message e)
                    " | DOM was " (pr-str (when handle (text handle)))
-                   " | residue " (pr-str (dissoc (runtime/residue) :entries))))
+                   " | residue " (pr-str (dissoc (rf.hicasso.test.runtime/residue) :entries))))
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -248,15 +248,15 @@
 
 (deftest the-first-render-opportunity-after-a-reincarnation-observes-the-successor
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no rendering opportunity") (done))
       (do
-        (support/leave-act-environment!)
+        (rf.hicasso.checkpoint-support/leave-act-environment!)
         (seat! "A")
         (-> (mount-live!)
             (.then
               (fn [handle]
-                (let [token-a (frame/frame-incarnation-token frame-id)
+                (let [token-a (rf.frame/frame-incarnation-token frame-id)
                       ;; Register the frame observation BEFORE the transition,
                       ;; so the callback is queued against the rendering
                       ;; opportunity that follows this very task.
@@ -279,7 +279,7 @@
                             nothing"
                     (is (= "A-live" (text handle))))
 
-                  (-> (support/drain-checkpoint #(= "B" (text handle)))
+                  (-> (rf.hicasso.checkpoint-support/drain-checkpoint #(= "B" (text handle)))
                       (.then
                         (fn [turns]
                           (testing "and it is corrected INSIDE the microtask
@@ -290,7 +290,7 @@
                                     event loop reaches a rendering opportunity"
                             (is (some? turns)
                                 (str "not corrected within the checkpoint ("
-                                     support/checkpoint-turn-budget
+                                     rf.hicasso.checkpoint-support/checkpoint-turn-budget
                                      " promise turns); the DOM read "
                                      (pr-str (text handle)))))
                           framed))
@@ -307,12 +307,12 @@
                                     replaced the attachment, it did not add a
                                     second"
                             (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
-                                   (dissoc (runtime/residue) :entries))))
+                                   (dissoc (rf.hicasso.test.runtime/residue) :entries))))
 
                           (exercised! :paint-order/mounted-reincarnation)
-                          (mount/unmount! handle)
-                          (.then (runtime/quiesced!)
-                                 (fn [_] (mount/release! handle) nil))))
+                          (rf.hicasso.impl.mount/unmount! handle)
+                          (.then (rf.hicasso.test.runtime/quiesced!)
+                                 (fn [_] (rf.hicasso.impl.mount/release! handle) nil))))
                       (.catch (report-failure! "W1 paint-order witness" handle))))))
             (.catch (report-failure! "W1 paint-order witness" nil))
             ;; The single trailing step, which BOTH arms reach: this row's
@@ -338,16 +338,16 @@
   ;; ORDERING GUARANTEE and not the repair — which is exactly the finding the
   ;; bead's ruling rests on.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no rendering opportunity") (done))
       (do
-        (support/leave-act-environment!)
+        (rf.hicasso.checkpoint-support/leave-act-environment!)
         (seat! "A")
         (-> (mount-live!)
             (.then
               (fn [handle]
-                (support/with-macrotask-deferral #(reincarnate! "B"))
-                (-> (support/drain-checkpoint #(= "B" (text handle)))
+                (rf.hicasso.checkpoint-support/with-macrotask-deferral #(reincarnate! "B"))
+                (-> (rf.hicasso.checkpoint-support/drain-checkpoint #(= "B" (text handle)))
                     (.then
                       (fn [turns]
                         (testing "with the macrotask deferral restored the
@@ -371,9 +371,9 @@
                                   green is the scheduling and nothing else"
                           (is (= "B" later)))
                         (exercised! :paint-order/macrotask-sabotage)
-                        (mount/unmount! handle)
-                        (.then (runtime/quiesced!)
-                               (fn [_] (mount/release! handle) nil))))
+                        (rf.hicasso.impl.mount/unmount! handle)
+                        (.then (rf.hicasso.test.runtime/quiesced!)
+                               (fn [_] (rf.hicasso.impl.mount/release! handle) nil))))
                     (.catch (report-failure! "W1 sabotage control" handle)))))
             (.catch (report-failure! "W1 sabotage control" nil))
             ;; The single trailing step, which BOTH arms reach: this row's
@@ -413,12 +413,12 @@
   ;; reincarnation restarts the frame's install epoch, so basis@render and
   ;; basis@commit can be the same number across it.
   (async done
-    (if-not (mount/browser?)
+    (if-not (rf.hicasso.impl.mount/browser?)
       (do (skip! ":node-test has no rendering opportunity") (done))
       (do
-        (support/leave-act-environment!)
+        (rf.hicasso.checkpoint-support/leave-act-environment!)
         (seat! "A")
-        (let [container (mount/fresh-container!)
+        (let [container (rf.hicasso.impl.mount/fresh-container!)
               root      (react-dom-client/createRoot container)
               handle    {:root root :container container :frame frame-id}]
           ;; A concurrent root, deliberately not `mount/root!`: that door
@@ -427,7 +427,7 @@
           (.render root
                    (react/createElement
                      (.-Fragment react) nil
-                     (mount/provider frame-id (codec/root-element frame-id [who-line {}]))
+                     (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id [who-line {}]))
                      (react/createElement gap-reincarnator nil)))
           (-> (poll #(seq (text handle)) "the boundary commits")
               (.then
@@ -453,12 +453,12 @@
                   (testing "and it is corrected ONCE: one cell, one reader, no
                             second registration left by the correcting render"
                     (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
-                           (dissoc (runtime/residue) :entries))))
+                           (dissoc (rf.hicasso.test.runtime/residue) :entries))))
 
                   (exercised! :paint-order/staged-gap)
-                  (mount/unmount! handle)
-                  (.then (runtime/quiesced!)
-                         (fn [_] (mount/release! handle) nil))))
+                  (rf.hicasso.impl.mount/unmount! handle)
+                  (.then (rf.hicasso.test.runtime/quiesced!)
+                         (fn [_] (rf.hicasso.impl.mount/release! handle) nil))))
               (.catch (report-failure! "W2 staged-gap witness" handle))
               ;; The single trailing step, which BOTH arms reach: this row's
               ;; roots go down first, and the single `done` is the last act.
@@ -469,7 +469,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-declared-population-was-actually-exercised
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no rendering opportunity, so nothing is exercised")
     (is (= declared-population @!exercised)
         (str "every declared paint-order mechanism must be reached; missing: "

--- a/implementation/hicasso/test/re_frame/hicasso/reincarnation_routing_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/reincarnation_routing_cljs_test.cljs
@@ -56,16 +56,16 @@
   `reincarnation_paint_dom_cljs_test` takes it in a real browser, where
   the ordering of that repair against paint is what is at stake."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.frames :as frames]
-            [re-frame.hicasso.impl.generation :as generation]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.frames :as rf.hicasso.impl.frames]
+            [re-frame.hicasso.impl.generation :as rf.hicasso.impl.generation]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::reincarnation)
 
@@ -83,12 +83,12 @@
 (rf/reg-sub   :reinc/who  (fn [db _] (:who db)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :init-fn       (fn []
-                      (collector/reset-runtime!)
-                      (error-emit/clear-error-listeners!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!)
+                      (rf.error-emit/clear-error-listeners!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -112,11 +112,11 @@
   importing the bench tree's helper."
   [who]
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-  (when (frame/frame-incarnation-token frame-id) (rf/destroy-frame! frame-id))
-  (frames/forget-frame-ops! frame-id)
+  (when (rf.frame/frame-incarnation-token frame-id) (rf/destroy-frame! frame-id))
+  (rf.hicasso.impl.frames/forget-frame-ops! frame-id)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:reinc/seed who]))
-  (frame/frame-incarnation-token frame-id))
+  (rf.frame/frame-incarnation-token frame-id))
 
 (defn- reincarnate!
   "Destroy the live incarnation and seat a fresh one under the same public
@@ -125,7 +125,7 @@
   (rf/destroy-frame! frame-id)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:reinc/seed who]))
-  (frame/frame-incarnation-token frame-id))
+  (rf.frame/frame-incarnation-token frame-id))
 
 (defn- marked [] (:marked (rf/app-db-value frame-id)))
 
@@ -140,10 +140,10 @@
   [thunk]
   (let [seen (atom [])
         k    (keyword "rf2-hic-013" (name (gensym "refusal")))]
-    (error-emit/register-error-listener!
+    (rf.error-emit/register-error-listener!
       k (fn [r] (when (= :rf.error/frame-destroyed (:error r)) (swap! seen conj r))))
     (try {:result (thunk) :refusals @seen}
-         (finally (error-emit/unregister-error-listener! k)))))
+         (finally (rf.error-emit/unregister-error-listener! k)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. The public id is stable; the incarnation is not — and the number the
@@ -158,9 +158,9 @@
       (is (some? token-b))
       (is (not (identical? token-a token-b))
           "destroy + same-id recreate is a NEW incarnation, distinct by identity")
-      (is (false? (frame/frame-incarnation-live? frame-id token-a))
+      (is (false? (rf.frame/frame-incarnation-live? frame-id token-a))
           "and the predecessor's token is no longer live under the id")
-      (is (true? (frame/frame-incarnation-live? frame-id token-b)))))
+      (is (true? (rf.frame/frame-incarnation-live? frame-id token-b)))))
 
   (testing "`commit-basis` TIES across the transition — the fourth axis
             `re-frame.hicasso.impl.generation/commit-basis` documents as not
@@ -169,9 +169,9 @@
             frame fact, so a successor holding a DIFFERENT value reports the
             same number its predecessor did"
     (let [_       (incarnate! "A")
-          basis-a (generation/commit-basis frame-id)
+          basis-a (rf.hicasso.impl.generation/commit-basis frame-id)
           _       (reincarnate! "B")
-          basis-b (generation/commit-basis frame-id)]
+          basis-b (rf.hicasso.impl.generation/commit-basis frame-id)]
       (is (= "B" (:who (rf/app-db-value frame-id)))
           "sanity: the successor really does hold a different value")
       (is (= basis-a basis-b)
@@ -184,9 +184,9 @@
   ;; number that just failed to move.
   (testing "the basis is a live instrument: an ordinary in-incarnation write moves it"
     (incarnate! "A")
-    (let [before (generation/commit-basis frame-id)]
+    (let [before (rf.hicasso.impl.generation/commit-basis frame-id)]
       (rf/with-frame frame-id (rf/dispatch-sync [:reinc/mark :ordinary]))
-      (is (> (generation/commit-basis frame-id) before)
+      (is (> (rf.hicasso.impl.generation/commit-basis frame-id) before)
           "an ordinary write advances the basis, so the tie above is the
            reincarnation's property and not a stuck counter"))))
 
@@ -202,7 +202,7 @@
             ;; Exactly what a render leaves behind: the memoised bundle in the
             ;; arm's one frame row, which every boundary of that incarnation
             ;; shares.
-            handle-a (:ops (collector/frame-row frame-id))
+            handle-a (:ops (rf.hicasso.impl.collector/frame-row frame-id))
             _        (reincarnate! "B")
             _        (is (nil? (marked)) "sanity: the successor starts unmarked")
             {:keys [refusals]} (with-refusals #(invoke handle-a))]
@@ -219,7 +219,7 @@
             successor's app-db nor leave a reaction in the successor's
             sub-cache"
     (let [_        (incarnate! "A")
-          handle-a (:ops (collector/frame-row frame-id))
+          handle-a (:ops (rf.hicasso.impl.collector/frame-row frame-id))
           _        (reincarnate! "B")
           {:keys [result refusals]} (with-refusals #((:subscribe handle-a) [:reinc/who]))]
       (is (nil? result) "the recovery is nil, never the successor's value")
@@ -279,7 +279,7 @@
   `impl.collector/run-once` binds for a body's dynamic extent, and therefore
   exactly what every callback that body lowers retains."
   []
-  (collector/frame-dispatch frame-id))
+  (rf.hicasso.impl.collector/frame-dispatch frame-id))
 
 (def ^:private postures
   "The three states the arm's one frame row can be in when a retained callback
@@ -298,8 +298,8 @@
             is the ordinary case: a boundary that rendered but that nobody
             clicked before the teardown."
   [[:cold  (fn [])]
-   [:warm  (fn [] (collector/frame-dispatch frame-id))]
-   [:reset (fn [] (frames/forget-frame-ops! frame-id))]])
+   [:warm  (fn [] (rf.hicasso.impl.collector/frame-dispatch frame-id))]
+   [:reset (fn [] (rf.hicasso.impl.frames/forget-frame-ops! frame-id))]])
 
 (deftest a-retained-callback-is-pinned-to-the-incarnation-that-lowered-it
   (doseq [[posture establish!] postures]
@@ -349,11 +349,11 @@
   (let [_     (incarnate! "A")
         a1    (render-dispatch)
         a2    (render-dispatch)
-        ops-a (:ops (collector/frame-row frame-id))
+        ops-a (:ops (rf.hicasso.impl.collector/frame-row frame-id))
         _     (reincarnate! "B")
         b1    (render-dispatch)
         b2    (render-dispatch)
-        ops-b (:ops (collector/frame-row frame-id))]
+        ops-b (:ops (rf.hicasso.impl.collector/frame-row frame-id))]
     (is (identical? a1 a2)
         "repeated renders of ONE incarnation share one handler — the memo is
          still a memo, and a boundary re-render allocates nothing")
@@ -365,8 +365,8 @@
     (is (not (identical? ops-a ops-b))
         "the captured bundle underneath moved with it — the row is ONE record,
          so the closure and the bundle cannot describe different incarnations")
-    (is (true? (frame/frame-incarnation-live?
-                 frame-id (:incarnation (collector/frame-row frame-id))))
+    (is (true? (rf.frame/frame-incarnation-live?
+                 frame-id (:incarnation (rf.hicasso.impl.collector/frame-row frame-id))))
         "and the row answering now is pinned to the incarnation live now")))
 
 ;; ---------------------------------------------------------------------------
@@ -380,11 +380,11 @@
 ;; where that shows up.
 (def ^:private lowering-paths
   [[:intent-vector
-    (fn [tag] (intent/lower-prop :on-click [:reinc/mark tag]))]
+    (fn [tag] (rf.hicasso.impl.intent/lower-prop :on-click [:reinc/mark tag]))]
    [:h-fn-returning-an-intent
-    (fn [tag] (intent/lower-prop :on-click (intent/callback (fn [_e] [:reinc/mark tag]))))]
+    (fn [tag] (rf.hicasso.impl.intent/lower-prop :on-click (rf.hicasso.impl.intent/callback (fn [_e] [:reinc/mark tag]))))]
    [:key-map-branch
-    (fn [tag] (intent/lower-prop :on-key-down {"Enter" [:reinc/mark tag]}))]
+    (fn [tag] (rf.hicasso.impl.intent/lower-prop :on-key-down {"Enter" [:reinc/mark tag]}))]
    [:handler-inside-a-render-callback
     ;; The render callback is lowered under the boundary, then INVOKED — which
     ;; is when its inner handler is lowered, against the gate — and the handler
@@ -392,15 +392,15 @@
     ;; boundary's dispatch once the call has returned, so this path inherits
     ;; the pin one level deeper than the other three.
     (fn [tag]
-      ((intent/lower-prop :row-render
-                          (intent/callback
-                            (fn [] (intent/lower-prop :on-click [:reinc/mark tag]))))))]])
+      ((rf.hicasso.impl.intent/lower-prop :row-render
+                          (rf.hicasso.impl.intent/callback
+                            (fn [] (rf.hicasso.impl.intent/lower-prop :on-click [:reinc/mark tag]))))))]])
 
 (defn- lower-under-boundary
   "Lower through `f` inside the render-time ambient binding a boundary body
   runs under — `impl.collector/run-once`'s, spelled out."
   [f]
-  (intent/with-frame frame-id (render-dispatch) f))
+  (rf.hicasso.impl.intent/with-frame frame-id (render-dispatch) f))
 
 (defn- fire!
   "Invoke a lowered handler the way its position's invoker would. One event
@@ -439,14 +439,14 @@
 (deftest reset-empties-the-frame-memo
   (incarnate! "A")
   (render-dispatch)
-  (is (contains? @frames/!frame-ops frame-id)
+  (is (contains? @rf.hicasso.impl.frames/!frame-ops frame-id)
       "a render leaves exactly one row behind — the bundle and the ambient
        dispatch are one record now, so acquiring the dispatch acquires both")
-  (is (= 1 (:frames (runtime/stats)))
+  (is (= 1 (:frames (rf.hicasso.test.runtime/stats)))
       "which is what the residue census counts under its `:frame-ops` token")
-  (collector/reset-runtime!)
-  (is (= {} @frames/!frame-ops) "and the whole-runtime reset empties it")
-  (is (= 0 (:frames (runtime/stats)))))
+  (rf.hicasso.impl.collector/reset-runtime!)
+  (is (= {} @rf.hicasso.impl.frames/!frame-ops) "and the whole-runtime reset empties it")
+  (is (= 0 (:frames (rf.hicasso.test.runtime/stats)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 8. NEGATIVE CONTROL — restore late keyword resolution and BOTH failures
@@ -473,7 +473,7 @@
   [!memo]
   (fn late-frame-dispatch [frame-kw]
     (fn late-dispatch-for-frame [event]
-      (collector/with-commit
+      (rf.hicasso.impl.collector/with-commit
         (fn []
           (let [ops (or (get @!memo frame-kw)
                         (let [captured (rf/capture-frame frame-kw)]

--- a/implementation/hicasso/test/re_frame/hicasso/reincarnation_seams_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/reincarnation_seams_cljs_test.cljs
@@ -62,17 +62,17 @@
   argued, because \"it did not reproduce\" and \"it cannot happen\" are
   different claims and only the second closes the audit."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso.impl.boundary :as boundary]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.routing.link :as routing-link]
-            [re-frame.test-support :as test-support]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso.impl.boundary :as rf.hicasso.impl.boundary]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.routing.link :as rf.routing.link]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::seams)
 
@@ -91,13 +91,13 @@
 ;; containing an `(async done …)` test, and section 4's end-to-end row is only
 ;; observable across the router's queue drain.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
      :init-fn       (fn []
-                      (collector/reset-runtime!)
-                      (error-emit/clear-error-listeners!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!)
+                      (rf.error-emit/clear-error-listeners!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness — deliberately the sibling suite's, so the two files are comparable
@@ -112,11 +112,11 @@
   is the state the arm is genuinely in when a page first mounts."
   [who]
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-  (when (frame/frame-incarnation-token frame-id) (rf/destroy-frame! frame-id))
-  (collector/reset-runtime!)
+  (when (rf.frame/frame-incarnation-token frame-id) (rf/destroy-frame! frame-id))
+  (rf.hicasso.impl.collector/reset-runtime!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:seams/seed who]))
-  (frame/frame-incarnation-token frame-id))
+  (rf.frame/frame-incarnation-token frame-id))
 
 (defn- reincarnate!
   "Destroy the live incarnation and seat a fresh one under the same public id,
@@ -125,7 +125,7 @@
   (rf/destroy-frame! frame-id)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id (rf/dispatch-sync [:seams/seed who]))
-  (frame/frame-incarnation-token frame-id))
+  (rf.frame/frame-incarnation-token frame-id))
 
 (defn- render!
   "Leave the arm's memo row describing the incarnation live NOW — what a
@@ -143,7 +143,7 @@
   late-binding mechanism passes, which is the same mistake in its detectable
   form."
   []
-  (collector/frame-dispatch frame-id))
+  (rf.hicasso.impl.collector/frame-dispatch frame-id))
 
 (defn- marked [] (:marked (rf/app-db-value frame-id)))
 
@@ -157,10 +157,10 @@
   [thunk]
   (let [seen (atom [])
         k    (keyword "rf2-q9cf" (name (gensym "refusal")))]
-    (error-emit/register-error-listener!
+    (rf.error-emit/register-error-listener!
       k (fn [r] (when (= :rf.error/frame-destroyed (:error r)) (swap! seen conj r))))
     (try {:result (thunk) :refusals @seen}
-         (finally (error-emit/unregister-error-listener! k)))))
+         (finally (rf.error-emit/unregister-error-listener! k)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. THE AXIS — the two doors in `impl.collector`, twenty lines apart, and the
@@ -179,7 +179,7 @@
   (testing "a RETAINED closure is a capability — minted under A, it is still
             A's after A dies, and core refuses it"
     (incarnate! "A")
-    (let [on-click (collector/frame-dispatch frame-id)]
+    (let [on-click (rf.hicasso.impl.collector/frame-dispatch frame-id)]
       (reincarnate! "B")
       (let [{:keys [refusals]} (with-refusals #(on-click [:seams/mark :capability]))]
         (is (nil? (marked))
@@ -197,7 +197,7 @@
     (render!)                                         ; leave a WARM row for A
     (reincarnate! "B")
     (let [{:keys [refusals]} (with-refusals
-                               #(collector/dispatch! frame-id [:seams/mark :address]))]
+                               #(rf.hicasso.impl.collector/dispatch! frame-id [:seams/mark :address]))]
       (is (= :address (marked))
           "the write lands in the LIVE incarnation, even from a warm row that
            described the predecessor a line ago — the row is replaced by the
@@ -208,12 +208,12 @@
             same state, which is what makes `capability or address?` a real
             question to ask of a seam rather than a form of words"
     (incarnate! "A")
-    (let [retained (collector/frame-dispatch frame-id)]
+    (let [retained (rf.hicasso.impl.collector/frame-dispatch frame-id)]
       (reincarnate! "B")
       (let [{:keys [refusals]} (with-refusals #(retained [:seams/mark :retained]))]
         (is (nil? (marked)))
         (is (= 1 (count refusals))))
-      (collector/dispatch! frame-id [:seams/mark :fresh])
+      (rf.hicasso.impl.collector/dispatch! frame-id [:seams/mark :fresh])
       (is (= :fresh (marked))))))
 
 ;; ---------------------------------------------------------------------------
@@ -247,7 +247,7 @@
 (defn- catch!
   "Hand `this` a caught error the way React's commit phase does."
   [this]
-  (.call (.-componentDidCatch (.-prototype boundary/boundary))
+  (.call (.-componentDidCatch (.-prototype rf.hicasso.impl.boundary/boundary))
          this
          (js/Error. "rf2-q9cf")
          #js {"componentStack" ""}))
@@ -367,7 +367,7 @@
     (render!)
     (let [handle {:frame frame-id}]                  ; the slot `dispatch!` reads
       (reincarnate! "B")
-      (let [{:keys [refusals]} (with-refusals #(mount/dispatch! handle [:seams/mark :handle]))]
+      (let [{:keys [refusals]} (with-refusals #(rf.hicasso.impl.mount/dispatch! handle [:seams/mark :handle]))]
         (is (= :handle (marked))
             "the retained handle reaches the LIVE incarnation")
         (is (empty? refusals)))))
@@ -380,9 +380,9 @@
             and the root would WRITE a frame it cannot READ: perfect markup
             above dead controls, which is the exact symptom rf2-x874 deleted"
     (incarnate! "A")
-    (is (= "A" (collector/render-body frame-id (fn [_] (collector/sub [:seams/who])) {})))
+    (is (= "A" (rf.hicasso.impl.collector/render-body frame-id (fn [_] (rf.hicasso.impl.collector/sub [:seams/who])) {})))
     (reincarnate! "B")
-    (is (= "B" (collector/render-body frame-id (fn [_] (collector/sub [:seams/who])) {}))
+    (is (= "B" (rf.hicasso.impl.collector/render-body frame-id (fn [_] (rf.hicasso.impl.collector/sub [:seams/who])) {}))
         "the root's reads moved to the successor with nothing asked of them"))
 
   (testing "the handle carries a KEYWORD and not a capability — there is no
@@ -419,20 +419,20 @@
   "Run `thunk` with `f` published at `:routing/activate-link!`, restoring
   whatever was there before — nil included."
   [f thunk]
-  (let [previous (late-bind/get-fn :routing/activate-link!)]
-    (late-bind/set-fn! :routing/activate-link! f)
+  (let [previous (rf.late-bind/get-fn :routing/activate-link!)]
+    (rf.late-bind/set-fn! :routing/activate-link! f)
     (try (thunk)
-         (finally (late-bind/set-fn! :routing/activate-link! previous)))))
+         (finally (rf.late-bind/set-fn! :routing/activate-link! previous)))))
 
 (defn- lower-navigate
   "Lower one `[intent/navigate-head {…}]` under the ambient binding a boundary body
   runs — `impl.collector/run-once`'s, spelled out — and answer the closure the
   browser would call. The map is exactly what `route-link` mints."
   [tag]
-  (intent/with-frame frame-id (collector/frame-dispatch frame-id)
+  (rf.hicasso.impl.intent/with-frame frame-id (rf.hicasso.impl.collector/frame-dispatch frame-id)
     (fn []
-      (intent/lower-prop :on-click
-                         [intent/navigate-head {:frame   frame-id
+      (rf.hicasso.impl.intent/lower-prop :on-click
+                         [rf.hicasso.impl.intent/navigate-head {:frame   frame-id
                                                 :payload [:seams/mark tag]
                                                 :native? false
                                                 :veto    nil}]))))
@@ -476,7 +476,7 @@
   ;; paraphrase of it — the caller-veto / modifier / native-anchor law and the
   ;; `router/dispatch!` opts are the shipped ones.
   (async done
-    (with-activate-link routing-link/activate-link!
+    (with-activate-link rf.routing.link/activate-link!
       (fn []
         (incarnate! "A")
         (let [on-click (lower-navigate :navigated)]

--- a/implementation/hicasso/test/re_frame/hicasso/retaining_host_callbacks_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/retaining_host_callbacks_dom_cljs_test.cljs
@@ -86,18 +86,18 @@
   This file does not restate it: it asks whether the law survives a real
   React vendor holding the closure, and what the law costs there."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.frames :as frames]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.native :as n]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.frames :as rf.hicasso.impl.frames]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.native :as rf.hicasso.native]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]))
 
 (def ^:private frame-id ::retaining-host)
@@ -127,8 +127,8 @@
 (rf/reg-sub ::ticks (fn [db _] (:tick db)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The MAP shape, because section 6's delayed row is `(async done …)`.
      ;; A fn-form fixture unwinds the instant it returns, which for an async
@@ -136,8 +136,8 @@
      ;; loudly enough to take the whole namespace down with it.
      :async?        true
      :init-fn       (fn []
-                      (collector/reset-runtime!)
-                      (error-emit/clear-error-listeners!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!)
+                      (rf.error-emit/clear-error-listeners!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The vendor — ordinary React, memoized, and it KEEPS what it is handed
@@ -176,7 +176,7 @@
 
 (def ^:private sink (react/memo sink-body))
 
-(h/defhost sink-event
+(rf.hicasso/defhost sink-event
   "The crossing under the RULED DEFAULT `:server :client-only`, so the grid
   measures the path a consumer gets by writing nothing. The gate that
   policy mints is a plain function component that hands its props object
@@ -205,26 +205,26 @@
   author's own function does not hoist what the vendor sees. That is the
   `:event-hoisted` row, and it is the row that shows the churn is the
   LOWERING's and not the author's."
-  (h/event [& _] (swap! !plain-calls inc) [::ping :hoisted]))
+  (rf.hicasso/event [& _] (swap! !plain-calls inc) [::ping :hoisted]))
 
 ;; ---------------------------------------------------------------------------
 ;; The interpreted parent — one boundary, one read, eight carriers
 ;; ---------------------------------------------------------------------------
 
-(h/defview host-parent
+(rf.hicasso/defview host-parent
   "Reads a piece of app-db the vendor's props do not depend on, so every
   tick re-runs this body and hands the crossing a fresh props object
   carrying semantically identical values. Whether the vendor re-renders
   is then a question about ONE thing: the identity of what sits at
   `:on-ping`."
   [{:keys [arm]}]
-  (let [tick (h/sub [::ticks])]
+  (let [tick (rf.hicasso/sub [::ticks])]
     [:div.parent {:data-tick (str tick)}
      (case arm
        :absent        [sink-event   {:label "s"}]
        :plain-fn      [sink-event   {:label "s" :on-ping plain-ping}]
        :intent-vector [sink-event   {:label "s" :on-ping [::ping :vector]}]
-       :event-inline  [sink-event   {:label "s" :on-ping (h/event [& _] [::ping :inline])}]
+       :event-inline  [sink-event   {:label "s" :on-ping (rf.hicasso/event [& _] [::ping :inline])}]
        :event-hoisted [sink-event   {:label "s" :on-ping hoisted-event}]
        :key-map       [sink-event   {:label "s" :on-ping {"Enter" [::ping :key-map]}}])]))
 
@@ -254,8 +254,8 @@
   solution the standing rule asks about, assembled out of surface that
   already ships."
   [^js _props]
-  (let [_tick   (n/use-sub [::ticks])
-        ops     (n/use-frame)
+  (let [_tick   (rf.hicasso.native/use-sub [::ticks])
+        ops     (rf.hicasso.native/use-frame)
         on-ping (react/useCallback
                   (fn [& _] ((:dispatch-sync ops) [::ping :native-stable]) nil)
                   #js [ops])]
@@ -267,16 +267,16 @@
   bail-out to the island, to the missing gate, or to `use-frame` itself
   rather than to the memoisation of the closure."
   [^js _props]
-  (let [_tick (n/use-sub [::ticks])
-        ops   (n/use-frame)]
+  (let [_tick (rf.hicasso.native/use-sub [::ticks])
+        ops   (rf.hicasso.native/use-frame)]
     (react/createElement sink
                          #js {:label  "s"
                               :onPing (fn [& _]
                                         ((:dispatch-sync ops) [::ping :native-churn])
                                         nil)})))
 
-(h/defview stable-parent [_] (react/createElement stable-island nil))
-(h/defview churn-parent  [_] (react/createElement churning-island nil))
+(rf.hicasso/defview stable-parent [_] (react/createElement stable-island nil))
+(rf.hicasso/defview churn-parent  [_] (react/createElement churning-island nil))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -294,9 +294,9 @@
   inside one."
   ([] (fresh! "A"))
   ([who]
-   (support/leave-act-environment!)
-   (when (frame/frame-incarnation-token frame-id) (rf/destroy-frame! frame-id))
-   (frames/forget-frame-ops! frame-id)
+   (rf.hicasso.checkpoint-support/leave-act-environment!)
+   (when (rf.frame/frame-incarnation-token frame-id) (rf/destroy-frame! frame-id))
+   (rf.hicasso.impl.frames/forget-frame-ops! frame-id)
    (rf/make-frame {:id frame-id})
    (rf/with-frame frame-id (rf/dispatch-sync [::seed who]))
    (reset! !sink-runs 0)
@@ -327,10 +327,10 @@
   [thunk]
   (let [seen (atom [])
         k    (keyword "rf2-hic-029" (name (gensym "refusal")))]
-    (error-emit/register-error-listener!
+    (rf.error-emit/register-error-listener!
       k (fn [r] (when (= :rf.error/frame-destroyed (:error r)) (swap! seen conj r))))
     (try {:result (thunk) :refusals @seen}
-         (finally (error-emit/unregister-error-listener! k)))))
+         (finally (rf.error-emit/unregister-error-listener! k)))))
 
 (defn- fire!
   "Invoke a retained handler the way its position's invoker would. One
@@ -345,11 +345,11 @@
   defeated by identity."
   [form]
   (fresh!)
-  (let [handle (mount/root! (mount/fresh-container!) frame-id form)]
+  (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id form)]
     (try
-      (dotimes [_ ticks] (mount/dispatch! handle [::tick]))
+      (dotimes [_ ticks] (rf.hicasso.impl.mount/dispatch! handle [::tick]))
       @!sink-runs
-      (finally (mount/release! handle)))))
+      (finally (rf.hicasso.impl.mount/release! handle)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — THE GRID. What a memoized vendor costs, per carrier
@@ -369,7 +369,7 @@
    [:native-churn  [churn-parent {}]                   :re-renders]])
 
 (deftest the-memoized-vendor-grid
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM, and a memo bail-out is React's own")
     (doseq [[carrier form expectation] grid]
       (testing (str (name carrier) " — the vendor "
@@ -388,20 +388,20 @@
   ;; no longer notifies, a tick that no longer writes. So the same
   ;; scenario is asked the opposite question: the carriers that churn must
   ;; churn by exactly the number of ticks that were driven.
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (testing "the parent really did re-render once per tick"
         (fresh!)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id
+        (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                   [host-parent {:arm :intent-vector}])]
           (try
-            (dotimes [_ ticks] (mount/dispatch! handle [::tick]))
+            (dotimes [_ ticks] (rf.hicasso.impl.mount/dispatch! handle [::tick]))
             (is (= (str ticks) (.getAttribute (.querySelector (:container handle) ".parent")
                                               "data-tick"))
                 "the parent painted every tick, so the bail-out rows above were
                  given something to bail out of")
-            (finally (mount/release! handle)))))
+            (finally (rf.hicasso.impl.mount/release! handle)))))
 
       (testing "and the vendor is one component, so the two answers are
                 comparable rather than two different memos"
@@ -416,34 +416,34 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest what-the-vendor-holds-across-renders
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (testing "a lowered intent vector hands the vendor a NEW function every
                 render — which is the mechanism the grid measures the
                 consequence of"
         (fresh!)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id
+        (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                   [host-parent {:arm :intent-vector}])]
           (try
-            (dotimes [_ ticks] (mount/dispatch! handle [::tick]))
+            (dotimes [_ ticks] (rf.hicasso.impl.mount/dispatch! handle [::tick]))
             (is (= (inc ticks) (count @!held)))
             (is (= (inc ticks) (count (set @!held)))
                 "every one of them is a distinct object")
-            (finally (mount/release! handle)))))
+            (finally (rf.hicasso.impl.mount/release! handle)))))
 
       (testing "the identity-stable carriers hand it the SAME function every
                 render, so the bail-out above is `Object.is` answering true
                 rather than React skipping a render for some other reason"
         (doseq [arm [:plain-fn]]
           (fresh!)
-          (let [handle (mount/root! (mount/fresh-container!) frame-id
+          (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                     [host-parent {:arm arm}])]
             (try
-              (dotimes [_ ticks] (mount/dispatch! handle [::tick]))
+              (dotimes [_ ticks] (rf.hicasso.impl.mount/dispatch! handle [::tick]))
               (is (= 1 (count @!held))
                   (str (name arm) " re-rendered the vendor"))
-              (finally (mount/release! handle)))))))))
+              (finally (rf.hicasso.impl.mount/release! handle)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — RETENTION. A callback the vendor kept still routes inside its own
@@ -451,17 +451,17 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-mount-renders-callback-still-routes-after-later-renders
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                 [host-parent {:arm :intent-vector}])]
         (try
-          (dotimes [_ ticks] (mount/dispatch! handle [::tick]))
+          (dotimes [_ ticks] (rf.hicasso.impl.mount/dispatch! handle [::tick]))
           (let [oldest (first @!held)
                 {:keys [refusals]} (with-refusals #(fire! oldest))]
-            (mount/settle!)
+            (rf.hicasso.impl.mount/settle!)
             (is (= 1 (pings))
                 "the closure minted by the MOUNT render — five renders stale,
                  and the only one a vendor holding its first handler would
@@ -471,21 +471,21 @@
                 "and nothing is refused: staleness across renders is not
                  staleness across incarnations, and only the second is a
                  fault"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — TEARDOWN and RETIREMENT. Harmless afterwards, and LOUDLY so
 ;; ---------------------------------------------------------------------------
 
 (deftest a-retained-callback-is-harmless-after-the-frame-is-retired
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle   (mount/root! (mount/fresh-container!) frame-id
+      (let [handle   (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                   [host-parent {:arm :intent-vector}])
-            retained (do (mount/dispatch! handle [::tick]) (first @!held))]
-        (mount/unmount! handle)
+            retained (do (rf.hicasso.impl.mount/dispatch! handle [::tick]) (first @!held))]
+        (rf.hicasso.impl.mount/unmount! handle)
         (rf/destroy-frame! frame-id)
         (let [{:keys [refusals]} (with-refusals #(fire! retained))]
           (is (= 1 (count refusals))
@@ -494,7 +494,7 @@
                indistinguishable from a handler that quietly worked")
           (is (= frame-id (:frame (first refusals))) "attributed to the captured id")
           (is (= ::ping (:event-id (first refusals))) "carrying the refused event's head"))
-        (is (nil? (frame/frame-incarnation-token frame-id))
+        (is (nil? (rf.frame/frame-incarnation-token frame-id))
             "and the retirement really happened, so the refusal above is not a
              frame that was never there")))))
 
@@ -504,16 +504,16 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-retained-callback-cannot-write-the-successor-under-the-same-id
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (testing "SAFETY — the predecessor's callback, still held by a live
                 vendor, is refused against a successor at the same address"
         (fresh! "A")
-        (let [handle   (mount/root! (mount/fresh-container!) frame-id
+        (let [handle   (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                     [host-parent {:arm :intent-vector}])
               retained (first @!held)]
-          (mount/unmount! handle)
+          (rf.hicasso.impl.mount/unmount! handle)
           (reincarnate! "B")
           (is (zero? (pings)) "sanity: the successor starts unpinged")
           (let [{:keys [refusals]} (with-refusals #(fire! retained))]
@@ -528,14 +528,14 @@
                 one, so the silence above is a refusal and not a runtime in
                 which nothing dispatches at all"
         (fresh! "B")
-        (let [handle (mount/root! (mount/fresh-container!) frame-id
+        (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                   [host-parent {:arm :intent-vector}])]
           (try
             (let [{:keys [refusals]} (with-refusals #(fire! (first @!held)))]
-              (mount/settle!)
+              (rf.hicasso.impl.mount/settle!)
               (is (= 1 (pings)) "the live incarnation's own vendor writes its own app-db")
               (is (empty? refusals)))
-            (finally (mount/release! handle))))))))
+            (finally (rf.hicasso.impl.mount/release! handle))))))))
 
 (deftest NEGATIVE-CONTROL-an-unpinned-capture-does-reach-the-successor
   ;; Section 5's safety half asserts a NON-event, and the bead names the
@@ -544,7 +544,7 @@
   ;; seam rather than by redefining a runtime var — `rf/capture-frame`
   ;; taken while NO frame is live under the id pins nothing, so the ops
   ;; stay address-directed and write whoever occupies the address later.
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (let [unpinned (rf/capture-frame frame-id)]    ; captured with no live frame
       (fresh! "A")
@@ -566,14 +566,14 @@
   ;; a vendor never fires from. This one goes through a real `setTimeout`,
   ;; long after the render's dynamic extent has unwound and after the
   ;; teardown — the debounce, the socket message, the animation frame.
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (async done
       (fresh! "A")
-      (let [handle   (mount/root! (mount/fresh-container!) frame-id
+      (let [handle   (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                   [host-parent {:arm :intent-vector}])
             retained (first @!held)]
-        (mount/unmount! handle)
+        (rf.hicasso.impl.mount/unmount! handle)
         (reincarnate! "B")
         (js/setTimeout
           (fn []
@@ -598,18 +598,18 @@
   ;; page and without one. `hm/bodies-run` is the page-wide reading for
   ;; exactly this and it settles inside the thunk, which `mount/dispatch!`
   ;; already does.
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (doseq [arm [:absent :intent-vector :plain-fn]]
       (testing (str "one tick runs one boundary body with the " (name arm)
                     " carrier on the page")
         (fresh!)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id
+        (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id
                                   [host-parent {:arm arm}])]
           (try
-            (is (= 1 (hm/bodies-run #(mount/dispatch! handle [::tick])))
+            (is (= 1 (rf.hicasso.test.mounted/bodies-run #(rf.hicasso.impl.mount/dispatch! handle [::tick])))
                 "the parent's body, and nothing else. The crossing, the gate
                  and the vendor are not boundaries, and the pin the safety
                  rests on is a memo row acquired once per incarnation rather
                  than work done per render")
-            (finally (mount/release! handle))))))))
+            (finally (rf.hicasso.impl.mount/release! handle))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/revision_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/revision_dom_cljs_test.cljs
@@ -62,8 +62,8 @@
   Runtime: `-dom-cljs-test`. Every row needs a real React tree over a real
   document; under `:node-test` each degrades to a stated skip."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.controlled :as controlled]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.controlled :as rf.hicasso.impl.controlled]
             ["react" :as react]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
@@ -135,7 +135,7 @@
 (def ^:private walled-field
   (react/memo
    (fn [props]
-     (codec/as-element
+     (rf.hicasso.impl.codec/as-element
       (field (keyword (unchecked-get props "tag"))
              (unchecked-get props "value")
              (unchecked-get props "revision"))))))
@@ -174,12 +174,12 @@
       (let [c    (container!)
             root (react-dom-client/createRoot c)]
         (try
-          (render! root (codec/as-element (field :input "committed")))
+          (render! root (rf.hicasso.impl.codec/as-element (field :input "committed")))
           (let [n (node c)]
             (is (= "committed" (.-value n)))
             (drift! n "foreign")
             (is (= "foreign" (.-value n)) "the drift really landed")
-            (render! root (codec/as-element (field :input "committed")))
+            (render! root (rf.hicasso.impl.codec/as-element (field :input "committed")))
             (is (= "committed" (.-value n))
                 "the commit re-asserted the model over the drift")
             (is (identical? n (node c))
@@ -196,11 +196,11 @@
       (let [c    (container!)
             root (react-dom-client/createRoot c)]
         (try
-          (render! root (codec/as-element (field :textarea "committed")))
+          (render! root (rf.hicasso.impl.codec/as-element (field :textarea "committed")))
           (let [n (node c)]
             (is (= "TEXTAREA" (.-tagName n)))
             (drift! n "foreign")
-            (render! root (codec/as-element (field :textarea "committed")))
+            (render! root (rf.hicasso.impl.codec/as-element (field :textarea "committed")))
             (is (= "committed" (.-value n)))
             (is (identical? n (node c))))
           (finally (react-dom/flushSync #(.unmount root)) (drop-container! c)))))))
@@ -232,9 +232,9 @@
            field's first, so no reset ever fires and the draft survives.
            What THIS row pins is the fact underneath that: the prop cannot
            influence adoption at all."
-    (let [with-rev    (codec/as-element (field :input "server" "rev-1"))
-          bumped      (codec/as-element (field :input "server" "rev-2"))
-          without-rev (codec/as-element (field :input "server"))
+    (let [with-rev    (rf.hicasso.impl.codec/as-element (field :input "server" "rev-1"))
+          bumped      (rf.hicasso.impl.codec/as-element (field :input "server" "rev-2"))
+          without-rev (rf.hicasso.impl.codec/as-element (field :input "server"))
           names       (fn [el] (vec (sort (js/Object.keys (.-props el)))))
           plain       (fn [el] (into {} (for [k (names el)
                                               :let [v (unchecked-get (.-props el) k)]
@@ -256,7 +256,7 @@
            two places, so a `revision` cannot reach the wire by construction
            rather than by a server-side special case"
     (let [bytes (react-dom-server/renderToString
-                 (codec/as-element (field :input "server" "rev-1")))]
+                 (rf.hicasso.impl.codec/as-element (field :input "server" "rev-1")))]
       (is (re-find #"value=\"server\"" bytes))
       (is (not (re-find #"revision" bytes)) bytes))))
 
@@ -391,7 +391,7 @@
              ["a <select>, which has no text cursor and no mirror"
               [:select {:re-frame.hicasso/revision "r" :value "x" :on-input noop-input}]]]]
       (is (= :rf.error/hicasso-revision-not-controlled
-             (:rf.error/id (errors-of #(codec/as-element hiccup))))
+             (:rf.error/id (errors-of #(rf.hicasso.impl.codec/as-element hiccup))))
           what)))
   (testing "and the coverage is stated honestly rather than overstated.
            `controlled-text-tag?` is deliberately TYPE-BLIND — tag plus a
@@ -405,7 +405,7 @@
              ["an <input type=number>, with caret semantics that do not apply"
               [:input {:type :number :value "1"
                        :re-frame.hicasso/revision "r" :on-input noop-input}]]]]
-      (is (nil? (errors-of #(codec/as-element hiccup))) what))))
+      (is (nil? (errors-of #(rf.hicasso.impl.codec/as-element hiccup))) what))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — NEVER A DOM ATTRIBUTE
@@ -418,7 +418,7 @@
            bytes cannot carry a revision by construction rather than by a
            server-side special case."
     (let [bytes (react-dom-server/renderToString
-                 (codec/as-element (field :input "committed" "rev-1")))]
+                 (rf.hicasso.impl.codec/as-element (field :input "committed" "rev-1")))]
       (is (not (re-find #"revision" bytes))
           (str "no revision in the server bytes: " bytes))
       (is (re-find #"value=\"committed\"" bytes)
@@ -429,7 +429,7 @@
       (let [c    (container!)
             root (react-dom-client/createRoot c)]
         (try
-          (render! root (codec/as-element (field :input "committed" "rev-1")))
+          (render! root (rf.hicasso.impl.codec/as-element (field :input "committed" "rev-1")))
           (let [n (node c)]
             (is (not (.hasAttribute n "revision")))
             (is (not (re-find #"revision" (.-outerHTML n)))
@@ -438,15 +438,15 @@
           (finally (react-dom/flushSync #(.unmount root)) (drop-container! c))))))
   (testing "and the marker the codec stashes for `install!` does not survive
            it either — it exists for the length of one call"
-    (let [el (codec/as-element (field :input "committed" "rev-1"))]
-      (is (undefined? (unchecked-get (.-props el) controlled/revision-slot))
+    (let [el (rf.hicasso.impl.codec/as-element (field :input "committed" "rev-1"))]
+      (is (undefined? (unchecked-get (.-props el) rf.hicasso.impl.controlled/revision-slot))
           "deleted as it was read")
       (is (undefined? (unchecked-get (.-props el) "revision"))
           "and never emitted under its own name")))
   (testing "every OTHER spelling is an ordinary attribute, which is the
            documented honest loss: the exact namespaced keyword or nothing"
     (let [bytes (react-dom-server/renderToString
-                 (codec/as-element
+                 (rf.hicasso.impl.codec/as-element
                   [:input {:value "committed" :on-input noop-input :revision "rev-1"}]))]
       (is (re-find #"revision=\"rev-1\"" bytes)
           (str "a misspelled bare :revision is silent and becomes an
@@ -481,14 +481,14 @@
       (let [c    (container!)
             root (react-dom-client/createRoot c)]
         (try
-          (render! root (codec/as-element (field :input "committed" "rev-1")))
+          (render! root (rf.hicasso.impl.codec/as-element (field :input "committed" "rev-1")))
           (let [n (node c)]
             (.focus n)
             (composing-input! n "kana-in-flight")
             (is (= "kana-in-flight" (.-value n))
                 "the shadow holds the live draft, so React's own restore
                  finds nothing to write")
-            (render! root (codec/as-element (field :input "committed" "rev-2")))
+            (render! root (rf.hicasso.impl.codec/as-element (field :input "committed" "rev-2")))
             (is (= "kana-in-flight" (.-value n))
                 "THE DEFERRAL: the revision bumped mid-composition and the
                  exchange was NOT destroyed — no immediate write, so no
@@ -521,7 +521,7 @@
             !model (atom "committed")
             accept (fn [e] (reset! !model (.. e -target -value)))
             paint! (fn [rev]
-                     (render! root (codec/as-element
+                     (render! root (rf.hicasso.impl.codec/as-element
                                     [:input {:id "f" :value @!model :on-input accept
                                              :re-frame.hicasso/revision rev}])))]
         (try
@@ -587,7 +587,7 @@
             !runs (atom 0)
             paint! (fn [rev]
                      (render! root
-                              (codec/as-element
+                              (rf.hicasso.impl.codec/as-element
                                [:input {:id "f" :value "committed"
                                         :on-input (fn [_e] (swap! !runs inc))
                                         :re-frame.hicasso/revision rev}])))]

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -49,16 +49,16 @@
   dependency. What is NEW here is that every row runs TWO roots at once;
   the prototype's rows all run one."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.roots :as roots]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.motion :as motion]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.roots :as rf.hicasso.impl.roots]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.motion :as rf.hicasso.motion]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-a ::frame-a)
 (def ^:private frame-b ::frame-b)
@@ -73,17 +73,17 @@
 (rf/reg-event ::seed (fn [_ [_ label]] {:db {:label label}}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The app
 ;; ---------------------------------------------------------------------------
 
-(h/defview screen
+(rf.hicasso/defview screen
   "One boundary, one prop and one subscription read.
 
   `title` is a PROP so a server/client divergence is a one-argument
@@ -93,7 +93,7 @@
   [{:keys [title]}]
   [:div.screen
    [:h1.title title]
-   [:p.value (h/sub label-q)]])
+   [:p.value (rf.hicasso/sub label-q)]])
 
 ;; ---------------------------------------------------------------------------
 ;; The presence app — H5's, and the observable that makes a PHASE readable
@@ -104,7 +104,7 @@
   ;; order. Reset at the top of the row that reads it.
   (atom {}))
 
-(h/defview phase-probe
+(rf.hicasso/defview phase-probe
   "A presence child that is a BOUNDARY, so the machine merges the phase's
   override map into its PROPS (`impl.presence/with-phase`, HD-030)
   instead of into a node's attributes. The tray below declares
@@ -128,31 +128,31 @@
   (swap! !phases update tag (fnil conj []) phase)
   [:span.probe (name phase)])
 
-(h/defview tray-screen
+(rf.hicasso/defview tray-screen
   "A screen with a presence tray in it. Reads the label subscription as
   [[screen]] does, so this root acquires a frame-keyed cell and its commit
   is observable; the tray is what the row is about."
   [{:keys [tag]}]
   [:div.screen
-   [:p.value (h/sub label-q)]
-   [motion/presence {:timeout-ms 50}
+   [:p.value (rf.hicasso/sub label-q)]
+   [rf.hicasso.motion/presence {:timeout-ms 50}
     [phase-probe {:key                 "one"
                   :tag                 tag
-                  ::motion/mounting    {:phase :mounting}
-                  ::motion/unmounting  {:phase :unmounting}}]]])
+                  ::rf.hicasso.motion/mounting    {:phase :mounting}
+                  ::rf.hicasso.motion/unmounting  {:phase :unmounting}}]]])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
 ;; ---------------------------------------------------------------------------
 
 (defn- fresh! []
-  (sup/leave-act-environment!)
+  (rf.hicasso.roots-frames-support/leave-act-environment!)
   (rf/make-frame {:id frame-a})
   (rf/make-frame {:id frame-b})
   (rf/with-frame frame-a (rf/dispatch-sync [::seed "alpha"]))
   (rf/with-frame frame-b (rf/dispatch-sync [::seed "beta"]))
-  (collector/reset-runtime!)
-  (runtime/reset-body-runs!)
+  (rf.hicasso.impl.collector/reset-runtime!)
+  (rf.hicasso.test.runtime/reset-body-runs!)
   nil)
 
 (defn- both-committed?
@@ -160,7 +160,7 @@
   before it, so a frame appearing in the cell table is that root's own
   completion signal — which the page-wide adoption window cannot be."
   []
-  (= #{frame-a frame-b} (sup/cell-frames)))
+  (= #{frame-a frame-b} (rf.hicasso.roots-frames-support/cell-frames)))
 
 (defn- text-in [container sel]
   (some-> (.querySelector container sel) .-textContent))
@@ -220,45 +220,45 @@
 
 (deftest two-overlapping-hydrating-roots-each-adopt-their-own-server-dom
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
-        (let [html-a (sup/server-html! frame-a [screen {:title "A"}])
-              html-b (sup/server-html! frame-b [screen {:title "B"}])
-              ca     (sup/stamp-server-nodes! (sup/server-dom! html-a))
-              cb     (sup/stamp-server-nodes! (sup/server-dom! html-b))]
-          (is (sup/every-server-node? ca ".screen, .title, .value")
+        (let [html-a (rf.hicasso.roots-frames-support/server-html! frame-a [screen {:title "A"}])
+              html-b (rf.hicasso.roots-frames-support/server-html! frame-b [screen {:title "B"}])
+              ca     (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-a))
+              cb     (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-b))]
+          (is (rf.hicasso.roots-frames-support/every-server-node? ca ".screen, .title, .value")
               "premise: the stamps are on the server's own nodes")
           (is (re-find #"alpha" html-a) "premise: frame A's markup carries frame A's value")
           (is (re-find #"beta"  html-b) "premise: frame B's markup carries frame B's value")
-          (collector/reset-runtime!)
-          (let [ha (mount/hydrate-root! ca frame-a [screen {:title "A"}])
-                hb (mount/hydrate-root! cb frame-b [screen {:title "B"}])]
+          (rf.hicasso.impl.collector/reset-runtime!)
+          (let [ha (rf.hicasso.impl.mount/hydrate-root! ca frame-a [screen {:title "A"}])
+                hb (rf.hicasso.impl.mount/hydrate-root! cb frame-b [screen {:title "B"}])]
             ;; The overlap is a CONSTRUCTION, not a timing guess: both
             ;; roots were handed to React before either had adopted, and
             ;; each root's OWN window being open on this line is what says
             ;; so. Two windows, because the window is per root —
             ;; asserting one page-wide flag here would be satisfied by
             ;; either root alone.
-            (is (true? (roots/adopting? (:adoption ha)))
+            (is (true? (rf.hicasso.impl.roots/adopting? (:adoption ha)))
                 "root A is in flight — `hydrate-root!` returns before the
                  tree is adopted, so its window outlives the call")
-            (is (true? (roots/adopting? (:adoption hb)))
+            (is (true? (rf.hicasso.impl.roots/adopting? (:adoption hb)))
                 "and so is root B, in its own window")
-            (-> (sup/wait-until! both-committed?)
+            (-> (rf.hicasso.roots-frames-support/wait-until! both-committed?)
                 (.then
                   (fn [ok]
                     (is (true? ok)
                         (str "both roots must commit; cell frames were "
-                             (pr-str (sup/cell-frames))))
+                             (pr-str (rf.hicasso.roots-frames-support/cell-frames))))
 
                     (testing "each root ADOPTED its own server DOM — the nodes
                               are the very nodes the markup produced, which no
                               re-render could reconstruct"
-                      (is (sup/every-server-node? ca ".screen, .title, .value")
+                      (is (rf.hicasso.roots-frames-support/every-server-node? ca ".screen, .title, .value")
                           "root A kept the server's nodes")
-                      (is (sup/every-server-node? cb ".screen, .title, .value")
+                      (is (rf.hicasso.roots-frames-support/every-server-node? cb ".screen, .title, .value")
                           "root B kept the server's nodes"))
 
                     (testing "and neither root's adoption reached into the
@@ -271,14 +271,14 @@
                     (testing "the cell table split by frame across the two
                               adoptions, exactly as it does across two ordinary
                               mounts"
-                      (is (= #{[frame-a label-q] [frame-b label-q]} (sup/cell-keys)))
-                      (is (= #{frame-a frame-b} (sup/frame-memo-frames))))))
-                (sup/settle-row!
+                      (is (= #{[frame-a label-q] [frame-b label-q]} (rf.hicasso.roots-frames-support/cell-keys)))
+                      (is (= #{frame-a frame-b} (rf.hicasso.roots-frames-support/frame-memo-frames))))))
+                (rf.hicasso.roots-frames-support/settle-row!
                   {:row      "H1 — two overlapping adoptions, each keeping its own DOM"
                    :done     done
                    :release! (fn []
-                               (mount/release! ha)
-                               (mount/release! hb))}))))))))
+                               (rf.hicasso.impl.mount/release! ha)
+                               (rf.hicasso.impl.mount/release! hb))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; H2 — two overlapping mismatches, two independent complaints
@@ -335,23 +335,23 @@
 ;; construction rather than on a schedule.
 (deftest two-overlapping-hydrating-roots-recover-and-complain-independently
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
-        (let [html-a (sup/server-html! frame-a [screen {:title "server-A"}])
-              html-b (sup/server-html! frame-b [screen {:title "server-B"}])
-              ca     (sup/server-dom! html-a)
-              cb     (sup/server-dom! html-b)]
-          (collector/reset-runtime!)
-          (let [{:keys [seen stop!]}      (sup/watch-mismatches!)
+        (let [html-a (rf.hicasso.roots-frames-support/server-html! frame-a [screen {:title "server-A"}])
+              html-b (rf.hicasso.roots-frames-support/server-html! frame-b [screen {:title "server-B"}])
+              ca     (rf.hicasso.roots-frames-support/server-dom! html-a)
+              cb     (rf.hicasso.roots-frames-support/server-dom! html-b)]
+          (rf.hicasso.impl.collector/reset-runtime!)
+          (let [{:keys [seen stop!]}      (rf.hicasso.roots-frames-support/watch-mismatches!)
                 ;; MANUFACTURED here and asserted on here — the only shape
                 ;; of call site at which swallowing an uncaught error is
                 ;; not the fail-open the pageerror rule forbids.
-                {:keys [captured close!]} (sup/open-console-capture! {:swallow-uncaught? true})
-                ha (mount/hydrate-root! ca frame-a [screen {:title "client-A"}])
-                hb (mount/hydrate-root! cb frame-b [screen {:title "client-B"}])]
-            (-> (sup/wait-until! both-committed?)
+                {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture! {:swallow-uncaught? true})
+                ha (rf.hicasso.impl.mount/hydrate-root! ca frame-a [screen {:title "client-A"}])
+                hb (rf.hicasso.impl.mount/hydrate-root! cb frame-b [screen {:title "client-B"}])]
+            (-> (rf.hicasso.roots-frames-support/wait-until! both-committed?)
                 (.then
                   (fn [ok]
                     ;; Closed and stopped HERE, and named in `:release!` as
@@ -392,12 +392,12 @@
                       (is (= 2 (count @seen))
                           (str "`:rf.ssr/hydration-mismatch` count; got "
                                (count @seen) " — "
-                               (pr-str (mapv (comp :error sup/tags-of) @seen)))))
+                               (pr-str (mapv (comp :error rf.hicasso.roots-frames-support/tags-of) @seen)))))
 
                     (testing "and what did fire is the framework diagnostic
                               Spec 011 names, tier-discriminated by its door"
                       (doseq [ev @seen]
-                        (let [tags (sup/tags-of ev)]
+                        (let [tags (rf.hicasso.roots-frames-support/tags-of ev)]
                           (is (= :rf.ssr/hydration-mismatch (:operation ev)))
                           (is (= 're-frame.hicasso.impl.mount/hydrate-root! (:where tags)))
                           (is (= :warned-and-replaced (:recovery tags)))
@@ -410,14 +410,14 @@
                       (is (= "client-B" (text-in cb ".title")))
                       (is (= "alpha" (text-in ca ".value")))
                       (is (= "beta"  (text-in cb ".value")))))))
-                (sup/settle-row!
+                (rf.hicasso.roots-frames-support/settle-row!
                   {:row      "H2 — two overlapping mismatches, two complaints"
                    :done     done
                    :release! (fn []
                                (close!)
                                (stop!)
-                               (mount/release! ha)
-                               (mount/release! hb))}))))))))
+                               (rf.hicasso.impl.mount/release! ha)
+                               (rf.hicasso.impl.mount/release! hb))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; H3 — independent teardown of two hydrated roots
@@ -425,48 +425,48 @@
 
 (deftest tearing-down-one-hydrated-root-leaves-the-other-adopted-and-live
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
-        (let [html-a (sup/server-html! frame-a [screen {:title "A"}])
-              html-b (sup/server-html! frame-b [screen {:title "B"}])
-              ca     (sup/server-dom! html-a)
-              cb     (sup/stamp-server-nodes! (sup/server-dom! html-b))]
-          (collector/reset-runtime!)
-          (let [ha (mount/hydrate-root! ca frame-a [screen {:title "A"}])
-                hb (mount/hydrate-root! cb frame-b [screen {:title "B"}])]
-            (-> (sup/wait-until! both-committed?)
+        (let [html-a (rf.hicasso.roots-frames-support/server-html! frame-a [screen {:title "A"}])
+              html-b (rf.hicasso.roots-frames-support/server-html! frame-b [screen {:title "B"}])
+              ca     (rf.hicasso.roots-frames-support/server-dom! html-a)
+              cb     (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-b))]
+          (rf.hicasso.impl.collector/reset-runtime!)
+          (let [ha (rf.hicasso.impl.mount/hydrate-root! ca frame-a [screen {:title "A"}])
+                hb (rf.hicasso.impl.mount/hydrate-root! cb frame-b [screen {:title "B"}])]
+            (-> (rf.hicasso.roots-frames-support/wait-until! both-committed?)
                 (.then
                   (fn [ok]
                     (is (true? ok) "both roots must commit")
                     ;; `unmount!`, not `release!` — `release!` resets the
                     ;; runtime by fiat, and every count below would then
                     ;; read zero whatever the teardown did.
-                    (mount/unmount! ha)
+                    (rf.hicasso.impl.mount/unmount! ha)
                     ;; The inner chain is RETURNED from this handler, so the
                     ;; outer promise adopts it and ONE `sup/settle-row!` at the
                     ;; outer tail settles the whole row. Two — one per chain —
                     ;; would call `done` twice on the green path.
-                    (-> (sup/quiesced!)
+                    (-> (rf.hicasso.roots-frames-support/quiesced!)
                         (.then
                           (fn [_]
                             (testing "frame A's keys are released and frame B's
                                       survive"
-                              (is (= #{[frame-b label-q]} (sup/cell-keys))
-                                  (str "got " (pr-str (sup/cell-keys)))))
+                              (is (= #{[frame-b label-q]} (rf.hicasso.roots-frames-support/cell-keys))
+                                  (str "got " (pr-str (rf.hicasso.roots-frames-support/cell-keys)))))
 
                             (testing "and root B is still ADOPTED — its nodes are
                                       still the server's, so the sibling's
                                       teardown did not force it through a
                                       re-render"
-                              (is (sup/every-server-node? cb ".screen, .title, .value")))
+                              (is (rf.hicasso.roots-frames-support/every-server-node? cb ".screen, .title, .value")))
 
                             (testing "and still live: a render into the surviving
                                       root re-runs its body and keeps its own
                                       frame's value"
-                              (let [ran (sup/body-runs-delta!
-                                          (fn [] (mount/render! hb [screen {:title "B2"}])))]
+                              (let [ran (rf.hicasso.roots-frames-support/body-runs-delta!
+                                          (fn [] (rf.hicasso.impl.mount/render! hb [screen {:title "B2"}])))]
                                 (is (= 1 ran)))
                               (is (= "B2" (text-in cb ".title")))
                               (is (= "beta" (text-in cb ".value"))))
@@ -489,12 +489,12 @@
                                       zero body runs, and every node is still the
                                       SERVER's — neither render remounted the
                                       tree the adoption established"
-                              (let [ran (sup/body-runs-delta!
-                                          (fn [] (mount/render! hb [screen {:title "B2"}])))]
+                              (let [ran (rf.hicasso.roots-frames-support/body-runs-delta!
+                                          (fn [] (rf.hicasso.impl.mount/render! hb [screen {:title "B2"}])))]
                                 (is (zero? ran)
                                     (str "a props-equal render! after adoption "
                                          "ran no body; read " ran)))
-                              (is (sup/every-server-node? cb ".screen, .title, .value")
+                              (is (rf.hicasso.roots-frames-support/every-server-node? cb ".screen, .title, .value")
                                   "and the surviving root's nodes still answer to
                                    the server-node mark — a render! that handed
                                    this root a bare provider where its Fragment
@@ -502,13 +502,13 @@
                                    them"))
 
                             (testing "and tearing the survivor down leaves nothing"
-                              (is (= sup/released (sup/teardown-census! hb)))))))))
-                (sup/settle-row!
+                              (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/teardown-census! hb)))))))))
+                (rf.hicasso.roots-frames-support/settle-row!
                   {:row      "H3 — independent teardown of two hydrated roots"
                    :done     done
                    :release! (fn []
-                               (mount/release! ha)
-                               (mount/release! hb))}))))))))
+                               (rf.hicasso.impl.mount/release! ha)
+                               (rf.hicasso.impl.mount/release! hb))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; H4 — a COMPLETED root's later recovery is not a mismatch, however many
@@ -552,31 +552,31 @@
 ;; scheduler and would go green or red on timing. It is the same technique
 ;; the deleted row used, turned on the property instead of on the defect.
 (deftest a-completed-roots-later-recovery-is-not-a-mismatch-while-a-sibling-adopts
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [{:keys [seen stop!]}      (sup/watch-mismatches!)
+      (let [{:keys [seen stop!]}      (rf.hicasso.roots-frames-support/watch-mismatches!)
             ;; MANUFACTURED here and asserted on here — the only shape of
             ;; call site at which swallowing an uncaught error is not the
             ;; fail-open the pageerror rule forbids.
-            {:keys [captured close!]} (sup/open-console-capture! {:swallow-uncaught? true})
-            window-a (roots/open-adoption-window!)
-            window-b (roots/open-adoption-window!)
-            report-a (mount/hydration-reporter window-a)
-            report-b (mount/hydration-reporter window-b)
+            {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture! {:swallow-uncaught? true})
+            window-a (rf.hicasso.impl.roots/open-adoption-window!)
+            window-b (rf.hicasso.impl.roots/open-adoption-window!)
+            report-a (rf.hicasso.impl.mount/hydration-reporter window-a)
+            report-b (rf.hicasso.impl.mount/hydration-reporter window-b)
             later-a  (js/Error. "a concurrent render root A recovered from")
             genuine-b (js/Error. "Hydration failed on root B")]
         (try
-          (is (true? (roots/adopting? window-a)) "premise: root A is adopting")
-          (is (true? (roots/adopting? window-b)) "premise: root B is adopting")
+          (is (true? (rf.hicasso.impl.roots/adopting? window-a)) "premise: root A is adopting")
+          (is (true? (rf.hicasso.impl.roots/adopting? window-b)) "premise: root B is adopting")
 
           ;; Root A's hydration commits. Its closer shuts ITS window.
-          (roots/close-adoption-window! window-a)
+          (rf.hicasso.impl.roots/close-adoption-window! window-a)
 
           (testing "one root's closer shuts one root's window"
-            (is (false? (roots/adopting? window-a)) "root A has completed")
-            (is (true? (roots/adopting? window-b))
+            (is (false? (rf.hicasso.impl.roots/adopting? window-a)) "root A has completed")
+            (is (true? (rf.hicasso.impl.roots/adopting? window-b))
                 "and root B is STILL ADOPTING — this single pair of readings
                  is the whole repair, and it is what the deleted row
                  measured going the other way"))
@@ -587,7 +587,7 @@
             (report-a later-a nil)
             (is (= 0 (count @seen))
                 (str "nothing should have been emitted; got "
-                     (pr-str (mapv (comp :error sup/tags-of) @seen)))))
+                     (pr-str (mapv (comp :error rf.hicasso.roots-frames-support/tags-of) @seen)))))
 
           (testing "while root B's genuine mismatch, arriving while B is still
                     adopting, DOES emit — the assertion a page-global boolean
@@ -595,19 +595,19 @@
             (report-b genuine-b nil)
             (is (= 1 (count @seen)) "exactly one diagnostic")
             (is (= "Hydration failed on root B"
-                   (:error (sup/tags-of (first @seen))))
+                   (:error (rf.hicasso.roots-frames-support/tags-of (first @seen))))
                 "and it is B's error, not A's"))
 
           (testing "IN-ROW DISCRIMINATION: the same later error on A, read
                     against a window some OTHER root is still holding open, is
                     mislabelled a mismatch. So the zero above is a property of
                     the scoping and not of the error"
-            ((mount/hydration-reporter window-b) later-a nil)
+            ((rf.hicasso.impl.mount/hydration-reporter window-b) later-a nil)
             (is (= 2 (count @seen))
                 "a page-wide window still open elsewhere would have labelled
                  A's later recovery a hydration mismatch")
             (is (= "a concurrent render root A recovered from"
-                   (:error (sup/tags-of (last @seen))))))
+                   (:error (rf.hicasso.roots-frames-support/tags-of (last @seen))))))
 
           (testing "and rf2-mwx08's fail-open is untouched in every case: the
                     reporter ALWAYS delegates, emit or no emit"
@@ -617,7 +617,7 @@
           (finally
             (close!)
             (stop!)
-            (roots/close-adoption-window! window-b)))))))
+            (rf.hicasso.impl.roots/close-adoption-window! window-b)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; H5 — presence isolation: adoption belongs to a SUBTREE, not to the page
@@ -651,8 +651,8 @@
 ;; landed on main as commit `fdbf5d6907`.
 (deftest presence-adoption-belongs-to-a-subtree-not-to-the-page
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       ;; `held` is what lets ONE settlement cover this row, and it is here
       ;; because this row is the only one whose releasables are minted INSIDE
       ;; the chain: `ha` needs the server's bytes, and those arrive as a
@@ -665,7 +665,7 @@
       (let [held (atom {})]
         (fresh!)
         (reset! !phases {})
-        (-> (sup/settled-server-html!
+        (-> (rf.hicasso.roots-frames-support/settled-server-html!
               frame-a [tray-screen {:tag :hydrated}]
               (fn [c] (= "present" (text-in c ".probe"))))
             (.then
@@ -675,17 +675,17 @@
                           PRESENT — " html))
                 ;; The server render's own phases are not this row's subject.
                 (reset! !phases {})
-                (collector/reset-runtime!)
-                (let [ca (sup/stamp-server-nodes! (sup/server-dom! html))
-                      cb (mount/fresh-container!)
-                      {:keys [seen stop!]} (sup/watch-mismatches!)
-                      ha (mount/hydrate-root! ca frame-a [tray-screen {:tag :hydrated}])]
+                (rf.hicasso.impl.collector/reset-runtime!)
+                (let [ca (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+                      cb (rf.hicasso.impl.mount/fresh-container!)
+                      {:keys [seen stop!]} (rf.hicasso.roots-frames-support/watch-mismatches!)
+                      ha (rf.hicasso.impl.mount/hydrate-root! ca frame-a [tray-screen {:tag :hydrated}])]
                   (swap! held assoc :stop! stop! :ha ha)
-                  (is (true? (roots/adopting? (:adoption ha)))
+                  (is (true? (rf.hicasso.impl.roots/adopting? (:adoption ha)))
                       "premise: root A is adopting on THIS line, so what follows
                        happens inside its window by construction")
                   ;; An ORDINARY root, mounted inside root A's adoption window.
-                  (let [hb (mount/root! cb frame-b [tray-screen {:tag :ordinary}])]
+                  (let [hb (rf.hicasso.impl.mount/root! cb frame-b [tray-screen {:tag :ordinary}])]
                     (swap! held assoc :hb hb)
                     (testing "the ordinary sibling gets its ENTER phase, even
                               though a hydration is in flight elsewhere on the
@@ -701,9 +701,9 @@
                               what makes the repair free for it: no object, no
                               provider, no branch"
                       (is (nil? (:adoption hb)))
-                      (is (false? (roots/adopting? (:adoption hb)))))
+                      (is (false? (rf.hicasso.impl.roots/adopting? (:adoption hb)))))
 
-                    (-> (sup/adopted! ha)
+                    (-> (rf.hicasso.roots-frames-support/adopted! ha)
                         (.then
                           (fn [ok]
                             ;; Stopped here and named in `:release!` too —
@@ -726,16 +726,16 @@
                             (testing "so the client's first pass AGREED with the
                                       server's bytes — the adopted nodes are the
                                       server's own, and nothing diverged"
-                              (is (sup/every-server-node? ca ".screen, .probe"))
+                              (is (rf.hicasso.roots-frames-support/every-server-node? ca ".screen, .probe"))
                               (is (= 0 (count @seen))
                                   (str "no hydration mismatch; got "
-                                       (pr-str (mapv (comp :error sup/tags-of)
+                                       (pr-str (mapv (comp :error rf.hicasso.roots-frames-support/tags-of)
                                                      @seen)))))
 
                             (testing "closing root A's window changed nothing
                                       about root B: B still completed its own
                                       enter transition, on its own clock"
-                              (is (false? (roots/adopting? (:adoption ha))))
+                              (is (false? (rf.hicasso.impl.roots/adopting? (:adoption ha))))
                               (is (= [:mounting :present]
                                      (vec (distinct (get @!phases :ordinary))))
                                   (str "root B entered and then settled; saw "
@@ -753,23 +753,23 @@
                                       uses), rather than on a live root whose
                                       mid-hydration teardown would be
                                       measuring React's unmount instead"
-                              (let [window (roots/open-adoption-window!)
+                              (let [window (rf.hicasso.impl.roots/open-adoption-window!)
                                     orphan {:frame     frame-a
-                                            :container (mount/fresh-container!)
+                                            :container (rf.hicasso.impl.mount/fresh-container!)
                                             :root      nil
                                             :adoption  window}]
-                                (is (true? (roots/adopting? window))
+                                (is (true? (rf.hicasso.impl.roots/adopting? window))
                                     "premise: open, and its closer has not run")
-                                (mount/unmount! orphan)
-                                (is (false? (roots/adopting? window))
+                                (rf.hicasso.impl.mount/unmount! orphan)
+                                (is (false? (rf.hicasso.impl.roots/adopting? window))
                                     "teardown shut it"))))))))))
-            (sup/settle-row!
+            (rf.hicasso.roots-frames-support/settle-row!
               {:row      "H5 — presence adoption belongs to a subtree, not to the page"
                :done     done
                :release! (fn []
                            (when-let [stop! (:stop! @held)] (stop!))
-                           (some-> (:ha @held) mount/release!)
-                           (some-> (:hb @held) mount/release!))}))))))
+                           (some-> (:ha @held) rf.hicasso.impl.mount/release!)
+                           (some-> (:hb @held) rf.hicasso.impl.mount/release!))}))))))
 
 ;; ---------------------------------------------------------------------------
 ;; H6 — THE EXECUTING SABOTAGE CONTROL for this risk family
@@ -810,45 +810,45 @@
 ;; than none.
 (deftest a-page-global-adoption-window-steals-an-ordinary-roots-enter-transition
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
         (reset! !phases {})
-        (let [html (sup/server-html! frame-a [screen {:title "A"}])]
-          (collector/reset-runtime!)
+        (let [html (rf.hicasso.roots-frames-support/server-html! frame-a [screen {:title "A"}])]
+          (rf.hicasso.impl.collector/reset-runtime!)
           (let [armed
-                (sup/with-page-global-adoption
+                (rf.hicasso.roots-frames-support/with-page-global-adoption
                   (fn [page-window]
-                    (is (false? (roots/adopting? page-window))
+                    (is (false? (rf.hicasso.impl.roots/adopting? page-window))
                         "premise: the page-global window is SHUT before anything
                          hydrates, so an open one below was opened by a ROOT and
                          not handed over by the arming")
-                    (let [ha (mount/hydrate-root! (sup/server-dom! html) frame-a
+                    (let [ha (rf.hicasso.impl.mount/hydrate-root! (rf.hicasso.roots-frames-support/server-dom! html) frame-a
                                                   [screen {:title "A"}])]
-                      (is (true? (roots/adopting? page-window))
+                      (is (true? (rf.hicasso.impl.roots/adopting? page-window))
                           "premise: root A's hydration opened it — and under this
                            mutation it is the only window there is")
                       {:ha          ha
                        :page-window page-window
-                       :hb          (mount/root! (mount/fresh-container!) frame-b
+                       :hb          (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-b
                                                  [tray-screen {:tag :under-page-global}])})))
                 disarmed
-                (let [ha (mount/hydrate-root! (sup/server-dom! html) frame-a
+                (let [ha (rf.hicasso.impl.mount/hydrate-root! (rf.hicasso.roots-frames-support/server-dom! html) frame-a
                                               [screen {:title "A"}])]
                   (is (not (identical? (:adoption ha) (:page-window armed)))
                       "premise: the arming restored the per-root mint, so this
                        root's window is its own — a half that inherited the
                        page-global would be no control at all")
-                  (is (true? (roots/adopting? (:adoption ha)))
+                  (is (true? (rf.hicasso.impl.roots/adopting? (:adoption ha)))
                       "premise: root A is adopting in this half too, so the two
                        halves differ only in the SCOPE of its window")
-                  (is (true? (roots/adopting? (:page-window armed)))
+                  (is (true? (rf.hicasso.impl.roots/adopting? (:page-window armed)))
                       "premise: and the armed half's PAGE-WIDE window is still
                        open on this line — so what the tray below reads is the
                        scoping, not the absence of a window")
                   {:ha ha
-                   :hb (mount/root! (mount/fresh-container!) frame-b
+                   :hb (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-b
                                     [tray-screen {:tag :under-root-scoped}])})]
 
             (testing "ARMED — the ordinary root's tray was told it was adopting,
@@ -877,21 +877,21 @@
             ;; holds FOUR handles — so a single rejected adoption stranded all
             ;; four, which is why this is the most expensive row in the file
             ;; to leave unsettled.
-            (-> (js/Promise.all #js [(sup/adopted! (:ha armed))
-                                     (sup/adopted! (:ha disarmed))])
+            (-> (js/Promise.all #js [(rf.hicasso.roots-frames-support/adopted! (:ha armed))
+                                     (rf.hicasso.roots-frames-support/adopted! (:ha disarmed))])
                 (.then
                   (fn [oks]
                     (is (= [true true] (vec oks))
                         "both hydrating roots must reach their own closer, or
                          this row left an open window behind")))
-                (sup/settle-row!
+                (rf.hicasso.roots-frames-support/settle-row!
                   {:row      "H6 — the page-global sabotage control"
                    :done     done
                    :release! (fn []
-                               (mount/release! (:hb armed))
-                               (mount/release! (:ha armed))
-                               (mount/release! (:hb disarmed))
-                               (mount/release! (:ha disarmed)))}))))))))
+                               (rf.hicasso.impl.mount/release! (:hb armed))
+                               (rf.hicasso.impl.mount/release! (:ha armed))
+                               (rf.hicasso.impl.mount/release! (:hb disarmed))
+                               (rf.hicasso.impl.mount/release! (:ha disarmed)))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; H7 — THE LEAK CONTROL: a rejected adoption still releases BOTH roots
@@ -917,15 +917,15 @@
 ;; containers in the document for whatever runs next.
 
 (deftest a-rejected-adoption-still-releases-both-roots-and-the-watcher
-  (if-not (mount/browser?)
-    (sup/skip! "what a rejection can leak here is two real roots")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! "what a rejection can leak here is two real roots")
     (async done
       (fresh!)
-      (let [html-a   (sup/server-html! frame-a [screen {:title "A"}])
-            html-b   (sup/server-html! frame-b [screen {:title "B"}])
-            ca       (sup/stamp-server-nodes! (sup/server-dom! html-a))
-            cb       (sup/stamp-server-nodes! (sup/server-dom! html-b))
-            watch    (sup/watch-mismatches!)
+      (let [html-a   (rf.hicasso.roots-frames-support/server-html! frame-a [screen {:title "A"}])
+            html-b   (rf.hicasso.roots-frames-support/server-html! frame-b [screen {:title "B"}])
+            ca       (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-a))
+            cb       (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-b))
+            watch    (rf.hicasso.roots-frames-support/watch-mismatches!)
             ;; NOT `:swallow-uncaught? true`: this row manufactures a
             ;; rejected PROMISE, which `sup/settle-row!` handles, and no uncaught
             ;; window error at all. Swallowing anywhere else is the fail-open
@@ -933,32 +933,32 @@
             stops    (atom 0)
             finishes (atom 0)
             reports  (atom [])]
-        (collector/reset-runtime!)
-        (let [ha (mount/hydrate-root! ca frame-a [screen {:title "A"}])
-              hb (mount/hydrate-root! cb frame-b [screen {:title "B"}])]
-          (-> (js/Promise.all #js [(sup/adopted! ha) (sup/adopted! hb)])
+        (rf.hicasso.impl.collector/reset-runtime!)
+        (let [ha (rf.hicasso.impl.mount/hydrate-root! ca frame-a [screen {:title "A"}])
+              hb (rf.hicasso.impl.mount/hydrate-root! cb frame-b [screen {:title "B"}])]
+          (-> (js/Promise.all #js [(rf.hicasso.roots-frames-support/adopted! ha) (rf.hicasso.roots-frames-support/adopted! hb)])
               (.then
                 (fn [oks]
                   (is (= [true true] (vec oks)) "premise: both roots really did adopt")
-                  (is (not= sup/released (sup/census))
+                  (is (not= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/census))
                       (str "premise: the runtime is holding these roots' cells "
                            "and edges, so the census taken after the rejection "
                            "is a RELEASE and not an empty page; got "
-                           (pr-str (sup/census))))
+                           (pr-str (rf.hicasso.roots-frames-support/census))))
                   (js/Promise.reject (js/Error. "adoption rejected on purpose"))))
-              (sup/settle-row!
+              (rf.hicasso.roots-frames-support/settle-row!
                 {:row      "the rejected-adoption control"
                  :done     (fn [] (swap! finishes inc))
                  :report!  (fn [e] (swap! reports conj e))
                  :release! (fn []
                              (swap! stops inc)
                              ((:stop! watch))
-                             (mount/release! ha)
-                             (mount/release! hb))})
+                             (rf.hicasso.impl.mount/release! ha)
+                             (rf.hicasso.impl.mount/release! hb))})
               ;; The cell reapers are armed at unmount and run past a bare
               ;; macrotask, so the tables are read at the runtime's own horizon
               ;; rather than one tick after the release.
-              (.then (fn [_] (sup/quiesced!)))
+              (.then (fn [_] (rf.hicasso.roots-frames-support/quiesced!)))
               (.then
                 (fn [_]
                   (testing "the rejection is REPORTED — which is the whole of
@@ -980,19 +980,19 @@
                             all the same, because a row that leans on the
                             fixture to stop its own watcher is measuring the
                             fixture)"
-                    (is (= sup/released (sup/census))
-                        (str "neither root left: residue was " (pr-str (sup/census))))
-                    (is (empty? (sup/cell-frames))
+                    (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/census))
+                        (str "neither root left: residue was " (pr-str (rf.hicasso.roots-frames-support/census))))
+                    (is (empty? (rf.hicasso.roots-frames-support/cell-frames))
                         (str "no frame: the cell table still mentions "
-                             (pr-str (sup/cell-frames))))
+                             (pr-str (rf.hicasso.roots-frames-support/cell-frames))))
                     (is (= 1 @stops)
                         (str "the mismatch watcher was stopped — `stop!` is what "
                              "unregisters the trace listener; it ran "
                              @stops " times")))))
-              (sup/settle-row!
+              (rf.hicasso.roots-frames-support/settle-row!
                 {:row      "the rejected-adoption control's own settlement"
                  :done     done
                  :release! (fn []
                              ((:stop! watch))
-                             (mount/release! ha)
-                             (mount/release! hb))})))))))
+                             (rf.hicasso.impl.mount/release! ha)
+                             (rf.hicasso.impl.mount/release! hb))})))))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_isolation_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_isolation_dom_cljs_test.cljs
@@ -38,15 +38,15 @@
   frame argument at all. It is one view, mounted twice; the only thing
   that differs between the two mounts is the root each one sits under."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]))
 
 (def ^:private frame-a ::frame-a)
@@ -67,8 +67,8 @@
 (rf/reg-event ::bump (fn [{:keys [db]} _] {:db (update db :count inc)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; `nil` and not the default: the default leaves a dynamic-var frame
      ;; stamp in ambient scope, and a boundary that failed to resolve its
      ;; own frame could then answer that one instead — an isolation miss
@@ -81,13 +81,13 @@
      ;; that aborts the whole browser run at this namespace, not just this
      ;; file.
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The app — ONE view, mounted twice
 ;; ---------------------------------------------------------------------------
 
-(h/defview panel
+(rf.hicasso/defview panel
   "The whole app. Reads two subscriptions and carries one intent, and
   takes no frame argument: the frame arrives from the root it is mounted
   under, through the substrate's single internal React context.
@@ -98,8 +98,8 @@
   frames or not at all."
   [{:keys [tag]}]
   [:div.panel {:data-tag tag :data-frame (str (rf/current-frame-id))}
-   [:span.label (h/sub label-q)]
-   [:span.count (str (h/sub count-q))]
+   [:span.label (rf.hicasso/sub label-q)]
+   [:span.count (str (rf.hicasso/sub count-q))]
    [:button.bump {:on-click [::bump]} "bump"]])
 
 (defn- exploding-cleanup-component
@@ -119,15 +119,15 @@
     #js [])
   nil)
 
-(h/defhost exploder exploding-cleanup-component {:server :render})
+(rf.hicasso/defhost exploder exploding-cleanup-component {:server :render})
 
-(h/defview fragile-panel
+(rf.hicasso/defview fragile-panel
   "[[panel]]'s tree with the charge attached. Same subscriptions, same
   intent, so the two roots stay comparable."
   [{:keys [tag]}]
   [:div.panel {:data-tag tag :data-frame (str (rf/current-frame-id))}
-   [:span.label (h/sub label-q)]
-   [:span.count (str (h/sub count-q))]
+   [:span.label (rf.hicasso/sub label-q)]
+   [:span.count (str (rf.hicasso/sub count-q))]
    [:button.bump {:on-click [::bump]} "bump"]
    [exploder {}]])
 
@@ -142,13 +142,13 @@
   well as in the tables; the counts start equal so a cross-frame DISPATCH
   is legible as a difference that appears."
   []
-  (sup/leave-act-environment!)
+  (rf.hicasso.roots-frames-support/leave-act-environment!)
   (rf/make-frame {:id frame-a})
   (rf/make-frame {:id frame-b})
   (rf/with-frame frame-a (rf/dispatch-sync [::seed "alpha"]))
   (rf/with-frame frame-b (rf/dispatch-sync [::seed "beta"]))
-  (collector/reset-runtime!)
-  (runtime/reset-body-runs!)
+  (rf.hicasso.impl.collector/reset-runtime!)
+  (rf.hicasso.test.runtime/reset-body-runs!)
   nil)
 
 (defn- text-at [handle sel]
@@ -160,27 +160,27 @@
 (defn- keys-for
   "The live sub-keys belonging to `frame-kw`."
   [frame-kw]
-  (into #{} (filter (fn [[f _]] (= frame-kw f))) (sup/cell-keys)))
+  (into #{} (filter (fn [[f _]] (= frame-kw f))) (rf.hicasso.roots-frames-support/cell-keys)))
 
 ;; ---------------------------------------------------------------------------
 ;; W1 — the cell table splits by frame
 ;; ---------------------------------------------------------------------------
 
 (deftest two-roots-under-two-frames-split-the-cell-table
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM")
     (let [_ (fresh!)
-          a (mount/root! (mount/fresh-container!) frame-a [panel {:tag "a"}])
-          b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])]
+          a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-a [panel {:tag "a"}])
+          b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-b [panel {:tag "b"}])]
       (try
         (testing "one view, two frames, two reads each — four cells, and the
                   frame is what tells them apart"
           (is (= #{[frame-a label-q] [frame-a count-q]
                    [frame-b label-q] [frame-b count-q]}
-                 (sup/cell-keys))
+                 (rf.hicasso.roots-frames-support/cell-keys))
               (str "the cell table must be keyed by (frame, query); got "
-                   (pr-str (sup/cell-keys))))
-          (is (= #{frame-a frame-b} (sup/cell-frames))
+                   (pr-str (rf.hicasso.roots-frames-support/cell-keys))))
+          (is (= #{frame-a frame-b} (rf.hicasso.roots-frames-support/cell-frames))
               "both frames must appear — a runtime that resolved one frame
                for both mounts would show one"))
 
@@ -188,18 +188,18 @@
                   leak destroys, because a leak is two readers on one key
                   rather than one reader on each of two"
           (is (= [1 1 1 1]
-                 [(sup/readers-of [frame-a label-q]) (sup/readers-of [frame-a count-q])
-                  (sup/readers-of [frame-b label-q]) (sup/readers-of [frame-b count-q])])
-              (str "reader counts: " (pr-str (runtime/residue)))))
+                 [(rf.hicasso.roots-frames-support/readers-of [frame-a label-q]) (rf.hicasso.roots-frames-support/readers-of [frame-a count-q])
+                  (rf.hicasso.roots-frames-support/readers-of [frame-b label-q]) (rf.hicasso.roots-frames-support/readers-of [frame-b count-q])])
+              (str "reader counts: " (pr-str (rf.hicasso.test.runtime/residue)))))
 
         (testing "and the frame-locked ambient dispatch memoised for each body
                   is keyed by frame too — a second table saying the same thing
                   on a different axis"
-          (is (= #{frame-a frame-b} (sup/frame-memo-frames))
-              (str "got " (pr-str (sup/frame-memo-frames))))
+          (is (= #{frame-a frame-b} (rf.hicasso.roots-frames-support/frame-memo-frames))
+              (str "got " (pr-str (rf.hicasso.roots-frames-support/frame-memo-frames))))
           (is (= [true true]
-                 (mapv #(frame/frame-incarnation-live?
-                          % (:incarnation (sup/frame-memo-row %)))
+                 (mapv #(rf.frame/frame-incarnation-live?
+                          % (:incarnation (rf.hicasso.roots-frames-support/frame-memo-row %)))
                        [frame-a frame-b]))
               "and each row is pinned to the incarnation that is LIVE under its
                id (rf2-x874) — the reading that replaced 'the bundle memo is
@@ -214,24 +214,24 @@
           (is (= (str frame-a) (attr-at a ".panel" "data-frame")))
           (is (= (str frame-b) (attr-at b ".panel" "data-frame"))))
 
-        (finally (mount/release! a) (mount/release! b))))))
+        (finally (rf.hicasso.impl.mount/release! a) (rf.hicasso.impl.mount/release! b))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W2 — a dispatch moves one frame, and re-runs one body
 ;; ---------------------------------------------------------------------------
 
 (deftest a-dispatch-is-frame-local-in-bodies-and-in-state
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM")
     (let [_ (fresh!)
-          a (mount/root! (mount/fresh-container!) frame-a [panel {:tag "a"}])
-          b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])
+          a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-a [panel {:tag "a"}])
+          b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-b [panel {:tag "b"}])
           ;; Sampled BEFORE the dispatch, because the property below is that
           ;; the dispatch did not disturb it.
-          row-b-before (sup/frame-memo-row frame-b)]
+          row-b-before (rf.hicasso.roots-frames-support/frame-memo-row frame-b)]
       (try
         (testing "one dispatch into frame A re-runs exactly one body"
-          (let [ran (sup/body-runs-delta! (fn [] (mount/dispatch! a [::bump])))]
+          (let [ran (rf.hicasso.roots-frames-support/body-runs-delta! (fn [] (rf.hicasso.impl.mount/dispatch! a [::bump])))]
             (is (= 1 ran)
                 (str "a commit in one frame must notify only that frame's
                       readers; " ran " bodies ran"))))
@@ -243,33 +243,33 @@
         (testing "and the dispatch touched frame A's memo row alone — B's row is
                   the SAME object it was before, so one frame's traffic cannot
                   re-pin another's"
-          (is (identical? row-b-before (sup/frame-memo-row frame-b))
+          (is (identical? row-b-before (rf.hicasso.roots-frames-support/frame-memo-row frame-b))
               "frame B's row was replaced by a dispatch into frame A")
-          (is (= #{frame-a frame-b} (sup/frame-memo-frames))
-              (str "got " (pr-str (sup/frame-memo-frames)))))
+          (is (= #{frame-a frame-b} (rf.hicasso.roots-frames-support/frame-memo-frames))
+              (str "got " (pr-str (rf.hicasso.roots-frames-support/frame-memo-frames)))))
 
         (testing "the counter can read 2, so `1` above was a discrimination
                   and not a ceiling — both frames are exercised, which is
                   what stops this row passing vacuously"
-          (let [ran (sup/body-runs-delta!
-                      (fn [] (mount/dispatch! a [::bump])
-                             (mount/dispatch! b [::bump])))]
+          (let [ran (rf.hicasso.roots-frames-support/body-runs-delta!
+                      (fn [] (rf.hicasso.impl.mount/dispatch! a [::bump])
+                             (rf.hicasso.impl.mount/dispatch! b [::bump])))]
             (is (= 2 ran)))
           (is (= "2" (text-at a ".count")))
           (is (= "1" (text-at b ".count"))))
 
-        (finally (mount/release! a) (mount/release! b))))))
+        (finally (rf.hicasso.impl.mount/release! a) (rf.hicasso.impl.mount/release! b))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W3 — the shipped intent path, driven by a real DOM click
 ;; ---------------------------------------------------------------------------
 
 (deftest a-real-click-dispatches-into-its-own-root-and-no-other
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM")
     (let [_ (fresh!)
-          a (mount/root! (mount/fresh-container!) frame-a [panel {:tag "a"}])
-          b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])]
+          a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-a [panel {:tag "a"}])
+          b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-b [panel {:tag "b"}])]
       (try
         (testing "a click on root A's button — the shipped intent path, on a
                   real discrete browser event — reaches frame A alone"
@@ -277,9 +277,9 @@
           ;; synchronously inside the discrete event, but React schedules
           ;; the store notification at the SYNC lane rather than committing
           ;; it inline, and the body-run happens on that commit.
-          (let [ran (sup/body-runs-delta!
+          (let [ran (rf.hicasso.roots-frames-support/body-runs-delta!
                       (fn [] (.click (.querySelector (:container a) ".bump"))
-                             (mount/settle!)))]
+                             (rf.hicasso.impl.mount/settle!)))]
             (is (= 1 ran) "one body ran"))
           (is (= "1" (text-at a ".count")))
           (is (= "0" (text-at b ".count"))))
@@ -288,11 +288,11 @@
                   are clicked, so an intent that had resolved one
                   last-rendered frame for both would show here"
           (.click (.querySelector (:container b) ".bump"))
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
           (is (= "1" (text-at a ".count")))
           (is (= "1" (text-at b ".count"))))
 
-        (finally (mount/release! a) (mount/release! b))))))
+        (finally (rf.hicasso.impl.mount/release! a) (rf.hicasso.impl.mount/release! b))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W4 — independent unmount
@@ -300,16 +300,16 @@
 
 (deftest unmounting-one-root-releases-its-keys-and-leaves-the-other-live
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (let [_ (fresh!)
-            a (mount/root! (mount/fresh-container!) frame-a [panel {:tag "a"}])
-            b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])]
+            a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-a [panel {:tag "a"}])
+            b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-b [panel {:tag "b"}])]
         ;; `unmount!` and NOT `release!`: `release!` resets the runtime, so
         ;; every count below would read zero whether the teardown released
         ;; anything or not.
-        (mount/unmount! a)
-        (-> (sup/quiesced!)
+        (rf.hicasso.impl.mount/unmount! a)
+        (-> (rf.hicasso.roots-frames-support/quiesced!)
             (.then
               (fn [_]
                 (try
@@ -320,20 +320,20 @@
                     (is (= #{[frame-b label-q] [frame-b count-q]} (keys-for frame-b))
                         (str "frame B's cells must survive its sibling's
                               teardown; got " (pr-str (keys-for frame-b))))
-                    (is (= #{frame-b} (sup/cell-frames))))
+                    (is (= #{frame-b} (rf.hicasso.roots-frames-support/cell-frames))))
 
                   (testing "and the survivor is LIVE, not merely present — it
                             still re-runs its body and still moves its DOM"
-                    (let [ran (sup/body-runs-delta! (fn [] (mount/dispatch! b [::bump])))]
+                    (let [ran (rf.hicasso.roots-frames-support/body-runs-delta! (fn [] (rf.hicasso.impl.mount/dispatch! b [::bump])))]
                       (is (= 1 ran)))
                     (is (= "1" (text-at b ".count")))
                     (is (= "beta" (text-at b ".label"))))
 
                   (testing "and tearing the survivor down leaves nothing at all"
-                    (is (= sup/released (sup/teardown-census! b))))
+                    (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/teardown-census! b))))
                   (finally
-                    (mount/release! a)
-                    (mount/release! b)
+                    (rf.hicasso.impl.mount/release! a)
+                    (rf.hicasso.impl.mount/release! b)
                     (done))))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -342,19 +342,19 @@
 
 (deftest a-root-whose-teardown-throws-cannot-strand-its-siblings-state
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (let [_ (fresh!)
-            a (mount/root! (mount/fresh-container!) frame-a [fragile-panel {:tag "a"}])
-            b (mount/root! (mount/fresh-container!) frame-b [panel {:tag "b"}])
+            a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-a [fragile-panel {:tag "a"}])
+            b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-b [panel {:tag "b"}])
             ;; `:swallow-uncaught?` is legitimate at exactly this call site
             ;; and nowhere else in these suites: the error below is
             ;; MANUFACTURED by this row and asserted on by this row.
-            {:keys [captured close!]} (sup/open-console-capture! {:swallow-uncaught? true})]
-        (is (= #{frame-a frame-b} (sup/cell-frames))
+            {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture! {:swallow-uncaught? true})]
+        (is (= #{frame-a frame-b} (rf.hicasso.roots-frames-support/cell-frames))
             "precondition: both roots are live before the charge goes off")
-        (mount/unmount! a)
-        (-> (sup/quiesced!)
+        (rf.hicasso.impl.mount/unmount! a)
+        (-> (rf.hicasso.roots-frames-support/quiesced!)
             (.then
               (fn [_]
                 (close!)
@@ -369,14 +369,14 @@
                             reader counts, and the frame-op bundle it dispatches
                             through"
                     (is (= #{[frame-b label-q] [frame-b count-q]} (keys-for frame-b)))
-                    (is (= [1 1] [(sup/readers-of [frame-b label-q])
-                                  (sup/readers-of [frame-b count-q])]))
-                    (is (contains? (sup/cell-frames) frame-b)))
+                    (is (= [1 1] [(rf.hicasso.roots-frames-support/readers-of [frame-b label-q])
+                                  (rf.hicasso.roots-frames-support/readers-of [frame-b count-q])]))
+                    (is (contains? (rf.hicasso.roots-frames-support/cell-frames) frame-b)))
 
                   (testing "and it is still LIVE — a dispatch still re-runs its
                             body and still moves its DOM, which a stranded
                             runtime could not do"
-                    (let [ran (sup/body-runs-delta! (fn [] (mount/dispatch! b [::bump])))]
+                    (let [ran (rf.hicasso.roots-frames-support/body-runs-delta! (fn [] (rf.hicasso.impl.mount/dispatch! b [::bump])))]
                       (is (= 1 ran)))
                     (is (= "1" (text-at b ".count"))))
 
@@ -386,6 +386,6 @@
                     (is (= #{} (keys-for frame-a))
                         (str "got " (pr-str (keys-for frame-a)))))
                   (finally
-                    (mount/release! a)
-                    (mount/release! b)
+                    (rf.hicasso.impl.mount/release! a)
+                    (rf.hicasso.impl.mount/release! b)
                     (done))))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_shared_frame_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_shared_frame_dom_cljs_test.cljs
@@ -55,15 +55,15 @@
   `re-frame.hicasso.roots-frames-support` states once for all three
   files."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.roots :as roots]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.roots :as rf.hicasso.impl.roots]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ONE frame. The whole file is about what two roots do to it.
 (def ^:private shared-frame ::shared)
@@ -83,8 +83,8 @@
 (rf/reg-event ::bump (fn [{:keys [db]} _] {:db (update db :count inc)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; `nil` and not the default: the default leaves a dynamic-var frame
      ;; stamp in ambient scope, so a boundary that failed to resolve its
      ;; own frame could answer that one instead. This suite makes its own.
@@ -93,13 +93,13 @@
      ;; refuses an async test under a fn-form fixture and aborts the whole
      ;; browser run at this namespace when it does.
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The app — one view, mounted twice, under ONE frame
 ;; ---------------------------------------------------------------------------
 
-(h/defview panel
+(rf.hicasso/defview panel
   "The whole app: two subscription reads and one intent, in a single
   boundary body. Takes no frame argument — the frame arrives from the
   root it is mounted under, which here is the same frame for both.
@@ -110,10 +110,10 @@
   number read twice."
   [{:keys [tag]}]
   [:div.panel {:data-tag tag :data-frame (str (rf/current-frame-id))}
-   [:span.label (h/sub label-q)]
-   [:span.count (str (h/sub count-q))]])
+   [:span.label (rf.hicasso/sub label-q)]
+   [:span.count (str (rf.hicasso/sub count-q))]])
 
-(h/defview screen
+(rf.hicasso/defview screen
   "The hydration rows' app. `title` is a PROP, so a server/client
   divergence is a one-argument change at the call site rather than a
   second app; the subscription read is what makes the root acquire a
@@ -121,7 +121,7 @@
   [{:keys [title]}]
   [:div.screen
    [:h1.title title]
-   [:p.value (h/sub label-q)]])
+   [:p.value (rf.hicasso/sub label-q)]])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -130,11 +130,11 @@
 (defn- fresh!
   "One frame, seeded, and an empty runtime."
   []
-  (sup/leave-act-environment!)
+  (rf.hicasso.roots-frames-support/leave-act-environment!)
   (rf/make-frame {:id shared-frame})
   (rf/with-frame shared-frame (rf/dispatch-sync [::seed "alpha"]))
-  (collector/reset-runtime!)
-  (runtime/reset-body-runs!)
+  (rf.hicasso.impl.collector/reset-runtime!)
+  (rf.hicasso.test.runtime/reset-body-runs!)
   nil)
 
 (defn- text-at [handle sel]
@@ -151,54 +151,54 @@
   predicate would answer true with a root still in flight. Two readers on
   the shared key is the reading that needs both."
   []
-  (= 2 (sup/readers-of [shared-frame label-q])))
+  (= 2 (rf.hicasso.roots-frames-support/readers-of [shared-frame label-q])))
 
 ;; ---------------------------------------------------------------------------
 ;; S1 — one cell, two readers, and both of them real
 ;; ---------------------------------------------------------------------------
 
 (deftest two-roots-under-one-frame-share-one-cell-and-both-read-it
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM")
     (let [_ (fresh!)
-          a (mount/root! (mount/fresh-container!) shared-frame [panel {:tag "a"}])
-          b (mount/root! (mount/fresh-container!) shared-frame [panel {:tag "b"}])]
+          a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) shared-frame [panel {:tag "a"}])
+          b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) shared-frame [panel {:tag "b"}])]
       (try
         (testing "two roots reading two queries under one frame make TWO cells,
                   not four — the sub-key is (frame, query) and mentions no
                   root, so sharing a frame is sharing the cell. This is the
                   exact shape the two-frame suites never produce"
-          (is (= #{[shared-frame label-q] [shared-frame count-q]} (sup/cell-keys))
-              (str "got " (pr-str (sup/cell-keys))))
-          (is (= #{shared-frame} (sup/cell-frames))))
+          (is (= #{[shared-frame label-q] [shared-frame count-q]} (rf.hicasso.roots-frames-support/cell-keys))
+              (str "got " (pr-str (rf.hicasso.roots-frames-support/cell-keys))))
+          (is (= #{shared-frame} (rf.hicasso.roots-frames-support/cell-frames))))
 
         (testing "and each shared key carries TWO readers — the fan-out that
                   makes `release-cell!`'s arithmetic load-bearing, and that
                   every existing row pins at one"
-          (is (= [2 2] [(sup/readers-of [shared-frame label-q])
-                        (sup/readers-of [shared-frame count-q])])
-              (str "reader counts: " (pr-str (runtime/residue)))))
+          (is (= [2 2] [(rf.hicasso.roots-frames-support/readers-of [shared-frame label-q])
+                        (rf.hicasso.roots-frames-support/readers-of [shared-frame count-q])])
+              (str "reader counts: " (pr-str (rf.hicasso.test.runtime/residue)))))
 
         (testing "and the two readers are two DISTINCT boundaries, not one
                   counted twice — `:boundaries` counts registrations and
                   `readers-of` counts slots, so the two numbers can disagree
                   and here they corroborate"
-          (is (= 2 (:boundaries (runtime/stats)))
-              (str "got " (pr-str (runtime/stats))))
-          (is (= 4 (:cell-refs (runtime/residue)))
+          (is (= 2 (:boundaries (rf.hicasso.test.runtime/stats)))
+              (str "got " (pr-str (rf.hicasso.test.runtime/stats))))
+          (is (= 4 (:cell-refs (rf.hicasso.test.runtime/residue)))
               "two keys at fan-out two"))
 
         (testing "one frame is one memo row, however many roots render it —
                   the row is keyed by frame and a second root must not mint a
                   second"
-          (is (= #{shared-frame} (sup/frame-memo-frames))
-              (str "got " (pr-str (sup/frame-memo-frames)))))
+          (is (= #{shared-frame} (rf.hicasso.roots-frames-support/frame-memo-frames))
+              (str "got " (pr-str (rf.hicasso.roots-frames-support/frame-memo-frames)))))
 
         (testing "BOTH roots are live readers of the shared key: one dispatch
                   re-runs TWO bodies. This is what stops the counts above
                   passing vacuously — a second reader slot that never re-ran
                   would satisfy every assertion so far"
-          (let [ran (sup/body-runs-delta! (fn [] (mount/dispatch! a [::bump])))]
+          (let [ran (rf.hicasso.roots-frames-support/body-runs-delta! (fn [] (rf.hicasso.impl.mount/dispatch! a [::bump])))]
             (is (= 2 ran)
                 (str "a commit on a shared key must notify every reader of it; "
                      ran " bodies ran"))))
@@ -215,7 +215,7 @@
           (is (= (str shared-frame) (.getAttribute (.querySelector (:container b) ".panel")
                                                    "data-frame"))))
 
-        (finally (mount/release! a) (mount/release! b))))))
+        (finally (rf.hicasso.impl.mount/release! a) (rf.hicasso.impl.mount/release! b))))))
 
 ;; ---------------------------------------------------------------------------
 ;; S2 — a teardown DECREMENTS a shared key. It does not dispose it.
@@ -252,19 +252,19 @@
 ;; green under all three.
 (deftest unmounting-one-root-decrements-the-shared-key-and-does-not-dispose-it
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (let [_ (fresh!)
-            a (mount/root! (mount/fresh-container!) shared-frame [panel {:tag "a"}])
-            b (mount/root! (mount/fresh-container!) shared-frame [panel {:tag "b"}])]
-        (is (= [2 2] [(sup/readers-of [shared-frame label-q])
-                      (sup/readers-of [shared-frame count-q])])
+            a (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) shared-frame [panel {:tag "a"}])
+            b (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) shared-frame [panel {:tag "b"}])]
+        (is (= [2 2] [(rf.hicasso.roots-frames-support/readers-of [shared-frame label-q])
+                      (rf.hicasso.roots-frames-support/readers-of [shared-frame count-q])])
             "precondition: both roots are reading the shared keys")
         ;; `unmount!` and NOT `release!` — `release!` resets the runtime, so
         ;; every count below would read zero whether the teardown released
         ;; anything or not.
-        (mount/unmount! a)
-        (-> (sup/quiesced!)
+        (rf.hicasso.impl.mount/unmount! a)
+        (-> (rf.hicasso.roots-frames-support/quiesced!)
             (.then
               (fn [_]
                 (try
@@ -272,27 +272,27 @@
                             departure — the reaper is armed on the last reader
                             and root B is still one"
                     (is (= #{[shared-frame label-q] [shared-frame count-q]}
-                           (sup/cell-keys))
+                           (rf.hicasso.roots-frames-support/cell-keys))
                         (str "a sibling's teardown disposed a key root B still
-                              reads; got " (pr-str (sup/cell-keys)))))
+                              reads; got " (pr-str (rf.hicasso.roots-frames-support/cell-keys)))))
 
                   (testing "decremented, not merely present: one reader each,
                             and one boundary. A cell that kept root A's slot
                             would be a leak and reads the same as a survivor
                             unless the number is taken"
-                    (is (= [1 1] [(sup/readers-of [shared-frame label-q])
-                                  (sup/readers-of [shared-frame count-q])])
-                        (str "got " (pr-str (runtime/residue))))
-                    (is (= 1 (:boundaries (runtime/stats)))
-                        (str "got " (pr-str (runtime/stats)))))
+                    (is (= [1 1] [(rf.hicasso.roots-frames-support/readers-of [shared-frame label-q])
+                                  (rf.hicasso.roots-frames-support/readers-of [shared-frame count-q])])
+                        (str "got " (pr-str (rf.hicasso.test.runtime/residue))))
+                    (is (= 1 (:boundaries (rf.hicasso.test.runtime/stats)))
+                        (str "got " (pr-str (rf.hicasso.test.runtime/stats)))))
 
                   (testing "and the survivor is LIVE, which is the half a count
                             cannot show. A cell disposed out from under root B
                             leaves its DOM intact and its body silent — no
                             error, no complaint, just a screen that stopped
                             moving"
-                    (let [ran (sup/body-runs-delta!
-                                (fn [] (mount/dispatch! b [::bump])))]
+                    (let [ran (rf.hicasso.roots-frames-support/body-runs-delta!
+                                (fn [] (rf.hicasso.impl.mount/dispatch! b [::bump])))]
                       (is (= 1 ran)
                           (str "the surviving root must still re-run on a
                                 commit; " ran " bodies ran")))
@@ -303,10 +303,10 @@
                   (testing "and tearing the survivor down then releases
                             everything — residue read BEFORE the reset, which
                             is the only reading that can go red"
-                    (is (= sup/released (sup/teardown-census! b))))
+                    (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/teardown-census! b))))
                   (finally
-                    (mount/release! a)
-                    (mount/release! b)
+                    (rf.hicasso.impl.mount/release! a)
+                    (rf.hicasso.impl.mount/release! b)
                     (done))))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -345,26 +345,26 @@
 ;; `a-page-global-adoption-window-steals-an-ordinary-roots-enter-transition`.
 (deftest two-hydrating-roots-on-one-frame-hold-windows-of-their-own
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
-        (let [html-a (sup/server-html! shared-frame [screen {:title "A"}])
-              html-b (sup/server-html! shared-frame [screen {:title "B"}])
-              ca     (sup/stamp-server-nodes! (sup/server-dom! html-a))
-              cb     (sup/stamp-server-nodes! (sup/server-dom! html-b))]
-          (is (sup/every-server-node? ca ".screen, .title, .value")
+        (let [html-a (rf.hicasso.roots-frames-support/server-html! shared-frame [screen {:title "A"}])
+              html-b (rf.hicasso.roots-frames-support/server-html! shared-frame [screen {:title "B"}])
+              ca     (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-a))
+              cb     (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html-b))]
+          (is (rf.hicasso.roots-frames-support/every-server-node? ca ".screen, .title, .value")
               "premise: the stamps are on the server's own nodes")
-          (collector/reset-runtime!)
-          (let [ha (mount/hydrate-root! ca shared-frame [screen {:title "A"}])
-                hb (mount/hydrate-root! cb shared-frame [screen {:title "B"}])]
+          (rf.hicasso.impl.collector/reset-runtime!)
+          (let [ha (rf.hicasso.impl.mount/hydrate-root! ca shared-frame [screen {:title "A"}])
+                hb (rf.hicasso.impl.mount/hydrate-root! cb shared-frame [screen {:title "B"}])]
             (testing "each root minted a window OF ITS OWN, though both name
                       one frame — the reading a frame-keyed registry cannot
                       produce, taken by construction and not on a timer"
-              (is (true? (roots/adopting? (:adoption ha)))
+              (is (true? (rf.hicasso.impl.roots/adopting? (:adoption ha)))
                   "root A is in flight — `hydrate-root!` returns before the
                    tree is adopted, so its window outlives the call")
-              (is (true? (roots/adopting? (:adoption hb)))
+              (is (true? (rf.hicasso.impl.roots/adopting? (:adoption hb)))
                   "and so is root B")
               (is (not (identical? (:adoption ha) (:adoption hb)))
                   "two roots sharing a frame must not share a window"))
@@ -373,28 +373,28 @@
                       the page-global defect rf2-6tmu repaired, asked again at
                       frame granularity — where every existing row happens to
                       be immune because no two of its roots share a frame"
-              (roots/close-adoption-window! (:adoption ha))
-              (is (false? (roots/adopting? (:adoption ha))))
-              (is (true? (roots/adopting? (:adoption hb)))
+              (rf.hicasso.impl.roots/close-adoption-window! (:adoption ha))
+              (is (false? (rf.hicasso.impl.roots/adopting? (:adoption ha))))
+              (is (true? (rf.hicasso.impl.roots/adopting? (:adoption hb)))
                   "root B must still be adopting after its frame-mate closed"))
 
-            (-> (sup/wait-until! both-committed?)
+            (-> (rf.hicasso.roots-frames-support/wait-until! both-committed?)
                 (.then
                   (fn [ok]
                     (try
                       (is (true? ok)
                           (str "both roots must commit; readers on the shared
                                 key were "
-                               (sup/readers-of [shared-frame label-q])))
+                               (rf.hicasso.roots-frames-support/readers-of [shared-frame label-q])))
 
                       (testing "and each root ADOPTED ITS OWN server DOM — the
                                 nodes are the very nodes each container's
                                 markup produced, which no re-render could
                                 reconstruct, and sharing a frame did not make
                                 either root adopt the other's tree"
-                        (is (sup/every-server-node? ca ".screen, .title, .value")
+                        (is (rf.hicasso.roots-frames-support/every-server-node? ca ".screen, .title, .value")
                             "root A kept the server's nodes")
-                        (is (sup/every-server-node? cb ".screen, .title, .value")
+                        (is (rf.hicasso.roots-frames-support/every-server-node? cb ".screen, .title, .value")
                             "root B kept the server's nodes"))
 
                       (testing "the two roots differ where their markup differs
@@ -408,11 +408,11 @@
                                 readers here exactly as it is for two ordinary
                                 mounts — adoption changes the acquisition's
                                 timing and not its shape"
-                        (is (= #{[shared-frame label-q]} (sup/cell-keys))
-                            (str "got " (pr-str (sup/cell-keys))))
-                        (is (= 2 (sup/readers-of [shared-frame label-q]))))
+                        (is (= #{[shared-frame label-q]} (rf.hicasso.roots-frames-support/cell-keys))
+                            (str "got " (pr-str (rf.hicasso.roots-frames-support/cell-keys))))
+                        (is (= 2 (rf.hicasso.roots-frames-support/readers-of [shared-frame label-q]))))
 
-                      (finally (mount/release! ha) (mount/release! hb) (done))))))))))))
+                      (finally (rf.hicasso.impl.mount/release! ha) (rf.hicasso.impl.mount/release! hb) (done))))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; S4 — two divergent roots on one frame complain twice
@@ -434,23 +434,23 @@
 ;; a window never shut at all.
 (deftest two-divergent-hydrating-roots-on-one-frame-complain-independently
   (async done
-    (if-not (mount/browser?)
-      (do (sup/skip! ":node-test has no DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no DOM") (done))
       (do
         (fresh!)
-        (let [html-a (sup/server-html! shared-frame [screen {:title "server-A"}])
-              html-b (sup/server-html! shared-frame [screen {:title "server-B"}])
-              ca     (sup/server-dom! html-a)
-              cb     (sup/server-dom! html-b)]
-          (collector/reset-runtime!)
-          (let [{:keys [seen stop!]}      (sup/watch-mismatches!)
+        (let [html-a (rf.hicasso.roots-frames-support/server-html! shared-frame [screen {:title "server-A"}])
+              html-b (rf.hicasso.roots-frames-support/server-html! shared-frame [screen {:title "server-B"}])
+              ca     (rf.hicasso.roots-frames-support/server-dom! html-a)
+              cb     (rf.hicasso.roots-frames-support/server-dom! html-b)]
+          (rf.hicasso.impl.collector/reset-runtime!)
+          (let [{:keys [seen stop!]}      (rf.hicasso.roots-frames-support/watch-mismatches!)
                 ;; MANUFACTURED here and asserted on here — the only shape of
                 ;; call site at which swallowing an uncaught error is not the
                 ;; fail-open the pageerror rule forbids.
-                {:keys [captured close!]} (sup/open-console-capture! {:swallow-uncaught? true})
-                ha (mount/hydrate-root! ca shared-frame [screen {:title "client-A"}])
-                hb (mount/hydrate-root! cb shared-frame [screen {:title "client-B"}])]
-            (-> (sup/wait-until! both-committed?)
+                {:keys [captured close!]} (rf.hicasso.roots-frames-support/open-console-capture! {:swallow-uncaught? true})
+                ha (rf.hicasso.impl.mount/hydrate-root! ca shared-frame [screen {:title "client-A"}])
+                hb (rf.hicasso.impl.mount/hydrate-root! cb shared-frame [screen {:title "client-B"}])]
+            (-> (rf.hicasso.roots-frames-support/wait-until! both-committed?)
                 (.then
                   (fn [ok]
                     (close!)
@@ -479,12 +479,12 @@
                           (is (= 2 (count @seen))
                               (str "`:rf.ssr/hydration-mismatch` count; got "
                                    (count @seen) " — "
-                                   (pr-str (mapv (comp :error sup/tags-of) @seen))))))
+                                   (pr-str (mapv (comp :error rf.hicasso.roots-frames-support/tags-of) @seen))))))
 
                       (testing "and what fired is the framework diagnostic Spec
                                 011 names, tier-discriminated by its door"
                         (doseq [ev @seen]
-                          (let [tags (sup/tags-of ev)]
+                          (let [tags (rf.hicasso.roots-frames-support/tags-of ev)]
                             (is (= :rf.ssr/hydration-mismatch (:operation ev)))
                             (is (= 're-frame.hicasso.impl.mount/hydrate-root!
                                    (:where tags)))
@@ -499,4 +499,4 @@
                         (is (= "alpha" (text-in ca ".value")))
                         (is (= "alpha" (text-in cb ".value"))))
 
-                      (finally (mount/release! ha) (mount/release! hb) (done))))))))))))
+                      (finally (rf.hicasso.impl.mount/release! ha) (rf.hicasso.impl.mount/release! hb) (done))))))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
@@ -69,12 +69,12 @@
   `re-frame.hicasso.frame-doors-dom-cljs-test`, a file in this package."
   (:require [cljs.test :refer-macros [is]]
             [clojure.string :as str]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.frames :as frames]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.roots :as roots]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.frames :as rf.hicasso.impl.frames]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.roots :as rf.hicasso.impl.roots]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; ---------------------------------------------------------------------------
 ;; Lane
@@ -190,7 +190,7 @@
   produce ONE key — and would still render two visually plausible
   subtrees, which is exactly why the DOM is not where this is read."
   []
-  (set (keys @collector/!cells)))
+  (set (keys @rf.hicasso.impl.collector/!cells)))
 
 (defn cell-frames
   "The frames the live cell table mentions, as a set."
@@ -205,7 +205,7 @@
   one key, and `(+ 1 1)` and `2` are different numbers on different
   keys."
   [sub-key]
-  (count (runtime/cell-readers sub-key)))
+  (count (rf.hicasso.test.runtime/cell-readers sub-key)))
 
 (defn frame-memo-frames
   "The frames the arm's frame memo holds a row for.
@@ -225,14 +225,14 @@
   incarnations — and which is why a render, not a dispatch, is now what
   fills this. `test.runtime/stats`'s `:frames` counts the same rows."
   []
-  (set (keys @frames/!frame-ops)))
+  (set (keys @rf.hicasso.impl.frames/!frame-ops)))
 
 (defn frame-memo-row
   "The arm's memo row for `frame-kw`, or nil — `{:incarnation :ops
   :dispatch}`. Read by IDENTITY, never by value: what a witness wants to
   know is whether this is the same row it saw before."
   [frame-kw]
-  (get @frames/!frame-ops frame-kw))
+  (get @rf.hicasso.impl.frames/!frame-ops frame-kw))
 
 (defn body-runs-delta!
   "Run `f`, answer how many boundary bodies ran while it did.
@@ -241,9 +241,9 @@
   a reading of everything since the page loaded — the counter is monotone
   by design and `reset-runtime!` deliberately leaves it alone."
   [f]
-  (runtime/reset-body-runs!)
+  (rf.hicasso.test.runtime/reset-body-runs!)
   (f)
-  (runtime/body-runs))
+  (rf.hicasso.test.runtime/body-runs))
 
 ;; ---------------------------------------------------------------------------
 ;; Teardown census — read BETWEEN the unmount and the reset
@@ -261,7 +261,7 @@
   asserting them here would be asserting a schedule rather than a
   release — [[quiesced!]] is where those two become readable."
   []
-  (select-keys (runtime/residue) [:cell-refs :boundaries :edges]))
+  (select-keys (rf.hicasso.test.runtime/residue) [:cell-refs :boundaries :edges]))
 
 (defn teardown-census!
   "Unmount `handle`, read the census, and only THEN finish the release.
@@ -277,9 +277,9 @@
   reset the runtime, drop the container — without unmounting a root that
   is already gone."
   [handle]
-  (mount/unmount! handle)
+  (rf.hicasso.impl.mount/unmount! handle)
   (let [c (census)]
-    (mount/release! (assoc handle :root nil))
+    (rf.hicasso.impl.mount/release! (assoc handle :root nil))
     c))
 
 (defn quiesced!
@@ -287,7 +287,7 @@
   has run. `test.runtime/quiesced!`, re-exported so a suite settles
   against the runtime's horizon rather than against a copy of it."
   []
-  (runtime/quiesced!))
+  (rf.hicasso.test.runtime/quiesced!))
 
 ;; ---------------------------------------------------------------------------
 ;; Server bytes, and the node identity that survives them
@@ -314,17 +314,17 @@
   trees rendered through this fn carry none — see
   [[settled-server-html!]] for the ones that do."
   [frame-kw hiccup]
-  (let [container (mount/fresh-container!)
-        handle    (mount/root! container frame-kw hiccup)
+  (let [container (rf.hicasso.impl.mount/fresh-container!)
+        handle    (rf.hicasso.impl.mount/root! container frame-kw hiccup)
         html      (.-innerHTML container)]
-    (mount/release! handle)
+    (rf.hicasso.impl.mount/release! handle)
     html))
 
 (defn server-dom!
   "A container carrying `html`, attached to the document — the page as it
   arrives, before any JavaScript has adopted it."
   [html]
-  (let [container (mount/fresh-container!)]
+  (let [container (rf.hicasso.impl.mount/fresh-container!)]
     (set! (.-innerHTML container) html)
     container))
 
@@ -385,7 +385,7 @@
              window   (:adoption handle)]
          (letfn [(tick []
                    (cond
-                     (not (roots/adopting? window))
+                     (not (rf.hicasso.impl.roots/adopting? window))
                      ;; Past the closer AND past the entry reap horizon,
                      ;; so a reading of the entry cache is taken on the
                      ;; far side of the race.
@@ -453,14 +453,14 @@
   by PLAYING its transition, which is precisely the thing the hydrated
   root must not do."
   [frame-kw hiccup settled?]
-  (let [container (mount/fresh-container!)
-        handle    (mount/root! container frame-kw hiccup)]
+  (let [container (rf.hicasso.impl.mount/fresh-container!)
+        handle    (rf.hicasso.impl.mount/root! container frame-kw hiccup)]
     (-> (wait-until! (fn [] (settled? container)))
         (.then (fn [ok]
                  (is (true? ok)
                      "premise: the server tree settled before its bytes were read")
                  (let [html (.-innerHTML container)]
-                   (mount/release! handle)
+                   (rf.hicasso.impl.mount/release! handle)
                    html))))))
 
 ;; ---------------------------------------------------------------------------
@@ -528,10 +528,10 @@
   []
   (let [seen (atom [])
         k    (keyword (str "rf2-hic-012-" (gensym)))]
-    (trace-tooling/register-listener!
+    (rf.trace.tooling/register-listener!
       k (fn [ev] (when (= :rf.ssr/hydration-mismatch (:operation ev))
                    (swap! seen conj ev))))
-    {:seen seen :stop! (fn [] (trace-tooling/unregister-listener! k) @seen)}))
+    {:seen seen :stop! (fn [] (rf.trace.tooling/unregister-listener! k) @seen)}))
 
 (defn tags-of
   "A diagnostic's tags merged with its top level, so a read is robust to
@@ -619,17 +619,17 @@
   which is the pre-fix behaviour exactly."
   [f]
   (let [page-window   #js {"open" false}
-        mint-original roots/open-adoption-window!
-        here-original roots/adopting-here?]
-    (set! roots/open-adoption-window!
+        mint-original rf.hicasso.impl.roots/open-adoption-window!
+        here-original rf.hicasso.impl.roots/adopting-here?]
+    (set! rf.hicasso.impl.roots/open-adoption-window!
           (fn [] (set! (.-open page-window) true) page-window))
-    (set! roots/adopting-here?
+    (set! rf.hicasso.impl.roots/adopting-here?
           (fn []
             ;; Let-bound, never inlined into the `or`: short-circuiting
             ;; past it would skip the hook, which is the whole hazard.
             (let [in-this-roots-own-window? (here-original)]
-              (or (roots/adopting? page-window) in-this-roots-own-window?))))
+              (or (rf.hicasso.impl.roots/adopting? page-window) in-this-roots-own-window?))))
     (try (f page-window)
          (finally
-           (set! roots/open-adoption-window! mint-original)
-           (set! roots/adopting-here? here-original)))))
+           (set! rf.hicasso.impl.roots/open-adoption-window! mint-original)
+           (set! rf.hicasso.impl.roots/adopting-here? here-original)))))

--- a/implementation/hicasso/test/re_frame/hicasso/route_link_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/route_link_cljs_test.cljs
@@ -11,23 +11,23 @@
   `defaultPrevented`. The real browser click, the real route change and
   the real page re-render are `shapes/route_link_dom_cljs_test`'s."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.impl.route-link :as link]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.impl.route-link :as rf.hicasso.impl.route-link]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.routing :as routing]
-            [re-frame.test-support :as test-support]))
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.routing :as rf.routing]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 (def ^:private frame-id ::grammar)
 
 (defn- fresh! []
-  (routing/reg-route :conduit.profile/show {} "/profile/:username")
+  (rf.routing/reg-route :conduit.profile/show {} "/profile/:username")
   (rf/make-frame {:id frame-id :initial-events [[:rf/set-db {}]]})
   frame-id)
 
@@ -36,8 +36,8 @@
   [[intent/with-frame]] — and answer the hiccup value."
   [props & children]
   (fresh!)
-  (intent/with-frame frame-id (fn [_] nil)
-    (fn [] (apply link/route-link props children))))
+  (rf.hicasso.impl.intent/with-frame frame-id (fn [_] nil)
+    (fn [] (apply rf.hicasso.impl.route-link/route-link props children))))
 
 (defn- ev
   "A stand-in click event: `:button`/`:metaKey` select the click class,
@@ -75,7 +75,7 @@
 (deftest the-click-decision-is-readable-off-the-tree
   (let [[_ attrs] (rendered {:to :conduit.profile/show :params {:username "jane"}} "jane")
         on-click  (:on-click attrs)]
-    (is (intent/navigate-head? on-click) "the click position carries the navigate head")
+    (is (rf.hicasso.impl.intent/navigate-head? on-click) "the click position carries the navigate head")
     (let [{:keys [frame payload native? veto]} (second on-click)]
       (is (= frame-id frame) "the frame was captured at render, as data")
       (is (= [:rf.route/url-requested {:url "/profile/jane"
@@ -108,9 +108,9 @@
 
 (deftest a-prevent-veto-rides-the-vector-as-data
   (let [[_ attrs] (rendered {:to :conduit.profile/show :params {:username "jane"}
-                             :on-click [intent/prevent-head [:conduit/track "jane"]]}
+                             :on-click [rf.hicasso.impl.intent/prevent-head [:conduit/track "jane"]]}
                             "jane")]
-    (is (= [intent/prevent-head [:conduit/track "jane"]]
+    (is (= [rf.hicasso.impl.intent/prevent-head [:conduit/track "jane"]]
            (:veto (second (:on-click attrs))))
         "the declarative veto is visible to `=` on the rendered tree")))
 
@@ -138,7 +138,7 @@
   (fresh!)
   (is (thrown-with-msg?
         js/Error #"hicasso-route-link-outside-boundary"
-        (link/route-link {:to :conduit.profile/show :params {:username "jane"}} "jane"))))
+        (rf.hicasso.impl.route-link/route-link {:to :conduit.profile/show :params {:username "jane"}} "jane"))))
 
 (deftest a-prefetch-key-never-reaches-the-anchor
   (testing "`:prefetch` is routing's link-model key, not an HTML attribute,
@@ -154,8 +154,8 @@
 (defn- lower-navigate
   "Lower `[intent/navigate-head m]` at an event position and answer the closure."
   [m]
-  (intent/with-frame frame-id (fn [_] nil)
-    (fn [] (intent/lower-prop :on-click [intent/navigate-head m]))))
+  (rf.hicasso.impl.intent/with-frame frame-id (fn [_] nil)
+    (fn [] (rf.hicasso.impl.intent/lower-prop :on-click [rf.hicasso.impl.intent/navigate-head m]))))
 
 (deftest the-navigate-map-lowers-to-a-closure
   (testing "HD-027's four keys — :frame, :payload, :native? and :veto — lower
@@ -169,11 +169,11 @@
 (deftest prevent-does-not-wrap-a-navigate
   (is (thrown-with-msg?
         js/Error #"hicasso-malformed-prevent"
-        (intent/with-frame frame-id (fn [_] nil)
-          (fn [] (intent/lower-prop
+        (rf.hicasso.impl.intent/with-frame frame-id (fn [_] nil)
+          (fn [] (rf.hicasso.impl.intent/lower-prop
                    :on-click
-                   [intent/prevent-head
-                    [intent/navigate-head {:frame frame-id :payload [:x]
+                   [rf.hicasso.impl.intent/prevent-head
+                    [rf.hicasso.impl.intent/navigate-head {:frame frame-id :payload [:x]
                                            :native? false :veto nil}]]))))
       "decorators do not nest, in either order"))
 
@@ -187,14 +187,14 @@
   [props]
   (let [!seen  (atom [])
         [_ attrs] (rendered props "jane")
-        h      (intent/with-frame frame-id
+        h      (rf.hicasso.impl.intent/with-frame frame-id
                  (fn [ev] (swap! !seen conj ev) nil)
-                 (fn [] (intent/lower-prop :on-click (:on-click attrs))))]
+                 (fn [] (rf.hicasso.impl.intent/lower-prop :on-click (:on-click attrs))))]
     [h !seen]))
 
 (deftest a-prevent-veto-cancels-the-navigation-and-dispatches-instead
   (let [[h !seen] (lowered-click {:to :conduit.profile/show :params {:username "jane"}
-                                  :on-click [intent/prevent-head [:conduit/track "jane"]]})
+                                  :on-click [rf.hicasso.impl.intent/prevent-head [:conduit/track "jane"]]})
         !prevented (atom false)]
     (h (ev {:prevented !prevented}))
     (is (true? @!prevented)
@@ -231,10 +231,10 @@
   previous registration in `finally` so the suite's other rows keep
   running against routing's real seam."
   [f thunk]
-  (let [previous (late-bind/get-fn :routing/activate-link!)]
-    (late-bind/set-fn! :routing/activate-link! f)
+  (let [previous (rf.late-bind/get-fn :routing/activate-link!)]
+    (rf.late-bind/set-fn! :routing/activate-link! f)
     (try (thunk)
-         (finally (late-bind/set-fn! :routing/activate-link! previous)))))
+         (finally (rf.late-bind/set-fn! :routing/activate-link! previous)))))
 
 (deftest a-function-veto-rides-the-vector-and-reaches-the-seam-by-identity
   (testing "the roster's IMPERATIVE half (HD-024: whoever holds the event
@@ -304,7 +304,7 @@
            routing artefact's absence, which is what keeps the degrade a
            navigation policy rather than a lost click"
     (let [[h !seen]  (lowered-click {:to :conduit.profile/show :params {:username "jane"}
-                                     :on-click [intent/prevent-head [:conduit/track "jane"]]})
+                                     :on-click [rf.hicasso.impl.intent/prevent-head [:conduit/track "jane"]]})
           !prevented (atom false)]
       (with-activate-link nil #(h (ev {:prevented !prevented})))
       (is (true? @!prevented))
@@ -317,9 +317,9 @@
            :to, and the two coordinates the author needs to repair it.
            Asserted as ex-data rather than a message regex, per the
            refusal-shape convention"
-    (let [previous (late-bind/get-fn :routing/link-model)]
+    (let [previous (rf.late-bind/get-fn :routing/link-model)]
       (try
-        (late-bind/set-fn! :routing/link-model nil)
+        (rf.late-bind/set-fn! :routing/link-model nil)
         (let [data (try
                      (rendered {:to :conduit.profile/show :params {:username "jane"}} "jane")
                      ::returned-without-refusing
@@ -331,4 +331,4 @@
               "…and the dependency to add")
           (is (re-find #"re-frame\.routing" (str (:reason data)))
               "…and the namespace to require at boot"))
-        (finally (late-bind/set-fn! :routing/link-model previous))))))
+        (finally (rf.late-bind/set-fn! :routing/link-model previous))))))

--- a/implementation/hicasso/test/re_frame/hicasso/select_multiple_value_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/select_multiple_value_dom_cljs_test.cljs
@@ -30,7 +30,7 @@
   faked where there is no document — the same shape
   `controlled_dom_cljs_test` uses for its caret rows."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.hicasso.impl.intent :as intent]))
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]))
 
 (defn- browser? []
   (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
@@ -89,7 +89,7 @@
   (testing "two options picked materialize as two values, in tree order"
     (let [target (select-stand-in true ["a" "c"])]
       (is (= [:tb/pick ["a" "c"]]
-             (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
+             (rf.hicasso.impl.intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
           (str "`.value` answers \"a\" for this target because HTML says the "
                "first selected option is the value; the SELECTION is both, and "
                "an intent that lowers to the first one discards the author's "
@@ -97,12 +97,12 @@
   (testing "one option picked is still a vector — the shape follows the control"
     (let [target (select-stand-in true ["b"])]
       (is (= [:tb/pick ["b"]]
-             (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
+             (rf.hicasso.impl.intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
           "a one-option selection is a selection of one, not a bare value")))
   (testing "nothing picked is an empty selection, not the empty string"
     (let [target (select-stand-in true [])]
       (is (= [:tb/pick []]
-             (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
+             (rf.hicasso.impl.intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
           "`.value` would answer \"\" here, which is indistinguishable from a
            selected option whose value is empty"))))
 
@@ -110,7 +110,7 @@
   (testing "no :multiple means `.value`, exactly as before"
     (let [target (select-stand-in false ["a"])]
       (is (= [:tb/pick "a"]
-             (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
+             (rf.hicasso.impl.intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
           "the ordinary select is the overwhelming case and answers a string"))))
 
 (deftest an-input-carrying-multiple-is-not-a-select
@@ -122,7 +122,7 @@
             row (rf2-lhsvs)."
     (let [target #js {:files nil :multiple true :value "a@b.com,c@d.com"}]
       (is (= [:tb/pick "a@b.com,c@d.com"]
-             (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
+             (rf.hicasso.impl.intent/materialize [:tb/pick :re-frame.hicasso/value] (ev target)))
           (str "`.multiple` alone is the WRONG test — it is an <input> "
                "attribute too. Only a <select> has `.selectedOptions`, and "
                "asking for it is what keeps every input on the fast path")))))
@@ -137,6 +137,6 @@
               (str "the browser's own answer, and the reason the naive reader "
                    "looks right: `.value` is a plausible non-empty string"))
           (is (= [:tb/pick ["a" "c"]]
-                 (intent/materialize [:tb/pick :re-frame.hicasso/value] (ev n)))
+                 (rf.hicasso.impl.intent/materialize [:tb/pick :re-frame.hicasso/value] (ev n)))
               "the selection the user actually made")
           (finally (drop! n)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/server_render_body_ssr_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/server_render_body_ssr_cljs_test.cljs
@@ -37,14 +37,14 @@
   always-on `:node-test`. Every row renders to a string; none needs a DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.server :as server]
-            [re-frame.subs :as subs]
-            [re-frame.test-support :as test-support]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.server :as rf.hicasso.server]
+            [re-frame.subs :as rf.subs]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]))
 
 ;; Registered ABOVE `use-fixtures`, for the sibling suites' reason: the reset
@@ -54,7 +54,7 @@
 
 (rf/reg-sub ::greeting (fn [db _] (:greeting db)))
 
-(subs/reg-runtime-sub ::flavour
+(rf.subs/reg-runtime-sub ::flavour
   (fn [runtime-db _] (get-in runtime-db [::kitchen :flavour])))
 
 (def ^:private !boot-events-run
@@ -74,8 +74,8 @@
   (fn [_ _] (throw (js/Error. "the sub that recovers to nil"))))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; `:ambient-frame nil` — `render-body` makes its own top-level frame,
      ;; and the fixture's carried `:rf/default` stamp would be a scope the
      ;; request is not rendering. The sibling `frame_doors_ssr` suite opts
@@ -83,26 +83,26 @@
      :ambient-frame nil
      :init-fn       (fn []
                       (reset! !boot-events-run [])
-                      (collector/reset-runtime!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The probes
 ;; ---------------------------------------------------------------------------
 
-(h/defview both-partitions
+(rf.hicasso/defview both-partitions
   "Reads one app-db sub and one runtime-db sub, so a row can tell WHICH
   partition failed to restore rather than only that something did."
   [_]
   [:div.page
-   [:p.greeting (str (h/sub [::greeting]))]
-   [:p.flavour (str (h/sub [::flavour]))]])
+   [:p.greeting (str (rf.hicasso/sub [::greeting]))]
+   [:p.flavour (str (rf.hicasso/sub [::flavour]))]])
 
-(h/defview detonating
+(rf.hicasso/defview detonating
   "Reads the sub that throws. The framework recovers it to `nil`, so this
   body returns normally and the render produces markup — which is exactly
   the hazard §4 is about."
   [_]
-  [:div.page [:p.greeting (str (h/sub [::detonates]))]])
+  [:div.page [:p.greeting (str (rf.hicasso/sub [::detonates]))]])
 
 (defn- id-probe
   "One `useId`, rendered as text. A React hook, so it is written where React
@@ -111,9 +111,9 @@
   [^js _props]
   (react/createElement "b" #js {:className "probe"} (react/useId)))
 
-(h/defhost id-host id-probe {:server :render})
+(rf.hicasso/defhost id-host id-probe {:server :render})
 
-(h/defview id-page
+(rf.hicasso/defview id-page
   [_]
   [:div.page [id-host {}]])
 
@@ -130,10 +130,10 @@
     :rf/runtime-db {::kitchen {:flavour "vanilla"}}}))
 
 (defn- render-body! [hiccup opts]
-  (server/render-body (merge {:hiccup hiccup :render-state (state)} opts)))
+  (rf.hicasso.server/render-body (merge {:hiccup hiccup :render-state (state)} opts)))
 
 (defn- live-frame-ids []
-  (set (keys @frame/frames)))
+  (set (keys @rf.frame/frames)))
 
 ;; ---------------------------------------------------------------------------
 ;; §1 — inner markup, and nothing else

--- a/implementation/hicasso/test/re_frame/hicasso/server_render_recovered_error_ssr_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/server_render_recovered_error_ssr_cljs_test.cljs
@@ -52,14 +52,14 @@
   always-on `:node-test`. Every row renders to a string; none needs a DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.server :as server]
-            [re-frame.test-support :as test-support]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.server :as rf.hicasso.server]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; Registered ABOVE `use-fixtures`, for the sibling suites' reason: the reset
 ;; fixture captures its source-store baseline when the `use-fixtures` form is
@@ -102,7 +102,7 @@
     ;; Re-enter the SAME door. Under the fixed-key form this REPLACED the outer
     ;; listener, and the inner `finally` then removed it outright.
     (reset! !inner-outcome
-            (try (server/render {:hiccup   [:div.inner "inner"]
+            (try (rf.hicasso.server/render {:hiccup   [:div.inner "inner"]
                                  :snapshot {:label "inner"}
                                  :payload  [:label]})
                  :returned
@@ -118,14 +118,14 @@
 (def ^:private no-handler-event ::deliberately-unregistered)
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; `:ambient-frame nil` — `render` makes its own top-level frame, and
      ;; the fixture's carried `:rf/default` stamp would be a scope the
      ;; request is not rendering. The sibling `server_render_body_ssr` and
      ;; `frame_doors_ssr` suites opt out for the same reason.
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The listener keys, spelled out
@@ -159,40 +159,40 @@
 ;; `re-frame.trace.tooling/listeners` for the same reason.
 #_{:clj-kondo/ignore [:private-call]}
 (defn- live-error-listener-ids []
-  (set (keys @error-emit/listeners)))
+  (set (keys @rf.error-emit/listeners)))
 
 (defn- live-frame-ids []
-  (set (keys @frame/frames)))
+  (set (keys @rf.frame/frames)))
 
 ;; ---------------------------------------------------------------------------
 ;; The probes
 ;; ---------------------------------------------------------------------------
 
-(h/defview page
+(rf.hicasso/defview page
   "Reads one ordinary sub. The tree the control renders and the tree the
   refusal renders differ in the SUB and nothing else."
   [_]
-  [:div.page [:p.label (str (h/sub [::label]))]])
+  [:div.page [:p.label (str (rf.hicasso/sub [::label]))]])
 
-(h/defview detonating
+(rf.hicasso/defview detonating
   "Reads the sub that throws. The framework recovers it to `nil`, so this
   body returns normally and the render produces markup — which is exactly
   the hazard §1 is about."
   [_]
-  [:div.page [:p.label (str (h/sub [::detonates]))]])
+  [:div.page [:p.label (str (rf.hicasso/sub [::detonates]))]])
 
 (def ^:private !listeners-mid-render
   "What the `:errors` registry held while a render was in flight. §4's
   whole instrument."
   (atom ::unset))
 
-(h/defview watching
+(rf.hicasso/defview watching
   "Reads the live `:errors` listener registry from INSIDE the render — a
   view body is a callback React runs during `renderToString`, so this is
   the one moment the door's window is observably open."
   [_]
   (reset! !listeners-mid-render (live-error-listener-ids))
-  [:div.page [:p.label (str (h/sub [::label]))]])
+  [:div.page [:p.label (str (rf.hicasso/sub [::label]))]])
 
 ;; ---------------------------------------------------------------------------
 ;; The request
@@ -216,7 +216,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-recovered-render-error-fails-the-whole-page-render
-  (let [thrown (try (server/render (request :hiccup [detonating {}]))
+  (let [thrown (try (rf.hicasso.server/render (request :hiccup [detonating {}]))
                     (catch :default e e))]
     (is (instance? ExceptionInfo thrown)
         "a sub that throws mid-render must not answer a document with a hole in the page")
@@ -237,14 +237,14 @@
             refusal mask the render's. Omitting `:payload` from a
             DETONATING request must still answer the render's verdict, not
             the policy's"
-    (let [data (try (server/render (dissoc (request :hiccup [detonating {}]) :payload))
+    (let [data (try (rf.hicasso.server/render (dissoc (request :hiccup [detonating {}]) :payload))
                     (catch :default e (ex-data e)))]
       (is (= :rf.error/ssr-render-failed (:rf.error/id data))
           "the render's verdict wins"))
     (testing "control: the same omission on a CLEAN render does reach the
               policy, so the row above is about ordering and not about
               `:payload` being optional"
-      (let [data (try (server/render (dissoc (request) :payload))
+      (let [data (try (rf.hicasso.server/render (dissoc (request) :payload))
                       (catch :default e (ex-data e)))]
         (is (= :rf.error/ssr-missing-payload-policy (:rf.error/id data)))))))
 
@@ -254,7 +254,7 @@
 
 (deftest the-control-a-tree-with-no-recovered-error-returns-the-existing-shape
   (let [{:keys [frame-id html payload payload-edn payload-script document] :as result}
-        (server/render (request))]
+        (rf.hicasso.server/render (request))]
     (is (= #{:frame-id :html :payload :payload-edn :payload-script :document}
            (set (keys result)))
         "the response map's keys are exactly the six the door has always answered")
@@ -289,26 +289,26 @@
          the `finally` doing its job and not a vacuous never-registered")
 
     (testing "success"
-      (server/render (request))
+      (rf.hicasso.server/render (request))
       (is (= frames-before (live-frame-ids))    "no frame left behind")
       (is (= listeners-before (live-error-listener-ids)) "and no listener"))
 
     (testing "recovered-error refusal"
-      (is (thrown? :default (server/render (request :hiccup [detonating {}]))))
+      (is (thrown? :default (rf.hicasso.server/render (request :hiccup [detonating {}]))))
       (is (= frames-before (live-frame-ids)))
       (is (= listeners-before (live-error-listener-ids))))
 
     (testing "a direct render throw — the view takes the render down, so the
               verdict is never reached and only the `finally` can clean up"
       (is (thrown? :default
-                   (server/render (request :hiccup [(fn [] (throw (js/Error. "boom")))]))))
+                   (rf.hicasso.server/render (request :hiccup [(fn [] (throw (js/Error. "boom")))]))))
       (is (= frames-before (live-frame-ids)))
       (is (= listeners-before (live-error-listener-ids))))
 
     (testing "and the runtime is not left mid-render: the next request still
               renders, which is what makes the three rows above evidence of
               cleanup rather than of a door that stopped working"
-      (is (str/includes? (:html (server/render (request))) "alpha")))))
+      (is (str/includes? (:html (rf.hicasso.server/render (request))) "alpha")))))
 
 ;; ---------------------------------------------------------------------------
 ;; §4 — the doors do not share a listener key
@@ -324,7 +324,7 @@
 (deftest each-door-arms-its-own-listener-and-only-its-own
   (testing "`render`'s window, observed from inside `render`"
     (reset! !listeners-mid-render ::unset)
-    (server/render (request :hiccup [watching {}]))
+    (rf.hicasso.server/render (request :hiccup [watching {}]))
     (let [live @!listeners-mid-render]
       (is (set? live) "the probe ran inside the render")
       (is (= 1 (count (door-keys render-listener-tag live)))
@@ -335,7 +335,7 @@
 
   (testing "`render-body`'s window, observed from inside `render-body`"
     (reset! !listeners-mid-render ::unset)
-    (server/render-body {:hiccup       [watching {}]
+    (rf.hicasso.server/render-body {:hiccup       [watching {}]
                          :render-state {:rf/app-db {:label "alpha"} :rf/runtime-db {}}})
     (let [live @!listeners-mid-render]
       (is (set? live))
@@ -389,7 +389,7 @@
         ;; Two boot events, in order: the first re-enters the door and returns,
         ;; the second emits the recovered error the outer listener must still be
         ;; alive to see.
-        thrown           (try (server/render
+        thrown           (try (rf.hicasso.server/render
                                 (request :initial-events [[::re-enter-then-recover]
                                                           [no-handler-event]]))
                               (catch :default e e))]
@@ -418,7 +418,7 @@
             door gaining the same verdict, and running one after the other
             leaves nothing behind"
     (let [listeners-before (live-error-listener-ids)
-          data             (try (server/render-body
+          data             (try (rf.hicasso.server/render-body
                                   {:hiccup       [detonating {}]
                                    :render-state {:rf/app-db {:label "alpha"} :rf/runtime-db {}}})
                                 (catch :default e (ex-data e)))]
@@ -426,7 +426,7 @@
       (is (= 're-frame.hicasso.server/render-body (:where data))
           "still the body-only door's own symbol")
       (is (= listeners-before (live-error-listener-ids)))
-      (is (thrown? :default (server/render (request :hiccup [detonating {}])))
+      (is (thrown? :default (rf.hicasso.server/render (request :hiccup [detonating {}])))
           "and the whole-page door refuses right after it")
       (is (= listeners-before (live-error-listener-ids))
           "with both registries back where they started"))))

--- a/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
@@ -72,20 +72,20 @@
   reported against the next."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.roots :as roots]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.hicasso.server :as server]
-            [re-frame.hicasso.test.server :as ts]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.roots :as rf.hicasso.impl.roots]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.hicasso.server :as rf.hicasso.server]
+            [re-frame.hicasso.test.server :as rf.hicasso.test.server]
             [re-frame.interop :as rf.interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.constants :as ssr-constants]
-            [re-frame.test-support :as test-support]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.constants :as rf.ssr.constants]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]
             ["react-dom/server" :as react-dom-server]))
 
@@ -119,11 +119,11 @@
   (fn [_ _] {:fx [[::client-only-spy {}] [::server-only-spy {}]]}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The probe — a `useId` that reaches the server bytes
@@ -143,16 +143,16 @@
     (react/createElement "b" #js {:className "probe"} (react/useId))
     (react/createElement "i" #js {:className "label"} (.-label props))))
 
-(h/defhost id-host id-probe {:server :render})
+(rf.hicasso/defhost id-host id-probe {:server :render})
 
-(h/defview id-page
+(rf.hicasso/defview id-page
   "The page both sides render. One subscription read, so the root
   acquires a frame-keyed cell and its commit is observable at all; one
   island, so the page has an id in it."
   [_]
   [:div.page
-   [:p.value (h/sub [::label])]
-   [id-host {:label (h/sub [::label])}]])
+   [:p.value (rf.hicasso/sub [::label])]
+   [id-host {:label (rf.hicasso/sub [::label])}]])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -190,7 +190,7 @@
   reach into another suite's private."
   [frame-kw hiccup prefix]
   (react-dom-server/renderToString
-    (mount/provider frame-kw (codec/root-element frame-kw hiccup))
+    (rf.hicasso.impl.mount/provider frame-kw (rf.hicasso.impl.codec/root-element frame-kw hiccup))
     #js {"identifierPrefix" prefix}))
 
 (defn- door-shaped-html!
@@ -203,7 +203,7 @@
   the entry, which is the property being asserted."
   [frame-kw hiccup prefix]
   (react-dom-server/renderToString
-    (mount/tree {:frame frame-kw :adoption (roots/open-adoption-window!)} hiccup)
+    (rf.hicasso.impl.mount/tree {:frame frame-kw :adoption (rf.hicasso.impl.roots/open-adoption-window!)} hiccup)
     #js {"identifierPrefix" prefix}))
 
 (defn- plain-html-for-this-request!
@@ -252,7 +252,7 @@
   bailing out of the island and re-reading a body that never ran."
   [label]
   (rf/with-frame wire-frame (rf/dispatch-sync [::relabel label]))
-  (mount/settle!)
+  (rf.hicasso.impl.mount/settle!)
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -274,7 +274,7 @@
                "whole file is measuring nothing; got " (pr-str plain) " both times"))
 
       (testing "and the entry's bytes carry the DOOR's id"
-        (let [entry (id-in-html (:html (server/render (request))))]
+        (let [entry (id-in-html (:html (rf.hicasso.server/render (request))))]
           (is (some? entry))
           (is (= door entry)
               (str "server/render must emit the tree hydrate-root! adopts; got "
@@ -287,9 +287,9 @@
 (deftest the-entry-honours-the-identifier-prefix
   (testing "`:identifier-prefix` reaches React's own option — the half a
             hydrating root must be handed the same string for"
-    (let [a (id-in-html (:html (server/render (request :identifier-prefix "pfx-a-"))))
-          b (id-in-html (:html (server/render (request :identifier-prefix "pfx-b-"))))
-          n (id-in-html (:html (server/render (request :identifier-prefix nil))))]
+    (let [a (id-in-html (:html (rf.hicasso.server/render (request :identifier-prefix "pfx-a-"))))
+          b (id-in-html (:html (rf.hicasso.server/render (request :identifier-prefix "pfx-b-"))))
+          n (id-in-html (:html (rf.hicasso.server/render (request :identifier-prefix nil))))]
       (is (str/includes? a "pfx-a-") (str "got " (pr-str a)))
       (is (str/includes? b "pfx-b-") (str "got " (pr-str b)))
       (is (not= a b) "two prefixes, two ids")
@@ -305,7 +305,7 @@
             per-request gensym is INVISIBLE on the wire — the two renders
             take different ids, so a document that mentioned one could not
             be byte-identical to the other"
-    (let [{:keys [identical? differs-at first second]} (ts/render-twice (request))]
+    (let [{:keys [identical? differs-at first second]} (rf.hicasso.test.server/render-twice (request))]
       (is identical?
           (str "two renders of one request differed at character " differs-at))
       (is (not= (:frame-id first) (:frame-id second))
@@ -321,7 +321,7 @@
     ;; never existed, so the nil below is only evidence beside a control
     ;; that a LIVE frame answers something. Without it this row would stay
     ;; green under a `render` that never made a frame at all.
-    (let [{:keys [frame-id]} (server/render (request))]
+    (let [{:keys [frame-id]} (rf.hicasso.server/render (request))]
       (rf/make-frame {:id ::control :initial-events [[:rf/set-db snapshot]]})
       (is (some? (rf/app-db-value ::control))
           "control: a live frame answers its app-db, so nil below means gone")
@@ -334,12 +334,12 @@
             request under any real load"
     (let [seen (atom nil)]
       (is (thrown? :default
-                   (server/render (request :hiccup [(fn [] (throw (js/Error. "boom")))]))))
+                   (rf.hicasso.server/render (request :hiccup [(fn [] (throw (js/Error. "boom")))]))))
       ;; The id is not observable from outside a successful render, so the
       ;; standing proof is that the NEXT request still renders cleanly: a
       ;; leaked frame would not stop it, but a runtime left mid-render
       ;; would.
-      (reset! seen (:html (server/render (request))))
+      (reset! seen (:html (rf.hicasso.server/render (request))))
       (is (str/includes? @seen "alpha")
           "a request after a failed one still renders"))))
 
@@ -351,13 +351,13 @@
   (testing "omitting `:payload` raises the framework's own refusal — this
             module adds no check, it hands the value straight to
             `payload-policy`, and this row is what says so"
-    (is (thrown? :default (server/render (dissoc (request) :payload)))))
+    (is (thrown? :default (rf.hicasso.server/render (dissoc (request) :payload)))))
 
   (testing "an allowlisted key rides and an un-allowlisted one does not.
             `:secret` is in the snapshot the page rendered FROM, so a
             green here is the allowlist working rather than the key being
             absent"
-    (let [{:keys [payload document]} (server/render (request))
+    (let [{:keys [payload document]} (rf.hicasso.server/render (request))
           db (:rf/app-db payload)]
       (is (contains? db :label) (str "the allowlisted key must ride; got " (pr-str db)))
       (is (not (contains? db :secret)) (str "and the other must not; got " (pr-str db)))
@@ -368,19 +368,19 @@
             per-request gensym (rf2-lm2yzy: stamping the gensym
             guarantees :rf.error/hydration-frame-id-mismatch on every
             real page)"
-    (let [{:keys [payload frame-id]} (server/render (request))]
+    (let [{:keys [payload frame-id]} (rf.hicasso.server/render (request))]
       (is (= wire-frame (:rf/frame-id payload)))
       (is (not= frame-id (:rf/frame-id payload)))))
 
   (testing "and omitting `:client-frame-id` omits the key — the
             anonymous-server-frame shape, not a nil stamped on the wire"
-    (let [{:keys [payload]} (server/render (dissoc (request) :client-frame-id))]
+    (let [{:keys [payload]} (rf.hicasso.server/render (dissoc (request) :client-frame-id))]
       (is (not (contains? payload :rf/frame-id))))))
 
 (deftest the-document-carries-the-pinned-payload-script
   (let [{:keys [document payload-edn]}
-        (server/render (request :app-element-id "app" :script-src "/js/app.js" :title "The feed"))]
-    (is (str/includes? document (str "id=\"" ssr-constants/payload-script-id "\""))
+        (rf.hicasso.server/render (request :app-element-id "app" :script-src "/js/app.js" :title "The feed"))]
+    (is (str/includes? document (str "id=\"" rf.ssr.constants/payload-script-id "\""))
         "the script id is the framework CONSTANT the client bootstrap reads")
     (is (str/includes? document "<div id=\"app\">"))
     (is (str/includes? document "<script src=\"/js/app.js\"></script>"))
@@ -389,7 +389,7 @@
     (testing "the payload script follows the app root's close and the
               bootstrap is last — `ssr-ring`'s own order"
       (is (< (.indexOf document "</div>")
-             (.indexOf document (str "id=\"" ssr-constants/payload-script-id "\""))
+             (.indexOf document (str "id=\"" rf.ssr.constants/payload-script-id "\""))
              (.indexOf document "/js/app.js"))))))
 
 (deftest a-hostile-value-cannot-break-out-of-the-envelope
@@ -400,7 +400,7 @@
             only the fenced bench donor's pin"
     (let [evil "</script><script>window.pwned=1</script>"
           {:keys [document payload]}
-          (server/render (request :snapshot {:label evil :secret "x"}))]
+          (rf.hicasso.server/render (request :snapshot {:label evil :secret "x"}))]
       (is (= evil (get-in payload [:rf/app-db :label]))
           "the premise: the hostile value IS on the allowlisted wire —
            without this the absence below could be the allowlist's doing")
@@ -412,7 +412,7 @@
   (testing "the document envelope's own text and attribute positions
             escape too — the title through `escape-html`"
     (let [{:keys [document]}
-          (server/render (request :title "Bob's <Feed> & Friends"))]
+          (rf.hicasso.server/render (request :title "Bob's <Feed> & Friends"))]
       (is (str/includes? document "<title>Bob&#39;s &lt;Feed&gt; &amp; Friends</title>")
           (str "every reserved character in its HTML spelling: " document))
       (is (not (str/includes? document "<Feed>"))
@@ -423,7 +423,7 @@
             own comment records the page silently getting id=\"\" when
             this regressed"
     (let [{:keys [document]}
-          (server/render (request :title nil :app-element-id nil))]
+          (rf.hicasso.server/render (request :title nil :app-element-id nil))]
       (is (str/includes? document "<div id=\"app\">")
           "the app element default survives an explicit nil")
       (is (str/includes? document "<title>Hicasso SSR</title>")
@@ -437,7 +437,7 @@
             per-request frame or replace the seed. The invariant is one
             `assoc`, and nothing pinned it"
     (let [{:keys [document payload frame-id]}
-          (server/render (request :frame-opts {:id             ::hijack
+          (rf.hicasso.server/render (request :frame-opts {:id             ::hijack
                                                :initial-events [[::relabel "hijacked"]]}))]
       (is (not= ::hijack frame-id)
           "the per-request gensym rules the frame id")
@@ -452,18 +452,18 @@
             schema's integer (Spec-Schemas pins `:rf/version` as `:int`,
             and a whole-number string is parsed rather than rejected)"
     (let [{:keys [payload]}
-          (server/render (request :version "7" :schema-digest "digest-abc"))]
+          (rf.hicasso.server/render (request :version "7" :schema-digest "digest-abc"))]
       (is (= 7 (:rf/version payload)))
       (is (= "digest-abc" (:rf/schema-digest payload))))
     (testing "an omitted `:version` still ships the slot — the SSR
               artefact's own protocol constant, so both wire ends agree
               with no host wiring; an `(or version …)` here once silently
               defeated the version-mismatch check"
-      (let [{:keys [payload]} (server/render (request))]
+      (let [{:keys [payload]} (rf.hicasso.server/render (request))]
         (is (pos-int? (:rf/version payload)))))
     (testing "while an omitted `:schema-digest` omits the KEY — the
               no-participation shape, not a nil stamped on the wire"
-      (let [{:keys [payload]} (server/render (request))]
+      (let [{:keys [payload]} (rf.hicasso.server/render (request))]
         (is (not (contains? payload :rf/schema-digest)))))))
 
 (deftest the-request-frame-is-server-platform-and-no-caller-can-invert-it
@@ -493,7 +493,7 @@
              along and the tag did nothing")
 
         (reset! platform-spy [])
-        (server/render (request :initial-events [[::fire-both-platform-arms]]))
+        (rf.hicasso.server/render (request :initial-events [[::fire-both-platform-arms]]))
         (is (= [:server] @platform-spy)
             "exactly the server-only effect ran inside the request frame")
 
@@ -502,7 +502,7 @@
                   :client` is assoc'd OVER rather than merged under, exactly
                   as `:id` and `:initial-events` are"
           (reset! platform-spy [])
-          (server/render (request :initial-events [[::fire-both-platform-arms]]
+          (rf.hicasso.server/render (request :initial-events [[::fire-both-platform-arms]]
                                   :frame-opts     {:platform :client}))
           (is (= [:server] @platform-spy)
               "the hostile `:platform :client` did not reach the frame"))
@@ -566,7 +566,7 @@
           reports  (atom [])]
       (-> (js/Promise.resolve true)
           (.then (fn [_] (throw (js/Error. "the body threw"))))
-          (sup/settle-row! {:row      "the throwing-body control"
+          (rf.hicasso.roots-frames-support/settle-row! {:row      "the throwing-body control"
                             :done     (fn [] (swap! finishes inc))
                             :release! (fn [] (swap! releases inc))
                             :report!  (fn [e] (swap! reports conj e))})
@@ -586,7 +586,7 @@
                 (is (str/includes? (str (first @reports)) "the body threw")
                     (str "naming the error the body raised; got "
                          (pr-str @reports))))))
-          (sup/settle-row! {:row "the throwing-body control's own settlement"
+          (rf.hicasso.roots-frames-support/settle-row! {:row "the throwing-body control's own settlement"
                             :done done})))))
 
 (deftest a-rejected-adoption-leaves-the-next-row-a-clean-page
@@ -595,43 +595,43 @@
   ;; resource the row owns is live and committed at that moment, so there
   ;; is strictly more to release than there would be had `adopted!`
   ;; rejected before the root ever adopted.
-  (if-not (mount/browser?)
-    (sup/skip! "what a rejection can leak is a real root and a real console")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! "what a rejection can leak is a real root and a real console")
     (async done
-      (sup/leave-act-environment!)
-      (let [{:keys [html]} (server/render (request))
-            container      (sup/stamp-server-nodes! (sup/server-dom! html))
-            watch          (sup/watch-mismatches!)
+      (rf.hicasso.roots-frames-support/leave-act-environment!)
+      (let [{:keys [html]} (rf.hicasso.server/render (request))
+            container      (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+            watch          (rf.hicasso.roots-frames-support/watch-mismatches!)
             console-before (.-error js/console)
-            capture        (sup/open-console-capture!)
+            capture        (rf.hicasso.roots-frames-support/open-console-capture!)
             stops          (atom 0)
             finishes       (atom 0)
             reports        (atom [])]
         (rf/make-frame {:id wire-frame :initial-events [[:rf/set-db snapshot]]})
-        (let [handle (h/hydrate! container
+        (let [handle (rf.hicasso/hydrate! container
                                  {:frame wire-frame :identifier-prefix "pfx-a-"}
                                  [id-page {}])]
-          (-> (sup/adopted! handle)
+          (-> (rf.hicasso.roots-frames-support/adopted! handle)
               (.then (fn [shut?]
                        (is shut? "premise: the root really did adopt")
-                       (is (not= sup/released (sup/census))
+                       (is (not= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/census))
                            (str "premise: the runtime is holding this root's "
                                 "cells and edges, so the census taken after "
                                 "the rejection is a RELEASE and not an empty "
-                                "page; got " (pr-str (sup/census))))
+                                "page; got " (pr-str (rf.hicasso.roots-frames-support/census))))
                        (js/Promise.reject (js/Error. "adoption rejected on purpose"))))
-              (sup/settle-row! {:row      "the rejected-adoption control"
+              (rf.hicasso.roots-frames-support/settle-row! {:row      "the rejected-adoption control"
                                 :done     (fn [] (swap! finishes inc))
                                 :report!  (fn [e] (swap! reports conj e))
                                 :release! (fn []
                                             ((:close! capture))
                                             (swap! stops inc)
                                             ((:stop! watch))
-                                            (h/unmount! handle))})
+                                            (rf.hicasso/unmount! handle))})
               ;; The cell reapers are armed at unmount and run past a bare
               ;; macrotask, so the table is read at the runtime's own
               ;; horizon rather than one tick after the release.
-              (.then (fn [_] (sup/quiesced!)))
+              (.then (fn [_] (rf.hicasso.roots-frames-support/quiesced!)))
               (.then
                 (fn [_]
                   (testing "the rejection is reported, and the row ends once"
@@ -645,62 +645,62 @@
                             resets frames, the cell table and the runtime, but
                             it does not unmount a root, unregister a trace
                             listener, or hand `console.error` back"
-                    (is (= sup/released (sup/census))
-                        (str "no root: residue was " (pr-str (sup/census))))
-                    (is (empty? (sup/cell-frames))
+                    (is (= rf.hicasso.roots-frames-support/released (rf.hicasso.roots-frames-support/census))
+                        (str "no root: residue was " (pr-str (rf.hicasso.roots-frames-support/census))))
+                    (is (empty? (rf.hicasso.roots-frames-support/cell-frames))
                         (str "no frame: the cell table still mentions "
-                             (pr-str (sup/cell-frames))))
+                             (pr-str (rf.hicasso.roots-frames-support/cell-frames))))
                     (is (= 1 @stops)
                         (str "the mismatch watcher was stopped — `stop!` is "
                              "what unregisters the trace listener; it ran "
                              @stops " times"))
                     (is (identical? console-before (.-error js/console))
                         "`console.error` is the page's own again"))))
-              (sup/settle-row! {:row      "the rejected-adoption control's own settlement"
+              (rf.hicasso.roots-frames-support/settle-row! {:row      "the rejected-adoption control's own settlement"
                                 :done     done
                                 :release! (fn []
                                             ((:close! capture))
                                             ((:stop! watch))
-                                            (h/unmount! handle))})))))))
+                                            (rf.hicasso/unmount! handle))})))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — the far side: the bytes hydrate through the PUBLIC door
 ;; ---------------------------------------------------------------------------
 
 (deftest the-entry-s-bytes-hydrate-through-h-hydrate-without-a-mismatch
-  (if-not (mount/browser?)
-    (sup/skip! "adoption is React's own DOM business")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! "adoption is React's own DOM business")
     (async done
-      (let [{:keys [html]} (server/render (request))
-            container      (sup/stamp-server-nodes! (sup/server-dom! html))
-            watch          (sup/watch-mismatches!)
-            handle         (h/hydrate! container
+      (let [{:keys [html]} (rf.hicasso.server/render (request))
+            container      (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+            watch          (rf.hicasso.roots-frames-support/watch-mismatches!)
+            handle         (rf.hicasso/hydrate! container
                                        {:frame wire-frame :identifier-prefix "pfx-a-"}
                                        [id-page {}])]
         (rf/make-frame {:id wire-frame :initial-events [[:rf/set-db snapshot]]})
-        (-> (sup/adopted! handle)
+        (-> (rf.hicasso.roots-frames-support/adopted! handle)
             (.then (fn [shut?]
                      (is shut? "the root's own adoption window shut")
                      (testing "the page is the SERVER's nodes — an expando
                                survives adoption and does not survive a
                                replacement, which is the entire difference
                                between adopted and re-rendered"
-                       (is (sup/every-server-node? container ".page")))
+                       (is (rf.hicasso.roots-frames-support/every-server-node? container ".page")))
                      (testing "and the framework reported no hydration mismatch"
                        (is (= [] ((:stop! watch)))))
                      (testing "the handle is the one every other door takes"
                        (is (some? (:root handle)))
                        (is (= wire-frame (:frame handle)))
-                       (is (nil? (h/unmount! handle))))))
+                       (is (nil? (rf.hicasso/unmount! handle))))))
             ;; The unmount above is an ASSERTION about the door's answer,
             ;; not this row's teardown; the teardown is named again here
             ;; so a rejection still gets one, and `unmount!` is
             ;; idempotent by contract.
-            (sup/settle-row! {:row      "§4's hydration row"
+            (rf.hicasso.roots-frames-support/settle-row! {:row      "§4's hydration row"
                               :done     done
                               :release! (fn []
                                           ((:stop! watch))
-                                          (h/unmount! handle))}))))))
+                                          (rf.hicasso/unmount! handle))}))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4b — THE READING: the id itself, read off the bytes and read back off
@@ -736,7 +736,7 @@
   (testing "one snapshot, one prefix, two tree shapes. The closer renders
             no DOM, so the id is the ONLY byte that may move — and this
             row is what says so rather than assuming it"
-    (let [door  (:html (server/render (request)))
+    (let [door  (:html (rf.hicasso.server/render (request)))
           plain (plain-html-for-this-request!)
           d-id  (id-in-html door)
           p-id  (id-in-html plain)]
@@ -757,23 +757,23 @@
                " chars, hand-rolled " (count plain))))))
 
 (deftest the-door-s-id-survives-the-adoption-and-a-real-client-render
-  (if-not (mount/browser?)
-    (sup/skip! "an id read back off the DOM needs a real React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! "an id read back off the DOM needs a real React DOM")
     (async done
-      (sup/leave-act-environment!)
-      (let [{:keys [html]} (server/render (request))
+      (rf.hicasso.roots-frames-support/leave-act-environment!)
+      (let [{:keys [html]} (rf.hicasso.server/render (request))
             server-id      (id-in-html html)
-            container      (sup/stamp-server-nodes! (sup/server-dom! html))
-            watch          (sup/watch-mismatches!)]
+            container      (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+            watch          (rf.hicasso.roots-frames-support/watch-mismatches!)]
         ;; State before DOM, the order `h/hydrate!`'s own docstring
         ;; teaches, so the first client render sees what the server
         ;; rendered from and the only thing left to disagree about is the
         ;; id.
         (rf/make-frame {:id wire-frame :initial-events [[:rf/set-db snapshot]]})
-        (let [handle (h/hydrate! container
+        (let [handle (rf.hicasso/hydrate! container
                                  {:frame wire-frame :identifier-prefix "pfx-a-"}
                                  [id-page {}])]
-          (-> (sup/adopted! handle)
+          (-> (rf.hicasso.roots-frames-support/adopted! handle)
               (.then (fn [shut?]
                        (is shut? "the root's own adoption window shut")
                        (is (some? server-id) "premise: the bytes carry an id")
@@ -783,7 +783,7 @@
                                  at `.page` — an expando does not survive a
                                  replacement, so this is what says the id
                                  below was read off an adopted node"
-                         (is (sup/every-server-node? container ".page, .value, .probe")))
+                         (is (rf.hicasso.roots-frames-support/every-server-node? container ".page, .value, .probe")))
 
                        (relabel! "alpha'")
                        (testing "premise: a real client render ran. Both the
@@ -804,33 +804,33 @@
 
                        (testing "and nothing reached Spec 011's channel"
                          (is (= [] ((:stop! watch)))))))
-              (sup/settle-row! {:row      "§4b-2's reading row"
+              (rf.hicasso.roots-frames-support/settle-row! {:row      "§4b-2's reading row"
                                 :done     done
                                 :release! (fn []
                                             ((:stop! watch))
-                                            (h/unmount! handle))})))))))
+                                            (rf.hicasso/unmount! handle))})))))))
 
 (deftest the-hand-rolled-bytes-lose-the-id-through-the-same-door
   ;; THE CONTROL. Same public door, same helpers, same run — the other
   ;; answer, shown rather than inferred.
-  (if-not (mount/browser?)
-    (sup/skip! "an id read back off the DOM needs a real React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! "an id read back off the DOM needs a real React DOM")
     (async done
-      (sup/leave-act-environment!)
+      (rf.hicasso.roots-frames-support/leave-act-environment!)
       (let [html      (plain-html-for-this-request!)
             server-id (id-in-html html)
-            container (sup/stamp-server-nodes! (sup/server-dom! html))
-            watch     (sup/watch-mismatches!)
+            container (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+            watch     (rf.hicasso.roots-frames-support/watch-mismatches!)
             ;; MANUFACTURED here and asserted on here — the only shape of
             ;; call site at which swallowing an uncaught error is not the
             ;; fail-open the runner's pageerror rule exists to prevent.
             ;; React routes a hydration failure to `reportError`.
-            capture   (sup/open-console-capture! {:swallow-uncaught? true})]
+            capture   (rf.hicasso.roots-frames-support/open-console-capture! {:swallow-uncaught? true})]
         (rf/make-frame {:id wire-frame :initial-events [[:rf/set-db snapshot]]})
-        (let [handle (h/hydrate! container
+        (let [handle (rf.hicasso/hydrate! container
                                  {:frame wire-frame :identifier-prefix "pfx-a-"}
                                  [id-page {}])]
-          (-> (sup/adopted! handle)
+          (-> (rf.hicasso.roots-frames-support/adopted! handle)
               (.then (fn [shut?]
                        ;; Closed HERE and not only in the settlement: the
                        ;; assertions below must report through the page's
@@ -851,9 +851,9 @@
                                                   @(:captured capture)))))
                            (when (seq seen)
                              (is (= 're-frame.hicasso.impl.mount/hydrate-root!
-                                    (:where (sup/tags-of (first seen))))
+                                    (:where (rf.hicasso.roots-frames-support/tags-of (first seen))))
                                  (str "attributed to source; got "
-                                      (pr-str (:where (sup/tags-of (first seen)))))))))
+                                      (pr-str (:where (rf.hicasso.roots-frames-support/tags-of (first seen)))))))))
 
                        (relabel! "alpha'")
                        (testing "premise: a real client render ran"
@@ -874,12 +874,12 @@
               ;; A rejection here would leave `console.error` replaced for
               ;; every row that follows, which is the one leak in this file
               ;; that no fixture takes back.
-              (sup/settle-row! {:row      "§4b-3's control row"
+              (rf.hicasso.roots-frames-support/settle-row! {:row      "§4b-3's control row"
                                 :done     done
                                 :release! (fn []
                                             ((:close! capture))
                                             ((:stop! watch))
-                                            (h/unmount! handle))})))))))
+                                            (rf.hicasso/unmount! handle))})))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5 — THE DOCUMENTED ROUND TRIP: payload script → state → DOM
@@ -906,14 +906,14 @@
   ;; Every assertion in the round-trip row below is about the frame having
   ;; been CREATED; without this row a green there would be equally
   ;; consistent with `ssr/hydrate!` seeding a frame it made itself.
-  (if-not (mount/browser?)
-    (sup/skip! "the payload script is read off a real document")
-    (let [{:keys [payload payload-script]} (server/render (request))
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! "the payload script is read off a real document")
+    (let [{:keys [payload payload-script]} (rf.hicasso.server/render (request))
           remove!                          (plant-payload-script! payload-script)]
       (try
         (is (nil? (rf/app-db-value wire-frame))
             "premise: no client frame exists yet — this is a cold page")
-        (let [applied (ssr/hydrate! {:frame wire-frame})]
+        (let [applied (rf.ssr/hydrate! {:frame wire-frame})]
           (testing "the false comfort: the read succeeded and the call
                     answers the payload, so a boot that checks only this
                     return value sees a hydration that worked"
@@ -928,19 +928,19 @@
         (finally (remove!))))))
 
 (deftest the-payload-script-seeds-the-frame-the-server-dom-then-adopts
-  (if-not (mount/browser?)
-    (sup/skip! "adoption is React's own DOM business")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! "adoption is React's own DOM business")
     (async done
-      (let [{:keys [html payload-script]} (server/render (request))
+      (let [{:keys [html payload-script]} (rf.hicasso.server/render (request))
             remove!   (plant-payload-script! payload-script)
-            container (sup/stamp-server-nodes! (sup/server-dom! html))
-            watch     (sup/watch-mismatches!)]
+            container (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))
+            watch     (rf.hicasso.roots-frames-support/watch-mismatches!)]
         (rf/make-frame {:id wire-frame :platform :client})
         (is (nil? (:label (rf/app-db-value wire-frame)))
             "premise: the frame starts EMPTY, so every value below arrived
              over the wire rather than having been put there by hand")
 
-        (let [applied (ssr/hydrate! {:frame wire-frame})
+        (let [applied (rf.ssr/hydrate! {:frame wire-frame})
               db      (rf/app-db-value wire-frame)]
           (testing "state first, and off the document's own payload script"
             (is (some? applied))
@@ -950,26 +950,26 @@
                     is the egress projection working"
             (is (not (contains? db :secret)))))
 
-        (let [handle (h/hydrate! container
+        (let [handle (rf.hicasso/hydrate! container
                                  {:frame wire-frame :identifier-prefix "pfx-a-"}
                                  [id-page {}])]
-          (-> (sup/adopted! handle)
+          (-> (rf.hicasso.roots-frames-support/adopted! handle)
               (.then (fn [shut?]
                        (is shut? "the root's own adoption window shut")
                        (testing "the first client render saw the server's
                                  snapshot: the server's nodes are still the
                                  page's nodes, and they still carry the
                                  server's value"
-                         (is (sup/every-server-node? container ".page"))
+                         (is (rf.hicasso.roots-frames-support/every-server-node? container ".page"))
                          (is (= "alpha"
                                 (.-textContent (.querySelector container ".value")))))
                        (testing "and the framework reported no mismatch — the
                                  whole claim, since a frame seeded after the
                                  adopt would have diverged on this text"
                          (is (= [] ((:stop! watch)))))))
-              (sup/settle-row! {:row      "§5's round-trip row"
+              (rf.hicasso.roots-frames-support/settle-row! {:row      "§5's round-trip row"
                                 :done     done
                                 :release! (fn []
                                             ((:stop! watch))
-                                            (h/unmount! handle)
+                                            (rf.hicasso/unmount! handle)
                                             (remove!))})))))))

--- a/implementation/hicasso/test/re_frame/hicasso/slot_cljs_test.cljc
+++ b/implementation/hicasso/test/re_frame/hicasso/slot_cljs_test.cljc
@@ -47,7 +47,7 @@
   are."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
-            [re-frame.hicasso.impl.slot :as slot]))
+            [re-frame.hicasso.impl.slot :as rf.hicasso.impl.slot]))
 
 (def corpus
   "Authored prop key → the canonical React slot it emits into.
@@ -121,7 +121,7 @@
 
 (deftest the-slot-rule-answers-the-corpus
   (doseq [[k expected] corpus]
-    (is (= expected (slot/prop-name k))
+    (is (= expected (rf.hicasso.impl.slot/prop-name k))
         (str "slot for " (pr-str k)))))
 
 (deftest the-slot-rule-is-a-pure-function-of-the-key
@@ -129,7 +129,7 @@
             on a rule that holds no state at all — the codec's caches are
             an accelerant over this, never a source of a different answer"
     (doseq [[k expected] corpus]
-      (is (= expected (slot/prop-name k) (slot/prop-name k))
+      (is (= expected (rf.hicasso.impl.slot/prop-name k) (rf.hicasso.impl.slot/prop-name k))
           (str "repeated for " (pr-str k))))))
 
 (deftest every-branch-of-the-rule-is-represented

--- a/implementation/hicasso/test/re_frame/hicasso/smoke_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/smoke_cljs_test.cljs
@@ -32,14 +32,14 @@
   and an SSR entry to the package is the consumer app's."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom/server" :as react-dom-server]))
 
 (def ^:private frame-id ::smoke)
@@ -56,21 +56,21 @@
 ;; subscription under it never notifies and a "the value changed" assertion
 ;; would pass vacuously by never firing.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The consumer's whole source file
 ;; ---------------------------------------------------------------------------
 
-(h/defview greeting-line
+(rf.hicasso/defview greeting-line
   "A boundary declared exactly as a consumer declares one: the macro off
   the public door, the read off the public door, and nothing imported from
   below it."
   [{:keys [tag]}]
-  [:p {:class tag} (h/sub [:smoke/greeting])])
+  [:p {:class tag} (rf.hicasso/sub [:smoke/greeting])])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -90,7 +90,7 @@
 (defn- html
   [hiccup]
   (react-dom-server/renderToString
-    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+    (rf.hicasso.impl.mount/provider frame-id (rf.hicasso.impl.codec/root-element frame-id hiccup))))
 
 ;; ---------------------------------------------------------------------------
 ;; The round-trip
@@ -100,7 +100,7 @@
   (testing "the door hands over a real minted boundary, not a plain fn —
             which is what `defview` expanding correctly through the
             self-required macro namespace looks like"
-    (is (true? (codec/boundary-head? greeting-line))
+    (is (true? (rf.hicasso.impl.codec/boundary-head? greeting-line))
         "greeting-line should be a Hicasso boundary head"))
 
   (testing "a boundary's body reads its subscription and the value reaches
@@ -134,4 +134,4 @@
     (seeded! "hello")
     (html [greeting-line {:tag "greet"}])
     (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0}
-           (dissoc (runtime/residue) :entries)))))
+           (dissoc (rf.hicasso.test.runtime/residue) :entries)))))

--- a/implementation/hicasso/test/re_frame/hicasso/staged_reincarnation_basis_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/staged_reincarnation_basis_cljs_test.cljs
@@ -50,13 +50,13 @@
   `render-body` is the render, `commit-boundary!` is React's `subscribe`,
   and `snapshot-of` is the number React compares."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::staged-reincarnation)
 
@@ -66,11 +66,11 @@
 (rf/reg-sub   :staged/n     (fn [db _] (:n db)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (def ^:private held-key [frame-id [:staged/n]])
 
@@ -78,12 +78,12 @@
   "Make the frame under its public id, seed it with `who`, and install
   `touches` more times. Answers the frame's install epoch."
   [who touches]
-  (support/leave-act-environment!)
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id
     (rf/dispatch-sync [:staged/seed who])
     (dotimes [_ touches] (rf/dispatch-sync [:staged/touch])))
-  (frame/frame-commit-epoch frame-id))
+  (rf.frame/frame-commit-epoch frame-id))
 
 (defn- reincarnate-to-epoch!
   "Destroy the frame and remake it under the same id, seeded with `who`,
@@ -94,24 +94,24 @@
   (rf/make-frame {:id frame-id})
   (rf/with-frame frame-id
     (rf/dispatch-sync [:staged/seed who])
-    (while (< (frame/frame-commit-epoch frame-id) epoch)
+    (while (< (rf.frame/frame-commit-epoch frame-id) epoch)
       (rf/dispatch-sync [:staged/touch])))
-  (frame/frame-commit-epoch frame-id))
+  (rf.frame/frame-commit-epoch frame-id))
 
 (defn- commit-held!
   "A committed boundary holding a cell on the frame — the OTHER cell the
   reincarnation's side effect reaches. Answers its release fn."
   []
-  (collector/render-body frame-id (fn [_] (collector/sub [:staged/n])) {})
-  (collector/commit-boundary! (collector/last-reads) (fn [])))
+  (rf.hicasso.impl.collector/render-body frame-id (fn [_] (rf.hicasso.impl.collector/sub [:staged/n])) {})
+  (rf.hicasso.impl.collector/commit-boundary! (rf.hicasso.impl.collector/last-reads) (fn [])))
 
 (defn- render-staged!
   "Render — and only render — a boundary reading the staged key. Answers
   what it painted, its entry, and the number React captured at render."
   []
-  (let [value (collector/render-body frame-id (fn [_] (collector/sub [:staged/who])) {})
-        entry (collector/last-reads)]
-    {:value value :entry entry :at-render (runtime/snapshot-of entry)}))
+  (let [value (rf.hicasso.impl.collector/render-body frame-id (fn [_] (rf.hicasso.impl.collector/sub [:staged/who])) {})
+        entry (rf.hicasso.impl.collector/last-reads)]
+    {:value value :entry entry :at-render (rf.hicasso.test.runtime/snapshot-of entry)}))
 
 (deftest a-staged-key-committed-across-a-same-id-reincarnation-sees-the-store-move
   (async done
@@ -119,7 +119,7 @@
           release-held (commit-held!)
           {:keys [value entry at-render]} (render-staged!)]
       (is (= "A" value) "the render painted the predecessor's value")
-      (is (some? (runtime/cell-reaction held-key))
+      (is (some? (rf.hicasso.test.runtime/cell-reaction held-key))
           "and the frame holds one other cell, whose reaction the teardown will dispose")
 
       ;; THE GAP. The frame dies and comes back under the same id, with a
@@ -128,16 +128,16 @@
       (let [epoch-b (reincarnate-to-epoch! "B" epoch-a)]
         (is (= epoch-a epoch-b)
             "precondition: the successor's install epoch ties the predecessor's at render")
-        (is (nil? (runtime/cell-reaction held-key))
+        (is (nil? (rf.hicasso.test.runtime/cell-reaction held-key))
             "the held cell's reaction was dropped synchronously by the teardown")
 
-        (support/at-the-checkpoint
-          #(some? (runtime/cell-reaction held-key))
+        (rf.hicasso.checkpoint-support/at-the-checkpoint
+          #(some? (rf.hicasso.test.runtime/cell-reaction held-key))
           "the held cell's reincarnation rewire"
           done
           (fn [_turns]
-            (let [release-staged (collector/commit-boundary! entry (fn []))
-                  at-commit      (runtime/snapshot-of entry)]
+            (let [release-staged (rf.hicasso.impl.collector/commit-boundary! entry (fn []))
+                  at-commit      (rf.hicasso.test.runtime/snapshot-of entry)]
               (testing "the commit lands after the rewire, so React's
                         post-subscribe re-read of `getSnapshot` must differ
                         from the number the fiber captured at render — the
@@ -146,8 +146,8 @@
                     (str "basis@render " at-render " vs basis@commit " at-commit
                          ": a tie here is the predecessor's value left on screen")))
               (testing "and the cell the commit acquired answers for the successor"
-                (is (= "B" (collector/render-body frame-id
-                                                  (fn [_] (collector/sub [:staged/who]))
+                (is (= "B" (rf.hicasso.impl.collector/render-body frame-id
+                                                  (fn [_] (rf.hicasso.impl.collector/sub [:staged/who]))
                                                   {}))))
               (release-staged)
               (release-held))))))))
@@ -161,8 +161,8 @@
   (incarnate! "A" 3)
   (let [release-held (commit-held!)
         {:keys [entry at-render]} (render-staged!)
-        release-staged (collector/commit-boundary! entry (fn []))]
-    (is (= at-render (runtime/snapshot-of entry))
+        release-staged (rf.hicasso.impl.collector/commit-boundary! entry (fn []))]
+    (is (= at-render (rf.hicasso.test.runtime/snapshot-of entry))
         "a cell born at the basis the render read contributes the same number")
     (release-staged)
     (release-held)))

--- a/implementation/hicasso/test/re_frame/hicasso/state_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/state_cljs_test.cljs
@@ -36,13 +36,13 @@
   [[re-frame.hicasso.state-dom-cljs-test]], which is where the
   prototype's `arm1/state-dom-cljs-test` landed."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.hicasso.impl.state :as state]
+            [re-frame.hicasso.impl.state :as rf.hicasso.impl.state]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
-(use-fixtures :each (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+(use-fixtures :each (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; The harness
@@ -70,10 +70,10 @@
   [thunk]
   (let [direct  (volatile! nil)
         records (volatile! [])]
-    (error-emit/register-error-listener! ::state (fn [r] (vswap! records conj r)))
+    (rf.error-emit/register-error-listener! ::state (fn [r] (vswap! records conj r)))
     (try
       (try (thunk) (catch :default e (vreset! direct (ex-data e))))
-      (finally (error-emit/unregister-error-listener! ::state)))
+      (finally (rf.error-emit/unregister-error-listener! ::state)))
     (->> (concat [@direct]
                  (map (comp ex-data :exception) @records)
                  (map (comp ex-data ex-cause :exception) @records))
@@ -103,7 +103,7 @@
 (deftest two-instances-of-one-widget-are-independent
   (testing "the pitfall this sugar deletes: two disclosures on one page,
            one concern, two keys, two values"
-    (state/reg-state ::open? {:default false})
+    (rf.hicasso.impl.state/reg-state ::open? {:default false})
     (let [f (frame! ::independent)]
       (is (= false (read* f [::open? :billing])) "unwritten reads the default")
       (is (= false (read* f [::open? :shipping])))
@@ -119,7 +119,7 @@
   (testing "two widgets given ONE key are one instance on purpose — a
            master/detail pair that must open together says so by sharing
            the key, and nothing here treats that as an error"
-    (state/reg-state ::open? {:default false})
+    (rf.hicasso.impl.state/reg-state ::open? {:default false})
     (let [f (frame! ::shared)]
       (send! f [::open? :billing true])
       (is (= true (read* f [::open? :billing])))
@@ -127,13 +127,13 @@
           "one key, one entry, however many widgets read it"))))
 
 (deftest a-default-is-per-concern-and-any-value
-  (state/reg-state ::draft {:default ""})
-  (state/reg-state ::tab {:default :first})
+  (rf.hicasso.impl.state/reg-state ::draft {:default ""})
+  (rf.hicasso.impl.state/reg-state ::tab {:default :first})
   (let [f (frame! ::defaults)]
     (is (= "" (read* f [::draft [:order/id 42]])))
     (is (= :first (read* f [::tab :panel])))
     (testing "a concern registered with no options at all defaults to nil"
-      (state/reg-state ::no-opts)
+      (rf.hicasso.impl.state/reg-state ::no-opts)
       (is (nil? (read* f [::no-opts :x]))))))
 
 ;; ---------------------------------------------------------------------------
@@ -143,21 +143,21 @@
 (deftest clear-restores-the-default-by-removing-the-entry
   (testing "the entry is GONE, not set to the default — one representation
            of unset, and the concern map is pruned once it empties"
-    (state/reg-state ::open? {:default false})
+    (rf.hicasso.impl.state/reg-state ::open? {:default false})
     (let [f (frame! ::cleared)]
       (send! f [::open? :billing true])
       (is (= {:ui {::open? {:billing true}}} (db-of f)))
-      (send! f [state/clear-event-id ::open? :billing])
+      (send! f [rf.hicasso.impl.state/clear-event-id ::open? :billing])
       (is (= false (read* f [::open? :billing])) "back to the default")
       (is (= {:ui {}} (db-of f))
           "the entry is removed AND the emptied concern map is pruned"))))
 
 (deftest clear-leaves-its-siblings-alone
-  (state/reg-state ::open? {:default false})
+  (rf.hicasso.impl.state/reg-state ::open? {:default false})
   (let [f (frame! ::clear-sibling)]
     (send! f [::open? :billing true])
     (send! f [::open? :shipping true])
-    (send! f [state/clear-event-id ::open? :billing])
+    (send! f [rf.hicasso.impl.state/clear-event-id ::open? :billing])
     (is (= {:ui {::open? {:shipping true}}} (db-of f))
         "one key removed, the concern map kept because it is not empty")
     (is (= false (read* f [::open? :billing])))
@@ -166,9 +166,9 @@
 (deftest clear-of-something-never-written-changes-nothing
   (testing "and in particular does not plant an empty `:ui` root in a db
            that never had one"
-    (state/reg-state ::open? {:default false})
+    (rf.hicasso.impl.state/reg-state ::open? {:default false})
     (let [f (frame! ::clear-absent)]
-      (send! f [state/clear-event-id ::open? :billing])
+      (send! f [rf.hicasso.impl.state/clear-event-id ::open? :billing])
       (is (= {} (db-of f)))
       (is (= false (read* f [::open? :billing]))))))
 
@@ -177,7 +177,7 @@
            silent dissoc: a concern whose values are keywords could be set
            to the sentinel by legitimate domain data. Clear is an event, so
            there is no value this concern cannot hold."
-    (state/reg-state ::tab {:default :first})
+    (rf.hicasso.impl.state/reg-state ::tab {:default :first})
     (let [f (frame! ::sentinel-free)]
       (doseq [v [:second :re-frame.hicasso/clear ::anything nil false]]
         (send! f [::tab :panel v])
@@ -191,7 +191,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-bad-instance-key-is-refused-at-the-read-naming-the-concern
-  (state/reg-state ::open? {:default false})
+  (rf.hicasso.impl.state/reg-state ::open? {:default false})
   (let [f (frame! ::bad-read)]
     (testing "nil — what a missing prop, a mistyped destructure and a
              forgotten argument all evaluate to"
@@ -214,7 +214,7 @@
                     #(read* f [::open?]))))))
 
 (deftest a-bad-instance-key-is-refused-at-the-write-naming-the-concern
-  (state/reg-state ::open? {:default false})
+  (rf.hicasso.impl.state/reg-state ::open? {:default false})
   (let [f (frame! ::bad-write)]
     (is (refused? :rf.error/hicasso-state-bad-argument ::open?
                   #(send! f [::open? nil true])))
@@ -229,37 +229,37 @@
                                   #(send! f [::open? nil true])))))))
 
   (testing "clear refuses a bad key too — it is a write"
-    (state/reg-state ::open? {:default false})
+    (rf.hicasso.impl.state/reg-state ::open? {:default false})
     (let [f (frame! ::bad-clear)]
       (is (refused? :rf.error/hicasso-state-bad-argument ::open?
-                    #(send! f [state/clear-event-id ::open? nil]))))))
+                    #(send! f [rf.hicasso.impl.state/clear-event-id ::open? nil]))))))
 
 (deftest registration-refuses-an-unqualified-concern
   (is (refused? :rf.error/hicasso-state-bad-argument :open?
-                #(state/reg-state :open? {:default false})))
+                #(rf.hicasso.impl.state/reg-state :open? {:default false})))
   (is (refused? :rf.error/hicasso-state-bad-argument "open?"
-                #(state/reg-state "open?" {:default false}))))
+                #(rf.hicasso.impl.state/reg-state "open?" {:default false}))))
 
 (deftest registration-refuses-an-unknown-option
   (testing "an option that is quietly ignored is a setting its author
            believes is in force"
     (is (refused? :rf.error/hicasso-state-bad-argument ::typo
-                  #(state/reg-state ::typo {:default false :defualt true})))
+                  #(rf.hicasso.impl.state/reg-state ::typo {:default false :defualt true})))
     (is (refused? :rf.error/hicasso-state-bad-argument ::not-a-map
-                  #(state/reg-state ::not-a-map [:default false])))
+                  #(rf.hicasso.impl.state/reg-state ::not-a-map [:default false])))
     (testing "and the refusal names what it did not recognise"
       (is (= [:defualt]
              (:unknown (refusal :rf.error/hicasso-state-bad-argument
-                                #(state/reg-state ::typo2 {:defualt true}))))))))
+                                #(rf.hicasso.impl.state/reg-state ::typo2 {:defualt true}))))))))
 
 (deftest re-registering-replaces-the-registration-and-the-last-default-wins
   (testing "a namespace reload re-runs the same call, and that must work"
-    (is (= ::reloaded (state/reg-state ::reloaded {:default 0})))
-    (is (= ::reloaded (state/reg-state ::reloaded {:default 0}))))
+    (is (= ::reloaded (rf.hicasso.impl.state/reg-state ::reloaded {:default 0})))
+    (is (= ::reloaded (rf.hicasso.impl.state/reg-state ::reloaded {:default 0}))))
   (testing "a DIFFERENT default is the ordinary hot-reload edit: the new
            registration replaces the old, and every un-set instance reads
            the new default"
-    (is (= ::reloaded (state/reg-state ::reloaded {:default 1})))
+    (is (= ::reloaded (rf.hicasso.impl.state/reg-state ::reloaded {:default 1})))
     (let [f (frame! ::reg-twice)]
       (is (= 1 (read* f [::reloaded :a]))))))
 
@@ -270,45 +270,45 @@
 (deftest instance-key-admits-exactly-the-composable-shapes
   (testing "admitted"
     (doseq [k [:kw ::ns-kw "s" 0 -1 1.5 [:a] [:a 1 "b"] [[:order/id 42] :row] []]]
-      (is (state/instance-key? k) (str (pr-str k) " is an instance key"))))
+      (is (rf.hicasso.impl.state/instance-key? k) (str (pr-str k) " is an instance key"))))
   (testing "refused"
     (doseq [k [nil false true {} {:id 1} #{:a} '(:a) [:a nil] [:a {}]]]
-      (is (not (state/instance-key? k)) (str (pr-str k) " is not an instance key")))))
+      (is (not (rf.hicasso.impl.state/instance-key? k)) (str (pr-str k) " is not an instance key")))))
 
 (deftest child-key-nests-and-deep-nests
   (testing "a scalar parent key becomes a two-element vector"
-    (is (= [:panel :row] (state/child-key :panel :row)))
-    (is (= ["panel" 0] (state/child-key "panel" 0))))
+    (is (= [:panel :row] (rf.hicasso.impl.state/child-key :panel :row)))
+    (is (= ["panel" 0] (rf.hicasso.impl.state/child-key "panel" 0))))
   (testing "a vector parent key CONJes — so depth costs one element, not
            one level of nesting, and no component needs to know how deep
            it is"
-    (is (= [:panel :row :cell] (state/child-key [:panel :row] :cell)))
+    (is (= [:panel :row :cell] (rf.hicasso.impl.state/child-key [:panel :row] :cell)))
     (is (= [:panel :row :cell :label]
-           (-> :panel (state/child-key :row) (state/child-key :cell) (state/child-key :label)))))
+           (-> :panel (rf.hicasso.impl.state/child-key :row) (rf.hicasso.impl.state/child-key :cell) (rf.hicasso.impl.state/child-key :label)))))
   (testing "and every key it produces is a legal instance key, which is
            what makes nesting total"
-    (is (state/instance-key? (state/child-key [[:order/id 42]] :row)))))
+    (is (rf.hicasso.impl.state/instance-key? (rf.hicasso.impl.state/child-key [[:order/id 42]] :row)))))
 
 (deftest sibling-widgets-nested-under-one-parent-do-not-collide
-  (state/reg-state ::open? {:default false})
+  (rf.hicasso.impl.state/reg-state ::open? {:default false})
   (let [f    (frame! ::nested)
-        row1 (state/child-key :panel 1)
-        row2 (state/child-key :panel 2)]
-    (send! f [::open? (state/child-key row1 :detail) true])
-    (is (= true  (read* f [::open? (state/child-key row1 :detail)])))
-    (is (= false (read* f [::open? (state/child-key row2 :detail)])))
+        row1 (rf.hicasso.impl.state/child-key :panel 1)
+        row2 (rf.hicasso.impl.state/child-key :panel 2)]
+    (send! f [::open? (rf.hicasso.impl.state/child-key row1 :detail) true])
+    (is (= true  (read* f [::open? (rf.hicasso.impl.state/child-key row1 :detail)])))
+    (is (= false (read* f [::open? (rf.hicasso.impl.state/child-key row2 :detail)])))
     (is (= false (read* f [::open? :panel]))
         "the parent's own key is a different key from any child's")))
 
 (deftest a-fresh-but-equal-key-vector-is-the-same-instance
   (testing "keys are compared by VALUE, so a key rebuilt every render
            addresses the entry the previous render wrote"
-    (state/reg-state ::draft {:default ""})
+    (rf.hicasso.impl.state/reg-state ::draft {:default ""})
     (let [f (frame! ::value-equality)]
       (send! f [::draft [:order/id 42] "hi"])
       (is (= "hi" (read* f [::draft (into [] [:order/id 42])]))
           "a distinct vector object, equal by value")
-      (is (= "hi" (read* f [::draft (state/child-key :order/id 42)]))
+      (is (= "hi" (read* f [::draft (rf.hicasso.impl.state/child-key :order/id 42)]))
           "and one composed by child-key")
       (is (= 1 (count (get-in (db-of f) [:ui ::draft])))
           "one entry, not two"))))
@@ -320,7 +320,7 @@
 (deftest two-frames-hold-the-same-concern-and-key-independently
   (testing "per-frame isolation costs this namespace NOTHING — app-db is
            per-frame already, and there is not one line about frames in it"
-    (state/reg-state ::open? {:default false})
+    (rf.hicasso.impl.state/reg-state ::open? {:default false})
     (let [a (frame! ::frame-a)
           b (frame! ::frame-b)]
       (send! a [::open? :billing true])
@@ -330,6 +330,6 @@
       (is (= {} (db-of b)))
       (testing "and clearing in one frame leaves the other"
         (send! b [::open? :billing true])
-        (send! a [state/clear-event-id ::open? :billing])
+        (send! a [rf.hicasso.impl.state/clear-event-id ::open? :billing])
         (is (= false (read* a [::open? :billing])))
         (is (= true  (read* b [::open? :billing])))))))

--- a/implementation/hicasso/test/re_frame/hicasso/state_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/state_dom_cljs_test.cljs
@@ -43,24 +43,24 @@
   React DOM; under `:node-test` every DOM claim degrades to a stated
   skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as checkpoint]
-            [re-frame.hicasso.hook-probe :as probe]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.state :as state]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.roots-frames-support :as support]
-            [re-frame.test-support :as test-support]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.hook-probe :as rf.hicasso.hook-probe]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.state :as rf.hicasso.impl.state]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (def ^:private frame-id ::state-dom)
 
@@ -76,18 +76,18 @@
 
 (defn- reset-runs! [] (reset! !panel-runs 0) (reset! !page-runs 0) nil)
 
-(h/defview disclosure
+(rf.hicasso/defview disclosure
   "A disclosure panel. It holds its own open flag and knows nothing about
   where it is on the page beyond the instance key it was handed — which
   is the ergonomic claim: the widget is written ONCE and mounted twice."
   [{:keys [ikey title]}]
   (swap! !panel-runs inc)
-  (let [shown? (collector/sub [open? ikey])]
+  (let [shown? (rf.hicasso.impl.collector/sub [open? ikey])]
     [:section.panel {:data-ikey (pr-str ikey)}
      [:button.toggle {:on-click [open? ikey (not shown?)]} title]
      (when shown? [:div.body "body of " title])]))
 
-(h/defview page
+(rf.hicasso/defview page
   "Two disclosures, and a page-level read of its own so a chrome write
   can re-render the page without touching either panel. Every child key
   is REBUILT here on every render — `child-key` allocates — which is
@@ -95,9 +95,9 @@
   [_]
   (swap! !page-runs inc)
   [:div.page
-   [:h1.chrome (str (collector/sub [label :page]))]
-   [disclosure {:key "billing"  :ikey (state/child-key :panel :billing)  :title "Billing"}]
-   [disclosure {:key "shipping" :ikey (state/child-key :panel :shipping) :title "Shipping"}]])
+   [:h1.chrome (str (rf.hicasso.impl.collector/sub [label :page]))]
+   [disclosure {:key "billing"  :ikey (rf.hicasso.impl.state/child-key :panel :billing)  :title "Billing"}]
+   [disclosure {:key "shipping" :ikey (rf.hicasso.impl.state/child-key :panel :shipping) :title "Shipping"}]])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -106,12 +106,12 @@
 (defn- skip! [why] (is true (str "a reg-state DOM claim needs a real React DOM — " why)))
 
 (defn- fresh! []
-  (checkpoint/leave-act-environment!)
-  (state/reg-state open? {:default false})
-  (state/reg-state label {:default ""})
+  (rf.hicasso.checkpoint-support/leave-act-environment!)
+  (rf.hicasso.impl.state/reg-state open? {:default false})
+  (rf.hicasso.impl.state/reg-state label {:default ""})
   (rf/make-frame {:id frame-id})
   (reset-runs!)
-  (runtime/reset-body-runs!)
+  (rf.hicasso.test.runtime/reset-body-runs!)
   frame-id)
 
 (defn- panels [handle]
@@ -125,7 +125,7 @@
   (-> (nth (vec (panels handle)) i)
       (.querySelector "button.toggle")
       (.click))
-  (mount/settle!)
+  (rf.hicasso.impl.mount/settle!)
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -133,21 +133,21 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest two-mounted-instances-of-one-widget-are-independent
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [[result captured]
-            (support/capture-console!
+            (rf.hicasso.roots-frames-support/capture-console!
               (fn []
-                (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+                (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [page {}])]
                   (try
                     (let [before (bodies handle)]
                       (click! handle 0)
                       {:before before
                        :after  (bodies handle)
                        :db     (rf/app-db-value frame-id)})
-                    (finally (mount/release! handle))))))]
+                    (finally (rf.hicasso.impl.mount/release! handle))))))]
         (is (= [nil nil] (:before result)) "both panels start closed — the default")
         (is (= ["body of Billing" nil] (:after result))
             "one click opened ONE panel. Before the explicit-key ruling the
@@ -164,9 +164,9 @@
 
 (deftest a-reg-state-widget-shell-still-calls-exactly-two-hooks
   (cond
-    (not (mount/browser?)) (skip! ":node-test has no DOM")
+    (not (rf.hicasso.impl.mount/browser?)) (skip! ":node-test has no DOM")
 
-    (not (probe/install!))
+    (not (rf.hicasso.hook-probe/install!))
     (is false (str "React's internals slot was not found, so the ≤2-hook budget "
                    "is UNWITNESSED for reg-state. A gate nobody has watched fire "
                    "is not evidence — fix "
@@ -176,20 +176,20 @@
     :else
     (do
       (fresh!)
-      (let [container (mount/fresh-container!)
+      (let [container (rf.hicasso.impl.mount/fresh-container!)
             !handle   (volatile! nil)
-            names     (probe/record!
+            names     (rf.hicasso.hook-probe/record!
                         (fn []
                           (vreset! !handle
-                                   (mount/root! container frame-id
+                                   (rf.hicasso.impl.mount/root! container frame-id
                                                 [disclosure {:ikey :solo :title "Solo"}]))))]
-        (mount/release! @!handle)
+        (rf.hicasso.impl.mount/release! @!handle)
         (is (= ["useContext" "useSyncExternalStore"] names)
             (str "the shell called " (pr-str names) " — reg-state mints a sub "
                  "and an event, and a sub read through the ambient collector is "
                  "not a hook. A third call here is a budget breach (HD-020(b)) "
                  "and would mean this sugar had grown machinery."))
-        (is (= (count runtime/shell-hook-ledger) (count names))
+        (is (= (count rf.hicasso.test.runtime/shell-hook-ledger) (count names))
             "and the declared ledger is still the measured one — reg-state
              added nothing to it")
         (is (not-any? #{"useRef" "useState"} names)
@@ -201,15 +201,15 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-fresh-but-equal-key-vector-does-not-defeat-the-memo-bail-out
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [page {}])]
         (try
           (let [nodes-before (vec (panels handle))]
             (reset-runs!)
-            (mount/dispatch! handle [label :page "chrome moved"])
+            (rf.hicasso.impl.mount/dispatch! handle [label :page "chrome moved"])
             (is (= 1 @!page-runs) "the page re-ran — it reads the chrome")
             (is (= 0 @!panel-runs)
                 "and NEITHER panel did, although the page rebuilt both their
@@ -229,22 +229,22 @@
             (click! handle 1)
             (is (= ["" "body of Shipping"] (mapv #(or % "") (bodies handle))))
             (is (= 1 @!panel-runs) "exactly the panel that moved, and no other"))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — a bad key refuses on the page, and the page keeps working
 ;; ---------------------------------------------------------------------------
 
 (deftest a-nil-keyed-widget-refuses-loudly-and-its-sibling-keeps-rendering
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [records (volatile! [])]
-        (error-emit/register-error-listener! ::state-dom (fn [r] (vswap! records conj r)))
-        (let [handle (mount/root! (mount/fresh-container!) frame-id [:div.empty])]
+        (rf.error-emit/register-error-listener! ::state-dom (fn [r] (vswap! records conj r)))
+        (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [:div.empty])]
           (try
-            (mount/render! handle
+            (rf.hicasso.impl.mount/render! handle
                            [:div.page
                             [disclosure {:key "good" :ikey :billing :title "Billing"}]
                             [disclosure {:key "bad" :ikey nil :title "Broken"}]])
@@ -263,5 +263,5 @@
                 "the well-keyed sibling still rendered — one widget's bad key
                  is not the page's problem")
             (finally
-              (error-emit/unregister-error-listener! ::state-dom)
-              (mount/release! handle))))))))
+              (rf.error-emit/unregister-error-listener! ::state-dom)
+              (rf.hicasso.impl.mount/release! handle))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/substrate_react_shared_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/substrate_react_shared_cljs_test.cljs
@@ -51,36 +51,36 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [use-fixtures]]
             [re-frame.adapter.react-shared-suite]
-            [re-frame.hicasso.substrate :as substrate]
-            [re-frame.test-support :as test-support])
+            [re-frame.hicasso.substrate :as rf.hicasso.substrate]
+            [re-frame.test-support :as rf.test-support])
   (:require-macros
    [re-frame.adapter.react-shared-suite-tests
     :refer [define-react-shared-suite-tests!]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter substrate/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.hicasso.substrate/adapter}))
 
 (def ^:private cfg
-  {:adapter          substrate/adapter
+  {:adapter          rf.hicasso.substrate/adapter
    :substrate-kw     :hicasso
    :name             "Hicasso"
    :producer-ns      're-frame.hicasso.substrate
-   :wrap-view        (:wrap-view substrate/spine-fns)
-   :set-emitter!     (:set-hiccup-emitter! substrate/spine-fns)
-   :render-to-string (:render-to-string substrate/adapter)
+   :wrap-view        (:wrap-view rf.hicasso.substrate/spine-fns)
+   :set-emitter!     (:set-hiccup-emitter! rf.hicasso.substrate/spine-fns)
+   :render-to-string (:render-to-string rf.hicasso.substrate/adapter)
    :public-surface-keys [:set-hiccup-emitter! :use-current-frame :frame-provider
                          :use-subscribe :flush-views! :wrap-view]
-   :public-surface   {:set-hiccup-emitter! (:set-hiccup-emitter! substrate/spine-fns)
-                      :use-current-frame   (:use-current-frame substrate/spine-fns)
+   :public-surface   {:set-hiccup-emitter! (:set-hiccup-emitter! rf.hicasso.substrate/spine-fns)
+                      :use-current-frame   (:use-current-frame rf.hicasso.substrate/spine-fns)
                       ;; The contract slot IS the publication route here: the
                       ;; frame-keyword arg is ignored (the frame lives in the
                       ;; Provider's `:value` at render time), so passing nil
                       ;; asks for the component and nothing else.
-                      :frame-provider      ((:register-context-provider substrate/adapter) nil)
-                      :use-subscribe       (:use-subscribe substrate/spine-fns)
-                      :flush-views!        (:flush-views! substrate/spine-fns)
-                      :wrap-view           (:wrap-view substrate/spine-fns)}})
+                      :frame-provider      ((:register-context-provider rf.hicasso.substrate/adapter) nil)
+                      :use-subscribe       (:use-subscribe rf.hicasso.substrate/spine-fns)
+                      :flush-views!        (:flush-views! rf.hicasso.substrate/spine-fns)
+                      :wrap-view           (:wrap-view rf.hicasso.substrate/spine-fns)}})
 
 ;; Emit one (deftest name (re-frame.adapter.react-shared-suite/assert-name cfg))
 ;; per row in `react-shared-suite-tests/test-specs`.

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_a11y_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_a11y_cljs_test.cljs
@@ -43,14 +43,14 @@
   `re-frame.hicasso.examples.slice.a11y-focus-dom-cljs-test`'s question,
   and it is a different one."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil}))
 
 ;; ---------------------------------------------------------------------------
@@ -62,7 +62,7 @@
   no view. The trio's whole domain is a tree, and this is the shortest
   honest way to get one."
   [form]
-  (ht/tree [(fn [_] form) {}]))
+  (rf.hicasso.test/tree [(fn [_] form) {}]))
 
 (defn- outcome
   "`{:returned v}` or `{:refused <ex-data>}` — the same discriminator the
@@ -76,15 +76,15 @@
   [outcome']
   (some-> (:refused outcome') (select-keys [:rf.error/id :where])))
 
-(h/defview a-child
+(rf.hicasso/defview a-child
   "A minted boundary, so the boundary row below records a CALL rather
   than the refusal a plain function in head position earns."
   [_]
   [:p "child"])
 
-(defn- tagged [tree tag] (ht/find tree #(= tag (:tag %))))
+(defn- tagged [tree tag] (rf.hicasso.test/find tree #(= tag (:tag %))))
 
-(defn- classed [tree class] (ht/find tree #(= class (:class (ht/attrs %)))))
+(defn- classed [tree class] (rf.hicasso.test/find tree #(= class (:class (rf.hicasso.test/attrs %)))))
 
 ;; ---------------------------------------------------------------------------
 ;; role — every arm of the table, and both sides of every condition
@@ -94,34 +94,34 @@
   (let [t (markup [:div
                    [:p.s {:role "status"} "saved"]
                    [:p.k {:role :alert} "no"]])]
-    (is (= :status (ht/role (classed t "s"))) "the string spelling")
-    (is (= :alert (ht/role (classed t "k"))) "and the keyword spelling")))
+    (is (= :status (rf.hicasso.test/role (classed t "s"))) "the string spelling")
+    (is (= :alert (rf.hicasso.test/role (classed t "k"))) "and the keyword spelling")))
 
 (deftest an-explicit-role-is-a-token-list-and-the-first-token-wins
   (testing "a fallback chain is read the way a user agent reads it — the
             first token, not the last and not the whole string"
     (is (= :doc-subtitle
-           (ht/role (tagged (markup [:p {:role "doc-subtitle heading"}]) :p))))
+           (rf.hicasso.test/role (tagged (markup [:p {:role "doc-subtitle heading"}]) :p))))
     (is (= :heading
-           (ht/role (tagged (markup [:p {:role "heading doc-subtitle"}]) :p)))
+           (rf.hicasso.test/role (tagged (markup [:p {:role "heading doc-subtitle"}]) :p)))
         "and the SAME two tokens the other way round answer the other
          one, so this is about order rather than about which of the two
          names the reader happens to know")))
 
 (deftest an-explicit-role-beats-the-tag
   (let [t (markup [:div [:button {:role "link"} "go"] [:button "press"]])]
-    (is (= :link (ht/role (ht/find t #(= "link" (:role (ht/attrs %))))))
+    (is (= :link (rf.hicasso.test/role (rf.hicasso.test/find t #(= "link" (:role (rf.hicasso.test/attrs %))))))
         "the author's answer")
-    (is (= :button (ht/role (ht/find t #(and (= :button (:tag %))
-                                             (nil? (:role (ht/attrs %)))))))
+    (is (= :button (rf.hicasso.test/role (rf.hicasso.test/find t #(and (= :button (:tag %))
+                                             (nil? (:role (rf.hicasso.test/attrs %)))))))
         "and the tag's, unaltered beside it")))
 
 (deftest an-anchor-is-a-link-only-when-it-has-somewhere-to-go
   (let [t (markup [:div
                    [:a.linked {:href "/x"} "x"]
                    [:a.bare "y"]])]
-    (is (= :link (ht/role (classed t "linked"))))
-    (is (nil? (ht/role (classed t "bare")))
+    (is (= :link (rf.hicasso.test/role (classed t "linked"))))
+    (is (nil? (rf.hicasso.test/role (classed t "bare")))
         "an `<a>` with no href is not a link and never was — this is the
          false positive the clj-kondo export was reopened to remove
          (rf2-hic-022, audit #7791), and the kit must not re-introduce it")))
@@ -139,22 +139,22 @@
                    [:input.i {:type "password"}]
                    [:input.j {:type "hidden"}]
                    [:input.k {:type :email}]])]
-    (is (= :textbox (ht/role (classed t "a"))))
-    (is (= :textbox (ht/role (classed t "b")))
+    (is (= :textbox (rf.hicasso.test/role (classed t "a"))))
+    (is (= :textbox (rf.hicasso.test/role (classed t "b")))
         "no :type at all is `text`, which is HTML's own default and not a
          miss")
-    (is (= :searchbox (ht/role (classed t "c"))))
-    (is (= :checkbox (ht/role (classed t "d"))))
-    (is (= :radio (ht/role (classed t "e"))))
-    (is (= :button (ht/role (classed t "f"))))
-    (is (= :slider (ht/role (classed t "g"))))
-    (is (= :spinbutton (ht/role (classed t "h"))))
-    (is (= :textbox (ht/role (classed t "k"))) "a keyword :type reads the same")
+    (is (= :searchbox (rf.hicasso.test/role (classed t "c"))))
+    (is (= :checkbox (rf.hicasso.test/role (classed t "d"))))
+    (is (= :radio (rf.hicasso.test/role (classed t "e"))))
+    (is (= :button (rf.hicasso.test/role (classed t "f"))))
+    (is (= :slider (rf.hicasso.test/role (classed t "g"))))
+    (is (= :spinbutton (rf.hicasso.test/role (classed t "h"))))
+    (is (= :textbox (rf.hicasso.test/role (classed t "k"))) "a keyword :type reads the same")
     (testing "and the two types ARIA gives no role — the other side of the
               same table, without which the table could answer :textbox
               for everything it did not recognise"
-      (is (nil? (ht/role (classed t "i"))))
-      (is (nil? (ht/role (classed t "j")))))))
+      (is (nil? (rf.hicasso.test/role (classed t "i"))))
+      (is (nil? (rf.hicasso.test/role (classed t "j")))))))
 
 (deftest a-select-is-a-combobox-until-it-takes-more-than-one
   (let [t (markup [:div
@@ -162,10 +162,10 @@
                    [:select.many {:multiple true}]
                    [:select.tall {:size 4}]
                    [:select.short {:size 1}]])]
-    (is (= :combobox (ht/role (classed t "one"))))
-    (is (= :listbox (ht/role (classed t "many"))))
-    (is (= :listbox (ht/role (classed t "tall"))))
-    (is (= :combobox (ht/role (classed t "short")))
+    (is (= :combobox (rf.hicasso.test/role (classed t "one"))))
+    (is (= :listbox (rf.hicasso.test/role (classed t "many"))))
+    (is (= :listbox (rf.hicasso.test/role (classed t "tall"))))
+    (is (= :combobox (rf.hicasso.test/role (classed t "short")))
         "`:size 1` is one visible row and still a combobox — the boundary
          of the condition rather than a value far from it")))
 
@@ -174,11 +174,11 @@
                    [:img.described {:src "a.png" :alt "a chart"}]
                    [:img.decorative {:src "b.png" :alt ""}]
                    [:img.silent {:src "c.png"}]])]
-    (is (= :img (ht/role (classed t "described"))))
-    (is (= :presentation (ht/role (classed t "decorative")))
+    (is (= :img (rf.hicasso.test/role (classed t "described"))))
+    (is (= :presentation (rf.hicasso.test/role (classed t "decorative")))
         "an empty alt is the author saying `ignore this` and is the ONE
          attribute value that changes an element's role")
-    (is (= :img (ht/role (classed t "silent")))
+    (is (= :img (rf.hicasso.test/role (classed t "silent")))
         "a MISSING alt is not an empty one — the image is still an image,
          it is merely unnamed, which is what unnamed-controls is for")))
 
@@ -191,16 +191,16 @@
                    [:progress]
                    [:hr]
                    [:dialog]])]
-    (is (= :main (ht/role t)))
-    (is (= :navigation (ht/role (tagged t :nav))))
-    (is (= :list (ht/role (tagged t :ul))))
-    (is (= :listitem (ht/role (tagged t :li))))
-    (is (= :heading (ht/role (tagged t :h3))))
-    (is (= :textbox (ht/role (tagged t :textarea))))
-    (is (= :option (ht/role (tagged t :option))))
-    (is (= :progressbar (ht/role (tagged t :progress))))
-    (is (= :separator (ht/role (tagged t :hr))))
-    (is (= :dialog (ht/role (tagged t :dialog))))))
+    (is (= :main (rf.hicasso.test/role t)))
+    (is (= :navigation (rf.hicasso.test/role (tagged t :nav))))
+    (is (= :list (rf.hicasso.test/role (tagged t :ul))))
+    (is (= :listitem (rf.hicasso.test/role (tagged t :li))))
+    (is (= :heading (rf.hicasso.test/role (tagged t :h3))))
+    (is (= :textbox (rf.hicasso.test/role (tagged t :textarea))))
+    (is (= :option (rf.hicasso.test/role (tagged t :option))))
+    (is (= :progressbar (rf.hicasso.test/role (tagged t :progress))))
+    (is (= :separator (rf.hicasso.test/role (tagged t :hr))))
+    (is (= :dialog (rf.hicasso.test/role (tagged t :dialog))))))
 
 (deftest the-tags-whose-role-depends-on-context-answer-nothing
   (testing "`<header>`, `<section>`, `<form>` and `<td>` have roles that
@@ -209,26 +209,26 @@
             and a guess is the failure this trio exists to avoid — so the
             omission is asserted rather than left to be noticed"
     (let [t (markup [:div [:header] [:section] [:form] [:table [:tr [:td]]]])]
-      (is (nil? (ht/role (tagged t :header))))
-      (is (nil? (ht/role (tagged t :section))))
-      (is (nil? (ht/role (tagged t :form))))
-      (is (nil? (ht/role (tagged t :td)))))))
+      (is (nil? (rf.hicasso.test/role (tagged t :header))))
+      (is (nil? (rf.hicasso.test/role (tagged t :section))))
+      (is (nil? (rf.hicasso.test/role (tagged t :form))))
+      (is (nil? (rf.hicasso.test/role (tagged t :td)))))))
 
 (deftest role-is-total-over-the-node-set
   (let [t (markup [:<> [:div] "text"])]
-    (is (nil? (ht/role nil)) "nil in, nil out — so it threads through a miss")
-    (is (nil? (ht/role t)) "a fragment is not an element")
-    (is (nil? (ht/role (tagged t :div))) "and a div has no role of its own"))
+    (is (nil? (rf.hicasso.test/role nil)) "nil in, nil out — so it threads through a miss")
+    (is (nil? (rf.hicasso.test/role t)) "a fragment is not an element")
+    (is (nil? (rf.hicasso.test/role (tagged t :div))) "and a div has no role of its own"))
   (testing "text content is REFUSED rather than answered nil, because a
             string reaching a projection is a caller reading the wrong
             thing and a nil would let it read on"
     (is (= {:rf.error/id :rf.error/ui-tree-malformed
             :where       're-frame.hicasso.test}
-           (refusal (outcome #(ht/role "milk")))))))
+           (refusal (outcome #(rf.hicasso.test/role "milk")))))))
 
 (deftest a-boundary-node-has-no-role-and-that-is-not-an-error
   (let [t (markup [:div [a-child {}]])]
-    (is (nil? (ht/role (ht/find t #(some? (:view-id %)))))
+    (is (nil? (rf.hicasso.test/role (rf.hicasso.test/find t #(some? (:view-id %)))))
         "L2 records a child boundary as the CALL it is; what it renders —
          and therefore what role it presents — is the child's own tree to
          answer")))
@@ -242,43 +242,43 @@
                    [:span {:id "verb"} "Delete"]
                    [:span {:id "noun"} "draft"]
                    [:button {:aria-labelledby "verb noun"}]])]
-    (is (= "Delete draft" (ht/accessible-name t (tagged t :button)))))
+    (is (= "Delete draft" (rf.hicasso.test/accessible-name t (tagged t :button)))))
   (testing "the ORDER is the attribute's and not the document's"
     (let [t (markup [:div
                      [:span {:id "verb"} "Delete"]
                      [:span {:id "noun"} "draft"]
                      [:button {:aria-labelledby "noun verb"}]])]
-      (is (= "draft Delete" (ht/accessible-name t (tagged t :button))))))
+      (is (= "draft Delete" (rf.hicasso.test/accessible-name t (tagged t :button))))))
   (testing "an id that resolves to nothing contributes nothing, and does
             not take the rest of the name down with it"
     (let [t (markup [:div
                      [:span {:id "verb"} "Delete"]
                      [:button {:aria-labelledby "verb absent"}]])]
-      (is (= "Delete" (ht/accessible-name t (tagged t :button)))))))
+      (is (= "Delete" (rf.hicasso.test/accessible-name t (tagged t :button)))))))
 
 (deftest aria-labelledby-beats-aria-label-beats-the-content
   (let [t (markup [:div
                    [:span {:id "ref"} "from the reference"]
                    [:button {:aria-labelledby "ref" :aria-label "from the label"}
                     "from the content"]])]
-    (is (= "from the reference" (ht/accessible-name t (tagged t :button)))
+    (is (= "from the reference" (rf.hicasso.test/accessible-name t (tagged t :button)))
         "three sources, three DIFFERENT strings, so the winner identifies
          the step — a row whose sources agreed would be green under any
          ordering"))
   (let [t (markup [:div [:button {:aria-label "from the label"} "from the content"]])]
-    (is (= "from the label" (ht/accessible-name t (tagged t :button)))))
+    (is (= "from the label" (rf.hicasso.test/accessible-name t (tagged t :button)))))
   (let [t (markup [:div [:button "from the content"]])]
-    (is (= "from the content" (ht/accessible-name t (tagged t :button))))))
+    (is (= "from the content" (rf.hicasso.test/accessible-name t (tagged t :button))))))
 
 (deftest a-blank-aria-label-does-not-count-as-a-name
   (let [t (markup [:div [:button {:aria-label "   "} "Save"]])]
-    (is (= "Save" (ht/accessible-name t (tagged t :button)))
+    (is (= "Save" (rf.hicasso.test/accessible-name t (tagged t :button)))
         "whitespace is not a name, so the fallback continues past it —
          and the content is what a screen reader would announce")))
 
 (deftest a-name-is-flattened
   (let [t (markup [:div [:button "  Save \n   draft "]])]
-    (is (= "Save draft" (ht/accessible-name t (tagged t :button)))
+    (is (= "Save draft" (rf.hicasso.test/accessible-name t (tagged t :button)))
         "the platform's own flat-string step: runs collapse, the ends go")))
 
 (deftest a-control-is-named-by-its-label-either-way-round
@@ -286,17 +286,17 @@
     (let [t (markup [:form
                      [:label {:for "title"} "Title"]
                      [:input {:id "title" :type "text"}]])]
-      (is (= "Title" (ht/accessible-name t (tagged t :input))))))
+      (is (= "Title" (rf.hicasso.test/accessible-name t (tagged t :input))))))
   (testing "and a `<label>` that simply contains the control — the wrapping
             form, which no attribute records"
     (let [t (markup [:form
                      [:label [:input {:type "checkbox"}] "Published"]])]
-      (is (= "Published" (ht/accessible-name t (tagged t :input))))))
+      (is (= "Published" (rf.hicasso.test/accessible-name t (tagged t :input))))))
   (testing "both at once concatenate in DOCUMENT order"
     (let [t (markup [:form
                      [:label {:for "p"} "Publish"]
                      [:label [:input {:id "p" :type "checkbox"}] "immediately"]])]
-      (is (= "Publish immediately" (ht/accessible-name t (tagged t :input)))))))
+      (is (= "Publish immediately" (rf.hicasso.test/accessible-name t (tagged t :input)))))))
 
 (deftest a-label-names-the-control-it-points-at-and-no-other
   (testing "the discrimination the `for`/`id` pair exists for: two labels,
@@ -307,24 +307,24 @@
                      [:label {:for "title"} "Title"]
                      [:input.title {:id "title" :type "text"}]
                      [:textarea.body {:id "body"}]])]
-      (is (= "Title" (ht/accessible-name t (classed t "title"))))
-      (is (= "Body" (ht/accessible-name t (classed t "body"))))))
+      (is (= "Title" (rf.hicasso.test/accessible-name t (classed t "title"))))
+      (is (= "Body" (rf.hicasso.test/accessible-name t (classed t "body"))))))
   (testing "and a `for` that points nowhere leaves its control unnamed
             rather than borrowing the label beside it"
     (let [t (markup [:form
                      [:label {:for "typo"} "Title"]
                      [:input {:id "title" :type "text"}]])]
-      (is (nil? (ht/accessible-name t (tagged t :input)))))))
+      (is (nil? (rf.hicasso.test/accessible-name t (tagged t :input)))))))
 
 (deftest a-label-beats-the-controls-own-text-and-aria-label-beats-the-label
   (let [t (markup [:form
                    [:label {:for "x"} "from the label"]
                    [:input {:id "x" :type "text" :aria-label "from aria"}]])]
-    (is (= "from aria" (ht/accessible-name t (tagged t :input)))))
+    (is (= "from aria" (rf.hicasso.test/accessible-name t (tagged t :input)))))
   (let [t (markup [:form
                    [:label {:for "x"} "from the label"]
                    [:input {:id "x" :type "text" :title "from the title"}]])]
-    (is (= "from the label" (ht/accessible-name t (tagged t :input)))
+    (is (= "from the label" (rf.hicasso.test/accessible-name t (tagged t :input)))
         "and `:title` is the LAST resort, below the label rather than
          above it")))
 
@@ -332,19 +332,19 @@
   (testing "a submit button is named by its :value, which is markup no
             label and no content supplies"
     (let [t (markup [:form [:input {:type "submit" :value "Send"}]])]
-      (is (= "Send" (ht/accessible-name t (tagged t :input))))))
+      (is (= "Send" (rf.hicasso.test/accessible-name t (tagged t :input))))))
   (testing "an image by its alt"
     (let [t (markup [:div [:img {:src "a.png" :alt "A bar chart"}]])]
-      (is (= "A bar chart" (ht/accessible-name t (tagged t :img))))))
+      (is (= "A bar chart" (rf.hicasso.test/accessible-name t (tagged t :img))))))
   (testing "and a fieldset by its FIRST legend child, so a nested
             fieldset's legend cannot be borrowed by the one above it"
     (let [t (markup [:fieldset
                      [:legend "Outer"]
                      [:fieldset [:legend "Inner"]]])]
-      (is (= "Outer" (ht/accessible-name t t)))
-      (is (= "Inner" (ht/accessible-name
+      (is (= "Outer" (rf.hicasso.test/accessible-name t t)))
+      (is (= "Inner" (rf.hicasso.test/accessible-name
                        t
-                       (ht/find t #(and (= :fieldset (:tag %))
+                       (rf.hicasso.test/find t #(and (= :fieldset (:tag %))
                                         (not (identical? % t))))))
           "read off the outer tree, so the two fieldsets are one
            document and the inner one still answers its own legend"))))
@@ -356,19 +356,19 @@
                    [:li.item "an item"]
                    [:a.link {:href "/x"} "a link"]
                    [:h2.head "a heading"]])]
-    (is (= "an item" (ht/accessible-name t (classed t "item"))))
-    (is (= "a link" (ht/accessible-name t (classed t "link"))))
-    (is (= "a heading" (ht/accessible-name t (classed t "head"))))
+    (is (= "an item" (rf.hicasso.test/accessible-name t (classed t "item"))))
+    (is (= "a link" (rf.hicasso.test/accessible-name t (classed t "link"))))
+    (is (= "a heading" (rf.hicasso.test/accessible-name t (classed t "head"))))
     (testing "an alert is announced when it appears and is not NAMED by
               what it says — answering `Could not save` here would be the
               kit inventing a name the platform does not give"
-      (is (nil? (ht/accessible-name t (classed t "alert")))))
+      (is (nil? (rf.hicasso.test/accessible-name t (classed t "alert")))))
     (testing "and ordinary prose has no role, so no name"
-      (is (nil? (ht/accessible-name t (classed t "plain")))))))
+      (is (nil? (rf.hicasso.test/accessible-name t (classed t "plain")))))))
 
 (deftest title-is-the-last-resort-and-is-still-a-name
   (let [t (markup [:div [:input {:type "text" :title "Search"}]])]
-    (is (= "Search" (ht/accessible-name t (tagged t :input))))))
+    (is (= "Search" (rf.hicasso.test/accessible-name t (tagged t :input))))))
 
 (deftest accessible-name-refuses-a-node-from-somewhere-else
   (let [labelled (markup [:form
@@ -378,24 +378,24 @@
     (testing "the legal twin first: read against its OWN tree the control
               is named, so the refusal below is about the pairing and not
               about markup that was broken anyway"
-      (is (= "Title" (ht/accessible-name labelled (tagged labelled :input)))))
+      (is (= "Title" (rf.hicasso.test/accessible-name labelled (tagged labelled :input)))))
     (testing "and against a tree it is not in, a REFUSAL rather than nil —
               nil would report a labelled control as unlabelled, which is
               the wrong answer in the one direction that matters"
       (is (= {:rf.error/id :rf.error/ui-tree-malformed
               :where       're-frame.hicasso.test}
-             (refusal (outcome #(ht/accessible-name elsewhere
+             (refusal (outcome #(rf.hicasso.test/accessible-name elsewhere
                                                     (tagged labelled :input)))))))
     (testing "the discriminator reports :returned for the legal pairing,
               so the refusal row is not a helper that only knows one verb"
       (is (= {:returned "Title"}
-             (outcome #(ht/accessible-name labelled (tagged labelled :input))))))))
+             (outcome #(rf.hicasso.test/accessible-name labelled (tagged labelled :input))))))))
 
 (deftest accessible-name-nil-puns-and-refuses-text
-  (is (nil? (ht/accessible-name (markup [:div]) nil)))
+  (is (nil? (rf.hicasso.test/accessible-name (markup [:div]) nil)))
   (is (= {:rf.error/id :rf.error/ui-tree-malformed
           :where       're-frame.hicasso.test}
-         (refusal (outcome #(ht/accessible-name (markup [:div]) "milk"))))))
+         (refusal (outcome #(rf.hicasso.test/accessible-name (markup [:div]) "milk"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; unnamed-controls — the auditor, sabotaged in both directions
@@ -418,7 +418,7 @@
    [:a {:href "/x"} "Named link"]])
 
 (deftest a-fully-named-form-reports-nothing
-  (is (= [] (ht/unnamed-controls (markup a-named-form)))
+  (is (= [] (rf.hicasso.test/unnamed-controls (markup a-named-form)))
       "the legal side. Six naming mechanisms, one assertion — and an
        auditor that reported any of them would be a nag rather than a
        gate"))
@@ -426,42 +426,42 @@
 (deftest removing-any-one-name-reports-that-one-control-and-only-it
   (testing "the content off a button"
     (let [t (markup (assoc a-named-form 1 [:button {:type "button"}]))
-          found (ht/unnamed-controls t)]
+          found (rf.hicasso.test/unnamed-controls t)]
       (is (= 1 (count found)))
       (is (= :button (:tag (first found))))))
   (testing "the aria-label off the second button"
     (let [t (markup (assoc a-named-form 2 [:button.aria {:type "button"}]))
-          found (ht/unnamed-controls t)]
+          found (rf.hicasso.test/unnamed-controls t)]
       (is (= 1 (count found)))
-      (is (= "aria" (:class (ht/attrs (first found)))))))
+      (is (= "aria" (:class (rf.hicasso.test/attrs (first found)))))))
   (testing "the `for` off the label — the control keeps its id and the
             label keeps its text, so nothing about the markup LOOKS
             different except the one attribute that binds them"
     (let [t (markup (assoc a-named-form 3 [:label "Named by for"]))
-          found (ht/unnamed-controls t)]
+          found (rf.hicasso.test/unnamed-controls t)]
       (is (= 1 (count found)))
-      (is (= "by-for" (:id (ht/attrs (first found)))))))
+      (is (= "by-for" (:id (rf.hicasso.test/attrs (first found)))))))
   (testing "the TEXT out of the wrapping label, keeping the containment —
             so what this row measures is the label's contribution and not
             merely whether a label is nearby"
     (let [t (markup (assoc a-named-form 5
                            [:label [:input.wrapped {:type "checkbox"}]]))
-          found (ht/unnamed-controls t)]
+          found (rf.hicasso.test/unnamed-controls t)]
       (is (= 1 (count found)))
-      (is (= "wrapped" (:class (ht/attrs (first found)))))))
+      (is (= "wrapped" (:class (rf.hicasso.test/attrs (first found)))))))
   (testing "the referent of aria-labelledby"
     (let [t (markup (assoc a-named-form 6 [:span {:id "other"} "Named by reference"]))
-          found (ht/unnamed-controls t)]
+          found (rf.hicasso.test/unnamed-controls t)]
       (is (= 1 (count found)))
-      (is (= "referenced" (:class (ht/attrs (first found)))))))
+      (is (= "referenced" (:class (rf.hicasso.test/attrs (first found)))))))
   (testing "the :value off the submit button"
     (let [t (markup (assoc a-named-form 8 [:input.submit {:type "submit"}]))
-          found (ht/unnamed-controls t)]
+          found (rf.hicasso.test/unnamed-controls t)]
       (is (= 1 (count found)))
-      (is (= "submit" (:class (ht/attrs (first found)))))))
+      (is (= "submit" (:class (rf.hicasso.test/attrs (first found)))))))
   (testing "the text out of the link"
     (let [t (markup (assoc a-named-form 9 [:a {:href "/x"}]))
-          found (ht/unnamed-controls t)]
+          found (rf.hicasso.test/unnamed-controls t)]
       (is (= 1 (count found)))
       (is (= :a (:tag (first found)))))))
 
@@ -473,7 +473,7 @@
     (let [t (markup [:form
                      [:label "Published"]
                      [:input.wrapped {:type "checkbox"}]])]
-      (is (= ["wrapped"] (mapv #(:class (ht/attrs %)) (ht/unnamed-controls t)))))))
+      (is (= ["wrapped"] (mapv #(:class (rf.hicasso.test/attrs %)) (rf.hicasso.test/unnamed-controls t)))))))
 
 (deftest what-the-auditor-must-not-report
   (testing "a nameless element that is not operable is not a finding —
@@ -486,18 +486,18 @@
                      [:ul [:li]]
                      [:img {:src "a.png" :alt ""}]
                      [:a "a bare anchor, which is not a link"]])]
-      (is (= [] (ht/unnamed-controls t)))))
+      (is (= [] (rf.hicasso.test/unnamed-controls t)))))
   (testing "and a control that is DISABLED is still a control — it is
             announced, it can be enabled, and it needs its name"
     (let [t (markup [:form [:button {:type "button" :disabled true}]])]
-      (is (= 1 (count (ht/unnamed-controls t)))))))
+      (is (= 1 (count (rf.hicasso.test/unnamed-controls t)))))))
 
 (deftest the-auditor-reports-in-document-order-and-reports-every-offender
   (let [t (markup [:form
                    [:button.one {:type "button"}]
                    [:button.two {:type "button"} "named"]
                    [:input.three {:type "text"}]])]
-    (is (= ["one" "three"] (mapv #(:class (ht/attrs %)) (ht/unnamed-controls t)))
+    (is (= ["one" "three"] (mapv #(:class (rf.hicasso.test/attrs %)) (rf.hicasso.test/unnamed-controls t)))
         "both offenders and the named one skipped — a helper that
          short-circuited at the first finding would answer `[one]` and
          look right")))

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_cljs_test.cljs
@@ -34,14 +34,14 @@
   (:require [cljs.reader :as reader]
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]))
 
 (def ^:private frame-id ::test-kit)
@@ -59,12 +59,12 @@
 ;; UIx adapter because plain-atom never notifies, no ambient frame because
 ;; this suite seats its own, and the collector emptied between rows.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :init-fn       (fn []
                       (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-                      (collector/reset-runtime!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The discriminator
@@ -97,12 +97,12 @@
             so the :refused assertions below are not a helper that only
             knows one verb"
     (is (= {:returned {:rf.ui/tree-version 1 :tag :p}}
-           (outcome #(ht/tree [(fn [_] [:p])  {}])))))
+           (outcome #(rf.hicasso.test/tree [(fn [_] [:p])  {}])))))
 
   (testing "and :refused, with the id, for one that is not"
     (is (= {:rf.error/id :rf.error/hicasso-test-not-a-body
             :where       're-frame.hicasso.test}
-           (refusal (outcome #(ht/tree [:not-a-body-fn 1])) [])))))
+           (refusal (outcome #(rf.hicasso.test/tree [:not-a-body-fn 1])) [])))))
 
 (deftest a-refusal-s-payload-cannot-rewrite-the-identity-it-rides-on
   ;; The constructor directly, because no refusal site in the kit spells an
@@ -110,7 +110,7 @@
   ;; can, including the one somebody writes next year. Driving the weakest
   ;; case means handing it the four keys it guarantees, not a well-formed
   ;; payload that would pass under either merge order.
-  (let [o (outcome #(#'ht/refuse! :rf.error/hicasso-test-not-a-body
+  (let [o (outcome #(#'rf.hicasso.test/refuse! :rf.error/hicasso-test-not-a-body
                                   "render's head is the BODY FUNCTION."
                                   {:rf.error/id :rf.error/hicasso-true-child
                                    :where       'app.impostor/elsewhere
@@ -145,7 +145,7 @@
 (defn- badge-component [^js props]
   (react/createElement "b" #js {"className" "badge"} (.-label props)))
 
-(h/defhost badge badge-component {:server :render})
+(rf.hicasso/defhost badge badge-component {:server :render})
 
 ;; The `<name>-body` pair, which is the spelling this suite's own examples
 ;; teach — and which used to be unrenderable. `h/defview` named
@@ -156,14 +156,14 @@
 ;; in scope is the author's; `a-body-may-call-a-helper-named-after-its-view`
 ;; below is what says so.
 (defn- greeting-body [{:keys [who]}] [:p (str "hi " who)])
-(h/defview greeting [props] (greeting-body props))
+(rf.hicasso/defview greeting [props] (greeting-body props))
 
 ;; The pair the minted-head render rows below run, spelled the OTHER way —
 ;; a helper whose name is not derived from the view's — so those rows keep
 ;; measuring the retention contract rather than doubling as the
 ;; helper-naming witness.
 (defn- farewell-text [{:keys [who]}] [:p (str "bye " who)])
-(h/defview farewell [props] (farewell-text props))
+(rf.hicasso/defview farewell [props] (farewell-text props))
 
 (def ^:private unretained-head
   "A boundary head carrying NO retained body — which is exactly what an
@@ -173,42 +173,42 @@
 
   Marked through the codec's own door, so what is under test is the
   runtime's notion of a boundary head rather than this file's."
-  (doto (codec/mark-boundary! (fn [_] [:p "never runs at L2"]))
+  (doto (rf.hicasso.impl.codec/mark-boundary! (fn [_] [:p "never runs at L2"]))
     (unchecked-set "displayName"
                    "re-frame.hicasso.test-kit-cljs-test/unretained-head")))
 
 (deftest the-abi-predicates-discriminate-rather-than-restate-fn?
   (testing "a `defview` var is a boundary and its own body function is not —
             which is the whole discrimination, since both are functions"
-    (is (true?  (ht/boundary? greeting)))
-    (is (false? (ht/boundary? greeting-body)))
-    (is (false? (ht/boundary? badge))))
+    (is (true?  (rf.hicasso.test/boundary? greeting)))
+    (is (false? (rf.hicasso.test/boundary? greeting-body)))
+    (is (false? (rf.hicasso.test/boundary? badge))))
 
   (testing "a `defhost` var is a crossing and the component it named is not"
-    (is (true?  (ht/host? badge)))
-    (is (false? (ht/host? badge-component)))
-    (is (false? (ht/host? greeting))))
+    (is (true?  (rf.hicasso.test/host? badge)))
+    (is (false? (rf.hicasso.test/host? badge-component)))
+    (is (false? (rf.hicasso.test/host? greeting))))
 
   (testing "`h/event` is the one callback form and an identically-written
             plain `fn` is not"
-    (is (true?  (ht/callback? (h/event [e] [:tk/picked (.-value e)]))))
-    (is (false? (ht/callback? (fn [e] [:tk/picked (.-value e)])))))
+    (is (true?  (rf.hicasso.test/callback? (rf.hicasso/event [e] [:tk/picked (.-value e)]))))
+    (is (false? (rf.hicasso.test/callback? (fn [e] [:tk/picked (.-value e)])))))
 
   (testing "the minted name is the one React DevTools and Spec 009's
             render measure are keyed on"
-    (is (= "re-frame.hicasso.test-kit-cljs-test/greeting" (ht/view-name greeting)))
-    (is (= "re-frame.hicasso.test-kit-cljs-test/badge" (ht/view-name badge)))
-    (is (nil? (ht/view-name {:not "a minted value"}))))
+    (is (= "re-frame.hicasso.test-kit-cljs-test/greeting" (rf.hicasso.test/view-name greeting)))
+    (is (= "re-frame.hicasso.test-kit-cljs-test/badge" (rf.hicasso.test/view-name badge)))
+    (is (nil? (rf.hicasso.test/view-name {:not "a minted value"}))))
 
   (testing "the declared server policy is read back off the crossing as data"
-    (is (= :render (ht/host-policy badge))))
+    (is (= :render (rf.hicasso.test/host-policy badge))))
 
   (testing "and asking a NON-host for a policy refuses rather than
             answering nil — a nil here would read as :client-only's
             neighbour"
     (is (= {:rf.error/id :rf.error/hicasso-test-not-a-host
             :where       're-frame.hicasso.test}
-           (refusal (outcome #(ht/host-policy greeting)) [])))))
+           (refusal (outcome #(rf.hicasso.test/host-policy greeting)) [])))))
 
 ;; ---------------------------------------------------------------------------
 ;; L1 — the codec, projected
@@ -219,74 +219,74 @@
             an explicit id WINS over `#id`, the shorthand class is
             PREPENDED to a declared one"
     (is (= {"id" "main" "className" "wide tall"}
-           (ht/element-props [:div#ignored.wide {:id "main" :class "tall"}]))))
+           (rf.hicasso.test/element-props [:div#ignored.wide {:id "main" :class "tall"}]))))
 
   (testing "and the control: without the shorthand the same props emit the
             same slots MINUS the folded halves, so the row above is
             measuring the fold rather than the props"
     (is (= {"id" "main" "className" "tall"}
-           (ht/element-props [:div {:id "main" :class "tall"}]))))
+           (rf.hicasso.test/element-props [:div {:id "main" :class "tall"}]))))
 
   (testing "canonical slot names, not the author's spelling"
     (is (= {"tabIndex" 0 "htmlFor" "x"}
-           (ht/element-props [:label {:tab-index 0 :for "x"}]))))
+           (rf.hicasso.test/element-props [:label {:tab-index 0 :for "x"}]))))
 
   (testing "a caller's map merged with the owned keys last: the literal
             the element writes wins by presence, and the projection sees
             the one merged map the codec sees"
     (is (= {"className" "owned" "title" "from-caller"}
-           (ht/element-props [:div (merge {:class "hijacked" :title "from-caller"}
+           (rf.hicasso.test/element-props [:div (merge {:class "hijacked" :title "from-caller"}
                                           {:class "owned"})]))))
 
   (testing "a lowered handler records as 004B's opaque marker — the site's
             existence and spelling are the claim, its behaviour is L3"
     (is (= {"onClick" {:rf.ui/opaque :fn}}
-           (ht/element-props [:button {:on-click [:tk/toggle 1]}]))))
+           (rf.hicasso.test/element-props [:button {:on-click [:tk/toggle 1]}]))))
 
   (testing "and a non-native form is refused rather than projected"
     (is (= {:rf.error/id :rf.error/hicasso-test-not-a-native-form
             :where       're-frame.hicasso.test}
-           (refusal (outcome #(ht/element-props [greeting {}])) [])))))
+           (refusal (outcome #(rf.hicasso.test/element-props [greeting {}])) [])))))
 
 (deftest materialize-is-the-runtime-marker-law
   (testing "`::h/value` takes the target's value"
     (is (= [:tk/set-filter "done"]
-           (ht/materialize [:tk/set-filter :re-frame.hicasso/value]
+           (rf.hicasso.test/materialize [:tk/set-filter :re-frame.hicasso/value]
                            {:value "done"}))))
 
   (testing "`::h/checked` takes the target's checked state, and a marker
             that is not present is left alone — the substitution is a
             roster, not a positional rule"
     (is (= [:tk/set 7 true]
-           (ht/materialize [:tk/set 7 :re-frame.hicasso/checked]
+           (rf.hicasso.test/materialize [:tk/set 7 :re-frame.hicasso/checked]
                            {:value "ignored" :checked true}))))
 
   (testing "an intent carrying no marker comes back identical, so a green
             equality above is not a green everything"
-    (is (= [:tk/toggle 1] (ht/materialize [:tk/toggle 1] {:value "x"}))))
+    (is (= [:tk/toggle 1] (rf.hicasso.test/materialize [:tk/toggle 1] {:value "x"}))))
 
   (testing "and a non-vector refuses"
     (is (= {:rf.error/id :rf.error/hicasso-test-not-an-intent
             :where       're-frame.hicasso.test}
-           (refusal (outcome #(ht/materialize {:not "an intent"} {})) [])))))
+           (refusal (outcome #(rf.hicasso.test/materialize {:not "an intent"} {})) [])))))
 
 (deftest the-controlled-and-revision-laws-read-as-data
   (testing "a text input carrying a value and a change handler IS the
             controlled door — the runtime's own selection, not a
             re-derivation of it"
-    (is (true? (ht/controlled? [:input {:type  "text"
+    (is (true? (rf.hicasso.test/controlled? [:input {:type  "text"
                                         :value "milk"
                                         :on-change [:tk/edit]}]))))
 
   (testing "and the near neighbours are not: an uncontrolled input, and a
             div carrying the identical props"
-    (is (false? (ht/controlled? [:input {:type "text"}])))
-    (is (false? (ht/controlled? [:div {:value "milk" :on-change [:tk/edit]}]))))
+    (is (false? (rf.hicasso.test/controlled? [:input {:type "text"}])))
+    (is (false? (rf.hicasso.test/controlled? [:div {:value "milk" :on-change [:tk/edit]}]))))
 
   (testing "the revision trigger reads off the author's own attribute map"
-    (is (= 7 (ht/revision [:input {:value "milk"
+    (is (= 7 (rf.hicasso.test/revision [:input {:value "milk"
                                    :re-frame.hicasso/revision 7}])))
-    (is (nil? (ht/revision [:input {:value "milk"}])))))
+    (is (nil? (rf.hicasso.test/revision [:input {:value "milk"}])))))
 
 ;; ---------------------------------------------------------------------------
 ;; L1 — intent capture at Spec 009's observation port
@@ -305,7 +305,7 @@
   (seeded!)
   (testing "what the frame dispatched, in order, as the vectors themselves"
     (let [{:keys [intents value]}
-          (ht/capture-intents frame-id
+          (rf.hicasso.test/capture-intents frame-id
                               (fn []
                                 (rf/with-frame frame-id
                                   (rf/dispatch-sync [:tk/toggle 1])
@@ -318,12 +318,12 @@
             without this row an assertion of [] could be green for a
             capture that was never armed"
     (is (= {:value :nothing-dispatched :intents []}
-           (ht/capture-intents frame-id (fn [] :nothing-dispatched)))))
+           (rf.hicasso.test/capture-intents frame-id (fn [] :nothing-dispatched)))))
 
   (testing "another frame's events are not this frame's capture"
     (rf/make-frame {:id ::other})
     (rf/with-frame ::other (rf/dispatch-sync [:tk/seed {:todos {}}]))
-    (is (= [] (:intents (ht/capture-intents
+    (is (= [] (:intents (rf.hicasso.test/capture-intents
                           frame-id
                           (fn [] (rf/with-frame ::other
                                    (rf/dispatch-sync [:tk/seed {:todos {}}])))))))))
@@ -336,18 +336,18 @@
   "A body written exactly as an author writes one: `h/sub` from the public
   door, hiccup out, no hooks and nothing React-shaped."
   [{:keys [id]}]
-  (let [todo (h/sub [:tk/todo id])]
+  (let [todo (rf.hicasso/sub [:tk/todo id])]
     [:li.row {:data-id id :on-click [:tk/toggle id]}
      [:span.text (:text todo)]
      (when (:done todo) [:span.done "✓"])]))
 
 (deftest render-answers-the-versioned-004b-tree
-  (let [tree (ht/tree [todo-row-body {:id 1}]
+  (let [tree (rf.hicasso.test/tree [todo-row-body {:id 1}]
                         {:subs {[:tk/todo 1] {:text "milk" :done false}}})]
 
     (testing "the root carries the version gate every consumer validates first"
       (is (= 1 (:rf.ui/tree-version tree)))
-      (is (= 1 ht/tree-version)))
+      (is (= 1 rf.hicasso.test/tree-version)))
 
     (testing "the whole tree is plain serialisable data — no wrapper types,
               no metadata-carried contract"
@@ -360,50 +360,50 @@
       (is (= tree (reader/read-string (pr-str tree)))))
 
     (testing "the projections read it"
-      (is (= "milk" (ht/text tree)))
-      (is (= :span (:tag (ht/find tree #(= "text" (:class (:attrs %)))))))
-      (is (= 2 (count (ht/find-all tree map?))))
-      (is (= [:tk/toggle 1] (:on-click (ht/attrs tree)))))
+      (is (= "milk" (rf.hicasso.test/text tree)))
+      (is (= :span (:tag (rf.hicasso.test/find tree #(= "text" (:class (:attrs %)))))))
+      (is (= 2 (count (rf.hicasso.test/find-all tree map?))))
+      (is (= [:tk/toggle 1] (:on-click (rf.hicasso.test/attrs tree)))))
 
     (testing "and `attrs` MERGES events with attributes, which is the one
               attribute read — a keyword lookup on the node is a field miss"
-      (is (= {:data-id 1 :class "row" :on-click [:tk/toggle 1]} (ht/attrs tree)))
+      (is (= {:data-id 1 :class "row" :on-click [:tk/toggle 1]} (rf.hicasso.test/attrs tree)))
       (is (nil? (:on-click tree)))))
 
   (testing "the branch not taken contributes no node, and the branch taken
             does — so the row above is reading the body's control flow
             rather than a fixed shape"
-    (let [tree (ht/tree [todo-row-body {:id 1}]
+    (let [tree (rf.hicasso.test/tree [todo-row-body {:id 1}]
                           {:subs {[:tk/todo 1] {:text "milk" :done true}}})]
-      (is (= "milk✓" (ht/text tree)))
-      (is (some? (ht/find tree #(= "done" (:class (:attrs %)))))))))
+      (is (= "milk✓" (rf.hicasso.test/text tree)))
+      (is (some? (rf.hicasso.test/find tree #(= "done" (:class (:attrs %)))))))))
 
 (deftest the-tree-carries-intents-as-data
-  (let [tree (ht/tree [(fn [_]
+  (let [tree (rf.hicasso.test/tree [(fn [_]
                            [:ul
                             [:li {:on-click [:tk/toggle 1]} "one"]
                             [:li {:on-click [:tk/toggle 2]
                                   :on-key-down {"Enter"  [:tk/commit 2]
                                                 "Escape" [:tk/cancel 2]}} "two"]
-                            [:li {:on-click (h/event [_] [:tk/opaque])} "three"]])
+                            [:li {:on-click (rf.hicasso/event [_] [:tk/opaque])} "three"]])
                          {}])]
     (testing "every literal intent site, in document order, including both
               branches of a data key-map"
       (is (= [[:tk/toggle 1] [:tk/toggle 2] [:tk/commit 2] [:tk/cancel 2]]
-             (ht/intents tree))))
+             (rf.hicasso.test/intents tree))))
 
     (testing "a callback site contributes nothing — it is exactly the site
               whose intent is not data — and records as the opaque marker"
       (is (= {:rf.ui/opaque :fn}
-             (:on-click (ht/attrs (ht/find tree #(= "three" (ht/text %))))))))
+             (:on-click (rf.hicasso.test/attrs (rf.hicasso.test/find tree #(= "three" (rf.hicasso.test/text %))))))))
 
     (testing "and the empty case answers empty, so an equality against a
               stated expectation cannot pass vacuously"
-      (is (= [] (ht/intents (ht/tree [(fn [_] [:p "no handlers here"]) {}])))))))
+      (is (= [] (rf.hicasso.test/intents (rf.hicasso.test/tree [(fn [_] [:p "no handlers here"]) {}])))))))
 
 (deftest a-child-boundary-records-the-call-and-never-its-rendering
-  (let [tree (ht/tree [(fn [_] [:div [greeting {:key 9 :who "ada"} "extra"]]) {}])
-        node (ht/find tree :view-id)]
+  (let [tree (rf.hicasso.test/tree [(fn [_] [:div [greeting {:key 9 :who "ada"} "extra"]]) {}])
+        node (rf.hicasso.test/find tree :view-id)]
     (testing "the node is the CALL: the view id, the props the call site
               passed, and the children it wrote"
       (is (= {:view-id  "re-frame.hicasso.test-kit-cljs-test/greeting"
@@ -415,8 +415,8 @@
     (testing "and nothing of the child's own rendering is in it — the body
               did not run, so `text` answers the call site's children and
               the word the child would have rendered is absent"
-      (is (= "extra" (ht/text node)))
-      (is (nil? (re-find #"hi ada" (ht/text tree)))))))
+      (is (= "extra" (rf.hicasso.test/text node)))
+      (is (nil? (re-find #"hi ada" (rf.hicasso.test/text tree)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; L2 — honest opacity. Every refusal, with its legal twin.
@@ -429,28 +429,28 @@
   ;; The refusal is not gone — the last row below is it, reached the one way
   ;; it can still be reached.
   (testing "a minted `h/defview` head renders, and answers the body's tree"
-    (let [tree (ht/tree [farewell {:who "ada"}])]
+    (let [tree (rf.hicasso.test/tree [farewell {:who "ada"}])]
       (is (= :p (:tag tree)))
-      (is (= "bye ada" (ht/text tree)))))
+      (is (= "bye ada" (rf.hicasso.test/text tree)))))
 
   (testing "and it is the SAME tree the body answers when named directly —
             which is what running a view AS WRITTEN has to mean, and rules
             out a second rendering path that merely agrees on the text"
-    (is (= (ht/tree [farewell-text {:who "ada"}])
-           (ht/tree [farewell {:who "ada"}]))))
+    (is (= (rf.hicasso.test/tree [farewell-text {:who "ada"}])
+           (rf.hicasso.test/tree [farewell {:who "ada"}]))))
 
   (testing "what it cost is ONE own property on the head: the head is still
             the function `defview` defined and still a boundary, so no memo
             object escaped as the public representation (rf2-2rtt6.52)"
     (is (fn? farewell))
-    (is (true? (ht/boundary? farewell)))
-    (is (fn? (codec/retained-body farewell))))
+    (is (true? (rf.hicasso.test/boundary? farewell)))
+    (is (fn? (rf.hicasso.impl.codec/retained-body farewell))))
 
   (testing "the retention is DEV-ONLY, so the refusal is still live and still
             named: a boundary head with no retained body — an `:advanced` +
             `goog.DEBUG=false` mint — refuses with the id, the view and the
             L3 pointer it always carried"
-    (let [o (outcome #(ht/tree [unretained-head {:who "ada"}]))]
+    (let [o (outcome #(rf.hicasso.test/tree [unretained-head {:who "ada"}]))]
       (is (= {:rf.error/id :rf.error/hicasso-test-boundary-body-not-retained
               :where       're-frame.hicasso.test
               :view        "re-frame.hicasso.test-kit-cljs-test/unretained-head"}
@@ -467,46 +467,46 @@
   ;; naming no view, no id and no macro.
   (testing "the helper the body calls is the author's, so a view whose helper
             is named after it renders rather than recursing"
-    (let [tree (ht/tree [greeting {:who "ada"}])]
+    (let [tree (rf.hicasso.test/tree [greeting {:who "ada"}])]
       (is (= :p (:tag tree)))
-      (is (= "hi ada" (ht/text tree)))))
+      (is (= "hi ada" (rf.hicasso.test/text tree)))))
 
   (testing "and it is the SAME tree the helper answers when rendered directly,
             which rules out a body that recursed once and happened to stop"
-    (is (= (ht/tree [greeting-body {:who "ada"}])
-           (ht/tree [greeting {:who "ada"}]))))
+    (is (= (rf.hicasso.test/tree [greeting-body {:who "ada"}])
+           (rf.hicasso.test/tree [greeting {:who "ada"}]))))
 
   (testing "the control: `farewell`, whose helper is NOT named after it, was
             always renderable — so the rows above measure the collision and
             not the kit's minted-head path in general"
-    (is (= "bye ada" (ht/text (ht/tree [farewell {:who "ada"}]))))))
+    (is (= "bye ada" (rf.hicasso.test/text (rf.hicasso.test/tree [farewell {:who "ada"}]))))))
 
 (deftest a-host-crossing-is-opaque-at-l2
   (testing "at the root"
     (is (= {:rf.error/id :rf.error/hicasso-test-host-is-opaque
             :where       're-frame.hicasso.test
             :host        "re-frame.hicasso.test-kit-cljs-test/badge"}
-           (refusal (outcome #(ht/tree [badge {:label "x"}])) [:host]))))
+           (refusal (outcome #(rf.hicasso.test/tree [badge {:label "x"}])) [:host]))))
 
   (testing "and inside a body's own tree, which is where a crossing
             actually appears"
     (is (= {:rf.error/id :rf.error/hicasso-test-host-is-opaque
             :where       're-frame.hicasso.test
             :host        "re-frame.hicasso.test-kit-cljs-test/badge"}
-           (refusal (outcome #(ht/tree [(fn [_] [:div [badge {:label "x"}]]) {}]))
+           (refusal (outcome #(rf.hicasso.test/tree [(fn [_] [:div [badge {:label "x"}]]) {}]))
                     [:host]))))
 
   (testing "the legal twin: the same body WITHOUT the crossing renders, so
             the refusal is the crossing's and not the div's"
     (is (= {:rf.ui/tree-version 1 :tag :div}
-           (ht/tree [(fn [_] [:div]) {}])))))
+           (rf.hicasso.test/tree [(fn [_] [:div]) {}])))))
 
 (deftest raw-react-is-opaque-at-l2
   (testing "an element only React can interpret has no semantic form here"
     (is (= {:rf.error/id :rf.error/hicasso-test-react-is-opaque
             :where       're-frame.hicasso.test}
            (refusal (outcome
-                      #(ht/tree [(fn [_]
+                      #(rf.hicasso.test/tree [(fn [_]
                                      [:div (react/createElement "b" nil "raw")])
                                    {}]))
                     []))))
@@ -525,7 +525,7 @@
             brings the runtime's reason with it or it is not a borrowing."
     (is (= {:rf.error/id :rf.error/hicasso-deferred-read-at-boundary
             :where       're-frame.hicasso.test}
-           (refusal (outcome #(ht/tree [(fn [_] [:div (delay [:p])]) {}]))
+           (refusal (outcome #(rf.hicasso.test/tree [(fn [_] [:div (delay [:p])]) {}]))
                     [])))))
 
 (deftest a-plain-function-in-head-position-refuses-as-the-runtime-does
@@ -533,12 +533,12 @@
             too rather than teaching a spelling the runtime rejects"
     (is (= {:rf.error/id :rf.error/hicasso-test-plain-fn-head
             :where       're-frame.hicasso.test}
-           (refusal (outcome #(ht/tree [(fn [_] [:div [greeting-body {:who "x"}]])
+           (refusal (outcome #(rf.hicasso.test/tree [(fn [_] [:div [greeting-body {:who "x"}]])
                                           {}]))
                     []))))
 
   (testing "the legal twin: the same function IS the root form's head"
-    (is (= "hi x" (ht/text (ht/tree [greeting-body {:who "x"}]))))))
+    (is (= "hi x" (rf.hicasso.test/text (rf.hicasso.test/tree [greeting-body {:who "x"}]))))))
 
 ;; ---------------------------------------------------------------------------
 ;; L2 — the injected read fixtures
@@ -547,7 +547,7 @@
 (deftest a-read-no-fixture-answers-refuses-rather-than-resolving-to-nil
   (testing "the refusal names the query, so the message is actionable
             without a debugger"
-    (let [o (outcome #(ht/tree [todo-row-body {:id 3}] {:subs {}}))]
+    (let [o (outcome #(rf.hicasso.test/tree [todo-row-body {:id 3}] {:subs {}}))]
       (is (= {:rf.error/id :rf.error/hicasso-test-missing-read-fixture
               :where       're-frame.hicasso.test
               :phase       :after-body-run
@@ -558,20 +558,20 @@
             renders — so the refusal is about the fixture and not about a
             body that was broken anyway"
     (is (= "bread"
-           (ht/text (ht/tree [todo-row-body {:id 3}]
+           (rf.hicasso.test/text (rf.hicasso.test/tree [todo-row-body {:id 3}]
                                {:subs {[:tk/todo 3] {:text "bread"}}})))))
 
   (testing "a fixture supplied but NOT read is not an error — the read set
             is what the body did, not what the caller offered"
     (is (= "milk"
-           (ht/text (ht/tree [todo-row-body {:id 1}]
+           (rf.hicasso.test/text (rf.hicasso.test/tree [todo-row-body {:id 1}]
                                {:subs {[:tk/todo 1] {:text "milk"}
                                         [:tk/filter] :all}})))))
 
   (testing "and :subs itself is checked"
     (is (= {:rf.error/id :rf.error/hicasso-test-bad-reads
             :where       're-frame.hicasso.test}
-           (refusal (outcome #(ht/tree [greeting-body {}] {:subs [:not :a :map]}))
+           (refusal (outcome #(rf.hicasso.test/tree [greeting-body {}] {:subs [:not :a :map]}))
                     [])))))
 
 (deftest the-option-roster-is-closed-so-a-key-nothing-reads-cannot-look-set
@@ -587,7 +587,7 @@
     (is (= {:rf.error/id :rf.error/hicasso-test-bad-option
             :where       're-frame.hicasso.test
             :unknown     [:reads]}
-           (refusal (outcome #(ht/tree [greeting-body {:who "ada"}]
+           (refusal (outcome #(rf.hicasso.test/tree [greeting-body {:who "ada"}]
                                        {:reads {[:tk/todo 1] {:text "milk"}}}))
                     [:unknown]))))
 
@@ -596,56 +596,56 @@
             reported a missing read fixture rather than the bad option"
     (is (= :rf.error/hicasso-test-bad-option
            (:rf.error/id
-            (:refused (outcome #(ht/tree [todo-row-body {:id 3}]
+            (:refused (outcome #(rf.hicasso.test/tree [todo-row-body {:id 3}]
                                          {:reads {[:tk/todo 3] {:text "bread"}}})))))))
 
   (testing "an unrecognised key is refused whatever it is spelled, and the
             refusal NAMES what it did not recognise — sorted, so two typos
             read the same way twice"
     (is (= [:sbus :subz]
-           (:unknown (:refused (outcome #(ht/tree [greeting-body {:who "ada"}]
+           (:unknown (:refused (outcome #(rf.hicasso.test/tree [greeting-body {:who "ada"}]
                                                   {:subz {} :sbus {}})))))))
 
   (testing "options that are not a map at all"
     (is (= {:rf.error/id :rf.error/hicasso-test-bad-option
             :where       're-frame.hicasso.test
             :value       [:subs {}]}
-           (refusal (outcome #(ht/tree [greeting-body {:who "ada"}] [:subs {}]))
+           (refusal (outcome #(rf.hicasso.test/tree [greeting-body {:who "ada"}] [:subs {}]))
                     [:value]))))
 
   (testing "and the legal twins, which are what say the roster refuses the
             unknown rather than everything: the one-arg default still
             renders, and so does a correctly spelled :subs"
-    (is (= "hi ada" (ht/text (ht/tree [greeting-body {:who "ada"}]))))
-    (is (= "hi ada" (ht/text (ht/tree [greeting-body {:who "ada"}] {}))))
+    (is (= "hi ada" (rf.hicasso.test/text (rf.hicasso.test/tree [greeting-body {:who "ada"}]))))
+    (is (= "hi ada" (rf.hicasso.test/text (rf.hicasso.test/tree [greeting-body {:who "ada"}] {}))))
     (is (= "milk"
-           (ht/text (ht/tree [todo-row-body {:id 1}]
+           (rf.hicasso.test/text (rf.hicasso.test/tree [todo-row-body {:id 1}]
                              {:subs {[:tk/todo 1] {:text "milk"}}}))))))
 
 (deftest the-read-resolver-is-discardable
   (testing "the fixture cells exist for the body run and are gone when it
             returns — nothing subscribed, nothing watched, nothing left to
             dispose"
-    (let [before (count @collector/!cells)]
-      (ht/tree [todo-row-body {:id 1}] {:subs {[:tk/todo 1] {:text "milk"}}})
-      (is (= before (count @collector/!cells)))))
+    (let [before (count @rf.hicasso.impl.collector/!cells)]
+      (rf.hicasso.test/tree [todo-row-body {:id 1}] {:subs {[:tk/todo 1] {:text "milk"}}})
+      (is (= before (count @rf.hicasso.impl.collector/!cells)))))
 
   (testing "and the runtime's own retention tables are as they were — the
             render acquired no cell, took no reference and recorded no edge"
-    (let [before (dissoc (runtime/residue) :entries)]
-      (ht/tree [todo-row-body {:id 1}] {:subs {[:tk/todo 1] {:text "milk"}}})
-      (is (= before (dissoc (runtime/residue) :entries)))
+    (let [before (dissoc (rf.hicasso.test.runtime/residue) :entries)]
+      (rf.hicasso.test/tree [todo-row-body {:id 1}] {:subs {[:tk/todo 1] {:text "milk"}}})
+      (is (= before (dissoc (rf.hicasso.test.runtime/residue) :entries)))
       (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0}
-             (dissoc (runtime/residue) :entries))
+             (dissoc (rf.hicasso.test.runtime/residue) :entries))
           "and the baseline itself is the empty one, so the equality above
            is not two identical wrong numbers")))
 
   (testing "the probe frame is minted per call, so two renders cannot see
             each other's fixtures"
-    (is (= "milk" (ht/text (ht/tree [todo-row-body {:id 1}]
+    (is (= "milk" (rf.hicasso.test/text (rf.hicasso.test/tree [todo-row-body {:id 1}]
                                       {:subs {[:tk/todo 1] {:text "milk"}}}))))
     (is (= :rf.error/hicasso-test-missing-read-fixture
-           (:rf.error/id (:refused (outcome #(ht/tree [todo-row-body {:id 1}]
+           (:rf.error/id (:refused (outcome #(rf.hicasso.test/tree [todo-row-body {:id 1}]
                                                         {:subs {}}))))))))
 
 (deftest the-body-runs-on-the-runtime-s-own-path
@@ -654,8 +654,8 @@
             is what says this harness runs bodies rather than imitating one"
     (let [escaped (volatile! nil)
           o (outcome
-              #(ht/tree [(fn [_]
-                             (vreset! escaped (fn [] (h/sub [:tk/filter])))
+              #(rf.hicasso.test/tree [(fn [_]
+                             (vreset! escaped (fn [] (rf.hicasso/sub [:tk/filter])))
                              [:p])
                            {}]))]
       (is (map? (:returned o)) "the body itself is legal")
@@ -665,9 +665,9 @@
 
   (testing "and the body-run counter moved, so the row above is not green
             for a body that never ran"
-    (runtime/reset-body-runs!)
-    (ht/tree [greeting-body {:who "ada"}])
-    (is (= 1 (runtime/body-runs)))))
+    (rf.hicasso.test.runtime/reset-body-runs!)
+    (rf.hicasso.test/tree [greeting-body {:who "ada"}])
+    (is (= 1 (rf.hicasso.test.runtime/body-runs)))))
 
 ;; ---------------------------------------------------------------------------
 ;; L2 — the projections' own refusals
@@ -678,19 +678,19 @@
             whichever the discrimination order reaches first"
     (is (= :rf.error/ui-tree-malformed
            (:rf.error/id
-            (:refused (outcome #(ht/attrs {:tag :p :view-id "x"})))))))
+            (:refused (outcome #(rf.hicasso.test/attrs {:tag :p :view-id "x"})))))))
 
   (testing "text content is not a node, at either projection"
     (is (= :rf.error/ui-tree-malformed
-           (:rf.error/id (:refused (outcome #(ht/attrs "milk"))))))
+           (:rf.error/id (:refused (outcome #(rf.hicasso.test/attrs "milk"))))))
     (is (= :rf.error/ui-tree-malformed
-           (:rf.error/id (:refused (outcome #(ht/text "milk")))))))
+           (:rf.error/id (:refused (outcome #(rf.hicasso.test/text "milk")))))))
 
   (testing "and nil threads through a missed traversal rather than throwing,
             so `(attrs (find …))` nil-puns"
-    (is (nil? (ht/attrs nil)))
-    (is (nil? (ht/text nil)))
-    (is (nil? (ht/find {:rf.ui/tree-version 1 :tag :p} #(= :div (:tag %)))))))
+    (is (nil? (rf.hicasso.test/attrs nil)))
+    (is (nil? (rf.hicasso.test/text nil)))
+    (is (nil? (rf.hicasso.test/find {:rf.ui/tree-version 1 :tag :p} #(= :div (:tag %)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; L0 — the ladder is data, and the refusals cite it
@@ -699,17 +699,17 @@
 (deftest the-ladder-is-the-single-source-of-the-tier-vocabulary
   (testing "five rows, in tier order, each naming what it proves and the
             mechanism it is written with"
-    (is (= [:l0 :l1 :l2 :l3 :l4] (mapv :tier ht/ladder)))
+    (is (= [:l0 :l1 :l2 :l3 :l4] (mapv :tier rf.hicasso.test/ladder)))
     (is (every? (fn [row] (and (string? (:proves row)) (string? (:mechanism row))))
-                ht/ladder)))
+                rf.hicasso.test/ladder)))
 
   (testing "this namespace ships L1 and L2 and says so, which is what makes
             a reader's `where do I write this` answerable from data"
-    (is (= [:l1 :l2] (mapv :tier (filterv :here? ht/ladder)))))
+    (is (= [:l1 :l2] (mapv :tier (filterv :here? rf.hicasso.test/ladder)))))
 
   (testing "and an opacity refusal quotes the L3 row rather than restating
             it — so a tier description has one home"
-    (let [l3  (first (filterv #(= :l3 (:tier %)) ht/ladder))
-          msg (:message (outcome #(ht/tree [badge {}])))]
+    (let [l3  (first (filterv #(= :l3 (:tier %)) rf.hicasso.test/ladder))
+          msg (:message (outcome #(rf.hicasso.test/tree [badge {}])))]
       (is (str/includes? msg (:proves l3)))
       (is (str/includes? msg (:mechanism l3))))))

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_clock_dom_cljs_test.cljs
@@ -56,15 +56,15 @@
   (`:ns-regexp \"cljs-test$\"` matches `-dom-cljs-test`), and each row
   degrades there to a STATED skip rather than to a false green."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.motion :as motion]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.motion :as rf.hicasso.motion]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The screen
@@ -92,29 +92,29 @@
   rather than about rounding."
   1000)
 
-(h/defview tray
+(rf.hicasso/defview tray
   "A toast tray: presence over the keyed children a subscription
   supplies. The dismissed child declares its own exit appearance as data,
   which is what gives the rows below a second, independent reading of the
   same fact — the node's count, and the exit class on it."
   [_]
-  [motion/presence {:timeout-ms retention-ms}
-   (for [t (h/sub [::toasts])]
+  [rf.hicasso.motion/presence {:timeout-ms retention-ms}
+   (for [t (rf.hicasso/sub [::toasts])]
      [:div.toast {:key           t
-                  ::motion/unmounting {:class "toast toast--exit"}}
+                  ::rf.hicasso.motion/unmounting {:class "toast toast--exit"}}
       (name t)])])
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      ;; The MAP shape, because every row here is `async`. `cljs.test`
      ;; refuses an async test under a fn-form fixture and aborts the whole
      ;; run at this namespace.
      :async?        true
      :init-fn       (fn []
-                      (sup/leave-act-environment!)
-                      (collector/reset-runtime!))}))
+                      (rf.hicasso.roots-frames-support/leave-act-environment!)
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Reading the page
@@ -126,7 +126,7 @@
 (defn- two-toasts
   "One clocked mount of the tray, seeded with two toasts."
   []
-  (hm/mount! [tray] {:clock true :initial-events [[::set [:a :b]]]}))
+  (rf.hicasso.test.mounted/mount! [tray] {:clock true :initial-events [[::set [:a :b]]]}))
 
 ;; ---------------------------------------------------------------------------
 ;; Reading the PLATFORM — the five functions the clock replaces
@@ -227,15 +227,15 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-clock-retires-a-retained-child-and-only-at-its-deadline
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM, so no effect runs and no timer is armed")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM, so no effect runs and no timer is armed")
     (async done
       (let [m (two-toasts)]
         (testing "premise: both toasts are painted before anything leaves"
           (is (= 2 (toast-count m)))
           (is (nil? (exiting m))))
 
-        (hm/dispatch-and-settle! m [::set [:a]])
+        (rf.hicasso.test.mounted/dispatch-and-settle! m [::set [:a]])
 
         (testing "RETENTION: the dismissed toast outlives its data, wearing the
                   exit phase. This is the state every assertion below is
@@ -244,7 +244,7 @@
           (is (= 2 (toast-count m)) "the node survives the data — that is the module")
           (is (some? (exiting m)) "wearing the author's own `::motion/unmounting` class"))
 
-        (hm/advance-clock! m (dec retention-ms))
+        (rf.hicasso.test.mounted/advance-clock! m (dec retention-ms))
 
         (testing "ONE MILLISECOND SHORT — and it is still here. The retirement
                   belongs to the DEADLINE, not to the advance: a clock that
@@ -254,7 +254,7 @@
           (is (= 2 (toast-count m)))
           (is (some? (exiting m))))
 
-        (hm/advance-clock! m 1)
+        (rf.hicasso.test.mounted/advance-clock! m 1)
 
         (testing "AT the deadline it leaves. Nothing between this reading and
                   the one above except one virtual millisecond — no dispatch, no
@@ -269,8 +269,8 @@
                   this window, and a release that dropped them instead of
                   re-arming them would report residue the runtime was about to
                   release"
-          (-> (hm/unmount! m)
-              (hm/assert-clean!)
+          (-> (rf.hicasso.test.mounted/unmount! m)
+              (rf.hicasso.test.mounted/assert-clean!)
               (.then (fn [report]
                        (is (true? (:clean? report)))
                        (is (nil? (:leaked report)))
@@ -281,20 +281,20 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-virtual-instant-moves-and-the-wall-clock-does-not
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [m  (two-toasts)
             t0 (js/Date.now)]
 
-        (hm/advance-clock! m 250)
+        (rf.hicasso.test.mounted/advance-clock! m 250)
 
         (testing "the instant moved exactly as far as it was told — which is
                   what lets a timer callback's own deadline comparison come out
                   right (`impl.presence/expire` takes `now`)"
           (is (= (+ t0 250) (js/Date.now))))
 
-        (hm/advance-clock! m 60000)
+        (rf.hicasso.test.mounted/advance-clock! m 60000)
 
         (testing "AND THE WALL CLOCK DID NOT MOVE WITH IT. The `Date`
                   CONSTRUCTOR reads the system clock and is deliberately not
@@ -305,15 +305,15 @@
           (is (< 30000 (- (js/Date.now) (.getTime (js/Date.))))
               "the virtual instant has run away from the machine's own clock"))
 
-        (-> (hm/unmount! m) (hm/assert-clean!) (.then (fn [_] (done))))))))
+        (-> (rf.hicasso.test.mounted/unmount! m) (rf.hicasso.test.mounted/assert-clean!) (.then (fn [_] (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W3 — the window: installed by the mount, gone with it, and refused outside
 ;; ---------------------------------------------------------------------------
 
 (deftest the-clock-is-the-mounts-window-and-nothing-wider
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [platform (.-setTimeout js/globalThis)
             m        (two-toasts)]
@@ -321,7 +321,7 @@
         (testing "inside the window the platform's scheduler has been replaced"
           (is (not (identical? platform (.-setTimeout js/globalThis)))))
 
-        (hm/unmount! m)
+        (rf.hicasso.test.mounted/unmount! m)
 
         (testing "and the teardown puts it back. An instrument that rewrote the
                   platform and left it rewritten would make every later suite in
@@ -332,21 +332,21 @@
                   An advance with no clock under it would move nothing and
                   assert nothing — the row would go green for exactly the reason
                   it was written to rule out"
-          (let [thrown (try (hm/advance-clock! m 5) nil (catch :default e e))]
+          (let [thrown (try (rf.hicasso.test.mounted/advance-clock! m 5) nil (catch :default e e))]
             (is (some? thrown))
             (is (= {:ms 5 :frame (:frame m)} (ex-data thrown)))))
 
-        (-> (hm/assert-clean! m)
+        (-> (rf.hicasso.test.mounted/assert-clean! m)
             (.then (fn [_]
                      (testing "and a mount that never asked for one is refused
                                the same way"
-                       (let [plain  (hm/mount! [tray] {:initial-events [[::set [:a]]]})
-                             thrown (try (hm/advance-clock! plain 5) nil
+                       (let [plain  (rf.hicasso.test.mounted/mount! [tray] {:initial-events [[::set [:a]]]})
+                             thrown (try (rf.hicasso.test.mounted/advance-clock! plain 5) nil
                                          (catch :default e e))]
                          (is (some? thrown))
                          (is (= {:ms 5 :frame (:frame plain)} (ex-data thrown)))
-                         (-> (hm/unmount! plain)
-                             (hm/assert-clean!)
+                         (-> (rf.hicasso.test.mounted/unmount! plain)
+                             (rf.hicasso.test.mounted/assert-clean!)
                              (.then (fn [report]
                                       (is (true? (:clean? report)))
                                       (done)))))))))))))
@@ -369,12 +369,12 @@
 ;; it hangs, or it goes GREEN on a surface it never exercised.
 
 (deftest a-failed-clocked-mount-leaves-no-clock-installed
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM, so no root and no clock")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM, so no root and no clock")
     (async done
       (let [platform (platform-surface)
             frames   (set (rf/frame-ids))
-            thrown   (try (hm/mount! [tray] {:clock          true
+            thrown   (try (rf.hicasso.test.mounted/mount! [tray] {:clock          true
                                              :initial-events [[::set [:a]] [::boom]]})
                           nil
                           (catch :default e e))
@@ -407,11 +407,11 @@
           (let [m (two-toasts)]
             (is (not (identical? (:set-timeout platform) (.-setTimeout js/globalThis)))
                 "premise: this mount really installed a clock of its own")
-            (hm/unmount! m)
+            (rf.hicasso.test.mounted/unmount! m)
             (surface-is! platform (platform-surface)
                          "back after the only remaining holder let go")
             (install-surface! platform)
-            (-> (hm/assert-clean! m)
+            (-> (rf.hicasso.test.mounted/assert-clean! m)
                 (.then (fn [report]
                          (is (true? (:clean? report)))
                          ;; The last word is the platform's: a real timer,
@@ -438,8 +438,8 @@
 ;; and the peer's own teardown is then enough to put the platform back.
 
 (deftest a-failed-clocked-mount-releases-only-its-own-hold
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM, so no root and no clock")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM, so no root and no clock")
     (async done
       (let [platform (platform-surface)
             peer     (two-toasts)
@@ -448,7 +448,7 @@
         (testing "premise: the peer is standing on a clock"
           (is (not (identical? (:set-timeout platform) (:set-timeout clocked)))))
 
-        (let [thrown (try (hm/mount! [tray] {:clock true :initial-events [[::boom]]})
+        (let [thrown (try (rf.hicasso.test.mounted/mount! [tray] {:clock true :initial-events [[::boom]]})
                           nil
                           (catch :default e e))]
 
@@ -463,14 +463,14 @@
                     here, because a restored platform would leave these
                     globals looking fine to `identical?` on a later install
                     and still move nothing on an advance"
-            (hm/dispatch-and-settle! peer [::set [:a]])
+            (rf.hicasso.test.mounted/dispatch-and-settle! peer [::set [:a]])
             (is (= 2 (toast-count peer)) "retained, mid-exit")
-            (hm/advance-clock! peer (dec retention-ms))
+            (rf.hicasso.test.mounted/advance-clock! peer (dec retention-ms))
             (is (= 2 (toast-count peer)) "one millisecond short")
-            (hm/advance-clock! peer 1)
+            (rf.hicasso.test.mounted/advance-clock! peer 1)
             (is (= 1 (toast-count peer)) "and gone at its deadline")))
 
-        (hm/unmount! peer)
+        (rf.hicasso.test.mounted/unmount! peer)
 
         (testing "and now — the peer being the last holder — the platform comes
                   back. A failure that released NOTHING would leave a holder
@@ -480,7 +480,7 @@
 
         (install-surface! platform)
 
-        (-> (hm/assert-clean! peer)
+        (-> (rf.hicasso.test.mounted/assert-clean! peer)
             (.then (fn [report]
                      (is (true? (:clean? report)))
                      (done))))))))
@@ -507,8 +507,8 @@
 ;; out the ids a fresh page hands out.
 
 (deftest a-virtual-handle-cannot-alias-a-platform-one
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM, so no root and no clock")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM, so no root and no clock")
     (async done
       (let [platform              (platform-surface)
             {:keys [log surface]} (recorder platform)
@@ -548,14 +548,14 @@
 
           (testing "…and the virtual timers are untouched by it. A collision
                     would have cleared THIS one and left the real one running"
-            (hm/advance-clock! m 50)
+            (rf.hicasso.test.mounted/advance-clock! m 50)
             (is (= [:v1 :iv] @!fired)))
 
           (testing "and a SPENT virtual id — the ordinary cleanup of a timer
                     that has already fired — cannot cancel an unrelated real
                     timer. It is out of the table, so it goes to the platform;
                     it just names nothing the platform holds"
-            (hm/advance-clock! m 50)
+            (rf.hicasso.test.mounted/advance-clock! m 50)
             (is (= [:v1 :iv :v2 :iv] @!fired) "premise: v2 fired, so its id is stale")
             (js/clearTimeout v2)
             (is (not (cleared? r2)) "the real timer numbered 2 is still armed"))
@@ -563,14 +563,14 @@
           (testing "either clearer cancels either kind, as the platform's own
                     do — and on both sides of the boundary"
             (js/clearTimeout iv)
-            (hm/advance-clock! m 500)
+            (rf.hicasso.test.mounted/advance-clock! m 500)
             (is (= [:v1 :iv :v2 :iv] @!fired) "a clearTimeout retired the VIRTUAL interval")
             (js/clearInterval r2)
             (is (cleared? r2) "and a clearInterval reached the REAL timeout"))
 
-          (hm/unmount! m)
+          (rf.hicasso.test.mounted/unmount! m)
           (install-surface! platform)
-          (-> (hm/assert-clean! m)
+          (-> (rf.hicasso.test.mounted/assert-clean! m)
               (.then (fn [report]
                        (is (true? (:clean? report)))
                        (done)))))))))
@@ -592,8 +592,8 @@
 ;; reading here depends on the wall clock.
 
 (deftest an-interval-hands-back-the-deadline-it-had-left
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM, so no root and no clock")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM, so no root and no clock")
     (async done
       (let [platform                      (platform-surface)
             {:keys [log surface cancel!]} (recorder platform)
@@ -602,11 +602,11 @@
         (install-surface! surface)
         (let [m (two-toasts)]
           (js/setInterval (fn [& args] (swap! !ticks conj (vec args))) retention-ms "tick" 7)
-          (hm/advance-clock! m (dec retention-ms))
+          (rf.hicasso.test.mounted/advance-clock! m (dec retention-ms))
           (is (empty? @!ticks) "premise: one virtual millisecond short of the first tick")
 
           (let [mark (count @log)
-                _    (hm/unmount! m)
+                _    (rf.hicasso.test.mounted/unmount! m)
                 over (vec (drop mark @log))]
             (install-surface! platform)
 
@@ -641,7 +641,7 @@
                               after))
                     (doseq [e (intervals after)] (cancel! e))))))
 
-            (-> (hm/assert-clean! m)
+            (-> (rf.hicasso.test.mounted/assert-clean! m)
                 (.then (fn [report]
                          (is (true? (:clean? report)))
                          (done))))))))))
@@ -671,8 +671,8 @@
 ;; throw would only move the divergence.
 
 (deftest a-throwing-tick-does-not-disarm-the-handed-back-interval
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM, so no root and no clock")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM, so no root and no clock")
     (async done
       (let [platform                      (platform-surface)
             {:keys [log surface cancel!]} (recorder platform)
@@ -687,11 +687,11 @@
                             (when (= 1 (count @!ticks))
                               (throw (js/Error. "the first bridged tick throws, deliberately"))))
                           retention-ms "tick" 7)
-          (hm/advance-clock! m (dec retention-ms))
+          (rf.hicasso.test.mounted/advance-clock! m (dec retention-ms))
           (is (empty? @!ticks) "premise: one virtual millisecond short of the first tick")
 
           (let [mark (count @log)
-                _    (hm/unmount! m)
+                _    (rf.hicasso.test.mounted/unmount! m)
                 over (vec (drop mark @log))]
             (install-surface! platform)
 
@@ -740,7 +740,7 @@
                     (doseq [e cadence] (apply (:f e) (:args e)))
                     (is (= [["tick" 7] ["tick" 7]] @!ticks))))))
 
-            (-> (hm/assert-clean! m)
+            (-> (rf.hicasso.test.mounted/assert-clean! m)
                 (.then (fn [report]
                          (is (true? (:clean? report)))
                          (done))))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_dogfood_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_dogfood_cljs_test.cljs
@@ -46,12 +46,12 @@
   rows needed exactly one door, and the tree row is a claim the bench
   file could not make at all."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]))
 
 (def ^:private frame-id ::dogfood)
 (def ^:private new-draft-key ::new)
@@ -111,12 +111,12 @@
                                (assoc :next-id (inc id)))})))))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :init-fn       (fn []
                       (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-                      (collector/reset-runtime!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (defn- seeded!
   ([] (seeded! 3))
@@ -213,7 +213,7 @@
   (seeded! 3)
   (is (false? (read-sub [:dg/done? 1])))
   (let [{:keys [intents prevented?]}
-        (ht/fire! frame-id [:button {:on-click [:dg/toggle 1]} "toggle"] :on-click {})]
+        (rf.hicasso.test/fire! frame-id [:button {:on-click [:dg/toggle 1]} "toggle"] :on-click {})]
 
     (testing "the intent the position dispatched, as the vector itself"
       (is (= [[:dg/toggle 1]] intents)))
@@ -235,29 +235,29 @@
                                    :re-frame.hicasso/value]}]]
 
     (testing "the form IS the controlled door — the runtime's own selection"
-      (is (true? (ht/controlled? field)))
-      (is (= "" (get (ht/element-props field) "value"))))
+      (is (true? (rf.hicasso.test/controlled? field)))
+      (is (= "" (get (rf.hicasso.test/element-props field) "value"))))
 
     (testing "the marker is substituted from the event's own target, and the
               substituted intent is what reached the handler"
       (is (= {:intents [[:dg/edit-draft new-draft-key "mi"]] :prevented? false}
-             (ht/fire! frame-id field :on-input {:value "mi"})))
+             (rf.hicasso.test/fire! frame-id field :on-input {:value "mi"})))
       (is (= "mi" (read-sub [:dg/draft new-draft-key])))
       (is (= {:intents [[:dg/edit-draft new-draft-key "milk"]] :prevented? false}
-             (ht/fire! frame-id field :on-input {:value "milk"})))
+             (rf.hicasso.test/fire! frame-id field :on-input {:value "milk"})))
       (is (= "milk" (read-sub [:dg/draft new-draft-key]))))
 
     (testing "and the same substitution read as pure data agrees with what
               the fired handler dispatched — two doors, one law"
       (is (= [:dg/edit-draft new-draft-key "milk"]
-             (ht/materialize [:dg/edit-draft new-draft-key :re-frame.hicasso/value]
+             (rf.hicasso.test/materialize [:dg/edit-draft new-draft-key :re-frame.hicasso/value]
                              {:value "milk"}))))))
 
 (deftest l1-the-form-submits-once-and-prevents-the-browsers-navigation
   (seeded! 3)
   (send! [:dg/edit-draft new-draft-key "milk"])
   (let [{:keys [intents prevented?]}
-        (ht/fire! frame-id [:form {:on-submit [:dg/create]}] :on-submit {})]
+        (rf.hicasso.test/fire! frame-id [:form {:on-submit [:dg/create]}] :on-submit {})]
 
     (testing "the default action is prevented, by policy and without the
               author writing `::h/prevent` — `on-submit` carries it"
@@ -280,10 +280,10 @@
               expectation for both is SILENCE, which is a claim about the
               intents and not only about app-db"
       (is (= {:intents [] :prevented? false}
-             (ht/fire! frame-id field :on-key-down
+             (rf.hicasso.test/fire! frame-id field :on-key-down
                        {:key "Enter" :composing? true :key-code 13})))
       (is (= {:intents [] :prevented? false}
-             (ht/fire! frame-id field :on-key-down
+             (rf.hicasso.test/fire! frame-id field :on-key-down
                        {:key "Enter" :composing? false :key-code 229})))
       (is (= "todo 1" (:title (read-sub [:dg/todo 1]))))
       (is (= "renamed" (read-sub [:dg/draft 1])) "and the draft survives"))
@@ -291,28 +291,28 @@
     (testing "a settled Enter commits — the control that says the two rows
               above are silence rather than a dead handler"
       (is (= [[:dg/commit 1]]
-             (:intents (ht/fire! frame-id field :on-key-down
+             (:intents (rf.hicasso.test/fire! frame-id field :on-key-down
                                  {:key "Enter" :composing? false :key-code 13}))))
       (is (= "renamed" (:title (read-sub [:dg/todo 1])))))
 
     (testing "Escape takes the map's other branch"
       (send! [:dg/edit-draft 1 "second thoughts"])
       (is (= [[:dg/cancel 1]]
-             (:intents (ht/fire! frame-id field :on-key-down
+             (:intents (rf.hicasso.test/fire! frame-id field :on-key-down
                                  {:key "Escape" :composing? false :key-code 27}))))
       (is (= "" (read-sub [:dg/draft 1])))
       (is (= "renamed" (:title (read-sub [:dg/todo 1])))))
 
     (testing "and a key the map does not name dispatches nothing, so a
               key-map is not a catch-all wearing a lookup"
-      (is (= [] (:intents (ht/fire! frame-id field :on-key-down {:key "a"})))))))
+      (is (= [] (:intents (rf.hicasso.test/fire! frame-id field :on-key-down {:key "a"})))))))
 
 (deftest l1-a-position-the-form-does-not-write-refuses
   (testing "a silently absent handler is the fault this door exists to make
             loud, so naming one refuses rather than answering no intents —
             which would be indistinguishable from a handler that fired and
             dispatched nothing"
-    (let [refused (try (ht/fire! frame-id [:button {:on-click [:dg/toggle 1]}]
+    (let [refused (try (rf.hicasso.test/fire! frame-id [:button {:on-click [:dg/toggle 1]}]
                                  :on-double-click {})
                        nil
                        (catch :default e (ex-data e)))]
@@ -334,8 +334,8 @@
 
 (defn- row-body
   [{:keys [id]}]
-  (let [todo  (h/sub [:dg/todo id])
-        draft (h/sub [:dg/draft id])]
+  (let [todo  (rf.hicasso/sub [:dg/todo id])
+        draft (rf.hicasso/sub [:dg/draft id])]
     [:li.row {:data-id id}
      [:input.toggle {:type      "checkbox"
                      :checked   (:done? todo)
@@ -349,7 +349,7 @@
 
 (defn- filters-body
   [_]
-  (let [current (h/sub [:dg/filter])]
+  (let [current (rf.hicasso/sub [:dg/filter])]
     [:nav.filters
      (for [f [:all :active :done]]
        [:button.filter {:key      f
@@ -359,7 +359,7 @@
         (name f)])]))
 
 (deftest l2-the-rendered-row-carries-its-intents-as-data
-  (let [tree (ht/tree [row-body {:id 1}]
+  (let [tree (rf.hicasso.test/tree [row-body {:id 1}]
                         {:subs {[:dg/todo 1]  {:id 1 :title "todo 1" :done? false}
                                  [:dg/draft 1] ""}})]
 
@@ -372,43 +372,43 @@
               [:dg/commit 1]
               [:dg/cancel 1]
               [:dg/remove 1]]
-             (ht/intents tree))))
+             (rf.hicasso.test/intents tree))))
 
     (testing "the marker is retained as the authored keyword rather than
               resolved — a tree cannot know what a target will carry, and
               writing a value there would be the tree claiming one"
       (is (= [:dg/edit-draft 1 :re-frame.hicasso/value]
-             (:on-input (ht/attrs (ht/find tree #(= "draft" (:class (:attrs %)))))))))
+             (:on-input (rf.hicasso.test/attrs (rf.hicasso.test/find tree #(= "draft" (:class (:attrs %)))))))))
 
     (testing "the read values reached the markup"
-      (is (= "todo 1×" (ht/text tree)))
-      (is (false? (:checked (ht/attrs (ht/find tree #(= "toggle" (:class (:attrs %)))))))))
+      (is (= "todo 1×" (rf.hicasso.test/text tree)))
+      (is (false? (:checked (rf.hicasso.test/attrs (rf.hicasso.test/find tree #(= "toggle" (:class (:attrs %)))))))))
 
     (testing "and the control: the same body with a DONE to-do renders the
               other value, so the row above is reading the fixture"
-      (is (true? (:checked (ht/attrs (ht/find (ht/tree [row-body {:id 1}]
+      (is (true? (:checked (rf.hicasso.test/attrs (rf.hicasso.test/find (rf.hicasso.test/tree [row-body {:id 1}]
                                                          {:subs {[:dg/todo 1] {:done? true}
                                                                   [:dg/draft 1] ""}})
                                               #(= "toggle" (:class (:attrs %)))))))))))
 
 (deftest l2-a-dynamic-child-list-renders-inside-the-body-s-own-window
-  (let [tree (ht/tree [filters-body {}] {:subs {[:dg/filter] :active}})]
+  (let [tree (rf.hicasso.test/tree [filters-body {}] {:subs {[:dg/filter] :active}})]
 
     (testing "a `for` inside the body splices its members as children — the
               runtime's one-level flatten, not a second rule"
-      (is (= 3 (count (ht/find-all tree #(= :button (:tag %))))))
-      (is (= "allactivedone" (ht/text tree))))
+      (is (= 3 (count (rf.hicasso.test/find-all tree #(= :button (:tag %))))))
+      (is (= "allactivedone" (rf.hicasso.test/text tree))))
 
     (testing "each member keeps the key it was written with"
       (is (= [:all :active :done]
-             (mapv :key (ht/find-all tree #(= :button (:tag %)))))))
+             (mapv :key (rf.hicasso.test/find-all tree #(= :button (:tag %)))))))
 
     (testing "and the read taken INSIDE the loop is the read the fixture
               answered — which is what says the walk happened inside the
               body's own render window rather than after it"
       (is (= "filter on"
-             (:class (ht/attrs (ht/find tree #(= :active (:data-filter (:attrs %))))))))
+             (:class (rf.hicasso.test/attrs (rf.hicasso.test/find tree #(= :active (:data-filter (:attrs %))))))))
       (is (= "filter"
-             (:class (ht/attrs (ht/find tree #(= :all (:data-filter (:attrs %))))))))
+             (:class (rf.hicasso.test/attrs (rf.hicasso.test/find tree #(= :all (:data-filter (:attrs %))))))))
       (is (= [[:dg/set-filter :all] [:dg/set-filter :active] [:dg/set-filter :done]]
-             (ht/intents tree))))))
+             (rf.hicasso.test/intents tree))))))

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_dom_cljs_test.cljs
@@ -26,7 +26,7 @@
   (`cljs-test$` matches `-dom-cljs-test`), and every DOM claim degrades
   there to a STATED skip rather than to a false green."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.hicasso.test :as ht]))
+            [re-frame.hicasso.test :as rf.hicasso.test]))
 
 (defn- browser? []
   (and (exists? js/document) (some? (.-createElement js/document))))
@@ -54,7 +54,7 @@
 
       (testing "two pages written in different attribute orders are the same
                 page, which `innerHTML` alone cannot say"
-        (is (= (ht/canonical-dom a) (ht/canonical-dom b)))
+        (is (= (rf.hicasso.test/canonical-dom a) (rf.hicasso.test/canonical-dom b)))
         (is (not= (.-innerHTML a) (.-innerHTML b))
             "and the control: the raw serialisation genuinely differs, so the
              equality above is the comparator's answer and not the DOM's"))
@@ -62,24 +62,24 @@
       (testing "the names are sorted, so the canonical form is stated rather
                 than merely self-consistent"
         (is (= "<p class=\"row\" data-i=\"3\" id=\"one\">milk</p>"
-               (ht/canonical-dom a))))
+               (rf.hicasso.test/canonical-dom a))))
 
       (testing "a page that differs in an attribute VALUE is a different page"
-        (is (not= (ht/canonical-dom a) (ht/canonical-dom c))))
+        (is (not= (rf.hicasso.test/canonical-dom a) (rf.hicasso.test/canonical-dom c))))
 
       (testing "and so is one that differs in its text — without this the
                 comparator could be a constant and every parity claim made
                 through it would be vacuous"
-        (is (not= (ht/canonical-dom a) (ht/canonical-dom d))))
+        (is (not= (rf.hicasso.test/canonical-dom a) (rf.hicasso.test/canonical-dom d))))
 
       (testing "comments contribute nothing, because a comment is not the page"
-        (is (= (ht/canonical-dom a)
-               (ht/canonical-dom
+        (is (= (rf.hicasso.test/canonical-dom a)
+               (rf.hicasso.test/canonical-dom
                  (node! "<!-- note --><p id=\"one\" class=\"row\" data-i=\"3\">milk</p>")))))
 
       (testing "and a value that is not a DOM node refuses rather than
                 serialising to something plausible"
-        (let [refused (try (ht/canonical-dom {:tag :p}) nil
+        (let [refused (try (rf.hicasso.test/canonical-dom {:tag :p}) nil
                            (catch :default e (ex-data e)))]
           (is (= {:rf.error/id :rf.error/hicasso-test-not-a-dom-node
                   :where       're-frame.hicasso.test}

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
@@ -65,16 +65,16 @@
   compiles this namespace too (`cljs-test$` matches `-dom-cljs-test`), and
   each row degrades there to a STATED skip rather than to a false green."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.roots-frames-support :as sup]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.routing :as routing]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.routing :as rf.routing]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The screen — the dogfood row's shape, local to this file
@@ -103,7 +103,7 @@
   [_props]
   [:span.unreachable "never rendered"])
 
-(h/defview row-with-a-plain-function-child
+(rf.hicasso/defview row-with-a-plain-function-child
   "A VALID registered view whose BODY is malformed. The view itself mounts;
   what the runtime refuses is the child head inside its body, from inside
   React's own render, which is the position a refusal is most easily lost
@@ -111,7 +111,7 @@
   [_]
   [:li.row [plain-child {}]])
 
-(h/defview row
+(rf.hicasso/defview row
   "One to-do, with a toggle button. Reads exactly ONE subscription, which
   is what makes the residue arithmetic below readable: one live row is one
   cell, one reader membership, one boundary and one edge.
@@ -120,7 +120,7 @@
   mounted under — see `roots-frames-isolation-dom-cljs-test`, which states
   the same rule for the same reason."
   [{:keys [id]}]
-  (let [todo (h/sub [::todo id])]
+  (let [todo (rf.hicasso/sub [::todo id])]
     [:li.row {:data-id id}
      [:span.title (:title todo)]
      [:span.done (str (boolean (:done? todo)))]
@@ -158,13 +158,13 @@
   registration, so calling it from the fixture as well as at load costs
   nothing."
   []
-  (routing/reg-route here  {:doc "W7's first page."}  "/hicasso-test-kit-mounted")
-  (routing/reg-route there {:doc "W7's second page."} "/hicasso-test-kit-mounted/there")
+  (rf.routing/reg-route here  {:doc "W7's first page."}  "/hicasso-test-kit-mounted")
+  (rf.routing/reg-route there {:doc "W7's second page."} "/hicasso-test-kit-mounted/there")
   nil)
 
 (register-routes!)
 
-(h/defview two-pages
+(rf.hicasso/defview two-pages
   "The smallest page that can leave work ENQUEUED: an `h/route-link` and a
   reading of where the router thinks we are.
 
@@ -172,14 +172,14 @@
   is what claims the click, and if it did not, this page would navigate
   the test runner away."
   [_]
-  (let [id (h/sub [:rf.route/id])]
+  (let [id (rf.hicasso/sub [:rf.route/id])]
     [:div.pages
-     (h/route-link {:to there :class "to-there"} "go there")
+     (rf.hicasso/route-link {:to there :class "to-there"} "go there")
      [:span.where (if (= there id) "there" "here")]]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      ;; `nil` and not the default: a dynamic-var frame stamp left in ambient
      ;; scope would let a boundary that failed to resolve its own frame
      ;; answer that one instead, and the isolation row below would read a
@@ -190,8 +190,8 @@
      ;; this namespace.
      :async?        true
      :init-fn       (fn []
-                      (sup/leave-act-environment!)
-                      (collector/reset-runtime!)
+                      (rf.hicasso.roots-frames-support/leave-act-environment!)
+                      (rf.hicasso.impl.collector/reset-runtime!)
                       ;; The reset rolled the registrar back past the
                       ;; load-time registration above — see that comment.
                       (register-routes!))}))
@@ -206,15 +206,15 @@
 (defn- seeded
   "One mount of the row, under its own frame, seeded with three to-dos."
   ([] (seeded 1))
-  ([id] (hm/mount! [row {:id id}] {:initial-events [[::seed 3]]})))
+  ([id] (rf.hicasso.test.mounted/mount! [row {:id id}] {:initial-events [[::seed 3]]})))
 
 ;; ---------------------------------------------------------------------------
 ;; W1 — the dogfood claim, one rung up: a REAL click on a REAL page
 ;; ---------------------------------------------------------------------------
 
 (deftest l3-a-real-click-on-a-real-button-moves-the-real-page
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [m (seeded)]
         (testing "the mount rendered the seeded screen into a container that is
@@ -234,7 +234,7 @@
                   at L1 no element exists, so there is no bubbling, no default
                   action and no React event system"
           (.click (node-at m ".toggle"))
-          (hm/settle! m)
+          (rf.hicasso.test.mounted/settle! m)
           (is (= "true" (text-at m ".done")))
           (is (true? (:done? (rf/with-frame (:frame m)
                                (deref (rf/subscribe [::todo 1])))))))
@@ -242,15 +242,15 @@
         (testing "and dispatch-and-settle! drives the same page from OUTSIDE
                   it — the handle's frame, the runtime's synchronous door, the
                   commit landed before the next line"
-          (hm/dispatch-and-settle! m [::toggle 1])
+          (rf.hicasso.test.mounted/dispatch-and-settle! m [::toggle 1])
           (is (= "false" (text-at m ".done"))))
 
         (testing "teardown is clean, and this is the positive control the
                   sabotage rows below are measured against: without it, an
                   assert-clean! that never went green would be satisfied by an
                   instrument that always reds"
-          (-> (hm/unmount! m)
-              (hm/assert-clean!)
+          (-> (rf.hicasso.test.mounted/unmount! m)
+              (rf.hicasso.test.mounted/assert-clean!)
               (.then (fn [report]
                        (is (true? (:clean? report)))
                        (is (nil? (:leaked report)))
@@ -261,8 +261,8 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest l3-two-mounts-are-two-isolated-frames
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [a (seeded)
             b (seeded)]
@@ -276,26 +276,26 @@
                   structure and cannot repair it, which is why the claim is read
                   here rather than off the page"
           (is (= #{[(:frame a) [::todo 1]] [(:frame b) [::todo 1]]}
-                 (sup/cell-keys))
-              (str "got " (pr-str (sup/cell-keys))))
-          (is (= [1 1] [(sup/readers-of [(:frame a) [::todo 1]])
-                        (sup/readers-of [(:frame b) [::todo 1]])])
+                 (rf.hicasso.roots-frames-support/cell-keys))
+              (str "got " (pr-str (rf.hicasso.roots-frames-support/cell-keys))))
+          (is (= [1 1] [(rf.hicasso.roots-frames-support/readers-of [(:frame a) [::todo 1]])
+                        (rf.hicasso.roots-frames-support/readers-of [(:frame b) [::todo 1]])])
               "one reader each — a leak is TWO readers on ONE key"))
 
         (testing "a dispatch into A's frame moves A's page and NOT B's. This is
                   the property the whole framework rests on, and a facade that
                   let one mount reach the other would have broken it"
-          (hm/dispatch-and-settle! a [::toggle 1])
+          (rf.hicasso.test.mounted/dispatch-and-settle! a [::toggle 1])
           (is (= "true"  (text-at a ".done")))
           (is (= "false" (text-at b ".done"))))
 
         (testing "both come down clean, each measured against its own baseline"
-          (hm/unmount! a)
-          (hm/unmount! b)
-          (-> (hm/assert-clean! a)
+          (rf.hicasso.test.mounted/unmount! a)
+          (rf.hicasso.test.mounted/unmount! b)
+          (-> (rf.hicasso.test.mounted/assert-clean! a)
               (.then (fn [ra]
                        (is (true? (:clean? ra)))
-                       (hm/assert-clean! b)))
+                       (rf.hicasso.test.mounted/assert-clean! b)))
               (.then (fn [rb]
                        (is (true? (:clean? rb)))
                        (done)))))))))
@@ -305,8 +305,8 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest l3-assert-clean-sees-a-leaked-subscription
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [m      (seeded)
             ;; THE SABOTAGE. A second root, put up inside the mount's window
@@ -319,9 +319,9 @@
             ;; deliberately: a facade mount is a PEER and says so in the report
             ;; (`:standing`), and a peer explained by the instrument is not the
             ;; fault this row exists to detect.
-            orphan (mount/root! (mount/fresh-container!) (:frame m) [row {:id 2}])]
-        (hm/unmount! m)
-        (-> (hm/residue m)
+            orphan (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) (:frame m) [row {:id 2}])]
+        (rf.hicasso.test.mounted/unmount! m)
+        (-> (rf.hicasso.test.mounted/residue m)
             (.then (fn [report]
                      (testing "the instrument moved: the mount is not clean"
                        (is (false? (:clean? report)))
@@ -346,7 +346,7 @@
 
                      ;; Restore: the orphan is this row's, and it does not
                      ;; belong to the next one.
-                     (mount/release! orphan)
+                     (rf.hicasso.impl.mount/release! orphan)
 
                      ;; And FINALISE. `residue` reads; only `assert-clean!`
                      ;; records the verdict and releases this mount's private
@@ -355,15 +355,15 @@
                      ;; never be read — and holds the reset gate off zero for
                      ;; every row after it. The tests for a cleanliness
                      ;; instrument have to be clean themselves.
-                     (-> (hm/assert-clean! m)
+                     (-> (rf.hicasso.test.mounted/assert-clean! m)
                          (.then (fn [after]
                                   (is (true? (:clean? after))
                                       "the induced fault was repaired before the verdict")
                                   (done)))))))))))
 
 (deftest l3-assert-clean-sees-a-frame-the-app-left-behind
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [m (seeded)]
         ;; THE SABOTAGE. A frame opened inside the mount's window and never
@@ -371,8 +371,8 @@
         ;; a preview and forgets it. A count would say "one more frame"; the
         ;; report names the id, which is the one thing here a reader can act on.
         (rf/make-frame {:id ::spawned})
-        (hm/unmount! m)
-        (-> (hm/residue m)
+        (rf.hicasso.test.mounted/unmount! m)
+        (-> (rf.hicasso.test.mounted/residue m)
             (.then (fn [report]
                      (is (false? (:clean? report)))
                      (is (= #{::spawned} (:frames (:leaked report)))
@@ -384,29 +384,29 @@
                      (rf/destroy-frame! ::spawned)
 
                      ;; And FINALISE — see the row above.
-                     (-> (hm/assert-clean! m)
+                     (-> (rf.hicasso.test.mounted/assert-clean! m)
                          (.then (fn [after]
                                   (is (true? (:clean? after))
                                       "the spawned frame was destroyed before the verdict")
                                   (done)))))))))))
 
 (deftest l3-assert-clean-sees-a-root-that-was-never-unmounted
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [m (seeded)]
         ;; THE SABOTAGE. No unmount! at all. A live root's cells ARE residue by
         ;; every number in the census, so an instrument that only counted would
         ;; red with a leak report and send a reader hunting a subscription. The
         ;; missing teardown is reported as itself.
-        (-> (hm/residue m)
+        (-> (rf.hicasso.test.mounted/residue m)
             (.then (fn [report]
                      (is (true? (:still-mounted? report)))
                      (is (false? (:clean? report))
                          "the live root's own cell is above the baseline")
                      (is (= 1 (:cells (:leaked report))))
-                     (-> (hm/unmount! m)
-                         (hm/assert-clean!)
+                     (-> (rf.hicasso.test.mounted/unmount! m)
+                         (rf.hicasso.test.mounted/assert-clean!)
                          (.then (fn [after]
                                   (testing "and after the teardown it does go
                                             clean — the control that says the
@@ -438,22 +438,22 @@
 ;; would read as clean.
 
 (deftest l3-the-reset-gate-holds-while-a-sibling-mount-awaits-its-verdict
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [mb     (seeded 1)
-            orphan (mount/root! (mount/fresh-container!) (:frame mb) [row {:id 2}])
-            _      (hm/unmount! mb)
+            orphan (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) (:frame mb) [row {:id 2}])
+            _      (rf.hicasso.test.mounted/unmount! mb)
             ma     (seeded 2)]
-        (hm/unmount! ma)
-        (-> (hm/assert-clean! ma)
+        (rf.hicasso.test.mounted/unmount! ma)
+        (-> (rf.hicasso.test.mounted/assert-clean! ma)
             (.then
               (fn [ra]
                 (is (true? (:clean? ra))
                     (str "premise: A is clean — the orphan predates A's own "
                          "baseline, so nothing here is A's residue. Got: "
                          (pr-str (:leaked ra))))
-                (-> (hm/residue mb)
+                (-> (rf.hicasso.test.mounted/residue mb)
                     (.then
                       (fn [rb]
                         (is (false? (:clean? rb))
@@ -473,8 +473,8 @@
                         ;; states: the tests for a cleanliness instrument
                         ;; have to be clean themselves, and B's verdict is
                         ;; what lets the gate reach zero and reset.
-                        (mount/release! orphan)
-                        (-> (hm/assert-clean! mb)
+                        (rf.hicasso.impl.mount/release! orphan)
+                        (-> (rf.hicasso.test.mounted/assert-clean! mb)
                             (.then (fn [after]
                                      (is (true? (:clean? after))
                                          "the induced fault was repaired
@@ -486,12 +486,12 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest l3-render-changes-props-without-remounting
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [m  (seeded 1)
             li (node-at m ".row")]
-        (hm/rerender! m [row {:id 2}])
+        (rf.hicasso.test.mounted/rerender! m [row {:id 2}])
 
         (testing "the new props reached the body and the page moved"
           (is (= "todo 2" (text-at m ".title")))
@@ -502,8 +502,8 @@
                   door exists and a claim no semantic tree can make"
           (is (identical? li (node-at m ".row"))))
 
-        (-> (hm/unmount! m)
-            (hm/assert-clean!)
+        (-> (rf.hicasso.test.mounted/unmount! m)
+            (rf.hicasso.test.mounted/assert-clean!)
             (.then (fn [report] (is (true? (:clean? report))) (done))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -511,8 +511,8 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest l3-hydrate-adopts-the-server-nodes
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [;; A throwaway frame, purely to produce the bytes an SSR route
             ;; would deliver. Released before anything is measured, so the
@@ -520,36 +520,36 @@
             bytes-frame ::server
             _           (rf/make-frame {:id bytes-frame
                                         :initial-events [[::seed 3]]})
-            html        (sup/server-html! bytes-frame [row {:id 1}])
+            html        (rf.hicasso.roots-frames-support/server-html! bytes-frame [row {:id 1}])
             _           (rf/destroy-frame! bytes-frame)
-            _           (collector/reset-runtime!)
+            _           (rf.hicasso.impl.collector/reset-runtime!)
             ;; The page as it arrives: the server's nodes, stamped with an
             ;; EXPANDO. An expando cannot survive serialisation and cannot be
             ;; reconstructed, so a node still carrying it is THE node the
             ;; server markup produced — the only observable that tells adoption
             ;; from a client render that happens to agree.
-            container   (sup/stamp-server-nodes! (sup/server-dom! html))]
-        (is (sup/every-server-node? container ".row") "premise: the bytes were stamped")
-        (-> (hm/hydrate! [row {:id 1}] {:container container
+            container   (rf.hicasso.roots-frames-support/stamp-server-nodes! (rf.hicasso.roots-frames-support/server-dom! html))]
+        (is (rf.hicasso.roots-frames-support/every-server-node? container ".row") "premise: the bytes were stamped")
+        (-> (rf.hicasso.test.mounted/hydrate! [row {:id 1}] {:container container
                                         :initial-events [[::seed 3]]})
             (.then (fn [m]
                      (testing "the promise resolved on THIS root's adoption
                                window shutting, so the DOM on this line is the
                                adopted one — hydrate-root! itself returns while
                                the page is still the server's"
-                       (is (sup/every-server-node? (:container m) ".row")
+                       (is (rf.hicasso.roots-frames-support/every-server-node? (:container m) ".row")
                            "the server's own nodes were adopted, not replaced")
                        (is (= "todo 1" (text-at m ".title"))))
 
                      (testing "and it is live: a dispatch reaches the adopted
                                tree"
-                       (hm/dispatch-and-settle! m [::toggle 1])
+                       (rf.hicasso.test.mounted/dispatch-and-settle! m [::toggle 1])
                        (is (= "true" (text-at m ".done")))
-                       (is (sup/every-server-node? (:container m) ".row")
+                       (is (rf.hicasso.roots-frames-support/every-server-node? (:container m) ".row")
                            "still the same nodes after a commit"))
 
-                     (-> (hm/unmount! m)
-                         (hm/assert-clean!)
+                     (-> (rf.hicasso.test.mounted/unmount! m)
+                         (rf.hicasso.test.mounted/assert-clean!)
                          (.then (fn [report]
                                   (is (true? (:clean? report)))
                                   (done)))))))))))
@@ -582,12 +582,12 @@
 (defn- body-children [] (.-childElementCount js/document.body))
 
 (deftest l3-mount-propagates-the-runtimes-refusal-and-leaves-nothing-behind
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
-      (let [before   (hm/census)
+      (let [before   (rf.hicasso.test.mounted/census)
             children (body-children)
-            outcome  (try (hm/mount! [row-with-a-plain-function-child {}])
+            outcome  (try (rf.hicasso.test.mounted/mount! [row-with-a-plain-function-child {}])
                           (catch :default e e))]
 
         (testing "the refusal reached the CALLER, carrying the runtime's own id,
@@ -606,7 +606,7 @@
               (is (identical? plain-child (:head data))
                   "the offending head is the one the body wrote"))))
 
-        (-> (runtime/quiesced!)
+        (-> (rf.hicasso.test.runtime/quiesced!)
             (.then
               (fn [_]
                 (testing "and the page is as the call found it. The frame this
@@ -615,9 +615,9 @@
                           programmer who catches this refusal has nothing left
                           to clean up and no handle they would have had to be
                           given one"
-                  (is (= before (hm/census))
+                  (is (= before (rf.hicasso.test.mounted/census))
                       (str "the census moved: " (pr-str before) " → "
-                           (pr-str (hm/census))))
+                           (pr-str (rf.hicasso.test.mounted/census))))
                   (is (= children (body-children))
                       "the container the failed mount appended is still attached"))
 
@@ -626,16 +626,16 @@
                           `!standing` left incremented by the failed call shows
                           up here and nowhere else"
                   (let [m (seeded)]
-                    (hm/unmount! m)
-                    (-> (hm/assert-clean! m)
+                    (rf.hicasso.test.mounted/unmount! m)
+                    (-> (rf.hicasso.test.mounted/assert-clean! m)
                         (.then (fn [report]
                                  (is (zero? (:standing report)))
                                  (is (true? (:clean? report)))
                                  (done)))))))))))))
 
 (deftest l3-hydrate-rejects-a-form-the-codec-refuses-and-leaves-nothing-behind
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [;; The caller's OWN container, carrying the caller's own bytes —
             ;; the arm where the rollback must NOT tidy up, because the node is
@@ -643,12 +643,12 @@
             container (js/document.createElement "div")
             _         (set! (.-innerHTML container) "<li class=\"row\">server</li>")
             _         (.appendChild js/document.body container)
-            before    (hm/census)
+            before    (rf.hicasso.test.mounted/census)
             children  (body-children)]
         ;; THE FAULT: an empty hiccup vector has no head, and the codec refuses
         ;; it while `hydrate-root!` is still building its root element — on
         ;; that call's own stack, before React is handed anything.
-        (-> (hm/hydrate! [] {:container container})
+        (-> (rf.hicasso.test.mounted/hydrate! [] {:container container})
             (.then (fn [m]
                      (is false (str "hydrate! resolved with " (pr-str m)
                                     " for a form the codec refuses")))
@@ -660,12 +660,12 @@
                        (is (instance? ExceptionInfo e))
                        (is (= :rf.error/hicasso-empty-vector
                               (:rf.error/id (ex-data e)))))))
-            (.then (fn [_] (runtime/quiesced!)))
+            (.then (fn [_] (rf.hicasso.test.runtime/quiesced!)))
             (.then (fn [_]
                      (testing "the frame is destroyed and no counter moved"
-                       (is (= before (hm/census))
+                       (is (= before (rf.hicasso.test.mounted/census))
                            (str "the census moved: " (pr-str before) " → "
-                                (pr-str (hm/census)))))
+                                (pr-str (rf.hicasso.test.mounted/census)))))
                      (testing "and the caller's container is EXACTLY where they
                                left it, with the bytes they put in it. A
                                rollback that removed it would delete a node the
@@ -677,16 +677,16 @@
                      (done))))))))
 
 (deftest l3-hydrate-that-never-adopts-rejects-and-leaves-nothing-behind
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [bytes-frame ::timeout-server
             _           (rf/make-frame {:id bytes-frame
                                         :initial-events [[::seed 3]]})
-            html        (sup/server-html! bytes-frame [row {:id 1}])
+            html        (rf.hicasso.roots-frames-support/server-html! bytes-frame [row {:id 1}])
             _           (rf/destroy-frame! bytes-frame)
-            _           (collector/reset-runtime!)
-            before      (hm/census)
+            _           (rf.hicasso.impl.collector/reset-runtime!)
+            before      (rf.hicasso.test.mounted/census)
             children    (body-children)
             ;; THE ROLLBACK'S OWN NOISE, captured rather than suppressed.
             ;;
@@ -714,7 +714,7 @@
         ;; body that throws during adoption — never resolves EITHER, but it
         ;; also reports an uncaught error at the window, and that is a
         ;; different fault with a channel of its own.
-        (-> (hm/hydrate! [row {:id 1}] {:html html :initial-events [[::seed 3]]} -1)
+        (-> (rf.hicasso.test.mounted/hydrate! [row {:id 1}] {:html html :initial-events [[::seed 3]]} -1)
             (.then (fn [m]
                      (is false (str "hydrate! resolved with " (pr-str m)
                                     " on a spent budget")))
@@ -735,12 +735,12 @@
                          (is (keyword? frame))
                          (is (not (contains? (set (rf/frame-ids)) frame))
                              (str frame " is still registered"))))))
-            (.then (fn [_] (runtime/quiesced!)))
+            (.then (fn [_] (rf.hicasso.test.runtime/quiesced!)))
             (.then (fn [_]
                      (.removeEventListener js/window "error" on-error)
-                     (is (= before (hm/census))
+                     (is (= before (rf.hicasso.test.mounted/census))
                          (str "the census moved: " (pr-str before) " → "
-                              (pr-str (hm/census))))
+                              (pr-str (rf.hicasso.test.mounted/census))))
                      (testing "and the container the facade minted for the
                                server bytes is gone, because this one IS the
                                facade's to remove"
@@ -778,7 +778,7 @@
 (defn- routed
   "One mount of [[two-pages]], opened on the first route."
   []
-  (hm/mount! [two-pages {}]
+  (rf.hicasso.test.mounted/mount! [two-pages {}]
              {:initial-events [[:rf.route/navigate {:to here}]]}))
 
 (defn- route-id-of
@@ -790,8 +790,8 @@
   (rf/subscribe-once [:rf.route/id] {:frame (:frame m)}))
 
 (deftest l3-settle-until-lands-work-the-router-merely-enqueued
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [m (routed)]
         (is (= here (route-id-of m)) "premise: the page opened on the first route")
@@ -811,12 +811,12 @@
                   `interop/next-tick`, a next-turn TASK, and at this line
                   nothing has reached React for the flush to commit. Neither
                   app-db nor the page has moved"
-          (hm/settle! m)
+          (rf.hicasso.test.mounted/settle! m)
           (is (= here (route-id-of m))
               "the navigation is enqueued, not landed")
           (is (= "here" (text-at m ".where"))))
 
-        (-> (hm/settle-until! m #(= there (route-id-of m))
+        (-> (rf.hicasso.test.mounted/settle-until! m #(= there (route-id-of m))
                               {:label "the route-link's navigate to drain"})
             (.then
               (fn [answered]
@@ -838,22 +838,22 @@
                                      (pr-str (ex-data e))))
                       nil))
             (.then (fn [_]
-                     (-> (hm/unmount! m)
-                         (hm/assert-clean!)
+                     (-> (rf.hicasso.test.mounted/unmount! m)
+                         (rf.hicasso.test.mounted/assert-clean!)
                          (.then (fn [report]
                                   (is (true? (:clean? report)))
                                   (done)))))))))))
 
 (deftest l3-settle-until-fails-at-its-deadline-rather-than-hanging
-  (if-not (mount/browser?)
-    (sup/skip! ":node-test has no React DOM")
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM")
     (async done
       (let [m (routed)]
         ;; THE SABOTAGE: a condition that cannot ever hold, and nothing
         ;; clicked, so no navigation is even enqueued. The only way out of
         ;; this row is the deadline — which is what makes it a witness for
         ;; the WAITING rather than for the returning.
-        (-> (hm/settle-until! m (constantly false)
+        (-> (rf.hicasso.test.mounted/settle-until! m (constantly false)
                               {:timeout-ms 50
                                :interval-ms 5
                                :label "a condition that never holds"})
@@ -882,8 +882,8 @@
                                its handler at all is that claim"
                        (is true "the rejection reached a handler"))))
             (.then (fn [_]
-                     (-> (hm/unmount! m)
-                         (hm/assert-clean!)
+                     (-> (rf.hicasso.test.mounted/unmount! m)
+                         (rf.hicasso.test.mounted/assert-clean!)
                          (.then (fn [report]
                                   (is (true? (:clean? report)))
                                   (done)))))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_runtime_parity_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_runtime_parity_cljs_test.cljs
@@ -45,13 +45,13 @@
   paraphrase would carry `re-frame.hicasso.test` and red."
   (:require [clojure.string :as str]
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.intent :as intent]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]))
 
 (def ^:private frame-id ::parity)
@@ -61,12 +61,12 @@
 ;; frame because this suite seats its own, the collector emptied between
 ;; rows.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :init-fn       (fn []
                       (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-                      (collector/reset-runtime!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The two probes
@@ -104,8 +104,8 @@
   nothing about Hicasso. What the row is about is that the value crosses
   UNFORCED, and the token says exactly that."
   [x]
-  (let [o (outcome #(intent/with-frame frame-id (collector/frame-dispatch frame-id)
-                      (fn [] (codec/as-element x))))]
+  (let [o (outcome #(rf.hicasso.impl.intent/with-frame frame-id (rf.hicasso.impl.collector/frame-dispatch frame-id)
+                      (fn [] (rf.hicasso.impl.codec/as-element x))))]
     (if-some [d (:refused o)]
       [:refused (:rf.error/id d)]
       (let [v (:returned o)]
@@ -131,7 +131,7 @@
   travels the kit's real path rather than a walk reached behind its
   door."
   [form]
-  (let [o (outcome #(ht/tree [(fn [_] form)]))]
+  (let [o (outcome #(rf.hicasso.test/tree [(fn [_] form)]))]
     (if-some [d (:refused o)]
       {:refused (select-keys d [:rf.error/id :where])}
       {:tree (:returned o)})))
@@ -140,13 +140,13 @@
 ;; The table
 ;; ---------------------------------------------------------------------------
 
-(h/defhost a-host js/Object {:server :client-only})
+(rf.hicasso/defhost a-host js/Object {:server :client-only})
 
-(h/defview a-boundary [props] [:i (str (:x props))])
+(rf.hicasso/defview a-boundary [props] [:i (str (:x props))])
 
 (defn- raw-component [] nil)
 
-(def ^:private v ht/tree-version)
+(def ^:private v rf.hicasso.test/tree-version)
 
 (def ^:private rows
   [{:case    "a body that renders nothing roots in an EMPTY FRAGMENT"

--- a/implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs
@@ -83,17 +83,17 @@
   file's own, and transcribing the ledger row is the ledger's, as it was
   for D10–D13."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.hook-probe :as probe]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.native :as n]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.hook-probe :as rf.hicasso.hook-probe]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.native :as rf.hicasso.native]
+            [re-frame.test-support :as rf.test-support]
             [uix.core :as uix :refer-macros [defui]]
             ["react" :as react]
             ["react-dom/server" :as react-dom-server]))
@@ -105,12 +105,12 @@
 (rf/reg-event ::seed (fn [_ [_ db]] {:db db}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :init-fn       (fn []
-                      (support/leave-act-environment!)
-                      (collector/reset-runtime!))}))
+                      (rf.hicasso.checkpoint-support/leave-act-environment!)
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The two routes, as components
@@ -141,8 +141,8 @@
   [^js props]
   (uix/$ uix-cell {:label (.-label props)}))
 
-(h/defhost react-cell-host react-cell {:server :render})
-(h/defhost uix-cell-host uix-cell-arm {:server :render})
+(rf.hicasso/defhost react-cell-host react-cell {:server :render})
+(rf.hicasso/defhost uix-cell-host uix-cell-arm {:server :render})
 
 ;; ---------------------------------------------------------------------------
 ;; The corpus
@@ -389,7 +389,7 @@
             builds has the author's own function as its type and the
             author's own slot as its props — zero wrappers, which is
             budgets.md row D14"
-    (let [^js el (codec/as-element [react-cell-host {:label "42"}])]
+    (let [^js el (rf.hicasso.impl.codec/as-element [react-cell-host {:label "42"}])]
       (is (identical? react-cell (.-type el)))
       (is (= ["label"] (slots el))))))
 
@@ -426,7 +426,7 @@
   (testing "and through the crossing the same hop is visible: the UIx arm's
             host hands React a plain shim as the element type, and it is the
             shim — not the door — that opens `argv` one level down"
-    (let [^js el (codec/as-element [uix-cell-host {:label "42"}])]
+    (let [^js el (rf.hicasso.impl.codec/as-element [uix-cell-host {:label "42"}])]
       (is (identical? uix-cell-arm (.-type el)))
       (is (= ["label"] (slots el)))))
 
@@ -450,9 +450,9 @@
   Client-only crossing would leave the premise row reading two arms and
   calling it three."
   [^js _props]
-  (react/createElement "b" #js {:className "island"} (str (n/use-sub [::price]))))
+  (react/createElement "b" #js {:className "island"} (str (rf.hicasso.native/use-sub [::price]))))
 
-(h/defhost island-host island {:server :render})
+(rf.hicasso/defhost island-host island {:server :render})
 
 (defui uix-reader
   "The UIx route's read, through the adapter's own hook, in the EXPLICIT
@@ -475,7 +475,7 @@
   the browser lane's to exercise, and `re-frame.adapter.uix`'s own
   `uix_use_subscribe_dom_cljs_test` is where it already is."
   [_]
-  (uix/$ :u {:class "uix"} (str (uix-adapter/use-subscribe frame-id [::price]))))
+  (uix/$ :u {:class "uix"} (str (rf.adapter.uix/use-subscribe frame-id [::price]))))
 
 (defn uix-reader-arm
   "The crossing into the UIx tree — a plain React shim, for
@@ -483,7 +483,7 @@
   [_props]
   (uix/$ uix-reader))
 
-(h/defhost uix-reader-host
+(rf.hicasso/defhost uix-reader-host
   "The UIx arm's crossing into the tree, through the named door.
 
   `{:server :render}` and not the default, and the reason belongs in the
@@ -496,12 +496,12 @@
   uix-reader-arm
   {:server :render})
 
-(h/defview boundary
+(rf.hicasso/defview boundary
   "The interpreted route's read: `h/sub`, the ambient collector."
   [_]
-  [:i.boundary (str (h/sub [::price]))])
+  [:i.boundary (str (rf.hicasso/sub [::price]))])
 
-(h/defview page
+(rf.hicasso/defview page
   "One tree holding all three doors, so the reads are of the same frame
   in the same render rather than three separate renders that happen to
   agree."
@@ -523,17 +523,17 @@
   order."
   [hiccup]
   (let [!html (volatile! nil)
-        hooks (probe/record!
+        hooks (rf.hicasso.hook-probe/record!
                 (fn []
                   (vreset! !html
                            (react-dom-server/renderToString
-                             (mount/provider frame-id
-                                             (codec/root-element frame-id hiccup))))))]
+                             (rf.hicasso.impl.mount/provider frame-id
+                                             (rf.hicasso.impl.codec/root-element frame-id hiccup))))))]
     {:html @!html :hooks hooks}))
 
 (deftest the-three-doors-read-one-frame-and-agree
   (seeded!)
-  (is (true? (probe/install!))
+  (is (true? (rf.hicasso.hook-probe/install!))
       "React's client-internals dispatcher slot was not found — the hook
        counts below are UNWITNESSED, not satisfied")
   (let [{:keys [html hooks]} (server-render! [page {}])]
@@ -563,7 +563,7 @@
     (testing "I9 holds at two, read off the ledger the shell declares — the
               tree above added a raw-React island and a foreign UIx subtree
               and moved it by nothing"
-      (is (= 2 (count runtime/shell-hook-ledger))))
+      (is (= 2 (count rf.hicasso.test.runtime/shell-hook-ledger))))
 
     (testing "and neither `useRef` nor `useState` is among them: HD-020(b)'s
               two named prohibitions, over every hook Hicasso spent on this

--- a/implementation/hicasso/test/re_frame/hicasso/three_way_parity_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/three_way_parity_dom_cljs_test.cljs
@@ -75,14 +75,14 @@
   measuring a component this file went to some trouble to keep foreign."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.checkpoint-support :as support]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.roots-frames-support :as roots-support]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.test-support :as rf.test-support]
             [uix.core :as uix :refer-macros [defui]]
             ["react" :as react]))
 
@@ -129,14 +129,14 @@
 (def ^:private uix-ref   (fn [node] (record-ref! :uix node)))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :init-fn       (fn []
-                      (support/leave-act-environment!)
+                      (rf.hicasso.checkpoint-support/leave-act-environment!)
                       (reset! !refs {})
                       (reset! !renders {})
-                      (collector/reset-runtime!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The two routes, as components
@@ -166,17 +166,17 @@
   [^js props]
   (uix/$ uix-cell {:label (.-label props) :inner-ref (.-innerRef props)}))
 
-(h/defhost react-host react-cell {:server :render})
-(h/defhost uix-host   uix-arm    {:server :render})
+(rf.hicasso/defhost react-host react-cell {:server :render})
+(rf.hicasso/defhost uix-host   uix-arm    {:server :render})
 
-(h/defview page
+(rf.hicasso/defview page
   "Both arms in one tree, under one frame, in one commit — so a row
   comparing them is comparing one render and not two that happened to
   agree."
   [_]
   [:div.page
-   [react-host {:label (str (h/sub [::price])) :inner-ref react-ref}]
-   [uix-host   {:label (str (h/sub [::price])) :inner-ref uix-ref}]])
+   [react-host {:label (str (rf.hicasso/sub [::price])) :inner-ref react-ref}]
+   [uix-host   {:label (str (rf.hicasso/sub [::price])) :inner-ref uix-ref}]])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -194,8 +194,8 @@
 
 (defn- mounted!
   []
-  (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
-    (mount/settle!)
+  (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id [page {}])]
+    (rf.hicasso.impl.mount/settle!)
     handle))
 
 (defn- cells
@@ -223,7 +223,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-two-routes-paint-the-same-dom
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no React DOM")
     (do
       (seeded!)
@@ -250,14 +250,14 @@
               (is (seq handwritten) "the premise: normalising left markup")
               (is (some? (re-find #"<span" handwritten)))
               (is (= handwritten (normalised (:uix found))))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. Refs
 ;; ---------------------------------------------------------------------------
 
 (deftest a-ref-reaches-a-real-node-on-every-route-and-is-released-on-unmount
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no commit, so no ref is ever filled")
     (do
       (seeded!)
@@ -278,7 +278,7 @@
           (doseq [route routes]
             (is (= "SPAN" (.-tagName ^js (first (get @!refs route)))))))
 
-        (roots-support/teardown-census! handle)
+        (rf.hicasso.roots-frames-support/teardown-census! handle)
 
         (testing "unmount calls each route's ref again with nil, which is
                   React's own contract and the half a mounted-only row cannot
@@ -294,7 +294,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest teardown-releases-everything-the-two-route-tree-acquired
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test acquires nothing, so it can release nothing")
     (do
       (seeded!)
@@ -309,7 +309,7 @@
           ;; `count` throws `ICounted` rather than answering two.
           (is (= 2 (.-length (.querySelectorAll ^js container "span.cell")))))
 
-        (let [census (roots-support/teardown-census! handle)]
+        (let [census (rf.hicasso.roots-frames-support/teardown-census! handle)]
 
           (testing "the container is empty — React unmounted the whole tree,
                     both foreign subtrees included"
@@ -336,7 +336,7 @@
 ;; React fills once per mount and would fill again on a remount.
 
 (deftest a-re-render-updates-every-route-rather-than-remounting-it
-  (if-not (mount/browser?)
+  (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no second render")
     (do
       (seeded!)
@@ -349,7 +349,7 @@
             (is (= [1 1] (mapv #(count (get @!refs %)) routes))))
 
           (rf/with-frame frame-id (rf/dispatch-sync [::seed {:price 192}]))
-          (mount/settle!)
+          (rf.hicasso.impl.mount/settle!)
 
           (testing "the write really re-rendered the page — every route's
                     body ran a second time and repainted the new value.
@@ -372,4 +372,4 @@
                     remount would read two — the observable the DOM cannot
                     provide, since the pixels are identical either way"
             (is (= [1 1] (mapv #(count (get @!refs %)) routes))))
-          (finally (mount/release! handle)))))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/tool_reads_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/tool_reads_cljs_test.cljs
@@ -36,17 +36,17 @@
   Nothing under `src/` is changed by this suite."
   (:require [cljs.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.evidence :as evidence]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.tool :as tool]
-            [re-frame.interop :as interop]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.evidence :as rf.hicasso.evidence]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.tool :as rf.hicasso.tool]
+            [re-frame.interop :as rf.interop]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (def ^:private frame-id ::tool-reads)
 
@@ -68,14 +68,14 @@
 ;; ledger, and `codec/retained-body` is the kit's route from the minted
 ;; head back to that body, so the harness can render it through the same
 ;; seam as an anonymous fn.
-(h/defview named-probe [_] (h/sub [:tr/left]) nil)
-(h/defview twin-probe  [_] (h/sub [:tr/left]) nil)
+(rf.hicasso/defview named-probe [_] (rf.hicasso/sub [:tr/left]) nil)
+(rf.hicasso/defview twin-probe  [_] (rf.hicasso/sub [:tr/left]) nil)
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
-     :init-fn       (fn [] (collector/reset-runtime!))}))
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness — a real frame, real boundaries, the real commit seam
@@ -96,8 +96,8 @@
   its reference exactly as React's passive effect would. Answers the
   unsubscribe React would hold."
   [fid body-fn]
-  (collector/render-body fid body-fn {})
-  (collector/commit-boundary! (collector/last-reads) (fn [])))
+  (rf.hicasso.impl.collector/render-body fid body-fn {})
+  (rf.hicasso.impl.collector/commit-boundary! (rf.hicasso.impl.collector/last-reads) (fn [])))
 
 (defn- mount! [body-fn] (mount-in! frame-id body-fn))
 
@@ -116,10 +116,10 @@
 (defn- envelopes
   "All four reads, in one turn."
   []
-  {:mounted-boundaries (tool/read-mounted-boundaries)
-   :read-attribution   (tool/read-read-attribution)
-   :intents            (tool/read-intents)
-   :explain-render     (tool/explain-render)})
+  {:mounted-boundaries (rf.hicasso.tool/read-mounted-boundaries)
+   :read-attribution   (rf.hicasso.tool/read-read-attribution)
+   :intents            (rf.hicasso.tool/read-intents)
+   :explain-render     (rf.hicasso.tool/explain-render)})
 
 (defn- boundary-keys [envelope]
   (into #{} (map (comp :key :boundary)) (:boundaries envelope)))
@@ -130,7 +130,7 @@
 
 (deftest this-build-has-the-reads-enabled
   (testing "every assertion below is about a DEV build; the production arm is separate"
-    (is (true? interop/debug-enabled?))))
+    (is (true? rf.interop/debug-enabled?))))
 
 ;; ---------------------------------------------------------------------------
 ;; Read 1 — mounted boundaries
@@ -139,9 +139,9 @@
 (deftest the-mounted-roster-counts-every-committed-boundary
   (seeded!)
   (testing "nothing mounted is an EMPTY roster on a basis that CAN see — a clean bill"
-    (let [e (tool/read-mounted-boundaries)]
-      (is (= evidence/schema (:schema e)))
-      (is (= evidence/producer (:producer e)))
+    (let [e (rf.hicasso.tool/read-mounted-boundaries)]
+      (is (= rf.hicasso.evidence/schema (:schema e)))
+      (is (= rf.hicasso.evidence/producer (:producer e)))
       (is (= :mounted-boundaries (:read e)))
       (is (true? (:complete? e)))
       (is (nil? (:loss e)))
@@ -152,17 +152,17 @@
             discriminated refs-gating from entries-not-existing. A
             regression to counting unclaimed entries silently inflates
             the roster `:complete? true` is staked on"
-    (collector/render-body frame-id (fn [_] (h/sub [:tr/row 0]) nil) {})
-    (is (pos? (:entries (runtime/residue)))
+    (rf.hicasso.impl.collector/render-body frame-id (fn [_] (rf.hicasso/sub [:tr/row 0]) nil) {})
+    (is (pos? (:entries (rf.hicasso.test.runtime/residue)))
         "the premise: the probe left a REAL entry in the cache")
-    (is (= [] (:boundaries (tool/read-mounted-boundaries)))
+    (is (= [] (:boundaries (rf.hicasso.tool/read-mounted-boundaries)))
         "which the roster does not count, because no reference claims it"))
 
-  (let [a (mount! (fn [_] (h/sub [:tr/left]) nil))
-        b (mount! (fn [_] (h/sub [:tr/left]) nil))
-        c (mount! (fn [_] (h/sub [:tr/left]) (h/sub [:tr/right]) nil))]
+  (let [a (mount! (fn [_] (rf.hicasso/sub [:tr/left]) nil))
+        b (mount! (fn [_] (rf.hicasso/sub [:tr/left]) nil))
+        c (mount! (fn [_] (rf.hicasso/sub [:tr/left]) (rf.hicasso/sub [:tr/right]) nil))]
     (testing "two boundaries with one edge set are ONE row with :instances 2"
-      (let [e    (tool/read-mounted-boundaries)
+      (let [e    (rf.hicasso.tool/read-mounted-boundaries)
             rows (into {} (map (juxt (comp :key :boundary) identity)) (:boundaries e))]
         (is (= 2 (count rows)) "one row per DISTINCT edge set")
         (is (= 2 (:instances (get rows [(boundary-read-key [:tr/left])]))))
@@ -172,18 +172,18 @@
 
     (testing "a boundary that read NOTHING is still counted — the cell table cannot see it"
       (let [d (mount! (fn [_] nil))
-            e (tool/read-mounted-boundaries)
+            e (rf.hicasso.tool/read-mounted-boundaries)
             row (first (filter #(= [] (:key (:boundary %))) (:boundaries e)))]
         (is (some? row) "the read-free boundary must appear")
         (is (= 1 (:instances row)))
         (is (= [] (:reads row)) "its read roster is an honest survey result, not a loss")
-        (is (= evidence/unknown (:frame row))
+        (is (= rf.hicasso.evidence/unknown (:frame row))
             "with no reads there is no frame to name, and the row says so explicitly")
         (d)))
 
     (testing "an unmounted boundary leaves the roster"
       (a) (b) (c)
-      (is (= [] (:boundaries (tool/read-mounted-boundaries)))))))
+      (is (= [] (:boundaries (rf.hicasso.tool/read-mounted-boundaries)))))))
 
 (deftest two-read-orders-of-one-edge-set-collapse-to-one-row-that-says-so
   (seeded!)
@@ -194,10 +194,10 @@
             nowhere above 1, so the collapse arm of `entry-rows` could
             rot into duplicate DOM ids for a panel and an ambiguous join
             for a consumer with every existing row green"
-    (let [a (mount! (fn [_] (h/sub [:tr/left]) (h/sub [:tr/right]) nil))
-          b (mount! (fn [_] (h/sub [:tr/right]) (h/sub [:tr/left]) nil))
-          e (tool/read-mounted-boundaries)]
-      (is (= 2 (:entries (runtime/residue)))
+    (let [a (mount! (fn [_] (rf.hicasso/sub [:tr/left]) (rf.hicasso/sub [:tr/right]) nil))
+          b (mount! (fn [_] (rf.hicasso/sub [:tr/right]) (rf.hicasso/sub [:tr/left]) nil))
+          e (rf.hicasso.tool/read-mounted-boundaries)]
+      (is (= 2 (:entries (rf.hicasso.test.runtime/residue)))
           "the premise: the runtime really holds TWO entries — without
            this, one row could mean the orders were never distinguished")
       (is (= 1 (count (:boundaries e)))
@@ -217,17 +217,17 @@
 
 (deftest a-body-with-no-name-leaves-the-views-unknown
   (seeded!)
-  (let [release (mount! (fn [_] (h/sub [:tr/left]) nil))
-        row     (first (:boundaries (tool/read-mounted-boundaries)))]
+  (let [release (mount! (fn [_] (rf.hicasso/sub [:tr/left]) nil))
+        row     (first (:boundaries (rf.hicasso.tool/read-mounted-boundaries)))]
     (testing "a harness fn carries no displayName, so the row states the explicit unknown — never [] and never an absent key"
       (is (contains? row :views))
-      (is (= evidence/unknown (:views row))))
+      (is (= rf.hicasso.evidence/unknown (:views row))))
     (release)))
 
 (deftest the-mounted-roster-names-the-declared-view-that-rendered-it
   (seeded!)
-  (let [release (mount! (codec/retained-body named-probe))
-        e       (tool/read-mounted-boundaries)
+  (let [release (mount! (rf.hicasso.impl.codec/retained-body named-probe))
+        e       (rf.hicasso.tool/read-mounted-boundaries)
         row     (first (:boundaries e))
         [v]     (:views row)]
     (testing "the row names the view by the `<ns>/<sym>` defview stamped"
@@ -240,11 +240,11 @@
       (is (pos? (:line (:source v))))
       (is (string? (:file (:source v)))))
     (testing "the attribution readers carry the same name, so the way IN is named too"
-      (let [edge (first (filter #(= :tr/left (:sub-id %)) (:edges (tool/read-read-attribution))))]
+      (let [edge (first (filter #(= :tr/left (:sub-id %)) (:edges (rf.hicasso.tool/read-read-attribution))))]
         (is (= [{:view named-probe-name :source (:source v)}]
                (:views (first (:readers edge)))))))
     (testing "and so does the explanation row"
-      (is (= (:views row) (:views (first (:explanations (tool/explain-render)))))))
+      (is (= (:views row) (:views (first (:explanations (rf.hicasso.tool/explain-render)))))))
     (testing "the roster's own claim is untouched by naming — it is still a complete census"
       (is (true? (:complete? e)))
       (is (nil? (:loss e))))
@@ -252,9 +252,9 @@
 
 (deftest two-declared-views-over-one-edge-set-are-one-row-naming-both
   (seeded!)
-  (let [a   (mount! (codec/retained-body named-probe))
-        b   (mount! (codec/retained-body twin-probe))
-        e   (tool/read-mounted-boundaries)
+  (let [a   (mount! (rf.hicasso.impl.codec/retained-body named-probe))
+        b   (mount! (rf.hicasso.impl.codec/retained-body twin-probe))
+        e   (rf.hicasso.tool/read-mounted-boundaries)
         row (first (:boundaries e))]
     (is (= 1 (count (:boundaries e)))
         "the identity is still the edge set — two views reading one set share one entry")
@@ -265,15 +265,15 @@
 
 (deftest a-name-minted-outside-defview-has-no-source
   (seeded!)
-  (let [body (fn [_] (h/sub [:tr/left]) nil)]
+  (let [body (fn [_] (rf.hicasso/sub [:tr/left]) nil)]
     ;; `mint-view!` is what stamps the name; a harness stamping it by hand
     ;; stands in for a boundary minted outside the macro — a tool's, or an
     ;; HMR re-registration — which the error ledger never heard about.
     (unchecked-set body "displayName" "erasure.harness/by-hand")
     (let [release (mount! body)
-          [v]     (:views (first (:boundaries (tool/read-mounted-boundaries))))]
+          [v]     (:views (first (:boundaries (rf.hicasso.tool/read-mounted-boundaries))))]
       (is (= "erasure.harness/by-hand" (:view v)))
-      (is (= evidence/unknown (:source v))
+      (is (= rf.hicasso.evidence/unknown (:source v))
           "no coordinate was declared, and the row says so rather than guessing")
       (release))))
 
@@ -284,10 +284,10 @@
 
 (deftest an-unmounted-view-leaves-the-row-its-twin-still-holds
   (seeded!)
-  (let [a1  (mount! (codec/retained-body named-probe))
-        a2  (mount! (codec/retained-body named-probe))
-        b   (mount! (codec/retained-body twin-probe))
-        row (fn [] (first (:boundaries (tool/read-mounted-boundaries))))]
+  (let [a1  (mount! (rf.hicasso.impl.codec/retained-body named-probe))
+        a2  (mount! (rf.hicasso.impl.codec/retained-body named-probe))
+        b   (mount! (rf.hicasso.impl.codec/retained-body twin-probe))
+        row (fn [] (first (:boundaries (rf.hicasso.tool/read-mounted-boundaries))))]
     (testing "the premise: one row, three holders, both names"
       (is (= 3 (:instances (row))))
       (is (= [named-probe-name twin-probe-name] (mapv :view (:views (row))))))
@@ -303,23 +303,23 @@
       (is (= [twin-probe-name] (mapv :view (:views (row))))
           "a name that outlives its reference misattributes the twin's row")
       (let [edge (first (filter #(= :tr/left (:sub-id %))
-                                (:edges (tool/read-read-attribution))))]
+                                (:edges (rf.hicasso.tool/read-read-attribution))))]
         (is (= [twin-probe-name] (mapv :view (:views (first (:readers edge)))))
             "and the attribution reader, named through the same entry, agrees")))
     (b)))
 
 (deftest a-render-react-never-commits-names-no-live-row
   (seeded!)
-  (let [b (mount! (codec/retained-body twin-probe))]
+  (let [b (mount! (rf.hicasso.impl.codec/retained-body twin-probe))]
     (testing "the premise: the twin's row is live and named"
       (is (= [twin-probe-name]
-             (mapv :view (:views (first (:boundaries (tool/read-mounted-boundaries))))))))
+             (mapv :view (:views (first (:boundaries (rf.hicasso.tool/read-mounted-boundaries))))))))
     ;; A speculative render over the SAME edge set: React runs a body it
     ;; then discards — a suspended attempt, an aborted transition,
     ;; StrictMode's first invoke — so this resolves the live entry and no
     ;; `subscribe` ever follows.
-    (collector/render-body frame-id (codec/retained-body named-probe) {})
-    (let [row (first (:boundaries (tool/read-mounted-boundaries)))]
+    (rf.hicasso.impl.collector/render-body frame-id (rf.hicasso.impl.codec/retained-body named-probe) {})
+    (let [row (first (:boundaries (rf.hicasso.tool/read-mounted-boundaries)))]
       (is (= 1 (:instances row)) "nothing committed, so nothing new holds the row")
       (is (= [twin-probe-name] (mapv :view (:views row)))
           "a body React never committed must not be named on a row it never held"))
@@ -333,24 +333,24 @@
   ;; (entry, view), and a fiber's view never changes — so the identity
   ;; moves exactly when the entry does: zero additional re-subscribes.
   (seeded!)
-  (let [body (codec/retained-body named-probe)
-        _    (collector/render-body frame-id body {})
-        e1   (collector/last-reads)
-        s1   (.-subscribe collector/rstate)
-        _    (collector/render-body frame-id body {})
-        s2   (.-subscribe collector/rstate)]
+  (let [body (rf.hicasso.impl.codec/retained-body named-probe)
+        _    (rf.hicasso.impl.collector/render-body frame-id body {})
+        e1   (rf.hicasso.impl.collector/last-reads)
+        s1   (.-subscribe rf.hicasso.impl.collector/rstate)
+        _    (rf.hicasso.impl.collector/render-body frame-id body {})
+        s2   (.-subscribe rf.hicasso.impl.collector/rstate)]
     (is (fn? s1))
-    (is (identical? e1 (collector/last-reads))
+    (is (identical? e1 (rf.hicasso.impl.collector/last-reads))
         "the premise: an unchanged read set hits the same entry")
     (is (identical? s1 s2)
         "and the same named `subscribe`, so React does not call it again")
     (is (not (identical? s1 (.-subscribe e1)))
         "it is the wrapper that counts the name, not the entry's own closure")
-    (collector/render-body frame-id (fn [_] (h/sub [:tr/left]) nil) {})
-    (is (identical? (.-subscribe e1) (.-subscribe collector/rstate))
+    (rf.hicasso.impl.collector/render-body frame-id (fn [_] (rf.hicasso/sub [:tr/left]) nil) {})
+    (is (identical? (.-subscribe e1) (.-subscribe rf.hicasso.impl.collector/rstate))
         "a body with no name is handed the entry's own closure, as before")
-    (collector/render-body frame-id (codec/retained-body twin-probe) {})
-    (is (not (identical? s1 (.-subscribe collector/rstate)))
+    (rf.hicasso.impl.collector/render-body frame-id (rf.hicasso.impl.codec/retained-body twin-probe) {})
+    (is (not (identical? s1 (.-subscribe rf.hicasso.impl.collector/rstate)))
         "a different view over the same entry has its own wrapper — no fiber
          ever changes view, so no fiber pays a re-subscribe for it")))
 
@@ -360,10 +360,10 @@
 
 (deftest attribution-is-the-reverse-edge-itself
   (seeded!)
-  (let [a (mount! (fn [_] (h/sub [:tr/left]) nil))
-        b (mount! (fn [_] (h/sub [:tr/left]) nil))
-        c (mount! (fn [_] (h/sub [:tr/left]) (h/sub [:tr/right]) nil))
-        e (tool/read-read-attribution)
+  (let [a (mount! (fn [_] (rf.hicasso/sub [:tr/left]) nil))
+        b (mount! (fn [_] (rf.hicasso/sub [:tr/left]) nil))
+        c (mount! (fn [_] (rf.hicasso/sub [:tr/left]) (rf.hicasso/sub [:tr/right]) nil))
+        e (rf.hicasso.tool/read-read-attribution)
         by-sub (into {} (map (juxt :sub-id identity)) (:edges e))]
     (testing "the envelope is exact — this read prints a table"
       (is (= :read-attribution (:read e)))
@@ -372,11 +372,11 @@
     (testing ":fan-out is the cell's own reader-slot count"
       (is (= 3 (:fan-out (:tr/left by-sub))))
       (is (= 1 (:fan-out (:tr/right by-sub))))
-      (is (= (count (runtime/cell-readers (sub-key [:tr/left])))
+      (is (= (count (rf.hicasso.test.runtime/cell-readers (sub-key [:tr/left])))
              (:fan-out (:tr/left by-sub)))
           "the projection must not derive a number the table already holds"))
     (testing ":readers are the SAME keys the mounted roster states — the rosters join"
-      (let [mounted (boundary-keys (tool/read-mounted-boundaries))
+      (let [mounted (boundary-keys (rf.hicasso.tool/read-mounted-boundaries))
             readers (into #{} (map :key) (:readers (:tr/left by-sub)))]
         (is (= #{[(boundary-read-key [:tr/left])]
                  [(boundary-read-key [:tr/left]) (boundary-read-key [:tr/right])]}
@@ -393,13 +393,13 @@
 
 (deftest the-intent-stream-is-spec-009s-window-and-is-always-capped
   (seeded!)
-  (let [release (mount! (fn [_] (h/sub [:tr/left]) nil))]
+  (let [release (mount! (fn [_] (rf.hicasso/sub [:tr/left]) nil))]
     (rf/with-frame frame-id (rf/dispatch-sync [:tr/bump]))
-    (let [e (tool/read-intents)]
+    (let [e (rf.hicasso.tool/read-intents)]
       (testing "a ring is a cap, so this read never claims completeness"
         (is (= :intents (:read e)))
         (is (false? (:complete? e)))
-        (is (= {:reason :cap :dropped evidence/unknown} (:loss e)))
+        (is (= {:reason :cap :dropped rf.hicasso.evidence/unknown} (:loss e)))
         (is (= [frame-id] (:frames e))))
       (testing "the dispatched events are there, oldest first"
         (is (pos? (count (:intents e))))
@@ -414,14 +414,14 @@
 
 (deftest explain-render-separates-the-proven-half-from-the-uncorrelated-half
   (seeded!)
-  (let [release (mount! (fn [_] (h/sub [:tr/left]) (h/sub [:tr/right]) nil))]
+  (let [release (mount! (fn [_] (rf.hicasso/sub [:tr/left]) (rf.hicasso/sub [:tr/right]) nil))]
     (rf/with-frame frame-id (rf/dispatch-sync [:tr/bump]))
-    (let [e  (tool/explain-render)
+    (let [e  (rf.hicasso.tool/explain-render)
           ex (first (:explanations e))]
       (testing "the envelope's own loss is :uncorrelated, structurally and forever"
         (is (= :explain-render (:read e)))
         (is (false? (:complete? e)))
-        (is (= {:reason :uncorrelated :dropped evidence/unknown} (:loss e))))
+        (is (= {:reason :uncorrelated :dropped rf.hicasso.evidence/unknown} (:loss e))))
       (testing "PROVEN: the reads whose values moved most recently, off the epoch stamps"
         (is (= [{:sub-id :tr/left :query [:tr/left] :frame-id frame-id}]
                (:latest-reads ex))
@@ -429,8 +429,8 @@
         (is (number? (:peak-epoch ex)))
         (is (number? (:snapshot ex))))
       (testing "UNCORRELATED: the row's own loss says the join is missing, and candidates are leads"
-        (is (= {:reason :uncorrelated :dropped evidence/unknown} (:loss ex)))
-        (is (= {:frames [frame-id] :retained-runs (count (trace-tooling/trace-buffer frame-id))}
+        (is (= {:reason :uncorrelated :dropped rf.hicasso.evidence/unknown} (:loss ex)))
+        (is (= {:frames [frame-id] :retained-runs (count (rf.trace.tooling/trace-buffer frame-id))}
                (:window ex))
             "the row names the window it searched")
         (is (some #(= :tr/bump (:event-id %)) (:candidates ex))
@@ -440,18 +440,18 @@
 (deftest an-empty-window-is-cap-and-a-live-window-is-uncorrelated
   (testing "the two loss reasons are DIFFERENT and a reader can drive between them"
     (seeded!)
-    (let [release (mount! (fn [_] (h/sub [:tr/left]) nil))]
+    (let [release (mount! (fn [_] (rf.hicasso/sub [:tr/left]) nil))]
       (rf/with-frame frame-id (rf/dispatch-sync [:tr/bump]))
-      (let [looked (first (:explanations (tool/explain-render)))]
+      (let [looked (first (:explanations (rf.hicasso.tool/explain-render)))]
         (is (= :uncorrelated (:reason (:loss looked))))
         (is (vector? (:candidates looked))
             "with runs retained, the search really ran and its result is a vector"))
 
-      (trace-tooling/clear-trace-buffer! frame-id)
-      (let [blind (first (:explanations (tool/explain-render)))]
+      (rf.trace.tooling/clear-trace-buffer! frame-id)
+      (let [blind (first (:explanations (rf.hicasso.tool/explain-render)))]
         (is (= :cap (:reason (:loss blind)))
             "with the window empty, no search happened — a different reason")
-        (is (= evidence/unknown (:candidates blind))
+        (is (= rf.hicasso.evidence/unknown (:candidates blind))
             "and the leads state the explicit unknown, never an [] that reads as none"))
       (release))))
 
@@ -462,8 +462,8 @@
 (deftest the-cells-really-hold-the-secret
   (testing "NON-VACUITY: the state these projections read from is carrying the seed"
     (seeded!)
-    (let [release (mount! (fn [_] (h/sub [:tr/token]) nil))]
-      (is (= the-secret @(runtime/cell-reaction (sub-key [:tr/token])))
+    (let [release (mount! (fn [_] (rf.hicasso/sub [:tr/token]) nil))]
+      (is (= the-secret @(rf.hicasso.test.runtime/cell-reaction (sub-key [:tr/token])))
           (str "the cell's live reaction must deref to the seeded secret — if it "
                "does not, every no-egress assertion below is passing against a "
                "runtime that never saw the value"))
@@ -476,7 +476,7 @@
 
 (deftest no-read-carries-a-value
   (seeded!)
-  (let [release (mount! (fn [_] (h/sub [:tr/token]) (h/sub [:tr/left]) nil))]
+  (let [release (mount! (fn [_] (rf.hicasso/sub [:tr/token]) (rf.hicasso/sub [:tr/left]) nil))]
     (rf/with-frame frame-id (rf/dispatch-sync [:tr/bump]))
     (doseq [[read-name envelope] (envelopes)]
       (is (not (leaked? envelope))
@@ -486,12 +486,12 @@
 (deftest the-query-projector-is-really-invoked-and-fails-closed
   (testing "a read whose frame is gone redacts the WHOLE query rather than shipping it"
     (seeded!)
-    (let [release (mount! (fn [_] (h/sub [:tr/row 0]) nil))
-          live    (tool/read-mounted-boundaries)]
+    (let [release (mount! (fn [_] (rf.hicasso/sub [:tr/row 0]) nil))
+          live    (rf.hicasso.tool/read-mounted-boundaries)]
       (is (= [:tr/row 0] (:query (first (:reads (first (:boundaries live))))))
           "with the frame alive and nothing declared, the query rides as itself")
       (rf/destroy-frame! frame-id)
-      (let [dead (tool/read-mounted-boundaries)
+      (let [dead (rf.hicasso.tool/read-mounted-boundaries)
             row  (first (:boundaries dead))]
         (is (= :rf/redacted (:query (first (:reads row))))
             (str "with the frame destroyed no policy is reachable, so "
@@ -516,18 +516,18 @@
   (testing "with the policy unreachable, the argument is absent from EVERY path out"
     (seeded!)
     ;; No release: the frame is destroyed below, which is the point.
-    (mount-in! frame-id (fn [_] (h/sub [:tr/row the-secret]) nil))
+    (mount-in! frame-id (fn [_] (rf.hicasso/sub [:tr/row the-secret]) nil))
     (rf/with-frame frame-id (rf/dispatch-sync [:tr/bump]))
-    (is (leaked? (tool/read-mounted-boundaries))
+    (is (leaked? (rf.hicasso.tool/read-mounted-boundaries))
         (str "NON-VACUITY: with the frame ALIVE and nothing declared, the "
              "argument really is in the state these projections read — the "
              "classification model is fail-open and the query rides as itself. "
              "If this row ever fails, the assertions below are passing against "
              "a boundary that never carried the argument at all"))
     (rf/destroy-frame! frame-id)
-    (let [mounted     (tool/read-mounted-boundaries)
-          attribution (tool/read-read-attribution)
-          why         (tool/explain-render)]
+    (let [mounted     (rf.hicasso.tool/read-mounted-boundaries)
+          attribution (rf.hicasso.tool/read-read-attribution)
+          why         (rf.hicasso.tool/explain-render)]
       (is (not (leaked? (map (comp :key :boundary) (:boundaries mounted))))
           "the mounted roster's boundary KEY must not carry the argument")
       (is (not (leaked? mounted))
@@ -545,9 +545,9 @@
   ;; one name for two different reads whose projected identity the door
   ;; already held.
   (seeded!)
-  (let [release (mount! (fn [_] (h/sub [:tr/row 1]) (h/sub [:tr/row 2]) nil))]
+  (let [release (mount! (fn [_] (rf.hicasso/sub [:tr/row 1]) (rf.hicasso/sub [:tr/row 2]) nil))]
     (rf/with-frame frame-id (rf/dispatch-sync [:tr/bump]))
-    (let [ex     (first (:explanations (tool/explain-render)))
+    (let [ex     (first (:explanations (rf.hicasso.tool/explain-render)))
           latest (:latest-reads ex)]
       (is (= 2 (count latest))
           "two reads of one registered sub are two entries, never one")
@@ -575,13 +575,13 @@
   ;; :cap into a false :uncorrelated) and offered B's runs as A's leads.
   (seeded!)
   (seed-other!)
-  (let [in-a (mount-in! frame-id       (fn [_] (h/sub [:tr/left]) nil))
-        in-b (mount-in! other-frame-id (fn [_] (h/sub [:tr/left]) nil))]
+  (let [in-a (mount-in! frame-id       (fn [_] (rf.hicasso/sub [:tr/left]) nil))
+        in-b (mount-in! other-frame-id (fn [_] (rf.hicasso/sub [:tr/left]) nil))]
     ;; ASYMMETRIC WINDOWS: B has run, A has not.
     (rf/with-frame other-frame-id (rf/dispatch-sync [:tr/bump]))
-    (trace-tooling/clear-trace-buffer! frame-id)
+    (rf.trace.tooling/clear-trace-buffer! frame-id)
     (let [by-frame (into {} (map (juxt :frame identity))
-                         (:explanations (tool/explain-render)))
+                         (:explanations (rf.hicasso.tool/explain-render)))
           a        (get by-frame frame-id)
           b        (get by-frame other-frame-id)]
       (is (some? a) "frame A's boundary must be explained")
@@ -589,7 +589,7 @@
       (testing "A's window is A's — B's activity cannot claim a search of it"
         (is (= :cap (:reason (:loss a)))
             "A's ring is empty, so nothing was searched for A")
-        (is (= evidence/unknown (:candidates a))
+        (is (= rf.hicasso.evidence/unknown (:candidates a))
             "and its leads state the explicit unknown, never an [] nor B's runs"))
       (testing "B's window really was searched, and B keeps its own leads"
         (is (= :uncorrelated (:reason (:loss b))))
@@ -610,14 +610,14 @@
   (seed-other!)
   ;; A boundary in each frame, so BOTH rings are ones this runtime
   ;; dispatches through and the stream really has two sources to order.
-  (let [in-b    (mount-in! other-frame-id (fn [_] (h/sub [:tr/left]) nil))
-        release (mount! (fn [_] (h/sub [:tr/left]) nil))]
+  (let [in-b    (mount-in! other-frame-id (fn [_] (rf.hicasso/sub [:tr/left]) nil))
+        release (mount! (fn [_] (rf.hicasso/sub [:tr/left]) nil))]
     ;; Interleave the two frames. `other-frame-id` sorts AFTER frame-id by
     ;; pr-str, so a frame-ordered concatenation cannot reproduce this.
     (rf/with-frame other-frame-id (rf/dispatch-sync [:tr/bump]))
     (rf/with-frame frame-id       (rf/dispatch-sync [:tr/bump]))
     (rf/with-frame other-frame-id (rf/dispatch-sync [:tr/bump]))
-    (let [rows (:intents (tool/read-intents))
+    (let [rows (:intents (rf.hicasso.tool/read-intents))
           ids  (mapv :dispatch-id rows)]
       (is (= ids (vec (sort ids)))
           "the stream is ordered by the process-monotonic dispatch id, oldest first")
@@ -637,15 +637,15 @@
 
 (deftest every-read-is-deterministic
   (seeded!)
-  (let [a (mount! (fn [_] (h/sub [:tr/left]) nil))
-        b (mount! (fn [_] (h/sub [:tr/right]) (h/sub [:tr/left]) nil))
-        c (mount! (fn [_] (h/sub [:tr/row 2]) nil))]
+  (let [a (mount! (fn [_] (rf.hicasso/sub [:tr/left]) nil))
+        b (mount! (fn [_] (rf.hicasso/sub [:tr/right]) (rf.hicasso/sub [:tr/left]) nil))
+        c (mount! (fn [_] (rf.hicasso/sub [:tr/row 2]) nil))]
     (rf/with-frame frame-id (rf/dispatch-sync [:tr/bump]))
     (testing "two calls over one runtime state print identically"
-      (doseq [[read-name f] [[:mounted-boundaries tool/read-mounted-boundaries]
-                             [:read-attribution   tool/read-read-attribution]
-                             [:intents            tool/read-intents]
-                             [:explain-render     tool/explain-render]]]
+      (doseq [[read-name f] [[:mounted-boundaries rf.hicasso.tool/read-mounted-boundaries]
+                             [:read-attribution   rf.hicasso.tool/read-read-attribution]
+                             [:intents            rf.hicasso.tool/read-intents]
+                             [:explain-render     rf.hicasso.tool/explain-render]]]
         (is (= (pr-str (f)) (pr-str (f)))
             (str read-name " must be byte-identical across two calls — a roster "
                  "ordered by a hash map's seq is not"))))
@@ -660,21 +660,21 @@
   ;; This row builds the same logical population twice, in OPPOSITE
   ;; mount orders, and requires the projected orders to agree — which
   ;; only a real total order over the rows can deliver.
-  (let [bodies   [(fn [_] (h/sub [:tr/left]) nil)
-                  (fn [_] (h/sub [:tr/right]) nil)
-                  (fn [_] (h/sub [:tr/row 0]) nil)
-                  (fn [_] (h/sub [:tr/row 1]) nil)
-                  (fn [_] (h/sub [:tr/row 2]) nil)]
+  (let [bodies   [(fn [_] (rf.hicasso/sub [:tr/left]) nil)
+                  (fn [_] (rf.hicasso/sub [:tr/right]) nil)
+                  (fn [_] (rf.hicasso/sub [:tr/row 0]) nil)
+                  (fn [_] (rf.hicasso/sub [:tr/row 1]) nil)
+                  (fn [_] (rf.hicasso/sub [:tr/row 2]) nil)]
         orders   (fn []
                    {:roster (mapv (comp :key :boundary)
-                                  (:boundaries (tool/read-mounted-boundaries)))
-                    :edges  (mapv :sub-id (:edges (tool/read-read-attribution)))})
+                                  (:boundaries (rf.hicasso.tool/read-mounted-boundaries)))
+                    :edges  (mapv :sub-id (:edges (rf.hicasso.tool/read-read-attribution)))})
         build!   (fn [bs] (seeded!) (mapv mount! bs))
         forward  (let [stops (build! bodies)
                        o     (orders)]
                    (run! #(%) stops)
                    o)
-        _        (collector/reset-runtime!)
+        _        (rf.hicasso.impl.collector/reset-runtime!)
         backward (let [stops (build! (vec (rseq bodies)))
                        o     (orders)]
                    (run! #(%) stops)
@@ -691,10 +691,10 @@
 
 (deftest no-read-takes-a-consumer-discriminator
   (testing "ONE door: Xray and Pair cannot be handed different shapes"
-    (doseq [[read-name f] [[:mounted-boundaries tool/read-mounted-boundaries]
-                           [:read-attribution   tool/read-read-attribution]
-                           [:intents            tool/read-intents]
-                           [:explain-render     tool/explain-render]]]
+    (doseq [[read-name f] [[:mounted-boundaries rf.hicasso.tool/read-mounted-boundaries]
+                           [:read-attribution   rf.hicasso.tool/read-read-attribution]
+                           [:intents            rf.hicasso.tool/read-intents]
+                           [:explain-render     rf.hicasso.tool/explain-render]]]
       (is (zero? (.-length f))
           (str read-name " must take no argument at all — an audience, a profile "
                "or a verbosity parameter is how two consumers come to hold two "
@@ -706,14 +706,14 @@
 
 (deftest every-read-answers-nil-when-the-debug-define-is-off
   (seeded!)
-  (let [release (mount! (fn [_] (h/sub [:tr/left]) nil))]
-    (with-redefs [interop/debug-enabled? false]
-      (doseq [[read-name f] [[:mounted-boundaries tool/read-mounted-boundaries]
-                             [:read-attribution   tool/read-read-attribution]
-                             [:intents            tool/read-intents]
-                             [:explain-render     tool/explain-render]]]
+  (let [release (mount! (fn [_] (rf.hicasso/sub [:tr/left]) nil))]
+    (with-redefs [rf.interop/debug-enabled? false]
+      (doseq [[read-name f] [[:mounted-boundaries rf.hicasso.tool/read-mounted-boundaries]
+                             [:read-attribution   rf.hicasso.tool/read-read-attribution]
+                             [:intents            rf.hicasso.tool/read-intents]
+                             [:explain-render     rf.hicasso.tool/explain-render]]]
         (is (nil? (f))
             (str read-name " must answer nil with the debug define off"))))
     (testing "and the guard is not one-way — the same read answers again with it on"
-      (is (some? (tool/read-mounted-boundaries))))
+      (is (some? (rf.hicasso.tool/read-mounted-boundaries))))
     (release)))

--- a/implementation/hicasso/test/re_frame/hicasso/tool_views_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/tool_views_dom_cljs_test.cljs
@@ -15,14 +15,14 @@
   as the residue witnesses do, because `mount/release!` empties every
   table by fiat. On the node lane every row states a skip."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.roots-frames-support :as support]
-            [re-frame.hicasso.tool :as tool]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.roots-frames-support :as rf.hicasso.roots-frames-support]
+            [re-frame.hicasso.tool :as rf.hicasso.tool]
+            [re-frame.test-support :as rf.test-support]
             ["react" :as react]))
 
 (def ^:private frame-id ::tool-views-dom)
@@ -30,10 +30,10 @@
 (rf/reg-sub ::left (fn [db _] (:left db)))
 (rf/reg-event ::seed (fn [_ _] {:db {:left 1}}))
 
-(h/defview alpha-view [_] [:b.alpha (str (h/sub [::left]))])
-(h/defview beta-view  [_] [:i.beta  (str (h/sub [::left]))])
-(h/defhost strict-mode react/StrictMode {:server :render})
-(h/defview strict-alpha
+(rf.hicasso/defview alpha-view [_] [:b.alpha (str (rf.hicasso/sub [::left]))])
+(rf.hicasso/defview beta-view  [_] [:i.beta  (str (rf.hicasso/sub [::left]))])
+(rf.hicasso/defhost strict-mode react/StrictMode {:server :render})
+(rf.hicasso/defview strict-alpha
   "`alpha-view` under React's own StrictMode, which double-invokes the
   body and runs mount/unmount/mount over the subscription effect."
   [_]
@@ -43,13 +43,13 @@
 (def ^:private beta-name  "re-frame.hicasso.tool-views-dom-cljs-test/beta-view")
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      :ambient-frame nil
      :async?        true
      :init-fn       (fn []
-                      (support/leave-act-environment!)
-                      (collector/reset-runtime!))}))
+                      (rf.hicasso.roots-frames-support/leave-act-environment!)
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 (def ^:private k [frame-id [::left]])
 
@@ -58,29 +58,29 @@
   []
   (some (fn [r] (when (some #(= ::left (:sub-id %)) (:reads r))
                   (mapv :view (:views r))))
-        (:boundaries (tool/read-mounted-boundaries))))
+        (:boundaries (rf.hicasso.tool/read-mounted-boundaries))))
 
 (defn- mount-root!
   "A root of its own for `hiccup`, joining `frame-id` and seeding it on
   the first mount only."
   [hiccup]
-  (mount/root! (mount/fresh-container!) frame-id hiccup
+  (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!) frame-id hiccup
                {:initial-events [[::seed]]}))
 
 (defn- finish!
   "Release every root and end the row once."
   [done handles]
   (fn [_]
-    (doseq [h handles] (mount/release! (assoc h :root nil)))
+    (doseq [h handles] (rf.hicasso.impl.mount/release! (assoc h :root nil)))
     (done)))
 
 (deftest a-view-react-unmounts-leaves-the-row-its-twin-still-holds
   (async done
-    (if-not (mount/browser?)
-      (do (support/skip! ":node-test has no React DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM") (done))
       (let [a (mount-root! [alpha-view {}])
             b (mount-root! [beta-view {}])]
-        (-> (support/wait-until! #(= 2 (support/readers-of k)))
+        (-> (rf.hicasso.roots-frames-support/wait-until! #(= 2 (rf.hicasso.roots-frames-support/readers-of k)))
             (.then
               (fn [subscribed?]
                 (testing "the premise: React committed both roots — two
@@ -89,11 +89,11 @@
                   (is (= [alpha-name beta-name] (names-of))))
                 (testing "React's unmount cleanup released alpha's reference,
                           and the name went with it: beta's row names beta"
-                  (mount/unmount! a)
-                  (is (= 1 (support/readers-of k)))
+                  (rf.hicasso.impl.mount/unmount! a)
+                  (is (= 1 (rf.hicasso.roots-frames-support/readers-of k)))
                   (is (= [beta-name] (names-of))))
                 (testing "and the last holder leaving leaves no row at all"
-                  (mount/unmount! b)
+                  (rf.hicasso.impl.mount/unmount! b)
                   (is (nil? (names-of))))
                 nil))
             (.catch (fn [e] (is false (str "twin unmount — " (.-message e)))))
@@ -101,10 +101,10 @@
 
 (deftest strict-modes-discarded-render-and-replayed-effect-name-the-view-once
   (async done
-    (if-not (mount/browser?)
-      (do (support/skip! ":node-test has no React DOM") (done))
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (rf.hicasso.roots-frames-support/skip! ":node-test has no React DOM") (done))
       (let [a (mount-root! [strict-alpha {}])]
-        (-> (support/wait-until! #(= 1 (support/readers-of k)))
+        (-> (rf.hicasso.roots-frames-support/wait-until! #(= 1 (rf.hicasso.roots-frames-support/readers-of k)))
             (.then
               (fn [subscribed?]
                 (testing "the premise: one reader — StrictMode's replayed
@@ -113,11 +113,11 @@
                 (testing "the discarded first render wrote no name, and the
                           effect's unmount/mount replay left the count at one"
                   (let [row (first (filter (fn [r] (some #(= ::left (:sub-id %)) (:reads r)))
-                                           (:boundaries (tool/read-mounted-boundaries))))]
+                                           (:boundaries (rf.hicasso.tool/read-mounted-boundaries))))]
                     (is (= 1 (:instances row)))
                     (is (= [alpha-name] (mapv :view (:views row))))))
                 (testing "and its unmount takes the name with it"
-                  (mount/unmount! a)
+                  (rf.hicasso.impl.mount/unmount! a)
                   (is (nil? (names-of))))
                 nil))
             (.catch (fn [e] (is false (str "StrictMode naming — " (.-message e)))))

--- a/implementation/hicasso/test/re_frame/hicasso/view_alias_registry_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/view_alias_registry_cljs_test.cljs
@@ -46,10 +46,10 @@
   nothing at all."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.registrar :as registrar]
-            [re-frame.test-support :as test-support]))
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---------------------------------------------------------------------------
 ;; The declarations — ABOVE `use-fixtures`, and that is load-bearing
@@ -63,13 +63,13 @@
 ;; hazard the fixture's own docstring describes. Declared above it, they are
 ;; part of this file's baseline and are reinstated before every row.
 
-(h/defview aliased-row
+(rf.hicasso/defview aliased-row
   "A DOCUMENTED boundary — the `:doc` half of the slot needs one that has a
   docstring to carry."
   [{:keys [label]}]
   [:li label])
 
-(h/defview undocumented-row
+(rf.hicasso/defview undocumented-row
   [_]
   [:li "no docstring"])
 
@@ -81,7 +81,7 @@
   [:li "core"])
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:ambient-frame nil}))
 
 ;; ---------------------------------------------------------------------------
@@ -185,7 +185,7 @@
             whole — same id, same coord keys, same untouched head"
     (let [head #(:hicasso/component (slot ::aliased-row))
           before (head)]
-      (collector/publish-view-alias!
+      (rf.hicasso.impl.collector/publish-view-alias!
         ::aliased-row (select-keys (slot ::aliased-row) coord-keys) before)
       (is (identical? before (head)))
       (is (not (contains? (slot ::aliased-row) :handler-fn))))))
@@ -204,7 +204,7 @@
         coords    (select-keys (slot ::aliased-row) coord-keys)
         before    (count (rf/registrations :view))]
 
-    (collector/publish-view-alias! ::aliased-row coords reloaded)
+    (rf.hicasso.impl.collector/publish-view-alias! ::aliased-row coords reloaded)
 
     (testing "one entry, not two — the registrar replaces the slot behind
               the id it already holds"
@@ -248,7 +248,7 @@
   (atom nil))
 
 (defonce ^:private recording-hook
-  (do (registrar/add-replacement-hook!
+  (do (rf.registrar/add-replacement-hook!
         (fn [m]
           (when @recorded
             (swap! recorded conj (select-keys m [:kind :id :different-fn?])))))
@@ -279,7 +279,7 @@
               devtool refreshes on"
       (let [rotated (fn rotated-row [_] nil)
             calls   (while-recording
-                      #(collector/publish-view-alias! ::aliased-row coords rotated))]
+                      #(rf.hicasso.impl.collector/publish-view-alias! ::aliased-row coords rotated))]
         (is (= 1 (count calls)) "exactly one replacement, not zero and not two")
         (is (= {:kind :view :id ::aliased-row :different-fn? true}
                (first calls)))))
@@ -289,7 +289,7 @@
               like, and still says so"
       (let [same  (head)
             calls (while-recording
-                    #(collector/publish-view-alias! ::aliased-row coords same))]
+                    #(rf.hicasso.impl.collector/publish-view-alias! ::aliased-row coords same))]
         (is (= 1 (count calls)) "the hook fires on every re-registration")
         (is (= {:kind :view :id ::aliased-row :different-fn? false}
                (first calls)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/view_body_retention_elision_prod_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/view_body_retention_elision_prod_test.cljs
@@ -38,16 +38,16 @@
   `deftest`, and its `sentinel-row` is minted by the same `h/defview` door
   every application view is."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.hicasso.coord-sentinel-source :as sentinel]
-            [re-frame.hicasso.impl.codec :as codec]))
+            [re-frame.hicasso.coord-sentinel-source :as rf.hicasso.coord-sentinel-source]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]))
 
 (deftest the-sentinel-head-is-a-real-minted-boundary-in-this-bundle
   (testing "the POSITIVE CONTROL, and the reason the absences below are not
             green for the wrong reason: an unminted, missing or
             wholly-DCE'd head would satisfy every one of them trivially"
-    (is (fn? sentinel/sentinel-row))
-    (is (true? (codec/boundary-head? sentinel/sentinel-row)))
-    (is (= sentinel/view-name (.-displayName sentinel/sentinel-row))
+    (is (fn? rf.hicasso.coord-sentinel-source/sentinel-row))
+    (is (true? (rf.hicasso.impl.codec/boundary-head? rf.hicasso.coord-sentinel-source/sentinel-row)))
+    (is (= rf.hicasso.coord-sentinel-source/view-name (.-displayName rf.hicasso.coord-sentinel-source/sentinel-row))
         "the view name is NOT elided — it is the measure id and the React
          DevTools label")))
 
@@ -55,7 +55,7 @@
   (testing "`(when ^boolean js/goog.DEBUG (codec/retain-body! head body-fn))`
             in `mint-view!` folds away whole, so the slot the test kit reads
             was never written and the body is unreachable from the head"
-    (is (nil? (codec/retained-body sentinel/sentinel-row)))))
+    (is (nil? (rf.hicasso.impl.codec/retained-body rf.hicasso.coord-sentinel-source/sentinel-row)))))
 
 (deftest no-own-property-of-a-production-head-holds-a-function
   (testing "the slot-name-independent form of the same claim: the body is a
@@ -64,9 +64,9 @@
             accidentally-duplicated retention is caught here even though the
             row above reads one slot"
     (let [held (into {}
-                     (comp (map (fn [k] [k (unchecked-get sentinel/sentinel-row k)]))
+                     (comp (map (fn [k] [k (unchecked-get rf.hicasso.coord-sentinel-source/sentinel-row k)]))
                            (filter (fn [[_ v]] (fn? v))))
-                     (js->clj (js/Object.keys sentinel/sentinel-row)))]
+                     (js->clj (js/Object.keys rf.hicasso.coord-sentinel-source/sentinel-row)))]
       (is (= {} held)
           "a production head's own properties are the display name and the
            boundary markers — never a body"))))

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
@@ -224,12 +224,12 @@
   (:refer-clojure :exclude [find])
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.error :as error]
-            [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.controlled :as controlled]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.impl.intent :as intent]))
+            [re-frame.error :as rf.error]
+            [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.controlled :as rf.hicasso.impl.controlled]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.hicasso.impl.intent :as rf.hicasso.impl.intent]))
 
 ;; ---------------------------------------------------------------------------
 ;; Refusals — one constructor, so every refusal has the same identity shape
@@ -251,7 +251,7 @@
   cannot hand a catch site a different `:rf.error/id` from the one in the
   message beside it — this kit's refusal is the runtime's refusal."
   [id reason extra]
-  (throw (error/ex-info-from-data
+  (throw (rf.error/ex-info-from-data
            (merge extra
                   {:rf.error/id id :where where
                    :reason reason :recovery :no-recovery}))))
@@ -320,21 +320,21 @@
   discrimination that makes this an assertion rather than a restatement
   of `fn?`."
   [v]
-  (codec/boundary-head? v))
+  (rf.hicasso.impl.codec/boundary-head? v))
 
 (defn host?
   "Is `v` a minted host crossing — the value `h/defhost` defines? False
   for the foreign component the declaration named, which is the point:
   the crossing is a distinct value with a policy of its own."
   [v]
-  (codec/host-head? v))
+  (rf.hicasso.impl.codec/host-head? v))
 
 (defn callback?
   "Is `v` the one callback form — the value `h/event` expands to? False for
   an identically-written plain `fn`, so a position that imposes a
   contract can tell them apart and so can a test."
   [v]
-  (intent/callback? v))
+  (rf.hicasso.impl.intent/callback? v))
 
 (defn view-name
   "The `\"<ns>/<sym>\"` name a minted boundary or host carries — the same
@@ -358,7 +358,7 @@
              (str "host-policy reads the `:server` policy off a minted `h/defhost` "
                   "crossing; it was given " (pr-str (type v)) ".")
              {:value v}))
-  (codec/host-server v))
+  (rf.hicasso.impl.codec/host-server v))
 
 ;; ---------------------------------------------------------------------------
 ;; L1 — the codec, projected
@@ -428,10 +428,10 @@
              (str "element-props projects ONE native hiccup form — a vector "
                   "whose head is a tag keyword. It was given " (pr-str form) ".")
              {:value form}))
-  (let [parsed (codec/cached-parse (nth form 0))
+  (let [parsed (rf.hicasso.impl.codec/cached-parse (nth form 0))
         props  (form-props form)
-        js-props (intent/with-frame l1-frame probe-dispatch
-                   (fn [] (codec/convert-props props parsed)))]
+        js-props (rf.hicasso.impl.intent/with-frame l1-frame probe-dispatch
+                   (fn [] (rf.hicasso.impl.codec/convert-props props parsed)))]
     (persistent!
       (reduce (fn [m k] (assoc! m k (opaque-value (unchecked-get js-props k))))
               (transient {})
@@ -457,7 +457,7 @@
              (str "materialize takes an intent VECTOR; it was given "
                   (pr-str intent-v) ".")
              {:value intent-v}))
-  (intent/materialize intent-v #js {"target" #js {"value" value "checked" checked}}))
+  (rf.hicasso.impl.intent/materialize intent-v #js {"target" #js {"value" value "checked" checked}}))
 
 (defn controlled?
   "Does the codec install the **controlled shadow** for this native form —
@@ -474,12 +474,12 @@
              (str "controlled? asks about ONE native hiccup form — a vector "
                   "whose head is a tag keyword. It was given " (pr-str form) ".")
              {:value form}))
-  (let [parsed   (codec/cached-parse (nth form 0))
+  (let [parsed   (rf.hicasso.impl.codec/cached-parse (nth form 0))
         props    (form-props form)
-        js-props (intent/with-frame l1-frame probe-dispatch
-                   (fn [] (codec/convert-props props parsed)))
+        js-props (rf.hicasso.impl.intent/with-frame l1-frame probe-dispatch
+                   (fn [] (rf.hicasso.impl.codec/convert-props props parsed)))
         tag      (.-tag parsed)]
-    (not (identical? tag (controlled/install! tag js-props)))))
+    (not (identical? tag (rf.hicasso.impl.controlled/install! tag js-props)))))
 
 (defn revision
   "The `::h/revision` value a native form carries, or nil.
@@ -489,7 +489,7 @@
   law). It is read **pre-conversion**, off the author's own attribute
   map, which is where the codec reads it — here as there."
   [form]
-  (get (form-props form) codec/revision-key))
+  (get (form-props form) rf.hicasso.impl.codec/revision-key))
 
 ;; ---------------------------------------------------------------------------
 ;; L1 — the canonical DOM comparator
@@ -543,7 +543,7 @@
               (case (.-nodeType n)
                 1 (let [tag   (str/lower-case (.-tagName n))
                         attrs (->> (array-seq (.-attributes n))
-                                   (remove (fn [a] (contains? runtime/annotation-attributes
+                                   (remove (fn [a] (contains? rf.hicasso.test.runtime/annotation-attributes
                                                               (.-name a))))
                                    (map (fn [a] [(.-name a) (.-value a)]))
                                    (sort-by first))]
@@ -668,8 +668,8 @@
                     "the fault this door exists to make loud; the positions "
                     "written are " (pr-str (vec (keys props))) ".")
                {:position prop :written (vec (keys props))}))
-    (let [handler (intent/with-frame frame-kw (collector/frame-dispatch frame-kw)
-                    (fn [] (intent/lower-prop prop (get props prop))))]
+    (let [handler (rf.hicasso.impl.intent/with-frame frame-kw (rf.hicasso.impl.collector/frame-dispatch frame-kw)
+                    (fn [] (rf.hicasso.impl.intent/lower-prop prop (get props prop))))]
       (when-not (fn? handler)
         (refuse! :rf.error/hicasso-test-position-is-not-a-handler
                  (str (pr-str prop) " lowered to " (pr-str handler)
@@ -966,7 +966,7 @@
   (into []
         (remove #(= "" %))
         (reduce (fn add [out x]
-                  (let [kind (codec/child-kind x)]
+                  (let [kind (rf.hicasso.impl.codec/child-kind x)]
                     (case kind
                       :nothing out
                       :splice  (reduce add out x)
@@ -976,18 +976,18 @@
 
 (defn- element-node
   [form ns-ctx]
-  (let [parsed  (codec/cached-parse (nth form 0))
+  (let [parsed  (rf.hicasso.impl.codec/cached-parse (nth form 0))
         tag     (keyword (.-tag parsed))
         props   (form-props form)
         ;; The codec's own two shorthand rules, taken from it rather than
         ;; restated: an explicit id WINS over `#id`, and the shorthand
         ;; class is PREPENDED to a declared one
         ;; (`codec/fold-shorthand!`).
-        classes (codec/class-names (.-className parsed) (:class props))
+        classes (rf.hicasso.impl.codec/class-names (.-className parsed) (:class props))
         id      (or (:id props) (.-id parsed))
         events  (persistent!
                   (reduce-kv (fn [m k v]
-                               (if (intent/event-prop? k)
+                               (if (rf.hicasso.impl.intent/event-prop? k)
                                  (assoc! m k (opaque-prop :attr k v))
                                  m))
                              (transient {})
@@ -995,7 +995,7 @@
         attrs   (persistent!
                   (reduce-kv (fn [m k v]
                                (cond
-                                 (intent/event-prop? k) m
+                                 (rf.hicasso.impl.intent/event-prop? k) m
                                  (= :key k)             m
                                  (= :class k)           m
                                  (= :id k)              m
@@ -1080,7 +1080,7 @@
   malformed HEAD, and `[:> :div]` with a pointer to L3: an instruction to
   go mount, in a browser, a form that cannot mount anywhere."
   [form ns-ctx]
-  (case (codec/vector-kind form)
+  (case (rf.hicasso.impl.codec/vector-kind form)
     :tag      (element-node form ns-ctx)
     :fragment (fragment-node form ns-ctx)
     :boundary (boundary-node form ns-ctx)
@@ -1197,7 +1197,7 @@
   live cell, and [[tree]] removes every one of them on the way out."
   [frame-kw fixtures]
   (let [keys' (mapv (fn [[query-v _]] [frame-kw query-v]) fixtures)]
-    (swap! collector/!cells
+    (swap! rf.hicasso.impl.collector/!cells
            (fn [cells]
              (reduce-kv (fn [m query-v v]
                           ;; `epoch` alongside the reaction because a
@@ -1224,7 +1224,7 @@
   correctly present."
   [frame-kw fixtures entry]
   (let [supplied (into #{} (map (fn [[q _]] [frame-kw q])) fixtures)
-        missing  (remove supplied (runtime/reads-of entry))]
+        missing  (remove supplied (rf.hicasso.test.runtime/reads-of entry))]
     (when (seq missing)
       (refuse! :rf.error/hicasso-test-missing-read-fixture
                (str "the body read " (count missing) " subscription"
@@ -1338,8 +1338,8 @@
          ;; property (rf2-kjf5). Substituting it here is the whole of L2's
          ;; support for `[some-view …]`: everything below then reads the
          ;; body function, and the view runs AS WRITTEN.
-         head   (if (codec/boundary-head? minted)
-                  (or (codec/retained-body minted)
+         head   (if (rf.hicasso.impl.codec/boundary-head? minted)
+                  (or (rf.hicasso.impl.codec/retained-body minted)
                       ;; Reachable in one build only — `:advanced` with
                       ;; `goog.DEBUG=false`, where the property was never
                       ;; written. There is genuinely nothing to run, so the
@@ -1356,7 +1356,7 @@
                                     (tier-pointer :l3))
                                {:view (view-name minted)}))
                   minted)]
-     (when (codec/host-head? head)
+     (when (rf.hicasso.impl.codec/host-head? head)
        (refuse-opaque! :rf.error/hicasso-test-host-is-opaque
                        (str "`" (view-name head) "` is a `h/defhost` crossing. "
                             "What a foreign React component renders is React's "
@@ -1384,19 +1384,19 @@
            ;; drop them. `codec/realize-children` is the flatten, so the
            ;; one-level seq splice is the runtime's rather than a second
            ;; rule with the same name.
-           props    (if-some [cs (codec/realize-children form (if has-props? 2 1))]
+           props    (if-some [cs (rf.hicasso.impl.codec/realize-children form (if has-props? 2 1))]
                       (assoc props :children cs)
                       props)
            !tree    (volatile! nil)
            keys'    (install-fixtures! frame-kw fixtures)]
        (try
-         (collector/render-body
+         (rf.hicasso.impl.collector/render-body
            frame-kw
            (fn hicasso-test-body [p]
              (vreset! !tree (canonical-children [(head p)] nil))
              nil)
            props)
-         (verify-fixtures! frame-kw fixtures (collector/last-reads))
+         (verify-fixtures! frame-kw fixtures (rf.hicasso.impl.collector/last-reads))
          ;; 004B §Versioning — the emitter returns the ROOT NODE, always a
          ;; map, carrying the version. A body that answered ONE node roots
          ;; in it; a body that answered text, several nodes, or NOTHING
@@ -1410,7 +1410,7 @@
              (assoc (nth children 0) tree-version-key tree-version)
              {tree-version-key tree-version :children children}))
          (finally
-           (swap! collector/!cells (fn [cells] (apply dissoc cells keys')))))))))
+           (swap! rf.hicasso.impl.collector/!cells (fn [cells] (apply dissoc cells keys')))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; L2 — the projections (004B §Projections; `re-frame.freehand.test`'s

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/mounted.cljs
@@ -187,12 +187,12 @@
             [clojure.walk :as walk]
             [cljs.test :as t]
             [re-frame.core :as rf]
-            [re-frame.error :as error]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.impl.roots :as roots]
-            [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.test-support :as test-support]
+            [re-frame.error :as rf.error]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.impl.roots :as rf.hicasso.impl.roots]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]))
 
@@ -478,7 +478,7 @@
   facade does not visit should read it through the same door the report
   does, rather than through a second assembly of the same numbers."
   []
-  (assoc (runtime/residue) :frames (set (rf/frame-ids))))
+  (assoc (rf.hicasso.test.runtime/residue) :frames (set (rf/frame-ids))))
 
 ;; ---------------------------------------------------------------------------
 ;; The work counter — the census's opposite number
@@ -568,9 +568,9 @@
   where this counter bumps once per body INVOCATION — so on a body the
   fence re-ran the two disagree by design."
   [f]
-  (runtime/reset-body-runs!)
+  (rf.hicasso.test.runtime/reset-body-runs!)
   (f)
-  (runtime/body-runs))
+  (rf.hicasso.test.runtime/body-runs))
 
 (defn- leaked
   "What `now` has that `baseline` did not — the report's `:leaked` map, or
@@ -720,7 +720,7 @@
                              #js {:onUncaughtError (fn [error _info] (catch! error))})
                 :frame     frame-kw
                 :container container}]
-    (try (mount/render! handle hiccup)
+    (try (rf.hicasso.impl.mount/render! handle hiccup)
          (catch :default e (catch! e)))
     handle))
 
@@ -750,7 +750,7 @@
   So the rollback takes it down and the complaint is the honest residue
   of a hydration that failed."
   [frame-kw node supplied? root]
-  (when (some? root) (mount/unmount! root))
+  (when (some? root) (rf.hicasso.impl.mount/unmount! root))
   (when-not supplied?
     (when-some [p (.-parentNode node)] (.removeChild p node)))
   (swap! !facade-frames disj frame-kw)
@@ -842,7 +842,7 @@
    (try
      (let [[frame-kw ordinal] (mint-frame! initial-events)
            baseline           (census)
-           node               (or container (mount/fresh-container!))
+           node               (or container (rf.hicasso.impl.mount/fresh-container!))
            !refusal           (volatile! nil)
            root               (catching-root! node frame-kw form
                                               (fn [error]
@@ -914,11 +914,11 @@
   ([form {:keys [initial-events container html clock]} budget-ms]
    (let [[frame-kw ordinal] (mint-frame! initial-events)
          baseline  (census)
-         node      (or container (mount/fresh-container!))
+         node      (or container (rf.hicasso.impl.mount/fresh-container!))
          supplied? (some? container)
          _         (when (some? html) (set! (.-innerHTML node) html))
          !refusal  (volatile! nil)
-         root      (try (mount/hydrate-root! node frame-kw form)
+         root      (try (rf.hicasso.impl.mount/hydrate-root! node frame-kw form)
                         (catch :default e (vreset! !refusal e) nil))]
      (if-some [refusal @!refusal]
        (do (abandon! frame-kw node supplied? nil)
@@ -929,7 +929,7 @@
            (fn [resolve reject]
              (letfn [(tick []
                        (cond
-                         (not (roots/adopting? window))
+                         (not (rf.hicasso.impl.roots/adopting? window))
                          ;; Past the closer AND past the reap horizon, so the
                          ;; handle a caller receives is one whose tables have
                          ;; settled. This is also where the construction
@@ -974,7 +974,7 @@
 
   Takes a hydrated handle unchanged."
   [handle form]
-  (mount/render! handle form)
+  (rf.hicasso.impl.mount/render! handle form)
   handle)
 
 (defn settle!
@@ -1019,7 +1019,7 @@
   The flush is React's and is therefore page-wide; the handle is taken so
   that every door in this facade reads the same way."
   [handle]
-  (mount/settle!)
+  (rf.hicasso.impl.mount/settle!)
   handle)
 
 (defn settle-until!
@@ -1082,7 +1082,7 @@
   calls `done`; `re-frame.test-support/poll-until` says why."
   ([handle pred] (settle-until! handle pred nil))
   ([handle pred opts]
-   (.then (test-support/poll-until pred opts)
+   (.then (rf.test-support/poll-until pred opts)
           (fn [_] (settle! handle)))))
 
 (defn advance-clock!
@@ -1172,7 +1172,7 @@
 
   It is not `act`: see the namespace docstring."
   [handle event]
-  (mount/dispatch! handle event)
+  (rf.hicasso.impl.mount/dispatch! handle event)
   handle)
 
 (defn unmount!
@@ -1201,7 +1201,7 @@
   Idempotent: unmounting twice is not an error, and only the first call
   counts against the standing-mount census."
   [handle]
-  (mount/unmount! handle)
+  (rf.hicasso.impl.mount/unmount! handle)
   (when (= :mounted @(get handle state-key))
     (vreset! (get handle state-key) :unmounted)
     (swap! !standing dec))
@@ -1257,7 +1257,7 @@
   (release-clock-for! handle)
   (let [baseline (get handle baseline-key)
         mounted? (= :mounted @(get handle state-key))]
-    (.then (runtime/quiesced!)
+    (.then (rf.hicasso.test.runtime/quiesced!)
            (fn [_]
              (let [now (census)
                    l   (leaked baseline now)]
@@ -1339,7 +1339,7 @@
            (when (= :unmounted @(get handle state-key))
              (vreset! (get handle state-key) :read)
              (when (zero? (swap! !open dec))
-               (collector/reset-runtime!))
+               (rf.hicasso.impl.collector/reset-runtime!))
              (swap! !facade-frames disj (:frame handle))
              (rf/destroy-frame! (:frame handle)))
            report)))
@@ -1408,7 +1408,7 @@
   `:rf.error/hicasso-test-bad-option`. See the namespace docstring §Refusals
   on why this door refuses at all and why it mints no id to do it."
   [reason extra]
-  (throw (error/ex-info-from-data
+  (throw (rf.error/ex-info-from-data
            (merge extra
                   {:rf.error/id :rf.error/hicasso-test-bad-option
                    :where       're-frame.hicasso.test.mounted
@@ -1510,7 +1510,7 @@
   (persistent!
     (reduce (fn [attributes attribute]
               (let [attribute-name (.-name attribute)]
-                (if (contains? runtime/annotation-attributes attribute-name)
+                (if (contains? rf.hicasso.test.runtime/annotation-attributes attribute-name)
                   attributes
                   (assoc! attributes
                           attribute-name

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/runtime.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/runtime.cljs
@@ -29,10 +29,10 @@
   place — stays on the collector: it is the runtime's own seam rather
   than an instrument, and Xray's suites drive it through the artefact's
   published paths, which this source root is outside of."
-  (:require [re-frame.hicasso.impl.codec :as codec]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.frames :as frames]
-            [re-frame.hicasso.impl.generation :as generation]))
+  (:require [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.frames :as rf.hicasso.impl.frames]
+            [re-frame.hicasso.impl.generation :as rf.hicasso.impl.generation]))
 
 ;; ---------------------------------------------------------------------------
 ;; What a DOM comparison must not see
@@ -73,17 +73,17 @@
   whose body read nothing retains nothing in this table, so it is
   correctly absent (its read-set entry is still counted by `:entries`)."
   []
-  (let [cells       @collector/!cells
+  (let [cells       @rf.hicasso.impl.collector/!cells
         memberships (reduce-kv (fn [acc _ ^js c] (+ acc (alength (.-readers c)))) 0 cells)
         boundaries  (reduce-kv (fn [acc _ ^js c] (into acc (.-readers c))) #{} cells)]
     {:cells      (count cells)
      :cell-refs  memberships
      :edges      memberships
      :boundaries (count boundaries)
-     :entries    (reduce + 0 (map (fn [[_ v]] (count v)) @collector/!entries))
-     :generation (generation/generation)
-     :frames     (count @frames/!frame-ops)
-     :codec      (codec/cache-sizes)}))
+     :entries    (reduce + 0 (map (fn [[_ v]] (count v)) @rf.hicasso.impl.collector/!entries))
+     :generation (rf.hicasso.impl.generation/generation)
+     :frames     (count @rf.hicasso.impl.frames/!frame-ops)
+     :codec      (rf.hicasso.impl.codec/cache-sizes)}))
 
 (defn residue
   "What must be zero after a clean teardown. `:cell-refs` is the standing
@@ -114,8 +114,8 @@
     (fn [resolve]
       ((fn settle []
          (js/setTimeout (fn []
-                          (if (collector/reapers-armed?) (settle) (resolve nil)))
-                        (inc collector/entry-reap-horizon-ms)))))))
+                          (if (rf.hicasso.impl.collector/reapers-armed?) (settle) (resolve nil)))
+                        (inc rf.hicasso.impl.collector/entry-reap-horizon-ms)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The cell and entry witnesses
@@ -128,7 +128,7 @@
   The failure the disposal rows pin is what a HELD container answers
   after its disposal, so they have to be able to hold it."
   [sub-key]
-  (some-> ^js (get @collector/!cells sub-key) (.-reaction)))
+  (some-> ^js (get @rf.hicasso.impl.collector/!cells sub-key) (.-reaction)))
 
 (defn cell-readers
   "The registrations currently reading `sub-key` — the cell's own reader
@@ -145,7 +145,7 @@
   baseline that mutates into the result is a witness that cannot see a
   leak."
   [sub-key]
-  (if-some [^js c (get @collector/!cells sub-key)]
+  (if-some [^js c (get @rf.hicasso.impl.collector/!cells sub-key)]
     (vec (aclone (.-readers c)))
     []))
 
@@ -188,12 +188,12 @@
   the thing they are measuring, which is why `collector/reset-runtime!`
   deliberately leaves it alone."
   []
-  (.-bodyRuns collector/rstate))
+  (.-bodyRuns rf.hicasso.impl.collector/rstate))
 
 (defn reset-body-runs!
   "Zero [[body-runs]]. Explicit, and not part of `collector/reset-runtime!`."
   []
-  (set! (.-bodyRuns collector/rstate) 0)
+  (set! (.-bodyRuns rf.hicasso.impl.collector/rstate) 0)
   nil)
 
 (def shell-hook-ledger

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test/server.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test/server.cljs
@@ -16,7 +16,7 @@
   `server/render-twice` (naming-ledger row 50); it moved here under
   rf2-6c12m.15 because nothing a running host does calls it.
   Design record: docs/design/hicasso/product/naming-ledger.md row 50."
-  (:require [re-frame.hicasso.server :as server]))
+  (:require [re-frame.hicasso.server :as rf.hicasso.server]))
 
 (defn render-twice
   "`server/render` the same `opts` twice and compare the two documents
@@ -27,8 +27,8 @@
   frame ids, which is what makes this the standing proof that the
   per-request id is invisible on the wire."
   [opts]
-  (let [a (server/render opts)
-        b (server/render opts)
+  (let [a (rf.hicasso.server/render opts)
+        b (rf.hicasso.server/render opts)
         x (:document a)
         y (:document b)]
     {:first      a

--- a/implementation/hicasso/test_kit/test/re_frame/hicasso/shadow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test_kit/test/re_frame/hicasso/shadow_dom_cljs_test.cljs
@@ -64,13 +64,13 @@
   rather than a false green. The refusal rows mount nothing — shadow!
   validates its options before it allocates — so they run in both lanes."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test :as ht]
-            [re-frame.hicasso.test.mounted :as hm]
-            [re-frame.test-support :as test-support]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test :as rf.hicasso.test]
+            [re-frame.hicasso.test.mounted :as rf.hicasso.test.mounted]
+            [re-frame.test-support :as rf.test-support]
             ;; The ONE second view library this namespace names, and only so
             ;; that [[foreign-title-row]] is a genuinely foreign element type.
             ;; `hm/shadow!` itself still requires none — that is its design.
@@ -117,8 +117,8 @@
               (fn [{:keys [db]} [_ v]] {:db (assoc db :picked v)}))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter       uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
      ;; No ambient dynamic-var frame stamp: the only thing that may name a
      ;; frame here is the root each mount sits under, which is the isolation
      ;; the whole door rests on.
@@ -127,25 +127,25 @@
                       ;; React's `act` queue is not the browser's scheduler,
                       ;; and every reading here is taken outside it.
                       (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-                      (collector/reset-runtime!))}))
+                      (rf.hicasso.impl.collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The reference, the candidate, and three twins one form apart
 ;; ---------------------------------------------------------------------------
 
-(h/defview reference-row
+(rf.hicasso/defview reference-row
   "The original: one body, everything read at the top."
   [_]
-  (let [title    (h/sub [:hicasso.shadow/title])
-        editing? (h/sub [:hicasso.shadow/editing?])
-        saved    (h/sub [:hicasso.shadow/saved])]
+  (let [title    (rf.hicasso/sub [:hicasso.shadow/title])
+        editing? (rf.hicasso/sub [:hicasso.shadow/editing?])
+        saved    (rf.hicasso/sub [:hicasso.shadow/saved])]
     [:div.row
      [:h3.title title]
      (if editing?
        [:span.editor
         [:input.title {:value       title
                        :placeholder "Title"
-                       :on-input    [:hicasso.shadow/set-title ::h/value]}]
+                       :on-input    [:hicasso.shadow/set-title ::rf.hicasso/value]}]
         [:button.save {:on-click [:hicasso.shadow/save]} "Save"]]
        [:button.edit {:on-click [:hicasso.shadow/edit]} "Edit"])
      [:p.saved (str "saved: " (or saved "—"))]]))
@@ -158,69 +158,69 @@
   [:span.editor
    [:input.title {:value       title
                   :placeholder "Title"
-                  :on-input    [:hicasso.shadow/set-title ::h/value]}]
+                  :on-input    [:hicasso.shadow/set-title ::rf.hicasso/value]}]
    [:button.save {:on-click [:hicasso.shadow/save]} "Save"]])
 
-(h/defview candidate-row
+(rf.hicasso/defview candidate-row
   "The port: the same screen, written differently — reads pushed down
   into the branches that need them, and the editor lifted into a helper."
   [_]
   [:div.row
-   [:h3.title (h/sub [:hicasso.shadow/title])]
-   (if (h/sub [:hicasso.shadow/editing?])
-     (editor-markup (h/sub [:hicasso.shadow/title]))
+   [:h3.title (rf.hicasso/sub [:hicasso.shadow/title])]
+   (if (rf.hicasso/sub [:hicasso.shadow/editing?])
+     (editor-markup (rf.hicasso/sub [:hicasso.shadow/title]))
      [:button.edit {:on-click [:hicasso.shadow/edit]} "Edit"])
-   [:p.saved (str "saved: " (or (h/sub [:hicasso.shadow/saved]) "—"))]])
+   [:p.saved (str "saved: " (or (rf.hicasso/sub [:hicasso.shadow/saved]) "—"))]])
 
-(h/defview drifted-intent-row
+(rf.hicasso/defview drifted-intent-row
   "[[candidate-row]] with ONE form changed: the save button's intent
   carries an extra argument. The app-db lands in the same place and the
   page is identical, so only the intent stream can see it."
   [_]
   [:div.row
-   [:h3.title (h/sub [:hicasso.shadow/title])]
-   (if (h/sub [:hicasso.shadow/editing?])
+   [:h3.title (rf.hicasso/sub [:hicasso.shadow/title])]
+   (if (rf.hicasso/sub [:hicasso.shadow/editing?])
      [:span.editor
-      [:input.title {:value       (h/sub [:hicasso.shadow/title])
+      [:input.title {:value       (rf.hicasso/sub [:hicasso.shadow/title])
                      :placeholder "Title"
-                     :on-input    [:hicasso.shadow/set-title ::h/value]}]
+                     :on-input    [:hicasso.shadow/set-title ::rf.hicasso/value]}]
       [:button.save {:on-click [:hicasso.shadow/save :force]} "Save"]]
      [:button.edit {:on-click [:hicasso.shadow/edit]} "Edit"])
-   [:p.saved (str "saved: " (or (h/sub [:hicasso.shadow/saved]) "—"))]])
+   [:p.saved (str "saved: " (or (rf.hicasso/sub [:hicasso.shadow/saved]) "—"))]])
 
-(h/defview drifted-dom-row
+(rf.hicasso/defview drifted-dom-row
   "[[candidate-row]] with ONE attribute changed, and inside the branch
   the first script step opens — so the difference cannot be seen at the
   mount and the run must actually drive to reach it."
   [_]
   [:div.row
-   [:h3.title (h/sub [:hicasso.shadow/title])]
-   (if (h/sub [:hicasso.shadow/editing?])
+   [:h3.title (rf.hicasso/sub [:hicasso.shadow/title])]
+   (if (rf.hicasso/sub [:hicasso.shadow/editing?])
      [:span.editor
-      [:input.title {:value       (h/sub [:hicasso.shadow/title])
+      [:input.title {:value       (rf.hicasso/sub [:hicasso.shadow/title])
                      :placeholder "Article title"
-                     :on-input    [:hicasso.shadow/set-title ::h/value]}]
+                     :on-input    [:hicasso.shadow/set-title ::rf.hicasso/value]}]
       [:button.save {:on-click [:hicasso.shadow/save]} "Save"]]
      [:button.edit {:on-click [:hicasso.shadow/edit]} "Edit"])
-   [:p.saved (str "saved: " (or (h/sub [:hicasso.shadow/saved]) "—"))]])
+   [:p.saved (str "saved: " (or (rf.hicasso/sub [:hicasso.shadow/saved]) "—"))]])
 
 ;; ---------------------------------------------------------------------------
 ;; The live-control pair — one prop apart, and not one byte apart
 ;; ---------------------------------------------------------------------------
 
-(h/defview select-row
+(rf.hicasso/defview select-row
   "A native `<select>` bound to a value. Two mounts of it differ by that
   ONE prop and by nothing in the markup: React writes a selection by
   moving `option.selected`, and no content attribute tracks it."
   [{:keys [value]}]
   [:div.pick
    [:select.pick {:value     value
-                  :on-change [:hicasso.shadow/pick ::h/value]}
+                  :on-change [:hicasso.shadow/pick ::rf.hicasso/value]}
     [:option {:value "one"} "One"]
     [:option {:value "two"} "Two"]
     [:option {:value "three"} "Three"]]])
 
-(h/defview uncontrolled-fields
+(rf.hicasso/defview uncontrolled-fields
   "Three UNCONTROLLED controls — no bound value, no handler, nothing
   read. Each can be made dirty by hand without dispatching an intent,
   which is what makes a red here unambiguously the DOM comparison's:
@@ -255,7 +255,7 @@
 
 (defn- run
   [candidate]
-  (hm/shadow! {:reference      [reference-row {}]
+  (rf.hicasso.test.mounted/shadow! {:reference      [reference-row {}]
                :candidate      [candidate {}]
                :initial-events seed
                :script         script}))
@@ -316,7 +316,7 @@
   (if-not (browser?)
     (skip! "a selector is resolved against a real container")
     (let [{:keys [status checkpoint difference]}
-          (hm/shadow! {:reference      [reference-row {}]
+          (rf.hicasso.test.mounted/shadow! {:reference      [reference-row {}]
                        :candidate      [candidate-row {}]
                        :initial-events seed
                        :script         [{:click "button.no-such-control"}]})]
@@ -334,12 +334,12 @@
 ;; The live control state — the false green PR #8007's audit found
 ;; ---------------------------------------------------------------------------
 
-(defn- markup-of [handle] (ht/canonical-dom (:container handle)))
+(defn- markup-of [handle] (rf.hicasso.test/canonical-dom (:container handle)))
 
 (deftest a-select-showing-a-different-option-is-not-a-green
   (if-not (browser?)
     (skip! "a selection lives in a real element's properties")
-    (let [s (hm/shadow! {:reference [select-row {:value "two"}]
+    (let [s (rf.hicasso.test.mounted/shadow! {:reference [select-row {:value "two"}]
                          :candidate [select-row {:value "one"}]})]
       (try
         (testing "the two pages genuinely show a user different options"
@@ -370,7 +370,7 @@
 (deftest two-selects-showing-the-same-option-stay-green
   (if-not (browser?)
     (skip! "a selection lives in a real element's properties")
-    (let [s (hm/shadow! {:reference [select-row {:value "two"}]
+    (let [s (rf.hicasso.test.mounted/shadow! {:reference [select-row {:value "two"}]
                          :candidate [select-row {:value "two"}]})]
       (try
         (is (= {:status :green :checkpoints 1} ((:checkpoint! s)))
@@ -395,7 +395,7 @@
   or both sides' live control state with `mutate!`, and answer the next
   verdict — with `::started-green?` and `::same-markup?` beside it."
   [form mutate!]
-  (let [s (hm/shadow! {:reference form :candidate form})]
+  (let [s (rf.hicasso.test.mounted/shadow! {:reference form :candidate form})]
     (try
       (let [green? (= :green (:status ((:checkpoint! s))))]
         (mutate! (:container (:reference s)) (:container (:candidate s)))
@@ -477,7 +477,7 @@
 (deftest each-mount-owns-its-own-frame
   (if-not (browser?)
     (skip! "two frames need two roots")
-    (let [s (hm/shadow! {:reference      [reference-row {}]
+    (let [s (rf.hicasso.test.mounted/shadow! {:reference      [reference-row {}]
                          :candidate      [candidate-row {}]
                          :initial-events seed})]
       (try
@@ -488,7 +488,7 @@
           (is (= {:status :green :checkpoints 1} ((:checkpoint! s)))
               "checkpoint 0 — the same seed produced the same page twice")
 
-          (hm/dispatch-and-settle! (:reference s) [:hicasso.shadow/edit])
+          (rf.hicasso.test.mounted/dispatch-and-settle! (:reference s) [:hicasso.shadow/edit])
           (testing "a write on one side does not reach the other"
             (is (true? (rf/subscribe-once [:hicasso.shadow/editing?]
                                           {:frame ref-frame})))
@@ -505,23 +505,23 @@
 (deftest a-mounts-own-address-normalises
   (if-not (browser?)
     (skip! "an address is a live frame's keyword")
-    (let [s (hm/shadow! {:reference      [reference-row {}]
+    (let [s (rf.hicasso.test.mounted/shadow! {:reference      [reference-row {}]
                          :candidate      [candidate-row {}]
                          :initial-events seed})]
       (try
         ((:checkpoint! s))                                  ;; drain the seed
         (testing "each side's OWN frame keyword compares equal"
-          (hm/dispatch-and-settle! (:reference s)
+          (rf.hicasso.test.mounted/dispatch-and-settle! (:reference s)
                                    [:hicasso.shadow/noted (:frame (:reference s))])
-          (hm/dispatch-and-settle! (:candidate s)
+          (rf.hicasso.test.mounted/dispatch-and-settle! (:candidate s)
                                    [:hicasso.shadow/noted (:frame (:candidate s))])
           (is (= :green (:status ((:checkpoint! s))))
               (str "two isolated mounts have two frame keywords by construction; "
                    "an intent carrying its own is an ADDRESS, and comparing it "
                    "raw would redden every view holding an h/route-link")))
         (testing "and a FOREIGN address still reddens — the rule is narrow"
-          (hm/dispatch-and-settle! (:reference s) [:hicasso.shadow/noted ::alien-a])
-          (hm/dispatch-and-settle! (:candidate s) [:hicasso.shadow/noted ::alien-b])
+          (rf.hicasso.test.mounted/dispatch-and-settle! (:reference s) [:hicasso.shadow/noted ::alien-a])
+          (rf.hicasso.test.mounted/dispatch-and-settle! (:candidate s) [:hicasso.shadow/noted ::alien-b])
           (let [{:keys [status difference]} ((:checkpoint! s))]
             (is (= :red status))
             (is (= :intent (:kind difference)))
@@ -556,7 +556,7 @@
   remount the subtree under it on every pass."
   (r/reactify-component reagent-title-row))
 
-(h/defview hicasso-title-row
+(rf.hicasso/defview hicasso-title-row
   "The port of [[reagent-title-row]] — same markup, same single-word prop."
   [{:keys [title]}]
   [:div.row [:h3.title title]])
@@ -565,7 +565,7 @@
   (if-not (browser?)
     (skip! "a crossed foreign original needs a real React DOM")
     (is (= {:status :green :checkpoints 1}
-           (hm/shadow! {:reference      [:> foreign-title-row {:title "Original title"}]
+           (rf.hicasso.test.mounted/shadow! {:reference      [:> foreign-title-row {:title "Original title"}]
                         :candidate      [hicasso-title-row {:title "Original title"}]
                         :initial-events seed
                         :script         []}))
@@ -588,7 +588,7 @@
   (try (f) ::no-refusal (catch :default e (ex-data e))))
 
 (deftest the-option-roster-is-closed
-  (let [d (refusal #(hm/shadow! {:reference [reference-row {}]
+  (let [d (refusal #(rf.hicasso.test.mounted/shadow! {:reference [reference-row {}]
                                  :candidate [candidate-row {}]
                                  :seed      seed}))]
     (is (= :rf.error/hicasso-test-bad-option (:rf.error/id d))
@@ -598,11 +598,11 @@
     (is (= [:seed] (:unknown d)))))
 
 (deftest the-options-must-be-a-map
-  (let [d (refusal #(hm/shadow! [:reference [reference-row {}]]))]
+  (let [d (refusal #(rf.hicasso.test.mounted/shadow! [:reference [reference-row {}]]))]
     (is (= :rf.error/hicasso-test-bad-option (:rf.error/id d)))))
 
 (deftest the-script-verb-roster-is-closed
-  (let [d (refusal #(hm/shadow! {:reference [reference-row {}]
+  (let [d (refusal #(rf.hicasso.test.mounted/shadow! {:reference [reference-row {}]
                                  :candidate [candidate-row {}]
                                  :script    [{:clik "button.edit"}]}))]
     (is (= :rf.error/hicasso-test-bad-option (:rf.error/id d))
@@ -611,10 +611,10 @@
     (is (= {:clik "button.edit"} (:step d))))
   (testing "and each verb's own argument shape"
     (is (= :rf.error/hicasso-test-bad-option
-           (:rf.error/id (refusal #(hm/shadow! {:reference [reference-row {}]
+           (:rf.error/id (refusal #(rf.hicasso.test.mounted/shadow! {:reference [reference-row {}]
                                                 :candidate [candidate-row {}]
                                                 :script    [{:click :button}]})))))
     (is (= :rf.error/hicasso-test-bad-option
-           (:rf.error/id (refusal #(hm/shadow! {:reference [reference-row {}]
+           (:rf.error/id (refusal #(rf.hicasso.test.mounted/shadow! {:reference [reference-row {}]
                                                 :candidate [candidate-row {}]
                                                 :script    [{:type "input.title"}]})))))))

--- a/implementation/hicasso/testbed/hicasso_hmr_testbed/core.cljs
+++ b/implementation/hicasso/testbed/hicasso_hmr_testbed/core.cljs
@@ -54,12 +54,12 @@
   published witness readers, which is what they are for."
   (:require ["react" :as react]
             [hicasso-hmr-testbed.views :as views]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.test.runtime :as runtime]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]))
 
 ;; ---------------------------------------------------------------------------
 ;; The two frames — the routing row's whole premise
@@ -244,7 +244,7 @@
   nothing is claimed here about whether the runtime should also protect
   this one."
   [frame-kw query]
-  (mapv identity (runtime/cell-readers (sub-key frame-kw query))))
+  (mapv identity (rf.hicasso.test.runtime/cell-readers (sub-key frame-kw query))))
 
 (defn- capture-baseline!
   "Freeze the objects the next comparison is made against: the view head
@@ -254,10 +254,10 @@
   (reset! !baseline
           {:head     views/app
            :tokens   (into {} (map (fn [{:keys [frame]}]
-                                     [frame (frame/frame-incarnation-token frame)]))
+                                     [frame (rf.frame/frame-incarnation-token frame)]))
                            frames)
            :rows     (into {} (map (fn [{:keys [frame]}]
-                                     [frame (collector/frame-row frame)]))
+                                     [frame (rf.hicasso.impl.collector/frame-row frame)]))
                            frames)
            :readers  (into {} (for [{:keys [frame]} frames
                                     query watched-queries]
@@ -329,9 +329,9 @@
        (into {} (map (fn [{:keys [frame]}]
                        [(name frame)
                         {:token-same?    (identical? (get-in base [:tokens frame])
-                                                     (frame/frame-incarnation-token frame))
+                                                     (rf.frame/frame-incarnation-token frame))
                          :row-same?      (identical? (get-in base [:rows frame])
-                                                     (collector/frame-row frame))
+                                                     (rf.hicasso.impl.collector/frame-row frame))
                          :instance-same? (identical? (get-in base [:instances frame])
                                                      (get-in @!instances [frame :current]))}]))
              frames)
@@ -352,7 +352,7 @@
   []
   (doseq [{:keys [frame]} frames]
     (when-some [handle (get @!handles frame)]
-      (h/render! handle [views/app {:ref-sink    (get ref-sinks frame)
+      (rf.hicasso/render! handle [views/app {:ref-sink    (get ref-sinks frame)
                                     :island-refs (island-refs-for frame)}]))))
 
 (defn- seed!
@@ -414,7 +414,7 @@
     #js {:reloads       (fn [] @!reloads)
          :model         (fn [frame-name]
                           (js/JSON.stringify (clj->js (rf/app-db-value (frame-of frame-name)))))
-         :residue       (fn [] (clj->js (runtime/residue)))
+         :residue       (fn [] (clj->js (rf.hicasso.test.runtime/residue)))
          :capture       (fn [] (capture-baseline!))
          :identity      (fn [] (identity-report))
          :instance      (fn [frame-name]
@@ -425,7 +425,7 @@
          :note          (fn [frame-name text]
                           (some-> ^js (get-in @!instances [(frame-of frame-name) :current])
                                   (.note text)))
-         :quiesce       (fn [] (runtime/quiesced!))
+         :quiesce       (fn [] (rf.hicasso.test.runtime/quiesced!))
          :sabotage      (fn [on?] (vreset! !sabotage? (boolean on?)) @!sabotage?)
          :staleNotified (fn [] @!stale-notified)
          :setLabel      (fn [frame-name label]
@@ -446,12 +446,12 @@
 (defn ^:export init
   []
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (doseq [{:keys [frame container label]} frames]
     (rf/make-frame {:id frame})
     (seed! frame label)
     (swap! !handles assoc frame
-           (h/mount! (js/document.getElementById container)
+           (rf.hicasso/mount! (js/document.getElementById container)
                      {:frame frame}
                      [views/app {:ref-sink    (get ref-sinks frame)
                                  :island-refs (island-refs-for frame)}])))

--- a/implementation/hicasso/testbed/hicasso_hmr_testbed/views.cljs
+++ b/implementation/hicasso/testbed/hicasso_hmr_testbed/views.cljs
@@ -54,7 +54,7 @@
   preserved."
   (:require ["react" :as react]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]))
+            [re-frame.hicasso :as rf.hicasso]))
 
 ;; ---------------------------------------------------------------------------
 ;; The hot line
@@ -316,17 +316,17 @@
 ;; `(defhost sym "doc" Component opts?)`. Written the other way round the
 ;; docstring lands in the `opts` position and `mint-host!` walks a string
 ;; as an option map.
-(h/defhost hook-host
+(rf.hicasso/defhost hook-host
   "The host crossing the hook child sits inside, so the row is `child hook
   state IN A HOST` and not merely `hook state somewhere on the page`."
   HookChild)
 
-(h/defhost note-host
+(rf.hicasso/defhost note-host
   "The imperative host. Its instance arrives through a callback `:ref` —
   HD-022's v0 spelling, a function and never a vector."
   imperative-note)
 
-(h/defhost suspense-host
+(rf.hicasso/defhost suspense-host
   "React's own Suspense, wrapping the split region and NOTHING else. The
   scope is deliberate: this region shows its fallback on every save, and a
   boundary drawn any wider would take the controlled field, the hook child
@@ -335,7 +335,7 @@
   (.-Suspense react)
   {:slots #{:fallback}})
 
-(h/defhost island-host
+(rf.hicasso/defhost island-host
   "The `defhost` crossing over the lazy head — a declaration, with the
   island's server policy written where a crossing declares one.
   `:server :client-only` is the default and needs no writing; it is
@@ -345,26 +345,26 @@
   host-head
   {:server :client-only})
 
-(h/defview field
+(rf.hicasso/defview field
   "The focused controlled input. An ordinary `:value` off a subscription
   and an intent vector at `:on-input`; nothing test-only on it."
   [_]
   [:input {:data-testid "field"
            :type        "text"
-           :value       (h/sub [:hmr/text])
-           :on-input    [:hmr/edit ::h/value]}])
+           :value       (rf.hicasso/sub [:hmr/text])
+           :on-input    [:hmr/edit ::rf.hicasso/value]}])
 
-(h/defview digits-field
+(rf.hicasso/defview digits-field
   "The refusing field the composition row is driven on — the case
   `hmr_registry`'s browser sibling could not reach, and the one where a
   held draft is provably the model's refusal rather than its agreement."
   [_]
   [:input {:data-testid "digits"
            :type        "text"
-           :value       (h/sub [:hmr/digits])
-           :on-input    [:hmr/edit-digits ::h/value]}])
+           :value       (rf.hicasso/sub [:hmr/digits])
+           :on-input    [:hmr/edit-digits ::rf.hicasso/value]}])
 
-(h/defview app
+(rf.hicasso/defview app
   "The head whose re-mint is the whole mechanism. Mounted once per frame,
   so each root reads its own frame and the routing row can compare them.
 
@@ -377,7 +377,7 @@
   [{:keys [ref-sink island-refs]}]
   [:main {:data-testid "hmr-app"}
    [:span {:data-testid "gen-label"} generation-label]
-   [:span {:data-testid "frame-label"} (h/sub [:hmr/label])]
+   [:span {:data-testid "frame-label"} (rf.hicasso/sub [:hmr/label])]
    [field {}]
    [digits-field {}]
    [hook-host {}]

--- a/implementation/hicasso/testbed/hicasso_testbed/core.cljs
+++ b/implementation/hicasso/testbed/hicasso_testbed/core.cljs
@@ -122,9 +122,9 @@
   a claim about both halves. Nothing here mutates anything the app could
   not reach through an ordinary dispatch."
   (:require [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]))
+            [re-frame.hicasso :as rf.hicasso]))
 
 (def ^:private frame-id ::testbed)
 
@@ -458,7 +458,7 @@
 ;; The views — every field written the way authoring.md writes one
 ;; ---------------------------------------------------------------------------
 
-(h/defview text-field
+(rf.hicasso/defview text-field
   "One controlled `<input>`. `:value` off the subscription, an intent
   vector at `:on-input`, and nothing else."
   [{:keys [field]}]
@@ -466,18 +466,18 @@
     [:input {:data-testid id
              :id          id
              :type        "text"
-             :value       (h/sub [:tb/field field])
-             :on-input    [:tb/edit field ::h/value]}]))
+             :value       (rf.hicasso/sub [:tb/field field])
+             :on-input    [:tb/edit field ::rf.hicasso/value]}]))
 
-(h/defview notes-field
+(rf.hicasso/defview notes-field
   "The same law on the other convergeable tag."
   [_]
   [:textarea {:data-testid "notes"
               :id          "notes"
-              :value       (h/sub [:tb/field :notes])
-              :on-input    [:tb/edit :notes ::h/value]}])
+              :value       (rf.hicasso/sub [:tb/field :notes])
+              :on-input    [:tb/edit :notes ::rf.hicasso/value]}])
 
-(h/defview revision-field
+(rf.hicasso/defview revision-field
   "The reset trigger, carried as the author carries it: one `::h/revision`
   on the element's own attribute map. It is never an attribute, and the
   field is otherwise an ordinary controlled field.
@@ -491,21 +491,21 @@
     [:input {:data-testid   id
              :id            id
              :type          "text"
-             ::h/revision   (h/sub [:tb/revision])
-             :value         (h/sub [:tb/field field])
-             :on-input      [:tb/edit field ::h/value]}]))
+             ::rf.hicasso/revision   (rf.hicasso/sub [:tb/revision])
+             :value         (rf.hicasso/sub [:tb/field field])
+             :on-input      [:tb/edit field ::rf.hicasso/value]}]))
 
-(h/defview flag-box
+(rf.hicasso/defview flag-box
   "The owned `::h/checked` pair. `false` is a presence here, not a
   falsehood."
   [_]
   [:input {:data-testid "flag"
            :id          "flag"
            :type        "checkbox"
-           :checked     (h/sub [:tb/flag])
-           :on-change   [:tb/toggle-flag ::h/checked]}])
+           :checked     (rf.hicasso/sub [:tb/flag])
+           :on-change   [:tb/toggle-flag ::rf.hicasso/checked]}])
 
-(h/defview reset-form
+(rf.hicasso/defview reset-form
   "A real form with a real reset button, so `form.reset()` is the
   browser's own and not a simulation of it.
 
@@ -521,14 +521,14 @@
             :id          "form-a"
             :name        "form-a"
             :type        "text"
-            :value       (h/sub [:tb/field :form-a])
-            :on-input    [:tb/edit :form-a ::h/value]}]
+            :value       (rf.hicasso/sub [:tb/field :form-a])
+            :on-input    [:tb/edit :form-a ::rf.hicasso/value]}]
    [:input {:data-testid "form-b"
             :id          "form-b"
             :name        "form-b"
             :type        "text"
-            :value       (h/sub [:tb/field :form-b])
-            :on-input    [:tb/edit :form-b ::h/value]}]
+            :value       (rf.hicasso/sub [:tb/field :form-b])
+            :on-input    [:tb/edit :form-b ::rf.hicasso/value]}]
    ;; A controlled checkbox INSIDE the form, so the extraction row reads a
    ;; control whose owned slot is `::h/checked` rather than a value, and
    ;; the reset row has a `defaultChecked` mirror to act on.
@@ -537,29 +537,29 @@
             :name        "form-flag"
             :type        "checkbox"
             :value       "yes"
-            :checked     (h/sub [:tb/flag])
-            :on-change   [:tb/toggle-flag ::h/checked]}]
+            :checked     (rf.hicasso/sub [:tb/flag])
+            :on-change   [:tb/toggle-flag ::rf.hicasso/checked]}]
    ;; …and a controlled select, whose extraction is `selected` rather than
    ;; an attribute.
    [:select {:data-testid "form-pick"
              :id          "form-pick"
              :name        "form-pick"
-             :value       (h/sub [:tb/field :form-pick])
-             :on-change   [:tb/edit :form-pick ::h/value]}
+             :value       (rf.hicasso/sub [:tb/field :form-pick])
+             :on-change   [:tb/edit :form-pick ::rf.hicasso/value]}
     [:option {:value "one"} "one"]
     [:option {:value "two"} "two"]]
    [:button {:data-testid "form-reset" :type "reset"} "reset"]])
 
-(h/defview mountable-field
+(rf.hicasso/defview mountable-field
   "Rendered behind a flag, so the driver can take the fiber away from
   under a live composition."
   [_]
-  (if (h/sub [:tb/mounted?])
+  (if (rf.hicasso/sub [:tb/mounted?])
     [:input {:data-testid "mountable"
              :id          "mountable"
              :type        "text"
-             :value       (h/sub [:tb/field :mountable])
-             :on-input    [:tb/edit :mountable ::h/value]}]
+             :value       (rf.hicasso/sub [:tb/field :mountable])
+             :on-input    [:tb/edit :mountable ::rf.hicasso/value]}]
     [:p {:data-testid "mountable-gone"} "unmounted"]))
 
 ;; ---------------------------------------------------------------------------
@@ -567,7 +567,7 @@
 ;; authoring.md writes it and NOT the way a harness would find convenient
 ;; ---------------------------------------------------------------------------
 
-(h/defview radio-group
+(rf.hicasso/defview radio-group
   "Three radios on one model slot. `:checked` is owned off the
   subscription and the intent carries the option as a constant, because a
   radio's `::h/checked` is always `true` at the moment it fires — the
@@ -581,7 +581,7 @@
   through the shadow component and its `convergeable?` re-ask — the inert
   path, on a type with no caret."
   [_]
-  (let [choice (h/sub [:tb/radio])]
+  (let [choice (rf.hicasso/sub [:tb/radio])]
     [:fieldset {:data-testid "radios"}
      (for [option ["a" "b" "c"]]
        [:label {:key option}
@@ -593,7 +593,7 @@
                  :on-change   [:tb/pick-radio option]}]
         option])]))
 
-(h/defview select-single
+(rf.hicasso/defview select-single
   "A controlled `<select>`. Nothing in `impl.controlled` applies to it —
   `convergeable-tag?` answers false for `select` and the namespace
   docstring says why (no text cursor, no `defaultValue` mirror) — so what
@@ -602,13 +602,13 @@
   [_]
   [:select {:data-testid "pick"
             :id          "pick"
-            :value       (h/sub [:tb/field :pick])
-            :on-change   [:tb/edit :pick ::h/value]}
+            :value       (rf.hicasso/sub [:tb/field :pick])
+            :on-change   [:tb/edit :pick ::rf.hicasso/value]}
    [:option {:value "one"} "one"]
    [:option {:value "two"} "two"]
    [:option {:value "banned"} "banned"]])
 
-(h/defview select-multiple
+(rf.hicasso/defview select-multiple
   "The same control with `:multiple`, written the SUPPORTED way.
 
   `h/event` rather than `::h/value`, and that is the whole content of this
@@ -620,8 +620,8 @@
   [:select {:data-testid "picks"
             :id          "picks"
             :multiple    true
-            :value       (h/sub [:tb/picks])
-            :on-change   (h/event [e]
+            :value       (rf.hicasso/sub [:tb/picks])
+            :on-change   (rf.hicasso/event [e]
                            [:tb/pick-many
                             (mapv #(.-value %)
                                   (array-seq (.. e -target -selectedOptions)))])}
@@ -630,7 +630,7 @@
    [:option {:value "banned"} "banned"]
    [:option {:value "c"} "c"]])
 
-(h/defview select-multiple-marker
+(rf.hicasso/defview select-multiple-marker
   "The same control again, written the way an author reaches for FIRST —
   the reserved marker at the change position — so that what it costs is
   measured rather than asserted in prose. The handler does the obvious
@@ -639,13 +639,13 @@
   [:select {:data-testid "picks-marker"
             :id          "picks-marker"
             :multiple    true
-            :value       (h/sub [:tb/picks-marker])
-            :on-change   [:tb/pick-many-marker ::h/value]}
+            :value       (rf.hicasso/sub [:tb/picks-marker])
+            :on-change   [:tb/pick-many-marker ::rf.hicasso/value]}
    [:option {:value "a"} "a"]
    [:option {:value "b"} "b"]
    [:option {:value "c"} "c"]])
 
-(h/defview file-field
+(rf.hicasso/defview file-field
   "A file input, UNCONTROLLED, which is the only thing it can be:
   `HTMLInputElement.value` refuses every assignment but `\"\"`, so a
   `:value` off a subscription would be a promise the platform cannot
@@ -656,12 +656,12 @@
            :id          "file"
            :type        "file"
            :multiple    true
-           :on-change   (h/event [e]
+           :on-change   (rf.hicasso/event [e]
                           [:tb/take-files
                            (mapv #(.-name %)
                                  (array-seq (.. e -target -files)))])}])
 
-(h/defview typed-field
+(rf.hicasso/defview typed-field
   "One `<input>` of a type with no text cursor — `number`, `date` or
   `range`. Written identically to the text fields: `:value` off a
   subscription, an intent at `:on-input`.
@@ -676,11 +676,11 @@
     [:input (merge {:data-testid id
                     :id          id
                     :type        kind
-                    :value       (h/sub [:tb/field field])
-                    :on-input    [:tb/edit field ::h/value]}
+                    :value       (rf.hicasso/sub [:tb/field field])
+                    :on-input    [:tb/edit field ::rf.hicasso/value]}
                    extra)]))
 
-(h/defview editable-region
+(rf.hicasso/defview editable-region
   "A `contenteditable` region. It is NOT a controlled field and this
   testbed does not pretend otherwise: there is no owned `:value` slot for
   one, the content is the browser's, and the author's handler reads it
@@ -691,10 +691,10 @@
          :id               "prose"
          :content-editable "plaintext-only"
          :suppress-content-editable-warning true
-         :on-input         (h/event [e] [:tb/set-prose (.. e -target -textContent)])}
-   (h/sub [:tb/prose])])
+         :on-input         (rf.hicasso/event [e] [:tb/set-prose (.. e -target -textContent)])}
+   (rf.hicasso/sub [:tb/prose])])
 
-(h/defview blur-probe
+(rf.hicasso/defview blur-probe
   "A controlled field behind a mount flag, carrying focus and blur
   handlers that write to the model.
 
@@ -708,17 +708,17 @@
   and what it RECORDS is where the focus lands afterwards, which is the
   engines' to differ on."
   [_]
-  (if (h/sub [:tb/probe-mounted?])
+  (if (rf.hicasso/sub [:tb/probe-mounted?])
     [:input {:data-testid "blur-probe"
              :id          "blur-probe"
              :type        "text"
-             :value       (h/sub [:tb/field :async])
-             :on-input    [:tb/edit :async ::h/value]
+             :value       (rf.hicasso/sub [:tb/field :async])
+             :on-input    [:tb/edit :async ::rf.hicasso/value]
              :on-focus    [:tb/focus-edge "focus"]
              :on-blur     [:tb/focus-edge "blur"]}]
     [:p {:data-testid "blur-probe-gone"} "unmounted"]))
 
-(h/defview svg-figure
+(rf.hicasso/defview svg-figure
   "SVG, written in the two spellings an author uses: a camel attribute
   React renames nothing about (`:view-box` → `viewBox`) and kebab
   presentation attributes (`:stroke-width`, `:stroke-linecap`). The
@@ -734,7 +734,7 @@
              :stroke         "black"}]
    [:text {:data-testid "svg-text" :x 2 :y 18 :font-size 4} "hi"]])
 
-(h/defview custom-element-figure
+(rf.hicasso/defview custom-element-figure
   "A custom element. React 19 hands an unknown element's props through as
   ATTRIBUTES under the name it was given, so the slot rule decides what
   the DOM ends up with — and the slot rule camelCases a kebab keyword.
@@ -757,7 +757,7 @@
   [:plain :digits :empty :grouped :upper :notes :revision :revision-strict
    :form-a :form-b :mountable :pick :count :day :level :async])
 
-(h/defview trace-row
+(rf.hicasso/defview trace-row
   "One field's committed value and the number of intents that have reached
   the store for it. `pr-str` rather than the bare string, so `\"\"` and a
   trailing space are visible — a trace that renders an empty model as an
@@ -766,10 +766,10 @@
   (let [id (name field)]
     [:tr
      [:td id]
-     [:td {:data-testid (str "trace-" id "-value")} (pr-str (h/sub [:tb/field field]))]
-     [:td {:data-testid (str "trace-" id "-edits")} (str (h/sub [:tb/edits field]))]]))
+     [:td {:data-testid (str "trace-" id "-value")} (pr-str (rf.hicasso/sub [:tb/field field]))]
+     [:td {:data-testid (str "trace-" id "-edits")} (str (rf.hicasso/sub [:tb/edits field]))]]))
 
-(h/defview trace
+(rf.hicasso/defview trace
   "The store, on screen. The manual native-IME session reads its
   `app-db clean until commit` and `arrives exactly once` checks off this
   table, because a browser shell with no devtools has nowhere else to read
@@ -781,7 +781,7 @@
     (for [field traced-fields]
       [trace-row {:key (name field) :field field}])]])
 
-(h/defview armed-edges
+(rf.hicasso/defview armed-edges
   "The two mid-composition edges, reachable without a pointer-down that
   would close the composition first.
 
@@ -790,7 +790,7 @@
   meant to, and it is the only thing a driver can read about an arm
   without waiting five seconds for it to fire."
   [_]
-  (let [armed (h/sub [:tb/armed])
+  (let [armed (rf.hicasso/sub [:tb/armed])
         what  (:what armed)
         event (:event armed)]
     [:p
@@ -804,7 +804,7 @@
              " fires in " (humanise-ms (:ms armed)))
         "idle")]]))
 
-(h/defview app
+(rf.hicasso/defview app
   [_]
   [:main {:data-testid "hicasso-controlled-testbed"}
    [:h1 "Hicasso controlled-input testbed"]
@@ -883,8 +883,8 @@
 
 (defn ^:export init
   []
-  (rf/init! uix-adapter/adapter)
+  (rf/init! rf.adapter.uix/adapter)
   (rf/make-frame {:id frame-id :initial-events [[:tb/seed]]})
-  (h/mount! (js/document.getElementById "app") {:frame frame-id} [app {}])
+  (rf.hicasso/mount! (js/document.getElementById "app") {:frame frame-id} [app {}])
   (unchecked-set js/window "__RF2_HIC_TB__" #js {:model model-json})
   nil)

--- a/scripts/require-alias-baseline.edn
+++ b/scripts/require-alias-baseline.edn
@@ -14,7 +14,7 @@
 ;; observes. It is not a style rule: it is what stops the checker
 ;; reporting a confident zero over a corpus it has stopped being able
 ;; to read.
-{:min-edges 9695
+{:min-edges 9784
 
  :surfaces
  {
@@ -22,13 +22,13 @@
   "bench"                                 0
   "docs"                                  0
   "examples"                              0
-  "implementation/adapters"               337
+  "implementation/adapters"               2
   "implementation/core"                   0
   "implementation/derivation-conformance" 0
-  "implementation/epoch"                  196
+  "implementation/epoch"                  0
   "implementation/event-conformance"      0
-  "implementation/flows"                  155
-  "implementation/hicasso"                1017
+  "implementation/flows"                  0
+  "implementation/hicasso"                0
   "implementation/http"                   0
   "implementation/machines"               0
   "implementation/reply-conformance"      0


### PR DESCRIPTION
## rf2-7sx1 — a FENCED SUBSET, four surfaces

The bead stays **open**. It is a per-surface roster and this slice takes only the
surfaces no peer held: `implementation/epoch`, `implementation/flows`,
`implementation/hicasso`, `implementation/adapters`. Everything else on the
roster is untouched and its measured remainder is listed below so the next
dispatch starts from a number rather than a guess.

`scripts/require-alias-baseline.edn` is deliberately **in** this PR's scope: the
ratchet is two-sided, so a cleanup that does not lower its own floor in the same
commit reds the gate exactly as an increase would.

Two commits: the alias walk (356 files), and a three-line repair to two hicasso
release-gate rosters that the walk broke by design — see *The roster premises*
below.

## Per-surface floor, before and after

| surface | floor before | actual after | floor after |
|---|---|---|---|
| `implementation/hicasso` | 1017 | 0 | **0** |
| `implementation/adapters` | 337 | 2 | **2** |
| `implementation/epoch` | 196 | 0 | **0** |
| `implementation/flows` | 155 | 0 | **0** |

`:min-edges` 9695 → 9784. It is `int(total_edges * 0.9)` tracking the trunk's
edge count, so a rise **tightens** the anti-blindness guard. It is not an effect
of a rename, whose edge count is identical before and after — it moved because
the trunk grew.

Repo-wide non-canonical edges **2433 → 730**. Files (2800) and re-frame require
edges (10880) unchanged; the alias commit is 11017 insertions / 11017 deletions
with no line added or removed anywhere, which is the shape of a pure rename.
1703 libspec aliases and 10150 use sites moved across 355 files.

### Why `implementation/adapters` lands at 2 and not 0

`implementation/adapters/uix/test/re_frame/adapter/uix_component_recipe_dom_cljs_test.cljs`
is pinned **byte for byte** to a fenced `clojure` block in
`docs/core/testing/views.md` by `uix_component_recipe_docs_pin_test`. Renaming
its `uix-adapter` and `ts` aliases is therefore a two-file change reaching into
`docs/core/`, which this slice does not own. The file is excluded and the floor
is set to 2 rather than 0, so the ground actually won is held and the remainder
stays visible to the gate.

## The roster premises (second commit)

The hicasso release chain's two gates locate their sentinels and positive
controls by a **literal source string**, and refuse to run when that string is no
longer in the file it names. Three of those premises spelled the view idiom
`(h/defview …`, which is what hicasso's source said before this branch walked it
onto the canonical dialect. Both self-tests broke — exactly as designed, and with
a message prescribing the repair:

* `check_production_erasure.cjs` — 1 premise (the consumer-app control)
* `check_bundle_isolation.cjs` — 2 premises (the forms sentinel, the same control)

**What deliberately does not move, because it would be a different claim.** The
`sentinel:` and `control:` values beside them are the fully-qualified
`re-frame.hicasso.forms/buffered-field` and `re-frame.hicasso.consumer-app/app` —
namespace and var, which is what `mint-view!` stamps as the boundary's
`displayName`, and a require-alias rename moves neither. Every `h/` in the
surrounding prose (`h/defview`, `h/portal`, `h/reg-state`) also stays: that is
not stale source but the vocabulary the documentation teaches — `docs/core/hicasso/`
binds `[re-frame.hicasso :as h]` at 39 sites, and those comments describe the
idiom a consumer writes, not the bytes in this repo. And the other eighteen
premises across the two files are `def` forms, string literals and keywords
(`"hicassoBoundary"`, `:data-rf-view`, `:rf.error/hicasso-empty-vector`, the
`displayName` strings) that a require-alias rename cannot reach. The net script
diff against `main` is three lines.

## Left on the roster, measured at this base

`implementation/ssr` 392 · `implementation/ssr-ring` 128 ·
`implementation/schemas` 112 · `implementation/scripts` 46 ·
`implementation/security` 45 · `implementation/test-quiet` 5 ·
`implementation/adapters` 2 (the pinned recipe above).

Every other surface in the baseline is already at 0 — including `examples`,
`docs`, `implementation/derivation-conformance` and
`implementation/event-conformance`, all of which were inside this slice's fence
and needed no work.

## How the rewrite was done

Binding-aware, reusing the checker's **own** reader-level mask, libspec scanner
and exemption predicate, so the set of edges rewritten is exactly the set the
gate counts. Consequences that matter for review:

* Strings, `;` comments, character literals and `#_` discards are blanked before
  anything is searched, so **no edit can land inside one**. A separate pass over
  all 355 changed files extracts the ordered list of string literals and comment
  bodies from the merge base and from the working tree and asserts they are
  identical — they are. That rules out the campaign's emitted-output hazard by
  construction rather than by inspection.
* `::alias/key` moves (it denotes the aliased namespace); `:alias/key` does not
  (it is a value whose first segment merely collides).
* The host-conditional `substrate` alias — one name deliberately bound to two
  namespaces by reader arm — is left alone, because the gate exempts it. The
  rewriter also refuses any file where a rename would create a new
  multi-namespace alias.

### One shape worth recording for the surfaces still ahead

A quoted or var-quoted use site — `'alias/foo`, `#'alias/foo` — reads like a
symbol whose preceding character is a symbol constituent, and treating `'` as one
silently skips it: the libspec moves and the use site does not. It is not silent
for long, because it cannot compile; the epoch JVM lane caught it at
`#'state/listeners`. **40 of the 10150 use sites here were of that shape.**

## Gates

All re-run on the final base after rebasing onto `8d144eeb83`. Every exit code
below was captured with the redirect and the `echo` on one command line, and is
the runner's own number.

| gate | exit |
|---|---|
| `python scripts/check_require_alias_dialect.py` | **0** |
| `… --report` | **0** |
| `… --self-test` | **0** (79 passed, 0 failed) |
| every `scripts/check_*.py` + `scripts/lint_kondo.py` (43 gates) | **0** each, identical to the same sweep at the merge base |
| `jvm-repo-source-walks` — all 7 namespaces from `implementation/core` | **0** each |
| `clojure -M:test` — epoch | **0** (557 tests / 7269 assertions) |
| `clojure -M:test` — flows | **0** (261 / 6187) |
| `clojure -M:test` — hicasso | **0** (3 / 92) |
| `clojure -M:test` — adapters reagent / reagent-slim / uix / test-react | **0** each (0/0, 10/10, 4/34, 35/157) |
| `npm run test:hicasso-invariants` | **0** |
| `node scripts/check-per-ns-isolation.cjs --self-test` | **0** |
| `node scripts/check-per-ns-isolation.cjs` | **0** (16 namespaces, 191 tests / 709 assertions) |
| `npm run test:hicasso-compile` | **0** |
| `npm run build:hicasso-release` (release + 2 self-tests + 2 gates) | **0** (8 and 6 sentinels absent, 3 and 4 controls present) |
| CLJS compile (`scripts/compile-node-test.cjs node-test`) | **0** (1906 files, 0 warnings) |
| CLJS run (`node out/node-test.js`) | **0** (11295 tests / 57009 assertions) |
| `node implementation/scripts/check-examples-compile.cjs` | **0** (all 58 swept builds, zero warnings) |
| `python implementation/hicasso/scripts/check_guide_samples.py --self-test` | **0** |
| `python implementation/hicasso/scripts/check_guide_samples.py` | **0** (74 verbs, 401 sites, 29 pages) |
| `sh scripts/check-commit-attribution.sh origin/main` | **0** |

Every JVM artefact suite was run **before** the change as well, on the same
worktree, and each after-run reports the identical test and assertion counts —
so the after-only green is meaningful rather than vacuous.

### Proof each gate read this branch's tree

* **The subject gate — planted fault.** Reverting one libspec in
  `implementation/hicasso/src/re_frame/hicasso.cljc` to `:as codec` red the
  ratchet at exit 1, naming the file, line 61 and the libspec, **against a floor
  of 0 that exists only on this branch** — on `main` that surface's floor is
  1017, where a single violation is comfortably green. So a run that had wandered
  into another checkout would have come back green. Restore verified by git blob
  hash against the committed object, not by reading a diff.
* **The release-chain self-tests — planted fault.** Reverting the premise to
  `(h/defview app` reproduced the CI failure locally at exit 1, with the same
  `ROSTER PREMISE BROKEN` message; the repaired premise exits 0. Restore verified
  by git blob hash.
* **The non-code verifier — planted fault.** A one-word change inside a `;;`
  comment in `implementation/epoch/src/re_frame/epoch/state.cljc` made it exit 1,
  quoting the comment before and after. Restore verified by git blob hash.
* **The CLJS lane, the release build and the examples-compile sweep — printed
  root.** All three name this worktree's own `implementation/shadow-cljs.edn`.
* **The JVM lanes — an unplanned planted fault.** The first rewrite pass left
  `#'state/listeners` stale in `epoch_concurrency_stress_test.clj`; the epoch JVM
  lane refused to compile, naming that file and line. That fault existed in no
  other tree.

## Not done, deliberately

* No surface outside the four above was touched, however close to done it looked.
* `implementation/shadow-cljs.edn` (hot-zone) is untouched; the examples sweep
  derives its 58-build roster from it and was asked to enumerate its own coverage
  rather than grepped for a build id.
* `docs/core/testing/views.md` is untouched — see the adapters note above.
