### PR TITLE
api(subs): sweep examples/ and testbeds/ from the `:<-` chain and the positional input-fn onto `{:inputs …}`

### DIFF
--- a/examples/capabilities/machines/state_machine_walkthrough/core.cljc
+++ b/examples/capabilities/machines/state_machine_walkthrough/core.cljc
@@ -265,12 +265,12 @@
   (fn [db _] (get-in db [:auth :login-form :draft])))
 
 (rf/reg-sub :walkthrough.login/state
-  :<- [:rf/machine :walkthrough.login/flow]
-  (fn [machine _] (:state machine)))
+  {:inputs [[:rf/machine :walkthrough.login/flow]]}
+  (fn [[machine] _] (:state machine)))
 
 (rf/reg-sub :walkthrough.login/error
-  :<- [:rf/machine :walkthrough.login/flow]
-  (fn [machine _] (get-in machine [:data :error])))
+  {:inputs [[:rf/machine :walkthrough.login/flow]]}
+  (fn [[machine] _] (get-in machine [:data :error])))
 
 ;; And here's where the purity pays off. Because the table is plain data and
 ;; `machines/machine-transition` is a pure fn over (table, snapshot, event), the

--- a/examples/capabilities/resources/resources/core.cljs
+++ b/examples/capabilities/resources/resources/core.cljs
@@ -351,13 +351,13 @@
 ;; Want to compute something *over* a resource's data? There's no resource-local
 ;; select — you just layer an ordinary sub on top of the passive
 ;; `[:rf.resource/data …]` sub, exactly as you'd layer any sub on any other.
-;; The input-fn is a pure `(fn [query-v])` returning a vector of query vectors
-;; (never a deref'd subscribe), and the compute fn then gets the resolved inputs
-;; back positionally: `[[articles] _]`.
+;; Dependencies are declared once, under `:inputs` in the metadata map — a
+;; literal vector of query vectors (never a deref'd subscribe), since this one
+;; needs nothing from the outer query-v. The compute fn then gets the resolved
+;; inputs back as a vector: `[[articles] _]`.
 ;; See ../../../../docs/core/glossary.md#subscription
 (rf/reg-sub :resources.app/first-slug
-  (fn [_query-v]
-    [[:rf.resource/data {:resource :articles/list :params {}}]])
+  {:inputs [[:rf.resource/data {:resource :articles/list :params {}}]]}
   (fn [[articles] _query-v]
     (:slug (first articles))))
 

--- a/examples/capabilities/routing/routing/core.cljs
+++ b/examples/capabilities/routing/routing/core.cljs
@@ -87,8 +87,8 @@
   (fn [db _] (:routing.app/articles-list db)))
 
 (rf/reg-sub :routing.app/article-by-id
-  :<- [:routing.app/articles-list]
-  (fn [articles [_ id]]
+  {:inputs [[:routing.app/articles-list]]}
+  (fn [[articles] [_ id]]
     (first (filter #(= id (:id %)) articles))))
 
 ;; ============================================================================

--- a/examples/core/login/model.cljc
+++ b/examples/core/login/model.cljc
@@ -701,15 +701,15 @@
 ;; sub — the public doorway to a machine's live value
 ;; (docs/machines/glossary.md#snapshot).
 (rf/reg-sub :auth.login/state
-  {:doc "Current state of the login flow."}
-  :<- [:rf/machine :auth.login/flow]
-  (fn sub-auth-login-state [snapshot _]
+  {:doc "Current state of the login flow."
+   :inputs [[:rf/machine :auth.login/flow]]}
+  (fn sub-auth-login-state [[snapshot] _]
     (:state snapshot)))
 
 (rf/reg-sub :auth.login/error
-  {:doc "Current error message, if any."}
-  :<- [:rf/machine :auth.login/flow]
-  (fn sub-auth-login-error [snapshot _]
+  {:doc "Current error message, if any."
+   :inputs [[:rf/machine :auth.login/flow]]}
+  (fn sub-auth-login-error [[snapshot] _]
     (get-in snapshot [:data :error])))
 
 ;; --- Form-slice subs --------------------------------------------------------
@@ -727,17 +727,17 @@
 
 (rf/reg-sub :auth.login/draft
   {:doc "The login-form draft — what the user has currently typed. Each input
-         binds its :value to a field of this map (controlled inputs)."}
-  :<- [:auth.login/form-slice]
-  (fn sub-auth-login-draft [slice _]
+         binds its :value to a field of this map (controlled inputs)."
+   :inputs [[:auth.login/form-slice]]}
+  (fn sub-auth-login-draft [[slice] _]
     (:draft slice)))
 
 (rf/reg-sub :auth.login/field-error
   {:doc "Per-field validation error for the login form. Reveal a field's
          error once it is :touched OR once the form has had its first
-         submit click (docs/core/how-to/build-a-form.md)."}
-  :<- [:auth.login/form-slice]
-  (fn sub-auth-login-field-error [slice [_ field]]
+         submit click (docs/core/how-to/build-a-form.md)."
+   :inputs [[:auth.login/form-slice]]}
+  (fn sub-auth-login-field-error [[slice] [_ field]]
     (when (or (:submit-attempted? slice)
               (contains? (:touched slice) field))
       (first (get-in slice [:errors field])))))

--- a/examples/core/notebook/README.md
+++ b/examples/core/notebook/README.md
@@ -57,8 +57,8 @@ body through the markdown parser:
 
 ```clojure
 (rf/reg-sub :notebook/selected-hiccup
-  :<- [:notebook/selected-body]
-  (fn [body _] (markdown->hiccup body)))
+  {:inputs [[:notebook/selected-body]]}
+  (fn [[body] _] (markdown->hiccup body)))
 ```
 
 The preview view subscribes to `:notebook/selected-hiccup` and splices

--- a/examples/core/notebook/core.cljs
+++ b/examples/core/notebook/core.cljs
@@ -122,14 +122,14 @@
 ;; `-hiccup`) chain off this one in the same way. A little graph of pure
 ;; derivations. See docs/core/subscriptions.md.
 (rf/reg-sub :notebook/selected
-  :<- [:notebook/documents]
-  :<- [:notebook/selected-id]
+  {:inputs [[:notebook/documents]
+            [:notebook/selected-id]]}
   (fn [[docs id] _]
     (first (filter #(= (:id %) id) docs))))
 
 (rf/reg-sub :notebook/selected-body
-  :<- [:notebook/selected]
-  (fn [doc _] (or (:body doc) "")))
+  {:inputs [[:notebook/selected]]}
+  (fn [[doc] _] (or (:body doc) "")))
 
 ;; ============================================================================
 ;; MARKDOWN — tiny pure parser → hiccup
@@ -298,8 +298,8 @@
         blocks))))
 
 (rf/reg-sub :notebook/selected-hiccup
-  :<- [:notebook/selected-body]
-  (fn [body _] (markdown->hiccup body)))
+  {:inputs [[:notebook/selected-body]]}
+  (fn [[body] _] (markdown->hiccup body)))
 
 ;; ============================================================================
 ;; VIEWS — shared 'Editorial Warm' palette

--- a/examples/core/notebook/core.cljs
+++ b/examples/core/notebook/core.cljs
@@ -115,7 +115,7 @@
 (rf/reg-sub :notebook/selected-id
   (fn [db _] (:notebook/selected-id db)))
 
-;; Subs compose. The `:<-` lines wire this sub's inputs to other subs —
+;; Subs compose. The `:inputs` vector wires this sub's inputs to other subs —
 ;; here, the documents and the selected id — and the body below is a plain
 ;; function of their values. The payoff is that it recomputes only when
 ;; one of those inputs actually changes, and the subs downstream (`-body`,

--- a/examples/core/seven_guis/cells/core.cljs
+++ b/examples/core/seven_guis/cells/core.cljs
@@ -376,18 +376,18 @@
   (fn sub-cells-all-cells [db _] (get-in db [:cells :cells])))
 
 (rf/reg-sub :cells/raw
-  {:doc "Raw text the user typed into cell `id` (empty string if untouched)."}
-  :<- [:cells/all-cells]
-  (fn sub-cells-raw [cells [_ id]] (get-in cells [id :raw] "")))
+  {:doc "Raw text the user typed into cell `id` (empty string if untouched)."
+   :inputs [[:cells/all-cells]]}
+  (fn sub-cells-raw [[cells] [_ id]] (get-in cells [id :raw] "")))
 
 (rf/reg-sub :cells/value
   {:doc "Display value of cell `id` — a pure derivation over the whole cell map.
          The evaluator already turns bad input into typed error markers, so this
          try/catch is belt-and-suspenders: if some unforeseen input ever slips
          through and throws, one cell shows #EVAL instead of taking the entire
-         grid's render down with it."}
-  :<- [:cells/all-cells]
-  (fn sub-cells-value [cells [_ id]]
+         grid's render down with it."
+   :inputs [[:cells/all-cells]]}
+  (fn sub-cells-value [[cells] [_ id]]
     (try
       (evaluate-cell id cells #{})
       (catch :default _ :error/eval))))

--- a/examples/core/seven_guis/circle_drawer/core.cljs
+++ b/examples/core/seven_guis/circle_drawer/core.cljs
@@ -207,7 +207,7 @@
 
 ;; One Layer-2 slice sub does the digging; the Layer-3 readers below all read
 ;; from it. `:drawer/slice` reaches into app-db once to grab the `:drawer` map,
-;; and the subs below chain off it with `:<-`. So the [:drawer ...] walk happens
+;; and the subs below chain off it via `:inputs`. So the [:drawer ...] walk happens
 ;; a single time per app-db swap, not once per dependent recompute — a small
 ;; habit that keeps a subscription graph cheap as it grows.
 ;; See docs/core/subscriptions.md.

--- a/examples/core/seven_guis/circle_drawer/core.cljs
+++ b/examples/core/seven_guis/circle_drawer/core.cljs
@@ -215,12 +215,12 @@
 (rf/reg-sub :drawer/slice (fn [db _] (:drawer db)))
 
 (rf/reg-sub :drawer/circles
-  :<- [:drawer/slice]
-  (fn [drawer _] (:circles drawer)))
+  {:inputs [[:drawer/slice]]}
+  (fn [[drawer] _] (:circles drawer)))
 
 (rf/reg-sub :drawer/dialog
-  :<- [:drawer/slice]
-  (fn [drawer _] (:dialog drawer)))
+  {:inputs [[:drawer/slice]]}
+  (fn [[drawer] _] (:dialog drawer)))
 
 ;; The circles the CANVAS renders: the durable `:circles`, but with the resize
 ;; dialog's live `:draft-radius` overlaid onto the circle being edited. This is
@@ -232,8 +232,8 @@
 ;; open → drag → close still collapses into one tidy undo step. Live preview up
 ;; top, clean history underneath — the derivation is where the two meet.
 (rf/reg-sub :drawer/display-circles
-  :<- [:drawer/circles]
-  :<- [:drawer/dialog]
+  {:inputs [[:drawer/circles]
+            [:drawer/dialog]]}
   (fn [[circles dialog] _]
     (if-let [{:keys [circle-id draft-radius]} dialog]
       (mapv #(if (= circle-id (:id %))
@@ -243,12 +243,12 @@
       circles)))
 
 (rf/reg-sub :drawer/can-undo?
-  :<- [:drawer/slice]
-  (fn [drawer _] (seq (:undo drawer))))
+  {:inputs [[:drawer/slice]]}
+  (fn [[drawer] _] (seq (:undo drawer))))
 
 (rf/reg-sub :drawer/can-redo?
-  :<- [:drawer/slice]
-  (fn [drawer _] (seq (:redo drawer))))
+  {:inputs [[:drawer/slice]]}
+  (fn [[drawer] _] (seq (:redo drawer))))
 
 ;; ============================================================================
 ;; VIEW

--- a/examples/core/seven_guis/crud/core.cljs
+++ b/examples/core/seven_guis/crud/core.cljs
@@ -151,9 +151,9 @@
 (rf/reg-sub :crud/draft-surname (fn [db _] (get-in db [:crud :draft :surname])))
 
 (rf/reg-sub :crud/filtered-people
-  {:doc "People whose surname starts with the filter prefix (case-insensitive)."}
-  :<- [:crud/people]
-  :<- [:crud/filter-text]
+  {:doc "People whose surname starts with the filter prefix (case-insensitive)."
+   :inputs [[:crud/people]
+            [:crud/filter-text]]}
   (fn sub-crud-filtered-people [[people prefix] _]
     (let [pfx (str/lower-case (or prefix ""))]
       (if (str/blank? pfx)
@@ -167,9 +167,9 @@
          see. We don't drop the selection when the filter hides it, though — we
          just ask the *filtered* list whether the selection is in it. Clear the
          filter and the row reappears, and the buttons light back up on their
-         own."}
-  :<- [:crud/selected-id]
-  :<- [:crud/filtered-people]
+         own."
+   :inputs [[:crud/selected-id]
+            [:crud/filtered-people]]}
   (fn sub-crud-can-update? [[id visible-people] _]
     (boolean (and id (some #(= id (:id %)) visible-people)))))
 

--- a/examples/core/seven_guis/flight_booker/core.cljs
+++ b/examples/core/seven_guis/flight_booker/core.cljs
@@ -149,25 +149,25 @@
                (= d (.getUTCDate dt))))))))
 
 (rf/reg-sub :flight/return-enabled?
-  :<- [:flight/trip-type]
-  (fn sub-flight-return-enabled? [trip-type _]
+  {:inputs [[:flight/trip-type]]}
+  (fn sub-flight-return-enabled? [[trip-type] _]
     (= trip-type :return)))
 
 (rf/reg-sub :flight/start-valid?
-  :<- [:flight/start-text]
-  (fn [s _] (valid-date? s)))
+  {:inputs [[:flight/start-text]]}
+  (fn [[s] _] (valid-date? s)))
 
 (rf/reg-sub :flight/return-valid?
-  :<- [:flight/return-text]
-  :<- [:flight/return-enabled?]
+  {:inputs [[:flight/return-text]
+            [:flight/return-enabled?]]}
   (fn [[s enabled?] _]
     ;; If return isn't enabled, it doesn't need to be valid.
     (or (not enabled?) (valid-date? s))))
 
 (rf/reg-sub :flight/dates-coherent?
-  :<- [:flight/trip-type]
-  :<- [:flight/start-text]
-  :<- [:flight/return-text]
+  {:inputs [[:flight/trip-type]
+            [:flight/start-text]
+            [:flight/return-text]]}
   (fn [[trip-type s r] _]
     (case trip-type
       :one-way true
@@ -182,10 +182,10 @@
 (rf/reg-sub :flight/book-enabled?
   {:doc "The keystone sub: Book is clickable only when the start date is
          valid, the return date is valid (or unused), and the two are in a
-         sensible order. Three smaller answers, ANDed into one."}
-  :<- [:flight/start-valid?]
-  :<- [:flight/return-valid?]
-  :<- [:flight/dates-coherent?]
+         sensible order. Three smaller answers, ANDed into one."
+   :inputs [[:flight/start-valid?]
+            [:flight/return-valid?]
+            [:flight/dates-coherent?]]}
   (fn [[ok-s ok-r ok-c] _]
     (and ok-s ok-r ok-c)))
 

--- a/examples/core/seven_guis/flight_booker/core.cljs
+++ b/examples/core/seven_guis/flight_booker/core.cljs
@@ -19,7 +19,7 @@
    Demonstrates:
    - A schema-bound app-db slice
    - One event per distinct user intent
-   - Layered subs built with :<- chains
+   - Layered subs built from declared :inputs
    - UI state driven by sub return values"
   (:require [re-frame.core :as rf]
             ;; Loading re-frame.schemas registers its late-bind hooks, which
@@ -113,9 +113,9 @@
 ;;
 ;; The base layer (`:flight/trip-type`, `:flight/start-text`,
 ;; `:flight/return-text`) just reads the slice. Each sub above it asks one
-;; sharper question by `:<-` chaining off the answers below: is the start date
-;; valid, does return need validating at all, do the two dates make sense
-;; together. `:flight/book-enabled?` sits at the top and ANDs the lot.
+;; sharper question by declaring the answers below as its `:inputs`: is the
+;; start date valid, does return need validating at all, do the two dates make
+;; sense together. `:flight/book-enabled?` sits at the top and ANDs the lot.
 ;;
 ;; The payoff: the button's enabled-ness is a pure function of state that
 ;; recomputes itself. Nothing in the event handlers has to remember to keep it

--- a/examples/core/seven_guis/temperature/core.cljs
+++ b/examples/core/seven_guis/temperature/core.cljs
@@ -110,9 +110,10 @@
 ;;
 ;; A little two-layer graph. Three tiny *extractors* (Layer 1) pluck the raw
 ;; fields straight out of the slice: :temp/active, :temp/canonical-celsius,
-;; :temp/typing. Then two *derivations* (Layer 2) chain off all three with
-;; `:<-` to compute what each box should actually display. The view reads only
-;; those two `-text` subs and stays blissfully unaware of the rest.
+;; :temp/typing. Then two *derivations* (Layer 2) chain off all three — named
+;; in their `:inputs` — to compute what each box should actually display. The
+;; view reads only those two `-text` subs and stays blissfully unaware of the
+;; rest.
 ;;
 ;; The cleverness all lives in the two `-text` subs, and it's one rule: for
 ;; the box you're *currently editing*, hand back your raw keystrokes; for the
@@ -120,7 +121,7 @@
 ;; pass-through vs. derive — which is the whole reason typing "1." doesn't
 ;; reformat itself out from under you mid-keystroke.
 ;;
-;; For the layers, the equality gate, and the `:<-` arrow in full, see
+;; For the layers, the equality gate, and the `:inputs` slot in full, see
 ;; `docs/core/subscriptions.md`.
 
 (rf/reg-sub :temp/active

--- a/examples/core/seven_guis/temperature/core.cljs
+++ b/examples/core/seven_guis/temperature/core.cljs
@@ -134,10 +134,10 @@
 
 (rf/reg-sub :temp/celsius-text
   {:doc "What the Celsius box shows: raw keystrokes while it's the active box,
-         otherwise the canonical value formatted to two places."}
-  :<- [:temp/active]
-  :<- [:temp/typing]
-  :<- [:temp/canonical-celsius]
+         otherwise the canonical value formatted to two places."
+   :inputs [[:temp/active]
+            [:temp/typing]
+            [:temp/canonical-celsius]]}
   (fn sub-temp-celsius-text [[active typing c] _]
     (case active
       :celsius     typing
@@ -145,10 +145,10 @@
 
 (rf/reg-sub :temp/fahrenheit-text
   {:doc "What the Fahrenheit box shows: raw keystrokes while it's the active
-         box, otherwise the canonical Celsius converted to °F, two places."}
-  :<- [:temp/active]
-  :<- [:temp/typing]
-  :<- [:temp/canonical-celsius]
+         box, otherwise the canonical Celsius converted to °F, two places."
+   :inputs [[:temp/active]
+            [:temp/typing]
+            [:temp/canonical-celsius]]}
   (fn sub-temp-fahrenheit-text [[active typing c] _]
     (case active
       :fahrenheit  typing

--- a/examples/core/seven_guis/timer/core.cljs
+++ b/examples/core/seven_guis/timer/core.cljs
@@ -214,14 +214,14 @@
 
 ;; Elapsed milliseconds, dressed up as seconds with one decimal for display.
 (rf/reg-sub :timer/elapsed-seconds
-  :<- [:timer/elapsed-ms]
-  (fn [ms _] (.toFixed (/ ms 1000.0) 1)))
+  {:inputs [[:timer/elapsed-ms]]}
+  (fn [[ms] _] (.toFixed (/ ms 1000.0) 1)))
 
 (rf/reg-sub :timer/progress-pct
   {:doc "How far along we are, 0 to 100. A zero duration counts as full —
-         otherwise we'd be dividing by zero, and nobody enjoys that."}
-  :<- [:timer/elapsed-ms]
-  :<- [:timer/duration-ms]
+         otherwise we'd be dividing by zero, and nobody enjoys that."
+   :inputs [[:timer/elapsed-ms]
+            [:timer/duration-ms]]}
   (fn [[e d] _]
     (cond
       (zero? d) 100

--- a/examples/core/seven_guis/timer/core.cljs
+++ b/examples/core/seven_guis/timer/core.cljs
@@ -205,7 +205,7 @@
 ;;
 ;; The two base subs just read raw numbers out of app-db. The ones above them
 ;; build on those — seconds and percentage are *derived*, never stored. The
-;; `:<-` arrows wire each sub to its inputs, so it recomputes only when an
+;; `:inputs` slot wires each sub to its inputs, so it recomputes only when an
 ;; input actually changes. The view asks for the polished values and stays out
 ;; of the arithmetic. Subscriptions: docs/core/subscriptions.md.
 

--- a/examples/core/todomvc/subs.cljs
+++ b/examples/core/todomvc/subs.cljs
@@ -15,8 +15,8 @@
 ;; :rf.route/not-found and an unset route quietly fall through to :all, so the UI
 ;; always has a sensible default to show.
 (rf/reg-sub :todo/showing
-  :<- [:rf.route/id]
-  (fn [route-id _]
+  {:inputs [[:rf.route/id]]}
+  (fn [[route-id] _]
     (case route-id
       :todo/active    :active
       :todo/completed :completed
@@ -27,13 +27,13 @@
     (:todos db)))
 
 (rf/reg-sub :todo/todos
-  :<- [:todo/sorted-todos]
-  (fn [sorted-todos _]
+  {:inputs [[:todo/sorted-todos]]}
+  (fn [[sorted-todos] _]
     (vals sorted-todos)))
 
 (rf/reg-sub :todo/visible-todos
-  :<- [:todo/todos]
-  :<- [:todo/showing]
+  {:inputs [[:todo/todos]
+            [:todo/showing]]}
   (fn [[todos showing] _]
     (let [predicate (case showing
                       :active    (complement :completed)
@@ -42,18 +42,18 @@
       (filter predicate todos))))
 
 (rf/reg-sub :todo/all-complete?
-  :<- [:todo/todos]
-  (fn [todos _]
+  {:inputs [[:todo/todos]]}
+  (fn [[todos] _]
     (and (seq todos) (every? :completed todos))))
 
 (rf/reg-sub :todo/completed-count
-  :<- [:todo/todos]
-  (fn [todos _]
+  {:inputs [[:todo/todos]]}
+  (fn [[todos] _]
     (count (filter :completed todos))))
 
 (rf/reg-sub :todo/footer-counts
-  :<- [:todo/todos]
-  :<- [:todo/completed-count]
+  {:inputs [[:todo/todos]
+            [:todo/completed-count]]}
   (fn [[todos completed-count] _]
     [(- (count todos) completed-count) completed-count]))
 
@@ -69,8 +69,8 @@
     (get-in db [:ui :editing-id])))
 
 (rf/reg-sub :todo.ui/editing?
-  :<- [:todo.ui/editing-id]
-  (fn [editing-id [_ id]]
+  {:inputs [[:todo.ui/editing-id]]}
+  (fn [[editing-id] [_ id]]
     (= editing-id id)))
 
 (rf/reg-sub :todo.ui/draft

--- a/examples/patterns/boot/boot.cljs
+++ b/examples/patterns/boot/boot.cljs
@@ -390,24 +390,24 @@
 ;; framework's `:rf/machine` sub (docs/machines/glossary.md#snapshot). The
 ;; small subs below are just convenient slices off that one snapshot.
 (rf/reg-sub :app.boot/snapshot
-  :<- [:rf/machine :app/boot]
-  (fn [snapshot _] snapshot))
+  {:inputs [[:rf/machine :app/boot]]}
+  (fn [[snapshot] _] snapshot))
 
 (rf/reg-sub :app.boot/state
-  :<- [:app.boot/snapshot]
-  (fn [snap _] (:state snap)))
+  {:inputs [[:app.boot/snapshot]]}
+  (fn [[snap] _] (:state snap)))
 
 (rf/reg-sub :app.boot/error
-  :<- [:app.boot/snapshot]
-  (fn [snap _] (get-in snap [:data :error])))
+  {:inputs [[:app.boot/snapshot]]}
+  (fn [[snap] _] (get-in snap [:data :error])))
 
 (rf/reg-sub :app.boot/ready?
-  :<- [:app.boot/state]
-  (fn [state _] (= state :ready)))
+  {:inputs [[:app.boot/state]]}
+  (fn [[state] _] (= state :ready)))
 
 (rf/reg-sub :app.boot/failed?
-  :<- [:app.boot/state]
-  (fn [state _] (= state :failed)))
+  {:inputs [[:app.boot/state]]}
+  (fn [[state] _] (= state :failed)))
 
 (rf/reg-sub :app/config (fn [db _] (:config db)))
 (rf/reg-sub :app/flags  (fn [db _] (:flags db)))

--- a/examples/patterns/long_running_work/worker.cljs
+++ b/examples/patterns/long_running_work/worker.cljs
@@ -360,48 +360,48 @@
 ;; only from the layer above — the usual subscription-graph shape.
 
 (rf/reg-sub :work/flow-snapshot
-  :<- [:rf/machine :work/flow]
-  (fn [snap _] snap))
+  {:inputs [[:rf/machine :work/flow]]}
+  (fn [[snap] _] snap))
 
 (rf/reg-sub :work/flow-state
-  :<- [:work/flow-snapshot]
-  (fn [snap _] (:state snap)))
+  {:inputs [[:work/flow-snapshot]]}
+  (fn [[snap] _] (:state snap)))
 
 (rf/reg-sub :work/flow-data
-  :<- [:work/flow-snapshot]
-  (fn [snap _] (:data snap)))
+  {:inputs [[:work/flow-snapshot]]}
+  (fn [[snap] _] (:data snap)))
 
 (rf/reg-sub :work/progress-map
-  :<- [:work/flow-data]
-  (fn [data _] (:progress data {})))
+  {:inputs [[:work/flow-data]]}
+  (fn [[data] _] (:progress data {})))
 
 (rf/reg-sub :work/total-items
-  :<- [:work/flow-data]
-  (fn [data _]
+  {:inputs [[:work/flow-data]]}
+  (fn [[data] _]
     (* (count (:shards data)) (:total data 0))))
 
 (rf/reg-sub :work/items-done
-  :<- [:work/progress-map]
-  (fn [progress _]
+  {:inputs [[:work/progress-map]]}
+  (fn [[progress] _]
     (reduce + 0 (vals progress))))
 
 (rf/reg-sub :work/progress-fraction
   {:doc "How far along, all up — a number from 0.0 to 1.0. The progress
-         bar multiplies by 100 to turn it into a width."}
-  :<- [:work/items-done]
-  :<- [:work/total-items]
+         bar multiplies by 100 to turn it into a width."
+   :inputs [[:work/items-done]
+            [:work/total-items]]}
   (fn [[done total] _]
     (if (pos? total)
       (/ done total)
       0)))
 
 (rf/reg-sub :work/outcome
-  :<- [:work/flow-data]
-  (fn [data _] (:outcome data)))
+  {:inputs [[:work/flow-data]]}
+  (fn [[data] _] (:outcome data)))
 
 (rf/reg-sub :work/running?
-  :<- [:work/flow-state]
-  (fn [state _] (= state :working)))
+  {:inputs [[:work/flow-state]]}
+  (fn [[state] _] (= state :working)))
 
 ;; ============================================================================
 ;; INITIALISATION

--- a/examples/patterns/nine_states/core.cljs
+++ b/examples/patterns/nine_states/core.cljs
@@ -635,29 +635,29 @@
 (rf/reg-sub :new-todo/slice
   (fn sub-new-todo [db _] (get db :new-todo)))
 
-(rf/reg-sub :new-todo/draft   :<- [:new-todo/slice] (fn [s _] (:draft s)))
-(rf/reg-sub :new-todo/errors  :<- [:new-todo/slice] (fn [s _] (:errors s)))
-(rf/reg-sub :new-todo/touched :<- [:new-todo/slice] (fn [s _] (:touched s)))
+(rf/reg-sub :new-todo/draft   {:inputs [[:new-todo/slice]]} (fn [[s] _] (:draft s)))
+(rf/reg-sub :new-todo/errors  {:inputs [[:new-todo/slice]]} (fn [[s] _] (:errors s)))
+(rf/reg-sub :new-todo/touched {:inputs [[:new-todo/slice]]} (fn [[s] _] (:touched s)))
 
 (rf/reg-sub :new-todo/field-error
   {:doc "The error for one field — but only once the user has actually
          touched it. Nobody likes a form that scolds you for leaving a
-         field blank before you've even reached it."}
-  :<- [:new-todo/errors]
-  :<- [:new-todo/touched]
+         field blank before you've even reached it."
+   :inputs [[:new-todo/errors]
+            [:new-todo/touched]]}
   (fn sub-new-todo-field-error [[errs touched] [_ field-id]]
     (when (touched field-id)
       (first (get errs field-id)))))
 
 ;; The todos themselves — read straight off the machine's snapshot.
 (rf/reg-sub :todos/items
-  :<- [:rf/machine :ui/nine-states]
-  (fn sub-todos-items [snap _]
+  {:inputs [[:rf/machine :ui/nine-states]]}
+  (fn sub-todos-items [[snap] _]
     (get-in snap [:data :items])))
 
 (rf/reg-sub :todos/error
-  :<- [:rf/machine :ui/nine-states]
-  (fn sub-todos-error [snap _]
+  {:inputs [[:rf/machine :ui/nine-states]]}
+  (fn sub-todos-error [[snap] _]
     (get-in snap [:data :error])))
 
 ;; ---- render-priority + :ui/render selector ----
@@ -698,9 +698,9 @@
   {:doc "Boil the whole page down to one keyword: walk the render-priority
          table against the machine's tag union and return the first match.
          This sub feeds the root view's `case` — the one and only place the
-         UI branches. Everything else just asks the tags directly."}
-  :<- [:rf/machine :ui/nine-states]
-  (fn sub-ui-render [snap _]
+         UI branches. Everything else just asks the tags directly."
+   :inputs [[:rf/machine :ui/nine-states]]}
+  (fn sub-ui-render [[snap] _]
     (let [tags (:tags snap)]
       (some (fn [{:keys [tag render]}]
               (when (contains? tags tag) render))

--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -762,12 +762,12 @@
   ;; through the framework `:rf/machine` sub rather than poking at app-db.
   ;; See docs/machines/glossary.md#snapshot.
   (rf/reg-sub :ws/snapshot
-    :<- [:rf/machine :ws/connection]
-    (fn [snapshot _] snapshot))
+    {:inputs [[:rf/machine :ws/connection]]}
+    (fn [[snapshot] _] snapshot))
 
   (rf/reg-sub :ws/state
-    :<- [:ws/snapshot]
-    (fn [snap _] (:state snap)))
+    {:inputs [[:ws/snapshot]]}
+    (fn [[snap] _] (:state snap)))
 
   ;; One little yes/no sub per tag. Each chains off the FRAMEWORK sub
   ;; `:rf.machine/has-tag?`, which returns the snapshot's tag-containment bit
@@ -776,36 +776,36 @@
   ;; itself.
   ;; See docs/machines/glossary.md#state-tag.
   (rf/reg-sub :ws/connecting?
-    :<- [:rf.machine/has-tag? :ws/connection :websocket/connecting]
-    (fn [has-tag? _] has-tag?))
+    {:inputs [[:rf.machine/has-tag? :ws/connection :websocket/connecting]]}
+    (fn [[has-tag?] _] has-tag?))
 
   (rf/reg-sub :ws/authenticating?
-    :<- [:rf.machine/has-tag? :ws/connection :websocket/authenticating]
-    (fn [has-tag? _] has-tag?))
+    {:inputs [[:rf.machine/has-tag? :ws/connection :websocket/authenticating]]}
+    (fn [[has-tag?] _] has-tag?))
 
   (rf/reg-sub :ws/connected?
-    :<- [:rf.machine/has-tag? :ws/connection :websocket/connected]
-    (fn [has-tag? _] has-tag?))
+    {:inputs [[:rf.machine/has-tag? :ws/connection :websocket/connected]]}
+    (fn [[has-tag?] _] has-tag?))
 
   (rf/reg-sub :ws/reconnecting?
-    :<- [:rf.machine/has-tag? :ws/connection :websocket/reconnecting]
-    (fn [has-tag? _] has-tag?))
+    {:inputs [[:rf.machine/has-tag? :ws/connection :websocket/reconnecting]]}
+    (fn [[has-tag?] _] has-tag?))
 
   (rf/reg-sub :ws/failed?
-    :<- [:rf.machine/has-tag? :ws/connection :websocket/failed]
-    (fn [has-tag? _] has-tag?))
+    {:inputs [[:rf.machine/has-tag? :ws/connection :websocket/failed]]}
+    (fn [[has-tag?] _] has-tag?))
 
   (rf/reg-sub :ws/queue-depth
-    :<- [:ws/snapshot]
-    (fn [snap _] (count (get-in snap [:data :queue]))))
+    {:inputs [[:ws/snapshot]]}
+    (fn [[snap] _] (count (get-in snap [:data :queue]))))
 
   (rf/reg-sub :ws/retries
-    :<- [:ws/snapshot]
-    (fn [snap _] (get-in snap [:data :retries])))
+    {:inputs [[:ws/snapshot]]}
+    (fn [[snap] _] (get-in snap [:data :retries])))
 
   (rf/reg-sub :ws/error
-    :<- [:ws/snapshot]
-    (fn [snap _] (get-in snap [:data :error])))
+    {:inputs [[:ws/snapshot]]}
+    (fn [[snap] _] (get-in snap [:data :error])))
 
   ;; --- init event -------------------------------------------------------
   (rf/reg-event :ws.connection/initialise

--- a/examples/patterns/websocket/messages.cljs
+++ b/examples/patterns/websocket/messages.cljs
@@ -607,16 +607,16 @@
     (fn [db _] (:messages db)))
 
   (rf/reg-sub :messages/draft
-    :<- [:messages/slice]
-    (fn [m _] (:draft m)))
+    {:inputs [[:messages/slice]]}
+    (fn [[m] _] (:draft m)))
 
   (rf/reg-sub :messages/received
-    :<- [:messages/slice]
-    (fn [m _] (:received m)))
+    {:inputs [[:messages/slice]]}
+    (fn [[m] _] (:received m)))
 
   (rf/reg-sub :messages/last-reply
-    :<- [:messages/slice]
-    (fn [m _] (:last-reply m))))
+    {:inputs [[:messages/slice]]}
+    (fn [[m] _] (:last-reply m))))
 
 ;; Loading this namespace registers it — the production-app idiom.
 (register!)

--- a/examples/real-apps/realworld_http/article_editor.cljs
+++ b/examples/real-apps/realworld_http/article_editor.cljs
@@ -489,32 +489,32 @@
 (rf/reg-sub :editor/slice
   (fn [db _] (:editor db)))
 
-(rf/reg-sub :editor/draft :<- [:editor/slice] (fn [editor _] (:draft editor)))
-(rf/reg-sub :editor/errors :<- [:editor/slice] (fn [editor _] (:errors editor)))
-(rf/reg-sub :editor/submit-error :<- [:editor/slice]
-  (fn [editor _] (:submit-error editor)))
+(rf/reg-sub :editor/draft {:inputs [[:editor/slice]]} (fn [[editor] _] (:draft editor)))
+(rf/reg-sub :editor/errors {:inputs [[:editor/slice]]} (fn [[editor] _] (:errors editor)))
+(rf/reg-sub :editor/submit-error {:inputs [[:editor/slice]]}
+  (fn [[editor] _] (:submit-error editor)))
 
 (rf/reg-sub :editor/field-error
   {:doc "The validation error for one field, or nil while we keep mum. Same
          courtesy as every other form here: nothing shown until the field is
          touched or the user has tried to submit. See the forms how-to:
-         ../../../docs/core/how-to/build-a-form.md"}
-  :<- [:editor/slice]
-  (fn [editor [_ field]]
+         ../../../docs/core/how-to/build-a-form.md"
+   :inputs [[:editor/slice]]}
+  (fn [[editor] [_ field]]
     (when (or (:submit-attempted? editor)
               (contains? (:touched editor) field))
       (get-in editor [:errors field]))))
 
 (rf/reg-sub :editor/form-error
   {:doc "The one-line, whole-form nudge (the :_form key under :errors) —
-         set when a submit attempt tripped client-side validation."}
-  :<- [:editor/slice]
-  (fn [editor _]
+         set when a submit attempt tripped client-side validation."
+   :inputs [[:editor/slice]]}
+  (fn [[editor] _]
     (when (:submit-attempted? editor)
       (get-in editor [:errors :_form]))))
 (rf/reg-sub :editor/dirty?
-  :<- [:editor/slice]
-  (fn [editor _]
+  {:inputs [[:editor/slice]]}
+  (fn [[editor] _]
     (not= (:draft editor) (:baseline editor))))
 
 (rf/reg-sub :editor/can-submit?
@@ -528,8 +528,8 @@
     (boolean (get-in db [:editor :can-submit?]))))
 
 (rf/reg-sub :editor/can-leave?
-  :<- [:editor/dirty?]
-  (fn [dirty? _]
+  {:inputs [[:editor/dirty?]]}
+  (fn [[dirty?] _]
     (not dirty?)))
 
 ;; ---- render-priority + :article-editor/render selector ----
@@ -556,9 +556,9 @@
 (rf/reg-sub :article-editor/render
   {:doc "Reduce the `:ui/article-editor` machine's active tags to a single
          render keyword, via the render-priority table. The root view's `case`
-         on it is the one and only branch site."}
-  :<- [:rf/machine :ui/article-editor]
-  (fn sub-editor-render [snap _]
+         on it is the one and only branch site."
+   :inputs [[:rf/machine :ui/article-editor]]}
+  (fn sub-editor-render [[snap] _]
     (let [tags (:tags snap)]
       (some (fn [{:keys [tag render]}]
               (when (contains? tags tag) render))

--- a/examples/real-apps/realworld_http/articles.cljs
+++ b/examples/real-apps/realworld_http/articles.cljs
@@ -318,9 +318,9 @@
 ;; ============================================================================
 
 (rf/reg-sub :articles/slice      (fn [db _] (:articles db)))
-(rf/reg-sub :articles/data       :<- [:articles/slice] (fn [s _] (:data s)))
-(rf/reg-sub :articles/error      :<- [:articles/slice] (fn [s _] (:error s)))
-(rf/reg-sub :articles/count      :<- [:articles/slice] (fn [s _] (:articles-count s 0)))
+(rf/reg-sub :articles/data       {:inputs [[:articles/slice]]} (fn [[s] _] (:data s)))
+(rf/reg-sub :articles/error      {:inputs [[:articles/slice]]} (fn [[s] _] (:error s)))
+(rf/reg-sub :articles/count      {:inputs [[:articles/slice]]} (fn [[s] _] (:articles-count s 0)))
 
 ;; The `:tags/data` sub is defined in `realworld-http.tags`, where the
 ;; popular-tags lifecycle lives entirely in a machine: items are read off
@@ -353,9 +353,9 @@
 (rf/reg-sub :articles.home/render
   {:doc "Boil the machine's active tags down to a single render keyword, by
          running them past the render-priority table. The home view's `case`
-         on this keyword is the one and only branch site."}
-  :<- [:rf/machine :realworld/articles-home]
-  (fn sub-articles-home-render [snap _]
+         on this keyword is the one and only branch site."
+   :inputs [[:rf/machine :realworld/articles-home]]}
+  (fn sub-articles-home-render [[snap] _]
     (let [tags (:tags snap)]
       (some (fn [{:keys [tag render]}]
               (when (contains? tags tag) render))
@@ -364,10 +364,10 @@
 (rf/reg-sub :articles.home/active-articles
   {:doc "Whichever article list the home view should be showing right now. The
          `:feed` region's active state decides which app-db slice to pull from
-         — `:feed` for your-feed, `:articles` for everything else."}
-  :<- [:rf/machine :realworld/articles-home]
-  :<- [:articles/data]
-  :<- [:feed/data]
+         — `:feed` for your-feed, `:articles` for everything else."
+   :inputs [[:rf/machine :realworld/articles-home]
+            [:articles/data]
+            [:feed/data]]}
   (fn sub-active-articles [[snap global-items feed-items] _]
     (case (get-in snap [:state :feed])
       :user-feed (or feed-items [])
@@ -383,10 +383,10 @@
 (rf/reg-sub :articles.home/articles-count
   {:doc "Grand article count for the active home feed (global / user-feed),
          from whichever slice the `:feed` region is rendering. Drives the
-         page count."}
-  :<- [:rf/machine :realworld/articles-home]
-  :<- [:articles/count]
-  :<- [:feed/count]
+         page count."
+   :inputs [[:rf/machine :realworld/articles-home]
+            [:articles/count]
+            [:feed/count]]}
   (fn sub-home-count [[snap global-count feed-count] _]
     (case (get-in snap [:state :feed])
       :user-feed (or feed-count 0)
@@ -395,16 +395,16 @@
 (rf/reg-sub :articles.home/current-page
   {:doc "The 1-indexed current page for the home feed, read off the route
          query (`?page=`; `:query-defaults {:page 1}` fills it when absent).
-         Composes off `:home/page` (tags.cljs)."}
-  :<- [:home/page]
-  (fn sub-home-page [page _]
+         Composes off `:home/page` (tags.cljs)."
+   :inputs [[:home/page]]}
+  (fn sub-home-page [[page] _]
     (or page 1)))
 
 (rf/reg-sub :articles.home/page-count
   {:doc "Total number of pages for the active home feed —
-         `(ceil articles-count / page-size)`, never below 1."}
-  :<- [:articles.home/articles-count]
-  (fn sub-home-page-count [total _]
+         `(ceil articles-count / page-size)`, never below 1."
+   :inputs [[:articles.home/articles-count]]}
+  (fn sub-home-page-count [[total] _]
     (rh/page-count total)))
 
 ;; ============================================================================

--- a/examples/real-apps/realworld_http/auth.cljs
+++ b/examples/real-apps/realworld_http/auth.cljs
@@ -650,31 +650,31 @@
          handler has a db value but no subs."}
   (fn [db _] (restoring-session? db)))
 
+;; Snapshots live in runtime-db, but you don't go digging for them by path
+;; — `:rf/machine` is the front door. Read through it.
 (rf/reg-sub :auth/flow-state
-  {:doc "The current auth machine snapshot."}
-  ;; Snapshots live in runtime-db, but you don't go digging for them by path
-  ;; — `:rf/machine` is the front door. Read through it.
-  :<- [:rf/machine :auth/flow]
-  (fn [snapshot _] snapshot))
+  {:doc "The current auth machine snapshot."
+   :inputs [[:rf/machine :auth/flow]]}
+  (fn [[snapshot] _] snapshot))
 
 (rf/reg-sub :auth/state
-  :<- [:auth/flow-state]
-  (fn [snapshot _]
+  {:inputs [[:auth/flow-state]]}
+  (fn [[snapshot] _]
     (:state snapshot)))
 
 (rf/reg-sub :auth/error
-  :<- [:auth/flow-state]
-  (fn [snapshot _]
+  {:inputs [[:auth/flow-state]]}
+  (fn [[snapshot] _]
     (get-in snapshot [:data :error])))
 
 (rf/reg-sub :auth/authenticated?
-  :<- [:auth/state]
-  (fn [state _]
+  {:inputs [[:auth/state]]}
+  (fn [[state] _]
     (= state :authed)))
 
 (rf/reg-sub :auth/submitting?
-  :<- [:auth/state]
-  (fn [state _]
+  {:inputs [[:auth/state]]}
+  (fn [[state] _]
     (or (= state :submitting) (= state :restoring))))
 
 (rf/reg-sub :auth.login-form/draft
@@ -687,9 +687,9 @@
   {:doc "The validation error for one login-form field — or nil while we're
          keeping quiet. The rule of politeness: don't nag about a field until
          the user has either touched it or hit submit at least once. See the
-         forms how-to: ../../../docs/core/how-to/build-a-form.md"}
-  :<- [:auth.login-form/slice]
-  (fn [form [_ field]]
+         forms how-to: ../../../docs/core/how-to/build-a-form.md"
+   :inputs [[:auth.login-form/slice]]}
+  (fn [[form] [_ field]]
     (when (or (:submit-attempted? form)
               (contains? (:touched form) field))
       (get-in form [:errors field]))))
@@ -704,9 +704,9 @@
   {:doc "The validation error for one register-form field, or nil while we
          hold our tongue. Same rule as the login form: stay quiet until the
          field is touched or the user has tried to submit. See the forms
-         how-to: ../../../docs/core/how-to/build-a-form.md"}
-  :<- [:auth.register-form/slice]
-  (fn [form [_ field]]
+         how-to: ../../../docs/core/how-to/build-a-form.md"
+   :inputs [[:auth.register-form/slice]]}
+  (fn [[form] [_ field]]
     (when (or (:submit-attempted? form)
               (contains? (:touched form) field))
       (get-in form [:errors field]))))

--- a/examples/real-apps/realworld_http/comments.cljs
+++ b/examples/real-apps/realworld_http/comments.cljs
@@ -659,14 +659,14 @@
 ;; ============================================================================
 
 (rf/reg-sub :article/slice (fn [db _] (:article db)))
-(rf/reg-sub :article/data :<- [:article/slice] (fn [slice _] (:data slice)))
-(rf/reg-sub :article/status :<- [:article/slice] (fn [slice _] (:status slice)))
-(rf/reg-sub :article/error :<- [:article/slice] (fn [slice _] (:error slice)))
+(rf/reg-sub :article/data {:inputs [[:article/slice]]} (fn [[slice] _] (:data slice)))
+(rf/reg-sub :article/status {:inputs [[:article/slice]]} (fn [[slice] _] (:status slice)))
+(rf/reg-sub :article/error {:inputs [[:article/slice]]} (fn [[slice] _] (:error slice)))
 
 (rf/reg-sub :article/author
-  {:doc "The current article's author profile (username, image, following)."}
-  :<- [:article/data]
-  (fn [article _] (:author article)))
+  {:doc "The current article's author profile (username, image, following)."
+   :inputs [[:article/data]]}
+  (fn [[article] _] (:author article)))
 
 (rf/reg-sub :article/own?
   {:doc "Is this the reader's own article? True when the signed-in user is the
@@ -677,9 +677,9 @@
       (and me (= me (get-in db [:article :data :author :username]))))))
 
 (rf/reg-sub :comments/slice (fn [db _] (:comments db)))
-(rf/reg-sub :comments/data :<- [:comments/slice] (fn [slice _] (:data slice)))
-(rf/reg-sub :comments/status :<- [:comments/slice] (fn [slice _] (:status slice)))
-(rf/reg-sub :comments/error :<- [:comments/slice] (fn [slice _] (:error slice)))
+(rf/reg-sub :comments/data {:inputs [[:comments/slice]]} (fn [[slice] _] (:data slice)))
+(rf/reg-sub :comments/status {:inputs [[:comments/slice]]} (fn [[slice] _] (:status slice)))
+(rf/reg-sub :comments/error {:inputs [[:comments/slice]]} (fn [[slice] _] (:error slice)))
 
 (rf/reg-sub :comment-form/draft
   (fn [db _] (get-in db [:comment-form :draft])))
@@ -697,9 +697,9 @@
   {:doc "The validation error for one comment-form field, or nil while we stay
          quiet. Same courtesy as the other forms: no error shown until the
          field is touched or the user has tried to submit. See the forms
-         how-to: ../../../docs/core/how-to/build-a-form.md"}
-  :<- [:comment-form/slice]
-  (fn [form [_ field]]
+         how-to: ../../../docs/core/how-to/build-a-form.md"
+   :inputs [[:comment-form/slice]]}
+  (fn [[form] [_ field]]
     (when (or (:submit-attempted? form)
               (contains? (:touched form) field))
       (get-in form [:errors field]))))

--- a/examples/real-apps/realworld_http/favorites.cljs
+++ b/examples/real-apps/realworld_http/favorites.cljs
@@ -199,9 +199,9 @@
 ;; ============================================================================
 
 (rf/reg-sub :feed/slice (fn [db _] (:feed db)))
-(rf/reg-sub :feed/data :<- [:feed/slice] (fn [slice _] (:data slice)))
-(rf/reg-sub :feed/error :<- [:feed/slice] (fn [slice _] (:error slice)))
-(rf/reg-sub :feed/count :<- [:feed/slice] (fn [slice _] (:articles-count slice 0)))
-(rf/reg-sub :feed/loading? :<- [:feed/slice]
-  (fn [slice _] (#{:loading :fetching} (:status slice))))
+(rf/reg-sub :feed/data {:inputs [[:feed/slice]]} (fn [[slice] _] (:data slice)))
+(rf/reg-sub :feed/error {:inputs [[:feed/slice]]} (fn [[slice] _] (:error slice)))
+(rf/reg-sub :feed/count {:inputs [[:feed/slice]]} (fn [[slice] _] (:articles-count slice 0)))
+(rf/reg-sub :feed/loading? {:inputs [[:feed/slice]]}
+  (fn [[slice] _] (#{:loading :fetching} (:status slice))))
 

--- a/examples/real-apps/realworld_http/profile.cljs
+++ b/examples/real-apps/realworld_http/profile.cljs
@@ -606,8 +606,8 @@
 ;; ============================================================================
 
 (rf/reg-sub :profile/slice   (fn [db _] (:profile db)))
-(rf/reg-sub :profile/data    :<- [:profile/slice] (fn [s _] (:data s)))
-(rf/reg-sub :profile/error   :<- [:profile/slice] (fn [s _] (:error s)))
+(rf/reg-sub :profile/data    {:inputs [[:profile/slice]]} (fn [[s] _] (:data s)))
+(rf/reg-sub :profile/error   {:inputs [[:profile/slice]]} (fn [[s] _] (:error s)))
 
 (rf/reg-sub :profile/follow-pending?
   {:doc "Is a follow/unfollow mutation in flight for the profile ON SCREEN? The
@@ -674,9 +674,9 @@
 (rf/reg-sub :profile/render
   {:doc "Reduce the `:ui/profile` machine's active tags to one render keyword,
          via the render-priority table. The root view's `case` on it is the
-         only branch site."}
-  :<- [:rf/machine :ui/profile]
-  (fn sub-profile-render [snap _]
+         only branch site."
+   :inputs [[:rf/machine :ui/profile]]}
+  (fn sub-profile-render [[snap] _]
     (let [tags (:tags snap)]
       (some (fn [{:keys [tag render]}]
               (when (contains? tags tag) render))
@@ -684,10 +684,10 @@
 
 (rf/reg-sub :profile/current-articles
   {:doc "Whichever article list the active tab calls for: the `:tab` region's
-         state picks the app-db slice — favorited vs authored."}
-  :<- [:rf/machine :ui/profile]
-  :<- [:profile.articles/data]
-  :<- [:profile.favorites/data]
+         state picks the app-db slice — favorited vs authored."
+   :inputs [[:rf/machine :ui/profile]
+            [:profile.articles/data]
+            [:profile.favorites/data]]}
   (fn sub-current-articles [[snap authored favorited] _]
     (case (get-in snap [:state :tab])
       :favorites (or favorited [])
@@ -703,10 +703,10 @@
 
 (rf/reg-sub :profile/current-count
   {:doc "Grand article count for the active profile tab — drives the page
-         count for the tab's `?page=` control."}
-  :<- [:rf/machine :ui/profile]
-  :<- [:profile.articles/count]
-  :<- [:profile.favorites/count]
+         count for the tab's `?page=` control."
+   :inputs [[:rf/machine :ui/profile]
+            [:profile.articles/count]
+            [:profile.favorites/count]]}
   (fn sub-current-count [[snap authored-count favorited-count] _]
     (case (get-in snap [:state :tab])
       :favorites (or favorited-count 0)
@@ -714,16 +714,16 @@
 
 (rf/reg-sub :profile/current-page
   {:doc "The 1-indexed current page for the active profile tab, read off the
-         route query (`?page=`; defaulted to 1 by `:query-defaults`)."}
-  :<- [:rf.route/query]
-  (fn sub-profile-page [query _]
+         route query (`?page=`; defaulted to 1 by `:query-defaults`)."
+   :inputs [[:rf.route/query]]}
+  (fn sub-profile-page [[query] _]
     (or (:page query) 1)))
 
 (rf/reg-sub :profile/page-count
   {:doc "Total pages for the active profile tab — `(ceil count / page-size)`,
-         never below 1."}
-  :<- [:profile/current-count]
-  (fn sub-profile-page-count [total _]
+         never below 1."
+   :inputs [[:profile/current-count]]}
+  (fn sub-profile-page-count [[total] _]
     (rh/page-count total)))
 
 (rf/reg-event :profile/show-page

--- a/examples/real-apps/realworld_http/routing.cljs
+++ b/examples/real-apps/realworld_http/routing.cljs
@@ -158,9 +158,9 @@
 ;; user, full stop".
 (rf/reg-sub :realworld.routing/authed?
   {:doc "The :can-enter auth guard: true when a user is signed in. Read by the
-         :requires-auth routes' :can-enter slot."}
-  :<- [:auth/user]
-  (fn [user _] (some? user)))
+         :requires-auth routes' :can-enter slot."
+   :inputs [[:auth/user]]}
+  (fn [[user] _] (some? user)))
 
 ;; The denial handler — the FRESH-RETURN recipe (Spec 012 §Entry is terminal).
 ;; Entry denial is TERMINAL: the runtime commits nothing and parks nothing, so
@@ -229,9 +229,9 @@
 (rf/reg-sub :realworld.routing/deferred-entry?
   {:doc "True while a protected deep link is parked waiting on a cold-boot
          session restore: identity unknown AND no route committed. The app shell
-         (core.cljs) reads it to show a brief 'restoring your session' state."}
-  :<- [:auth/restoring-session?]
-  :<- [:rf.route/id]
+         (core.cljs) reads it to show a brief 'restoring your session' state."
+   :inputs [[:auth/restoring-session?]
+            [:rf.route/id]]}
   (fn [[restoring? route-id] _]
     (and restoring? (nil? route-id))))
 

--- a/examples/real-apps/realworld_http/settings.cljs
+++ b/examples/real-apps/realworld_http/settings.cljs
@@ -377,23 +377,23 @@
 ;; to the view as a plain boolean — the machine-ness stays behind the curtain.
 
 (rf/reg-sub :settings/draft
-  {:doc "The settings-form draft, read out of the machine's :data."}
-  :<- [:rf/machine :settings/form]
-  (fn sub-settings-draft [snap _]
+  {:doc "The settings-form draft, read out of the machine's :data."
+   :inputs [[:rf/machine :settings/form]]}
+  (fn sub-settings-draft [[snap] _]
     (get-in snap [:data :draft])))
 
 (rf/reg-sub :settings/submit-error
-  {:doc "The latest settings-submit error, read out of the machine's :data."}
-  :<- [:rf/machine :settings/form]
-  (fn sub-settings-submit-error [snap _]
+  {:doc "The latest settings-submit error, read out of the machine's :data."
+   :inputs [[:rf/machine :settings/form]]}
+  (fn sub-settings-submit-error [[snap] _]
     (get-in snap [:data :submit-error])))
 
 (rf/reg-sub :settings/submitting?
   {:doc "Is a save in flight? A tag-shaped read of the form's in-flight intent —
          the machine-form stand-in for a slice's `(= :submitting status)`. Views
-         just see a boolean."}
-  :<- [:rf.machine/has-tag? :settings/form :settings/in-flight]
-  (fn sub-settings-submitting? [in-flight? _]
+         just see a boolean."
+   :inputs [[:rf.machine/has-tag? :settings/form :settings/in-flight]]}
+  (fn sub-settings-submitting? [[in-flight?] _]
     (boolean in-flight?)))
 
 ;; ============================================================================

--- a/examples/real-apps/realworld_http/tags.cljs
+++ b/examples/real-apps/realworld_http/tags.cljs
@@ -204,15 +204,15 @@
 ;;     @(rf/subscribe [:rf.machine/has-tag? :realworld/tags :tags/in-flight])   ;; in-flight, loading OR fetching
 
 (rf/reg-sub :tags/data
-  {:doc "The popular-tags items, read out of the machine's :data."}
-  :<- [:rf/machine :realworld/tags]
-  (fn sub-tags-data [snap _]
+  {:doc "The popular-tags items, read out of the machine's :data."
+   :inputs [[:rf/machine :realworld/tags]]}
+  (fn sub-tags-data [[snap] _]
     (get-in snap [:data :tags])))
 
 (rf/reg-sub :tags/error
-  {:doc "The latest tags-fetch error, read out of the machine's :data."}
-  :<- [:rf/machine :realworld/tags]
-  (fn sub-tags-error [snap _]
+  {:doc "The latest tags-fetch error, read out of the machine's :data."
+   :inputs [[:rf/machine :realworld/tags]]}
+  (fn sub-tags-error [[snap] _]
     (get-in snap [:data :error])))
 
 ;; ============================================================================
@@ -322,11 +322,11 @@
 
 (rf/reg-sub :home/selected-tag
   {:doc "The active tag — read from the `/tag/:tag` route's PATH params, since
-         that's where it lives (a path param, not a `?tag=` query)."}
-  :<- [:rf.route/params]
-  (fn [params _] (:tag params)))
+         that's where it lives (a path param, not a `?tag=` query)."
+   :inputs [[:rf.route/params]]}
+  (fn [[params] _] (:tag params)))
 
 (rf/reg-sub :home/page
-  {:doc "The 1-indexed home/tag page, straight off the route query (`?page=`)."}
-  :<- [:rf.route/query]
-  (fn [query _] (or (:page query) 1)))
+  {:doc "The 1-indexed home/tag page, straight off the route query (`?page=`)."
+   :inputs [[:rf.route/query]]}
+  (fn [[query] _] (or (:page query) 1)))

--- a/examples/real-apps/realworld_resources/article_editor.cljs
+++ b/examples/real-apps/realworld_resources/article_editor.cljs
@@ -455,14 +455,14 @@
 ;; ============================================================================
 
 (rf/reg-sub :editor/slice (fn [db _] (:editor db)))
-(rf/reg-sub :editor/draft :<- [:editor/slice] (fn [e _] (:draft e)))
-(rf/reg-sub :editor/slug  :<- [:editor/slice] (fn [e _] (:slug e)))
+(rf/reg-sub :editor/draft {:inputs [[:editor/slice]]} (fn [[e] _] (:draft e)))
+(rf/reg-sub :editor/slug  {:inputs [[:editor/slice]]} (fn [[e] _] (:slug e)))
 
 (rf/reg-sub :editor/field-error
   {:doc "Per-field validation error — held back until either the first submit
-         attempt or the moment the field is touched, whichever comes first."}
-  :<- [:editor/slice]
-  (fn [e [_ field]]
+         attempt or the moment the field is touched, whichever comes first."
+   :inputs [[:editor/slice]]}
+  (fn [[e] [_ field]]
     (when (or (:submit-attempted? e) (contains? (:touched e) field))
       (get-in e [:errors field]))))
 
@@ -475,16 +475,16 @@
     (boolean (get-in db [:editor :can-submit?]))))
 
 (rf/reg-sub :editor/dirty?
-  :<- [:editor/slice]
-  (fn [e _] (not= (:draft e) (:baseline e))))
+  {:inputs [[:editor/slice]]}
+  (fn [[e] _] (not= (:draft e) (:baseline e))))
 
 (rf/reg-sub :editor/can-leave?
   {:doc "The route `:can-leave` guard query. A clean (or just-saved) draft leaves
          freely; a dirty one blocks, and the app shell shows the confirm dialog off
          `:rf/pending-navigation`. See route guard:
-         ../../../docs/routing/glossary.md#route-guard."}
-  :<- [:editor/dirty?]
-  (fn [dirty? _] (not dirty?)))
+         ../../../docs/routing/glossary.md#route-guard."
+   :inputs [[:editor/dirty?]]}
+  (fn [[dirty?] _] (not dirty?)))
 
 ;; ============================================================================
 ;; VIEW  (a pure Form-1 render — no lifecycle, because the view holds no owner)

--- a/examples/real-apps/realworld_resources/auth.cljs
+++ b/examples/real-apps/realworld_resources/auth.cljs
@@ -669,24 +669,24 @@
 (rf/reg-sub :auth/user  (fn [db _] (get-in db [:auth :user])))
 
 (rf/reg-sub :auth/flow-state
-  :<- [:rf/machine :auth/flow]
-  (fn [snapshot _] snapshot))
+  {:inputs [[:rf/machine :auth/flow]]}
+  (fn [[snapshot] _] snapshot))
 
 (rf/reg-sub :auth/state
-  :<- [:auth/flow-state]
-  (fn [snapshot _] (:state snapshot)))
+  {:inputs [[:auth/flow-state]]}
+  (fn [[snapshot] _] (:state snapshot)))
 
 (rf/reg-sub :auth/error
-  :<- [:auth/flow-state]
-  (fn [snapshot _] (get-in snapshot [:data :error])))
+  {:inputs [[:auth/flow-state]]}
+  (fn [[snapshot] _] (get-in snapshot [:data :error])))
 
 (rf/reg-sub :auth/authenticated?
-  :<- [:auth/state]
-  (fn [state _] (= state :authed)))
+  {:inputs [[:auth/state]]}
+  (fn [[state] _] (= state :authed)))
 
 (rf/reg-sub :auth/submitting?
-  :<- [:auth/state]
-  (fn [state _] (or (= state :submitting) (= state :restoring))))
+  {:inputs [[:auth/state]]}
+  (fn [[state] _] (or (= state :submitting) (= state :restoring))))
 
 (rf/reg-sub :auth/viewer-resolving?
   {:doc "True during the ONE window where the viewer is genuinely unknown: a saved

--- a/examples/real-apps/realworld_resources/routing.cljs
+++ b/examples/real-apps/realworld_resources/routing.cljs
@@ -285,9 +285,9 @@
 ;; HANDLER below is where "no user YET" is told apart from "no user, full stop".
 (rf/reg-sub :realworld-resources.routing/authed?
   {:doc "The :can-enter auth guard: true when a user is signed in. Read by the
-         :requires-auth routes' :can-enter slot."}
-  :<- [:auth/user]
-  (fn [user _] (some? user)))
+         :requires-auth routes' :can-enter slot."
+   :inputs [[:auth/user]]}
+  (fn [[user] _] (some? user)))
 
 ;; The denial handler — the FRESH-RETURN recipe (Spec 012 §Entry is terminal).
 ;; Entry denial is TERMINAL: the runtime commits nothing and parks nothing (no

--- a/examples/real-apps/realworld_resources/views.cljs
+++ b/examples/real-apps/realworld_resources/views.cljs
@@ -90,9 +90,9 @@
                       (> page 1) (assoc :page page))]
           {:fx [[:dispatch [:rf.route/navigate {:to :realworld/home :query query}]]]})))))
 
-(rf/reg-sub :home/selected-tag :<- [:rf.route/params] (fn [p _] (:tag p)))
-(rf/reg-sub :home/your-feed?   :<- [:rf.route/query]  (fn [q _] (= following-feed-token (:feed q))))
-(rf/reg-sub :home/page         :<- [:rf.route/query]  (fn [q _] (or (:page q) 1)))
+(rf/reg-sub :home/selected-tag {:inputs [[:rf.route/params]]} (fn [[p] _] (:tag p)))
+(rf/reg-sub :home/your-feed?   {:inputs [[:rf.route/query]]}  (fn [[q] _] (= following-feed-token (:feed q))))
+(rf/reg-sub :home/page         {:inputs [[:rf.route/query]]}  (fn [[q] _] (or (:page q) 1)))
 
 ;; ============================================================================
 ;; FAVORITE / FOLLOW — fire a mutation, watch its instance
@@ -590,10 +590,10 @@
 ;; all. The view reads the route id to choose which list resource to subscribe to,
 ;; and reads the page off the route query.
 
-(rf/reg-sub :profile/favorites-tab? :<- [:rf.route/id]
-  (fn [id _] (= id :realworld.profile/favorites)))
-(rf/reg-sub :profile/page :<- [:rf.route/query]
-  (fn [q _] (or (:page q) 1)))
+(rf/reg-sub :profile/favorites-tab? {:inputs [[:rf.route/id]]}
+  (fn [[id] _] (= id :realworld.profile/favorites)))
+(rf/reg-sub :profile/page {:inputs [[:rf.route/query]]}
+  (fn [[q] _] (or (:page q) 1)))
 
 ;; Paging within a profile tab keeps the current route and username and swaps only
 ;; `?page=`. Page 1 drops the param — the canonical first-page URL.

--- a/examples/substrates/uix/dashboard/README.md
+++ b/examples/substrates/uix/dashboard/README.md
@@ -36,9 +36,9 @@ each metric's series to the last N points:
 
 ```clojure
 (rf/reg-sub :dashboard/visible-metrics
-  :<- [:dashboard/metrics]
-  :<- [:dashboard/active-tags]
-  :<- [:dashboard/selected-range]
+  {:inputs [[:dashboard/metrics]
+            [:dashboard/active-tags]
+            [:dashboard/selected-range]]}
   (fn [[metrics active-tags {:keys [points]}] _]
     (->> metrics
          (filter #(contains? active-tags (:tag %)))

--- a/examples/substrates/uix/dashboard/core.cljs
+++ b/examples/substrates/uix/dashboard/core.cljs
@@ -116,8 +116,8 @@
 ;; small: take the stored range id and look up its full record (label,
 ;; point count).
 (rf/reg-sub :dashboard/selected-range
-  :<- [:dashboard/range]
-  (fn [range-id _]
+  {:inputs [[:dashboard/range]]}
+  (fn [[range-id] _]
     (some #(when (= range-id (:id %)) %) ranges)))
 
 ;; This is the heart of the example — the one function the whole UI reads to
@@ -127,9 +127,9 @@
 ;; control and the framework re-runs this — and only this, plus whatever
 ;; downstream actually changed. One pure function, one source of truth.
 (rf/reg-sub :dashboard/visible-metrics
-  :<- [:dashboard/metrics]
-  :<- [:dashboard/active-tags]
-  :<- [:dashboard/selected-range]
+  {:inputs [[:dashboard/metrics]
+            [:dashboard/active-tags]
+            [:dashboard/selected-range]]}
   (fn [[metrics active-tags {:keys [points]}] _]
     (->> metrics
          (filter #(contains? active-tags (:tag %)))

--- a/examples/substrates/uix/dashboard/core.cljs
+++ b/examples/substrates/uix/dashboard/core.cljs
@@ -13,7 +13,7 @@
      - `:dashboard/visible-metrics` — one derived sub fed by three
        inputs, re-running whenever a control moves
      - the derivation graph — base subs read app-db, derived subs read
-       other subs (that's the `:<-` syntax), views sit at the leaves
+       other subs (that's the `:inputs` declaration), views sit at the leaves
      - UIx views (`defui`) pulling subscriptions in through `use-subscribe`
      - sparklines drawn as inline SVG from plain CLJS arithmetic — no
        chart library
@@ -110,11 +110,12 @@
 (rf/reg-sub :dashboard/range
   (fn [db _] (:dashboard/range db)))
 
-;; Our first derived sub, and the place to meet `:<-`. It declares this
+;; Our first derived sub, and the place to meet `:inputs`. It declares this
 ;; sub's input as ANOTHER sub rather than app-db. The base subs above read
-;; app-db directly; from here on, subs read other subs. This one's job is
-;; small: take the stored range id and look up its full record (label,
-;; point count).
+;; app-db directly; from here on, subs read other subs. A declared input list
+;; always reaches the body as a VECTOR — at one input as much as at three —
+;; which is why the body destructures `[range-id]`. This one's job is small:
+;; take the stored range id and look up its full record (label, point count).
 (rf/reg-sub :dashboard/selected-range
   {:inputs [[:dashboard/range]]}
   (fn [[range-id] _]

--- a/testbeds/deep_machine/core.cljs
+++ b/testbeds/deep_machine/core.cljs
@@ -307,28 +307,28 @@
 ;; ----------------------------------------------------------------------------
 
 (rf/reg-sub :work-state
-  :<- [:rf/machine :deep/main]
-  (fn [snap _]
+  {:inputs [[:rf/machine :deep/main]]}
+  (fn [[snap] _]
     (get-in snap [:state :work])))
 
 (rf/reg-sub :health-state
-  :<- [:rf/machine :deep/main]
-  (fn [snap _]
+  {:inputs [[:rf/machine :deep/main]]}
+  (fn [[snap] _]
     (get-in snap [:state :health])))
 
 (rf/reg-sub :tags
-  :<- [:rf/machine :deep/main]
-  (fn [snap _]
+  {:inputs [[:rf/machine :deep/main]]}
+  (fn [[snap] _]
     (:tags snap)))
 
 (rf/reg-sub :tick-count
-  :<- [:rf/machine :deep/main]
-  (fn [snap _]
+  {:inputs [[:rf/machine :deep/main]]}
+  (fn [[snap] _]
     (get-in snap [:data :tick-count])))
 
 (rf/reg-sub :phase-b-all-finished?
-  :<- [:rf/machine :deep/main]
-  (fn [snap _]
+  {:inputs [[:rf/machine :deep/main]]}
+  (fn [[snap] _]
     (get-in snap [:data :phase-b-all-finished?])))
 
 (reg-view buttons []

--- a/testbeds/non_trivial_app_db/core.cljs
+++ b/testbeds/non_trivial_app_db/core.cljs
@@ -216,8 +216,12 @@
 ;; the whole snapshot in one slot (e.g. snapshot identity verification).
 
 (rf/reg-sub :app-db-snapshot
-  :<- [:user] :<- [:settings] :<- [:cart] :<- [:catalog]
-  :<- [:session] :<- [:metrics]
+  {:inputs [[:user]
+            [:settings]
+            [:cart]
+            [:catalog]
+            [:session]
+            [:metrics]]}
   (fn [[user settings cart catalog session metrics] _]
     {:user user :settings settings :cart cart
      :catalog catalog :session session :metrics metrics}))


### PR DESCRIPTION
rf2-kuky.47 — consumer sweep of the rf2-kuky.45 ruling over `examples/` and top-level `testbeds/`, following the registrar change rf2-kuky.46 landed (PR #9327). A subscription declares its dependencies ONCE, under `:inputs` in the metadata map, and a declared list ALWAYS arrives at the body as a vector.

## Two axes, reported separately

There are two retired spellings and only one carries a token, so a single number would hide the other. Both were measured before and after, on this branch, with a control each time.

**Axis A — the `:<-` token.** Counted three ways per the line-break hazard: line-oriented, whitespace-collapsed, and comment-markers-stripped-then-collapsed. All three agree at every reading, over git-tracked files only.

| tree | before (1 / 2 / 3) | after (1 / 2 / 3) |
|---|---|---|
| `examples/` | 180 / 180 / 180 | **0 / 0 / 0** |
| `testbeds/` | 11 / 11 / 11 | **0 / 0 / 0** |

Control, same instrument, same run: `implementation/` reads 423 / 423 / 423 (out of fence, untouched) and `tools/` reads 0 / 0 / 0 (swept by PR #9337). The instrument discriminates rather than answering zero everywhere.

Of the 180 example tokens, 167 sat inside a `reg-sub` chain, 4 in the two README code blocks, and 9 in prose that taught the arrow spelling. All three groups are handled.

**Axis B — the POSITIONAL TWO-FN form, which carries no token at all** and is recognisable only structurally. Measured with a rewrite-clj classifier over every `reg-sub` form (any alias), classifying each as `:arrow` / `:two-fn` / `:declared` / `:db`.

| tree | before | after |
|---|---|---|
| `examples/` | 138 arrow-chain + **1 positional two-fn** = 139 sites | 0 + 0 — 139 now `:declared` |
| `testbeds/` | 6 arrow-chain + 0 positional = 6 sites | 0 + 0 — 6 now `:declared` |

Total `reg-sub` registrations under both trees is 279 before and 279 after — nothing was lost or duplicated in the rewrite. Both figures match this bead's stated counts and the independent census a sibling worker ran while sweeping `tools/`.

Classifier control: run unchanged over `implementation/` it reports 161 arrow + 38 two-fn; over `tools/` it reports 0 + 0. It also declines to classify two deliberately-malformed `reg-sub` fixtures in the framework's own guard tests rather than miscounting them as the two-fn form.

## What changed

The 144 arrow-chain sites were rewritten syntax-aware (rewrite-clj zippers over the node tree — formatting, comments and reader conditionals preserved), then reviewed hunk by hunk. 21 multi-input bodies move byte-identical; the 123 single-input bodies gain the wrapping vector on their first binding form, whatever that form is, since a declared list no longer arrives bare. 45 sites merge `:inputs` into a metadata map they already carried; 29 short registrations keep their one-line shape.

The single positional two-fn site is `examples/capabilities/resources/resources/core.cljs` `:resources.app/first-slug`. Its producer is provably literal — no free symbols, nothing read from the outer `query-v` — so per ruling refinement (2) it folds to the literal `:inputs` vector; the body is unchanged, because a parametric producer has always delivered a vector.

**`:input-kind` witness.** The exact `:inputs` value that site now registers, put through the production normalisation seam `re-frame.subs/declared-inputs->slots` (the one `parse-reg-sub-args` calls) on the JVM:

```
{:input-kind :static, :input-signals [[:rf.resource/data {:resource :articles/list, :params {}}]], :vector-inputs? true}
```

That witnesses the registrar seam on the literal the example carries. A full CLJS `sub-topology` read would need a test namespace, which `examples/` may not carry (rf2-8cevm) and `implementation/` is another worker's fence this PR deliberately does not cross.

Prose moves with the code: nine comments and docstrings that named the arrow now name the `:inputs` slot, and the two README code blocks match the sources they quote. The UIx dashboard's "meet your first derived sub" comment gains the one sentence the change makes load-bearing — a declared input list always reaches the body as a vector, which is why that body destructures `[range-id]`.

No new `*.spec.cjs` under `examples/` (rf2-8cevm). No file outside `examples/**` and top-level `testbeds/**` is touched — 33 files under `examples/`, 2 under `testbeds/`.

## Gates

Every exit code below was captured by `echo $?` on the same command line as the redirect, and is the runner's own number.

| gate | exit |
|---|---|
| `node implementation/scripts/check-examples-compile.cjs` — all 58 swept `:examples/*` + `:testbeds/*` builds, zero warnings | **0** |
| `npm run test:cljs` — 11300 tests, 57023 assertions, 0 failures, 0 errors | **0** |
| `scripts/check_doc_slugs.py` | **0** |
| `scripts/check_readme_links.py --ci` (the gate that actually covers the two READMEs) | **0** |
| `scripts/check_retired_spellings.py` | **0** |
| `scripts/check_retired_composition_vocab.py` | **0** |
| `scripts/check_retired_image_keys.py` | **0** |
| `scripts/check_keyword_catalogue_drift.py` | **0** |
| `scripts/check_readme_inventories.py` | **0** |
| `scripts/check_ambient_durable_reads.py` | **0** |
| `scripts/check_adapter_disposition.py` | **0** |
| `scripts/check_failure_corpus_residue.py` | **0** |
| `scripts/check_inject_cofx_residue.py` | **0** |
| `scripts/check_thrown_error_messages.py` | **0** |
| `scripts/check_require_alias_dialect.py` | **0** |
| `scripts/check_architecture_census.py` | **0** |
| `scripts/check-no-hardcoded-paths.sh` | **0** |
| `scripts/check-ai-tracking-ratchet.sh` | **0** |
| `scripts/check-beads-pr-boundary.sh origin/main` | **0** |
| `scripts/check-commit-attribution.sh origin/main` | **0** |

`npm run test:adapter-smokes` and the reagent-slim smoke were NOT run and are not claimed: the surface classifier reports `adapter_testbed_smokes=false` for this diff, and nothing here is reachable from an adapter testbed — the adapter smokes mount `implementation/adapters/<name>/testbed/`, which this PR does not touch.

Surface classifier on this diff: `examples_compile=true`, `cljs_node_test=true`, `implementation_jvm=true`, `cljs_browser=true`, `cljs_prod=true`, `bundle_isolation=true`. Control: handed `CLAUDE.md` the same classifier reports `examples_compile=false`, so it discriminates on input rather than arming everything.

## How each gate was proved to read this branch's checkout

**`check-examples-compile.cjs` — planted fault.** With the branch committed and the tree clean, one undefined symbol was planted at a line this PR already edits (`testbeds/deep_machine/core.cljs`, the `:work-state` body), match count verified as exactly 1 before spending a run. The gate came back **exit 1**, naming `Use of undeclared Var deep-machine.core/planted-fault-exsubs-a-1` at that line and failing `:testbeds/deep-machine`. The fault existed only in this checkout, so a run that had wandered into another would have come back green. Restored with `git checkout --`, and the restore verified by git blob hash rather than by reading a diff: `b17b0b796bc463ce576fca90cf0526b7f0351c64` before the plant and the identical hash after, with the working tree clean and zero occurrences of the planted symbol remaining.

**`npm run test:cljs` — printed root.** Its first line names the `shadow-cljs.edn` under this branch's own `implementation/` tree, not another checkout's.

`implementation/node_modules` here is a REAL directory installed from the lockfile (`npm ci --prefix implementation`, exit 0, 101 entries), not a link into a shared tree — so no installer could reach anything outside this checkout, and there is no link to unwind.

## Re-run on the final base

The branch was rebased onto `origin/main` after the gates first ran. The only trunk movement in the interval was `.beads/issues.jsonl` (3 checkpoint commits, 1 file, verified by `git diff --stat`), but the gates were re-run on the final base regardless rather than reasoning about it: `check-examples-compile.cjs` exit 0 (58 builds), `npm run test:cljs` exit 0 (11300 tests), and every ratchet above re-run to exit 0. The diff against the branch's merge base (`origin/main...HEAD`) is 35 files, all inside the fence, and reverts nothing a sibling landed.
