### PR TITLE
refactor(ssr,schemas,security,scripts,test-quiet): canonical rf.* require aliases (rf2-7sx1)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -16,14 +16,14 @@
 
   This namespace re-exports the supported entry points and publishes the
   hooks used by core and other optional artefacts."
-  (:require [re-frame.late-bind :as late-bind]
+  (:require [re-frame.late-bind :as rf.late-bind]
             ;; Publishes the default validator bundle at namespace load.
             [re-frame.schemas.malli]
-            [re-frame.schemas.digest :as digest]
-            [re-frame.schemas.storage :as storage]
-            [re-frame.schemas.validate :as validate]
-            [re-frame.schemas.validator :as validator]
-            [re-frame.schemas.walker :as walker]))
+            [re-frame.schemas.digest :as rf.schemas.digest]
+            [re-frame.schemas.storage :as rf.schemas.storage]
+            [re-frame.schemas.validate :as rf.schemas.validate]
+            [re-frame.schemas.validator :as rf.schemas.validator]
+            [re-frame.schemas.walker :as rf.schemas.walker]))
 
 ;; Raw registry and validator atoms stay private to their owning namespaces.
 ;; Snapshot, restore, clear, and setter functions preserve representation and
@@ -32,69 +32,69 @@
 ;; Prefer the bundle setter when installing a validator port so validate,
 ;; explain, and print functions change together. Per-function setters remain
 ;; available for isolated adjustments.
-(def set-schema-fns!         validator/set-schema-fns!)
-(def set-schema-validator!   validator/set-schema-validator!)
-(def set-schema-explainer!   validator/set-schema-explainer!)
-(def set-schema-printer!     validator/set-schema-printer!)
-(def reset-schema-validator! validator/reset-schema-validator!)
+(def set-schema-fns!         rf.schemas.validator/set-schema-fns!)
+(def set-schema-validator!   rf.schemas.validator/set-schema-validator!)
+(def set-schema-explainer!   rf.schemas.validator/set-schema-explainer!)
+(def set-schema-printer!     rf.schemas.validator/set-schema-printer!)
+(def reset-schema-validator! rf.schemas.validator/reset-schema-validator!)
 
 ;; Bundle-level snapshot and restore for runtime-isolating fixtures.
-(def snapshot-schema-fns     validator/snapshot-schema-fns)
-(def restore-schema-fns!     validator/restore-schema-fns!)
+(def snapshot-schema-fns     rf.schemas.validator/snapshot-schema-fns)
+(def restore-schema-fns!     rf.schemas.validator/restore-schema-fns!)
 
 ;; Production caches are bounded by boot-time schema cardinality. Fixtures
 ;; that generate fresh schemas clear them between tests.
-(def clear-edn-print-cache!       validator/clear-edn-print-cache!)
-(def clear-sensitive-paths-cache! walker/clear-sensitive-paths-cache!)
+(def clear-edn-print-cache!       rf.schemas.validator/clear-edn-print-cache!)
+(def clear-sensitive-paths-cache! rf.schemas.walker/clear-sensitive-paths-cache!)
 
 ;; Registration + per-frame query (Spec 010 §Per-frame schemas).
-(def reg-app-schema       storage/reg-app-schema)
-(def reg-app-schemas      storage/reg-app-schemas)
-(def app-schema-at        storage/app-schema-at)
-(def app-schema-meta-at   storage/app-schema-meta-at)
-(def app-schemas          storage/app-schemas)
-(def frame-schema-entries storage/frame-schema-entries)
+(def reg-app-schema       rf.schemas.storage/reg-app-schema)
+(def reg-app-schemas      rf.schemas.storage/reg-app-schemas)
+(def app-schema-at        rf.schemas.storage/app-schema-at)
+(def app-schema-meta-at   rf.schemas.storage/app-schema-meta-at)
+(def app-schemas          rf.schemas.storage/app-schemas)
+(def frame-schema-entries rf.schemas.storage/frame-schema-entries)
 
 ;; Test-support snapshot / restore / clear.
-(def snapshot-schemas-by-frame storage/snapshot-schemas-by-frame)
-(def restore-schemas-by-frame! storage/restore-schemas-by-frame!)
-(def clear-schemas-by-frame!   storage/clear-schemas-by-frame!)
-(def on-frame-destroyed!       storage/on-frame-destroyed!)
+(def snapshot-schemas-by-frame rf.schemas.storage/snapshot-schemas-by-frame)
+(def restore-schemas-by-frame! rf.schemas.storage/restore-schemas-by-frame!)
+(def clear-schemas-by-frame!   rf.schemas.storage/clear-schemas-by-frame!)
+(def on-frame-destroyed!       rf.schemas.storage/on-frame-destroyed!)
 (def clear-validator-unavailable-warned!
-  storage/clear-validator-unavailable-warned!)
+  rf.schemas.storage/clear-validator-unavailable-warned!)
 (def clear-walker-opaque-warned!
-  storage/clear-walker-opaque-warned!)
+  rf.schemas.storage/clear-walker-opaque-warned!)
 
 ;; Per-slot flag extractors support schema-local validation and tool egress.
 ;; Durable app-db classification is owned by frame commit effects, not schemas.
-(def extract-large-paths-from-schema  walker/extract-large-paths-from-schema)
-(def extract-sensitive-paths-from-schema walker/extract-sensitive-paths-from-schema)
-(def schema-has-sensitive?            walker/schema-has-sensitive?)
-(def schema-sensitive-at?             walker/schema-sensitive-at?)
+(def extract-large-paths-from-schema  rf.schemas.walker/extract-large-paths-from-schema)
+(def extract-sensitive-paths-from-schema rf.schemas.walker/extract-sensitive-paths-from-schema)
+(def schema-has-sensitive?            rf.schemas.walker/schema-has-sensitive?)
+(def schema-sensitive-at?             rf.schemas.walker/schema-sensitive-at?)
 ;; Opaque schemas cannot be inspected for flags and therefore take the
 ;; conservative failure-redaction path.
-(def schema-has-large?                walker/schema-has-large?)
-(def schema-opaque?                   walker/schema-opaque?)
+(def schema-has-large?                rf.schemas.walker/schema-has-large?)
+(def schema-opaque?                   rf.schemas.walker/schema-opaque?)
 ;; Redaction and registration warnings use the recursive opaque check because
 ;; a walkable vector can contain an opaque descendant.
-(def schema-has-opaque-child?         walker/schema-has-opaque-child?)
+(def schema-has-opaque-child?         rf.schemas.walker/schema-has-opaque-child?)
 
 ;; Schema digest (Spec 010 §Digest algorithm).
-(def app-schemas-digest digest/app-schemas-digest)
+(def app-schemas-digest rf.schemas.digest/app-schemas-digest)
 
 ;; Validation entry points in the order defined by Spec 010. Recordable cofx
 ;; values are validated by `re-frame.cofx`, not by this dev-time family.
-(def validate-app-schema! validate/validate-app-schema!)
-(def validate-event!      validate/validate-event!)
-(def validate-fx!         validate/validate-fx!)
-(def validate-sub!        validate/validate-sub!)
+(def validate-app-schema! rf.schemas.validate/validate-app-schema!)
+(def validate-event!      rf.schemas.validate/validate-event!)
+(def validate-fx!         rf.schemas.validate/validate-fx!)
+(def validate-sub!        rf.schemas.validate/validate-sub!)
 
 ;; Production-side boundary-validation seam.
-(def validate-with-registered-fn validate/validate-with-registered-fn)
-(def explain-with-registered-fn  validate/explain-with-registered-fn)
+(def validate-with-registered-fn rf.schemas.validate/validate-with-registered-fn)
+(def explain-with-registered-fn  rf.schemas.validate/explain-with-registered-fn)
 ;; Shared schema-aware redaction for validation failures emitted by callers
 ;; outside this artefact.
-(def redact-validation-tags      validate/redact-validation-tags)
+(def redact-validation-tags      rf.schemas.validate/redact-validation-tags)
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
@@ -109,40 +109,40 @@
 
 ;; Validation hot-path hooks (consumed by router / subs / epoch).
 ;; Recordable cofx validation owns its own production error contract.
-(late-bind/set-fn! :schemas/validate-app-schema! validate-app-schema!)
-(late-bind/set-fn! :schemas/validate-event!      validate-event!)
-(late-bind/set-fn! :schemas/validate-sub!        validate-sub!)
-(late-bind/set-fn! :schemas/validate-fx!         validate-fx!)
-(late-bind/set-fn! :schemas/frame-schema-entries frame-schema-entries)
+(rf.late-bind/set-fn! :schemas/validate-app-schema! validate-app-schema!)
+(rf.late-bind/set-fn! :schemas/validate-event!      validate-event!)
+(rf.late-bind/set-fn! :schemas/validate-sub!        validate-sub!)
+(rf.late-bind/set-fn! :schemas/validate-fx!         validate-fx!)
+(rf.late-bind/set-fn! :schemas/frame-schema-entries frame-schema-entries)
 ;; Frame-destroy cleanup hook (consumed by frame/destroy-frame!,
 ;; mirrors :machines/on-frame-destroyed! and :ssr/on-frame-destroyed).
-(late-bind/set-fn! :schemas/on-frame-destroyed!  on-frame-destroyed!)
+(rf.late-bind/set-fn! :schemas/on-frame-destroyed!  on-frame-destroyed!)
 
 ;; Boundary-validation seam.
-(late-bind/set-fn! :schemas/validate-with-registered-fn validate-with-registered-fn)
-(late-bind/set-fn! :schemas/explain-with-registered-fn  explain-with-registered-fn)
+(rf.late-bind/set-fn! :schemas/validate-with-registered-fn validate-with-registered-fn)
+(rf.late-bind/set-fn! :schemas/explain-with-registered-fn  explain-with-registered-fn)
 ;; Shared validation-failure redaction hook.
-(late-bind/set-fn! :schemas/redact-validation-tags      redact-validation-tags)
+(rf.late-bind/set-fn! :schemas/redact-validation-tags      redact-validation-tags)
 
 ;; Public-API re-export hooks (consumed by re-frame.core-schemas).
-(late-bind/set-fn! :schemas/reg-app-schema        reg-app-schema)
-(late-bind/set-fn! :schemas/reg-app-schemas       reg-app-schemas)
-(late-bind/set-fn! :schemas/app-schema-at         app-schema-at)
-(late-bind/set-fn! :schemas/app-schema-meta-at    app-schema-meta-at)
-(late-bind/set-fn! :schemas/app-schemas           app-schemas)
-(late-bind/set-fn! :schemas/app-schemas-digest    app-schemas-digest)
-(late-bind/set-fn! :schemas/set-schema-validator! set-schema-validator!)
-(late-bind/set-fn! :schemas/set-schema-explainer! set-schema-explainer!)
-(late-bind/set-fn! :schemas/set-schema-printer!   set-schema-printer!)
-(late-bind/set-fn! :schemas/set-schema-fns!       set-schema-fns!)
+(rf.late-bind/set-fn! :schemas/reg-app-schema        reg-app-schema)
+(rf.late-bind/set-fn! :schemas/reg-app-schemas       reg-app-schemas)
+(rf.late-bind/set-fn! :schemas/app-schema-at         app-schema-at)
+(rf.late-bind/set-fn! :schemas/app-schema-meta-at    app-schema-meta-at)
+(rf.late-bind/set-fn! :schemas/app-schemas           app-schemas)
+(rf.late-bind/set-fn! :schemas/app-schemas-digest    app-schemas-digest)
+(rf.late-bind/set-fn! :schemas/set-schema-validator! set-schema-validator!)
+(rf.late-bind/set-fn! :schemas/set-schema-explainer! set-schema-explainer!)
+(rf.late-bind/set-fn! :schemas/set-schema-printer!   set-schema-printer!)
+(rf.late-bind/set-fn! :schemas/set-schema-fns!       set-schema-fns!)
 
 ;; Pure-data per-slot extractors. These do not populate durable app-db
 ;; classification; frame commit effects own that policy.
-(late-bind/set-fn! :schemas/extract-large-paths-from-schema     extract-large-paths-from-schema)
-(late-bind/set-fn! :schemas/extract-sensitive-paths-from-schema extract-sensitive-paths-from-schema)
+(rf.late-bind/set-fn! :schemas/extract-large-paths-from-schema     extract-large-paths-from-schema)
+(rf.late-bind/set-fn! :schemas/extract-sensitive-paths-from-schema extract-sensitive-paths-from-schema)
 
 ;; Test-support hooks (consumed by re-frame.test-support's
 ;; make-reset-runtime-fixture).
-(late-bind/set-fn! :schemas/snapshot-by-frame    snapshot-schemas-by-frame)
-(late-bind/set-fn! :schemas/restore-by-frame!    restore-schemas-by-frame!)
-(late-bind/set-fn! :schemas/clear-by-frame!      clear-schemas-by-frame!)
+(rf.late-bind/set-fn! :schemas/snapshot-by-frame    snapshot-schemas-by-frame)
+(rf.late-bind/set-fn! :schemas/restore-by-frame!    restore-schemas-by-frame!)
+(rf.late-bind/set-fn! :schemas/clear-by-frame!      clear-schemas-by-frame!)

--- a/implementation/schemas/src/re_frame/schemas/digest.cljc
+++ b/implementation/schemas/src/re_frame/schemas/digest.cljc
@@ -27,10 +27,10 @@
       have shifted under them."
   (:require #?@(:cljs [[goog.crypt :as gcrypt]
                        [goog.crypt.Sha256]])
-            [re-frame.identity :as identity]
-            [re-frame.path :as path]
-            [re-frame.schemas.storage :as storage]
-            [re-frame.schemas.validator :as validator])
+            [re-frame.identity :as rf.identity]
+            [re-frame.path :as rf.path]
+            [re-frame.schemas.storage :as rf.schemas.storage]
+            [re-frame.schemas.validator :as rf.schemas.validator])
   #?(:clj (:import [java.security MessageDigest]
                    [java.nio.charset StandardCharsets])))
 
@@ -91,9 +91,9 @@
   is a deterministic UTF-8 token stream (`v[k::a k::b]`), so the digest is
   cross-host byte-stable for every admitted segment kind."
   [path schema-value]
-  (str (identity/canonical-bytes (path/normalize-concrete path))
+  (str (rf.identity/canonical-bytes (rf.path/normalize-concrete path))
        " "
-       (sha256-hex (validator/run-printer schema-value))
+       (sha256-hex (rf.schemas.validator/run-printer schema-value))
        "\n"))
 
 (defn- compare-utf8-bytes
@@ -156,5 +156,5 @@
   travel), and pair-tool drift detection."
   ([] (app-schemas-digest {}))
   ([opts-or-frame-id]
-   (let [frame-id (storage/coerce->frame-id opts-or-frame-id)]
-     (compute-digest (storage/app-schemas {:frame frame-id})))))
+   (let [frame-id (rf.schemas.storage/coerce->frame-id opts-or-frame-id)]
+     (compute-digest (rf.schemas.storage/app-schemas {:frame frame-id})))))

--- a/implementation/schemas/src/re_frame/schemas/malli.cljc
+++ b/implementation/schemas/src/re_frame/schemas/malli.cljc
@@ -45,8 +45,8 @@
   See the `re-frame.schemas` namespace docstring for the bundle boundary."
   (:require [malli.core]
             [malli.error]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -61,8 +61,8 @@
 ;; can register their own default validator pair without changing this
 ;; namespace.
 
-(late-bind/set-fn! :schemas/malli-validate  malli.core/validate)
-(late-bind/set-fn! :schemas/malli-explain   malli.core/explain)
+(rf.late-bind/set-fn! :schemas/malli-validate  malli.core/validate)
+(rf.late-bind/set-fn! :schemas/malli-explain   malli.core/explain)
 
 ;; Development only. `re-frame.schemas.validate` reads
 ;; `:schemas/humanize-explain!` solely inside its
@@ -71,5 +71,5 @@
 ;; `malli.error` for nothing. Same gate here: `:advanced` +
 ;; `goog.DEBUG=false` folds the form away and `malli.error` leaves the
 ;; bundle. Consumers use the same hook regardless of validator adapter.
-(when interop/debug-enabled?
-  (late-bind/set-fn! :schemas/humanize-explain! malli.error/humanize))
+(when rf.interop/debug-enabled?
+  (rf.late-bind/set-fn! :schemas/humanize-explain! malli.error/humanize))

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -16,15 +16,15 @@
     - `snapshot-schemas-by-frame` / `restore-schemas-by-frame!` /
       `clear-schemas-by-frame!` — test-support hooks consumed by
       `re-frame.test-support`'s reset-runtime fixture."
-  (:require [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.path :as path]
-            [re-frame.privacy :as privacy]
-            [re-frame.schemas.validator :as validator]
-            [re-frame.schemas.walker :as walker]
-            [re-frame.source-coords :as source-coords]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.path :as rf.path]
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.schemas.validator :as rf.schemas.validator]
+            [re-frame.schemas.walker :as rf.schemas.walker]
+            [re-frame.source-coords :as rf.source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -44,11 +44,11 @@
   ([opts operation]
    (let [frame-target (:frame opts)
          frame-id     (if (some? frame-target)
-                        (frame/frame-target->id frame-target)
-                        (frame/require-current-frame!
+                        (rf.frame/frame-target->id frame-target)
+                        (rf.frame/require-current-frame!
                           operation {:where 'rf/reg-app-schema}))]
      (when-not (keyword? frame-id)
-       (error/throw-error!
+       (rf.error/throw-error!
          :rf.error/app-schemas-bad-arg
          'rf/app-schemas
           (str "the :frame opt must be a frame-id keyword or a frame value "
@@ -72,10 +72,10 @@
     (nil? opts-or-frame-id) {}
     ;; A frame value is a map; keep this branch before the generic map branch.
     (or (keyword? opts-or-frame-id)
-        (frame/frame-value? opts-or-frame-id)) {:frame opts-or-frame-id}
+        (rf.frame/frame-value? opts-or-frame-id)) {:frame opts-or-frame-id}
     (map? opts-or-frame-id) opts-or-frame-id
     :else
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/app-schemas-bad-arg
       'rf/app-schemas
       (str "app-schemas expects a keyword frame-id, a frame value, or an "
@@ -136,7 +136,7 @@
     (nil? metadata) {}
     (map? metadata) metadata
     :else
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/app-schema-bad-metadata
       'rf/reg-app-schema
       (str "reg-app-schema's middle arg must be a registration-metadata map — "
@@ -177,7 +177,7 @@
   canonical digest-key encoding."
   [path]
   (and (sequential? path)
-       (every? path/segment? path)))
+       (every? rf.path/segment? path)))
 
 ;; ---- runtime-db first-segment rejection -----------------------------------
 ;; App schemas validate app-db only. Runtime-db is framework-owned, so a
@@ -231,7 +231,7 @@
   ([path] (assert-app-schema-path! path nil))
   ([path frame]
    (when-not (valid-app-schema-path? path)
-     (error/throw-error!
+     (rf.error/throw-error!
        :rf.error/app-schema-bad-path
        'rf/reg-app-schema
        (str "reg-app-schema path " (pr-str path) " is invalid; pass "
@@ -246,7 +246,7 @@
        {:recovery :supply-a-concrete-get-in-path
         :extra    {:received path}}))
    (when (runtime-app-schema-path? path)
-     (error/throw-error!
+     (rf.error/throw-error!
        :rf.error/app-schema-runtime-path
        'rf/reg-app-schema
        (str "app schemas validate only app-db; a "
@@ -283,7 +283,7 @@
   documented empty no-op)."
   [path->schema]
   (when-not (valid-bulk-schemas-arg? path->schema)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/app-schemas-bad-batch
       'rf/reg-app-schemas
       (str "reg-app-schemas expects a {path -> schema} map (possibly empty); "
@@ -356,7 +356,7 @@
   top-level opaque schema's. `schema-has-opaque-child?` recurses the
   whole tree so this predicate is accurate at any depth."
   [schema]
-  (not (walker/schema-has-opaque-child? schema)))
+  (not (rf.schemas.walker/schema-has-opaque-child? schema)))
 
 (defn- maybe-warn-walker-opaque!
   "Emit `:rf.warning/schema-walker-opaque` once per process when
@@ -373,7 +373,7 @@
   (when (and (not (walker-introspectable? schema))
              (not @walker-opaque-warned))
     (when (compare-and-set! walker-opaque-warned false true)
-      (when-let [emit! (late-bind/get-fn :trace/emit!)]
+      (when-let [emit! (rf.late-bind/get-fn :trace/emit!)]
         (emit! :warning :rf.warning/schema-walker-opaque
                {:path path
                 :schema-kind (if (map? schema)
@@ -412,10 +412,10 @@
   unconditional helper call and defeat the elision sentinel."
   []
   (when (and (not @validator-unavailable-warned)
-             (nil? (late-bind/get-fn :schemas/malli-validate))
-             (validator/using-default-validator?))
+             (nil? (rf.late-bind/get-fn :schemas/malli-validate))
+             (rf.schemas.validator/using-default-validator?))
     (when (compare-and-set! validator-unavailable-warned false true)
-      (when-let [emit! (late-bind/get-fn :trace/emit!)]
+      (when-let [emit! (rf.late-bind/get-fn :trace/emit!)]
         (emit! :warning :rf.warning/schema-validator-unavailable
                {:reason
                 (str "reg-app-schema was called but :schemas/malli-validate"
@@ -456,7 +456,7 @@
 ;; (`re-frame.schemas.validate`, the
 ;; `(or schema-has-sensitive? schema-opaque?)` posture). This is the redaction
 ;; half of the same fail-closed posture for the hot-reload egress edge.
-(def ^:private redacted-sentinel privacy/redacted-sentinel)
+(def ^:private redacted-sentinel rf.privacy/redacted-sentinel)
 
 (defn- maybe-emit-schema-violation!
   "Emit `:rf.schema/violation` when a re-registration changes the schema
@@ -484,8 +484,8 @@
   [frame-id path prior-registered? prior-schema new-schema]
   (when (and prior-registered?
              (not= prior-schema new-schema))
-    (when-let [validate-fn @validator/validator-fn]
-      (let [app-db      (frame/frame-app-db-value frame-id)
+    (when-let [validate-fn @rf.schemas.validator/validator-fn]
+      (let [app-db      (rf.frame/frame-app-db-value frame-id)
             live-value (get-in app-db path)
             ;; A malformed new schema can make the validator throw
             ;; (e.g. Malli's `:malli.core/child-error` on a childless
@@ -495,7 +495,7 @@
             passes?   (try (boolean (validate-fn new-schema live-value))
                            (catch #?(:clj Throwable :cljs :default) _ true))]
         (when-not passes?
-          (when-let [emit! (late-bind/get-fn :trace/emit!)]
+          (when-let [emit! (rf.late-bind/get-fn :trace/emit!)]
             ;; Fail closed on an opaque schema. The
             ;; pure-data walker cannot see a `{:sensitive? true}` slot inside a
             ;; compiled `m/schema` value, so `schema-has-sensitive?` alone would
@@ -508,8 +508,8 @@
             ;; not the root-only
             ;; `schema-opaque?` — a vector-form `new-schema` can embed a nested
             ;; opaque child the root-only check would miss.
-            (let [sensitive? (or (walker/schema-has-sensitive? new-schema)
-                                 (walker/schema-has-opaque-child? new-schema))]
+            (let [sensitive? (or (rf.schemas.walker/schema-has-sensitive? new-schema)
+                                 (rf.schemas.walker/schema-has-opaque-child? new-schema))]
               (emit! :warning :rf.schema/violation
                      {:path               path
                       :pre-reload-schema  prior-schema
@@ -573,10 +573,10 @@
    (assert-app-schema-path! path (best-effort-frame-id frame-opts))
    (let [frame-id     (resolve-frame frame-opts)
          ;; Storage, lookup, and digesting share one canonical vector identity.
-         path         (path/normalize-concrete path)
+         path         (rf.path/normalize-concrete path)
          ;; Preserve open registration metadata, but stamp the positional
          ;; schema and resolved path/frame over caller-supplied values.
-         schema-meta  (source-coords/merge-coords
+         schema-meta  (rf.source-coords/merge-coords
                         (assoc (dissoc metadata :schema :frame)
                                :schema schema :path path :frame frame-id))
          ;; Capture before replacement for the dev-only hot-reload check.
@@ -591,7 +591,7 @@
          prior-schema (:schema (get prior-paths path))]
      (swap! schemas-by-frame assoc-in [frame-id path] schema-meta)
      ;; Read-only diagnostics are absent from production builds.
-     (when interop/debug-enabled?
+     (when rf.interop/debug-enabled?
        (maybe-warn-validator-unavailable!)
        (maybe-warn-walker-opaque! schema path)
        (maybe-emit-schema-violation! frame-id path prior-known? prior-schema
@@ -659,7 +659,7 @@
   ([path opts-or-frame-id]
    ;; Lookup uses the same canonical concrete path identity as registration.
    (let [frame-id (coerce->frame-id opts-or-frame-id)
-         path     (path/normalize-concrete path)]
+         path     (rf.path/normalize-concrete path)]
      (when-let [registration-metadata (get-in @schemas-by-frame [frame-id path])]
        (:schema registration-metadata)))))
 
@@ -684,7 +684,7 @@
   ([path opts-or-frame-id]
    ;; Lookup uses the same canonical concrete path identity as registration.
    (let [frame-id (coerce->frame-id opts-or-frame-id)
-         path     (path/normalize-concrete path)]
+         path     (rf.path/normalize-concrete path)]
      (get-in @schemas-by-frame [frame-id path]))))
 
 (defn app-schemas

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -72,21 +72,21 @@
   the router rolls back; it does NOT install the unvalidated commit), and
   keeps validating the frame's sibling schemas so one bad registration
   cannot disable frame-wide post-commit validation."
-  (:require [re-frame.elision :as elision]
-            [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.privacy :as privacy]
-            [re-frame.schemas.storage :as storage]
-            [re-frame.schemas.validator :as validator]
-            [re-frame.schemas.walker :as walker]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.elision :as rf.elision]
+            [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.schemas.storage :as rf.schemas.storage]
+            [re-frame.schemas.validator :as rf.schemas.validator]
+            [re-frame.schemas.walker :as rf.schemas.walker]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
 ;; Canonical privacy sentinel for value-bearing trace slots.
-(def ^:private redacted-sentinel privacy/redacted-sentinel)
+(def ^:private redacted-sentinel rf.privacy/redacted-sentinel)
 
 ;; The canonical value-bearing tag slots — the ones that carry the failing
 ;; value (or a value-bearing lookup key) verbatim and so must be scrubbed
@@ -132,7 +132,7 @@
   the whole-payload nature of these slots (a single marker, not a path-walk;
   the value-bearing slots carry the whole checked value, not a leaf)."
   [v]
-  (elision/->marker v [] {:reason :effect :hint nil}))
+  (rf.elision/->marker v [] {:reason :effect :hint nil}))
 
 (defn- elide-large-slots
   "Substitute the `:rf.size/large-elided` marker (for `v`, the whole checked
@@ -300,7 +300,7 @@
   prove every dev-only surface absent from optimized bundles."
   [subject id-or-path slot-tail schema value]
   (str subject id-or-path slot-tail (pr-str schema)
-       ", got " (error/type-of-value value) "."))
+       ", got " (rf.error/type-of-value value) "."))
 
 (defn- humanize-explain
   "Compute the operator-readable `:explain-humanized` payload from a
@@ -318,7 +318,7 @@
   failure trace itself)."
   [explanation]
   (when (some? explanation)
-    (when-let [humanize-fn (late-bind/get-fn :schemas/humanize-explain!)]
+    (when-let [humanize-fn (rf.late-bind/get-fn :schemas/humanize-explain!)]
       (try (humanize-fn explanation)
            (catch #?(:clj Throwable :cljs :default) _ nil)))))
 
@@ -332,7 +332,7 @@
   category keyword in one place; future cross-cutting tag shaping
   lands here."
   [tags]
-  (trace/emit-error! :rf.error/schema-validation-failure tags))
+  (rf.trace/emit-error! :rf.error/schema-validation-failure tags))
 
 (defn- record-type-tag
   "TOTAL, CLOSED type tag for the always-on `:errors` record's `:reason`.
@@ -480,7 +480,7 @@
 
   Returns nil."
   [registered-path event-id frame-id leaf-value]
-  (when-let [dispatch-error-record! (late-bind/get-fn-cached
+  (when-let [dispatch-error-record! (rf.late-bind/get-fn-cached
                                       :error-emit/dispatch-error-record)]
     (dispatch-error-record!
       {:error           :rf.error/schema-validation-failure
@@ -499,7 +499,7 @@
                              registered-path " failed its schema (got "
                              (record-type-tag leaf-value)
                              "); the candidate transition was rejected and nothing installed.")
-       :time            (interop/now-ms)}))
+       :time            (rf.interop/now-ms)}))
   nil)
 
 (defn- emit-malformed-schema-rejection-record!
@@ -546,7 +546,7 @@
   never a static require into core's error-emit namespace. A nil hook is a
   silent skip. Returns nil."
   [registered-path event-id frame-id]
-  (when-let [dispatch-error-record! (late-bind/get-fn-cached
+  (when-let [dispatch-error-record! (rf.late-bind/get-fn-cached
                                       :error-emit/dispatch-error-record)]
     (dispatch-error-record!
       {:error           :rf.error/malformed-schema
@@ -562,7 +562,7 @@
        ;; absent from a release bundle by `check-elision.cjs`.
        :reason          (str "Registered app-db schema at path " registered-path
                              " is malformed and could not be evaluated; the candidate transition was rejected fail-closed and nothing installed.")
-       :time            (interop/now-ms)}))
+       :time            (rf.interop/now-ms)}))
   nil)
 
 (defn- emit-malformed-schema!
@@ -587,14 +587,14 @@
   surfaces retain structural locator tags but never include a value-bearing
   slot because the validator did not establish sensitivity."
   [tags]
-  (trace/emit-error! :rf.error/malformed-schema tags))
+  (rf.trace/emit-error! :rf.error/malformed-schema tags))
 
 (defn- safe-explain
   "Invoke the diagnostic-only explainer without allowing it to change the
   validation verdict. A throwing explainer degrades to nil."
   [schema value]
   (try
-    (validator/run-explainer schema value)
+    (rf.schemas.validator/run-explainer schema value)
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
 (defn- validate-entry-result
@@ -684,7 +684,7 @@
   [reg-meta value build-base-tags continue?]
   (if-not (continue?)
     :rf/stale-incarnation
-    (if-let [validate-fn @validator/validator-fn]
+    (if-let [validate-fn @rf.schemas.validator/validator-fn]
       ;; KEY-presence, not value truthiness (rf2-6eh5h): a present nil /
       ;; false `:schema` is delegated verbatim — default Malli then throws
       ;; on the non-schema form and the malformed isolation below fails
@@ -771,8 +771,8 @@
                 ;; `:cat`/`:map` element that is itself a compiled `m/schema`
                 ;; value) is just as unintrospectable, so the whole-payload
                 ;; check uses the recursive `schema-has-opaque-child?`.
-                        sensitive?  (or (walker/schema-has-sensitive? schema)
-                                        (walker/schema-has-opaque-child? schema))
+                        sensitive?  (or (rf.schemas.walker/schema-has-sensitive? schema)
+                                        (rf.schemas.walker/schema-has-opaque-child? schema))
                 ;; When the schema declares any `:large?`
                 ;; slot AND the failure is not sensitive (sensitive wins),
                 ;; elide the value-bearing slots to the `:rf.size/large-elided`
@@ -780,7 +780,7 @@
                 ;; SENSITIVE above (which subsumes large), so `:large?` is only
                 ;; consulted for a walkable schema here.
                         large?      (and (not sensitive?)
-                                         (walker/schema-has-large? schema))
+                                         (rf.schemas.walker/schema-has-large? schema))
                 ;; Humanize from the raw explanation here,
                 ;; before redaction, and fold the slot into base-tags so
                 ;; `redact-tags` scrubs it symmetrically with `:explain`
@@ -861,12 +861,12 @@
   result so the caller can decide rollback deterministically — but
   every failing schema is still surfaced as its own trace so consumers
   see the full set."
-  ([db] (validate-app-schema! db nil (frame/current-frame)))
-  ([db event-id] (validate-app-schema! db event-id (frame/current-frame)))
+  ([db] (validate-app-schema! db nil (rf.frame/current-frame)))
+  ([db event-id] (validate-app-schema! db event-id (rf.frame/current-frame)))
   ([db event-id frame-id]
-   (if-let [owner-token (frame/current-event-owner-token)]
+   (if-let [owner-token (rf.frame/current-event-owner-token)]
      (validate-app-schema! db event-id frame-id
-                           #(frame/event-continuation-live? frame-id owner-token))
+                           #(rf.frame/event-continuation-live? frame-id owner-token))
      (validate-app-schema! db event-id frame-id (constantly true))))
   ([db event-id frame-id continue?]
    ;; Per Spec 009 §Production builds the entire body lives inside a
@@ -880,13 +880,13 @@
    ;; gate predicate (the deref defeats Closure's reachability proof).
    ;;
    ;; Dereference the validator once outside the per-schema loop.
-   (if interop/debug-enabled?
-     (if-let [validate-fn @validator/validator-fn]
+   (if rf.interop/debug-enabled?
+     (if-let [validate-fn @rf.schemas.validator/validator-fn]
        ;; reduce + atomic short-circuit replaced doseq so we can emit
        ;; a trace per failure (full surface for consumers) AND return
        ;; a single conjoined boolean (single signal for the rollback
        ;; gate). Pass-state stays `true` only when every entry passed.
-        (loop [entries (seq (storage/frame-schema-entries frame-id))
+        (loop [entries (seq (rf.schemas.storage/frame-schema-entries frame-id))
                ok?     true]
           (if-not (continue?)
             :rf/stale-incarnation
@@ -1048,8 +1048,8 @@
                        ;; failing path (rather than "opaque anywhere in the
                        ;; schema") preserves leaf precision: an opaque sibling must
                        ;; not taint an unrelated non-opaque leaf's `:value`.
-                       leaf-sensitive?  (walker/schema-sensitive-at? schema in-path)
-                       whole-sensitive? (walker/schema-sensitive-at? schema nil)
+                       leaf-sensitive?  (rf.schemas.walker/schema-sensitive-at? schema in-path)
+                       whole-sensitive? (rf.schemas.walker/schema-sensitive-at? schema nil)
                        ;; A `:large?` non-sensitive schema
                        ;; elides the value-bearing slots to the size marker
                        ;; (sensitive wins; opaque is fail-closed sensitive,
@@ -1058,7 +1058,7 @@
                        ;; same shape on the narrowed `:value` (built from the
                        ;; failing leaf) and the whole-payload `:explain`.
                        whole-large?     (and (not whole-sensitive?)
-                                             (walker/schema-has-large? schema))
+                                             (rf.schemas.walker/schema-has-large? schema))
                        ;; Some `:in`
                        ;; segments are value-bearing, not structural: a
                        ;; `:set` failure's segment is the failing ELEMENT
@@ -1081,7 +1081,7 @@
                        ;; `:map-of` keys are kept so `:path` stays a useful
                        ;; locator for those shapes).
                             trace-in-path   (if (and in-path leaf-sensitive?)
-                                              (walker/sanitize-sensitive-path schema in-path)
+                                              (rf.schemas.walker/sanitize-sensitive-path schema in-path)
                                               in-path)
                             trace-path      (if trace-in-path
                                               (vec (concat registered-path trace-in-path))
@@ -1169,7 +1169,7 @@
   ([event-id event handler-meta frame]
    (validate-event! event-id event handler-meta frame (constantly true)))
   ([event-id event handler-meta frame continue?]
-   (if interop/debug-enabled?
+   (if rf.interop/debug-enabled?
      (run-validation
        handler-meta
        event
@@ -1204,7 +1204,7 @@
   ([sub-id query-v value sub-meta frame]
    (validate-sub! sub-id query-v value sub-meta frame (constantly true)))
   ([sub-id query-v value sub-meta frame continue?]
-   (if interop/debug-enabled?
+   (if rf.interop/debug-enabled?
      (run-validation
        sub-meta
        value
@@ -1249,7 +1249,7 @@
   ([fx-id event-id args fx-meta frame]
    (validate-fx! fx-id event-id args fx-meta frame (constantly true)))
   ([fx-id event-id args fx-meta frame continue?]
-   (if interop/debug-enabled?
+   (if rf.interop/debug-enabled?
      (run-validation
        fx-meta
        args
@@ -1313,7 +1313,7 @@
   runs in production by design."
   [schema value]
   (try
-    (boolean (validator/run-validator schema value))
+    (boolean (rf.schemas.validator/run-validator schema value))
     (catch #?(:clj Throwable :cljs :default) _ false)))
 
 (defn explain-with-registered-fn
@@ -1326,7 +1326,7 @@
   never change the verdict."
   [schema value]
   (try
-    (validator/run-explainer schema value)
+    (rf.schemas.validator/run-explainer schema value)
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
 (defn redact-validation-tags
@@ -1374,10 +1374,10 @@
   Pure; `redact-tags` is idempotent so a double-call (or a call on a
   tags map a path-based pre-scrub already touched) is safe."
   [schema tags]
-  (let [sensitive? (or (walker/schema-has-sensitive? schema)
-                       (walker/schema-has-opaque-child? schema))
+  (let [sensitive? (or (rf.schemas.walker/schema-has-sensitive? schema)
+                       (rf.schemas.walker/schema-has-opaque-child? schema))
         large?     (and (not sensitive?)
-                        (walker/schema-has-large? schema))]
+                        (rf.schemas.walker/schema-has-large? schema))]
     (cond-> tags
       sensitive? redact-tags
       large?     (elide-large-slots (:value tags)))))

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -40,8 +40,8 @@
   The Malli adapter publishes its functions through late binding. The façade
   loads that adapter automatically; the absent-hook soft-pass remains a
   defensive contract for substitute ports and isolated tests."
-  (:require [re-frame.late-bind :as late-bind]
-            [re-frame.schemas.cache :as cache]))
+  (:require [re-frame.late-bind :as rf.late-bind]
+            [re-frame.schemas.cache :as rf.schemas.cache]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -54,7 +54,7 @@
   Apps that want Malli-absent behaviour to be a hard fail register
   a stricter validator via `set-schema-validator!`."
   [schema value]
-  (if-let [v (late-bind/get-fn :schemas/malli-validate)]
+  (if-let [v (rf.late-bind/get-fn :schemas/malli-validate)]
     (v schema value)
     true))
 
@@ -64,7 +64,7 @@
   `re-frame.schemas.malli`. Returns nil when the adapter
   ns is not loaded — the failure trace then omits the `:explain` key."
   [schema value]
-  (when-let [e (late-bind/get-fn :schemas/malli-explain)]
+  (when-let [e (rf.late-bind/get-fn :schemas/malli-explain)]
     (e schema value)))
 
 (defn- compare-by-pr-str
@@ -108,7 +108,7 @@
 
 ;; The process-lifetime print cache is bounded by boot-time schema
 ;; cardinality and can be cleared by test fixtures that generate schemas.
-(let [[memo clear!] (cache/clearable-memo compute-edn-print)]
+(let [[memo clear!] (rf.schemas.cache/clearable-memo compute-edn-print)]
 
   (def
     ^{:doc "The default schema-print companion. Per Spec 010

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -21,7 +21,7 @@
   precise privacy declarations.
   The traversal is parameterized by flag key so both supported flags share the
   same operator and path semantics."
-  (:require [re-frame.schemas.cache :as cache]))
+  (:require [re-frame.schemas.cache :as rf.schemas.cache]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -290,7 +290,7 @@
 ;; The sensitive-path walk is memoized for boot-time schema reuse and
 ;; clearable by fixtures that generate many distinct schemas.
 (let [[memo clear!]
-      (cache/clearable-memo
+      (rf.schemas.cache/clearable-memo
         (fn [schema base-path]
           (walk-flagged-schema :sensitive? schema base-path {})))]
 

--- a/implementation/schemas/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/schemas/test/re_frame/late_bind_missing_test.clj
@@ -29,7 +29,7 @@
   the façade artefact-missing/safe-default contract no longer applies)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Loading schemas registers its late-bind hooks. The
             ;; `with-hook-as-nil` helper below re-establishes the absent
             ;; state by flipping the hook value at runtime; restoration
@@ -40,12 +40,12 @@
   "Run `f` with the named late-bind hook set to nil. Restores the
   original value after `f` returns or throws."
   [hook-key f]
-  (let [original (late-bind/get-fn hook-key)]
+  (let [original (rf.late-bind/get-fn hook-key)]
     (try
-      (late-bind/set-fn! hook-key nil)
+      (rf.late-bind/set-fn! hook-key nil)
       (f)
       (finally
-        (late-bind/set-fn! hook-key original)))))
+        (rf.late-bind/set-fn! hook-key original)))))
 
 (deftest reg-app-schema-raises-when-schemas-artefact-missing
   (testing "rf/reg-app-schema (macro) raises :rf.error/schemas-artefact-missing when the :schemas/reg-app-schema hook is nil"

--- a/implementation/schemas/test/re_frame/schemas/digest_parity_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas/digest_parity_cljs_test.cljs
@@ -18,7 +18,7 @@
   test lives at `re-frame.schemas.digest-parity-test` and pins the
   same literals against the same fixtures."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.schemas.digest-parity-fixtures :as fixtures]))
+            [re-frame.schemas.digest-parity-fixtures :as rf.schemas.digest-parity-fixtures]))
 
 ;; ---- pinned-literal vectors -----------------------------------------------
 
@@ -27,8 +27,8 @@
             hashes to its pinned `\"sha256:\" + 16-hex` literal under
             the CLJS digest pipeline. Byte-identity with the JVM-side
             literal is what locks the cross-runtime invariant."
-    (doseq [{:keys [label input expected rationale]} fixtures/all-fixtures]
-      (let [actual (fixtures/compute-digest input)]
+    (doseq [{:keys [label input expected rationale]} rf.schemas.digest-parity-fixtures/all-fixtures]
+      (let [actual (rf.schemas.digest-parity-fixtures/compute-digest input)]
         (is (= expected actual)
             (str "CLJS digest for fixture " (pr-str label) " — "
                  rationale
@@ -41,9 +41,9 @@
             independence (paths, props) and metadata stripping — every
             fixture pair MUST produce byte-identical digests under
             the CLJS pipeline."
-    (doseq [{:keys [label input-a input-b rationale]} fixtures/invariant-pairs]
-      (let [da (fixtures/compute-digest input-a)
-            db (fixtures/compute-digest input-b)]
+    (doseq [{:keys [label input-a input-b rationale]} rf.schemas.digest-parity-fixtures/invariant-pairs]
+      (let [da (rf.schemas.digest-parity-fixtures/compute-digest input-a)
+            db (rf.schemas.digest-parity-fixtures/compute-digest input-b)]
         (is (= da db)
             (str "CLJS invariant pair " (pr-str label) " — "
                  rationale
@@ -58,7 +58,7 @@
             is redundant with the JVM-side check (they read the same
             `def`s) but cheap; an accidental edit that introduced a
             duplicate would fail both."
-    (let [literals (mapv :expected fixtures/all-fixtures)]
+    (let [literals (mapv :expected rf.schemas.digest-parity-fixtures/all-fixtures)]
       (is (= (count literals) (count (set literals)))
           (str "Fixture literals must be pairwise distinct — got "
                (pr-str literals))))))

--- a/implementation/schemas/test/re_frame/schemas/digest_parity_test.clj
+++ b/implementation/schemas/test/re_frame/schemas/digest_parity_test.clj
@@ -26,7 +26,7 @@
   `compute-digest`, so per-fixture assertions are runtime-agnostic."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.schemas.digest]
-            [re-frame.schemas.digest-parity-fixtures :as fixtures]))
+            [re-frame.schemas.digest-parity-fixtures :as rf.schemas.digest-parity-fixtures]))
 
 ;; ---- pinned-literal vectors -----------------------------------------------
 ;;
@@ -40,8 +40,8 @@
             hashes to its pinned `\"sha256:\" + 16-hex` literal under
             the JVM digest pipeline. Byte-identity with the CLJS-side
             literal is what locks the cross-runtime invariant."
-    (doseq [{:keys [label input expected rationale]} fixtures/all-fixtures]
-      (let [actual (fixtures/compute-digest input)]
+    (doseq [{:keys [label input expected rationale]} rf.schemas.digest-parity-fixtures/all-fixtures]
+      (let [actual (rf.schemas.digest-parity-fixtures/compute-digest input)]
         (is (= expected actual)
             (str "JVM digest for fixture " (pr-str label) " — "
                  rationale
@@ -59,9 +59,9 @@
             independence (paths, props) and metadata stripping — every
             fixture pair MUST produce byte-identical digests under
             the JVM pipeline."
-    (doseq [{:keys [label input-a input-b rationale]} fixtures/invariant-pairs]
-      (let [da (fixtures/compute-digest input-a)
-            db (fixtures/compute-digest input-b)]
+    (doseq [{:keys [label input-a input-b rationale]} rf.schemas.digest-parity-fixtures/invariant-pairs]
+      (let [da (rf.schemas.digest-parity-fixtures/compute-digest input-a)
+            db (rf.schemas.digest-parity-fixtures/compute-digest input-b)]
         (is (= da db)
             (str "JVM invariant pair " (pr-str label) " — "
                  rationale
@@ -82,7 +82,7 @@
             collisions) but it would mean the corpus failed to
             discriminate between the schema sets, defeating the
             point of pinning."
-    (let [literals (mapv :expected fixtures/all-fixtures)]
+    (let [literals (mapv :expected rf.schemas.digest-parity-fixtures/all-fixtures)]
       (is (= (count literals) (count (set literals)))
           (str "Fixture literals must be pairwise distinct — got "
                (pr-str literals))))))

--- a/implementation/schemas/test/re_frame/schemas/printer_seam_test.clj
+++ b/implementation/schemas/test/re_frame/schemas/printer_seam_test.clj
@@ -23,15 +23,15 @@
   clojure.spec port) needs to be able to plug into the digest
   pipeline without re-implementing it."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.frame :as frame]
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.validator :as validator]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.validator :as rf.schemas.validator]))
 
 (defn- reset [test-fn]
   ;; Per rf2-froe / rf2-wla45 — the validator/explainer/printer atoms
   ;; are framework-wide; restore the defaults around each test so
   ;; sibling tests are not poisoned.
-  (schemas/reset-schema-validator!)
+  (rf.schemas/reset-schema-validator!)
   ;; EP-0002 (rf2-5q7um6): the digest-seam tests register schemas via
   ;; reg-app-schema, which is now context-required frame-local. Pin
   ;; :rf/default as the established scope so those ambient registrations
@@ -40,9 +40,9 @@
   ;; carried STAMP (it writes the plain `schemas-by-frame` atom), and the
   ;; schema-derived elision-populate step no-ops when the frame has no live
   ;; runtime-db container.
-  (try (binding [frame/*current-frame* :rf/default]
+  (try (binding [rf.frame/*current-frame* :rf/default]
          (test-fn))
-       (finally (schemas/reset-schema-validator!))))
+       (finally (rf.schemas/reset-schema-validator!))))
 
 (use-fixtures :each reset)
 
@@ -55,19 +55,19 @@
             literals (rf2-xssfv `digest_parity_fixtures.cljc`) keep
             matching."
     (is (= "[:map [:id :uuid]]"
-           (validator/run-printer [:map [:id :uuid]]))
+           (rf.schemas.validator/run-printer [:map [:id :uuid]]))
         "vector schema serialises as straightforward pr-str")
     (is (= "[:map {:closed true, :title \"User\"} [:id :uuid]]"
-           (validator/run-printer
+           (rf.schemas.validator/run-printer
              [:map (array-map :title "User" :closed true) [:id :uuid]]))
         "map-keys in the props map sort by (compare (pr-str a) (pr-str b))
          — :closed sorts before :title — regardless of insertion order")
     (is (= "[:map [:id :uuid]]"
-           (validator/run-printer
+           (rf.schemas.validator/run-printer
              ^{:doc "user-id"} [:map [:id :uuid]]))
         "metadata is stripped (`:doc` does not appear in the printed bytes)")
     (is (= ":int"
-           (validator/run-printer :int))
+           (rf.schemas.validator/run-printer :int))
         "primitive keyword schemas pass through pr-str unchanged")))
 
 (deftest set-schema-printer!-swaps-the-printer-atom
@@ -75,10 +75,10 @@
             the next call — the digest pipeline picks up the new bytes
             without a restart."
     (let [marker-printer (fn [_schema] "::SENTINEL::")]
-      (schemas/set-schema-printer! marker-printer)
-      (is (= "::SENTINEL::" (validator/run-printer [:map [:id :uuid]]))
+      (rf.schemas/set-schema-printer! marker-printer)
+      (is (= "::SENTINEL::" (rf.schemas.validator/run-printer [:map [:id :uuid]]))
           "every schema serialises to the sentinel, regardless of shape")
-      (is (= "::SENTINEL::" (validator/run-printer :int))
+      (is (= "::SENTINEL::" (rf.schemas.validator/run-printer :int))
           "primitive keyword schemas route through the registered fn too"))))
 
 (deftest schema-print-swap-flips-the-digest-bytes
@@ -89,17 +89,17 @@
             cross-port distinction Spec 010 §Locked rules line 491
             describes: 'two ports using *different* schema languages
             produce different digests by construction'."
-    (schemas/reg-app-schema [:n] :int)
-    (let [default-digest (schemas/app-schemas-digest)]
-      (schemas/set-schema-printer! (fn [_schema] "::DIFFERENT::"))
-      (let [swapped-digest (schemas/app-schemas-digest)]
+    (rf.schemas/reg-app-schema [:n] :int)
+    (let [default-digest (rf.schemas/app-schemas-digest)]
+      (rf.schemas/set-schema-printer! (fn [_schema] "::DIFFERENT::"))
+      (let [swapped-digest (rf.schemas/app-schemas-digest)]
         (is (not= default-digest swapped-digest)
             "digest changes once the printer registers different bytes")))
     ;; Restoring the default brings the digest back — the printer
     ;; surface is purely a contract over the serialisation step.
-    (schemas/set-schema-printer! nil)
+    (rf.schemas/set-schema-printer! nil)
     (is (= "sha256:e7939756d704eaab"
-           (schemas/app-schemas-digest))
+           (rf.schemas/app-schemas-digest))
         "set-schema-printer! nil restores the default — the digest matches
          the rf2-xssfv `single-prim` literal byte-for-byte (the path key is
          CEDN-1 `canonical-bytes`, not pr-str — rf2-ujmc3u)")))
@@ -110,8 +110,8 @@
             entry point is symmetrical across all three fns (rf2-froe +
             rf2-wla45 + rf2-13meg)."
     (let [marker (fn [_] "::FROM-BUNDLE::")]
-      (schemas/set-schema-fns! {:print marker})
-      (is (= "::FROM-BUNDLE::" (validator/run-printer :int))
+      (rf.schemas/set-schema-fns! {:print marker})
+      (is (= "::FROM-BUNDLE::" (rf.schemas.validator/run-printer :int))
           "the registered printer reaches the hot path"))))
 
 (deftest set-schema-fns!-nil-print-coerces-to-default
@@ -123,12 +123,12 @@
             'falls back to the default' promise is true at the write
             site (rf2-13meg)."
     ;; Poison first so a no-op would be observable.
-    (schemas/set-schema-printer! (fn [_] "::POISONED::"))
-    (is (= "::POISONED::" (validator/run-printer :int)))
-    (schemas/set-schema-fns! {:print nil})
-    (is (some? @validator/printer-fn)
+    (rf.schemas/set-schema-printer! (fn [_] "::POISONED::"))
+    (is (= "::POISONED::" (rf.schemas.validator/run-printer :int)))
+    (rf.schemas/set-schema-fns! {:print nil})
+    (is (some? @rf.schemas.validator/printer-fn)
         "printer-fn is never nil after a {:print nil} bundle swap")
-    (is (= ":int" (validator/run-printer :int))
+    (is (= ":int" (rf.schemas.validator/run-printer :int))
         "{:print nil} falls back to default-edn-print, not 'no printer'")))
 
 (deftest set-schema-printer!-nil-falls-back-to-default
@@ -136,10 +136,10 @@
             default EDN canonicaliser — the digest is never undefined
             for a present schema set, even when the validator and
             explainer have been nilled out (rf2-wla45 contract)."
-    (schemas/set-schema-printer! (fn [_] "::REPLACED::"))
-    (is (= "::REPLACED::" (validator/run-printer :int)))
-    (schemas/set-schema-printer! nil)
-    (is (= ":int" (validator/run-printer :int))
+    (rf.schemas/set-schema-printer! (fn [_] "::REPLACED::"))
+    (is (= "::REPLACED::" (rf.schemas.validator/run-printer :int)))
+    (rf.schemas/set-schema-printer! nil)
+    (is (= ":int" (rf.schemas.validator/run-printer :int))
         "nil printer falls back to default-edn-print; not 'no printer'")))
 
 (deftest reset-schema-validator!-restores-default-printer
@@ -148,10 +148,10 @@
             Test-support call sites that previously only had to
             worry about validator/explainer poisoning now also reset
             the printer for free."
-    (schemas/set-schema-printer! (fn [_] "::POISONED::"))
-    (is (= "::POISONED::" (validator/run-printer :int)))
-    (schemas/reset-schema-validator!)
-    (is (= ":int" (validator/run-printer :int))
+    (rf.schemas/set-schema-printer! (fn [_] "::POISONED::"))
+    (is (= "::POISONED::" (rf.schemas.validator/run-printer :int)))
+    (rf.schemas/reset-schema-validator!)
+    (is (= ":int" (rf.schemas.validator/run-printer :int))
         "reset restores the default EDN canonicaliser")))
 
 (deftest printer-only-affects-per-schema-bytes-not-pipeline-shape
@@ -161,14 +161,14 @@
             that returns a constant still produces a well-formed wire
             form — and the empty-set digest is unaffected because the
             pipeline never invokes the printer (zero entries)."
-    (schemas/set-schema-printer! (fn [_] "::CONSTANT::"))
+    (rf.schemas/set-schema-printer! (fn [_] "::CONSTANT::"))
     ;; Empty set — printer never called; the empty-set digest is
     ;; the historical sha256:e3b0c44298fc1c14 (rf2-0z1z).
     (is (= "sha256:e3b0c44298fc1c14"
-           (schemas/app-schemas-digest))
+           (rf.schemas/app-schemas-digest))
         "empty schema set still produces the canonical empty-string SHA")
-    (schemas/reg-app-schema [:n] :int)
-    (let [d1 (schemas/app-schemas-digest)]
+    (rf.schemas/reg-app-schema [:n] :int)
+    (let [d1 (rf.schemas/app-schemas-digest)]
       (is (re-matches #"^sha256:[0-9a-f]{16}$" d1)
           "wire form is still '\"sha256:\" + 16-hex' regardless of printer"))))
 
@@ -188,7 +188,7 @@
     (let [v-fn (fn [_ _] true)
           e-fn (fn [_ _] {:explained true})
           p-fn (fn [_] "::RET-PRINTER::")
-          ret  (schemas/set-schema-fns! {:validate v-fn :explain e-fn :print p-fn})]
+          ret  (rf.schemas/set-schema-fns! {:validate v-fn :explain e-fn :print p-fn})]
       (is (map? ret) "the return is a bundle map, not a single fn")
       (is (= #{:validate :explain :print} (set (keys ret)))
           "the bundle map always carries all three keys")
@@ -197,7 +197,7 @@
       (is (= p-fn (:print ret))    ":print in the return is the installed printer")
       ;; The returned printer is the one the hot path now uses — observed
       ;; through the public run-printer seam, not a raw atom deref.
-      (is (= "::RET-PRINTER::" (validator/run-printer :int))
+      (is (= "::RET-PRINTER::" (rf.schemas.validator/run-printer :int))
           "the returned :print fn is live on the digest hot path"))))
 
 (deftest set-schema-fns!-print-only-returns-whole-bundle-incl-untouched
@@ -208,12 +208,12 @@
             unrelated to what it set; now the return reflects the printer it
             installed AND the untouched fns."
     (let [marker (fn [_] "::PRINT-ONLY::")
-          ret    (schemas/set-schema-fns! {:print marker})]
+          ret    (rf.schemas/set-schema-fns! {:print marker})]
       (is (= #{:validate :explain :print} (set (keys ret)))
           "the bundle map carries all three keys even for a partial update")
       (is (= marker (:print ret))
           "the return's :print is the printer this call installed")
-      (is (= "::PRINT-ONLY::" (validator/run-printer :int))
+      (is (= "::PRINT-ONLY::" (rf.schemas.validator/run-printer :int))
           "the installed printer reaches the hot path")
       ;; Untouched fns keep their prior (default) registrations and appear
       ;; in the return — the reset fixture restored defaults before this test.
@@ -226,14 +226,14 @@
             coercion: never nil. A caller observing the return sees the
             actual printer that will be hashed, not the literal nil it passed."
     ;; Poison first so a no-op would be observable.
-    (schemas/set-schema-printer! (fn [_] "::POISONED::"))
-    (is (= "::POISONED::" (validator/run-printer :int)))
-    (let [ret (schemas/set-schema-fns! {:print nil})]
+    (rf.schemas/set-schema-printer! (fn [_] "::POISONED::"))
+    (is (= "::POISONED::" (rf.schemas.validator/run-printer :int)))
+    (let [ret (rf.schemas/set-schema-fns! {:print nil})]
       (is (some? (:print ret))
           "the returned :print is the coerced default, never the nil passed")
       ;; The returned printer IS the live default — verified via run-printer
       ;; rather than a raw atom deref.
-      (is (= ":int" (validator/run-printer :int))
+      (is (= ":int" (rf.schemas.validator/run-printer :int))
           "{:print nil} falls back to default-edn-print on the hot path")
       (is (= ":int" ((:print ret) :int))
           "calling the returned :print fn directly yields the default bytes"))))
@@ -246,9 +246,9 @@
     (let [v-fn (fn [_ _] true)
           e-fn (fn [_ _] {:e true})
           p-fn (fn [_] "::P::")]
-      (is (= v-fn (schemas/set-schema-validator! v-fn))
+      (is (= v-fn (rf.schemas/set-schema-validator! v-fn))
           "set-schema-validator! returns the single validator it installed")
-      (is (= e-fn (schemas/set-schema-explainer! e-fn))
+      (is (= e-fn (rf.schemas/set-schema-explainer! e-fn))
           "set-schema-explainer! returns the single explainer it installed")
-      (is (= p-fn (schemas/set-schema-printer! p-fn))
+      (is (= p-fn (rf.schemas/set-schema-printer! p-fn))
           "set-schema-printer! returns the single printer it installed"))))

--- a/implementation/schemas/test/re_frame/schemas/test_fixture.clj
+++ b/implementation/schemas/test/re_frame/schemas/test_fixture.clj
@@ -64,28 +64,28 @@
   `make-frame` so its `:initial-events` cascade still fires synchronously — see
   `schemas_conformance_test`.)"
   (:require [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.flows :as rf.flows]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (defn reset-runtime
   "The canonical `:each` fixture for schemas-artefact JVM tests."
   [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (schemas/reset-schema-validator!)
-  (schemas/clear-validator-unavailable-warned!)
-  (schemas/clear-walker-opaque-warned!)
-  (schemas/clear-edn-print-cache!)
-  (schemas/clear-sensitive-paths-cache!)
-  (registrar/clear-warning-caches!)
-  (rf/init! plain-atom/adapter)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf.flows/reset-flows!)
+  (rf.schemas/clear-schemas-by-frame!)
+  (rf.schemas/reset-schema-validator!)
+  (rf.schemas/clear-validator-unavailable-warned!)
+  (rf.schemas/clear-walker-opaque-warned!)
+  (rf.schemas/clear-edn-print-cache!)
+  (rf.schemas/clear-sensitive-paths-cache!)
+  (rf.registrar/clear-warning-caches!)
+  (rf/init! rf.substrate.plain-atom/adapter)
   ;; EP-0002 (rf2-5q7um6): establish an explicit :rf/default scope for the
   ;; body so ambient reg-app-schema calls carry a frame stamp.
-  (frame/ensure-default-frame!)
-  (binding [frame/*current-frame* :rf/default]
+  (rf.frame/ensure-default-frame!)
+  (binding [rf.frame/*current-frame* :rf/default]
     (test-fn)))

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
@@ -46,7 +46,7 @@
   boundary is a no-op in dev (per Spec 010 L145)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Per rf2-t0hq the CLJS default validator routes through the
             ;; late-bind hook `:schemas/malli-validate`, published at load
             ;; time by the `re-frame.schemas.malli` adapter ns — which the
@@ -54,9 +54,9 @@
             ;; Ruling A). Requiring `re-frame.schemas` is the whole opt-in,
             ;; so the boundary interceptor sees real Malli verdicts here
             ;; with no second require at app boot.
-            [re-frame.schemas :as schemas]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support])
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support])
   ;; rf2-bhh8my: the shared trace recorder supersedes the per-test
   ;; register-listener!/unregister-listener! capture bracket. The macro
   ;; ships from the `#?(:clj ...)` arm of re-frame.test-support, so CLJS
@@ -68,8 +68,8 @@
 ;; side-table between tests (rf2-cq1ak — app-db schemas are NOT a
 ;; registrar kind).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter            reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter            rf.adapter.reagent/adapter
      :clear-app-schemas? true}))
 
 ;; ---- boundary interceptor under `:advanced` + `goog.DEBUG=false` ---------
@@ -247,7 +247,7 @@
             `nil` disables every validation surface — including the
             boundary interceptor. The handler runs on a wildly malformed
             payload because validation has been opted out."
-    (schemas/set-schema-validator! nil)
+    (rf.schemas/set-schema-validator! nil)
     (try
       (let [calls (atom 0)]
         (rf/reg-event :api/disabled
@@ -258,7 +258,7 @@
         (is (= 1 @calls)
             "handler ran — nil validator means no boundary check, even in production"))
       (finally
-        (schemas/reset-schema-validator!)))))
+        (rf.schemas/reset-schema-validator!)))))
 
 ;; ---- rf2-tiymn — the humanizer is NOT published in production ------------
 ;;
@@ -273,9 +273,9 @@
 (deftest humanizer-unpublished-in-prod-cljs
   (testing "rf2-tiymn — under `:advanced` + `goog.DEBUG=false` the humanize
             hook is unbound while the validator hook is bound"
-    (is (nil? (late-bind/get-fn :schemas/humanize-explain!))
+    (is (nil? (rf.late-bind/get-fn :schemas/humanize-explain!))
         "no humanizer in a production build")
-    (is (fn? (late-bind/get-fn :schemas/malli-validate))
+    (is (fn? (rf.late-bind/get-fn :schemas/malli-validate))
         "the validator from the same adapter ns-load IS bound — the absence above is the gate, not a missing adapter")))
 
 ;; ---- rf2-6eh5h — a present NIL :schema cannot run a boundary handler -----
@@ -309,7 +309,7 @@
             false verdict rejects the event and the handler is not invoked"
     (let [seen  (atom [])
           calls (atom 0)]
-      (schemas/set-schema-validator!
+      (rf.schemas/set-schema-validator!
         (fn [schema _value] (swap! seen conj schema) false))
       (try
         (rf/reg-event :wire/custom
@@ -321,4 +321,4 @@
         (is (= [nil] @seen)
             "the validator RECEIVED the exact nil token in the production path")
         (finally
-          (schemas/reset-schema-validator!))))))
+          (rf.schemas/reset-schema-validator!))))))

--- a/implementation/schemas/test/re_frame/schemas_bundle_probe.cljs
+++ b/implementation/schemas/test/re_frame/schemas_bundle_probe.cljs
@@ -62,7 +62,7 @@
   `:schemas-bundle-control`, which is what makes the two figures
   subtractable."
   (:require [re-frame.core    :as rf]
-            [re-frame.schemas :as schemas]))
+            [re-frame.schemas :as rf.schemas]))
 
 (defn ^:export boot
   "Probe init-fn. Touches the schemas surface so DCE retains every
@@ -76,7 +76,7 @@
 
   Named `boot` (not `run!`) to avoid shadowing `cljs.core/run!`."
   []
-  (schemas/set-schema-validator! nil)
-  (schemas/reg-app-schema [:probe] [:int])
-  (schemas/app-schemas)
-  (schemas/app-schemas-digest))
+  (rf.schemas/set-schema-validator! nil)
+  (rf.schemas/reg-app-schema [:probe] [:int])
+  (rf.schemas/app-schemas)
+  (rf.schemas/app-schemas-digest))

--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -16,7 +16,7 @@
   contract."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Per rf2-t0hq the CLJS default validator routes through the
             ;; late-bind hook `:schemas/malli-validate`, published at load
             ;; time by the `re-frame.schemas.malli` adapter ns — which the
@@ -24,9 +24,9 @@
             ;; Ruling A). Requiring `re-frame.schemas` is therefore the
             ;; whole opt-in: there is no second require for an app to make,
             ;; and no "schemas loaded, adapter absent" posture to model.
-            [re-frame.schemas :as schemas]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support])
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.test-support :as rf.test-support])
   ;; rf2-bhh8my: the shared trace recorder supersedes the per-test
   ;; register-listener!/unregister-listener! capture brackets. The macro
   ;; ships from the `#?(:clj ...)` arm of re-frame.test-support, so CLJS
@@ -49,8 +49,8 @@
 ;; snapshot still holds those entries, so the restore on the way out
 ;; leaves nine-states.core's schemas intact for downstream tests.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter            reagent-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter            rf.adapter.reagent/adapter
      :clear-app-schemas? true}))
 
 ;; ---- live dispatch fires app-db schema validation -------------------------
@@ -144,10 +144,10 @@
             require: the facade loads the Malli adapter (rf2-v96fh), so
             the hook is bound by the time any app code runs. We unbind it
             deliberately here and restore it in the `finally`."
-    (let [prior-v (late-bind/get-fn :schemas/malli-validate)
-          prior-e (late-bind/get-fn :schemas/malli-explain)]
-      (late-bind/set-fn! :schemas/malli-validate nil)
-      (late-bind/set-fn! :schemas/malli-explain  nil)
+    (let [prior-v (rf.late-bind/get-fn :schemas/malli-validate)
+          prior-e (rf.late-bind/get-fn :schemas/malli-explain)]
+      (rf.late-bind/set-fn! :schemas/malli-validate nil)
+      (rf.late-bind/set-fn! :schemas/malli-explain  nil)
       (try
         (rf/reg-app-schema [:n] :int)
         (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "definitely-not-an-int")}))
@@ -160,8 +160,8 @@
                malformed commit silently 'conforms' to the spec's
                defensive default"))
         (finally
-          (late-bind/set-fn! :schemas/malli-validate prior-v)
-          (late-bind/set-fn! :schemas/malli-explain  prior-e))))))
+          (rf.late-bind/set-fn! :schemas/malli-validate prior-v)
+          (rf.late-bind/set-fn! :schemas/malli-explain  prior-e))))))
 
 ;; ---- rf2-jwm4 — event-payload validation under Reagent -------------------
 ;;
@@ -319,7 +319,7 @@
             canonical wire form."
     (rf/reg-app-schema [:user]  [:map [:id :uuid]])
     (rf/reg-app-schema [:todos] [:vector :string])
-    (let [d (schemas/app-schemas-digest)]
+    (let [d (rf.schemas/app-schemas-digest)]
       (is (string? d)
           "digest returns a string")
       (is (re-matches #"sha256:[0-9a-f]{16}" d)
@@ -328,7 +328,7 @@
       ;; — produces the well-defined empty-set digest.
       (rf/make-frame {:id :test/empty-cljs})
       (is (= "sha256:e3b0c44298fc1c14"
-             (schemas/app-schemas-digest :test/empty-cljs))
+             (rf.schemas/app-schemas-digest :test/empty-cljs))
           "empty-set digest is byte-identical with the JVM path"))))
 
 ;; ---- rf2-froe — set-schema-validator! seam under CLJS ---------------------
@@ -340,7 +340,7 @@
             Locks the cross-substrate seam contract."
     (let [calls (atom 0)
           custom (fn [_s v] (swap! calls inc) (= v 42))]
-      (schemas/set-schema-validator! custom)
+      (rf.schemas/set-schema-validator! custom)
       (try
         (rf/reg-app-schema [:n] :int)
         (rf/reg-event :n/init  (fn [_ _] {:db {:n 42}}))
@@ -357,13 +357,13 @@
                 "the custom validator's falsey result fired the failure trace once
                  — for the :n/break commit; :n/init's value of 42 passed.")))
         (finally
-          (schemas/reset-schema-validator!))))))
+          (rf.schemas/reset-schema-validator!))))))
 
 (deftest nil-validator-disables-reagent-validation
   (testing "Per Spec 010 §Non-Malli validators (rf2-froe): nil validator
             disables every validation site under Reagent — including
             the live :db commit that would otherwise fire."
-    (schemas/set-schema-validator! nil)
+    (rf.schemas/set-schema-validator! nil)
     (try
       (rf/reg-app-schema [:n] :int)
       (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "definitely-not-an-int")}))
@@ -374,7 +374,7 @@
                             @traces))
             "no validation trace fires when the validator is nil"))
       (finally
-        (schemas/reset-schema-validator!)))))
+        (rf.schemas/reset-schema-validator!)))))
 
 ;; ---- rf2-r2uh — :rf.schema/at-boundary dev-mode no-op (rf2-84e9) ---------
 ;;
@@ -458,11 +458,11 @@
 (deftest humanizer-published-in-dev-cljs
   (testing "rf2-tiymn — under goog.DEBUG=true the adapter has published the
             humanizer, and an app-db failure carries :explain-humanized"
-    (is (fn? (late-bind/get-fn :schemas/humanize-explain!))
+    (is (fn? (rf.late-bind/get-fn :schemas/humanize-explain!))
         "the humanize hook is bound in a development build")
     (rf/reg-app-schema [:auth :token] [:string])
     (with-trace-recorder! [traces]
-      (schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad)
+      (rf.schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v) "a validation-failure trace fired")

--- a/implementation/schemas/test/re_frame/schemas_concurrency_stress_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_concurrency_stress_test.clj
@@ -80,13 +80,13 @@
   schemas-by-frame atom CAN race across threads. JVM-only by design."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.storage :as storage]
-            [re-frame.schemas.test-fixture :as tf])
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.storage :as rf.schemas.storage]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture])
   (:import [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicLong]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 ;; Per-thread iteration count. Kept at the rf2-1gpx8 / rf2-35rgj
 ;; standard 5000 so CI stays under ~60s wall-clock with the default
@@ -168,7 +168,7 @@
               "reg thread completed within 120s wall-clock")))
 
       ;; --- Invariant 1: no entry dropped --------------------------
-      (let [final-entries (storage/frame-schema-entries stress-frame)
+      (let [final-entries (rf.schemas.storage/frame-schema-entries stress-frame)
             actual-count  (count final-entries)
             expected      (* n-threads stress-iters)]
         (is (= expected actual-count)
@@ -283,7 +283,7 @@
                   ;; pure reduce-kv inside `app-schemas`. The captured
                   ;; value is a fully-realised immutable map at this
                   ;; point; no later writer mutation can perturb it.
-                  (let [snap (storage/app-schemas
+                  (let [snap (rf.schemas.storage/app-schemas
                                {:frame stress-frame})]
                     (swap! (nth per-reader-results r) conj snap))))))]
       (.countDown latch)
@@ -335,10 +335,10 @@
                                         :frame  temp-frame}))
                               {}
                               snap)]
-              (swap! storage/schemas-by-frame
+              (swap! rf.schemas.storage/schemas-by-frame
                      assoc temp-frame meta-snap)
-              (let [d1 (schemas/app-schemas-digest {:frame temp-frame})
-                    d2 (schemas/app-schemas-digest {:frame temp-frame})]
+              (let [d1 (rf.schemas/app-schemas-digest {:frame temp-frame})
+                    d2 (rf.schemas/app-schemas-digest {:frame temp-frame})]
                 (is (= d1 d2)
                     (str "Reader " r ": digest of frozen captured "
                          "snapshot is non-deterministic — first call "
@@ -347,7 +347,7 @@
                          "cross-thread state pollution in the digest "
                          "pipeline.")))))
           (finally
-            (swap! storage/schemas-by-frame dissoc temp-frame))))
+            (swap! rf.schemas.storage/schemas-by-frame dissoc temp-frame))))
 
       ;; --- Invariant: every captured snapshot's keys are well-formed paths
       ;; the writer is known to have issued. A torn-read fragment
@@ -435,7 +435,7 @@
           ;; byte-for-byte. Computed BEFORE the futures launch so the
           ;; comparison happens against a snapshot fixed in evaluation
           ;; order (no later main-thread mutation could perturb it).
-          baseline (schemas/extract-sensitive-paths-from-schema
+          baseline (rf.schemas/extract-sensitive-paths-from-schema
                      schema [])
           latch    (CountDownLatch. 1)
           ;; Per-thread divergence record + per-thread call count.
@@ -448,7 +448,7 @@
                 (.await latch)
                 (dotimes [_ stress-iters]
                   (.incrementAndGet ^AtomicLong (nth per-thread-counts t))
-                  (let [r (schemas/extract-sensitive-paths-from-schema
+                  (let [r (rf.schemas/extract-sensitive-paths-from-schema
                             schema [])]
                     (when (not= r baseline)
                       (swap! (nth divergences t) conj
@@ -491,7 +491,7 @@
       ;; would indicate the contention exposed a memoisation cache or
       ;; mutable global the walker reads through (currently neither;
       ;; this is the future-proof guard).
-      (let [post (schemas/extract-sensitive-paths-from-schema schema [])]
+      (let [post (rf.schemas/extract-sensitive-paths-from-schema schema [])]
         (is (= baseline post)
             (str "Post-stress walker baseline drifted: expected "
                  (pr-str baseline) "; got " (pr-str post)))))))
@@ -551,7 +551,7 @@
               "ordering thread completed within 120s wall-clock")))
 
       ;; --- Invariant: exactly one entry for the contested path ----
-      (let [entries (storage/frame-schema-entries stress-frame)]
+      (let [entries (rf.schemas.storage/frame-schema-entries stress-frame)]
         (is (= 1 (count entries))
             (str "Expected exactly one entry under contested path "
                  "(per-path hot-reload is overwrite-in-place, not "
@@ -622,7 +622,7 @@
       ;; that thread (and ONLY that thread) issued.
       (doseq [t (range n-threads)
               :let [fid     (nth per-thread-frames t)
-                    entries (storage/frame-schema-entries fid)
+                    entries (rf.schemas.storage/frame-schema-entries fid)
                     winner  (-> entries (get shared-path) :schema)
                     own-issued
                     (set (for [m (range stress-iters)] (mk-schema t m)))]]

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -64,19 +64,19 @@
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [re-frame.conformance :as conformance]
+            [re-frame.conformance :as rf.conformance]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             ;; Load-bearing beyond its alias: loading the facade is what
             ;; publishes the Malli validate/explain hooks (rf2-v96fh) and
             ;; binds core's `reg-app-schema` re-export through late-bind.
             ;; clj-kondo reports the ALIAS unused here; the require is not.
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.test-fixture :as tf]
-            [re-frame.subs :as subs]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
+            [re-frame.subs :as rf.subs]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 ;; ---- fixture discovery ----------------------------------------------------
 
@@ -234,12 +234,12 @@
   via the substrate adapter plus the dispatch surface. Mirrors core's
   runner shape."
   []
-  {:read-db!  (fn [frame-id] (frame/frame-app-db-value frame-id))
+  {:read-db!  (fn [frame-id] (rf.frame/frame-app-db-value frame-id))
    ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION via swap-frame-db! —
    ;; app-db-container is now a read-only projection over the one physical
    ;; frame-state container.
    :write-db! (fn [frame-id new-db]
-                (frame/swap-frame-db! frame-id (constantly new-db)))
+                (rf.frame/swap-frame-db! frame-id (constantly new-db)))
    :dispatch! (fn [event frame-id] (rf/dispatch event {:frame frame-id}))})
 
 ;; Handler-body realisation reuses the SHARED primitives owned by
@@ -291,7 +291,7 @@
               meta (get cofx-registry cofx-id {})]
           (if (:provided? meta)
             (rf/reg-cofx cofx-id meta)
-            (rf/reg-cofx cofx-id meta (conformance/realise-cofx-supplier body))))))
+            (rf/reg-cofx cofx-id meta (rf.conformance/realise-cofx-supplier body))))))
     ;; ---- events --------------------------------------------------------
     ;; Per Spec 010 §step 1 (rf2-jwm4): event meta carries :schema; the
     ;; runtime calls `:schemas/validate-event!` before the handler runs.
@@ -313,10 +313,10 @@
     ;; returned db into a `{:db …}` effect — same observable behaviour); an
     ;; event-fx body is already the single form and passes through.
     (doseq [[id steps] (:event hmap)]
-      (let [handler  (conformance/normalize-event-handler
-                       (conformance/realise-event-handler steps))
+      (let [handler  (rf.conformance/normalize-event-handler
+                       (rf.conformance/realise-event-handler steps))
             meta     (get event-meta id {})
-            ks       (conformance/collect-cofx-keys steps)
+            ks       (rf.conformance/collect-cofx-keys steps)
             cofx-ids (vec (mapcat (fn [k]
                                     (or (get cofx-by-key k)
                                         (when (contains? cofx-registry k) [k])))
@@ -331,14 +331,14 @@
     ;; Per Spec 010 §step 6 (rf2-wcam): sub meta carries :schema; the
     ;; runtime calls `:schemas/validate-sub!` after each compute.
     (doseq [[id steps] (:sub hmap)]
-      (let [{:keys [kind inputs body]} (conformance/realise-sub steps)
+      (let [{:keys [kind inputs body]} (rf.conformance/realise-sub steps)
             meta                       (get sub-meta id {})]
         (case kind
           :layer-1 (if (seq meta) (rf/reg-sub id meta body) (rf/reg-sub id body))
           ;; Use the fn-form `subs/reg-sub` — the public `rf/reg-sub`
           ;; is a JVM macro (Spec 001 §Source-coordinate capture); a
           ;; macro var isn't `apply`-able.
-          :layer-2 (apply subs/reg-sub id
+          :layer-2 (apply rf.subs/reg-sub id
                           (concat (when (seq meta) [meta])
                                   (interleave (repeat :<-) inputs)
                                   [body])))))
@@ -352,7 +352,7 @@
       (doseq [id all-ids]
         (let [body    (get fx-bodies id [[:noop]])
               meta    (get fx-registry id {})
-              handler (conformance/realise-fx-handler id body helpers)]
+              handler (rf.conformance/realise-fx-handler id body helpers)]
           (rf/reg-fx id (assoc meta :handler-fn handler) handler))))
     ;; NOTE: app-schemas are intentionally NOT registered here — see
     ;; `realise-app-schemas` below. Per rf2-wkxng / rf2-6m0se,
@@ -468,7 +468,7 @@
             ;; SYNCHRONOUSLY — the frame engine async-queues initial-events when
             ;; `*current-frame*` is bound (Spec 002 §make-frame from inside a
             ;; handler), which would land the seed AFTER the first dispatch.
-            _            (binding [frame/*current-frame* nil]
+            _            (binding [rf.frame/*current-frame* nil]
                            (rf/make-frame (assoc frame-config :id :rf/default)))
             dispatches   (or (:fixture/dispatches fixture) [])
             ;; EP-0017 `:expect-error` mismatches (rf2-hqwki4) — a context-assembly
@@ -482,14 +482,14 @@
               sub-checks
               (doall
                 (for [[query-v expected-val] (or (:sub-values expect) {})]
-                  (let [[frame-id qv] (conformance/resolve-sub :rf/default query-v)]
+                  (let [[frame-id qv] (rf.conformance/resolve-sub :rf/default query-v)]
                     {:query    query-v
                      :expected expected-val
                      :actual   (rf/subscribe-once qv {:frame frame-id})})))
-              trace-failures (conformance/check-trace-emissions
+              trace-failures (rf.conformance/check-trace-emissions
                                @traces (:trace-emissions expect))]
           {:fixture-id     fid
-           :passed?        (and (or (nil? expected-db) (conformance/submap? expected-db final-db))
+           :passed?        (and (or (nil? expected-db) (rf.conformance/submap? expected-db final-db))
                                 (every? #(= (:expected %) (:actual %)) sub-checks)
                                 (empty? trace-failures)
                                 (empty? @dispatch-error-failures))

--- a/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
@@ -37,11 +37,11 @@
   verdict is preserved."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 (defn- capture
   "Run `body-fn` while collecting trace events; return the captured vector."
@@ -187,14 +187,14 @@
   (testing "rf2-a5kzs (finding 2, boundary seam) — validate-with-registered-fn
             isolates a malformed-schema throw and returns FALSE (fail closed)
             rather than propagating to the interceptor's (catch … true)."
-    (is (false? (schemas/validate-with-registered-fn [:vector] [:anything]))
+    (is (false? (rf.schemas/validate-with-registered-fn [:vector] [:anything]))
         "childless [:vector] → false (not a throw, not a pass)")
-    (is (false? (schemas/validate-with-registered-fn [:not-a-real-op :int] 1))
+    (is (false? (rf.schemas/validate-with-registered-fn [:not-a-real-op :int] 1))
         "unknown op → false")
     ;; A well-formed schema still returns a real verdict.
-    (is (true?  (schemas/validate-with-registered-fn [:cat [:= :ok] :int] [:ok 1]))
+    (is (true?  (rf.schemas/validate-with-registered-fn [:cat [:= :ok] :int] [:ok 1]))
         "well-formed conforming → true")
-    (is (false? (schemas/validate-with-registered-fn [:cat [:= :ok] :int] [:ok "no"]))
+    (is (false? (rf.schemas/validate-with-registered-fn [:cat [:= :ok] :int] [:ok "no"]))
         "well-formed non-conforming → false")))
 
 (deftest direct-validate-event-malformed-schema-returns-false
@@ -202,7 +202,7 @@
             false (not a throw) on a malformed schema and emits the trace."
     (let [traces (capture
                    (fn []
-                     (is (false? (schemas/validate-event! :ev/x [:ev/x 1] {:schema [:vector]}))
+                     (is (false? (rf.schemas/validate-event! :ev/x [:ev/x 1] {:schema [:vector]}))
                          "malformed schema → false, no throw")))]
       (is (= 1 (count (malformed-traces traces)))))))
 
@@ -220,25 +220,25 @@
             :explain nil — the throw does not abort trace construction nor
             unwind into the router's catch-as-pass."
     ;; validate fails; explain throws.
-    (schemas/set-schema-fns! {:validate (fn [_ _] false)
+    (rf.schemas/set-schema-fns! {:validate (fn [_ _] false)
                               :explain  throwing-explainer})
     (try
       (rf/reg-app-schema [:n] [:int])
       (let [traces (capture
                      (fn []
-                       (is (false? (schemas/validate-app-schema! {:n "bad"} :n/bad))
+                       (is (false? (rf.schemas/validate-app-schema! {:n "bad"} :n/bad))
                            "fail-closed: false (rollback) — the explainer throw did not flip the verdict")))
             v      (first (validation-failures traces))]
         (is (some? v) "the failure trace still fired")
         (is (= :app-db (-> v :tags :where)))
         (is (nil? (-> v :tags :explain)) ":explain degraded to nil — explainer threw"))
-      (finally (schemas/reset-schema-validator!)))))
+      (finally (rf.schemas/reset-schema-validator!)))))
 
 (deftest sub-return-explainer-throw-preserves-failure
   (testing "rf2-a5kzs (finding 3) — a throwing explainer on the meta-bearing
             run-validation path (sub-return) still returns false; the sub
             yields the default and the failure trace fires with :explain nil."
-    (schemas/set-schema-fns! {:validate (fn [_ _] false)
+    (rf.schemas/set-schema-fns! {:validate (fn [_ _] false)
                               :explain  throwing-explainer})
     (try
       (rf/reg-event :s/init (fn [_ _] {:db {:v [1 2 3]}}))
@@ -254,17 +254,17 @@
         (is (some? v) "the sub-return failure trace fired")
         (is (= :sub-return (-> v :tags :where)))
         (is (nil? (-> v :tags :explain)) ":explain degraded to nil"))
-      (finally (schemas/reset-schema-validator!)))))
+      (finally (rf.schemas/reset-schema-validator!)))))
 
 (deftest direct-validate-event-explainer-throw-preserves-false
   (testing "rf2-a5kzs (finding 3) — validate-event! returns false (not a
             throw) when the explainer throws on a real validation failure."
-    (schemas/set-schema-fns! {:validate (fn [_ _] false)
+    (rf.schemas/set-schema-fns! {:validate (fn [_ _] false)
                               :explain  throwing-explainer})
     (try
       (let [traces (capture
                      (fn []
-                       (is (false? (schemas/validate-event!
+                       (is (false? (rf.schemas/validate-event!
                                      :ev/x [:ev/x "bad"]
                                      {:schema [:cat [:= :ev/x] :int]}))
                            "false despite the explainer throwing")))
@@ -272,16 +272,16 @@
         (is (some? v))
         (is (= :event (-> v :tags :where)))
         (is (nil? (-> v :tags :explain))))
-      (finally (schemas/reset-schema-validator!)))))
+      (finally (rf.schemas/reset-schema-validator!)))))
 
 (deftest boundary-explain-seam-isolates-explainer-throw
   (testing "rf2-a5kzs (finding 3, boundary seam) — explain-with-registered-fn
             degrades a throwing explainer to nil rather than propagating."
-    (schemas/set-schema-explainer! throwing-explainer)
+    (rf.schemas/set-schema-explainer! throwing-explainer)
     (try
-      (is (nil? (schemas/explain-with-registered-fn [:int] "bad"))
+      (is (nil? (rf.schemas/explain-with-registered-fn [:int] "bad"))
           "explainer throw → nil, not a propagated exception")
-      (finally (schemas/reset-schema-validator!)))))
+      (finally (rf.schemas/reset-schema-validator!)))))
 
 ;; ===========================================================================
 ;; Belt-and-braces — a non-throwing default explainer still attaches :explain
@@ -292,7 +292,7 @@
             path: a normal Malli failure still carries a non-nil :explain."
     (rf/reg-app-schema [:n] [:int])
     (let [traces (capture
-                   #(schemas/validate-app-schema! {:n "bad"} :n/bad))
+                   #(rf.schemas/validate-app-schema! {:n "bad"} :n/bad))
           v      (first (validation-failures traces))]
       (is (some? v))
       (is (some? (-> v :tags :explain))

--- a/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
@@ -40,13 +40,13 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.test-fixture :as tf]
-            [re-frame.schemas.validate :as validate]
-            [re-frame.schemas.validator :as validator]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
+            [re-frame.schemas.validate :as rf.schemas.validate]
+            [re-frame.schemas.validator :as rf.schemas.validator]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 (defn- capture-trace
   "Run `body-fn` while collecting :rf.error/schema-validation-failure
@@ -64,7 +64,7 @@
             explainer's :in (the failing value's navigation path)"
     (rf/reg-app-schema [:user] [:map [:id :int] [:email :string]])
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema!
+                   #(rf.schemas/validate-app-schema!
                       {:user {:id "not-an-int" :email "alice@example.com"}}
                       :user/set-bad))]
       (is (= 1 (count traces)))
@@ -81,7 +81,7 @@
             elision-probe substring stays distinctive per surface"
     (rf/reg-app-schema [:user] [:map [:age :int]])
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema! {:user {:age "old"}} :u/bad))
+                   #(rf.schemas/validate-app-schema! {:user {:age "old"}} :u/bad))
           v      (first traces)]
       (is (.contains ^String (-> v :tags :reason) "[:user :age]")
           ":reason names the leaf path"))))
@@ -91,7 +91,7 @@
             (Malli :in []), :path equals the registration root"
     (rf/reg-app-schema [:count] [:int])
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema! {:count "x"} :c/bad))
+                   #(rf.schemas/validate-app-schema! {:count "x"} :c/bad))
           v      (first traces)]
       (is (= [:count] (-> v :tags :path))
           ":path is the registered root — no leaf to narrow to")
@@ -106,7 +106,7 @@
                              [:b [:map
                                   [:c [:map [:d :int]]]]]]]])
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema!
+                   #(rf.schemas/validate-app-schema!
                       {:root {:a {:b {:c {:d "not-an-int"}}}}}
                       :r/bad))
           v      (first traces)]
@@ -133,7 +133,7 @@
     ;; CONFORMS — a sensitive sibling that does NOT appear in the narrowed
     ;; failing leaf value, but DOES ride inside the whole-map :explain slot.
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema!
+                   #(rf.schemas/validate-app-schema!
                       {:user {:name 42 :password "secret-pw"}}
                       :u/bad-name))
           v      (first traces)]
@@ -165,7 +165,7 @@
                         [:password {:sensitive? true} :string]])
     ;; :password is the failing leaf (int, not string).
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema!
+                   #(rf.schemas/validate-app-schema!
                       {:user {:name "alice" :password 99}}
                       :u/bad-pw))
           v      (first traces)]
@@ -186,7 +186,7 @@
     ;; :token is the failing leaf (int, not string); the container
     ;; [:auth] is sensitive, so the whole subtree is sensitive.
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema!
+                   #(rf.schemas/validate-app-schema!
                       {:auth {:token 42 :expiry 9999}}
                       :auth/bad))
           v      (first traces)]
@@ -203,7 +203,7 @@
                         [:name     :string]
                         [:password {:sensitive? true} :string]])
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema! {:user "wholly-bogus"} :u/bad))
+                   #(rf.schemas/validate-app-schema! {:user "wholly-bogus"} :u/bad))
           v      (first traces)]
       (is (true? (:sensitive? v))
           "descendant-sensitive — the failing value is the whole map and
@@ -216,7 +216,7 @@
     (rf/reg-app-schema [:auth] [:map [:token {:sensitive? true} :string]])
     (rf/reg-app-schema [:count] [:int])
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema!
+                   #(rf.schemas/validate-app-schema!
                       {:auth {:token 42} :count "not-an-int"}
                       :bulk/bad))]
       (is (= 2 (count traces)))
@@ -241,13 +241,13 @@
     ;; Register a validator/explainer pair where validate fails but
     ;; explain returns no `:in` data — simulates a non-Malli or
     ;; structurally-different explainer.
-    (schemas/set-schema-fns! {:validate (fn [_ _] false)
+    (rf.schemas/set-schema-fns! {:validate (fn [_ _] false)
                               :explain  (fn [_ _] nil)})
     (try
       (rf/reg-app-schema [:user]
                          [:map [:password {:sensitive? true} :string]])
       (let [traces (capture-trace
-                     #(schemas/validate-app-schema! {:user {:password "pw"}}
+                     #(rf.schemas/validate-app-schema! {:user {:password "pw"}}
                                                 :u/bad))
             v      (first traces)]
         (is (= 1 (count traces)))
@@ -261,24 +261,24 @@
             "conservative fallback — value redacted under whole-schema
             sensitivity"))
       (finally
-        (schemas/reset-schema-validator!)))))
+        (rf.schemas/reset-schema-validator!)))))
 
 (deftest fallback-non-sensitive-rides-verbatim
   (testing "fallback path with a non-sensitive schema still emits the
             verbatim value — the fallback only conserves the privacy
             posture, not the failure shape"
-    (schemas/set-schema-fns! {:validate (fn [_ _] false)
+    (rf.schemas/set-schema-fns! {:validate (fn [_ _] false)
                               :explain  (fn [_ _] nil)})
     (try
       (rf/reg-app-schema [:count] [:int])
       (let [traces (capture-trace
-                     #(schemas/validate-app-schema! {:count "x"} :c/bad))
+                     #(rf.schemas/validate-app-schema! {:count "x"} :c/bad))
             v      (first traces)]
         (is (= [:count] (-> v :tags :path)))
         (is (= "x" (-> v :tags :value)))
         (is (not (contains? v :sensitive?))))
       (finally
-        (schemas/reset-schema-validator!)))))
+        (rf.schemas/reset-schema-validator!)))))
 
 ;; ---- registered-path always present --------------------------------------
 
@@ -287,7 +287,7 @@
             whether leaf narrowing succeeded — tooling can pivot on it"
     (rf/reg-app-schema [:user] [:map [:age :int]])
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema! {:user {:age "x"}} :u/bad))
+                   #(rf.schemas/validate-app-schema! {:user {:age "x"}} :u/bad))
           v      (first traces)]
       (is (= [:user] (-> v :tags :registered-path))
           ":registered-path is the registration anchor — distinct from
@@ -301,18 +301,18 @@
             an empty path means 'the failing slot IS the schema'"
     (let [sens     [:map [:p {:sensitive? true} :string]]
           not-sens [:map [:p :string]]]
-      (is (true?  (schemas/schema-sensitive-at? sens     [])))
-      (is (true?  (schemas/schema-sensitive-at? sens     nil)))
-      (is (false? (schemas/schema-sensitive-at? not-sens [])))
-      (is (false? (schemas/schema-sensitive-at? not-sens nil))))))
+      (is (true?  (rf.schemas/schema-sensitive-at? sens     [])))
+      (is (true?  (rf.schemas/schema-sensitive-at? sens     nil)))
+      (is (false? (rf.schemas/schema-sensitive-at? not-sens [])))
+      (is (false? (rf.schemas/schema-sensitive-at? not-sens nil))))))
 
 (deftest sensitive-at-leaf-direct-match
   (testing "the failing leaf is itself flagged :sensitive?"
     (let [schema [:map
                   [:name     :string]
                   [:password {:sensitive? true} :string]]]
-      (is (true?  (schemas/schema-sensitive-at? schema [:password])))
-      (is (false? (schemas/schema-sensitive-at? schema [:name]))))))
+      (is (true?  (rf.schemas/schema-sensitive-at? schema [:password])))
+      (is (false? (rf.schemas/schema-sensitive-at? schema [:name]))))))
 
 (deftest sensitive-at-ancestor-flagged
   (testing "an ancestor along the path carries :sensitive? — leaf
@@ -320,8 +320,8 @@
     (let [schema [:map {:sensitive? true}
                   [:token :string]
                   [:expiry :int]]]
-      (is (true? (schemas/schema-sensitive-at? schema [:token])))
-      (is (true? (schemas/schema-sensitive-at? schema [:expiry]))))))
+      (is (true? (rf.schemas/schema-sensitive-at? schema [:token])))
+      (is (true? (rf.schemas/schema-sensitive-at? schema [:expiry]))))))
 
 (deftest sensitive-at-descendant-flagged
   (testing "a descendant of the failing slot is :sensitive? — the
@@ -330,10 +330,10 @@
                   [:user [:map
                           [:name     :string]
                           [:password {:sensitive? true} :string]]]]]
-      (is (true? (schemas/schema-sensitive-at? schema [:user]))
+      (is (true? (rf.schemas/schema-sensitive-at? schema [:user]))
           "failing at :user — its value contains the sensitive :password")
-      (is (true? (schemas/schema-sensitive-at? schema [:user :password])))
-      (is (false? (schemas/schema-sensitive-at? schema [:user :name]))
+      (is (true? (rf.schemas/schema-sensitive-at? schema [:user :password])))
+      (is (false? (rf.schemas/schema-sensitive-at? schema [:user :name]))
           "sibling-only sensitive — non-sensitive leaf stays clean"))))
 
 (deftest sensitive-at-unrelated-path
@@ -342,7 +342,7 @@
     (let [schema [:map
                   [:public  :string]
                   [:auth    [:map [:token {:sensitive? true} :string]]]]]
-      (is (false? (schemas/schema-sensitive-at? schema [:public]))
+      (is (false? (rf.schemas/schema-sensitive-at? schema [:public]))
           ":public is on a different branch from :auth/:token"))))
 
 ;; ---- G1: multi-error common-prefix narrowing (rf2-rbbmt) -----------------
@@ -369,7 +369,7 @@
                                 [:id  :int]
                                 [:age :int]]]])
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema!
+                   #(rf.schemas/validate-app-schema!
                       ;; BOTH children fail — :id and :age are strings,
                       ;; not ints. Two diverging :in paths under one schema.
                       {:root {:user {:id "bad" :age "also-bad"}}}
@@ -393,7 +393,7 @@
             empty-common-prefix fold from the single-error :in [] case."
     (rf/reg-app-schema [:rec] [:map [:id :int] [:age :int]])
     (let [traces (capture-trace
-                   #(schemas/validate-app-schema!
+                   #(rf.schemas/validate-app-schema!
                       {:rec {:id "bad" :age "bad"}}
                       :rec/bad))]
       (is (= 1 (count traces)))
@@ -408,7 +408,7 @@
 (deftest common-prefix-unit
   (testing "rf2-rbbmt — common-prefix returns the longest shared leading
             run of two sequential collections, as a vector"
-    (let [cp #'validate/common-prefix]
+    (let [cp #'rf.schemas.validate/common-prefix]
       (is (= [:a :b] (cp [:a :b :c]   [:a :b :d]))
           "diverge at index 2 → prefix is the first two elements")
       (is (= []      (cp [:x]         [:y]))
@@ -429,7 +429,7 @@
 (deftest failing-in-path-unit
   (testing "rf2-rbbmt — failing-in-path extracts and narrows the Malli
             explainer's per-error :in paths; nil when no extractable path"
-    (let [fip #'validate/failing-in-path]
+    (let [fip #'rf.schemas.validate/failing-in-path]
       (is (nil? (fip nil))
           "non-map explanation → nil")
       (is (nil? (fip {}))
@@ -450,9 +450,9 @@
           "three errors fold left to the shared [:a :b] prefix")))
   (testing "rf2-rbbmt — failing-in-path agrees with the live Malli
             explainer on a real two-child divergence"
-    (let [fip #'validate/failing-in-path
+    (let [fip #'rf.schemas.validate/failing-in-path
           schema [:map [:user [:map [:id :int] [:age :int]]]]
-          expl   (validator/run-explainer schema {:user {:id "x" :age "y"}})]
+          expl   (rf.schemas.validator/run-explainer schema {:user {:id "x" :age "y"}})]
       (is (= [:user] (fip expl))
           "live Malli explanation with two failing children narrows to
            the [:user] ancestor"))))

--- a/implementation/schemas/test/re_frame/schemas_implies_validation_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_implies_validation_test.clj
@@ -41,16 +41,16 @@
   artefact's load-time wiring, not on any private internals."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
             ;; DELIBERATELY require ONLY the facade — NOT
             ;; `re-frame.schemas.malli`. The whole point of rf2-v96fh is
             ;; that requiring the facade is sufficient to wire Malli.
             [re-frame.schemas]
-            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 (defn- failures-of
   [recorded]
@@ -65,9 +65,9 @@
             the `:schemas/malli-validate` late-bind hook is bound. Pre-fix
             the adapter ns was never loaded by the facade and this hook
             was nil, so the default validator soft-passed."
-    (is (some? (late-bind/get-fn :schemas/malli-validate))
+    (is (some? (rf.late-bind/get-fn :schemas/malli-validate))
         ":schemas/malli-validate is bound — the facade pulled the adapter")
-    (is (some? (late-bind/get-fn :schemas/malli-explain))
+    (is (some? (rf.late-bind/get-fn :schemas/malli-explain))
         ":schemas/malli-explain is bound too")))
 
 ;; ---- registering a schema implies validation ------------------------------
@@ -79,7 +79,7 @@
             silent no-op (the default validator soft-passed)."
     (rf/reg-app-schema [:count] [:int])
     (with-trace-recorder! [recorded]
-      (with-redefs [interop/debug-enabled? true]
+      (with-redefs [rf.interop/debug-enabled? true]
         (rf/reg-event :count/break (fn [{:keys [db]} _] {:db (assoc db :count "not-an-int")}))
         ;; validate-app-schema! runs the registered app-db schema set over
         ;; the supplied db value, exactly as the post-handler step does.
@@ -98,7 +98,7 @@
             reject."
     (rf/reg-app-schema [:count] [:int])
     (with-trace-recorder! [recorded]
-      (with-redefs [interop/debug-enabled? true]
+      (with-redefs [rf.interop/debug-enabled? true]
         (re-frame.schemas/validate-app-schema! {:count 7} :count/ok))
       (is (empty? (failures-of recorded))
           "no failure trace — the well-typed value conforms"))))

--- a/implementation/schemas/test/re_frame/schemas_presence_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_presence_test.clj
@@ -35,20 +35,20 @@
       controls stay green."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.test-fixture :as tf]
-            [re-frame.spec :as spec]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
+            [re-frame.spec :as rf.spec]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 (defn- spy-validator!
   "Install a validator that records every schema token it is handed and
   returns false. Returns the recording atom."
   []
   (let [seen (atom [])]
-    (schemas/set-schema-validator!
+    (rf.schemas/set-schema-validator!
       (fn [schema _value] (swap! seen conj schema) false))
     seen))
 
@@ -65,13 +65,13 @@
                   "verbatim to the validator, once per consult, and the "
                   "false verdict returns")
       (let [seen (atom [])]
-        (schemas/set-schema-validator!
+        (rf.schemas/set-schema-validator!
           (fn [schema _value] (swap! seen conj schema) false))
-        (is (false? (schemas/validate-event! :ev/x [:ev/x 1] {:schema token}))
+        (is (false? (rf.schemas/validate-event! :ev/x [:ev/x 1] {:schema token}))
             "event surface returns false — the caller skips the handler")
-        (is (false? (schemas/validate-fx! :fx/x :ev/x {:a 1} {:schema token}))
+        (is (false? (rf.schemas/validate-fx! :fx/x :ev/x {:a 1} {:schema token}))
             "fx surface returns false — the caller skips the fx")
-        (is (false? (schemas/validate-sub! :sub/x [:sub/x] 42 {:schema token}))
+        (is (false? (rf.schemas/validate-sub! :sub/x [:sub/x] 42 {:schema token}))
             "sub surface returns false — the caller replaces with default")
         (is (= [token token token] @seen)
             "the EXACT declared token was delegated, exactly once per surface")))))
@@ -106,7 +106,7 @@
       {:schema       nil
        :interceptors [:rf.schema/at-boundary]}
       (fn [_ _] {}))
-    (let [meta (registrar/lookup :event :wire/received)]
+    (let [meta (rf.registrar/lookup :event :wire/received)]
       (is (some? meta) "registration succeeded")
       (is (contains? meta :schema) "the :schema key is present")
       (is (nil? (:schema meta)) "…and its value is the authored nil"))))
@@ -123,7 +123,7 @@
         {:schema       nil
          :interceptors [:rf.schema/at-boundary]}
         (fn [_ _] {}))
-      (with-redefs [spec/dev-mode? (constantly false)]
+      (with-redefs [rf.spec/dev-mode? (constantly false)]
         (let [before (:before rf/validate-at-boundary-interceptor)
               ctx    (before {:coeffects {:event [:wire/received {:untrusted 1}]}})]
           (is (= [nil] @seen)
@@ -141,7 +141,7 @@
       {:schema       nil
        :interceptors [:rf.schema/at-boundary]}
       (fn [_ _] {}))
-    (with-redefs [spec/dev-mode? (constantly false)]
+    (with-redefs [rf.spec/dev-mode? (constantly false)]
       (let [before (:before rf/validate-at-boundary-interceptor)
             ctx    (before {:coeffects {:event [:wire/received {:untrusted 1}]}})]
         (is (true? (:rf/skip-handler? ctx))
@@ -151,12 +151,12 @@
   (testing "AC 4 control — set-schema-validator! nil remains the documented
             global opt-out: even a present nil schema passes the boundary
             unchecked when validation is disabled"
-    (schemas/set-schema-validator! nil)
+    (rf.schemas/set-schema-validator! nil)
     (rf/reg-event :wire/received
       {:schema       nil
        :interceptors [:rf.schema/at-boundary]}
       (fn [_ _] {}))
-    (with-redefs [spec/dev-mode? (constantly false)]
+    (with-redefs [rf.spec/dev-mode? (constantly false)]
       (let [before (:before rf/validate-at-boundary-interceptor)
             ctx    (before {:coeffects {:event [:wire/received {:untrusted 1}]}})]
         (is (not (:rf/skip-handler? ctx))
@@ -171,7 +171,7 @@
     (testing (str "with default Malli a present " (pr-str token)
                   " schema fails CLOSED via :rf.error/malformed-schema")
       (with-trace-recorder! [traces]
-        (is (false? (schemas/validate-event! :ev/x [:ev/x 1] {:schema token}))
+        (is (false? (rf.schemas/validate-event! :ev/x [:ev/x 1] {:schema token}))
             "false — the caller runs its normal recovery (skip)")
         (let [mal (ops @traces :rf.error/malformed-schema)]
           (is (= 1 (count mal))
@@ -186,17 +186,17 @@
   (testing "an ABSENT :schema key remains a no-op on every meta surface —
             the validator is never invoked and every surface passes"
     (let [seen (spy-validator!)]
-      (is (true? (schemas/validate-event! :ev/x [:ev/x 1] {:doc "no schema"})))
-      (is (true? (schemas/validate-event! :ev/x [:ev/x 1] nil))
+      (is (true? (rf.schemas/validate-event! :ev/x [:ev/x 1] {:doc "no schema"})))
+      (is (true? (rf.schemas/validate-event! :ev/x [:ev/x 1] nil))
           "nil registration metadata is 'no declaration' too")
-      (is (true? (schemas/validate-fx! :fx/x :ev/x {:a 1} {})))
-      (is (true? (schemas/validate-sub! :sub/x [:sub/x] 42 {})))
+      (is (true? (rf.schemas/validate-fx! :fx/x :ev/x {:a 1} {})))
+      (is (true? (rf.schemas/validate-sub! :sub/x [:sub/x] 42 {})))
       (is (= [] @seen) "the validator was never consulted"))))
 
 (deftest nil-registered-validator-disables-validation-for-present-falsey-tokens
   (testing "set-schema-validator! nil disables validation even for a
             present nil / false declaration — the documented global opt-out"
-    (schemas/set-schema-validator! nil)
-    (is (true? (schemas/validate-event! :ev/x [:ev/x 1] {:schema nil})))
-    (is (true? (schemas/validate-fx! :fx/x :ev/x {:a 1} {:schema false})))
-    (is (true? (schemas/validate-sub! :sub/x [:sub/x] 42 {:schema nil})))))
+    (rf.schemas/set-schema-validator! nil)
+    (is (true? (rf.schemas/validate-event! :ev/x [:ev/x 1] {:schema nil})))
+    (is (true? (rf.schemas/validate-fx! :fx/x :ev/x {:a 1} {:schema false})))
+    (is (true? (rf.schemas/validate-sub! :sub/x [:sub/x] 42 {:schema nil})))))

--- a/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
@@ -33,16 +33,16 @@
             ;; classpath (the artefact deps on metosin/malli).
             [malli.core :as m]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             ;; Load-bearing beyond its alias: loading the facade is what
             ;; publishes the Malli validate/explain hooks (rf2-v96fh) and
             ;; binds core's `reg-app-schema` re-export through late-bind.
             ;; clj-kondo reports the ALIAS unused here; the require is not.
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 (defn- set-app-db!
   "Set the live app-db value for `frame-id` (defaults to :rf/default).
@@ -51,7 +51,7 @@
   frame-state container."
   ([db] (set-app-db! :rf/default db))
   ([frame-id db]
-   (frame/swap-frame-db! frame-id (constantly db))))
+   (rf.frame/swap-frame-db! frame-id (constantly db))))
 
 (defn- capture
   "Run `body-fn` collecting trace events whose `:operation` is
@@ -148,7 +148,7 @@
   `nil` rejects every value, `:needs-int` accepts only integers, any other
   token accepts."
   []
-  (schemas/set-schema-validator!
+  (rf.schemas/set-schema-validator!
     (fn [schema value]
       (cond
         (nil? schema)         false

--- a/implementation/schemas/test/re_frame/schemas_sensitive_path_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_path_cljs_test.cljs
@@ -11,13 +11,13 @@
   The corpus is pure vector-form data (no compiled schemas), so it loads
   identically under `:node-test`."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.schemas.walker :as walker]
-            [re-frame.schemas.walker-sanitize-path-fixtures :as sanitize-fx]))
+            [re-frame.schemas.walker :as rf.schemas.walker]
+            [re-frame.schemas.walker-sanitize-path-fixtures :as rf.schemas.walker-sanitize-path-fixtures]))
 
 (deftest cljs-sanitize-closed-map-extra-key-shared-corpus
   (testing "rf2-j538f7.13 — the shared sanitize-sensitive-path corpus holds on
             CLJS (closed-map extra keys scrub; declared locators survive;
             prior set / :map-of / ambiguous-tail behaviour unchanged)"
-    (doseq [{:keys [desc schema in expected]} sanitize-fx/cases]
-      (is (= expected (walker/sanitize-sensitive-path schema in))
+    (doseq [{:keys [desc schema in expected]} rf.schemas.walker-sanitize-path-fixtures/cases]
+      (is (= expected (rf.schemas.walker/sanitize-sensitive-path schema in))
           desc))))

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -41,28 +41,28 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.schemas :as schemas]
+            [re-frame.schemas :as rf.schemas]
             ;; Compiled schemas exercise fail-closed opaque handling.
             [malli.core :as m]
             ;; White-box tests cover the internal path sanitizer.
-            [re-frame.schemas.walker :as walker]
+            [re-frame.schemas.walker :as rf.schemas.walker]
             ;; Shared cross-host sanitizer corpus (rf2-j538f7.13) — the CLJS
             ;; half (re-frame.schemas-sensitive-path-cljs-test) asserts the
             ;; SAME cases so privacy behaviour cannot diverge by host.
-            [re-frame.schemas.walker-sanitize-path-fixtures :as sanitize-fx]
-            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.schemas.walker-sanitize-path-fixtures :as rf.schemas.walker-sanitize-path-fixtures]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 ;; ---- walker unit tests ----------------------------------------------------
 
 (deftest extract-no-sensitive-slots
   (testing "a schema with no :sensitive? props produces no entries"
-    (is (= {} (schemas/extract-sensitive-paths-from-schema
+    (is (= {} (rf.schemas/extract-sensitive-paths-from-schema
                 [:map [:name :string]] [])))
-    (is (= {} (schemas/extract-sensitive-paths-from-schema :string [])))
-    (is (= {} (schemas/extract-sensitive-paths-from-schema :int [:a :b])))))
+    (is (= {} (rf.schemas/extract-sensitive-paths-from-schema :string [])))
+    (is (= {} (rf.schemas/extract-sensitive-paths-from-schema :int [:a :b])))))
 
 (deftest extract-slot-level-sensitive
   (testing "the slot's per-slot props carry :sensitive? true"
@@ -70,20 +70,20 @@
                   [:user :string]
                   [:password {:sensitive? true} :string]]]
       (is (= {[:password] {:sensitive? true :source :schema}}
-             (schemas/extract-sensitive-paths-from-schema schema []))))))
+             (rf.schemas/extract-sensitive-paths-from-schema schema []))))))
 
 (deftest extract-honours-base-path
   (testing "base-path is prepended to every discovered slot path"
     (let [schema [:map
                   [:password {:sensitive? true} :string]]]
       (is (= {[:auth :password] {:sensitive? true :source :schema}}
-             (schemas/extract-sensitive-paths-from-schema schema [:auth]))))))
+             (rf.schemas/extract-sensitive-paths-from-schema schema [:auth]))))))
 
 (deftest extract-container-level-sensitive
   (testing "the schema's OWN props (container-level) claim the base-path"
     ;; `(reg-app-schema [:auth :token] [:string {:sensitive? true}])`
     (is (= {[:auth :token] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:string {:sensitive? true}] [:auth :token])))))
 
 (deftest extract-nested-map
@@ -95,7 +95,7 @@
                      [:map
                       [:ssn {:sensitive? true} :string]]]]]]]
       (is (= {[:user :profile :ssn] {:sensitive? true :source :schema}}
-             (schemas/extract-sensitive-paths-from-schema schema []))))))
+             (rf.schemas/extract-sensitive-paths-from-schema schema []))))))
 
 (deftest extract-multiple-sensitive-slots
   (testing "multiple sensitive slots in the same schema produce one entry each"
@@ -106,13 +106,13 @@
                   [:email :string]]]
       (is (= {[:password]  {:sensitive? true :source :schema}
               [:totp-code] {:sensitive? true :source :schema}}
-             (schemas/extract-sensitive-paths-from-schema schema []))))))
+             (rf.schemas/extract-sensitive-paths-from-schema schema []))))))
 
 (deftest extract-positional-combinator-descends
   (testing ":vector / :or / :and descend at the same base-path"
     ;; A :vector with sensitive props on its inner type's container.
     (is (= {[:tokens] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:vector [:string {:sensitive? true}]] [:tokens])))))
 
 ;; ---- schema-has-sensitive? -----------------------------------------------
@@ -123,14 +123,14 @@
             in the trace, so a sensitive child slot still leaks
             unredacted"
     (let [schema [:map [:password {:sensitive? true} :string]]]
-      (is (true? (schemas/schema-has-sensitive? schema))
+      (is (true? (rf.schemas/schema-has-sensitive? schema))
           "slot-level :sensitive? — conservative redact"))))
 
 (deftest schema-has-sensitive-container-level
   (testing "a container-level :sensitive? on a schema registered at a path
             triggers redaction"
     (let [schema [:string {:sensitive? true}]]
-      (is (true? (schemas/schema-has-sensitive? schema))))))
+      (is (true? (rf.schemas/schema-has-sensitive? schema))))))
 
 (deftest schema-has-sensitive-nested
   (testing "a nested :sensitive? slot deep inside a map also triggers redaction"
@@ -138,14 +138,14 @@
                   [:user [:map
                           [:profile [:map
                                      [:ssn {:sensitive? true} :string]]]]]]]
-      (is (true? (schemas/schema-has-sensitive? schema))))))
+      (is (true? (rf.schemas/schema-has-sensitive? schema))))))
 
 (deftest schema-has-sensitive-no-match
   (testing "no :sensitive? anywhere → false"
     (let [schema [:map [:user :string] [:age :int]]]
-      (is (false? (schemas/schema-has-sensitive? schema))))
-    (is (false? (schemas/schema-has-sensitive? :int)))
-    (is (false? (schemas/schema-has-sensitive? [:vector :string])))))
+      (is (false? (rf.schemas/schema-has-sensitive? schema))))
+    (is (false? (rf.schemas/schema-has-sensitive? :int)))
+    (is (false? (rf.schemas/schema-has-sensitive? [:vector :string])))))
 
 ;; ---- redaction at app-db validation site ----------------------------------
 
@@ -159,7 +159,7 @@
     (rf/reg-app-schema [:auth :token] [:string {:sensitive? true}])
     (with-trace-recorder! [traces]
       ;; The value at [:auth :token] is an int (42) — fails :string.
-      (schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad)
+      (rf.schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -197,7 +197,7 @@
       ;; the failing path. Since reg-app-schema validates the whole
       ;; registered slot, we need the :sensitive? to flag the WHOLE
       ;; failure when ANY slot within is sensitive.
-      (schemas/validate-app-schema! {:user {:name "alice" :password 99}}
+      (rf.schemas/validate-app-schema! {:user {:name "alice" :password 99}}
                                 :user/bad)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
@@ -212,7 +212,7 @@
             unchanged traces; :value and :explain ride verbatim"
     (rf/reg-app-schema [:count] [:int])
     (with-trace-recorder! [traces]
-      (schemas/validate-app-schema! {:count "not-an-int"} :count/bad)
+      (rf.schemas/validate-app-schema! {:count "not-an-int"} :count/bad)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v))
@@ -243,7 +243,7 @@
   [path schema db failing-id]
   (rf/reg-app-schema path schema)
   (with-trace-recorder! [traces]
-    (schemas/validate-app-schema! db failing-id)
+    (rf.schemas/validate-app-schema! db failing-id)
     (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                    @traces))))
 
@@ -631,7 +631,7 @@
                   [:map-of :int :int]                                     ;; branch 0 — non-sensitive key
                   [:map-of [:string {:sensitive? true}] [:map [:age :int]]]] ;; branch 1 — sensitive key
           in     ["secret-token-123" :age]
-          out    (walker/sanitize-sensitive-path schema in)]
+          out    (rf.schemas.walker/sanitize-sensitive-path schema in)]
       (is (= [:rf/redacted :rf/redacted] out)
           "every tail segment past the ambiguous :or is scrubbed to the sentinel")
       (is (not (some #{"secret-token-123"} out))
@@ -644,7 +644,7 @@
                   [:map-of :string [:map [:age :int]]]                    ;; conjunct 0 — non-sensitive key
                   [:map-of [:string {:sensitive? true}] [:map [:age :int]]]] ;; conjunct 1 — sensitive key
           in     ["secret-token-xyz" :age]
-          out    (walker/sanitize-sensitive-path schema in)]
+          out    (rf.schemas.walker/sanitize-sensitive-path schema in)]
       (is (= [:rf/redacted :rf/redacted] out))
       (is (not (some #{"secret-token-xyz"} out))
           "the sensitive :map-of key does NOT survive in the sanitized path"))))
@@ -654,9 +654,9 @@
             unambiguous, so the walk still descends precisely and KEEPS the
             navigable :map key (the fail-closed rule must not over-redact the
             unambiguous case)"
-    (is (= [:k] (walker/sanitize-sensitive-path [:or  [:map [:k :int]]] [:k]))
+    (is (= [:k] (rf.schemas.walker/sanitize-sensitive-path [:or  [:map [:k :int]]] [:k]))
         "single-child :or descends into its one branch and keeps the map key")
-    (is (= [:k] (walker/sanitize-sensitive-path [:and [:map [:k :int]]] [:k]))
+    (is (= [:k] (rf.schemas.walker/sanitize-sensitive-path [:and [:map [:k :int]]] [:k]))
         "single-child :and descends into its one branch and keeps the map key")))
 
 (deftest sanitize-scrubs-opaque-map-of-key
@@ -664,7 +664,7 @@
             pure-data walker, so schema-has-sensitive? on it is false) is scrubbed
             via the opaque-aware gate; the navigable inner :age key is kept"
     (let [schema [:map-of (m/schema [:string {:sensitive? true}]) [:map [:age :int]]]
-          out    (walker/sanitize-sensitive-path schema ["SECRET-KEY-XYZ" :age])]
+          out    (rf.schemas.walker/sanitize-sensitive-path schema ["SECRET-KEY-XYZ" :age])]
       (is (= [:rf/redacted :age] out)
           "the opaque sensitive :map-of key is scrubbed; the :age locator survives")
       (is (not (some #{"SECRET-KEY-XYZ"} out))
@@ -675,7 +675,7 @@
             m/schema (`[:and (m/schema …)]`) is scrubbed via the recursive
             opaque-aware (schema-has-opaque-child?) gate"
     (let [schema [:map-of [:and (m/schema [:string {:sensitive? true}])] [:map [:age :int]]]
-          out    (walker/sanitize-sensitive-path schema ["NESTED-SECRET-ABC" :age])]
+          out    (rf.schemas.walker/sanitize-sensitive-path schema ["NESTED-SECRET-ABC" :age])]
       (is (= [:rf/redacted :age] out))
       (is (not (some #{"NESTED-SECRET-ABC"} out))
           "the nested-opaque secret key does NOT survive in the sanitized path"))))
@@ -685,18 +685,18 @@
             sanitisation) is TRUE at a failing value under an opaque sensitive
             :map-of key; before the fix align-in-path descended only the VALUE
             schema and returned false, so the sanitiser never ran"
-    (is (true? (walker/schema-sensitive-at?
+    (is (true? (rf.schemas.walker/schema-sensitive-at?
                  [:map-of (m/schema [:string {:sensitive? true}]) [:map [:age :int]]]
                  ["SECRET-KEY-XYZ" :age]))
         "compiled m/schema key → leaf sensitive (fails closed)")
-    (is (true? (walker/schema-sensitive-at?
+    (is (true? (rf.schemas.walker/schema-sensitive-at?
                  [:map-of [:and (m/schema [:string {:sensitive? true}])] [:map [:age :int]]]
                  ["NESTED-SECRET-ABC" :age]))
         "nested-opaque [:and (m/schema …)] key → leaf sensitive (fails closed)")
     ;; Regression guard: a NON-sensitive, NON-opaque :map-of key must stay a
     ;; navigable locator (only the nested value is sensitive here) — no
     ;; over-redaction of the key.
-    (is (false? (walker/schema-sensitive-at?
+    (is (false? (rf.schemas.walker/schema-sensitive-at?
                   [:map-of :string [:map [:plain :int]]]
                   ["a" :plain]))
         "plain :map-of key with a fully non-sensitive value → NOT leaf-sensitive")))
@@ -724,20 +724,20 @@
     ;; `:maybe`, so the aligned path is [:s :k] and the extracted decl-path is
     ;; likewise [:s :k] (walk-flagged-schema descends `:maybe` at the same
     ;; base-path) — they prefix-match, so the leaf resolves sensitive.
-    (is (true? (walker/schema-sensitive-at?
+    (is (true? (rf.schemas.walker/schema-sensitive-at?
                  [:map [:s [:maybe [:map [:k {:sensitive? true} :string]]]]]
                  [:s :k]))
         "sensitive leaf under a `:maybe` wrapper → leaf sensitive at [:s :k]")
     ;; Companion: the same wrapper shape with a NON-sensitive leaf must NOT
     ;; over-redact — the `:maybe` descent is transparent, not a fail-open bail.
-    (is (false? (walker/schema-sensitive-at?
+    (is (false? (rf.schemas.walker/schema-sensitive-at?
                   [:map [:s [:maybe [:map [:k :string]]]]]
                   [:s :k]))
         "non-sensitive leaf under a `:maybe` wrapper → NOT leaf sensitive")
     ;; A sensitive leaf directly under a top-level `:maybe` (no outer :map):
     ;; `[:maybe [:map …]]` with :in [:k]. Align descends the `:maybe` with the
     ;; segment intact, keeps [:k], and resolves sensitive.
-    (is (true? (walker/schema-sensitive-at?
+    (is (true? (rf.schemas.walker/schema-sensitive-at?
                  [:maybe [:map [:k {:sensitive? true} :string]]]
                  [:k]))
         "top-level `:maybe` wrapper is transparent for the leaf decision too")))
@@ -750,7 +750,7 @@
     ;; inside the wrapper) are both navigable `get-in` locators — the `:maybe`
     ;; between them is transparent, so neither is scrubbed.
     (is (= [:s :k]
-           (walker/sanitize-sensitive-path
+           (rf.schemas.walker/sanitize-sensitive-path
              [:map [:s [:maybe [:map [:k {:sensitive? true} :string]]]]]
              [:s :k]))
         "navigable map keys survive verbatim across a `:maybe` wrapper"))
@@ -760,7 +760,7 @@
     ;; Malli reports a `:set` failure's `:in` segment as the failing ELEMENT
     ;; VALUE itself (not an index); the secret element must NOT ride verbatim in
     ;; `:path`. The outer map key `:s` is kept; the set element is redacted.
-    (let [out (walker/sanitize-sensitive-path
+    (let [out (rf.schemas.walker/sanitize-sensitive-path
                 [:map [:s [:maybe [:set [:string {:sensitive? true}]]]]]
                 [:s "SECRET-SET-ELEMENT"])]
       (is (= [:s :rf/redacted] out)
@@ -906,22 +906,22 @@
             a sensitive ancestor wrapped by :and/:multi/:orn (the
             consumed-ancestor prefix must carry through align-in-path's
             fallback)"
-    (is (true? (schemas/schema-sensitive-at?
+    (is (true? (rf.schemas/schema-sensitive-at?
                  [:map [:s {:sensitive? true} [:and [:map [:k :int]]]]]
                  [:s :k]))
         ":and ancestor")
-    (is (true? (schemas/schema-sensitive-at?
+    (is (true? (rf.schemas/schema-sensitive-at?
                  [:map [:s {:sensitive? true}
                         [:multi {:dispatch :t} [:a [:map [:t :keyword] [:k :int]]]]]]
                  [:s :k]))
         ":multi ancestor")
-    (is (true? (schemas/schema-sensitive-at?
+    (is (true? (rf.schemas/schema-sensitive-at?
                  [:map [:s {:sensitive? true} [:orn [:a [:map [:k :int]]]]]]
                  [:s :k]))
         ":orn ancestor")
     ;; A sensitive SIBLING outside the consumed prefix must NOT taint the
     ;; failing slot (the precise-narrowing win is preserved).
-    (is (false? (schemas/schema-sensitive-at?
+    (is (false? (rf.schemas/schema-sensitive-at?
                   [:map
                    [:s {:sensitive? true} [:and [:map [:k :int]]]]
                    [:other [:and [:map [:j :int]]]]]
@@ -934,27 +934,27 @@
   (testing "rf2-g5auo — schema-sensitive-at? matches an index-bearing :in
             path against the walker's index-free decl path"
     ;; :vector-of-map, :in = [1 :token]
-    (is (true? (schemas/schema-sensitive-at?
+    (is (true? (rf.schemas/schema-sensitive-at?
                  [:vector [:map [:token {:sensitive? true} :string]]]
                  [1 :token])))
     ;; :map-of value, :in = ["a" :secret]
-    (is (true? (schemas/schema-sensitive-at?
+    (is (true? (rf.schemas/schema-sensitive-at?
                  [:map-of :string [:map [:secret {:sensitive? true} :string]]]
                  ["a" :secret])))
     ;; :tuple, :in = [1]
-    (is (true? (schemas/schema-sensitive-at?
+    (is (true? (rf.schemas/schema-sensitive-at?
                  [:tuple :int [:string {:sensitive? true}]]
                  [1])))
     ;; deep mixed path, :in = [:items 0 :tok]
-    (is (true? (schemas/schema-sensitive-at?
+    (is (true? (rf.schemas/schema-sensitive-at?
                  [:map [:items [:vector [:map [:tok {:sensitive? true} :string]]]]]
                  [:items 0 :tok])))
     ;; non-sensitive collection failure stays false
-    (is (false? (schemas/schema-sensitive-at?
+    (is (false? (rf.schemas/schema-sensitive-at?
                   [:vector [:map [:name :string]]]
                   [0 :name])))
     ;; sibling-sensitive does not taint the failing non-sensitive leaf
-    (is (false? (schemas/schema-sensitive-at?
+    (is (false? (rf.schemas/schema-sensitive-at?
                   [:vector [:map
                             [:secret {:sensitive? true} :string]
                             [:age :int]]]
@@ -983,39 +983,39 @@
             the declared-sensitive position (and ancestor/descendant) still is"
     (let [s0 [:tuple [:string {:sensitive? true}] :int]]   ;; element 0 sensitive
       ;; SELF — the sensitive position fails → redact.
-      (is (true? (schemas/schema-sensitive-at? s0 [0]))
+      (is (true? (rf.schemas/schema-sensitive-at? s0 [0]))
           "the declared-sensitive position 0 redacts")
       ;; SIBLING — the non-sensitive position fails → must NOT redact.
-      (is (false? (schemas/schema-sensitive-at? s0 [1]))
+      (is (false? (rf.schemas/schema-sensitive-at? s0 [1]))
           "element 0 sensitive must NOT taint a failure at the non-sensitive element 1"))
     (let [s1 [:tuple :int [:string {:sensitive? true}]]]   ;; element 1 sensitive
-      (is (true? (schemas/schema-sensitive-at? s1 [1]))
+      (is (true? (rf.schemas/schema-sensitive-at? s1 [1]))
           "the declared-sensitive position 1 redacts")
-      (is (false? (schemas/schema-sensitive-at? s1 [0]))
+      (is (false? (rf.schemas/schema-sensitive-at? s1 [0]))
           "element 1 sensitive must NOT taint a failure at the non-sensitive element 0"))
     ;; ANCESTOR / DESCENDANT — a tuple element that is itself a container with
     ;; a nested sensitive slot: a failure at the slot, at the whole element, or
     ;; at the whole tuple all redact (the value carries the secret); a failure
     ;; at the OTHER element does not.
     (let [s [:tuple [:map [:tok {:sensitive? true} :string]] :int]]
-      (is (true?  (schemas/schema-sensitive-at? s [0 :tok])) "exact nested slot")
-      (is (true?  (schemas/schema-sensitive-at? s [0]))      "ancestor of the secret")
-      (is (true?  (schemas/schema-sensitive-at? s []))       "whole tuple carries the secret")
-      (is (false? (schemas/schema-sensitive-at? s [1]))      "non-sensitive sibling element 1"))))
+      (is (true?  (rf.schemas/schema-sensitive-at? s [0 :tok])) "exact nested slot")
+      (is (true?  (rf.schemas/schema-sensitive-at? s [0]))      "ancestor of the secret")
+      (is (true?  (rf.schemas/schema-sensitive-at? s []))       "whole tuple carries the secret")
+      (is (false? (rf.schemas/schema-sensitive-at? s [1]))      "non-sensitive sibling element 1"))))
 
 (deftest extract-tuple-emits-position-pinned-paths
   (testing "rf2-ss06u.4 — the walker emits a tuple element flag at its
             POSITION-pinned path ((conj base i)), not the index-free tuple
             base-path; this is what gives the sibling precision"
     (is (= {[0] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:tuple [:string {:sensitive? true}] :int] [])))
     (is (= {[1] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:tuple :int [:string {:sensitive? true}]] [])))
     ;; base-path threads through.
     (is (= {[:pt 0] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:tuple [:string {:sensitive? true}] :int] [:pt])))))
 
 (deftest app-db-validation-tuple-sibling-narrowed-value-verbatim-whole-explain-redacted
@@ -1394,15 +1394,15 @@
             base-path; this is what gives the event-payload sibling precision"
     ;; element 1 (the payload) is a sensitive :string.
     (is (= {[1] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:cat [:= :id] [:string {:sensitive? true}]] [])))
     ;; per-slot flag inside a :cat payload MAP claims the position + key.
     (is (= {[1 :tok] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:cat [:= :id] [:map [:tok {:sensitive? true} :string] [:age :int]]] [])))
     ;; base-path threads through.
     (is (= {[:ev 1] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:cat [:= :id] [:string {:sensitive? true}]] [:ev])))))
 
 (deftest extract-catn-emits-position-pinned-paths
@@ -1412,11 +1412,11 @@
             integer index in :in)"
     ;; entry-level flag on the :catn entry props.
     (is (= {[1] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:catn [:id [:= :id]] [:tok {:sensitive? true} :string]] [])))
     ;; per-slot flag inside a :catn payload MAP claims position + key.
     (is (= {[1 :pw] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:catn [:id [:= :id]]
               [:payload [:map [:pw {:sensitive? true} :string] [:age :int]]]] [])))))
 
@@ -1427,17 +1427,17 @@
             mirrors the :tuple position-precision contract (rf2-ss06u.4)"
     (let [s [:cat [:= :id] [:map [:pw {:sensitive? true} :string] [:age :int]]]]
       ;; SELF / DESCENDANT — the sensitive payload slot fails → redact.
-      (is (true?  (schemas/schema-sensitive-at? s [1 :pw])) "exact sensitive slot")
-      (is (true?  (schemas/schema-sensitive-at? s [1]))     "ancestor of the secret")
+      (is (true?  (rf.schemas/schema-sensitive-at? s [1 :pw])) "exact sensitive slot")
+      (is (true?  (rf.schemas/schema-sensitive-at? s [1]))     "ancestor of the secret")
       ;; SIBLING — the non-sensitive payload slot fails → must NOT redact.
-      (is (false? (schemas/schema-sensitive-at? s [1 :age]))
+      (is (false? (rf.schemas/schema-sensitive-at? s [1 :age]))
           ":pw sensitive must NOT taint a failure at the non-sensitive :age")
       ;; the id position (element 0) carries no secret.
-      (is (false? (schemas/schema-sensitive-at? s [0])) "the id position is not sensitive"))
+      (is (false? (rf.schemas/schema-sensitive-at? s [0])) "the id position is not sensitive"))
     ;; whole-element sensitivity: element 1 entirely sensitive.
     (let [s [:cat [:= :id] [:string {:sensitive? true}]]]
-      (is (true?  (schemas/schema-sensitive-at? s [1])) "the sensitive payload position redacts")
-      (is (false? (schemas/schema-sensitive-at? s [0])) "the non-sensitive id position does not"))))
+      (is (true?  (rf.schemas/schema-sensitive-at? s [1])) "the sensitive payload position redacts")
+      (is (false? (rf.schemas/schema-sensitive-at? s [0])) "the non-sensitive id position does not"))))
 
 ;; ---- rf2-a5kzs / rf2-o69h5 — shared validation-failure redaction seam ----
 ;; The production boundary interceptor (`re-frame.spec`) builds its own event-
@@ -1464,7 +1464,7 @@
                   :explain    {:value secret}
                   :source     :boundary
                   :recovery   :no-recovery}
-          out    (schemas/redact-validation-tags schema tags)]
+          out    (rf.schemas/redact-validation-tags schema tags)]
       (is (= :rf/redacted (:received out)) ":received redacted")
       (is (= :rf/redacted (:value out)) ":value redacted")
       (is (= :rf/redacted (:explain out)) ":explain redacted")
@@ -1485,7 +1485,7 @@
                   :received [:api/strict "not-an-int"]
                   :value    [:api/strict "not-an-int"]
                   :source   :boundary}
-          out    (schemas/redact-validation-tags schema tags)]
+          out    (rf.schemas/redact-validation-tags schema tags)]
       (is (= tags out) "tags ride back unchanged — nothing sensitive to redact")
       (is (not (contains? out :sensitive?))))))
 
@@ -1665,7 +1665,7 @@
             payload alongside the raw :explain"
     (rf/reg-app-schema [:auth :token] [:string])
     (with-trace-recorder! [traces]
-      (schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad)
+      (rf.schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v) "a trace fired")
@@ -1685,7 +1685,7 @@
             omitted — symmetric redaction per Spec 010 §Humanize-hook"
     (rf/reg-app-schema [:auth :token] [:string {:sensitive? true}])
     (with-trace-recorder! [traces]
-      (schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad)
+      (rf.schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v) "a trace fired")
@@ -1707,7 +1707,7 @@
       ;; itself is the sensitive material that must not surface.
       (rf/reg-app-schema [:auth :token] [:int {:sensitive? true}])
       (with-trace-recorder! [traces]
-        (schemas/validate-app-schema! {:auth {:token secret}} :auth/init-bad)
+        (rf.schemas/validate-app-schema! {:auth {:token secret}} :auth/init-bad)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v))
@@ -1780,7 +1780,7 @@
       ;; Value is a long string but is an int (42) here — actually let's
       ;; make it a wrong type to force a validation failure regardless
       ;; of how :large? would behave at runtime.
-      (schemas/validate-app-schema! {:user {:secret-pdf 42}} :doc/bad)
+      (rf.schemas/validate-app-schema! {:user {:secret-pdf 42}} :doc/bad)
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
         (is (some? v))
@@ -1805,7 +1805,7 @@
     (rf/reg-app-schema [:auth :token] [:string {:sensitive? true}])
     (with-trace-recorder! [traces]
       (with-redefs [re-frame.interop/debug-enabled? false]
-        (schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad))
+        (rf.schemas/validate-app-schema! {:auth {:token 42}} :auth/init-bad))
       (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
                           @traces))
           "no validation trace fires when debug-enabled? is false — redaction is moot"))))
@@ -1822,15 +1822,15 @@
 (deftest walker-opaque-predicate
   (testing "rf2-u9bjgr — schema-opaque? is true for a compiled m/schema /
             map / fn, false for vector-form EDN and bare keywords"
-    (is (true? (schemas/schema-opaque?
+    (is (true? (rf.schemas/schema-opaque?
                  (m/schema [:map [:password {:sensitive? true} :string]])))
         "compiled m/schema object is opaque")
-    (is (true? (schemas/schema-opaque? {:not :a-schema})) "a map is opaque")
-    (is (true? (schemas/schema-opaque? (fn [_] true))) "a fn is opaque")
-    (is (false? (schemas/schema-opaque? [:map [:k :int]]))
+    (is (true? (rf.schemas/schema-opaque? {:not :a-schema})) "a map is opaque")
+    (is (true? (rf.schemas/schema-opaque? (fn [_] true))) "a fn is opaque")
+    (is (false? (rf.schemas/schema-opaque? [:map [:k :int]]))
         "vector-form EDN is walkable, not opaque")
-    (is (false? (schemas/schema-opaque? :int)) "a bare keyword is not opaque")
-    (is (false? (schemas/schema-opaque? :my/registry-ref))
+    (is (false? (rf.schemas/schema-opaque? :int)) "a bare keyword is not opaque")
+    (is (false? (rf.schemas/schema-opaque? :my/registry-ref))
         "a registry-ref keyword is not opaque (provably-safe-or-silent caveat)")))
 
 (deftest event-validation-opaque-schema-fails-closed
@@ -1844,7 +1844,7 @@
       (with-trace-recorder! [traces]
         ;; The password value is a VECTOR where a :string is required, so it FAILS
         ;; the schema; the failing value carries the sentinel.
-        (schemas/validate-event! :auth/login [:auth/login {:password [secret]}]
+        (rf.schemas/validate-event! :auth/login [:auth/login {:password [secret]}]
                                  {:schema compiled})
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
@@ -1864,7 +1864,7 @@
                          (m/schema [:map [:token {:sensitive? true} :string]]))
       (with-trace-recorder! [traces]
         ;; :token is a VECTOR where a :string is required → fails the schema.
-        (schemas/validate-app-schema! {:user {:token [secret]}} :user/bad)
+        (rf.schemas/validate-app-schema! {:user {:token [secret]}} :user/bad)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v) "a validation-failure trace fired")
@@ -1882,7 +1882,7 @@
                     :value    {:secret secret}
                     :received {:secret secret}
                     :explain  {:value {:secret secret}}}
-          out      (schemas/redact-validation-tags compiled tags)]
+          out      (rf.schemas/redact-validation-tags compiled tags)]
       (is (true? (:sensitive? out)) "fail-closed: :sensitive? stamped")
       (is (= :rf/redacted (:value out)) ":value redacted")
       (is (= :rf/redacted (:received out)) ":received redacted")
@@ -1912,29 +1912,29 @@
             opaque (mirrors schema-opaque?) AND for a vector-form schema that
             NESTS an opaque child at any depth; false when no opaque value is
             reachable anywhere in the tree"
-    (is (true? (schemas/schema-has-opaque-child?
+    (is (true? (rf.schemas/schema-has-opaque-child?
                  (m/schema [:map [:password {:sensitive? true} :string]])))
         "a root-opaque compiled schema is caught (subsumes schema-opaque?)")
-    (is (true? (schemas/schema-has-opaque-child?
+    (is (true? (rf.schemas/schema-has-opaque-child?
                  [:map [:token (m/schema [:string {:sensitive? true}])]]))
         "a :map slot whose tail is a compiled m/schema value is caught")
-    (is (true? (schemas/schema-has-opaque-child?
+    (is (true? (rf.schemas/schema-has-opaque-child?
                  [:cat [:= :auth/login]
                   (m/schema [:map [:password {:sensitive? true} :string]])]))
         "a :cat element that is a compiled m/schema value is caught")
-    (is (true? (schemas/schema-has-opaque-child?
+    (is (true? (rf.schemas/schema-has-opaque-child?
                  [:vector (m/schema [:string {:sensitive? true}])]))
         "a homogeneous :vector element schema that is opaque is caught")
-    (is (true? (schemas/schema-has-opaque-child?
+    (is (true? (rf.schemas/schema-has-opaque-child?
                  [:multi {:dispatch :kind}
                   [:a (m/schema [:map [:secret {:sensitive? true} :string]])]]))
         "an :multi dispatch branch that is a compiled m/schema value is caught")
-    (is (false? (schemas/schema-has-opaque-child?
+    (is (false? (rf.schemas/schema-has-opaque-child?
                   [:map [:id :int] [:name :string]
                    [:auth [:map [:token {:sensitive? true} :string]]]]))
         "an all-vector-form schema (however deep, however sensitive) has no
          opaque descendant")
-    (is (false? (schemas/schema-has-opaque-child? :int))
+    (is (false? (rf.schemas/schema-has-opaque-child? :int))
         "a bare keyword has no opaque descendant")
     ;; rf2-hi0tf8 confirm-by-corpus: [:map [:n pos-int?]] is the EXACT shape
     ;; of the machine/data-schema-rollback conformance fixture's [:schemas
@@ -1948,7 +1948,7 @@
     ;; (rf2-ee38b.6) already applies — and must NOT be treated as opaque, or
     ;; every ordinary pos-int?/string?-style leaf in the codebase's own
     ;; conformance corpus would over-redact.
-    (is (false? (schemas/schema-has-opaque-child? [:map [:n pos-int?]]))
+    (is (false? (rf.schemas/schema-has-opaque-child? [:map [:n pos-int?]]))
         "a nested bare predicate fn (pos-int? / string? / …) is provably
          flag-free, same as a bare keyword — not opaque")
     ;; rf2-hi0tf8 — the ACTUAL runtime shape the conformance fixture hits:
@@ -1957,7 +1957,7 @@
     ;; symbol to the named fn/var at validate-time (confirmed: `(m/validate
     ;; [:map [:n 'pos-int?]] {:n 0})` => false, `{:n 5}` => true). A NESTED
     ;; bare symbol is exactly as provably flag-free as a nested bare fn.
-    (is (false? (schemas/schema-has-opaque-child? [:map [:n 'pos-int?]]))
+    (is (false? (rf.schemas/schema-has-opaque-child? [:map [:n 'pos-int?]]))
         "a nested bare SYMBOL (the EDN-sourced shape Malli resolves) is
          provably flag-free — not opaque")
     ;; rf2-hi0tf8 — the ROOT case does NOT get the nested exclusion: a bare
@@ -1969,11 +1969,11 @@
     ;; here (flows_schema_validation_test/non-conforming-output-emits-
     ;; violation-but-still-writes pins exactly this via redact-validation-
     ;; tags, the seam this predicate feeds)."
-    (is (true? (schemas/schema-has-opaque-child? pos-int?))
+    (is (true? (rf.schemas/schema-has-opaque-child? pos-int?))
         "a bare fn used AS the whole schema still fails closed, matching
          schema-opaque? — the root/nested split is deliberate, not an
          oversight")
-    (is (true? (schemas/schema-has-opaque-child? 'pos-int?))
+    (is (true? (rf.schemas/schema-has-opaque-child? 'pos-int?))
         "a bare symbol used AS the whole schema likewise fails closed")))
 
 (deftest event-validation-nested-opaque-schema-fails-closed
@@ -1991,7 +1991,7 @@
           schema        [:cat [:= :auth/login] nested-opaque]]
       (with-trace-recorder! [traces]
         ;; :password is a VECTOR where a :string is required -> fails the schema.
-        (schemas/validate-event! :auth/login [:auth/login {:password [secret]}]
+        (rf.schemas/validate-event! :auth/login [:auth/login {:password [secret]}]
                                  {:schema schema})
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
@@ -2019,7 +2019,7 @@
       (with-trace-recorder! [traces]
         ;; :token's value is a VECTOR where the nested compiled schema
         ;; requires a :string -> fails exactly at the opaque leaf ([:token]).
-        (schemas/validate-app-schema! {:token {:token [secret]}} :token/bad)
+        (rf.schemas/validate-app-schema! {:token {:token [secret]}} :token/bad)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v) "a validation-failure trace fired")
@@ -2039,7 +2039,7 @@
                     :value    {:secret secret}
                     :received {:secret secret}
                     :explain  {:value {:secret secret}}}
-          out      (schemas/redact-validation-tags schema tags)]
+          out      (rf.schemas/redact-validation-tags schema tags)]
       (is (true? (:sensitive? out)) "fail-closed: :sensitive? stamped")
       (is (= :rf/redacted (:value out)) ":value redacted")
       (is (= :rf/redacted (:received out)) ":received redacted")
@@ -2059,14 +2059,14 @@
 (deftest walker-has-large-predicate
   (testing "rf2-vmhu4i — schema-has-large? mirrors schema-has-sensitive? on the
             :large? flag"
-    (is (true? (schemas/schema-has-large?
+    (is (true? (rf.schemas/schema-has-large?
                  [:map [:blob {:large? true} :string]])))
-    (is (true? (schemas/schema-has-large?
+    (is (true? (rf.schemas/schema-has-large?
                  [:map [:doc [:map [:payload {:large? true} :string]]]]))
         "nested :large? detected")
-    (is (false? (schemas/schema-has-large? [:map [:n :int]]))
+    (is (false? (rf.schemas/schema-has-large? [:map [:n :int]]))
         "no :large? slot → false")
-    (is (false? (schemas/schema-has-large?
+    (is (false? (rf.schemas/schema-has-large?
                   [:map [:secret {:sensitive? true} :string]]))
         ":sensitive? is not :large? — the flags are independent")))
 
@@ -2078,7 +2078,7 @@
             retired :reason :schema), with the REQUIRED :hint slot present"
     (let [blob (apply str (repeat 200 "X"))]
       (with-trace-recorder! [traces]
-        (schemas/validate-event! :upload/save [:upload/save {:blob blob}]
+        (rf.schemas/validate-event! :upload/save [:upload/save {:blob blob}]
                                  {:schema [:cat [:= :upload/save]
                                            [:map [:blob {:large? true} :int]]]})
         (let [v      (first (filter #(= :rf.error/schema-validation-failure (:operation %))
@@ -2101,7 +2101,7 @@
             raw blob"
     (let [blob (apply str (repeat 500 "Z"))]
       (with-trace-recorder! [traces]
-        (schemas/validate-event! :upload/save [:upload/save {:blob blob}]
+        (rf.schemas/validate-event! :upload/save [:upload/save {:blob blob}]
                                  {:schema [:cat [:= :upload/save]
                                            [:map [:blob {:large? true} :int]]]})
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
@@ -2121,7 +2121,7 @@
     (let [blob (apply str (repeat 500 "Y"))]
       (rf/reg-app-schema [:upload] [:map [:blob {:large? true} :int]])
       (with-trace-recorder! [traces]
-        (schemas/validate-app-schema! {:upload {:blob blob}} :upload/bad)
+        (rf.schemas/validate-app-schema! {:upload {:blob blob}} :upload/bad)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v))
@@ -2137,7 +2137,7 @@
             :rf.size/large-elided marker is emitted (it would leak :bytes)"
     (let [secret (apply str (repeat 100 "S"))]
       (with-trace-recorder! [traces]
-        (schemas/validate-event! :x [:x {:blob secret}]
+        (rf.schemas/validate-event! :x [:x {:blob secret}]
                                  {:schema [:cat [:= :x]
                                            [:map [:blob {:large? true :sensitive? true} :int]]]})
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
@@ -2158,7 +2158,7 @@
           tags {:where   :flow-output
                 :value   {:blob blob}
                 :explain {:value {:blob blob}}}
-          out  (schemas/redact-validation-tags
+          out  (rf.schemas/redact-validation-tags
                  [:map [:blob {:large? true} :int]] tags)]
       (is (true? (:large? out)) ":large? stamped")
       (is (contains? (:value out) :rf.size/large-elided) ":value elided")
@@ -2170,7 +2170,7 @@
   (testing "rf2-vmhu4i — a plain (no :large? / :sensitive?) failure rides
             verbatim — the elision is precise, not a blanket marker"
     (with-trace-recorder! [traces]
-      (schemas/validate-event! :api/x [:api/x {:n "nope"}]
+      (rf.schemas/validate-event! :api/x [:api/x {:n "nope"}]
                                {:schema [:cat [:= :api/x] [:map [:n :int]]]})
       (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                              @traces))]
@@ -2204,8 +2204,8 @@
   (testing "rf2-j538f7.13 — the shared sanitize-sensitive-path corpus holds on
             the JVM (closed-map extra keys scrub; declared locators survive;
             prior set / :map-of / ambiguous-tail behaviour unchanged)"
-    (doseq [{:keys [desc schema in expected]} sanitize-fx/cases]
-      (is (= expected (walker/sanitize-sensitive-path schema in))
+    (doseq [{:keys [desc schema in expected]} rf.schemas.walker-sanitize-path-fixtures/cases]
+      (is (= expected (rf.schemas.walker/sanitize-sensitive-path schema in))
           desc))))
 
 ;; -- end-to-end via validate-app-schema! (:path / :reason / whole-trace egress) --

--- a/implementation/schemas/test/re_frame/schemas_storage_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_storage_test.clj
@@ -6,14 +6,14 @@
   seam consumed by tools and sibling artefacts."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.storage :as storage]
-            [re-frame.schemas.test-fixture :as tf]
-            [re-frame.schemas.validate :as validate]
+            [re-frame.frame :as rf.frame]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.storage :as rf.schemas.storage]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
+            [re-frame.schemas.validate :as rf.schemas.validate]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 (defn- frame-value
   "Construct a synthetic frame VALUE for `frame-id` — structurally identical
@@ -22,9 +22,9 @@
   substrate adapter. Uses the canonical marker / runnable-id keys off
   `re-frame.frame` so it stays correct if the representation moves."
   [frame-id]
-  {frame/object-marker   true
+  {rf.frame/object-marker   true
    :rf.frame/id          frame-id
-   frame/runnable-id-key frame-id})
+   rf.frame/runnable-id-key frame-id})
 
 ;; ---- app-schema-meta-at --------------------------------------------------
 
@@ -33,7 +33,7 @@
             including :schema, :path, :frame, and source-coords —
             distinct from app-schema-at which returns just :schema"
     (rf/reg-app-schema [:user] [:map [:id :int]])
-    (let [m (schemas/app-schema-meta-at [:user])]
+    (let [m (rf.schemas/app-schema-meta-at [:user])]
       (is (map? m))
       (is (= [:map [:id :int]] (:schema m))
           ":schema slot carries the registered form")
@@ -45,25 +45,25 @@
 (deftest meta-at-is-nil-for-unregistered-path
   (testing "an unregistered path yields nil — distinguishable from a
             registration that happened to carry a nil :schema"
-    (is (nil? (schemas/app-schema-meta-at [:never-registered])))))
+    (is (nil? (rf.schemas/app-schema-meta-at [:never-registered])))))
 
 (deftest meta-at-keyword-sugar-resolves-frame
   (testing "the keyword-sugar arity targets the named frame —
             parallel to app-schema-at"
     (rf/reg-app-schema [:user] {:frame :tenant/a} [:map])
     (rf/reg-app-schema [:user] {:frame :tenant/b} [:vector])
-    (is (= [:map] (:schema (schemas/app-schema-meta-at [:user] :tenant/a)))
+    (is (= [:map] (:schema (rf.schemas/app-schema-meta-at [:user] :tenant/a)))
         "frame :tenant/a's registration is isolated")
-    (is (= [:vector] (:schema (schemas/app-schema-meta-at [:user] :tenant/b)))
+    (is (= [:vector] (:schema (rf.schemas/app-schema-meta-at [:user] :tenant/b)))
         "frame :tenant/b's registration is isolated")
-    (is (nil? (schemas/app-schema-meta-at [:user] :tenant/never))
+    (is (nil? (rf.schemas/app-schema-meta-at [:user] :tenant/never))
         "unknown frame → nil")))
 
 (deftest meta-at-opts-map-arity
   (testing "the opts-map arity {:frame ...} matches the keyword sugar"
     (rf/reg-app-schema [:user] {:frame :tenant/a} [:map])
-    (is (= (schemas/app-schema-meta-at [:user] :tenant/a)
-           (schemas/app-schema-meta-at [:user] {:frame :tenant/a}))
+    (is (= (rf.schemas/app-schema-meta-at [:user] :tenant/a)
+           (rf.schemas/app-schema-meta-at [:user] {:frame :tenant/a}))
         "opts-map and keyword-sugar produce identical results")))
 
 (deftest meta-at-reflects-hot-reload-replacement
@@ -71,9 +71,9 @@
             meta map — hot-reload semantics on the introspection
             surface"
     (rf/reg-app-schema [:user] [:map [:id :int]])
-    (is (= [:map [:id :int]] (:schema (schemas/app-schema-meta-at [:user]))))
+    (is (= [:map [:id :int]] (:schema (rf.schemas/app-schema-meta-at [:user]))))
     (rf/reg-app-schema [:user] [:map [:id :uuid]])
-    (is (= [:map [:id :uuid]] (:schema (schemas/app-schema-meta-at [:user])))
+    (is (= [:map [:id :uuid]] (:schema (rf.schemas/app-schema-meta-at [:user])))
         "second registration replaces the first in the meta map")))
 
 ;; ---- frame-schema-entries ------------------------------------------------
@@ -82,15 +82,15 @@
   (testing "an unknown frame produces an empty map — the cross-artefact
             seam never blows up on consumers that ask before any
             registration has happened"
-    (is (= {} (schemas/frame-schema-entries :rf/default)))
-    (is (= {} (schemas/frame-schema-entries :never/created)))))
+    (is (= {} (rf.schemas/frame-schema-entries :rf/default)))
+    (is (= {} (rf.schemas/frame-schema-entries :never/created)))))
 
 (deftest frame-schema-entries-returns-path-to-meta-map
   (testing "frame-schema-entries returns the full {path → schema-meta}
             map for a frame — the shape the validation hot path walks"
     (rf/reg-app-schema [:user] [:map [:id :int]])
     (rf/reg-app-schema [:auth] [:map [:token :string]])
-    (let [entries (schemas/frame-schema-entries :rf/default)]
+    (let [entries (rf.schemas/frame-schema-entries :rf/default)]
       (is (= #{[:user] [:auth]} (set (keys entries)))
           "both registered paths present")
       (is (= [:map [:id :int]] (-> entries (get [:user]) :schema)))
@@ -101,11 +101,11 @@
             cross-artefact seam respects frame scoping"
     (rf/reg-app-schema [:user] {:frame :tenant/a} [:map])
     (rf/reg-app-schema [:user] {:frame :tenant/b} [:vector])
-    (is (= [:map]    (-> (schemas/frame-schema-entries :tenant/a)
+    (is (= [:map]    (-> (rf.schemas/frame-schema-entries :tenant/a)
                          (get [:user]) :schema)))
-    (is (= [:vector] (-> (schemas/frame-schema-entries :tenant/b)
+    (is (= [:vector] (-> (rf.schemas/frame-schema-entries :tenant/b)
                          (get [:user]) :schema)))
-    (is (not (contains? (schemas/frame-schema-entries :tenant/a)
+    (is (not (contains? (rf.schemas/frame-schema-entries :tenant/a)
                         [:other-path-in-tenant-b]))
         "tenant/a's view does not include tenant/b's entries")))
 
@@ -113,20 +113,20 @@
 
 (deftest coerce-opts-accepts-keyword
   (testing "keyword sugar coerces to {:frame keyword}"
-    (is (= {:frame :tenant/a} (storage/coerce-opts :tenant/a)))))
+    (is (= {:frame :tenant/a} (rf.schemas.storage/coerce-opts :tenant/a)))))
 
 (deftest coerce-opts-accepts-opts-map
   (testing "opts-map passes through verbatim"
     (is (= {:frame :tenant/a :other :thing}
-           (storage/coerce-opts {:frame :tenant/a :other :thing})))
-    (is (= {} (storage/coerce-opts {})))))
+           (rf.schemas.storage/coerce-opts {:frame :tenant/a :other :thing})))
+    (is (= {} (rf.schemas.storage/coerce-opts {})))))
 
 (deftest coerce-opts-accepts-nil-as-empty-opts
   (testing "rf2-iszpyg — nil coerces to {} (the empty-opts shape), identical
             to the no-arg arity: it means 'no override, resolve the frame
             from scope'. A nil OPTS has no analogue to the nil-PATH hazard,
             so accepting it removes a footgun for a trusted in-process caller."
-    (is (= {} (storage/coerce-opts nil)))))
+    (is (= {} (rf.schemas.storage/coerce-opts nil)))))
 
 (deftest coerce-opts-throws-on-bad-arg
   (testing "Per rf2-yv62u — a non-keyword, non-map argument throws
@@ -137,11 +137,11 @@
       (cond
         ;; keywords pass — exclude from the throw-loop sentinel above.
         (keyword? bad-arg)
-        (is (map? (storage/coerce-opts bad-arg))
+        (is (map? (rf.schemas.storage/coerce-opts bad-arg))
             (str "keyword " bad-arg " is accepted"))
 
         :else
-        (let [thrown (try (storage/coerce-opts bad-arg)
+        (let [thrown (try (rf.schemas.storage/coerce-opts bad-arg)
                           (catch clojure.lang.ExceptionInfo e e)
                           (catch Exception e e))]
           (is (instance? clojure.lang.ExceptionInfo thrown)
@@ -175,11 +175,11 @@
             the DEFAULT frame. Write and read agree."
     (rf/reg-app-schema [:user] {:frame :tenant/a} [:map [:id :int]])
     ;; Read the same way — both target :tenant/a.
-    (is (= [:map [:id :int]] (schemas/app-schema-at [:user] :tenant/a))
+    (is (= [:map [:id :int]] (rf.schemas/app-schema-at [:user] :tenant/a))
         "schema landed in :tenant/a, matching the read sugar")
-    (is (nil? (schemas/app-schema-at [:user]))
+    (is (nil? (rf.schemas/app-schema-at [:user]))
         "the DEFAULT frame is untouched — the silent-DEFAULT footgun is gone")
-    (is (nil? (schemas/app-schema-at [:user] :rf/default))
+    (is (nil? (rf.schemas/app-schema-at [:user] :rf/default))
         "explicit DEFAULT-frame read also empty")))
 
 (deftest reg-app-schema-bad-opts-shape-fails-loud
@@ -201,10 +201,10 @@
             against the named frame; the coercion is transparent for the
             common shape."
     (rf/reg-app-schema [:user] {:frame :tenant/b} [:map])
-    (is (= [:map] (schemas/app-schema-at [:user] :tenant/b)))
+    (is (= [:map] (rf.schemas/app-schema-at [:user] :tenant/b)))
     ;; And the zero-opts arity still defaults to the current frame.
     (rf/reg-app-schema [:auth] [:string])
-    (is (= [:string] (schemas/app-schema-at [:auth]))
+    (is (= [:string] (rf.schemas/app-schema-at [:auth]))
         "two-arg arity registers against the current (default) frame")))
 
 (deftest reg-app-schemas-keyword-opts-matches-read-frame
@@ -212,9 +212,9 @@
             keyword registers every entry against THAT frame, not the
             DEFAULT frame; a bad shape fails loud."
     (rf/reg-app-schemas {[:user] [:map] [:auth] [:string]} :tenant/c)
-    (is (= [:map]    (schemas/app-schema-at [:user] :tenant/c)))
-    (is (= [:string] (schemas/app-schema-at [:auth] :tenant/c)))
-    (is (nil? (schemas/app-schema-at [:user]))
+    (is (= [:map]    (rf.schemas/app-schema-at [:user] :tenant/c)))
+    (is (= [:string] (rf.schemas/app-schema-at [:auth] :tenant/c)))
+    (is (nil? (rf.schemas/app-schema-at [:user]))
         "DEFAULT frame untouched for the bulk form too")
     (let [thrown (try (rf/reg-app-schemas {[:user] [:map]} "tenant-c")
                       (catch clojure.lang.ExceptionInfo e e))]
@@ -253,15 +253,15 @@
     (let [fv (frame-value :tenant/fv-a)]
       (rf/reg-app-schema [:user] {:frame fv} [:map [:id :int]])
       ;; The load-bearing assertion: read-by-id resolves the value-keyed write.
-      (is (= [:map [:id :int]] (schemas/app-schema-at [:user] :tenant/fv-a))
+      (is (= [:map [:id :int]] (rf.schemas/app-schema-at [:user] :tenant/fv-a))
           "read-by-frame-id finds the schema registered via a frame VALUE")
       ;; And the stored registry key is the bare frame-id keyword, not the map.
       (is (= [:tenant/fv-a]
-             (keys (schemas/snapshot-schemas-by-frame)))
+             (keys (rf.schemas/snapshot-schemas-by-frame)))
           "schemas-by-frame is keyed by the resolved frame-id, not the value map")
       ;; The frame-value-opt read agrees with the frame-id read.
-      (is (= (schemas/app-schema-at [:user] :tenant/fv-a)
-             (schemas/app-schema-at [:user] {:frame fv}))
+      (is (= (rf.schemas/app-schema-at [:user] :tenant/fv-a)
+             (rf.schemas/app-schema-at [:user] {:frame fv}))
           "read via {:frame frame-value} and via the frame-id agree"))))
 
 (deftest reg-app-schema-bare-frame-value-routes-to-its-frame
@@ -270,12 +270,12 @@
             silently to the ambient/default frame"
     (let [fv (frame-value :tenant/fv-b)]
       (rf/reg-app-schema [:bare] {:frame fv} [:map])
-      (is (= [:map] (schemas/app-schema-at [:bare] :tenant/fv-b))
+      (is (= [:map] (rf.schemas/app-schema-at [:bare] :tenant/fv-b))
           "bare frame value registers against its frame, read-by-id finds it")
-      (is (nil? (schemas/app-schema-at [:bare]))
+      (is (nil? (rf.schemas/app-schema-at [:bare]))
           "the DEFAULT/ambient frame is untouched — no silent fallback")
       ;; coerce-opts lifts the bare value into the {:frame value} shape.
-      (is (= {:frame fv} (storage/coerce-opts fv))
+      (is (= {:frame fv} (rf.schemas.storage/coerce-opts fv))
           "coerce-opts wraps a bare frame value as {:frame value}"))))
 
 (deftest read-surface-accepts-frame-value-targets
@@ -286,16 +286,16 @@
     (let [fv (frame-value :tenant/fv-c)]
       (rf/reg-app-schema [:user] {:frame :tenant/fv-c} [:map])
       ;; app-schema-at
-      (is (= [:map] (schemas/app-schema-at [:user] fv)))
-      (is (= [:map] (schemas/app-schema-at [:user] {:frame fv})))
+      (is (= [:map] (rf.schemas/app-schema-at [:user] fv)))
+      (is (= [:map] (rf.schemas/app-schema-at [:user] {:frame fv})))
       ;; app-schema-meta-at
-      (is (= [:map] (:schema (schemas/app-schema-meta-at [:user] fv))))
+      (is (= [:map] (:schema (rf.schemas/app-schema-meta-at [:user] fv))))
       ;; app-schemas
-      (is (= {[:user] [:map]} (schemas/app-schemas fv)))
-      (is (= {[:user] [:map]} (schemas/app-schemas {:frame fv})))
+      (is (= {[:user] [:map]} (rf.schemas/app-schemas fv)))
+      (is (= {[:user] [:map]} (rf.schemas/app-schemas {:frame fv})))
       ;; app-schemas-digest agrees with the keyword-id digest
-      (is (= (schemas/app-schemas-digest :tenant/fv-c)
-             (schemas/app-schemas-digest fv))
+      (is (= (rf.schemas/app-schemas-digest :tenant/fv-c)
+             (rf.schemas/app-schemas-digest fv))
           "digest via a frame value equals digest via its frame-id"))))
 
 (deftest reg-app-schemas-bulk-frame-value-routes-to-its-frame
@@ -304,9 +304,9 @@
             `{:frame value}` opts map does too"
     (let [fv (frame-value :tenant/fv-d)]
       (rf/reg-app-schemas {[:user] [:map] [:auth] [:string]} fv)
-      (is (= [:map]    (schemas/app-schema-at [:user] :tenant/fv-d)))
-      (is (= [:string] (schemas/app-schema-at [:auth] :tenant/fv-d)))
-      (is (nil? (schemas/app-schema-at [:user]))
+      (is (= [:map]    (rf.schemas/app-schema-at [:user] :tenant/fv-d)))
+      (is (= [:string] (rf.schemas/app-schema-at [:auth] :tenant/fv-d)))
+      (is (nil? (rf.schemas/app-schema-at [:user]))
           "DEFAULT frame untouched for the bulk-by-value form too"))))
 
 (deftest coerce-opts-discriminates-frame-value-before-opts-map
@@ -314,11 +314,11 @@
             generic map? branch, so a bare frame value lifts to {:frame value}
             while an ordinary opts map still passes through verbatim"
     (let [fv (frame-value :tenant/fv-e)]
-      (is (= {:frame fv} (storage/coerce-opts fv))
+      (is (= {:frame fv} (rf.schemas.storage/coerce-opts fv))
           "a frame value is lifted, not passed through as an opts map")
       ;; A genuine opts map (NOT a frame value) still passes through.
       (is (= {:frame :tenant/x :other :thing}
-             (storage/coerce-opts {:frame :tenant/x :other :thing}))
+             (rf.schemas.storage/coerce-opts {:frame :tenant/x :other :thing}))
           "an ordinary opts map is untouched"))))
 
 (deftest resolve-frame-rejects-non-keyword-frame-target-loud
@@ -335,7 +335,7 @@
             is a bad frame target and MUST throw (Spec 010 §Per-frame schemas /
             API §Schemas), closing the old silent-ambient-fallback bug."
     (doseq [bad-frame ["stringframe" [:a :b] 42 {:not :a-frame}]]
-      (let [before (schemas/snapshot-schemas-by-frame)
+      (let [before (rf.schemas/snapshot-schemas-by-frame)
             thrown (try (rf/reg-app-schema [:user] {:frame bad-frame} [:map])
                         (catch clojure.lang.ExceptionInfo e e))]
         (is (instance? clojure.lang.ExceptionInfo thrown)
@@ -347,7 +347,7 @@
                 "names the canonical bad-arg category")
             (is (= bad-frame (:received data))
                 ":received carries the offending :frame value verbatim")))
-        (is (= before (schemas/snapshot-schemas-by-frame))
+        (is (= before (rf.schemas/snapshot-schemas-by-frame))
             (str "store unchanged after rejecting :frame " (pr-str bad-frame)))))))
 
 (deftest explicit-frame-honoured-not-silently-replaced-by-ambient
@@ -362,13 +362,13 @@
             a keyword but the same flawed plumbing silently dropped a non-frame
             map target (covered by the bad-target test above). This pins the
             POSITIVE half of the contract: the declared frame wins."
-    (binding [frame/*current-frame* :review/ambient]
+    (binding [rf.frame/*current-frame* :review/ambient]
       (rf/reg-app-schema [:user] {:frame :review/explicit} [:map [:id :int]])
-      (is (= [:map [:id :int]] (schemas/app-schema-at [:user] :review/explicit))
+      (is (= [:map [:id :int]] (rf.schemas/app-schema-at [:user] :review/explicit))
           "schema landed on the explicitly-declared frame")
-      (is (nil? (schemas/app-schema-at [:user] :review/ambient))
+      (is (nil? (rf.schemas/app-schema-at [:user] :review/ambient))
           "the AMBIENT frame was NOT silently used — no schema leaked onto it")
-      (is (= [:review/explicit] (keys (schemas/snapshot-schemas-by-frame)))
+      (is (= [:review/explicit] (keys (rf.schemas/snapshot-schemas-by-frame)))
           "exactly one frame entry, keyed by the declared target"))))
 
 (deftest meta-at-preserves-standard-and-open-registration-metadata
@@ -382,7 +382,7 @@
             :platforms and open keys were silently dropped — pair-tools/agents
             could not rely on the read surface as the full metadata anchor."
     (rf/reg-app-schema [:user] {:doc "User schema" :tags #{:auth} :platforms #{:client} :my/tool true} [:map])
-    (let [m (schemas/app-schema-meta-at [:user])]
+    (let [m (rf.schemas/app-schema-meta-at [:user])]
       (is (= [:map] (:schema m))         ":schema overlaid with the extracted form")
       (is (= [:user] (:path m))          ":path runtime-stamped")
       (is (some? (:frame m))             ":frame runtime-stamped")
@@ -401,7 +401,7 @@
     ;; (a) 2-slot: the bare schema IS the value slot (the canonical short form,
     ;; the exact shape the old :schema-in-metadata grammar used to reject).
     (rf/reg-app-schema [:user] [:map [:id :int]])
-    (is (= [:map [:id :int]] (schemas/app-schema-at [:user]))
+    (is (= [:map [:id :int]] (rf.schemas/app-schema-at [:user]))
         "2-slot registers the bare schema as the value slot")
     ;; (b) 3-slot with a non-map middle arg — a caller bug, rejected at the
     ;; authoring boundary.
@@ -419,13 +419,13 @@
             even though no PUBLIC frame-id keyword names it"
     ;; A direct frame value: marker + a gensym runnable id, no :rf.frame/id.
     (let [rid (keyword "rf.frame" (str (gensym "")))
-          fv  {frame/object-marker true frame/runnable-id-key rid}]
+          fv  {rf.frame/object-marker true rf.frame/runnable-id-key rid}]
       (rf/reg-app-schema [:direct] {:frame fv} [:map])
-      (is (= [:map] (schemas/app-schema-at [:direct] fv))
+      (is (= [:map] (rf.schemas/app-schema-at [:direct] fv))
           "read via the same direct value resolves the registration")
-      (is (= [:map] (schemas/app-schema-at [:direct] rid))
+      (is (= [:map] (rf.schemas/app-schema-at [:direct] rid))
           "read via the value's runnable-id resolves it too")
-      (is (= [rid] (keys (schemas/snapshot-schemas-by-frame)))
+      (is (= [rid] (keys (rf.schemas/snapshot-schemas-by-frame)))
           "stored under the runnable id, not the value map"))))
 
 ;; ---- path-shape validation (rf2-sk0ql) -----------------------------------
@@ -457,7 +457,7 @@
             string, number, nil) throws :rf.error/app-schema-bad-path and
             does NOT mutate schemas-by-frame"
     (doseq [bad-path [:n "user" 42 nil {:not :a-path} #{:n}]]
-      (let [before (schemas/snapshot-schemas-by-frame)
+      (let [before (rf.schemas/snapshot-schemas-by-frame)
             thrown (try (rf/reg-app-schema bad-path :int)
                         (catch clojure.lang.ExceptionInfo e e))]
         (is (instance? clojure.lang.ExceptionInfo thrown)
@@ -471,7 +471,7 @@
                 ":received slot carries the bad path verbatim")
             (is (= :rf.error/app-schema-bad-path (:rf.error/id data))
                 ":rf.error/id slot carries the framework error id")))
-        (is (= before (schemas/snapshot-schemas-by-frame))
+        (is (= before (rf.schemas/snapshot-schemas-by-frame))
             (str "store is unchanged after rejecting " (pr-str bad-path)
                  " — the malformed entry never lands"))))))
 
@@ -479,12 +479,12 @@
   (testing "rf2-sk0ql — valid sequential paths register fine: a vector
             key-path, the root `[]`, and a non-vector seq path"
     (rf/reg-app-schema [:n] :int)
-    (is (= :int (schemas/app-schema-at [:n])) "vector key-path registers")
+    (is (= :int (rf.schemas/app-schema-at [:n])) "vector key-path registers")
     (rf/reg-app-schema [] [:map [:n :int]])
-    (is (= [:map [:n :int]] (schemas/app-schema-at [])) "root [] registers")
+    (is (= [:map [:n :int]] (rf.schemas/app-schema-at [])) "root [] registers")
     ;; A non-vector seq is still a valid get-in path shape.
     (rf/reg-app-schema (list :a :b) :string)
-    (is (= :string (schemas/app-schema-at (list :a :b)))
+    (is (= :string (rf.schemas/app-schema-at (list :a :b)))
         "non-vector seq path registers (get-in accepts any sequential ks)")))
 
 (deftest reg-app-schema-normalizes-seq-path-to-canonical-vector
@@ -495,16 +495,16 @@
             overwrites the SAME slot (not a parallel list-keyed entry)"
     ;; Register via a non-vector seq; the stored key is the canonical vector.
     (rf/reg-app-schema (list :a :b) :string)
-    (let [frame-keys (keys (get (schemas/snapshot-schemas-by-frame) :rf/default))]
+    (let [frame-keys (keys (get (rf.schemas/snapshot-schemas-by-frame) :rf/default))]
       (is (every? vector? frame-keys)
           "every stored schemas-by-frame key is a canonical vector")
       (is (contains? (set frame-keys) [:a :b])
           "the stored key is the canonical VECTOR, not the supplied list"))
     ;; The vector-spelling lookup finds the list-registered entry.
-    (is (= :string (schemas/app-schema-at [:a :b]))
+    (is (= :string (rf.schemas/app-schema-at [:a :b]))
         "vector lookup resolves the list-registered entry — one identity")
     ;; The stored meta :path is itself the canonical vector.
-    (is (= [:a :b] (:path (schemas/app-schema-meta-at (list :a :b))))
+    (is (= [:a :b] (:path (rf.schemas/app-schema-meta-at (list :a :b))))
         "schema-meta :path is the canonical vector, regardless of read spelling")
     ;; reg-app-schema returns the normalized canonical-vector path.
     (is (= [:c :d] (rf/reg-app-schema (list :c :d) :int))
@@ -512,10 +512,10 @@
     ;; Re-registering via the vector spelling overwrites the SAME slot
     ;; (no parallel list-keyed entry survives).
     (rf/reg-app-schema [:a :b] :int)
-    (is (= :int (schemas/app-schema-at (list :a :b)))
+    (is (= :int (rf.schemas/app-schema-at (list :a :b)))
         "re-register via the vector spelling hits the same canonical slot")
     (is (= 1 (count (filter #(= [:a :b] %)
-                            (keys (get (schemas/snapshot-schemas-by-frame) :rf/default)))))
+                            (keys (get (rf.schemas/snapshot-schemas-by-frame) :rf/default)))))
         "exactly ONE entry for the path — no list-vs-vector key split")))
 
 (deftest app-schemas-digest-list-path-equals-vector-path
@@ -525,8 +525,8 @@
             vector, not the raw container shape)"
     (rf/reg-app-schema (list :a :b) {:frame :seq-frame} :string)
     (rf/reg-app-schema [:a :b] {:frame :vec-frame} :string)
-    (is (= (schemas/app-schemas-digest :vec-frame)
-           (schemas/app-schemas-digest :seq-frame))
+    (is (= (rf.schemas/app-schemas-digest :vec-frame)
+           (rf.schemas/app-schemas-digest :seq-frame))
         "list-keyed and vector-keyed frames produce byte-identical digests")))
 
 ;; ===========================================================================
@@ -554,14 +554,14 @@
                       [:a (Object.)]             ;; host-object segment
                       [:a 9007199254740992]      ;; unsafe-high integer segment
                       [:a -9007199254740992]]]   ;; unsafe-low integer segment
-      (let [before (schemas/snapshot-schemas-by-frame)
+      (let [before (rf.schemas/snapshot-schemas-by-frame)
             thrown (try (rf/reg-app-schema bad-path :int)
                         (catch clojure.lang.ExceptionInfo e e))]
         (is (instance? clojure.lang.ExceptionInfo thrown)
             (str "bad-segment path " (pr-str bad-path) " throws"))
         (is (= :rf.error/app-schema-bad-path (:rf.error/id (ex-data thrown)))
             (str "structured :rf.error/id for " (pr-str bad-path)))
-        (is (= before (schemas/snapshot-schemas-by-frame))
+        (is (= before (rf.schemas/snapshot-schemas-by-frame))
             (str "store unchanged after rejecting " (pr-str bad-path)))))))
 
 (deftest reg-app-schema-accepts-concrete-non-keyword-segments
@@ -570,15 +570,15 @@
             to the SHARED concrete domain, NOT keyword-only (which would break
             integer-indexed app-db paths like [:cart :items 42])"
     (rf/reg-app-schema [:cart :items 42 :qty] :int)
-    (is (= :int (schemas/app-schema-at [:cart :items 42 :qty]))
+    (is (= :int (rf.schemas/app-schema-at [:cart :items 42 :qty]))
         "an integer-indexed app-db path registers + looks up")
     (rf/reg-app-schema [:by-name "alice"] :string)
-    (is (= :string (schemas/app-schema-at [:by-name "alice"])) "a string segment")
+    (is (= :string (rf.schemas/app-schema-at [:by-name "alice"])) "a string segment")
     (rf/reg-app-schema [:flag true] :boolean)
-    (is (= :boolean (schemas/app-schema-at [:flag true])) "a boolean segment")
+    (is (= :boolean (rf.schemas/app-schema-at [:flag true])) "a boolean segment")
     ;; both safe-integer boundaries register (the canonical-identity range)
     (rf/reg-app-schema [:n 9007199254740991] :int)
-    (is (= :int (schemas/app-schema-at [:n 9007199254740991]))
+    (is (= :int (rf.schemas/app-schema-at [:n 9007199254740991]))
         "the max safe integer is an admitted segment")))
 
 (deftest app-schema-lookup-rejects-non-concrete-segment
@@ -586,11 +586,11 @@
             than silently missing (registration AND lookup route through the
             concrete boundary — rf2-ujmc3u acceptance)"
     (is (= :rf.error/bad-path
-           (try (schemas/app-schema-at [:a [:nested]]) nil
+           (try (rf.schemas/app-schema-at [:a [:nested]]) nil
                 (catch clojure.lang.ExceptionInfo e (:rf.error/id (ex-data e)))))
         "app-schema-at with a composite segment fails closed")
     (is (= :rf.error/bad-path
-           (try (schemas/app-schema-meta-at [:a 1.5]) nil
+           (try (rf.schemas/app-schema-meta-at [:a 1.5]) nil
                 (catch clojure.lang.ExceptionInfo e (:rf.error/id (ex-data e)))))
         "app-schema-meta-at with a float segment fails closed")))
 
@@ -599,7 +599,7 @@
             no entry in the batch lands when ANY key carries a non-concrete
             segment (the up-front sweep validates every segment before any
             store mutation — rf2-ujmc3u acceptance)"
-    (let [before (schemas/snapshot-schemas-by-frame)
+    (let [before (rf.schemas/snapshot-schemas-by-frame)
           thrown (try (rf/reg-app-schemas {[:good]            :int
                                            [:also :good]      :string
                                            [:bad [:composite]] :int}   ;; bad segment
@@ -608,16 +608,16 @@
       (is (instance? clojure.lang.ExceptionInfo thrown)
           "the batch with one bad-segment key throws")
       (is (= :rf.error/app-schema-bad-path (:rf.error/id (ex-data thrown))))
-      (is (= before (schemas/snapshot-schemas-by-frame))
+      (is (= before (rf.schemas/snapshot-schemas-by-frame))
           "NOTHING in the batch landed — atomic all-or-nothing")
-      (is (nil? (schemas/app-schema-at [:good] :bulk-frame))
+      (is (nil? (rf.schemas/app-schema-at [:good] :bulk-frame))
           "the earlier-iterated good key did NOT register before the bad one threw"))))
 
 (deftest reg-app-schemas-rejects-batch-with-bad-path-atomically
   (testing "rf2-sk0ql — a bulk batch containing a non-sequential path key
             is rejected ATOMICALLY: the whole call throws and NO entry
             lands (not even the well-formed siblings iterated first)"
-    (let [before (schemas/snapshot-schemas-by-frame)
+    (let [before (rf.schemas/snapshot-schemas-by-frame)
           thrown (try (rf/reg-app-schemas {[:good] :int
                                            :bad-key :string
                                            [:also-good] :boolean})
@@ -628,9 +628,9 @@
         ;; rf2-vvixub — branch on the canonical :rf.error/id, not the message.
         (is (= :rf.error/app-schema-bad-path (:rf.error/id (ex-data thrown)))
             "names the path-shape error category"))
-      (is (= before (schemas/snapshot-schemas-by-frame))
+      (is (= before (rf.schemas/snapshot-schemas-by-frame))
           "NO entry from the batch landed — all-or-nothing")
-      (is (nil? (schemas/app-schema-at [:good]))
+      (is (nil? (rf.schemas/app-schema-at [:good]))
           "the well-formed sibling did not half-register"))))
 
 (deftest reg-app-schemas-accepts-all-valid-paths
@@ -639,9 +639,9 @@
     (rf/reg-app-schemas {[:good]      :int
                          []           [:map]
                          [:cart :qty] :int})
-    (is (= :int    (schemas/app-schema-at [:good])))
-    (is (= [:map]  (schemas/app-schema-at [])))
-    (is (= :int    (schemas/app-schema-at [:cart :qty])))))
+    (is (= :int    (rf.schemas/app-schema-at [:good])))
+    (is (= [:map]  (rf.schemas/app-schema-at [])))
+    (is (= :int    (rf.schemas/app-schema-at [:cart :qty])))))
 
 ;; ---- runtime-db path hard-reject (rf2-k0ew8n) ----------------------------
 ;;
@@ -685,7 +685,7 @@
             framework-owned) and does NOT direct the user at the non-public,
             framework-owned `reg-runtime-schema` API, and stores NOTHING"
     (doseq [bad-path runtime-paths-rejected]
-      (let [before (schemas/snapshot-schemas-by-frame)
+      (let [before (rf.schemas/snapshot-schemas-by-frame)
             thrown (try (rf/reg-app-schema bad-path {:frame :tenant/rt} [:map])
                         (catch clojure.lang.ExceptionInfo e e))]
         (is (instance? clojure.lang.ExceptionInfo thrown)
@@ -712,16 +712,16 @@
                 ":reason states the runtime-db partition is framework-owned")
             (is (re-find #"(?i)app-?db" (str reason))
                 ":reason reminds the user app schemas validate app-db only")))
-        (is (= before (schemas/snapshot-schemas-by-frame))
+        (is (= before (rf.schemas/snapshot-schemas-by-frame))
             (str "store unchanged after rejecting " (pr-str bad-path)))))))
 
 (deftest reg-app-schema-runtime-path-distinct-from-shape-error
   (testing "rf2-k0ew8n — the runtime-path id is NOT the shape-error id; a
             runtime path is well-SHAPED (sequential) so it passes the shape
             gate and is rejected by the SEPARATE namespace gate"
-    (is (storage/valid-app-schema-path? [:rf.runtime/machines])
+    (is (rf.schemas.storage/valid-app-schema-path? [:rf.runtime/machines])
         "a runtime path is a valid SHAPE — sequential")
-    (is (storage/runtime-app-schema-path? [:rf.runtime/machines])
+    (is (rf.schemas.storage/runtime-app-schema-path? [:rf.runtime/machines])
         "but the first-segment runtime check catches it")
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf.error/app-schema-runtime-path"
@@ -734,20 +734,20 @@
             runtime root registers fine, and a runtime keyword NOT in head
             position is allowed"
     (rf/reg-app-schema [:user] {:frame :tenant/rt} [:map [:id :int]])
-    (is (= [:map [:id :int]] (schemas/app-schema-at [:user] :tenant/rt)))
+    (is (= [:map [:id :int]] (rf.schemas/app-schema-at [:user] :tenant/rt)))
     ;; A runtime keyword that is NOT the first segment is fine — only the
     ;; head matters (app-db could legitimately hold such a nested key).
     (rf/reg-app-schema [:user :rf.runtime/note] {:frame :tenant/rt} :string)
-    (is (= :string (schemas/app-schema-at [:user :rf.runtime/note] :tenant/rt)))
+    (is (= :string (rf.schemas/app-schema-at [:user :rf.runtime/note] :tenant/rt)))
     ;; The empty root [] is the whole-app-db schema — never runtime.
-    (is (not (storage/runtime-app-schema-path? [])))
-    (is (not (storage/runtime-app-schema-path? [:rf/something-else])))))
+    (is (not (rf.schemas.storage/runtime-app-schema-path? [])))
+    (is (not (rf.schemas.storage/runtime-app-schema-path? [:rf/something-else])))))
 
 (deftest reg-app-schemas-rejects-batch-with-runtime-path-atomically
   (testing "rf2-k0ew8n — a bulk batch containing one runtime-db path key is
             rejected ATOMICALLY with :rf.error/app-schema-runtime-path before
             any mutation: NO entry lands, not even well-formed app-db siblings"
-    (let [before (schemas/snapshot-schemas-by-frame)
+    (let [before (rf.schemas/snapshot-schemas-by-frame)
           thrown (try (rf/reg-app-schemas {[:good]                 :int
                                            [:rf.runtime/machines]  [:map]
                                            [:also-good]            :boolean}
@@ -760,9 +760,9 @@
         (is (= :rf.error/app-schema-runtime-path
                (:rf.error/id (ex-data thrown)))
             "names the distinct runtime-path error category"))
-      (is (= before (schemas/snapshot-schemas-by-frame))
+      (is (= before (rf.schemas/snapshot-schemas-by-frame))
           "NO entry from the batch landed — all-or-nothing")
-      (is (nil? (schemas/app-schema-at [:good] :tenant/rt))
+      (is (nil? (rf.schemas/app-schema-at [:good] :tenant/rt))
           "the well-formed app-db sibling did not half-register"))))
 
 ;; ---- end-to-end bypass invariant (rf2-sk0ql) -----------------------------
@@ -787,7 +787,7 @@
                           (rf/reg-app-schema :n :int)))
     ;; Nothing landed, so validate-app-schema! is a clean pass — it does
     ;; NOT throw the ISeq IllegalArgumentException any more.
-    (is (true? (validate/validate-app-schema! {:n "bad"} :test))
+    (is (true? (rf.schemas.validate/validate-app-schema! {:n "bad"} :test))
         "no registered schema → clean pass, no throw to be swallowed")))
 
 (deftest valid-path-validates-and-signals-mismatch
@@ -797,9 +797,9 @@
             roll the commit back) — proving the validation path the bug
             had silently disabled is live."
     (rf/reg-app-schema [:n] :int)
-    (is (false? (validate/validate-app-schema! {:n "bad"} :test))
+    (is (false? (rf.schemas.validate/validate-app-schema! {:n "bad"} :test))
         "a non-conforming value at the valid path fails validation")
-    (is (true? (validate/validate-app-schema! {:n 0} :test))
+    (is (true? (rf.schemas.validate/validate-app-schema! {:n 0} :test))
         "a conforming value at the valid path passes")))
 
 ;; ---- malformed-schema fail-closed invariant (rf2-ss06u.3) ----------------
@@ -824,7 +824,7 @@
   `:result` assertion loudly."
   [db failing-id frame]
   (with-trace-recorder! [traces]
-    (let [result (validate/validate-app-schema! db failing-id frame)]
+    (let [result (rf.schemas.validate/validate-app-schema! db failing-id frame)]
       {:result result :traces @traces})))
 
 (deftest malformed-schema-no-silent-pass-childless-vector
@@ -878,29 +878,29 @@
   (testing "snapshot captures the current state; restore replays it"
     (rf/reg-app-schema [:user] [:map [:id :int]])
     (rf/reg-app-schema [:auth] [:string])
-    (let [snap (schemas/snapshot-schemas-by-frame)]
+    (let [snap (rf.schemas/snapshot-schemas-by-frame)]
       ;; Mutate.
       (rf/reg-app-schema [:user] [:vector])
-      (is (= [:vector] (schemas/app-schema-at [:user]))
+      (is (= [:vector] (rf.schemas/app-schema-at [:user]))
           "mutation visible before restore")
       ;; Restore.
-      (schemas/restore-schemas-by-frame! snap)
-      (is (= [:map [:id :int]] (schemas/app-schema-at [:user]))
+      (rf.schemas/restore-schemas-by-frame! snap)
+      (is (= [:map [:id :int]] (rf.schemas/app-schema-at [:user]))
           "restore replays the captured state")
-      (is (= [:string] (schemas/app-schema-at [:auth]))
+      (is (= [:string] (rf.schemas/app-schema-at [:auth]))
           "sibling entries restored too"))))
 
 (deftest clear-removes-all-registrations
   (testing "clear-schemas-by-frame! drops every frame's registrations"
     (rf/reg-app-schema [:user] [:map])
     (rf/reg-app-schema [:user] {:frame :tenant/a} [:vector])
-    (schemas/clear-schemas-by-frame!)
-    (is (nil? (schemas/app-schema-at [:user]))
+    (rf.schemas/clear-schemas-by-frame!)
+    (is (nil? (rf.schemas/app-schema-at [:user]))
         "default-frame registration cleared")
-    (is (nil? (schemas/app-schema-at [:user] :tenant/a))
+    (is (nil? (rf.schemas/app-schema-at [:user] :tenant/a))
         "tenant-frame registration cleared")
-    (is (= {} (schemas/frame-schema-entries :rf/default)))
-    (is (= {} (schemas/frame-schema-entries :tenant/a)))))
+    (is (= {} (rf.schemas/frame-schema-entries :rf/default)))
+    (is (= {} (rf.schemas/frame-schema-entries :tenant/a)))))
 
 ;; ---- on-frame-destroyed! (Spec 002 §Destroy / rf2-rbbmt) -----------------
 ;;
@@ -917,14 +917,14 @@
     (rf/reg-app-schema [:user] {:frame :tenant/doomed} [:map [:id :int]])
     (rf/reg-app-schema [:auth] {:frame :tenant/doomed} [:string])
     (rf/reg-app-schema [:user] {:frame :tenant/survivor} [:map])
-    (is (= 2 (count (schemas/frame-schema-entries :tenant/doomed)))
+    (is (= 2 (count (rf.schemas/frame-schema-entries :tenant/doomed)))
         "doomed frame has both registrations before destroy")
-    (schemas/on-frame-destroyed! :tenant/doomed)
-    (is (= {} (schemas/frame-schema-entries :tenant/doomed))
+    (rf.schemas/on-frame-destroyed! :tenant/doomed)
+    (is (= {} (rf.schemas/frame-schema-entries :tenant/doomed))
         "destroyed frame's entries are gone")
-    (is (nil? (schemas/app-schema-at [:user] :tenant/doomed))
+    (is (nil? (rf.schemas/app-schema-at [:user] :tenant/doomed))
         "looking up a destroyed frame's schema yields nil")
-    (is (= [:map] (schemas/app-schema-at [:user] :tenant/survivor))
+    (is (= [:map] (rf.schemas/app-schema-at [:user] :tenant/survivor))
         "sibling frame's registration survives — destroy is frame-scoped")))
 
 (deftest on-frame-destroyed-is-idempotent-no-op-for-missing-frame
@@ -935,17 +935,17 @@
     ;; Never-registered frame — the swap! dissoc returns the (unchanged)
     ;; registry value and never throws. The destroyed frame is simply
     ;; absent from the result.
-    (let [after (schemas/on-frame-destroyed! :tenant/never)]
+    (let [after (rf.schemas/on-frame-destroyed! :tenant/never)]
       (is (map? after)
           "swap! dissoc returns the registry value; no throw")
       (is (not (contains? after :tenant/never))
           "the never-registered frame is absent from the registry"))
     ;; Double-destroy is safe.
-    (schemas/on-frame-destroyed! :tenant/keep)
-    (schemas/on-frame-destroyed! :tenant/keep)
-    (is (= {} (schemas/frame-schema-entries :tenant/keep))
+    (rf.schemas/on-frame-destroyed! :tenant/keep)
+    (rf.schemas/on-frame-destroyed! :tenant/keep)
+    (is (= {} (rf.schemas/frame-schema-entries :tenant/keep))
         "second destroy of an already-empty frame is a clean no-op")
-    (is (= {} (schemas/frame-schema-entries :tenant/never)))))
+    (is (= {} (rf.schemas/frame-schema-entries :tenant/never)))))
 
 (deftest on-frame-destroyed-allows-clean-re-registration
   (testing "rf2-rbbmt — after destroy, re-registering the same frame-id
@@ -953,10 +953,10 @@
             schemas re-fire against the re-created frame)"
     (rf/reg-app-schema [:user]   {:frame :tenant/reuse} [:map [:id :int]])
     (rf/reg-app-schema [:orphan] {:frame :tenant/reuse} [:string])
-    (schemas/on-frame-destroyed! :tenant/reuse)
+    (rf.schemas/on-frame-destroyed! :tenant/reuse)
     ;; Re-create with only ONE of the prior schemas.
     (rf/reg-app-schema [:user] {:frame :tenant/reuse} [:vector])
-    (let [entries (schemas/frame-schema-entries :tenant/reuse)]
+    (let [entries (rf.schemas/frame-schema-entries :tenant/reuse)]
       (is (= #{[:user]} (set (keys entries)))
           "only the freshly-registered path is present — :orphan did not
            survive the destroy")
@@ -971,8 +971,8 @@
             singular reg-app-schema would produce"
     (rf/reg-app-schemas {[:user] [:map [:id :int]]
                          [:auth] [:string]})
-    (let [m1 (schemas/app-schema-meta-at [:user])
-          m2 (schemas/app-schema-meta-at [:auth])]
+    (let [m1 (rf.schemas/app-schema-meta-at [:user])
+          m2 (rf.schemas/app-schema-meta-at [:auth])]
       (is (= [:map [:id :int]] (:schema m1)))
       (is (= [:string] (:schema m2)))
       (is (= [:user] (:path m1)))

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -27,19 +27,19 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.late-bind]
-            [re-frame.interop :as interop]
-            [re-frame.schemas :as schemas]
+            [re-frame.interop :as rf.interop]
+            [re-frame.schemas :as rf.schemas]
             ;; White-box tests reach raw state through its owning namespace;
             ;; callers outside this artefact use the encapsulated facade.
-            [re-frame.schemas.validator :as validator]
-            [re-frame.schemas.storage :as storage]
+            [re-frame.schemas.validator :as rf.schemas.validator]
+            [re-frame.schemas.storage :as rf.schemas.storage]
             ;; Reuse the shared empty-set digest fixture.
-            [re-frame.schemas.digest-parity-fixtures :as digest-fixtures]
-            [re-frame.schemas.test-fixture :as tf]
-            [re-frame.spec :as spec]
+            [re-frame.schemas.digest-parity-fixtures :as rf.schemas.digest-parity-fixtures]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
+            [re-frame.spec :as rf.spec]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 ;; ---- elision toggle -------------------------------------------------------
 
@@ -49,8 +49,8 @@
     (with-trace-recorder! [traces]
       ;; Dev mode is the JVM default; validate-app-schema! should walk the
       ;; registered schemas and emit on a malformed value.
-      (with-redefs [interop/debug-enabled? true]
-        (schemas/validate-app-schema! {:count "not-an-int"} :test/handler))
+      (with-redefs [rf.interop/debug-enabled? true]
+        (rf.schemas/validate-app-schema! {:count "not-an-int"} :test/handler))
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -68,8 +68,8 @@
     (with-trace-recorder! [traces]
       ;; Production mode — the validation site elides; even with a
       ;; malformed value, no trace fires.
-      (with-redefs [interop/debug-enabled? false]
-        (schemas/validate-app-schema! {:count "not-an-int"} :test/handler))
+      (with-redefs [rf.interop/debug-enabled? false]
+        (rf.schemas/validate-app-schema! {:count "not-an-int"} :test/handler))
       (is (empty? (filter #(= :rf.error/schema-validation-failure
                               (:operation %))
                           @traces))
@@ -79,8 +79,8 @@
   (testing "validate-app-schema! with a conforming value emits no trace"
     (rf/reg-app-schema [:count] [:int])
     (with-trace-recorder! [traces]
-      (with-redefs [interop/debug-enabled? true]
-        (schemas/validate-app-schema! {:count 42} :test/handler))
+      (with-redefs [rf.interop/debug-enabled? true]
+        (rf.schemas/validate-app-schema! {:count 42} :test/handler))
       (is (empty? (filter #(= :rf.error/schema-validation-failure
                               (:operation %))
                           @traces))
@@ -188,17 +188,17 @@
             no validator), false on any failure. The router consumes this
             to decide candidate rejection (rf2-uhk9ko)."
     (rf/reg-app-schema [:n] [:int])
-    (with-redefs [interop/debug-enabled? true]
-      (is (true?  (schemas/validate-app-schema! {:n 42}))
+    (with-redefs [rf.interop/debug-enabled? true]
+      (is (true?  (rf.schemas/validate-app-schema! {:n 42}))
           "conforming value returns true")
-      (is (false? (schemas/validate-app-schema! {:n "boom"}))
+      (is (false? (rf.schemas/validate-app-schema! {:n "boom"}))
           "non-conforming value returns false")
-      (is (true?  (schemas/validate-app-schema! {:n 42} :some/handler))
+      (is (true?  (rf.schemas/validate-app-schema! {:n 42} :some/handler))
           "conforming + event-id arity returns true")
-      (is (false? (schemas/validate-app-schema! {:n "boom"} :some/handler))
+      (is (false? (rf.schemas/validate-app-schema! {:n "boom"} :some/handler))
           "non-conforming + event-id arity returns false"))
-    (with-redefs [interop/debug-enabled? false]
-      (is (true? (schemas/validate-app-schema! {:n "boom"} :some/handler))
+    (with-redefs [rf.interop/debug-enabled? false]
+      (is (true? (rf.schemas/validate-app-schema! {:n "boom"} :some/handler))
           "production mode (debug-enabled? false) returns true unconditionally"))))
 
 ;; ---- rf2-jwm4 — event-payload validation ---------------------------------
@@ -275,7 +275,7 @@
         {:schema [:cat [:= :user/strict] :int]}
         (fn [{:keys [db]} _] (swap! calls inc) {:db db}))
       (with-trace-recorder! [traces]
-        (with-redefs [interop/debug-enabled? false]
+        (with-redefs [rf.interop/debug-enabled? false]
           (rf/dispatch-sync [:user/strict "not-an-int"]))
         (is (empty? (filter #(= :rf.error/schema-validation-failure
                                 (:operation %))
@@ -515,7 +515,7 @@
         (fn [_ _]
           {:fx [[:strict/fx {:x "not-an-int"}]]}))
       (with-trace-recorder! [traces]
-        (with-redefs [interop/debug-enabled? false]
+        (with-redefs [rf.interop/debug-enabled? false]
           (rf/dispatch-sync [:strict/trigger]))
         (is (empty? (filter #(= :rf.error/schema-validation-failure
                                 (:operation %))
@@ -529,11 +529,11 @@
             :where :fx-args trace with the locked tag shape"
     (with-trace-recorder! [traces]
       ;; Direct call — exercises the validate-fx! fn itself, not the integration.
-      (is (true? (schemas/validate-fx! :my/fx :ev/origin {:x 1} {:schema [:map [:x :int]]}))
+      (is (true? (rf.schemas/validate-fx! :my/fx :ev/origin {:x 1} {:schema [:map [:x :int]]}))
           "well-typed args pass")
-      (is (false? (schemas/validate-fx! :my/fx :ev/origin {:x "bad"} {:schema [:map [:x :int]]}))
+      (is (false? (rf.schemas/validate-fx! :my/fx :ev/origin {:x "bad"} {:schema [:map [:x :int]]}))
           "malformed args fail")
-      (is (true? (schemas/validate-fx! :my/fx :ev/origin {:x 1} {}))
+      (is (true? (rf.schemas/validate-fx! :my/fx :ev/origin {:x 1} {}))
           "no :schema → soft pass")
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
@@ -654,13 +654,13 @@
             fail, true on the no-:schema soft-pass arm; emits the
             canonical :where :event trace with the locked tag shape"
     (with-trace-recorder! [traces]
-      (is (true? (schemas/validate-event! :user/strict [:user/strict 7]
+      (is (true? (rf.schemas/validate-event! :user/strict [:user/strict 7]
                                           {:schema [:cat [:= :user/strict] :int]}))
           "well-typed event vector passes")
-      (is (false? (schemas/validate-event! :user/strict [:user/strict "bad"]
+      (is (false? (rf.schemas/validate-event! :user/strict [:user/strict "bad"]
                                            {:schema [:cat [:= :user/strict] :int]}))
           "malformed event vector fails")
-      (is (true? (schemas/validate-event! :user/strict [:user/strict "bad"] {}))
+      (is (true? (rf.schemas/validate-event! :user/strict [:user/strict "bad"] {}))
           "no :schema on meta → soft pass (validate.cljc:250 true arm)")
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
@@ -688,13 +688,13 @@
             fail, true on the no-:schema soft-pass arm; emits the
             canonical :where :sub-return trace with the locked tag shape"
     (with-trace-recorder! [traces]
-      (is (true? (schemas/validate-sub! :items [:items] ["a" "b"]
+      (is (true? (rf.schemas/validate-sub! :items [:items] ["a" "b"]
                                         {:schema [:vector :string]}))
           "well-typed sub return passes")
-      (is (false? (schemas/validate-sub! :items [:items] [1 2]
+      (is (false? (rf.schemas/validate-sub! :items [:items] [1 2]
                                          {:schema [:vector :string]}))
           "malformed sub return fails")
-      (is (true? (schemas/validate-sub! :items [:items] [1 2] {}))
+      (is (true? (rf.schemas/validate-sub! :items [:items] [1 2] {}))
           "no :schema on meta → soft pass (validate.cljc:250 true arm)")
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
@@ -722,8 +722,8 @@
   (testing "rf2-rbbmt — validate-sub! is a no-op (returns true, emits
             nothing) when debug-enabled? is false (production)"
     (with-trace-recorder! [traces]
-      (with-redefs [interop/debug-enabled? false]
-        (is (true? (schemas/validate-sub! :items [:items] [1 2]
+      (with-redefs [rf.interop/debug-enabled? false]
+        (is (true? (rf.schemas/validate-sub! :items [:items] [1 2]
                                           {:schema [:vector :string]}))
             "production gate returns true unconditionally — even on a
              value that would fail in dev"))
@@ -742,7 +742,7 @@
       ;; Sensitivity is now path-marked on the schema slot (the handler/
       ;; fx-meta `:sensitive?` annotation has been removed); a `:sensitive?
       ;; true` prop on the failing slot's schema drives redaction.
-      (is (false? (schemas/validate-fx! :my/secret
+      (is (false? (rf.schemas/validate-fx! :my/secret
                                         :ev/origin
                                         {:token 42}
                                         {:schema [:map [:token {:sensitive? true} :string]]})))
@@ -772,7 +772,7 @@
             the four siblings"
     (let [resolved (re-frame.late-bind/get-fn :schemas/validate-fx!)]
       (is (some? resolved) "hook resolves to a fn when schemas is loaded")
-      (is (= schemas/validate-fx! resolved) "hook points at the public fn"))))
+      (is (= rf.schemas/validate-fx! resolved) "hook points at the public fn"))))
 
 ;; ---- error projector → :rf/public-error mapping --------------------------
 
@@ -890,13 +890,13 @@
             registers against (current-frame), which is :rf/default outside
             (with-frame ...)."
     (rf/reg-app-schema [:user] [:map [:id :uuid]])
-    (is (= [:map [:id :uuid]] (schemas/app-schema-at [:user]))
+    (is (= [:map [:id :uuid]] (rf.schemas/app-schema-at [:user]))
         "schema is visible from the active frame's lookup")
-    (is (= [:map [:id :uuid]] (schemas/app-schema-at [:user] :rf/default))
+    (is (= [:map [:id :uuid]] (rf.schemas/app-schema-at [:user] :rf/default))
         "schema is visible from explicit :rf/default lookup")
-    (is (= {[:user] [:map [:id :uuid]]} (schemas/app-schemas))
+    (is (= {[:user] [:map [:id :uuid]]} (rf.schemas/app-schemas))
         "app-schemas returns the active frame's schema set")
-    (is (= {[:user] [:map [:id :uuid]]} (schemas/app-schemas :rf/default))
+    (is (= {[:user] [:map [:id :uuid]]} (rf.schemas/app-schemas :rf/default))
         "app-schemas with explicit :rf/default returns the same map")))
 
 (deftest reg-app-schema-explicit-frame-opt-isolates-schemas
@@ -905,12 +905,12 @@
     (rf/make-frame {:id :test/story})
     (rf/reg-app-schema [:user] {:frame :rf/default} [:map [:id :uuid]])
     (rf/reg-app-schema [:user] {:frame :test/story} [:map [:nick :string]])
-    (is (= [:map [:id :uuid]]   (schemas/app-schema-at [:user] :rf/default))
+    (is (= [:map [:id :uuid]]   (rf.schemas/app-schema-at [:user] :rf/default))
         "default frame keeps its own schema at [:user]")
-    (is (= [:map [:nick :string]] (schemas/app-schema-at [:user] :test/story))
+    (is (= [:map [:nick :string]] (rf.schemas/app-schema-at [:user] :test/story))
         "story frame has its own (different) schema at [:user]")
-    (is (= {[:user] [:map [:id :uuid]]}     (schemas/app-schemas :rf/default)))
-    (is (= {[:user] [:map [:nick :string]]} (schemas/app-schemas {:frame :test/story})))))
+    (is (= {[:user] [:map [:id :uuid]]}     (rf.schemas/app-schemas :rf/default)))
+    (is (= {[:user] [:map [:nick :string]]} (rf.schemas/app-schemas {:frame :test/story})))))
 
 (deftest sibling-frame-schemas-do-not-fire-on-each-others-dispatches
   (testing "Per Spec 010 §Per-frame schemas — validate-app-schema! only walks the
@@ -948,8 +948,8 @@
             (app-schemas {:frame frame-id}); both must return the same map."
     (rf/make-frame {:id :test/k})
     (rf/reg-app-schema [:k] {:frame :test/k} [:int])
-    (is (= (schemas/app-schemas :test/k)
-           (schemas/app-schemas {:frame :test/k}))
+    (is (= (rf.schemas/app-schemas :test/k)
+           (rf.schemas/app-schemas {:frame :test/k}))
         "keyword form == opts-map form")))
 
 ;; ---- rf2-0z1z — app-schemas-digest --------------------------------------
@@ -958,7 +958,7 @@
   (testing "Per Spec 010 §Digest algorithm — the digest is the literal
             prefix \"sha256:\" followed by 16 lowercase hex characters."
     (rf/reg-app-schema [:user] [:map [:id :uuid]])
-    (let [d (schemas/app-schemas-digest)]
+    (let [d (rf.schemas/app-schemas-digest)]
       (is (string? d))
       (is (re-matches #"sha256:[0-9a-f]{16}" d)
           "digest is exactly \"sha256:\" + 16 lowercase hex chars"))))
@@ -968,21 +968,21 @@
             set produces the same digest (cross-runtime byte-stable)."
     (rf/reg-app-schema [:user]  [:map [:id :uuid]])
     (rf/reg-app-schema [:todos] [:vector :string])
-    (let [d1 (schemas/app-schemas-digest)]
+    (let [d1 (rf.schemas/app-schemas-digest)]
       ;; Re-register the SAME schemas — last-write-wins, but the map is
       ;; structurally identical, so the digest must not move.
       (rf/reg-app-schema [:todos] [:vector :string])
       (rf/reg-app-schema [:user]  [:map [:id :uuid]])
-      (is (= d1 (schemas/app-schemas-digest))
+      (is (= d1 (rf.schemas/app-schemas-digest))
           "byte-identical schema set → byte-identical digest"))))
 
 (deftest app-schemas-digest-changes-on-schema-change
   (testing "A schema-set change perturbs the digest. Two different schema
             sets must produce distinct digests."
     (rf/reg-app-schema [:user] [:map [:id :uuid]])
-    (let [before (schemas/app-schemas-digest)]
+    (let [before (rf.schemas/app-schemas-digest)]
       (rf/reg-app-schema [:user] [:map [:id :string]])
-      (is (not= before (schemas/app-schemas-digest))
+      (is (not= before (rf.schemas/app-schemas-digest))
           "tightening / changing a schema flips the digest"))))
 
 (deftest app-schemas-digest-frame-isolated
@@ -994,13 +994,13 @@
     (rf/make-frame {:id :test/b})
     (rf/reg-app-schema [:user] {:frame :test/a} [:map [:id :uuid]])
     ;; :test/b has no schemas registered.
-    (let [da (schemas/app-schemas-digest :test/a)
-          db (schemas/app-schemas-digest :test/b)]
+    (let [da (rf.schemas/app-schemas-digest :test/a)
+          db (rf.schemas/app-schemas-digest :test/b)]
       (is (not= da db)
           "frames with different schema sets have different digests")
-      (is (= db (schemas/app-schemas-digest :test/b))
+      (is (= db (rf.schemas/app-schemas-digest :test/b))
           "the empty-schema digest is stable across calls")
-      (is (= db (schemas/app-schemas-digest {:frame :test/b}))
+      (is (= db (rf.schemas/app-schemas-digest {:frame :test/b}))
           "keyword-sugar arity equals opts-map arity"))))
 
 (deftest app-schemas-digest-keyword-and-opts-arities-agree
@@ -1009,8 +1009,8 @@
             same string."
     (rf/make-frame {:id :test/d})
     (rf/reg-app-schema [:k] {:frame :test/d} [:int])
-    (is (= (schemas/app-schemas-digest :test/d)
-           (schemas/app-schemas-digest {:frame :test/d}))
+    (is (= (rf.schemas/app-schemas-digest :test/d)
+           (rf.schemas/app-schemas-digest {:frame :test/d}))
         "keyword form == opts-map form")))
 
 (deftest app-schemas-digest-empty-set-is-defined
@@ -1018,13 +1018,13 @@
             the empty string, prefixed). Hosts with no schemas registered
             still get a usable digest, not nil."
     (rf/make-frame {:id :test/empty})
-    (let [d (schemas/app-schemas-digest :test/empty)]
+    (let [d (rf.schemas/app-schemas-digest :test/empty)]
       (is (string? d))
       (is (re-matches #"sha256:[0-9a-f]{16}" d))
       ;; rf2-rbbmt dedup D3 — the empty-set digest literal is single-
       ;; sourced from the parity fixtures (the namespace's own docstring
       ;; declares it the source of truth) rather than re-pinned here.
-      (is (= (:expected digest-fixtures/empty-set) d)
+      (is (= (:expected rf.schemas.digest-parity-fixtures/empty-set) d)
           "empty schema set hashes the empty concatenation per Spec 010"))))
 
 (deftest app-schemas-digest-independent-of-registration-order
@@ -1038,8 +1038,8 @@
     (rf/reg-app-schema [:todos] {:frame :test/o1} [:vector :string])
     (rf/reg-app-schema [:todos] {:frame :test/o2} [:vector :string])
     (rf/reg-app-schema [:user]  {:frame :test/o2} [:map [:id :uuid]])
-    (is (= (schemas/app-schemas-digest :test/o1)
-           (schemas/app-schemas-digest :test/o2))
+    (is (= (rf.schemas/app-schemas-digest :test/o1)
+           (rf.schemas/app-schemas-digest :test/o2))
         "same schema set, different registration order → same digest")))
 
 ;; ---- rf2-froe — set-schema-validator! seam -------------------------------
@@ -1059,7 +1059,7 @@
     (with-trace-recorder! [traces]
       ;; Malformed value triggers the default Malli validate to return
       ;; falsey -> trace fires.
-      (schemas/validate-app-schema! {:n "not-an-int"} :test/handler)
+      (rf.schemas/validate-app-schema! {:n "not-an-int"} :test/handler)
       (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces)]
         (is (= 1 (count violations))
@@ -1076,11 +1076,11 @@
           custom (fn [schema value]
                    (swap! calls conj [schema value])
                    (not (and (string? value) (str/includes? value "bad"))))]
-      (schemas/set-schema-validator! custom)
+      (rf.schemas/set-schema-validator! custom)
       (rf/reg-app-schema [:label] :string)
       (with-trace-recorder! [traces]
-        (schemas/validate-app-schema! {:label "hello"} :h/ok)        ;; passes
-        (schemas/validate-app-schema! {:label "totally-bad"} :h/no)  ;; fails
+        (rf.schemas/validate-app-schema! {:label "hello"} :h/ok)        ;; passes
+        (rf.schemas/validate-app-schema! {:label "totally-bad"} :h/no)  ;; fails
         (is (= 2 (count @calls))
             "custom validator was invoked for both validation calls")
         (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
@@ -1096,20 +1096,20 @@
             walker return true without inspecting the schema, and no
             trace fires. Parameterised over the surfaces that previously
             duplicated the no-op assertion as separate deftests."
-    (schemas/set-schema-validator! nil)
+    (rf.schemas/set-schema-validator! nil)
     (with-trace-recorder! [traces]
       (rf/reg-app-schema [:n] [:int])
       ;; Each malformed value would fire a trace under the default
       ;; (Malli) validator; with nil installed every call short-circuits
       ;; to true and emits nothing.
-      (is (true? (schemas/validate-app-schema! {:n "bad"} :test/h))
+      (is (true? (rf.schemas/validate-app-schema! {:n "bad"} :test/h))
           "app-db walk: nil validator → true, no trace")
-      (is (true? (schemas/validate-event! :ev/x [:ev/x "bad"]
+      (is (true? (rf.schemas/validate-event! :ev/x [:ev/x "bad"]
                                           {:schema [:cat [:= :ev/x] :int]}))
           "event: nil validator → true")
-      (is (true? (schemas/validate-sub! :sub/x [:sub/x] [1] {:schema [:vector :string]}))
+      (is (true? (rf.schemas/validate-sub! :sub/x [:sub/x] [1] {:schema [:vector :string]}))
           "sub-return: nil validator → true")
-      (is (true? (schemas/validate-fx! :fx/x :ev/o {:x "bad"} {:schema [:map [:x :int]]}))
+      (is (true? (rf.schemas/validate-fx! :fx/x :ev/o {:x "bad"} {:schema [:map [:x :int]]}))
           "fx-args: nil validator → true")
       (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
                           @traces))
@@ -1120,7 +1120,7 @@
             also holds through a live dispatch: the handler runs even on
             a payload that would fail the registered :schema, and no
             pre-handler validation trace fires."
-    (schemas/set-schema-validator! nil)
+    (rf.schemas/set-schema-validator! nil)
     (let [calls (atom 0)]
       (rf/reg-event :user/strict
         {:schema [:cat [:= :user/strict] :int]}
@@ -1142,11 +1142,11 @@
           explain-calls  (atom 0)
           v-fn (fn [_s v] (swap! validate-calls inc) (= v :good))
           e-fn (fn [s v]  (swap! explain-calls inc) {:my-explanation [s v]})]
-      (schemas/set-schema-fns! {:validate v-fn :explain e-fn})
+      (rf.schemas/set-schema-fns! {:validate v-fn :explain e-fn})
       (rf/reg-app-schema [:k] :keyword)
       (with-trace-recorder! [traces]
-        (schemas/validate-app-schema! {:k :good}   :h/pass)
-        (schemas/validate-app-schema! {:k :nope}   :h/fail)
+        (rf.schemas/validate-app-schema! {:k :good}   :h/pass)
+        (rf.schemas/validate-app-schema! {:k :nope}   :h/fail)
         (is (= 2 @validate-calls) "custom validate fn ran for both calls")
         (is (= 1 @explain-calls)  "custom explain fn ran only on the failure path")
         (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
@@ -1164,11 +1164,11 @@
     (let [v-fn (fn [_ _] true)
           e-fn (fn [_ _] {:explained true})
           p-fn (fn [_] "::BUNDLE-PRINTER::")]
-      (schemas/set-schema-fns! {:validate v-fn :explain e-fn :print p-fn})
-      (is (= v-fn @validator/validator-fn) "validator installed")
-      (is (= e-fn @validator/explainer-fn) "explainer installed")
-      (is (= p-fn @validator/printer-fn)   "printer installed")
-      (is (= "::BUNDLE-PRINTER::" (validator/run-printer :int))
+      (rf.schemas/set-schema-fns! {:validate v-fn :explain e-fn :print p-fn})
+      (is (= v-fn @rf.schemas.validator/validator-fn) "validator installed")
+      (is (= e-fn @rf.schemas.validator/explainer-fn) "explainer installed")
+      (is (= p-fn @rf.schemas.validator/printer-fn)   "printer installed")
+      (is (= "::BUNDLE-PRINTER::" (rf.schemas.validator/run-printer :int))
           "printer reaches the hot path"))))
 
 (deftest set-schema-validator-is-honest-validator-only
@@ -1177,14 +1177,14 @@
             gone: passing a map installs that literal map AS the validator
             fn-value (a single-purpose setter), it does NOT bundle-install.
             The explainer/printer are left at their defaults."
-    (let [default-explainer @validator/explainer-fn
-          default-printer   @validator/printer-fn
+    (let [default-explainer @rf.schemas.validator/explainer-fn
+          default-printer   @rf.schemas.validator/printer-fn
           v-fn (fn [_ _] true)]
-      (schemas/set-schema-validator! v-fn)
-      (is (= v-fn @validator/validator-fn) "validator installed")
-      (is (= default-explainer @validator/explainer-fn)
+      (rf.schemas/set-schema-validator! v-fn)
+      (is (= v-fn @rf.schemas.validator/validator-fn) "validator installed")
+      (is (= default-explainer @rf.schemas.validator/explainer-fn)
           "explainer untouched — set-schema-validator! does not touch it")
-      (is (= default-printer @validator/printer-fn)
+      (is (= default-printer @rf.schemas.validator/printer-fn)
           "printer untouched — set-schema-validator! does not touch it"))))
 
 (deftest set-schema-explainer-only-leaves-validator-untouched
@@ -1194,10 +1194,10 @@
           custom-e  (fn [_s v] (reset! explained v) {:custom-said v})]
       ;; Validator stays at its default (Malli); only the explainer is
       ;; substituted.
-      (schemas/set-schema-explainer! custom-e)
+      (rf.schemas/set-schema-explainer! custom-e)
       (rf/reg-app-schema [:n] [:int])
       (with-trace-recorder! [traces]
-        (schemas/validate-app-schema! {:n "broken"} :h/oops)
+        (rf.schemas/validate-app-schema! {:n "broken"} :h/oops)
         (is (= "broken" @explained) "custom explainer ran with the bad value")
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
@@ -1218,18 +1218,18 @@
     ;; Custom validator that fails everything; explainer nilled. The
     ;; default Malli explainer is replaced by nil so the failure branch
     ;; threads `nil` through `:explain` rather than a Malli explanation.
-    (schemas/set-schema-validator! (fn [_ _] false))
-    (schemas/set-schema-explainer! nil)
+    (rf.schemas/set-schema-validator! (fn [_ _] false))
+    (rf.schemas/set-schema-explainer! nil)
     (rf/reg-app-schema [:n] [:int])
     (with-trace-recorder! [traces]
       ;; app-db walk emit site.
-      (is (false? (schemas/validate-app-schema! {:n "bad"} :h/app-db)))
+      (is (false? (rf.schemas/validate-app-schema! {:n "bad"} :h/app-db)))
       ;; the three meta-bearing emit sites (run-validation core).
-      (is (false? (schemas/validate-event! :ev/x [:ev/x "bad"]
+      (is (false? (rf.schemas/validate-event! :ev/x [:ev/x "bad"]
                                            {:schema [:cat [:= :ev/x] :int]})))
-      (is (false? (schemas/validate-sub! :sub/x [:sub/x] [1]
+      (is (false? (rf.schemas/validate-sub! :sub/x [:sub/x] [1]
                                          {:schema [:vector :string]})))
-      (is (false? (schemas/validate-fx! :fx/x :ev/o {:x "bad"}
+      (is (false? (rf.schemas/validate-fx! :fx/x :ev/o {:x "bad"}
                                         {:schema [:map [:x :int]]})))
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
@@ -1249,18 +1249,18 @@
             resumes."
     ;; Install a sabotage validator: passes everything (so a known-bad
     ;; value would slip past).
-    (schemas/set-schema-validator! (fn [_ _] true))
+    (rf.schemas/set-schema-validator! (fn [_ _] true))
     (rf/reg-app-schema [:n] [:int])
     ;; First confirm the sabotage is in effect.
     (with-trace-recorder! [traces]
-      (schemas/validate-app-schema! {:n "bad"} :h/sabotage)
+      (rf.schemas/validate-app-schema! {:n "bad"} :h/sabotage)
       (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
                           @traces))
           "sabotage validator passes everything — no trace"))
     ;; Reset back to default Malli, retry the bad value, expect a trace.
-    (schemas/reset-schema-validator!)
+    (rf.schemas/reset-schema-validator!)
     (with-trace-recorder! [traces]
-      (schemas/validate-app-schema! {:n "bad"} :h/back-to-default)
+      (rf.schemas/validate-app-schema! {:n "bad"} :h/back-to-default)
       (is (= 1 (count (filter #(= :rf.error/schema-validation-failure (:operation %))
                               @traces)))
           "default Malli validator is back in place — bad value catches"))))
@@ -1271,19 +1271,19 @@
             does NOT consult interop/debug-enabled? (the boundary
             interceptor runs in production by design); it routes through
             the registered validator the same way the dev hot path does."
-    (schemas/set-schema-validator! (fn [_ v] (= v :good)))
-    (with-redefs [interop/debug-enabled? false]
-      (is (true?  (schemas/validate-with-registered-fn :keyword :good))
+    (rf.schemas/set-schema-validator! (fn [_ v] (= v :good)))
+    (with-redefs [rf.interop/debug-enabled? false]
+      (is (true?  (rf.schemas/validate-with-registered-fn :keyword :good))
           "valid value passes — debug gate ignored")
-      (is (false? (schemas/validate-with-registered-fn :keyword :bad))
+      (is (false? (rf.schemas/validate-with-registered-fn :keyword :bad))
           "invalid value fails — debug gate ignored"))))
 
 (deftest validator-set-via-public-api-is-visible-on-schemas-ns
   (testing "The public re-export rf/set-schema-validator! flows through to
             the schemas namespace's validator-fn atom."
     (let [my-fn (fn [_ _] :sentinel)]
-      (schemas/set-schema-validator! my-fn)
-      (is (= my-fn @validator/validator-fn)
+      (rf.schemas/set-schema-validator! my-fn)
+      (is (= my-fn @rf.schemas.validator/validator-fn)
           "the atom carries the fn the user registered"))))
 
 ;; ---- rf2-pk8ur — set-schema-printer! public-surface contract -------------
@@ -1308,10 +1308,10 @@
             printer-fn atom. Parallels the rf/set-schema-validator! /
             rf/set-schema-explainer! end-to-end pins above."
     (let [my-fn (fn [_schema-value] "::PUBLIC-SURFACE::")]
-      (schemas/set-schema-printer! my-fn)
-      (is (= my-fn @validator/printer-fn)
+      (rf.schemas/set-schema-printer! my-fn)
+      (is (= my-fn @rf.schemas.validator/printer-fn)
           "the atom carries the printer the public-surface caller registered")
-      (is (= "::PUBLIC-SURFACE::" (validator/run-printer :int))
+      (is (= "::PUBLIC-SURFACE::" (rf.schemas.validator/run-printer :int))
           "run-printer's hot path reaches the public-surface registration"))))
 
 (deftest printer-set-via-public-api-flips-digest-bytes
@@ -1324,9 +1324,9 @@
             different schema languages produce different digests by
             construction'."
     (rf/reg-app-schema [:n] :int)
-    (let [default-digest (schemas/app-schemas-digest)]
-      (schemas/set-schema-printer! (fn [_] "::CUSTOM-PORT::"))
-      (let [custom-digest (schemas/app-schemas-digest)]
+    (let [default-digest (rf.schemas/app-schemas-digest)]
+      (rf.schemas/set-schema-printer! (fn [_] "::CUSTOM-PORT::"))
+      (let [custom-digest (rf.schemas/app-schemas-digest)]
         (is (re-matches #"^sha256:[0-9a-f]{16}$" custom-digest)
             "digest is still the wire-form '\"sha256:\" + 16-hex'")
         (is (not= default-digest custom-digest)
@@ -1341,10 +1341,10 @@
             port-specific printer has been registered and then
             withdrawn. Mirrors the artefact-side `set-schema-printer!-
             nil-falls-back-to-default` test on the public symbol."
-    (schemas/set-schema-printer! (fn [_] "::TRANSIENT::"))
-    (is (= "::TRANSIENT::" (validator/run-printer :int)))
-    (schemas/set-schema-printer! nil)
-    (is (= ":int" (validator/run-printer :int))
+    (rf.schemas/set-schema-printer! (fn [_] "::TRANSIENT::"))
+    (is (= "::TRANSIENT::" (rf.schemas.validator/run-printer :int)))
+    (rf.schemas/set-schema-printer! nil)
+    (is (= ":int" (rf.schemas.validator/run-printer :int))
         "nil through the public surface falls back to default-edn-print")))
 
 (deftest printer-set-via-public-set-schema-fns-installs-printer
@@ -1355,11 +1355,11 @@
     (let [v-fn (fn [_ _] true)
           e-fn (fn [_ _] {:explained true})
           p-fn (fn [_] "::FROM-PUBLIC-BUNDLE::")]
-      (schemas/set-schema-fns! {:validate v-fn :explain e-fn :print p-fn})
-      (is (= v-fn @validator/validator-fn))
-      (is (= e-fn @validator/explainer-fn))
-      (is (= p-fn @validator/printer-fn))
-      (is (= "::FROM-PUBLIC-BUNDLE::" (validator/run-printer :int))
+      (rf.schemas/set-schema-fns! {:validate v-fn :explain e-fn :print p-fn})
+      (is (= v-fn @rf.schemas.validator/validator-fn))
+      (is (= e-fn @rf.schemas.validator/explainer-fn))
+      (is (= p-fn @rf.schemas.validator/printer-fn))
+      (is (= "::FROM-PUBLIC-BUNDLE::" (rf.schemas.validator/run-printer :int))
           "the printer installed via the bundle setter reaches the hot path"))))
 
 ;; ---- rf2-l4ljvr — bundle snapshot / restore ------------------------------
@@ -1379,8 +1379,8 @@
     (let [v-fn (fn [_ _] true)
           e-fn (fn [_ _] {:explained true})
           p-fn (fn [_] "::SNAPSHOT-ME::")]
-      (schemas/set-schema-fns! {:validate v-fn :explain e-fn :print p-fn})
-      (let [snap (schemas/snapshot-schema-fns)]
+      (rf.schemas/set-schema-fns! {:validate v-fn :explain e-fn :print p-fn})
+      (let [snap (rf.schemas/snapshot-schema-fns)]
         (is (= #{:validate :explain :print} (set (keys snap)))
             "snapshot is the {:validate :explain :print} bundle shape")
         (is (= v-fn (:validate snap)) "captures the live validator")
@@ -1396,20 +1396,20 @@
           e1 (fn [_ _] {:reason :first})
           p1 (fn [_] "::FIRST::")]
       ;; Install bundle 1 and snapshot it.
-      (schemas/set-schema-fns! {:validate v1 :explain e1 :print p1})
-      (let [snap (schemas/snapshot-schema-fns)]
+      (rf.schemas/set-schema-fns! {:validate v1 :explain e1 :print p1})
+      (let [snap (rf.schemas/snapshot-schema-fns)]
         ;; Mutate to a completely different bundle.
-        (schemas/set-schema-fns! {:validate (fn [_ _] false)
+        (rf.schemas/set-schema-fns! {:validate (fn [_ _] false)
                              :explain  (fn [_ _] {:reason :second})
                              :print    (fn [_] "::SECOND::")})
-        (is (= "::SECOND::" (validator/run-printer :int))
+        (is (= "::SECOND::" (rf.schemas.validator/run-printer :int))
             "mid-state: the second bundle is live")
         ;; Restore bundle 1.
-        (let [ret (schemas/restore-schema-fns! snap)]
-          (is (= v1 @validator/validator-fn) "validator restored")
-          (is (= e1 @validator/explainer-fn) "explainer restored")
-          (is (= p1 @validator/printer-fn)   "printer restored")
-          (is (= "::FIRST::" (validator/run-printer :int))
+        (let [ret (rf.schemas/restore-schema-fns! snap)]
+          (is (= v1 @rf.schemas.validator/validator-fn) "validator restored")
+          (is (= e1 @rf.schemas.validator/explainer-fn) "explainer restored")
+          (is (= p1 @rf.schemas.validator/printer-fn)   "printer restored")
+          (is (= "::FIRST::" (rf.schemas.validator/run-printer :int))
               "run-printer's hot path observes the restored printer")
           (is (= snap ret)
               "restore-schema-fns! returns the installed bundle (set-schema-fns! return)"))))))
@@ -1420,12 +1420,12 @@
             invariant run-printer relies on), exactly like set-schema-fns!"
     ;; A hand-built bundle with an explicit nil :print (snapshot-schema-fns
     ;; never produces nil :print, but the restore path must stay safe).
-    (schemas/restore-schema-fns! {:validate (fn [_ _] true)
+    (rf.schemas/restore-schema-fns! {:validate (fn [_ _] true)
                              :explain  nil
                              :print    nil})
-    (is (some? @validator/printer-fn)
+    (is (some? @rf.schemas.validator/printer-fn)
         "printer-fn is never nil after restore — coerced to the default")
-    (is (= ":int" (validator/run-printer :int))
+    (is (= ":int" (rf.schemas.validator/run-printer :int))
         "run-printer reaches the default EDN canonicaliser, no read-site guard")))
 
 (deftest snapshot-restore-bundle-composes-with-registry-pair
@@ -1436,23 +1436,23 @@
     (let [v-fn (fn [_ _] true)
           p-fn (fn [_] "::COMPOSED::")]
       ;; Establish a known runtime: a custom bundle + a registered schema.
-      (schemas/set-schema-fns! {:validate v-fn :print p-fn})
+      (rf.schemas/set-schema-fns! {:validate v-fn :print p-fn})
       (rf/reg-app-schema [:n] [:int])
       ;; Capture BOTH the bundle and the registry.
-      (let [bundle-snap   (schemas/snapshot-schema-fns)
-            registry-snap (schemas/snapshot-schemas-by-frame)]
+      (let [bundle-snap   (rf.schemas/snapshot-schema-fns)
+            registry-snap (rf.schemas/snapshot-schemas-by-frame)]
         ;; Tear the whole runtime down to a different state.
-        (schemas/reset-schema-validator!)
-        (schemas/clear-schemas-by-frame!)
-        (is (not= v-fn @validator/validator-fn) "bundle was reset away")
-        (is (= {} @storage/schemas-by-frame)  "registry was cleared")
+        (rf.schemas/reset-schema-validator!)
+        (rf.schemas/clear-schemas-by-frame!)
+        (is (not= v-fn @rf.schemas.validator/validator-fn) "bundle was reset away")
+        (is (= {} @rf.schemas.storage/schemas-by-frame)  "registry was cleared")
         ;; Restore BOTH through the encapsulated API.
-        (schemas/restore-schema-fns! bundle-snap)
-        (schemas/restore-schemas-by-frame! registry-snap)
-        (is (= v-fn @validator/validator-fn) "bundle validator restored")
-        (is (= "::COMPOSED::" (validator/run-printer :int))
+        (rf.schemas/restore-schema-fns! bundle-snap)
+        (rf.schemas/restore-schemas-by-frame! registry-snap)
+        (is (= v-fn @rf.schemas.validator/validator-fn) "bundle validator restored")
+        (is (= "::COMPOSED::" (rf.schemas.validator/run-printer :int))
             "bundle printer restored on the hot path")
-        (is (= [:int] (schemas/app-schema-at [:n]))
+        (is (= [:int] (rf.schemas/app-schema-at [:n]))
             "registry schema restored — the two pairs compose")))))
 
 ;; ---- rf2-r2uh — :rf.schema/at-boundary interceptor ---------------------
@@ -1494,7 +1494,7 @@
         ;; and passes for the well-typed payload, so the chain runs
         ;; and the boundary interceptor then validates again — both
         ;; passes silently.
-        (with-redefs [spec/dev-mode? (constantly false)]
+        (with-redefs [rf.spec/dev-mode? (constantly false)]
           (rf/dispatch-sync [:api/response {:status 200 :body "OK"}]))
         (is (= 1 @calls)
             "handler ran exactly once for the well-typed payload")
@@ -1519,7 +1519,7 @@
         (fn [_ [_ payload]]
           (swap! calls inc)
           {:db {:last-response payload}}))
-      (with-redefs [spec/dev-mode? (constantly false)]
+      (with-redefs [rf.spec/dev-mode? (constantly false)]
         (rf/dispatch-sync [:api/response {:status "not-an-int" :body 42}]))
       (is (= 0 @calls)
           "handler was skipped on the malformed payload"))))
@@ -1545,7 +1545,7 @@
       ;; dev-mode? false → boundary takes its prod branch; but
       ;; debug-enabled? stays true on the JVM so emit-error! actually
       ;; fires its body and the trace is observable.
-      (with-redefs [spec/dev-mode? (constantly false)]
+      (with-redefs [rf.spec/dev-mode? (constantly false)]
         (let [before (:before rf/validate-at-boundary-interceptor)]
           (before {:coeffects {:event [:api/strict "not-an-int"]}})))
       (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
@@ -1592,7 +1592,7 @@
     ;; without the dispatch's other moving parts. Production-side path
     ;; (dev-mode? false); the boundary interceptor takes its prod
     ;; branch and validates inline.
-    (with-redefs [spec/dev-mode? (constantly false)]
+    (with-redefs [rf.spec/dev-mode? (constantly false)]
       (let [before    (:before rf/validate-at-boundary-interceptor)
             valid-ctx (before {:coeffects {:event [:api/strict 42]}})
             bad-ctx   (before {:coeffects {:event [:api/strict "not-an-int"]}})]
@@ -1616,12 +1616,12 @@
                    (swap! validator-calls inc)
                    (= value [:api/custom :good]))
           handler-calls (atom 0)]
-      (schemas/set-schema-validator! custom)
+      (rf.schemas/set-schema-validator! custom)
       (rf/reg-event :api/custom
         {:schema :rf/any                     ;; opaque to the custom validator
          :interceptors [:rf.schema/at-boundary]}
         (fn [_ _] (swap! handler-calls inc) {}))
-      (with-redefs [spec/dev-mode? (constantly false)]
+      (with-redefs [rf.spec/dev-mode? (constantly false)]
         ;; Direct :before invocation so we observe the boundary's
         ;; validator call path without the router-side step-1 also
         ;; firing the same custom validator (which would double-count
@@ -1640,14 +1640,14 @@
   (testing "Per Spec 010 §Non-Malli validators — set-schema-validator! nil
             disables every validation surface, including the boundary
             interceptor. The handler runs even with a malformed payload."
-    (schemas/set-schema-validator! nil)
+    (rf.schemas/set-schema-validator! nil)
     (let [calls (atom 0)]
       (rf/reg-event :api/disabled
         {:schema [:cat [:= :api/disabled] :int]
          :interceptors [:rf.schema/at-boundary]}
         (fn [_ _] (swap! calls inc) {}))
       (with-trace-recorder! [traces]
-        (with-redefs [spec/dev-mode? (constantly false)]
+        (with-redefs [rf.spec/dev-mode? (constantly false)]
           (rf/dispatch-sync [:api/disabled "wildly-malformed"]))
         (is (= 1 @calls)
             "handler ran — nil validator means no boundary check")
@@ -1779,7 +1779,7 @@
     (rf/reg-app-schema [:label] {:frame :test.6lka/other} [:string])
 
     ;; 1. Snapshot.
-    (let [snap (schemas/snapshot-schemas-by-frame)]
+    (let [snap (rf.schemas/snapshot-schemas-by-frame)]
       (is (map? snap) "snapshot is a map")
       (is (contains? snap :rf/default)
           "snapshot covers :rf/default")
@@ -1793,20 +1793,20 @@
           "snapshot retains the schema under [:test.6lka/other [:label]]")
 
       ;; 2. Clear.
-      (schemas/clear-schemas-by-frame!)
-      (is (= {} @storage/schemas-by-frame)
+      (rf.schemas/clear-schemas-by-frame!)
+      (is (= {} @rf.schemas.storage/schemas-by-frame)
           "clear-schemas-by-frame! emptied the atom")
 
       ;; 3. Restore.
-      (schemas/restore-schemas-by-frame! snap)
-      (is (= snap @storage/schemas-by-frame)
+      (rf.schemas/restore-schemas-by-frame! snap)
+      (is (= snap @rf.schemas.storage/schemas-by-frame)
           "restore-schemas-by-frame! reproduces the atom byte-for-byte")
 
       ;; 4. Semantic faithfulness: validation against a restored
       ;;    schema fires exactly like it did before the round-trip.
       (with-trace-recorder! [traces]
         ;; A malformed value under [:n] on :rf/default — should fire.
-        (schemas/validate-app-schema! {:n "not-an-int"} :test.6lka/handler)
+        (rf.schemas/validate-app-schema! {:n "not-an-int"} :test.6lka/handler)
         (let [violations (filter #(= :rf.error/schema-validation-failure
                                      (:operation %))
                                  @traces)]
@@ -1819,26 +1819,26 @@
   (testing "clear-schemas-by-frame! drops all per-frame entries"
     (rf/reg-app-schema [:a] [:int])
     (rf/reg-app-schema [:b] [:string])
-    (is (seq @storage/schemas-by-frame)
+    (is (seq @rf.schemas.storage/schemas-by-frame)
         "pre-clear: registry is populated")
-    (schemas/clear-schemas-by-frame!)
-    (is (empty? @storage/schemas-by-frame)
+    (rf.schemas/clear-schemas-by-frame!)
+    (is (empty? @rf.schemas.storage/schemas-by-frame)
         "post-clear: registry is empty")))
 
 (deftest restore-replaces-not-merges
   (testing "restore-schemas-by-frame! REPLACES the atom (does not merge);
             schemas registered after the snapshot disappear on restore"
     ;; Capture an empty snapshot.
-    (let [empty-snap (schemas/snapshot-schemas-by-frame)]
+    (let [empty-snap (rf.schemas/snapshot-schemas-by-frame)]
       (is (= {} empty-snap)
           "fresh atom is empty (make-reset-runtime-fixture cleared it)")
       ;; Now register some schemas.
       (rf/reg-app-schema [:transient] [:int])
-      (is (seq @storage/schemas-by-frame)
+      (is (seq @rf.schemas.storage/schemas-by-frame)
           "post-reg: schemas present")
       ;; Restore to the empty snapshot.
-      (schemas/restore-schemas-by-frame! empty-snap)
-      (is (= {} @storage/schemas-by-frame)
+      (rf.schemas/restore-schemas-by-frame! empty-snap)
+      (is (= {} @rf.schemas.storage/schemas-by-frame)
           "restore replaced the atom — the transient schemas are gone, not merged"))))
 
 ;; ---- rf/reg-app-schemas (plural, rf2-jzs9) -------------------------------
@@ -1850,10 +1850,10 @@
        [:auth :token]           [:string]
        [:cart]                  [:map [:items [:vector :string]]]
        [:cart :items]           [:vector :string]})
-    (is (= [:map [:user :string]]      (schemas/app-schema-at [:auth])))
-    (is (= [:string]                   (schemas/app-schema-at [:auth :token])))
-    (is (= [:map [:items [:vector :string]]] (schemas/app-schema-at [:cart])))
-    (is (= [:vector :string]           (schemas/app-schema-at [:cart :items])))))
+    (is (= [:map [:user :string]]      (rf.schemas/app-schema-at [:auth])))
+    (is (= [:string]                   (rf.schemas/app-schema-at [:auth :token])))
+    (is (= [:map [:items [:vector :string]]] (rf.schemas/app-schema-at [:cart])))
+    (is (= [:vector :string]           (rf.schemas/app-schema-at [:cart :items])))))
 
 (deftest reg-app-schemas-returns-paths-registered
   (testing "rf/reg-app-schemas returns the vector of paths"
@@ -1873,17 +1873,17 @@
        [:cart] [:map [:items :any]]}
       {:frame :tenant/a})
     (is (= [:map [:user :string]]
-           (schemas/app-schema-at [:auth] {:frame :tenant/a})))
+           (rf.schemas/app-schema-at [:auth] {:frame :tenant/a})))
     (is (= [:map [:items :any]]
-           (schemas/app-schema-at [:cart] {:frame :tenant/a})))
-    (is (nil? (schemas/app-schema-at [:auth]))
+           (rf.schemas/app-schema-at [:cart] {:frame :tenant/a})))
+    (is (nil? (rf.schemas/app-schema-at [:auth]))
         "the default frame did NOT receive any of the entries")))
 
 (deftest reg-app-schemas-empty-map-no-op
   (testing "rf/reg-app-schemas on an empty map is a no-op and returns an empty vector"
     (let [paths (rf/reg-app-schemas {})]
       (is (= [] paths))
-      (is (= {} (schemas/app-schemas))
+      (is (= {} (rf.schemas/app-schemas))
           "no schemas registered on the active frame"))))
 
 ;; ---- rf2-naihn1 #2 — bulk-input false-green --------------------------------
@@ -1908,13 +1908,13 @@
   ;; rf2-naihn1 #2 — the load-bearing regression: pre-fix `(reg-app-schemas
   ;; nil)` returned `[]` (false green); post-fix it MUST throw.
   (testing "rf/reg-app-schemas rejects a nil first argument (not a silent no-op)"
-    (let [before @storage/schemas-by-frame]
+    (let [before @rf.schemas.storage/schemas-by-frame]
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo #":rf.error/app-schemas-bad-batch"
             (rf/reg-app-schemas nil))
           (str "nil batch must reject with :rf.error/app-schemas-bad-batch, "
                "not silently no-op to [] (the false-green this bead fixes)"))
-      (is (= before @storage/schemas-by-frame)
+      (is (= before @rf.schemas.storage/schemas-by-frame)
           (str "negative control: a rejected nil batch must NOT mutate the "
                "schema registry (throw fires before any swap!)")))))
 
@@ -1942,12 +1942,12 @@
                  42                          ; a number
                  #{[:a]}]]                   ; a set
       (testing (str "non-map arg " (pr-str bad))
-        (let [before @storage/schemas-by-frame]
+        (let [before @rf.schemas.storage/schemas-by-frame]
           (is (thrown-with-msg?
                 clojure.lang.ExceptionInfo #":rf.error/app-schemas-bad-batch"
                 (rf/reg-app-schemas bad))
               (str (pr-str bad) " must reject as a non-map batch"))
-          (is (= before @storage/schemas-by-frame)
+          (is (= before @rf.schemas.storage/schemas-by-frame)
               (str "negative control: rejected batch " (pr-str bad)
                    " must NOT mutate the schema registry")))))))
 
@@ -1956,7 +1956,7 @@
   ;; empty map is a map, so it passes the new shape gate and returns [].
   (testing "rf/reg-app-schemas {} remains the documented no-op returning []"
     (is (= [] (rf/reg-app-schemas {})))
-    (is (= {} (schemas/app-schemas)))))
+    (is (= {} (rf.schemas/app-schemas)))))
 
 ;; ---- rf2-ieu0i — :schema canonical ---------------------------------------
 ;;
@@ -1976,7 +1976,7 @@
       {:schema [:cat [:= :api/schema-key] :int]
        :interceptors [:rf.schema/at-boundary]}
       (fn [_ _] {}))
-    (with-redefs [spec/dev-mode? (constantly false)]
+    (with-redefs [rf.spec/dev-mode? (constantly false)]
       (let [before  (:before rf/validate-at-boundary-interceptor)
             valid   (before {:coeffects {:event [:api/schema-key 7]}})
             invalid (before {:coeffects {:event [:api/schema-key "no"]}})]

--- a/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
@@ -26,12 +26,12 @@
       of Malli — the warning would be noise."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 (defn- warnings-of
   "Filter the recorded events to the given operation keyword."
@@ -48,14 +48,14 @@
   process-wide concern), so we simulate the unloaded state by
   invalidating the hook around the test body."
   [f]
-  (let [prior (late-bind/get-fn :schemas/malli-validate)]
+  (let [prior (rf.late-bind/get-fn :schemas/malli-validate)]
     (try
-      (swap! late-bind/hooks dissoc :schemas/malli-validate)
-      (late-bind/invalidate-cache! :schemas/malli-validate)
+      (swap! rf.late-bind/hooks dissoc :schemas/malli-validate)
+      (rf.late-bind/invalidate-cache! :schemas/malli-validate)
       (f)
       (finally
         (when prior
-          (late-bind/set-fn! :schemas/malli-validate prior))))))
+          (rf.late-bind/set-fn! :schemas/malli-validate prior))))))
 
 ;; ---- positive paths -------------------------------------------------------
 
@@ -120,7 +120,7 @@
     (with-trace-recorder! [recorded]
       (with-unbound-malli-validate
         (fn []
-          (schemas/set-schema-validator! (fn [_schema _value] true))
+          (rf.schemas/set-schema-validator! (fn [_schema _value] true))
           (rf/reg-app-schema [:user] [:map [:id :int]])))
       (is (empty? (warnings-of recorded
                                :rf.warning/schema-validator-unavailable))
@@ -133,7 +133,7 @@
     (with-trace-recorder! [recorded]
       (with-unbound-malli-validate
         (fn []
-          (schemas/set-schema-fns! {:validate (fn [_ _] true)})
+          (rf.schemas/set-schema-fns! {:validate (fn [_ _] true)})
           (rf/reg-app-schema [:user] [:map])))
       (is (empty? (warnings-of recorded
                                :rf.warning/schema-validator-unavailable))))))
@@ -144,8 +144,8 @@
   (testing "with the Malli adapter loaded (`:schemas/malli-validate`
             is bound) the validation hot path runs — no warning"
     (with-trace-recorder! [recorded]
-      (let [prior (late-bind/get-fn :schemas/malli-validate)]
-        (late-bind/set-fn! :schemas/malli-validate (fn [_ _] true))
+      (let [prior (rf.late-bind/get-fn :schemas/malli-validate)]
+        (rf.late-bind/set-fn! :schemas/malli-validate (fn [_ _] true))
         (try
           (rf/reg-app-schema [:user] [:map])
           (finally
@@ -155,7 +155,7 @@
             ;; this stub does not leak a trivially-true validator process-wide
             ;; (rf2-hydpaf).
             (when prior
-              (late-bind/set-fn! :schemas/malli-validate prior))))
+              (rf.late-bind/set-fn! :schemas/malli-validate prior))))
         (is (empty? (warnings-of recorded
                                  :rf.warning/schema-validator-unavailable))
             ":schemas/malli-validate bound -> warning suppressed")))))
@@ -172,7 +172,7 @@
           (rf/reg-app-schema [:first] [:map])
           (is (= 1 (count (warnings-of recorded
                                        :rf.warning/schema-validator-unavailable))))
-          (schemas/clear-validator-unavailable-warned!)
+          (rf.schemas/clear-validator-unavailable-warned!)
           (rf/reg-app-schema [:second] [:map])
           (is (= 2 (count (warnings-of recorded
                                        :rf.warning/schema-validator-unavailable)))

--- a/implementation/schemas/test/re_frame/schemas_walker_large_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_large_test.clj
@@ -30,7 +30,7 @@
   `:large?`); these pin the propagate / omit behaviour at the walker
   level for both flags."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.schemas :as schemas]))
+            [re-frame.schemas :as rf.schemas]))
 
 ;; ---- :large? structural recognition --------------------------------------
 ;;
@@ -40,10 +40,10 @@
 
 (deftest large-no-slots
   (testing "a schema with no :large? props produces no entries"
-    (is (= {} (schemas/extract-large-paths-from-schema
+    (is (= {} (rf.schemas/extract-large-paths-from-schema
                 [:map [:name :string]] [])))
-    (is (= {} (schemas/extract-large-paths-from-schema :string [])))
-    (is (= {} (schemas/extract-large-paths-from-schema :int [:a :b])))))
+    (is (= {} (rf.schemas/extract-large-paths-from-schema :string [])))
+    (is (= {} (rf.schemas/extract-large-paths-from-schema :int [:a :b])))))
 
 (deftest large-slot-level
   (testing "the slot's per-slot props carry :large? true — claims (conj base k)"
@@ -51,19 +51,19 @@
                   [:id    :int]
                   [:blob  {:large? true} :string]]]
       (is (= {[:blob] {:large? true :source :schema}}
-             (schemas/extract-large-paths-from-schema schema []))))))
+             (rf.schemas/extract-large-paths-from-schema schema []))))))
 
 (deftest large-honours-base-path
   (testing "base-path is prepended to every discovered :large? slot path"
     (let [schema [:map [:blob {:large? true} :string]]]
       (is (= {[:user :blob] {:large? true :source :schema}}
-             (schemas/extract-large-paths-from-schema schema [:user]))))))
+             (rf.schemas/extract-large-paths-from-schema schema [:user]))))))
 
 (deftest large-container-level
   (testing "the schema's OWN props (container-level) claim the base-path —
             `(reg-app-schema [:user :pdf] [:string {:large? true}])`"
     (is (= {[:user :pdf] {:large? true :source :schema}}
-           (schemas/extract-large-paths-from-schema
+           (rf.schemas/extract-large-paths-from-schema
              [:string {:large? true}] [:user :pdf])))))
 
 (deftest large-nested-map
@@ -75,7 +75,7 @@
                      [:map
                       [:payload {:large? true} :string]]]]]]]
       (is (= {[:doc :attachment :payload] {:large? true :source :schema}}
-             (schemas/extract-large-paths-from-schema schema []))))))
+             (rf.schemas/extract-large-paths-from-schema schema []))))))
 
 (deftest large-multiple-slots
   (testing "multiple :large? slots in one schema produce one entry each"
@@ -86,13 +86,13 @@
                   [:caption  :string]]]
       (is (= {[:hi-res] {:large? true :source :schema}
               [:raw]    {:large? true :source :schema}}
-             (schemas/extract-large-paths-from-schema schema []))))))
+             (rf.schemas/extract-large-paths-from-schema schema []))))))
 
 (deftest large-positional-combinator-descends
   (testing ":vector descends at the same base-path for :large? — the
             inner type's container props claim the :vector's path"
     (is (= {[:frames] {:large? true :source :schema}}
-           (schemas/extract-large-paths-from-schema
+           (rf.schemas/extract-large-paths-from-schema
              [:vector [:string {:large? true}]] [:frames])))))
 
 (deftest large-dispatch-bearing-claims-parent-path
@@ -100,7 +100,7 @@
             (dispatch values are not path segments) — symmetric with the
             :sensitive? :orn/:catn/:altn cases in walker_operators_test"
     (is (= {[:asset] {:large? true :source :schema}}
-           (schemas/extract-large-paths-from-schema
+           (rf.schemas/extract-large-paths-from-schema
              [:multi {:dispatch :kind}
               [:photo {:large? true} [:map [:kind :string]]]
               [:icon  [:map [:kind :string]]]]
@@ -115,20 +115,20 @@
                   [:blob   {:large? true} :string]
                   [:secret {:sensitive? true} :string]]]
       (is (= {[:blob] {:large? true :source :schema}}
-             (schemas/extract-large-paths-from-schema schema []))
+             (rf.schemas/extract-large-paths-from-schema schema []))
           ":large? walker sees only the :large? slot, not the :sensitive? one")
       (is (= {[:secret] {:sensitive? true :source :schema}}
-             (schemas/extract-sensitive-paths-from-schema schema []))
+             (rf.schemas/extract-sensitive-paths-from-schema schema []))
           ":sensitive? walker sees only the :sensitive? slot, not the :large? one"))))
 
 (deftest large-opaque-and-degenerate-forms-tolerated
   (testing "opaque / degenerate forms yield no :large? declarations —
             the walker treats them as non-introspectable leaves rather
             than blowing up (matches the :sensitive? defensive contract)"
-    (is (= {} (schemas/extract-large-paths-from-schema 'malli/Opaque [])))
-    (is (= {} (schemas/extract-large-paths-from-schema (fn [_] true) [])))
-    (is (= {} (schemas/extract-large-paths-from-schema [] [])))
-    (is (= {} (schemas/extract-large-paths-from-schema [:string] [])))))
+    (is (= {} (rf.schemas/extract-large-paths-from-schema 'malli/Opaque [])))
+    (is (= {} (rf.schemas/extract-large-paths-from-schema (fn [_] true) [])))
+    (is (= {} (rf.schemas/extract-large-paths-from-schema [] [])))
+    (is (= {} (rf.schemas/extract-large-paths-from-schema [:string] [])))))
 
 ;; ---- :hint propagation (declaration-from-properties) ---------------------
 ;;
@@ -141,7 +141,7 @@
   (testing "a :large? slot carrying :hint surfaces the hint verbatim in
             the declaration map"
     (is (= {[:upload] {:large? true :source :schema :hint "video-blob"}}
-           (schemas/extract-large-paths-from-schema
+           (rf.schemas/extract-large-paths-from-schema
              [:map [:upload {:large? true :hint "video-blob"} :string]]
              [])))))
 
@@ -149,7 +149,7 @@
   (testing "a :sensitive? slot carrying :hint surfaces the hint verbatim —
             :hint composes with either flag"
     (is (= {[:password] {:sensitive? true :source :schema :hint "argon2id"}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:map [:password {:sensitive? true :hint "argon2id"} :string]]
              [])))))
 
@@ -157,10 +157,10 @@
   (testing "with no :hint prop the declaration map carries exactly
             {flag true :source :schema} — the :hint key is absent, not
             present-with-nil (minimal marker shape)"
-    (let [large (get (schemas/extract-large-paths-from-schema
+    (let [large (get (rf.schemas/extract-large-paths-from-schema
                        [:map [:blob {:large? true} :string]] [])
                      [:blob])
-          sens  (get (schemas/extract-sensitive-paths-from-schema
+          sens  (get (rf.schemas/extract-sensitive-paths-from-schema
                        [:map [:tok {:sensitive? true} :string]] [])
                      [:tok])]
       (is (= {:large? true :source :schema} large))
@@ -173,9 +173,9 @@
   (testing "a slot carrying :hint but NOT the flag set to true produces
             no declaration at all — the :hint is inert without its flag
             (declaration-from-properties gates on the flag-key, not on :hint)"
-    (is (= {} (schemas/extract-large-paths-from-schema
+    (is (= {} (rf.schemas/extract-large-paths-from-schema
                 [:map [:blob {:hint "orphan-hint"} :string]] []))
         ":hint without :large? true → no declaration")
-    (is (= {} (schemas/extract-large-paths-from-schema
+    (is (= {} (rf.schemas/extract-large-paths-from-schema
                 [:map [:blob {:large? false :hint "x"} :string]] []))
         ":large? false (not true) → no declaration even with a :hint")))

--- a/implementation/schemas/test/re_frame/schemas_walker_literal_operand_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_walker_literal_operand_cljs_test.cljs
@@ -16,8 +16,8 @@
   adapter in its own ns-form."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.walker-literal-operand-fixtures :as fx]))
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.walker-literal-operand-fixtures :as rf.schemas.walker-literal-operand-fixtures]))
 
 ;; ---- pure walker: shared cross-host corpus (parity anchor) ----------------
 
@@ -25,22 +25,22 @@
   (testing "rf2-3fc89f.12 — literal/config operands and their structural forms
             are walkable, so schema-has-opaque-child? is FALSE on CLJS too
             (byte-identical classification with the JVM half)"
-    (doseq [s fx/not-opaque-forms]
-      (is (false? (schemas/schema-has-opaque-child? s))
+    (doseq [s rf.schemas.walker-literal-operand-fixtures/not-opaque-forms]
+      (is (false? (rf.schemas/schema-has-opaque-child? s))
           (str "literal/walkable form must NOT be opaque: " (pr-str s))))))
 
 (deftest cljs-nested-compiled-values-still-fail-closed
   (testing "rf2-3fc89f.12 — a nested compiled m/schema value in a real
             child-schema position still fails closed (true) on CLJS"
-    (doseq [s fx/opaque-forms]
-      (is (true? (schemas/schema-has-opaque-child? s))
+    (doseq [s rf.schemas.walker-literal-operand-fixtures/opaque-forms]
+      (is (true? (rf.schemas/schema-has-opaque-child? s))
           (str "nested compiled value must fail closed: " (pr-str s))))))
 
 (deftest cljs-unknown-operator-shapes-fail-closed
   (testing "rf2-3fc89f.12 — an unclassified operator shape fails closed (true)
             on CLJS"
-    (doseq [s fx/unknown-op-forms]
-      (is (true? (schemas/schema-has-opaque-child? s))
+    (doseq [s rf.schemas.walker-literal-operand-fixtures/unknown-op-forms]
+      (is (true? (rf.schemas/schema-has-opaque-child? s))
           (str "unknown operator shape must fail closed: " (pr-str s))))))
 
 ;; ---- always-on redact-validation-tags (host-agnostic egress parity) -------
@@ -53,7 +53,7 @@
                       [:cat [:= :demo/e] [:enum 1 2]]
                       [:= 42]
                       [:enum "a" "b"]]]
-        (let [out (schemas/redact-validation-tags schema tags)]
+        (let [out (rf.schemas/redact-validation-tags schema tags)]
           (is (= tags out)
               (str "non-sensitive literal schema rides verbatim: " (pr-str schema)))
           (is (not (contains? out :sensitive?))
@@ -66,8 +66,8 @@
           ;; an explicit vector-form sensitive slot + the shared opaque corpus
           ;; (every entry nests a compiled child, so the redactor fails closed)
           schemas [[:cat [:= :demo/e] [:map [:pw {:sensitive? true} :string]]]]]
-      (doseq [schema (concat schemas fx/opaque-forms)]
-        (let [out (schemas/redact-validation-tags schema tags)]
+      (doseq [schema (concat schemas rf.schemas.walker-literal-operand-fixtures/opaque-forms)]
+        (let [out (rf.schemas/redact-validation-tags schema tags)]
           (is (true? (:sensitive? out))
               (str "sensitive/opaque schema is stamped: " (pr-str schema)))
           (is (= :rf/redacted (:value out))

--- a/implementation/schemas/test/re_frame/schemas_walker_literal_operand_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_literal_operand_test.clj
@@ -25,12 +25,12 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [malli.core :as m]
             [re-frame.core :as rf]
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.test-fixture :as tf]
-            [re-frame.schemas.walker-literal-operand-fixtures :as fx]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
+            [re-frame.schemas.walker-literal-operand-fixtures :as rf.schemas.walker-literal-operand-fixtures]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 (defn- warnings-of [recorded operation]
   (filterv (fn [ev] (and (= :warning (:op-type ev))
@@ -44,8 +44,8 @@
             members, comparator bounds, `:re` pattern) and their enclosing
             structural forms are fully walkable, so schema-has-opaque-child?
             is FALSE (pre-fix: every one returned true)"
-    (doseq [s fx/not-opaque-forms]
-      (is (false? (schemas/schema-has-opaque-child? s))
+    (doseq [s rf.schemas.walker-literal-operand-fixtures/not-opaque-forms]
+      (is (false? (rf.schemas/schema-has-opaque-child? s))
           (str "literal/walkable form must NOT be opaque: " (pr-str s))))))
 
 (deftest nested-compiled-values-still-fail-closed
@@ -53,15 +53,15 @@
             REAL child-schema position (root, :map slot, container element,
             :cat/:tuple element, :multi/:orn branch, :map-of key/value,
             combinator child) still fails closed (true)"
-    (doseq [s fx/opaque-forms]
-      (is (true? (schemas/schema-has-opaque-child? s))
+    (doseq [s rf.schemas.walker-literal-operand-fixtures/opaque-forms]
+      (is (true? (rf.schemas/schema-has-opaque-child? s))
           (str "nested compiled value must fail closed: " (pr-str s))))))
 
 (deftest unknown-operator-shapes-fail-closed
   (testing "rf2-3fc89f.12 — an unclassified operator shape cannot be proven
             walkable, so it fails closed (true)"
-    (doseq [s fx/unknown-op-forms]
-      (is (true? (schemas/schema-has-opaque-child? s))
+    (doseq [s rf.schemas.walker-literal-operand-fixtures/unknown-op-forms]
+      (is (true? (rf.schemas/schema-has-opaque-child? s))
           (str "unknown operator shape must fail closed: " (pr-str s))))))
 
 ;; ---- registration warning (ACCEPTANCE #2) ---------------------------------
@@ -95,7 +95,7 @@
   return the single :rf.error/schema-validation-failure trace."
   [schema event]
   (with-trace-recorder! [traces]
-    (schemas/validate-event! :demo/e event {:schema schema})
+    (rf.schemas/validate-event! :demo/e event {:schema schema})
     (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                    @traces))))
 
@@ -148,7 +148,7 @@
                       [:cat [:= :demo/e] [:enum 1 2]]
                       [:= 42]
                       [:enum "a" "b"]]]
-        (let [out (schemas/redact-validation-tags schema tags)]
+        (let [out (rf.schemas/redact-validation-tags schema tags)]
           (is (= tags out)
               (str "non-sensitive literal schema rides verbatim: " (pr-str schema)))
           (is (not (contains? out :sensitive?))
@@ -161,7 +161,7 @@
       (doseq [schema [[:cat [:= :demo/e] [:map [:pw {:sensitive? true} :string]]]
                       [:map [:tok (m/schema [:string {:sensitive? true}])]]
                       (m/schema [:string {:sensitive? true}])]]
-        (let [out (schemas/redact-validation-tags schema tags)]
+        (let [out (rf.schemas/redact-validation-tags schema tags)]
           (is (true? (:sensitive? out))
               (str "sensitive/opaque schema is stamped: " (pr-str schema)))
           (is (= :rf/redacted (:value out))

--- a/implementation/schemas/test/re_frame/schemas_walker_opaque_warning_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_opaque_warning_test.clj
@@ -25,11 +25,11 @@
   test-fixture cache-clear story."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.schemas :as schemas]
-            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 (defn- warnings-of
   "Filter the recorded events to the given operation keyword."
@@ -162,7 +162,7 @@
       (rf/reg-app-schema [:first] {:malli/schema :first})
       (is (= 1 (count (warnings-of recorded
                                    :rf.warning/schema-walker-opaque))))
-      (schemas/clear-walker-opaque-warned!)
+      (rf.schemas/clear-walker-opaque-warned!)
       (rf/reg-app-schema [:second] {:malli/schema :second})
       (is (= 2 (count (warnings-of recorded
                                    :rf.warning/schema-walker-opaque)))

--- a/implementation/schemas/test/re_frame/schemas_walker_operators_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_operators_test.clj
@@ -16,7 +16,7 @@
   `:sensitive?` flag (the parameterised walker serves both flags so
   pinning one suffices to lock the structural recognition)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.schemas :as schemas]))
+            [re-frame.schemas :as rf.schemas]))
 
 ;; ---- dispatch-bearing combinators ----------------------------------------
 ;;
@@ -33,7 +33,7 @@
   (testing ":orn — a branch's :sensitive? on its slot-props claims the
             parent path (mirrors :multi behaviour)"
     (is (= {[:value] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:orn
               [:secret {:sensitive? true} :string]
               [:public :string]]
@@ -44,7 +44,7 @@
             descends at the parent path (the dispatch value is not a
             path segment)"
     (is (= {[:value :token] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:orn
               [:authed [:map [:token {:sensitive? true} :string]]]
               [:anon   [:map [:guest :string]]]]
@@ -54,7 +54,7 @@
   (testing ":altn — a :sensitive? slot inside an alt branch descends at
             the parent path"
     (is (= {[:doc :ssn] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:altn
               [:full [:map [:ssn {:sensitive? true} :string]]]
               [:abbr [:map [:initials :string]]]]
@@ -74,7 +74,7 @@
 (deftest set-descends-at-parent-path
   (testing ":set — inner :sensitive? slot claims the :set's path"
     (is (= {[:tokens] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:set [:string {:sensitive? true}]]
              [:tokens])))))
 
@@ -82,7 +82,7 @@
   (testing ":sequential — inner :sensitive? slot claims the :sequential's
             path"
     (is (= {[:audit-log] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:sequential [:string {:sensitive? true}]]
              [:audit-log])))))
 
@@ -99,7 +99,7 @@
             sensitive claims `(conj base i)`, NOT the shared base-path"
     ;; element 1 is the sensitive :string → claims [:ev 1], not [:ev].
     (is (= {[:ev 1] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:cat :string [:string {:sensitive? true}]]
              [:ev])))))
 
@@ -109,7 +109,7 @@
             entry-level sensitive claims `(conj base i)`, not base"
     ;; entry 0 (:head) is sensitive → claims [:row 0], not [:row].
     (is (= {[:row 0] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:catn
               [:head {:sensitive? true} :string]
               [:tail :string]]
@@ -118,7 +118,7 @@
 (deftest and-descends-at-parent-path
   (testing ":and — every child descends at the parent path"
     (is (= {[:slot] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:and :string [:string {:sensitive? true}]]
              [:slot])))))
 
@@ -126,7 +126,7 @@
   (testing ":not — single-child positional; inner sensitive descends at
             the parent path"
     (is (= {[:slot] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
+           (rf.schemas/extract-sensitive-paths-from-schema
              [:not [:string {:sensitive? true}]]
              [:slot])))))
 
@@ -141,16 +141,16 @@
   (testing "an opaque schema value (not a vector form) yields no
             declarations — the walker doesn't try to peer inside"
     ;; A symbol — not a Malli vector form, not a keyword.
-    (is (= {} (schemas/extract-sensitive-paths-from-schema 'malli/AnyMap [])))
+    (is (= {} (rf.schemas/extract-sensitive-paths-from-schema 'malli/AnyMap [])))
     ;; A fn — also opaque.
-    (is (= {} (schemas/extract-sensitive-paths-from-schema (fn [_] true) [])))))
+    (is (= {} (rf.schemas/extract-sensitive-paths-from-schema (fn [_] true) [])))))
 
 (deftest empty-vector-form-tolerated
   (testing "an empty vector (degenerate schema form) does not blow up;
             it yields no declarations"
-    (is (= {} (schemas/extract-sensitive-paths-from-schema [] [])))))
+    (is (= {} (rf.schemas/extract-sensitive-paths-from-schema [] [])))))
 
 (deftest single-element-vector-form-tolerated
   (testing "a single-element vector form (no props, no children) does
             not blow up; it yields no declarations"
-    (is (= {} (schemas/extract-sensitive-paths-from-schema [:string] [])))))
+    (is (= {} (rf.schemas/extract-sensitive-paths-from-schema [:string] [])))))

--- a/implementation/schemas/test/re_frame/validate_before_install_test.clj
+++ b/implementation/schemas/test/re_frame/validate_before_install_test.clj
@@ -37,13 +37,13 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.walk :as walk]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.schemas.storage :as storage]
-            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.schemas.storage :as rf.schemas.storage]
+            [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.schemas.test-fixture/reset-runtime)
 
 (defn- seed-int-schema!
   "Register the canonical [:n]→[:int] app-schema + seed/ok/break events
@@ -89,7 +89,7 @@
             frame-state container — no forward write, no restore write
             (the retired pair performed two)"
     (seed-int-schema!)
-    (let [container (frame/frame-state-container :rf/default)
+    (let [container (rf.frame/frame-state-container :rf/default)
           writes    (atom [])]
       (is (some? container) "precondition: the frame-state container resolves")
       (add-watch container ::write-probe
@@ -194,10 +194,10 @@
             unchanged, no change traces, outcome :rolled-back — the
             retired treat-as-pass fail-OPEN arm is gone"
     (seed-int-schema!)
-    (let [original (late-bind/get-fn :schemas/validate-app-schema!)
+    (let [original (rf.late-bind/get-fn :schemas/validate-app-schema!)
           records  (atom [])]
       (try
-        (late-bind/set-fn! :schemas/validate-app-schema!
+        (rf.late-bind/set-fn! :schemas/validate-app-schema!
                            (fn [_db _event-id _frame _continue?]
                              (throw (ex-info "validator machinery exploded" {}))))
         (rf/register-listener! :events ::throw-probe
@@ -225,7 +225,7 @@
           (is (= :rolled-back (:outcome rec))
               "outcome :rolled-back — the reject reaches off-box shippers"))
         (finally
-          (late-bind/set-fn! :schemas/validate-app-schema! original))))))
+          (rf.late-bind/set-fn! :schemas/validate-app-schema! original))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6. Success path: exactly one validation pass, one commit, one forward emit.
@@ -236,10 +236,10 @@
             (pre-install; there is no post-commit second pass) and emits
             exactly one forward db-changed + one frame-state-changed"
     (seed-int-schema!)
-    (let [original (late-bind/get-fn :schemas/validate-app-schema!)
+    (let [original (rf.late-bind/get-fn :schemas/validate-app-schema!)
           calls    (atom 0)]
       (try
-        (late-bind/set-fn! :schemas/validate-app-schema!
+        (rf.late-bind/set-fn! :schemas/validate-app-schema!
                            (fn [db event-id frame-id continue?]
                              (swap! calls inc)
                              (original db event-id frame-id continue?)))
@@ -254,7 +254,7 @@
             (is (= 1 (count (filter #{:rf.event/frame-state-changed} ops)))
                 "exactly one frame-state-changed")))
         (finally
-          (late-bind/set-fn! :schemas/validate-app-schema! original))))))
+          (rf.late-bind/set-fn! :schemas/validate-app-schema! original))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 7. JVM registry-generation race — one snapshot per candidate.
@@ -271,16 +271,16 @@
     ;; Build the two whole-registry generation values.
     (rf/reg-app-schema [:a] [:int])
     (rf/reg-app-schema [:b] [:int])
-    (let [gen-pass (storage/snapshot-schemas-by-frame)]
-      (storage/clear-schemas-by-frame!)
+    (let [gen-pass (rf.schemas.storage/snapshot-schemas-by-frame)]
+      (rf.schemas.storage/clear-schemas-by-frame!)
       (rf/reg-app-schema [:a] [:string])
       (rf/reg-app-schema [:b] [:string])
-      (let [gen-fail (storage/snapshot-schemas-by-frame)
+      (let [gen-fail (rf.schemas.storage/snapshot-schemas-by-frame)
             stop?    (atom false)
             flipper  (future
                        (loop [pass? true]
                          (when-not @stop?
-                           (storage/restore-schemas-by-frame!
+                           (rf.schemas.storage/restore-schemas-by-frame!
                              (if pass? gen-pass gen-fail))
                            (recur (not pass?)))))]
         (try
@@ -296,4 +296,4 @@
           (finally
             (reset! stop? true)
             @flipper
-            (storage/restore-schemas-by-frame! gen-pass)))))))
+            (rf.schemas.storage/restore-schemas-by-frame! gen-pass)))))))

--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
@@ -37,7 +37,7 @@
   (:require [cljs.analyzer.api :as ana-api]
             [cljs.env :as env]
             [clojure.edn :as edn]
-            [re-frame.build.spec-resource :as spec-resource]))
+            [re-frame.build.spec-resource :as rf.build.spec-resource]))
 
 (defn- kind-of
   "Derive the manifest `:kind` for a CLJS analyzer var-info map. Mirrors
@@ -112,7 +112,7 @@
 (defn- read-sidecar
   "The parsed sidecar, read in the macro-expansion environment `env`."
   [env]
-  (edn/read-string (spec-resource/slurp-resource env sidecar-resource)))
+  (edn/read-string (rf.build.spec-resource/slurp-resource env sidecar-resource)))
 
 (defmacro emit-cljs-only-rows
   "Expand to a literal vector of the sidecar's `:cljs-only` manifest rows

--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -84,7 +84,7 @@
                     :refer [emit-ns-publics emit-cljs-only-rows
                             emit-classification-rows]])
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.api-manifest.cljs-probe :as probe]
+            [re-frame.api-manifest.cljs-probe :as rf.api-manifest.cljs-probe]
             ;; The covered CLJS-only namespaces. The `:require` forces the
             ;; analyzer to analyse each before `emit-ns-publics` expands,
             ;; so the macro reads a real surface. The aliases are unused at
@@ -252,9 +252,9 @@
 
 (deftest cljs-only-surface-in-sync
   (testing "live CLJS public surface reconciles with the :cljs-only rows"
-    (let [result (probe/reconcile live-publics reconcile-rows fully-rowed)]
-      (is (probe/in-sync? result)
-          (probe/report result)))))
+    (let [result (rf.api-manifest.cljs-probe/reconcile live-publics reconcile-rows fully-rowed)]
+      (is (rf.api-manifest.cljs-probe/in-sync? result)
+          (rf.api-manifest.cljs-probe/report result)))))
 
 (deftest every-covered-namespace-was-analysed
   (testing "each covered namespace enumerates at least one public var"

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -56,8 +56,8 @@
   only) is treated as a non-var row and skipped."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [re-frame.api-manifest.gen :as gen]
-            [re-frame.api-manifest.projection :as projection]))
+            [re-frame.api-manifest.gen :as rf.api-manifest.gen]
+            [re-frame.api-manifest.projection :as rf.api-manifest.projection]))
 
 (def ^:private min-var-rows
   "Non-vacuous extracted-row floor for the spec/API.md projection
@@ -70,7 +70,7 @@
    same calibration the secondary projection floors use (rf2-utvst)."
   150)
 
-(def ^:private api-md-file (delay (io/file gen/repo-root "spec" "API.md")))
+(def ^:private api-md-file (delay (io/file rf.api-manifest.gen/repo-root "spec" "API.md")))
 
 (def ^:private tier-tokens
   "The closed Tier vocabulary, longest-first so `internal-public` is
@@ -297,7 +297,7 @@
    an empty problem list with a collapsed extraction would otherwise report
    a vacuous OK."
   [extracted]
-  (projection/vacuity-floor-problem "spec/API.md" extracted min-var-rows))
+  (rf.api-manifest.projection/vacuity-floor-problem "spec/API.md" extracted min-var-rows))
 
 (defn read-api-md-lines
   "Read spec/API.md as `[[line-no line-text] ...]` (1-based). Shared by
@@ -314,11 +314,11 @@
    every API.md var-row resolves to a manifest row with a MATCHING tier;
    false (with a printed report) on any mismatch."
   []
-  (let [manifest   (gen/read-committed-manifest)
+  (let [manifest   (rf.api-manifest.gen/read-committed-manifest)
         rows       (:vars manifest)
         ;; API.md var-rows the sidecar marks as knowingly-unmanifested
         ;; (post-v1-lib surfaces the reference impl does not yet ship).
-        known-unmanifested (set (:api-md-known-unmanifested (gen/read-sidecar)))
+        known-unmanifested (set (:api-md-known-unmanifested (rf.api-manifest.gen/read-sidecar)))
         api-rows   (parse-api-md-var-rows)
         extracted  (count api-rows)
         ;; Non-vacuous floor (rf2-4ka7c2.2): if extraction has collapsed
@@ -339,9 +339,9 @@
         ;; same API.md prose, all on the same retirement-marker discipline.
         ;; These fire only on retired keyword forms, not prose phrasing.
         kw-probs   (concat
-                     (projection/ep0017-keyword-drift-problems "spec/API.md" api-md-lines)
-                     (projection/ep0011-reply-vocab-drift-problems "spec/API.md" api-md-lines)
-                     (projection/ep0015-privacy-vocab-drift-problems "spec/API.md" api-md-lines))]
+                     (rf.api-manifest.projection/ep0017-keyword-drift-problems "spec/API.md" api-md-lines)
+                     (rf.api-manifest.projection/ep0011-reply-vocab-drift-problems "spec/API.md" api-md-lines)
+                     (rf.api-manifest.projection/ep0015-privacy-vocab-drift-problems "spec/API.md" api-md-lines))]
     (cond
       ;; Vacuity-floor violation: extraction collapsed — refuse a green.
       floor

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
@@ -70,8 +70,8 @@
   (a set of `[namespace var]` pairs, empty/absent today) is the explicit escape
   hatch for a var intentionally documented only as a facade pointer elsewhere."
   (:require [clojure.string :as str]
-            [re-frame.api-manifest.gen :as gen]
-            [re-frame.api-manifest.projection :as proj]))
+            [re-frame.api-manifest.gen :as rf.api-manifest.gen]
+            [re-frame.api-manifest.projection :as rf.api-manifest.projection]))
 
 ;; The reference trees scanned. Each is an EXPECTED surface (it exists today
 ;; and is owned), so it uses `require-markdown-files` — a moved / renamed
@@ -134,8 +134,8 @@
   [files]
   (for [file  files
         alias ["rf" "story"]
-        ref   (proj/alias-call-references alias (proj/numbered-lines file))]
-    (assoc ref :file (proj/repo-relative file))))
+        ref   (rf.api-manifest.projection/alias-call-references alias (rf.api-manifest.projection/numbered-lines file))]
+    (assoc ref :file (rf.api-manifest.projection/repo-relative file))))
 
 ;; ---------------------------------------------------------------------------
 ;; Page + member coverage (rf2-e5692s).
@@ -167,7 +167,7 @@
                 (when-let [[_ ident] (re-matches #"#{2,4}\s+`([^`]+)`.*"
                                                  (str/trim line))]
                   (last (str/split ident #"/")))))
-        (proj/numbered-lines file)))
+        (rf.api-manifest.projection/numbered-lines file)))
 
 (defn- page-members
   "`{namespace-str -> #{covered-bare-var-name ...}}` for each namespace in
@@ -175,7 +175,7 @@
    the returned map has no page (→ a PAGE-MISSING problem downstream)."
   [namespaces]
   (reduce (fn [acc ns-str]
-            (let [f (proj/repo-file "docs" "api" (str ns-str ".md"))]
+            (let [f (rf.api-manifest.projection/repo-file "docs" "api" (str ns-str ".md"))]
               (if (.isFile ^java.io.File f)
                 (assoc acc ns-str (member-heading-names f))
                 acc)))
@@ -253,11 +253,11 @@
    eligible var has a member heading (or an explicit facade-pointer exemption);
    false (with a printed report) otherwise."
   []
-  (let [rows          (proj/manifest-rows)
+  (let [rows          (rf.api-manifest.projection/manifest-rows)
         eligible-rows (filter #(contains? eligible-tiers (:tier %)) rows)
         namespaces    (distinct (map :namespace eligible-rows))
         members       (page-members namespaces)
-        exempt        (set (:doc-api-coverage-exempt (gen/read-sidecar)))
+        exempt        (set (:doc-api-coverage-exempt (rf.api-manifest.gen/read-sidecar)))
         problems      (coverage-problems {:eligible-rows eligible-rows
                                           :members       members
                                           :exempt        exempt})]
@@ -265,24 +265,24 @@
 
 (defn check!
   []
-  (let [rows          (proj/manifest-rows)
+  (let [rows          (rf.api-manifest.projection/manifest-rows)
         ;; Resolution target: bare var names ANY manifest row carries. A
         ;; removed surface has no row in ANY namespace, so it is still caught.
         manifest-vars (set (map :var rows))
-        scoped-allow  (or (:doc-api-known-unmanifested-scoped (gen/read-sidecar)) {})
+        scoped-allow  (or (:doc-api-known-unmanifested-scoped (rf.api-manifest.gen/read-sidecar)) {})
         ;; Directory trees — fail loud if a tree moves/renames (rf2-utvst).
         dir-files     (mapcat (fn [[label segs]]
-                                (proj/require-markdown-files
-                                  label (apply proj/repo-file segs)))
+                                (rf.api-manifest.projection/require-markdown-files
+                                  label (apply rf.api-manifest.projection/repo-file segs)))
                               dir-surfaces)
         ;; The API reference is one doc per namespace under docs/api/ (covered
         ;; by the dir-surfaces tree above). spec/Privacy.md — a single
         ;; EXPECTED file; fail loud if it moves.
-        privacy-file  (apply proj/repo-file privacy-file-segs)
+        privacy-file  (apply rf.api-manifest.projection/repo-file privacy-file-segs)
         _             (when-not (.isFile ^java.io.File privacy-file)
                         (throw (ex-info
                                  (str "spec/Privacy.md: expected file is missing — "
-                                      (proj/repo-relative privacy-file)
+                                      (rf.api-manifest.projection/repo-relative privacy-file)
                                       ". The privacy projection gate cannot run "
                                       "against a non-existent surface; reconcile "
                                       "the path.")
@@ -295,11 +295,11 @@
         ;; Keyword-drift guards (EP-0017/EP-0011/EP-0015): spec/Privacy.md is
         ;; the EP-0015 surface, so a reintroduced retired `:rf.egress/*`
         ;; profile keyword goes RED here alongside any var-resolution drift.
-        kw-problems   (proj/keyword-drift-problems-over-files files)
+        kw-problems   (rf.api-manifest.projection/keyword-drift-problems-over-files files)
         problems      (concat var-problems kw-problems)
         ;; (1) Call-position reference discipline + keyword-drift over the
         ;; reference trees (the original rf2-vzupmg contract).
-        refs-ok       (proj/report-with-floor!
+        refs-ok       (rf.api-manifest.projection/report-with-floor!
                         "spec/Privacy.md + docs/api/ + docs/story/api/"
                         (count references) min-references problems)
         ;; (2) Page + member coverage of the manifest by docs/api/ (rf2-e5692s).

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
@@ -27,8 +27,8 @@
   removed name to the repo-relative migration files allowed to mention it in
   call position. The same reference in live teaching prose remains an error."
   (:require [clojure.string :as str]
-            [re-frame.api-manifest.gen :as gen]
-            [re-frame.api-manifest.projection :as proj]))
+            [re-frame.api-manifest.gen :as rf.api-manifest.gen]
+            [re-frame.api-manifest.projection :as rf.api-manifest.projection]))
 
 (def ^:private core-ns "re-frame.core")
 
@@ -76,10 +76,10 @@
 
 (defn check!
   []
-  (let [rows         (proj/manifest-rows)
-        core-vars    (set (map :var (proj/rows-in-ns rows core-ns)))
-        scoped-allow (:doc-guide-known-unmanifested-scoped (gen/read-sidecar))
-        dir          (proj/repo-file "docs" "core")
+  (let [rows         (rf.api-manifest.projection/manifest-rows)
+        core-vars    (set (map :var (rf.api-manifest.projection/rows-in-ns rows core-ns)))
+        scoped-allow (:doc-guide-known-unmanifested-scoped (rf.api-manifest.gen/read-sidecar))
+        dir          (rf.api-manifest.projection/repo-file "docs" "core")
         ;; require-markdown-files (rf2-utvst): fail loudly if docs/core/
         ;; moves or is renamed, rather than silently checking zero files.
         ;;
@@ -94,18 +94,18 @@
         ;; non-core surface it names (e.g. `rf/machine-meta`). doc-api-check
         ;; already covers this subtree for BOTH var-resolution and
         ;; keyword-drift, so the exclusion loses no coverage.
-        guide-files  (->> (proj/require-markdown-files "docs/core/" dir)
-                          (remove #(str/starts-with? (proj/repo-relative %)
+        guide-files  (->> (rf.api-manifest.projection/require-markdown-files "docs/core/" dir)
+                          (remove #(str/starts-with? (rf.api-manifest.projection/repo-relative %)
                                                      "docs/core/api/")))
         ;; Capability concept docs are a required one-level docs/* surface;
         ;; discovery covers new capabilities and fails loudly if the surface
         ;; disappears.
-        concept-files (proj/require-capability-doc-files
+        concept-files (rf.api-manifest.projection/require-capability-doc-files
                         "docs/*/concepts.md" "concepts.md")
         files        (concat guide-files concept-files)
         references   (for [file files
-                           ref  (proj/alias-call-references "rf" (proj/numbered-lines file))]
-                       (assoc ref :file (proj/repo-relative file)))
+                           ref  (rf.api-manifest.projection/alias-call-references "rf" (rf.api-manifest.projection/numbered-lines file))]
+                       (assoc ref :file (rf.api-manifest.projection/repo-relative file)))
         var-problems (reconcile {:references   references
                                  :core-vars    core-vars
                                  :scoped-allow scoped-allow})
@@ -114,9 +114,9 @@
         ;; `:work-id`), or EP-0015 egress-profile keyword vocabulary creeping
         ;; back into teaching prose. Fold the keyword scan in so a
         ;; reintroduction goes RED here too.
-        kw-problems  (proj/keyword-drift-problems-over-files files)
+        kw-problems  (rf.api-manifest.projection/keyword-drift-problems-over-files files)
         problems     (concat var-problems kw-problems)]
-    (proj/report-with-floor! "docs/core/ + docs/*/concepts.md"
+    (rf.api-manifest.projection/report-with-floor! "docs/core/ + docs/*/concepts.md"
                              (count references) min-references problems)))
 
 (defn -main [& _]

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
@@ -25,7 +25,7 @@
   inventory — never a bare token sweep."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [re-frame.api-manifest.gen :as gen]))
+            [re-frame.api-manifest.gen :as rf.api-manifest.gen]))
 
 ;; ---------------------------------------------------------------------------
 ;; Manifest indexing.
@@ -34,7 +34,7 @@
 (defn manifest-rows
   "The committed manifest's `:vars` vector (the resolution target)."
   []
-  (:vars (gen/read-committed-manifest)))
+  (:vars (rf.api-manifest.gen/read-committed-manifest)))
 
 ;; NB (rf2-6r9j.137): there is deliberately NO shared row index here. Each
 ;; check builds the projection its own contract needs — a bare-name set
@@ -58,7 +58,7 @@
 (defn repo-file
   "An `io/file` under the repo root for a repo-relative path segment seq."
   [& segs]
-  (apply io/file gen/repo-root segs))
+  (apply io/file rf.api-manifest.gen/repo-root segs))
 
 (defn markdown-files
   "Every `*.md` file under `dir` (an `io/file`), recursively, sorted by
@@ -80,7 +80,7 @@
   "`file` rendered relative to the repo root with forward slashes, for
    stable cross-platform reporting."
   [^java.io.File file]
-  (-> (.toPath (io/file gen/repo-root))
+  (-> (.toPath (io/file rf.api-manifest.gen/repo-root))
       (.relativize (.toPath file))
       str
       (str/replace "\\" "/")))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/skills_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/skills_check.clj
@@ -27,8 +27,8 @@
   (`:skills-known-unmanifested`) catches any further legitimate
   non-manifest reference in the checked skills."
   (:require [clojure.string :as str]
-            [re-frame.api-manifest.gen :as gen]
-            [re-frame.api-manifest.projection :as proj]))
+            [re-frame.api-manifest.gen :as rf.api-manifest.gen]
+            [re-frame.api-manifest.projection :as rf.api-manifest.projection]))
 
 (def ^:private core-ns "re-frame.core")
 
@@ -48,21 +48,21 @@
 
 (defn check!
   []
-  (let [rows      (proj/manifest-rows)
+  (let [rows      (rf.api-manifest.projection/manifest-rows)
         ;; `(rf/<var>` is the `re-frame.core` alias surface; resolve against
         ;; the core rows (front-porch + advanced + tooling + testing).
-        core-vars (set (map :var (proj/rows-in-ns rows core-ns)))
-        allow     (set (:skills-known-unmanifested (gen/read-sidecar)))
-        dir       (proj/repo-file "skills")
+        core-vars (set (map :var (rf.api-manifest.projection/rows-in-ns rows core-ns)))
+        allow     (set (:skills-known-unmanifested (rf.api-manifest.gen/read-sidecar)))
+        dir       (rf.api-manifest.projection/repo-file "skills")
         ;; require-markdown-files (rf2-utvst): fail loudly if skills/ moves
         ;; or is renamed, rather than silently checking zero files.
-        files     (->> (proj/require-markdown-files "skills/" dir)
+        files     (->> (rf.api-manifest.projection/require-markdown-files "skills/" dir)
                        (remove #(str/includes?
-                                 (str/replace (proj/repo-relative %) "\\" "/")
+                                 (str/replace (rf.api-manifest.projection/repo-relative %) "\\" "/")
                                  excluded-skill-dir)))
         results   (for [file files
-                        ref  (proj/alias-call-references "rf" (proj/numbered-lines file))]
-                    (assoc ref :file (proj/repo-relative file)))
+                        ref  (rf.api-manifest.projection/alias-call-references "rf" (rf.api-manifest.projection/numbered-lines file))]
+                    (assoc ref :file (rf.api-manifest.projection/repo-relative file)))
         var-problems (keep (fn [{:keys [var line raw file]}]
                              (when-not (or (contains? core-vars var)
                                            (contains? allow var))
@@ -75,9 +75,9 @@
         ;; EP-0017 `:rf.world/inputs`, EP-0011 reply-envelope (`:stale-key` /
         ;; bare `:work-id`), and EP-0015 egress-profile vocabulary reintroduced
         ;; outside an explicit retirement/rename mention.
-        kw-problems  (proj/keyword-drift-problems-over-files files)
+        kw-problems  (rf.api-manifest.projection/keyword-drift-problems-over-files files)
         problems     (concat var-problems kw-problems)]
-    (proj/report-with-floor! "skills/ (excl. re-frame-migration)"
+    (rf.api-manifest.projection/report-with-floor! "skills/ (excl. re-frame-migration)"
                              (count results) min-references problems)))
 
 (defn -main [& _]

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/story_spec_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/story_spec_check.clj
@@ -34,8 +34,8 @@
   rf2-i6kh dropped the exemptions and gave all five real `:cljs-only` rows,
   which this check resolves like any other var-row. A facade var missing from
   the manifest is a row to add, never a name to silence here."
-  (:require [re-frame.api-manifest.gen :as gen]
-            [re-frame.api-manifest.projection :as proj]))
+  (:require [re-frame.api-manifest.gen :as rf.api-manifest.gen]
+            [re-frame.api-manifest.projection :as rf.api-manifest.projection]))
 
 (def ^:private story-ns "re-frame.story")
 
@@ -50,19 +50,19 @@
 
 (defn check!
   []
-  (let [rows       (proj/manifest-rows)
-        story-vars (set (map :var (proj/rows-in-ns rows story-ns)))
-        allow      (set (:story-spec-known-unmanifested (gen/read-sidecar)))
-        file       (proj/repo-file "tools" "story" "spec" "API.md")
-        rel        (proj/repo-relative file)
-        var-rows   (proj/table-var-rows (proj/numbered-lines file))
+  (let [rows       (rf.api-manifest.projection/manifest-rows)
+        story-vars (set (map :var (rf.api-manifest.projection/rows-in-ns rows story-ns)))
+        allow      (set (:story-spec-known-unmanifested (rf.api-manifest.gen/read-sidecar)))
+        file       (rf.api-manifest.projection/repo-file "tools" "story" "spec" "API.md")
+        rel        (rf.api-manifest.projection/repo-relative file)
+        var-rows   (rf.api-manifest.projection/table-var-rows (rf.api-manifest.projection/numbered-lines file))
         problems   (keep (fn [{:keys [var line]}]
                            (when-not (or (contains? story-vars var)
                                          (contains? allow var))
                              {:file rel :line line :raw var
                               :detail "no re-frame.story manifest row"}))
                          var-rows)]
-    (proj/report-with-floor! "tools/story/spec/API.md"
+    (rf.api-manifest.projection/report-with-floor! "tools/story/spec/API.md"
                              (count var-rows) min-var-rows problems)))
 
 (defn -main [& _]

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/xray_spec_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/xray_spec_check.clj
@@ -47,8 +47,8 @@
   renamed to an unmanifested namespace, or a panel namespace is removed
   from the manifest while the spec still names it — the keystone allowlist
   discipline applied to the live panel + mount surface."
-  (:require [re-frame.api-manifest.gen :as gen]
-            [re-frame.api-manifest.projection :as proj]))
+  (:require [re-frame.api-manifest.gen :as rf.api-manifest.gen]
+            [re-frame.api-manifest.projection :as rf.api-manifest.projection]))
 
 (def ^:private xray-ns-prefix "day8.re-frame2-xray.")
 
@@ -113,14 +113,14 @@
 
 (defn check!
   []
-  (let [rows            (proj/manifest-rows)
-        sidecar         (gen/read-sidecar)
+  (let [rows            (rf.api-manifest.projection/manifest-rows)
+        sidecar         (rf.api-manifest.gen/read-sidecar)
         qualified-allow (set (map vec (:xray-spec-known-unmanifested-qualified sidecar)))
         bare-allow      (set (:xray-spec-known-unmanifested sidecar))
-        file            (proj/repo-file "tools" "xray" "spec" "API.md")
-        rel             (proj/repo-relative file)
-        lines           (proj/numbered-lines file)
-        qualified-refs  (distinct (proj/qualified-symbol-references xray-ns-prefix lines))
+        file            (rf.api-manifest.projection/repo-file "tools" "xray" "spec" "API.md")
+        rel             (rf.api-manifest.projection/repo-relative file)
+        lines           (rf.api-manifest.projection/numbered-lines file)
+        qualified-refs  (distinct (rf.api-manifest.projection/qualified-symbol-references xray-ns-prefix lines))
         bare-refs       (distinct (mount-references lines))
         problems        (reconcile {:rows            rows
                                     :qualified-refs  qualified-refs
@@ -128,7 +128,7 @@
                                     :qualified-allow qualified-allow
                                     :bare-allow      bare-allow
                                     :rel             rel})]
-    (proj/report-with-floor! "tools/xray/spec/API.md"
+    (rf.api-manifest.projection/report-with-floor! "tools/xray/spec/API.md"
                              (+ (count qualified-refs) (count bare-refs))
                              min-references
                              problems)))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -23,7 +23,7 @@
   `reconcile` reconciler with synthetic inputs, plus a live smoke that the
   committed spec/API.md + manifest still reconcile clean."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.api-manifest.api-md-check :as c]))
+            [re-frame.api-manifest.api-md-check :as rf.api-manifest.api-md-check]))
 
 ;; A minimal synthetic manifest reproducing the EXACT ambiguity the real
 ;; manifest has: the bare var `adapter` carried for four namespaces, three
@@ -43,10 +43,10 @@
    real `adapter-aliases` and an optional bare-name allowlist."
   [api-rows & {:keys [known-unmanifested]
                :or   {known-unmanifested #{}}}]
-  (c/reconcile {:rows               synthetic-rows
+  (rf.api-manifest.api-md-check/reconcile {:rows               synthetic-rows
                 :api-rows           api-rows
                 :known-unmanifested known-unmanifested
-                :aliases            c/adapter-aliases}))
+                :aliases            rf.api-manifest.api-md-check/adapter-aliases}))
 
 ;; ---------------------------------------------------------------------------
 ;; Qualified-row resolution.
@@ -55,7 +55,7 @@
 (deftest live-api-md-check-passes
   (testing "the committed tree passes the full api-md-check including the
             EP-0011/EP-0015 keyword-drift guards (no false +)"
-    (is (true? (c/check!))
+    (is (true? (rf.api-manifest.api-md-check/check!))
         "live drift: api-md-check failed with the keyword-drift guards wired")))
 
 (deftest qualified-alias-row-resolves-by-exact-ns+var
@@ -157,11 +157,11 @@
   (testing "the committed spec/API.md projection reconciles against the
             committed manifest with zero problems (the CI contract), and it
             actually exercises qualified rows"
-    (let [api-rows (c/parse-api-md-var-rows)]
+    (let [api-rows (rf.api-manifest.api-md-check/parse-api-md-var-rows)]
       (is (pos? (count (filter :qualifier api-rows)))
           "spec/API.md must actually name namespace/alias-qualified var-rows
            (otherwise this regression would be vacuous)")
-      (is (true? (c/check!))
+      (is (true? (rf.api-manifest.api-md-check/check!))
           "live drift: spec/API.md var-rows disagree with the manifest"))))
 
 ;; ---------------------------------------------------------------------------
@@ -176,26 +176,26 @@
 
 (deftest zero-extracted-rows-violates-the-floor
   (testing "ZERO extracted var-rows (a total parser collapse) trips the floor"
-    (is (some? (c/floor-violation 0))
+    (is (some? (rf.api-manifest.api-md-check/floor-violation 0))
         "zero extracted rows must be a floor violation (vacuous OK refused)")))
 
 (deftest near-collapse-extraction-violates-the-floor
   (testing "a near-collapse (a small subset extracted, well below the live
             ~196) trips the floor"
-    (is (some? (c/floor-violation 5))
+    (is (some? (rf.api-manifest.api-md-check/floor-violation 5))
         "5 extracted rows is a near-total collapse — must trip the floor")
-    (is (some? (c/floor-violation 149))
+    (is (some? (rf.api-manifest.api-md-check/floor-violation 149))
         "149 rows is below the 150 floor — must trip it")))
 
 (deftest healthy-extraction-does-not-violate-the-floor
   (testing "the live extracted-row count (~196) is comfortably above the floor"
-    (is (nil? (c/floor-violation 196))
+    (is (nil? (rf.api-manifest.api-md-check/floor-violation 196))
         "the live count must NOT trip the floor (no false positive)")
-    (is (nil? (c/floor-violation 150))
+    (is (nil? (rf.api-manifest.api-md-check/floor-violation 150))
         "exactly at the floor is acceptable (strictly-below trips)")
     ;; And the REAL parse over the committed API.md is above the floor — the
     ;; floor is calibrated below the live count, never tripping on real churn.
-    (is (nil? (c/floor-violation (count (c/parse-api-md-var-rows))))
+    (is (nil? (rf.api-manifest.api-md-check/floor-violation (count (rf.api-manifest.api-md-check/parse-api-md-var-rows))))
         "the real spec/API.md extraction must clear the floor")))
 
 ;; ---------------------------------------------------------------------------
@@ -221,7 +221,7 @@
 (deftest unknown-kind-marker-disappears-then-is-caught
   (testing "END-TO-END (rf2-asxo3): a root verb whose M/Fn marker is an unknown
             spelling (`Macro`) is DROPPED by the real parser"
-    (let [parsed (c/parse-var-rows synthetic-api-md-lines)]
+    (let [parsed (rf.api-manifest.api-md-check/parse-var-rows synthetic-api-md-lines)]
       (is (= #{"create-root" "hydrate-root" "unmount!"} (set (map :var parsed)))
           "render! must have DISAPPEARED from the parse (unknown marker skipped)"))))
 
@@ -231,5 +231,5 @@
             the marker drift, not the fixture)"
     (let [ok-lines (assoc-in synthetic-api-md-lines [3 1]
                              "| `render!` | M | sig | S1 | advanced | n |")
-          parsed   (c/parse-var-rows ok-lines)]
+          parsed   (rf.api-manifest.api-md-check/parse-var-rows ok-lines)]
       (is (= #{"create-root" "render!" "hydrate-root" "unmount!"} (set (map :var parsed)))))))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/doc_api_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/doc_api_check_test.clj
@@ -17,8 +17,8 @@
     * a file-scoped removed name is silenced ONLY in its approved file(s),
       and RED elsewhere (mirroring :doc-guide-known-unmanifested-scoped)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.api-manifest.doc-api-check :as c]
-            [re-frame.api-manifest.gen :as gen]))
+            [re-frame.api-manifest.doc-api-check :as rf.api-manifest.doc-api-check]
+            [re-frame.api-manifest.gen :as rf.api-manifest.gen]))
 
 (def ^:private manifest-vars
   ;; A small synthetic stand-in spanning several namespaces, exercising the
@@ -30,7 +30,7 @@
   {"reg-sub-raw" #{"migration/from-re-frame-v1/README.md"}})
 
 (defn- problems-for [references]
-  (c/reconcile {:references references
+  (rf.api-manifest.doc-api-check/reconcile {:references references
                 :manifest-vars manifest-vars
                 :scoped-allow scoped-allow}))
 
@@ -75,14 +75,14 @@
             reconcile against the committed manifest with zero problems
             (the CI contract — #4887/#4888 cleaned these trees + this PR
             corrected the residual path/unwrap drift the gate surfaced)"
-    (is (true? (c/check!))
+    (is (true? (rf.api-manifest.doc-api-check/check!))
         "live drift: a human-doc API-reference tree names a removed/renamed public surface")))
 
 (deftest scoped-allowlist-sidecar-key-is-present-and-a-map
   (testing "the committed sidecar carries the file-scoped allowlist key as a
             map (empty today; the tombstone uses bare-backtick names, not
             call-position forms, so no entry is needed)"
-    (let [scoped (:doc-api-known-unmanifested-scoped (gen/read-sidecar))]
+    (let [scoped (:doc-api-known-unmanifested-scoped (rf.api-manifest.gen/read-sidecar))]
       (is (map? scoped)
           "the scoped allowlist must be a {name -> #{files}} map"))))
 
@@ -100,7 +100,7 @@
 (deftest coverage-clean-when-every-eligible-var-has-a-member
   (testing "a namespace with a page whose member set covers every eligible var
             (bare or ns-qualified, both reduced to the bare name) reconciles clean"
-    (is (empty? (c/coverage-problems
+    (is (empty? (rf.api-manifest.doc-api-check/coverage-problems
                   {:eligible-rows cov-rows
                    :members {"re-frame.ui"      #{"defview" "sub"}
                              "re-frame.ui.test" #{"render" "find"}}
@@ -109,7 +109,7 @@
 (deftest coverage-flags-a-namespace-with-no-page
   (testing "an eligible namespace ABSENT from the members map (no docs/api page)
             yields ONE :page-missing problem that subsumes its members"
-    (let [probs (c/coverage-problems
+    (let [probs (rf.api-manifest.doc-api-check/coverage-problems
                   {:eligible-rows cov-rows
                    :members {"re-frame.ui" #{"defview" "sub"}} ; ui.test page absent
                    :exempt #{}})]
@@ -118,7 +118,7 @@
 (deftest coverage-flags-a-member-whose-heading-was-removed
   (testing "deleting a member's heading (an eligible var not in its page's member
             set) turns the check RED — the teeth proof"
-    (let [probs (c/coverage-problems
+    (let [probs (rf.api-manifest.doc-api-check/coverage-problems
                   {:eligible-rows cov-rows
                    :members {"re-frame.ui"      #{"defview"} ; `sub` heading removed
                              "re-frame.ui.test" #{"render" "find"}}
@@ -128,7 +128,7 @@
 (deftest coverage-exempt-silences-a-facade-pointer-member
   (testing "an explicit :doc-api-coverage-exempt [namespace var] pair silences a
             member that is intentionally documented only as a facade pointer"
-    (is (empty? (c/coverage-problems
+    (is (empty? (rf.api-manifest.doc-api-check/coverage-problems
                   {:eligible-rows cov-rows
                    :members {"re-frame.ui"      #{"defview"}
                              "re-frame.ui.test" #{"render" "find"}}
@@ -138,12 +138,12 @@
   (testing "the committed manifest reconciles against docs/api/ with full page +
             member coverage (the CI contract — every eligible var has a page and
             a member heading)"
-    (is (true? (c/check-coverage!))
+    (is (true? (rf.api-manifest.doc-api-check/check-coverage!))
         "live coverage drift: an eligible manifest var has no docs/api page or member heading")))
 
 (deftest coverage-exempt-sidecar-key-defaults-empty
   (testing "the coverage-exempt sidecar key, when present, is a collection of
             [namespace var] pairs (absent today → the checker defaults to #{})"
-    (let [exempt (:doc-api-coverage-exempt (gen/read-sidecar))]
+    (let [exempt (:doc-api-coverage-exempt (rf.api-manifest.gen/read-sidecar))]
       (is (or (nil? exempt) (coll? exempt))
           "the coverage-exempt allowlist must be a collection of [ns var] pairs (or absent)"))))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/doc_guide_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/doc_guide_check_test.clj
@@ -16,8 +16,8 @@
   pin that contract through the pure `reconcile` reconciler with synthetic
   references, plus a live smoke that the committed guide reconciles clean."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.api-manifest.doc-guide-check :as c]
-            [re-frame.api-manifest.gen :as gen]))
+            [re-frame.api-manifest.doc-guide-check :as rf.api-manifest.doc-guide-check]
+            [re-frame.api-manifest.gen :as rf.api-manifest.gen]))
 
 (def ^:private core-vars #{"reg-event" "reg-sub" "dispatch"})
 
@@ -27,7 +27,7 @@
    "reg-event-db" #{"docs/core/25-from-re-frame-v1.md"}})
 
 (defn- problems-for [references]
-  (c/reconcile {:references references :core-vars core-vars
+  (rf.api-manifest.doc-guide-check/reconcile {:references references :core-vars core-vars
                 :scoped-allow scoped-allow}))
 
 (deftest core-var-reference-resolves
@@ -78,13 +78,13 @@
 (deftest live-doc-guide-reconciles-clean
   (testing "the committed docs/core reconciles against the committed manifest
             + scoped allowlist with zero problems (the CI contract)"
-    (is (true? (c/check!))
+    (is (true? (rf.api-manifest.doc-guide-check/check!))
         "live drift: docs/core names removed APIs outside approved files")))
 
 (deftest scoped-allowlist-sidecar-key-is-present-and-scopes-inject-cofx
   (testing "the committed sidecar carries the file-scoped allowlist and scopes
             inject-cofx to exactly the two approved migration files"
-    (let [scoped (:doc-guide-known-unmanifested-scoped (gen/read-sidecar))]
+    (let [scoped (:doc-guide-known-unmanifested-scoped (rf.api-manifest.gen/read-sidecar))]
       (is (map? scoped) "the scoped allowlist must be a {name -> #{files}} map")
       (is (= #{"docs/core/25-from-re-frame-v1.md"
                "docs/core/coeffects.md"}

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
@@ -23,7 +23,7 @@
   (pure, synthetic inputs) plus `build-manifest` (the throw), and assert the
   live committed manifest is duplicate-free."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.api-manifest.gen :as gen]))
+            [re-frame.api-manifest.gen :as rf.api-manifest.gen]))
 
 ;; ---------------------------------------------------------------------------
 ;; duplicate-rows — pure detection over synthetic rows.
@@ -31,7 +31,7 @@
 
 (deftest no-duplicates-yields-empty
   (testing "a manifest with distinct [namespace var] keys has no duplicates"
-    (is (empty? (gen/duplicate-rows
+    (is (empty? (rf.api-manifest.gen/duplicate-rows
                   [{:namespace "re-frame.core" :var "reg-event"  :tier :front-porch}
                    {:namespace "re-frame.core" :var "subscribe"  :tier :front-porch}
                    {:namespace "re-frame.adapter.uix" :var "adapter" :tier :adapter}])))))
@@ -39,7 +39,7 @@
 (deftest duplicate-within-cljs-only-detected
   (testing "two rows sharing one [namespace var] (e.g. a duplicated :cljs-only
             sidecar entry, possibly with a CHANGED tier) are flagged"
-    (let [dups (gen/duplicate-rows
+    (let [dups (rf.api-manifest.gen/duplicate-rows
                  [{:namespace "re-frame.adapter.uix" :var "adapter" :tier :adapter}
                   ;; same [ns var], conflicting tier — the exact probe shape
                   {:namespace "re-frame.adapter.uix" :var "adapter" :tier :tooling}
@@ -50,7 +50,7 @@
 (deftest duplicate-between-jvm-and-cljs-only-detected
   (testing "a [namespace var] carried by BOTH a JVM-derived row and a
             :cljs-only row is flagged (the cross-category collision)"
-    (let [dups (gen/duplicate-rows
+    (let [dups (rf.api-manifest.gen/duplicate-rows
                  [{:namespace "re-frame.core" :var "frame-provider"
                    :tier :front-porch :runtime-verified? true}
                   {:namespace "re-frame.core" :var "frame-provider"
@@ -60,7 +60,7 @@
 
 (deftest duplicates-are-sorted
   (testing "the duplicate report is sorted by [namespace var] for stable output"
-    (let [dups (gen/duplicate-rows
+    (let [dups (rf.api-manifest.gen/duplicate-rows
                  [{:namespace "zzz" :var "b"} {:namespace "zzz" :var "b"}
                   {:namespace "aaa" :var "a"} {:namespace "aaa" :var "a"}])]
       (is (= [["aaa" "a"] ["zzz" "b"]] (map first dups))))))
@@ -78,7 +78,7 @@
    `:cljs-only` row and append a copy with a CHANGED tier (a conflicting
    duplicate, the worst case)."
   []
-  (let [sidecar (gen/read-sidecar)
+  (let [sidecar (rf.api-manifest.gen/read-sidecar)
         cljs    (vec (:cljs-only sidecar))
         _       (assert (seq cljs) "precondition: sidecar carries :cljs-only rows")
         dup     (assoc (first cljs) :tier :tooling)]
@@ -90,15 +90,15 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #"Duplicate manifest rows"
-          (gen/build-manifest (live-sidecar-with-duplicate-cljs-only))))))
+          (rf.api-manifest.gen/build-manifest (live-sidecar-with-duplicate-cljs-only))))))
 
 (deftest build-manifest-duplicate-ex-data-lists-the-key
   (testing "the thrown ex-data names the duplicate [namespace var] + count so
             the sidecar/source var can be fixed"
-    (let [dup-row (first (:cljs-only (gen/read-sidecar)))
+    (let [dup-row (first (:cljs-only (rf.api-manifest.gen/read-sidecar)))
           expected-key [(:namespace dup-row) (:var dup-row)]]
       (try
-        (gen/build-manifest (live-sidecar-with-duplicate-cljs-only))
+        (rf.api-manifest.gen/build-manifest (live-sidecar-with-duplicate-cljs-only))
         (is false "expected build-manifest to throw on the duplicate")
         (catch clojure.lang.ExceptionInfo e
           (is (= [[expected-key 2]] (:duplicates (ex-data e)))
@@ -111,9 +111,9 @@
 (deftest live-manifest-has-no-duplicate-rows
   (testing "the committed spec/api-manifest.edn carries one row per
             [namespace var] (non-vacuous: it has many rows)"
-    (let [rows (:vars (gen/read-committed-manifest))]
+    (let [rows (:vars (rf.api-manifest.gen/read-committed-manifest))]
       (is (pos? (count rows)) "precondition: the manifest is non-empty")
-      (is (empty? (gen/duplicate-rows rows))
+      (is (empty? (rf.api-manifest.gen/duplicate-rows rows))
           "the committed manifest must not carry duplicate [namespace var] rows"))))
 
 ;; ---------------------------------------------------------------------------
@@ -131,7 +131,7 @@
             :implementation row OFF the facade, an :internal-public facade
             row and an ordinary front-porch row are not"
     (is (= [["re-frame.core" "make-capture-frame"]]
-           (gen/implementation-facade-rows
+           (rf.api-manifest.gen/implementation-facade-rows
              [{:namespace "re-frame.core" :var "capture-frame"
                :tier :front-porch :facade? true}
               {:namespace "re-frame.core" :var "make-capture-frame"
@@ -144,7 +144,7 @@
 (deftest implementation-facade-rows-are-sorted
   (testing "the report is sorted by [namespace var] for stable output"
     (is (= [["a.ns" "b"] ["a.ns" "c"] ["z.ns" "a"]]
-           (gen/implementation-facade-rows
+           (rf.api-manifest.gen/implementation-facade-rows
              [{:namespace "z.ns" :var "a" :tier :implementation :facade? true}
               {:namespace "a.ns" :var "c" :tier :implementation :facade? true}
               {:namespace "a.ns" :var "b" :tier :implementation :facade? true}])))))
@@ -157,7 +157,7 @@
    rows had. Using the real sidecar keeps the missing/stale/duplicate checks
    passing so the facade-vs-disposition check is what fires."
   []
-  (let [sidecar (gen/read-sidecar)
+  (let [sidecar (rf.api-manifest.gen/read-sidecar)
         k       ["re-frame.core" "capture-frame"]]
     (assert (get-in sidecar [:classification k])
             "precondition: the sidecar classifies re-frame.core/capture-frame")
@@ -169,13 +169,13 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #"Implementation-only rows exported from a facade"
-          (gen/build-manifest (live-sidecar-with-demoted-facade-var))))))
+          (rf.api-manifest.gen/build-manifest (live-sidecar-with-demoted-facade-var))))))
 
 (deftest build-manifest-implementation-facade-ex-data-lists-the-key
   (testing "the thrown ex-data names the offending [namespace var] so the
             var can be moved off the facade"
     (try
-      (gen/build-manifest (live-sidecar-with-demoted-facade-var))
+      (rf.api-manifest.gen/build-manifest (live-sidecar-with-demoted-facade-var))
       (is false "expected build-manifest to throw on the planted row")
       (catch clojure.lang.ExceptionInfo e
         (is (= [["re-frame.core" "capture-frame"]]
@@ -202,7 +202,7 @@
   (testing "a facade row with no :justification is flagged; a facade row WITH
             one, and a non-facade row without one, are not"
     (is (= [["re-frame.core" "silent"]]
-           (gen/unjustified-facade-rows
+           (rf.api-manifest.gen/unjustified-facade-rows
              [{:namespace "re-frame.core" :var "spoken" :facade? true
                :action :keep :justification "day-one vocabulary"}
               {:namespace "re-frame.core" :var "silent" :facade? true
@@ -216,7 +216,7 @@
             refused exactly as an absent one is"
     (is (= [["re-frame.core" "blank"] ["re-frame.core" "empty"]
             ["re-frame.core" "not-a-string"]]
-           (gen/unjustified-facade-rows
+           (rf.api-manifest.gen/unjustified-facade-rows
              [{:namespace "re-frame.core" :var "empty" :facade? true
                :action :keep :justification ""}
               {:namespace "re-frame.core" :var "blank" :facade? true
@@ -229,11 +229,11 @@
             :move included, because the table must be able to RECORD a ruled
             move before the move executes"
     (is (empty?
-          (gen/bad-action-facade-rows
-            (for [a gen/facade-action-vocab]
+          (rf.api-manifest.gen/bad-action-facade-rows
+            (for [a rf.api-manifest.gen/facade-action-vocab]
               {:namespace "re-frame.core" :var (name a) :facade? true
                :action a :justification "reason"}))))
-    (is (= #{:keep :rename :move :internal-public} gen/facade-action-vocab))))
+    (is (= #{:keep :rename :move :internal-public} rf.api-manifest.gen/facade-action-vocab))))
 
 (deftest bad-action-facade-rows-flags-missing-and-unknown
   (testing "an absent :action (the shape a new, unclassified facade export
@@ -242,7 +242,7 @@
     (is (= [["re-frame.core" "absent" nil]
             ["re-frame.core" "coined" :defer]
             ["re-frame.core" "typo" :keeep]]
-           (gen/bad-action-facade-rows
+           (rf.api-manifest.gen/bad-action-facade-rows
              [{:namespace "re-frame.core" :var "typo" :facade? true
                :action :keeep :justification "reason"}
               {:namespace "re-frame.core" :var "coined" :facade? true
@@ -259,7 +259,7 @@
    duplicate / implementation-facade checks passing, so the axis under test
    is what fires."
   [& ks]
-  (let [sidecar (gen/read-sidecar)
+  (let [sidecar (rf.api-manifest.gen/read-sidecar)
         k       ["re-frame.core" "capture-frame"]]
     (assert (get-in sidecar [:classification k :justification])
             "precondition: the sidecar justifies re-frame.core/capture-frame")
@@ -273,12 +273,12 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #"Facade rows with no :justification"
-          (gen/build-manifest (live-sidecar-without :justification))))))
+          (rf.api-manifest.gen/build-manifest (live-sidecar-without :justification))))))
 
 (deftest build-manifest-unjustified-ex-data-lists-the-key
   (testing "the thrown ex-data names the offending [namespace var]"
     (try
-      (gen/build-manifest (live-sidecar-without :justification))
+      (rf.api-manifest.gen/build-manifest (live-sidecar-without :justification))
       (is false "expected build-manifest to throw on the unjustified row")
       (catch clojure.lang.ExceptionInfo e
         (is (= [["re-frame.core" "capture-frame"]]
@@ -287,14 +287,14 @@
 (deftest build-manifest-throws-on-unknown-action
   (testing "build-manifest refuses a facade row whose :action is outside the
             closed vocabulary"
-    (let [sidecar (assoc-in (gen/read-sidecar)
+    (let [sidecar (assoc-in (rf.api-manifest.gen/read-sidecar)
                             [:classification ["re-frame.core" "capture-frame"]
                              :action]
                             :defer)]
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
             #"Facade rows with a missing or unknown :action"
-            (gen/build-manifest sidecar))))))
+            (rf.api-manifest.gen/build-manifest sidecar))))))
 
 (deftest build-manifest-throws-on-missing-action
   (testing "an absent :action is refused too — it is the shape an unclassified
@@ -302,18 +302,18 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #"Facade rows with a missing or unknown :action"
-          (gen/build-manifest (live-sidecar-without :action))))))
+          (rf.api-manifest.gen/build-manifest (live-sidecar-without :action))))))
 
 (deftest build-manifest-does-not-require-the-axes-off-the-facade
   (testing "dropping both axes from a NON-facade row leaves generation green —
             the obligation is on facade exports only"
-    (let [sidecar (gen/read-sidecar)
+    (let [sidecar (rf.api-manifest.gen/read-sidecar)
           k       ["re-frame.epoch" "restore-epoch!"]]
       (assert (get-in sidecar [:classification k])
               "precondition: the sidecar classifies re-frame.epoch/restore-epoch!")
       (assert (nil? (get-in sidecar [:classification k :justification]))
               "precondition: a non-facade row carries no :justification today")
-      (is (map? (gen/build-manifest
+      (is (map? (rf.api-manifest.gen/build-manifest
                   (update-in sidecar [:classification k]
                              dissoc :justification :action)))))))
 
@@ -324,17 +324,17 @@
 (deftest live-manifest-facade-rows-all-carry-both-axes
   (testing "the committed spec/api-manifest.edn justifies and classifies every
             :facade? true row (non-vacuous: it has many facade rows)"
-    (let [rows   (:vars (gen/read-committed-manifest))
+    (let [rows   (:vars (rf.api-manifest.gen/read-committed-manifest))
           facade (filter :facade? rows)]
       (is (pos? (count facade)) "precondition: the manifest has facade rows")
-      (is (empty? (gen/unjustified-facade-rows rows)))
-      (is (empty? (gen/bad-action-facade-rows rows))))))
+      (is (empty? (rf.api-manifest.gen/unjustified-facade-rows rows)))
+      (is (empty? (rf.api-manifest.gen/bad-action-facade-rows rows))))))
 
 (deftest live-manifest-axes-are-facade-scoped
   (testing "no NON-facade row carries either axis — the two columns mean
             'facade audit', so a stray one on an ordinary row would read as a
             classification nobody made"
-    (let [rows (remove :facade? (:vars (gen/read-committed-manifest)))]
+    (let [rows (remove :facade? (:vars (rf.api-manifest.gen/read-committed-manifest)))]
       (is (pos? (count rows)) "precondition: the manifest has non-facade rows")
       (is (empty? (filter #(or (contains? % :action)
                                (contains? % :justification))
@@ -345,12 +345,12 @@
             at :tier :implementation, and the plant above is the only way to
             get one (non-vacuous: the manifest still carries :implementation
             rows OFF the facade and :facade? true rows at other tiers)"
-    (let [rows (:vars (gen/read-committed-manifest))]
+    (let [rows (:vars (rf.api-manifest.gen/read-committed-manifest))]
       (is (some #(and (= :implementation (:tier %)) (not (:facade? %))) rows)
           "precondition: :implementation rows exist off the facade")
       (is (some :facade? rows)
           "precondition: facade rows exist")
-      (is (empty? (gen/implementation-facade-rows rows))
+      (is (empty? (rf.api-manifest.gen/implementation-facade-rows rows))
           "the committed manifest must not carry an implementation-only facade row"))))
 
 ;; ---------------------------------------------------------------------------
@@ -369,7 +369,7 @@
             invariants without a Conventions change, and three `contains?`
             calls cannot see that."
     (is (= '#{re-frame.core re-frame.story day8.re-frame2-xray.core}
-           gen/facade-namespaces))))
+           rf.api-manifest.gen/facade-namespaces))))
 
 (deftest xray-facade-rows-are-cljs-only-and-carry-the-flag-per-row
   (testing "the Xray façade reaches the manifest by the `:cljs-only` route,
@@ -379,12 +379,12 @@
             two routes; without it, a reader could believe adding the name to
             that set is what flags the rows, and blanking the sidecar flags
             would then look safe."
-    (let [sidecar   (gen/read-sidecar)
+    (let [sidecar   (rf.api-manifest.gen/read-sidecar)
           xray-rows (filter #(= "day8.re-frame2-xray.core" (:namespace %))
                             (:cljs-only sidecar))]
       (is (seq xray-rows)
           "precondition: the sidecar carries :cljs-only rows for the Xray façade")
-      (is (not (contains? (set gen/jvm-namespaces) 'day8.re-frame2-xray.core))
+      (is (not (contains? (set rf.api-manifest.gen/jvm-namespaces) 'day8.re-frame2-xray.core))
           "the Xray façade is CLJS-only — it must not be on the JVM roster")
       (is (every? :facade? xray-rows)
           "every Xray façade row must carry :facade? true in the sidecar")
@@ -396,10 +396,10 @@
             :facade? true rows to the committed manifest — the non-vacuity
             guard that would catch `facade?` silently narrowing back to one
             namespace while --check stayed green (both sides would agree)"
-    (let [facade-rows (filter :facade? (:vars (gen/read-committed-manifest)))
+    (let [facade-rows (filter :facade? (:vars (rf.api-manifest.gen/read-committed-manifest)))
           by-ns       (set (map :namespace facade-rows))]
       (is (seq facade-rows) "precondition: the manifest carries facade rows")
-      (doseq [ns-sym gen/facade-namespaces]
+      (doseq [ns-sym rf.api-manifest.gen/facade-namespaces]
         (is (contains? by-ns (name ns-sym))
             (str "no :facade? true row for enrolled façade " ns-sym))))))
 
@@ -425,10 +425,10 @@
     ;; deliberately out of scope: it names individual vars whose home
     ;; namespace is mostly internal, and `resolve-extra-var` already throws
     ;; when one stops resolving.
-    (let [rows       (:vars (gen/read-committed-manifest))
+    (let [rows       (:vars (rf.api-manifest.gen/read-committed-manifest))
           rowed-nses (set (map :namespace rows))]
       (is (seq rows) "precondition: the committed manifest carries rows")
-      (doseq [ns-sym gen/jvm-namespaces]
+      (doseq [ns-sym rf.api-manifest.gen/jvm-namespaces]
         (is (contains? rowed-nses (name ns-sym))
             (str ns-sym " is in the generator's jvm-namespaces roster but "
                  "contributes NO row to the committed manifest — it either "

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/projection_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/projection_test.clj
@@ -14,29 +14,29 @@
   `require-markdown-files` throws (rather than returning nil) for a missing
   directory so a moved/renamed surface fails loudly."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.api-manifest.projection :as proj]))
+            [re-frame.api-manifest.projection :as rf.api-manifest.projection]))
 
 (deftest vacuity-floor-problem-trips-below-floor
   (testing "checked below the floor synthesises a floor-violation problem"
-    (let [p (proj/vacuity-floor-problem "skills/" 0 100)]
+    (let [p (rf.api-manifest.projection/vacuity-floor-problem "skills/" 0 100)]
       (is (some? p))
       (is (= "(extractor)" (:file p)))
       (is (re-find #"below the non-vacuous floor of 100" (:detail p)))))
   (testing "checked just below the floor still trips"
-    (is (some? (proj/vacuity-floor-problem "skills/" 99 100))))
+    (is (some? (rf.api-manifest.projection/vacuity-floor-problem "skills/" 99 100))))
   (testing "checked AT or ABOVE the floor does not trip"
-    (is (nil? (proj/vacuity-floor-problem "skills/" 100 100)))
-    (is (nil? (proj/vacuity-floor-problem "skills/" 505 100)))))
+    (is (nil? (rf.api-manifest.projection/vacuity-floor-problem "skills/" 100 100)))
+    (is (nil? (rf.api-manifest.projection/vacuity-floor-problem "skills/" 505 100)))))
 
 (deftest report-with-floor-goes-red-on-vacuous-empty
   (testing "an empty problem list with a sub-floor count is RED (the bug)"
     ;; The vacuous-green case: zero problems found because zero references
     ;; were extracted. Must be a FALSE verdict, not a vacuous OK.
-    (is (false? (proj/report-with-floor! "skills/" 0 100 []))))
+    (is (false? (rf.api-manifest.projection/report-with-floor! "skills/" 0 100 []))))
   (testing "an empty problem list ABOVE the floor is GREEN"
-    (is (true? (proj/report-with-floor! "skills/" 505 100 []))))
+    (is (true? (rf.api-manifest.projection/report-with-floor! "skills/" 505 100 []))))
   (testing "a real drift problem is RED regardless of the floor"
-    (is (false? (proj/report-with-floor!
+    (is (false? (rf.api-manifest.projection/report-with-floor!
                   "skills/" 505 100
                   [{:file "skills/x.md" :line 1 :raw "rf/gone" :detail "no row"}])))))
 
@@ -44,15 +44,15 @@
   (testing "a missing/renamed surface dir throws (does NOT return nil)"
     ;; An absolute path under the repo root, as real callers pass via
     ;; repo-file — a moved/renamed surface dir.
-    (let [absent (proj/repo-file (str "definitely-missing-surface-"
+    (let [absent (rf.api-manifest.projection/repo-file (str "definitely-missing-surface-"
                                       (System/currentTimeMillis)))]
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
             #"expected directory is missing"
-            (proj/require-markdown-files "skills/" absent)))))
+            (rf.api-manifest.projection/require-markdown-files "skills/" absent)))))
   (testing "an existing dir returns its markdown files (delegates to markdown-files)"
     ;; The committed skills/ surface exists and carries many *.md files.
-    (let [files (proj/require-markdown-files "skills/" (proj/repo-file "skills"))]
+    (let [files (rf.api-manifest.projection/require-markdown-files "skills/" (rf.api-manifest.projection/repo-file "skills"))]
       (is (pos? (count files))))))
 
 ;; ---------------------------------------------------------------------------
@@ -67,7 +67,7 @@
 
 (deftest keyword-drift-flags-bare-stale-mention
   (testing "a fresh :rf.world/inputs mention with no retirement marker is flagged"
-    (let [probs (proj/ep0017-keyword-drift-problems
+    (let [probs (rf.api-manifest.projection/ep0017-keyword-drift-problems
                   "docs/core/x.md"
                   [[10 "Supply recordable facts under :rf.world/inputs on dispatch."]])]
       (is (= 1 (count probs)))
@@ -77,24 +77,24 @@
 
 (deftest keyword-drift-allows-rename-mention-naming-replacement
   (testing "a :rf.world/inputs line that names the :rf.cofx replacement is approved"
-    (is (empty? (proj/ep0017-keyword-drift-problems
+    (is (empty? (rf.api-manifest.projection/ep0017-keyword-drift-problems
                   "spec/Spec-Schemas.md"
                   [[5 "The EP-0010 :rf.world/inputs field is renamed to :rf.cofx (EP-0017)."]])))))
 
 (deftest keyword-drift-allows-error-id-and-prose-markers
   (testing "a :rf.world/inputs line naming the generic unrecognised-opt surface + :rf.cofx is a legitimate mention"
-    (is (empty? (proj/ep0017-keyword-drift-problems
+    (is (empty? (rf.api-manifest.projection/ep0017-keyword-drift-problems
                   "spec/002-Frames.md"
                   [[1 "Supplying :rf.world/inputs rides the generic :rf.warning/unknown-dispatch-opt warning naming :rf.cofx."]]))))
   (testing "the prose words retired/renamed/migrat each mark a legitimate mention"
-    (is (empty? (proj/ep0017-keyword-drift-problems
+    (is (empty? (rf.api-manifest.projection/ep0017-keyword-drift-problems
                   "x.md"
                   [[1 "The :rf.world/inputs key is retired."]
                    [2 "A migration mention of :rf.world/inputs."]])))))
 
 (deftest keyword-drift-ignores-lines-without-the-keyword
   (testing "lines that do not mention :rf.world/inputs produce no problems"
-    (is (empty? (proj/ep0017-keyword-drift-problems
+    (is (empty? (rf.api-manifest.projection/ep0017-keyword-drift-problems
                   "x.md"
                   [[1 "Declare coeffects via :rf.cofx/requires; values arrive flat."]
                    [2 "The :rf.cofx envelope map is the one nested record."]])))))
@@ -106,9 +106,9 @@
     ;; The committed docs/core/ + skills/ surfaces carry only
     ;; retirement/rename mentions, so the live scan must be clean — a
     ;; regression catches a fresh reintroduction.
-    (let [guide-files (proj/markdown-files (proj/repo-file "docs" "core"))]
+    (let [guide-files (rf.api-manifest.projection/markdown-files (rf.api-manifest.projection/repo-file "docs" "core"))]
       (is (pos? (count guide-files)))
-      (is (empty? (proj/keyword-drift-problems-over-files guide-files))
+      (is (empty? (rf.api-manifest.projection/keyword-drift-problems-over-files guide-files))
           "live drift: a docs/core file reintroduced stale :rf.world/inputs"))))
 
 ;; ---------------------------------------------------------------------------
@@ -122,7 +122,7 @@
 
 (deftest ep0011-flags-fresh-stale-key
   (testing "a fresh :stale-key mention with no retirement marker is flagged"
-    (let [probs (proj/ep0011-reply-vocab-drift-problems
+    (let [probs (rf.api-manifest.projection/ep0011-reply-vocab-drift-problems
                   "spec/API.md"
                   [[7 "Suppress on a `:stale-key` `[:resource k gen]` head."]])]
       (is (= 1 (count probs)))
@@ -131,7 +131,7 @@
 
 (deftest ep0011-flags-fresh-bare-work-id
   (testing "a fresh bare :work-id (hyphen) mention with no marker is flagged"
-    (let [probs (proj/ep0011-reply-vocab-drift-problems
+    (let [probs (rf.api-manifest.projection/ep0011-reply-vocab-drift-problems
                   "docs/core/x.md"
                   [[3 "The reply map carries a `:work-id` attempt identity."]])]
       (is (= 1 (count probs)))
@@ -139,14 +139,14 @@
 
 (deftest ep0011-canonical-work-id-not-flagged
   (testing "the canonical namespaced :work/id is NOT a bare :work-id match"
-    (is (empty? (proj/ep0011-reply-vocab-drift-problems
+    (is (empty? (rf.api-manifest.projection/ep0011-reply-vocab-drift-problems
                   "x.md"
                   [[1 "The attempt identity is `:work/id` (one attempt, one id)."]])))))
 
 (deftest ep0011-allows-retirement-mentions
   (testing "a retired spelling on a line that names :work/id or the EP-0007
             rule, or sits in an :rf.observe/:correlation context, is approved"
-    (is (empty? (proj/ep0011-reply-vocab-drift-problems
+    (is (empty? (rf.api-manifest.projection/ep0011-reply-vocab-drift-problems
                   "spec/Managed-Effects.md"
                   [[1 "Stale suppression keys on :work/id; the separate :stale-key is dropped."]
                    [2 "No :stale-key-style synonym (EP-0007: one-name-per-fact)."]
@@ -162,20 +162,20 @@
 
 (deftest ep0015-flags-retired-profile-form
   (testing "a fresh retired :rf.egress/on-box-hidden-sensitive form is flagged"
-    (let [probs (proj/ep0015-privacy-vocab-drift-problems
+    (let [probs (rf.api-manifest.projection/ep0015-privacy-vocab-drift-problems
                   "docs/core/x.md"
                   [[9 "Set the profile to :rf.egress/on-box-hidden-sensitive for dev."]])]
       (is (= 1 (count probs)))
       (is (= ":rf.egress/on-box-hidden-sensitive" (:raw (first probs))))
       (is (re-find #":rf.egress/local-redacted" (:detail (first probs))))))
   (testing "the retired :rf.egress/trusted-local-raw form is flagged too"
-    (is (= 1 (count (proj/ep0015-privacy-vocab-drift-problems
+    (is (= 1 (count (rf.api-manifest.projection/ep0015-privacy-vocab-drift-problems
                       "skills/x.md"
                       [[1 "Use :rf.egress/trusted-local-raw for the operator."]]))))))
 
 (deftest ep0015-allows-rename-mentions
   (testing "a retired form on a line naming the replacement or 'renamed' is OK"
-    (is (empty? (proj/ep0015-privacy-vocab-drift-problems
+    (is (empty? (rf.api-manifest.projection/ep0015-privacy-vocab-drift-problems
                   "spec/API.md"
                   [[1 ":rf.egress/on-box-hidden-sensitive was renamed to :rf.egress/local-redacted."]
                    [2 "The earlier :rf.egress/trusted-local-raw spelling is retired."]])))))
@@ -183,7 +183,7 @@
 (deftest ep0015-current-egress-names-not-flagged
   (testing "the current :rf.egress/local-redacted / local-raw names are NOT drift,
             and the bare English adjectives on-box / trusted-local are not either"
-    (is (empty? (proj/ep0015-privacy-vocab-drift-problems
+    (is (empty? (rf.api-manifest.projection/ep0015-privacy-vocab-drift-problems
                   "x.md"
                   [[1 "Local dev defaults to :rf.egress/local-redacted; raw is :rf.egress/local-raw."]
                    [2 "A trusted-local operator on-box may opt into raw."]])))))
@@ -192,7 +192,7 @@
   (testing "the live docs/core surface carries no EP-0011/EP-0015 stale
             vocabulary either (the folded driver stays clean). docs/core has
             no migration-skill exclusion, so the whole tree must be clean."
-    (let [guide (proj/markdown-files (proj/repo-file "docs" "core"))]
+    (let [guide (rf.api-manifest.projection/markdown-files (rf.api-manifest.projection/repo-file "docs" "core"))]
       (is (pos? (count guide)))
-      (is (empty? (proj/keyword-drift-problems-over-files guide))
+      (is (empty? (rf.api-manifest.projection/keyword-drift-problems-over-files guide))
           "live drift: a docs/core file reintroduced stale reply/egress vocabulary"))))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/roster_completeness_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/roster_completeness_test.clj
@@ -32,7 +32,7 @@
   `assert-roster-complete!` (the throw), and assert the LIVE rosters account
   for the LIVE trees exactly."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.api-manifest.gen :as gen]))
+            [re-frame.api-manifest.gen :as rf.api-manifest.gen]))
 
 ;; ---------------------------------------------------------------------------
 ;; roster-drift — pure reconciliation over synthetic inputs.
@@ -51,8 +51,8 @@
   (testing "a tree whose every namespace is enrolled or recorded internal
             reports nothing in any of the three directions"
     (let [present (into #{'re-frame.ssr 're-frame.ssr.ring}
-                        (take 3 gen/internal-namespaces))
-          drift   (gen/roster-drift present no-cljs-sidecar)]
+                        (take 3 rf.api-manifest.gen/internal-namespaces))
+          drift   (rf.api-manifest.gen/roster-drift present no-cljs-sidecar)]
       (is (empty? (:unaccounted drift)))
       (is (empty? (:contradictory drift)))
       ;; Every internal entry NOT in this synthetic `present` reads as stale,
@@ -65,7 +65,7 @@
   (testing "a namespace named by NO roster is reported by name — the new
             public surface that would otherwise ship unscanned"
     (let [present #{'re-frame.ssr 're-frame.ssr.brand-new}
-          drift   (gen/roster-drift present no-cljs-sidecar)]
+          drift   (rf.api-manifest.gen/roster-drift present no-cljs-sidecar)]
       (is (= '[re-frame.ssr.brand-new] (:unaccounted drift))))))
 
 (deftest enrolment-accounts-for-a-namespace
@@ -73,15 +73,15 @@
             for — enrolment is what clears the finding, not a marker"
     ;; `re-frame.ssr.ring.node` is enrolled (rf2-8arzr.7), so it must NOT be
     ;; reported even though it is not on the internal roster.
-    (let [drift (gen/roster-drift #{'re-frame.ssr.ring.node} no-cljs-sidecar)]
+    (let [drift (rf.api-manifest.gen/roster-drift #{'re-frame.ssr.ring.node} no-cljs-sidecar)]
       (is (empty? (:unaccounted drift))))))
 
 (deftest a-cljs-only-sidecar-row-accounts-for-a-namespace
   (testing "a namespace the JVM cannot require is accounted for by its
             sidecar :cljs-only rows — the path a CLJS-only surface takes"
     (let [present #{'re-frame.hicasso.server}
-          bare    (gen/roster-drift present no-cljs-sidecar)
-          carried (gen/roster-drift
+          bare    (rf.api-manifest.gen/roster-drift present no-cljs-sidecar)
+          carried (rf.api-manifest.gen/roster-drift
                     present
                     {:cljs-only [{:namespace "re-frame.hicasso.server"
                                   :var       "render-body"}]})]
@@ -94,24 +94,24 @@
   (testing "an internal-roster entry whose source file is gone is reported —
             the roster rots the way the sidecar does, and is reconciled the
             same way"
-    (let [gone  (first (sort gen/internal-namespaces))
-          drift (gen/roster-drift
-                  (disj (set gen/internal-namespaces) gone)
+    (let [gone  (first (sort rf.api-manifest.gen/internal-namespaces))
+          drift (rf.api-manifest.gen/roster-drift
+                  (disj (set rf.api-manifest.gen/internal-namespaces) gone)
                   no-cljs-sidecar)]
       (is (= [gone] (:stale drift))))))
 
 (deftest claiming-both-is-contradictory
   (testing "a namespace enrolled as public AND recorded internal is a
             contradiction, not a classification"
-    (let [both  (first (sort gen/internal-namespaces))
-          drift (gen/roster-drift
+    (let [both  (first (sort rf.api-manifest.gen/internal-namespaces))
+          drift (rf.api-manifest.gen/roster-drift
                   #{both}
                   {:cljs-only [{:namespace (name both) :var "x"}]})]
       (is (= [both] (:contradictory drift))))))
 
 (deftest unaccounted-is-sorted
   (testing "findings are sorted, so the failure message is stable across runs"
-    (let [drift (gen/roster-drift
+    (let [drift (rf.api-manifest.gen/roster-drift
                   '#{re-frame.ssr.zzz re-frame.ssr.aaa re-frame.ssr.mmm}
                   no-cljs-sidecar)]
       (is (= '[re-frame.ssr.aaa re-frame.ssr.mmm re-frame.ssr.zzz]
@@ -127,10 +127,10 @@
     (let [present '#{re-frame.ssr re-frame.ssr.brand-new}]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"re-frame\.ssr\.brand-new"
-                            (gen/assert-roster-complete! present no-cljs-sidecar)))
+                            (rf.api-manifest.gen/assert-roster-complete! present no-cljs-sidecar)))
       (is (= '[re-frame.ssr.brand-new]
              (:unaccounted
-               (try (gen/assert-roster-complete! present no-cljs-sidecar)
+               (try (rf.api-manifest.gen/assert-roster-complete! present no-cljs-sidecar)
                     (catch clojure.lang.ExceptionInfo e (ex-data e)))))))))
 
 (deftest assert-message-names-both-remediation-paths
@@ -138,7 +138,7 @@
             enrol it, or record it internal. A gate that only says NO sends
             people to the nearest silencer (a ^:no-doc marker), which is the
             outcome this bead's fence forbids."
-    (let [msg (try (gen/assert-roster-complete! '#{re-frame.ssr.brand-new}
+    (let [msg (try (rf.api-manifest.gen/assert-roster-complete! '#{re-frame.ssr.brand-new}
                                                 no-cljs-sidecar)
                    (catch clojure.lang.ExceptionInfo e (ex-message e)))]
       (is (re-find #"jvm-namespaces" msg))
@@ -150,8 +150,8 @@
             assertion composes in the caller. `present` must carry the whole
             internal roster: an entry missing from the tree is STALE, which
             is a throw of its own."
-    (let [present (conj (set gen/internal-namespaces) 're-frame.ssr.ring.node)]
-      (is (= present (gen/assert-roster-complete! present no-cljs-sidecar))))))
+    (let [present (conj (set rf.api-manifest.gen/internal-namespaces) 're-frame.ssr.ring.node)]
+      (is (= present (rf.api-manifest.gen/assert-roster-complete! present no-cljs-sidecar))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The LIVE tree — the test that fails if the gate is orphaned again.
@@ -160,14 +160,14 @@
 (deftest covered-roots-are-non-empty
   (testing "the gate reconciles at least one real tree; an empty root list
             would make every assertion above vacuous"
-    (is (seq gen/roster-covered-roots))))
+    (is (seq rf.api-manifest.gen/roster-covered-roots))))
 
 (deftest live-rosters-account-for-the-live-trees
   (testing "every namespace under every covered root is classified, with no
             stale internal entries and no contradictions. This is the
             assertion `build-manifest` makes on every run and every --check."
-    (let [drift (gen/roster-drift (gen/covered-source-namespaces)
-                                  (gen/read-sidecar))]
+    (let [drift (rf.api-manifest.gen/roster-drift (rf.api-manifest.gen/covered-source-namespaces)
+                                  (rf.api-manifest.gen/read-sidecar))]
       (is (empty? (:unaccounted drift))
           (str "unaccounted: " (:unaccounted drift)))
       (is (empty? (:stale drift))
@@ -178,14 +178,14 @@
 (deftest the-crossing-namespaces-are-enrolled
   (testing "the two JVM-loadable ssr-node crossing namespaces rf2-8arzr.7
             found shipping unscanned are enrolled for introspection"
-    (is (contains? (set gen/jvm-namespaces) 're-frame.ssr.ring.node))
-    (is (contains? (set gen/jvm-namespaces) 're-frame.ssr.render-state))))
+    (is (contains? (set rf.api-manifest.gen/jvm-namespaces) 're-frame.ssr.ring.node))
+    (is (contains? (set rf.api-manifest.gen/jvm-namespaces) 're-frame.ssr.render-state))))
 
 (deftest covered-source-namespaces-reads-the-real-tree
   (testing "the live scan returns the artefact doors it must contain — a
             silently empty scan is the defect `namespaces-under` throws to
             prevent, and this pins that it did not happen"
-    (let [present (gen/covered-source-namespaces)]
+    (let [present (rf.api-manifest.gen/covered-source-namespaces)]
       (is (contains? present 're-frame.ssr))
       (is (contains? present 're-frame.ssr.ring))
       (is (contains? present 're-frame.ssr.ring.node))
@@ -223,20 +223,20 @@
             it. This drives the production call site rather than the helper, so
             it is what goes red if that call is ever removed and the gate is
             orphaned a second time."
-    (let [live    (gen/covered-source-namespaces)
-          sidecar (gen/read-sidecar)]
+    (let [live    (rf.api-manifest.gen/covered-source-namespaces)
+          sidecar (rf.api-manifest.gen/read-sidecar)]
       ;; CONTROL FIRST: the live tree is fully accounted for, so `build-manifest`
       ;; succeeds on it. Without this, a `build-manifest` that threw for some
       ;; unrelated reason (a missing classification, a duplicate row) would make
       ;; the assertion below pass for the wrong reason.
-      (is (map? (gen/build-manifest sidecar))
+      (is (map? (rf.api-manifest.gen/build-manifest sidecar))
           "control: the live tree builds a manifest")
-      (with-redefs [gen/covered-source-namespaces
+      (with-redefs [rf.api-manifest.gen/covered-source-namespaces
                     (constantly (conj live synthetic-unaccounted))]
         (is (thrown-with-msg?
               clojure.lang.ExceptionInfo
               #"re-frame\.ssr\.synthetic-unaccounted-probe"
-              (gen/build-manifest sidecar))
+              (rf.api-manifest.gen/build-manifest sidecar))
             "build-manifest must refuse, naming the unaccounted namespace")))))
 
 (deftest build-manifest-roster-refusal-carries-ex-data
@@ -245,12 +245,12 @@
             resemble it. Pinning the ex-data key is what distinguishes the
             roster assertion from the missing/stale/duplicate throws that
             follow it in the same fn."
-    (let [live    (gen/covered-source-namespaces)
-          sidecar (gen/read-sidecar)]
-      (with-redefs [gen/covered-source-namespaces
+    (let [live    (rf.api-manifest.gen/covered-source-namespaces)
+          sidecar (rf.api-manifest.gen/read-sidecar)]
+      (with-redefs [rf.api-manifest.gen/covered-source-namespaces
                     (constantly (conj live synthetic-unaccounted))]
         (try
-          (gen/build-manifest sidecar)
+          (rf.api-manifest.gen/build-manifest sidecar)
           (is false "expected build-manifest to throw on the unaccounted namespace")
           (catch clojure.lang.ExceptionInfo e
             (is (= [synthetic-unaccounted] (:unaccounted (ex-data e)))
@@ -263,8 +263,8 @@
             refusal must be the one that surfaces, because a later check firing
             first would mean an unaccounted namespace could be masked by any
             other drift in the tree."
-    (let [live    (gen/covered-source-namespaces)
-          sidecar (gen/read-sidecar)
+    (let [live    (rf.api-manifest.gen/covered-source-namespaces)
+          sidecar (rf.api-manifest.gen/read-sidecar)
           cljs    (vec (:cljs-only sidecar))
           _       (assert (seq cljs) "precondition: sidecar carries :cljs-only rows")
           ;; A sidecar that is ALSO duplicate-broken, so both checks would fire.
@@ -272,12 +272,12 @@
       ;; Control: with the rosters clean, this sidecar fails on the DUPLICATE.
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"Duplicate manifest rows"
-                            (gen/build-manifest broken))
+                            (rf.api-manifest.gen/build-manifest broken))
           "control: the duplicate check fires when the rosters are clean")
-      (with-redefs [gen/covered-source-namespaces
+      (with-redefs [rf.api-manifest.gen/covered-source-namespaces
                     (constantly (conj live synthetic-unaccounted))]
         (is (thrown-with-msg?
               clojure.lang.ExceptionInfo
               #"Unaccounted public-API source namespace"
-              (gen/build-manifest broken))
+              (rf.api-manifest.gen/build-manifest broken))
             "the roster refusal precedes the duplicate refusal")))))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/xray_spec_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/xray_spec_check_test.clj
@@ -10,9 +10,9 @@
   the pure `reconcile` reconciler with synthetic inputs — plus a live
   smoke that the committed spec + manifest still reconcile clean."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.api-manifest.gen :as gen]
-            [re-frame.api-manifest.projection :as proj]
-            [re-frame.api-manifest.xray-spec-check :as xray]))
+            [re-frame.api-manifest.gen :as rf.api-manifest.gen]
+            [re-frame.api-manifest.projection :as rf.api-manifest.projection]
+            [re-frame.api-manifest.xray-spec-check :as rf.api-manifest.xray-spec-check]))
 
 ;; A minimal synthetic manifest: two distinct panel namespaces, each
 ;; exporting the SAME bare var `Panel`, plus a bare-var mount fn. This is
@@ -29,7 +29,7 @@
    synthetic manifest with the given allowlists."
   [{:keys [qualified-refs bare-refs qualified-allow bare-allow]
     :or   {qualified-refs [] bare-refs [] qualified-allow #{} bare-allow #{}}}]
-  (xray/reconcile {:rows            synthetic-rows
+  (rf.api-manifest.xray-spec-check/reconcile {:rows            synthetic-rows
                    :qualified-refs  qualified-refs
                    :bare-refs       bare-refs
                    :qualified-allow qualified-allow
@@ -98,17 +98,17 @@
 (deftest live-spec-and-manifest-reconcile-clean
   (testing "the committed tools/xray/spec/API.md reconciles against the
             committed manifest with zero problems (the CI contract)"
-    (let [rows            (proj/manifest-rows)
-          sidecar         (gen/read-sidecar)
+    (let [rows            (rf.api-manifest.projection/manifest-rows)
+          sidecar         (rf.api-manifest.gen/read-sidecar)
           qualified-allow (set (map vec (:xray-spec-known-unmanifested-qualified sidecar)))
           bare-allow      (set (:xray-spec-known-unmanifested sidecar))
-          file            (proj/repo-file "tools" "xray" "spec" "API.md")
-          rel             (proj/repo-relative file)
-          lines           (proj/numbered-lines file)
-          qualified-refs  (distinct (proj/qualified-symbol-references
+          file            (rf.api-manifest.projection/repo-file "tools" "xray" "spec" "API.md")
+          rel             (rf.api-manifest.projection/repo-relative file)
+          lines           (rf.api-manifest.projection/numbered-lines file)
+          qualified-refs  (distinct (rf.api-manifest.projection/qualified-symbol-references
                                       "day8.re-frame2-xray." lines))
-          bare-refs       (distinct (xray/mount-references lines))
-          problems        (xray/reconcile {:rows            rows
+          bare-refs       (distinct (rf.api-manifest.xray-spec-check/mount-references lines))
+          problems        (rf.api-manifest.xray-spec-check/reconcile {:rows            rows
                                            :qualified-refs  qualified-refs
                                            :bare-refs       bare-refs
                                            :qualified-allow qualified-allow

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/derivation_egress.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/derivation_egress.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.bundle-isolation-positive-control.derivation-egress
-  (:require [re-frame.derivation.egress :as egress]))
+  (:require [re-frame.derivation.egress :as rf.derivation.egress]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationDerivationEgress"
-        egress/project-graph))
+        rf.derivation.egress/project-graph))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/derivation_graph.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/derivation_graph.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.bundle-isolation-positive-control.derivation-graph
-  (:require [re-frame.derivation.graph :as graph]))
+  (:require [re-frame.derivation.graph :as rf.derivation.graph]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationDerivationGraph"
-        #js [graph/derivation-graph graph/live-derivation-graph]))
+        #js [rf.derivation.graph/derivation-graph rf.derivation.graph/live-derivation-graph]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/epoch.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/epoch.cljs
@@ -1,12 +1,12 @@
 (ns re-frame.bundle-isolation-positive-control.epoch
-  (:require [re-frame.epoch :as epoch]
-            [re-frame.epoch.assembly :as assembly]
-            [re-frame.epoch.listeners :as listeners]))
+  (:require [re-frame.epoch :as rf.epoch]
+            [re-frame.epoch.assembly :as rf.epoch.assembly]
+            [re-frame.epoch.listeners :as rf.epoch.listeners]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationEpoch"
-        #js [epoch/restore-epoch!
-             epoch/replace-frame-state!
-             assembly/build-record
-             listeners/notify-listeners!
-             listeners/on-frame-destroyed!]))
+        #js [rf.epoch/restore-epoch!
+             rf.epoch/replace-frame-state!
+             rf.epoch.assembly/build-record
+             rf.epoch.listeners/notify-listeners!
+             rf.epoch.listeners/on-frame-destroyed!]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/flows.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/flows.cljs
@@ -1,7 +1,7 @@
 (ns re-frame.bundle-isolation-positive-control.flows
-  (:require [re-frame.flows.registry :as registry]
-            [re-frame.flows.topo :as topo]))
+  (:require [re-frame.flows.registry :as rf.flows.registry]
+            [re-frame.flows.topo :as rf.flows.topo]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationFlows"
-        #js [registry/reg-flow topo/topo-sort]))
+        #js [rf.flows.registry/reg-flow rf.flows.topo/topo-sort]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/flows_tooling.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/flows_tooling.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.bundle-isolation-positive-control.flows-tooling
-  (:require [re-frame.flows.tooling :as tooling]))
+  (:require [re-frame.flows.tooling :as rf.flows.tooling]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationFlowsTooling"
-        tooling/flow-algebra-view))
+        rf.flows.tooling/flow-algebra-view))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/hicasso.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/hicasso.cljs
@@ -20,10 +20,10 @@
   ;; `impl.codec` rather than the public door: the sentinels live in that
   ;; namespace's function bodies, and naming the exact fns is what keeps the
   ;; control honest under DCE.
-  (:require [re-frame.hicasso.impl.codec :as codec]))
+  (:require [re-frame.hicasso.impl.codec :as rf.hicasso.impl.codec]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationHicasso"
-        #js [codec/mark-boundary!
-             codec/boundary-head?
-             codec/vector-kind]))
+        #js [rf.hicasso.impl.codec/mark-boundary!
+             rf.hicasso.impl.codec/boundary-head?
+             rf.hicasso.impl.codec/vector-kind]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/machines_tooling.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/machines_tooling.cljs
@@ -1,7 +1,7 @@
 (ns re-frame.bundle-isolation-positive-control.machines-tooling
-  (:require [re-frame.machines.tooling :as tooling]))
+  (:require [re-frame.machines.tooling :as rf.machines.tooling]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationMachinesTooling"
-        #js [tooling/machine-algebra-view
-             tooling/machine-instance-algebra-view]))
+        #js [rf.machines.tooling/machine-algebra-view
+             rf.machines.tooling/machine-instance-algebra-view]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/resources_tooling.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/resources_tooling.cljs
@@ -1,7 +1,7 @@
 (ns re-frame.bundle-isolation-positive-control.resources-tooling
-  (:require [re-frame.resources.tooling :as tooling]))
+  (:require [re-frame.resources.tooling :as rf.resources.tooling]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationResourcesTooling"
-        #js [tooling/resource-algebra-view
-             tooling/resource-cache-algebra-view]))
+        #js [rf.resources.tooling/resource-algebra-view
+             rf.resources.tooling/resource-cache-algebra-view]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/routing.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/routing.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.bundle-isolation-positive-control.routing
-  (:require [re-frame.routing.registry :as registry]))
+  (:require [re-frame.routing.registry :as rf.routing.registry]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationRouting"
-        #js [registry/reg-route registry/route-url]))
+        #js [rf.routing.registry/reg-route rf.routing.registry/route-url]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/routing_tooling.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/routing_tooling.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.bundle-isolation-positive-control.routing-tooling
-  (:require [re-frame.routing.tooling :as tooling]))
+  (:require [re-frame.routing.tooling :as rf.routing.tooling]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationRoutingTooling"
-        #js [tooling/route-algebra-view tooling/route-slice-algebra-view]))
+        #js [rf.routing.tooling/route-algebra-view rf.routing.tooling/route-slice-algebra-view]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/ssr.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/ssr.cljs
@@ -1,10 +1,10 @@
 (ns re-frame.bundle-isolation-positive-control.ssr
-  (:require [re-frame.ssr.hydrate :as hydrate]
-            [re-frame.ssr.response :as response]))
+  (:require [re-frame.ssr.hydrate :as rf.ssr.hydrate]
+            [re-frame.ssr.response :as rf.ssr.response]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationSsr"
-        #js [hydrate/hydrate-event-handler
-             hydrate/verify-hydration!
-             response/default-response
-             response/set-status-fx]))
+        #js [rf.ssr.hydrate/hydrate-event-handler
+             rf.ssr.hydrate/verify-hydration!
+             rf.ssr.response/default-response
+             rf.ssr.response/set-status-fx]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/story.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/story.cljs
@@ -1,9 +1,9 @@
 (ns re-frame.bundle-isolation-positive-control.story
-  (:require [re-frame.story.decorators :as decorators]
-            [re-frame.story.registrar :as registrar]))
+  (:require [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.registrar :as rf.story.registrar]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationStory"
-        #js [registrar/reg-story*
-             decorators/resolve-decorator-refs
-             decorators/apply-hiccup-decorators]))
+        #js [rf.story.registrar/reg-story*
+             rf.story.decorators/resolve-decorator-refs
+             rf.story.decorators/apply-hiccup-decorators]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/subs_tooling.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/subs_tooling.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.bundle-isolation-positive-control.subs-tooling
-  (:require [re-frame.subs.tooling :as tooling]))
+  (:require [re-frame.subs.tooling :as rf.subs.tooling]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationSubsTooling"
-        #js [tooling/sub-topology tooling/sub-algebra-view]))
+        #js [rf.subs.tooling/sub-topology rf.subs.tooling/sub-algebra-view]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/trace_cascade.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/trace_cascade.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.bundle-isolation-positive-control.trace-cascade
-  (:require [re-frame.trace.cascade :as cascade]))
+  (:require [re-frame.trace.cascade :as rf.trace.cascade]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationTraceCascade"
-        #js [cascade/aggregate-cascade cascade/capture-for-epoch!]))
+        #js [rf.trace.cascade/aggregate-cascade rf.trace.cascade/capture-for-epoch!]))

--- a/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/trace_tooling.cljs
+++ b/implementation/scripts/bundle-isolation-positive-control/src/re_frame/bundle_isolation_positive_control/trace_tooling.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.bundle-isolation-positive-control.trace-tooling
-  (:require [re-frame.trace.tooling :as tooling]))
+  (:require [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (defn ^:export run []
   (aset js/globalThis "__rf2BundleIsolationTraceTooling"
-        #js [tooling/trace-buffer tooling/register-listener!]))
+        #js [rf.trace.tooling/trace-buffer rf.trace.tooling/register-listener!]))

--- a/implementation/security/test/re_frame/security/classification_fail_open_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/classification_fail_open_security_cljs_test.cljc
@@ -13,15 +13,15 @@
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.privacy :as privacy]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as ts]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; The fixture supplies the default frame required by dispatch and egress.
 (use-fixtures :each
-  (ts/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter}))
 
 (def ^:private secret "S3CR3T-rf2-nk2h6m-DO-NOT-LEAK")
 
@@ -38,10 +38,10 @@
         {:db        (assoc-in db [:auth :token] secret)
          :sensitive [[:auth :token]]}))
     (rf/dispatch-sync [:auth/login])
-    (is (= secret (get-in (frame/frame-app-db-value :rf/default) [:auth :token]))
+    (is (= secret (get-in (rf.frame/frame-app-db-value :rf/default) [:auth :token]))
         "classification does not alter app-db")
-    (let [wire (rf/elide-wire-value (frame/frame-app-db-value :rf/default))]
-      (is (= privacy/redacted-sentinel (get-in wire [:auth :token]))
+    (let [wire (rf/elide-wire-value (rf.frame/frame-app-db-value :rf/default))]
+      (is (= rf.privacy/redacted-sentinel (get-in wire [:auth :token]))
           "the classified path projects :rf/redacted at egress")
       (is (not (contains-secret? wire))
           "the raw secret does not survive anywhere in the projected value"))))
@@ -57,8 +57,8 @@
                         (assoc-in [:ui :rendered-token] secret))
          :sensitive [[:auth :token]]}))
     (rf/dispatch-sync [:auth/login-and-copy])
-    (let [wire (rf/elide-wire-value (frame/frame-app-db-value :rf/default))]
-      (is (= privacy/redacted-sentinel (get-in wire [:auth :token]))
+    (let [wire (rf/elide-wire-value (rf.frame/frame-app-db-value :rf/default))]
+      (is (= rf.privacy/redacted-sentinel (get-in wire [:auth :token]))
           "the classified path is redacted")
       (is (= secret (get-in wire [:ui :rendered-token]))
           "the unclassified copy remains visible because values are not tracked")
@@ -72,7 +72,7 @@
       (fn [{:keys [db]} _]
         {:db (assoc-in db [:auth :token] secret)}))
     (rf/dispatch-sync [:auth/login-unclassified])
-    (let [wire (rf/elide-wire-value (frame/frame-app-db-value :rf/default))]
+    (let [wire (rf/elide-wire-value (rf.frame/frame-app-db-value :rf/default))]
       (is (= secret (get-in wire [:auth :token]))
           "the unclassified path ships raw — fail-open on omission")
       (is (contains-secret? wire)))))
@@ -86,7 +86,7 @@
             UNCHANGED — positional indices are not path-addressable, so the
             path-based redactor cannot reach them (KNOWN fail-open limitation)"
     (let [positional-event [:auth/login "alice" secret]
-          redacted         (privacy/redact-event positional-event [[:token]])]
+          redacted         (rf.privacy/redact-event positional-event [[:token]])]
       (is (= positional-event redacted)
           "the positional-arg event passes through redact-event unchanged")
       (is (= secret (nth redacted 2))
@@ -100,8 +100,8 @@
             authorial remediation: carry sensitive args in the arg-map and
             classify the path"
     (let [map-event [:auth/login {:user "alice" :token secret}]
-          redacted  (privacy/redact-event map-event [[:token]])]
-      (is (= privacy/redacted-sentinel (get-in redacted [1 :token]))
+          redacted  (rf.privacy/redact-event map-event [[:token]])]
+      (is (= rf.privacy/redacted-sentinel (get-in redacted [1 :token]))
           "the classified arg-map path redacts to :rf/redacted")
       (is (not (contains-secret? redacted))
           "no raw secret survives when the secret rides a classified arg-map

--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -16,7 +16,7 @@
             ;; without it `route-url` soft-passes (no validation throw) and the
             ;; `:schemas/redact-validation-tags` sensitivity oracle is unbound.
             [re-frame.schemas.malli]
-            [re-frame.mcp-base.sensitive :as sens]
+            [re-frame.mcp-base.sensitive :as rf.mcp-base.sensitive]
             ;; SIDE-EFFECT REQUIRE, no alias: `rf/reg-route` is a late-bound
             ;; facade over the OPTIONAL `day8/re-frame2-routing` artefact,
             ;; which `re-frame.core` deliberately does not require. Loading
@@ -25,17 +25,17 @@
             [re-frame.routing]
             ;; A validation reject short-circuits before browser effects, so
             ;; the handler can be driven directly with synthetic coeffects.
-            [re-frame.routing.navigate :as navigate]
-            [re-frame.routing.registry :as registry]
-            #?(:clj  [re-frame.test-support :as test-support :refer [with-trace-recorder!]]
-               :cljs [re-frame.test-support :as test-support :refer-macros [with-trace-recorder!]])
+            [re-frame.routing.navigate :as rf.routing.navigate]
+            [re-frame.routing.registry :as rf.routing.registry]
+            #?(:clj  [re-frame.test-support :as rf.test-support :refer [with-trace-recorder!]]
+               :cljs [re-frame.test-support :as rf.test-support :refer-macros [with-trace-recorder!]])
             ;; Drive the production trace emitter so tests observe the top-level
             ;; sensitivity stamp consumed by MCP egress.
-            [re-frame.trace :as trace]
-            [re-frame.security.gen :as gen]))
+            [re-frame.trace :as rf.trace]
+            [re-frame.security.gen :as rf.security.gen]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:clear-app-schemas? true}))
 
 (def ^:private sentinel "S3CR3T-rf2-zsm03-ERROR-SLOT-DO-NOT-LEAK")
@@ -43,7 +43,7 @@
 (defn- contains-sentinel?
   "True when the sentinel survives anywhere in `x`, including stringified data."
   [x]
-  (gen/contains-string? x sentinel))
+  (rf.security.gen/contains-string? x sentinel))
 
 (def ^:private sensitive-machine-id :sec/sensitive-machine)
 (def ^:private plain-machine-id     :sec/plain-machine)
@@ -79,7 +79,7 @@
   delivered envelope after projection and sensitivity hoisting."
   [tags]
   (with-trace-recorder! [traces]
-    (trace/emit-error! :rf.error/machine-action-exception tags)
+    (rf.trace/emit-error! :rf.error/machine-action-exception tags)
     (first (filter #(= :rf.error/machine-action-exception (:operation %))
                    @traces))))
 
@@ -118,9 +118,9 @@
             sensitive reads are disabled"
     (declare-machine-marks!)
     (let [out          (emit-machine-action-exception-for sensitive-machine-id)
-          [kept dropped] (sens/strip-sensitive [out] false)]
+          [kept dropped] (rf.mcp-base.sensitive/strip-sensitive [out] false)]
       (is (some? out) "the machine-action-exception trace was delivered")
-      (is (true? (sens/sensitive-event? out))
+      (is (true? (rf.mcp-base.sensitive/sensitive-event? out))
           "MCP egress classifies the emitted event as sensitive (top-level flag)")
       (is (= 1 dropped) "the sensitive machine exception event dropped")
       (is (empty? kept) "nothing egressed with --allow-sensitive-reads disabled"))))
@@ -136,7 +136,7 @@
       (is (map? (:exception-data tags)) ":exception-data NOT redacted")
       (is (not (:sensitive? out))
           "no top-level :sensitive? when the machine declares nothing sensitive")
-      (is (false? (sens/sensitive-event? out)) "MCP egress treats it as non-sensitive"))))
+      (is (false? (rf.mcp-base.sensitive/sensitive-event? out)) "MCP egress treats it as non-sensitive"))))
 
 (deftest machine-exception-data-verbatim-for-unregistered-machine
   (testing "an unregistered machine keeps :exception-data verbatim"
@@ -227,7 +227,7 @@
   (if (<= depth 0)
     (fn [rng] [sentinel rng])
     (fn [rng]
-      (let [[wrap rng1] (gen/rand-nth rng [:map :vector :set :nested-map])
+      (let [[wrap rng1] (rf.security.gen/rand-nth rng [:map :vector :set :nested-map])
             [inner rng2] ((gen-ex-data (dec depth)) rng1)]
         (case wrap
           :map        [{:k inner} rng2]
@@ -237,7 +237,7 @@
 
 (def ^:private gen-nested-ex-data
   (fn [rng]
-    (let [[depth rng1] (gen/next-int rng 5)]
+    (let [[depth rng1] (rf.security.gen/next-int rng 5)]
       ((gen-ex-data (inc depth)) rng1))))
 
 (deftest sensitive-machine-redacts-ex-data-at-arbitrary-nesting
@@ -250,14 +250,14 @@
             property coverage."
     (declare-machine-marks!)
     (doseq [id-key [:actor-id :machine-id]]
-      (let [result (gen/for-all
+      (let [result (rf.security.gen/for-all
                      gen-nested-ex-data 120 41
                      (fn [ex-data]
                        (let [tags (assoc (machine-action-exception-tags
                                            id-key sensitive-machine-id)
                                          :exception-data ex-data)
                              out  (emit-machine-action-exception tags)
-                             [kept dropped] (sens/strip-sensitive [out] false)]
+                             [kept dropped] (rf.mcp-base.sensitive/strip-sensitive [out] false)]
                          (and (some? out)
                               (= :rf/redacted (-> out :tags :exception-data))
                               (true? (:sensitive? out))
@@ -283,7 +283,7 @@
   (rf/reg-route :sec/route {:params params-schema} "/doc/:doc")
   (with-trace-recorder! [traces]
     ;; :doc must be rejected by the integer schema.
-    (navigate/navigate-handler {:db {} :rf.frame/id :rf/default}
+    (rf.routing.navigate/navigate-handler {:db {} :rf.frame/id :rf/default}
                                [:rf.route/navigate {:to :sec/route :params {:doc sentinel}}])
     (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                    @traces))))
@@ -329,7 +329,7 @@
     (let [machine-ev (emit-machine-action-exception-for sensitive-machine-id)
           nav-trace  (capture-navigate-failure sensitive-params-schema)
           events     (filterv some? [machine-ev nav-trace])
-          [kept _]   (sens/strip-sensitive events true)]
+          [kept _]   (rf.mcp-base.sensitive/strip-sensitive events true)]
       (is (= 2 (count events)) "both redacted events were produced")
       (is (not-any? contains-sentinel? kept)
           (str "the sentinel reached the MCP boundary even after redaction: "
@@ -341,7 +341,7 @@
             navigate :error slot would ship it"
     (rf/reg-route :sec/raw-route {:params sensitive-params-schema} "/doc/:doc")
     (let [ex (try
-               (registry/route-url {:to :sec/raw-route :params {:doc sentinel}})
+               (rf.routing.registry/route-url {:to :sec/raw-route :params {:doc sentinel}})
                nil
                (catch #?(:clj Throwable :cljs :default) e e))]
       (is (some? ex) "route-url threw on the non-conforming sensitive param")

--- a/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
@@ -10,25 +10,25 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             ;; Publishes the Malli late-bind validate/explain hooks; without
             ;; it the default validator soft-passes and a malformed schema
             ;; never throws (so there is nothing to fail-closed against).
             [re-frame.schemas.malli]
-            [re-frame.schemas :as schemas]
-            [re-frame.routing.url :as url]
-            [re-frame.ssr.hydrate :as hydrate]
-            #?(:clj  [re-frame.test-support :as test-support :refer [with-trace-recorder!]]
-               :cljs [re-frame.test-support :as test-support :refer-macros [with-trace-recorder!]])
-            [re-frame.security.gen :as gen]))
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.routing.url :as rf.routing.url]
+            [re-frame.ssr.hydrate :as rf.ssr.hydrate]
+            #?(:clj  [re-frame.test-support :as rf.test-support :refer [with-trace-recorder!]]
+               :cljs [re-frame.test-support :as rf.test-support :refer-macros [with-trace-recorder!]])
+            [re-frame.security.gen :as rf.security.gen]))
 
 ;; App schemas are frame-local. Bind a scope for registration without creating
 ;; an adapter-backed frame; hydration tests carry their own explicit stamp.
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:clear-app-schemas? true})
   (fn [test-fn]
-    (binding [frame/*current-frame* :rf/default]
+    (binding [rf.frame/*current-frame* :rf/default]
       (test-fn))))
 
 (defn- capture
@@ -55,7 +55,7 @@
             schema and never propagates the validator throw. A true result would run
             the boundary handler on an unvalidated untrusted payload."
     (doseq [schema malformed-schemas]
-      (let [verdict (try (schemas/validate-with-registered-fn schema [:anything])
+      (let [verdict (try (rf.schemas/validate-with-registered-fn schema [:anything])
                          (catch #?(:clj Throwable :cljs :default) e [:threw e]))]
         (is (false? verdict)
             (str "malformed schema " (pr-str schema)
@@ -68,15 +68,15 @@
     (doseq [schema malformed-schemas]
       ;; :where :event
       (let [traces (capture
-                     #(is (false? (schemas/validate-event! :ev/x [:ev/x 1] {:schema schema}))
+                     #(is (false? (rf.schemas/validate-event! :ev/x [:ev/x 1] {:schema schema}))
                           (str "event / " (pr-str schema) " → false")))]
         (is (pos? (count (ops traces :rf.error/malformed-schema)))
             (str "event / " (pr-str schema) " emits :rf.error/malformed-schema")))
       ;; :where :fx-args
-      (is (false? (schemas/validate-fx! :fx/x :ev/x {:any :thing} {:schema schema}))
+      (is (false? (rf.schemas/validate-fx! :fx/x :ev/x {:any :thing} {:schema schema}))
           (str "fx / " (pr-str schema) " → false"))
       ;; :where :sub-return
-      (is (false? (schemas/validate-sub! :sub/x [:sub/x] {:any :thing} {:schema schema}))
+      (is (false? (rf.schemas/validate-sub! :sub/x [:sub/x] {:any :thing} {:schema schema}))
           (str "sub / " (pr-str schema) " → false")))))
 
 (deftest app-db-validation-never-passes-a-malformed-schema
@@ -86,7 +86,7 @@
     (doseq [schema malformed-schemas]
       (rf/reg-app-schema [:root] schema)
       (let [traces (capture
-                     #(is (false? (schemas/validate-app-schema! {:root {:anything 1}} :root/bad))
+                     #(is (false? (rf.schemas/validate-app-schema! {:root {:anything 1}} :root/bad))
                           (str "app-db / " (pr-str schema) " → false (rollback)")))]
         (is (pos? (count (ops traces :rf.error/malformed-schema)))
             (str "app-db / " (pr-str schema) " emits :rf.error/malformed-schema"))))))
@@ -96,12 +96,12 @@
             (a buggy / hostile custom validator) fails CLOSED at the
             boundary seam, not OPEN. The throw is isolated; the verdict is
             false (reject), never true."
-    (schemas/set-schema-fns! {:validate (fn [_ _] (throw (ex-info "validator boom" {})))
+    (rf.schemas/set-schema-fns! {:validate (fn [_ _] (throw (ex-info "validator boom" {})))
                               :explain  (fn [_ _] nil)})
     (try
-      (is (false? (schemas/validate-with-registered-fn [:int] 1))
+      (is (false? (rf.schemas/validate-with-registered-fn [:int] 1))
           "throwing validator → false (fail closed), not a propagated throw, not true")
-      (finally (schemas/reset-schema-validator!)))))
+      (finally (rf.schemas/reset-schema-validator!)))))
 
 (def ^:private untrusted-url-inputs
   "Hostile / malformed URL-sink inputs. Each MUST classify EXTERNAL
@@ -136,9 +136,9 @@
             in-app URL. Without a window, external-url? uses the same
             fail-closed lexical fallback."
     (doseq [input untrusted-url-inputs]
-      (is (false? (url/safe-in-app-url? input))
+      (is (false? (rf.routing.url/safe-in-app-url? input))
           (str (pr-str input) " must NOT pass the in-app lexical gate"))
-      (is (true? (url/external-url? input))
+      (is (true? (rf.routing.url/external-url? input))
           (str (pr-str input) " must classify EXTERNAL (fail closed)")))))
 
 (deftest legitimate-in-app-urls-still-pass
@@ -147,25 +147,25 @@
             still classifies in-app, so fail-closed didn't break real nav."
     (doseq [ok-url ["/" "/dashboard" "/users/42" "/a/b/c" "?q=1" "#frag"
                     "/search?sort=asc#top"]]
-      (is (true? (url/safe-in-app-url? ok-url))
+      (is (true? (rf.routing.url/safe-in-app-url? ok-url))
           (str (pr-str ok-url) " is a legitimate in-app reference"))
-      (is (false? (url/external-url? ok-url))
+      (is (false? (rf.routing.url/external-url? ok-url))
           (str (pr-str ok-url) " classifies in-app (not external)")))))
 
 (def ^:private gen-non-string
-  (gen/gen-one-of
-    (gen/gen-elem [nil true false :kw 'sym {} [] #{}])
-    (gen/gen-int -1000 1000)))
+  (rf.security.gen/gen-one-of
+    (rf.security.gen/gen-elem [nil true false :kw 'sym {} [] #{}])
+    (rf.security.gen/gen-int -1000 1000)))
 
 (deftest non-string-url-inputs-always-fail-closed
   (testing "any non-string URL-sink input classifies
             external and never passes the in-app gate. JavaScript would
             stringify it (`new URL(x, base)`); the guard rejects it first."
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-non-string 200 11
                    (fn [x]
-                     (and (false? (url/safe-in-app-url? x))
-                          (true? (url/external-url? x)))))]
+                     (and (false? (rf.routing.url/safe-in-app-url? x))
+                          (true? (rf.routing.url/external-url? x)))))]
       (is (nil? result)
           (str "a non-string URL input was not failed closed: "
                (pr-str (when result (dissoc result :threw))))))))
@@ -179,7 +179,7 @@
   [payload]
   (let [out (atom nil)
         traces (capture
-                 #(reset! out (hydrate/hydrate-event-handler
+                 #(reset! out (rf.ssr.hydrate/hydrate-event-handler
                                 {:db existing-db :rf.frame/id :rf/default}
                                 [:rf/hydrate payload])))]
     {:result @out :traces traces}))
@@ -280,7 +280,7 @@
   [payload]
   (let [out (atom nil)
         traces (capture
-                 #(reset! out (hydrate/hydrate-event-handler
+                 #(reset! out (rf.ssr.hydrate/hydrate-event-handler
                                 {:db            existing-db
                                  :rf.db/runtime existing-runtime-db
                                  :rf.frame/id   :rf/default}
@@ -316,9 +316,9 @@
                  " must fire no compatibility-check fxs"))))))
 
 (def ^:private gen-non-map
-  (gen/gen-one-of
-    (gen/gen-elem [nil true false :kw "str" 'sym [] #{} [:a :b]])
-    (gen/gen-int -100 100)))
+  (rf.security.gen/gen-one-of
+    (rf.security.gen/gen-elem [nil true false :kw "str" 'sym [] #{} [:a :b]])
+    (rf.security.gen/gen-int -100 100)))
 
 (deftest non-map-hydration-inputs-always-fail-closed
   (testing "a non-map payload, or a map
@@ -327,7 +327,7 @@
             the diagnostic fires. One installed-garbage case = one
             fail-open. Both load-bearing partition slices are exercised."
     (let [result
-          (gen/for-all
+          (rf.security.gen/for-all
             gen-non-map 200 23
             (fn [bad]
               (let [;; The whole payload is the non-map `bad`.

--- a/implementation/security/test/re_frame/security/gen_parity_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/gen_parity_security_cljs_test.cljc
@@ -6,14 +6,14 @@
   carries an unsigned 32-bit state on both hosts."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
-            [re-frame.security.gen :as gen]))
+            [re-frame.security.gen :as rf.security.gen]))
 
 (defn- draws
   "Thread the PRNG from `seed`, drawing `n` ints in [0,bound)."
   [seed bound n]
-  (loop [rng (gen/make-rng seed), i 0, acc []]
+  (loop [rng (rf.security.gen/make-rng seed), i 0, acc []]
     (if (< i n)
-      (let [[v rng'] (gen/next-int rng bound)]
+      (let [[v rng'] (rf.security.gen/next-int rng bound)]
         (recur rng' (inc i) (conj acc v)))
       acc)))
 
@@ -29,14 +29,14 @@
 
 (deftest sample-and-for-all-reproduce-from-seed
   (testing "the documented `(seed, g, n)` reproducibility holds on this runtime"
-    (let [g (gen/gen-int 0 1000)]
+    (let [g (rf.security.gen/gen-int 0 1000)]
       ;; The second assertion ensures the seed participates in the draw.
-      (is (= (gen/sample g 20 7) (gen/sample g 20 7)))
-      (is (not= (gen/sample g 20 7) (gen/sample g 20 8))))
+      (is (= (rf.security.gen/sample g 20 7) (rf.security.gen/sample g 20 7)))
+      (is (not= (rf.security.gen/sample g 20 7) (rf.security.gen/sample g 20 8))))
     ;; Re-drawing through the reported index must reproduce the counterexample.
-    (let [g    (gen/gen-int 0 1000)
-          {:keys [fail index seed]} (gen/for-all g 50 99 (fn [n] (< n 5)))]
+    (let [g    (rf.security.gen/gen-int 0 1000)
+          {:keys [fail index seed]} (rf.security.gen/for-all g 50 99 (fn [n] (< n 5)))]
       (is (some? fail) "a [0,1000) draw should exceed 5 within 50 draws")
       (is (= 99 seed))
-      (is (= fail (last (gen/sample g (inc index) seed)))
+      (is (= fail (last (rf.security.gen/sample g (inc index) seed)))
           "the reported seed/index must reproduce the failing draw exactly"))))

--- a/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
@@ -8,8 +8,8 @@
   reads is the operator's explicit raw-egress opt-in."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
-            [re-frame.mcp-base.sensitive :as sens]
-            [re-frame.security.gen :as gen]))
+            [re-frame.mcp-base.sensitive :as rf.mcp-base.sensitive]
+            [re-frame.security.gen :as rf.security.gen]))
 
 ;; These property tests intentionally drive thousands of malformed
 ;; `:sensitive?` stamps through `sens/strip-sensitive` / `scrub-snapshot` /
@@ -24,29 +24,29 @@
   stringified slots. The sentinel is a unique long literal, so a substring
   scan cannot be satisfied by an unrelated value."
   [x]
-  (gen/contains-string? x sentinel))
+  (rf.security.gen/contains-string? x sentinel))
 
 (def ^:private gen-clean-event
   "A non-sensitive trace event - no :sensitive? stamp (or explicit false)."
-  (gen/gen-fmap
+  (rf.security.gen/gen-fmap
     (fn [[op stamp]]
       (cond-> {:operation op :tags {:k "public-data"}}
         (= stamp :false) (assoc :sensitive? false)))
     (fn [rng]
-      (let [[op rng1]    (gen/rand-nth rng [:event/run-start :event/db-changed
+      (let [[op rng1]    (rf.security.gen/rand-nth rng [:event/run-start :event/db-changed
                                             :sub/recompute :fx/run])
-            [stamp rng2] (gen/rand-nth rng1 [:absent :false])]
+            [stamp rng2] (rf.security.gen/rand-nth rng1 [:absent :false])]
         [[op stamp] rng2]))))
 
 (def ^:private gen-sensitive-event
   "A sensitive event carrying the sentinel in a value slot AND the literal
   top-level :sensitive? true stamp."
-  (gen/gen-fmap
+  (rf.security.gen/gen-fmap
     (fn [op]
       {:operation op
        :sensitive? true
        :tags {:value sentinel :received [sentinel]}})
-    (gen/gen-elem [:event/run-start :sub/recompute :fx/run])))
+    (rf.security.gen/gen-elem [:event/run-start :sub/recompute :fx/run])))
 
 (def ^:private malformed-stamps
   ;; Truthy non-booleans indicate contract drift and fail closed.
@@ -55,34 +55,34 @@
 (def ^:private gen-malformed-sensitive-event
   "A sensitive event whose :sensitive? stamp is a truthy NON-boolean
   (contract drift). The fail-closed posture must still drop it."
-  (gen/gen-fmap
+  (rf.security.gen/gen-fmap
     (fn [[op stamp]]
       {:operation op :sensitive? stamp :tags {:value sentinel}})
     (fn [rng]
-      (let [[op rng1]    (gen/rand-nth rng [:event/run-start :sub/recompute])
-            [stamp rng2] (gen/rand-nth rng1 malformed-stamps)]
+      (let [[op rng1]    (rf.security.gen/rand-nth rng [:event/run-start :sub/recompute])
+            [stamp rng2] (rf.security.gen/rand-nth rng1 malformed-stamps)]
         [[op stamp] rng2]))))
 
 (def ^:private gen-event
-  (gen/gen-one-of gen-clean-event gen-sensitive-event gen-malformed-sensitive-event))
+  (rf.security.gen/gen-one-of gen-clean-event gen-sensitive-event gen-malformed-sensitive-event))
 
 (def ^:private gen-event-vec
   "A vector of 0..12 mixed events."
-  (gen/gen-vec (gen/gen-int 0 13) gen-event))
+  (rf.security.gen/gen-vec (rf.security.gen/gen-int 0 13) gen-event))
 
 (deftest allow-sensitive-disabled-strips-every-sensitive-event
   (testing "with sensitive reads disabled, strip-sensitive drops every
             :sensitive?-stamped (and malformed-truthy) event across 400
             generated mixed event vectors; the sentinel never survives"
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-event-vec 400 23
                    (fn [events]
-                     (sens/reset-malformed-count!)
-                     (let [[kept _dropped] (sens/strip-sensitive events false)]
+                     (rf.mcp-base.sensitive/reset-malformed-count!)
+                     (let [[kept _dropped] (rf.mcp-base.sensitive/strip-sensitive events false)]
                        ;; Check both content and classification: stripping a
                        ;; stamp alone must not hide a secondary-slot leak.
                        (and (not-any? contains-sentinel? kept)
-                            (not-any? sens/sensitive-event? kept)))))]
+                            (not-any? rf.mcp-base.sensitive/sensitive-event? kept)))))]
       (is (nil? result)
           (str "a sensitive event survived the allow-sensitive-disabled egress: "
                (pr-str (when result (dissoc result :threw))))))))
@@ -93,12 +93,12 @@
     (let [survivor       {:operation :sub/recompute
                           :tags {:value "public-data"
                                  :received [sentinel]}}
-          [kept dropped] (sens/strip-sensitive [survivor] false)]
+          [kept dropped] (rf.mcp-base.sensitive/strip-sensitive [survivor] false)]
       (is (= [survivor] kept))
       (is (zero? dropped))
       (is (not-any? #(= sentinel (-> % :tags :value)) kept)
           "a primary-slot check is blind to :received")
-      (is (not-any? sens/sensitive-event? kept)
+      (is (not-any? rf.mcp-base.sensitive/sensitive-event? kept)
           "classification alone is blind because the survivor is not stamped")
       (is (some contains-sentinel? kept)
           "the deep scan catches the sentinel in :tags :received")
@@ -108,22 +108,22 @@
   (testing "a malformed truthy stamp is dropped and increments the
             observability counter exactly once"
     (doseq [stamp malformed-stamps]
-      (sens/reset-malformed-count!)
+      (rf.mcp-base.sensitive/reset-malformed-count!)
       (let [ev {:operation :x :sensitive? stamp :tags {:value sentinel}}
-            [kept dropped] (sens/strip-sensitive [ev] false)]
+            [kept dropped] (rf.mcp-base.sensitive/strip-sensitive [ev] false)]
         (is (= [] kept) (str "malformed stamp " (pr-str stamp) " was NOT dropped"))
         (is (= 1 dropped))
-        (is (= 1 (sens/malformed-count))
+        (is (= 1 (rf.mcp-base.sensitive/malformed-count))
             (str "malformed stamp " (pr-str stamp)
                  " must bump the counter exactly once per event"))))))
 
 (deftest allow-sensitive-enabled-opt-in-passes-through-verbatim
   (testing "with include? true (operator opted in via --allow-sensitive-reads),
             strip-sensitive is identity - the opt-in is the sole control point"
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-event-vec 200 29
                    (fn [events]
-                     (let [[kept dropped] (sens/strip-sensitive events true)]
+                     (let [[kept dropped] (rf.mcp-base.sensitive/strip-sensitive events true)]
                        (and (= events kept) (zero? dropped)))))]
       (is (nil? result) (str "opt-in egress altered the events: " (pr-str result))))))
 
@@ -141,7 +141,7 @@
 (def ^:private gen-snapshot
   "A snapshot map: 1..4 frame-keyed entries."
   (fn [rng]
-    (let [[n rng1] ((gen/gen-int 1 5) rng)]
+    (let [[n rng1] ((rf.security.gen/gen-int 1 5) rng)]
       (loop [i 0, rng rng1, acc {}]
         (if (< i n)
           (let [[frame rng'] (gen-frame rng)]
@@ -157,7 +157,7 @@
           (when (map? fm)
             (let [slices (concat (:traces fm) (:epochs fm))]
               (or (some contains-sentinel? slices)
-                  (some sens/sensitive-event? slices)))))
+                  (some rf.mcp-base.sensitive/sensitive-event? slices)))))
         scrubbed))
 
 (deftest allow-sensitive-disabled-scrub-snapshot-leaves-no-sensitive-event
@@ -165,11 +165,11 @@
             events from every frame's
             :traces/:epochs across 300 generated multi-frame snapshots;
             :app-db is left untouched"
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-snapshot 300 31
                    (fn [snap]
-                     (sens/reset-malformed-count!)
-                     (let [[scrubbed _dropped] (sens/scrub-snapshot snap false)]
+                     (rf.mcp-base.sensitive/reset-malformed-count!)
+                     (let [[scrubbed _dropped] (rf.mcp-base.sensitive/scrub-snapshot snap false)]
                        (and (not (snapshot-leaks-sentinel? scrubbed))
                             ;; :app-db must survive verbatim (read-time
                             ;; scrubbing is trace/epoch-only by design).
@@ -192,7 +192,7 @@
                                           :tags {:value "public-data"}}]
                                 :epochs []
                                 :app-db {:public "kept"}}}]
-      (is (not (some sens/sensitive-event? (-> leaked :frame-0 :traces)))
+      (is (not (some rf.mcp-base.sensitive/sensitive-event? (-> leaked :frame-0 :traces)))
           "classification alone is blind because the survivor is not stamped")
       (is (snapshot-leaks-sentinel? leaked)
           "deep scan flags the sentinel in a frame's :tags :received")
@@ -202,9 +202,9 @@
 (deftest malformed-stamp-corpus-fail-closed
   (testing "each truthy non-boolean stamp classifies as sensitive"
     (doseq [stamp malformed-stamps]
-      (is (true? (sens/sensitive-event? {:sensitive? stamp}))
+      (is (true? (rf.mcp-base.sensitive/sensitive-event? {:sensitive? stamp}))
           (str "stamp " (pr-str stamp) " must classify as sensitive (drop)")))
     (testing "explicit false / nil / absent pass (non-sensitive)"
-      (is (false? (sens/sensitive-event? {:sensitive? false})))
-      (is (false? (sens/sensitive-event? {:sensitive? nil})))
-      (is (false? (sens/sensitive-event? {:operation :x}))))))
+      (is (false? (rf.mcp-base.sensitive/sensitive-event? {:sensitive? false})))
+      (is (false? (rf.mcp-base.sensitive/sensitive-event? {:sensitive? nil})))
+      (is (false? (rf.mcp-base.sensitive/sensitive-event? {:operation :x}))))))

--- a/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
@@ -13,32 +13,32 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.frame :as frame]
+            [re-frame.elision :as rf.elision]
+            [re-frame.frame :as rf.frame]
             ;; Used only to contrast trace plumbing with public projection.
-            [re-frame.mcp-base.sensitive :as sens]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as ts]
-            [re-frame.security.gen :as gen]))
+            [re-frame.mcp-base.sensitive :as rf.mcp-base.sensitive]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.security.gen :as rf.security.gen]))
 
 (use-fixtures :each
-  (ts/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter}))
 
 (def ^:private sentinel "S3CR3T-rf2-3cfvt-PUBLIC-PROFILE-DO-NOT-SHIP")
 
 (defn- contains-sentinel?
   "True when the sentinel survives anywhere in `x` (substring scan)."
   [x]
-  (gen/contains-string? x sentinel))
+  (rf.security.gen/contains-string? x sentinel))
 
 (def ^:private big-string (apply str (repeat 40000 \x)))
 
 (defn- mk-frame! [frame-id]
   (rf/make-frame {:id frame-id})
   ;; Install the durable app-db classification through the commit-plane path.
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt
                {:sensitive [[:auth :token]]
                 :large     [[:docs :blob]]}))))
 
@@ -58,9 +58,9 @@
                      :rf.egress/local-redacted]]
       (let [out (rf/project-egress (app-db-value)
                   {:frame :pub/offbox :rf.egress/profile profile})]
-        (is (gen/redacted? (get-in out [:auth :token]))
+        (is (rf.security.gen/redacted? (get-in out [:auth :token]))
             (str profile ": frame-owned sensitive app-db leaf redacted"))
-        (is (gen/large-marker? (get-in out [:docs :blob]))
+        (is (rf.security.gen/large-marker? (get-in out [:docs :blob]))
             (str profile ": frame-owned large app-db leaf elided to a marker"))
         (is (= 3 (get-in out [:public :count]))
             (str profile ": unmarked sibling passes through"))
@@ -80,10 +80,10 @@
   (testing "project-egress with no live frame redacts the whole value — no
             :rf/default synthesis"
     ;; Rebind the ambient frame AWAY so the egress is genuinely frameless.
-    (binding [frame/*current-frame* nil]
+    (binding [rf.frame/*current-frame* nil]
       (let [out (rf/project-egress (app-db-value)
                   {:rf.egress/profile :rf.egress/off-box-tool})]
-        (is (gen/redacted? out) "frameless egress fails closed to :rf/redacted")
+        (is (rf.security.gen/redacted? out) "frameless egress fails closed to :rf/redacted")
         (is (not (contains-sentinel? out))))
       ;; The deliberate opt-out: include-sensitive? true gets an identity walk
       ;; against the no-frame policy (the single control point).
@@ -97,11 +97,11 @@
             unresolvable frame's empty registry must NOT fall through to a
             permissive identity walk"
     ;; :pub/never-registered is never make-frame'd — its registry is unreachable.
-    (binding [frame/*current-frame* nil]
+    (binding [rf.frame/*current-frame* nil]
       (let [out (rf/project-egress (app-db-value)
                   {:frame :pub/never-registered
                    :rf.egress/profile :rf.egress/off-box-tool})]
-        (is (gen/redacted? out)
+        (is (rf.security.gen/redacted? out)
             "an unknown / destroyed frame fails closed, identically to frameless")
         (is (not (contains-sentinel? out)))))))
 
@@ -109,11 +109,11 @@
   (testing "a classified :large :app-db leaf elides to a structural marker —
             the off-box-tool profile carries the indicator, no raw bytes"
     (rf/make-frame {:id :pub/large})
-    (frame/swap-runtime-db! :pub/large
-      (fn [rt] (elision/apply-classification-effects rt {:large [[:upload]]})))
+    (rf.frame/swap-runtime-db! :pub/large
+      (fn [rt] (rf.elision/apply-classification-effects rt {:large [[:upload]]})))
     (let [out (rf/project-egress {:upload big-string :public "ok"}
                 {:frame :pub/large :rf.egress/profile :rf.egress/off-box-tool})]
-      (is (gen/large-marker? (:upload out)) "the large leaf is a structural marker")
+      (is (rf.security.gen/large-marker? (:upload out)) "the large leaf is a structural marker")
       (is (not= big-string (:upload out)) "the raw large value is NOT shipped")
       (is (= "ok" (:public out))))))
 
@@ -121,26 +121,26 @@
   (testing "a path declared BOTH :sensitive and :large redacts, never
             large-elides — so NO path/size/digest marker can leak for it"
     (rf/make-frame {:id :pub/both})
-    (frame/swap-runtime-db! :pub/both
-      (fn [rt] (elision/apply-classification-effects rt
+    (rf.frame/swap-runtime-db! :pub/both
+      (fn [rt] (rf.elision/apply-classification-effects rt
                  {:sensitive [[:secret]]
                   :large     [[:secret]]})))
     (let [out (rf/project-egress {:secret big-string}
                 {:frame :pub/both
                  :rf.egress/profile :rf.egress/off-box-observability})]
-      (is (gen/redacted? (:secret out)) "the both-marked path is :rf/redacted")
-      (is (not (gen/large-marker? (:secret out)))
+      (is (rf.security.gen/redacted? (:secret out)) "the both-marked path is :rf/redacted")
+      (is (not (rf.security.gen/large-marker? (:secret out)))
           "NO large marker — no path/size/digest can leak for a sensitive path"))))
 
 (def ^:private gen-path
   "A 1..3-segment keyword app-db path."
-  (gen/gen-vec (gen/gen-int 1 4)
-               (gen/gen-elem [:a :b :c :auth :token :tenant :user :data])))
+  (rf.security.gen/gen-vec (rf.security.gen/gen-int 1 4)
+               (rf.security.gen/gen-elem [:a :b :c :auth :token :tenant :user :data])))
 
 (deftest framed-corpus-redacts-declared-path
   (testing "for 200 random frames classifying a random app-db path sensitive,
             project-egress redacts the sentinel planted at that path"
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-path 200 41
                    (fn [path]
                      (let [path  (vec path)
@@ -149,14 +149,14 @@
                         ;; Each draw reuses the frame, so clear the append-only
                         ;; classification slot before installing the new path.
                        (rf/make-frame {:id fid})
-                       (frame/swap-runtime-db! fid
+                       (rf.frame/swap-runtime-db! fid
                          (fn [rt]
                            (-> (dissoc rt :rf.runtime/elision)
-                               (elision/apply-classification-effects {:sensitive [path]}))))
+                               (rf.elision/apply-classification-effects {:sensitive [path]}))))
                        (let [out (rf/project-egress value
                                    {:frame fid
                                     :rf.egress/profile :rf.egress/off-box-tool})]
-                         (and (gen/redacted? (get-in out path))
+                         (and (rf.security.gen/redacted? (get-in out path))
                               (not (contains-sentinel? out)))))))]
       (is (nil? result)
           (str "a declared-sensitive path leaked the sentinel: "
@@ -171,7 +171,7 @@
                                :epochs []
                                :app-db (app-db-value)}}
           ;; scrub-snapshot is a trace/epoch-only walker.
-          [scrubbed _dropped] (sens/scrub-snapshot snapshot false)
+          [scrubbed _dropped] (rf.mcp-base.sensitive/scrub-snapshot snapshot false)
           raw-app-db (get-in scrubbed [:pub/snap :app-db])]
       (is (= sentinel (get-in raw-app-db [:auth :token]))
           "PLUMBING: scrub-snapshot leaves :app-db raw (trace/epoch-only by design)")
@@ -182,9 +182,9 @@
       (let [projected (rf/project-egress raw-app-db
                         {:frame :pub/snap
                          :rf.egress/profile :rf.egress/off-box-tool})]
-        (is (gen/redacted? (get-in projected [:auth :token]))
+        (is (rf.security.gen/redacted? (get-in projected [:auth :token]))
             "PUBLIC: project-egress of the snapshot :app-db redacts the sensitive leaf")
-        (is (gen/large-marker? (get-in projected [:docs :blob]))
+        (is (rf.security.gen/large-marker? (get-in projected [:docs :blob]))
             "PUBLIC: project-egress elides the large leaf")
         (is (not (contains-sentinel? projected))
             "PUBLIC: no sentinel crosses the projected boundary")))))
@@ -194,14 +194,14 @@
             trace EVENTS, but it is NOT the durable app-db egress boundary: a
             raw app-db-shaped map with no :sensitive? stamp passes UNTOUCHED.
             Durable app-db egress uses frame-owned project-egress."
-    (let [[kept dropped] (sens/strip-sensitive
+    (let [[kept dropped] (rf.mcp-base.sensitive/strip-sensitive
                            [{:operation :x :sensitive? true :tags {:value sentinel}}]
                            false)]
       (is (= [] kept) "PLUMBING: a stamped trace event is dropped")
       (is (= 1 dropped)))
     ;; An unstamped app-db-shaped map is not a trace event the filter can classify.
     (let [raw {:auth {:token sentinel}}
-          [kept _dropped] (sens/strip-sensitive [raw] false)]
+          [kept _dropped] (rf.mcp-base.sensitive/strip-sensitive [raw] false)]
       (is (= [raw] kept)
           "PLUMBING: strip-sensitive does NOT redact unstamped app-db data —
            the durable boundary is frame-owned project-egress")

--- a/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
@@ -11,24 +11,24 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.frame :as frame]
+            [re-frame.elision :as rf.elision]
+            [re-frame.frame :as rf.frame]
             ;; Families use the internal reply substrate directly.
-            [re-frame.reply :as reply]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as ts]
-            [re-frame.security.gen :as gen]))
+            [re-frame.reply :as rf.reply]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.security.gen :as rf.security.gen]))
 
 (use-fixtures :each
-  (ts/make-reset-runtime-fixture
-    {:adapter plain-atom/adapter}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter}))
 
 (def ^:private sentinel "S3CR3T-rf2-3cfvt-REPLY-EGRESS-DO-NOT-SHIP")
 
 (defn- contains-sentinel?
   "True when the sentinel survives anywhere in `x` (substring scan)."
   [x]
-  (gen/contains-string? x sentinel))
+  (rf.security.gen/contains-string? x sentinel))
 
 ;; CROSS-RECORD SPELLING (rf2-l7s7b7, Managed-Effects §The reply map). Every
 ;; top-level REPLY ENVELOPE below single-roots the work identity as
@@ -54,8 +54,8 @@
 (defn- mk-frame! [frame-id]
   (rf/make-frame {:id frame-id})
   ;; Install durable classification through the commit-plane path.
-  (frame/swap-runtime-db! frame-id
-    (fn [rt] (elision/apply-classification-effects rt
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt
                {:sensitive [[:token] [:partner-key] [:detail :token]]
                 :large     [[:doc]]}))))
 
@@ -76,17 +76,17 @@
                      :rf.reply/work-status  :failed
                      :rf.frame/id  :reply/framed
                      :completed-at 1781078400456}
-          out (reply/trace-summary reply-map
+          out (rf.reply/trace-summary reply-map
                 {:frame :reply/framed
                  :rf.size/include-sensitive? false
                  :rf.size/include-large?     false})]
-      (is (gen/redacted? (get-in out [:value :token])) ":value sensitive leaf redacted")
-      (is (gen/large-marker? (get-in out [:value :doc])) ":value large leaf elided")
+      (is (rf.security.gen/redacted? (get-in out [:value :token])) ":value sensitive leaf redacted")
+      (is (rf.security.gen/large-marker? (get-in out [:value :doc])) ":value large leaf elided")
       (is (= 7 (get-in out [:value :public])) "unmarked sibling rides through")
-      (is (gen/redacted? (get-in out [:error :detail :token])) ":error sensitive leaf redacted")
-      (is (gen/redacted? (get-in out [:correlation :partner-key])) ":correlation sensitive leaf redacted")
+      (is (rf.security.gen/redacted? (get-in out [:error :detail :token])) ":error sensitive leaf redacted")
+      (is (rf.security.gen/redacted? (get-in out [:correlation :partner-key])) ":correlation sensitive leaf redacted")
       (is (= "t-1" (get-in out [:correlation :trace-id])) "non-sensitive correlation fact rides")
-      (is (gen/redacted? (get-in out [:meta :token])) ":meta sensitive leaf redacted")
+      (is (rf.security.gen/redacted? (get-in out [:meta :token])) ":meta sensitive leaf redacted")
       (is (not (contains-sentinel? (:value out))))
       (is (not (contains-sentinel? (:error out))))
       (is (not (contains-sentinel? (:correlation out))))
@@ -116,8 +116,8 @@
           reply-map {:status :ok :value value
                      :rf.reply/work-id [:rf.work/http :x 1]
                      :rf.reply/work-status :completed}
-          out (reply/trace-summary reply-map opts)]
-      (is (= (:value out) (elision/elide-wire-value value opts))
+          out (rf.reply/trace-summary reply-map opts)]
+      (is (= (:value out) (rf.elision/elide-wire-value value opts))
           ":value slot is exactly elide-wire-value under the resolved opts"))))
 
 (deftest frameless-trace-summary-fails-closed
@@ -125,17 +125,17 @@
             wire-bearing slot to :rf/redacted (fail-closed; no :rf/default
             synthesis) — the sentinel never rides off-box"
     ;; Remove ambient scope so no other frame's policy can be borrowed.
-    (binding [frame/*current-frame* nil]
+    (binding [rf.frame/*current-frame* nil]
       (let [reply-map {:status      :error
                        :error       {:kind :rf.http/cors :detail sentinel}
                        :correlation {:partner-key sentinel}
                        :meta        {:secret sentinel}
                        :rf.reply/work-id [:rf.work/http :y 2]
                        :rf.reply/work-status :failed}
-            out (reply/trace-summary reply-map nil)]
-        (is (gen/redacted? (:error out)) ":error fails closed (whole slot redacted)")
-        (is (gen/redacted? (:correlation out)) ":correlation fails closed")
-        (is (gen/redacted? (:meta out)) ":meta fails closed")
+            out (rf.reply/trace-summary reply-map nil)]
+        (is (rf.security.gen/redacted? (:error out)) ":error fails closed (whole slot redacted)")
+        (is (rf.security.gen/redacted? (:correlation out)) ":correlation fails closed")
+        (is (rf.security.gen/redacted? (:meta out)) ":meta fails closed")
         (is (not (contains-sentinel? out)) "no sentinel survives frameless egress")
         (is (= :error (:status out)))
         (is (= [:rf.work/http :y 2] (:rf.reply/work-id out)))
@@ -143,7 +143,7 @@
         (is (not (contains? out :work/id))
             "TOOTH — frameless egress grows no top-level bare :work/id alias (rf2-xy3g)"))
       ;; Explicit sensitive inclusion is the trusted-local opt-out.
-      (let [out (reply/trace-summary {:status :ok :value {:token sentinel}
+      (let [out (rf.reply/trace-summary {:status :ok :value {:token sentinel}
                                       :rf.reply/work-id [:rf.work/http :z 3]
                                       :rf.reply/work-status :completed}
                   {:rf.size/include-sensitive? true})]
@@ -154,7 +154,7 @@
   "A status-correct reply map carrying the sentinel in its wire slots. The
   status drives which value/error slots are present (so the corpus stays
   validate-reply-legal), but every present wire slot plants the sentinel."
-  (gen/gen-fmap
+  (rf.security.gen/gen-fmap
     (fn [[status work-status]]
       (let [base {:rf.reply/work-id   [:rf.work/http :gen 1]
                   :rf.reply/work-kind :http
@@ -178,8 +178,8 @@
                                 :rf.reply/stale-reason :rf.reply/correlation-mismatch
                                 :rf.reply/work-status :suppressed)))))
     (fn [rng]
-      (let [[status rng1] (gen/rand-nth rng (vec reply/statuses))
-            [ws rng2]     (gen/rand-nth rng1 (vec reply/work-statuses))]
+      (let [[status rng1] (rf.security.gen/rand-nth rng (vec rf.reply/statuses))
+            [ws rng2]     (rf.security.gen/rand-nth rng1 (vec rf.reply/work-statuses))]
         [[status ws] rng2]))))
 
 (deftest framed-corpus-never-ships-sentinel
@@ -187,16 +187,16 @@
             egress never ships the sentinel through any wire slot, and the
             status stays in the closed taxonomy"
     (mk-frame! :reply/corpus)
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-reply 300 17
                    (fn [reply-map]
-                     (let [out (reply/trace-summary reply-map
+                     (let [out (rf.reply/trace-summary reply-map
                                  {:frame :reply/corpus})]
                        (and (not (contains-sentinel? (:value out)))
                             (not (contains-sentinel? (:error out)))
                             (not (contains-sentinel? (:correlation out)))
                             (not (contains-sentinel? (:meta out)))
-                            (contains? reply/statuses (:status out))
+                            (contains? rf.reply/statuses (:status out))
                             ;; rf2-xy3g — across every status the canonical
                             ;; TRANSIENT-ENVELOPE identity survives egress and
                             ;; no bare ledger alias appears beside it.
@@ -223,7 +223,7 @@
                    :rf.reply/work-id [:rf.work/http :a 1]
                    :rf.reply/work-kind :http
                    :rf.frame/id :reply/stale :completed-at 1781078400456}
-          {:keys [deliver? reply] :as outcome} (reply/suppress nil carried current natural)]
+          {:keys [deliver? reply] :as outcome} (rf.reply/suppress nil carried current natural)]
       (is (false? deliver?) "a superseded app reply is NOT delivered")
       (is (= :stale (:status reply)) "the forced status is :stale")
       (is (true? (:stale? reply)) ":stale? marker forced on")
@@ -237,7 +237,7 @@
           "TOOTH — suppression grows no top-level bare :work/id alias (rf2-xy3g)")
       (is (= :reply/stale (:rf.frame/id reply)))
       (is (= 1781078400456 (:completed-at reply)) "causal completion time survives")
-      (is (reply/valid-reply? reply) "the suppression reply is contract-valid")
+      (is (rf.reply/valid-reply? reply) "the suppression reply is contract-valid")
       ;; Suppression traces retain correlation without carrying the value.
       (let [trace (:trace outcome)]
         (is (true? (:rf.reply/suppressed? trace)))
@@ -272,7 +272,7 @@
                            :re-frame.reply/stale-authority true}
                           {:event [:app/on-reply] :dispatch-stale? true
                            :re-frame.reply/stale-authority "trusted"}]]
-        (let [{:keys [deliver? reply]} (reply/suppress app-target carried current)]
+        (let [{:keys [deliver? reply]} (rf.reply/suppress app-target carried current)]
           (is (false? deliver?)
               (str "app target " (pr-str app-target) " must NOT deliver a stale envelope"))
           (is (= :stale (:status reply)) "the outcome is still a well-formed stale reply")
@@ -287,17 +287,17 @@
           reply-with-handle {:status :ok :value {:on-done handle}
                              :rf.reply/work-id [:rf.work/http :h 1]
                              :rf.reply/work-status :completed}
-          problems (reply/validate-reply reply-with-handle)]
+          problems (rf.reply/validate-reply reply-with-handle)]
       (is (some #(= :rf.reply/host-handle (:rf.reply/problem %)) problems)
           "validate-reply flags the host handle in the reply :value"))
     (let [bad-target {:event [:app/on-reply (fn [] :smuggled)] :delivery :append}
-          data (try (reply/durable-target bad-target)
+          data (try (rf.reply/durable-target bad-target)
                     nil
                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e
                       (ex-data e)))]
       (is (= :rf.error/reply-non-data-target (:rf.error/id data))
           "a host handle in a durable target's public field fails loud"))
-    (is (reply/valid-reply? {:status :ok :value {:public 1}
+    (is (rf.reply/valid-reply? {:status :ok :value {:public 1}
                              :rf.reply/work-id [:rf.work/http :h 2]
                              :rf.reply/work-status :completed}))
-    (is (reply/data-only-target? {:event [:app/on-reply] :delivery :append}))))
+    (is (rf.reply/data-only-target? {:event [:app/on-reply] :delivery :append}))))

--- a/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc
@@ -35,14 +35,14 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             ;; Publishes the Malli late-bind validate/explain hooks; without
             ;; it the default validator soft-passes and no failure fires.
             [re-frame.schemas.malli]
-            [re-frame.schemas :as schemas]
-            #?(:clj  [re-frame.test-support :as test-support :refer [with-trace-recorder!]]
-               :cljs [re-frame.test-support :as test-support :refer-macros [with-trace-recorder!]])
-            [re-frame.security.gen :as gen]))
+            [re-frame.schemas :as rf.schemas]
+            #?(:clj  [re-frame.test-support :as rf.test-support :refer [with-trace-recorder!]]
+               :cljs [re-frame.test-support :as rf.test-support :refer-macros [with-trace-recorder!]])
+            [re-frame.security.gen :as rf.security.gen]))
 
 ;; Reset per-test so app-schema registrations don't bleed across cases.
 ;; No adapter needed - `validate-app-schema!` is called directly (not via
@@ -64,10 +64,10 @@
 ;; installed adapter, which this adapter-less validate-direct suite has not
 ;; got (it would raise `:rf.error/no-adapter-installed`).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:clear-app-schemas? true})
   (fn [test-fn]
-    (binding [frame/*current-frame* :rf/default]
+    (binding [rf.frame/*current-frame* :rf/default]
       (test-fn))))
 
 ;; ---------------------------------------------------------------------------
@@ -84,7 +84,7 @@
   wrapper over the shared `gen/contains-string?` (rf2-n5bkm7), which
   matches the sentinel as a substring."
   [x]
-  (gen/contains-string? x sentinel))
+  (rf.security.gen/contains-string? x sentinel))
 
 ;; ---------------------------------------------------------------------------
 ;; Recursive generator - build [schema db] where a :sensitive? scalar slot
@@ -102,7 +102,7 @@
 (def ^:private gen-nested-sensitive
   "Draw a `[schema db-value]` with a sentinel-bearing :sensitive? slot at a
   random 1..6-deep collection/map nesting."
-  (gen/nested-sensitive-generator
+  (rf.security.gen/nested-sensitive-generator
     sentinel
     [:map :vector :sequential :map-of :tuple :map-of-key :set :and :or :multi :orn]
     6))
@@ -116,8 +116,8 @@
   [schema db]
   (rf/reg-app-schema [:root] schema)
   (with-trace-recorder! [traces]
-    (schemas/validate-app-schema! {:root db} :root/bad)
-    #?(:clj (schemas/clear-sensitive-paths-cache!))
+    (rf.schemas/validate-app-schema! {:root db} :root/bad)
+    #?(:clj (rf.schemas/clear-sensitive-paths-cache!))
     (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                    @traces))))
 
@@ -128,7 +128,7 @@
 (deftest sensitive-sentinel-never-leaks-at-arbitrary-nesting
   (testing "rf2-g5auo - a :sensitive? slot at ANY generated collection/map
             nesting depth redacts: the sentinel never appears in the trace"
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-nested-sensitive 300 11
                    (fn [[schema db]]
                      (let [v (failure-trace schema db)]

--- a/implementation/security/test/re_frame/security/ssr_escaping_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/ssr_escaping_security_cljs_test.cljc
@@ -15,9 +15,9 @@
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])
             [clojure.string :as str]
-            [re-frame.ssr.html-helpers :as h]
-            [re-frame.ssr.emit :as emit]
-            [re-frame.security.gen :as gen]))
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]
+            [re-frame.ssr.emit :as rf.ssr.emit]
+            [re-frame.security.gen :as rf.security.gen]))
 
 (def ^:private canonical-handlers
   ["onclick" "onload" "onerror" "onmouseover" "onmouseout" "onsubmit"
@@ -59,21 +59,21 @@
   "Draws a `[k v]` attribute pair whose KEY is a randomly-recased canonical
   event-handler name (a hostile attribute key controlling a handler). The
   value is an attacker JS payload string."
-  (gen/gen-fmap
+  (rf.security.gen/gen-fmap
     (fn [[base bits]]
       [(keyword (recase base bits)) "alert(document.cookie)"])
     (fn [rng]
-      (let [[base rng1] (gen/rand-nth rng canonical-handlers)
-            [bits rng2] ((gen/gen-vec (count base) (gen/gen-elem [0 1])) rng1)]
+      (let [[base rng1] (rf.security.gen/rand-nth rng canonical-handlers)
+            [bits rng2] ((rf.security.gen/gen-vec (count base) (rf.security.gen/gen-elem [0 1])) rng1)]
         [[base bits] rng2]))))
 
 (deftest no-recased-canonical-handler-serialises
   (testing "across 600 randomly-recased canonical handler names,
             attr-string strips every one (empty output, no live on*= attr)"
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-handler-casing 600 1
                    (fn [[k v]]
-                     (let [out (h/attr-string {k v})]
+                     (let [out (rf.ssr.html-helpers/attr-string {k v})]
                        ;; A stripped handler yields "" for a single-entry map.
                        (and (= "" out)
                             (not (live-handler-attr? out))))))]
@@ -105,7 +105,7 @@
   makes the lower-cased name impossible to collide with a canonical allowlist
   entry, so the ONLY matcher arm that strips it is `event-handler-name-re`.
   The value is an attacker JS payload string."
-  (gen/gen-fmap
+  (rf.security.gen/gen-fmap
     (fn [[form prefix-bits tail]]
       (let [tail-str (apply str tail)
             base     (case form
@@ -115,11 +115,11 @@
                        :kebab (str "on-" tail-str))]
         [(keyword (recase-on-prefix base prefix-bits)) "alert(document.cookie)"]))
     (fn [rng]
-      (let [[form rng1] (gen/rand-nth rng [:camel :kebab])
-            [pb0 rng2]  (gen/rand-nth rng1 [0 1])
-            [pb1 rng3]  (gen/rand-nth rng2 [0 1])
-            [tail rng4] ((gen/gen-vec (gen/gen-int 4 7)
-                                      (gen/gen-elem structural-tail-letters))
+      (let [[form rng1] (rf.security.gen/rand-nth rng [:camel :kebab])
+            [pb0 rng2]  (rf.security.gen/rand-nth rng1 [0 1])
+            [pb1 rng3]  (rf.security.gen/rand-nth rng2 [0 1])
+            [tail rng4] ((rf.security.gen/gen-vec (rf.security.gen/gen-int 4 7)
+                                      (rf.security.gen/gen-elem structural-tail-letters))
                          rng3)]
         [[form [pb0 pb1] tail] rng4]))))
 
@@ -127,10 +127,10 @@
   (testing "across 600 non-allowlist structural handler names
             (camelCase / kebab, recased prefix), attr-string strips every one
             via event-handler-name-re alone"
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-custom-structural-handler 600 5
                    (fn [[k v]]
-                     (let [out (h/attr-string {k v})]
+                     (let [out (rf.ssr.html-helpers/attr-string {k v})]
                        (and (= "" out)
                             (not (live-handler-attr? out))))))]
       (is (nil? result)
@@ -154,7 +154,7 @@
 (deftest hostile-handler-corpus-all-stripped
   (testing "every hostile handler key strips to an empty attribute string"
     (doseq [k hostile-handler-keys]
-      (let [out (h/attr-string {k "javascript:alert(1)"})]
+      (let [out (rf.ssr.html-helpers/attr-string {k "javascript:alert(1)"})]
         (is (= "" out)
             (str "handler key " (pr-str k) " was NOT stripped - leaked: "
                  (pr-str out)))
@@ -166,7 +166,7 @@
             trace of the JavaScript payload"
     (doseq [k [:ontouchstart :ontouchmove :ontouchend :ontouchcancel]]
       (let [payload "alert(document.cookie)"
-            html    (emit/emit-element [:div {k payload :id "ok"} "child"])]
+            html    (rf.ssr.emit/emit-element [:div {k payload :id "ok"} "child"])]
         (is (str/includes? html "id=\"ok\"")
             (str "the benign attr should survive for key " (pr-str k)))
         (is (str/includes? html "child")
@@ -185,7 +185,7 @@
             allowlist can catch it"
     (let [payload "globalThis.pwned++"]
       (doseq [k [:oncommand :ONCOMMAND :OnCommand :oNcOmMaNd]]
-        (let [out (h/attr-string {k payload})]
+        (let [out (rf.ssr.html-helpers/attr-string {k payload})]
           (is (= "" out)
               (str "handler key " (pr-str k) " was NOT stripped - leaked: "
                    (pr-str out)))
@@ -197,7 +197,7 @@
                    (pr-str out)))))
       ;; Non-vacuity: the SAME payload under a benign key serialises, so the
       ;; empty results above prove handler stripping, not value rejection.
-      (is (str/includes? (h/attr-string {:data-x payload}) payload)
+      (is (str/includes? (rf.ssr.html-helpers/attr-string {:data-x payload}) payload)
           "the payload under a benign attribute must serialise"))))
 
 (deftest oncommand-payload-never-reaches-wire-html
@@ -205,7 +205,7 @@
             attribute and child text while omitting the handler name and the
             JavaScript payload entirely"
     (let [payload "globalThis.pwned++"
-          html    (emit/emit-element [:div {:oncommand payload :id "ok"}
+          html    (rf.ssr.emit/emit-element [:div {:oncommand payload :id "ok"}
                                       "child"])]
       (is (str/includes? html "id=\"ok\"")
           "the benign sibling attr should survive")
@@ -220,7 +220,7 @@
   (testing "the matcher must NOT over-strip innocuous English-word keys -
             `online`/`once`/`only`/`on` are real attribute names, not handlers"
     (doseq [k [:online :once :only :on :one :ongoing]]
-      (let [out (h/attr-string {k "v"})]
+      (let [out (rf.ssr.html-helpers/attr-string {k "v"})]
         (is (str/includes? out (name k))
             (str "innocuous key " (pr-str k) " was wrongly stripped"))))))
 
@@ -230,20 +230,20 @@
   "Draws a hostile attribute key that splices a breakout char into an
   otherwise-plausible name, attempting to escape attribute-name context to
   inject a sibling `onclick=` attribute."
-  (gen/gen-fmap
+  (rf.security.gen/gen-fmap
     (fn [[prefix ch suffix]]
       (str prefix ch suffix))
     (fn [rng]
-      (let [[prefix rng1] (gen/rand-nth rng ["data-x" "class" "title" "id" "x"])
-            [ch rng2]     (gen/rand-nth rng1 breakout-chars)
-            [suffix rng3] (gen/rand-nth rng2 ["onclick=alert(1)" "\"onload=x"
+      (let [[prefix rng1] (rf.security.gen/rand-nth rng ["data-x" "class" "title" "id" "x"])
+            [ch rng2]     (rf.security.gen/rand-nth rng1 breakout-chars)
+            [suffix rng3] (rf.security.gen/rand-nth rng2 ["onclick=alert(1)" "\"onload=x"
                                                "><script>" "/>" "=\"y\" onmouseover=z"])]
         [[prefix ch suffix] rng3]))))
 
 (defn- throws-invalid-attr-name?
   [attrs]
   (try
-    (h/attr-string attrs)
+    (rf.ssr.html-helpers/attr-string attrs)
     false
     (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
       (= :rf.error/ssr-invalid-attribute-name
@@ -253,7 +253,7 @@
   (testing "across 400 generated grammar-breakout keys,
             attr-string throws :rf.error/ssr-invalid-attribute-name; never
             silently serialises a key that escapes attribute-name context"
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-breakout-key 400 7
                    (fn [k]
                       ;; A raw string preserves `/`; keyword conversion would
@@ -276,22 +276,22 @@
 (def ^:private gen-script-breakout
   "Draws a hostile string embedding a randomly-recased `</script...>`
   payload that would prematurely close a <script> body."
-  (gen/gen-fmap
+  (rf.security.gen/gen-fmap
     (fn [[bits tail]]
       (str "{\"k\":\"" (recase "</script" bits) tail "\"}"))
     (fn [rng]
-      (let [[bits rng1] ((gen/gen-vec (count "</script") (gen/gen-elem [0 1])) rng)
-            [tail rng2] (gen/rand-nth rng1 [">" " >" "/" "\t" "\n"])]
+      (let [[bits rng1] ((rf.security.gen/gen-vec (count "</script") (rf.security.gen/gen-elem [0 1])) rng)
+            [tail rng2] (rf.security.gen/rand-nth rng1 [">" " >" "/" "\t" "\n"])]
         [[bits tail] rng2]))))
 
 (deftest script-body-breakout-neutralised
   (testing "escape-script-body-string escapes every `<`
             so no `</script` (any casing) survives in a script body; sweep
             500 recased closing-tag payloads"
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-script-breakout 500 3
                    (fn [payload]
-                     (let [escaped (h/escape-script-body-string payload)]
+                     (let [escaped (rf.ssr.html-helpers/escape-script-body-string payload)]
                         ;; Without a literal `<`, no closing tag can begin.
                        (and (not (str/includes? escaped "<"))
                             (str/includes? escaped "\\u003c")))))]
@@ -306,7 +306,7 @@
                      "</title><script>alert(1)</script>"
                      "\"><svg onload=alert(1)>"
                      "<!--<script>--><script>x</script>"]]
-      (let [out (h/escape-html payload)]
+      (let [out (rf.ssr.html-helpers/escape-html payload)]
         (is (not (str/includes? out "<")) (str "raw < survived: " (pr-str out)))
         (is (not (str/includes? out ">")) (str "raw > survived: " (pr-str out)))
         (is (not (str/includes? out "\"")) (str "raw \" survived: " (pr-str out)))))))
@@ -328,12 +328,12 @@
   STRING VALUE embeds a randomly-recased closing-tag breakout. The breakout
   lives inside an EDN string literal, so the escape must neutralise it AND
   round-trip."
-  (gen/gen-fmap
+  (rf.security.gen/gen-fmap
     (fn [[bits tail]]
       (pr-str {:k (str "x" (recase "</script" bits) tail "y")}))
     (fn [rng]
-      (let [[bits rng1] ((gen/gen-vec (count "</script") (gen/gen-elem [0 1])) rng)
-            [tail rng2] (gen/rand-nth rng1 [">" " >" "/" "\t" "\n"])]
+      (let [[bits rng1] ((rf.security.gen/gen-vec (count "</script") (rf.security.gen/gen-elem [0 1])) rng)
+            [tail rng2] (rf.security.gen/rand-nth rng1 [">" " >" "/" "\t" "\n"])]
         [[bits tail] rng2]))))
 
 (deftest edn-script-string-breakout-neutralised-and-round-trips
@@ -341,10 +341,10 @@
             `</script` in an EDN string literal so none survives in the body,
             AND the reader recovers the original document verbatim; sweep 500
             recased closing-tag payloads"
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-edn-string-breakout 500 11
                    (fn [edn-doc]
-                     (let [escaped (h/escape-edn-script-body edn-doc)]
+                     (let [escaped (rf.ssr.html-helpers/escape-edn-script-body edn-doc)]
                        (and (no-script-breakout? escaped)
                             ;; Reading the escaped body must recover the same value.
                             (= (edn/read-string edn-doc)
@@ -370,7 +370,7 @@
             breakout"
     (doseq [doc edn-token-with-angle-corpus]
       (let [edn-doc (pr-str doc)
-            escaped (h/escape-edn-script-body edn-doc)]
+            escaped (rf.ssr.html-helpers/escape-edn-script-body edn-doc)]
         (is (no-script-breakout? escaped)
             (str "doc " (pr-str doc) " left a </script breakout: " escaped))
         (is (= doc (edn/read-string escaped))
@@ -386,7 +386,7 @@
                      "{:tag<!-- 1}"
                      "{:k </script}"]]
       (let [thrown (try
-                     (h/escape-edn-script-body edn-doc)
+                     (rf.ssr.html-helpers/escape-edn-script-body edn-doc)
                      nil
                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
                        (:rf.error/id (ex-data e))))]
@@ -402,7 +402,7 @@
                  {:s "a</b><![CDATA[x]]>"}
                  {:s "</SCRIPT/></script >"}]]
       (let [edn-doc (pr-str doc)
-            escaped (h/escape-edn-script-body edn-doc)]
+            escaped (rf.ssr.html-helpers/escape-edn-script-body edn-doc)]
         (is (no-script-breakout? escaped)
             (str "string-literal breakout survived for " (pr-str doc)))
         (is (= doc (edn/read-string escaped))

--- a/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
@@ -56,12 +56,12 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             ;; Publishes the Malli late-bind validate/explain hooks; without
             ;; it the default validator soft-passes and no failure fires.
             [re-frame.schemas.malli]
-            [re-frame.schemas :as schemas]
-            [re-frame.machines.data-validation :as machine-data]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.machines.data-validation :as rf.machines.data-validation]
             ;; rf2-g1a4ho — the two PRODUCTION-PATH drivers below register a
             ;; flow / a sub-override and drive the real drain + subscribe
             ;; cascades end-to-end. Requiring `re-frame.flows` publishes the
@@ -76,11 +76,11 @@
             ;; is a CLJS-only dev surface). Scoping the require to `:cljs`
             ;; keeps the JVM branch honest rather than carrying a require no
             ;; `:clj` form reads.
-            #?(:cljs [re-frame.late-bind :as late-bind])
-            [re-frame.substrate.plain-atom :as plain-atom]
-            #?(:clj  [re-frame.test-support :as test-support :refer [with-trace-recorder!]]
-               :cljs [re-frame.test-support :as test-support :refer-macros [with-trace-recorder!]])
-            [re-frame.security.gen :as gen]))
+            #?(:cljs [re-frame.late-bind :as rf.late-bind])
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            #?(:clj  [re-frame.test-support :as rf.test-support :refer [with-trace-recorder!]]
+               :cljs [re-frame.test-support :as rf.test-support :refer-macros [with-trace-recorder!]])
+            [re-frame.security.gen :as rf.security.gen]))
 
 ;; Reset per-test so app-schema registrations don't bleed across cases.
 ;;
@@ -95,10 +95,10 @@
 ;; side-table — no registered frame / container needed (so no adapter, and
 ;; not `ensure-default-frame!`, which would require one).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (rf.test-support/make-reset-runtime-fixture
     {:clear-app-schemas? true})
   (fn [test-fn]
-    (binding [frame/*current-frame* :rf/default]
+    (binding [rf.frame/*current-frame* :rf/default]
       (test-fn))))
 
 ;; ---------------------------------------------------------------------------
@@ -113,7 +113,7 @@
   stringified form). Thin wrapper over the shared `gen/contains-string?`
   (rf2-n5bkm7), which matches the sentinel as a substring."
   [x]
-  (gen/contains-string? x sentinel))
+  (rf.security.gen/contains-string? x sentinel))
 
 ;; ---------------------------------------------------------------------------
 ;; Trace capture — register a listener, run `f`, return the single
@@ -127,7 +127,7 @@
   [op f]
   (with-trace-recorder! [traces]
     (f)
-    #?(:clj (schemas/clear-sensitive-paths-cache!))
+    #?(:clj (rf.schemas/clear-sensitive-paths-cache!))
     (first (filter #(= op (:operation %)) @traces))))
 
 (defn- capture-failure
@@ -217,7 +217,7 @@
   (testing "rf2-a5kzs#1 — :where :event (validate-event!) redacts the
             sensitive payload"
     (let [trace (capture-failure
-                  #(schemas/validate-event!
+                  #(rf.schemas/validate-event!
                      :auth/login failing-sensitive-event
                      {:schema sensitive-event-schema}))]
       (assert-no-leak ":where :event" trace)
@@ -236,7 +236,7 @@
   (testing ":where :fx-args (validate-fx!) redacts the sensitive fx args (incl.
             the per-surface :rf.fx/args slot)"
     (let [trace (capture-failure
-                  #(schemas/validate-fx!
+                  #(rf.schemas/validate-fx!
                      :fx/secret :some/event failing-sensitive-value
                      {:schema sensitive-map-schema}))]
       (assert-no-leak ":where :fx-args" trace)
@@ -247,7 +247,7 @@
   (testing ":where :sub-return (validate-sub!) redacts the sensitive return
             value (incl. the per-surface :rf.sub/query-v lookup key)"
     (let [trace (capture-failure
-                  #(schemas/validate-sub!
+                  #(rf.schemas/validate-sub!
                      :sub/secret [:sub/secret sentinel] failing-sensitive-value
                      {:schema sensitive-map-schema}))]
       (assert-no-leak ":where :sub-return" trace)
@@ -259,7 +259,7 @@
             post-commit slice"
     (rf/reg-app-schema [:root] sensitive-map-schema)
     (let [trace (capture-failure
-                  #(schemas/validate-app-schema!
+                  #(rf.schemas/validate-app-schema!
                      {:root failing-sensitive-value} :root/bad))]
       (assert-no-leak ":where :app-db" trace)
       (is (= :rf/redacted (-> trace :tags :value)) ":value redacted")
@@ -270,7 +270,7 @@
             redacts the sensitive :data map. Pre-fix this emitted :value /
             :received / :explain verbatim."
     (let [trace (capture-failure
-                  #(machine-data/validate-snapshot-data!
+                  #(rf.machines.data-validation/validate-snapshot-data!
                      :my/machine {:data failing-sensitive-value}
                      sensitive-map-schema :macrostep))]
       (assert-no-leak ":where :machine-data" trace)
@@ -297,7 +297,7 @@
             value-bearing slot) redacts under the root check and the conforming
             sibling never egresses"
     (let [trace (capture-failure
-                  #(schemas/validate-event!
+                  #(rf.schemas/validate-event!
                      :auth/profile failing-sibling-event
                      {:schema sibling-sensitive-event-schema}))]
       (assert-no-leak ":where :event (conforming sibling)" trace)
@@ -315,7 +315,7 @@
             to a non-sensitive failing :count; the whole fx args redact (incl.
             :rf.fx/args)"
     (let [trace (capture-failure
-                  #(schemas/validate-fx!
+                  #(rf.schemas/validate-fx!
                      :fx/effect :some/event failing-sibling-value
                      {:schema sibling-sensitive-map-schema}))]
       (assert-no-leak ":where :fx-args (conforming sibling)" trace)
@@ -327,7 +327,7 @@
             next to a non-sensitive failing :count; the whole return value
             redacts"
     (let [trace (capture-failure
-                  #(schemas/validate-sub!
+                  #(rf.schemas/validate-sub!
                      :sub/view [:sub/view] failing-sibling-value
                      {:schema sibling-sensitive-map-schema}))]
       (assert-no-leak ":where :sub-return (conforming sibling)" trace)
@@ -343,7 +343,7 @@
             root check, so the conforming sibling never egresses"
     (rf/reg-app-schema [:root] sibling-sensitive-map-schema)
     (let [trace (capture-failure
-                  #(schemas/validate-app-schema!
+                  #(rf.schemas/validate-app-schema!
                      {:root failing-sibling-value} :root/bad))]
       (assert-no-leak ":where :app-db (conforming sibling)" trace)
       ;; The narrowed :value is the failing non-sensitive :count leaf, verbatim.
@@ -357,7 +357,7 @@
             next to a non-sensitive failing :count in the :data map; the whole
             :data redacts via the shared seam (root check)"
     (let [trace (capture-failure
-                  #(machine-data/validate-snapshot-data!
+                  #(rf.machines.data-validation/validate-snapshot-data!
                      :my/machine {:data failing-sibling-value}
                      sibling-sensitive-map-schema :macrostep))]
       (assert-no-leak ":where :machine-data (conforming sibling)" trace)
@@ -425,8 +425,8 @@
   fixture's boundary does not already cover, and every caller wraps its
   whole test body in exactly one `with-runtime*`."
   [thunk]
-  (rf/init! plain-atom/adapter)
-  (frame/ensure-default-frame!)
+  (rf/init! rf.substrate.plain-atom/adapter)
+  (rf.frame/ensure-default-frame!)
   (thunk))
 
 (deftest flow-output-production-path-redacts-sensitive
@@ -625,7 +625,7 @@
                        (fn [_db _] {:secret "ok"}))
            ;; Publish the override resolver the Story carriage would publish:
            ;; an exact-query-vector HIT returns `[value]`.
-           (late-bind/set-fn! :subs/resolve-sub-override
+           (rf.late-bind/set-fn! :subs/resolve-sub-override
              (fn [query-v]
                (when (= query-v [:sub/secret])
                  [failing-sensitive-value])))
@@ -640,7 +640,7 @@
                (is (= :rf/redacted (-> trace :tags :rf.sub/query-v))
                    ":rf.sub/query-v redacted"))
              (finally
-               (late-bind/set-fn! :subs/resolve-sub-override nil))))))))
+               (rf.late-bind/set-fn! :subs/resolve-sub-override nil))))))))
 
 ;; SUPPLEMENTARY (rf2-g1a4ho) — the handcrafted tag-shape tests below now
 ;; backstop the production-path drivers above: they exercise the shared seam
@@ -661,7 +661,7 @@
                  :value          failing-sensitive-value
                  :explain        {:value failing-sensitive-value}
                  :recovery       :replaced-with-default}
-          out   (schemas/redact-validation-tags sensitive-map-schema tags)]
+          out   (rf.schemas/redact-validation-tags sensitive-map-schema tags)]
       (is (true? (:sensitive? out)) ":sensitive? stamped")
       (is (= :rf/redacted (:value out)) ":value redacted")
       (is (= :rf/redacted (:received out)) ":received redacted")
@@ -682,7 +682,7 @@
                  :value      failing-sensitive-value
                  :explain    {:value failing-sensitive-value}
                  :recovery   :no-recovery}
-          out   (schemas/redact-validation-tags sensitive-map-schema tags)]
+          out   (rf.schemas/redact-validation-tags sensitive-map-schema tags)]
       (is (true? (:sensitive? out)) ":sensitive? stamped")
       (is (= :rf/redacted (:value out)) ":value redacted")
       (is (= :rf/redacted (:explain out)) ":explain redacted")
@@ -703,7 +703,7 @@
 ;; `:map-of-key`-before-`:tuple` order below is this suite's historical draw
 ;; order, preserved deliberately - see the shared block comment on the drift.
 (def ^:private gen-nested-sensitive
-  (gen/nested-sensitive-generator
+  (rf.security.gen/nested-sensitive-generator
     sentinel
     [:map :vector :sequential :map-of :map-of-key :tuple :set :and :or :multi :orn]
     5))
@@ -718,16 +718,16 @@
         [;; :where :event — the payload schema is the generated shape, the
          ;; event wraps it under a :cat (the rf2-a5kzs#1 shape).
          (capture-failure
-           #(schemas/validate-event! :gen/id event-value {:schema event-schema}))
+           #(rf.schemas/validate-event! :gen/id event-value {:schema event-schema}))
          ;; :where :fx-args
          (capture-failure
-           #(schemas/validate-fx! :gen/fx :gen/ev value {:schema schema}))
+           #(rf.schemas/validate-fx! :gen/fx :gen/ev value {:schema schema}))
          ;; :where :sub-return
          (capture-failure
-           #(schemas/validate-sub! :gen/sub [:gen/sub sentinel] value {:schema schema}))
+           #(rf.schemas/validate-sub! :gen/sub [:gen/sub sentinel] value {:schema schema}))
          ;; :where :machine-data
          (capture-failure
-           #(machine-data/validate-snapshot-data!
+           #(rf.machines.data-validation/validate-snapshot-data!
               :gen/machine {:data value} schema :macrostep))]]
     (every? (fn [trace]
               (and (some? trace)
@@ -740,7 +740,7 @@
             :sensitive? slot, EVERY callable validation kind (event /
             fx / sub-return / machine-data) redacts the sentinel and stamps
             :sensitive?. One escaped kind/shape = one leak."
-    (let [result (gen/for-all
+    (let [result (rf.security.gen/for-all
                    gen-nested-sensitive 120 17
                    all-kinds-redact?)]
       (is (nil? result)
@@ -759,11 +759,11 @@
     (let [plain-schema [:map [:n :int]]
           plain-value  {:n "not-an-int"}
           event-trace  (capture-failure
-                         #(schemas/validate-event!
+                         #(rf.schemas/validate-event!
                             :plain/ev [:plain/ev plain-value]
                             {:schema [:cat [:= :plain/ev] plain-schema]}))
           machine-trace (capture-failure
-                          #(machine-data/validate-snapshot-data!
+                          #(rf.machines.data-validation/validate-snapshot-data!
                              :plain/machine {:data plain-value} plain-schema :macrostep))]
       (is (some? event-trace))
       (is (not (contains? (:tags event-trace) :sensitive?))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -9,15 +9,15 @@
 
   This façade exposes the non-streaming handler and middleware, the streaming
   handler, the default shell, and cookie serialization."
-  (:require [re-frame.error :as error]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.ring.cookie :as cookie]
-            [re-frame.ssr.ring.lifecycle :as lifecycle]
-            [re-frame.ssr.ring.pipeline :as pipeline]
-            [re-frame.ssr.ring.shell :as shell]
+  (:require [re-frame.error :as rf.error]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.ring.cookie :as rf.ssr.ring.cookie]
+            [re-frame.ssr.ring.lifecycle :as rf.ssr.ring.lifecycle]
+            [re-frame.ssr.ring.pipeline :as rf.ssr.ring.pipeline]
+            [re-frame.ssr.ring.shell :as rf.ssr.ring.shell]
             ;; Loaded eagerly for the façade; only stream-handler requests
             ;; create writer threads.
-            [re-frame.ssr.ring.streaming :as streaming]))
+            [re-frame.ssr.ring.streaming :as rf.ssr.ring.streaming]))
 
 (set! *warn-on-reflection* true)
 
@@ -39,7 +39,7 @@
   [src-sym]
   (when-not (resolve src-sym)
     ;; Author error at namespace load; retain the canonical structured shape.
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/ssr-ring-import-fn-unresolved
       'rf.ssr.ring/import-fn
       (str "import-fn cannot resolve the source var " src-sym
@@ -55,13 +55,13 @@
                                  [:doc :arglists :added :deprecated]))
        (var ~exported-sym))))
 
-(import-fn cookie/cookie->set-cookie-header)
-(import-fn shell/default-html-shell)
+(import-fn rf.ssr.ring.cookie/cookie->set-cookie-header)
+(import-fn rf.ssr.ring.shell/default-html-shell)
 
 ;; Chunked-HTTP counterpart of `ssr-handler`.
-(import-fn streaming/stream-handler)
-(import-fn streaming/default-streaming-prefix)
-(import-fn streaming/default-streaming-suffix)
+(import-fn rf.ssr.ring.streaming/stream-handler)
+(import-fn rf.ssr.ring.streaming/default-streaming-prefix)
+(import-fn rf.ssr.ring.streaming/default-streaming-suffix)
 
 ;; ---- handler defaults + re-exported construction helpers ------------------
 ;;
@@ -73,9 +73,9 @@
 ;; authored `:doc` so REPL `doc` works at the façade, but it is correctly
 ;; excluded from the fn-arglists api-manifest check (data var, like
 ;; `handler-defaults`).
-(def default-on-error lifecycle/default-on-error)
+(def default-on-error rf.ssr.ring.lifecycle/default-on-error)
 (alter-meta! #'default-on-error assoc
-             :doc (-> #'lifecycle/default-on-error meta :doc))
+             :doc (-> #'rf.ssr.ring.lifecycle/default-on-error meta :doc))
 
 (def handler-defaults
   "Default `ssr-handler` opts merged under caller-supplied opts at
@@ -94,7 +94,7 @@
   explicit Content-Type — in control. So the on-the-wire default is
   unchanged."
   {:emit-hash? true
-   :html-shell shell/default-html-shell})
+   :html-shell rf.ssr.ring.shell/default-html-shell})
 
 ;; ---- ssr-handler ----------------------------------------------------------
 
@@ -281,7 +281,7 @@
                              :html-shell     ssr-ring-app/shell}))
     (jetty/run-jetty handler {:port 3000 :join? false})"
   [raw-opts]
-  (lifecycle/validate-construction-opts! raw-opts)
+  (rf.ssr.ring.lifecycle/validate-construction-opts! raw-opts)
   ;; Merge defaults once at construction time so the pipeline helpers
   ;; (`setup-request-frame!`, `build-full-response`) can destructure
   ;; without re-stating the `:or` map. Caller-supplied values win.
@@ -289,11 +289,11 @@
   ;; Resolve `:on-error` separately so handler-defaults stays orthogonal to
   ;; the caller-or-locked-default precedence.
   (let [opts        (-> (merge handler-defaults raw-opts)
-                        (assoc :on-error (lifecycle/resolve-on-error raw-opts)))
+                        (assoc :on-error (rf.ssr.ring.lifecycle/resolve-on-error raw-opts)))
         {:keys [on-error]} opts]
     (fn ring-handler [request]
       (let [{:keys [frame-id frame short-circuit]}
-            (pipeline/setup-request-frame! opts request)]
+            (rf.ssr.ring.pipeline/setup-request-frame! opts request)]
         (if short-circuit
           short-circuit
           (try
@@ -301,20 +301,20 @@
             ;; status/headers/cookies/redirect AND the projected `:public-error`
             ;; (one drain), so the handler classifies the drain-time outcome
             ;; without re-inferring projection from `(:status resp)`.
-            (let [{:keys [response public-error]} (ssr/flush-response-result! frame-id)]
+            (let [{:keys [response public-error]} (rf.ssr/flush-response-result! frame-id)]
               (cond
                 ;; Redirect precedence FIRST (Spec 011 §Redirect precedence) —
                 ;; a pending projection is ignored while a redirect stands.
                 (some? (:redirect response))
-                (pipeline/ssr-response->ring-response response nil)
+                (rf.ssr.ring.pipeline/ssr-response->ring-response response nil)
 
                 ;; A projected 5xx discovered during the drain (a handler/fx
                 ;; exception, a custom 5xx projection) — the app-db is in an
                 ;; arbitrary partial state, so DISCARD the root body + payload
                 ;; and ship the projected-error arm (Spec 011 §Drain-time error
                 ;; classification, rf2-oytx7j).
-                (pipeline/projected-5xx? public-error)
-                (pipeline/materialise-projected-error frame-id response public-error opts)
+                (rf.ssr.ring.pipeline/projected-5xx? public-error)
+                (rf.ssr.ring.pipeline/materialise-projected-error frame-id response public-error opts)
 
                 ;; A projected 4xx (routing miss / bad client input) or no
                 ;; projection keeps the app's OWN body: the root view renders
@@ -322,15 +322,15 @@
                 ;; hydrates into a working SPA. A post-render recovered-to-nil
                 ;; 5xx is caught inside `build-full-response`.
                 :else
-                (pipeline/build-full-response frame-id opts)))
+                (rf.ssr.ring.pipeline/build-full-response frame-id opts)))
             (catch Throwable t
               ;; A failing caller hook falls back to the locked response.
-              (lifecycle/safe-on-error on-error request t))
+              (rf.ssr.ring.lifecycle/safe-on-error on-error request t))
             (finally
               ;; Frame teardown also clears its per-request side channels.
               ;; Destroy the VALUE (incarnation-EXACT, rf2-moftbs); the keyword
               ;; `frame-id` names the frame on any failure trace.
-              (lifecycle/destroy-frame-quietly! frame frame-id))))))))
+              (rf.ssr.ring.lifecycle/destroy-frame-quietly! frame frame-id))))))))
 
 ;; ---- ssr-middleware -------------------------------------------------------
 

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
@@ -20,8 +20,8 @@
   would otherwise allow header-splitting via `\\r\\n` injection. Cookie
   `:name` carries a separate RFC 6265 §4.1.1 token-grammar gate."
   (:require [clojure.string :as str]
-            [re-frame.error :as error]
-            [re-frame.ssr.http-validation :as http-validation])
+            [re-frame.error :as rf.error]
+            [re-frame.ssr.http-validation :as rf.ssr.http-validation])
   (:import [java.net URLEncoder]
            [java.nio.charset StandardCharsets]
            [java.time Instant ZoneOffset ZonedDateTime]
@@ -56,8 +56,8 @@
 (defn- validate-cookie-attribute!
   [attribute-key attribute-value]
   (let [wire-value (str attribute-value)]
-    (when (http-validation/contains-cookie-attr-injection-char? wire-value)
-      (error/throw-error!
+    (when (rf.ssr.http-validation/contains-cookie-attr-injection-char? wire-value)
+      (rf.error/throw-error!
         :rf.error/cookie-invalid-attribute
         'rf.ssr/cookie->set-cookie-header
         (str "cookie attribute " attribute-key
@@ -79,7 +79,7 @@
   ;; cookie-name error instead of leaking a ClassCastException.
   (when-not (or (string? cookie-name)
                 (instance? clojure.lang.Named cookie-name))
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/cookie-invalid-name
       'rf.ssr/cookie->set-cookie-header
       (str "cookie :name must be a string or a keyword/symbol; got a "
@@ -90,9 +90,9 @@
        :extra    {:name cookie-name
                   :type (.getName (class cookie-name))}}))
   (let [wire-name (clojure.core/name cookie-name)]
-    (if (http-validation/valid-token-name? wire-name)
+    (if (rf.ssr.http-validation/valid-token-name? wire-name)
       wire-name
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/cookie-invalid-name
         'rf.ssr/cookie->set-cookie-header
         (str "cookie :name violates RFC 6265 §4.1.1"
@@ -139,7 +139,7 @@
   [{:keys [name value max-age secure http-only same-site path domain expires]
     :as cookie}]
   (when (nil? name)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/cookie-missing-name
       'rf.ssr/cookie->set-cookie-header
       "cookie map must carry :name; add a :name key to the cookie map."
@@ -154,7 +154,7 @@
     ;; `:rf.error/cookie-invalid-expires` so the misuse surfaces with the
     ;; cookie's actual shape attached.
     (when (and (some? expires) (not (integer? expires)))
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/cookie-invalid-expires
         'rf.ssr/cookie->set-cookie-header
         (str ":expires must be an epoch-millis long; got "

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -8,9 +8,9 @@
   pairs into vectors so multi-valued headers (Set-Cookie, Vary,
   Link, ...) round-trip correctly."
   (:require [clojure.string :as str]
-            [re-frame.interop :as interop]
-            [re-frame.ssr.ring.cookie :as cookie]
-            [re-frame.trace :as trace]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr.ring.cookie :as rf.ssr.ring.cookie]
+            [re-frame.trace :as rf.trace]))
 
 (set! *warn-on-reflection* true)
 
@@ -44,10 +44,10 @@
   values and emits a development warning. Nil remains nil instead of being
   fabricated into an empty header."
   [ring-headers [header-name header-value]]
-  (when (and interop/debug-enabled?
+  (when (and rf.interop/debug-enabled?
              (some? header-value)
              (not (string? header-value)))
-    (trace/emit! :warning :rf.ssr/ssr-non-string-header-value
+    (rf.trace/emit! :warning :rf.ssr/ssr-non-string-header-value
                  {:where      :ssr-ring/merge-pair-into-header-map
                   :header     header-name
                   :value-type (some-> header-value class .getName)
@@ -87,7 +87,7 @@
     (fn [ring-headers cookie-map]
       (merge-pair-into-header-map
         ring-headers
-        ["Set-Cookie" (cookie/cookie->set-cookie-header cookie-map)]))
+        ["Set-Cookie" (rf.ssr.ring.cookie/cookie->set-cookie-header cookie-map)]))
     headers-map
     cookies))
 

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -6,12 +6,12 @@
   the frame-scoped `:rf.server/request` coeffect rather than being appended to
   initial event vectors. Per Spec 011 §Request storage and §Head/meta."
   (:require [re-frame.core :as rf]
-            [re-frame.error :as error]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.ring.trust :as trust]
-            [re-frame.trace :as trace]))
+            [re-frame.error :as rf.error]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.ssr.ring.trust :as rf.ssr.ring.trust]
+            [re-frame.trace :as rf.trace]))
 
 (set! *warn-on-reflection* true)
 
@@ -27,7 +27,7 @@
   <ms> + flat category keys}`. No-op when the producer hasn't loaded.
   Returns nil."
   [record]
-  (when-let [dispatch-error-record! (late-bind/get-fn :error-emit/dispatch-error-record)]
+  (when-let [dispatch-error-record! (rf.late-bind/get-fn :error-emit/dispatch-error-record)]
     (dispatch-error-record! record))
   nil)
 
@@ -61,7 +61,7 @@
   (try
     (on-error request t)
     (catch Throwable on-error-t
-      (trace/emit-error! :rf.error/ssr-ring-on-error-failed
+      (rf.trace/emit-error! :rf.error/ssr-ring-on-error-failed
                          {:exception (.getMessage on-error-t)
                           :ex-class  (.getName (class on-error-t))
                           :recovery  :fell-back-to-default-on-error})
@@ -95,7 +95,7 @@
    (try
      (rf/destroy-frame! frame-target)
      (catch Throwable t
-       (trace/emit! :warning :rf.ssr/destroy-frame-failed
+       (rf.trace/emit! :warning :rf.ssr/destroy-frame-failed
                     {:frame    diag-frame-id
                      :reason   (or (.getMessage t) (.getName (class t)))
                      :ex-class (.getName (class t))
@@ -143,7 +143,7 @@
     (vector? root-view) root-view
     (fn?     root-view) (root-view)
     :else
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/invalid-root-view
       'rf.ssr/ssr-handler
       (str "root-view must be a hiccup vector or a 0-arity fn returning "
@@ -181,7 +181,7 @@
        :body-attrs (:body-attrs model)
        :head-model model})
     (catch Throwable t
-      (trace/emit-error! :rf.error/ssr-head-resolution-failed
+      (rf.trace/emit-error! :rf.error/ssr-head-resolution-failed
                          {:frame     frame-id
                           :exception t
                           :recovery  :no-recovery})
@@ -190,7 +190,7 @@
       (emit-always-on-error!
         {:error     :rf.error/ssr-head-resolution-failed
          :frame     frame-id
-         :time      (interop/now-ms)
+         :time      (rf.interop/now-ms)
          :exception t
          :recovery  :no-recovery})
       {:head-html "" :html-attrs nil :body-attrs nil :head-model nil})))
@@ -327,7 +327,7 @@
     (let [derived (initial-events request)]
       (if (vector? derived)
         derived
-        (error/throw-error!
+        (rf.error/throw-error!
           :rf.error/invalid-initial-events
           'rf.ssr/ssr-handler
           (str ":initial-events fn must return an :initial-events vector; the "
@@ -337,7 +337,7 @@
            :extra    {:returned derived}})))
 
     :else
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/invalid-initial-events
       'rf.ssr/ssr-handler
       (str ":initial-events must be a vector OR a (fn [request] initial-events-vector); "
@@ -356,13 +356,13 @@
   worse, inside an already-committed writer. Returns `opts` unchanged."
   [{:keys [initial-events root-view renderer] :as opts}]
   (when-not initial-events
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/ssr-ring-missing-initial-events
       'rf.ssr/ssr-handler
       "ssr-handler requires :initial-events (a vector of events); supply :initial-events in the handler opts."
       {:recovery :supply-the-initial-events-opt}))
   (when-not (or root-view renderer)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/ssr-ring-missing-root-view
       'rf.ssr/ssr-handler
       (str "ssr-handler requires :root-view (a hiccup vector or 0-arity fn) "
@@ -398,8 +398,8 @@
   threading position cleanly."
   [opts]
   (validate-required-opts! opts)
-  (payload-policy/validate-policy-opts! opts)
-  (trust/validate-trusted-shell-opts! opts))
+  (rf.ssr.payload-policy/validate-policy-opts! opts)
+  (rf.ssr.ring.trust/validate-trusted-shell-opts! opts))
 
 (defn validate-streaming-opts!
   "Reject opts the streaming handler CANNOT honour, at handler-
@@ -444,7 +444,7 @@
   Returns `opts` unchanged on success."
   [opts]
   (when (some? (:renderer opts))
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/ssr-streaming-unsupported-opt
       'rf.ssr/stream-handler
       (str "stream-handler does not support :renderer — the streaming "
@@ -457,7 +457,7 @@
        :extra    {:opt-key :renderer
                   :got     (:renderer opts)}}))
   (when (some? (:html-shell opts))
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/ssr-streaming-unsupported-opt
       'rf.ssr/stream-handler
       (str "stream-handler does not support :html-shell — the "

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/node.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/node.clj
@@ -115,9 +115,9 @@
   transport to secure."
   (:require [clojure.data.json :as json]
             [clojure.string :as str]
-            [re-frame.error :as error]
-            [re-frame.ssr.manifest :as manifest]
-            [re-frame.ssr.render-state :as render-state])
+            [re-frame.error :as rf.error]
+            [re-frame.ssr.manifest :as rf.ssr.manifest]
+            [re-frame.ssr.render-state :as rf.ssr.render-state])
   (:import [java.io IOException]
            [java.net URI URISyntaxException]
            [java.net.http HttpClient HttpClient$Version HttpConnectTimeoutException
@@ -165,7 +165,7 @@
 ;; ---- construction validation ----------------------------------------------
 
 (defn- throw-opt-invalid! [option-key received reason]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/ssr-node-renderer-opt-invalid error-origin
     (str "re-frame.ssr.ring.node/renderer " option-key " " reason ".")
     {:recovery :correct-the-renderer-opt
@@ -222,7 +222,7 @@
   (endpoint-uri endpoint)
   (require-non-empty-string! :entry entry)
   (require-non-empty-string! :build-id build-id)
-  (when (and (contains? opts :args) (not (manifest/edn-carryable? args)))
+  (when (and (contains? opts :args) (not (rf.ssr.manifest/edn-carryable? args)))
     (throw-opt-invalid! :args args
                         (str "must be EDN the sidecar's safe reader reads back "
                              "EQUAL — no fn, host object, record, ratio, "
@@ -230,7 +230,7 @@
                              "or #uuid")))
   (require-integer! :timeout-ms timeout-ms 1)
   (require-integer! :admission-ms admission-ms 0)
-  (render-state/validate-policy-opts! opts)
+  (rf.ssr.render-state/validate-policy-opts! opts)
   opts)
 
 (defn http-timeout-ms
@@ -258,7 +258,7 @@
   field names, both partitions as per-key EDN text. `args` rides only when
   the caller gave one (the protocol makes it optional)."
   [{:keys [entry args build-id timeout-ms] :as opts} frame-id partitions]
-  (let [serialized-partitions (render-state/serialize partitions)]
+  (let [serialized-partitions (rf.ssr.render-state/serialize partitions)]
     (cond-> {"protocol"  1
              "entry"     entry
              "state"     (:rf/app-db serialized-partitions)
@@ -278,7 +278,7 @@
       (.build)))
 
 (defn- throw-unreachable! [{:keys [endpoint]} ^Throwable cause]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/ssr-node-unreachable error-origin
     (str "the Node render sidecar at " endpoint " gave no HTTP answer ("
          (.getName (class cause)) "). Start the sidecar (re-frame2-ssr-node "
@@ -289,7 +289,7 @@
                 :ex-message (.getMessage cause)}}))
 
 (defn- throw-deadline! [{:keys [timeout-ms] :as opts} observed-by]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/ssr-node-deadline error-origin
     (str "the Node render did not finish within its " timeout-ms " ms deadline "
          "(observed by the " (name observed-by) "). Raise :timeout-ms, or make "
@@ -300,7 +300,7 @@
                 :http-timeout-ms (http-timeout-ms opts)}}))
 
 (defn- throw-refused! [{:keys [endpoint]} status refusal message detail]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/ssr-node-refused error-origin
     (str "the Node render sidecar at " endpoint " refused the render (HTTP "
          status (when refusal (str ", " refusal)) ")"
@@ -317,7 +317,7 @@
   the answer named none. The two causes read differently to an operator, so
   the sentence names which one it is; the id and the ex-data slots are one."
   [{:keys [build-id endpoint]} serving]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/ssr-node-build-skew error-origin
     (str "the Node render sidecar at " endpoint " answered 200 "
          (if serving
@@ -416,7 +416,7 @@
                                (endpoint-uri (:endpoint validated-opts)))
         client               (build-client transport-timeout-ms)]
     (fn node-renderer [{:keys [frame-id]}]
-      (let [partitions   (render-state/project frame-id validated-opts)
+      (let [partitions   (rf.ssr.render-state/project frame-id validated-opts)
             request-json (json/write-str
                            (request-body validated-opts frame-id partitions)
                            :escape-slash false)

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
@@ -19,7 +19,7 @@
   (`re-frame.ssr.streaming/build-final-payload`). This namespace owns
   only the non-streaming wrapper: project the handed-in `app-db` +
   runtime-db, then assemble."
-  (:require [re-frame.ssr.payload-policy :as payload-policy]))
+  (:require [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]))
 
 (set! *warn-on-reflection* true)
 
@@ -71,15 +71,15 @@
   ([frame-id app-db render-hash policy-opts]
    (build-payload frame-id app-db nil render-hash policy-opts))
   ([frame-id app-db runtime-db render-hash {:as policy-opts}]
-   (payload-policy/build-payload
+   (rf.ssr.payload-policy/build-payload
     ;; WIRE :rf/frame-id — the stable, ahead-of-time client id, or nil to omit
     ;; (never the per-request projection gensym). Decoupled per rf2-lm2yzy.
     (:client-frame-id policy-opts)
     ;; Apply the allowlist before the frame-scoped hydration-egress projection,
     ;; so classified values inside the surviving slice are still elided. The
     ;; projection target is the REAL per-request frame-id.
-    (payload-policy/project-app-db-egress
-     (payload-policy/apply-policy app-db policy-opts)
+    (rf.ssr.payload-policy/project-app-db-egress
+     (rf.ssr.payload-policy/apply-policy app-db policy-opts)
      frame-id)
     render-hash
     ;; rf2-f02diw — project the runtime-db under the EXPLICIT carried `frame-id`
@@ -90,4 +90,4 @@
     ;; route / machine / resource runtime state under the right frame's policy.
     ;; The host's request-frame binding stays a correctness convenience for other
     ;; code, never the projector's target authority (finishing the clean break).
-    (assoc policy-opts :runtime-db (payload-policy/project-runtime-db runtime-db frame-id)))))
+    (assoc policy-opts :runtime-db (rf.ssr.payload-policy/project-runtime-db runtime-db frame-id)))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -29,13 +29,13 @@
   drain-time 5xx errors. Transport failures outside that projector use the
   handler's fixed-detail fallback."
   (:require [re-frame.core :as rf]
-            [re-frame.error :as error]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.ring.headers :as headers]
-            [re-frame.ssr.ring.lifecycle :as lifecycle]
-            [re-frame.ssr.ring.payload :as payload]
-            [re-frame.trace :as trace]))
+            [re-frame.error :as rf.error]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.ring.headers :as rf.ssr.ring.headers]
+            [re-frame.ssr.ring.lifecycle :as rf.ssr.ring.lifecycle]
+            [re-frame.ssr.ring.payload :as rf.ssr.ring.payload]
+            [re-frame.trace :as rf.trace]))
 
 (set! *warn-on-reflection* true)
 
@@ -128,15 +128,15 @@
   [status]
   (let [;; Computed ONCE and shared by both axes.
         status-type (some-> status class .getName)]
-    (lifecycle/emit-always-on-error!
+    (rf.ssr.ring.lifecycle/emit-always-on-error!
       {:error       :rf.error/ssr-ring-response-status-invalid
        :frame       nil
-       :time        (interop/now-ms)
+       :time        (rf.interop/now-ms)
        :where       :ssr-ring/ssr-response->ring-response
        :status-type status-type
        :reason      :non-integer-status
        :recovery    :failed-closed-to-500})
-    (trace/emit! :warning :rf.ssr/ssr-non-integer-status
+    (rf.trace/emit! :warning :rf.ssr/ssr-non-integer-status
                  {:where       :ssr-ring/ssr-response->ring-response
                   :status      status
                   :status-type status-type
@@ -221,7 +221,7 @@
        ;; redirect. We still emit the status (we have no target to
        ;; invent) — the trace is the signal.
        (when-not target
-         (trace/emit! :warning :rf.ssr/ssr-redirect-no-target
+         (rf.trace/emit! :warning :rf.ssr/ssr-redirect-no-target
                       {:where    :ssr-ring/ssr-response->ring-response
                        :status   wire-status
                        :reason   (str ":rf.server/redirect set :redirect with no "
@@ -230,9 +230,9 @@
                                       "redirect; the browser has no target)")
                        :recovery :warned-and-emitted-statusonly}))
        {:status  wire-status
-        :headers (-> (headers/headers->ring-map+content-type-override
+        :headers (-> (rf.ssr.ring.headers/headers->ring-map+content-type-override
                        headers default-content-type)
-                     (headers/append-set-cookies cookies)
+                     (rf.ssr.ring.headers/append-set-cookies cookies)
                      ;; The Location value must be a string — a non-string
                      ;; target (the `:location` is caller-trusted at the fx
                      ;; boundary) is coerced so the Ring header map is valid.
@@ -240,15 +240,15 @@
                                                         target
                                                         (str target))))
                       ;; A bodiless redirect cannot honour an app-set length.
-                     (headers/strip-content-length))
+                     (rf.ssr.ring.headers/strip-content-length))
         :body    ""})
      {:status  (fail-closed-status status 200)
-      :headers (-> (headers/headers->ring-map+content-type-override
+      :headers (-> (rf.ssr.ring.headers/headers->ring-map+content-type-override
                      headers default-content-type)
-                   (headers/append-set-cookies cookies)
+                   (rf.ssr.ring.headers/append-set-cookies cookies)
                     ;; The adapter assembles the body after the drain, so let
                     ;; the Ring server frame it.
-                   (headers/strip-content-length))
+                   (rf.ssr.ring.headers/strip-content-length))
       :body    (or body "")})))
 
 (defn setup-request-frame!
@@ -293,7 +293,7 @@
   ;; The alphabetic prefix keeps the payload frame id valid for strict EDN
   ;; readers; keyword construction itself does not validate local names.
   (let [frame-id (keyword "rf.frame" (str (gensym "f")))]
-    (ssr/set-request! frame-id request)
+    (rf.ssr/set-request! frame-id request)
     (try
       ;; KEEP the frame VALUE — it carries the exact incarnation token the
       ;; handler's teardown consumes for incarnation-EXACT cleanup (rf2-moftbs).
@@ -305,7 +305,7 @@
                         ;; Resolve after `set-request!`: the function form can derive
                         ;; durable event payloads while handlers use the request coeffect
                         ;; for ambient reads.
-                       :initial-events (lifecycle/resolve-initial-events! initial-events request)}
+                       :initial-events (rf.ssr.ring.lifecycle/resolve-initial-events! initial-events request)}
                 fx-overrides (assoc :fx-overrides fx-overrides)
                 ssr          (assoc :ssr           ssr)
                 ;; BY PRESENCE, not truthiness: make-frame's preflight reads a
@@ -328,10 +328,10 @@
         ;; target would then pin and destroy B (rf2-c6lp3). So we do NOT reap by
         ;; bare id — construction rollback owns exactly one incarnation, and the
         ;; request slot is the only per-request state this catch owns.
-        (ssr/clear-request! frame-id)
+        (rf.ssr/clear-request! frame-id)
         ;; Setup runs outside the handler body's catch, so contain a failing
         ;; caller hook here as well.
-        {:short-circuit (lifecycle/safe-on-error on-error request t)}))))
+        {:short-circuit (rf.ssr.ring.lifecycle/safe-on-error on-error request t)}))))
 
 (defn render-error-body
   "Build a minimal HTML body from a public-error map — the host's
@@ -365,7 +365,7 @@
                     [:p {:data-rf-error-code error-code}
                      (str "Error code: " error-code
                           " (status " error-status ")")])]]]
-    (ssr/render-to-string error-document
+    (rf.ssr/render-to-string error-document
                           {:doctype? true})))
 
 (defn ^:private emit-error-view-failed!
@@ -390,12 +390,12 @@
                      {:exception (.getMessage ^Throwable detail)
                       :ex-class  (.getName (class detail))}
                      {:reason detail})]
-    (trace/emit-error! :rf.error/ssr-ring-error-view-failed
+    (rf.trace/emit-error! :rf.error/ssr-ring-error-view-failed
                        (merge common detail-map))
-    (lifecycle/emit-always-on-error!
+    (rf.ssr.ring.lifecycle/emit-always-on-error!
       (merge common detail-map
              {:error :rf.error/ssr-ring-error-view-failed
-              :time  (interop/now-ms)}))
+              :time  (rf.interop/now-ms)}))
     nil))
 
 (defn resolve-error-body
@@ -453,7 +453,7 @@
               (keyword? error-view)
               (if-let [view-fn (rf/view error-view)]
                 [view-fn public-error]
-                (error/throw-error!
+                (rf.error/throw-error!
                   :rf.error/ssr-ring-invalid-error-view
                   'rf.ssr/ssr-handler
                   (str ":error-view keyword " error-view " names no "
@@ -466,7 +466,7 @@
               (error-view public-error)
 
               :else
-              (error/throw-error!
+              (rf.error/throw-error!
                 :rf.error/ssr-ring-invalid-error-view
                 'rf.ssr/ssr-handler
                 (str ":error-view must be a registered-view keyword "
@@ -475,17 +475,17 @@
                  :extra    {:received error-view}}))
             error-view-html
             (rf/with-frame frame-id
-              (ssr/render-to-string error-view-hiccup
+              (rf.ssr/render-to-string error-view-hiccup
                                     {:doctype? false}))]
         ;; Open-proof containment (rf2-oytx7j): a reactive sub inside the
         ;; error view that recovered-to-nil buffered a fail-closed projection
         ;; without throwing. Detect it (pure peek), fall back ONCE to the
         ;; locked template, and clear the buffer so it is never re-projected.
-        (if (ssr/pending-error-trace? frame-id)
+        (if (rf.ssr/pending-error-trace? frame-id)
           (do
             (emit-error-view-failed! frame-id
                                      :reactive-sub-recovered-to-nil-in-error-view)
-            (ssr/clear-pending-error-traces! frame-id)
+            (rf.ssr/clear-pending-error-traces! frame-id)
             (render-error-body public-error))
           error-view-html))
       (catch Throwable t
@@ -575,12 +575,12 @@
   that root gets no marker on either channel (rf2-q1b96)."
   [{:keys [opts]}]
   (let [{:keys [root-view emit-hash?]} opts
-        resolved-root (lifecycle/resolve-root-view root-view)
+        resolved-root (rf.ssr.ring.lifecycle/resolve-root-view root-view)
         ;; Compute the body hash once for both the emitted marker and the
         ;; payload. nil for an unresolved root form — that root gets NO hash
         ;; on either channel (rf2-q1b96; see `render-document-hash`).
-        render-hash (lifecycle/render-document-hash resolved-root)]
-    {:body-html   (ssr/render-to-string
+        render-hash (rf.ssr.ring.lifecycle/render-document-hash resolved-root)]
+    {:body-html   (rf.ssr/render-to-string
                      resolved-root
                      {:doctype?    false
                       :render-hash (when emit-hash? render-hash)})
@@ -599,7 +599,7 @@
     :as   opts}]
   ;; Blocking route resources settle before rendering; absent resource hooks
   ;; make this a no-op.
-  (ssr/drain-blocking-resources! frame-id opts)
+  (rf.ssr/drain-blocking-resources! frame-id opts)
   (let [;; Single `with-frame` block covers the frame-aware stages: the
         ;; body render (root-view resolution — a 0-arity fn may close over
         ;; subscribe-time reads — and the render walk's subs on registered
@@ -621,7 +621,7 @@
                 render-body (or renderer local-renderer)
                 {:keys [body-html render-hash]}
                 (render-body {:frame-id frame-id
-                              :request  (ssr/get-request frame-id)
+                              :request  (rf.ssr/get-request frame-id)
                               :opts     opts})
                 ;; Explicit head HTML bypasses route-derived attributes and has
                 ;; no client-reconstructible model.
@@ -629,16 +629,16 @@
                             {:head-html  explicit-head
                              :html-attrs nil
                              :body-attrs nil}
-                            (lifecycle/resolve-head frame-id))
+                            (rf.ssr.ring.lifecycle/resolve-head frame-id))
                 ;; Hash the head model on its separate reconstructible channel.
-                head-hash (lifecycle/render-head-hash (:head-model head-data))
+                head-hash (rf.ssr.ring.lifecycle/render-head-hash (:head-model head-data))
                 ;; Read after rendering and inside the frame scope. Optional
                 ;; resource projection uses the carried frame to apply derived
                 ;; sensitivity before serializing the durable runtime slice.
                 app-db     (rf/app-db-value frame-id)
                 runtime-db (:rf.db/runtime (rf/frame-state-value frame-id))
                 hydration-payload
-                (payload/build-payload frame-id app-db runtime-db render-hash
+                (rf.ssr.ring.payload/build-payload frame-id app-db runtime-db render-hash
                                        {:version         version
                                         :schema-digest   schema-digest
                                         :payload         payload
@@ -669,7 +669,7 @@
         ;; to the error arm (rf2-oytx7j).
         {post-render-response     :response
          post-render-public-error :public-error}
-        (ssr/flush-response-result! frame-id)]
+        (rf.ssr/flush-response-result! frame-id)]
     (if (projected-5xx? post-render-public-error)
       ;; A recovered-to-nil sub buffered a fail-closed 5xx during the render
       ;; walk. DISCARD the degraded html + hydration payload and materialise
@@ -716,15 +716,15 @@
   `[error-view public-error]` view lookup); `resolve-error-body` re-pins
   `*current-frame*` around its own render."
   [frame-id ^Throwable t opts]
-  (let [public-error       (ssr/project-render-exception! frame-id t)
-        projected-response (ssr/peek-response frame-id)
+  (let [public-error       (rf.ssr/project-render-exception! frame-id t)
+        projected-response (rf.ssr/peek-response frame-id)
         ;; An unrenderable root/shell throw cannot supply a body, so it ALWAYS
         ;; takes the error page — even when a custom projector chose a 4xx
         ;; (e.g. the 418 teapot test): classification-by-status is the
         ;; drain/post-render rule; a render throw is the necessary exception
         ;; (Spec 011 §Drain-time error classification). When projection returns
         ;; nil (no server frame) the locked generic-500 is substituted.
-        resolved-public-error (or public-error ssr/fallback-public-error)]
+        resolved-public-error (or public-error rf.ssr/fallback-public-error)]
     ;; The construction-time Content-Type labels only successful bodies; a
     ;; projected error is HTML, so `materialise-error-arm` keeps the
     ;; accumulator's header. It re-pins the request frame for the error-body

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
@@ -11,8 +11,8 @@
   string content cannot close the script element, token content still
   round-trips through the EDN reader, and unsafe token-position breakout
   sequences fail loudly. The streaming path uses the same encoder."
-  (:require [re-frame.ssr.constants :as constants]
-            [re-frame.ssr.html-helpers :as html]))
+  (:require [re-frame.ssr.constants :as rf.ssr.constants]
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]))
 
 (set! *warn-on-reflection* true)
 
@@ -47,8 +47,8 @@
   (`\"__rf_payload\"`) — the contract with the client bootstrap's
   `document.getElementById(...)` read."
   [payload-edn]
-  (str "<script id=\"" constants/payload-script-id "\" type=\"application/edn\">"
-       (html/escape-edn-script-body payload-edn)
+  (str "<script id=\"" rf.ssr.constants/payload-script-id "\" type=\"application/edn\">"
+       (rf.ssr.html-helpers/escape-edn-script-body payload-edn)
        "</script>"))
 
 ;; ---- single-source document envelope (prefix + suffix) --------------------
@@ -75,7 +75,7 @@
            lang           "en"}}]
   (let [attr-bag (html-attr-bag html-attrs lang)]
     (str "<!DOCTYPE html>"
-         "<html" (html/attr-string attr-bag) ">"
+         "<html" (rf.ssr.html-helpers/attr-string attr-bag) ">"
          "<head"
          ;; The head-model hash is separate from the body's render hash.
          (when head-hash (str " data-rf-head-hash=\"" head-hash "\""))
@@ -83,10 +83,10 @@
          "<meta charset=\"utf-8\">"
          (or head-html "")
          "</head>"
-         "<body" (html/attr-string body-attrs) ">"
+         "<body" (rf.ssr.html-helpers/attr-string body-attrs) ">"
          ;; Attribute values are escaped; raw trust applies only to the
          ;; `:head` and `:body-end` content hooks.
-         "<div id=\"" (html/escape-attr app-element-id) "\""
+         "<div id=\"" (rf.ssr.html-helpers/escape-attr app-element-id) "\""
          ;; Only streaming supplies this body-only structural hash marker.
          (when render-hash
            (str " data-rf-render-hash=\"" render-hash "\""))
@@ -107,7 +107,7 @@
     :or   {script-src "/main.js"}}]
   (str (when script-src
          ;; `:script-src` is an attribute value; `:body-end` is raw content.
-         (str "<script src=\"" (html/escape-attr script-src) "\"></script>"))
+         (str "<script src=\"" (rf.ssr.html-helpers/escape-attr script-src) "\"></script>"))
        (or body-end "")
        "</body>"
        "</html>"))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -43,13 +43,13 @@
   chunks arrive, reconciling against the final `__rf_payload`
   (`:replace-frame-state`) when it lands."
   (:require [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.ring.lifecycle :as lifecycle]
-            [re-frame.ssr.ring.pipeline :as pipeline]
-            [re-frame.ssr.ring.shell :as shell]
-            [re-frame.ssr.streaming :as streaming]
-            [re-frame.trace :as trace])
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.ring.lifecycle :as rf.ssr.ring.lifecycle]
+            [re-frame.ssr.ring.pipeline :as rf.ssr.ring.pipeline]
+            [re-frame.ssr.ring.shell :as rf.ssr.ring.shell]
+            [re-frame.ssr.streaming :as rf.ssr.streaming]
+            [re-frame.trace :as rf.trace])
   (:import [java.io PipedInputStream PipedOutputStream OutputStream]
            [java.nio.charset StandardCharsets]))
 
@@ -87,7 +87,7 @@
   [head-html {:keys [render-hash] :as opts}]
   ;; Delegate all envelope and escaping decisions to the shared renderer;
   ;; streaming alone supplies the optional app-root render hash.
-  (shell/document-prefix head-html render-hash opts))
+  (rf.ssr.ring.shell/document-prefix head-html render-hash opts))
 
 (defn default-streaming-suffix
   "The shell suffix flushed after the final-payload chunk. Emits the
@@ -107,7 +107,7 @@
   [opts]
   ;; The shared suffix owns bootstrap escaping, raw body-end content, and the
   ;; document close; the app root closes in the shell chunk.
-  (shell/document-suffix opts))
+  (rf.ssr.ring.shell/document-suffix opts))
 
 ;; ---- shell phase (request thread, before response materialisation) -------
 ;;
@@ -182,21 +182,21 @@
   [frame-id {:keys [root-view] :as opts}]
   ;; Blocking route resources settle before the shell; suspense continuation
   ;; deferral is a separate axis. Absent resource hooks make this a no-op.
-  (ssr/drain-blocking-resources! frame-id opts)
+  (rf.ssr/drain-blocking-resources! frame-id opts)
   ;; Pin the frame on the request thread for registered view and head lookups.
   (rf/with-frame frame-id
-    (let [hiccup     (lifecycle/resolve-root-view root-view)
+    (let [hiccup     (rf.ssr.ring.lifecycle/resolve-root-view root-view)
           head-bag   (if (:head opts)
                        {:head-html (:head opts) :html-attrs nil :body-attrs nil}
-                       (lifecycle/resolve-head frame-id))
+                       (rf.ssr.ring.lifecycle/resolve-head frame-id))
           {:keys [head-html html-attrs body-attrs]} head-bag
           ;; Compute the body-only shell hash once on the request thread.
-          doc-hash   (lifecycle/render-document-hash hiccup)
+          doc-hash   (rf.ssr.ring.lifecycle/render-document-hash hiccup)
           ;; The SEPARATE client-reconstructible head-model hash — nil when
           ;; the head is not client-reconstructible (explicit `:head`
           ;; string / degraded resolution).
-          head-hash  (lifecycle/render-head-hash (:head-model head-bag))
-          {:keys [shell-html continuations]} (streaming/render-shell hiccup)]
+          head-hash  (rf.ssr.ring.lifecycle/render-head-hash (:head-model head-bag))
+          {:keys [shell-html continuations]} (rf.ssr.streaming/render-shell hiccup)]
       {:head-html     head-html
        :html-attrs    html-attrs
        :body-attrs    body-attrs
@@ -325,10 +325,10 @@
                 ;; the thread boundary), so `render-continuation`'s frame lookups
                 ;; + registered-view resolution operate on the request frame.
                 (rf/with-frame frame-id
-                  (streaming/render-continuation frame-id continuation))
+                  (rf.ssr.streaming/render-continuation frame-id continuation))
                 render-template (if failed?
-                                  streaming/failed-template
-                                  streaming/resolved-template)]
+                                  rf.ssr.streaming/failed-template
+                                  rf.ssr.streaming/resolved-template)]
             ;; A continuation write names
             ;; the boundary :id so ops correlate the failure to a specific
             ;; deferred subtree (not just "some continuation broke").
@@ -360,7 +360,7 @@
             ;; script.
             (let [projected-delta
                   (rf/with-frame frame-id
-                    (streaming/project-delta delta frame-id
+                    (rf.ssr.streaming/project-delta delta frame-id
                                              {:payload payload}))]
               (when (and (not failed?)
                          (map? projected-delta)
@@ -368,7 +368,7 @@
                 (vreset! writer-position [:continuation-delta boundary-id])
                 (write-chunk!
                   output-stream
-                  (streaming/hydrate-delta-script
+                  (rf.ssr.streaming/hydrate-delta-script
                     boundary-id (pr-str projected-delta)))))
             ;; Pop the drained entry, append any nested continuations at
             ;; the tail (FIFO), continue until empty.
@@ -395,10 +395,10 @@
               ;; Only continuations can mutate state between shell and payload.
               (let [post-drain-hash
                     (if (and root-view (seq continuations))
-                      (lifecycle/render-document-hash
-                        (lifecycle/resolve-root-view root-view))
+                      (rf.ssr.ring.lifecycle/render-document-hash
+                        (rf.ssr.ring.lifecycle/resolve-root-view root-view))
                       doc-hash)]
-                (streaming/build-final-payload
+                (rf.ssr.streaming/build-final-payload
                   frame-id post-drain-hash
                   {:version         version
                    :schema-digest   schema-digest
@@ -409,7 +409,7 @@
                    :client-frame-id client-frame-id})))]
         ;; Shared id-pinned, script-body-escaped payload element.
         (write-chunk! output-stream
-                      (shell/payload-script-tag (pr-str final-payload))))
+                      (rf.ssr.ring.shell/payload-script-tag (pr-str final-payload))))
       ;; Chunk N+3 — shell suffix close.
       (vreset! writer-position [:suffix nil])
       (write-chunk! output-stream (default-streaming-suffix opts)))
@@ -431,13 +431,13 @@
                                   :recovery   :truncate-and-close}
                            (some? boundary-id)
                            (assoc :boundary-id boundary-id))]
-        (trace/emit-error! :rf.error/ssr-streaming-writer-failed failure-tags)
+        (rf.trace/emit-error! :rf.error/ssr-streaming-writer-failed failure-tags)
         ;; Post-commit writer errors are always-on, non-projecting telemetry;
         ;; the status is already on the wire and cannot change.
-        (lifecycle/emit-always-on-error!
+        (rf.ssr.ring.lifecycle/emit-always-on-error!
           (assoc failure-tags
                  :error :rf.error/ssr-streaming-writer-failed
-                 :time  (interop/now-ms)))))
+                 :time  (rf.interop/now-ms)))))
     (finally
       (try (.close output-stream) (catch Throwable _ nil))))))
 
@@ -464,9 +464,9 @@
   rf2-moftbs); `frame-id` remains the keyword for the failure trace."
   [response frame-id frame]
   (try
-    (pipeline/ssr-response->ring-response response nil)
+    (rf.ssr.ring.pipeline/ssr-response->ring-response response nil)
     (finally
-      (lifecycle/destroy-frame-quietly! frame frame-id))))
+      (rf.ssr.ring.lifecycle/destroy-frame-quietly! frame frame-id))))
 
 (defn- stream-projected-error!
   "Materialise a projected 5xx as a plain-String error response on the
@@ -485,9 +485,9 @@
   the failure trace use."
   [frame-id response public-error opts frame]
   (try
-    (pipeline/materialise-projected-error frame-id response public-error opts)
+    (rf.ssr.ring.pipeline/materialise-projected-error frame-id response public-error opts)
     (finally
-      (lifecycle/destroy-frame-quietly! frame frame-id))))
+      (rf.ssr.ring.lifecycle/destroy-frame-quietly! frame frame-id))))
 
 (defn- render-shell-or-projected-error
   "Render the streaming shell on THIS (request) thread, BEFORE the chunked
@@ -523,8 +523,8 @@
     (render-streaming-shell! frame-id opts)
     (catch Throwable t
       (let [projected-error-response
-            (pipeline/project-render-throw->ring-response frame-id t opts)]
-        (lifecycle/destroy-frame-quietly! frame frame-id)
+            (rf.ssr.ring.pipeline/project-render-throw->ring-response frame-id t opts)]
+        (rf.ssr.ring.lifecycle/destroy-frame-quietly! frame frame-id)
         (reduced projected-error-response)))))
 
 (defn- stream-rendered-response
@@ -568,7 +568,7 @@
   (let [;; No body default-stamp here (we pass our own InputStream); `:body` is
         ;; assoc'd after the writer is wired below. Content-Length is already
         ;; stripped by the shared materialiser.
-        ring-response (pipeline/ssr-response->ring-response
+        ring-response (rf.ssr.ring.pipeline/ssr-response->ring-response
                         post-shell-response "" content-type)
         ;; 16 KiB pipe buffer — large enough to absorb the shell chunk in one
         ;; write so the writer rarely blocks on a slow consumer, small enough
@@ -586,7 +586,7 @@
               ;; happens here so it does NOT block the response close on the
               ;; slower destroy path. Destroy the VALUE (incarnation-EXACT,
               ;; rf2-moftbs); the keyword names the frame on any failure trace.
-              (lifecycle/destroy-frame-quietly! frame frame-id))))
+              (rf.ssr.ring.lifecycle/destroy-frame-quietly! frame frame-id))))
         ^String (str "rf2-ssr-streaming-" (name frame-id)))
       (.setDaemon true)
       (.start))
@@ -707,7 +707,7 @@
   ;; positions), `:script-src` / `:app-element-id` escape-attr'd
   ;; (attribute-value positions) by the streaming
   ;; prefix/suffix. See `validate-construction-opts!` for details.
-  (lifecycle/validate-construction-opts! raw-opts)
+  (rf.ssr.ring.lifecycle/validate-construction-opts! raw-opts)
   ;; Reject opts the streaming path cannot honour (`:renderer` and
   ;; `:html-shell`) at construction time. `ssr-handler` builds its response
   ;; from a one-piece `:html-shell` fn; the streaming path flushes a SPLIT
@@ -716,7 +716,7 @@
   ;; silently dropped — a fail-OPEN API-contract gap (a production app
   ;; switching ssr-handler → stream-handler would lose CSP nonces / asset
   ;; URLs / root markup with no signal). Fail CLOSED at boot instead.
-  (lifecycle/validate-streaming-opts! raw-opts)
+  (rf.ssr.ring.lifecycle/validate-streaming-opts! raw-opts)
   ;; Mirror ssr-handler's defaults so streaming and non-streaming
   ;; handlers feel symmetric to callers. `:on-error` resolves the same
   ;; way via the shared `lifecycle/resolve-on-error`: caller's
@@ -729,11 +729,11 @@
   ;; default-seeded `text/html; charset=utf-8` — or the app's Content-Type
   ;; — in control (the on-the-wire default is unchanged).
   (let [opts        (-> (merge {:emit-hash? true} raw-opts)
-                        (assoc :on-error (lifecycle/resolve-on-error raw-opts)))
+                        (assoc :on-error (rf.ssr.ring.lifecycle/resolve-on-error raw-opts)))
         {:keys [on-error content-type]} opts]
     (fn ring-handler [request]
       (let [{:keys [frame-id frame short-circuit]}
-            (pipeline/setup-request-frame! opts request)]
+            (rf.ssr.ring.pipeline/setup-request-frame! opts request)]
         (if short-circuit
           short-circuit
           (try
@@ -746,7 +746,7 @@
             ;; the chunked head ONLY once the shell is known-renderable. The
             ;; helpers (`render-shell-or-projected-error`, `stream-rendered-
             ;; response`, `redirect-response!`) carry the per-step rationale.
-            (let [{:keys [response public-error]} (ssr/flush-response-result! frame-id)]
+            (let [{:keys [response public-error]} (rf.ssr/flush-response-result! frame-id)]
               (cond
                 ;; Redirect precedence FIRST (Spec 011 §Redirect precedence).
                 (some? (:redirect response))
@@ -755,7 +755,7 @@
                 ;; A drain-time projected 5xx — NO shell, NO writer thread; a
                 ;; plain-String projected-error body on the request thread
                 ;; (Spec 011 §Streaming pre-commit rule, rf2-oytx7j).
-                (pipeline/projected-5xx? public-error)
+                (rf.ssr.ring.pipeline/projected-5xx? public-error)
                 (stream-projected-error! frame-id response public-error opts frame)
 
                 :else
@@ -770,7 +770,7 @@
                     ;; before materialising the head.
                     (let [{post-shell-response     :response
                            post-shell-public-error :public-error}
-                          (ssr/flush-response-result! frame-id)]
+                          (rf.ssr/flush-response-result! frame-id)]
                       (cond
                         ;; A redirect here is defense in depth: in v1 it
                         ;; cannot surface at the post-shell re-read (only the
@@ -789,7 +789,7 @@
                         ;; rf2-oytx7j SUPERSEDES the old stream-the-degraded-
                         ;; shell-under-500 behaviour: a 5xx before the chunked
                         ;; head commits never ships a partial-state shell.
-                        (pipeline/projected-5xx? post-shell-public-error)
+                        (rf.ssr.ring.pipeline/projected-5xx? post-shell-public-error)
                         (stream-projected-error!
                           frame-id post-shell-response
                           post-shell-public-error opts frame)
@@ -810,6 +810,6 @@
               ;; internals.
               ;; Destroy the VALUE (incarnation-EXACT, rf2-moftbs); the keyword
               ;; `frame-id` names the frame on any failure trace.
-              (try (lifecycle/destroy-frame-quietly! frame frame-id)
+              (try (rf.ssr.ring.lifecycle/destroy-frame-quietly! frame frame-id)
                    (catch Throwable _ nil))
-              (lifecycle/safe-on-error on-error request t))))))))
+              (rf.ssr.ring.lifecycle/safe-on-error on-error request t))))))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/trust.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/trust.clj
@@ -45,7 +45,7 @@
   opts at construction time — colocating the contract here avoids the
   circular require between the streaming sub-namespace and the Ring façade."
   (:require [clojure.string :as str]
-            [re-frame.error :as error]))
+            [re-frame.error :as rf.error]))
 
 (set! *warn-on-reflection* true)
 
@@ -83,7 +83,7 @@
     (when (contains? opts option-key)
       (let [option-value (get opts option-key)]
         (when (and (some? option-value) (not (string? option-value)))
-          (error/throw-error!
+          (rf.error/throw-error!
             :rf.error/ssr-trusted-shell-opt-invalid
             'rf.ssr/trusted-shell
             (str "ssr-handler / stream-handler " (pr-str option-key)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/app_db_egress_projection_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/app_db_egress_projection_test.clj
@@ -17,11 +17,11 @@
   carrying a `:sensitive :app-db` declaration."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.privacy :as privacy]
-            [re-frame.ssr.ring.payload :as payload]
-            [re-frame.ssr.ring.test-support :as ts]))
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.ssr.ring.payload :as rf.ssr.ring.payload]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 (def ^:private server-frame :rf.bt9kct/server)
 
@@ -56,10 +56,10 @@
             projection; the public sibling (:user) rides verbatim; unlisted
             keys (:public / :secrets) are omitted by the allowlist"
     (reg-sensitive-frame!)
-    (let [out    (payload/build-payload server-frame app-db "h1"
+    (let [out    (rf.ssr.ring.payload/build-payload server-frame app-db "h1"
                                         {:payload [:session :public]})
           db     (:rf/app-db out)]
-      (is (= privacy/redacted-sentinel (get-in db [:session :token]))
+      (is (= rf.privacy/redacted-sentinel (get-in db [:session :token]))
           "the frame-sensitive nested :token is redacted on the hydration wire")
       (is (= "alice" (get-in db [:session :user]))
           "the public sibling rides verbatim")
@@ -75,10 +75,10 @@
             but STILL projects frame-sensitive children — the raw token never
             rides even when the whole app-db is opted in"
     (reg-sensitive-frame!)
-    (let [out (payload/build-payload server-frame app-db "h1"
+    (let [out (rf.ssr.ring.payload/build-payload server-frame app-db "h1"
                                      {:payload :rf.ssr.payload/whole-app-db})
           db  (:rf/app-db out)]
-      (is (= privacy/redacted-sentinel (get-in db [:session :token]))
+      (is (= rf.privacy/redacted-sentinel (get-in db [:session :token]))
           "whole-app-db still redacts the frame-sensitive :token")
       (is (= "alice" (get-in db [:session :user])))
       (is (= "internal-only" (get-in db [:secrets :api-key]))
@@ -92,9 +92,9 @@
             elision policy) fails CLOSED — the whole app-db slice redacts to
             the :rf/redacted sentinel rather than ship under no policy"
     ;; deliberately do NOT register :rf.bt9kct/ghost
-    (let [out (payload/build-payload :rf.bt9kct/ghost app-db "h1"
+    (let [out (rf.ssr.ring.payload/build-payload :rf.bt9kct/ghost app-db "h1"
                                      {:payload [:session]})]
-      (is (= privacy/redacted-sentinel (:rf/app-db out))
+      (is (= rf.privacy/redacted-sentinel (:rf/app-db out))
           "an unresolvable frame redacts the whole slice (fail-closed)")
       (is (not (.contains (pr-str out) "secret-jwt"))
           "no raw value escapes under a missing frame policy"))))
@@ -104,7 +104,7 @@
             allowlisted slice verbatim (the projection is a precise
             classification walk, not a blanket scrub)"
     (rf/make-frame {:id :rf.bt9kct/plain :platform :server})
-    (let [out (payload/build-payload :rf.bt9kct/plain app-db "h1"
+    (let [out (rf.ssr.ring.payload/build-payload :rf.bt9kct/plain app-db "h1"
                                      {:payload [:session]})
           db  (:rf/app-db out)]
       (is (= {:token "secret-jwt" :user "alice"} (:session db))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
@@ -84,14 +84,14 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.test-support :as ts])
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support])
   (:import [java.io InputStream]
            [java.net.http HttpResponse$BodyHandlers]
            [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicInteger AtomicLong]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ===========================================================================
 ;; Knobs
@@ -132,7 +132,7 @@
   rf2-fun38: returns the leaked-thread vec on timeout (does not throw) so
   the assertion can name the offenders."
   [timeout-ms]
-  (ts/await-no-streaming-threads! timeout-ms leak-poll-ms))
+  (rf.ssr.ring.test-support/await-no-streaming-threads! timeout-ms leak-poll-ms))
 
 ;; ===========================================================================
 ;; Token-echo handler — proves per-request frame isolation
@@ -204,12 +204,12 @@
   (testing (str n-threads " threads × " n-reqs-per-thread
                 " requests against stream-handler — no drops, no bleed, no orphan threads")
     (register-echo-handlers!)
-    (let [handler (ssr-ring/stream-handler
+    (let [handler (rf.ssr.ring/stream-handler
                     {:initial-events [[:rf.test.ozhy9/init]]
                      :root-view [(rf/view :rf.test.ozhy9/root)]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler]
-        (let [client     (ts/new-http-client)
+      (rf.ssr.ring.test-support/with-jetty [port handler]
+        (let [client     (rf.ssr.ring.test-support/new-http-client)
               latch      (CountDownLatch. 1)
               ;; AtomicInteger counts COMPLETIONS — successful response
               ;; receipt regardless of body content. The body-token
@@ -230,7 +230,7 @@
                     (try
                       (dotimes [iter-idx n-reqs-per-thread]
                         (let [token    (token-for thread-idx iter-idx)
-                              req      (ts/http-get-request port (str "/req/" token) read-timeout-secs)
+                              req      (rf.ssr.ring.test-support/http-get-request port (str "/req/" token) read-timeout-secs)
                               response (.send client req
                                               (HttpResponse$BodyHandlers/ofString))
                               status   (.statusCode response)
@@ -340,12 +340,12 @@
   (testing (str n-threads " threads × " n-reqs-per-thread
                 " concurrent disconnect-mid-stream — no orphan threads, no hangs")
     (register-echo-handlers!)
-    (let [handler (ssr-ring/stream-handler
+    (let [handler (rf.ssr.ring/stream-handler
                     {:initial-events [[:rf.test.ozhy9/init]]
                      :root-view [(rf/view :rf.test.ozhy9/root)]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler]
-        (let [client     (ts/new-http-client)
+      (rf.ssr.ring.test-support/with-jetty [port handler]
+        (let [client     (rf.ssr.ring.test-support/new-http-client)
               latch      (CountDownLatch. 1)
               completed  (AtomicInteger. 0)
               futures
@@ -356,7 +356,7 @@
                     (dotimes [iter-idx n-reqs-per-thread]
                       (try
                         (let [token    (token-for thread-idx iter-idx)
-                              req      (ts/http-get-request port (str "/req/" token) read-timeout-secs)
+                              req      (rf.ssr.ring.test-support/http-get-request port (str "/req/" token) read-timeout-secs)
                               response (.send client req
                                               (HttpResponse$BodyHandlers/ofInputStream))
                               ^InputStream body-is (.body response)
@@ -421,12 +421,12 @@
 (deftest ^:stress daemon-thread-count-bounded-during-burst
   (testing "writer-thread count bounded during burst, decays to zero after"
     (register-echo-handlers!)
-    (let [handler (ssr-ring/stream-handler
+    (let [handler (rf.ssr.ring/stream-handler
                     {:initial-events [[:rf.test.ozhy9/init]]
                      :root-view [(rf/view :rf.test.ozhy9/root)]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler]
-        (let [client     (ts/new-http-client)
+      (rf.ssr.ring.test-support/with-jetty [port handler]
+        (let [client     (rf.ssr.ring.test-support/new-http-client)
               latch      (CountDownLatch. 1)
               ;; AtomicInteger that we sample peak across — every
               ;; sampler thread contends here.
@@ -444,7 +444,7 @@
                   ;; sampler-stop counts down. CPU cost is bounded by
                   ;; the burst duration (a few seconds at most).
                   (while (zero? (.getCount sampler-stop))
-                    (let [n (count (ts/live-streaming-threads))]
+                    (let [n (count (rf.ssr.ring.test-support/live-streaming-threads))]
                       (loop []
                         (let [cur (.get peak-count)]
                           (when (and (> n cur)
@@ -458,7 +458,7 @@
                     (.await latch)
                     (dotimes [iter-idx n-reqs-per-thread]
                       (let [token (token-for thread-idx iter-idx)
-                            req   (ts/http-get-request port (str "/req/" token) read-timeout-secs)]
+                            req   (rf.ssr.ring.test-support/http-get-request port (str "/req/" token) read-timeout-secs)]
                         (.send client req
                                (HttpResponse$BodyHandlers/ofString)))))))]
           (.start sampler-thread)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/facade_examples_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/facade_examples_test.clj
@@ -23,8 +23,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.lifecycle :as lifecycle]))
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.lifecycle :as rf.ssr.ring.lifecycle]))
 
 (defn- example-block
   "Return the text following the `Example:` marker in `docstring`, i.e.
@@ -69,7 +69,7 @@
             policy and the example opts map passes
             validate-construction-opts! (so a copy-paste is constructible,
             not a fail-closed boot throw)"
-    (let [doc   (-> #'ssr-ring/ssr-handler meta :doc)
+    (let [doc   (-> #'rf.ssr.ring/ssr-handler meta :doc)
           forms (read-forms (example-block doc))
           call  (find-call "ssr-handler" forms)
           opts  (second call)]
@@ -86,7 +86,7 @@
       (rf/reg-view* :pages/facade-example (fn [] [:div "facade example"]))
       (is (= (assoc opts :initial-events [[:init/facade-example]]
                          :root-view [(rf/view :pages/facade-example)])
-             (lifecycle/validate-construction-opts!
+             (rf.ssr.ring.lifecycle/validate-construction-opts!
                (assoc opts :initial-events [[:init/facade-example]]
                            :root-view [(rf/view :pages/facade-example)])))
           "the ssr-handler example opts map passes validate-construction-opts!"))))
@@ -95,7 +95,7 @@
   (testing "the ssr-middleware façade example uses the correct
             CURRIED composition shape — `((ssr-middleware opts) handler)` —
             and its opts map carries :payload"
-    (let [doc   (-> #'ssr-ring/ssr-middleware meta :doc)
+    (let [doc   (-> #'rf.ssr.ring/ssr-middleware meta :doc)
           block (example-block doc)
           forms (read-forms block)
           call  (find-call "ssr-middleware" forms)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/facade_metadata_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/facade_metadata_test.clj
@@ -13,7 +13,7 @@
   so it carries no `:arglists`). `default-on-error` still gets a doc
   check below since it is a documented public surface."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.ssr.ring :as ssr-ring]))
+            [re-frame.ssr.ring :as rf.ssr.ring]))
 
 ;; The public FUNCTION surface of the facade — every entry MUST carry a
 ;; non-empty docstring AND a useful :arglists. (Listed explicitly rather

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj
@@ -59,10 +59,10 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.registrar :as registrar]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.node :as node]
-            [re-frame.ssr.ring.test-support :as ts]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.node :as rf.ssr.ring.node]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]
             ;; THE SUBJECT. Requiring it is half the witness.
             [hicasso.login.host :as host]
             [hicasso.login.policy :as policy])
@@ -80,7 +80,7 @@
   registrations the model leans on, then the model itself. Same pattern,
   and same reason, as `re-frame.examples-test`'s fixture."
   [f]
-  (ts/reset-runtime
+  (rf.ssr.ring.test-support/reset-runtime
     (fn []
       (require 're-frame.cofx :reload)
       (require 're-frame.http.managed :reload)
@@ -217,12 +217,12 @@
 
   (testing "the shared model really is in the registrar, not merely on the
             classpath — `:initial-events` names a registration that exists"
-    (is (some? (registrar/lookup :event :auth.login/initialise-form))
+    (is (some? (rf.registrar/lookup :event :auth.login/initialise-form))
         ":auth.login/initialise-form — the host's one boot event")
-    (is (some? (registrar/lookup :fx :auth.login.demo/managed-stub))
+    (is (some? (rf.registrar/lookup :fx :auth.login.demo/managed-stub))
         ":auth.login.demo/managed-stub — the demo backend the host's
          :fx-overrides remaps :rf.http/managed to")
-    (is (some? (registrar/lookup :sub :auth.login/draft))
+    (is (some? (rf.registrar/lookup :sub :auth.login/draft))
         ":auth.login/draft — a named sub the server-rendered view reads")))
 
 (deftest render-state-is-one-source
@@ -320,7 +320,7 @@
             crosses; drive the machine from `:initial-events` and the
             snapshot rides the runtime partition."
     (let [{:keys [url]} (sidecar!)
-          h (ssr-ring/ssr-handler
+          h (rf.ssr.ring/ssr-handler
               {:initial-events [[:auth.login/initialise-form]
                                 ;; `:idle` -> `:submitting`, action
                                 ;; `:clear-error`. A pure data transition —
@@ -328,7 +328,7 @@
                                 ;; `submit-form`, not by the machine.
                                 [:auth.login/flow [:auth.login/submit]]]
                :payload        [:auth]
-               :renderer       (node/renderer
+               :renderer       (rf.ssr.ring.node/renderer
                                  {:endpoint     url
                                   :entry        policy/root-entry
                                   :build-id     host/build-id
@@ -356,11 +356,11 @@
       (fn [{:keys [db]} _]
         {:db (assoc db :auth.login/not-on-the-list "widened")}))
     (let [{:keys [url]} (sidecar!)
-          widened (ssr-ring/ssr-handler
+          widened (rf.ssr.ring/ssr-handler
                     {:initial-events [[:auth.login/initialise-form]
                                       [:login-host-test/seed-extra]]
                      :payload        [:auth]
-                     :renderer       (node/renderer
+                     :renderer       (rf.ssr.ring.node/renderer
                                        {:endpoint     url
                                         :entry        policy/root-entry
                                         :build-id     host/build-id

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/node_crossing_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/node_crossing_test.clj
@@ -35,9 +35,9 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.node :as node]
-            [re-frame.ssr.ring.test-support :as ts])
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.node :as rf.ssr.ring.node]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support])
   (:import [java.net InetSocketAddress ServerSocket URI]
            [java.net.http HttpClient HttpRequest HttpResponse$BodyHandlers]
            [java.time Duration]
@@ -129,11 +129,11 @@
         (stop-sidecar! s)))))
 
 (use-fixtures :once with-sidecar)
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ---- /health ----------------------------------------------------------------
 
-(def ^:private ^HttpClient probe-client (ts/new-http-client))
+(def ^:private ^HttpClient probe-client (rf.ssr.ring.test-support/new-http-client))
 
 (defn- health
   "The sidecar's `/health` body, parsed."
@@ -182,7 +182,7 @@
 (defn- node-renderer
   [url & {:keys [timeout-ms render-state build-id]
           :or   {timeout-ms 1000 build-id "crossing-build-1"}}]
-  (node/renderer {:endpoint     url
+  (rf.ssr.ring.node/renderer {:endpoint     url
                   :entry        "app/root"
                   :args         {:root :crossing}
                   :build-id     build-id
@@ -195,7 +195,7 @@
   NARROWER than the render-state policy (c), and an `:error-view` that
   stamps a marker no success page carries."
   [renderer & {:keys [delay-ms]}]
-  (ssr-ring/ssr-handler
+  (rf.ssr.ring/ssr-handler
     {:initial-events [[:rf.test.crossing/init {:delay-ms delay-ms}]]
      :payload        [:heading]
      :renderer       renderer
@@ -461,14 +461,14 @@
   {:entry "app/root" :build-id "b1" :render-state {:app-db [:heading]}})
 
 (defn- construction-error [opts]
-  (try (node/renderer opts) nil
+  (try (rf.ssr.ring.node/renderer opts) nil
        (catch clojure.lang.ExceptionInfo e (ex-data e))))
 
 (deftest the-node-renderer-validates-its-opts-at-construction
   (testing "the defaults: endpoint, deadline, admission budget, and the derived timeout"
-    (is (fn? (node/renderer good-opts)) "entry + build-id + render-state suffice")
+    (is (fn? (rf.ssr.ring.node/renderer good-opts)) "entry + build-id + render-state suffice")
     (is (= (+ 1000 250 500)
-           (node/http-timeout-ms {:timeout-ms 1000 :admission-ms 250}))
+           (rf.ssr.ring.node/http-timeout-ms {:timeout-ms 1000 :admission-ms 250}))
         "the explicit per-request HTTP timeout = timeoutMs + admission + wire margin"))
   (testing "each required opt fails closed with :rf.error/ssr-node-renderer-opt-invalid naming it"
     (doseq [[opt opts] [[:entry    (dissoc good-opts :entry)]
@@ -486,9 +486,9 @@
         (is (= opt (:opt data)) (pr-str opt))
         (is (keyword? (:recovery data))))))
   (testing "a non-loopback endpoint is NOT refused (S7 — trust the programmer)"
-    (is (fn? (node/renderer (assoc good-opts :endpoint "https://render.internal:8148")))))
+    (is (fn? (rf.ssr.ring.node/renderer (assoc good-opts :endpoint "https://render.internal:8148")))))
   (testing ":args is optional; nil is a value and rides"
-    (is (fn? (node/renderer (assoc good-opts :args nil)))))
+    (is (fn? (rf.ssr.ring.node/renderer (assoc good-opts :args nil)))))
   (testing ":render-state is required — the payload family's missing-policy id, with :opt :render-state"
     (let [data (construction-error (dissoc good-opts :render-state))]
       (is (= :rf.error/ssr-missing-payload-policy (:rf.error/id data)))
@@ -497,4 +497,4 @@
       (is (= :rf.error/ssr-malformed-payload-allowlist (:rf.error/id data)))
       (is (= :render-state (:opt data)))))
   (testing "the escape-hatch projector constructs"
-    (is (fn? (node/renderer (assoc good-opts :render-state (fn [_] {:rf/app-db {}})))))))
+    (is (fn? (rf.ssr.ring.node/renderer (assoc good-opts :render-state (fn [_] {:rf/app-db {}})))))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/payload_explicit_frame_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/payload_explicit_frame_test.clj
@@ -24,12 +24,12 @@
   raw."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.frame :as frame]
-            [re-frame.ssr.ring.payload :as payload]
-            [re-frame.ssr.ring.test-support :as ts]))
+            [re-frame.elision :as rf.elision]
+            [re-frame.frame :as rf.frame]
+            [re-frame.ssr.ring.payload :as rf.ssr.ring.payload]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 (def ^:private server-frame :review/ssr-ring-target)
 (def ^:private ambient-frame :review/other-ambient)
@@ -44,7 +44,7 @@
   a projection run under B would leak the raw token."
   []
   (-> {}
-      (elision/apply-classification-effects
+      (rf.elision/apply-classification-effects
         {:sensitive [[:rf.runtime/routing :current :query :token]]
          :large     [[:rf.runtime/routing :current :params :payload]]})
       (assoc :rf.runtime/routing
@@ -62,15 +62,15 @@
   ;; consults B's empty registry and the token would ride verbatim.
   (rf/make-frame {:id ambient-frame :doc      "rf2-f02diw mismatched ambient frame B (no classifications)"
                   :platform :server})
-  (frame/swap-runtime-db! server-frame (constantly (frame-a-runtime-db))))
+  (rf.frame/swap-runtime-db! server-frame (constantly (frame-a-runtime-db))))
 
 (defn- build-a
   "Call the non-streaming Ring wrapper for frame A, reading A's live runtime-db
   value and handing it in as the wrapper's `runtime-db` arg. app-db is empty so
   the test isolates the runtime-db route projection."
   []
-  (payload/build-payload
-    server-frame {} (frame/frame-runtime-db-value server-frame) "hash"
+  (rf.ssr.ring.payload/build-payload
+    server-frame {} (rf.frame/frame-runtime-db-value server-frame) "hash"
     {:payload :rf.ssr.payload/whole-app-db}))
 
 (defn- assert-frame-a-redacts [payload where]
@@ -100,7 +100,7 @@
             the pre-clean-break one-arity wrapper resolve-current-frame → nil,
             project-routing-egress fails OPEN, and the token would ride raw."
     (setup-frames!)
-    (let [payload (binding [frame/*current-frame* nil] (build-a))]
+    (let [payload (binding [rf.frame/*current-frame* nil] (build-a))]
       (assert-frame-a-redacts payload "outside with-frame"))))
 
 (deftest build-payload-explicit-frame-wins-over-ambient
@@ -109,7 +109,7 @@
             explicit target rather than borrowing the ambient scope (rf2-f02diw).
             Under B's empty registry the token would otherwise ride raw."
     (setup-frames!)
-    (is (= ambient-frame (rf/with-frame ambient-frame (frame/resolve-current-frame)))
+    (is (= ambient-frame (rf/with-frame ambient-frame (rf.frame/resolve-current-frame)))
         "sanity: the ambient frame inside the body is B, not A")
     (let [payload (rf/with-frame ambient-frame (build-a))]
       (assert-frame-a-redacts payload "mismatched ambient B"))))
@@ -130,11 +130,11 @@
             :params blob / app-db secret rides. Mirrors the streaming builder's
             teardown-race fail-closed."
     (setup-frames!)
-    (let [runtime-db (frame/frame-runtime-db-value server-frame)
+    (let [runtime-db (rf.frame/frame-runtime-db-value server-frame)
           app-db     {:secret "app-db-secret" :public "ok"}]
       ;; Teardown race: the request frame is gone before the wrapper projects.
       (rf/destroy-frame! server-frame)
-      (let [payload (payload/build-payload
+      (let [payload (rf.ssr.ring.payload/build-payload
                       server-frame app-db runtime-db "hash"
                       {:payload :rf.ssr.payload/whole-app-db})]
         ;; rf2-lm2yzy — wire :rf/frame-id decoupled from the (dead) projection

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
@@ -44,12 +44,12 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.headers :as headers]
-            [re-frame.ssr.ring.pipeline :as pipeline]
-            [re-frame.ssr.ring.test-support :as ts]))
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.headers :as rf.ssr.ring.headers]
+            [re-frame.ssr.ring.pipeline :as rf.ssr.ring.pipeline]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ===========================================================================
 ;; ssr-response->ring-response — redirect target resolution (:location only)
@@ -66,7 +66,7 @@
 (deftest redirect-resolves-location-key
   (testing "a redirect map keyed by :location emits a Location header"
     (let [resp {:redirect {:status 302 :location "/by-location"}}
-          ring (pipeline/ssr-response->ring-response resp nil)]
+          ring (rf.ssr.ring.pipeline/ssr-response->ring-response resp nil)]
       (is (= 302 (:status ring)))
       (is (= "/by-location" (get (:headers ring) "Location")))
       (is (= "" (:body ring)) "redirect has no body"))))
@@ -78,7 +78,7 @@
             The runtime rejects :url loudly before this point; the adapter's
             last-line behaviour must NOT silently resolve the retired key."
     (let [resp {:redirect {:status 303 :url "/by-url"}}
-          ring (pipeline/ssr-response->ring-response resp nil)]
+          ring (rf.ssr.ring.pipeline/ssr-response->ring-response resp nil)]
       (is (= 303 (:status ring)) "the redirect map's :status still rides through")
       (is (nil? (get (:headers ring) "Location"))
           ":url is NOT resolved as the Location target — retired spelling"))))
@@ -87,7 +87,7 @@
   (testing "rf2-vngir: a redirect map carrying ONLY the retired :to spelling
             (NOT :location) likewise emits no Location header"
     (let [resp {:redirect {:status 307 :to "/by-to"}}
-          ring (pipeline/ssr-response->ring-response resp nil)]
+          ring (rf.ssr.ring.pipeline/ssr-response->ring-response resp nil)]
       (is (= 307 (:status ring)))
       (is (nil? (get (:headers ring) "Location"))
           ":to is NOT resolved as the Location target — retired spelling"))))
@@ -97,7 +97,7 @@
             keys, ONLY :location is resolved (the retired keys are inert at
             the materialiser — :location is the canonical target)"
     (is (= "/loc"
-           (get (:headers (pipeline/ssr-response->ring-response
+           (get (:headers (rf.ssr.ring.pipeline/ssr-response->ring-response
                             {:redirect {:status 302
                                         :location "/loc" :url "/url" :to "/to"}}
                             nil))
@@ -108,7 +108,7 @@
   (testing "rf2-ynjts.14: a redirect map with a target but no :status
             defaults to 302 (the materialiser's `(or redirect-status
             status 302)` fallback)"
-    (let [ring (pipeline/ssr-response->ring-response
+    (let [ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                  {:redirect {:location "/x"}} nil)]
       (is (= 302 (:status ring))
           "absent redirect :status → 302 default")
@@ -120,7 +120,7 @@
             tolerance — the warning-trace branch is pinned end-to-end by
             ring_test/handler-redirect-no-target-warns; here we pin the
             materialiser's header-omission half directly)"
-    (let [ring (pipeline/ssr-response->ring-response
+    (let [ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                  {:redirect {:status 302}} nil)]
       (is (= 302 (:status ring)) "status still emitted (no target to invent)")
       (is (nil? (get (:headers ring) "Location"))
@@ -134,7 +134,7 @@
 (deftest body-response-defaults-status-200
   (testing "rf2-ynjts.14: a non-redirect response with no :status defaults
             to 200 and carries the supplied body verbatim"
-    (let [ring (pipeline/ssr-response->ring-response
+    (let [ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                  {:headers [["Content-Type" "text/html"]]}
                  "<p>hi</p>")]
       (is (= 200 (:status ring)) "absent :status → 200 default")
@@ -143,7 +143,7 @@
 (deftest body-response-nil-body-becomes-empty-string
   (testing "rf2-ynjts.14: a nil body materialises to the empty string, not
             nil (Ring bodies must be writable — `(or body \"\")`)"
-    (let [ring (pipeline/ssr-response->ring-response
+    (let [ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                  {:status 204 :headers []} nil)]
       (is (= 204 (:status ring)))
       (is (= "" (:body ring)) "nil body → empty string"))))
@@ -170,32 +170,32 @@
             `:rf.server/set-status \"404\"` leaves on the accumulator) does
             NOT reach the wire as a non-int — the materialiser fails closed
             to a valid 500 Ring response"
-    (let [ring (pipeline/ssr-response->ring-response
+    (let [ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                  {:status "404" :headers [["Content-Type" "text/html"]]}
                  "<p>x</p>")]
       (is (integer? (:status ring))
           "the Ring :status is an integer regardless of accumulator garbage")
       (is (= 500 (:status ring)) "a non-int status fails closed to 500")))
   (testing "rf2-v0qbng: a non-integer redirect :status also fails closed"
-    (let [ring (pipeline/ssr-response->ring-response
+    (let [ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                  {:redirect {:status "302" :location "/ok"}} nil)]
       (is (integer? (:status ring)) "redirect :status is an integer")
       (is (= 500 (:status ring)) "non-int redirect status → 500")))
   (testing "rf2-v0qbng: a float status (200.0) is not a valid Ring int → 500"
-    (is (= 500 (:status (pipeline/ssr-response->ring-response
+    (is (= 500 (:status (rf.ssr.ring.pipeline/ssr-response->ring-response
                           {:status 200.0 :headers []} "x"))))))
 
 (deftest integer-status-passes-through-unchanged
   (testing "rf2-v0qbng: a genuine integer status is untouched by the
             fail-closed guard (no false-positive coercion)"
-    (is (= 201 (:status (pipeline/ssr-response->ring-response
+    (is (= 201 (:status (rf.ssr.ring.pipeline/ssr-response->ring-response
                           {:status 201 :headers []} "x"))))
-    (is (= 302 (:status (pipeline/ssr-response->ring-response
+    (is (= 302 (:status (rf.ssr.ring.pipeline/ssr-response->ring-response
                           {:redirect {:status 302 :location "/x"}} nil))))
-    (is (= 200 (:status (pipeline/ssr-response->ring-response
+    (is (= 200 (:status (rf.ssr.ring.pipeline/ssr-response->ring-response
                           {:headers []} "x")))
         "absent status still defaults to 200")
-    (is (= 302 (:status (pipeline/ssr-response->ring-response
+    (is (= 302 (:status (rf.ssr.ring.pipeline/ssr-response->ring-response
                           {:redirect {:location "/x"}} nil)))
         "absent redirect status still defaults to 302")))
 
@@ -231,7 +231,7 @@
             fail-closed-to-500 recovery; the response still fails closed to 500"
     (let [warnings (collect-non-integer-status-warnings
                      (fn []
-                       (let [ring (pipeline/ssr-response->ring-response
+                       (let [ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                                     {:status "404"
                                      :headers [["Content-Type" "text/html"]]}
                                     "<p>x</p>")]
@@ -266,7 +266,7 @@
             `status-rewrite-always-on-test/one-rewrite-fans-exactly-one-record`."
     (let [warnings (collect-non-integer-status-warnings
                      (fn []
-                       (let [ring (pipeline/ssr-response->ring-response
+                       (let [ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                                     {:redirect {:status "302"}} nil)]
                          (is (= 500 (:status ring))
                              "the redirect arm still fails closed to 500"))))]
@@ -279,9 +279,9 @@
             defect-only diagnostic, not a per-request emission"
     (let [warnings (collect-non-integer-status-warnings
                      (fn []
-                       (pipeline/ssr-response->ring-response
+                       (rf.ssr.ring.pipeline/ssr-response->ring-response
                          {:status 200 :headers []} "x")
-                       (pipeline/ssr-response->ring-response
+                       (rf.ssr.ring.pipeline/ssr-response->ring-response
                          {:headers []} "x")))]  ;; absent status → 200 default
       (is (= [] warnings)
           "no warning for a valid integer status or an absent (defaulted) one"))))
@@ -291,7 +291,7 @@
             soft-passed `:rf.server/set-header {:name \"X-Count\" :value 5}`
             leaves) is coerced to a string in the emitted Ring header map —
             the value is never a raw scalar on the wire"
-    (let [ring (pipeline/ssr-response->ring-response
+    (let [ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                  {:status 200 :headers [["X-Count" 5]
                                         ["X-Flag" true]
                                         ["X-Kw" :enabled]]}
@@ -310,7 +310,7 @@
             caller-trusted and `(str loc)` passes its shape gate, so a raw
             scalar can reach the accumulator) is coerced to a string in the
             emitted Location header"
-    (let [ring (pipeline/ssr-response->ring-response
+    (let [ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                  {:redirect {:status 302 :location 5}} nil)
           loc  (get (:headers ring) "Location")]
       (is (= 302 (:status ring)))
@@ -327,7 +327,7 @@
 (deftest content-type-override-sets-when-pairs-carry-none
   (testing "rf2-nncni3: pairs that declare no Content-Type get the override
             value set (with no existing Content-Type, override = assoc)"
-    (let [result (headers/headers->ring-map+content-type-override
+    (let [result (rf.ssr.ring.headers/headers->ring-map+content-type-override
                    [["X-Custom" "v"]]
                    "text/html; charset=utf-8")]
       (is (= "text/html; charset=utf-8" (get result "Content-Type"))
@@ -338,14 +338,14 @@
   (testing "rf2-nncni3: a nil `content-type` arg is NO override — the folded
             map flows verbatim, so the runtime seed / app-set Content-Type
             stays in control (the redirect path passes nil)"
-    (let [result (headers/headers->ring-map+content-type-override
+    (let [result (rf.ssr.ring.headers/headers->ring-map+content-type-override
                    [["X-Custom" "v"]]
                    nil)]
       (is (not (contains? result "Content-Type"))
           "no Content-Type key when the override is nil and pairs carry none")
       (is (= "v" (get result "X-Custom"))))
     (testing "a nil override preserves a caller-supplied Content-Type verbatim"
-      (let [result (headers/headers->ring-map+content-type-override
+      (let [result (rf.ssr.ring.headers/headers->ring-map+content-type-override
                      [["content-type" "application/json"]]
                      nil)]
         (is (= "application/json" (get result "content-type"))
@@ -354,7 +354,7 @@
 (deftest empty-pairs-with-nil-override-yields-empty-map
   (testing "rf2-nncni3: empty pairs + nil override → empty header map (no
             spurious keys)"
-    (is (= {} (headers/headers->ring-map+content-type-override [] nil)))))
+    (is (= {} (rf.ssr.ring.headers/headers->ring-map+content-type-override [] nil)))))
 
 ;; ===========================================================================
 ;; merge-pair-into-header-map — repeated names collapse into a vector
@@ -369,15 +369,15 @@
 (deftest single-value-header-stays-scalar
   (testing "rf2-ynjts.14: a name seen once stays a scalar string (nil arm)"
     (is (= {"Vary" "Accept"}
-           (headers/merge-pair-into-header-map {} ["Vary" "Accept"])))))
+           (rf.ssr.ring.headers/merge-pair-into-header-map {} ["Vary" "Accept"])))))
 
 (deftest second-value-promotes-to-vector
   (testing "rf2-ynjts.14: a name seen twice promotes scalar → 2-vector
             (string arm)"
     (is (= {"Vary" ["Accept" "Cookie"]}
            (-> {}
-               (headers/merge-pair-into-header-map ["Vary" "Accept"])
-               (headers/merge-pair-into-header-map ["Vary" "Cookie"]))))))
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["Vary" "Accept"])
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["Vary" "Cookie"]))))))
 
 (deftest third-value-conjs-onto-vector-preserving-order
   (testing "rf2-ynjts.14: a name seen three+ times conjs onto the vector,
@@ -385,9 +385,9 @@
             load-bearing multi-valued-header round-trip)"
     (is (= {"Link" ["a" "b" "c"]}
            (-> {}
-               (headers/merge-pair-into-header-map ["Link" "a"])
-               (headers/merge-pair-into-header-map ["Link" "b"])
-               (headers/merge-pair-into-header-map ["Link" "c"]))))))
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["Link" "a"])
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["Link" "b"])
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["Link" "c"]))))))
 
 (deftest repeated-non-string-value-coerced-and-does-not-wipe-header-map
   (testing "rf2-v0qbng (was rf2-5t8mr.14): a repeated header name whose value
@@ -400,10 +400,10 @@
             value is a vector OF STRINGS, never of raw scalars"
     (is (= {"X-Count" ["5" "6"]}
            (-> {}
-               (headers/merge-pair-into-header-map ["X-Count" 5])
-               (headers/merge-pair-into-header-map ["X-Count" 6])))
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["X-Count" 5])
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["X-Count" 6])))
         "two non-string values under one name collapse to a vector of strings")
-    (let [result (headers/headers->ring-map+content-type-override
+    (let [result (rf.ssr.ring.headers/headers->ring-map+content-type-override
                    [["X-Count" 5]
                     ["X-Count" 6]
                     ["X-Other" "keep"]]
@@ -436,14 +436,14 @@
             in declaration order (the case-insensitive fold)"
     (is (= {"Vary" ["Accept" "Origin"]}
            (-> {}
-               (headers/merge-pair-into-header-map ["Vary" "Accept"])
-               (headers/merge-pair-into-header-map ["vary" "Origin"])))
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["Vary" "Accept"])
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["vary" "Origin"])))
         "second-seen lower-case `vary` folds under the first-seen `Vary` key")
     (is (= {"Vary" ["Accept" "Origin" "Accept-Encoding"]}
            (-> {}
-               (headers/merge-pair-into-header-map ["Vary" "Accept"])
-               (headers/merge-pair-into-header-map ["vary" "Origin"])
-               (headers/merge-pair-into-header-map ["VARY" "Accept-Encoding"])))
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["Vary" "Accept"])
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["vary" "Origin"])
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["VARY" "Accept-Encoding"])))
         "three casings collapse to one key; values stay in declaration order")))
 
 (deftest mixed-case-fold-retains-first-seen-spelling-not-latest
@@ -451,8 +451,8 @@
             later case variant does NOT rename the key"
     (is (= ["Origin" "Accept"]
            (get (-> {}
-                    (headers/merge-pair-into-header-map ["vary" "Origin"])
-                    (headers/merge-pair-into-header-map ["Vary" "Accept"]))
+                    (rf.ssr.ring.headers/merge-pair-into-header-map ["vary" "Origin"])
+                    (rf.ssr.ring.headers/merge-pair-into-header-map ["Vary" "Accept"]))
                 "vary"))
         "first-seen lower-case `vary` is the stable emitted key")))
 
@@ -460,7 +460,7 @@
   (testing "rf2-3fc89f.16 (accept #2): mixed-case Content-Type with a nil
             handler override collapses to exactly one logical key carrying
             both values in order (vector semantics follow append-header)"
-    (let [result (headers/headers->ring-map+content-type-override
+    (let [result (rf.ssr.ring.headers/headers->ring-map+content-type-override
                    [["content-type" "text/html"]
                     ["Content-Type" "application/json"]]
                    nil)
@@ -474,7 +474,7 @@
 (deftest mixed-case-content-type-with-override-strips-every-casing
   (testing "rf2-3fc89f.16 (accept #2): a non-nil override still strips every
             prior spelling and emits one canonical `Content-Type` scalar"
-    (let [result (headers/headers->ring-map+content-type-override
+    (let [result (rf.ssr.ring.headers/headers->ring-map+content-type-override
                    [["content-type" "text/html"]
                     ["Content-Type" "application/json"]]
                    "text/xml; charset=utf-8")
@@ -489,7 +489,7 @@
   (testing "rf2-3fc89f.16 (accept #3): structured cookies appended to a
             pre-existing differently-cased Set-Cookie entry yield ONE logical
             key preserving every value in order"
-    (let [result (headers/append-set-cookies
+    (let [result (rf.ssr.ring.headers/append-set-cookies
                    {"set-cookie" "pre=1"}
                    [{:name "session" :value "abc"}
                     {:name "theme" :value "dark"}])
@@ -508,12 +508,12 @@
   (testing "rf2-3fc89f.16: the case-insensitive fold leaves same-case
             singleton/scalar/vector behaviour exactly as before"
     (is (= {"Vary" "Accept"}
-           (headers/merge-pair-into-header-map {} ["Vary" "Accept"]))
+           (rf.ssr.ring.headers/merge-pair-into-header-map {} ["Vary" "Accept"]))
         "a singleton stays a scalar")
     (is (= {"Vary" ["Accept" "Cookie"]}
            (-> {}
-               (headers/merge-pair-into-header-map ["Vary" "Accept"])
-               (headers/merge-pair-into-header-map ["Vary" "Cookie"])))
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["Vary" "Accept"])
+               (rf.ssr.ring.headers/merge-pair-into-header-map ["Vary" "Cookie"])))
         "same-case repeats still promote to an ordered vector")))
 
 ;; ===========================================================================
@@ -547,7 +547,7 @@
             fail-closed coercion — the wire value is always a string)"
     (let [warnings (collect-non-string-header-warnings
                      (fn []
-                       (let [result (headers/merge-pair-into-header-map
+                       (let [result (rf.ssr.ring.headers/merge-pair-into-header-map
                                       {} ["X-Count" 5])]
                          (is (= {"X-Count" "5"} result)
                              "the non-string value folds in coerced to a string"))))]
@@ -565,10 +565,10 @@
             path) emits NO warning"
     (let [warnings (collect-non-string-header-warnings
                      (fn []
-                       (headers/merge-pair-into-header-map {} ["X-Custom" "v"])
+                       (rf.ssr.ring.headers/merge-pair-into-header-map {} ["X-Custom" "v"])
                        (-> {}
-                           (headers/merge-pair-into-header-map ["Vary" "Accept"])
-                           (headers/merge-pair-into-header-map ["Vary" "Cookie"]))))]
+                           (rf.ssr.ring.headers/merge-pair-into-header-map ["Vary" "Accept"])
+                           (rf.ssr.ring.headers/merge-pair-into-header-map ["Vary" "Cookie"]))))]
       (is (= [] warnings)
           "no non-string-header-value warning for string-valued headers"))))
 
@@ -576,7 +576,7 @@
   (testing "rf2-ynjts.14: the full fold collapses repeated names into a
             vector AND keeps singletons scalar in one pass — the contract
             the materialiser relies on for multi-valued headers"
-    (let [result (headers/headers->ring-map+content-type-override
+    (let [result (rf.ssr.ring.headers/headers->ring-map+content-type-override
                    [["Set-Cookie" "a=1"]
                     ["Set-Cookie" "b=2"]
                     ["X-One" "only"]]
@@ -593,7 +593,7 @@
 (deftest append-set-cookies-folds-multiple-into-vector
   (testing "rf2-ynjts.14: two structured cookies fold into a 2-vector under
             Set-Cookie, each serialised per RFC 6265"
-    (let [result (headers/append-set-cookies
+    (let [result (rf.ssr.ring.headers/append-set-cookies
                    {}
                    [{:name "session" :value "abc"}
                     {:name "theme" :value "dark"}])
@@ -605,7 +605,7 @@
 
 (deftest append-set-cookies-empty-is-noop
   (testing "rf2-ynjts.14: no cookies → header map unchanged"
-    (is (= {"X" "y"} (headers/append-set-cookies {"X" "y"} [])))))
+    (is (= {"X" "y"} (rf.ssr.ring.headers/append-set-cookies {"X" "y"} [])))))
 
 ;; ===========================================================================
 ;; ssr-middleware — DEFAULT :match? (matches every GET; non-GET falls through)
@@ -626,7 +626,7 @@
     (let [wrapped-called (atom false)
           wrapped        (fn [_req] (reset! wrapped-called true)
                            {:status 204 :headers {} :body ""})
-          app ((ssr-ring/ssr-middleware
+          app ((rf.ssr.ring/ssr-middleware
                  {:initial-events      [[:init/mw-blank]]
                   :root-view      [(rf/view :pages/mw-blank)]
                   :payload :rf.ssr.payload/whole-app-db})
@@ -644,7 +644,7 @@
     (let [wrapped-called (atom false)
           wrapped        (fn [_req] (reset! wrapped-called true)
                            {:status 201 :headers {} :body "from wrapped"})
-          app ((ssr-ring/ssr-middleware
+          app ((rf.ssr.ring/ssr-middleware
                  {:initial-events      [[:init/mw-blank]]
                   :root-view      [(rf/view :pages/mw-blank)]
                   :payload :rf.ssr.payload/whole-app-db})

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/render_hash_tier_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/render_hash_tier_test.clj
@@ -25,12 +25,12 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.lifecycle :as lifecycle]
-            [re-frame.ssr.ring.test-support :as ts]))
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.lifecycle :as rf.ssr.ring.lifecycle]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ---- extraction helpers ---------------------------------------------------
 
@@ -86,30 +86,30 @@
   (testing "rf2-q1b96: a vector whose head is a callable — a raw fn, a Var
             reference, or `(rf/view :id)` — is the UNRESOLVED root form"
     (register-app!)
-    (is (true? (lifecycle/unresolved-root-form? [(rf/view :q1b96/root)]))
+    (is (true? (rf.ssr.ring.lifecycle/unresolved-root-form? [(rf/view :q1b96/root)]))
         "a registered-view reference is a reference, not a tree")
-    (is (true? (lifecycle/unresolved-root-form? [#'a-component]))
+    (is (true? (rf.ssr.ring.lifecycle/unresolved-root-form? [#'a-component]))
         "a Var head too — a Var is `ifn?` but NOT `fn?` on the JVM, so the
          test cannot be `fn?` (rf2-wtd8z finding 2 made the same correction
          in the emitter)")
-    (is (true? (lifecycle/unresolved-root-form? [a-component {}]))
+    (is (true? (rf.ssr.ring.lifecycle/unresolved-root-form? [a-component {}]))
         "the adoption tier's `[<component> {props}]` shape")))
 
 (deftest unresolved-root-form-excludes-real-render-trees
   (testing "rf2-q1b96: keyword heads are DOM / custom elements on every host
             (rf2-j81hs), so a keyword-headed vector is a real render tree —
             and so is anything that is not a callable-headed vector"
-    (is (false? (lifecycle/unresolved-root-form? [:div.page [:h1 "x"]]))
+    (is (false? (rf.ssr.ring.lifecycle/unresolved-root-form? [:div.page [:h1 "x"]]))
         "an ordinary DOM root")
-    (is (false? (lifecycle/unresolved-root-form? [:<> [:div "a"] [:div "b"]]))
+    (is (false? (rf.ssr.ring.lifecycle/unresolved-root-form? [:<> [:div "a"] [:div "b"]]))
         "a fragment root — Spec 011 threads the marker through it onto the
          first DOM child, so it must stay hashable")
-    (is (false? (lifecycle/unresolved-root-form? (list [:div "x"])))
+    (is (false? (rf.ssr.ring.lifecycle/unresolved-root-form? (list [:div "x"])))
         "a lazy-seq / list root is threaded through likewise (rf2-a73idu)")
-    (is (false? (lifecycle/unresolved-root-form? []))
+    (is (false? (rf.ssr.ring.lifecycle/unresolved-root-form? []))
         "an empty vector has no head to be callable")
-    (is (false? (lifecycle/unresolved-root-form? "just text")))
-    (is (false? (lifecycle/unresolved-root-form? nil)))))
+    (is (false? (rf.ssr.ring.lifecycle/unresolved-root-form? "just text")))
+    (is (false? (rf.ssr.ring.lifecycle/unresolved-root-form? nil)))))
 
 ;; ===========================================================================
 ;; The measurement — why a degenerate value is worse than an absent one
@@ -128,22 +128,22 @@
 
     ;; Arity 1 — `[<callable>]`, the shape `:root-view [(rf/view :id)]` takes.
     (is (= "f1d63f7e"
-           (ssr/render-tree-hash [(rf/view :q1b96/root)])
-           (ssr/render-tree-hash [(rf/view :q1b96/other)]))
+           (rf.ssr/render-tree-hash [(rf/view :q1b96/root)])
+           (rf.ssr/render-tree-hash [(rf/view :q1b96/other)]))
         "two unrelated views hash IDENTICALLY as [#fn[]]")
 
     ;; Arity 2 — `[<component> {props}]`, the adoption tier's root form. This
     ;; is the same 83b865f8 rf2-2rtt6.91 measured on the Freehand bench.
     (is (= "83b865f8"
-           (ssr/render-tree-hash [a-component {}])
-           (ssr/render-tree-hash [b-component {}]))
+           (rf.ssr/render-tree-hash [a-component {}])
+           (rf.ssr/render-tree-hash [b-component {}]))
         "two entirely different screens hash IDENTICALLY as [#fn[] {}] — a
          client comparing that value would find the server agreed with it
          about two different pages")
 
     ;; The non-vacuity control: a real DOM-rooted tree does discriminate.
-    (is (not= (ssr/render-tree-hash [:div "a"])
-              (ssr/render-tree-hash [:div "b"]))
+    (is (not= (rf.ssr/render-tree-hash [:div "a"])
+              (rf.ssr/render-tree-hash [:div "b"]))
         "a genuine render tree hashes differently for different content")))
 
 (deftest render-document-hash-omits-the-unresolved-root-form
@@ -151,9 +151,9 @@
             root form — the same OMIT-rather-than-ship shape `render-head-hash`
             already uses for a head the client cannot reconstruct"
     (register-app!)
-    (is (nil? (lifecycle/render-document-hash [(rf/view :q1b96/root)])))
-    (is (nil? (lifecycle/render-document-hash [a-component {}])))
-    (is (some? (lifecycle/render-document-hash ((rf/view :q1b96/root))))
+    (is (nil? (rf.ssr.ring.lifecycle/render-document-hash [(rf/view :q1b96/root)])))
+    (is (nil? (rf.ssr.ring.lifecycle/render-document-hash [a-component {}])))
+    (is (some? (rf.ssr.ring.lifecycle/render-document-hash ((rf/view :q1b96/root))))
         "the RESOLVED tree still hashes — the channel is not disabled, it is
          conditioned on a hashable tree existing")))
 
@@ -166,7 +166,7 @@
             on the root element and NO :rf/render-hash key in the payload,
             even under the default `:emit-hash? true`"
     (register-app!)
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:rf.test.q1b96/init]]
                      :root-view      [(rf/view :q1b96/root)]
                      :payload        :rf.ssr.payload/whole-app-db})
@@ -194,7 +194,7 @@
             so the first server arm that does must not re-create the fail-open
             gate rf2-2rtt6.91 closed on the client."
     (rf/reg-event :rf.test.q1b96/init {:platforms #{:server}} (fn [_ _] {:db {}}))
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:rf.test.q1b96/init]]
                      :root-view      [a-component {}]
                      :payload        :rf.ssr.payload/whole-app-db})
@@ -210,7 +210,7 @@
             client `:render-tree-fn #((rf/view :id))` computes, which the
             unresolved form never could."
     (register-app!)
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:rf.test.q1b96/init]]
                      ;; Note the OUTER call, mirroring the client's `#(…)`.
                      :root-view      (fn [] ((rf/view :q1b96/root)))
@@ -237,19 +237,19 @@
                       :initial-events [[:rf.test.q1b96/init]]})
       (try
         (rf/with-frame fid
-          (let [server-resolved   (lifecycle/resolve-root-view
+          (let [server-resolved   (rf.ssr.ring.lifecycle/resolve-root-view
                                     (fn [] ((rf/view :q1b96/root))))
-                server-unresolved (lifecycle/resolve-root-view
+                server-unresolved (rf.ssr.ring.lifecycle/resolve-root-view
                                     [(rf/view :q1b96/root)])
                 client-tree       ((rf/view :q1b96/root))]
-            (is (= (lifecycle/render-document-hash server-resolved)
-                   (ssr/render-tree-hash client-tree))
+            (is (= (rf.ssr.ring.lifecycle/render-document-hash server-resolved)
+                   (rf.ssr/render-tree-hash client-tree))
                 "resolving server root == client `#((rf/view :id))` hash")
-            (is (nil? (lifecycle/render-document-hash server-unresolved))
+            (is (nil? (rf.ssr.ring.lifecycle/render-document-hash server-unresolved))
                 "the unresolved form now carries nothing rather than a
                  never-matching constant")
-            (is (= (ssr/render-to-string server-resolved {})
-                   (ssr/render-to-string server-unresolved {}))
+            (is (= (rf.ssr/render-to-string server-resolved {})
+                   (rf.ssr/render-to-string server-unresolved {}))
                 "both spellings emit byte-identical HTML — the choice is
                  invisible on the page and decisive on the hash channel,
                  which is why `resolve-root-view`'s docstring now says so")))
@@ -268,7 +268,7 @@
             `:emit-hash?` (`render-to-string` reads a true `:emit-hash?` with
             no supplied hash as 'compute it yourself' — rf2-atmvj)."
     (register-app!)
-    (let [handler (ssr-ring/stream-handler
+    (let [handler (rf.ssr.ring/stream-handler
                     {:initial-events [[:rf.test.q1b96/init]]
                      :root-view      [(rf/view :q1b96/root)]
                      :payload        :rf.ssr.payload/whole-app-db})

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/renderer_seam_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/renderer_seam_test.clj
@@ -18,11 +18,11 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.pipeline :as pipeline]
-            [re-frame.ssr.ring.test-support :as ts]))
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.pipeline :as rf.ssr.ring.pipeline]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ---- extraction helpers ---------------------------------------------------
 
@@ -93,7 +93,7 @@
             marker; no payload :rf/render-hash; head, __rf_payload, shell,
             status and headers are JVM-built; :root-view omitted without error"
     (register-app!)
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     ;; No :root-view: with a custom renderer nothing reads it.
                     (assoc base-opts
                            :emit-hash? true
@@ -124,12 +124,12 @@
   (testing "rf2-8arzr.1 Acceptance 2 on the wire: status, Content-Type and
             the whole document are JVM-built around the renderer's body"
     (register-app!)
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     (assoc base-opts :renderer fixed-renderer))
-          client  (ts/new-http-client)]
-      (ts/with-jetty [port handler]
+          client  (rf.ssr.ring.test-support/new-http-client)]
+      (rf.ssr.ring.test-support/with-jetty [port handler]
         (let [{:keys [status headers body]}
-              (ts/http-get client port "/seam" 10 :with-headers? true)
+              (rf.ssr.ring.test-support/http-get client port "/seam" 10 :with-headers? true)
               ct (first (content-type-of headers))]
           (is (= 200 status))
           (is (str/includes? (str ct) "text/html"))
@@ -147,10 +147,10 @@
   (testing "rf2-8arzr S1: with a custom :renderer, :root-view is optional and
             ignored — a supplied one is simply never read"
     (register-app!)
-    (let [without ((ssr-ring/ssr-handler
+    (let [without ((rf.ssr.ring/ssr-handler
                      (assoc base-opts :renderer fixed-renderer))
                    request)
-          with    ((ssr-ring/ssr-handler
+          with    ((rf.ssr.ring/ssr-handler
                      (assoc base-opts
                             :root-view [(rf/view :seam/root)]
                             :renderer  fixed-renderer))
@@ -164,13 +164,13 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/ssr-ring-missing-root-view"
-          (ssr-ring/ssr-handler base-opts))))
+          (rf.ssr.ring/ssr-handler base-opts))))
   (testing "…an explicit-nil :renderer is absent, not custom: the default
             renderer will read :root-view, so it is still required"
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/ssr-ring-missing-root-view"
-          (ssr-ring/ssr-handler (assoc base-opts :renderer nil))))))
+          (rf.ssr.ring/ssr-handler (assoc base-opts :renderer nil))))))
 
 ;; ===========================================================================
 ;; S1 — what the renderer is handed, and where it runs
@@ -183,7 +183,7 @@
             frame-relative read resolves without naming the frame"
     (register-app!)
     (let [seen    (atom nil)
-          handler (ssr-ring/ssr-handler
+          handler (rf.ssr.ring/ssr-handler
                     (assoc base-opts
                            :root-view [(rf/view :seam/root)]
                            :renderer
@@ -221,9 +221,9 @@
             marker and the payload hash still agree"
     (register-app!)
     (let [opts     (assoc base-opts :root-view (fn [] ((rf/view :seam/root))))
-          implicit ((ssr-ring/ssr-handler opts) request)
-          explicit ((ssr-ring/ssr-handler
-                      (assoc opts :renderer pipeline/local-renderer))
+          implicit ((rf.ssr.ring/ssr-handler opts) request)
+          explicit ((rf.ssr.ring/ssr-handler
+                      (assoc opts :renderer rf.ssr.ring.pipeline/local-renderer))
                     request)]
       (is (= (:status implicit) (:status explicit)))
       (is (= (:headers implicit) (:headers explicit)))
@@ -245,7 +245,7 @@
             :rf/render-hash; the wire marker is the renderer's own to stamp"
     (register-app!)
     (let [stamped "<div data-rf-render-hash=\"0badf00d\">stamped</div>"
-          handler (ssr-ring/ssr-handler
+          handler (rf.ssr.ring/ssr-handler
                     (assoc base-opts
                            :root-view [(rf/view :seam/root)]
                            :renderer  (fn [_] {:body-html   stamped
@@ -257,7 +257,7 @@
   (testing "…and a hash returned WITHOUT a marker in the body is not stamped
             by the pipeline: the payload carries it, the wire does not"
     (register-app!)
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     (assoc base-opts
                            :root-view [(rf/view :seam/root)]
                            :renderer  (fn [_] {:body-html   "<div>bare</div>"
@@ -278,7 +278,7 @@
             ex-data naming the opt, the value and a recovery"
     (register-app!)
     (let [ex   (is (thrown? clojure.lang.ExceptionInfo
-                     (ssr-ring/stream-handler
+                     (rf.ssr.ring/stream-handler
                        (assoc base-opts
                               :root-view [(rf/view :seam/root)]
                               :renderer  fixed-renderer))))
@@ -298,7 +298,7 @@
             refuses rather than silently rendering nothing"
     (register-app!)
     (let [ex (is (thrown? clojure.lang.ExceptionInfo
-                   (ssr-ring/stream-handler
+                   (rf.ssr.ring/stream-handler
                      (assoc base-opts :renderer fixed-renderer))))]
       (is (= :rf.error/ssr-streaming-unsupported-opt
              (:rf.error/id (ex-data ex))))
@@ -310,7 +310,7 @@
     (doseq [opts [(assoc base-opts :root-view [(rf/view :seam/root)])
                   (assoc base-opts :root-view [(rf/view :seam/root)]
                                    :renderer nil)]]
-      (let [handler  (ssr-ring/stream-handler opts)
+      (let [handler  (rf.ssr.ring/stream-handler opts)
             response (handler request)
             body     (drain-stream (:body response))]
         (is (= 200 (:status response)))
@@ -326,7 +326,7 @@
             handles it — projected 500, the projector's public message, no
             hydration payload, no throwable detail on the wire"
     (register-app!)
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     (assoc base-opts
                            :root-view [(rf/view :seam/root)]
                            :renderer

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/resource_payload_projection_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/resource_payload_projection_test.clj
@@ -41,13 +41,13 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.resources.state :as state]
-            [re-frame.ssr.ring.lifecycle :as lifecycle]
-            [re-frame.ssr.ring.pipeline :as pipeline]
-            [re-frame.ssr.ring.shell :as shell]
-            [re-frame.ssr.ring.test-support :as ts]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.resources.state :as rf.resources.state]
+            [re-frame.ssr.ring.lifecycle :as rf.ssr.ring.lifecycle]
+            [re-frame.ssr.ring.pipeline :as rf.ssr.ring.pipeline]
+            [re-frame.ssr.ring.shell :as rf.ssr.ring.shell]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]
             ;; load-bearing side-effecting requires: register the :resource +
             ;; :resource-scope registrar kinds, the schemas walker hooks, and
             ;; (crucially) the `:ssr/extend-runtime-db-projection` late-bind
@@ -56,7 +56,7 @@
             [re-frame.resources.ssr]
             [re-frame.schemas]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ---------------------------------------------------------------------------
 ;; App: a `{:from-db}` session-scoped feed resource.
@@ -77,8 +77,8 @@
   supplied per frame by the caller via a commit-plane `:sensitive` effect run
   through `:initial-events` at frame construction."
   [owner-sensitive?]
-  (registrar/clear-kind! :resource-scope)
-  (registrar/clear-kind! :resource)
+  (rf.registrar/clear-kind! :resource-scope)
+  (rf.registrar/clear-kind! :resource)
   ;; resolver reading the FRAME-SENSITIVE viewer-identity path. EP-0025: this no
   ;; longer propagates sensitivity to the resource (no inheritance arm).
   (rf/reg-resource-scope :p026f5/session
@@ -101,9 +101,9 @@
   byte `key-id`; the kind-preserving scoped-key vector rides inside the
   entry per rf2-9e0tyq)."
   [username page data]
-  (let [sk (state/scoped-resource-key [:rf.scope/session {:username username}]
+  (let [sk (rf.resources.state/scoped-resource-key [:rf.scope/session {:username username}]
                                       :p026f5/feed {:page page})]
-    [sk (merge (state/empty-entry :p026f5/feed sk)
+    [sk (merge (rf.resources.state/empty-entry :p026f5/feed sk)
                {:status :loaded :data data :loaded-at 1000 :stale-at 9.0e15})]))
 
 (defn- seed-feed-runtime-db!
@@ -117,9 +117,9 @@
   paths."
   [frame-id username page data]
   (let [[sk entry] (loaded-feed-entry username page data)]
-    (frame/swap-runtime-db!
+    (rf.frame/swap-runtime-db!
       frame-id
-      assoc state/resources-key {:entries     {(state/key-id sk) entry}
+      assoc rf.resources.state/resources-key {:entries     {(rf.resources.state/key-id sk) entry}
                                  :tag-index   {}
                                  :owner-index {}})))
 
@@ -171,11 +171,11 @@
         (let [opts     {:initial-events nil
                         :root-view  [(rf/view :p026f5/root)]
                         :emit-hash? true
-                        :html-shell shell/default-html-shell
+                        :html-shell rf.ssr.ring.shell/default-html-shell
                         ;; whole-app-db so the test isolates the runtime-db
                         ;; resource projection, not the app-db allowlist.
                         :payload    :rf.ssr.payload/whole-app-db}
-              resp     (#'pipeline/build-full-response* fid opts)
+              resp     (#'rf.ssr.ring.pipeline/build-full-response* fid opts)
               body     (:body resp)
               payload  (payload-edn body)
               entries  (get-in payload [:rf/runtime-db
@@ -194,7 +194,7 @@
             (is (= sk wk)
                 "EP-0025: the wire key rides verbatim (no inheritance redaction)")))
         (finally
-          (lifecycle/destroy-frame-quietly! fid))))))
+          (rf.ssr.ring.lifecycle/destroy-frame-quietly! fid))))))
 
 ;; ===========================================================================
 ;; Confirm-by-revert: a resource declared :sensitive? is still governed by its
@@ -225,9 +225,9 @@
         (let [opts     {:initial-events nil
                         :root-view  [(rf/view :p026f5/root)]
                         :emit-hash? true
-                        :html-shell shell/default-html-shell
+                        :html-shell rf.ssr.ring.shell/default-html-shell
                         :payload    :rf.ssr.payload/whole-app-db}
-              resp     (#'pipeline/build-full-response* fid opts)
+              resp     (#'rf.ssr.ring.pipeline/build-full-response* fid opts)
               body     (:body resp)
               payload  (payload-edn body)
               entries  (get-in payload [:rf/runtime-db
@@ -256,7 +256,7 @@
                                   "rf/redacted"))
               "rf2-4bjep: no redaction token rides the runtime-db slice either"))
         (finally
-          (lifecycle/destroy-frame-quietly! fid))))))
+          (rf.ssr.ring.lifecycle/destroy-frame-quietly! fid))))))
 
 ;; ===========================================================================
 ;; A NON-sensitive resource still serializes verbatim — the in-frame
@@ -269,8 +269,8 @@
             NON-sensitive input serializes its data + scope verbatim in the
             non-streaming payload — the in-frame projection does not
             over-redact (the inheritance arm only fires for sensitive inputs)."
-    (registrar/clear-kind! :resource-scope)
-    (registrar/clear-kind! :resource)
+    (rf.registrar/clear-kind! :resource-scope)
+    (rf.registrar/clear-kind! :resource)
     (rf/reg-resource-scope :p026f5/locale
       {:inputs {:locale [:db [:i18n :locale]]}}
       (fn [{:keys [locale]} _]
@@ -289,21 +289,21 @@
       (rf/make-frame {:id fid :platform       :server
                       :initial-events [[:p026f5/classify-2]]})
       (try
-        (let [sk    (state/scoped-resource-key [:rf.scope/locale {:locale :en}]
+        (let [sk    (rf.resources.state/scoped-resource-key [:rf.scope/locale {:locale :en}]
                                                :p026f5/prefs {})
-              entry (merge (state/empty-entry :p026f5/prefs sk)
+              entry (merge (rf.resources.state/empty-entry :p026f5/prefs sk)
                            {:status :loaded :data {:theme "dark"}
                             :loaded-at 1000 :stale-at 9.0e15})]
           ;; swap (not replace) to preserve the frame's elision registry.
-          (frame/swap-runtime-db!
-            fid assoc state/resources-key {:entries     {(state/key-id sk) entry}
+          (rf.frame/swap-runtime-db!
+            fid assoc rf.resources.state/resources-key {:entries     {(rf.resources.state/key-id sk) entry}
                                            :tag-index   {} :owner-index {}})
           (let [opts    {:initial-events nil
                          :root-view  [(rf/view :p026f5/root2)]
                          :emit-hash? true
-                         :html-shell shell/default-html-shell
+                         :html-shell rf.ssr.ring.shell/default-html-shell
                          :payload    :rf.ssr.payload/whole-app-db}
-                resp    (#'pipeline/build-full-response* fid opts)
+                resp    (#'rf.ssr.ring.pipeline/build-full-response* fid opts)
                 payload (payload-edn (:body resp))
                 we      (val (first (get-in payload [:rf/runtime-db
                                                      :rf.runtime/resources
@@ -313,4 +313,4 @@
             (is (= sk (:resource/key we))
                 "rf2-p026f5: the wire key rides verbatim (no redaction)")))
         (finally
-          (lifecycle/destroy-frame-quietly! fid))))))
+          (rf.ssr.ring.lifecycle/destroy-frame-quietly! fid))))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/status_rewrite_always_on_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/status_rewrite_always_on_test.clj
@@ -55,11 +55,11 @@
   channel counted twice."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.ssr.ring.pipeline :as pipeline]
-            [re-frame.ssr.ring.test-support :as ts]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr.ring.pipeline :as rf.ssr.ring.pipeline]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 (def ^:private status-rewrite-category
   :rf.error/ssr-ring-response-status-invalid)
@@ -110,7 +110,7 @@
     (let [ring    (atom nil)
           records (collect-status-rewrite-records
                     (fn []
-                      (reset! ring (pipeline/ssr-response->ring-response
+                      (reset! ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                                      {:status "404" :headers [["content-type" "text/html"]]}
                                      "<p>x</p>"))))]
       (is (= 1 (count records))
@@ -126,7 +126,7 @@
             reaches an off-box shipper, so a slot someone adds later must red
             here rather than ship."
     (let [record (first (collect-status-rewrite-records
-                          (fn [] (pipeline/ssr-response->ring-response
+                          (fn [] (rf.ssr.ring.pipeline/ssr-response->ring-response
                                    {:status "404" :headers []} "x"))))]
       (is (some? record) "a record was fanned")
       (is (= expected-record-slots (set (keys record)))
@@ -154,7 +154,7 @@
             every value, so a rename cannot quietly reintroduce it."
     (let [secret "sekrit-session-token"
           record (first (collect-status-rewrite-records
-                          (fn [] (pipeline/ssr-response->ring-response
+                          (fn [] (rf.ssr.ring.pipeline/ssr-response->ring-response
                                    {:status secret :headers []} "x"))))]
       (is (some? record))
       (is (not (contains? record :status))
@@ -176,11 +176,11 @@
             record per request."
     (let [records (collect-status-rewrite-records
                     (fn []
-                      (pipeline/ssr-response->ring-response {:status 201 :headers []} "x")
-                      (pipeline/ssr-response->ring-response {:headers []} "x")
-                      (pipeline/ssr-response->ring-response
+                      (rf.ssr.ring.pipeline/ssr-response->ring-response {:status 201 :headers []} "x")
+                      (rf.ssr.ring.pipeline/ssr-response->ring-response {:headers []} "x")
+                      (rf.ssr.ring.pipeline/ssr-response->ring-response
                         {:redirect {:status 302 :location "/x"}} nil)
-                      (pipeline/ssr-response->ring-response
+                      (rf.ssr.ring.pipeline/ssr-response->ring-response
                         {:redirect {:location "/x"}} nil)))]
       (is (= [] records)
           "no record for a valid, absent or defaulted status"))))
@@ -201,7 +201,7 @@
     (let [ring    (atom nil)
           records (collect-status-rewrite-records
                     (fn []
-                      (reset! ring (pipeline/ssr-response->ring-response
+                      (reset! ring (rf.ssr.ring.pipeline/ssr-response->ring-response
                                      {:redirect {:status "302"}} nil))))]
       (is (= 1 (count records))
           "ONE rewrite fans ONE record, even on the redirect arm that reports
@@ -228,13 +228,13 @@
                                   (swap! warnings conj ev))))
                      (try
                        (collect-status-rewrite-records
-                         (fn [] (pipeline/ssr-response->ring-response
+                         (fn [] (rf.ssr.ring.pipeline/ssr-response->ring-response
                                   {:status "404" :headers []} "x")))
                        (finally
                          (rf/unregister-listener! :trace ::status-rewrite-trace-watch))))]
       (is (= 1 (count records))
           "axis 1 (always-on) carries the rewrite in EVERY build")
-      (if interop/debug-enabled?
+      (if rf.interop/debug-enabled?
         (do
           (is (= 1 (count @warnings))
               "axis 2 (dev trace) also carries it in a dev build")

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -80,15 +80,15 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.streaming :as streaming]
-            [re-frame.ssr.ring.test-support :as ts])
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.streaming :as rf.ssr.ring.streaming]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support])
   (:import [java.io InputStream IOException
                     PipedInputStream PipedOutputStream]
            [java.net.http HttpResponse$BodyHandlers]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ===========================================================================
 ;; Shared test scaffolding — handlers, view registrations, helpers
@@ -147,7 +147,7 @@
   rf2-fun38: returns the leaked-thread vec on timeout (does not throw) so
   the assertion can name the offenders."
   [timeout-ms]
-  (ts/await-no-streaming-threads! timeout-ms leak-poll-ms))
+  (rf.ssr.ring.test-support/await-no-streaming-threads! timeout-ms leak-poll-ms))
 
 ;; ===========================================================================
 ;; Test 1 — broken pipe on .write absorbed by the writer's catch arm
@@ -210,7 +210,7 @@
                     :shell-html    "<div></div>"
                     :continuations []}
           result   (try
-                     (@#'streaming/run-streaming-writer!
+                     (@#'rf.ssr.ring.streaming/run-streaming-writer!
                        pipe-out :no-such-frame rendered {:root-view [:div]})
                      ::returned-normally
                      (catch Throwable t
@@ -261,13 +261,13 @@
 (deftest client-disconnect-mid-stream-cleans-up
   (testing "abrupt client disconnect → writer terminates cleanly, no orphan daemon thread"
     (register-baseline-handlers!)
-    (let [handler (ssr-ring/stream-handler
+    (let [handler (rf.ssr.ring/stream-handler
                     {:initial-events [[:rf.test.server/init]]
                      :root-view [(rf/view :test/root)]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler]
-        (let [client   (ts/new-http-client)
-              req      (ts/http-get-request port "/" read-timeout-secs)
+      (rf.ssr.ring.test-support/with-jetty [port handler]
+        (let [client   (rf.ssr.ring.test-support/new-http-client)
+              req      (rf.ssr.ring.test-support/http-get-request port "/" read-timeout-secs)
               response (.send client req (HttpResponse$BodyHandlers/ofInputStream))
               ;; Read a small prefix so we know the writer thread has
               ;; flushed the shell chunk. We don't care WHAT we read,
@@ -340,13 +340,13 @@
     (let [throwing-root  (fn root-view-fn []
                            (throw (ex-info ":rf.test/intentional-root-view-throw"
                                            {:reason "shell-render fail-closed probe"})))
-          handler        (ssr-ring/stream-handler
+          handler        (rf.ssr.ring/stream-handler
                            {:initial-events [[:rf.test.server/init-min]]
                             :root-view throwing-root
                             :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler]
-        (let [client   (ts/new-http-client)
-              req      (ts/http-get-request port "/" read-timeout-secs)
+      (rf.ssr.ring.test-support/with-jetty [port handler]
+        (let [client   (rf.ssr.ring.test-support/new-http-client)
+              req      (rf.ssr.ring.test-support/http-get-request port "/" read-timeout-secs)
               response (.send client req (HttpResponse$BodyHandlers/ofString))
               status   (.statusCode response)
               body     (.body response)]
@@ -409,7 +409,7 @@
          [:rf/suspense-boundary
           {:id :test/parker :fallback [:p "loading"]}
           [(rf/view :test/parking-section)]]])
-      (let [handler  (ssr-ring/stream-handler
+      (let [handler  (rf.ssr.ring/stream-handler
                        {:initial-events [[:rf.test.server/init]]
                         :root-view [(rf/view :test/parking-root)]
                         :payload :rf.ssr.payload/whole-app-db})
@@ -418,7 +418,7 @@
         (try
           (is (.await latch 5 java.util.concurrent.TimeUnit/SECONDS)
               "the writer thread reached the parking-section continuation")
-          (reset! observed (ts/live-streaming-threads))
+          (reset! observed (rf.ssr.ring.test-support/live-streaming-threads))
           (finally
             (.countDown release)
             @drain))
@@ -426,7 +426,7 @@
             "at least one rf2-ssr-streaming-* daemon thread was alive
              while the writer was mid-render")
         (let [names (map (fn [^Thread t] (.getName t)) @observed)]
-          (is (every? #(.startsWith ^String % ts/daemon-thread-name-prefix) names)
+          (is (every? #(.startsWith ^String % rf.ssr.ring.test-support/daemon-thread-name-prefix) names)
               (str "every captured thread name starts with the
                    `rf2-ssr-streaming-` prefix — captured names: "
                    (vec names))))
@@ -515,7 +515,7 @@
       (into [:div]
             (for [i (range 4000)]
               ^{:key i} [:p (str "row-" i "-padding-padding-padding")])))
-    (let [handler   (ssr-ring/stream-handler
+    (let [handler   (rf.ssr.ring/stream-handler
                       {:initial-events [[:rf.test.server/init-bad-cookie]]
                        :root-view [(rf/view :test/big-root)]
                        :payload :rf.ssr.payload/whole-app-db})
@@ -589,7 +589,7 @@
     (rf/reg-event :rf.test.server/init-min
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
-    (let [handler (ssr-ring/stream-handler
+    (let [handler (rf.ssr.ring/stream-handler
                     {:initial-events [[:rf.test.server/init-min]]
                      :root-view [(rf/view :test/uses-throwing-sub)]
                      :ssr       {:public-error-id   :rf.ssr/default-error-projector
@@ -600,10 +600,10 @@
       ;; request) thread, which is where rf2-r06pc now runs the shell
       ;; render + the post-shell re-read — so the buffered 500 is observed
       ;; and committed before the response is returned to Jetty.
-      (with-redefs [interop/debug-enabled? false]
-        (ts/with-jetty [port handler]
-          (let [client (ts/new-http-client)
-                {:keys [status]} (ts/http-get client port "/" read-timeout-secs)]
+      (with-redefs [rf.interop/debug-enabled? false]
+        (rf.ssr.ring.test-support/with-jetty [port handler]
+          (let [client (rf.ssr.ring.test-support/new-http-client)
+                {:keys [status]} (rf.ssr.ring.test-support/http-get client port "/" read-timeout-secs)]
             (is (= 500 status)
                 "render-time sub-throw fail-closed 500 rides the full
                  Jetty round-trip — never a silent 200 (rf2-r06pc)")))))))
@@ -654,13 +654,13 @@
         {:id :wire/outer :fallback [:p "wire outer loading"]}
         [(rf/view :test/wire-outer)]]
        [:footer "End"]])
-    (let [handler (ssr-ring/stream-handler
+    (let [handler (rf.ssr.ring/stream-handler
                     {:initial-events [[:rf.test.server/init-nested]]
                      :root-view [(rf/view :test/wire-nested-root)]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler]
-        (let [client (ts/new-http-client)
-              {:keys [status body]} (ts/http-get client port "/" read-timeout-secs)
+      (rf.ssr.ring.test-support/with-jetty [port handler]
+        (let [client (rf.ssr.ring.test-support/new-http-client)
+              {:keys [status body]} (rf.ssr.ring.test-support/http-get client port "/" read-timeout-secs)
               idx-outer-resolved (str/index-of body "data-rf2-suspense-id=\":wire/outer\" data-rf2-suspense-resolved=\"1\"")
               idx-inner-resolved (str/index-of body "data-rf2-suspense-id=\":wire/inner\" data-rf2-suspense-resolved=\"1\"")
               idx-inner-body     (str/index-of body "WIRE_INNER_BODY")

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
@@ -43,18 +43,18 @@
   (:require [clojure.set]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.lifecycle :as lifecycle]
-            [re-frame.ssr.ring.pipeline :as pipeline]
-            [re-frame.ssr.ring.streaming :as streaming]
-            [re-frame.ssr.ring.test-support :as ts]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.lifecycle :as rf.ssr.ring.lifecycle]
+            [re-frame.ssr.ring.pipeline :as rf.ssr.ring.pipeline]
+            [re-frame.ssr.ring.streaming :as rf.ssr.ring.streaming]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]
             [re-frame.test-support :refer [with-trace-recorder!]])
   (:import [java.io InputStream OutputStream PipedInputStream PipedOutputStream]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ===========================================================================
 ;; The trace emit itself — the gap streaming_robustness_test left open.
@@ -78,7 +78,7 @@
       ;; pre-broken pipe → IOException → the catch arm runs and emits
       ;; the trace.
       (with-trace-recorder! [captured]
-        (@#'streaming/run-streaming-writer!
+        (@#'rf.ssr.ring.streaming/run-streaming-writer!
           pipe-out :no-such-frame
           {:head-html "" :html-attrs nil :body-attrs nil
            :shell-html "<div></div>" :continuations []}
@@ -135,12 +135,12 @@
       (fn [_ _] {:db {}}))
     (let [throwing-root (fn [] (throw (ex-info "shell-render teardown probe"
                                                {:reason :rf2-u91hb})))
-          handler  (ssr-ring/stream-handler
+          handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.writer/init]]
                       :root-view throwing-root
                       :payload :rf.ssr.payload/whole-app-db})
           ;; Frame ids BEFORE the request — baseline.
-          baseline-fids (disj (frame/frame-ids) :rf/default)
+          baseline-fids (disj (rf.frame/frame-ids) :rf/default)
           response (handler {:uri "/" :request-method :get})]
       ;; rf2-r06pc — the shell render threw on the request thread, so the
       ;; response is the projected non-200 error page (an ordinary String
@@ -152,7 +152,7 @@
       (is (not (instance? InputStream (:body response)))
           "no streamed InputStream body — the chunked response was never
            committed (the shell render failed before the head commit)")
-      (let [end-fids (disj (frame/frame-ids) :rf/default)
+      (let [end-fids (disj (rf.frame/frame-ids) :rf/default)
             leaked   (clojure.set/difference end-fids baseline-fids)]
         (is (empty? leaked)
             (str "the per-request frame MUST be destroyed even though
@@ -203,7 +203,7 @@
   "Register a real per-request server frame for `opts` and return its
   frame-id. The `:initial-events` event seeds the app-db the views read."
   [opts]
-  (let [{:keys [frame-id]} (pipeline/setup-request-frame! opts {:uri "/" :request-method :get})]
+  (let [{:keys [frame-id]} (rf.ssr.ring.pipeline/setup-request-frame! opts {:uri "/" :request-method :get})]
     frame-id))
 
 (defn- capture-writer-failure
@@ -212,7 +212,7 @@
   nil). `rendered` is a genuine `render-streaming-shell!` result."
   [frame-id rendered opts throw-at-write]
   (with-trace-recorder! [captured]
-    (@#'streaming/run-streaming-writer!
+    (@#'rf.ssr.ring.streaming/run-streaming-writer!
       (throw-on-nth-write-stream throw-at-write) frame-id rendered opts)
     (->> @captured
          (filterv #(= :rf.error/ssr-streaming-writer-failed (:operation %)))
@@ -236,9 +236,9 @@
           ;;   1 shell-prefix, 2 shell-html, 3 final-payload, 4 suffix.
           mk       (fn [throw-at]
                      (let [fid      (setup-streaming-frame! opts)
-                           rendered (#'streaming/render-streaming-shell! fid opts)
+                           rendered (#'rf.ssr.ring.streaming/render-streaming-shell! fid opts)
                            ev       (capture-writer-failure fid rendered opts throw-at)]
-                       (lifecycle/destroy-frame-quietly! fid)
+                       (rf.ssr.ring.lifecycle/destroy-frame-quietly! fid)
                        ev))
           prefix-ev (mk 1)
           final-ev  (mk 3)
@@ -287,14 +287,14 @@
                     :emit-hash? true
                     :payload :rf.ssr.payload/whole-app-db}
           fid      (setup-streaming-frame! opts)
-          rendered (#'streaming/render-streaming-shell! fid opts)]
+          rendered (#'rf.ssr.ring.streaming/render-streaming-shell! fid opts)]
       ;; With one boundary the write order is:
       ;;   1 shell-prefix, 2 shell-html, 3 continuation-template, ...
       ;; Throw on write 3 to hit the continuation-template phase.
       (is (seq (:continuations rendered))
           "the rendered shell registered the suspense continuation")
       (let [ev (capture-writer-failure fid rendered opts 3)]
-        (lifecycle/destroy-frame-quietly! fid)
+        (rf.ssr.ring.lifecycle/destroy-frame-quietly! fid)
         (is (= :continuation-template (-> ev :tags :phase))
             "throw on the boundary's template write → :phase :continuation-template")
         (is (= :rf.test.phase/the-boundary (-> ev :tags :boundary-id))
@@ -318,7 +318,7 @@
             trace, which is elided under debug-off). NON-PROJECTING: the
             chunked 200 is already on the wire, so there is no status to
             flip — pure off-box telemetry."
-    (error-emit/clear-error-listeners!)
+    (rf.error-emit/clear-error-listeners!)
     (let [pipe-in  (PipedInputStream. 1024)
           pipe-out (PipedOutputStream. pipe-in)
           _        (.close pipe-in) ;; pre-broken pipe — every write throws
@@ -326,13 +326,13 @@
       (rf/register-listener! :errors
         ::hhutya-writer-recorder
         (fn [record] (swap! seen conj record)))
-      (with-redefs [interop/debug-enabled? false]
-        (@#'streaming/run-streaming-writer!
+      (with-redefs [rf.interop/debug-enabled? false]
+        (@#'rf.ssr.ring.streaming/run-streaming-writer!
           pipe-out :no-such-frame
           {:head-html "" :html-attrs nil :body-attrs nil
            :shell-html "<div></div>" :continuations []}
           {:root-view [:div]}))
-      (error-emit/clear-error-listeners!)
+      (rf.error-emit/clear-error-listeners!)
       (let [hits (filterv #(= :rf.error/ssr-streaming-writer-failed (:error %))
                           @seen)]
         (is (= 1 (count hits))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/test_support.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/test_support.clj
@@ -26,11 +26,11 @@
   `:init-fn` seam (runs after adapter install, under the ambient
   `:rf/default` scope, before each test body)."
   (:require [ring.adapter.jetty :as jetty]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.error-listener :as error-listener]
-            [re-frame.ssr.request :as request]
-            [re-frame.ssr.response :as response]
-            [re-frame.test-support :as test-support])
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.error-listener :as rf.ssr.error-listener]
+            [re-frame.ssr.request :as rf.ssr.request]
+            [re-frame.ssr.response :as rf.ssr.response]
+            [re-frame.test-support :as rf.test-support])
   (:import [java.net URI]
            [java.net.http HttpClient HttpRequest HttpResponse$BodyHandlers]
            [java.time Duration]
@@ -72,9 +72,9 @@
      resolves through (`:routing/reg-route`, Spec 012) — resurrect. This
      restores them."
   []
-  (reset! request/request-slots {})
-  (reset! response/response-slots {})
-  (reset! error-listener/pending-error-traces {})
+  (reset! rf.ssr.request/request-slots {})
+  (reset! rf.ssr.response/response-slots {})
+  (reset! rf.ssr.error-listener/pending-error-traces {})
   (require 're-frame.routing  :reload)
   (require 're-frame.ssr      :reload)
   (require 're-frame.ssr.head :reload)
@@ -91,8 +91,8 @@
   test body under the same ambient `:rf/default` scope. Built once at
   ns-load so the registrar baseline is pinned to THIS suite's ns-load
   registrations for run-order independence."
-  (test-support/make-reset-runtime-fixture
-    {:adapter ssr/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.ssr/adapter
      :init-fn reset-ssr-runtime!}))
 
 (defn reset-runtime

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/test_support_contract_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/test_support_contract_test.clj
@@ -6,7 +6,7 @@
   returns (rather than throws) the leaked set on timeout."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.ssr.ring.test-support :as ts]))
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]))
 
 (deftest with-jetty-round-trips-a-ring-handler
   (testing "ts/with-jetty stands up an ephemeral-port Jetty,
@@ -17,9 +17,9 @@
                     {:status  201
                      :headers {"Content-Type" "text/plain"}
                      :body    "ts-smoke-ok"})]
-      (ts/with-jetty [port handler]
-        (let [client (ts/new-http-client)
-              {:keys [status body]} (ts/http-get client port "/" 5)]
+      (rf.ssr.ring.test-support/with-jetty [port handler]
+        (let [client (rf.ssr.ring.test-support/new-http-client)
+              {:keys [status body]} (rf.ssr.ring.test-support/http-get client port "/" 5)]
           (is (= 201 status) "wire status is the handler's status")
           (is (= "ts-smoke-ok" body) "wire body is the handler's body"))))))
 
@@ -30,9 +30,9 @@
                     {:status  200
                      :headers {"X-Ts-Smoke" "yep"}
                      :body    "h"})]
-      (ts/with-jetty [port handler]
-        (let [client (ts/new-http-client)
-              {:keys [status headers]} (ts/http-get client port "/" 5
+      (rf.ssr.ring.test-support/with-jetty [port handler]
+        (let [client (rf.ssr.ring.test-support/new-http-client)
+              {:keys [status headers]} (rf.ssr.ring.test-support/http-get client port "/" 5
                                                     :with-headers? true)]
           (is (= 200 status))
           (is (map? headers) "headers present as a map")
@@ -44,14 +44,14 @@
 (deftest leak-detector-reports-empty-when-no-writers
   (testing "with no streaming request in flight, the leak
             detector sees no rf2-ssr-streaming-* threads"
-    (is (= "rf2-ssr-streaming-" ts/daemon-thread-name-prefix)
+    (is (= "rf2-ssr-streaming-" rf.ssr.ring.test-support/daemon-thread-name-prefix)
         "the prefix matches the writer thread's naming contract")
-    (is (empty? (ts/live-streaming-threads))
+    (is (empty? (rf.ssr.ring.test-support/live-streaming-threads))
         "no streaming-writer daemon thread is alive in a quiescent JVM")))
 
 (deftest await-no-streaming-threads-returns-empty-fast-when-quiescent
   (testing "await-no-streaming-threads! returns [] immediately when nothing
             is leaked and does not throw"
-    (let [result (ts/await-no-streaming-threads! 1000 10)]
+    (let [result (rf.ssr.ring.test-support/await-no-streaming-threads! 1000 10)]
       (is (= [] result)
           "returns an empty vector (no leak) rather than throwing"))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/url_strategy_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/url_strategy_test.clj
@@ -32,11 +32,11 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.routing :as routing]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.test-support :as ts]))
+            [re-frame.routing :as rf.routing]
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 (defn- register-linked-app!
   "One route, one no-op server init event, one root view whose only
@@ -50,7 +50,7 @@
       [:div.page [rf/route-link {:to :route/active} "Active"]])))
 
 (defn- based-strategy []
-  (routing/with-base-path routing/history-url-strategy "/realworld"))
+  (rf.routing/with-base-path rf.routing/history-url-strategy "/realworld"))
 
 (defn- handler-opts [& {:as extra}]
   (merge {:initial-events [[:init/url-strategy]]
@@ -71,7 +71,7 @@
 (deftest ssr-handler-declared-url-strategy-reaches-the-request-frame
   (register-linked-app!)
   (let [strategy (based-strategy)
-        handler  (ssr-ring/ssr-handler (handler-opts :url-strategy strategy))
+        handler  (rf.ssr.ring/ssr-handler (handler-opts :url-strategy strategy))
         response (handler {:uri "/" :request-method :get})]
     (testing "the wire body carries the based href"
       (is (= 200 (:status response)))
@@ -94,7 +94,7 @@
 
 (deftest stream-handler-declared-url-strategy-reaches-the-request-frame
   (register-linked-app!)
-  (let [handler  (ssr-ring/stream-handler
+  (let [handler  (rf.ssr.ring/stream-handler
                    (handler-opts :url-strategy (based-strategy)))
         response (handler {:uri "/" :request-method :get})
         body     (with-open [in ^java.io.InputStream (:body response)]
@@ -107,7 +107,7 @@
 
 (deftest omitted-url-strategy-keeps-the-default-path-form
   (register-linked-app!)
-  (let [handler  (ssr-ring/ssr-handler (handler-opts))
+  (let [handler  (rf.ssr.ring/ssr-handler (handler-opts))
         response (handler {:uri "/" :request-method :get})]
     (is (= 200 (:status response)))
     (is (str/includes? (:body response) "href=\"/active\"")
@@ -142,7 +142,7 @@
   (let [bad       {:encode "not-callable"}
         client-ex (client-door-ex bad)
         captured  (atom nil)
-        handler   (ssr-ring/ssr-handler
+        handler   (rf.ssr.ring/ssr-handler
                     (handler-opts :url-strategy bad
                                   :on-error     (capturing-on-error captured)))
         response  (handler {:uri "/" :request-method :get})]
@@ -165,7 +165,7 @@
 (deftest explicit-nil-url-strategy-is-a-declaration-and-fails
   (register-linked-app!)
   (let [captured (atom nil)
-        handler  (ssr-ring/ssr-handler
+        handler  (rf.ssr.ring/ssr-handler
                    (handler-opts :url-strategy nil
                                  :on-error     (capturing-on-error captured)))
         response (handler {:uri "/" :request-method :get})]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
@@ -82,10 +82,10 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.schemas :as schemas]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.test-support :as ts])
+            [re-frame.fx :as rf.fx]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support])
   (:import [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicLong]))
 
@@ -95,7 +95,7 @@
 ;; `:rf.route/handle-url-change`, `:rf.route/navigate`, the
 ;; `:rf.server/request` cofx, and the always-on error-emit-projection-
 ;; listener are all live between tests.
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ===========================================================================
 ;; Jetty + java.net.http harness
@@ -114,7 +114,7 @@
   "Issue a real HTTP GET and return `{:status :body}` observed on the
   wire (this suite's 30s read-timeout pinned via the shared helper)."
   [client port path]
-  (ts/http-get client port path read-timeout-secs))
+  (rf.ssr.ring.test-support/http-get client port path read-timeout-secs))
 
 ;; ===========================================================================
 ;; Stub validator — interpret a `:params` schema as a Clojure predicate
@@ -124,7 +124,7 @@
 ;; ===========================================================================
 
 (defn- with-stub-validator []
-  (let [snap     (schemas/snapshot-schema-fns)
+  (let [snap     (rf.schemas/snapshot-schema-fns)
         ;; rf2-ps05ug: the stub is process-global, so while installed EVERY
         ;; schema-validating boundary uses it — including the routing
         ;; recordable allocation cofx, whose `:schema` is a real Malli VECTOR
@@ -143,8 +143,8 @@
         explain  (fn [schema value]
                    (when (fn? schema)
                      {:reason :stub-explainer :value value}))]
-    (schemas/set-schema-fns! {:validate validate :explain explain})
-    (fn [] (schemas/restore-schema-fns! snap))))
+    (rf.schemas/set-schema-fns! {:validate validate :explain explain})
+    (fn [] (rf.schemas/restore-schema-fns! snap))))
 
 ;; ===========================================================================
 ;; Test 1 — drain-time :rf.error/no-such-handler → projected 404 on the wire
@@ -187,7 +187,7 @@
     (rf/reg-view* :pages/not-found
       (fn [] [:div.not-found "Not found page renders"]))
 
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/route-to-missing]]
                      :root-view [(rf/view :pages/not-found)]
                      :ssr       {:public-error-id   :rf.ssr/default-error-projector
@@ -214,8 +214,8 @@
 
       (testing "bytes-on-the-wire through Jetty — a real HTTP server
                 preserves the projected 404 status"
-        (ts/with-jetty [port handler]
-          (let [client (ts/new-http-client)
+        (rf.ssr.ring.test-support/with-jetty [port handler]
+          (let [client (rf.ssr.ring.test-support/new-http-client)
                 {:keys [status body]} (http-get client port "/no-such-page")]
             (is (= 404 status)
                 "the projected 404 survives the full Jetty round-trip")
@@ -257,7 +257,7 @@
         ;; ns) — the stub must REPLACE that source-store slot, not sit beside
         ;; it as a cross-namespace duplicate that fails the request frame's
         ;; default-image assembly loud (rf2-h1vqa4; :rf.error/image-duplicate-id).
-        (fx/reg-fx :rf.nav/push-url
+        (rf.fx/reg-fx :rf.nav/push-url
                    {:platforms #{:server :client}}
                    (fn [_ _url] nil))
         (rf/reg-event :init/navigate-bad-param
@@ -270,7 +270,7 @@
         (rf/reg-view* :pages/article
           (fn [] [:div.article "Article page renders"]))
 
-        (let [handler (ssr-ring/ssr-handler
+        (let [handler (rf.ssr.ring/ssr-handler
                         {:initial-events [[:init/navigate-bad-param]]
                          :root-view [(rf/view :pages/article)]
                          :ssr       {:public-error-id   :rf.ssr/default-error-projector
@@ -289,8 +289,8 @@
                    a projected 5xx diverts to the projected-error arm")))
 
           (testing "bytes-on-the-wire through Jetty — 400 survives the round-trip"
-            (ts/with-jetty [port handler]
-              (let [client (ts/new-http-client)
+            (rf.ssr.ring.test-support/with-jetty [port handler]
+              (let [client (rf.ssr.ring.test-support/new-http-client)
                     {:keys [status body]} (http-get client port "/articles/zoo")]
                 (is (= 400 status)
                     "drain-time :schema-validation-failure → default
@@ -334,14 +334,14 @@
     (rf/reg-view* :pages/concurrent-root
       (fn [] [:main "concurrent root"]))
 
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/route-from-uri]]
                      :root-view [(rf/view :pages/concurrent-root)]
                      :ssr       {:public-error-id   :rf.ssr/default-error-projector
                                  :dev-error-detail? false}
                      :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler]
-        (let [client       (ts/new-http-client)
+      (rf.ssr.ring.test-support/with-jetty [port handler]
+        (let [client       (rf.ssr.ring.test-support/new-http-client)
               n-threads     8
               n-per-thread  10
               latch         (CountDownLatch. 1)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_view_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_view_test.clj
@@ -27,13 +27,13 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.interop :as interop]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.test-support :as ts])
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support])
   (:import [java.io ByteArrayOutputStream InputStream]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ---------------------------------------------------------------------------
 ;; helpers
@@ -113,7 +113,7 @@
     (reg-drain-boom-event!)
     (reg-counting-root!)
     (reset! error-view-calls 0)
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/set-safe] [:init/boom]]
                       :root-view  [(rf/view :pages/counting-root)]
                       :error-view (fn [{:keys [status message]}]
@@ -147,7 +147,7 @@
             ships no payload."
     (reg-drain-boom-event!)
     (reg-counting-root!)
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/boom]]
                       :root-view [(rf/view :pages/counting-root)]
                       :payload   :rf.ssr.payload/whole-app-db})
@@ -173,7 +173,7 @@
     (rf/reg-view* :pages/not-found
       (fn [] [:div.not-found "APP-NOT-FOUND-UI"]))
     (reset! error-view-calls 0)
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/route-to-missing]]
                       :root-view  [(rf/view :pages/not-found)]
                       :error-view (fn [_] (swap! error-view-calls inc)
@@ -199,7 +199,7 @@
                  :message "SERVICE-DEGRADED-MARKER" :retryable? true}))
       (reg-drain-boom-event!)
       (reg-counting-root!)
-      (let [handler  (ssr-ring/ssr-handler
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events [[:init/boom]]
                         :root-view [(rf/view :pages/counting-root)]
                         :ssr       {:public-error-id :myapp/degraded}
@@ -216,7 +216,7 @@
         {:platforms #{:server}}
         (fn [_ _] {:fx [[:rf.server/set-status 500]]}))
       (reg-counting-root!)
-      (let [handler  (ssr-ring/ssr-handler
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events [[:init/set-500]]
                         :root-view [(rf/view :pages/counting-root)]
                         :payload   :rf.ssr.payload/whole-app-db})
@@ -239,7 +239,7 @@
     (testing "keyword form"
       (rf/reg-view* :myapp/kw-error
         (fn [_public] [:div.kw-error @(rf/subscribe [:err/detail])]))
-      (let [handler  (ssr-ring/ssr-handler
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events [[:init/boom]]
                         :root-view  [:div "root"]
                         :error-view :myapp/kw-error
@@ -249,7 +249,7 @@
         (is (str/includes? (body->str (:body response)) "SUB-VALUE-UNDER-FRAME")
             "keyword error view resolved its sub under the request frame")))
     (testing "fn form"
-      (let [handler  (ssr-ring/ssr-handler
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events [[:init/boom]]
                         :root-view  [:div "root"]
                         :error-view (fn [_public]
@@ -275,15 +275,15 @@
       (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
       (rf/reg-view* :pages/render-throws-ev
         (fn [] (throw (ex-info "root-throw-detail" {}))))
-      (error-emit/clear-error-listeners!)
+      (rf.error-emit/clear-error-listeners!)
       (let [calls (atom 0)
             seen  (capture-always-on!)
             traces (atom [])]
         (rf/register-listener! :trace ::ev-throw
           (fn [ev] (when (= :rf.error/ssr-ring-error-view-failed (:operation ev))
                      (swap! traces conj ev))))
-        (with-redefs [interop/debug-enabled? debug?]
-          (let [handler  (ssr-ring/ssr-handler
+        (with-redefs [rf.interop/debug-enabled? debug?]
+          (let [handler  (rf.ssr.ring/ssr-handler
                            {:initial-events [[:init/ok]]
                             :root-view  [(rf/view :pages/render-throws-ev)]
                             :error-view (fn [_public]
@@ -305,7 +305,7 @@
                     (some #{:rf.error/ssr-ring-error-view-failed} @seen))
                 ":rf.error/ssr-ring-error-view-failed emitted for containment")))
         (rf/unregister-listener! :trace ::ev-throw)
-        (error-emit/clear-error-listeners!)))))
+        (rf.error-emit/clear-error-listeners!)))))
 
 (deftest error-view-recovered-nil-sub-falls-back-to-template
   (testing "OPEN PROOF (rf2-oytx7j): an error view whose reactive sub RECOVERS
@@ -331,8 +331,8 @@
     ;; render — that buffered trace is exactly what `pending-error-trace?`
     ;; detects. `capture-always-on!` adds a recorder ALONGSIDE it.
     (let [seen (capture-always-on!)]
-      (with-redefs [interop/debug-enabled? false]
-        (let [handler  (ssr-ring/ssr-handler
+      (with-redefs [rf.interop/debug-enabled? false]
+        (let [handler  (rf.ssr.ring/ssr-handler
                          {:initial-events [[:init/ok]]
                           :root-view  [(rf/view :pages/render-throws-rn)]
                           :error-view :myapp/sub-error-view
@@ -353,7 +353,7 @@
           (is (= 1 (count (filter #{:rf.error/ssr-ring-error-view-failed} @seen)))
               "exactly one :rf.error/ssr-ring-error-view-failed record (the
                fallback fired once, no re-projection loop)")))
-      (error-emit/clear-error-listeners!))))
+      (rf.error-emit/clear-error-listeners!))))
 
 (deftest redirect-beats-pending-projection
   (testing "a redirect set during the drain beats a pending projection — the
@@ -365,7 +365,7 @@
               [:dispatch [:init/boom]]]}))
     (reg-drain-boom-event!)
     (reg-counting-root!)
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/redirect-then-boom]]
                       :root-view  [(rf/view :pages/counting-root)]
                       :error-view (fn [_] [:div "SHOULD-NOT-APPEAR"])
@@ -391,8 +391,8 @@
          [:h1 "DEGRADED-ROOT-MARKER"]
          [:p (str "v: " @(rf/subscribe [:render/throwing]))]]))
     (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
-    (with-redefs [interop/debug-enabled? false]
-      (let [handler  (ssr-ring/ssr-handler
+    (with-redefs [rf.interop/debug-enabled? false]
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events [[:init/ok]]
                         :root-view  [(rf/view :pages/uses-throwing-render-sub)]
                         :ssr        {:public-error-id   :rf.ssr/default-error-projector
@@ -418,7 +418,7 @@
             NO writer thread and NO hydration payload."
     (reg-drain-boom-event!)
     (reg-counting-root!)
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:init/boom]]
                       :root-view  [(rf/view :pages/counting-root)]
                       :error-view (fn [{:keys [message]}]
@@ -449,8 +449,8 @@
          [:h1 "DEGRADED-SHELL-MARKER"]
          [:p (str "v: " @(rf/subscribe [:shell/throwing]))]]))
     (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
-    (with-redefs [interop/debug-enabled? false]
-      (let [handler  (ssr-ring/stream-handler
+    (with-redefs [rf.interop/debug-enabled? false]
+      (let [handler  (rf.ssr.ring/stream-handler
                        {:initial-events [[:init/ok]]
                         :root-view [(rf/view :pages/shell-uses-throwing-sub)]
                         :ssr       {:public-error-id   :rf.ssr/default-error-projector

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
@@ -83,13 +83,13 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.test-support :as ts]))
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]))
 
 ;; rf2-i3qc0 / rf2-09iktm — canonical reset-runtime fixture; same shape as
 ;; `ring_test.clj`. Each test starts from a reset registrar with the SSR
 ;; adapter installed so the per-test registrations don't bleed.
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; The NUL byte as a one-char string. Defined once here so the wire-
 ;; scan helper below reads as obvious set membership.
@@ -113,7 +113,7 @@
   (preserved verbatim so the CRLF scan reads every value), via the shared
   `ts/http-get` helper with a per-call client."
   [port path]
-  (ts/http-get (ts/new-http-client) port path read-timeout-secs
+  (rf.ssr.ring.test-support/http-get (rf.ssr.ring.test-support/new-http-client) port path read-timeout-secs
                :with-headers? true))
 
 (defn- any-header-contains-crlf?
@@ -164,11 +164,11 @@
     (rf/reg-view* :pages/bad-tag
                   (fn [] [(keyword "has space")]))
 
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/ok-bad-tag]]
                      :root-view [(rf/view :pages/bad-tag)]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler]
+      (rf.ssr.ring.test-support/with-jetty [port handler]
         (let [{:keys [status body headers]} (http-get port "/")]
           (is (= 500 status)
               "tag-name validator throw surfaces as 500 on the wire —
@@ -219,11 +219,11 @@
       (fn [_ _] {}))
     (rf/reg-view* :pages/render-throw
                   (fn [] [(keyword "render throw")]))
-    (let [handler-a (ssr-ring/ssr-handler
+    (let [handler-a (rf.ssr.ring/ssr-handler
                       {:initial-events [[:init/ok-render-throw]]
                        :root-view [(rf/view :pages/render-throw)]
                        :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler-a]
+      (rf.ssr.ring.test-support/with-jetty [port handler-a]
         (let [{status-a :status body-a :body} (http-get port "/")]
           (is (= 500 status-a))
           ;; Path B: drain-time throw via CRLF cookie value (separate
@@ -237,11 +237,11 @@
                       :value "abc\r\nbad"}]]}))
           (rf/reg-view* :pages/drain-throw
                         (fn [] [:div "drain-throw page renders"]))
-          (let [handler-b (ssr-ring/ssr-handler
+          (let [handler-b (rf.ssr.ring/ssr-handler
                             {:initial-events [[:init/drain-throw]]
                              :root-view [(rf/view :pages/drain-throw)]
                              :payload :rf.ssr.payload/whole-app-db})]
-            (ts/with-jetty [port-b handler-b]
+            (rf.ssr.ring.test-support/with-jetty [port-b handler-b]
               (let [{status-b :status body-b :body} (http-get port-b "/")]
                 (is (= 500 status-b))
                 (is (= status-a status-b)
@@ -304,11 +304,11 @@
     (rf/reg-view* :pages/bad-cookie-page
                   (fn [] [:div.page "rendered after projection"]))
 
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/bad-cookie]]
                      :root-view [(rf/view :pages/bad-cookie-page)]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler]
+      (rf.ssr.ring.test-support/with-jetty [port handler]
         (let [{:keys [status headers]} (http-get port "/")]
           (is (= 500 status)
               "validator's `:rf.error/cookie-invalid-attribute` trace flowed
@@ -350,11 +350,11 @@
     (rf/reg-view* :pages/bad-header-page
                   (fn [] [:div.page "rendered after projection"]))
 
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/bad-header]]
                      :root-view [(rf/view :pages/bad-header-page)]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler]
+      (rf.ssr.ring.test-support/with-jetty [port handler]
         (let [{:keys [status headers]} (http-get port "/")]
           (is (= 500 status)
               "validator's `:rf.error/header-invalid-value` trace flowed
@@ -402,7 +402,7 @@
                        [:h1 t]
                        [:p "Bytes-on-wire e2e proof."]])))
 
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/ok]]
                      ;; rf2-q1b96 — the RESOLVING root-view form. The
                      ;; data-rf-render-hash assertion below is what forces
@@ -410,7 +410,7 @@
                      ;; bytes but carries no hash on either channel.
                      :root-view (fn [] ((rf/view :pages/greeting)))
                      :payload :rf.ssr.payload/whole-app-db})]
-      (ts/with-jetty [port handler]
+      (rf.ssr.ring.test-support/with-jetty [port handler]
         (let [{:keys [status body headers]} (http-get port "/")]
           (is (= 200 status))
           (let [ct (or (first (get headers "content-type"))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
@@ -59,11 +59,11 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.test-support :as ts]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]))
 
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ===========================================================================
 ;; Jetty + java.net.http harness
@@ -79,7 +79,7 @@
   "Issue a real HTTP GET and return `{:status :body}` observed on the
   wire (30s read-timeout pinned via the shared helper)."
   [client port path]
-  (ts/http-get client port path read-timeout-secs))
+  (rf.ssr.ring.test-support/http-get client port path read-timeout-secs))
 
 ;; ===========================================================================
 ;; A root-view whose reactive sub THROWS during the render walk.
@@ -125,7 +125,7 @@
             frame-destroy)."
     (register-throwing-sub-view!)
     (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/ok]]
                      :root-view [(rf/view :pages/uses-throwing-sub)]
                      :ssr       {:public-error-id   :rf.ssr/default-error-projector
@@ -133,7 +133,7 @@
                      :payload :rf.ssr.payload/whole-app-db})]
       ;; Production hardening — the dev-only trace listener elides; the
       ;; always-on error-emit substrate is the status source of truth.
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         (testing "direct in-process handler call — render-time sub-throw
                   fails closed to 500 (the buffered fail-closed status,
                   re-flushed after the render walk per rf2-c0bq1), and
@@ -156,8 +156,8 @@
 
         (testing "bytes-on-the-wire through Jetty — the 500 survives the
                   full round-trip"
-          (ts/with-jetty [port handler]
-            (let [client (ts/new-http-client)
+          (rf.ssr.ring.test-support/with-jetty [port handler]
+            (let [client (rf.ssr.ring.test-support/new-http-client)
                   {:keys [status]} (http-get client port "/uses-throwing-sub")]
               (is (= 500 status)
                   "the render-time sub-throw fail-closed 500 rides the
@@ -181,13 +181,13 @@
         (let [v @(rf/subscribe [:clean-sub])]
           [:main [:h1 "clean"] [:p (str "value: " v)]])))
     (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/ok]]
                      :root-view [(rf/view :pages/uses-clean-sub)]
                      :ssr       {:public-error-id   :rf.ssr/default-error-projector
                                  :dev-error-detail? false}
                      :payload :rf.ssr.payload/whole-app-db})]
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         (let [response (handler {:uri "/uses-clean-sub" :request-method :get})]
           (is (= 200 (:status response))
               "clean render → empty error buffer → re-flush no-op → 200")

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -13,17 +13,17 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.lifecycle :as lifecycle]
-            [re-frame.ssr.ring.test-support :as ts])
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.lifecycle :as rf.ssr.ring.lifecycle]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support])
   (:import [java.io InputStream]))
 
 (defn- reset+reg-test-handlers
   [test-fn]
-  (ts/reset-runtime
+  (rf.ssr.ring.test-support/reset-runtime
     (fn []
       (rf/reg-event :rf.test/seed-articles
         (fn [_ [_ arts]] {:db {:articles arts}}))
@@ -66,7 +66,7 @@
 
 (deftest stream-handler-emits-shell-then-resolved-then-payload
   (testing "chunk order: shell prefix → shell-html → resolved templates → final __rf_payload → close"
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init]]
                       :root-view [(rf/view :test/root)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -116,7 +116,7 @@
             and payload all stream OUTSIDE `#app` (Spec 011 §998-1001). The
             `:test/root` shell has NO inner `<div>`, so the only `</div>` in
             the wire is the app-root close."
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init]]
                       :root-view [(rf/view :test/root)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -160,7 +160,7 @@
   (testing "rf2-z9dduj: `default-streaming-suffix` no longer carries the
             app-root `</div>` (it moved to the shell chunk). The suffix is now
             purely the bootstrap script + body-end + document close."
-    (let [suffix (ssr-ring/default-streaming-suffix {:script-src "/main.js"})]
+    (let [suffix (rf.ssr.ring/default-streaming-suffix {:script-src "/main.js"})]
       (is (not (str/includes? suffix "</div>"))
           "the suffix no longer closes the app root")
       (is (str/includes? suffix "</body></html>")
@@ -174,7 +174,7 @@
             shell-prefix + shell-html + `</div>` + payload + suffix."
     (rf/reg-view ^{:rf/id :test/static-only} static-only []
       [:main [:h1 "Static"]])
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init]]
                       :root-view [(rf/view :test/static-only)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -198,7 +198,7 @@
        [:rf/suspense-boundary {:id :a :fallback [:p "A loading"]} [:p "A done"]]
        [:rf/suspense-boundary {:id :b :fallback [:p "B loading"]} [:p "B done"]]
        [:rf/suspense-boundary {:id :c :fallback [:p "C loading"]} [:p "C done"]]])
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init]]
                       :root-view [(rf/view :test/multi-root)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -229,7 +229,7 @@
         {:id :test/throwy :fallback [:p "Still loading…"]}
         [(rf/view :test/throwing-section)]]
        [:footer "End"]])
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init]]
                       :root-view [(rf/view :test/fragile-root)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -265,7 +265,7 @@
         {:id :test/outer :fallback [:p.outer-fallback "outer loading"]}
         [(rf/view :test/outer-section)]]
        [:footer "End"]])
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init]]
                       :root-view [(rf/view :test/nested-root)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -328,7 +328,7 @@
   (testing "A tree with NO :rf/suspense-boundary still streams cleanly (degenerate case)"
     (rf/reg-view ^{:rf/id :test/static-root} static-root []
       [:main [:h1 "Just static"]])
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init]]
                       :root-view [(rf/view :test/static-root)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -378,7 +378,7 @@
         {:id :test/unchanged :fallback [:p "unchanged loading"]}
         [(rf/view :test/reading-section)]]
        [:footer "End"]])
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init]]
                       :root-view [(rf/view :test/delta-root)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -430,11 +430,11 @@
         {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
     (rf/reg-view ^{:rf/id :test/should-not-stream} should-not-stream []
       [:div "should not render under redirect"])
-    (let [handler       (ssr-ring/stream-handler
+    (let [handler       (rf.ssr.ring/stream-handler
                           {:initial-events [[:rf.test.stream/redirect]]
                            :root-view [(rf/view :test/should-not-stream)]
                            :payload :rf.ssr.payload/whole-app-db})
-          baseline-fids (disj (frame/frame-ids) :rf/default)
+          baseline-fids (disj (rf.frame/frame-ids) :rf/default)
           response      (handler {:uri "/secret" :request-method :get})]
       ;; Redirect response shape — status + Location, empty body, no
       ;; chunked InputStream (a redirect has no streamed body).
@@ -448,13 +448,13 @@
           "redirect body is NOT a streamed pipe — it short-circuits")
       ;; Teardown — the per-request frame + its request slot MUST be
       ;; gone immediately after the call (no writer thread to wait on).
-      (let [end-fids (disj (frame/frame-ids) :rf/default)
+      (let [end-fids (disj (rf.frame/frame-ids) :rf/default)
             leaked   (clojure.set/difference end-fids baseline-fids)]
         (is (empty? leaked)
             (str "the per-request frame MUST be destroyed on the streaming
                  redirect path — found leaked frame-ids: " (vec leaked))))
-      (doseq [fid (disj (frame/frame-ids) :rf/default)]
-        (is (nil? (ssr/get-request fid))
+      (doseq [fid (disj (rf.frame/frame-ids) :rf/default)]
+        (is (nil? (rf.ssr/get-request fid))
             (str "no request slot leaks for frame " fid))))))
 
 ;; ===========================================================================
@@ -479,27 +479,27 @@
       [:div "should not render under redirect"])
     (let [real-destroy    rf/destroy-frame!
           teardown-target (atom ::none)
-          handler         (ssr-ring/stream-handler
+          handler         (rf.ssr.ring/stream-handler
                             {:initial-events [[:rf.test.stream/redirect2]]
                              :root-view [(rf/view :test/should-not-stream2)]
                              :payload :rf.ssr.payload/whole-app-db})
-          baseline-fids   (disj (frame/frame-ids) :rf/default)]
+          baseline-fids   (disj (rf.frame/frame-ids) :rf/default)]
       (with-redefs [rf/destroy-frame!
                     (fn [target & more]
                       (when (and (= ::none @teardown-target)
-                                 (frame/frame-value? target))
+                                 (rf.frame/frame-value? target))
                         (reset! teardown-target target))
                       (apply real-destroy target more))]
         (let [response (handler {:uri "/secret" :request-method :get})]
           (is (= 302 (:status response)) "redirect short-circuit on the wire")))
       ;; N released: no per-request frame leaks after the inline teardown.
-      (is (empty? (clojure.set/difference (disj (frame/frame-ids) :rf/default)
+      (is (empty? (clojure.set/difference (disj (rf.frame/frame-ids) :rf/default)
                                           baseline-fids))
           "the per-request incarnation is fully released on the streaming redirect path")
       ;; N+1 protected: the terminal teardown targeted the incarnation VALUE.
-      (is (frame/frame-value? @teardown-target)
+      (is (rf.frame/frame-value? @teardown-target)
           "streaming terminal teardown targeted the make-frame VALUE, not the bare id")
-      (is (some? (frame/frame-value-incarnation-token @teardown-target))
+      (is (some? (rf.frame/frame-value-incarnation-token @teardown-target))
           "the teardown target carries the exact incarnation token — so a same-id
            successor (N+1) is left intact by the two-argument destroy"))))
 
@@ -515,7 +515,7 @@
         {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
     (rf/reg-view ^{:rf/id :test/redirect-ct-root} redirect-ct-root []
       [:div "noop"])
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.stream/redirect-ct]]
                       :root-view [(rf/view :test/redirect-ct-root)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -529,7 +529,7 @@
       ;; `:content-type` default on top — it passes the 2-arg form. Pin
       ;; the agreement: whatever Content-Type rides is the accumulator's,
       ;; identical to the non-streaming redirect of the same response.
-      (let [ns-handler (ssr-ring/ssr-handler
+      (let [ns-handler (rf.ssr.ring/ssr-handler
                          {:initial-events [[:rf.test.stream/redirect-ct]]
                           :root-view [(rf/view :test/redirect-ct-root)]
                           :payload :rf.ssr.payload/whole-app-db})
@@ -581,7 +581,7 @@
     (let [throwing-root (fn root-view-fn []
                           (throw (ex-info ":rf.test/root-view-throw"
                                           {:reason "shell-render fail-closed probe"})))
-          handler       (ssr-ring/stream-handler
+          handler       (rf.ssr.ring/stream-handler
                           {:initial-events [[:rf.test.server/init-min]]
                            :root-view throwing-root
                            :payload :rf.ssr.payload/whole-app-db})
@@ -614,7 +614,7 @@
        [:h1 "Header"]
        [(rf/view :test/shell-throwing-section)]
        [:footer "End"]])
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init-min]]
                       :root-view [(rf/view :test/shell-throwing-root)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -647,7 +647,7 @@
     (rf/reg-event :rf.test.server/init-min
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
-    (let [handler (ssr-ring/stream-handler
+    (let [handler (rf.ssr.ring/stream-handler
                     {:initial-events [[:rf.test.server/init-min]]
                      :root-view [(rf/view :test/uses-throwing-sub)]
                      :ssr       {:public-error-id   :rf.ssr/default-error-projector
@@ -655,7 +655,7 @@
                      :payload :rf.ssr.payload/whole-app-db})]
       ;; Production hardening — the dev-only trace listener elides; the
       ;; always-on error-emit substrate is the status source of truth.
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         (let [response (handler {:uri "/" :request-method :get})]
           (is (= 500 (:status response))
               "render-time sub-throw under production hardening →
@@ -686,13 +686,13 @@
     (rf/reg-event :rf.test.server/init-min
       {:platforms #{:server}}
       (fn [_ _] {:db {}}))
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init-min]]
                       :root-view [(rf/view :test/uses-clean-sub)]
                       :ssr       {:public-error-id   :rf.ssr/default-error-projector
                                   :dev-error-detail? false}
                       :payload :rf.ssr.payload/whole-app-db})]
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         (let [response (handler {:uri "/" :request-method :get})
               body     (streamed-body (:body response))]
           (is (= 200 (:status response))
@@ -741,7 +741,7 @@
       (fn [_ _] {:db {}}))
     (rf/reg-view ^{:rf/id :test/plain-root} plain-root []
       [:main [:h1 "rendered shell"]])
-    (let [real-flush ssr/flush-response-result!
+    (let [real-flush rf.ssr/flush-response-result!
           ;; Per-frame call counter so we stub ONLY the second
           ;; flush-response-result! (the post-shell re-read) for our frame,
           ;; leaving the first (early-branch drain read) untouched. Keying on
@@ -752,7 +752,7 @@
                          :headers  []
                          :cookies  []
                          :redirect {:status 302 :location "/post-shell-login"}}]
-      (with-redefs [ssr/flush-response-result!
+      (with-redefs [rf.ssr/flush-response-result!
                     (fn [fid]
                       (let [n (swap! calls inc)]
                         ;; 1st call = early-branch drain read → real value
@@ -763,11 +763,11 @@
                         (if (= n 2)
                           {:response redirect-resp :public-error nil}
                           (real-flush fid))))]
-        (let [handler       (ssr-ring/stream-handler
+        (let [handler       (rf.ssr.ring/stream-handler
                               {:initial-events [[:rf.test.server/init-min]]
                                :root-view [(rf/view :test/plain-root)]
                                :payload :rf.ssr.payload/whole-app-db})
-              baseline-fids (disj (frame/frame-ids) :rf/default)
+              baseline-fids (disj (rf.frame/frame-ids) :rf/default)
               response      (handler {:uri "/secret" :request-method :get})]
           (is (= 302 (:status response))
               "post-shell redirect ships the 3xx status on the wire")
@@ -784,7 +784,7 @@
           ;; No writer thread spawned + frame torn down inline (the writer's
           ;; finally — the streaming teardown path — never runs on this
           ;; branch, so the inline destroy is load-bearing).
-          (let [end-fids (disj (frame/frame-ids) :rf/default)
+          (let [end-fids (disj (rf.frame/frame-ids) :rf/default)
                 leaked   (clojure.set/difference end-fids baseline-fids)]
             (is (empty? leaked)
                 (str "the per-request frame MUST be destroyed inline on the
@@ -843,12 +843,12 @@
                 ;; `hiccup` = (resolve-root-view root-view). When the host
                 ;; passes an EXPANDED form (symmetric with the client's
                 ;; :render-tree-fn), this is the marker-bearing root tree.
-                server-hiccup (lifecycle/resolve-root-view
+                server-hiccup (rf.ssr.ring.lifecycle/resolve-root-view
                                 (fn [] ((rf/view :test/hash-root))))
-                server-hash   (ssr/render-tree-hash server-hiccup)
+                server-hash   (rf.ssr/render-tree-hash server-hiccup)
                 ;; The client verifies via :render-tree-fn #((rf/view :root)).
                 client-hiccup ((rf/view :test/hash-root))
-                client-hash   (ssr/render-tree-hash client-hiccup)]
+                client-hash   (rf.ssr/render-tree-hash client-hiccup)]
             ;; The marker IS present in both trees (the equality is NOT
             ;; achieved by stripping it).
             (is (str/includes? (pr-str server-hiccup) ":rf/suspense-boundary")
@@ -914,7 +914,7 @@
                       (when (= :rf.error/ssr-head-resolution-failed
                                (:operation ev))
                         (swap! traces conj ev))))
-          handler (ssr-ring/stream-handler
+          handler (rf.ssr.ring/stream-handler
                     {:initial-events [[:rf.test.stream/seed-throwing-head-route]]
                      :root-view [(rf/view :test/stream-head-body)]
                      :payload   :rf.ssr.payload/whole-app-db})
@@ -990,7 +990,7 @@
          ;; verbatim header casing.
          :fx [[:rf.server/set-header {:name "Content-Length" :value "7"}]
               [:rf.server/append-header {:name "content-length" :value "13"}]]}))
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init-with-content-length]]
                       :root-view [(rf/view :test/root)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -1026,7 +1026,7 @@
       (fn [_ _]
         {:db {:articles [] :comments []}
          :fx [[:rf.server/set-header {:name "Content-Length" :value "999"}]]}))
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init-cl-and-ct]]
                       :root-view [(rf/view :test/root)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -1052,7 +1052,7 @@
   (testing "rf2-nncni3: a custom :content-type opt force-replaces the
             default-seeded text/html on the STREAMED response head — no
             duplicate content-type key, and the body still streams in full"
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init]]
                       :root-view      [(rf/view :test/root)]
                       :content-type   "application/xhtml+xml; charset=utf-8"
@@ -1093,7 +1093,7 @@
     (let [custom-shell (fn [body-html payload-edn _opts]
                          (str "<custom>" body-html payload-edn "</custom>"))
           ex (is (thrown? clojure.lang.ExceptionInfo
-                   (ssr-ring/stream-handler
+                   (rf.ssr.ring/stream-handler
                      {:initial-events  [[:rf.test.server/init]]
                       :root-view  [(rf/view :test/root)]
                       :payload    :rf.ssr.payload/whole-app-db
@@ -1116,7 +1116,7 @@
             string / map / vector fails closed the same way a fn does"
     (doseq [bad ["<html>…</html>" {:shape :map} [:vector]]]
       (let [ex (is (thrown? clojure.lang.ExceptionInfo
-                     (ssr-ring/stream-handler
+                     (rf.ssr.ring/stream-handler
                        {:initial-events  [[:rf.test.server/init]]
                         :root-view  [(rf/view :test/root)]
                         :payload    :rf.ssr.payload/whole-app-db
@@ -1131,7 +1131,7 @@
             cleanly and streams normally — the rejection gates only a
             non-nil override, never the no-override common path"
     ;; Absent — the default streaming construction path.
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events [[:rf.test.server/init]]
                       :root-view [(rf/view :test/root)]
                       :payload   :rf.ssr.payload/whole-app-db})
@@ -1143,7 +1143,7 @@
       (is (str/includes? body "<h1>News</h1>")
           "the default split envelope streams the rendered shell"))
     ;; Explicit nil — "no override requested" passes the gate.
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events  [[:rf.test.server/init]]
                       :root-view  [(rf/view :test/root)]
                       :payload    :rf.ssr.payload/whole-app-db
@@ -1214,7 +1214,7 @@
             explicit :head STRING carries no reconstructible model, so
             :rf/head-hash / data-rf-head-hash is OMITTED entirely."
     (let [mk      (fn [head]
-                    (ssr-ring/stream-handler
+                    (rf.ssr.ring/stream-handler
                       {:initial-events [[:rf.test.server/init]]
                        ;; rf2-q1b96 — resolving form; the body-only-hash
                        ;; assertions below need a hash to exist.
@@ -1256,7 +1256,7 @@
       (fn [{rt :rf.db/runtime} _]
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :test.stream/route-b})}))
     (let [mk      (fn [init]
-                    (ssr-ring/stream-handler
+                    (rf.ssr.ring/stream-handler
                       {:initial-events [[:rf.test.server/init] [init]]
                        ;; rf2-q1b96 — resolving form: `(= ha hb)` below would
                        ;; hold vacuously (nil = nil) on an unresolved root.
@@ -1293,7 +1293,7 @@
             :rf/head-hash (the separate channel — a default head is always
             reconstructible via active-head, so the channel is present even
             with no explicit :head/:reg-head)."
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events  [[:rf.test.server/init]]
                       ;; rf2-q1b96 — resolving form; an unresolved root
                       ;; carries no hash on either channel.
@@ -1326,7 +1326,7 @@
             NO data-rf-render-hash / data-rf-head-hash on the streamed
             shell. Toggling the opt now has an observable effect on the
             wire (it was a no-op for the HTML path before)."
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      {:initial-events  [[:rf.test.server/init]]
                       ;; rf2-q1b96 — resolving form, so this test still
                       ;; isolates the `:emit-hash?` toggle: the payload keys
@@ -1418,7 +1418,7 @@
        [:rf/suspense-boundary
         {:id :test/bump :fallback [:p "loading"]}
         [(rf/view :test/counter-mutator)]]])
-    (let [handler  (ssr-ring/stream-handler
+    (let [handler  (rf.ssr.ring/stream-handler
                      ;; EXPANDED :root-view form (symmetric with the client's
                      ;; :render-tree-fn) so the streamed hash is over the
                      ;; rendered counter-bearing tree, not an unexpanded
@@ -1453,7 +1453,7 @@
             ;; whole-db replace event).
             (rf/dispatch-sync [:rf.test/hydrate-db db-slice])
             (let [client-hiccup ((rf/view :test/counter-root))
-                  client-hash   (lifecycle/render-document-hash client-hiccup)]
+                  client-hash   (rf.ssr.ring.lifecycle/render-document-hash client-hiccup)]
               ;; THE PIN — the load-bearing assertion. Pre-fix the server hash
               ;; describes counter=0 (pre-drain) while the client renders
               ;; counter=1 (post-drain), so these DIFFER → spurious mismatch.
@@ -1499,7 +1499,7 @@
         (fn [_ _] {}))
       (rf/reg-view* :pages/stream-once
         (fn [] [:div.page "once"]))
-      (let [handler  (ssr-ring/stream-handler
+      (let [handler  (rf.ssr.ring/stream-handler
                        {:initial-events [[:rf.test/init-once]]
                         :root-view (fn []
                                      (swap! call-count inc)
@@ -1526,7 +1526,7 @@
     (rf/reg-view* :pages/stream-noni
       (fn [n] [:div {:data-call n} "noni"]))
     (let [counter   (atom 0)
-          handler   (ssr-ring/stream-handler
+          handler   (rf.ssr.ring/stream-handler
                       {:initial-events [[:rf.test/init-noni]]
                        ;; rf2-q1b96 — outer call: RESOLVES the view instead of
                        ;; handing back a reference, so a hash exists at all.

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -13,22 +13,22 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.lifecycle :as lifecycle]
-            [re-frame.ssr.ring.pipeline :as pipeline]
-            [re-frame.ssr.ring.shell :as shell]
-            [re-frame.ssr.ring.test-support :as ts]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.lifecycle :as rf.ssr.ring.lifecycle]
+            [re-frame.ssr.ring.pipeline :as rf.ssr.ring.pipeline]
+            [re-frame.ssr.ring.shell :as rf.ssr.ring.shell]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]))
 
 ;; rf2-i3qc0 / rf2-09iktm — the canonical reset-runtime fixture is
 ;; artefact-local in `re-frame.ssr.ring.test-support`. It wraps the
 ;; published `re-frame.test-support/make-reset-runtime-fixture` and layers
 ;; the four SSR per-request side-channel atom resets, so no external
 ;; `../ssr/test` path is required.
-(use-fixtures :each ts/reset-runtime)
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
 
 ;; ===========================================================================
 ;; Cookie serialisation (RFC 6265)
@@ -37,16 +37,16 @@
 (deftest cookie-set-cookie-header-canonical
   (testing "minimal cookie: name + value only"
     (is (= "session=abc123"
-           (ssr-ring/cookie->set-cookie-header
+           (rf.ssr.ring/cookie->set-cookie-header
              {:name "session" :value "abc123"}))))
 
   (testing "value gets URL-encoded"
     (is (= "session=a%20b%26c"
-           (ssr-ring/cookie->set-cookie-header
+           (rf.ssr.ring/cookie->set-cookie-header
              {:name "session" :value "a b&c"}))))
 
   (testing "full attribute set in canonical order"
-    (let [s (ssr-ring/cookie->set-cookie-header
+    (let [s (rf.ssr.ring/cookie->set-cookie-header
               {:name      "session"
                :value     "abc"
                :max-age   3600
@@ -64,16 +64,16 @@
       (is (str/includes? s "SameSite=Lax"))))
 
   (testing "same-site tokens map to canonical strings"
-    (is (str/includes? (ssr-ring/cookie->set-cookie-header
+    (is (str/includes? (rf.ssr.ring/cookie->set-cookie-header
                          {:name "s" :value "" :same-site :strict})
                        "SameSite=Strict"))
-    (is (str/includes? (ssr-ring/cookie->set-cookie-header
+    (is (str/includes? (rf.ssr.ring/cookie->set-cookie-header
                          {:name "s" :value "" :same-site :none})
                        "SameSite=None")))
 
   (testing "missing :name raises a structured error"
     (is (thrown? clojure.lang.ExceptionInfo
-                 (ssr-ring/cookie->set-cookie-header {:value "abc"})))))
+                 (rf.ssr.ring/cookie->set-cookie-header {:value "abc"})))))
 
 ;; ===========================================================================
 ;; rf2-rpedl — CRLF injection in Set-Cookie attributes + cookie-name grammar
@@ -96,7 +96,7 @@
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
             #":rf\.error/cookie-invalid-attribute"
-            (ssr-ring/cookie->set-cookie-header
+            (rf.ssr.ring/cookie->set-cookie-header
               {:name "session" :value "abc" :domain hostile}))
           (str "hostile :domain " (pr-str hostile) " must be rejected"))))
 
@@ -104,26 +104,26 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/cookie-invalid-attribute"
-          (ssr-ring/cookie->set-cookie-header
+          (rf.ssr.ring/cookie->set-cookie-header
             {:name "session" :value "abc" :path "/\r\nSet-Cookie: x=1"}))))
 
   (testing "rf2-rpedl §P1.2 — CR / LF / NUL in :max-age (string-shaped) throws"
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/cookie-invalid-attribute"
-          (ssr-ring/cookie->set-cookie-header
+          (rf.ssr.ring/cookie->set-cookie-header
             {:name "session" :value "abc" :max-age "3600\r\nbad"}))))
 
   (testing "rf2-rpedl §P1.2 — CR / LF / NUL in :same-site (string-shaped) throws"
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/cookie-invalid-attribute"
-          (ssr-ring/cookie->set-cookie-header
+          (rf.ssr.ring/cookie->set-cookie-header
             {:name "session" :value "abc" :same-site "Lax\r\nbad"}))))
 
   (testing "rf2-rpedl §P1.2 — clean attributes still serialise (regression
             guard: validation doesn't reject valid input)"
-    (let [s (ssr-ring/cookie->set-cookie-header
+    (let [s (rf.ssr.ring/cookie->set-cookie-header
               {:name      "session"
                :value     "abc"
                :domain    "example.com"
@@ -147,34 +147,34 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/cookie-invalid-attribute"
-          (ssr-ring/cookie->set-cookie-header
+          (rf.ssr.ring/cookie->set-cookie-header
             {:name "sid" :value "abc" :path "/; SameSite=None; Secure"}))))
 
   (testing "rf2-j538f7.16 — a `;` in string :max-age forges attributes (repro 2)"
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/cookie-invalid-attribute"
-          (ssr-ring/cookie->set-cookie-header
+          (rf.ssr.ring/cookie->set-cookie-header
             {:name "sid" :value "abc" :max-age "3600; SameSite=None; Secure"}))))
 
   (testing "rf2-j538f7.16 — a `;` in :domain is rejected"
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/cookie-invalid-attribute"
-          (ssr-ring/cookie->set-cookie-header
+          (rf.ssr.ring/cookie->set-cookie-header
             {:name "sid" :value "abc" :domain "evil.com; Secure"}))))
 
   (testing "rf2-j538f7.16 — a `;` in string :same-site is rejected"
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/cookie-invalid-attribute"
-          (ssr-ring/cookie->set-cookie-header
+          (rf.ssr.ring/cookie->set-cookie-header
             {:name "sid" :value "abc" :same-site "Lax; Secure"}))))
 
   (testing "rf2-j538f7.16 — the offending attribute + original value ride the
             structured error payload"
     (try
-      (ssr-ring/cookie->set-cookie-header
+      (rf.ssr.ring/cookie->set-cookie-header
         {:name "sid" :value "abc" :path "/; SameSite=None"})
       (is false "expected a thrown :rf.error/cookie-invalid-attribute")
       (catch clojure.lang.ExceptionInfo e
@@ -188,7 +188,7 @@
 
   (testing "rf2-j538f7.16 — a `;` in cookie :value is DATA, not a delimiter:
             it is percent-encoded (`%3B`), so it must NOT be over-rejected"
-    (let [s (ssr-ring/cookie->set-cookie-header
+    (let [s (rf.ssr.ring/cookie->set-cookie-header
               {:name "sid" :value "a;b" :path "/"})]
       (is (str/includes? s "sid=a%3Bb")
           "semicolon in :value serialises as %3B (data stays data)")
@@ -198,7 +198,7 @@
 
   (testing "rf2-j538f7.16 — clean attributes (canonical `/` path, plain
             domain, integer max-age) still serialise unchanged"
-    (let [s (ssr-ring/cookie->set-cookie-header
+    (let [s (rf.ssr.ring/cookie->set-cookie-header
               {:name    "sid"  :value "abc"
                :path    "/app" :domain "example.com"
                :max-age 3600   :same-site :none})]
@@ -223,7 +223,7 @@
                 :path  "/; SameSite=None; Secure"}]]}))
     (rf/reg-view* :pages/hostile-cookie
       (fn [] [:div "hostile"]))
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/hostile-cookie]]
                       :root-view [(rf/view :pages/hostile-cookie)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -249,7 +249,7 @@
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
             #":rf\.error/cookie-invalid-name"
-            (ssr-ring/cookie->set-cookie-header
+            (rf.ssr.ring/cookie->set-cookie-header
               {:name "session id" :value "abc"}))))
 
     (testing "name with separator chars throws"
@@ -258,7 +258,7 @@
         (is (thrown-with-msg?
               clojure.lang.ExceptionInfo
               #":rf\.error/cookie-invalid-name"
-              (ssr-ring/cookie->set-cookie-header
+              (rf.ssr.ring/cookie->set-cookie-header
                 {:name bad :value "abc"}))
             (str "separator-bearing name " (pr-str bad) " must be rejected"))))
 
@@ -267,21 +267,21 @@
         (is (thrown-with-msg?
               clojure.lang.ExceptionInfo
               #":rf\.error/cookie-invalid-name"
-              (ssr-ring/cookie->set-cookie-header
+              (rf.ssr.ring/cookie->set-cookie-header
                 {:name bad :value "abc"}))
             (str "control-char name " (pr-str bad) " must be rejected"))))
 
     (testing "valid token-grammar names pass through"
       (doseq [ok ["session" "_csrf" "X-CSRF-TOKEN" "data-1.2.3" "a"]]
         (is (str/starts-with?
-              (ssr-ring/cookie->set-cookie-header {:name ok :value "v"})
+              (rf.ssr.ring/cookie->set-cookie-header {:name ok :value "v"})
               (str ok "="))
             (str "valid name " (pr-str ok) " should serialise"))))
 
     (testing "keyword / symbol names are coerced via clojure.core/name"
       (doseq [named [:session 'session :data-1.2.3]]
         (is (str/starts-with?
-              (ssr-ring/cookie->set-cookie-header {:name named :value "v"})
+              (rf.ssr.ring/cookie->set-cookie-header {:name named :value "v"})
               (str (clojure.core/name named) "="))
             (str "Named cookie name " (pr-str named) " should serialise"))))
 
@@ -295,7 +295,7 @@
         ;; structured ex-info — a narrow `catch ExceptionInfo` would let the
         ;; bug's raw exception escape the test and obscure the failure.
         (let [t (try
-                  (ssr-ring/cookie->set-cookie-header {:name bad :value "v"})
+                  (rf.ssr.ring/cookie->set-cookie-header {:name bad :value "v"})
                   ::no-throw
                   (catch clojure.lang.ExceptionInfo e e)
                   (catch Throwable e e))]
@@ -354,7 +354,7 @@
     (register-articles-app! [{:id "a" :title "Article A"}
                              {:id "b" :title "Article B"}])
 
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     ;; rf2-q1b96 — the RESOLVING root-view form. The hash
                     ;; assertion below is what forces it: an unresolved
                     ;; `[(rf/view :pages/articles)]` renders byte-identical
@@ -397,7 +397,7 @@
               (fn [ev]
                 (when (= :rf.frame/destroyed (:operation ev))
                   (swap! destroyed conj (:frame ev)))))
-          handler (ssr-ring/ssr-handler
+          handler (rf.ssr.ring/ssr-handler
                     {:initial-events    [[:rf/server-init]]
                      :root-view    [(rf/view :pages/articles)]
                      :fx-overrides {:http/get :http/get.canned}
@@ -425,7 +425,7 @@
     (register-articles-app! [{:id "x" :title "Article X"}])
     (let [real-destroy    rf/destroy-frame!
           teardown-target (atom ::none)
-          handler (ssr-ring/ssr-handler
+          handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:rf/server-init]]
                      :root-view      [(rf/view :pages/articles)]
                      :fx-overrides   {:http/get :http/get.canned}
@@ -437,7 +437,7 @@
       (with-redefs [rf/destroy-frame!
                     (fn [target & more]
                       (when (and (= ::none @teardown-target)
-                                 (frame/frame-value? target))
+                                 (rf.frame/frame-value? target))
                         (reset! teardown-target target))
                       (apply real-destroy target more))]
         (let [response (handler {:uri "/" :request-method :get})]
@@ -446,9 +446,9 @@
       (is (= frames-before (set (rf/frame-ids)))
           "the per-request incarnation is fully released — no frame leak")
       ;; N+1 protected: teardown targets the incarnation-carrying VALUE.
-      (is (frame/frame-value? @teardown-target)
+      (is (rf.frame/frame-value? @teardown-target)
           "per-request teardown targeted the make-frame VALUE, not the bare gensym id")
-      (is (some? (frame/frame-value-incarnation-token @teardown-target))
+      (is (some? (rf.frame/frame-value-incarnation-token @teardown-target))
           "the teardown target carries the exact incarnation token, so the
            two-argument destroy no-ops against any same-id successor (N+1)
            (proven end-to-end by re-frame.frame-lifecycle-test)"))))
@@ -467,7 +467,7 @@
     (rf/reg-view* :pages/should-not-render
       (fn [] [:div "should not render under redirect"]))
 
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/redirect]]
                      :root-view [(rf/view :pages/should-not-render)]
                      :payload :rf.ssr.payload/whole-app-db})
@@ -497,7 +497,7 @@
       (rf/register-listener! :trace ::redirect-no-target-watch
         (fn [ev] (when (= :rf.ssr/ssr-redirect-no-target (:operation ev))
                    (swap! traces conj ev))))
-      (let [handler  (ssr-ring/ssr-handler
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events [[:init/redirect-no-target]]
                         :root-view [(rf/view :pages/noop-rt)]
                         :payload :rf.ssr.payload/whole-app-db})
@@ -533,7 +533,7 @@
     (rf/reg-view* :pages/cookied
       (fn [] [:div "cookied"]))
 
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/with-cookies]]
                       :root-view [(rf/view :pages/cookied)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -570,7 +570,7 @@
     (rf/reg-view* :pages/broken
       (fn [] (throw (ex-info "boom-internal-jdbc-url-secret" {}))))
 
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/ok]]
                      :root-view [(rf/view :pages/broken)]
                      :payload :rf.ssr.payload/whole-app-db})
@@ -623,7 +623,7 @@
          :message    "I'm a teapot"
          :retryable? false}))
 
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/ok]]
                      :root-view [(rf/view :pages/broken-2)]
                      :ssr       {:public-error-id :myapp/teapot}
@@ -664,7 +664,7 @@
          [:p.code (name code)]
          [:p.status (str status)]
          [:p.msg message]]))
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events  [[:init/ok]]
                       :root-view  [(rf/view :pages/broken-ev)]
                       :error-view :myapp/error-page
@@ -689,7 +689,7 @@
     (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/broken-evf
       (fn [] (throw (ex-info "boom" {}))))
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events  [[:init/ok]]
                       :root-view  [(rf/view :pages/broken-evf)]
                       :error-view (fn [public]
@@ -715,7 +715,7 @@
       (rf/register-listener! :trace ::error-view-throw-watch
         (fn [ev] (when (= :rf.error/ssr-ring-error-view-failed (:operation ev))
                    (swap! traces conj ev))))
-      (let [handler  (ssr-ring/ssr-handler
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events  [[:init/ok]]
                         :root-view  [(rf/view :pages/broken-evt)]
                         :error-view (fn [_public]
@@ -760,7 +760,7 @@
       (rf/reg-view* :pages/once
         (fn [] [:div.page "once"]))
 
-      (let [handler  (ssr-ring/ssr-handler
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events [[:init/ok-once]]
                         :root-view (fn []
                                      (swap! call-count inc)
@@ -790,7 +790,7 @@
       (rf/reg-view* :pages/noni
         (fn [n] [:div {:data-call n} "noni"]))
 
-      (let [handler  (ssr-ring/ssr-handler
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events [[:init/ok-noni]]
                         ;; rf2-q1b96 — outer call: the fn RESOLVES the view
                         ;; rather than handing back a reference to it, so the
@@ -890,7 +890,7 @@
     (rf/reg-view* :pages/fixed-body (fn [] [:div.body "identical body"]))
 
     (let [mk      (fn [head]
-                    (ssr-ring/ssr-handler
+                    (rf.ssr.ring/ssr-handler
                       {:initial-events [[:init/noop-head]]
                        ;; rf2-q1b96 — resolving form; the body-only-hash
                        ;; assertions below need a hash to exist.
@@ -945,7 +945,7 @@
     (rf/reg-view* :pages/shared-body (fn [] [:div.body "same body, different head"]))
 
     (let [mk      (fn [init]
-                    (ssr-ring/ssr-handler
+                    (rf.ssr.ring/ssr-handler
                       {:initial-events [[init]]
                        :root-view [(rf/view :pages/shared-body)]
                        :payload   :rf.ssr.payload/whole-app-db}))
@@ -992,7 +992,7 @@
     (rf/reg-view* :pages/attrs-body (fn [] [:div.body "body"]))
 
     (let [mk      (fn [init]
-                    (ssr-ring/ssr-handler
+                    (rf.ssr.ring/ssr-handler
                       {:initial-events [[init]]
                        :root-view [(rf/view :pages/attrs-body)]
                        :payload   :rf.ssr.payload/whole-app-db}))
@@ -1052,7 +1052,7 @@
     (rf/reg-view* :app/root
       (fn [] [:div.app [:h1 "Regression"] [:p "count is stable"]]))
 
-    (let [handler     (ssr-ring/ssr-handler
+    (let [handler     (rf.ssr.ring/ssr-handler
                         {:initial-events [[:rf.test.regression/init]
                                           [:rf.test.regression/seed-route]]
                          ;; Documented EXPANDED :root-view form — symmetric
@@ -1074,7 +1074,7 @@
           ;; rf2-1oxjxk concern) even if a stable `:client-frame-id` were
           ;; later configured on the handler.
           payload     (dissoc (edn/read-string payload-edn) :rf/frame-id)
-          client-frame (frame/make-anon-frame-record!
+          client-frame (rf.frame/make-anon-frame-record!
                          {:doc      "rf2-1oxjxk regression client frame"
                           :platform :client
                           :ssr      {:on-mismatch :hard-error}})]
@@ -1096,7 +1096,7 @@
       ;; body, so this call threw :rf.ssr/hydration-mismatch on every
       ;; single SSR page — even here under :on-mismatch :hard-error.
       (is (= payload
-             (ssr/hydrate! {:frame          client-frame
+             (rf.ssr/hydrate! {:frame          client-frame
                             :payload        payload
                             :render-tree-fn #((rf/view :app/root))}))
           "rf2-1oxjxk: hydrate! completes without a spurious mismatch throw
@@ -1123,7 +1123,7 @@
             frame is omitted from the wire) and seeds the client app-db"
     (rf/reg-event :rf.lm2yzy/init (fn [{:keys [db]} _] {:db (assoc db :count 42)}))
     (rf/reg-view* :app/root (fn [] [:div.app [:h1 "lm2yzy"] [:p "stable"]]))
-    (let [handler     (ssr-ring/ssr-handler
+    (let [handler     (rf.ssr.ring/ssr-handler
                         {:initial-events [[:rf.lm2yzy/init]]
                          :root-view      (fn [] ((rf/view :app/root)))
                          :payload        :rf.ssr.payload/whole-app-db})
@@ -1141,7 +1141,7 @@
           "rf2-lm2yzy: the shipped wire payload omits the per-request gensym :rf/frame-id")
       ;; THE REGRESSION — must NOT throw. Pre-fix this threw
       ;; :rf.error/hydration-frame-id-mismatch on the gensym vs :app/main.
-      (is (= payload (ssr/hydrate! {:frame :app/main :payload payload}))
+      (is (= payload (rf.ssr/hydrate! {:frame :app/main :payload payload}))
           "rf2-lm2yzy: documented hydrate! completes without a frame-id mismatch")
       (is (= 42 (:count (rf/app-db-value :app/main)))
           "the client app-db carries the server's seeded slice after hydration")))
@@ -1151,7 +1151,7 @@
             the SAME frame succeeds"
     (rf/reg-event :rf.lm2yzy/init2 (fn [{:keys [db]} _] {:db (assoc db :count 7)}))
     (rf/reg-view* :app/root (fn [] [:div.app "stamped"]))
-    (let [handler     (ssr-ring/ssr-handler
+    (let [handler     (rf.ssr.ring/ssr-handler
                         {:initial-events  [[:rf.lm2yzy/init2]]
                          :root-view       (fn [] ((rf/view :app/root)))
                          :payload         :rf.ssr.payload/whole-app-db
@@ -1164,7 +1164,7 @@
           _           (rf/make-frame {:id :app/stamped :doc "lm2yzy stamped" :platform :client})]
       (is (= :app/stamped (:rf/frame-id payload))
           "the configured stable :client-frame-id rides the wire as :rf/frame-id")
-      (is (= payload (ssr/hydrate! {:frame :app/stamped :payload payload}))
+      (is (= payload (rf.ssr/hydrate! {:frame :app/stamped :payload payload}))
           "hydrate! into the matching stable frame succeeds (no mismatch)"))))
 
 ;; ===========================================================================
@@ -1191,7 +1191,7 @@
 
       (rf/reg-view* :pages/blank (fn [] [:div]))
 
-      (let [handler  (ssr-ring/ssr-handler
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events [[:init/capture-request-cofx]]
                         :root-view [(rf/view :pages/blank)]
                         :payload :rf.ssr.payload/whole-app-db})
@@ -1216,14 +1216,14 @@
 
       (rf/reg-view* :pages/blank2 (fn [] [:div]))
 
-      (let [handler (ssr-ring/ssr-handler
+      (let [handler (rf.ssr.ring/ssr-handler
                       {:initial-events [[:init/capture-frame-id]]
                        :root-view [(rf/view :pages/blank2)]
                        :payload :rf.ssr.payload/whole-app-db})]
         (handler {:uri "/x" :request-method :get})
         (is (some? @captured-fid)
             "the initial-events handler captured the per-request frame-id")
-        (is (nil? (ssr/get-request @captured-fid))
+        (is (nil? (rf.ssr/get-request @captured-fid))
             "the request slot was cleared on frame teardown — no leak across requests")))))
 
 (deftest handler-isolates-request-slots-across-requests
@@ -1238,7 +1238,7 @@
 
       (rf/reg-view* :pages/blank3 (fn [] [:div]))
 
-      (let [handler (ssr-ring/ssr-handler
+      (let [handler (rf.ssr.ring/ssr-handler
                       {:initial-events [[:init/observe-request]]
                        :root-view [(rf/view :pages/blank3)]
                        :payload :rf.ssr.payload/whole-app-db})]
@@ -1283,7 +1283,7 @@
 
       (rf/reg-view* :pages/blank-auth (fn [] [:div]))
 
-      (let [handler (ssr-ring/ssr-handler
+      (let [handler (rf.ssr.ring/ssr-handler
                       ;; The fn form: derive the setup vector from the request.
                       {:initial-events (fn [req]
                                          [[:auth/server-init (extract-user req)]])
@@ -1307,7 +1307,7 @@
           {:db (assoc db :uri uri)}))
       (rf/reg-view* :pages/blank-once (fn [] [:div]))
 
-      (let [handler (ssr-ring/ssr-handler
+      (let [handler (rf.ssr.ring/ssr-handler
                       {:initial-events (fn [req]
                                          (swap! calls conj (:uri req))
                                          [[:init/noted (:uri req)]])
@@ -1326,7 +1326,7 @@
         (fn [{:keys [db]} _] (reset! seen true) {:db db}))
       (rf/reg-view* :pages/blank-plain (fn [] [:div]))
 
-      (let [handler  (ssr-ring/ssr-handler
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events [[:init/plain]]
                         :root-view [(rf/view :pages/blank-plain)]
                         :payload :rf.ssr.payload/whole-app-db})
@@ -1339,7 +1339,7 @@
   (testing "an :initial-events fn whose result is NOT a vector throws
             :rf.error/invalid-initial-events inside setup — routed to on-error 500"
     (rf/reg-view* :pages/blank-bad (fn [] [:div]))
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      ;; Returns a map, not a vector — programmer error.
                      {:initial-events (fn [_req] {:not "a vector"})
                       :root-view [(rf/view :pages/blank-bad)]
@@ -1355,19 +1355,19 @@
             resolution, and the two invalid-shape throws (unit)"
     (let [req {:uri "/u" :headers {}}]
       ;; Vector passes through verbatim.
-      (is (= [[:e 1]] (lifecycle/resolve-initial-events! [[:e 1]] req)))
+      (is (= [[:e 1]] (rf.ssr.ring.lifecycle/resolve-initial-events! [[:e 1]] req)))
       ;; A 1-arity fn is called with the request; its vector result is returned.
       (is (= [[:derived "/u"]]
-             (lifecycle/resolve-initial-events!
+             (rf.ssr.ring.lifecycle/resolve-initial-events!
                (fn [r] [[:derived (:uri r)]]) req)))
       ;; A fn returning a non-vector throws invalid-initial-events.
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"initial-events fn must return an :initial-events vector"
-                            (lifecycle/resolve-initial-events! (fn [_] {:nope true}) req)))
+                            (rf.ssr.ring.lifecycle/resolve-initial-events! (fn [_] {:nope true}) req)))
       ;; A non-vector, non-fn value throws invalid-initial-events.
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"initial-events must be a vector OR a"
-                            (lifecycle/resolve-initial-events! '(:list-not-vector) req))))))
+                            (rf.ssr.ring.lifecycle/resolve-initial-events! '(:list-not-vector) req))))))
 
 (deftest resolve-root-view-invalid-shape-unit-contract
   (testing "lifecycle/resolve-root-view — hiccup passthrough, 0-arity fn
@@ -1378,17 +1378,17 @@
             :rf.error/invalid-root-view for a value that is neither a hiccup
             vector nor a 0-arity fn — was untested (rf2-njkw94)."
     ;; A hiccup vector passes through verbatim.
-    (is (= [:div "x"] (lifecycle/resolve-root-view [:div "x"])))
+    (is (= [:div "x"] (rf.ssr.ring.lifecycle/resolve-root-view [:div "x"])))
     ;; A 0-arity fn is invoked exactly once; its hiccup result is returned.
     (let [calls (atom 0)]
-      (is (= [:section] (lifecycle/resolve-root-view
+      (is (= [:section] (rf.ssr.ring.lifecycle/resolve-root-view
                           (fn [] (swap! calls inc) [:section]))))
       (is (= 1 @calls) "the fn-form is resolved exactly once (rf2-6t36h)"))
     ;; Every non-vector, non-fn shape hits the :else arm and throws the
     ;; canonical :rf.error/invalid-root-view — pinned across scalar shapes so
     ;; the fail-closed branch (not accidental happy-path fallthrough) fires.
     (doseq [bad ["a-string" :a-keyword {:a :map} 42 nil]]
-      (let [ex (try (lifecycle/resolve-root-view bad)
+      (let [ex (try (rf.ssr.ring.lifecycle/resolve-root-view bad)
                     (catch clojure.lang.ExceptionInfo e e))]
         (is (instance? clojure.lang.ExceptionInfo ex)
             (str "resolve-root-view must throw for " (pr-str bad)))
@@ -1429,7 +1429,7 @@
 
       (rf/reg-view* :pages/blank-for-ssr-opt (fn [] [:div]))
 
-      (let [handler (ssr-ring/ssr-handler
+      (let [handler (rf.ssr.ring/ssr-handler
                       {:initial-events [[:init/capture-ssr-meta]]
                        :root-view [(rf/view :pages/blank-for-ssr-opt)]
                        :ssr       {:dev-error-detail? true
@@ -1457,7 +1457,7 @@
 
     (rf/reg-view* :pages/echo (fn [] [:div "echo"]))
 
-    (let [handler (ssr-ring/ssr-handler
+    (let [handler (rf.ssr.ring/ssr-handler
                     {:initial-events    [[:init/many-keys]]
                      :root-view    [(rf/view :pages/echo)]
                      :payload [:public/articles]})
@@ -1499,7 +1499,7 @@
 
     (rf/reg-view* :pages/echo (fn [] [:div "echo"]))
 
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/seed-runtime]]
                       :root-view [(rf/view :pages/echo)]
                       :payload   [:public/page]})
@@ -1557,7 +1557,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/ssr-missing-payload-policy"
-          (ssr-ring/ssr-handler
+          (rf.ssr.ring/ssr-handler
             {:initial-events [[:init/no-policy]]
              :root-view [(rf/view :pages/no-policy)]}))
         "ssr-handler MUST throw at construction time when the policy
@@ -1574,7 +1574,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/ssr-missing-payload-policy"
-          (ssr-ring/stream-handler
+          (rf.ssr.ring/stream-handler
             {:initial-events [[:init/no-policy-stream]]
              :root-view [(rf/view :pages/no-policy-stream)]}))
         "stream-handler MUST throw at construction time when the
@@ -1595,7 +1595,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/ssr-ring-missing-initial-events"
-          (ssr-ring/ssr-handler
+          (rf.ssr.ring/ssr-handler
             {:root-view [(rf/view :pages/no-oncreate)]
              :payload :rf.ssr.payload/whole-app-db})))))
 
@@ -1607,7 +1607,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/ssr-ring-missing-initial-events"
-          (ssr-ring/stream-handler
+          (rf.ssr.ring/stream-handler
             {:root-view [(rf/view :pages/no-oncreate-stream)]
              :payload :rf.ssr.payload/whole-app-db})))))
 
@@ -1620,7 +1620,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/ssr-ring-missing-root-view"
-          (ssr-ring/stream-handler
+          (rf.ssr.ring/stream-handler
             {:initial-events [[:init/no-rootview-stream]]
              :payload :rf.ssr.payload/whole-app-db})))))
 
@@ -1646,7 +1646,7 @@
     (rf/reg-view* :pages/policy-probe
       (fn [] [:div.page "policy probe"]))
 
-    (let [handler   (ssr-ring/ssr-handler
+    (let [handler   (rf.ssr.ring/ssr-handler
                       ;; The allowlist names ONLY the public slice.
                       ;; Every other server-only key on app-db is
                       ;; un-permitted and MUST be dropped.
@@ -1700,7 +1700,7 @@
     (rf/reg-view* :pages/wholeapp
       (fn [] [:div.page "whole app"]))
 
-    (let [handler   (ssr-ring/ssr-handler
+    (let [handler   (rf.ssr.ring/ssr-handler
                       {:initial-events      [[:init/wholeapp]]
                        :root-view      [(rf/view :pages/wholeapp)]
                        :payload :rf.ssr.payload/whole-app-db})
@@ -1726,7 +1726,7 @@
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
           #":rf\.error/ssr-unknown-payload-policy"
-          (ssr-ring/ssr-handler
+          (rf.ssr.ring/ssr-handler
             {:initial-events [[:init/typo-policy]]
              :root-view [(rf/view :pages/typo-policy)]
              :payload   :rf.ssr.payload/whole-db})) ; typo
@@ -1792,7 +1792,7 @@
           (is (thrown-with-msg?
                 clojure.lang.ExceptionInfo
                 #":rf\.error/ssr-trusted-shell-opt-invalid"
-                (ssr-ring/ssr-handler (assoc base-opts opt-k bad-val)))
+                (rf.ssr.ring/ssr-handler (assoc base-opts opt-k bad-val)))
               (str "ssr-handler MUST reject " (pr-str opt-k) " = "
                    (pr-str bad-val)
                    " with :rf.error/ssr-trusted-shell-opt-invalid"))))
@@ -1800,7 +1800,7 @@
       (testing "ex-data carries the structured diagnostic shape — :opt-key
                 names the offending opt; :got carries the rejected value;
                 :got-type names the type"
-        (let [ex (try (ssr-ring/ssr-handler
+        (let [ex (try (rf.ssr.ring/ssr-handler
                         (assoc base-opts :body-end {:script "evil"}))
                       (catch clojure.lang.ExceptionInfo e e))]
           (is (some? ex) "an exception was thrown")
@@ -1815,7 +1815,7 @@
       (testing "strings pass through unchanged — the framework names
                 the boundary but does not gate the content; the
                 trust call itself remains the caller's"
-        (is (fn? (ssr-ring/ssr-handler
+        (is (fn? (rf.ssr.ring/ssr-handler
                    (assoc base-opts
                           :head           "<title>OK</title>"
                           :body-end       "<script src=\"/analytics.js\"></script>"
@@ -1825,7 +1825,7 @@
 
       (testing "nil values pass — explicit nil signals 'no override,
                 use the default'; the construction-time check accepts it"
-        (is (fn? (ssr-ring/ssr-handler
+        (is (fn? (rf.ssr.ring/ssr-handler
                    (assoc base-opts
                           :head           nil
                           :body-end       nil
@@ -1835,7 +1835,7 @@
       (testing "absent keys pass (regression guard — the check is
                 contains?-aware so absent opts don't trip on the
                 non-nil branch)"
-        (is (fn? (ssr-ring/ssr-handler base-opts)))))))
+        (is (fn? (rf.ssr.ring/ssr-handler base-opts)))))))
 
 (deftest stream-handler-construction-rejects-non-string-trusted-shell-opts
   (testing "rf2-o6ndb: stream-handler shares the trusted-shell-hook
@@ -1860,12 +1860,12 @@
           (is (thrown-with-msg?
                 clojure.lang.ExceptionInfo
                 #":rf\.error/ssr-trusted-shell-opt-invalid"
-                (ssr-ring/stream-handler (assoc base-opts opt-k bad-val)))
+                (rf.ssr.ring/stream-handler (assoc base-opts opt-k bad-val)))
               (str "stream-handler MUST reject " (pr-str opt-k) " = "
                    (pr-str bad-val)))))
 
       (testing "stream-handler accepts strings on all four"
-        (is (fn? (ssr-ring/stream-handler
+        (is (fn? (rf.ssr.ring/stream-handler
                    (assoc base-opts
                           :head           "<meta name=\"x\">"
                           :body-end       "<script src=\"/x.js\"></script>"
@@ -1886,7 +1886,7 @@
     (let [;; A quote-bearing-but-otherwise-trusted value: an asset URL the
           ;; caller assembled with a query-string carrying a quote, and an
           ;; id with a stray quote. Both are attribute-value positions.
-          html (ssr-ring/default-html-shell
+          html (rf.ssr.ring/default-html-shell
                  "body" "{}"
                  {:app-element-id "ap\"p"
                   :script-src     "/main.js?v=\"x\""})]
@@ -1903,14 +1903,14 @@
 
   (testing "rf2-7x0qk: an ampersand in :script-src (legal query-string
             separator) is escape-attr'd to &amp; — lossless, position-correct"
-    (let [html (ssr-ring/default-html-shell
+    (let [html (rf.ssr.ring/default-html-shell
                  "body" "{}" {:script-src "/main.js?a=1&b=2"})]
       (is (str/includes? html "src=\"/main.js?a=1&amp;b=2\"")
           "& in the URL is encoded as &amp; (the attribute-value escape)")))
 
   (testing "rf2-7x0qk: benign values are unaffected (escape-attr only
             touches & and \") — the common case round-trips verbatim"
-    (let [html (ssr-ring/default-html-shell
+    (let [html (rf.ssr.ring/default-html-shell
                  "body" "{}" {:app-element-id "root" :script-src "/bootstrap.js"})]
       (is (str/includes? html "<div id=\"root\">"))
       (is (str/includes? html "src=\"/bootstrap.js\"")))))
@@ -1958,16 +1958,16 @@
                      :body-end       "<script>ga();</script>"}
           body      "<main><h1>Hi</h1></main>"
           payload   "{:rf/app-db {:x 1} :rf/version 1}"
-          shell-out (ssr-ring/default-html-shell body payload opts)
+          shell-out (rf.ssr.ring/default-html-shell body payload opts)
           ;; The streaming prefix with NO :render-hash reproduces the
           ;; non-streaming shell's prefix exactly (the #app root carries no
           ;; data-rf-render-hash marker in the non-streaming mode). `:head`
           ;; is threaded as the prefix's positional head-html arg.
-          composed  (str (ssr-ring/default-streaming-prefix (:head opts) opts)
+          composed  (str (rf.ssr.ring/default-streaming-prefix (:head opts) opts)
                          body
                          "</div>"
-                         (shell/payload-script-tag payload)
-                         (ssr-ring/default-streaming-suffix opts))]
+                         (rf.ssr.ring.shell/payload-script-tag payload)
+                         (rf.ssr.ring/default-streaming-suffix opts))]
       (is (= shell-out composed)
           "the non-streaming shell is byte-identical to the composition of
            the shared streaming prefix/suffix renderers")
@@ -1988,8 +1988,8 @@
             data-rf-render-hash on #app when supplied; a render-hash-less
             call matches the non-streaming shell's marker-free #app root"
     (let [opts   {:app-element-id "app"}
-          hashed (ssr-ring/default-streaming-prefix "" (assoc opts :render-hash "cafebabe"))
-          plain  (ssr-ring/default-streaming-prefix "" opts)]
+          hashed (rf.ssr.ring/default-streaming-prefix "" (assoc opts :render-hash "cafebabe"))
+          plain  (rf.ssr.ring/default-streaming-prefix "" opts)]
       (is (str/includes? hashed "<div id=\"app\" data-rf-render-hash=\"cafebabe\">")
           "streaming prefix stamps the marker when :render-hash is supplied")
       (is (str/includes? plain "<div id=\"app\">")
@@ -2018,7 +2018,7 @@
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/x})}))
     (rf/reg-view* :pages/blank-for-title (fn [] [:div]))
 
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/seed-route]]
                       :root-view [(rf/view :pages/blank-for-title)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -2040,7 +2040,7 @@
     (rf/reg-view* :pages/blank-no-head (fn [] [:div]))
     (rf/reg-event :init/noop (fn [{:keys [db]} _] {:db db}))
 
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/noop]]
                       :root-view [(rf/view :pages/blank-no-head)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -2069,7 +2069,7 @@
         {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/no-title})}))
     (rf/reg-view* :pages/blank-no-title (fn [] [:div]))
 
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/seed-no-title]]
                       :root-view [(rf/view :pages/blank-no-title)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -2113,7 +2113,7 @@
     (register-attrs-app! {:html-attrs {:lang "fr" :data-theme "dark"}
                           :body-attrs {:class "page-article"}})
 
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/seed-attrs-route]]
                       :root-view [(rf/view :pages/blank-attrs)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -2132,7 +2132,7 @@
             is the default for routes that don't opt into attr bags."
     (register-attrs-app! {:title "T"}) ; no attr bags
 
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/seed-attrs-route]]
                       :root-view [(rf/view :pages/blank-attrs)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -2149,7 +2149,7 @@
             The bag still wins for every other attribute it declares."
     (register-attrs-app! {:html-attrs {:data-theme "dark"}})
 
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/seed-attrs-route]]
                       :root-view [(rf/view :pages/blank-attrs)]
                       :lang      "ja"
@@ -2183,7 +2183,7 @@
                                        :hidden         false  ; omitted
                                        :inert          true}})
 
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/seed-attrs-route]]
                       :root-view [(rf/view :pages/blank-attrs)]
                       :payload :rf.ssr.payload/whole-app-db})
@@ -2224,7 +2224,7 @@
           wrapped        (fn [_req]
                            (reset! wrapped-called true)
                            {:status 204 :headers {} :body ""})
-          mw             (ssr-ring/ssr-middleware
+          mw             (rf.ssr.ring/ssr-middleware
                            {:initial-events    [[:rf/server-init]]
                             :root-view    [(rf/view :pages/articles)]
                             :fx-overrides {:http/get :http/get.canned}
@@ -2298,7 +2298,7 @@
     (rf/reg-view* :pages/dashboard
       (fn [] [:div.page [:h1 "Public dashboard"]]))
 
-    (let [handler   (ssr-ring/ssr-handler
+    (let [handler   (rf.ssr.ring/ssr-handler
                       {:initial-events [[:auth/login]]
                        :root-view [(rf/view :pages/dashboard)]
                        :payload :rf.ssr.payload/whole-app-db})
@@ -2391,7 +2391,7 @@
     (rf/reg-view* :pages/vary
       (fn [] [:div.page [:h1 "vary"]]))
 
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:vary/emit]]
                       :root-view      [(rf/view :pages/vary)]
                       :payload        :rf.ssr.payload/whole-app-db})
@@ -2477,7 +2477,7 @@
             opt is no longer a silent no-op, and no duplicate key survives"
     (rf/reg-event :init/ct-ok {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/ct-body (fn [] [:div "body"]))
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/ct-ok]]
                       :root-view      [(rf/view :pages/ct-body)]
                       :content-type   "application/xhtml+xml; charset=utf-8"
@@ -2495,7 +2495,7 @@
             (text/html; charset=utf-8) rides the wire unchanged"
     (rf/reg-event :init/ct-def {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/ct-def-body (fn [] [:div "body"]))
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/ct-def]]
                       :root-view      [(rf/view :pages/ct-def-body)]
                       :payload        :rf.ssr.payload/whole-app-db})
@@ -2515,7 +2515,7 @@
         {:fx [[:rf.server/set-header {:name  "Content-Type"
                                       :value "application/json"}]]}))
     (rf/reg-view* :pages/ct-appset-body (fn [] [:div "body"]))
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/ct-appset]]
                       :root-view      [(rf/view :pages/ct-appset-body)]
                       :payload        :rf.ssr.payload/whole-app-db})
@@ -2557,7 +2557,7 @@
         (into [:ul]
               (for [{:keys [title]} (rf/subscribe-once [:articles])]
                 [:li title]))))
-    (let [handler  (ssr-ring/ssr-handler
+    (let [handler  (rf.ssr.ring/ssr-handler
                      {:initial-events [[:init/cl-stale]]
                       :root-view      [(rf/view :pages/cl-body)]
                       :payload        :rf.ssr.payload/whole-app-db})
@@ -2604,7 +2604,7 @@
 
       (rf/reg-view* :pages/hostile-page (fn [] [:div "ok"]))
 
-      (let [handler  (ssr-ring/ssr-handler
+      (let [handler  (rf.ssr.ring/ssr-handler
                        {:initial-events [[:init/hostile]]
                         :root-view [(rf/view :pages/hostile-page)]
                         :payload :rf.ssr.payload/whole-app-db})
@@ -2655,7 +2655,7 @@
             tag is broken, even before any runtime path. Pin the helper
             contract independent of the handler lifecycle."
     (let [payload-edn "{:greeting \"</script><script>x()</script>\"}"
-          html        (ssr-ring/default-html-shell "body" payload-edn {})]
+          html        (rf.ssr.ring/default-html-shell "body" payload-edn {})]
       (is (not (str/includes? html "</script><script>x()"))
           "shell-level: closing-tag pattern is broken")
       (is (str/includes? html "\\u003c/script>\\u003cscript>x()")
@@ -2674,7 +2674,7 @@
     (let [payload-edn (pr-str {:a<b 1
                                :tag :<
                                :public/title "</script><script>alert(1)</script>"})
-          html        (ssr-ring/default-html-shell "body" payload-edn {})
+          html        (rf.ssr.ring/default-html-shell "body" payload-edn {})
           body-edn    (second
                         (re-find
                           #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>"
@@ -2706,7 +2706,7 @@
     (let [payload-edn (pr-str {:k (symbol "a</script>b")})]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #":rf.error/ssr-edn-script-breakout"
-                            (ssr-ring/default-html-shell "body" payload-edn {}))))))
+                            (rf.ssr.ring/default-html-shell "body" payload-edn {}))))))
 
 (deftest shell-with-default-head-emits-exactly-one-charset-meta
   (testing "rf2-q78s1: the default shell owns the baseline <meta charset>;
@@ -2720,10 +2720,10 @@
             tag, yielding two."
     (let [;; The head fragment as the pipeline produces it for a route
           ;; with no declared :head — default-head rendered to HTML.
-          f          (frame/make-anon-frame-record! {:doc "Charset probe" :platform :server})
+          f          (rf.frame/make-anon-frame-record! {:doc "Charset probe" :platform :server})
           head-model (rf/active-head f)
           head-html  (rf/head-model->html head-model)
-          html       (ssr-ring/default-html-shell "body" "{}" {:head head-html})
+          html       (rf.ssr.ring/default-html-shell "body" "{}" {:head head-html})
           n-charset  (count (re-seq #"(?i)<meta\s+charset" html))]
       (is (= 1 n-charset)
           (str "expected exactly one <meta charset> in the default document; saw "
@@ -2941,7 +2941,7 @@
                       (when (= :rf.error/ssr-head-resolution-failed
                                (:operation ev))
                         (swap! traces conj ev))))
-          handler (ssr-ring/ssr-handler
+          handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:init/seed-throwing-head-route]]
                      :root-view [(rf/view :pages/head-throws-body)]
                      :payload   :rf.ssr.payload/whole-app-db})
@@ -3000,7 +3000,7 @@
             (never stamped as `:rf/frame-id`, so no hydration-frame-id-mismatch)"
     (register-articles-app! [{:id "a" :title "Article A"}])
 
-    (let [handler     (ssr-ring/ssr-handler
+    (let [handler     (rf.ssr.ring/ssr-handler
                         {:initial-events      [[:rf/server-init]]
                          :root-view      [(rf/view :pages/articles)]
                          :fx-overrides   {:http/get :http/get.canned}
@@ -3054,7 +3054,7 @@
     (let [secret-msg "boom-jdbc-secret:postgres://internal-db.svc:5432/auth"
           t          (ex-info secret-msg {})
           req        {:uri "/anything" :request-method :get}
-          response   (ssr-ring/default-on-error req t)]
+          response   (rf.ssr.ring/default-on-error req t)]
       (is (= 500 (:status response))
           "status pinned to 500 — Ring-layer fallback default")
       (is (= {"Content-Type" "text/plain; charset=utf-8"}
@@ -3105,7 +3105,7 @@
           (fn [_req _t]
             (throw (ex-info "boom in the caller's on-error — leaks JDBC URL etc."
                             {:internal :topology})))
-          handler (ssr-ring/ssr-handler
+          handler (rf.ssr.ring/ssr-handler
                     {:initial-events '(:rf/server-init) ;; non-vector → setup throws
                      :root-view [:div]
                      :payload [:x]
@@ -3153,7 +3153,7 @@
     (let [throwing-on-error
           (fn [_req _t]
             (throw (ex-info "boom in the caller's on-error" {:internal :topology})))
-          handler (ssr-ring/ssr-handler
+          handler (rf.ssr.ring/ssr-handler
                     {:initial-events [[:rf.test/init-bad-cookie]]
                      :root-view [:div "hello"]
                      :payload :rf.ssr.payload/whole-app-db
@@ -3206,10 +3206,10 @@
              ;; THEN A's constructor rethrows into `setup-request-frame!`.
              (reset! captured-id id)
              (real-make {:id id :doc "successor B" :platform :server})
-             (reset! b-token (frame/frame-incarnation-token id))
+             (reset! b-token (rf.frame/frame-incarnation-token id))
              (throw (ex-info "incarnation A setup failed (already rolled back by core)"
                              {:simulated true})))]
-          (let [result (pipeline/setup-request-frame!
+          (let [result (rf.ssr.ring.pipeline/setup-request-frame!
                          {;; A valid (empty) :initial-events so setup reaches the
                           ;; `make-frame` call (our stub); the throw models A's
                           ;; construction failing, not a bad-opt rejection.
@@ -3224,9 +3224,9 @@
 
         ;; The load-bearing assertion: B's EXACT incarnation is still live after
         ;; the catch. With the removed bare-id reap present it would be destroyed.
-        (is (frame/frame-incarnation-live? @captured-id @b-token)
+        (is (rf.frame/frame-incarnation-live? @captured-id @b-token)
             "same-id successor B survives the setup-failure catch (no bare-id reap)")
-        (is (some? (frame/frame @captured-id))
+        (is (some? (rf.frame/frame @captured-id))
             "the id still resolves to a live frame (B), not a reaped/absent slot")
         (finally
           (when-let [id @captured-id]
@@ -3264,18 +3264,18 @@
             :rf.error/ssr-render-failed record to register-error-listener!
             under debug-off. Promotion adds the off-box record; the 5xx
             wire outcome is unchanged."
-    (error-emit/clear-error-listeners!)
+    (rf.error-emit/clear-error-listeners!)
     (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/render-throws
       (fn [] (throw (ex-info "render boom" {}))))
     (let [seen (capture-always-on-categories!)]
-      (with-redefs [interop/debug-enabled? false]
-        (let [handler  (ssr-ring/ssr-handler
+      (with-redefs [rf.interop/debug-enabled? false]
+        (let [handler  (rf.ssr.ring/ssr-handler
                          {:initial-events [[:init/ok]]
                           :root-view [(rf/view :pages/render-throws)]
                           :payload   :rf.ssr.payload/whole-app-db})
               response (handler {:uri "/render-throws" :request-method :get})]
-          (error-emit/clear-error-listeners!)
+          (rf.error-emit/clear-error-listeners!)
           ;; WIRE-UNCHANGED: a render-time throw still projects 5xx.
           (is (= 500 (:status response))
               "render-failed still ships a 5xx through the full handler")
@@ -3290,16 +3290,16 @@
             :rf.error/ssr-head-resolution-failed record to register-error-
             listener! under debug-off. Promotion ships the off-box record
             but NEVER flips the deliberate degraded-200."
-    (error-emit/clear-error-listeners!)
+    (rf.error-emit/clear-error-listeners!)
     (register-head-throwing-app!)
     (let [seen (capture-always-on-categories!)]
-      (with-redefs [interop/debug-enabled? false]
-        (let [handler  (ssr-ring/ssr-handler
+      (with-redefs [rf.interop/debug-enabled? false]
+        (let [handler  (rf.ssr.ring/ssr-handler
                          {:initial-events [[:init/seed-throwing-head-route]]
                           :root-view [(rf/view :pages/head-throws-body)]
                           :payload   :rf.ssr.payload/whole-app-db})
               response (handler {:uri "/head-throws" :request-method :get})]
-          (error-emit/clear-error-listeners!)
+          (rf.error-emit/clear-error-listeners!)
           ;; WIRE-UNCHANGED: degraded 200, body intact.
           (is (= 200 (:status response))
               "throwing :head fn degrades to a 200 — promotion did NOT flip
@@ -3317,20 +3317,20 @@
             render-time 5xx already stamped is unchanged, NON-PROJECTING)
             AND delivers a :rf.error/ssr-ring-error-view-failed record to
             register-error-listener! under debug-off."
-    (error-emit/clear-error-listeners!)
+    (rf.error-emit/clear-error-listeners!)
     (rf/reg-event :init/ok {:platforms #{:server}} (fn [_ _] {}))
     (rf/reg-view* :pages/broken-evt-hhutya
       (fn [] (throw (ex-info "boom" {}))))
     (let [seen (capture-always-on-categories!)]
-      (with-redefs [interop/debug-enabled? false]
-        (let [handler  (ssr-ring/ssr-handler
+      (with-redefs [rf.interop/debug-enabled? false]
+        (let [handler  (rf.ssr.ring/ssr-handler
                          {:initial-events  [[:init/ok]]
                           :root-view  [(rf/view :pages/broken-evt-hhutya)]
                           :error-view (fn [_public]
                                         (throw (ex-info "error-view itself broke" {})))
                           :payload :rf.ssr.payload/whole-app-db})
               response (handler {:uri "/broken" :request-method :get})]
-          (error-emit/clear-error-listeners!)
+          (rf.error-emit/clear-error-listeners!)
           ;; WIRE-UNCHANGED: the error boundary holds at 500 with the locked
           ;; default template; the error-view's own failure did NOT re-flip
           ;; or escape (NON-PROJECTING).

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -9,108 +9,108 @@
   per-frame request and response side channels, error projection, streaming
   primitives, and the headless adapter. Core reaches this optional artefact
   only through `re-frame.late-bind`; this artefact may depend on core."
-  (:require [re-frame.cofx :as cofx]
-            [re-frame.emit :as rf-emit]
-            [re-frame.events :as events]
-            [re-frame.fx :as fx]
-            [re-frame.late-bind :as late-bind]
+  (:require [re-frame.cofx :as rf.cofx]
+            [re-frame.emit :as rf.emit]
+            [re-frame.events :as rf.events]
+            [re-frame.fx :as rf.fx]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Loaded eagerly so both hydration boot re-exports resolve.
-            [re-frame.ssr.boot :as boot]
-            [re-frame.ssr.emit :as emit]
+            [re-frame.ssr.boot :as rf.ssr.boot]
+            [re-frame.ssr.emit :as rf.ssr.emit]
             ;; The cross-host suspense COMPONENT — the streaming authoring
             ;; surface on every substrate.
-            [re-frame.ssr.suspense :as suspense]
-            [re-frame.ssr.error-listener :as error-listener]
-            [re-frame.ssr.error-projector :as error-projector]
+            [re-frame.ssr.suspense :as rf.ssr.suspense]
+            [re-frame.ssr.error-listener :as rf.ssr.error-listener]
+            [re-frame.ssr.error-projector :as rf.ssr.error-projector]
             ;; Publishes the head hooks at namespace load.
             re-frame.ssr.head
-            [re-frame.ssr.hash :as hash]
-            [re-frame.ssr.hydrate :as hydrate]
-            [re-frame.ssr.request :as request]
-            [re-frame.ssr.response :as response]
+            [re-frame.ssr.hash :as rf.ssr.hash]
+            [re-frame.ssr.hydrate :as rf.ssr.hydrate]
+            [re-frame.ssr.request :as rf.ssr.request]
+            [re-frame.ssr.response :as rf.ssr.response]
             ;; Plain-data schemas attached to the seven server effects.
-            [re-frame.ssr.server-fx-schemas :as server-fx-schemas]
-            [re-frame.ssr.substrate :as substrate]
+            [re-frame.ssr.server-fx-schemas :as rf.ssr.server-fx-schemas]
+            [re-frame.ssr.substrate :as rf.ssr.substrate]
             ;; The S5 structural-tree -> HTML serialiser (rf2-3omxp).
-            [re-frame.ssr.ui-tree :as ui-tree]
+            [re-frame.ssr.ui-tree :as rf.ssr.ui-tree]
             ;; Publishes streaming server hooks at namespace load.
             re-frame.ssr.streaming
             ;; CLJS-only DOM consumer for streamed boundary chunks.
-            #?(:cljs [re-frame.ssr.streaming.client :as streaming-client])
+            #?(:cljs [re-frame.ssr.streaming.client :as rf.ssr.streaming.client])
             ;; Listener registration lives on the tooling surface so production
             ;; code that does not use SSR does not retain trace tooling.
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; ---- public-surface re-exports --------------------------------------------
 ;;
 ;; `def`s expose the supported sub-namespace functions at the façade.
 
-(def render-to-string                emit/render-to-string)
+(def render-to-string                rf.ssr.emit/render-to-string)
 ;; The S5 tree->HTML seam: an already-rendered version-1 structural tree
 ;; (from the JVM emitter) -> HTML string. Distinct from `render-to-string`,
 ;; which consumes hiccup and renders it (calls views, resolves subs).
 ;; Per Spec 004B §The SSR consumption boundary (rf2-3omxp).
-(def emit-ui-tree                    ui-tree/emit-ui-tree)
+(def emit-ui-tree                    rf.ssr.ui-tree/emit-ui-tree)
 ;; rf2-8vi4q — `format-view-source-coord` (and its emitter-side companion
 ;; `inject-coord-on-root-hiccup`) are deleted: dev-mode view annotation
 ;; now lives at the reg-view registration boundary
 ;; (`re-frame.views.jvm-source-coord-annotation`), not in the emitter.
-(def render-tree-hash                hash/render-tree-hash)
+(def render-tree-hash                rf.ssr.hash/render-tree-hash)
 ;; framework-private: tests reach into `#'ssr/canonical-edn` for the
 ;; JVM↔CLJS canonical-EDN parity check (hash_check_cljs_test).
-(def ^:private canonical-edn         hash/canonical-edn)
-(def ^:private fnv-1a-32             hash/fnv-1a-32)
-(def adapter                         substrate/adapter)
-(def verify-hydration!               hydrate/verify-hydration!)
+(def ^:private canonical-edn         rf.ssr.hash/canonical-edn)
+(def ^:private fnv-1a-32             rf.ssr.hash/fnv-1a-32)
+(def adapter                         rf.ssr.substrate/adapter)
+(def verify-hydration!               rf.ssr.hydrate/verify-hydration!)
 ;; `hydrate!` preserves read → hydrate → verify ordering. The DOM reader is
 ;; CLJS-only.
-(def hydrate!                        boot/hydrate!)
+(def hydrate!                        rf.ssr.boot/hydrate!)
 ;; A page is N roots; `hydrate-page!` boots them with per-root failure
 ;; isolation, so one failing root cannot stop the others (Spec 011
 ;; §Failed-root isolation).
-(def hydrate-page!                   boot/hydrate-page!)
-#?(:cljs (def read-server-payload    boot/read-server-payload))
-(def default-response                response/default-response)
+(def hydrate-page!                   rf.ssr.boot/hydrate-page!)
+#?(:cljs (def read-server-payload    rf.ssr.boot/read-server-payload))
+(def default-response                rf.ssr.response/default-response)
 ;; The response accumulator is a per-frame side channel, not application
 ;; state, so it cannot enter the hydration payload.
 ;; Tests reach the var via `(resolve 're-frame.ssr/response-slots)`.
-(def ^:private response-slots        response/response-slots)
-(def public-error-keys               error-projector/public-error-keys)
-(def fallback-public-error           error-projector/fallback-public-error)
-(def default-error-projector-fn      error-projector/default-error-projector-fn)
-(def reg-error-projector             error-projector/reg-error-projector)
-(def project-error                   error-projector/project-error)
-(def apply-error-projection!         error-listener/apply-error-projection!)
+(def ^:private response-slots        rf.ssr.response/response-slots)
+(def public-error-keys               rf.ssr.error-projector/public-error-keys)
+(def fallback-public-error           rf.ssr.error-projector/fallback-public-error)
+(def default-error-projector-fn      rf.ssr.error-projector/default-error-projector-fn)
+(def reg-error-projector             rf.ssr.error-projector/reg-error-projector)
+(def project-error                   rf.ssr.error-projector/project-error)
+(def apply-error-projection!         rf.ssr.error-listener/apply-error-projection!)
 ;; Host adapters route render-time exceptions through the same projector as
 ;; drain-time errors so both paths materialise an equivalent wire response.
-(def project-render-exception!       error-listener/project-render-exception!)
-(def get-response                    error-listener/get-response)
+(def project-render-exception!       rf.ssr.error-listener/project-render-exception!)
+(def get-response                    rf.ssr.error-listener/get-response)
 ;; `peek-response` is a pure read (no projector drain);
 ;; `flush-response!` drains pending error projections then reads.
 ;; `get-response` is kept as the drain-then-read host-adapter alias.
 ;; `flush-response-result!` is the drain-then-read variant that ALSO returns
 ;; the projected `:public-error` so host adapters classify drain-time
 ;; outcomes (4xx app arm vs 5xx error arm) without re-inferring from status.
-(def peek-response                   error-listener/peek-response)
-(def flush-response!                 error-listener/flush-response!)
-(def flush-response-result!          error-listener/flush-response-result!)
+(def peek-response                   rf.ssr.error-listener/peek-response)
+(def flush-response!                 rf.ssr.error-listener/flush-response!)
+(def flush-response-result!          rf.ssr.error-listener/flush-response-result!)
 ;; framework-private at the public surface — Spec 011 §Per-request
 ;; frame teardown. Tests reach the var via `(resolve ...)`.
-(def ^:private pending-error-traces  error-listener/pending-error-traces)
+(def ^:private pending-error-traces  rf.ssr.error-listener/pending-error-traces)
 ;; The error-view containment peek + one-shot clear (rf2-oytx7j) — a host
 ;; adapter detects a reactive sub that recovered-to-nil inside the error view
 ;; and falls back to the locked template without re-projecting.
-(def pending-error-trace?            error-listener/pending-error-trace?)
-(def clear-pending-error-traces!     error-listener/clear-pending-error-traces!)
+(def pending-error-trace?            rf.ssr.error-listener/pending-error-trace?)
+(def clear-pending-error-traces!     rf.ssr.error-listener/clear-pending-error-traces!)
 ;; Private at the façade. Tests reach via
 ;; `re-frame.ssr.test-fixture/reset-runtime` (the canonical reset surface)
 ;; or by `:require`-ing `re-frame.ssr.request` directly. Production
 ;; consumers go through `set-request!` / `get-request` / `clear-request!`.
-(def ^:private request-slots         request/request-slots)
-(def set-request!                    request/set-request!)
-(def get-request                     request/get-request)
-(def clear-request!                  request/clear-request!)
-(def on-frame-destroyed!             request/on-frame-destroyed!)
+(def ^:private request-slots         rf.ssr.request/request-slots)
+(def set-request!                    rf.ssr.request/set-request!)
+(def get-request                     rf.ssr.request/get-request)
+(def clear-request!                  rf.ssr.request/clear-request!)
+(def on-frame-destroyed!             rf.ssr.request/on-frame-destroyed!)
 
 ;; ---- streaming SSR public surface -----------------------------------------
 ;;
@@ -131,7 +131,7 @@
 ;; Server: expands to the `:rf/suspense-boundary` marker the shell walker
 ;; defers on. Client: renders the body, or the declared `:fallback` when
 ;; the boundary is in the failed set the final payload carried.
-(def boundary                       suspense/boundary)
+(def boundary                       rf.ssr.suspense/boundary)
 (def streaming-render-shell         re-frame.ssr.streaming/render-shell)
 (def streaming-render-continuation  re-frame.ssr.streaming/render-continuation)
 (def streaming-build-final-payload  re-frame.ssr.streaming/build-final-payload)
@@ -146,7 +146,7 @@
 ;; the final `__rf_payload` `:rf/hydrate` (which `ssr/hydrate!` applies).
 ;; Host opt-in — a streaming-aware bootstrap calls it; non-streaming
 ;; pages skip it.
-#?(:cljs (def streaming-install!    streaming-client/install!))
+#?(:cljs (def streaming-install!    rf.ssr.streaming.client/install!))
 
 ;; ---- SSR blocking-resource drain ------------------------------------------
 ;;
@@ -213,7 +213,7 @@
   (see `re-frame.resources.ssr/drain-blocking-resources!`)."
   ([frame-id] (drain-blocking-resources! frame-id nil))
   ([frame-id {:keys [ssr-blocking-timeout-ms tick-ms] :as opts}]
-   (if-let [drain (late-bind/get-fn :resources/drain-blocking-ssr!)]
+   (if-let [drain (rf.late-bind/get-fn :resources/drain-blocking-ssr!)]
      (drain frame-id
             {:deadline-ms (or ssr-blocking-timeout-ms default-ssr-blocking-timeout-ms)
              ;; an EXPLICIT `:pump!` (even nil — a sync test stub that drives a
@@ -236,70 +236,70 @@
 ;; (Conventions §Reserved registration meta) — without it, every hydrate
 ;; dispatch would trip the `:rf.warning/app-handler-runtime-effect`
 ;; ownership diagnostic in development.
-(events/reg-event :rf/hydrate
+(rf.events/reg-event :rf/hydrate
                      {:rf/framework-authority? true}
-                     hydrate/hydrate-event-handler)
+                     rf.ssr.hydrate/hydrate-event-handler)
 
-(fx/reg-fx :rf.ssr/check-version
+(rf.fx/reg-fx :rf.ssr/check-version
   {:doc       "Compare the payload's :rf/version (server) against the
 client runtime's version. A mismatch emits a structured
 :rf.ssr/version-mismatch trace; the hydration handler still applies
 (best-effort). Per Spec 011 §The :rf/hydrate event."
    :platforms #{:client}}
-  hydrate/check-version-fx)
+  rf.ssr.hydrate/check-version-fx)
 
-(fx/reg-fx :rf.ssr/check-schema-digest
+(rf.fx/reg-fx :rf.ssr/check-schema-digest
   {:doc       "Compare the payload's :rf/schema-digest (server) against
 the client's registered app-schema digest. A mismatch emits a structured
 :rf.ssr/schema-digest-mismatch trace. Per Spec 011 §The :rf/hydrate event."
    :platforms #{:client}}
-  hydrate/check-schema-digest-fx)
+  rf.ssr.hydrate/check-schema-digest-fx)
 
 ;; ---- the seven :rf.server/* response-shape fxs ----------------------------
 ;;
 ;; Per Spec 011 §HTTP response contract.
 
-(fx/reg-fx :rf.server/set-status
+(rf.fx/reg-fx :rf.server/set-status
   {:doc       "Set the HTTP response status. Last-write-wins. A second
 write in the same drain emits :rf.warning/multiple-status-set per
 [Spec 011 §Multiple-status policy]."
-   :schema    server-fx-schemas/set-status-args
+   :schema    rf.ssr.server-fx-schemas/set-status-args
    :platforms #{:server}}
-  response/set-status-fx)
+  rf.ssr.response/set-status-fx)
 
-(fx/reg-fx :rf.server/set-header
+(rf.fx/reg-fx :rf.server/set-header
   {:doc       "Replace any existing header with the same name (case-
 insensitive) and write [name value]. Per Spec 011 §Header replacement
 vs append."
-   :schema    server-fx-schemas/set-header-args
+   :schema    rf.ssr.server-fx-schemas/set-header-args
    :platforms #{:server}}
-  response/set-header-fx)
+  rf.ssr.response/set-header-fx)
 
-(fx/reg-fx :rf.server/append-header
+(rf.fx/reg-fx :rf.server/append-header
   {:doc       "Append [name value] to headers — preserves any existing
 header with the same name. Required for Set-Cookie-style multi-valued
 headers. Per Spec 011 §Header replacement vs append."
-   :schema    server-fx-schemas/append-header-args
+   :schema    rf.ssr.server-fx-schemas/append-header-args
    :platforms #{:server}}
-  response/append-header-fx)
+  rf.ssr.response/append-header-fx)
 
-(fx/reg-fx :rf.server/set-cookie
+(rf.fx/reg-fx :rf.server/set-cookie
   {:doc       "Add a structured cookie to the :cookies vector. Cookie
 attributes are stored as a structured map (RFC 6265 wire-form
 serialisation is host-adapter business). Per Spec 011 §Cookie shape."
-   :schema    server-fx-schemas/set-cookie-args
+   :schema    rf.ssr.server-fx-schemas/set-cookie-args
    :platforms #{:server}}
-  response/set-cookie-fx)
+  rf.ssr.response/set-cookie-fx)
 
-(fx/reg-fx :rf.server/delete-cookie
+(rf.fx/reg-fx :rf.server/delete-cookie
   {:doc       "Sugar over :rf.server/set-cookie with :max-age 0 and an
 empty :value. The host adapter materialises the delete-marker semantics
 on the wire. Per Spec 011 §Cookie shape."
-   :schema    server-fx-schemas/delete-cookie-args
+   :schema    rf.ssr.server-fx-schemas/delete-cookie-args
    :platforms #{:server}}
-  response/delete-cookie-fx)
+  rf.ssr.response/delete-cookie-fx)
 
-(fx/reg-fx :rf.server/redirect
+(rf.fx/reg-fx :rf.server/redirect
   {:doc       "Set :redirect on the response accumulator. Defaults
 :status to 302 if absent. Multiple writes emit
 :rf.warning/multiple-redirects (last-write-wins). Per Spec 011
@@ -309,11 +309,11 @@ Caller-trusted :location — accepts arbitrary URL strings without
 allowlist or relative-only gating. For caller-untrusted location strings
 (e.g. a `?next=` URL param), use :rf.server/safe-redirect (below).
 The trusted path still rejects header-splitting characters."
-   :schema    server-fx-schemas/redirect-args
+   :schema    rf.ssr.server-fx-schemas/redirect-args
    :platforms #{:server}}
-  response/redirect-fx)
+  rf.ssr.response/redirect-fx)
 
-(fx/reg-fx :rf.server/safe-redirect
+(rf.fx/reg-fx :rf.server/safe-redirect
   {:doc       "Set :redirect after a five-step validation gate (per
 Spec 011 §HTTP response contract §Standard fx). Mitigation for the
 open-redirect class — an attacker-controlled `?next=...` URL parameter
@@ -332,15 +332,15 @@ Validation order: (1) URL must parse — :rf.error/safe-redirect-invalid-url;
 :rf.error/safe-redirect-host-disallowed (:reason :relative-only-violation);
 (4) :allow allowlist mismatch — :rf.error/safe-redirect-host-disallowed
 (:reason :not-in-allowlist); (5) pass — set Location header."
-   :schema    server-fx-schemas/safe-redirect-args
+   :schema    rf.ssr.server-fx-schemas/safe-redirect-args
    :platforms #{:server}}
-  response/safe-redirect-fx)
+  rf.ssr.response/safe-redirect-fx)
 
 ;; ---- :rf.server/request cofx ----------------------------------------------
 ;;
 ;; Per Spec 011 §Server-only `reg-cofx` for request context.
 
-(cofx/reg-cofx :rf.server/request
+(rf.cofx/reg-cofx :rf.server/request
   {:doc       "The active host-supplied HTTP request. Server only.
 
 This is an ambient, per-frame read. It is suitable for transient decisions
@@ -358,7 +358,7 @@ The host calls `set-request!` before draining the frame. Handlers declare
 `:rf.server/request`. Tests without a host adapter populate the same slot
 explicitly."
    :platforms #{:server}}
-  request/request-cofx)
+  rf.ssr.request/request-cofx)
 
 ;; ---- error-projector registry + trace-listener ----------------------------
 ;;
@@ -384,8 +384,8 @@ explicitly."
 ;; categories. A sub that throws mid-render projects a fail-closed 5xx under
 ;; production hardening instead of recovering to nil and producing an HTTP
 ;; 200; an unroutable URL projects 404 instead of a soft-404 200.
-(rf-emit/register-error-listener! ::error-projection
-                                  error-listener/error-emit-projection-listener)
+(rf.emit/register-error-listener! ::error-projection
+                                  rf.ssr.error-listener/error-emit-projection-listener)
 
 ;; The development trace listener covers the same categories on the DEV
 ;; trace bus, plus the ones that ride it ALONE and so DCE under
@@ -400,8 +400,8 @@ explicitly."
 ;; `::error-projection` to keep the contract surface addressable as one
 ;; logical projector — `apply-error-projection!` 1-arity is
 ;; last-write-wins, so the duplicate buffer entry under dev is benign.
-(trace-tooling/register-listener! ::error-projection
-                                  error-listener/error-projection-listener)
+(rf.trace.tooling/register-listener! ::error-projection
+                                  rf.ssr.error-listener/error-projection-listener)
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
@@ -412,14 +412,14 @@ explicitly."
 ;; classpath the lookups return nil and the consumer raises
 ;; `:rf.error/ssr-artefact-missing`.
 
-(late-bind/set-fn! :ssr/render-tree-hash    render-tree-hash)
-(late-bind/set-fn! :ssr/render-to-string    render-to-string)
-(late-bind/set-fn! :ssr/reg-error-projector reg-error-projector)
-(late-bind/set-fn! :ssr/project-error       project-error)
+(rf.late-bind/set-fn! :ssr/render-tree-hash    render-tree-hash)
+(rf.late-bind/set-fn! :ssr/render-to-string    render-to-string)
+(rf.late-bind/set-fn! :ssr/reg-error-projector reg-error-projector)
+(rf.late-bind/set-fn! :ssr/project-error       project-error)
 ;; Frame teardown looks up this hook and clears the SSR side-channel atoms
 ;; (`pending-error-traces`, `request-slots`, `response-slots`) for the
 ;; destroyed frame.
-(late-bind/set-fn! :ssr/on-frame-destroyed  on-frame-destroyed!)
+(rf.late-bind/set-fn! :ssr/on-frame-destroyed  on-frame-destroyed!)
 
 ;; `re-frame.ssr.head` is required above so its late-bind hooks
 ;; (`:ssr/reg-head`, `:ssr/render-head`, `:ssr/active-head`,

--- a/implementation/ssr/src/re_frame/ssr/boot.cljc
+++ b/implementation/ssr/src/re_frame/ssr/boot.cljc
@@ -9,18 +9,18 @@
 
   `read-server-payload` is CLJS-only and reads the pinned `__rf_payload`
   element. `hydrate!` is platform-neutral when given an explicit payload."
-  (:require [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.router :as router]
-            [re-frame.ssr.hydrate :as hydrate]
-            [re-frame.ssr.install :as install]
-            [re-frame.trace :as trace]
+  (:require [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.router :as rf.router]
+            [re-frame.ssr.hydrate :as rf.ssr.hydrate]
+            [re-frame.ssr.install :as rf.ssr.install]
+            [re-frame.trace :as rf.trace]
             ;; `constants` + `cljs.reader` are only used by the CLJS-only
             ;; `read-server-payload` (DOM read); require them on CLJS so a
             ;; JVM lint of this `.cljc` doesn't flag them unused.
-            #?(:cljs [re-frame.ssr.constants :as constants])
+            #?(:cljs [re-frame.ssr.constants :as rf.ssr.constants])
             #?(:cljs [cljs.reader :as reader])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -37,11 +37,11 @@
   error-emitter hook is absent."
   [where element-id reason]
   (when-let [dispatch-error-record!
-             (late-bind/get-fn :error-emit/dispatch-error-record)]
+             (rf.late-bind/get-fn :error-emit/dispatch-error-record)]
     (dispatch-error-record!
       {:error      :rf.error/malformed-hydration-payload
        :frame      nil
-       :time       (interop/now-ms)
+       :time       (rf.interop/now-ms)
        :where      where
        :failing-id :rf/hydrate
        :element-id element-id
@@ -81,7 +81,7 @@
      A host that overrode `:html-shell` with a custom payload id must
      read that id itself rather than calling this fn (the framework's
      bundled boot reads only the pinned id)."
-     ([] (read-server-payload constants/payload-script-id))
+     ([] (read-server-payload rf.ssr.constants/payload-script-id))
      ([element-id]
       (when-let [el (.getElementById js/document element-id)]
         (try
@@ -91,8 +91,8 @@
                               "did not parse as EDN; treating the "
                               "page as client-only (no hydration). "
                               (ex-message e))]
-              (when interop/debug-enabled?
-                (trace/emit-error! :rf.error/malformed-hydration-payload
+              (when rf.interop/debug-enabled?
+                (rf.trace/emit-error! :rf.error/malformed-hydration-payload
                                    {:where      'rf.ssr/read-server-payload
                                     :failing-id :rf/hydrate
                                     :element-id element-id
@@ -125,7 +125,7 @@
   (let [payload-frame-id (:rf/frame-id payload)]
     (when (and (some? payload-frame-id)
                (not= payload-frame-id target))
-      (let [ex   (error/thrown-ex-info
+      (let [ex   (rf.error/thrown-ex-info
                    :rf.error/hydration-frame-id-mismatch
                    'rf.ssr/hydrate!
                    (str "Hydration frame-id mismatch: the explicit "
@@ -140,8 +140,8 @@
                                :target-frame     target
                                :payload-frame-id payload-frame-id}})
             data (ex-data ex)]
-        (when interop/debug-enabled?
-          (trace/emit-error! :rf.error/hydration-frame-id-mismatch data))
+        (when rf.interop/debug-enabled?
+          (rf.trace/emit-error! :rf.error/hydration-frame-id-mismatch data))
         (throw ex)))))
 
 (defn hydrate!
@@ -318,11 +318,11 @@
         ;; The client hydration target is supplied explicitly. A nil stamp is an absent target,
         ;; not a request to synthesise `:rf/default`; surface the always-on
         ;; `:rf.error/no-frame-context`. Per Spec 002 §Frame target resolution.
-        frame   (frame/require-frame-stamp!
+        frame   (rf.frame/require-frame-stamp!
                   frame :rf.ssr/hydrate {:where 'rf.ssr/hydrate!})
         payload (or payload
                     #?(:cljs (read-server-payload
-                               (or element-id constants/payload-script-id))
+                               (or element-id rf.ssr.constants/payload-script-id))
                        :clj nil))]
     (when payload
       ;; The payload's `:rf/frame-id` is metadata and validation
@@ -346,7 +346,7 @@
       ;; ratified "later roots find it live and do not re-seed"). A
       ;; DIFFERENT payload under the same id throws before any install.
       (let [{:keys [decision claim]}
-            (install/preflight! 'rf.ssr/hydrate!
+            (rf.ssr.install/preflight! 'rf.ssr/hydrate!
                                 {:payload    payload
                                  :payload-id frame
                                  :root-id    root-id
@@ -398,10 +398,10 @@
           ;;
           ;; Unconditional, never `debug-enabled?`-gated: a root can fail in
           ;; production, so the claim must be released in production.
-          (let [incarnation (frame/frame-incarnation-token frame)]
-            (router/dispatch-sync! [:rf/hydrate payload] {:frame frame})
-            (if-not (frame/frame-incarnation-live? frame incarnation)
-              (install/release-claim! frame claim)
+          (let [incarnation (rf.frame/frame-incarnation-token frame)]
+            (rf.router/dispatch-sync! [:rf/hydrate payload] {:frame frame})
+            (if-not (rf.frame/frame-incarnation-live? frame incarnation)
+              (rf.ssr.install/release-claim! frame claim)
               ;; HOT PATH — post-render hash-mismatch detection. Symmetric with
               ;; the server's `:render-hash`-stamped `data-rf-render-hash` marker.
               ;; Runs only on a landed seed: verifying a client tree against a
@@ -419,7 +419,7 @@
               ;; `*current-frame*` for the one call; a `render-tree-fn` that establishes
               ;; its own scope (or ignores it — a plain-hiccup fn) is unaffected.
               (when render-tree-fn
-                (hydrate/verify-hydration! frame ((frame/bind-fn frame render-tree-fn)))))))))
+                (rf.ssr.hydrate/verify-hydration! frame ((rf.frame/bind-fn frame render-tree-fn)))))))))
     payload))
 
 ;; ---------------------------------------------------------------------------
@@ -463,17 +463,17 @@
                     (exception-message exception))
         record {:error     :rf.error/root-boot-failed
                 :frame     frame
-                :time      (interop/now-ms)
+                :time      (rf.interop/now-ms)
                 :where     where
                 :root-id   root-id
                 :phase     phase
                 :reason    reason
                 :exception exception
                 :recovery  :warned-and-continued}]
-    (when interop/debug-enabled?
-      (trace/emit-error! :rf.error/root-boot-failed (dissoc record :error :time)))
+    (when rf.interop/debug-enabled?
+      (rf.trace/emit-error! :rf.error/root-boot-failed (dissoc record :error :time)))
     (when-let [dispatch-error-record!
-               (late-bind/get-fn :error-emit/dispatch-error-record)]
+               (rf.late-bind/get-fn :error-emit/dispatch-error-record)]
       (dispatch-error-record! record)))
   nil)
 

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -39,11 +39,11 @@
   ;; hiccup → HTML function with no registry dependency at all, which is
   ;; the honest shape — resolving a name was never the emitter's job.
   (:require [clojure.string]
-            [re-frame.error :as error]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.ssr.hash :as hash]
-            [re-frame.ssr.html-helpers :as html]
-            #?(:cljs [re-frame.substrate.plain-atom :as plain-atom-cljs])))
+            [re-frame.error :as rf.error]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.ssr.hash :as rf.ssr.hash]
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]
+            #?(:cljs [re-frame.substrate.plain-atom :as rf.substrate.plain-atom])))
 
 ;; ---- shared HTML helpers --------------------------------------------------
 ;;
@@ -54,7 +54,7 @@
 ;; consumed directly via the `html/` alias — they have no `emit/`-qualified
 ;; consumers.
 
-(def attr-string html/attr-string)
+(def attr-string rf.ssr.html-helpers/attr-string)
 
 ;; Per HTML5 spec, these elements are void — they self-close and have no
 ;; closing tag.
@@ -133,7 +133,7 @@
   [tag-name source-kw]
   (when-not (and (string? tag-name)
                  (re-matches tag-name-re tag-name))
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/invalid-tag-name
       'rf.ssr/emit
       (str "tag-name " (pr-str tag-name)
@@ -322,8 +322,8 @@
   crossing: this arm is
   reached only for a keyword in the reserved `:rf/*` namespace."
   [element head]
-  (let [safe-element (error/safe-form element)]
-    (error/throw-error!
+  (let [safe-element (rf.error/safe-form element)]
+    (rf.error/throw-error!
       :rf.error/invalid-hiccup-head
       'rf.ssr/emit
       (str "hiccup vector head " (pr-str head)
@@ -365,8 +365,8 @@
   `error/safe-form` first; `(first element)` is read from the crossed value,
   so the head is covered by the same one crossing."
   [element]
-  (let [safe-element (error/safe-form element)]
-    (error/throw-error!
+  (let [safe-element (rf.error/safe-form element)]
+    (rf.error/throw-error!
       :rf.error/invalid-hiccup-head
       'rf.ssr/emit
       (str "hiccup vector head " (pr-str (first safe-element))
@@ -566,7 +566,7 @@
       ;; with the same args (Form-2 semantics) to get the hiccup.
       (let [rendered (invoke-form-2-render-fn resolved args)]
         (if (fn? rendered)
-          (error/throw-error!
+          (rf.error/throw-error!
             :rf.error/ssr-nonrenderable-component
             'rf.ssr/emit
             (str "a callable hiccup component resolved to a fn even after the"
@@ -591,14 +591,14 @@
   ([el root-attrs]
    (cond
      (nil? el)         ""
-     (string? el)      (html/escape-html el)
+     (string? el)      (rf.ssr.html-helpers/escape-html el)
      ;; Canonicalise the numeric print form so the emitted HTML matches the
      ;; render-tree hash byte-for-byte across runtimes (rf2-0ypnnk): a
      ;; whole-valued double renders `9` (not the JVM `9.0`), agreeing with
      ;; CLJS. `canonical-number` uses `pr-str`, which coincides with `str`
      ;; for numbers (no quoting), so ordinary integers/decimals are
      ;; unchanged.
-     (number? el)      (hash/canonical-number el)
+     (number? el)      (rf.ssr.hash/canonical-number el)
      (boolean? el)     ""
      ;; A keyword or symbol CHILD is spelled by its `name` — no leading
      ;; colon, namespace dropped (rf2-53lsj).
@@ -621,7 +621,7 @@
      ;; `(or (keyword? el) (symbol? el))` rather than `named?` — the
      ;; latter is CLJS-only, and this is a `.cljc` emitter.
      (or (keyword? el) (symbol? el))
-     (html/escape-html (name el))
+     (rf.ssr.html-helpers/escape-html (name el))
      (vector? el)
      (let [head (first el)]
        (cond
@@ -664,8 +664,8 @@
          ;; …]` is what `:>` interop is FOR, and a React 19 provider is a
          ;; cyclic object graph.
          (= :> head)
-         (let [el (error/safe-form el)]
-           (error/throw-error!
+         (let [el (rf.error/safe-form el)]
+           (rf.error/throw-error!
              :rf.error/ssr-reagent-native-head
              'rf.ssr/emit
              (str "Reagent-native interop head `:>` "
@@ -698,8 +698,8 @@
          ;; boundary's `:fallback` is ordinary hiccup and can carry a
          ;; foreign JS value anywhere inside it.
          (= :rf/suspense-boundary head)
-         (let [el (error/safe-form el)]
-           (error/throw-error!
+         (let [el (rf.error/safe-form el)]
+           (rf.error/throw-error!
              :rf.error/ssr-suspense-boundary-outside-stream
              'rf.ssr/emit
              (str ":rf/suspense-boundary (element "
@@ -773,7 +773,7 @@
                ;; case.
                normalised-tag-name (clojure.string/lower-case tag-name)
                void?        (contains? void-elements (keyword normalised-tag-name))
-               raw-text?    (contains? html/raw-text-tags normalised-tag-name)]
+               raw-text?    (contains? rf.ssr.html-helpers/raw-text-tags normalised-tag-name)]
            (cond
              void?     (str "<" tag-name (attr-string attrs) ">")
              ;; rf2-xbvzh — an ordinary inline <script>/<style> with STRING
@@ -787,7 +787,7 @@
              ;; no compiled child-shape grammar).
              (and raw-text? (seq children) (every? string? children))
              (str "<" tag-name (attr-string attrs) ">"
-                  (html/escape-raw-text normalised-tag-name
+                  (rf.ssr.html-helpers/escape-raw-text normalised-tag-name
                                         (clojure.string/join children))
                   "</" tag-name ">")
              :else
@@ -831,7 +831,7 @@
      ;; `data-rf-render-hash` marker; thread it onto the first DOM child,
      ;; exactly like the `:<>` fragment root.
      (sequential? el) (emit-children-threading-root-attrs el root-attrs)
-     :else (html/escape-html el))))
+     :else (rf.ssr.html-helpers/escape-html el))))
 
 (defn render-to-string
   "Pure hiccup → HTML string. Per Spec 011 §The render-tree → HTML
@@ -898,12 +898,12 @@
      (catch Throwable _ nil)))
 
 #?(:cljs
-   (plain-atom-cljs/set-hiccup-emitter! render-to-string))
+   (rf.substrate.plain-atom/set-hiccup-emitter! render-to-string))
 
 ;; Reagent adapter wiring (load-order-symmetric counterpart to the
 ;; plain-atom path above). No-op when the Reagent adapter isn't on the
 ;; classpath.
-(when-let [reagent-set-emitter! (late-bind/get-fn :reagent/set-hiccup-emitter!)]
+(when-let [reagent-set-emitter! (rf.late-bind/get-fn :reagent/set-hiccup-emitter!)]
   (reagent-set-emitter! render-to-string))
 
 ;; rf2-vxgfnd.204 — retain the current SSR emitter durably so a substrate
@@ -921,4 +921,4 @@
 ;; install replay is a harmless idempotent re-apply. Load-order symmetric with
 ;; the publications above — whichever of ssr / adapter loads last, the durable
 ;; slot plus the install replay converge on the same armed state.
-(late-bind/set-fn! :ssr/current-hiccup-emitter render-to-string)
+(rf.late-bind/set-fn! :ssr/current-hiccup-emitter render-to-string)

--- a/implementation/ssr/src/re_frame/ssr/error_listener.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_listener.cljc
@@ -7,11 +7,11 @@
   Listeners buffer candidate errors instead of projecting inside the callback.
   The settle-point drain then chooses the final error, respects redirect
   precedence, and updates the per-frame response accumulator atomically."
-  (:require [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.ssr.error-projector :as error-projector]
-            [re-frame.ssr.response :as response]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr.error-projector :as rf.ssr.error-projector]
+            [re-frame.ssr.response :as rf.ssr.response]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- always-on error emission ---------------------------------------------
 ;;
@@ -46,7 +46,7 @@
   frame."
   [trace-event]
   (let [tag-frame (get-in trace-event [:tags :frame])]
-    (when (and tag-frame (error-projector/server-frame? tag-frame))
+    (when (and tag-frame (rf.ssr.error-projector/server-frame? tag-frame))
       tag-frame)))
 
 ;; Categories that are RECOVERABLE DEGRADATIONS, not request failures.
@@ -175,7 +175,7 @@
 (defn- buffer-error-trace!
   ;; All SSR side channels use the process-local frame address.
   [frame-id trace-event]
-  (swap! pending-error-traces update (frame/frame-address frame-id)
+  (swap! pending-error-traces update (rf.frame/frame-address frame-id)
          (fnil conj []) trace-event))
 
 (defn- consume-pending-traces!
@@ -189,7 +189,7 @@
   next drain). No trace is dropped either way. `swap-vals!` is available
   on both the JVM (Clojure ≥1.9) and ClojureScript."
   [frame-id]
-  (let [frame-address (frame/frame-address frame-id)
+  (let [frame-address (rf.frame/frame-address frame-id)
         [prior-traces _updated-traces]
         (swap-vals! pending-error-traces dissoc frame-address)]
     (get prior-traces frame-address [])))
@@ -221,16 +221,16 @@
   `:redirect`, the redirect's :status is locked through and this fn
   does not overwrite it."
   ([frame-id]
-   (when-let [last-trace (when (and frame-id (error-projector/server-frame? frame-id))
+   (when-let [last-trace (when (and frame-id (rf.ssr.error-projector/server-frame? frame-id))
                            (last (consume-pending-traces! frame-id)))]
      (apply-error-projection! frame-id last-trace)))
   ([frame-id trace-event]
-   (when (and frame-id trace-event (error-projector/server-frame? frame-id))
-     (let [public-error     (error-projector/project-error frame-id trace-event)
-           current-response (response/response-of frame-id)
+   (when (and frame-id trace-event (rf.ssr.error-projector/server-frame? frame-id))
+     (let [public-error     (rf.ssr.error-projector/project-error frame-id trace-event)
+           current-response (rf.ssr.response/response-of frame-id)
            redirect         (:redirect current-response)]
        (when-not redirect
-         (response/swap-response! frame-id
+         (rf.ssr.response/swap-response! frame-id
                                   (fn [response]
                                     (assoc response :status (:status public-error)))))
        public-error))))
@@ -262,13 +262,13 @@
   prefer eager exceptions during dev (to surface bugs early) opt in
   per-frame. Production should always project (the default)."
   [frame-id ^Throwable t]
-  (when (and frame-id (error-projector/server-frame? frame-id)
-             (= :throw (get-in (frame/frame-meta frame-id)
+  (when (and frame-id (rf.ssr.error-projector/server-frame? frame-id)
+             (= :throw (get-in (rf.frame/frame-meta frame-id)
                                [:ssr :on-view-exception])))
     ;; Dev opt-in — surface the original throwable to the host's outer
     ;; handler rather than projecting it to a sanitised public-error.
     (throw t))
-  (when (and frame-id (error-projector/server-frame? frame-id))
+  (when (and frame-id (rf.ssr.error-projector/server-frame? frame-id))
     (let [tags {:frame             frame-id
                 :exception         t
                 :exception-message #?(:clj  (.getMessage t)
@@ -297,7 +297,7 @@
       ;; listener will buffer the trace under :ssr.error/render-failed;
       ;; we drain it again via the 1-arity call below so the buffer
       ;; clears.
-      (trace/emit-error! :rf.error/ssr-render-failed tags)
+      (rf.trace/emit-error! :rf.error/ssr-render-failed tags)
       ;; EP-0008 (rf2-hhutya): ALSO ride the always-on error-emit axis so
       ;; an off-box shipper on a `-Dre-frame.debug=false` JVM SSR host sees
       ;; the structured render-failure record (the dev trace above is
@@ -308,10 +308,10 @@
       ;; drops BOTH buffered duplicates, so the wire status is driven solely
       ;; by the DIRECT `apply-error-projection!` call (no double-stamp, no
       ;; re-project on a later flush). Union record shape.
-      (error-projector/emit-always-on-error!
+      (rf.ssr.error-projector/emit-always-on-error!
         {:error :rf.error/ssr-render-failed
          :frame frame-id
-         :time  (interop/now-ms)
+         :time  (rf.interop/now-ms)
          :exception         t
          :exception-message #?(:clj  (.getMessage t)
                                :cljs (.-message t))
@@ -448,7 +448,7 @@
                          :tags      (-> (dissoc record :error)
                                         (update :recovery #(or % :no-recovery)))}]
         (when (and direct-frame-id
-                   (error-projector/server-frame? direct-frame-id))
+                   (rf.ssr.error-projector/server-frame? direct-frame-id))
           (buffer-error-trace! direct-frame-id trace-event))))))
 
 (defn peek-response
@@ -461,8 +461,8 @@
   projector buffer (the side-effect baked into `get-response`) would
   consume a trace the host had not yet observed."
   [frame-id]
-  (-> (response/response-of frame-id)
-      (dissoc response/status-writes-key response/redirect-writes-key)))
+  (-> (rf.ssr.response/response-of frame-id)
+      (dissoc rf.ssr.response/status-writes-key rf.ssr.response/redirect-writes-key)))
 
 (defn flush-response-result!
   "Drain any pending error projection for `frame-id` ONCE and return BOTH
@@ -538,11 +538,11 @@
   recovered-to-nil error-view sub — the signal to fall back once to the
   locked template."
   [frame-id]
-  (boolean (seq (get @pending-error-traces (frame/frame-address frame-id)))))
+  (boolean (seq (get @pending-error-traces (rf.frame/frame-address frame-id)))))
 
 (defn clear-pending-error-traces!
   "Drop frame-id's entry from the pending-error-traces buffer.
   Called from `re-frame.ssr.request/on-frame-destroyed!`. Keyed by the frame
   address."
   [frame-id]
-  (swap! pending-error-traces dissoc (frame/frame-address frame-id)))
+  (swap! pending-error-traces dissoc (rf.frame/frame-address frame-id)))

--- a/implementation/ssr/src/re_frame/ssr/error_projector.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_projector.cljc
@@ -25,12 +25,12 @@
   `re-frame.ssr.error-listener`. This namespace stays effect-free
   (apart from registering the built-in default projector) so the
   projector logic can be exercised standalone."
-  (:require [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.source-coords :as source-coords]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.source-coords :as rf.source-coords]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- always-on error emission ---------------------------------------------
 ;;
@@ -66,7 +66,7 @@
   nil-return contract cannot drift. The ssr-ring artefact keeps a local wrapper
   to preserve the artefact boundary."
   [record]
-  (when-let [dispatch-error-record! (late-bind/get-fn :error-emit/dispatch-error-record)]
+  (when-let [dispatch-error-record! (rf.late-bind/get-fn :error-emit/dispatch-error-record)]
     (dispatch-error-record! record))
   nil)
 
@@ -281,8 +281,8 @@
   ([id projector-fn]
    (reg-error-projector id {} projector-fn))
   ([id metadata projector-fn]
-   (registrar/register! :error-projector id
-                        (assoc (source-coords/merge-coords metadata)
+   (rf.registrar/register! :error-projector id
+                        (assoc (rf.source-coords/merge-coords metadata)
                                :handler-fn projector-fn))
    id))
 
@@ -294,7 +294,7 @@
   EXPLICITLY-configured projector (a recognised-but-unhonourable config,
   worth a diagnostic) apart from the plain default-fallback path (rf2-mlodrn)."
   [frame-id]
-  (get-in (frame/frame-meta frame-id) [:ssr :public-error-id]))
+  (get-in (rf.frame/frame-meta frame-id) [:ssr :public-error-id]))
 
 (defn- frame-projector-id
   "Read the :ssr config's :public-error-id for a frame, falling back
@@ -309,7 +309,7 @@
   :details key with the raw trace event."
   [frame-id]
   (boolean
-    (get-in (frame/frame-meta frame-id) [:ssr :dev-error-detail?])))
+    (get-in (rf.frame/frame-meta frame-id) [:ssr :dev-error-detail?])))
 
 (defn project-error
   "Resolve the active projector for the given frame and apply it to
@@ -330,7 +330,7 @@
   [frame-id trace-event]
   (let [configured-id (frame-configured-projector-id frame-id)
         projector-id  (frame-projector-id frame-id)
-        projector-fn  (registrar/handler :error-projector projector-id)
+        projector-fn  (rf.registrar/handler :error-projector projector-id)
         dev-detail?   (frame-dev-error-detail? frame-id)
         ;; Two failure modes for the projector:
         ;;   :threw      — the catch path returns this in `result`
@@ -344,7 +344,7 @@
             (projector-fn trace-event)
             ::no-projector)
           (catch #?(:clj Throwable :cljs :default) e
-            (trace/emit-error! :rf.error/sanitised-on-projection
+            (rf.trace/emit-error! :rf.error/sanitised-on-projection
                                {:projector-id      projector-id
                                 :frame             frame-id
                                 :exception         e
@@ -358,7 +358,7 @@
             (emit-always-on-error!
               {:error :rf.error/sanitised-on-projection
                :frame frame-id
-               :time  (interop/now-ms)
+               :time  (rf.interop/now-ms)
                :projector-id      projector-id
                :exception         e
                :exception-message #?(:clj  (.getMessage e)
@@ -403,19 +403,19 @@
                                                           " projector — using the locked"
                                                           " generic-500 fallback.")
                           :recovery                  :register-the-configured-projector-or-fix-the-id}]
-                (trace/emit-error! :rf.error/sanitised-on-projection tags)
+                (rf.trace/emit-error! :rf.error/sanitised-on-projection tags)
                 ;; EP-0008 (rf2-hhutya): ALSO ride the always-on axis so an
                 ;; off-box shipper on a `-Dre-frame.debug=false` JVM SSR host
                 ;; sees the misconfiguration. One-shot + NON-PROJECTING.
                 (emit-always-on-error!
                   (merge {:error :rf.error/sanitised-on-projection
-                          :time  (interop/now-ms)}
+                          :time  (rf.interop/now-ms)}
                          tags))))
             fallback-public-error)
 
           :else
           (do
-            (trace/emit-error! :rf.error/sanitised-on-projection
+            (rf.trace/emit-error! :rf.error/sanitised-on-projection
                                {:projector-id      projector-id
                                 :frame             frame-id
                                 :returned          result
@@ -428,7 +428,7 @@
             (emit-always-on-error!
               {:error :rf.error/sanitised-on-projection
                :frame frame-id
-               :time  (interop/now-ms)
+               :time  (rf.interop/now-ms)
                :projector-id      projector-id
                :returned          result
                :reason            "Error projector returned a non-conforming shape — using fallback."
@@ -441,4 +441,4 @@
   "True when the frame's :platform is :server. The error-projection
   hook only fires for server frames."
   [frame-id]
-  (= :server (:platform (frame/frame-meta frame-id))))
+  (= :server (:platform (rf.frame/frame-meta frame-id))))

--- a/implementation/ssr/src/re_frame/ssr/head.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head.cljc
@@ -28,18 +28,18 @@
   §Optional-artefact wrapper convention), each public surface is
   reachable via `re-frame.core` through a late-bind hook so core never
   statically `:require`s `re-frame.ssr.head`."
-  (:require [re-frame.late-bind :as late-bind]
-            [re-frame.ssr.head.emit :as head-emit]
-            [re-frame.ssr.head.registry :as registry]))
+  (:require [re-frame.late-bind :as rf.late-bind]
+            [re-frame.ssr.head.emit :as rf.ssr.head.emit]
+            [re-frame.ssr.head.registry :as rf.ssr.head.registry]))
 
 ;; ---- public-surface re-exports --------------------------------------------
 
-(def head-model->html    head-emit/head-model->html)
+(def head-model->html    rf.ssr.head.emit/head-model->html)
 
-(def reg-head            registry/reg-head)
-(def render-head         registry/render-head)
-(def active-head         registry/active-head)
-(def default-head        registry/default-head)
+(def reg-head            rf.ssr.head.registry/reg-head)
+(def render-head         rf.ssr.head.registry/render-head)
+(def active-head         rf.ssr.head.registry/active-head)
+(def default-head        rf.ssr.head.registry/default-head)
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
@@ -49,11 +49,11 @@
 ;; every hook, regardless of which sub-ns happened to define the
 ;; underlying fn.
 
-(late-bind/set-fn! :ssr/reg-head          reg-head)
-(late-bind/set-fn! :ssr/render-head       render-head)
-(late-bind/set-fn! :ssr/active-head       active-head)
+(rf.late-bind/set-fn! :ssr/reg-head          reg-head)
+(rf.late-bind/set-fn! :ssr/render-head       render-head)
+(rf.late-bind/set-fn! :ssr/active-head       active-head)
 ;; NB: late-bind keys conventionally use `-` only (the drift-detector
 ;; regex limits its grammar to alpha-numeric + standard symbol chars);
 ;; the user-facing fn is `head-model->html` but the hook key drops the
 ;; `->` decoration.
-(late-bind/set-fn! :ssr/head-model-html   head-model->html)
+(rf.late-bind/set-fn! :ssr/head-model-html   head-model->html)

--- a/implementation/ssr/src/re_frame/ssr/head/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/emit.cljc
@@ -21,8 +21,8 @@
   ;; inside `ld-json-string`'s `:clj` arm (the hand-rolled JSON emitter and
   ;; its two fail-fast gates). CLJS goes through `js/JSON.stringify`.
   (:require #?@(:clj [[clojure.string :as str]
-                      [re-frame.error :as error]])
-            [re-frame.ssr.html-helpers :as html]))
+                      [re-frame.error :as rf.error]])
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]))
 
 ;; Reflection warnings guard the hand-rolled JVM JSON emitter.
 ;; The JVM-side `ld-json-string` is hand-rolled JSON emission; the
@@ -34,18 +34,18 @@
 
 (defn- emit-title [title]
   (when (and title (not= "" title))
-    (str "<title>" (html/escape-html title) "</title>")))
+    (str "<title>" (rf.ssr.html-helpers/escape-html title) "</title>")))
 
 (defn- emit-meta-tag [attrs]
-  (str "<meta" (html/attr-string attrs) ">"))
+  (str "<meta" (rf.ssr.html-helpers/attr-string attrs) ">"))
 
 (defn- emit-link-tag [attrs]
-  (str "<link" (html/attr-string attrs) ">"))
+  (str "<link" (rf.ssr.html-helpers/attr-string attrs) ">"))
 
 (defn- emit-script-tag [attrs]
   ;; `attr-string` already iterates the whole map in declaration order;
   ;; pass `attrs` straight through.
-  (str "<script" (html/attr-string attrs) "></script>"))
+  (str "<script" (rf.ssr.html-helpers/attr-string attrs) "></script>"))
 
 (defn- ld-json-string
   "Serialise a JSON-LD object map to its `<script type=\"application/ld+json\">`
@@ -68,7 +68,7 @@
   literal escape for `<`, so the payload round-trips unchanged."
   [value]
   #?(:cljs (-> (js/JSON.stringify (clj->js value))
-               html/escape-script-body-string)
+               rf.ssr.html-helpers/escape-script-body-string)
      :clj  (letfn [(emit-number [number]
                      ;; `(str v)` produces non-JSON for two
                      ;; numeric shapes the JVM admits but JSON.parse rejects:
@@ -82,7 +82,7 @@
                        (and (or (instance? Double number)
                                 (instance? Float number))
                             (not (Double/isFinite (double number))))
-                       (error/throw-error!
+                       (rf.error/throw-error!
                          :rf.error/invalid-json-ld-number
                          'rf.ssr.head/emit
                          (str "JSON-LD number " (pr-str number)
@@ -133,7 +133,7 @@
                               ;; Escape `<` so user-controlled
                               ;; string contents can't close the
                               ;; surrounding <script>.
-                              html/escape-script-body-string)
+                              rf.ssr.html-helpers/escape-script-body-string)
                           "\""))
                    (emit-key [map-key]
                      ;; JSON object keys must be quoted
@@ -152,7 +152,7 @@
                                               (str key-namespace "/" (name map-key))
                                               (name map-key)))
                        (nil? map-key)
-                       (error/throw-error!
+                       (rf.error/throw-error!
                          :rf.error/invalid-json-ld-key
                          'rf.ssr.head/emit
                          (str "JSON-LD object key is nil"

--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -15,10 +15,10 @@
   Reading a head is a pure read: the model a caller wants is the value
   `render-head` / `active-head` returned. There is no side-channel
   register, so there is nothing to clear on frame teardown."
-  (:require [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.source-coords :as source-coords]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.source-coords :as rf.source-coords]))
 
 ;; ---- reg-head -------------------------------------------------------------
 
@@ -46,8 +46,8 @@
   ([id head-fn]
    (reg-head id {} head-fn))
   ([id metadata head-fn]
-   (registrar/register! :head id
-                        (assoc (source-coords/merge-coords metadata)
+   (rf.registrar/register! :head id
+                        (assoc (rf.source-coords/merge-coords metadata)
                                :handler-fn head-fn))
    id))
 
@@ -71,7 +71,7 @@
   too produced two `<meta charset>` tags in the non-streaming default
   document."
   [frame-id]
-  (let [doc (when frame-id (:doc (frame/frame-meta frame-id)))]
+  (let [doc (when frame-id (:doc (rf.frame/frame-meta frame-id)))]
     {:title (or doc "")
      :meta  [{:name "viewport" :content "width=device-width, initial-scale=1"}]}))
 
@@ -83,7 +83,7 @@
   never been written resolves to nil."
   [frame-id]
   (when frame-id
-    (let [runtime-db (frame/frame-runtime-db-value frame-id)]
+    (let [runtime-db (rf.frame/frame-runtime-db-value frame-id)]
       (when runtime-db
         (get-in runtime-db [:rf.runtime/routing :current])))))
 
@@ -98,7 +98,7 @@
   `:rf.error/no-frame-context` (no `:rf/default`-against-absence
   rendering). Per Spec 002 §Frame target resolution."
   [head-id {:keys [frame] :as opts}]
-  (let [frame    (frame/require-frame-stamp!
+  (let [frame    (rf.frame/require-frame-stamp!
                    frame :rf.ssr/render-head
                    {:where 'rf/render-head :event-id head-id})
         route    (if (contains? opts :route)
@@ -108,9 +108,9 @@
         ;; (rf2-afdlyr realm collapse: the realm substrate is a single default
         ;; realm, whose registrar IS the process-global table, so the former
         ;; per-frame realm-registrar binding was always the no-op default path).
-        head-registration (registrar/lookup :head head-id)]
+        head-registration (rf.registrar/lookup :head head-id)]
     (when-not head-registration
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/no-such-head
         'rf/active-head
         (str "No head registered under " head-id
@@ -121,7 +121,7 @@
     (let [head-fn (:handler-fn head-registration)
           ;; `frame` is a required non-nil stamp here (require-frame-stamp!
           ;; above), so the app-db read is unconditional.
-          app-db     (frame/frame-app-db-value frame)
+          app-db     (rf.frame/frame-app-db-value frame)
           head-model (head-fn app-db route)]
       head-model)))
 
@@ -173,7 +173,7 @@
   default path)."
   [route]
   (when-let [route-id (:route-id route)]
-    (when-let [route-meta (registrar/lookup :route route-id)]
+    (when-let [route-meta (rf.registrar/lookup :route route-id)]
       (:head route-meta))))
 
 (defn active-head
@@ -194,7 +194,7 @@
 
   Returns the resolved head-model. Per Spec 011 §`render-head`."
   [frame-id]
-  (let [frame-id (frame/require-frame-stamp!
+  (let [frame-id (rf.frame/require-frame-stamp!
                    frame-id :rf.ssr/active-head
                    {:where 'rf/active-head})
         route    (frame-current-route frame-id)

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -49,8 +49,8 @@
                                     and overloaded-boolean names keep
                                     presence semantics; `nil` → omitted."
   (:require [clojure.string :as str]
-            [re-frame.error :as error]
-            [re-frame.ssr.hash :as hash]))
+            [re-frame.error :as rf.error]
+            [re-frame.ssr.hash :as rf.ssr.hash]))
 
 (defn escape-html
   "Full text-node HTML escape: `& < > \" '`. Stringifies non-strings."
@@ -272,7 +272,7 @@
               (if (or (= nxt \/) (= nxt \!))
                 ;; `</` or `<!` in token position is a real HTML breakout
                 ;; precursor with no readable in-token EDN escape.
-                (error/throw-error!
+                (rf.error/throw-error!
                   :rf.error/ssr-edn-script-breakout
                   'rf.ssr/html-helpers
                   (str "EDN script body carries a `<"
@@ -316,7 +316,7 @@
   (let [s (name k)]
     (if (re-matches attr-name-grammar s)
       s
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/ssr-invalid-attribute-name
         'rf.ssr/html-helpers
         (str "attribute name violates the HTML5 grammar "
@@ -772,7 +772,7 @@
                      (let [css-name (style-name->css raw)]
                        (str css-name ":"
                             (if (number? v)
-                              (let [n (hash/canonical-number v)]
+                              (let [n (rf.ssr.hash/canonical-number v)]
                                 (if (or (zero? v)
                                         (contains? unitless-style-css-names css-name))
                                   n
@@ -877,7 +877,7 @@
                                    ;; Without this the hash would AGREE while the
                                    ;; server/client attribute strings diverged — a
                                    ;; silent hydration inconsistency.
-                                   (number? v) (hash/canonical-number v)
+                                   (number? v) (rf.ssr.hash/canonical-number v)
                                    :else       v)]
                              (str (validate-attr-name! k)
                                   "=\"" (escape-attr rendered-val) "\""))))

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -17,14 +17,14 @@
   `(registrar/clear-all!)` re-installs them. This namespace exports
   the handler fns only."
   (:require [clojure.string :as str]
-            [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.projection :as projection]
-            [re-frame.ssr.hash :as hash]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.trace :as trace]))
+            [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.projection :as rf.projection]
+            [re-frame.ssr.hash :as rf.ssr.hash]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.trace :as rf.trace]))
 
 (defn- client-platform?
   "Resolve the active platform for `frame-id` and answer whether
@@ -36,8 +36,8 @@
   the fx's own `:platforms #{:client}` gate would otherwise emit a
   `:rf.fx/skipped-on-platform` warning per check."
   [frame-id]
-  (let [resolved (or (some-> frame-id frame/frame :config :platform)
-                     (interop/active-platform))]
+  (let [resolved (or (some-> frame-id rf.frame/frame :config :platform)
+                     (rf.interop/active-platform))]
     (= :client resolved)))
 
 (declare hydrate-event-handler*)
@@ -187,8 +187,8 @@
                :failing-id :rf/hydrate
                :reason     reason
                :recovery   :no-recovery}]
-     (when interop/debug-enabled?
-       (trace/emit-error! error-id (merge base extra)))
+     (when rf.interop/debug-enabled?
+       (rf.trace/emit-error! error-id (merge base extra)))
      ;; The frame-scoped shape guard rides the always-on axis alongside the
      ;; development trace.
      ;; UNGATED. Union record shape via the late-bind hook. (The PRE-FRAME
@@ -200,9 +200,9 @@
      ;; deserialised payload value never fans out to a corpus listener raw.
      ;; Fail-closed on an unresolvable / frameless frame (whole-value redact).
      (when-let [dispatch-error-record!
-                (late-bind/get-fn :error-emit/dispatch-error-record)]
+                (rf.late-bind/get-fn :error-emit/dispatch-error-record)]
        (let [safe-extra  (when (seq extra)
-                           (projection/project-egress
+                           (rf.projection/project-egress
                              extra
                              {:frame             frame
                               :rf.egress/profile :rf.egress/off-box-observability}))
@@ -221,7 +221,7 @@
                            reason)]
          (dispatch-error-record!
            (merge {:error  error-id
-                   :time   (interop/now-ms)}
+                   :time   (rf.interop/now-ms)}
                   base
                   {:reason safe-reason}
                   safe-extra)))))))
@@ -399,7 +399,7 @@
                    ;; return before this handler and so arm nothing either.
                    (and client?
                         (some? payload-runtime-db)
-                        (some? (late-bind/get-fn :machines/rearm-after-hydration!)))
+                        (some? (rf.late-bind/get-fn :machines/rearm-after-hydration!)))
                    (conj [:rf.machine/hydrate-rearm {}]))}
       ;; Install the runtime-db partition when EITHER a server-settled
       ;; runtime-db slice rode the payload OR hydration metadata was produced.
@@ -424,7 +424,7 @@
                ;; symmetric COUNTERPART of `:ssr/extend-runtime-db-projection`
                ;; (the server projection hook in `project-runtime-db`).
                (if-let [reconcile-runtime-db
-                        (late-bind/get-fn :resources/hydrate-runtime-db)]
+                        (rf.late-bind/get-fn :resources/hydrate-runtime-db)]
                  (reconcile-runtime-db hydration-runtime-db frame-id)
                  hydration-runtime-db))))))
 
@@ -486,7 +486,7 @@
   source of truth, so a scalar `:rf.ssr/check-version` on a matching build
   compares equal (no host wiring, and it never resolves to nil)."
   []
-  payload-policy/pattern-protocol-version)
+  rf.ssr.payload-policy/pattern-protocol-version)
 
 (defn- schema-digest-lookup
   "Look up the active frame's `app-schemas-digest`. Sourced via the
@@ -495,7 +495,7 @@
   in builds where schemas is absent the lookup returns nil and the
   check emits `:rf.ssr/compatibility-check-skipped`."
   []
-  (when-let [f (late-bind/get-fn :schemas/app-schemas-digest)]
+  (when-let [f (rf.late-bind/get-fn :schemas/app-schemas-digest)]
     (f)))
 
 (defn check-version-fx
@@ -511,7 +511,7 @@
       (nil? expected) nil                              ;; nothing to check
 
       (not= expected actual)
-      (trace/emit! :warning :rf.ssr/version-mismatch
+      (rf.trace/emit! :warning :rf.ssr/version-mismatch
                    {:expected expected
                     :actual   actual
                     :frame    frame
@@ -533,7 +533,7 @@
       (nil? expected) nil                              ;; nothing to check
 
       (nil? actual)
-      (trace/emit! :warning :rf.ssr/compatibility-check-skipped
+      (rf.trace/emit! :warning :rf.ssr/compatibility-check-skipped
                    {:check    :rf.ssr/check-schema-digest
                     :expected expected
                     :reason   "No schema digest available for comparison (schemas artefact not on classpath, or :schemas/app-schemas-digest hook absent)."
@@ -541,7 +541,7 @@
                     :recovery :skipped})
 
       (not= expected actual)
-      (trace/emit! :warning :rf.ssr/schema-digest-mismatch
+      (rf.trace/emit! :warning :rf.ssr/schema-digest-mismatch
                    {:expected expected
                     :actual   actual
                     :frame    frame
@@ -560,7 +560,7 @@
   win, at the cost of silent mismatches. Absence of the key (the common
   case) leaves detection ON."
   [frame-id]
-  (let [configured-value (get-in (frame/frame-meta frame-id)
+  (let [configured-value (get-in (rf.frame/frame-meta frame-id)
                                  [:ssr :detect-mismatch?])]
     (if (some? configured-value) (boolean configured-value) true)))
 
@@ -571,7 +571,7 @@
   a thrown structured exception (dev/CI fail-fast). Any other value falls
   back to `:warn`."
   [frame-id]
-  (let [configured-value (get-in (frame/frame-meta frame-id) [:ssr :on-mismatch])]
+  (let [configured-value (get-in (rf.frame/frame-meta frame-id) [:ssr :on-mismatch])]
     (if (= :hard-error configured-value) :hard-error :warn)))
 
 (defn verify-hydration!
@@ -610,13 +610,13 @@
      ;; SSR hydration metadata is durable runtime-db
      ;; state at `[:rf.runtime/ssr :hydration]` — read it off the runtime-db
      ;; partition.
-     (let [runtime-db (frame/frame-runtime-db-value frame-id)
+     (let [runtime-db (rf.frame/frame-runtime-db-value frame-id)
            server-hash (or server-hash
                            (get-in runtime-db
                                    [:rf.runtime/ssr :hydration :server-hash]))
            client-hash (cond
                          (string? tree-or-hash) tree-or-hash
-                         tree-or-hash           (hash/render-tree-hash tree-or-hash))]
+                         tree-or-hash           (rf.ssr.hash/render-tree-hash tree-or-hash))]
        (when (and server-hash client-hash (not= server-hash client-hash))
          (let [hard-error? (= :hard-error (mismatch-policy frame-id))
                recovery (if hard-error? :hard-error :warned-and-replaced)
@@ -642,7 +642,7 @@
                                       :recovery    recovery}
                                first-diff-path
                                (assoc :first-diff-path first-diff-path))
-               emit-error! (late-bind/get-fn :trace/emit-error!)]
+               emit-error! (rf.late-bind/get-fn :trace/emit-error!)]
            ;; Always emit the trace (monitoring integrations rely on it),
            ;; THEN escalate in strict mode. The thrown ex-info carries the
            ;; same structured payload so a CI run sees the full diff.
@@ -655,4 +655,4 @@
              ;; the sentence, TRAILING the [:rf.ssr/hydration-mismatch] token)
              ;; in ONE call, instead of re-deriving error/human-message inline.
              ;; The payload IS the ex-data verbatim (one map, throw + trace agree).
-             (throw (error/ex-info-from-data mismatch-data)))))))))
+             (throw (rf.error/ex-info-from-data mismatch-data)))))))))

--- a/implementation/ssr/src/re_frame/ssr/install.cljc
+++ b/implementation/ssr/src/re_frame/ssr/install.cljc
@@ -77,9 +77,9 @@
   Layer-2 per-response page registry here either: this is the CLIENT-side
   install ledger, keyed by payload id, and it takes no position on how a
   server assembles a page."
-  (:require [re-frame.error :as error]
-            [re-frame.ssr.hash :as hash]
-            [re-frame.ssr.manifest :as manifest]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.ssr.hash :as rf.ssr.hash]
+            [re-frame.ssr.manifest :as rf.ssr.manifest]))
 
 ;; ---------------------------------------------------------------------------
 ;; The ledger
@@ -103,7 +103,7 @@
   which is what makes `:already-installed` a reliable verdict rather than
   a hopeful one."
   [payload]
-  (hash/render-tree-hash payload))
+  (rf.ssr.hash/render-tree-hash payload))
 
 (defn installed-payload
   "-> the install record for `payload-id`, or `nil` when nothing is
@@ -175,7 +175,7 @@
 
 (defn- throw-payload-conflict!
   [where payload-id arriving-digest root-id existing-claim]
-  (error/throw-error!
+  (rf.error/throw-error!
    :rf.error/frame-payload-conflict where
    (str "root " (pr-str root-id) " references payload "
         (pr-str payload-id) ", but a DIFFERENT payload is already "
@@ -235,7 +235,7 @@
   immediately following element sibling (Spec 011 §Discovery). Returns
   nil on the JVM, where there is no DOM to read."
   [container]
-  #?(:cljs (manifest/discover container)
+  #?(:cljs (rf.ssr.manifest/discover container)
      :clj  (do container nil)))
 
 (defn resolve-manifest!
@@ -260,11 +260,11 @@
   unchanged."
   [where {:keys [manifest container]}]
   (cond
-    (some? manifest) (manifest/validate! where manifest)
+    (some? manifest) (rf.ssr.manifest/validate! where manifest)
 
     (some? container)
     (or (discover-manifest container)
-        (error/throw-error!
+        (rf.error/throw-error!
          :rf.error/root-manifest-invalid where
          (str "no Root Manifest was found for this hydrating root. The "
               "manifest is the container's IMMEDIATELY FOLLOWING element "

--- a/implementation/ssr/src/re_frame/ssr/manifest.cljc
+++ b/implementation/ssr/src/re_frame/ssr/manifest.cljc
@@ -76,13 +76,13 @@
   CONSUMES a discovered manifest are later S5 leaves — this namespace
   supplies the shape, the wire, and the finder they will use."
   (:require [clojure.string :as str]
-            [re-frame.error :as error]
-            [re-frame.ssr.constants :as constants]
-            [re-frame.ssr.html-helpers :as html]
+            [re-frame.error :as rf.error]
+            [re-frame.ssr.constants :as rf.ssr.constants]
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]
             ;; CLJS-only: the `:ssr/discover-root-manifest` publication at the
             ;; bottom of this namespace is the DOM-side discovery seam, so the
             ;; registry is only reached on the host that has a DOM.
-            #?(:cljs [re-frame.late-bind :as late-bind])
+            #?(:cljs [re-frame.late-bind :as rf.late-bind])
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as reader])))
 
@@ -179,7 +179,7 @@
   never partially adopted."
   [where m]
   (if-let [p (problems m)]
-    (error/throw-error!
+    (rf.error/throw-error!
      :rf.error/root-manifest-invalid where
      (str "root manifest is not a valid Root Manifest v1 ("
           (pr-str p) "). Root Manifest v1 is the versioned SUPERSET of "
@@ -204,7 +204,7 @@
   [where container-id]
   (if (and (string? container-id) (not (str/blank? container-id)))
     {:id container-id}
-    (error/throw-error!
+    (rf.error/throw-error!
      :rf.error/root-manifest-invalid where
      (str "a host-authored root container has no `id` — the manifest's "
           ":element-locator vocabulary is the closed `{:id …}` form, and "
@@ -340,7 +340,7 @@
   [where props]
   (when (some? props)
     (when-not (map? props)
-      (error/throw-error!
+      (rf.error/throw-error!
        :rf.error/root-manifest-invalid where
        (str "root props must be a map to ride the manifest; got "
             (pr-str props))
@@ -354,7 +354,7 @@
     (doseq [[k v] props]
       (let [bad-key? (not (edn-carryable? k))]
         (when (or bad-key? (not (edn-carryable? v)))
-          (error/throw-error!
+          (rf.error/throw-error!
            :rf.error/root-manifest-invalid where
            (str "root prop " (pr-str k) " has a "
                 (if bad-key? "KEY" "value")
@@ -557,7 +557,7 @@
   [m]
   (validate! 'rf.ssr/manifest-script m)
   (when-let [k (unwireable-key m)]
-    (error/throw-error!
+    (rf.error/throw-error!
      :rf.error/root-manifest-invalid 'rf.ssr/manifest-script
      (str "root manifest key " (pr-str k) " holds a value the EDN wire "
           "cannot carry, so the emitted body would not read back AS "
@@ -574,7 +574,7 @@
       :extra    {:unserialisable-manifest-key k}}))
   (when-let [{:keys [collision path collapses browser-number] :as c}
              (numeric-collision m)]
-    (error/throw-error!
+    (rf.error/throw-error!
      :rf.error/root-manifest-invalid 'rf.ssr/manifest-script
      (str "root manifest holds a cross-host numeric collision at "
           (pr-str path) ": the distinct "
@@ -591,8 +591,8 @@
      {:recovery :re-render-the-root-manifest
       :extra    c}))
   (str "<script type=\"" manifest-script-type "\" "
-       constants/root-manifest-marker-attribute ">"
-       (html/escape-edn-script-body (pr-str m))
+       rf.ssr.constants/root-manifest-marker-attribute ">"
+       (rf.ssr.html-helpers/escape-edn-script-body (pr-str m))
        "</script>"))
 
 (defn- read-edn-forms
@@ -634,14 +634,14 @@
   (let [forms (try
                 (read-edn-forms (str s))
                 (catch #?(:clj Exception :cljs :default) e
-                  (error/throw-error!
+                  (rf.error/throw-error!
                    :rf.error/root-manifest-invalid where
                    (str "root manifest script body is not readable EDN: "
                         #?(:clj (.getMessage ^Exception e) :cljs (.-message e)))
                    {:recovery :re-render-the-root-manifest
                     :extra    {:invalid :unreadable}})))]
     (when-not (= 1 (count forms))
-      (error/throw-error!
+      (rf.error/throw-error!
        :rf.error/root-manifest-invalid where
        (str "root manifest script body must hold EXACTLY ONE EDN form; "
             "found " (count forms) ". A body with trailing content or a "
@@ -689,7 +689,7 @@
       (and el
            (= "SCRIPT" (.-tagName el))
            (= manifest-script-type (.getAttribute el "type"))
-           (.hasAttribute el constants/root-manifest-marker-attribute)))))
+           (.hasAttribute el rf.ssr.constants/root-manifest-marker-attribute)))))
 
 #?(:cljs
    (defn discover
@@ -750,4 +750,4 @@
 ;; hook key grammar rule 3, enforced by `late_bind_drift_test.clj`): this
 ;; publication, the `re-frame.late-bind.directory` row, and any consumer land as
 ;; ONE change.
-#?(:cljs (late-bind/set-fn! :ssr/discover-root-manifest discover))
+#?(:cljs (rf.late-bind/set-fn! :ssr/discover-root-manifest discover))

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -89,11 +89,11 @@
     `re-frame.ssr.ring.payload/build-payload`     - non-streaming SSR
     `re-frame.ssr.streaming/build-final-payload`  - streaming SSR"
   (:refer-clojure :exclude [resolve])
-  (:require [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.projection :as projection]
-            [re-frame.trace :as trace]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.projection :as rf.projection]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -210,7 +210,7 @@
     ;; missing-policy bucket where a `select-keys` would otherwise ship a
     ;; wrong/empty slice (rf2-hzttr finding 2).
     (malformed-allowlist? payload)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/ssr-malformed-payload-allowlist
       'rf.ssr/payload-policy
       (str "ssr-handler :payload allowlist must be a "
@@ -230,7 +230,7 @@
     ;; `:rf.ssr.payload/whole-db`) doesn't silently land in the
     ;; missing-policy bucket.
     (keyword? payload)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/ssr-unknown-payload-policy
       'rf.ssr/payload-policy
       (str "ssr-handler :payload keyword must be "
@@ -242,7 +242,7 @@
                   :recognised #{whole-app-db-policy}}})
 
     :else
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/ssr-missing-payload-policy
       'rf.ssr/payload-policy
       (str "ssr-handler requires an explicit hydration-"
@@ -320,7 +320,7 @@
   runs against that frame's real declarations; a nil `frame-id` is the same
   fail-closed case (no frame policy ⇒ whole-value redaction)."
   [db-slice frame-id]
-  (projection/project-egress
+  (rf.projection/project-egress
     db-slice
     {:frame             frame-id
      :rf.egress/profile :rf.egress/ssr-hydration}))
@@ -401,7 +401,7 @@
     ;; closed (redacts whole) under a destroyed / re-registered / unresolvable
     ;; one — no longer routed around (the former verbatim else-branch was the
     ;; rf2-j538f7.15 leak).
-    (projection/project-egress
+    (rf.projection/project-egress
       slice
       {:frame             frame-id
        :path              [:rf.runtime/routing]
@@ -540,7 +540,7 @@
    ;; Convenience: project under the AMBIENT scope frame. Correct only when the
    ;; call site is inside the frame's own `with-frame` (ambient == the target).
    ;; The security-critical builders pass the explicit target (rf2-3fc89f.15).
-   (project-runtime-db runtime-db (frame/resolve-current-frame)))
+   (project-runtime-db runtime-db (rf.frame/resolve-current-frame)))
   ([runtime-db frame-id]
    (when (map? runtime-db)
     (let [;; rf2-j538f7.15 — an EXPLICIT `frame-id` that no longer resolves to a
@@ -557,8 +557,8 @@
           ;; is omitted. A nil `frame-id` is the frameless / ambient-nil
           ;; convenience (no frame policy to lose) and stays precise, matching the
           ;; established one-arity contract.
-          stale-target?    (and (some? frame-id) (nil? (frame/frame frame-id)))
-          project-machines (late-bind/get-fn :machines/project-ssr-runtime-db)
+          stale-target?    (and (some? frame-id) (nil? (rf.frame/frame frame-id)))
+          project-machines (rf.late-bind/get-fn :machines/project-ssr-runtime-db)
           machines-slice   (when (contains? runtime-db :rf.runtime/machines)
                              (cond
                                stale-target?    :rf/redacted
@@ -601,7 +601,7 @@
           ;; durable `:entries` of `:rf.runtime/resources` (the
           ;; `:tag-index` / `:owner-index` are recomputable-from-entries
           ;; and need not ride the wire — Spec 016 §Restore and replay).
-          slice (if-let [extend-fn (late-bind/get-fn :ssr/extend-runtime-db-projection)]
+          slice (if-let [extend-fn (rf.late-bind/get-fn :ssr/extend-runtime-db-projection)]
                   ;; The extension hook (resources) takes the EXPLICIT target as a
                   ;; second parameter (rf2-f02diw — finishing the clean break: the
                   ;; hook is re-signatured `[runtime-db frame-id]`), so it projects
@@ -666,7 +666,7 @@
     (do
       ;; `trace/emit!` self-gates on `interop/debug-enabled?` (production
       ;; CLJS bundles DCE the body), so no outer guard is needed here.
-      (trace/emit! :warning :rf.ssr/invalid-version
+      (rf.trace/emit! :warning :rf.ssr/invalid-version
                    {:value    v
                     :reason   (str "Hydration :rf/version must be an integer "
                                    "pattern-protocol version (per Spec-Schemas "

--- a/implementation/ssr/src/re_frame/ssr/render_state.cljc
+++ b/implementation/ssr/src/re_frame/ssr/render_state.cljc
@@ -109,10 +109,10 @@
   should be — the honest wrong page, and the operator's allowlist mistake
   rather than a framework failure. The framework cannot tell a key the
   render needs from one it merely could read; only the allowlist says."
-  (:require [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.ssr.manifest :as manifest]
-            [re-frame.ssr.payload-policy :as payload-policy]
+  (:require [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.ssr.manifest :as rf.ssr.manifest]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as reader])))
 
@@ -160,7 +160,7 @@
   `:render-state` allowlist is the same class of fault one wire over, and
   `:opt :render-state` in the ex-data carries the distinction."
   [reason render-state]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/ssr-malformed-payload-allowlist where
     (str "ssr-handler :render-state — " reason ".")
     {:recovery :declare-payload-policy
@@ -218,7 +218,7 @@
     :else
     ;; The payload family's missing-policy id, reused — see
     ;; `throw-malformed-policy!`.
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/ssr-missing-payload-policy where
       (str "ssr-handler requires an explicit render-state policy for a "
            "non-local renderer: pass :render-state {:app-db [<top-level "
@@ -233,7 +233,7 @@
 ;; ---- the envelope, validated ----------------------------------------------
 
 (defn- throw-malformed-partitions! [reason partitions]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/ssr-render-state-invalid where
     (str "render state must be {:rf/app-db <map> :rf/runtime-db <map>}; " reason ".")
     {:recovery :return-the-two-partition-envelope
@@ -275,9 +275,9 @@
   [partitions]
   (doseq [[partition slice] partitions
           [k v] slice]
-    (let [bad-key? (or (not (keyword? k)) (not (manifest/edn-carryable? k)))]
-      (when (or bad-key? (not (manifest/edn-carryable? v)))
-        (error/throw-error!
+    (let [bad-key? (or (not (keyword? k)) (not (rf.ssr.manifest/edn-carryable? k)))]
+      (when (or bad-key? (not (rf.ssr.manifest/edn-carryable? v)))
+        (rf.error/throw-error!
           :rf.error/ssr-render-state-invalid where
           (str "render state " partition " entry " (pr-str k) " has a "
                (if bad-key? "KEY" "value")
@@ -305,8 +305,8 @@
 ;; one. Recorded on the `:rf.error/frame-destroyed` row of Spec 009
 ;; §Error contract (rf2-t6yr) — do not "fix" this to recover.
 (defn- require-live-frame! [frame-id]
-  (when-not (frame/frame frame-id)
-    (error/throw-error!
+  (when-not (rf.frame/frame frame-id)
+    (rf.error/throw-error!
       :rf.error/frame-destroyed where
       (str "render state needs a LIVE frame; " (pr-str frame-id)
            " is not registered (destroyed, or never made).")
@@ -317,12 +317,12 @@
 
 (defn- allowlist-project
   [frame-id {app-keys :app-db rt-keys :runtime-db}]
-  (let [app-db     (frame/frame-app-db-value frame-id)
-        runtime-db (frame/frame-runtime-db-value frame-id)
+  (let [app-db     (rf.frame/frame-app-db-value frame-id)
+        runtime-db (rf.frame/frame-runtime-db-value frame-id)
         app-slice  (if (seq app-keys)
                      ;; Allowlist FIRST, then the frame-scoped egress walk over
                      ;; the survivors, exactly as the payload builder orders it.
-                     (payload-policy/project-app-db-egress
+                     (rf.ssr.payload-policy/project-app-db-egress
                        (select-keys app-db app-keys) frame-id)
                      {})
         rt-slice   (if (seq rt-keys)
@@ -334,7 +334,7 @@
                        ;; lets a late-bound extension (resources) win for a key
                        ;; it projected.
                        (merge (apply dissoc selected projector-owned-runtime-keys)
-                              (payload-policy/project-runtime-db selected frame-id)))
+                              (rf.ssr.payload-policy/project-runtime-db selected frame-id)))
                      {})]
     {:rf/app-db app-slice :rf/runtime-db rt-slice}))
 
@@ -422,9 +422,9 @@
   [frame-id partitions]
   (let [{app :rf/app-db rt :rf/runtime-db} (normalise-partitions! partitions)]
     (require-live-frame! frame-id)
-    (or (frame/replace-frame-state! frame-id
-                                    {frame/app-partition-key     app
-                                     frame/runtime-partition-key rt})
+    (or (rf.frame/replace-frame-state! frame-id
+                                    {rf.frame/app-partition-key     app
+                                     rf.frame/runtime-partition-key rt})
         ;; `replace-frame-state!` answers nil only for a frame that vanished
         ;; between the liveness check and the write.
         (require-live-frame! frame-id))))

--- a/implementation/ssr/src/re_frame/ssr/request.cljc
+++ b/implementation/ssr/src/re_frame/ssr/request.cljc
@@ -10,10 +10,10 @@
   The slots live outside app-db so concurrent frames remain isolated and host
   request data cannot enter the hydration payload. Frame teardown clears the
   request, response and pending-error side channels."
-  (:require [re-frame.frame :as frame]
-            [re-frame.ssr.error-listener :as error-listener]
-            [re-frame.ssr.install :as install]
-            [re-frame.ssr.response :as response]))
+  (:require [re-frame.frame :as rf.frame]
+            [re-frame.ssr.error-listener :as rf.ssr.error-listener]
+            [re-frame.ssr.install :as rf.ssr.install]
+            [re-frame.ssr.response :as rf.ssr.response]))
 
 (defonce
   ^{:doc "Per-frame storage for the active HTTP request. Keys are
@@ -38,7 +38,7 @@
   Returns `frame-id`."
   [frame-id request]
   ;; All SSR side channels use the process-local frame address.
-  (swap! request-slots assoc (frame/frame-address frame-id) request)
+  (swap! request-slots assoc (rf.frame/frame-address frame-id) request)
   frame-id)
 
 (defn get-request
@@ -51,7 +51,7 @@
   Public read surface — host adapters and tools may inspect the active
   request via this fn."
   [frame-id]
-  (get @request-slots (frame/frame-address frame-id)))
+  (get @request-slots (rf.frame/frame-address frame-id)))
 
 (defn clear-request!
   "Clear the per-frame request slot. Host adapters call this after
@@ -60,7 +60,7 @@
 
   Returns `frame-id`."
   [frame-id]
-  (swap! request-slots dissoc (frame/frame-address frame-id))
+  (swap! request-slots dissoc (rf.frame/frame-address frame-id))
   frame-id)
 
 ;; ---- per-request frame teardown -------------------------------------------
@@ -94,15 +94,15 @@
   the model), so the head namespace keeps no per-frame bookkeeping and
   there is nothing here to release on its behalf."
   [frame-id]
-  (error-listener/clear-pending-error-traces! frame-id)
+  (rf.ssr.error-listener/clear-pending-error-traces! frame-id)
   (clear-request! frame-id)
-  (response/clear-response! frame-id)
+  (rf.ssr.response/clear-response! frame-id)
   ;; S5 — release this frame's hydration-payload install claim. Payload ids
   ;; ARE frame ids (004C §6), so a destroyed frame's claim must go with it:
   ;; a frame later re-created under the same id would otherwise meet a
   ;; phantom `:rf.error/frame-payload-conflict` raised by a lifetime that
   ;; no longer exists.
-  (install/release-payload! frame-id)
+  (rf.ssr.install/release-payload! frame-id)
   nil)
 
 (defn request-cofx
@@ -125,4 +125,4 @@
   `set-request!` the slot for the target frame first (the visible seam),
   before dispatch."
   []
-  (get-request frame/*current-frame*))
+  (get-request rf.frame/*current-frame*))

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -48,14 +48,14 @@
   Frame teardown releases the response slot together with the other SSR side
   channels."
   (:require [clojure.string]
-            [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.privacy.url :as url-egress]
-            [re-frame.ssr.egress :as egress]
-            [re-frame.ssr.http-validation :as http-validation]
-            [re-frame.trace :as trace])
+            [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.privacy.url :as rf.privacy.url]
+            [re-frame.ssr.egress :as rf.ssr.egress]
+            [re-frame.ssr.http-validation :as rf.ssr.http-validation]
+            [re-frame.trace :as rf.trace])
   #?(:clj (:import [java.net URI URISyntaxException])))
 
 (defonce
@@ -198,18 +198,18 @@
   identifier travels through an explicitly trusted field; the summary is
   never asked to guess that an app-supplied value is structural."
   [fx-id arg-key value expected]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/server-fx-args-invalid
     'rf.ssr/response
     (str fx-id " " arg-key " must be " expected "; got "
-         (pr-str (error/diag-value-summary value))
+         (pr-str (rf.error/diag-value-summary value))
          ". Fix the fx args map at the dispatch site — the reserved"
          " :rf.server/* fx guard their own args in every build, so this"
          " rejection does not depend on -Dre-frame.debug.")
     {:recovery :supply-a-well-formed-fx-argument
      :extra    {:fx-id    fx-id
                 :key      arg-key
-                :value    (error/diag-value-summary value)
+                :value    (rf.error/diag-value-summary value)
                 :expected expected}}))
 
 (defn- validate-args-map!
@@ -329,8 +329,8 @@
   deprecated; no CTLs allowed in `field-content`."
   [header-name value]
   (let [header-value (str value)]
-    (when (http-validation/contains-injection-char? header-value)
-      (error/throw-error!
+    (when (rf.ssr.http-validation/contains-injection-char? header-value)
+      (rf.error/throw-error!
         :rf.error/header-invalid-value
         'rf.ssr/response
         (str "header " (pr-str header-name)
@@ -361,8 +361,8 @@
   the caller-untrusted path."
   [location]
   (let [location-string (str location)]
-    (when (http-validation/contains-injection-char? location-string)
-      (error/throw-error!
+    (when (rf.ssr.http-validation/contains-injection-char? location-string)
+      (rf.error/throw-error!
         :rf.error/redirect-invalid-location
         'rf.ssr/response
         (str "redirect :location contains CR/LF/NUL"
@@ -394,8 +394,8 @@
   whitespace, or separators. Same gate as the cookie-name validator."
   [header-name]
   (let [header-name-string (str header-name)]
-    (when-not (http-validation/valid-token-name? header-name-string)
-      (error/throw-error!
+    (when-not (rf.ssr.http-validation/valid-token-name? header-name-string)
+      (rf.error/throw-error!
         :rf.error/header-invalid-name
         'rf.ssr/response
         (str "header :name " (pr-str header-name-string)
@@ -421,7 +421,7 @@
   not a `Named` at all — is the case `(name cookie-name)` cannot survive."
   [cookie-name]
   (when (nil? cookie-name)
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/cookie-invalid-name
       'rf.ssr/response
       "cookie :name is required; supply a non-nil :name on the cookie map."
@@ -443,7 +443,7 @@
   (when-not (or (string? cookie-name)
                 #?(:clj  (instance? clojure.lang.Named cookie-name)
                    :cljs (or (keyword? cookie-name) (symbol? cookie-name))))
-    (error/throw-error!
+    (rf.error/throw-error!
       :rf.error/cookie-invalid-name
       'rf.ssr/response
       (str "cookie :name must be a string or a keyword/symbol; got "
@@ -454,8 +454,8 @@
        :extra    {:name cookie-name}}))
   (let [cookie-name-string (#?(:clj clojure.core/name :cljs cljs.core/name)
                             cookie-name)]
-    (when-not (http-validation/valid-token-name? cookie-name-string)
-      (error/throw-error!
+    (when-not (rf.ssr.http-validation/valid-token-name? cookie-name-string)
+      (rf.error/throw-error!
         :rf.error/cookie-invalid-name
         'rf.ssr/response
         (str "cookie :name " (pr-str cookie-name-string)
@@ -514,11 +514,11 @@
         ;; reject the `;` cookie-attribute delimiter.
         value-attribute? (= attribute-key :value)
         invalid? (if value-attribute?
-                   (http-validation/contains-injection-char? serialised-value)
-                   (http-validation/contains-cookie-attr-injection-char?
+                   (rf.ssr.http-validation/contains-injection-char? serialised-value)
+                   (rf.ssr.http-validation/contains-cookie-attr-injection-char?
                      serialised-value))]
     (when invalid?
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/cookie-invalid-attribute
         'rf.ssr/response
         (str "cookie attribute " attribute-key " " (pr-str serialised-value)
@@ -601,7 +601,7 @@
   on the process-local frame address — O(small-map) swap, no app-db
   ping-pong. `frame-address` is the bare process-local frame id."
   [frame-id update-fn]
-  (let [frame-address (frame/frame-address frame-id)
+  (let [frame-address (rf.frame/frame-address frame-id)
         updated-response (-> (swap! response-slots
                                     update frame-address
                                     #(update-fn (ensure-response %)))
@@ -611,7 +611,7 @@
 (defn response-of
   "Read the current response accumulator (with defaults applied)."
   [frame-id]
-  (ensure-response (get @response-slots (frame/frame-address frame-id))))
+  (ensure-response (get @response-slots (rf.frame/frame-address frame-id))))
 
 (defn clear-response!
   "Drop `frame-id`'s response slot. Called from
@@ -619,7 +619,7 @@
   `:ssr/on-frame-destroyed` late-bind hook. Idempotent — tolerates a frame-id
   with no slot."
   [frame-id]
-  (swap! response-slots dissoc (frame/frame-address frame-id))
+  (swap! response-slots dissoc (rf.frame/frame-address frame-id))
   frame-id)
 
 ;; ---- header helpers ------------------------------------------------------
@@ -670,7 +670,7 @@
   [response writes-key warning-id final-key frame-id]
   (let [writes (get response writes-key)]
     (when (and response (> (count writes) 1))
-      (trace/emit! :warning warning-id
+      (rf.trace/emit! :warning warning-id
                    {:writes   writes
                     final-key (last writes)
                     :frame    frame-id
@@ -807,7 +807,7 @@
   (let [retired-keys (filterv #(contains? redirect-map %)
                               retired-redirect-target-keys)]
     (when (seq retired-keys)
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/redirect-retired-target-key
         'rf.ssr/response
         (str "redirect target key(s) " (pr-str retired-keys)
@@ -1037,7 +1037,7 @@
   `:reason` is a framework enum, and `:recovery` is fixed."
   [tags]
   (-> (merge {:recovery :no-recovery} tags)
-      (url-egress/redact-url-tag :location)))
+      (rf.privacy.url/redact-url-tag :location)))
 
 (defn- dispatch-safe-redirect-record!
   "Fan the rejected redirect out on the ALWAYS-ON error axis (rf2-6jqa8) —
@@ -1092,11 +1092,11 @@
   no host at all, leaving no value in it that the caller chose."
   [operation tags]
   (when-let [dispatch-error-record!
-             (late-bind/get-fn :error-emit/dispatch-error-record)]
+             (rf.late-bind/get-fn :error-emit/dispatch-error-record)]
     (dispatch-error-record!
-      (assoc (egress/safe-redirect-record-tags tags)
+      (assoc (rf.ssr.egress/safe-redirect-record-tags tags)
              :error operation
-             :time  (interop/now-ms))))
+             :time  (rf.interop/now-ms))))
   nil)
 
 (defn- emit-safe-redirect-error!
@@ -1112,7 +1112,7 @@
   [operation tags]
   (let [tags (safe-redirect-tags tags)]
     (dispatch-safe-redirect-record! operation tags)
-    (trace/emit-error! operation tags))
+    (rf.trace/emit-error! operation tags))
   nil)
 
 (defn safe-redirect-fx

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -67,8 +67,8 @@
   directly, as the bundled Ring adapter does."
   (:require [clojure.data]
             [clojure.string]
-            [re-frame.error :as error]
-            [re-frame.frame :as frame]
+            [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
             ;; rf2-j81hs — `re-frame.registrar` / `re-frame.interop` dropped
             ;; with the walker's keyword-view branch (registry lookup +
             ;; debug-gated source-coord injection). The shell walk no longer
@@ -78,12 +78,12 @@
             ;; require is acyclic: the component expands TO the marker this
             ;; walker consumes, and both sides read the slot path from one
             ;; source rather than repeating the literal.
-            [re-frame.ssr.suspense :as suspense]
-            [re-frame.ssr.emit :as emit]
-            [re-frame.ssr.html-helpers :as html]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.streaming.constants :as wire]
-            [re-frame.trace :as trace]))
+            [re-frame.ssr.suspense :as rf.ssr.suspense]
+            [re-frame.ssr.emit :as rf.ssr.emit]
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.ssr.streaming.constants :as rf.ssr.streaming.constants]
+            [re-frame.trace :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -108,8 +108,8 @@
   and open/close-tag wrapping live here once. The three public builders
   below are thin one-liners over this."
   [id markers body-html]
-  (str "<template " wire/attr-suspense-id "=\""
-       (html/escape-attr (str id))
+  (str "<template " rf.ssr.streaming.constants/attr-suspense-id "=\""
+       (rf.ssr.html-helpers/escape-attr (str id))
        "\" " markers ">"
        body-html
        "</template>"))
@@ -131,14 +131,14 @@
   therefore requires the client runtime to show fallbacks — non-JS clients
   see the shell structure without painted skeletons until the final payload."
   [id fallback-html]
-  (suspense-template id (str wire/attr-suspense-fallback "=\"1\"") fallback-html))
+  (suspense-template id (str rf.ssr.streaming.constants/attr-suspense-fallback "=\"1\"") fallback-html))
 
 (defn resolved-template
   "The resolved-subtree chunk shape — flushed when a continuation drains
   successfully. The client-side streaming runtime swaps the matching
   fallback placeholder for this resolved content in DOM."
   [id resolved-html]
-  (suspense-template id (str wire/attr-suspense-resolved "=\"1\"") resolved-html))
+  (suspense-template id (str rf.ssr.streaming.constants/attr-suspense-resolved "=\"1\"") resolved-html))
 
 (defn failed-template
   "The failed-continuation chunk shape — same wire shape as
@@ -147,8 +147,8 @@
   surfacing a 500. Per Spec 011 §Failure semantics — inline fallback."
   [id fallback-html]
   (suspense-template id
-                     (str wire/attr-suspense-resolved "=\"1\" "
-                          wire/attr-suspense-failed "=\"1\"")
+                     (str rf.ssr.streaming.constants/attr-suspense-resolved "=\"1\" "
+                          rf.ssr.streaming.constants/attr-suspense-failed "=\"1\"")
                      fallback-html))
 
 (defn hydrate-delta-script
@@ -156,8 +156,8 @@
   reads the EDN, then `(swap! app-db merge delta)`s. Per Spec 011
   §Hydration interleaving."
   [id delta-edn]
-  (str "<script " wire/attr-suspense-hydrate "=\""
-       (html/escape-attr (str id))
+  (str "<script " rf.ssr.streaming.constants/attr-suspense-hydrate "=\""
+       (rf.ssr.html-helpers/escape-attr (str id))
        "\" type=\"application/edn\">"
        ;; EDN-aware escape: `<` inside string
        ;; literals becomes `<` so a delta carrying `</script>` from
@@ -166,7 +166,7 @@
        ;; unchanged through the client's EDN reader. A `</` / `<!`
        ;; breakout in a token position fails loud. Same encoder as the
        ;; final-payload escape in payload-script-tag.
-       (html/escape-edn-script-body delta-edn)
+       (rf.ssr.html-helpers/escape-edn-script-body delta-edn)
        "</script>"))
 
 ;; ---- per-subtree hydration delta -----------------------------------------
@@ -252,14 +252,14 @@
   [delta frame-id {:as policy-opts}]
   (if-not (seq delta)
     {}
-    (let [allowed (payload-policy/apply-policy delta policy-opts)]
+    (let [allowed (rf.ssr.payload-policy/apply-policy delta policy-opts)]
       ;; An allowlist that drops every changed key yields an empty map — there
       ;; is nothing to project (and projecting `{}` against a fail-closed
       ;; unresolvable frame would redact the empty map to the scalar
       ;; `:rf/redacted` sentinel, which the host's `(seq …)` emit guard cannot
       ;; walk). Short-circuit to `{}` so the host emits no delta script.
       (if (seq allowed)
-        (payload-policy/project-app-db-egress allowed frame-id)
+        (rf.ssr.payload-policy/project-app-db-egress allowed frame-id)
         {}))))
 
 ;; ---- continuation registry (per-request, transient) -----------------------
@@ -321,7 +321,7 @@
     (when (seq duplicate-wire-ids)
       (doseq [duplicate-wire-id duplicate-wire-ids]
         (let [duplicate-group (continuations-by-wire-id duplicate-wire-id)]
-          (trace/emit-error! :rf.error/suspense-boundary-duplicate-id
+          (rf.trace/emit-error! :rf.error/suspense-boundary-duplicate-id
                              {:id       duplicate-wire-id
                               :raw-ids  (mapv :id duplicate-group)
                               :count    (count duplicate-group)
@@ -372,21 +372,21 @@
   parsed tag."
   [element continuation-accumulator]
   (let [head                  (first element)
-        [tag-name tag-attrs]  (emit/parse-tag-name head)
+        [tag-name tag-attrs]  (rf.ssr.emit/parse-tag-name head)
         [user-attrs children] (if (map? (second element))
                                 [(second element) (drop 2 element)]
                                 [{} (rest element)])
-        merged-attrs          (emit/merge-class-attrs tag-attrs user-attrs)
+        merged-attrs          (rf.ssr.emit/merge-class-attrs tag-attrs user-attrs)
         ;; Void + raw-text classification are case-insensitive, mirroring
         ;; the non-streaming emitter. A `[:BR]` admitted by
         ;; `validate-tag-name!` must be recognised as void here too, or the
         ;; shell walker emits a `<BR></BR>` open+close pair.
         normalised-tag-name   (clojure.string/lower-case tag-name)
-        void?                 (contains? emit/void-elements
+        void?                 (contains? rf.ssr.emit/void-elements
                                          (keyword normalised-tag-name))
-        raw-text?             (contains? html/raw-text-tags normalised-tag-name)]
+        raw-text?             (contains? rf.ssr.html-helpers/raw-text-tags normalised-tag-name)]
     (cond
-      void?     (str "<" tag-name (emit/attr-string merged-attrs) ">")
+      void?     (str "<" tag-name (rf.ssr.emit/attr-string merged-attrs) ">")
       ;; rf2-xbvzh — mirror the non-streaming emitter: an ordinary inline
       ;; `<script>`/`<style>` with STRING content is author content, emitted
       ;; VERBATIM with only the shared closing-sequence rewrite
@@ -394,12 +394,12 @@
       ;; S5 serialiser. Any structural child falls through to the standard
       ;; child walk (element children pass through inert).
       (and raw-text? (seq children) (every? string? children))
-      (str "<" tag-name (emit/attr-string merged-attrs) ">"
-           (html/escape-raw-text normalised-tag-name
+      (str "<" tag-name (rf.ssr.emit/attr-string merged-attrs) ">"
+           (rf.ssr.html-helpers/escape-raw-text normalised-tag-name
                                  (clojure.string/join children))
            "</" tag-name ">")
       :else
-      (str "<" tag-name (emit/attr-string merged-attrs) ">"
+      (str "<" tag-name (rf.ssr.emit/attr-string merged-attrs) ">"
            (walk-children children continuation-accumulator)
            "</" tag-name ">"))))
 
@@ -418,7 +418,7 @@
         children (vec (drop 2 element))
         child-count (count children)]
     (when-not (suspense-attrs? attrs)
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/suspense-boundary-invalid-attrs
         'rf.ssr/streaming
         (str ":rf/suspense-boundary requires an attrs map with both "
@@ -441,7 +441,7 @@
           ;; walk — fallbacks cannot nest suspense-boundaries (they
           ;; render synchronously inline). A `:rf/suspense-boundary`
           ;; INSIDE a fallback is a programmer error; we do not check.
-          fallback-html (emit/render-to-string fallback nil)]
+          fallback-html (rf.ssr.emit/render-to-string fallback nil)]
       (record-continuation! continuation-accumulator id subtree fallback)
       (fallback-template id fallback-html))))
 
@@ -479,14 +479,14 @@
         ;; as raw text. Delegate to the standard emitter so the single
         ;; `:rf.error/ssr-reagent-native-head` throw lives in one place.
         (= :> head)
-        (emit/emit-element element)
+        (rf.ssr.emit/emit-element element)
 
         ;; An unrecognised head in the reserved `:rf/*` scheme — delegate
         ;; to the standard emitter so the single
         ;; `:rf.error/invalid-hiccup-head` reserved-head throw lives in
         ;; one place, exactly as the `:>` branch above does (rf2-j81hs).
-        (emit/reserved-rf-head? head)
-        (emit/reject-reserved-rf-hiccup-head! element head)
+        (rf.ssr.emit/reserved-rf-head? head)
+        (rf.ssr.emit/reject-reserved-rf-hiccup-head! element head)
 
         ;; DOM / custom element — always recurse via `walk-dom-tag` so
         ;; nested suspense-boundaries are reachable. Per rf2-muasb the
@@ -525,7 +525,7 @@
     ;; (outer fn → inner render fn) identically to the sync emitter: the
     ;; inner fn is invoked once with the same args rather than left to
     ;; stringify its `.toString` as page text.
-    (walk-shell (emit/resolve-component-head (first element) (rest element))
+    (walk-shell (rf.ssr.emit/resolve-component-head (first element) (rest element))
                 continuation-accumulator)
 
     ;; rf2-y1jbaq — a vector reaching here (not a suspense boundary, not a
@@ -535,14 +535,14 @@
     ;; `(sequential? element)` and splice it as a child-seq, which silently drops
     ;; the bad head and could ride attacker-controlled child strings.
     (vector? element)
-    (emit/reject-invalid-hiccup-head! element)
+    (rf.ssr.emit/reject-invalid-hiccup-head! element)
 
     (sequential? element)
     (walk-children element continuation-accumulator)
 
     :else
     ;; Scalar / no-recursion-needed — delegate to the standard emitter.
-    (emit/emit-element element)))
+    (rf.ssr.emit/emit-element element)))
 
 ;; ---- public surface ------------------------------------------------------
 
@@ -568,7 +568,7 @@
   ;; walker's DOM-tag emissions and any inline fallback renders share
   ;; one cache for the whole shell pass. The cache lives only for the
   ;; duration of `render-shell`.
-  (binding [emit/*tag-name-cache* (volatile! {})]
+  (binding [rf.ssr.emit/*tag-name-cache* (volatile! {})]
     (let [continuation-accumulator (new-continuation-accumulator)
           shell-html               (walk-shell root-hiccup
                                                 continuation-accumulator)
@@ -618,7 +618,7 @@
   ;; walked with. Apps that need true async-resolution per-subtree wire
   ;; their fetches as initial-events-time fanout (the test below
   ;; demonstrates the pattern); see Spec 011 §Streaming SSR.
-  (let [before-db (frame/frame-app-db-value frame-id)]
+  (let [before-db (rf.frame/frame-app-db-value frame-id)]
     (try
       ;; Bind the per-render parse-tag-name memo (mirrors `render-shell`)
       ;; and drain the subtree through `walk-shell` so a nested boundary
@@ -626,12 +626,12 @@
       ;; emitter's `:rf/suspense-boundary` reject. `dedupe-continuations`
       ;; applies the same last-write-wins duplicate-id contract within
       ;; this continuation's nested registrations.
-      (binding [emit/*tag-name-cache* (volatile! {})]
+      (binding [rf.ssr.emit/*tag-name-cache* (volatile! {})]
         (let [continuation-accumulator (new-continuation-accumulator)
               resolved-html (walk-shell subtree continuation-accumulator)
               nested-continuations (dedupe-continuations
                                      @continuation-accumulator)
-              after-db      (frame/frame-app-db-value frame-id)
+              after-db      (rf.frame/frame-app-db-value frame-id)
               delta         (subtree-delta before-db after-db)]
           {:id            id
            :html          resolved-html
@@ -639,14 +639,14 @@
            :failed?       false
            :continuations nested-continuations}))
       (catch #?(:clj Throwable :cljs :default) render-throwable
-        (trace/emit-error! :rf.ssr/suspense-boundary-failed
+        (rf.trace/emit-error! :rf.ssr/suspense-boundary-failed
                            {:id        id
                             :frame     frame-id
                             :exception (#?(:clj .getMessage :cljs ex-message)
                                         render-throwable)
                             :recovery  :inline-fallback})
         (let [fallback-html (try
-                              (emit/render-to-string fallback nil)
+                              (rf.ssr.emit/render-to-string fallback nil)
                               (catch #?(:clj Throwable :cljs :default) _
                                 ;; Fallback render also threw — emit
                                 ;; an empty placeholder. The client-
@@ -678,7 +678,7 @@
   [projected policy-opts]
   (let [failed (:failed-boundaries policy-opts)]
     (if (seq failed)
-      (assoc-in (or projected {}) suspense/failed-boundaries-path (set failed))
+      (assoc-in (or projected {}) rf.ssr.suspense/failed-boundaries-path (set failed))
       projected)))
 
 (defn build-final-payload
@@ -748,21 +748,21 @@
         ;; frame between this capture and the projection; re-checking the
         ;; incarnation token below detects both, so classified state is never
         ;; serialized under an absent or SUBSTITUTED policy.
-        token      (frame/frame-incarnation-token frame-id)
-        app-db     (frame/frame-app-db-value frame-id)
+        token      (rf.frame/frame-incarnation-token frame-id)
+        app-db     (rf.frame/frame-app-db-value frame-id)
         ;; EP-0001 (rf2-30kzz2): project the live runtime-db value to the
         ;; serializable `:rf/runtime-db` slice (machine snapshots, route slice,
         ;; elision declarations, SSR metadata) so the streamed final payload
         ;; hydrates a coherent frame-state, symmetric with the non-streaming
         ;; path. Transient side channels are excluded by `project-runtime-db`.
-        runtime-db (frame/frame-runtime-db-value frame-id)
+        runtime-db (rf.frame/frame-runtime-db-value frame-id)
         ;; The captured state is coherent ONLY if the frame is STILL the same
         ;; live incarnation it was at capture. A nil pin (frame already gone) or
         ;; a changed token (destroyed / re-registered mid-assembly) fails closed.
         coherent?  (and (some? token)
-                        (identical? token (frame/frame-incarnation-token frame-id)))]
+                        (identical? token (rf.frame/frame-incarnation-token frame-id)))]
     (if coherent?
-      (payload-policy/build-payload
+      (rf.ssr.payload-policy/build-payload
        ;; WIRE :rf/frame-id — the stable client id from `:client-frame-id`, or
        ;; nil to omit (never the per-request projection gensym). rf2-lm2yzy.
        (:client-frame-id policy-opts)
@@ -772,8 +772,8 @@
        ;; with the non-streaming `re-frame.ssr.ring.payload/build-payload` so a
        ;; frame-sensitive child inside an allowlisted key never rides the final
        ;; `__rf_payload` raw.
-       (payload-policy/project-app-db-egress
-        (payload-policy/apply-policy app-db policy-opts)
+       (rf.ssr.payload-policy/project-app-db-egress
+        (rf.ssr.payload-policy/apply-policy app-db policy-opts)
         frame-id)
        render-hash
        ;; rf2-3fc89f.15 — project the runtime-db under the EXPLICIT carried
@@ -781,7 +781,7 @@
        ;; ambient one. A streaming build called outside `with-frame`, or under a
        ;; different ambient frame, otherwise serialized classified route / machine
        ;; / resource runtime state under nil / the wrong frame's policy.
-       (assoc policy-opts :runtime-db (-> (payload-policy/project-runtime-db runtime-db frame-id)
+       (assoc policy-opts :runtime-db (-> (rf.ssr.payload-policy/project-runtime-db runtime-db frame-id)
                                           (with-failed-boundaries policy-opts))))
       ;; rf2-j538f7.15 — the request frame was destroyed / re-registered between
       ;; state capture and projection: its classification authority is gone, so
@@ -789,7 +789,7 @@
       ;; policy. Fail closed — redact the whole app-db slice and omit the
       ;; runtime-db — while still stamping the requested target so the client sees
       ;; a well-formed, safe payload rather than a leak.
-      (payload-policy/build-payload
+      (rf.ssr.payload-policy/build-payload
        ;; WIRE :rf/frame-id — stable client id or nil to omit (rf2-lm2yzy).
        (:client-frame-id policy-opts)
        :rf/redacted

--- a/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
+++ b/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
@@ -93,13 +93,13 @@
   This namespace is CLJS-only and host-opted-in: it reaches into the DOM and
   installs a `MutationObserver`."
   (:require [cljs.reader :as reader]
-            [re-frame.frame :as frame]
-            [re-frame.ssr.constants :as constants]
+            [re-frame.frame :as rf.frame]
+            [re-frame.ssr.constants :as rf.ssr.constants]
             ;; The suspense component's render-time failed-boundary record.
             ;; `suspense` depends on core only, never on this ns.
-            [re-frame.ssr.suspense :as suspense]
-            [re-frame.ssr.streaming.constants :as wire]
-            [re-frame.trace :as trace]))
+            [re-frame.ssr.suspense :as rf.ssr.suspense]
+            [re-frame.ssr.streaming.constants :as rf.ssr.streaming.constants]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- wire-shape constants (the attribute names the server stamps) ---------
 ;;
@@ -112,11 +112,11 @@
 ;; shared source rather than a comment. Aliased here so the call sites read
 ;; the same as before.
 
-(def ^:private attr-suspense-id        wire/attr-suspense-id)
-(def ^:private attr-suspense-fallback  wire/attr-suspense-fallback)
-(def ^:private attr-suspense-resolved  wire/attr-suspense-resolved)
-(def ^:private attr-suspense-failed    wire/attr-suspense-failed)
-(def ^:private attr-suspense-hydrate   wire/attr-suspense-hydrate)
+(def ^:private attr-suspense-id        rf.ssr.streaming.constants/attr-suspense-id)
+(def ^:private attr-suspense-fallback  rf.ssr.streaming.constants/attr-suspense-fallback)
+(def ^:private attr-suspense-resolved  rf.ssr.streaming.constants/attr-suspense-resolved)
+(def ^:private attr-suspense-failed    rf.ssr.streaming.constants/attr-suspense-failed)
+(def ^:private attr-suspense-hydrate   rf.ssr.streaming.constants/attr-suspense-hydrate)
 
 ;; The client-owned LIVE mount element. The server emits the fallback
 ;; wrapped in a `<template>`, whose content is INERT by the HTML spec
@@ -130,8 +130,8 @@
 ;; expressed over the server's `<template>`-marker protocol. Client-owned
 ;; but pinned in the shared `wire` ns alongside the server-emitted
 ;; attributes.
-(def ^:private attr-suspense-mount     wire/attr-suspense-mount)
-(def ^:private mount-tag               wire/mount-tag)
+(def ^:private attr-suspense-mount     rf.ssr.streaming.constants/attr-suspense-mount)
+(def ^:private mount-tag               rf.ssr.streaming.constants/mount-tag)
 
 ;; ---- id parsing ------------------------------------------------------------
 
@@ -314,7 +314,7 @@
   canonical replace."
   [frame-id delta]
   (when (and (map? delta) (seq delta))
-    (frame/swap-frame-db! frame-id
+    (rf.frame/swap-frame-db! frame-id
                           (fn [app-db]
                             (into app-db delta)))))
 
@@ -330,7 +330,7 @@
   merged in to carry the branch-specific field (`:exception` for the reader
   throw, `:malformed-value-type` for a non-map parse)."
   [frame-id wire-id-string reason extra]
-  (trace/emit-error! :rf.ssr/suspense-boundary-failed
+  (rf.trace/emit-error! :rf.ssr/suspense-boundary-failed
                      (merge {:id       (read-boundary-id wire-id-string)
                              :frame    frame-id
                              :where    'rf.ssr/streaming-client
@@ -393,7 +393,7 @@
   sibling of `malformed-delta!`'s `:skipped-delta` and the swap-time
   `:inline-fallback`."
   [frame-id wire-id-string]
-  (trace/emit-error! :rf.ssr/suspense-boundary-failed
+  (rf.trace/emit-error! :rf.ssr/suspense-boundary-failed
                      {:id       (read-boundary-id wire-id-string)
                       :frame    frame-id
                       :where    'rf.ssr/streaming-client
@@ -557,7 +557,7 @@
         ;; by `apply-ready-deltas!` at the sweep level so it survives arriving
         ;; in a later observer batch than this template (rf2-x76af2.35).
         (when (and failed? swapped?)
-          (trace/emit-error! :rf.ssr/suspense-boundary-failed
+          (rf.trace/emit-error! :rf.ssr/suspense-boundary-failed
                              {:id        (read-boundary-id wire-id-string)
                               :frame     frame-id
                               :where     'rf.ssr/streaming-client
@@ -697,7 +697,7 @@
     ;; Publish the failed set BEFORE unwrapping / readiness: the
     ;; `boundary` component reads it during the hydration render that
     ;; `on-ready` triggers, so it has to be in place by then.
-    (suspense/record-failed-boundaries! (:failed report))
+    (rf.ssr.suspense/record-failed-boundaries! (:failed report))
     (unwrap-mounts! root)
     (stop!)
     (when (compare-and-set! ready? false true)
@@ -787,12 +787,12 @@
      ;; closed on, never a synthesised `:rf/default`. `payload-id` defaults
      ;; to the pinned `constants/payload-script-id` (main).
      :or   {root       (when (exists? js/document) js/document)
-            payload-id constants/payload-script-id}}]
+            payload-id rf.ssr.constants/payload-script-id}}]
    ;; The streaming delta-merge target is supplied explicitly via `:frame`.
    ;; A nil stamp is an absent target,
    ;; not a request to synthesise `:rf/default`; surface the always-on
    ;; `:rf.error/no-frame-context`. Per Spec 002 §Frame target resolution.
-   (let [frame-id (frame/require-frame-stamp!
+   (let [frame-id (rf.frame/require-frame-stamp!
                     frame :rf.ssr/streaming-install
                     {:where 'rf.ssr.streaming.client/install!})]
      ;; No DOM (a non-browser runtime / a host calling install! too early)

--- a/implementation/ssr/src/re_frame/ssr/substrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/substrate.cljc
@@ -19,8 +19,8 @@
   re-frame.ssr/adapter; this ns deliberately avoids
   re-frame.ssr.adapter so CLJS does not see a child-namespace /
   parent-var name clash."
-  (:require [re-frame.error :as error]
-            [re-frame.ssr.emit :as emit]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.ssr.emit :as rf.ssr.emit]))
 
 (defn- ssr-make-state-container [initial-value]
   (atom initial-value))
@@ -48,7 +48,7 @@
 (defn- ssr-render [_ _ _]
   ;; SSR uses render-to-string exclusively. Calling render on the SSR
   ;; adapter is a programmer error worth surfacing loudly.
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/render-on-headless-adapter
     'rf/render
     (str "render is not supported on the SSR adapter (it is headless — no "
@@ -84,6 +84,6 @@
    :subscribe-container       ssr-subscribe-container
    :make-derived-value        ssr-make-derived-value
    :render                    ssr-render
-   :render-to-string          emit/render-to-string
+   :render-to-string          rf.ssr.emit/render-to-string
    :register-context-provider ssr-register-context-provider
    :dispose-adapter!          ssr-dispose-adapter!})

--- a/implementation/ssr/src/re_frame/ssr/suspense.cljc
+++ b/implementation/ssr/src/re_frame/ssr/suspense.cljc
@@ -85,8 +85,8 @@
   Absence of a recorded outcome — a plain client mount, a non-streamed
   page, no frame scope at all — means the body renders. That is the
   ordinary case and it fails soft by construction."
-  (:require [re-frame.error :as error]
-            [re-frame.frame :as frame]))
+  (:require [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]))
 
 ;; ---- reserved runtime-db slot ---------------------------------------------
 
@@ -112,7 +112,7 @@
   For consumers that HAVE a frame — host code, tools, tests, server-side
   assertions. The component cannot use this; see below."
   [frame-id]
-  (or (get-in (frame/frame-runtime-db-value frame-id) failed-boundaries-path)
+  (or (get-in (rf.frame/frame-runtime-db-value frame-id) failed-boundaries-path)
       #{}))
 
 ;; ---- the render-time record ------------------------------------------------
@@ -179,7 +179,7 @@
   ;; mistake reads identically whichever host catches it first. A
   ;; client-only app would otherwise discover a missing `:fallback` only
   ;; when its server build ran.
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/suspense-boundary-invalid-attrs
     'rf.ssr/boundary
     (str "boundary requires an attrs map with both :id and :fallback; "

--- a/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
+++ b/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
@@ -58,9 +58,9 @@
   react-dom byte-parity corpus (004B §Emission is pure) is a separate S5
   leaf; only the conversion-table rows the seam actually needs ship here."
   (:require [clojure.string :as str]
-            [re-frame.error :as error]
-            [re-frame.ssr.hash :as hash]
-            [re-frame.ssr.html-helpers :as html]))
+            [re-frame.error :as rf.error]
+            [re-frame.ssr.hash :as rf.ssr.hash]
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]))
 
 ;; ---------------------------------------------------------------------------
 ;; Version gate — the headline. Validated FIRST, before any emission.
@@ -84,11 +84,11 @@
   (let [tree-version (:rf.ui/tree-version tree)]
     (when-not (and (integer? tree-version)
                    (contains? supported-tree-versions tree-version))
-      (error/throw-error!
+      (rf.error/throw-error!
         :rf.error/ssr-ui-tree-version-unsupported
         'rf.ssr/emit-ui-tree
         (str "re-frame.ssr/emit-ui-tree requires a root :rf.ui/tree-version in "
-             (pr-str supported-tree-versions) " — got " (error/pr-form tree-version)
+             (pr-str supported-tree-versions) " — got " (rf.error/pr-form tree-version)
              ". The serialiser validates the version FIRST, before any emission, so "
              "a future-version or corrupt tree never emits plausible markup. This is "
              "an OPERATIONAL deploy-skew condition (the server is too old for the tree "
@@ -100,7 +100,7 @@
          ;; rf2-9s68n — `tree-version` is read straight off a caller-supplied tree, so
          ;; it crosses `error/safe-form` on the ex-data side exactly as
          ;; it crosses `error/pr-form` on the message side above.
-         :extra    {:got (error/safe-form tree-version)
+         :extra    {:got (rf.error/safe-form tree-version)
                     :supported supported-tree-versions}}))))
 
 ;; ---------------------------------------------------------------------------
@@ -476,16 +476,16 @@
   "HTML boolean attributes: true -> presence (attr=\"\"), false/absent ->
   omitted. Tracks react-dom 19.2.0; keyed by the hyphen-collapsed
   lowercase author name."
-  html/boolean-attrs)
+  rf.ssr.html-helpers/boolean-attrs)
 
 (def booleanish-attrs
   "true/false -> \"true\"/\"false\", never omitted. Tracks react-dom 19.2.0."
-  html/booleanish-attrs)
+  rf.ssr.html-helpers/booleanish-attrs)
 
 (def overloaded-boolean-attrs
   "true -> bare presence, false -> omitted, other values stringify.
   Tracks react-dom 19.2.0."
-  html/overloaded-boolean-attrs)
+  rf.ssr.html-helpers/overloaded-boolean-attrs)
 
 (def property-only-attrs
   "Names React never serialises to markup on NON-custom elements. Tracks
@@ -593,7 +593,7 @@
   [value]
   (cond
     (string? value)                          value
-    (number? value)                          (hash/canonical-number value)
+    (number? value)                          (rf.ssr.hash/canonical-number value)
     (or (keyword? value) (symbol? value))    (name value)
     :else                                    (str value)))
 
@@ -649,7 +649,7 @@
 
       (contains? boolean-attrs collapsed-name)
       ;; presence/absence; presence serialises as attr="".
-      (when (html/presence-value-truthy? attribute-value)
+      (when (rf.ssr.html-helpers/presence-value-truthy? attribute-value)
         [(dom-attr-name attribute-name) ""])
 
       (boolean? attribute-value)
@@ -742,11 +742,11 @@
   string is built before it arrives here. `path` is framework-built —
   `:children` keywords and integers — so it needs no crossing."
   [reason path extra]
-  (error/throw-error!
+  (rf.error/throw-error!
     :rf.error/ui-tree-malformed
     'rf.ssr/emit-ui-tree
     (str reason " (at tree path " (pr-str path) ")")
-    {:extra (assoc (error/safe-form extra) :path path)}))
+    {:extra (assoc (rf.error/safe-form extra) :path path)}))
 
 (declare emit-node mark-selected selected-values)
 
@@ -783,7 +783,7 @@
   [tag-lc children path]
   (cond
     (every? string? children)
-    (html/escape-raw-text tag-lc (str/join children))
+    (rf.ssr.html-helpers/escape-raw-text tag-lc (str/join children))
 
     (and (= 1 (count children))
          (map? (first children))
@@ -795,7 +795,7 @@
       (str "a <" tag-lc "> raw-text element takes EITHER string content OR a "
            "single trusted-markup (:html) child — never a structural, mixed, or "
            "multi-child body (which the raw-text fast path would otherwise "
-           "stringify into the element): " (error/pr-form children))
+           "stringify into the element): " (rf.error/pr-form children))
       path {:value children})))
 
 (defn- transparent-wrapper?
@@ -853,7 +853,7 @@
           (str "a <textarea> takes its content from EITHER :value / "
                ":default-value OR a single text child, never both — "
                "react-dom/server 19.2 rejects a textarea given a value AND a "
-               "child: " (error/pr-form child))
+               "child: " (rf.error/pr-form child))
           child-path {:value raw-children}))
 
       (> (count effective-child-entries) 1)
@@ -863,7 +863,7 @@
                (count effective-child-entries)
                " reached it after splicing — react-dom/server 19.2 rejects a "
                "textarea with more than one child: "
-               (error/pr-form (mapv first effective-child-entries)))
+               (rf.error/pr-form (mapv first effective-child-entries)))
           second-child-path {:value raw-children}))
 
       (= 1 (count effective-child-entries))
@@ -875,7 +875,7 @@
                  "react-dom/server 19.2 rejects dangerouslySetInnerHTML on a "
                  "textarea (its content is value/defaultValue or a text child); "
                  "supply the text via :value or a string child: "
-                 (error/pr-form child))
+                 (rf.error/pr-form child))
             child-path {:value raw-children})
 
           (and (map? child) (contains? child :tag))
@@ -883,7 +883,7 @@
             (str "a <textarea> takes a single TEXT child, not a structural "
                  "element — react-dom/server 19.2 renders an element child as "
                  "\"[object Object]\"; supply the text via :value or a string "
-                 "child: " (error/pr-form child))
+                 "child: " (rf.error/pr-form child))
             child-path {:value raw-children}))))))
 
 (defn- emit-element
@@ -897,7 +897,7 @@
         tag-name            (name tag)
         normalised-tag-name (str/lower-case tag-name)
         void?               (contains? void-tags (keyword normalised-tag-name))
-        raw-text?           (contains? html/raw-text-tags normalised-tag-name)
+        raw-text?           (contains? rf.ssr.html-helpers/raw-text-tags normalised-tag-name)
         property-props      (if (custom-element-tag? tag)
                               (set (or (:rf.ui/property-props element) #{}))
                               #{})
@@ -1023,7 +1023,7 @@
                " — every map node is EXACTLY ONE of :tag (element), :view-id "
                "(view boundary), :html (trusted markup), or a fragment (none of "
                "these, splicing its :children); an ambiguous map must not be "
-               "interpreted by branch order: " (error/pr-form node))
+               "interpreted by branch order: " (rf.error/pr-form node))
           path {:value node :got discriminators})
 
         (= 1 (count discriminators))
@@ -1035,7 +1035,7 @@
                        trusted-html
                        (malformed-node!
                          (str "a trusted-HTML node's :html is not a string: "
-                              (error/pr-form node))
+                              (rf.error/pr-form node))
                          path {:value node})))
           ;; view boundary erases — its children splice into the stream.
           :view-id (emit-children (:children node) path))
@@ -1050,12 +1050,12 @@
           (str "a tree node carries no node discriminator — every map node is "
                "an element (:tag), a view boundary (:view-id), trusted markup "
                "(:html), or a fragment (:children); a map with none is not a "
-               "renderable tree node: " (error/pr-form node))
+               "renderable tree node: " (rf.error/pr-form node))
           path {:value node :got []})))
 
     :else
     (malformed-node!
-      (str "malformed tree node in re-frame.ssr/emit-ui-tree: " (error/pr-form node))
+      (str "malformed tree node in re-frame.ssr/emit-ui-tree: " (rf.error/pr-form node))
       path {:value node})))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/ssr/test/re_frame/flows_integration_test.clj
+++ b/implementation/ssr/test/re_frame/flows_integration_test.clj
@@ -66,15 +66,15 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.interop :as interop]
-            [re-frame.schemas :as schemas]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.interop :as rf.interop]
+            [re-frame.schemas :as rf.schemas]
             ;; Loading the Malli adapter publishes the
             ;; `:schemas/malli-validate` late-bind hook the default
             ;; validator routes through (Spec 010 §Recommended soft-pass /
             ;; rf2-t0hq); without it `reg-app-schema` validation soft-passes.
             [re-frame.schemas.malli]
-            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; ---- per-test reset / trace recorder -------------------------------------
@@ -100,16 +100,16 @@
 (def ^:dynamic ^:private *captured* nil)
 
 (defn- reset-runtime [test-fn]
-  (tf/reset-runtime
+  (rf.ssr.test-fixture/reset-runtime
     (fn []
-      (schemas/reset-schema-validator!)
-      (error-emit/clear-error-listeners!)
+      (rf.schemas/reset-schema-validator!)
+      (rf.error-emit/clear-error-listeners!)
       (with-trace-recorder! [captured]
         (binding [*captured* captured]
           (try
             (test-fn)
             (finally
-              (schemas/reset-schema-validator!))))))))
+              (rf.schemas/reset-schema-validator!))))))))
 
 (use-fixtures :each reset-runtime)
 
@@ -244,7 +244,7 @@
       ;; Trace-level confirmation: a single :rf.flow/computed for the event.
       ;; rf2-lwtlk — dev-instrumentation arm. The eval COUNT it restates is
       ;; pinned posture-independently by `(= 1 (count @flow-evals))` above.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (= 1 (count (by-op :rf.flow/computed)))
             "exactly one :rf.flow/computed trace fired for the macrostep
              dispatch — no double / missed eval")))))
@@ -325,7 +325,7 @@
         ;; The subject itself is absent. So the rejection assertions are kept
         ;; VERBATIM in a dev arm, and the posture that ships gets its own arm
         ;; below rather than silence.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           ;; The candidate never installed — neither the handler's :n write NOR
           ;; the flow's bad output ever reached the container.
           (is (= baseline-db (rf/app-db-value :rf/default))
@@ -343,7 +343,7 @@
         ;; and (c) — validation surviving the gate, with or without rollback —
         ;; were both REJECTED, so a change that quietly made `reg-app-schema`
         ;; always-on reddens here and sends the reader to the bead.
-        (when-not interop/debug-enabled?
+        (when-not rf.interop/debug-enabled?
           (is (= {:n -3 :derived {:doubled -6}} (rf/app-db-value :rf/default))
               "with no validator to reject it, the SCHEMA-VIOLATING candidate
                installs WHOLE — the flow's -6 and the handler's :n -3 land
@@ -370,7 +370,7 @@
         ;; rf2-lwtlk — dev-instrumentation arm. Note the `not-any?` and the
         ;; zero-db-changed half of `sig`: both are negatives over the trace
         ;; ring and would pass vacuously under the gate.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (let [sig (filterv #{:rf.event/db-changed
                                :rf.error/schema-validation-failure}
                              (ops))]
@@ -437,7 +437,7 @@
       ;; rf2-lwtlk — dev-instrumentation arm. Both `not-any?` halves are
       ;; negatives over the trace ring; under the gate they hold whatever the
       ;; drain did.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         ;; Trace signature (b): ZERO db-changed, a flow-eval-exception present.
         (is (not-any? #(= :rf.event/db-changed %) (ops))
             "NO :rf.event/db-changed in the throw stream — the event aborted
@@ -539,7 +539,7 @@
       ;; rf2-lwtlk — dev-instrumentation arm. Both assertions restate
       ;; `(= [1 2] @flow-inputs)` above, which is posture-independent and is
       ;; the same claim read off the flow itself rather than off the bus.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (let [computes (by-op :rf.flow/computed)]
           (is (= 2 (count computes))
               "exactly two :rf.flow/computed traces — one per dispatched event")
@@ -633,7 +633,7 @@
       ;; rf2-lwtlk — dev-instrumentation arm. Both restate
       ;; `(= [:route/article] @flow-inputs)` above, which is
       ;; posture-independent.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (let [computes (by-op :rf.flow/computed)]
           (is (= 1 (count computes))
               "exactly one :rf.flow/computed trace for the transition
@@ -709,7 +709,7 @@
         ;; app-db, the unchanged route slice and the zero `:on-match`
         ;; invocations. The `not-any?` half is a negative over the ring and
         ;; would pass vacuously under the gate.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           ;; Trace signature: :rf.flow/failed fired, but NO :rf.event/db-changed
           ;; for this dispatch — the event aborted before install.
           (is (seq (by-op :rf.flow/failed))
@@ -796,7 +796,7 @@
       ;; rf2-lwtlk — dev-instrumentation arm. The SKIP itself is pinned
       ;; posture-independently by `(= [] @flow-evals)` above — the flow body
       ;; did not run — which is the observation the trace announces.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (seq (by-op :rf.flow/skip))
             ":rf.flow/skip fired for the value-equal re-transition")))))
 

--- a/implementation/ssr/test/re_frame/framework_zero_ownership_diagnostics_test.clj
+++ b/implementation/ssr/test/re_frame/framework_zero_ownership_diagnostics_test.clj
@@ -91,16 +91,16 @@
   production face and nothing asserted it in either posture before."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.interop :as interop]
-            [re-frame.elision :as elision]
+            [re-frame.fx :as rf.fx]
+            [re-frame.interop :as rf.interop]
+            [re-frame.elision :as rf.elision]
             ;; The routing / ssr / machines subsystem namespaces are loaded
             ;; (and re-installed between tests) by `tf/reset-runtime`, so
             ;; their `:rf.route/*` / `:rf/hydrate` / machine-lifecycle event
             ;; + fx registrations are live without an explicit require here.
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -127,7 +127,7 @@
     a))
 
 (defn- stub-push-url! []
-  (fx/reg-fx :rf.nav/push-url
+  (rf.fx/reg-fx :rf.nav/push-url
              {:platforms #{:server :client}}
              (fn [_ _] nil)))
 
@@ -179,7 +179,7 @@
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
       ;; under the gate: the diagnostic ring is empty for every input there.
       ;; The four route-slice writes above are the posture-independent half.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (empty? @diags)
             (str "routing navigation events are framework-authority writers — "
                  "no ownership diagnostic; got " (diagnostic-ids diags)))))))
@@ -217,7 +217,7 @@
           ":rf.route/continue completed the navigation")
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
       ;; under the gate; the pending-slot writes above are the residue.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (empty? @diags)
             (str "url-requested / cancel / continue are framework-authority "
                  "writers — no ownership diagnostic; got " (diagnostic-ids diags)))))))
@@ -276,7 +276,7 @@
 
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
       ;; under the gate.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (empty? @diags)
             (str "machine reg / dispatch / spawn / destroy are framework-"
                  "authority writers (via :rf/machine?) — no ownership "
@@ -307,9 +307,9 @@
                        :large     [[:profile :avatar]]
                        :sensitive [[:profile :ssn]]}))
       (rf/dispatch-sync [:test/classify-profile])
-      (is (seq (elision/declarations :rf/default))
+      (is (seq (rf.elision/declarations :rf/default))
           "the :large path was classified into the elision registry")
-      (is (seq (elision/sensitive-declarations :rf/default))
+      (is (seq (rf.elision/sensitive-declarations :rf/default))
           "the :sensitive path was classified into the elision registry")
       (is (some? (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                          [:rf.runtime/elision]))
@@ -317,7 +317,7 @@
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
       ;; under the gate; the three elision-registry pins above are the
       ;; posture-independent half.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (empty? @diags)
             (str "commit-plane classification effects write runtime-db through "
                  "the privileged frame-state commit — no ownership diagnostic; got "
@@ -348,7 +348,7 @@
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
       ;; under the gate; the app-db replacement + server-hash pins above are
       ;; the posture-independent half.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (empty? @diags)
             (str ":rf/hydrate is a framework-authority writer "
                  "(:rf/framework-authority? true) — no ownership diagnostic; got "
@@ -384,7 +384,7 @@
       ;; CONTROL for the five `empty?` assertions above, and it is the one
       ;; that goes red first under the gate — correctly, because with the
       ;; diagnostic elided there is nothing for a control to control.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (= [:rf.warning/app-handler-runtime-effect] (diagnostic-ids diags))
             "a non-framework handler writing :rf.db/runtime trips exactly the warning")
         (is (= :app/sneaky-runtime-write (-> @diags first :tags :rf.trace/event-id))

--- a/implementation/ssr/test/re_frame/hash_parity_test.clj
+++ b/implementation/ssr/test/re_frame/hash_parity_test.clj
@@ -28,8 +28,8 @@
   pinned in `re-frame.ssr-hash-test` (rf2-6djjl); this namespace focuses
   on byte-identity literals, not structural equivalence."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.ssr.hash :as h]
-            [re-frame.ssr.hash-parity-fixtures :as fixtures]))
+            [re-frame.ssr.hash :as rf.ssr.hash]
+            [re-frame.ssr.hash-parity-fixtures :as rf.ssr.hash-parity-fixtures]))
 
 ;; ---- pinned-literal vectors -----------------------------------------------
 ;;
@@ -43,14 +43,14 @@
             fixture hashes to its pinned 8-hex literal under the JVM
             pipeline. Byte-identity with the CLJS-side literal locks
             the cross-runtime invariant."
-    (doseq [{:keys [label input expected rationale]} fixtures/all-fixtures]
-      (let [actual (h/render-tree-hash input)]
+    (doseq [{:keys [label input expected rationale]} rf.ssr.hash-parity-fixtures/all-fixtures]
+      (let [actual (rf.ssr.hash/render-tree-hash input)]
         (is (= expected actual)
             (str "JVM render-tree-hash for fixture " (pr-str label)
                  " — " rationale
                  " — expected " (pr-str expected)
                  ", got " (pr-str actual)
-                 " (canonical: " (pr-str (h/canonical-edn input)) ")"))))))
+                 " (canonical: " (pr-str (rf.ssr.hash/canonical-edn input)) ")"))))))
 
 ;; ---- nil-pruning equivalence pairs ---------------------------------------
 ;;
@@ -66,9 +66,9 @@
             the pruning step OR the FNV byte stream would fail one of
             the two assertions."
     (doseq [{:keys [label input-with-nil input-without-nil expected rationale]}
-            fixtures/nil-prune-pairs]
-      (let [h-with    (h/render-tree-hash input-with-nil)
-            h-without (h/render-tree-hash input-without-nil)]
+            rf.ssr.hash-parity-fixtures/nil-prune-pairs]
+      (let [h-with    (rf.ssr.hash/render-tree-hash input-with-nil)
+            h-without (rf.ssr.hash/render-tree-hash input-without-nil)]
         (is (= expected h-without)
             (str "JVM no-nil canonical hash for " (pr-str label) " — "
                  rationale " — expected " (pr-str expected)
@@ -88,9 +88,9 @@
   (testing "Spec 011 §Hydration-mismatch detection — attribute maps
             emit in sorted-key order. Fixture pairs MUST produce
             byte-identical hashes under the JVM pipeline."
-    (doseq [{:keys [label input-a input-b rationale]} fixtures/equality-pairs]
-      (let [ha (h/render-tree-hash input-a)
-            hb (h/render-tree-hash input-b)]
+    (doseq [{:keys [label input-a input-b rationale]} rf.ssr.hash-parity-fixtures/equality-pairs]
+      (let [ha (rf.ssr.hash/render-tree-hash input-a)
+            hb (rf.ssr.hash/render-tree-hash input-b)]
         (is (= ha hb)
             (str "JVM key-order pair " (pr-str label) " — " rationale
                  " — input-a → " (pr-str ha)
@@ -109,7 +109,7 @@
             be wrong (FNV-1a 32-bit doesn't forbid collisions) but it
             would mean the corpus failed to discriminate between the
             render trees, defeating the point of pinning."
-    (let [literals (mapv :expected fixtures/all-fixtures)]
+    (let [literals (mapv :expected rf.ssr.hash-parity-fixtures/all-fixtures)]
       (is (= (count literals) (count (set literals)))
           (str "Fixture literals must be pairwise distinct — got "
                (pr-str literals))))))

--- a/implementation/ssr/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/ssr/test/re_frame/late_bind_missing_test.clj
@@ -20,7 +20,7 @@
   prose at the call sites in `re-frame.core`."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Loading ssr registers its late-bind hooks. The
             ;; `with-hook-as-nil` helper below re-establishes the absent
             ;; state by flipping the hook value at runtime; restoration
@@ -31,12 +31,12 @@
   "Run `f` with the named late-bind hook set to nil. Restores the
   original value after `f` returns or throws."
   [hook-key f]
-  (let [original (late-bind/get-fn hook-key)]
+  (let [original (rf.late-bind/get-fn hook-key)]
     (try
-      (late-bind/set-fn! hook-key nil)
+      (rf.late-bind/set-fn! hook-key nil)
       (f)
       (finally
-        (late-bind/set-fn! hook-key original)))))
+        (rf.late-bind/set-fn! hook-key original)))))
 
 (deftest render-to-string-raises-when-ssr-artefact-missing
   (testing "rf/render-to-string raises :rf.error/ssr-artefact-missing when the :ssr/render-to-string hook is nil"

--- a/implementation/ssr/test/re_frame/source_coord_parity_test.clj
+++ b/implementation/ssr/test/re_frame/source_coord_parity_test.clj
@@ -43,13 +43,13 @@
   exact bare bytes the production gate emits."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.source-coords :as source-coords]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]
-            [re-frame.views.jvm-source-coord-annotation :as jvm-annot]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.source-coords :as rf.source-coords]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
+            [re-frame.views.jvm-source-coord-annotation :as rf.views.jvm-source-coord-annotation]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---- the canonical attribute-value shapes (shared spec) ------------------
 ;;
@@ -90,14 +90,14 @@
             the canonical <ns>:<sym>:<line>:<col> string — bytes match the
             literal the CLJS companion pins."
     (is (= expected-source-coord
-           (jvm-annot/format-source-coord fixture-id fixture-coords))
+           (rf.views.jvm-source-coord-annotation/format-source-coord fixture-id fixture-coords))
         "JVM data-rf2-source-coord value must match the canonical literal")))
 
 (deftest jvm-format-view-id-byte-identical-to-canonical
   (testing "rf2-8vi4q — the JVM `format-view-id` produces `(str id)`, the
             same `data-rf-view` value the CLJS host stamps. This is the
             attribute the SSR side previously never emitted."
-    (is (= expected-view-id (jvm-annot/format-view-id fixture-id))
+    (is (= expected-view-id (rf.views.jvm-source-coord-annotation/format-view-id fixture-id))
         "JVM data-rf-view value must match the canonical literal")))
 
 (deftest jvm-format-source-coord-degraded-shape-byte-identical
@@ -106,7 +106,7 @@
             CLJS helper's degraded shape. Per Spec 006 §Source-coord
             annotation."
     (is (= expected-source-coord-no-line-no-col
-           (jvm-annot/format-source-coord fixture-id fixture-coords-no-line-no-col))
+           (rf.views.jvm-source-coord-annotation/format-source-coord fixture-id fixture-coords-no-line-no-col))
         "JVM degraded source-coord must match the canonical degraded literal")))
 
 ;; ---- convergence: source-coords is the single cross-host owner (rf2-5q0jv) -
@@ -127,16 +127,16 @@
             owner emits the canonical literals and the JVM vars are the
             identical fn (not a re-derived copy that could drift)."
     (is (= expected-source-coord
-           (source-coords/format-source-coord fixture-id fixture-coords))
+           (rf.source-coords/format-source-coord fixture-id fixture-coords))
         "neutral owner must emit the canonical data-rf2-source-coord literal")
     (is (= expected-view-id
-           (source-coords/format-view-id fixture-id))
+           (rf.source-coords/format-view-id fixture-id))
         "neutral owner must emit the canonical data-rf-view literal")
-    (is (identical? source-coords/format-source-coord
-                    jvm-annot/format-source-coord)
+    (is (identical? rf.source-coords/format-source-coord
+                    rf.views.jvm-source-coord-annotation/format-source-coord)
         "JVM format-source-coord must be an alias of the neutral owner")
-    (is (identical? source-coords/format-view-id
-                    jvm-annot/format-view-id)
+    (is (identical? rf.source-coords/format-view-id
+                    rf.views.jvm-source-coord-annotation/format-view-id)
         "JVM format-view-id must be an alias of the neutral owner")))
 
 ;; ---- end-to-end byte parity: SSR-rendered HTML carries BOTH attributes ---
@@ -155,14 +155,14 @@
             root DOM element, and their values are exactly the shared
             formatters' output for the slot's stored coords."
     (rf/reg-view* fixture-id fixture-coords (fn [] [:p "body"]))
-    (let [html    (ssr/render-to-string [(rf/view fixture-id)] {})
+    (let [html    (rf.ssr/render-to-string [(rf/view fixture-id)] {})
           ;; The values the formatters produce for the coords actually
           ;; stored in the slot (the merge-coords result). Reading them off
           ;; the shared formatters keeps this test honest even if the fixture
           ;; coords are altered — it asserts the render used THE dialect, not
           ;; a hardcoded copy of it.
-          coord   (jvm-annot/format-source-coord fixture-id fixture-coords)
-          view-id (jvm-annot/format-view-id fixture-id)]
+          coord   (rf.views.jvm-source-coord-annotation/format-source-coord fixture-id fixture-coords)
+          view-id (rf.views.jvm-source-coord-annotation/format-view-id fixture-id)]
       ;; SEMANTIC, posture-independent (rf2-lwtlk): `(rf/view id)` resolves to
       ;; the registered view and the view renders its own root and body. The
       ;; gate can remove the attributes; it can never remove the element.
@@ -170,7 +170,7 @@
       (is (.endsWith html ">body</p>") (pr-str html))
 
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (.contains html (str "data-rf2-source-coord=\"" coord "\""))
             (str "server markup must carry the source-coord attribute; got: "
                  (pr-str html)))
@@ -187,7 +187,7 @@
       ;; wrapper is never installed, so the same callable head renders the
       ;; SAME element with neither attribute. Pinned by `=` rather than by a
       ;; `not contains?` pair, which would pass vacuously.
-      (when-not interop/debug-enabled?
+      (when-not rf.interop/debug-enabled?
         (is (= "<p>body</p>" html)
             (str "under the production gate the callable head must render the "
                  "bare root, both annotations elided; got: " (pr-str html)))))))

--- a/implementation/ssr/test/re_frame/ssr/diagnostic_cycle_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/diagnostic_cycle_cljs_test.cljs
@@ -47,9 +47,9 @@
   (:require ["react" :as react]
             [clojure.string :as str]
             [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.error :as error]
-            [re-frame.ssr.emit :as emit]
-            [re-frame.ssr.ui-tree :as ui-tree]))
+            [re-frame.error :as rf.error]
+            [re-frame.ssr.emit :as rf.ssr.emit]
+            [re-frame.ssr.ui-tree :as rf.ssr.ui-tree]))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -169,10 +169,10 @@
                        ["a nested acyclic obj" [:div {} [:span {:ctx acyclic-object}]]]
                        ["a string"             "text"]
                        ["nil"                  nil]]]
-      (is (identical? v (error/safe-form v))
+      (is (identical? v (rf.error/safe-form v))
           (str label " must come back identical")))
     (is (= (pr-str [acyclic-object {:value "dark"}])
-           (error/pr-form [acyclic-object {:value "dark"}]))
+           (rf.error/pr-form [acyclic-object {:value "dark"}]))
         "so pr-form IS pr-str wherever pr-str terminates — including on a
          foreign object, whose contents stay in the diagnostic")))
 
@@ -180,17 +180,17 @@
   (testing "The elision is the strict minimum: the token replaces the value
            `pr-str` cannot survive and nothing else, so the props and
            children around it go on discriminating the diagnostic."
-    (is (= "#js {…cyclic…}" (error/pr-form (self-referential-object))))
-    (is (= "#js […cyclic…]" (error/pr-form (self-referential-array))))
-    (is (= "#js {…cyclic…}" (error/pr-form provider)))
+    (is (= "#js {…cyclic…}" (rf.error/pr-form (self-referential-object))))
+    (is (= "#js […cyclic…]" (rf.error/pr-form (self-referential-array))))
+    (is (= "#js {…cyclic…}" (rf.error/pr-form provider)))
     (is (= "[#js {…cyclic…} {:value \"dark\"} [:p \"x\"]]"
-           (error/pr-form [provider {:value "dark"} [:p "x"]])))
+           (rf.error/pr-form [provider {:value "dark"} [:p "x"]])))
     (is (= "[:div {:ctx #js {…cyclic…}} \"x\"]"
-           (error/pr-form [:div {:ctx provider} "x"]))
+           (rf.error/pr-form [:div {:ctx provider} "x"]))
         "a cycle nested in an attrs map is elided in place, leaving the map
          around it intact")
     (is (= "[:div #js […cyclic…]]"
-           (error/pr-form [:div #js [(self-referential-object)]]))
+           (rf.error/pr-form [:div #js [(self-referential-object)]]))
         "a foreign value from which a cycle is REACHABLE is elided whole —
          the array holding the cycle is itself unprintable")))
 
@@ -201,14 +201,14 @@
            regression dressed up as a fix."
     (let [shared #js {"k" "v"}
           form   [:div {:a shared :b shared}]]
-      (is (identical? form (error/safe-form form)))
-      (is (= (pr-str form) (error/pr-form form)))))
+      (is (identical? form (rf.error/safe-form form)))
+      (is (= (pr-str form) (rf.error/pr-form form)))))
   (testing "and a persistent collection nested INSIDE a foreign value is
            crossed, not treated as the end of the graph — acyclic here, so
            it must come back untouched."
     (let [form [:div #js {"held" [:p "x"]}]]
-      (is (identical? form (error/safe-form form)))
-      (is (= (pr-str form) (error/pr-form form))))))
+      (is (identical? form (rf.error/safe-form form)))
+      (is (= (pr-str form) (rf.error/pr-form form))))))
 
 (deftest a-cycle-through-a-mixed-chain-is-found
   (testing "`pr-str` alternates between foreign values and persistent
@@ -217,13 +217,13 @@
            acyclic and hand `pr-str` the overflow — which is exactly what
            the control row above proves happens."
     (is (= "[:div #js {…cyclic…}]"
-           (error/pr-form [:div #js {"held" [:p provider]}])))
+           (rf.error/pr-form [:div #js {"held" [:p provider]}])))
     (is (= "#js {…cyclic…}"
-           (error/pr-form #js {"held" #js [[:p provider]]}))
+           (rf.error/pr-form #js {"held" #js [[:p provider]]}))
         "two collections deep and through an array as well")
     (rejected-with :rf.error/invalid-hiccup-head
                    "a mixed-chain cycle in head position"
-                   #(emit/emit-element [#js {"held" [:p provider]} {}]))))
+                   #(rf.ssr.emit/emit-element [#js {"held" [:p provider]} {}]))))
 
 ;; ---------------------------------------------------------------------------
 ;; re-frame.ssr.emit — four throw sites
@@ -241,34 +241,34 @@
                         ["a provider nested in markup"  [:div.hosts [:h1 "hosts"]
                                                          [provider {:value "dark"} "x"]]]]]
       (rejected-with :rf.error/invalid-hiccup-head label
-                     #(emit/emit-element el)))))
+                     #(rf.ssr.emit/emit-element el)))))
 
 (deftest render-to-string-is-the-shipped-entry-point-that-reaches-it
   (testing "The severity claim, executed: this is not a test-only path. The
            public `render-to-string` reaches the same throw."
     (rejected-with :rf.error/invalid-hiccup-head "render-to-string on a provider head"
-                   #(emit/render-to-string [:main [provider {:value "dark"} "x"]] nil))))
+                   #(rf.ssr.emit/render-to-string [:main [provider {:value "dark"} "x"]] nil))))
 
 (deftest emit-rejects-a-cyclic-reserved-rf-head-with-its-own-error
   (testing "`reject-reserved-rf-hiccup-head!` prints the ELEMENT, so a
            cyclic value anywhere in the element blew it up even though the
            head itself is an ordinary keyword."
     (rejected-with :rf.error/invalid-hiccup-head "an unrecognised :rf/* head"
-                   #(emit/emit-element [:rf/suspense-boundry {:ctx provider}]))))
+                   #(rf.ssr.emit/emit-element [:rf/suspense-boundry {:ctx provider}]))))
 
 (deftest emit-rejects-a-cyclic-reagent-native-head-with-its-own-error
   (testing "`[:> ctx.Provider …]` is what `:>` interop is FOR, so this arm
            is the one where a cyclic foreign value is not merely possible
            but EXPECTED."
     (rejected-with :rf.error/ssr-reagent-native-head "a :> provider element"
-                   #(emit/emit-element [:> provider {:value "dark"}]))))
+                   #(rf.ssr.emit/emit-element [:> provider {:value "dark"}]))))
 
 (deftest emit-rejects-a-cyclic-suspense-boundary-with-its-own-error
   (testing "A boundary's `:fallback` is ordinary hiccup and can carry a
            foreign value anywhere inside it."
     (rejected-with :rf.error/ssr-suspense-boundary-outside-stream
                    "a suspense boundary whose fallback holds a provider"
-                   #(emit/emit-element
+                   #(rf.ssr.emit/emit-element
                       [:rf/suspense-boundary {:id :b :fallback [:div {:ctx provider}]}]))))
 
 ;; ---------------------------------------------------------------------------
@@ -301,14 +301,14 @@
              ["a textarea given a structural child"
               (tree {:tag :textarea :children [{:tag :b :attrs {:ctx provider}}]})]]]
       (rejected-with :rf.error/ui-tree-malformed label
-                     #(ui-tree/emit-ui-tree t)))))
+                     #(rf.ssr.ui-tree/emit-ui-tree t)))))
 
 (deftest ui-tree-version-gate-rejects-a-cyclic-version-with-its-own-error
   (testing "The version gate runs FIRST and prints the version it got, so a
            foreign value in that slot reached `pr-str` before any node did."
     (rejected-with :rf.error/ssr-ui-tree-version-unsupported
                    "a cyclic :rf.ui/tree-version"
-                   #(ui-tree/emit-ui-tree {:rf.ui/tree-version provider}))))
+                   #(rf.ssr.ui-tree/emit-ui-tree {:rf.ui/tree-version provider}))))
 
 ;; ---------------------------------------------------------------------------
 ;; The acyclic path, byte for byte
@@ -322,7 +322,7 @@
            (what the hash walk does, and rightly) would have cost the
            diagnostic exactly the information it exists to carry."
     (let [el [acyclic-object {:value "dark"}]
-          o  (outcome #(emit/emit-element el))]
+          o  (outcome #(rf.ssr.emit/emit-element el))]
       (is (= :rf.error/invalid-hiccup-head (:error-id o))
           (str "the acyclic control still produces the correct error; got " (pr-str o)))
       (is (str/includes? (:message o) (str "hiccup vector head " (pr-str acyclic-object)))
@@ -331,16 +331,16 @@
           (str "element printed byte-identically to pr-str; got " (pr-str (:message o)))))
 
     (let [el [:> acyclic-object {:value "dark"}]
-          o  (outcome #(emit/emit-element el))]
+          o  (outcome #(rf.ssr.emit/emit-element el))]
       (is (= :rf.error/ssr-reagent-native-head (:error-id o)))
       (is (str/includes? (:message o) (str "(element " (pr-str el) ")"))))
 
     (let [node {:attrs {:ctx acyclic-object}}
-          o    (outcome #(ui-tree/emit-ui-tree (tree node)))]
+          o    (outcome #(rf.ssr.ui-tree/emit-ui-tree (tree node)))]
       (is (= :rf.error/ui-tree-malformed (:error-id o)))
       (is (str/includes? (:message o) (str "renderable tree node: " (pr-str node)))))
 
-    (let [o (outcome #(ui-tree/emit-ui-tree {:rf.ui/tree-version acyclic-object}))]
+    (let [o (outcome #(rf.ssr.ui-tree/emit-ui-tree {:rf.ui/tree-version acyclic-object}))]
       (is (= :rf.error/ssr-ui-tree-version-unsupported (:error-id o)))
       (is (str/includes? (:message o) (str " — got " (pr-str acyclic-object)))))))
 
@@ -348,7 +348,7 @@
   (testing "The crossing is on the FAILURE path only — nothing about a
            valid render moves."
     (is (= "<div class=\"x\"><p>hi</p></div>"
-           (emit/render-to-string [:div {:class "x"} [:p "hi"]] nil)))
+           (rf.ssr.emit/render-to-string [:div {:class "x"} [:p "hi"]] nil)))
     (is (= "<div><p>hi</p></div>"
-           (ui-tree/emit-ui-tree
+           (rf.ssr.ui-tree/emit-ui-tree
              (tree {:tag :div :children [{:tag :p :children ["hi"]}]}))))))

--- a/implementation/ssr/test/re_frame/ssr/emit_ui_tree_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/emit_ui_tree_cljs_test.cljc
@@ -23,8 +23,8 @@
   does not throw on `(inc nil)`, so the serialiser throws EXPLICITLY via the
   canonical builder — the ids and ex-data are identical on both hosts."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.ssr.ui-tree :as ui-tree]
-            [re-frame.ssr :as ssr]))
+            [re-frame.ssr.ui-tree :as rf.ssr.ui-tree]
+            [re-frame.ssr :as rf.ssr]))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers
@@ -55,7 +55,7 @@
              ["version 0"        {:rf.ui/tree-version 0  :tag :div} 0]
              ["string \"1\""     {:rf.ui/tree-version "1" :tag :div} "1"]
              ["version 2"        {:rf.ui/tree-version 2  :tag :div} 2]]]
-      (let [d (caught-ex-data #(ui-tree/emit-ui-tree root))]
+      (let [d (caught-ex-data #(rf.ssr.ui-tree/emit-ui-tree root))]
         (is (map? d)
             (str label ": expected a thrown ex-info, got " (pr-str d)))
         (is (= :rf.error/ssr-ui-tree-version-unsupported (:rf.error/id d))
@@ -70,8 +70,8 @@
   (testing "one structurally-identical tree emits at v1 and throws at v2"
     (let [good (v1 {:tag :div :children ["ok"]})
           bad  (assoc good :rf.ui/tree-version 2)]
-      (is (= "<div>ok</div>" (ui-tree/emit-ui-tree good)))
-      (let [d (caught-ex-data #(ui-tree/emit-ui-tree bad))]
+      (is (= "<div>ok</div>" (rf.ssr.ui-tree/emit-ui-tree good)))
+      (let [d (caught-ex-data #(rf.ssr.ui-tree/emit-ui-tree bad))]
         (is (= :rf.error/ssr-ui-tree-version-unsupported (:rf.error/id d)))
         (is (= 2 (:got d)))))))
 
@@ -79,7 +79,7 @@
   (testing "a v2 tree whose body would be perfectly emittable still throws"
     ;; If the gate ran AFTER emission (or not first) this would emit markup.
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree {:rf.ui/tree-version 2
+              #(rf.ssr.ui-tree/emit-ui-tree {:rf.ui/tree-version 2
                                       :tag :div
                                       :children [{:tag :span :children ["x"]}]}))]
       (is (= :rf.error/ssr-ui-tree-version-unsupported (:rf.error/id d))))))
@@ -91,7 +91,7 @@
 (deftest malformed-node-throws-the-shared-id-not-the-version-id
   (testing "multiple discriminators on a node past the version gate"
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree (v1 {:tag :div
+              #(rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div
                                           :children [{:tag :span :html "x"}]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d))
           "a malformed node is the SHARED tree-consumer id, not the version id")
@@ -100,19 +100,19 @@
 
   (testing "no discriminator and no :children"
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree (v1 {:tag :div :children [{:not-a-node 1}]})))]
+              #(rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div :children [{:not-a-node 1}]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))
       (is (= [] (:got d)))
       (is (= [:children 0] (:path d)))))
 
   (testing "a non-string, non-map node (a bare keyword child)"
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree (v1 {:tag :div :children [:nope]})))]
+              #(rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div :children [:nope]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))))
 
   (testing "a non-string :html is malformed"
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree (v1 {:tag :div :children [{:html 42}]})))]
+              #(rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div :children [{:html 42}]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d))))))
 
 (deftest trusted-html-child-under-textarea-is-rejected
@@ -126,7 +126,7 @@
     ;; RED-BEFORE lever: the shipped serialiser emitted the markup verbatim
     ;; ("<textarea><b>x</b></textarea>"), diverging from React 19.2.
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree
+              #(rf.ssr.ui-tree/emit-ui-tree
                  (v1 {:tag :textarea :children [{:html "<b>x</b>"}]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d))
           "a textarea trusted-markup child is the shared tree-consumer id")
@@ -135,15 +135,15 @@
   (testing "a leading-LF {:html …} child under <textarea> is rejected, NOT "
            "leading-LF-compensated — trusted-HTML compensation is pre/listing only"
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree
+              #(rf.ssr.ui-tree/emit-ui-tree
                  (v1 {:tag :textarea :children [{:html "\n<b>x</b>"}]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))))
   (testing "an ordinary <textarea> body still emits — only :html children reject"
     (is (= "<textarea>hi</textarea>"
-           (ui-tree/emit-ui-tree (v1 {:tag :textarea :children ["hi"]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :textarea :children ["hi"]})))
         "a string child is fine")
     (is (= "<textarea>plain</textarea>"
-           (ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "plain"}})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "plain"}})))
         ":value content is fine")))
 
 (deftest textarea-effective-child-stream-is-validated
@@ -156,7 +156,7 @@
     ;; RED-BEFORE lever: the fragment spliced {:html …} into the textarea and the
     ;; shipped serialiser emitted "<textarea><b>x</b></textarea>".
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree
+              #(rf.ssr.ui-tree/emit-ui-tree
                  (v1 {:tag :textarea
                       :children [{:children [{:html "<b>x</b>"}]}]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))
@@ -164,7 +164,7 @@
           "the diagnostic locates the SPLICED leaf, not the textarea")))
   (testing "trusted markup nested through a VIEW BOUNDARY is rejected"
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree
+              #(rf.ssr.ui-tree/emit-ui-tree
                  (v1 {:tag :textarea
                       :children [{:view-id :my/view
                                   :children [{:html "<b>x</b>"}]}]})))]
@@ -172,44 +172,44 @@
       (is (= [:children 0 :children 0] (:path d)))))
   (testing "a structural element child is rejected (React renders [object Object])"
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree
+              #(rf.ssr.ui-tree/emit-ui-tree
                  (v1 {:tag :textarea :children [{:tag :span :children ["x"]}]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))
       (is (= [:children 0] (:path d)))))
   (testing "more than one effective child is rejected (React allows at most one)"
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree (v1 {:tag :textarea :children ["a" "b"]})))]
+              #(rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :textarea :children ["a" "b"]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))
       (is (= [:children 1] (:path d)) "locates the surplus (second) child"))
     ;; a fragment does not hide the count — two spliced children still reject
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree
+              #(rf.ssr.ui-tree/emit-ui-tree
                  (v1 {:tag :textarea :children [{:children ["a" "b"]}]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))))
   (testing ":value / :default-value plus an authored child is rejected"
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree
+              #(rf.ssr.ui-tree/emit-ui-tree
                  (v1 {:tag :textarea :attrs {:value "v"} :children ["c"]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))
       (is (= [:children 0] (:path d))))
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree
+              #(rf.ssr.ui-tree/emit-ui-tree
                  (v1 {:tag :textarea :attrs {:default-value "v"} :children ["c"]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d))
           ":default-value maps to value and rejects the pair identically")))
   (testing "the valid shapes still emit unchanged — value, sole text, spliced text"
     (is (= "<textarea>plain</textarea>"
-           (ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "plain"}})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "plain"}})))
         ":value alone is valid")
     (is (= "<textarea>hi</textarea>"
-           (ui-tree/emit-ui-tree (v1 {:tag :textarea :children ["hi"]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :textarea :children ["hi"]})))
         "a sole string child is valid")
     (is (= "<textarea>hi</textarea>"
-           (ui-tree/emit-ui-tree
+           (rf.ssr.ui-tree/emit-ui-tree
              (v1 {:tag :textarea :children [{:children ["hi"]}]})))
         "a single string spliced through a fragment is valid")
     (is (= "<textarea>hi</textarea>"
-           (ui-tree/emit-ui-tree
+           (rf.ssr.ui-tree/emit-ui-tree
              (v1 {:tag :textarea :children [{:view-id :v :children ["hi"]}]})))
         "a single string spliced through a view boundary is valid")))
 
@@ -220,56 +220,56 @@
 (deftest emits-elements-attrs-and-text
   (testing "element with sorted attrs and escaped text"
     (is (= "<div class=\"box\" id=\"main\">hi</div>"
-           (ui-tree/emit-ui-tree (v1 {:tag :div
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div
                                       :attrs {:id "main" :class "box"}
                                       :children ["hi"]})))))
   (testing "full 5-char text escaping (&#x27; for apostrophe, matching React)"
     (is (= "<p>&lt;b&gt; &amp; &quot; &#x27;</p>"
-           (ui-tree/emit-ui-tree (v1 {:tag :p :children ["<b> & \" '"]}))))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :p :children ["<b> & \" '"]}))))))
 
 (deftest emits-conversion-table-name-rows
   (testing ":for/:class verbatim, :tab-index collapses, :view-box aliases"
     (is (= "<label for=\"x\" tabindex=\"3\"></label>"
-           (ui-tree/emit-ui-tree (v1 {:tag :label :attrs {:for "x" :tab-index 3}}))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :label :attrs {:for "x" :tab-index 3}}))))
     (is (= "<svg viewBox=\"0 0 1 1\"></svg>"
-           (ui-tree/emit-ui-tree (v1 {:tag :svg :attrs {:view-box "0 0 1 1"}}))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :svg :attrs {:view-box "0 0 1 1"}}))))
     (is (= "<a xlink:href=\"#a\"></a>"
-           (ui-tree/emit-ui-tree (v1 {:tag :a :attrs {:xlink-href "#a"}})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :a :attrs {:xlink-href "#a"}})))))
   (testing "data-* / aria-* names verbatim"
     (is (= "<div data-fooBar=\"1\"></div>"
-           (ui-tree/emit-ui-tree (v1 {:tag :div :attrs {:data-fooBar "1"}}))))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div :attrs {:data-fooBar "1"}}))))))
 
 (deftest emits-boolean-classes
   (testing "boolean attr: true -> presence, false -> omitted"
     (is (= "<input disabled=\"\">"
-           (ui-tree/emit-ui-tree (v1 {:tag :input :attrs {:disabled true :checked false}})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :input :attrs {:disabled true :checked false}})))))
   (testing "booleanish: true/false -> \"true\"/\"false\", never omitted"
     (is (= "<div contentEditable=\"false\"></div>"
-           (ui-tree/emit-ui-tree (v1 {:tag :div :attrs {:content-editable false}})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div :attrs {:content-editable false}})))))
   (testing "overloaded: true -> presence, false -> omitted, other -> value"
     (is (= "<a download=\"\"></a>"
-           (ui-tree/emit-ui-tree (v1 {:tag :a :attrs {:download true}}))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :a :attrs {:download true}}))))
     (is (= "<a download=\"file.txt\"></a>"
-           (ui-tree/emit-ui-tree (v1 {:tag :a :attrs {:download "file.txt"}})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :a :attrs {:download "file.txt"}})))))
   (testing "aria-* values always stringify, never omitted"
     (is (= "<div aria-hidden=\"false\"></div>"
-           (ui-tree/emit-ui-tree (v1 {:tag :div :attrs {:aria-hidden false}}))))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div :attrs {:aria-hidden false}}))))))
 
 (deftest emits-style-in-pinned-order
   (testing ":style map -> css declaration, sorted by property name"
     (is (= "<div style=\"color:red;margin-top:0\"></div>"
-           (ui-tree/emit-ui-tree (v1 {:tag :div :attrs {:style {:margin-top "0"
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div :attrs {:style {:margin-top "0"
                                                                  :color "red"}}}))))))
 
 (deftest emits-void-elements-self-closed
-  (is (= "<br>" (ui-tree/emit-ui-tree (v1 {:tag :br}))))
+  (is (= "<br>" (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :br}))))
   (is (= "<img src=\"a.png\">"
-         (ui-tree/emit-ui-tree (v1 {:tag :img :attrs {:src "a.png"}})))))
+         (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :img :attrs {:src "a.png"}})))))
 
 (deftest drops-events-and-keys
   (testing "events never serialise into HTML; :key has no HTML presence"
     (is (= "<button>Go</button>"
-           (ui-tree/emit-ui-tree (v1 {:tag :button
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :button
                                       :events {:on-click [:go]}
                                       :key 7
                                       :children ["Go"]}))))))
@@ -277,7 +277,7 @@
 (deftest ignores-reserved-diagnostic-keys
   (testing "node-level :rf.ui/* diagnostic keys never emit"
     (is (= "<div>x</div>"
-           (ui-tree/emit-ui-tree (v1 {:tag :div
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div
                                       :rf.ui/presence {:phase :present}
                                       :rf.ui/boundary :client-only
                                       :children ["x"]}))))))
@@ -285,18 +285,18 @@
 (deftest splices-fragments-and-erases-view-boundaries
   (testing "fragment root splices its children with no wrapper"
     (is (= "<span>a</span><span>b</span>"
-           (ui-tree/emit-ui-tree (v1 {:children [{:tag :span :children ["a"]}
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:children [{:tag :span :children ["a"]}
                                                  {:tag :span :children ["b"]}]})))))
   (testing "view boundary is erased; its children splice, its :props are ignored"
     (is (= "<span>x</span>"
-           (ui-tree/emit-ui-tree (v1 {:view-id :my/view
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:view-id :my/view
                                       :props {:whatever 1}
                                       :children [{:tag :span :children ["x"]}]}))))))
 
 (deftest writes-trusted-html-verbatim
   (testing ":html node content is NOT escaped"
     (is (= "<div><b>raw</b></div>"
-           (ui-tree/emit-ui-tree (v1 {:tag :div :children [{:html "<b>raw</b>"}]}))))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div :children [{:html "<b>raw</b>"}]}))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Raw-text elements — <script>/<style> content (rf2-2dh3b)
@@ -318,15 +318,15 @@
     ;; RED-BEFORE lever: the shipped `escape-html` path emitted
     ;; "<script>a &amp; b &lt; c &gt; d</script>" — a corrupted script body.
     (is (= "<script>a & b < c > d</script>"
-           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["a & b < c > d"]}))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :script :children ["a & b < c > d"]}))))
     (is (= "<script>if (a && b) {}</script>"
-           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["if (a && b) {}"]})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :script :children ["if (a && b) {}"]})))))
   (testing "ordinary ampersand / less-than in <style> stays LITERAL"
     (is (= "<style>a & b < c > d</style>"
-           (ui-tree/emit-ui-tree (v1 {:tag :style :children ["a & b < c > d"]})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :style :children ["a & b < c > d"]})))))
   (testing "a childless raw-text element still emits an explicit close tag"
-    (is (= "<script></script>" (ui-tree/emit-ui-tree (v1 {:tag :script}))))
-    (is (= "<style></style>" (ui-tree/emit-ui-tree (v1 {:tag :style}))))))
+    (is (= "<script></script>" (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :script}))))
+    (is (= "<style></style>" (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :style}))))))
 
 (deftest raw-text-closing-sequences-get-context-safe-spellings
   (testing "<script> content: (<|</)script -> the s/S becomes \\u0073 / \\u0053"
@@ -334,31 +334,31 @@
     ;; "&lt;/script&gt;" whose entities stay LITERAL inside raw text — the DOM
     ;; would carry the text </script> and terminate the element early.
     (is (= "<script>var x = '</\\u0073cript>';</script>"
-           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["var x = '</script>';"]}))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :script :children ["var x = '</script>';"]}))))
     (is (= "<script>a<\\u0073cript>b</script>"
-           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["a<script>b"]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :script :children ["a<script>b"]})))
         "an OPENING <script in content is escaped too, matching React")
     (is (= "<script>a</\\u0053CRIPT>b</script>"
-           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["a</SCRIPT>b"]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :script :children ["a</SCRIPT>b"]})))
         "case is preserved except the escaped s/S; uppercase S -> \\u0053")
     (is (= "<script>a</\\u0053cRiPt>b</script>"
-           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["a</ScRiPt>b"]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :script :children ["a</ScRiPt>b"]})))
         "mixed-case suffix preserved verbatim"))
   (testing "<style> content: (<|</)style -> the s/S becomes \\73 / \\53 (CSS escape)"
     (is (= "<style>.x{content:'</\\73 tyle>'}</style>"
-           (ui-tree/emit-ui-tree (v1 {:tag :style :children [".x{content:'</style>'}"]}))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :style :children [".x{content:'</style>'}"]}))))
     (is (= "<style>a</\\53 TYLE>b</style>"
-           (ui-tree/emit-ui-tree (v1 {:tag :style :children ["a</STYLE>b"]}))))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :style :children ["a</STYLE>b"]}))))))
 
 (deftest raw-text-own-lever-p-still-escapes
   (testing "VACUITY probe: the SAME text in a NON-raw-text element IS escaped"
     ;; The fix is narrow: only <script>/<style> bypass entity escaping. If the
     ;; branch mis-fired for ordinary elements this would drop the entities.
     (is (= "<p>a &amp; b &lt; c &gt; d</p>"
-           (ui-tree/emit-ui-tree (v1 {:tag :p :children ["a & b < c > d"]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :p :children ["a & b < c > d"]})))
         "an ordinary <p> keeps full 5-char escaping")
     (is (= "<div>&lt;/script&gt;</div>"
-           (ui-tree/emit-ui-tree (v1 {:tag :div :children ["</script>"]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div :children ["</script>"]})))
         "and </script> in a <div> is inert escaped text, not a raw-text escape")))
 
 ;; ---------------------------------------------------------------------------
@@ -380,19 +380,19 @@
     ;; RED-BEFORE lever (rf2-0spji): the shipped fast path emitted the literal
     ;; EDN "<script>{:html \"const x=1;\"}</script>".
     (is (= "<script>const x=1;</script>"
-           (ui-tree/emit-ui-tree (v1 {:tag :script :children [{:html "const x=1;"}]})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :script :children [{:html "const x=1;"}]})))))
   (testing "a sole {:html s} child under <style> likewise emits its trusted body"
     (is (= "<style>.x{color:red}</style>"
-           (ui-tree/emit-ui-tree (v1 {:tag :style :children [{:html ".x{color:red}"}]})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :style :children [{:html ".x{color:red}"}]})))))
   (testing "the :html body is VERBATIM — the trusted bypass, NEITHER escaped NOR closing-sequence-rewritten"
     ;; Contrast the STRING path: "</script>" as a string CHILD is rewritten to
     ;; "</\\u0073cript>" (raw-text-closing-sequences-*). The :html trusted bypass
     ;; writes it verbatim — exactly as react-dom pushes dangerouslySetInnerHTML
     ;; and as the general :html node path (writes-trusted-html-verbatim) does.
     (is (= "<script>var s = '</script>';</script>"
-           (ui-tree/emit-ui-tree (v1 {:tag :script :children [{:html "var s = '</script>';"}]}))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :script :children [{:html "var s = '</script>';"}]}))))
     (is (= "<script>if (1 < 2 && 3) {}</script>"
-           (ui-tree/emit-ui-tree (v1 {:tag :script :children [{:html "if (1 < 2 && 3) {}"}]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :script :children [{:html "if (1 < 2 && 3) {}"}]})))
         "< and & stay literal — the :html body is never 5-char escaped")))
 
 (deftest raw-text-structural-child-fails-loud-not-stringified
@@ -400,44 +400,44 @@
     ;; RED-BEFORE lever: the fast path stringified it to
     ;; "<script>{:tag :b, :children [\"x\"]}</script>".
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree
+              #(rf.ssr.ui-tree/emit-ui-tree
                  (v1 {:tag :script :children [{:tag :b :children ["x"]}]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d))
           "a structural child in a raw-text element is the SHARED malformed id")
       (is (= [] (:path d)) "locates the offending raw-text element (the root here)")))
   (testing "a non-string :html under <style> is the SAME shared malformed id, located at the child"
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree (v1 {:tag :style :children [{:html 42}]})))]
+              #(rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :style :children [{:html 42}]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))
       (is (= [:children 0] (:path d)) "the reused :html row locates the non-string body")))
   (testing "a body mixing string content with a structural child is malformed"
     ;; React forbids both `children` and `dangerouslySetInnerHTML`; a mixed body
     ;; likewise fails loud rather than half-stringifying.
     (let [d (caught-ex-data
-              #(ui-tree/emit-ui-tree
+              #(rf.ssr.ui-tree/emit-ui-tree
                  (v1 {:tag :script :children ["const x=1;" {:html "y"}]})))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id d))))))
 
 (deftest custom-element-property-props-omitted
   (testing "property-classified props never reach markup; attributes do"
     (is (= "<my-widget id=\"w\"></my-widget>"
-           (ui-tree/emit-ui-tree (v1 {:tag :my-widget
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :my-widget
                                       :attrs {:help-text "hi" :id "w"}
                                       :rf.ui/property-props #{:help-text}}))))))
 
 (deftest form-control-special-forms
   (testing ":default-value serialises as value"
     (is (= "<input value=\"d\">"
-           (ui-tree/emit-ui-tree (v1 {:tag :input :attrs {:default-value "d"}})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :input :attrs {:default-value "d"}})))))
   (testing ":value on :textarea serialises as the text child, not an attribute"
     (is (= "<textarea>hello</textarea>"
-           (ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "hello"}})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "hello"}})))))
   (testing ":value on :select serialises as selected on the matching option"
     (is (= (str "<select>"
                 "<option value=\"a\">A</option>"
                 "<option selected=\"\" value=\"b\">B</option>"
                 "</select>")
-           (ui-tree/emit-ui-tree
+           (rf.ssr.ui-tree/emit-ui-tree
              (v1 {:tag :select
                   :attrs {:value "b"}
                   :children [{:tag :option :attrs {:value "a"} :children ["A"]}
@@ -452,7 +452,7 @@
                 "<option value=\"b\">B</option>"
                 "<option selected=\"\" value=\"c\">C</option>"
                 "</select>")
-           (ui-tree/emit-ui-tree
+           (rf.ssr.ui-tree/emit-ui-tree
              (v1 {:tag :select
                   :attrs {:multiple true :value ["a" "c"]}
                   :children [{:tag :option :attrs {:value "a"} :children ["A"]}
@@ -463,7 +463,7 @@
                 "<option value=\"a\">A</option>"
                 "<option value=\"b\">B</option>"
                 "</select>")
-           (ui-tree/emit-ui-tree
+           (rf.ssr.ui-tree/emit-ui-tree
              (v1 {:tag :select
                   :attrs {:multiple true :value []}
                   :children [{:tag :option :attrs {:value "a"} :children ["A"]}
@@ -486,48 +486,48 @@
     ;; RED-BEFORE lever: the shipped serialiser emitted "<pre>\nhello</pre>",
     ;; which parses to a DOM with one FEWER newline than the tree authored.
     (is (= "<pre>\n\nhello</pre>"
-           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\nhello"]})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\nhello"]})))))
   (testing "each extra authored LF survives (one is eaten, the rest remain)"
     (is (= "<pre>\n\n\nhello</pre>"
-           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\n\nhello"]})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\n\nhello"]})))))
   (testing "pre child text is still HTML-escaped alongside the compensation"
     (is (= "<pre>\n\n&lt;a&gt; &amp; b</pre>"
-           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\n<a> & b"]})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\n<a> & b"]})))))
   (testing "<listing> is a newline-eating element too"
     (is (= "<listing>\n\nhello</listing>"
-           (ui-tree/emit-ui-tree (v1 {:tag :listing :children ["\nhello"]}))))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :listing :children ["\nhello"]}))))))
 
 (deftest leading-newline-compensated-for-textarea-value
   (testing ":value on <textarea> beginning with LF gets the doubled LF"
     ;; RED-BEFORE lever: emitted "<textarea>\nhello</textarea>" (one LF).
     (is (= "<textarea>\n\nhello</textarea>"
-           (ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "\nhello"}})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "\nhello"}})))))
   (testing "textarea :value is RCDATA-escaped alongside the compensation"
     (is (= "<textarea>\n\n&lt;a&gt;&amp;</textarea>"
-           (ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "\n<a>&"}})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "\n<a>&"}})))))
   (testing "a single string child (no :value) is compensated the same way"
     (is (= "<textarea>\n\nhi</textarea>"
-           (ui-tree/emit-ui-tree (v1 {:tag :textarea :children ["\nhi"]}))))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :textarea :children ["\nhi"]}))))))
 
 (deftest leading-newline-own-lever-only-a-single-lf-string-child
   (testing "VACUITY: no LF prefix ⇒ no compensation (the fix must not add one)"
     (is (= "<pre>hello</pre>"
-           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["hello"]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :pre :children ["hello"]})))
         "content not beginning with LF is emitted unchanged")
     (is (= "<textarea>hello</textarea>"
-           (ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "hello"}})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "hello"}})))))
   (testing "a leading CR (\\r) is NOT a newline-eating trigger — matches React"
     (is (= "<pre>\r\nhello</pre>"
-           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\r\nhello"]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\r\nhello"]})))
         "only a leading LF is eaten by the parser, so only LF is compensated"))
   (testing "MULTIPLE children ⇒ no compensation (React's single-string guard)"
     ;; Two text children are React's `children` array, not a string — no doctoring.
     (is (= "<pre>\nab</pre>"
-           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\na" "b"]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\na" "b"]})))
         "a multi-child pre body is left untouched even when the first begins LF"))
   (testing "a non-newline-eating element is never compensated"
     (is (= "<div>\nhello</div>"
-           (ui-tree/emit-ui-tree (v1 {:tag :div :children ["\nhello"]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div :children ["\nhello"]})))
         "the compensation is scoped to pre/listing/textarea only")))
 
 ;; ---------------------------------------------------------------------------
@@ -544,16 +544,16 @@
   (testing "<pre> sole {:html s} child beginning with LF gets React's compensating LF"
     ;; RED-BEFORE lever (rf2-0spji): emitted "<pre>\n<b>x</b></pre>" (one LF).
     (is (= "<pre>\n\n<b>x</b></pre>"
-           (ui-tree/emit-ui-tree (v1 {:tag :pre :children [{:html "\n<b>x</b>"}]})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :pre :children [{:html "\n<b>x</b>"}]})))))
   (testing "<listing> compensates a sole trusted-HTML LF body the same way"
     (is (= "<listing>\n\n<i>y</i></listing>"
-           (ui-tree/emit-ui-tree (v1 {:tag :listing :children [{:html "\n<i>y</i>"}]})))))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :listing :children [{:html "\n<i>y</i>"}]})))))
   (testing "VACUITY: a :html body NOT beginning with LF gets no compensation"
     (is (= "<pre><b>x</b></pre>"
-           (ui-tree/emit-ui-tree (v1 {:tag :pre :children [{:html "<b>x</b>"}]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :pre :children [{:html "<b>x</b>"}]})))
         "the fix must not add an LF when none is owed")
     (is (= "<div>\n<b>x</b></div>"
-           (ui-tree/emit-ui-tree (v1 {:tag :div :children [{:html "\n<b>x</b>"}]})))
+           (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag :div :children [{:html "\n<b>x</b>"}]})))
         "a non-newline-eating element is never compensated, even for a :html body")))
 
 (deftest opts-contract
@@ -564,23 +564,23 @@
   (let [tree (v1 {:tag :html})]
     (testing ":doctype? true prefixes the doctype"
       (is (= "<!DOCTYPE html><html></html>"
-             (ui-tree/emit-ui-tree tree {:doctype? true}))))
+             (rf.ssr.ui-tree/emit-ui-tree tree {:doctype? true}))))
     (testing "default (arity-1) emits no doctype"
       (is (= "<html></html>"
-             (ui-tree/emit-ui-tree tree))))
+             (rf.ssr.ui-tree/emit-ui-tree tree))))
     (testing "nil opts emits no doctype"
       (is (= "<html></html>"
-             (ui-tree/emit-ui-tree tree nil))))
+             (rf.ssr.ui-tree/emit-ui-tree tree nil))))
     (testing ":doctype? false emits no doctype"
       (is (= "<html></html>"
-             (ui-tree/emit-ui-tree tree {:doctype? false}))))
+             (rf.ssr.ui-tree/emit-ui-tree tree {:doctype? false}))))
     (testing "unknown keys are ignored — not rejected, not honoured"
       (is (= "<html></html>"
-             (ui-tree/emit-ui-tree tree {:emit-hash? true :bogus 1})))
+             (rf.ssr.ui-tree/emit-ui-tree tree {:emit-hash? true :bogus 1})))
       (is (= "<!DOCTYPE html><html></html>"
-             (ui-tree/emit-ui-tree tree {:doctype? true :emit-hash? true :bogus 1}))))))
+             (rf.ssr.ui-tree/emit-ui-tree tree {:doctype? true :emit-hash? true :bogus 1}))))))
 
 (deftest facade-re-export-is-the-same-fn
   (testing "re-frame.ssr/emit-ui-tree is the serialiser"
     (is (= "<div>hi</div>"
-           (ssr/emit-ui-tree (v1 {:tag :div :children ["hi"]}))))))
+           (rf.ssr/emit-ui-tree (v1 {:tag :div :children ["hi"]}))))))

--- a/implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc
@@ -59,22 +59,22 @@
   probe into a no-op and let it pass for the wrong reason."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
+            [re-frame.error-emit :as rf.error-emit]
             ;; JVM-only: the sole executable read is the `#?(:clj …)`
             ;; `with-redefs [interop/debug-enabled? false]` arm below.
-            #?(:clj [re-frame.interop :as interop])
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.boot :as boot]
-            [re-frame.ssr.install :as install]
-            [re-frame.ssr.payload-policy :as payload-policy]))
+            #?(:clj [re-frame.interop :as rf.interop])
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.boot :as rf.ssr.boot]
+            [re-frame.ssr.install :as rf.ssr.install]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]))
 
-(use-fixtures :once (fn [f] (rf/init! ssr/adapter) (f)))
+(use-fixtures :once (fn [f] (rf/init! rf.ssr/adapter) (f)))
 
 ;; `installed-payloads` is a process-global `defonce` ledger keyed by payload
 ;; id, outside app-db and untouched by `clear-all!` or a `frame/frames` reset.
 ;; A test that installs a payload and does not reset it leaks into every
 ;; sibling test in the shared runner process.
-(use-fixtures :each (fn [f] (install/reset-installed-payloads!) (f)))
+(use-fixtures :each (fn [f] (rf.ssr.install/reset-installed-payloads!) (f)))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -104,7 +104,7 @@
   "The page-wide hydration payload, built by the SHIPPED assembler so
   these tests track the real wire shape."
   [db]
-  (payload-policy/build-payload nil db "server-hash-1" {}))
+  (rf.ssr.payload-policy/build-payload nil db "server-hash-1" {}))
 
 (defn- reg-bump!
   "Register the mutation the interactivity probe dispatches. Per-test —
@@ -164,8 +164,8 @@
   arrives next meets `:rf.error/frame-payload-conflict`. This is a page
   composed from fragments rendered by two different server responses."
   [fid]
-  (install/payload-install-decision!
-   'test fid (install/payload-content-digest (payload-for {:count 99}))
+  (rf.ssr.install/payload-install-decision!
+   'test fid (rf.ssr.install/payload-content-digest (payload-for {:count 99}))
    :page/other-response))
 
 (defn- boot-page-without-isolation!
@@ -175,7 +175,7 @@
   escapes and every root after it is never reached."
   [specs]
   (mapv (fn [{:keys [mount-fn] :as spec}]
-          (let [payload (boot/hydrate! (dissoc spec :mount-fn))]
+          (let [payload (rf.ssr.boot/hydrate! (dissoc spec :mount-fn))]
             (when mount-fn (mount-fn))
             payload))
         specs))
@@ -210,8 +210,8 @@
     (reg-bump!)
     (let [frames (vec (repeatedly 3 fresh-frame!))
           specs  (root-specs frames fail-idx lever)]
-      (install/reset-installed-payloads!)
-      (assert-isolated! (ssr/hydrate-page! specs) frames fail-idx
+      (rf.ssr.install/reset-installed-payloads!)
+      (assert-isolated! (rf.ssr/hydrate-page! specs) frames fail-idx
                         (str label " @" fail-idx)))))
 
 ;; ---------------------------------------------------------------------------
@@ -246,9 +246,9 @@
       (reg-bump!)
       (let [frames (vec (repeatedly 3 fresh-frame!))
             specs  (root-specs frames fail-idx nil)]
-        (install/reset-installed-payloads!)
+        (rf.ssr.install/reset-installed-payloads!)
         (poison-with-a-conflicting-payload! (nth frames fail-idx))
-        (assert-isolated! (ssr/hydrate-page! specs) frames fail-idx
+        (assert-isolated! (rf.ssr/hydrate-page! specs) frames fail-idx
                           (str "conflict @" fail-idx))))))
 
 ;; ---------------------------------------------------------------------------
@@ -260,7 +260,7 @@
   [lever]
   (let [frames (vec (repeatedly 3 fresh-frame!))
         specs  (root-specs frames 0 lever)]
-    (install/reset-installed-payloads!)
+    (rf.ssr.install/reset-installed-payloads!)
     {:escaped? (try (boot-page-without-isolation! specs) false
                     (catch #?(:clj Throwable :cljs :default) _ true))
      :frames   frames}))
@@ -292,12 +292,12 @@
   (testing "the throw happens before any claim, so the ledger is untouched
             and the next root referencing that payload installs normally"
     (let [fid (fresh-frame!)]
-      (ssr/hydrate-page! [{:frame fid :root-id :page/a
+      (rf.ssr/hydrate-page! [{:frame fid :root-id :page/a
                            :payload (payload-for {:count 7})
                            :manifest {:rf.root/schema-version 2}}])
-      (is (nil? (install/installed-payload fid))
+      (is (nil? (rf.ssr.install/installed-payload fid))
           "no claim was made")
-      (is (= :hydrated (:status (first (ssr/hydrate-page!
+      (is (= :hydrated (:status (first (rf.ssr/hydrate-page!
                                         [{:frame fid :root-id :page/b
                                           :payload (payload-for {:count 7})}]))))
           "a later root got a true :install, not a poisoned :already-installed")
@@ -312,9 +312,9 @@
             ever hydrated."
     (let [fid (fresh-frame!)]
       (rf/destroy-frame! fid)
-      (boot/hydrate! {:frame fid :payload (payload-for {:count 7})
+      (rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 7})
                       :root-id :page/a})
-      (is (nil? (install/installed-payload fid))
+      (is (nil? (rf.ssr.install/installed-payload fid))
           (str "MEASURED: the seed did not land (the frame was not live), "
                "so the claim was released. Without the release this reads "
                "the claim record, and the assertion below fails."))
@@ -329,7 +329,7 @@
                "-tagged` never reaches it: nesting THESE opts back to "
                "`{:config {:platform :client}}` leaves that test green and "
                "reds only this line."))
-      (boot/hydrate! {:frame fid :payload (payload-for {:count 7})
+      (rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 7})
                       :root-id :page/b})
       (is (hydrated? fid)
           "the next root actually seeded the re-created frame"))))
@@ -341,15 +341,15 @@
             ledger exists to prevent."
     (reg-bump!)
     (let [fid (fresh-frame!)]
-      (ssr/hydrate-page! [{:frame fid :root-id :page/a
+      (rf.ssr/hydrate-page! [{:frame fid :root-id :page/a
                            :payload (payload-for {:count 7})
                            :mount-fn (boom! "mount")}])
-      (is (= :page/a (:installed-by (install/installed-payload fid)))
+      (is (= :page/a (:installed-by (rf.ssr.install/installed-payload fid)))
           "the payload IS installed — the seed committed before the mount died")
       (is (hydrated? fid) "and the frame carries the server slice")
       ;; A sibling root sharing that frame keeps running against it.
       (rf/dispatch-sync [::bump] {:frame fid})
-      (ssr/hydrate-page! [{:frame fid :root-id :page/b
+      (rf.ssr/hydrate-page! [{:frame fid :root-id :page/b
                            :payload (payload-for {:count 7})}])
       (is (= {:count 8} (rf/app-db-value fid))
           "the sibling found the payload live and did NOT re-seed — the
@@ -365,8 +365,8 @@
   dev-only trace bus."
   [f]
   (let [seen (atom [])]
-    (error-emit/register-error-listener! ::capture #(swap! seen conj %))
-    (try (f) (finally (error-emit/unregister-error-listener! ::capture)))
+    (rf.error-emit/register-error-listener! ::capture #(swap! seen conj %))
+    (try (f) (finally (rf.error-emit/unregister-error-listener! ::capture)))
     @seen))
 
 (defn- root-boot-failures [records]
@@ -379,7 +379,7 @@
             record naming the root"
     (let [frames  (vec (repeatedly 3 fresh-frame!))
           records (capture-error-records!
-                   #(ssr/hydrate-page! (root-specs frames 1 mount-lever)))
+                   #(rf.ssr/hydrate-page! (root-specs frames 1 mount-lever)))
           failed  (root-boot-failures records)]
       (is (= 1 (count failed)) "exactly one root failed, one record")
       (let [r (first failed)]
@@ -397,7 +397,7 @@
       (is (= :hydrate
              (:phase (first (root-boot-failures
                              (capture-error-records!
-                              #(ssr/hydrate-page!
+                              #(rf.ssr/hydrate-page!
                                 (root-specs frames 0 manifest-lever)))))))
           "a preflight death never reached the seed"))))
 
@@ -407,7 +407,7 @@
     (let [frames  (vec (repeatedly 3 fresh-frame!))
           specs   (-> (root-specs frames 0 manifest-lever)
                       (assoc-in [2 :mount-fn] (boom! "mount")))
-          records (capture-error-records! #(ssr/hydrate-page! specs))]
+          records (capture-error-records! #(rf.ssr/hydrate-page! specs))]
       (is (= #{:page/r0 :page/r2}
              (set (map :root-id (root-boot-failures records)))))
       (is (hydrated? (nth frames 1)) "and the survivor still hydrated"))))
@@ -427,11 +427,11 @@
                category is `always-on` in the Spec 009 catalogue, which
                `error-catalogue-channel-conformance-test` pins against
                the `always-on-axis-conformance-cljs-test` literal.)"
-       (with-redefs [interop/debug-enabled? false]
+       (with-redefs [rf.interop/debug-enabled? false]
          (reg-bump!)
          (let [frames  (vec (repeatedly 3 fresh-frame!))
                specs   (root-specs frames 1 mount-lever)
-               records (capture-error-records! #(ssr/hydrate-page! specs))]
+               records (capture-error-records! #(rf.ssr/hydrate-page! specs))]
            (is (= 1 (count (root-boot-failures records)))
                "the always-on record survives a production build")
            (doseq [i [0 2]]
@@ -449,7 +449,7 @@
             the single guarantee is that a failed root fails ALONE"
     (let [fid      (fresh-frame!)
           attempts (atom 0)
-          outcome  (first (ssr/hydrate-page!
+          outcome  (first (rf.ssr/hydrate-page!
                            [{:frame fid :root-id :page/a
                              :payload (payload-for {:count 7})
                              :mount-fn (fn [] (swap! attempts inc)
@@ -462,7 +462,7 @@
   (testing "so a caller correlates a failure positionally even when the
             root died before its id could be read from a manifest"
     (let [frames   (vec (repeatedly 3 fresh-frame!))
-          outcomes (ssr/hydrate-page! (root-specs frames 1 manifest-lever))]
+          outcomes (rf.ssr/hydrate-page! (root-specs frames 1 manifest-lever))]
       (is (= [:page/r0 :page/r1 :page/r2] (mapv :root-id outcomes)))
       (is (= [:hydrated :failed :hydrated] (mapv :status outcomes))))))
 
@@ -475,7 +475,7 @@
                            (assoc spec :mount-fn
                                   #(swap! mounted conj (:root-id spec))))
                          (root-specs frames nil nil))
-          outcomes (ssr/hydrate-page! specs)]
+          outcomes (rf.ssr/hydrate-page! specs)]
       (is (= [:hydrated :hydrated :hydrated] (mapv :status outcomes)))
       (is (= [:page/r0 :page/r1 :page/r2] @mounted) "every root mounted")
       (doseq [fid frames]

--- a/implementation/ssr/test/re_frame/ssr/failed_root_isolation_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/failed_root_isolation_dom_cljs_test.cljs
@@ -23,16 +23,16 @@
   actually asserts."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.install :as install]
-            [re-frame.ssr.manifest :as manifest]
-            [re-frame.ssr.payload-policy :as payload-policy]))
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.install :as rf.ssr.install]
+            [re-frame.ssr.manifest :as rf.ssr.manifest]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]))
 
-(use-fixtures :once (fn [f] (rf/init! ssr/adapter) (f)))
+(use-fixtures :once (fn [f] (rf/init! rf.ssr/adapter) (f)))
 
 ;; The process-global `defonce` install ledger — reset or it leaks into
 ;; every sibling test in the shared runner process.
-(use-fixtures :each (fn [f] (install/reset-installed-payloads!) (f)))
+(use-fixtures :each (fn [f] (rf.ssr.install/reset-installed-payloads!) (f)))
 
 (defn- browser? []
   (and (exists? js/document)
@@ -72,10 +72,10 @@
     (is (= :client (:platform (rf/frame-meta (fresh-frame!)))))))
 
 (defn- payload-for [db]
-  (payload-policy/build-payload nil db "server-hash-1" {}))
+  (rf.ssr.payload-policy/build-payload nil db "server-hash-1" {}))
 
 (defn- manifest-for [root-id]
-  {:rf.root/schema-version manifest/schema-version
+  {:rf.root/schema-version rf.ssr.manifest/schema-version
    :root-id                root-id
    :view-id                :app/root
    :element-locator        {:id (name root-id)}
@@ -99,7 +99,7 @@
                  (for [[rid manifest?] entries]
                    (str "<div id=\"" (name rid) "\">server markup</div>"
                         (when manifest?
-                          (manifest/script-html (manifest-for rid)))))))
+                          (rf.ssr.manifest/script-html (manifest-for rid)))))))
     (.appendChild (.-body js/document) page)
     page))
 
@@ -135,13 +135,13 @@
               page must still hydrate AND still run."
       (doseq [broken-idx (range 3)]
         (reg-bump!)
-        (install/reset-installed-payloads!)
+        (rf.ssr.install/reset-installed-payloads!)
         (let [ids     [:page/shop :page/cart :page/nav]
               entries (map-indexed (fn [i rid] [rid (not= i broken-idx)]) ids)
               page    (render-page! entries)
               frames  (vec (repeatedly 3 fresh-frame!))]
           (try
-            (let [outcomes (ssr/hydrate-page! (specs-for page entries frames))]
+            (let [outcomes (rf.ssr/hydrate-page! (specs-for page entries frames))]
               (is (= :failed (:status (nth outcomes broken-idx)))
                   (str "the manifest-less root at " broken-idx " failed"))
               (is (= :rf.error/root-manifest-invalid
@@ -174,11 +174,11 @@
                         (assoc-in [1 :payload] (payload-for {:count 99})))]
         (try
           ;; The middle root's frame was already installed from THIS response.
-          (install/payload-install-decision!
+          (rf.ssr.install/payload-install-decision!
            'test (nth frames 1)
-           (install/payload-content-digest (payload-for {:count 7}))
+           (rf.ssr.install/payload-content-digest (payload-for {:count 7}))
            :page/first-response)
-          (let [outcomes (ssr/hydrate-page! specs)]
+          (let [outcomes (rf.ssr/hydrate-page! specs)]
             (is (= :rf.error/frame-payload-conflict
                    (:rf.error/id (ex-data (:error (nth outcomes 1)))))
                 "the stale fragment's root failed loud")
@@ -211,7 +211,7 @@
                                   (swap! mounted conj i)))))
                      (specs-for page entries frames))]
         (try
-          (let [outcomes (ssr/hydrate-page! specs)]
+          (let [outcomes (rf.ssr/hydrate-page! specs)]
             (is (= :failed (:status (nth outcomes 1))))
             (is (= #{0 2} @mounted) "both surviving roots mounted")
             (doseq [i [0 2]]

--- a/implementation/ssr/test/re_frame/ssr/foreign_value_hash_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/foreign_value_hash_cljs_test.cljs
@@ -28,7 +28,7 @@
   row below could pass on an acyclic fixture and prove nothing."
   (:require ["react" :as react]
             [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.ssr.hash :as h]))
+            [re-frame.ssr.hash :as rf.ssr.hash]))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures — one hand-built cycle, one real React 19 context
@@ -102,7 +102,7 @@
                         [:div {:ctx provider} "x"]]
                        ["a cycle reached through a JS array"
                         #js [(self-referential-object)]]]]
-      (let [o (outcome #(h/render-tree-hash v))]
+      (let [o (outcome #(rf.ssr.hash/render-tree-hash v))]
         (is (hex-hash? (:hash o))
             (str label " must hash to 8 lowercase hex chars; got "
                  (pr-str o)))))))
@@ -118,26 +118,26 @@
            print `#js {:f #object[f]}`, smuggling a JS function's `.name`
            — which the `:advanced` compiler renames — back into the hash
            the fn branch exists to keep identity out of."
-    (is (= "#js{}" (h/canonical-edn #js {"a" 1 "b" "two"})))
-    (is (= "#js{}" (h/canonical-edn #js {})))
-    (is (= "#js{}" (h/canonical-edn #js {"f" (fn [] 1)}))
+    (is (= "#js{}" (rf.ssr.hash/canonical-edn #js {"a" 1 "b" "two"})))
+    (is (= "#js{}" (rf.ssr.hash/canonical-edn #js {})))
+    (is (= "#js{}" (rf.ssr.hash/canonical-edn #js {"f" (fn [] 1)}))
         "no #object[<munged name>] survives the crossing")
-    (is (= "#js[]" (h/canonical-edn #js [1 2 3])))
-    (is (= "#js[]" (h/canonical-edn #js [])))
-    (is (= "#js{}" (h/canonical-edn provider)))))
+    (is (= "#js[]" (rf.ssr.hash/canonical-edn #js [1 2 3])))
+    (is (= "#js[]" (rf.ssr.hash/canonical-edn #js [])))
+    (is (= "#js{}" (rf.ssr.hash/canonical-edn provider)))))
 
 (deftest the-form-around-a-foreign-value-still-hashes
   (testing "The token collapses the FOREIGN value and nothing else — the
            props and children of a provider-headed form go on
            discriminating, which is what keeps the hash a hash rather than
            a constant."
-    (let [dark  (h/render-tree-hash [provider {:value "dark"} [:p "x"]])
-          light (h/render-tree-hash [provider {:value "light"} [:p "x"]])
-          other (h/render-tree-hash [provider {:value "dark"} [:p "y"]])]
+    (let [dark  (rf.ssr.hash/render-tree-hash [provider {:value "dark"} [:p "x"]])
+          light (rf.ssr.hash/render-tree-hash [provider {:value "light"} [:p "x"]])
+          other (rf.ssr.hash/render-tree-hash [provider {:value "dark"} [:p "y"]])]
       (is (not= dark light) "a different prop is a different hash")
       (is (not= dark other) "a different child is a different hash")
       (is (= "[#js{} {:value \"dark\"} [:p \"x\"]]"
-             (h/canonical-edn [provider {:value "dark"} [:p "x"]]))))))
+             (rf.ssr.hash/canonical-edn [provider {:value "dark"} [:p "x"]]))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The predicates, bounded
@@ -149,12 +149,12 @@
            foreign value can take is bounded and recurses into nothing,
            so it keeps the serialisation it has always had — this row is
            what stops the foreign branch from quietly widening."
-    (is (= "#inst \"1970-01-01T00:00:00.000-00:00\"" (h/canonical-edn (js/Date. 0))))
-    (is (= "#\"ab+c\"" (h/canonical-edn #"ab+c")))
-    (is (= "#fn[]" (h/canonical-edn (fn [_] nil)))
+    (is (= "#inst \"1970-01-01T00:00:00.000-00:00\"" (rf.ssr.hash/canonical-edn (js/Date. 0))))
+    (is (= "#\"ab+c\"" (rf.ssr.hash/canonical-edn #"ab+c")))
+    (is (= "#fn[]" (rf.ssr.hash/canonical-edn (fn [_] nil)))
         "and a raw fn still takes the fn branch, ahead of either of these")
     (is (= "[:div {:class \"x\"} [:p \"hi\"]]"
-           (h/canonical-edn [:div {:class "x"} [:p "hi"]]))
+           (rf.ssr.hash/canonical-edn [:div {:class "x"} [:p "hi"]]))
         "ordinary CLJS data is untouched — the parity fixtures at
          re-frame.ssr.hash-parity-fixtures are the full statement of
          that, pinned on both runtimes")))

--- a/implementation/ssr/test/re_frame/ssr/form2_arity_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/form2_arity_cljs_test.cljc
@@ -45,7 +45,7 @@
   the JVM-only `re-frame.ssr-emit-test`."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.ssr.emit :as emit]))
+            [re-frame.ssr.emit :as rf.ssr.emit]))
 
 ;; ---------------------------------------------------------------------------
 ;; Outcome helper
@@ -73,7 +73,7 @@
   failure."
   [el]
   (try
-    (emit/emit-element el)
+    (rf.ssr.emit/emit-element el)
     (catch #?(:clj Throwable :cljs :default) e
       (if (arity-rejection? e)
         ::arity-rejected

--- a/implementation/ssr/test/re_frame/ssr/hash_parity_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/hash_parity_cljs_test.cljs
@@ -25,8 +25,8 @@
   is platform-neutral — no DOM, no React — so the node-test gate is
   sufficient."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.ssr.hash :as h]
-            [re-frame.ssr.hash-parity-fixtures :as fixtures]))
+            [re-frame.ssr.hash :as rf.ssr.hash]
+            [re-frame.ssr.hash-parity-fixtures :as rf.ssr.hash-parity-fixtures]))
 
 ;; ---- pinned-literal vectors -----------------------------------------------
 
@@ -35,14 +35,14 @@
             fixture hashes to its pinned 8-hex literal under the CLJS
             pipeline. Byte-identity with the JVM-side literal locks
             the cross-runtime invariant."
-    (doseq [{:keys [label input expected rationale]} fixtures/all-fixtures]
-      (let [actual (h/render-tree-hash input)]
+    (doseq [{:keys [label input expected rationale]} rf.ssr.hash-parity-fixtures/all-fixtures]
+      (let [actual (rf.ssr.hash/render-tree-hash input)]
         (is (= expected actual)
             (str "CLJS render-tree-hash for fixture " (pr-str label)
                  " — " rationale
                  " — expected " (pr-str expected)
                  ", got " (pr-str actual)
-                 " (canonical: " (pr-str (h/canonical-edn input)) ")"))))))
+                 " (canonical: " (pr-str (rf.ssr.hash/canonical-edn input)) ")"))))))
 
 ;; ---- nil-pruning equivalence pairs ---------------------------------------
 
@@ -51,9 +51,9 @@
             inputs MUST hash to the pinned literal under the CLJS
             pipeline."
     (doseq [{:keys [label input-with-nil input-without-nil expected rationale]}
-            fixtures/nil-prune-pairs]
-      (let [h-with    (h/render-tree-hash input-with-nil)
-            h-without (h/render-tree-hash input-without-nil)]
+            rf.ssr.hash-parity-fixtures/nil-prune-pairs]
+      (let [h-with    (rf.ssr.hash/render-tree-hash input-with-nil)
+            h-without (rf.ssr.hash/render-tree-hash input-without-nil)]
         (is (= expected h-without)
             (str "CLJS no-nil canonical hash for " (pr-str label) " — "
                  rationale " — expected " (pr-str expected)
@@ -69,9 +69,9 @@
   (testing "Spec 011 §Hydration-mismatch detection — attribute maps
             emit in sorted-key order. Fixture pairs MUST produce
             byte-identical hashes under the CLJS pipeline."
-    (doseq [{:keys [label input-a input-b rationale]} fixtures/equality-pairs]
-      (let [ha (h/render-tree-hash input-a)
-            hb (h/render-tree-hash input-b)]
+    (doseq [{:keys [label input-a input-b rationale]} rf.ssr.hash-parity-fixtures/equality-pairs]
+      (let [ha (rf.ssr.hash/render-tree-hash input-a)
+            hb (rf.ssr.hash/render-tree-hash input-b)]
         (is (= ha hb)
             (str "CLJS key-order pair " (pr-str label) " — " rationale
                  " — input-a → " (pr-str ha)
@@ -84,7 +84,7 @@
             check is redundant with the JVM-side check (they read the
             same `def`s) but cheap; an accidental edit that introduced
             a duplicate would fail both."
-    (let [literals (mapv :expected fixtures/all-fixtures)]
+    (let [literals (mapv :expected rf.ssr.hash-parity-fixtures/all-fixtures)]
       (is (= (count literals) (count (set literals)))
           (str "Fixture literals must be pairwise distinct — got "
                (pr-str literals))))))

--- a/implementation/ssr/test/re_frame/ssr/head_emit_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/head_emit_cljs_test.cljc
@@ -22,13 +22,13 @@
   so the test pins the contract a consumer actually sees."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.ssr.head.emit :as head-emit]))
+            [re-frame.ssr.head.emit :as rf.ssr.head.emit]))
 
 (deftest ld-json-string-serialises-structured-map
   (testing "rf2-usio0 — the CLJS JSON-LD path serialises a structured map
             and rides the <script type=\"application/ld+json\"> envelope
             (the JSON.stringify branch, on Node)."
-    (let [html (head-emit/head-model->html
+    (let [html (rf.ssr.head.emit/head-model->html
                  {:json-ld [{"@context" "https://schema.org"
                              "@type"    "Article"
                              "headline" "Hello"}]})]
@@ -47,7 +47,7 @@
             `<script type=\"application/ld+json\">` envelope. This is the
             security-critical assertion the CLJS branch lacked."
     (let [hostile "</script><script>alert(document.cookie)</script>"
-          html    (head-emit/head-model->html
+          html    (rf.ssr.head.emit/head-model->html
                     {:json-ld [{"@context" "https://schema.org"
                                 "@type"    "Article"
                                 "headline" hostile}]})]
@@ -65,7 +65,7 @@
             escaped on the CLJS path (the escape walks the whole
             stringified payload, keys included)."
     (let [hostile-key "</script>"
-          html        (head-emit/head-model->html
+          html        (rf.ssr.head.emit/head-model->html
                         {:json-ld [{hostile-key "value"}]})]
       (is (not (str/includes? html "</script>\":"))
           "</script> as a key cannot close the envelope")
@@ -83,7 +83,7 @@
             covers the JVM short-escape + \\u00XX table; this is the
             cross-branch parity guard.)"
     (let [headline (str "line1" \newline "line2" \tab "tab" \return "cr")
-          html     (head-emit/head-model->html
+          html     (rf.ssr.head.emit/head-model->html
                      {:json-ld [{"@type" "Article" "headline" headline}]})]
       (is (str/includes? html "\\n") "newline escaped on this runtime")
       (is (str/includes? html "\\t") "tab escaped on this runtime")

--- a/implementation/ssr/test/re_frame/ssr/machine_after_rearm_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/machine_after_rearm_cljs_test.cljc
@@ -28,18 +28,18 @@
   registrations, which would silently turn a dispatch into a no-op."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
             ;; Loading the machines artefact publishes the
             ;; `:machines/rearm-after-hydration!` hook the hydrate handler
             ;; gates on, and registers `:rf.machine/hydrate-rearm`.
             [re-frame.machines]
-            [re-frame.machines.timer :as timer]
-            [re-frame.router :as router]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.payload-policy :as payload-policy]))
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.router :as rf.router]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]))
 
-(use-fixtures :once (fn [f] (rf/init! ssr/adapter) (f)))
+(use-fixtures :once (fn [f] (rf/init! rf.ssr/adapter) (f)))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -60,7 +60,7 @@
 (defn- inner
   "`frame-id`'s inner `:after` timer table, or `{}` when it holds none."
   [frame-id]
-  (get @timer/after-timers frame-id {}))
+  (get @rf.machines.timer/after-timers frame-id {}))
 
 (defn- fire!
   "Run a captured host-clock thunk to completion. The thunk dispatches the
@@ -69,7 +69,7 @@
   to an inline call is the established seam for observing an async drain
   deterministically on both hosts."
   [thunk]
-  (with-redefs [interop/next-tick (fn [f] (f) nil)]
+  (with-redefs [rf.interop/next-tick (fn [f] (f) nil)]
     (thunk)))
 
 (def ^:private waiting-machine
@@ -92,12 +92,12 @@
     (rf/dispatch-sync [machine-id [:go]] {:frame sfid})
     (is (empty? (inner sfid))
         "precondition: the SERVER armed no `:after` host timer")
-    (payload-policy/build-payload
+    (rf.ssr.payload-policy/build-payload
       nil
       (rf/app-db-value sfid)
       "server-hash-1"
-      {:runtime-db (payload-policy/project-runtime-db
-                     (frame/frame-runtime-db-value sfid) sfid)})))
+      {:runtime-db (rf.ssr.payload-policy/project-runtime-db
+                     (rf.frame/frame-runtime-db-value sfid) sfid)})))
 
 ;; ---------------------------------------------------------------------------
 ;; The seam works end to end
@@ -120,11 +120,11 @@
           "precondition: so did the per-decl-path epoch")
       (is (empty? (inner cfid)) "precondition: the client holds no timers yet")
 
-      (with-redefs [interop/schedule-after! (fn [t ms]
+      (with-redefs [rf.interop/schedule-after! (fn [t ms]
                                              (swap! thunks conj t)
                                              (swap! armed conj ms)
                                              ::handle)]
-        (router/dispatch-sync! [:rf/hydrate payload] {:frame cfid}))
+        (rf.router/dispatch-sync! [:rf/hydrate payload] {:frame cfid}))
 
       (let [table (inner cfid)]
         (is (= 1 (count table))
@@ -139,13 +139,13 @@
             "for the FULL declared delay; nothing on the wire records a
              schedule instant to compute a remainder from"))
 
-      (is (= :waiting (get-in (frame/frame-runtime-db-value cfid)
+      (is (= :waiting (get-in (rf.frame/frame-runtime-db-value cfid)
                               [:rf.runtime/machines :snapshots :ssrrearm/one :state])))
       (fire! (first @thunks))
-      (is (= :timeout (get-in (frame/frame-runtime-db-value cfid)
+      (is (= :timeout (get-in (rf.frame/frame-runtime-db-value cfid)
                               [:rf.runtime/machines :snapshots :ssrrearm/one :state]))
           "the hydrated timer FIRED and drove the declared transition")
-      (is (= 1 (get-in (frame/frame-runtime-db-value cfid)
+      (is (= 1 (get-in (rf.frame/frame-runtime-db-value cfid)
                        [:rf.runtime/machines :snapshots :ssrrearm/one :data :entries]))
           (str "and `:entry` still ran exactly once — the server's. The re-arm "
                "reconstructs host work; it does not replay history.")))))
@@ -159,9 +159,9 @@
             loopback / test-harness shape — starts no host clocks"
     (let [payload (server-render! :ssrrearm/srv)
           target  (fresh-frame! :server)]
-      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
-        (router/dispatch-sync! [:rf/hydrate payload] {:frame target}))
-      (is (= :waiting (get-in (frame/frame-runtime-db-value target)
+      (with-redefs [rf.interop/schedule-after! (fn [_t _ms] ::handle)]
+        (rf.router/dispatch-sync! [:rf/hydrate payload] {:frame target}))
+      (is (= :waiting (get-in (rf.frame/frame-runtime-db-value target)
                               [:rf.runtime/machines :snapshots :ssrrearm/srv :state]))
           "the payload DID install — so the empty table below is the gate
            working, not the hydration failing")
@@ -173,24 +173,24 @@
             therefore arms nothing"
     (let [good (server-render! :ssrrearm/rej)
           cfid (fresh-frame! :client)]
-      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+      (with-redefs [rf.interop/schedule-after! (fn [_t _ms] ::handle)]
         ;; (a) malformed — a present-but-non-map `:rf/app-db` slice.
-        (router/dispatch-sync! [:rf/hydrate (assoc good :rf/app-db "not-a-map")]
+        (rf.router/dispatch-sync! [:rf/hydrate (assoc good :rf/app-db "not-a-map")]
                                {:frame cfid})
         (is (empty? (inner cfid)) "malformed payload: rejected, nothing armed")
-        (is (nil? (get-in (frame/frame-runtime-db-value cfid)
+        (is (nil? (get-in (rf.frame/frame-runtime-db-value cfid)
                           [:rf.runtime/machines :snapshots :ssrrearm/rej]))
             "and nothing installed either — the rejection is total")
 
         ;; (b) wrong frame — a payload stamped for a DIFFERENT frame id.
-        (router/dispatch-sync! [:rf/hydrate (assoc good :rf/frame-id :ssrrearm/somewhere-else)]
+        (rf.router/dispatch-sync! [:rf/hydrate (assoc good :rf/frame-id :ssrrearm/somewhere-else)]
                                {:frame cfid})
         (is (empty? (inner cfid)) "wrong-frame payload: rejected, nothing armed")
 
         ;; CONTROL — the same payload, unmangled, on the same frame DOES arm.
         ;; Without this the two assertions above would pass for a payload
         ;; that could never arm anything in the first place.
-        (router/dispatch-sync! [:rf/hydrate good] {:frame cfid})
+        (rf.router/dispatch-sync! [:rf/hydrate good] {:frame cfid})
         (is (= 1 (count (inner cfid)))
             "control: the well-formed payload arms, so the rejections above
              are about the rejection and not about the payload")))))
@@ -200,8 +200,8 @@
             there is no server-settled machine state to reconstruct from"
     (let [good (server-render! :ssrrearm/nort)
           cfid (fresh-frame! :client)]
-      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
-        (router/dispatch-sync! [:rf/hydrate (dissoc good :rf/runtime-db)]
+      (with-redefs [rf.interop/schedule-after! (fn [_t _ms] ::handle)]
+        (rf.router/dispatch-sync! [:rf/hydrate (dissoc good :rf/runtime-db)]
                                {:frame cfid}))
       (is (empty? (inner cfid))
           "no runtime-db slice, no re-arm"))))

--- a/implementation/ssr/test/re_frame/ssr/multi_root_hydration_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/multi_root_hydration_cljs_test.cljc
@@ -45,16 +45,16 @@
   reason."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.boot :as boot]
-            [re-frame.ssr.install :as install]
-            [re-frame.ssr.manifest :as manifest]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.router :as router]))
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.boot :as rf.ssr.boot]
+            [re-frame.ssr.install :as rf.ssr.install]
+            [re-frame.ssr.manifest :as rf.ssr.manifest]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.router :as rf.router]))
 
-(use-fixtures :once (fn [f] (rf/init! ssr/adapter) (f)))
+(use-fixtures :once (fn [f] (rf/init! rf.ssr/adapter) (f)))
 
-(use-fixtures :each (fn [f] (install/reset-installed-payloads!) (f)))
+(use-fixtures :each (fn [f] (rf.ssr.install/reset-installed-payloads!) (f)))
 
 ;; ---------------------------------------------------------------------------
 ;; Host-neutral fixtures
@@ -88,7 +88,7 @@
   target stand. The frame-id mismatch arm is covered by
   `ssr_hydration_test`."
   [db]
-  (payload-policy/build-payload nil db "server-hash-1" {}))
+  (rf.ssr.payload-policy/build-payload nil db "server-hash-1" {}))
 
 (defn- reg-bump!
   "Register the client-side mutation the idempotence proof interleaves.
@@ -99,7 +99,7 @@
 (def ^:private manifest-v1
   "A minimal valid Root Manifest v1 — only `:rf.root/schema-version` is
   required, which is exactly the subset property S5-A pinned."
-  {:rf.root/schema-version manifest/schema-version
+  {:rf.root/schema-version rf.ssr.manifest/schema-version
    :root-id                :page/shop
    :view-id                :app/shop-root
    :phase                  :server})
@@ -128,7 +128,7 @@
     (reg-bump!)
     (let [fid     (fresh-frame!)
           payload (payload-for {:count 7})]
-      (boot/hydrate! {:frame fid :payload payload})
+      (rf.ssr.boot/hydrate! {:frame fid :payload payload})
       (is (= {:count 7} (rf/app-db-value fid)) "first install seeded")
 
       (rf/dispatch-sync [::bump] {:frame fid})
@@ -136,7 +136,7 @@
           "the client moved past the server slice")
 
       ;; PAST the ledger, straight at the handler.
-      (router/dispatch-sync! [:rf/hydrate payload] {:frame fid})
+      (rf.router/dispatch-sync! [:rf/hydrate payload] {:frame fid})
 
       (is (= {:count 7} (rf/app-db-value fid))
           (str "MEASURED (this is the defect, not an aspiration): an "
@@ -157,13 +157,13 @@
     (let [fid     (fresh-frame!)
           payload (payload-for {:count 7})]
       ;; ROOT A boots.
-      (boot/hydrate! {:frame fid :payload payload :root-id :page/a})
+      (rf.ssr.boot/hydrate! {:frame fid :payload payload :root-id :page/a})
       (rf/dispatch-sync [::bump] {:frame fid})
       (let [after-one (rf/app-db-value fid)]
         (is (= {:count 8} after-one))
 
         ;; ROOT B boots — same page, same frame, same payload script.
-        (boot/hydrate! {:frame fid :payload payload :root-id :page/b})
+        (rf.ssr.boot/hydrate! {:frame fid :payload payload :root-id :page/b})
 
         (is (= after-one (rf/app-db-value fid))
             (str "the observable frame-state is IDENTICAL to installing "
@@ -176,8 +176,8 @@
             page WAS server-rendered, whichever root got there first"
     (let [fid     (fresh-frame!)
           payload (payload-for {:count 7})]
-      (is (= payload (boot/hydrate! {:frame fid :payload payload})))
-      (is (= payload (boot/hydrate! {:frame fid :payload payload}))
+      (is (= payload (rf.ssr.boot/hydrate! {:frame fid :payload payload})))
+      (is (= payload (rf.ssr.boot/hydrate! {:frame fid :payload payload}))
           "a caller branching on the return value cannot tell root order"))))
 
 (deftest the-installing-root-is-recorded-and-a-later-root-does-not-replace-it
@@ -185,9 +185,9 @@
             installed it, so a conflict can name the right party"
     (let [fid     (fresh-frame!)
           payload (payload-for {:count 7})]
-      (boot/hydrate! {:frame fid :payload payload :root-id :page/a})
-      (boot/hydrate! {:frame fid :payload payload :root-id :page/b})
-      (is (= :page/a (:installed-by (install/installed-payload fid)))
+      (rf.ssr.boot/hydrate! {:frame fid :payload payload :root-id :page/a})
+      (rf.ssr.boot/hydrate! {:frame fid :payload payload :root-id :page/b})
+      (is (= :page/a (:installed-by (rf.ssr.install/installed-payload fid)))
           "root B found the claim live; it did not take it over"))))
 
 (deftest order-independence-either-root-may-boot-first
@@ -196,9 +196,9 @@
     (let [payload (payload-for {:count 7})]
       (doseq [[first-root second-root] [[:page/a :page/b] [:page/b :page/a]]]
         (let [fid (fresh-frame!)]
-          (boot/hydrate! {:frame fid :payload payload :root-id first-root})
-          (boot/hydrate! {:frame fid :payload payload :root-id second-root})
-          (is (= first-root (:installed-by (install/installed-payload fid)))
+          (rf.ssr.boot/hydrate! {:frame fid :payload payload :root-id first-root})
+          (rf.ssr.boot/hydrate! {:frame fid :payload payload :root-id second-root})
+          (is (= first-root (:installed-by (rf.ssr.install/installed-payload fid)))
               (str "whichever root booted first owns the claim (order "
                    (pr-str [first-root second-root]) ")")))))))
 
@@ -216,11 +216,11 @@
   (testing "two roots referencing one payload id with DIFFERENT content is
             :rf.error/frame-payload-conflict — never a silent first-wins"
     (let [fid (fresh-frame!)]
-      (boot/hydrate! {:frame fid :payload (payload-for {:count 7})
+      (rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 7})
                       :root-id :page/a})
       (is (= :rf.error/frame-payload-conflict
              (caught-error-id
-              #(boot/hydrate! {:frame fid :payload (payload-for {:count 99})
+              #(rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 99})
                                :root-id :page/b})))))))
 
 (deftest a-conflicting-root-leaves-the-installed-payload-untouched
@@ -228,17 +228,17 @@
             frame it seeded, and the ledger record all survive intact"
     (reg-bump!)
     (let [fid (fresh-frame!)]
-      (boot/hydrate! {:frame fid :payload (payload-for {:count 7})
+      (rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 7})
                       :root-id :page/a})
       (rf/dispatch-sync [::bump] {:frame fid})
       (let [before-conflict (rf/app-db-value fid)
-            record-before   (install/installed-payload fid)]
+            record-before   (rf.ssr.install/installed-payload fid)]
         (caught-error-id
-         #(boot/hydrate! {:frame fid :payload (payload-for {:count 99})
+         #(rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 99})
                           :root-id :page/b}))
         (is (= before-conflict (rf/app-db-value fid))
             "the frame the first root seeded was not touched")
-        (is (= record-before (install/installed-payload fid))
+        (is (= record-before (rf.ssr.install/installed-payload fid))
             "the ledger still attributes the payload to root A — a
              conflicting root never overwrites, merges, or partially claims")))))
 
@@ -246,9 +246,9 @@
   (testing "ex-data carries :payload-id, :installed and :arriving, each with
             its content :digest (004C §7 — the S5 arm's own slot)"
     (let [fid (fresh-frame!)]
-      (boot/hydrate! {:frame fid :payload (payload-for {:count 7})
+      (rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 7})
                       :root-id :page/a})
-      (let [data (try (boot/hydrate! {:frame fid :payload (payload-for {:count 99})
+      (let [data (try (rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 99})
                                       :root-id :page/b})
                       nil
                       (catch #?(:clj Exception :cljs :default) e (ex-data e)))]
@@ -270,17 +270,17 @@
   (testing "the digest is a function of payload CONTENT, not identity —
             two roots reading the same script must agree without sharing
             an object"
-    (is (= (install/payload-content-digest (payload-for {:count 7}))
-           (install/payload-content-digest (payload-for {:count 7})))
+    (is (= (rf.ssr.install/payload-content-digest (payload-for {:count 7}))
+           (rf.ssr.install/payload-content-digest (payload-for {:count 7})))
         "separately constructed but equal payloads agree")
-    (is (not= (install/payload-content-digest (payload-for {:count 7}))
-              (install/payload-content-digest (payload-for {:count 8})))
+    (is (not= (rf.ssr.install/payload-content-digest (payload-for {:count 7}))
+              (rf.ssr.install/payload-content-digest (payload-for {:count 8})))
         "a differing app-db slice is a differing digest"))
 
   (testing "key order does not change the digest — the canonical-EDN walk
             sorts, so an unordered map literal cannot fake a conflict"
-    (is (= (install/payload-content-digest {:rf/app-db {:a 1 :b 2} :rf/version 1})
-           (install/payload-content-digest {:rf/version 1 :rf/app-db {:b 2 :a 1}})))))
+    (is (= (rf.ssr.install/payload-content-digest {:rf/app-db {:a 1 :b 2} :rf/version 1})
+           (rf.ssr.install/payload-content-digest {:rf/version 1 :rf/app-db {:b 2 :a 1}})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Preflight step 1 — the manifest
@@ -291,7 +291,7 @@
             not from a caller-supplied guess"
     (let [fid (fresh-frame!)
           {:keys [root-id decision manifest]}
-          (install/preflight! 'test {:payload    (payload-for {:count 7})
+          (rf.ssr.install/preflight! 'test {:payload    (payload-for {:count 7})
                                      :payload-id fid
                                      :manifest   manifest-v1})]
       (is (= :page/shop root-id) "read from the manifest's content")
@@ -304,10 +304,10 @@
     (let [fid (fresh-frame!)]
       (is (= :rf.error/root-manifest-invalid
              (caught-error-id
-              #(install/preflight! 'test {:payload    (payload-for {:count 7})
+              #(rf.ssr.install/preflight! 'test {:payload    (payload-for {:count 7})
                                           :payload-id fid
                                           :manifest   {:rf.root/schema-version 2}}))))
-      (is (nil? (install/installed-payload fid))
+      (is (nil? (rf.ssr.install/installed-payload fid))
           "the payload was NOT claimed — preflight failed first"))))
 
 (deftest an-explicit-root-id-wins-over-the-manifests
@@ -315,7 +315,7 @@
             default source, not an override"
     (let [fid (fresh-frame!)]
       (is (= :page/explicit
-             (:root-id (install/preflight! 'test
+             (:root-id (rf.ssr.install/preflight! 'test
                                            {:payload    (payload-for {:count 7})
                                             :payload-id fid
                                             :manifest   manifest-v1
@@ -326,7 +326,7 @@
             preflight adds a manifest STEP, it does not make manifests
             mandatory for a host that supplies its own payload"
     (let [fid (fresh-frame!)]
-      (boot/hydrate! {:frame fid :payload (payload-for {:count 7})})
+      (rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 7})})
       (is (= {:count 7} (rf/app-db-value fid))))))
 
 ;; ---------------------------------------------------------------------------
@@ -338,13 +338,13 @@
             under the same id must not meet a phantom conflict raised by a
             lifetime that no longer exists"
     (let [fid (fresh-frame!)]
-      (boot/hydrate! {:frame fid :payload (payload-for {:count 7})
+      (rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 7})
                       :root-id :page/a})
-      (install/release-payload! fid)
-      (is (nil? (install/installed-payload fid)))
+      (rf.ssr.install/release-payload! fid)
+      (is (nil? (rf.ssr.install/installed-payload fid)))
       ;; A DIFFERENT payload would have conflicted a moment ago.
       (is (= :install
-             (:decision (install/preflight! 'test
+             (:decision (rf.ssr.install/preflight! 'test
                                             {:payload    (payload-for {:count 99})
                                              :payload-id fid
                                              :root-id    :page/c})))))))

--- a/implementation/ssr/test/re_frame/ssr/multi_root_hydration_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/multi_root_hydration_dom_cljs_test.cljs
@@ -21,15 +21,15 @@
   actually asserts."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.boot :as boot]
-            [re-frame.ssr.install :as install]
-            [re-frame.ssr.manifest :as manifest]
-            [re-frame.ssr.payload-policy :as payload-policy]))
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.boot :as rf.ssr.boot]
+            [re-frame.ssr.install :as rf.ssr.install]
+            [re-frame.ssr.manifest :as rf.ssr.manifest]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]))
 
-(use-fixtures :once (fn [f] (rf/init! ssr/adapter) (f)))
+(use-fixtures :once (fn [f] (rf/init! rf.ssr/adapter) (f)))
 
-(use-fixtures :each (fn [f] (install/reset-installed-payloads!) (f)))
+(use-fixtures :each (fn [f] (rf.ssr.install/reset-installed-payloads!) (f)))
 
 (defn- browser? []
   (and (exists? js/document)
@@ -69,10 +69,10 @@
     (is (= :client (:platform (rf/frame-meta (fresh-frame!)))))))
 
 (defn- payload-for [db]
-  (payload-policy/build-payload nil db "server-hash-1" {}))
+  (rf.ssr.payload-policy/build-payload nil db "server-hash-1" {}))
 
 (defn- manifest-for [root-id]
-  {:rf.root/schema-version manifest/schema-version
+  {:rf.root/schema-version rf.ssr.manifest/schema-version
    :root-id                root-id
    :view-id                :app/root
    :element-locator        {:id (name root-id)}
@@ -92,7 +92,7 @@
           (apply str
                  (for [rid root-ids]
                    (str "<div id=\"" (name rid) "\">server markup</div>"
-                        (manifest/script-html (manifest-for rid))))))
+                        (rf.ssr.manifest/script-html (manifest-for rid))))))
     (.appendChild (.-body js/document) page)
     page))
 
@@ -113,7 +113,7 @@
           (doseq [rid [:page/shop :page/cart :page/nav]]
             (let [fid (fresh-frame!)
                   {:keys [root-id manifest]}
-                  (install/preflight! 'test {:payload    (payload-for {:count 7})
+                  (rf.ssr.install/preflight! 'test {:payload    (payload-for {:count 7})
                                              :payload-id fid
                                              :container  (container page rid)})]
               (is (= rid root-id)
@@ -133,7 +133,7 @@
         (.appendChild (.-body js/document) page)
         (try
           (let [fid  (fresh-frame!)
-                data (try (install/preflight!
+                data (try (rf.ssr.install/preflight!
                            'test {:payload    (payload-for {:count 7})
                                   :payload-id fid
                                   :container  (.querySelector page "#lonely")})
@@ -141,7 +141,7 @@
                           (catch :default e (ex-data e)))]
             (is (= :rf.error/root-manifest-invalid (:rf.error/id data)))
             (is (= :manifest (:missing data)))
-            (is (nil? (install/installed-payload fid))
+            (is (nil? (rf.ssr.install/installed-payload fid))
                 "preflight failed at step 1 — the payload was never claimed"))
           (finally (.remove page)))))))
 
@@ -158,7 +158,7 @@
         (.appendChild (.-body js/document) page)
         (try
           (is (= :rf.error/root-manifest-invalid
-                 (try (install/preflight!
+                 (try (rf.ssr.install/preflight!
                        'test {:payload    (payload-for {:count 7})
                               :payload-id (fresh-frame!)
                               :container  (.querySelector page "#shop")})
@@ -183,10 +183,10 @@
           (rf/reg-event ::bump (fn [{:keys [db]} _] {:db (update db :count inc)}))
           (let [payload (payload-for {:count 7})]
             ;; Root shop boots off the page.
-            (boot/hydrate! {:frame fid :payload payload
+            (rf.ssr.boot/hydrate! {:frame fid :payload payload
                             :container (container page :page/shop)})
             (is (= {:count 7} (rf/app-db-value fid)))
-            (is (= :page/shop (:installed-by (install/installed-payload fid)))
+            (is (= :page/shop (:installed-by (rf.ssr.install/installed-payload fid)))
                 "the installer was attributed from the DISCOVERED manifest —
                  no :root-id was passed in")
 
@@ -194,12 +194,12 @@
             (is (= {:count 8} (rf/app-db-value fid)))
 
             ;; Root cart boots second, off the same page.
-            (boot/hydrate! {:frame fid :payload payload
+            (rf.ssr.boot/hydrate! {:frame fid :payload payload
                             :container (container page :page/cart)})
             (is (= {:count 8} (rf/app-db-value fid))
                 "the second root found the payload live and did not re-seed —
                  the client mutation between the two boots survived")
-            (is (= :page/shop (:installed-by (install/installed-payload fid)))
+            (is (= :page/shop (:installed-by (rf.ssr.install/installed-payload fid)))
                 "root cart did not take over the claim"))
           (finally (.remove page)))))))
 
@@ -212,9 +212,9 @@
       (let [page (render-page! [:page/shop :page/cart])
             fid  (fresh-frame!)]
         (try
-          (boot/hydrate! {:frame fid :payload (payload-for {:count 7})
+          (rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 7})
                           :container (container page :page/shop)})
-          (let [data (try (boot/hydrate! {:frame fid
+          (let [data (try (rf.ssr.boot/hydrate! {:frame fid
                                           :payload (payload-for {:count 99})
                                           :container (container page :page/cart)})
                           nil

--- a/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
@@ -53,8 +53,8 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
-            [re-frame.interop :as interop]
-            [re-frame.ssr.payload-policy :as payload-policy]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
             #?(:clj  [re-frame.test-support :refer [with-trace-recorder!]]
                :cljs [re-frame.test-support :refer-macros [with-trace-recorder!]])))
 
@@ -73,7 +73,7 @@
 
 (deftest apply-policy-allowlist-slices-app-db
   (testing ":payload [<kws>] ships only the listed keys"
-    (let [slice (payload-policy/apply-policy
+    (let [slice (rf.ssr.payload-policy/apply-policy
                   sample-app-db
                   {:payload [:public/articles :public/user-id]})]
       (is (= {:public/articles [:a :b :c]
@@ -86,7 +86,7 @@
 (deftest apply-policy-allowlist-missing-keys-omitted
   (testing "allowlist keys absent from app-db → omitted from the slice
             (the policy is a permission, not a guarantee)"
-    (let [slice (payload-policy/apply-policy
+    (let [slice (rf.ssr.payload-policy/apply-policy
                   sample-app-db
                   {:payload [:public/articles :public/no-such-key]})]
       (is (= {:public/articles [:a :b :c]} slice)
@@ -95,7 +95,7 @@
 (deftest apply-policy-allowlist-as-vector
   (testing "rf2-d8vs9x — the allowlist is a VECTOR; the vector shape
             produces the expected slice"
-    (let [slice (payload-policy/apply-policy
+    (let [slice (rf.ssr.payload-policy/apply-policy
                   sample-app-db
                   {:payload [:public/articles]})]
       (is (= {:public/articles [:a :b :c]} slice)
@@ -110,19 +110,19 @@
             or lazy-seq) projects the same slice a vector does. Vectors stay
             the documented canonical spelling; the (every? keyword?) element
             guard and the empty-allowlist fail-closed are unchanged."
-    (let [slice (payload-policy/apply-policy
+    (let [slice (rf.ssr.payload-policy/apply-policy
                   sample-app-db
                   {:payload '(:public/articles)})]
       (is (= {:public/articles [:a :b :c]} slice)
           "a list allowlist projects the expected slice"))
-    (let [slice (payload-policy/apply-policy
+    (let [slice (rf.ssr.payload-policy/apply-policy
                   sample-app-db
                   {:payload (seq [:public/articles :public/user-id])})]
       (is (= {:public/articles [:a :b :c] :public/user-id "u-42"} slice)
           "a lazy seq allowlist projects the expected slice"))
     (testing "construction-time arm agrees — a list :payload validates OK"
       (is (= {:initial-events [[:init]] :payload '(:public/articles)}
-             (payload-policy/validate-policy-opts!
+             (rf.ssr.payload-policy/validate-policy-opts!
                {:initial-events [[:init]] :payload '(:public/articles)}))
           "validate-policy-opts! returns opts unchanged for a list allowlist"))))
 
@@ -133,7 +133,7 @@
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-missing-payload-policy"
-          (payload-policy/apply-policy
+          (rf.ssr.payload-policy/apply-policy
             sample-app-db
             {:payload #{:public/articles}})))))
 
@@ -149,13 +149,13 @@
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-malformed-payload-allowlist"
-          (payload-policy/apply-policy
+          (rf.ssr.payload-policy/apply-policy
             sample-app-db
             {:payload ["public/articles"]})))
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-malformed-payload-allowlist"
-          (payload-policy/apply-policy
+          (rf.ssr.payload-policy/apply-policy
             sample-app-db
             {:payload [:public/articles "public/user-id"]}))
         "a MIXED allowlist (one keyword, one string) is still malformed —
@@ -169,7 +169,7 @@
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-malformed-payload-allowlist"
-          (payload-policy/apply-policy
+          (rf.ssr.payload-policy/apply-policy
             sample-app-db
             {:payload '("public/articles")})))))
 
@@ -178,13 +178,13 @@
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-malformed-payload-allowlist"
-          (payload-policy/apply-policy
+          (rf.ssr.payload-policy/apply-policy
             sample-app-db
             {:payload [nil]})))
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-malformed-payload-allowlist"
-          (payload-policy/apply-policy
+          (rf.ssr.payload-policy/apply-policy
             sample-app-db
             {:payload [:public/articles nil]})))))
 
@@ -194,7 +194,7 @@
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-malformed-payload-allowlist"
-          (payload-policy/apply-policy
+          (rf.ssr.payload-policy/apply-policy
             sample-app-db
             {:payload [[:public/articles :public/user-id]]})))))
 
@@ -203,7 +203,7 @@
             non-keyword entries under `:bad-entries` so the developer can
             see exactly what to fix"
     (try
-      (payload-policy/validate-policy-opts!
+      (rf.ssr.payload-policy/validate-policy-opts!
         {:initial-events [[:init]] :payload [:public/articles "user-id" nil]})
       (is false "should have thrown")
       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
@@ -219,20 +219,20 @@
             valid all-keyword VECTOR allowlists (rf2-d8vs9x — the vector is
             the one accepted allowlist shape; a list spelling fails closed,
             asserted by apply-policy-list-payload-fails-closed)"
-    (let [slice (payload-policy/apply-policy
+    (let [slice (rf.ssr.payload-policy/apply-policy
                   sample-app-db
                   {:payload [:public/articles :public/user-id]})]
       (is (= {:public/articles [:a :b :c] :public/user-id "u-42"} slice)
           "all-keyword vector allowlist accepted"))
     (testing "construction-time arm agrees"
       (let [opts {:initial-events [[:init]] :payload [:public/articles]}]
-        (is (= opts (payload-policy/validate-policy-opts! opts)))))))
+        (is (= opts (rf.ssr.payload-policy/validate-policy-opts! opts)))))))
 
 ;; ---- apply-policy: whole-app-db branch (:payload keyword) ----------------
 
 (deftest apply-policy-whole-app-db-policy-ships-everything
   (testing ":payload :rf.ssr.payload/whole-app-db ships app-db verbatim"
-    (let [slice (payload-policy/apply-policy
+    (let [slice (rf.ssr.payload-policy/apply-policy
                   sample-app-db
                   {:payload :rf.ssr.payload/whole-app-db})]
       (is (= sample-app-db slice)
@@ -241,7 +241,7 @@
 (deftest apply-policy-whole-app-db-policy-keyword-is-public-constant
   (testing "the policy keyword is exposed as a public def for callers"
     (is (= :rf.ssr.payload/whole-app-db
-           payload-policy/whole-app-db-policy)
+           rf.ssr.payload-policy/whole-app-db-policy)
         "`whole-app-db-policy` constant matches the literal keyword
          documented in the contract")))
 
@@ -253,11 +253,11 @@
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-missing-payload-policy"
-          (payload-policy/apply-policy sample-app-db {})))
+          (rf.ssr.payload-policy/apply-policy sample-app-db {})))
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-missing-payload-policy"
-          (payload-policy/apply-policy sample-app-db nil))
+          (rf.ssr.payload-policy/apply-policy sample-app-db nil))
         "nil opts also throws — same contract")))
 
 (deftest apply-policy-throws-when-allowlist-empty
@@ -267,11 +267,11 @@
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-missing-payload-policy"
-          (payload-policy/apply-policy sample-app-db {:payload []})))
+          (rf.ssr.payload-policy/apply-policy sample-app-db {:payload []})))
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-missing-payload-policy"
-          (payload-policy/apply-policy sample-app-db {:payload nil})))))
+          (rf.ssr.payload-policy/apply-policy sample-app-db {:payload nil})))))
 
 (deftest apply-policy-throws-on-unknown-policy-keyword
   (testing "rf2-gtgf9: a typo'd :payload keyword surfaces as
@@ -281,14 +281,14 @@
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-unknown-payload-policy"
-          (payload-policy/apply-policy
+          (rf.ssr.payload-policy/apply-policy
             sample-app-db
             {:payload :rf.ssr.payload/whole-db})) ; typo
         "typo'd policy keyword throws unknown-policy")
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-unknown-payload-policy"
-          (payload-policy/apply-policy
+          (rf.ssr.payload-policy/apply-policy
             sample-app-db
             {:payload :myapp/custom-policy})))))
 
@@ -297,14 +297,14 @@
 (deftest validate-policy-opts-passes-allowlist
   (testing "valid :payload vector passes validation + returns opts unchanged"
     (let [opts {:initial-events [[:init]] :payload [:public/articles]}]
-      (is (= opts (payload-policy/validate-policy-opts! opts))
+      (is (= opts (rf.ssr.payload-policy/validate-policy-opts! opts))
           "returns opts unchanged on success — composes cleanly into
            threading/let positions"))))
 
 (deftest validate-policy-opts-passes-whole-app-db
   (testing "valid :payload whole-app-db keyword passes validation"
     (let [opts {:initial-events [[:init]] :payload :rf.ssr.payload/whole-app-db}]
-      (is (= opts (payload-policy/validate-policy-opts! opts))))))
+      (is (= opts (rf.ssr.payload-policy/validate-policy-opts! opts))))))
 
 (deftest validate-policy-opts-fails-closed
   (testing "rf2-gtgf9 fail-closed: validation throws on absence —
@@ -313,14 +313,14 @@
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-missing-payload-policy"
-          (payload-policy/validate-policy-opts! {:initial-events [[:init]]})))))
+          (rf.ssr.payload-policy/validate-policy-opts! {:initial-events [[:init]]})))))
 
 (deftest validate-policy-opts-throws-on-unknown-policy
   (testing "construction-time arm also catches typo'd :payload keywords"
     (is (thrown-with-msg?
           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
           #":rf\.error/ssr-unknown-payload-policy"
-          (payload-policy/validate-policy-opts!
+          (rf.ssr.payload-policy/validate-policy-opts!
             {:initial-events [[:init]] :payload :rf.ssr.payload/whole-db})))))
 
 (deftest error-ex-data-carries-recovery-tag
@@ -328,7 +328,7 @@
             :declare-payload-policy` so trace tooling can suggest the
             fix — Spec 009 error catalogue convention"
     (try
-      (payload-policy/validate-policy-opts! {:initial-events [[:init]]})
+      (rf.ssr.payload-policy/validate-policy-opts! {:initial-events [[:init]]})
       (is false "should have thrown")
       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
         (is (= :declare-payload-policy
@@ -364,7 +364,7 @@
   (testing "project-runtime-db ships machines / route :current / ssr, OMITS the
             elision declaration registry (rf2-ybn1yb), and drops the non-durable
             routing keys (:pending-navigation + any stale counter)"
-    (let [slice (payload-policy/project-runtime-db sample-runtime-db)]
+    (let [slice (rf.ssr.payload-policy/project-runtime-db sample-runtime-db)]
       (is (= {:snapshots {:auth.session/abc {:state :authenticated}}}
              (:rf.runtime/machines slice))
           "machine snapshots ride the wire whole")
@@ -392,7 +392,7 @@
   (testing "rf2-ybn1yb — the :rf.runtime/elision declaration registry is NOT in
             the projected runtime-db slice (the raw registry never crosses the
             hydration wire — its keys are classified paths)"
-    (let [slice (payload-policy/project-runtime-db sample-runtime-db)]
+    (let [slice (rf.ssr.payload-policy/project-runtime-db sample-runtime-db)]
       (is (not (contains? slice :rf.runtime/elision))
           "the elision declaration registry is omitted from the SSR slice")
       (is (not (str/includes? (pr-str slice) "sensitive-declarations"))
@@ -407,8 +407,8 @@
   (testing "rf2-ybn1yb — the full :rf/hydration-payload the client receives
             carries no :rf.runtime/elision registry and no classified path
             structure / embedded sensitive id"
-    (let [rt-slice (payload-policy/project-runtime-db sample-runtime-db)
-          payload  (payload-policy/build-payload
+    (let [rt-slice (rf.ssr.payload-policy/project-runtime-db sample-runtime-db)
+          payload  (rf.ssr.payload-policy/build-payload
                      :rf/default {:public/page :dashboard} "h1"
                      {:version 1 :runtime-db rt-slice})]
       (is (not (contains? (:rf/runtime-db payload) :rf.runtime/elision))
@@ -423,7 +423,7 @@
             other durable subsystem fact) projects to nil, so build-payload
             omits the optional :rf/runtime-db key entirely (the registry can
             never be the sole reason a runtime-db slice rides)"
-    (is (nil? (payload-policy/project-runtime-db
+    (is (nil? (rf.ssr.payload-policy/project-runtime-db
                 {:rf.runtime/elision {:sensitive-declarations
                                       {[:auth :token] #{{:source :effect}}}}}))
         "elision-only runtime-db contributes no wire slice")))
@@ -431,20 +431,20 @@
 (deftest project-runtime-db-nil-and-empty
   (testing "nil / empty / non-map runtime-db projects to nil so build-payload
             omits the optional :rf/runtime-db key"
-    (is (nil? (payload-policy/project-runtime-db nil)))
-    (is (nil? (payload-policy/project-runtime-db {})))
-    (is (nil? (payload-policy/project-runtime-db "not-a-map")))
-    (is (nil? (payload-policy/project-runtime-db {:rf.runtime/routing {:scroll-positions {}}}))
+    (is (nil? (rf.ssr.payload-policy/project-runtime-db nil)))
+    (is (nil? (rf.ssr.payload-policy/project-runtime-db {})))
+    (is (nil? (rf.ssr.payload-policy/project-runtime-db "not-a-map")))
+    (is (nil? (rf.ssr.payload-policy/project-runtime-db {:rf.runtime/routing {:scroll-positions {}}}))
         "a runtime-db with ONLY transient routing keys projects to nil")))
 
 (deftest build-payload-emits-runtime-db-when-present
   (testing "build-payload rides a non-nil :runtime-db opt as :rf/runtime-db,
             and omits the key when nil (client-only / no-server-runtime shape)"
-    (let [rt-slice (payload-policy/project-runtime-db sample-runtime-db)
-          with-rt  (payload-policy/build-payload
+    (let [rt-slice (rf.ssr.payload-policy/project-runtime-db sample-runtime-db)
+          with-rt  (rf.ssr.payload-policy/build-payload
                      :rf/default {:public/page :dashboard} "h1"
                      {:version 1 :runtime-db rt-slice})
-          without  (payload-policy/build-payload
+          without  (rf.ssr.payload-policy/build-payload
                      :rf/default {:public/page :dashboard} "h1"
                      {:version 1 :runtime-db nil})]
       (is (= rt-slice (:rf/runtime-db with-rt))
@@ -458,9 +458,9 @@
             the projection frame. A non-nil stable id is stamped; a nil id
             OMITS :rf/frame-id (the documented no-conflict shape for an
             anonymous per-request server frame — never a per-request gensym)"
-    (let [stamped (payload-policy/build-payload
+    (let [stamped (rf.ssr.payload-policy/build-payload
                     :app/main {:public/page :dashboard} "h1" {:version 1})
-          omitted (payload-policy/build-payload
+          omitted (rf.ssr.payload-policy/build-payload
                     nil {:public/page :dashboard} "h1" {:version 1})]
       (is (= :app/main (:rf/frame-id stamped))
           "a stable wire id is stamped as :rf/frame-id")
@@ -483,17 +483,17 @@
 (deftest resolve-version-coerces-and-rejects-to-integer
   (testing "explicit integer :version is taken verbatim"
     (is (= 7 (:rf/version
-               (payload-policy/build-payload :rf/default {} "h" {:version 7})))))
+               (rf.ssr.payload-policy/build-payload :rf/default {} "h" {:version 7})))))
 
   (testing "a whole-number STRING :version is tolerantly coerced to an int"
     (is (= 7 (:rf/version
-               (payload-policy/build-payload :rf/default {} "h" {:version "7"})))))
+               (rf.ssr.payload-policy/build-payload :rf/default {} "h" {:version "7"})))))
 
   (testing "a SEMVER-string :version is rejected → falls back to the v1 = 1 default,
             emitting exactly one :rf.ssr/invalid-version warning (rf2-latm0)"
     (with-trace-recorder! [traces]
       (let [v (:rf/version
-                (payload-policy/build-payload :rf/default {} "h" {:version "1.0.0"}))]
+                (rf.ssr.payload-policy/build-payload :rf/default {} "h" {:version "1.0.0"}))]
         (is (= 1 v) "non-integer semver string is rejected, not shipped")
         (is (int? v))
         ;; The rejection is not silent: coerce-version emits a
@@ -503,7 +503,7 @@
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
         ;; REJECTION is pinned above and is what governs the wire; this is
         ;; the developer-facing announcement of it.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (let [hits (filterv #(= :rf.ssr/invalid-version (:operation %)) @traces)]
             (is (= 1 (count hits))
                 (str "expected exactly one :rf.ssr/invalid-version trace; saw: "
@@ -520,8 +520,8 @@
     ;; rf2-qfb1i: the late-bind version hook was removed — with no explicit
     ;; :version opt, resolve-version falls back to the SSR artefact's
     ;; compiled-in constant (the SAME value the client reads).
-    (let [v (:rf/version (payload-policy/build-payload :rf/default {} "h" {}))]
-      (is (= payload-policy/pattern-protocol-version v)
+    (let [v (:rf/version (rf.ssr.payload-policy/build-payload :rf/default {} "h" {}))]
+      (is (= rf.ssr.payload-policy/pattern-protocol-version v)
           "absent :version opt → the SSR-owned constant")
       (is (int? v)))))
 
@@ -587,9 +587,9 @@
 (deftest build-payload-conforms-to-hydration-payload-schema
   (testing "rf2-g00l2t — build-payload output validates against the canonical
             HydrationPayload schema, with :rf/version as a true integer"
-    (let [rt-slice (payload-policy/project-runtime-db sample-runtime-db)]
+    (let [rt-slice (rf.ssr.payload-policy/project-runtime-db sample-runtime-db)]
       (testing "full two-partition payload (integer version)"
-        (let [payload (payload-policy/build-payload
+        (let [payload (rf.ssr.payload-policy/build-payload
                         :rf/default {:public/page :dashboard} "deadbeef"
                         {:version 7 :schema-digest "digest-abc" :runtime-db rt-slice})]
           (is (m/validate HydrationPayload payload)
@@ -599,7 +599,7 @@
 
       (testing "a SEMVER-string :version still yields a schema-conforming payload
                 (rejected + coerced to the integer default)"
-        (let [payload (payload-policy/build-payload
+        (let [payload (rf.ssr.payload-policy/build-payload
                         :rf/default {:public/page :dashboard} "deadbeef"
                         {:version "1.0.0" :runtime-db rt-slice})]
           (is (m/validate HydrationPayload payload)
@@ -609,7 +609,7 @@
           (is (int? (:rf/version payload)))))
 
       (testing "minimal client-only payload (no runtime-db / schema-digest)"
-        (let [payload (payload-policy/build-payload
+        (let [payload (rf.ssr.payload-policy/build-payload
                         :rf/default {} "h" {})]
           (is (m/validate HydrationPayload payload)
               (str "minimal payload must conform; explain: "
@@ -628,7 +628,7 @@
 
 (deftest build-payload-render-hash-is-optional
   (testing "a real hash is preserved verbatim (hiccup tier)"
-    (let [payload (payload-policy/build-payload
+    (let [payload (rf.ssr.payload-policy/build-payload
                     :rf/default {:public/page :dashboard} "deadbeef" {})]
       (is (= "deadbeef" (:rf/render-hash payload))
           "a supplied hash rides the payload unchanged")
@@ -637,7 +637,7 @@
                (pr-str (m/explain HydrationPayload payload))))))
 
   (testing "a nil hash OMITS the key rather than stamping nil (adoption tier)"
-    (let [payload (payload-policy/build-payload
+    (let [payload (rf.ssr.payload-policy/build-payload
                     :rf/default {:public/page :dashboard} nil {})]
       (is (not (contains? payload :rf/render-hash))
           "a nil render-hash omits :rf/render-hash entirely")
@@ -650,7 +650,7 @@
   (testing "a present-and-nil :rf/render-hash is REJECTED by the schema — what
             makes the omission load-bearing rather than cosmetic"
     (is (not (m/validate HydrationPayload
-                         (assoc (payload-policy/build-payload :rf/default {} nil {})
+                         (assoc (rf.ssr.payload-policy/build-payload :rf/default {} nil {})
                                 :rf/render-hash nil)))
         "a hand-stamped nil :rf/render-hash must not validate")))
 
@@ -671,7 +671,7 @@
   ;; any value — nil, an int, a map — rode through. These are the first
   ;; assertions in the corpus that look at it.
   (testing "a real head hash is preserved verbatim"
-    (let [payload (payload-policy/build-payload
+    (let [payload (rf.ssr.payload-policy/build-payload
                     :rf/default {:public/page :dashboard} "body-h"
                     {:head-hash "head-h"})]
       (is (= "head-h" (:rf/head-hash payload))
@@ -684,7 +684,7 @@
 
   (testing "a nil head hash OMITS the key (the explicit-:head-STRING shape,
             where the head is not client-reconstructible)"
-    (let [payload (payload-policy/build-payload
+    (let [payload (rf.ssr.payload-policy/build-payload
                     :rf/default {:public/page :dashboard} "body-h"
                     {:head-hash nil})]
       (is (not (contains? payload :rf/head-hash))
@@ -697,20 +697,20 @@
 
   (testing "a present-and-nil :rf/head-hash is REJECTED by the schema"
     (is (not (m/validate HydrationPayload
-                         (assoc (payload-policy/build-payload :rf/default {} "h" {})
+                         (assoc (rf.ssr.payload-policy/build-payload :rf/default {} "h" {})
                                 :rf/head-hash nil)))
         "a hand-stamped nil :rf/head-hash must not validate"))
 
   (testing "a non-string :rf/head-hash is REJECTED — the point of typing a slot
             the OPEN map previously let through unexamined"
     (is (not (m/validate HydrationPayload
-                         (assoc (payload-policy/build-payload :rf/default {} "h" {})
+                         (assoc (rf.ssr.payload-policy/build-payload :rf/default {} "h" {})
                                 :rf/head-hash 42)))
         "an integer head hash must not validate")))
 
 (deftest build-payload-schema-digest-is-optional
   (testing "a real digest is preserved verbatim"
-    (let [payload (payload-policy/build-payload
+    (let [payload (rf.ssr.payload-policy/build-payload
                     :rf/default {:public/page :dashboard} "h"
                     {:schema-digest "digest-abc"})]
       (is (= "digest-abc" (:rf/schema-digest payload))
@@ -721,7 +721,7 @@
 
   (testing "a nil digest OMITS the key (the app does not participate in the
             schema-digest check)"
-    (let [payload (payload-policy/build-payload
+    (let [payload (rf.ssr.payload-policy/build-payload
                     :rf/default {:public/page :dashboard} "h"
                     {:schema-digest nil})]
       (is (not (contains? payload :rf/schema-digest))
@@ -732,7 +732,7 @@
 
   (testing "a present-and-nil :rf/schema-digest is REJECTED by the schema"
     (is (not (m/validate HydrationPayload
-                         (assoc (payload-policy/build-payload :rf/default {} "h" {})
+                         (assoc (rf.ssr.payload-policy/build-payload :rf/default {} "h" {})
                                 :rf/schema-digest nil)))
         "a hand-stamped nil :rf/schema-digest must not validate")))
 
@@ -742,9 +742,9 @@
   ;; pin, while the slot read `[:maybe :map]`, is that the omission is the only
   ;; legal spelling of absence — so these are the schema-side arms.
   (testing "a projected slice conforms under the tightened :map slot"
-    (let [payload (payload-policy/build-payload
+    (let [payload (rf.ssr.payload-policy/build-payload
                     :rf/default {:public/page :dashboard} "h"
-                    {:runtime-db (payload-policy/project-runtime-db sample-runtime-db)})]
+                    {:runtime-db (rf.ssr.payload-policy/project-runtime-db sample-runtime-db)})]
       (is (map? (:rf/runtime-db payload)))
       (is (m/validate HydrationPayload payload)
           (str "a runtime-db-bearing payload conforms; explain: "
@@ -753,12 +753,12 @@
   (testing "a present-and-nil :rf/runtime-db is REJECTED by the schema — the
             fail-open `[:maybe :map]` admitted a second spelling of absence"
     (is (not (m/validate HydrationPayload
-                         (assoc (payload-policy/build-payload :rf/default {} "h" {})
+                         (assoc (rf.ssr.payload-policy/build-payload :rf/default {} "h" {})
                                 :rf/runtime-db nil)))
         "a hand-stamped nil :rf/runtime-db must not validate"))
 
   (testing "a non-map :rf/runtime-db is REJECTED"
     (is (not (m/validate HydrationPayload
-                         (assoc (payload-policy/build-payload :rf/default {} "h" {})
+                         (assoc (rf.ssr.payload-policy/build-payload :rf/default {} "h" {})
                                 :rf/runtime-db "not-a-map")))
         "a string runtime-db must not validate")))

--- a/implementation/ssr/test/re_frame/ssr/render_state_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/render_state_cljs_test.cljc
@@ -43,16 +43,16 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
+            [re-frame.frame :as rf.frame]
             ;; Loading the machines artefact publishes the late-bound
             ;; `:machines/project-ssr-runtime-db` hook the projector applies
             ;; to snapshot `:data`.
             [re-frame.machines]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.render-state :as render-state]
-            [re-frame.subs :as subs]))
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.render-state :as rf.ssr.render-state]
+            [re-frame.subs :as rf.subs]))
 
-(use-fixtures :once (fn [f] (rf/init! ssr/adapter) (f)))
+(use-fixtures :once (fn [f] (rf/init! rf.ssr/adapter) (f)))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -127,10 +127,10 @@
   snapshot's `:data :token` — the state a settled request frame carries."
   [mid]
   (let [sfid (fresh-frame! :server)]
-    (frame/replace-frame-state! sfid {frame/app-partition-key corpus-app-db})
+    (rf.frame/replace-frame-state! sfid {rf.frame/app-partition-key corpus-app-db})
     (rf/reg-machine mid auth-machine)
     (rf/dispatch-sync [mid [:login]] {:frame sfid})
-    (frame/swap-runtime-db! sfid merge
+    (rf.frame/swap-runtime-db! sfid merge
                             {:rf.runtime/routing {:current            route-slice
                                                   :pending-navigation {:to :route/next}}
                              :rf.runtime/ssr     {:hydration {:version 1}}
@@ -154,7 +154,7 @@
 (defn- round-trip
   "The wire, there and back: `serialize` then `deserialize`."
   [partitions]
-  (render-state/deserialize (render-state/serialize partitions)))
+  (rf.ssr.render-state/deserialize (rf.ssr.render-state/serialize partitions)))
 
 ;; ---------------------------------------------------------------------------
 ;; S3 — project: allowlists, classification, the projector's vocabulary
@@ -164,7 +164,7 @@
   (let [mid  (fresh-id "auth")
         sfid (settled-server-frame! mid)
         {app :rf/app-db rt :rf/runtime-db :as projected}
-        (render-state/project sfid full-policy)]
+        (rf.ssr.render-state/project sfid full-policy)]
     (testing "app-db: every allowlisted key, the classified path redacted"
       (is (= (set (keys corpus-app-db)) (set (keys app))))
       (is (= :rf/redacted (get-in app [:session :token]))
@@ -187,14 +187,14 @@
       (is (not (str/includes? (pr-str projected) "secret-session-token")))
       (is (not (str/includes? (pr-str projected) "secret-machine-token"))))
     (testing "an absent partition slot projects that partition as {}"
-      (is (= {} (:rf/runtime-db (render-state/project sfid {:render-state {:app-db [:todos]}}))))
-      (is (= {} (:rf/app-db (render-state/project sfid {:render-state {:runtime-db [:rf.runtime/ssr]}})))))
+      (is (= {} (:rf/runtime-db (rf.ssr.render-state/project sfid {:render-state {:app-db [:todos]}}))))
+      (is (= {} (:rf/app-db (rf.ssr.render-state/project sfid {:render-state {:runtime-db [:rf.runtime/ssr]}})))))
     (testing "the escape hatch is handed the live frame's id and replaces the allowlist step"
       (let [seen (atom nil)
-            out  (render-state/project
+            out  (rf.ssr.render-state/project
                    sfid {:render-state (fn [fid]
                                          (reset! seen fid)
-                                         {:rf/app-db (select-keys (frame/frame-app-db-value fid) [:todos])})})]
+                                         {:rf/app-db (select-keys (rf.frame/frame-app-db-value fid) [:todos])})})]
         (is (= sfid @seen))
         (is (= {:rf/app-db     {:todos (:todos corpus-app-db)}
                 :rf/runtime-db {}}
@@ -208,8 +208,8 @@
 (deftest round-trip-corpus-restores-both-partitions-identically
   (let [mid       (fresh-id "auth")
         sfid      (settled-server-frame! mid)
-        projected (render-state/project sfid full-policy)
-        wire      (render-state/serialize projected)]
+        projected (rf.ssr.render-state/project sfid full-policy)
+        wire      (rf.ssr.render-state/serialize projected)]
     (testing "the wire form is key text -> EDN text, per key, for both partitions"
       (is (= #{:rf/app-db :rf/runtime-db} (set (keys wire))))
       (is (every? (fn [[k v]] (and (string? k) (string? v)))
@@ -221,20 +221,20 @@
         (is (= projected read-back)))
       (let [cfid (fresh-frame! :server)]
         (testing "restore! seeds the fresh frame with both partitions in one write"
-          (is (empty? (frame/frame-app-db-value cfid))
+          (is (empty? (rf.frame/frame-app-db-value cfid))
               "precondition: the fresh frame ran no boot events")
-          (is (= #{frame/app-partition-key frame/runtime-partition-key}
-                 (render-state/restore! cfid read-back)))
-          (is (= (:rf/app-db projected) (frame/frame-app-db-value cfid)))
-          (is (= (:rf/runtime-db projected) (frame/frame-runtime-db-value cfid))
+          (is (= #{rf.frame/app-partition-key rf.frame/runtime-partition-key}
+                 (rf.ssr.render-state/restore! cfid read-back)))
+          (is (= (:rf/app-db projected) (rf.frame/frame-app-db-value cfid)))
+          (is (= (:rf/runtime-db projected) (rf.frame/frame-runtime-db-value cfid))
               "EXACTLY the projection: no hydration metadata, no elision registry, no re-arm"))
         (testing "framework and app subs on the fresh frame read the restored state"
-          (subs/reg-runtime-sub (fresh-id "machine-state") {:doc "test"}
+          (rf.subs/reg-runtime-sub (fresh-id "machine-state") {:doc "test"}
                                 (fn [rt [_ id]] (get-in rt [:rf.runtime/machines :snapshots id :state])))
           (let [machine-state (keyword "rf.ssrrs" (str "machine-state" @counter))
                 route-id      (fresh-id "route-id")
                 todo-count    (fresh-id "todo-count")]
-            (subs/reg-runtime-sub route-id {:doc "test"}
+            (rf.subs/reg-runtime-sub route-id {:doc "test"}
                                   (fn [rt _] (get-in rt [:rf.runtime/routing :current :route-id])))
             (rf/reg-sub todo-count (fn [db _] (count (:todos db))))
             (is (= :authed (rf/subscribe-once [machine-state mid] {:frame cfid}))
@@ -246,12 +246,12 @@
 (deftest deserialize-reads-an-absent-partition-as-empty-and-restore-installs-it
   (let [cfid (fresh-frame! :server)]
     (is (= {:rf/app-db {:a 1} :rf/runtime-db {}}
-           (render-state/deserialize {:rf/app-db {":a" "1"}})))
-    (is (= #{frame/app-partition-key}
-           (render-state/restore! cfid {:rf/app-db {:a 1}}))
+           (rf.ssr.render-state/deserialize {:rf/app-db {":a" "1"}})))
+    (is (= #{rf.frame/app-partition-key}
+           (rf.ssr.render-state/restore! cfid {:rf/app-db {:a 1}}))
         "only app-db changed — runtime-db was already {}")
-    (is (= {:a 1} (frame/frame-app-db-value cfid)))
-    (is (= {} (frame/frame-runtime-db-value cfid)))))
+    (is (= {:a 1} (rf.frame/frame-app-db-value cfid)))
+    (is (= {} (rf.frame/frame-runtime-db-value cfid)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Acceptance 2 — the negative fixture: unserialisable fails AT PROJECTION
@@ -262,8 +262,8 @@
 (deftest an-unserialisable-value-fails-at-projection-with-a-named-error
   (testing "a fn under an allowlisted app-db key (the allowlist path)"
     (let [sfid (fresh-frame! :server)]
-      (frame/replace-frame-state! sfid {frame/app-partition-key {:todos [] :on-click (fn [] :clicked)}})
-      (let [data (thrown-data #(render-state/project sfid {:render-state {:app-db [:todos :on-click]}}))]
+      (rf.frame/replace-frame-state! sfid {rf.frame/app-partition-key {:todos [] :on-click (fn [] :clicked)}})
+      (let [data (thrown-data #(rf.ssr.render-state/project sfid {:render-state {:app-db [:todos :on-click]}}))]
         (is (= :rf.error/ssr-render-state-invalid (:rf.error/id data)))
         (is (= :unserialisable (:invalid data)))
         (is (= :rf/app-db (:partition data)))
@@ -271,11 +271,11 @@
         (is (= :value (:half data))))
       ;; CONTROL — the same frame with the fn left off the allowlist projects.
       (is (= {:rf/app-db {:todos []} :rf/runtime-db {}}
-             (render-state/project sfid {:render-state {:app-db [:todos]}})))))
+             (rf.ssr.render-state/project sfid {:render-state {:app-db [:todos]}})))))
   (testing "a fn returned by the escape-hatch projector, in the runtime partition"
     (let [sfid (fresh-frame! :server)
           data (thrown-data
-                 #(render-state/project
+                 #(rf.ssr.render-state/project
                     sfid {:render-state (fn [_] {:rf/app-db     {}
                                                  :rf/runtime-db {:rf.runtime/custom (fn [] 1)}})}))]
       (is (= :rf.error/ssr-render-state-invalid (:rf.error/id data)))
@@ -285,16 +285,16 @@
   (testing "a record — map-shaped, not map-printing (it prints as a tagged literal)"
     (let [sfid (fresh-frame! :server)
           data (thrown-data
-                 #(render-state/project sfid {:render-state (fn [_] {:rf/app-db {:r (->Opaque 1)}})}))]
+                 #(rf.ssr.render-state/project sfid {:render-state (fn [_] {:rf/app-db {:r (->Opaque 1)}})}))]
       (is (= :rf.error/ssr-render-state-invalid (:rf.error/id data)))
       (is (= :r (:key data)))
       ;; CONTROL — converted explicitly, the same value rides.
       (is (= {:rf/app-db {:r {:x 1}} :rf/runtime-db {}}
-             (render-state/project sfid {:render-state (fn [_] {:rf/app-db {:r (into {} (->Opaque 1))}})})))))
+             (rf.ssr.render-state/project sfid {:render-state (fn [_] {:rf/app-db {:r (into {} (->Opaque 1))}})})))))
   (testing "an opaque top-level KEY — a string where a keyword must be"
     (let [sfid (fresh-frame! :server)
           data (thrown-data
-                 #(render-state/project sfid {:render-state (fn [_] {:rf/app-db {"todos" []}})}))]
+                 #(rf.ssr.render-state/project sfid {:render-state (fn [_] {:rf/app-db {"todos" []}})}))]
       (is (= :rf.error/ssr-render-state-invalid (:rf.error/id data)))
       (is (= :key (:half data)))
       (is (= "todos" (:key data))))))
@@ -307,24 +307,24 @@
   (let [sfid (fresh-frame! :server)
         view (fn [db]
                (str "<h1>" (get-in db [:user :name]) "</h1><ul>" (count (:todos db)) "</ul>"))]
-    (frame/replace-frame-state! sfid {frame/app-partition-key {:todos [{:id 1}]}})
+    (rf.frame/replace-frame-state! sfid {rf.frame/app-partition-key {:todos [{:id 1}]}})
     (testing "the allowlist names :user, which the frame never held"
-      (let [projected (render-state/project sfid {:render-state {:app-db [:todos :user]}})
+      (let [projected (rf.ssr.render-state/project sfid {:render-state {:app-db [:todos :user]}})
             cfid      (fresh-frame! :server)]
         (is (not (contains? (:rf/app-db projected) :user))
             "nothing to carry: no key, and no nil-valued key either")
-        (render-state/restore! cfid (round-trip projected))
-        (is (nil? (get-in (frame/frame-app-db-value cfid) [:user :name])))
-        (is (= (view (frame/frame-app-db-value sfid))
-               (view (frame/frame-app-db-value cfid)))
+        (rf.ssr.render-state/restore! cfid (round-trip projected))
+        (is (nil? (get-in (rf.frame/frame-app-db-value cfid) [:user :name])))
+        (is (= (view (rf.frame/frame-app-db-value sfid))
+               (view (rf.frame/frame-app-db-value cfid)))
             "and it is the same page the server would render — nil on both sides")))
     (testing "the allowlist OMITS :user, which the view reads — the operator's mistake, not a throw"
-      (frame/replace-frame-state! sfid {frame/app-partition-key {:todos [{:id 1}] :user {:name "Ada"}}})
-      (let [projected (render-state/project sfid {:render-state {:app-db [:todos]}})
+      (rf.frame/replace-frame-state! sfid {rf.frame/app-partition-key {:todos [{:id 1}] :user {:name "Ada"}}})
+      (let [projected (rf.ssr.render-state/project sfid {:render-state {:app-db [:todos]}})
             cfid      (fresh-frame! :server)]
-        (render-state/restore! cfid (round-trip projected))
-        (is (= "<h1>Ada</h1><ul>1</ul>" (view (frame/frame-app-db-value sfid))))
-        (is (= "<h1></h1><ul>1</ul>" (view (frame/frame-app-db-value cfid)))
+        (rf.ssr.render-state/restore! cfid (round-trip projected))
+        (is (= "<h1>Ada</h1><ul>1</ul>" (view (rf.frame/frame-app-db-value sfid))))
+        (is (= "<h1></h1><ul>1</ul>" (view (rf.frame/frame-app-db-value cfid)))
             "the honest wrong page: nil where :user should be, rendered without complaint")))))
 
 ;; ---------------------------------------------------------------------------
@@ -332,7 +332,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- policy-error [opts]
-  (thrown-data #(render-state/validate-policy-opts! opts)))
+  (thrown-data #(rf.ssr.render-state/validate-policy-opts! opts)))
 
 (deftest render-state-policy-is-fail-closed-and-distinct-from-payload
   (testing "absent / {} / a keyword / a :payload opt alone → missing, naming :render-state"
@@ -359,10 +359,10 @@
                   {:app-db '(:a :b) :runtime-db [:rf.runtime/machines]}
                   (fn [_] {})]]
       (let [opts {:render-state good :payload [:a]}]
-        (is (identical? opts (render-state/validate-policy-opts! opts))))))
+        (is (identical? opts (rf.ssr.render-state/validate-policy-opts! opts))))))
   (testing "project re-validates: the runtime arm fails the same way as the construction arm"
     (let [sfid (fresh-frame! :server)
-          data (thrown-data #(render-state/project sfid {:payload [:todos]}))]
+          data (thrown-data #(rf.ssr.render-state/project sfid {:payload [:todos]}))]
       (is (= :rf.error/ssr-missing-payload-policy (:rf.error/id data)))
       (is (= :render-state (:opt data))))))
 
@@ -375,21 +375,21 @@
     (let [sfid (fresh-frame! :server)]
       (doseq [bad [nil [] {:rf/app-db "not a map"} {:rf/app-db {} :rf/runtime-db nil}
                    {:rf/app-db {} :extra {}}]]
-        (let [data (thrown-data #(render-state/project sfid {:render-state (fn [_] bad)}))]
+        (let [data (thrown-data #(rf.ssr.render-state/project sfid {:render-state (fn [_] bad)}))]
           (is (= :rf.error/ssr-render-state-invalid (:rf.error/id data)) (pr-str bad))
           (is (= :envelope (:invalid data)) (pr-str bad))))))
   (testing "restore! refuses the same shapes and installs nothing"
     (let [cfid (fresh-frame! :server)]
-      (frame/replace-frame-state! cfid {frame/app-partition-key {:kept true}})
+      (rf.frame/replace-frame-state! cfid {rf.frame/app-partition-key {:kept true}})
       (doseq [bad [nil {:rf/app-db 1} {:rf/runtime-db [1 2]} {:rf/app-db {} :third {}}]]
-        (let [data (thrown-data #(render-state/restore! cfid bad))]
+        (let [data (thrown-data #(rf.ssr.render-state/restore! cfid bad))]
           (is (= :rf.error/ssr-render-state-invalid (:rf.error/id data)) (pr-str bad))
           (is (= :envelope (:invalid data)) (pr-str bad))))
-      (is (= {:kept true} (frame/frame-app-db-value cfid)) "nothing was installed")))
+      (is (= {:kept true} (rf.frame/frame-app-db-value cfid)) "nothing was installed")))
   (testing "a frame that is not live"
     (let [gone (fresh-frame! :server)]
       (rf/destroy-frame! gone)
       (is (= :rf.error/frame-destroyed
-             (:rf.error/id (thrown-data #(render-state/project gone {:render-state {:app-db [:a]}})))))
+             (:rf.error/id (thrown-data #(rf.ssr.render-state/project gone {:render-state {:app-db [:a]}})))))
       (is (= :rf.error/frame-destroyed
-             (:rf.error/id (thrown-data #(render-state/restore! gone {:rf/app-db {}}))))))))
+             (:rf.error/id (thrown-data #(rf.ssr.render-state/restore! gone {:rf/app-db {}}))))))))

--- a/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
@@ -23,8 +23,8 @@
   Runs on BOTH hosts (`.cljc`, `-cljs-test` ns): `clojure -M:test` from
   `implementation/ssr` and the node runner via `npm run test:cljs`."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.ssr.constants :as constants]
-            [re-frame.ssr.manifest :as manifest]
+            [re-frame.ssr.constants :as rf.ssr.constants]
+            [re-frame.ssr.manifest :as rf.ssr.manifest]
             #?(:clj  [clojure.edn]
                :cljs [cljs.reader])))
 
@@ -35,21 +35,21 @@
 (defrecord WireProbeRecord [x])
 
 (deftest schema-version-is-the-only-required-key
-  (is (nil? (manifest/problems {:rf.root/schema-version 1}))
+  (is (nil? (rf.ssr.manifest/problems {:rf.root/schema-version 1}))
       "the minimal valid manifest is the version alone")
-  (is (= {:missing :schema-version} (manifest/problems {:root-id :page/shop})))
+  (is (= {:missing :schema-version} (rf.ssr.manifest/problems {:root-id :page/shop})))
   (is (= {:invalid :schema-version :got 2 :expected 1}
-         (manifest/problems {:rf.root/schema-version 2}))
+         (rf.ssr.manifest/problems {:rf.root/schema-version 2}))
       "a foreign version is rejected — but there is no negotiation or
        upgrade path; v1 is the first version, not a compatibility layer")
   (is (= {:invalid :not-a-map :got (type "nope")}
-         (manifest/problems "nope"))))
+         (rf.ssr.manifest/problems "nope"))))
 
 (deftest unknown-keys-are-ignored-by-readers
   (testing "004C §2 rule 2 — including the dev-only :root-id-provenance an
             S1 descriptor still carries; stripping it is an EMIT duty, not
             a read-side rejection (or a descriptor could not validate)"
-    (is (nil? (manifest/problems
+    (is (nil? (rf.ssr.manifest/problems
                {:rf.root/schema-version 1
                 :root-id-provenance     :derived
                 :some.future/key        [:whatever]})))))
@@ -67,7 +67,7 @@
                  {:identifier-prefix :not-a-string}
                  {:frame-payload-ids ["shop"]}]]
       (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
-                   (manifest/manifest 'test d bad))
+                   (rf.ssr.manifest/manifest 'test d bad))
           (str "ill-formed extension fact fails at ASSEMBLY: " (pr-str bad))))))
 
 ;; ---------------------------------------------------------------------------
@@ -75,9 +75,9 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest host-authored-container-needs-an-id
-  (is (= {:id "shop-root"} (manifest/host-locator 'test "shop-root")))
+  (is (= {:id "shop-root"} (rf.ssr.manifest/host-locator 'test "shop-root")))
   (doseq [bad [nil "" "   "]]
-    (let [data (try (manifest/host-locator 'test bad) nil
+    (let [data (try (rf.ssr.manifest/host-locator 'test bad) nil
                     (catch #?(:clj clojure.lang.ExceptionInfo
                               :cljs cljs.core/ExceptionInfo) e
                       (ex-data e)))]
@@ -87,9 +87,9 @@
           "the emitter NEVER synthesises an id onto host-owned markup"))))
 
 (deftest synthesised-locator-inherits-slug-injectivity
-  (is (= {:id "rf2-root-page_Sshop"} (manifest/synthesised-locator "page_Sshop")))
-  (is (not= (manifest/synthesised-locator "page_Sshop")
-            (manifest/synthesised-locator "_V_Kshop_Sapp_Kleft"))
+  (is (= {:id "rf2-root-page_Sshop"} (rf.ssr.manifest/synthesised-locator "page_Sshop")))
+  (is (not= (rf.ssr.manifest/synthesised-locator "page_Sshop")
+            (rf.ssr.manifest/synthesised-locator "_V_Kshop_Sapp_Kleft"))
       "distinct slugs ⇒ distinct locators; the slug is injective (004C §1)"))
 
 ;; ---------------------------------------------------------------------------
@@ -98,7 +98,7 @@
 
 (deftest unserialisable-prop-fails-the-render-for-that-root
   (let [d    {:rf.root/schema-version 1 :root-id :page/shop}
-        data (try (manifest/manifest 'test d {:props {:promo :spring
+        data (try (rf.ssr.manifest/manifest 'test d {:props {:promo :spring
                                                       :chart-fn (fn [_] 1)}})
                   nil
                   (catch #?(:clj clojure.lang.ExceptionInfo
@@ -108,8 +108,8 @@
     (is (= :chart-fn (:unserialisable-prop data))
         "the offending prop is NAMED — a silently truncated manifest would
          hydrate a different tree, not a smaller one"))
-  (is (manifest/edn-carryable? {:a [1 "x" :k {:b #{1 2}}]}))
-  (is (not (manifest/edn-carryable? {:a [1 {:b (fn [])}]}))
+  (is (rf.ssr.manifest/edn-carryable? {:a [1 "x" :k {:b #{1 2}}]}))
+  (is (not (rf.ssr.manifest/edn-carryable? {:a [1 {:b (fn [])}]}))
       "opaqueness is detected through nesting"))
 
 ;; ---------------------------------------------------------------------------
@@ -118,9 +118,9 @@
 
 (deftest wire-form-round-trips
   (let [d {:rf.root/schema-version 1 :root-id :page/shop}
-        m (manifest/manifest d {:element-locator   {:id "shop-root"}
+        m (rf.ssr.manifest/manifest d {:element-locator   {:id "shop-root"}
                                 :identifier-prefix "rf2-page_Sshop-"})
-        html (manifest/script-html m)]
+        html (rf.ssr.manifest/script-html m)]
     (testing "the element carries both marks and no identity in attributes"
       (is (re-find #"^<script type=\"application/edn\" data-rf-root>" html))
       (is (re-find #"</script>$" html))
@@ -130,15 +130,15 @@
       (let [body (-> html
                      (subs (count "<script type=\"application/edn\" data-rf-root>"))
                      (as-> s (subs s 0 (- (count s) (count "</script>")))))]
-        (is (= m (manifest/read-manifest 'test body)))))))
+        (is (= m (rf.ssr.manifest/read-manifest 'test body)))))))
 
 (deftest wire-body-cannot-break-out-of-the-script
-  (let [m (manifest/manifest {:rf.root/schema-version 1 :root-id :page/shop}
+  (let [m (rf.ssr.manifest/manifest {:rf.root/schema-version 1 :root-id :page/shop}
                              {:props {:bio "</script><img onerror=x>"}})
-        html (manifest/script-html m)]
+        html (rf.ssr.manifest/script-html m)]
     (is (not (re-find #"(?i)</script" (subs html 0 (- (count html) 9))))
         "the shared EDN script-body escape neutralises the breakout")
-    (is (= m (manifest/read-manifest
+    (is (= m (rf.ssr.manifest/read-manifest
               'test
               (-> html
                   (subs (count "<script type=\"application/edn\" data-rf-root>"))
@@ -146,7 +146,7 @@
 
 (deftest unreadable-or-foreign-body-fails-loud
   (doseq [body ["{:rf.root/schema-version 1" "@@@" ""]]
-    (let [data (try (manifest/read-manifest 'test body) nil
+    (let [data (try (rf.ssr.manifest/read-manifest 'test body) nil
                     (catch #?(:clj clojure.lang.ExceptionInfo
                               :cljs cljs.core/ExceptionInfo) e
                       (ex-data e)))]
@@ -189,7 +189,7 @@
 (defn- round-trips?
   "The property, through the shipped emitter and the shipped reader."
   [m]
-  (= m (manifest/read-manifest 'test (script-body (manifest/script-html m)))))
+  (= m (rf.ssr.manifest/read-manifest 'test (script-body (rf.ssr.manifest/script-html m)))))
 
 (def ^:private wire-values
   "Every value class the manifest wire PROMISES to carry, spelled with
@@ -228,27 +228,27 @@
   (testing "rf2-v4foc — every manifest that reaches the wire reads back
             EQUAL, not merely readable, with and without extension facts"
     (let [d {:rf.root/schema-version 1 :root-id :page/shop}]
-      (is (round-trips? (manifest/manifest d {:element-locator    {:id "shop-root"}
+      (is (round-trips? (rf.ssr.manifest/manifest d {:element-locator    {:id "shop-root"}
                                               :props              {:promo :spring}
                                               :frame-payload-ids  [:shop :frame/session]
                                               :render-fingerprint "rf1-abc"
                                               :identifier-prefix  "rf2-page_Sshop-"}))
           "a fully-extended manifest survives the wire exactly")
-      (is (round-trips? (manifest/manifest d))
+      (is (round-trips? (rf.ssr.manifest/manifest d))
           "…and so does the bare one, so `nil` vs ABSENT is covered in both
            directions")))
 
   (testing "every value class the wire promises to carry, as a prop value
             and again as a prop KEY where the class can be a key"
     (doseq [[label v] wire-values]
-      (let [m (manifest/manifest {:rf.root/schema-version 1 :root-id :page/shop}
+      (let [m (rf.ssr.manifest/manifest {:rf.root/schema-version 1 :root-id :page/shop}
                                  {:props {:v v}})]
         (is (round-trips? m) (str "prop value " label " => " (pr-str v))))))
 
   (testing "a manifest whose props map is keyed by each carryable scalar —
             the KEY half of the entry rides the same wire as the value"
     (doseq [k [:k :a/b 'sym "str" 1 true nil]]
-      (let [m (manifest/manifest {:rf.root/schema-version 1 :root-id :page/shop}
+      (let [m (rf.ssr.manifest/manifest {:rf.root/schema-version 1 :root-id :page/shop}
                                  {:props {k :v}})]
         (is (round-trips? m) (str "prop key " (pr-str k)))))))
 
@@ -283,20 +283,20 @@
              the wrong question")
         (is (thrown? #?(:clj clojure.lang.ExceptionInfo
                         :cljs cljs.core/ExceptionInfo)
-                     (manifest/read-manifest
+                     (rf.ssr.manifest/read-manifest
                       'test (pr-str {:rf.root/schema-version 1 :props {:x r}})))
             "the safe reader has no constructor for the record's tag"))
 
       (testing "and the SHIPPED predicate closes it"
-        (is (not (manifest/edn-carryable? r)))
-        (is (not (manifest/edn-carryable? {:x r})))
-        (is (not (manifest/edn-carryable? {:x [1 {:y r}]}))
+        (is (not (rf.ssr.manifest/edn-carryable? r)))
+        (is (not (rf.ssr.manifest/edn-carryable? {:x r})))
+        (is (not (rf.ssr.manifest/edn-carryable? {:x [1 {:y r}]}))
             "detected through nesting, like every other opaque value")))))
 
 (deftest record-valued-prop-fails-before-emission
   (testing "rf2-v4foc — a record prop is rejected at ASSEMBLY, naming the
             prop, rather than emitting a body the client cannot read"
-    (let [data (try (manifest/manifest
+    (let [data (try (rf.ssr.manifest/manifest
                      'test {:rf.root/schema-version 1 :root-id :page/shop}
                      {:props {:promo :spring :row (->WireProbeRecord 1)}})
                     nil
@@ -312,7 +312,7 @@
             an opaque KEY reached `pr-str` and emitted `#object[…]`. Both
             halves are carried, so both halves are validated."
     (let [k    (fn [] 1)
-          data (try (manifest/manifest
+          data (try (rf.ssr.manifest/manifest
                      'test {:rf.root/schema-version 1 :root-id :page/shop}
                      {:props {k 1}})
                     nil
@@ -325,7 +325,7 @@
            different authoring mistakes")))
 
   (testing "a record used as a prop KEY is caught by the same arm"
-    (is (not (manifest/edn-carryable? {(->WireProbeRecord 1) :v})))))
+    (is (not (rf.ssr.manifest/edn-carryable? {(->WireProbeRecord 1) :v})))))
 
 ;; ---------------------------------------------------------------------------
 ;; THE NUMERIC HALF OF THE ROUND TRIP (rf2-v4foc, Codex audit of #6407)
@@ -365,7 +365,7 @@
             `read-manifest` on each host, yield DIFFERENT hydration props.
             Asserted as an observable VALUE: nothing throws, which is the
             entire danger."
-    (let [x (get-in (manifest/read-manifest 'test jvm-emitted-body) [:props :x])]
+    (let [x (get-in (rf.ssr.manifest/read-manifest 'test jvm-emitted-body) [:props :x])]
       #?(:clj
          (do
            (is (= (pr-str 9007199254740993N) "9007199254740993N")
@@ -396,55 +396,55 @@
            (is (true? (lenient-number? v))
                (str "the defective predicate waves " (pr-str v) " through — if
                      this ever goes false the lever is gone"))
-           (is (not (manifest/edn-carryable? v))
+           (is (not (rf.ssr.manifest/edn-carryable? v))
                (str "…and the SHIPPED predicate refuses it: " (pr-str v))))
          :cljs
          (let [nan js/NaN]
            (is (true? (lenient-number? nan)))
-           (is (not (manifest/edn-carryable? nan))))))))
+           (is (not (rf.ssr.manifest/edn-carryable? nan))))))))
 
 (deftest only-cross-host-numbers-ride-the-wire
   (testing "rf2-v4foc — what the numeric subset ADMITS. These must keep
             working: narrowing the wire must not narrow ordinary props."
     (doseq [v [0 -1 1 1.5 -1.5 9.0 0.1
-               manifest/max-safe-integer
-               (- manifest/max-safe-integer)
+               rf.ssr.manifest/max-safe-integer
+               (- rf.ssr.manifest/max-safe-integer)
                ##Inf ##-Inf
                #?(:clj 1.0E308 :cljs 1e308)]]
-      (is (manifest/edn-carryable? v) (str "must still carry " (pr-str v))))
+      (is (rf.ssr.manifest/edn-carryable? v) (str "must still carry " (pr-str v))))
 
     (testing "…including through nesting and as a prop KEY"
-      (is (manifest/edn-carryable? {:a [1 {:b #{2 3.5}}]}))
-      (is (manifest/edn-carryable? {1 :v}))))
+      (is (rf.ssr.manifest/edn-carryable? {:a [1 {:b #{2 3.5}}]}))
+      (is (rf.ssr.manifest/edn-carryable? {1 :v}))))
 
   (testing "what it REFUSES, and why each one is not merely pedantic"
-    (is (not (manifest/edn-carryable? #?(:clj Double/NaN :cljs js/NaN)))
+    (is (not (rf.ssr.manifest/edn-carryable? #?(:clj Double/NaN :cljs js/NaN)))
         "NaN is excluded by the round-trip property itself — it is not `=`
          to itself, so it cannot read back EQUAL on any host")
 
     #?(:clj
        (do
-         (is (not (manifest/edn-carryable? 9007199254740993N))
+         (is (not (rf.ssr.manifest/edn-carryable? 9007199254740993N))
              "bigint: prints an `N` token the browser reproduces as a
               different number")
-         (is (not (manifest/edn-carryable? 1.5M))
+         (is (not (rf.ssr.manifest/edn-carryable? 1.5M))
              "bigdec: prints an `M` token the browser reads as a plain
               number, changing the prop's TYPE")
-         (is (not (manifest/edn-carryable? 1/3))
+         (is (not (rf.ssr.manifest/edn-carryable? 1/3))
              "ratio: the browser reads `1/3` as 0.3333333333333333 — an
               APPROXIMATION, silently")
-         (is (not (manifest/edn-carryable? (inc manifest/max-safe-integer)))
+         (is (not (rf.ssr.manifest/edn-carryable? (inc rf.ssr.manifest/max-safe-integer)))
              "a Long one past 2^53-1 carries precision no double holds")
-         (is (not (manifest/edn-carryable? (- (inc manifest/max-safe-integer))))
+         (is (not (rf.ssr.manifest/edn-carryable? (- (inc rf.ssr.manifest/max-safe-integer))))
              "…and the bound is symmetric about zero")
-         (is (not (manifest/edn-carryable? (float 0.1)))
+         (is (not (rf.ssr.manifest/edn-carryable? (float 0.1)))
              "float: fails the property on the JVM ALONE — the printed
               shortest-decimal names the DOUBLE 0.1, so it does not read
               back equal even here")))
 
     (testing "a large DOUBLE is admitted though it dwarfs the integer
               bound — the bound is about representability, not magnitude"
-      (is (manifest/edn-carryable? #?(:clj 1.0E308 :cljs 1e308))))))
+      (is (rf.ssr.manifest/edn-carryable? #?(:clj 1.0E308 :cljs 1e308))))))
 
 ;; ---------------------------------------------------------------------------
 ;; ±INFINITY RIDES; ONLY NaN IS EXCLUDED (rf2-pdcoh — Spec 011 same-contract)
@@ -458,17 +458,17 @@
 
 (deftest infinities-ride-only-nan-is-excluded
   (testing "±Infinity is admitted on both hosts — EDN round-trips it exactly"
-    (is (manifest/edn-carryable? ##Inf))
-    (is (manifest/edn-carryable? ##-Inf)))
+    (is (rf.ssr.manifest/edn-carryable? ##Inf))
+    (is (rf.ssr.manifest/edn-carryable? ##-Inf)))
   (testing "…and NaN alone is refused, by the round-trip property on its own terms"
-    (is (not (manifest/edn-carryable? #?(:clj Double/NaN :cljs js/NaN)))))
+    (is (not (rf.ssr.manifest/edn-carryable? #?(:clj Double/NaN :cljs js/NaN)))))
   (testing "±Infinity survives the shipped wire, both hosts — the accepted pin"
     (doseq [inf [##Inf ##-Inf]]
-      (let [m (manifest/manifest {:rf.root/schema-version 1 :root-id :page/shop}
+      (let [m (rf.ssr.manifest/manifest {:rf.root/schema-version 1 :root-id :page/shop}
                                  {:props {:v inf}})]
         (is (round-trips? m) (str "±Inf prop " (pr-str inf) " round-trips"))
-        (is (= inf (get-in (manifest/read-manifest
-                            'test (script-body (manifest/script-html m)))
+        (is (= inf (get-in (rf.ssr.manifest/read-manifest
+                            'test (script-body (rf.ssr.manifest/script-html m)))
                            [:props :v]))
             "the exact infinity the server rendered is what the reader returns")))))
 
@@ -516,19 +516,19 @@
              "the COMPOSITE map-key tokens — the residual #6489's direct walk missed")
          (is (= "#{[1.0] [1]}" (pr-str #{[1] [1.0]}))
              "…and the composite set-element token")
-         (is (= 2 (count (get-in (manifest/read-manifest 'test (:map collision-bodies))
+         (is (= 2 (count (get-in (rf.ssr.manifest/read-manifest 'test (:map collision-bodies))
                                  [:props :lookup])))
              "the server round-trips two distinct keys — same-host is blind")
-         (is (= 2 (count (get-in (manifest/read-manifest 'test (:set collision-bodies))
+         (is (= 2 (count (get-in (rf.ssr.manifest/read-manifest 'test (:set collision-bodies))
                                  [:props :tags]))))
-         (is (= 2 (count (get-in (manifest/read-manifest 'test (:vec-map collision-bodies))
+         (is (= 2 (count (get-in (rf.ssr.manifest/read-manifest 'test (:vec-map collision-bodies))
                                  [:props :lookup])))
              "…and two distinct VECTOR keys — same-host is blind to composites too")
-         (is (= 2 (count (get-in (manifest/read-manifest 'test (:vec-set collision-bodies))
+         (is (= 2 (count (get-in (rf.ssr.manifest/read-manifest 'test (:vec-set collision-bodies))
                                  [:props :tags])))))
        :cljs
        (doseq [[label body] collision-bodies]
-         (let [data (try (manifest/read-manifest 'test body) nil
+         (let [data (try (rf.ssr.manifest/read-manifest 'test body) nil
                          (catch cljs.core/ExceptionInfo e (ex-data e)))]
            (is (= :rf.error/root-manifest-invalid (:rf.error/id data))
                (str label " — the browser rejects the colliding body"))
@@ -547,10 +547,10 @@
              m       {:rf.root/schema-version 1 :root-id :page/shop
                       :props {:lookup collide}}]
          (is (= 2 (count collide)) "the server really does hold two distinct keys")
-         (is (manifest/edn-carryable? collide)
+         (is (rf.ssr.manifest/edn-carryable? collide)
              "THE LEVER: each key and value rides the wire ALONE — exactly what
               PR #6437 checked. Per-value carryability is not the property.")
-         (let [data (try (manifest/script-html m) nil
+         (let [data (try (rf.ssr.manifest/script-html m) nil
                          (catch clojure.lang.ExceptionInfo e (ex-data e)))]
            (is (= :rf.error/root-manifest-invalid (:rf.error/id data))
                "the EXISTING error id — a colliding manifest is a malformed
@@ -564,7 +564,7 @@
        ;; set-element collision
        (let [m    {:rf.root/schema-version 1 :root-id :page/shop
                    :props {:tags #{1 1.0}}}
-             data (try (manifest/script-html m) nil
+             data (try (rf.ssr.manifest/script-html m) nil
                        (catch clojure.lang.ExceptionInfo e (ex-data e)))]
          (is (= :cross-host-numeric-collision (:invalid data)))
          (is (= :set-elements (:collision data)))
@@ -577,7 +577,7 @@
              m       {:rf.root/schema-version 1 :root-id :page/shop
                       :props {:lookup collide}}]
          (is (= 2 (count collide)) "0 (Long) and -0.0 (double) are two keys on the JVM")
-         (let [data (try (manifest/script-html m) nil
+         (let [data (try (rf.ssr.manifest/script-html m) nil
                          (catch clojure.lang.ExceptionInfo e (ex-data e)))]
            (is (= :cross-host-numeric-collision (:invalid data)))
            (is (= 0.0 (:browser-number data)) "0 and -0.0 share the browser's one zero")))
@@ -586,7 +586,7 @@
        ;; gated too, because `script-html` is the one door onto the wire
        (let [m    {:rf.root/schema-version 1 :root-id :page/shop
                    :static-props {:m {1 :a 1.0 :b}}}
-             data (try (manifest/script-html m) nil
+             data (try (rf.ssr.manifest/script-html m) nil
                        (catch clojure.lang.ExceptionInfo e (ex-data e)))]
          (is (= :cross-host-numeric-collision (:invalid data)))
          (is (= [:static-props :m] (:path data))
@@ -595,7 +595,7 @@
        ;; nested through a vector — collisions are found at any depth
        (let [m    {:rf.root/schema-version 1 :root-id :page/shop
                    :props {:xs [{:a 1} #{2 2.0}]}}
-             data (try (manifest/script-html m) nil
+             data (try (rf.ssr.manifest/script-html m) nil
                        (catch clojure.lang.ExceptionInfo e (ex-data e)))]
          (is (= :cross-host-numeric-collision (:invalid data)))
          (is (= :set-elements (:collision data)))
@@ -610,11 +610,11 @@
              m       {:rf.root/schema-version 1 :root-id :page/shop
                       :props {:lookup collide}}]
          (is (= 2 (count collide)) "two distinct VECTOR keys on the server")
-         (is (manifest/edn-carryable? collide)
+         (is (rf.ssr.manifest/edn-carryable? collide)
              "THE LEVER: each composite key rides the wire ALONE, and each is a
               vector, not a number — so the directly-numeric group had nothing to
               grab. Per-key carryability is not the property.")
-         (let [data (try (manifest/script-html m) nil
+         (let [data (try (rf.ssr.manifest/script-html m) nil
                          (catch clojure.lang.ExceptionInfo e (ex-data e)))]
            (is (= :rf.error/root-manifest-invalid (:rf.error/id data))
                "the EXISTING id — still a malformed manifest, no new catalogue row")
@@ -628,7 +628,7 @@
        ;; composite SET elements — same class, one collection out
        (let [m    {:rf.root/schema-version 1 :root-id :page/shop
                    :props {:tags #{[1] [1.0]}}}
-             data (try (manifest/script-html m) nil
+             data (try (rf.ssr.manifest/script-html m) nil
                        (catch clojure.lang.ExceptionInfo e (ex-data e)))]
          (is (= :cross-host-numeric-collision (:invalid data)))
          (is (= :set-elements (:collision data)))
@@ -639,7 +639,7 @@
        ;; residual is closed at ARBITRARY depth, not just one collection down.
        (let [m    {:rf.root/schema-version 1 :root-id :page/shop
                    :props {:xs [{:k #{[1] [1.0]}}]}}
-             data (try (manifest/script-html m) nil
+             data (try (rf.ssr.manifest/script-html m) nil
                        (catch clojure.lang.ExceptionInfo e (ex-data e)))]
          (is (= :cross-host-numeric-collision (:invalid data)))
          (is (= :set-elements (:collision data)))
@@ -678,7 +678,7 @@
              ;; distinct composite keys that are NOT a collision must still emit
              :two-vec-ok   {:rf.root/schema-version 1 :root-id :page/shop
                             :props {:lookup {[1 2] :a [1 3] :b}}}}]
-      (is (string? (manifest/script-html m))
+      (is (string? (rf.ssr.manifest/script-html m))
           (str label " — a non-colliding numeric collection still emits"))
       (is (round-trips? m)
           (str label " — …and round-trips exactly")))))
@@ -689,7 +689,7 @@
                the prop, and at the EMISSION gate naming the manifest key,
                exactly as an opaque value is. Not a second mechanism —
                the same `edn-carryable?`, told the truth about numbers."
-       (let [data (try (manifest/manifest
+       (let [data (try (rf.ssr.manifest/manifest
                         'test {:rf.root/schema-version 1 :root-id :page/shop}
                         {:props {:promo :spring :ratio 1/3}})
                        nil
@@ -702,7 +702,7 @@
 
        (testing "and the emission gate covers a DESCRIPTOR key too, which
                  `serialise-props` never sees"
-         (let [data (try (manifest/script-html
+         (let [data (try (rf.ssr.manifest/script-html
                           {:rf.root/schema-version 1
                            :root-id                :page/shop
                            :static-props           {:limit 9007199254740993N}})
@@ -714,7 +714,7 @@
        (testing "the bigint that started this: `script-html` no longer
                  emits the body the CLJS reader mangles"
          (is (thrown? clojure.lang.ExceptionInfo
-                      (manifest/script-html
+                      (rf.ssr.manifest/script-html
                        (assoc {:rf.root/schema-version 1 :root-id :page/shop}
                               :props {:x 9007199254740993N}))))))))
 
@@ -728,7 +728,7 @@
     (doseq [k [:static-props :props-shape :frame-plans :root-id]]
       (let [m    (assoc {:rf.root/schema-version 1 :root-id :page/shop}
                         k {:x (->WireProbeRecord 1)})
-            data (try (manifest/script-html m) nil
+            data (try (rf.ssr.manifest/script-html m) nil
                       (catch #?(:clj clojure.lang.ExceptionInfo
                                 :cljs cljs.core/ExceptionInfo) e
                         (ex-data e)))]
@@ -738,8 +738,8 @@
 
   (testing "the gate does NOT narrow what a valid manifest may hold —
             ordinary data still emits"
-    (is (string? (manifest/script-html
-                  (manifest/manifest {:rf.root/schema-version 1
+    (is (string? (rf.ssr.manifest/script-html
+                  (rf.ssr.manifest/manifest {:rf.root/schema-version 1
                                       :root-id                :page/shop
                                       :static-props           {:limit 10}})))
         "the gate rejects unwireable values, not ordinary data")))
@@ -755,7 +755,7 @@
                           :duplicate      (str "{:rf.root/schema-version 1} "
                                                "{:rf.root/schema-version 1}")
                           :empty          ""}]
-      (let [data (try (manifest/read-manifest 'test body) nil
+      (let [data (try (rf.ssr.manifest/read-manifest 'test body) nil
                       (catch #?(:clj clojure.lang.ExceptionInfo
                                 :cljs cljs.core/ExceptionInfo) e
                         (ex-data e)))]
@@ -769,17 +769,17 @@
     (doseq [body ["  {:rf.root/schema-version 1}  "
                   "\n\t{:rf.root/schema-version 1}\n"
                   "{:rf.root/schema-version 1}\n"]]
-      (is (= {:rf.root/schema-version 1} (manifest/read-manifest 'test body))
+      (is (= {:rf.root/schema-version 1} (rf.ssr.manifest/read-manifest 'test body))
           (str "whitespace-padded body " (pr-str body)))))
 
   (testing "a trailing `;` comment does not swallow the wrapper's closing
             bracket — the reader wraps in `[ … \\n]` precisely so it cannot"
     (is (= {:rf.root/schema-version 1}
-           (manifest/read-manifest 'test "{:rf.root/schema-version 1} ; note"))))
+           (rf.ssr.manifest/read-manifest 'test "{:rf.root/schema-version 1} ; note"))))
 
   (testing "an EDN discard is not a second form"
     (is (= {:rf.root/schema-version 1}
-           (manifest/read-manifest 'test "{:rf.root/schema-version 1} #_{:x 1}")))))
+           (rf.ssr.manifest/read-manifest 'test "{:rf.root/schema-version 1} #_{:x 1}")))))
 
 (deftest one-form-guard-is-load-bearing
   (testing "THE RED-BEFORE for the one-form rule, kept executable: the
@@ -797,8 +797,8 @@
                " — that is the hole `read-manifest` now closes")))))
 
 (deftest marker-attribute-is-pinned-in-one-place
-  (is (= "data-rf-root" constants/root-manifest-marker-attribute))
-  (is (= "application/edn" manifest/manifest-script-type)))
+  (is (= "data-rf-root" rf.ssr.constants/root-manifest-marker-attribute))
+  (is (= "application/edn" rf.ssr.manifest/manifest-script-type)))
 
 ;; ---------------------------------------------------------------------------
 ;; Discovery (CLJS) — adjacency, and nothing else
@@ -821,34 +821,34 @@
      ;; `m` carries an AUTHORED `:identifier-prefix`, so `discover` passes it
      ;; through verbatim and this test stays about ADJACENCY (the omitted-prefix
      ;; canonicalization has its own test below, rf2-y3swx).
-     (let [m    (manifest/manifest {:rf.root/schema-version 1
+     (let [m    (rf.ssr.manifest/manifest {:rf.root/schema-version 1
                                     :root-id :page/shop}
                                    {:element-locator   {:id "shop-root"}
                                     :identifier-prefix "shop-"})
            body (pr-str m)
            script (stub-el {:attrs {"type" "application/edn"
-                                    constants/root-manifest-marker-attribute ""}
+                                    rf.ssr.constants/root-manifest-marker-attribute ""}
                             :text  body})]
        (testing "the immediately following element sibling IS the manifest"
-         (is (= m (manifest/discover (stub-el {:tag "DIV" :next script})))))
+         (is (= m (rf.ssr.manifest/discover (stub-el {:tag "DIV" :next script})))))
 
        (testing "identity comes from the CONTENT, never the element"
          (is (= :page/shop
-                (:root-id (manifest/discover (stub-el {:tag "DIV" :next script}))))))
+                (:root-id (rf.ssr.manifest/discover (stub-el {:tag "DIV" :next script}))))))
 
        (testing "no sibling ⇒ nil; the caller decides what absence means"
-         (is (nil? (manifest/discover (stub-el {:tag "DIV" :next nil})))))
+         (is (nil? (rf.ssr.manifest/discover (stub-el {:tag "DIV" :next nil})))))
 
        (testing "an ordinary application/edn script is NOT a manifest —
                  the bare marker is what distinguishes the hydration
                  payload and data islands from a root manifest"
-         (is (nil? (manifest/discover
+         (is (nil? (rf.ssr.manifest/discover
                     (stub-el {:tag "DIV"
                               :next (stub-el {:attrs {"type" "application/edn"}
                                               :text  body})})))))
 
        (testing "a non-script sibling is not searched through"
-         (is (nil? (manifest/discover
+         (is (nil? (rf.ssr.manifest/discover
                     (stub-el {:tag "DIV"
                               :next (stub-el {:tag "DIV" :next script})})))
              "discovery does not walk — adjacency is the whole rule")))))
@@ -867,18 +867,18 @@
 (deftest canonicalize-effective-prefix-resolves-omitted-to-react-empty
   (testing "an OMITTED :identifier-prefix resolves to React's effective \"\""
     (is (= {:rf.root/schema-version 1 :root-id :page/shop :identifier-prefix ""}
-           (manifest/canonicalize-effective-prefix
+           (rf.ssr.manifest/canonicalize-effective-prefix
             {:rf.root/schema-version 1 :root-id :page/shop})))
     (is (= "" (:identifier-prefix
-               (manifest/canonicalize-effective-prefix
+               (rf.ssr.manifest/canonicalize-effective-prefix
                 {:rf.root/schema-version 1 :root-id :page/shop})))
         "the resolved effective prefix is the empty string, not nil"))
   (testing "an AUTHORED :identifier-prefix is passed through UNTOUCHED"
     (is (= {:rf.root/schema-version 1 :root-id :page/shop :identifier-prefix "shop-"}
-           (manifest/canonicalize-effective-prefix
+           (rf.ssr.manifest/canonicalize-effective-prefix
             {:rf.root/schema-version 1 :root-id :page/shop :identifier-prefix "shop-"})))
     (is (= {:rf.root/schema-version 1 :root-id :page/shop :identifier-prefix ""}
-           (manifest/canonicalize-effective-prefix
+           (rf.ssr.manifest/canonicalize-effective-prefix
             {:rf.root/schema-version 1 :root-id :page/shop :identifier-prefix ""}))
         "an explicitly-empty authored prefix is left as-is (already \"\")")))
 
@@ -887,11 +887,11 @@
      ;; RED-BEFORE: the shipped `discover` returned the bare manifest verbatim,
      ;; so `hydrate-root*` read a NIL prefix and the Layer-3 prefix-uniqueness
      ;; arm (a no-op on nil) admitted every omitted-prefix root.
-     (let [bare   (manifest/manifest {:rf.root/schema-version 1 :root-id :page/a})
+     (let [bare   (rf.ssr.manifest/manifest {:rf.root/schema-version 1 :root-id :page/a})
            script (stub-el {:attrs {"type" "application/edn"
-                                    constants/root-manifest-marker-attribute ""}
+                                    rf.ssr.constants/root-manifest-marker-attribute ""}
                             :text  (pr-str bare)})
-           found  (manifest/discover (stub-el {:tag "DIV" :next script}))]
+           found  (rf.ssr.manifest/discover (stub-el {:tag "DIV" :next script}))]
        (testing "the bare manifest omits :identifier-prefix on the wire"
          (is (not (contains? bare :identifier-prefix))
              "manifest optionality is preserved — the extension key is absent"))

--- a/implementation/ssr/test/re_frame/ssr/ssr_startup_recipe_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/ssr_startup_recipe_dom_cljs_test.cljs
@@ -106,15 +106,15 @@
   commit naturally — no `act()` wrapper is needed."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
             ;; The canonical mount helper `ssr.core/run` itself calls. Requiring
             ;; it — NOT `ssr.core` — is what lets this proof execute the real
             ;; adopt-vs-fresh React-root branch without pulling `ssr.core`'s app
             ;; registrations (and their bundle-wide id collisions) into the test.
             [ssr.mount :as mount]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.constants :as constants]
-            [re-frame.test-support :as test-support]))
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.constants :as rf.ssr.constants]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; ---- the app under the recipe (unique ids ⇒ no bundle collision) -----------
 ;;
@@ -176,10 +176,10 @@
   proven separately; here the point is the mount branch, not annotation
   parity.)"
   [handle]
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! rf.adapter.reagent/adapter)
   (rf/make-frame {:id app-frame :platform :client})
   (let [el      (and (exists? js/document) (js/document.getElementById "app"))
-        payload (ssr/hydrate! {:frame app-frame :render-tree-fn (fn [] [recipe-view])})
+        payload (rf.ssr/hydrate! {:frame app-frame :render-tree-fn (fn [] [recipe-view])})
         tree    [rf/frame-provider {:frame app-frame} [recipe-view]]]
     (mount/mount! handle el tree payload)
     payload))
@@ -189,8 +189,8 @@
 ;; recipe stands up its own `:rf/default`. `:adapter` installs the STOCK
 ;; Reagent adapter the recipe uses (its own `rf/init!` is idempotent).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter :async? true :ambient-frame nil}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter :async? true :ambient-frame nil}))
 
 ;; ---- browser gate ----------------------------------------------------------
 
@@ -235,14 +235,14 @@
     (set! (.-innerHTML host)
           (str "<div id=\"app\">" inner-html "</div>"
                (when payload?
-                 (str "<script id=\"" constants/payload-script-id
+                 (str "<script id=\"" rf.ssr.constants/payload-script-id
                       "\" type=\"application/edn\">{:rf/version 1 :rf/app-db {}}</script>"))))
     (.appendChild (.-body js/document) host)
     host))
 
 (defn- teardown! [host handle act-prev]
   ;; `unmount!` is idempotent and a no-op on a handle that never mounted.
-  (try (reagent-adapter/unmount! handle) (catch :default _ nil))
+  (try (rf.adapter.reagent/unmount! handle) (catch :default _ nil))
   (when-let [p (.-parentNode host)] (.removeChild p host))
   (restore-act-env! act-prev))
 
@@ -259,7 +259,7 @@
       (async done
         (clear-stale-apps!)
         (let [act-prev   (disable-act-env!)
-              handle     (reagent-adapter/client-root)
+              handle     (rf.adapter.reagent/client-root)
               host       (plant-host! {:inner-html server-markup :payload? true})
               app-el     (.getElementById js/document "app")
               ;; The EXACT server-rendered node, captured BEFORE startup.
@@ -318,7 +318,7 @@
       (async done
         (clear-stale-apps!)
         (let [act-prev  (disable-act-env!)
-              handle    (reagent-adapter/client-root)
+              handle    (rf.adapter.reagent/client-root)
               host      (plant-host!
                          {:inner-html "<div data-testid=\"stale-sentinel\">stale</div>"
                           :payload? false})

--- a/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
@@ -43,14 +43,14 @@
   (:require [clojure.string :as str]
             [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.constants :as constants]
-            [re-frame.ssr.streaming.constants :as wire]
-            [re-frame.ssr.streaming.client :as streaming-client]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.constants :as rf.ssr.constants]
+            [re-frame.ssr.streaming.constants :as rf.ssr.streaming.constants]
+            [re-frame.ssr.streaming.client :as rf.ssr.streaming.client]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 ;; Per cljs.test: async tests require fixtures supplied as a MAP (a fn-form
 ;; fixture's teardown runs before the async body completes — "Async tests require
@@ -60,8 +60,8 @@
 ;; dispose/install it hand-rolled. `:ambient-frame nil` preserves the
 ;; no-ambient-scope behaviour (each test creates its own client frame).
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter :async? true :ambient-frame nil}))
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter :async? true :ambient-frame nil}))
 
 ;; ---- browser gate ----------------------------------------------------------
 
@@ -84,7 +84,7 @@
   (str "<main class=\"dashboard\"><section class=\"cards\">"
        (->> ids
             (map (fn [id]
-                   (ssr/streaming-fallback-template
+                   (rf.ssr/streaming-fallback-template
                      id (str "<div class=\"card skeleton\">loading " (name id) "</div>"))))
             (str/join ""))
        "</section></main>"))
@@ -94,14 +94,14 @@
   by its hydrate-delta `<script>` — exactly the two nodes the writer
   thread flushes per drained continuation."
   [id resolved-html delta]
-  (str (ssr/streaming-resolved-template id resolved-html)
-       (ssr/streaming-hydrate-delta-script id (pr-str delta))))
+  (str (rf.ssr/streaming-resolved-template id resolved-html)
+       (rf.ssr/streaming-hydrate-delta-script id (pr-str delta))))
 
 (defn- failed-chunk-html
   "A failed-continuation chunk: failed `<template>` (fallback HTML +
   `data-rf2-suspense-failed`), no delta script."
   [id fallback-html]
-  (ssr/streaming-failed-template id fallback-html))
+  (rf.ssr/streaming-failed-template id fallback-html))
 
 (defn- failed-chunk-with-delta-html
   "A CONTRADICTORY wire shape (rf2-x76af2.40): a failed `<template>` (the
@@ -111,8 +111,8 @@
   must fail CLOSED on: the failed fallback swaps, but the delta must be
   quarantined, not merged."
   [id fallback-html delta]
-  (str (ssr/streaming-failed-template id fallback-html)
-       (ssr/streaming-hydrate-delta-script id (pr-str delta))))
+  (str (rf.ssr/streaming-failed-template id fallback-html)
+       (rf.ssr/streaming-hydrate-delta-script id (pr-str delta))))
 
 ;; ---- DOM scaffolding -------------------------------------------------------
 
@@ -144,7 +144,7 @@
   (count (array-seq (.querySelectorAll host (str "." cls)))))
 
 (defn- mount-for [host id]
-  (.querySelector host (str "[" wire/attr-suspense-mount "=\"" (pr-str id) "\"]")))
+  (.querySelector host (str "[" rf.ssr.streaming.constants/attr-suspense-mount "=\"" (pr-str id) "\"]")))
 
 (defn- showing-fallback?
   "True when boundary `id` is in its (live, visible) fallback state —
@@ -213,14 +213,14 @@
                                  "<div class=\"card resolved-revenue\">Revenue 42375</div>"
                                  {:cards {:revenue {:title "Revenue" :value 42375}}}))
           ;; signups has NOT resolved yet — its fallback is still inert.
-          (is (nil? (.querySelector host (str "#" constants/payload-script-id)))
+          (is (nil? (.querySelector host (str "#" rf.ssr.constants/payload-script-id)))
               "no final payload present — any hydration is purely from chunk deltas")
-          (is (= {} (frame/frame-app-db-value fid)) "app-db empty before install")
+          (is (= {} (rf.frame/frame-app-db-value fid)) "app-db empty before install")
 
           ;; Install runs its synchronous initial sweep: materialise the
           ;; un-resolved fallback into a visible mount, swap the resolved
           ;; chunk into its mount, and merge its delta.
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             (try
               ;; (a) revenue (resolved chunk present) swapped in-place.
               (is (false? (boolean (showing-fallback? host :card.revenue)))
@@ -267,7 +267,7 @@
                                  "<div class=\"card resolved-signups\">Signups</div>"
                                  {:cards {:revenue {:value 42375}
                                           :signups {:value 318}}}))
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             (try
               (is (= 42375 (:value @(rf/subscribe [:sct/card :revenue] {:frame fid})))
                   "revenue card survives the second chunk's :cards replacement")
@@ -287,20 +287,20 @@
             host     (make-root! [:card.flaky])
             captured (atom [])
             k        (str (gensym "stream-fail-cb"))]
-        (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+        (rf.trace.tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
         (try
           (append-chunk!
             host
             (failed-chunk-html :card.flaky "<div class=\"card card-failed\">unavailable</div>"))
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             (try
               (is (= 1 (card-count host "card-failed")) "the failed chunk's fallback HTML is in the DOM")
-              (is (= {} (frame/frame-app-db-value fid)) "no delta applied for a failed boundary")
+              (is (= {} (rf.frame/frame-app-db-value fid)) "no delta applied for a failed boundary")
               (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %)) @captured)
                   ":rf.ssr/suspense-boundary-failed trace emitted client-side")
               (finally (stop!))))
           (finally
-            (trace-tooling/unregister-listener! k)
+            (rf.trace.tooling/unregister-listener! k)
             (remove-root! host)))))))
 
 (deftest failed-boundary-suppresses-matching-hydration-delta
@@ -323,7 +323,7 @@
             k         (str (gensym "stream-failquarantine-cb"))
             failed-of #(filter (fn [ev] (= :rf.ssr/suspense-boundary-failed (:operation ev)))
                                @captured)]
-        (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+        (rf.trace.tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
         (try
           ;; A failed template AND a VALID-MAP delta for the SAME id — the
           ;; contradictory shape. The delta WOULD merge for a successful
@@ -333,15 +333,15 @@
             (failed-chunk-with-delta-html
               :card.flaky "<div class=\"card card-failed\">unavailable</div>"
               {:cards {:flaky {:value 99}}}))
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             (try
               (is (= 1 (card-count host "card-failed"))
                   "the failed chunk's fallback HTML swapped in")
-              (is (= {} (frame/frame-app-db-value fid))
+              (is (= {} (rf.frame/frame-app-db-value fid))
                   "the failed boundary's delta is NOT merged (fail-closed)")
               (is (nil? @(rf/subscribe [:sct/card :flaky] {:frame fid}))
                   "a subscription reads no speculative state for the failed boundary")
-              (is (zero? (count (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-hydrate "]")))))
+              (is (zero? (count (array-seq (.querySelectorAll host (str "[" rf.ssr.streaming.constants/attr-suspense-hydrate "]")))))
                   "the contradictory delta script is consumed (DOM left script-free)")
               ;; exactly one :quarantined-delta diagnostic.
               (let [q (filter #(= :quarantined-delta (:recovery %)) (failed-of))]
@@ -354,7 +354,7 @@
                     "the failed fallback swap still emits its :inline-fallback signal exactly once"))
               (finally (stop!))))
           (finally
-            (trace-tooling/unregister-listener! k)
+            (rf.trace.tooling/unregister-listener! k)
             (remove-root! host)))))))
 
 (deftest failed-boundary-suppresses-delta-arriving-first
@@ -373,17 +373,17 @@
               host     (make-root! [:card.flaky])
               captured (atom [])
               k        (str (gensym "stream-failfirst-cb"))]
-          (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+          (rf.trace.tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
           ;; Batch 1: ONLY the delta <script> — its (failed) template has not arrived.
           (append-chunk!
             host
-            (ssr/streaming-hydrate-delta-script
+            (rf.ssr/streaming-hydrate-delta-script
               :card.flaky (pr-str {:cards {:flaky {:value 99}}})))
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             ;; First sweep: boundary not swapped → delta held, not applied.
-            (is (= {} (frame/frame-app-db-value fid))
+            (is (= {} (rf.frame/frame-app-db-value fid))
                 "delta held (boundary not swapped yet) — nothing merged speculatively")
-            (is (= 1 (count (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-hydrate "]")))))
+            (is (= 1 (count (array-seq (.querySelectorAll host (str "[" rf.ssr.streaming.constants/attr-suspense-hydrate "]")))))
                 "the delta <script> waits in the DOM (not consumed before its swap)")
             ;; Batch 2: the FAILED template arrives → swaps → outcome :failed.
             (append-chunk!
@@ -393,9 +393,9 @@
               (fn []
                 (is (= 1 (card-count host "card-failed"))
                     "failed fallback swapped in the later sweep")
-                (is (= {} (frame/frame-app-db-value fid))
+                (is (= {} (rf.frame/frame-app-db-value fid))
                     "the delta (which arrived FIRST) is quarantined once its boundary resolved FAILED — never merged")
-                (is (zero? (count (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-hydrate "]")))))
+                (is (zero? (count (array-seq (.querySelectorAll host (str "[" rf.ssr.streaming.constants/attr-suspense-hydrate "]")))))
                     "the contradictory delta script is consumed")
                 ;; Scope the match to THIS boundary's own id. `captured` is a
                 ;; PROCESS-GLOBAL trace listener — it observes every namespace's
@@ -442,14 +442,14 @@
               host     (make-root! [:card.revenue])
               captured (atom [])
               k        (str (gensym "stream-nonmap-cb"))]
-          (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+          (rf.trace.tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
           (try
             (append-chunk!
               host
               (resolved-chunk-html :card.revenue
                                    "<div class=\"card resolved-revenue\">Revenue</div>"
                                    bad-delta))
-            (let [stop! (streaming-client/install! {:frame fid :root host})]
+            (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
               (try
                 ;; DOM still progresses — the resolved content swapped in.
                 (is (= 1 (card-count host "resolved-revenue"))
@@ -458,13 +458,13 @@
                 (is (false? (boolean (showing-fallback? host :card.revenue)))
                     (str (pr-str bad-delta) ": mount shows resolved content, not a skeleton"))
                 ;; app-db is UNCHANGED — the malformed delta was not merged.
-                (is (= {} (frame/frame-app-db-value fid))
+                (is (= {} (rf.frame/frame-app-db-value fid))
                     (str (pr-str bad-delta)
                          ": app-db must stay unchanged (malformed delta NOT merged)"))
                 (is (nil? @(rf/subscribe [:sct/card :revenue] {:frame fid}))
                     (str (pr-str bad-delta) ": subscription reads no speculative state"))
                 ;; The script is consumed regardless of delta validity.
-                (is (zero? (count (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-hydrate "]")))))
+                (is (zero? (count (array-seq (.querySelectorAll host (str "[" rf.ssr.streaming.constants/attr-suspense-hydrate "]")))))
                     (str (pr-str bad-delta) ": the delta script is dropped (DOM left script-free)"))
                 ;; The fail-closed diagnostic fires.
                 (let [skipped (filter #(and (= :rf.ssr/suspense-boundary-failed (:operation %))
@@ -476,7 +476,7 @@
                            (pr-str (mapv (juxt :operation :recovery) @captured)))))
                 (finally (stop!))))
             (finally
-              (trace-tooling/unregister-listener! k)
+              (rf.trace.tooling/unregister-listener! k)
               (remove-root! host))))))))
 
 (deftest empty-delta-body-is-not-malformed
@@ -491,7 +491,7 @@
             host     (make-root! [:card.empty :card.full])
             captured (atom [])
             k        (str (gensym "stream-empty-cb"))]
-        (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+        (rf.trace.tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
         (try
           ;; (a) empty-map delta — valid no-op, no app-db change, no trace.
           (append-chunk!
@@ -505,7 +505,7 @@
             (resolved-chunk-html :card.full
                                  "<div class=\"card resolved-full\">full</div>"
                                  {:cards {:full {:value 5}}}))
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             (try
               (is (= 1 (card-count host "resolved-empty")) "empty-delta chunk still swaps")
               (is (= 5 (:value @(rf/subscribe [:sct/card :full] {:frame fid}))) "valid delta merged")
@@ -514,7 +514,7 @@
                        (pr-str (mapv :operation @captured))))
               (finally (stop!))))
           (finally
-            (trace-tooling/unregister-listener! k)
+            (rf.trace.tooling/unregister-listener! k)
             (remove-root! host)))))))
 
 (deftest css-special-payload-id-does-not-throw
@@ -547,7 +547,7 @@
               (str "<script id=\"" pid "\" type=\"application/edn\">"
                    "{:rf/version 1 :rf/app-db {} :rf/render-hash \"00000000\"}"
                    "</script>"))
-            (let [stop! (streaming-client/install! {:frame fid :root host :payload-id pid})]
+            (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host :payload-id pid})]
               (try
                 ;; No throw is the headline assertion; the chunk still
                 ;; swapped (the sweep ran before completion-detection).
@@ -579,7 +579,7 @@
             ;; mount swaps, exactly the nested wire shape.
             host (make-root! [:card.outer])
             ;; The outer resolved content embeds the inner fallback template.
-            inner-fallback (ssr/streaming-fallback-template
+            inner-fallback (rf.ssr/streaming-fallback-template
                              :card.inner "<div class=\"card skeleton inner-skel\">loading inner</div>")
             outer-resolved-html (str "<section class=\"card resolved-outer\">outer "
                                      inner-fallback "</section>")]
@@ -605,9 +605,9 @@
             (resolved-chunk-html :card.outer
                                  outer-resolved-html
                                  {:cards {:outer {:value 7} :inner {:value 99}}}))
-          (is (nil? (.querySelector host (str "#" constants/payload-script-id)))
+          (is (nil? (.querySelector host (str "#" rf.ssr.constants/payload-script-id)))
               "no final payload — recovery is purely the sweep's doing")
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             (try
               (is (= 1 (card-count host "resolved-outer"))
                   "outer resolved content is live")
@@ -629,7 +629,7 @@
   read both."
   [host id]
   (array-seq
-    (.querySelectorAll host (str "[" wire/attr-suspense-mount "=\"" (pr-str id) "\"]"))))
+    (.querySelectorAll host (str "[" rf.ssr.streaming.constants/attr-suspense-mount "=\"" (pr-str id) "\"]"))))
 
 (defn- inert-fallback-template-count
   "Count of un-materialised fallback `<template>`s still in the DOM. After a
@@ -637,7 +637,7 @@
   mount (rf2-8en9mu: a duplicate-id boundary must not leave a stray inert
   template)."
   [host]
-  (count (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-fallback "]")))))
+  (count (array-seq (.querySelectorAll host (str "[" rf.ssr.streaming.constants/attr-suspense-fallback "]")))))
 
 (deftest fallback-is-inert-template-before-js-then-painted-on-install
   (testing "rf2-xzhf2a — the no-JS / first-byte contract. The shell's
@@ -656,7 +656,7 @@
         (try
           ;; BEFORE install (the no-JS / first-byte state): the fallback skeleton
           ;; is inert template content — NOT in the live painted DOM.
-          (is (some? (.querySelector host (str "[" wire/attr-suspense-fallback "]")))
+          (is (some? (.querySelector host (str "[" rf.ssr.streaming.constants/attr-suspense-fallback "]")))
               "the inert fallback <template> is present in the shell")
           (is (nil? (.querySelector host ".skeleton"))
               "the skeleton is INERT template content — not painted live DOM before JS")
@@ -664,7 +664,7 @@
               "no live <rf-suspense> mount exists before the client runs")
           ;; AFTER install: the runtime materialises the inert template into a
           ;; live, painted mount — the skeleton is now real DOM.
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             (try
               (is (zero? (inert-fallback-template-count host))
                   "the inert fallback <template> is consumed on install")
@@ -703,7 +703,7 @@
             (resolved-chunk-html :card.dupe
                                  "<div class=\"card resolved-dupe\">resolved 7</div>"
                                  {:cards {:dupe {:value 7}}}))
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             (try
               ;; (a) BOTH fallbacks materialised — no stray inert template.
               (is (zero? (inert-fallback-template-count host))
@@ -749,7 +749,7 @@
               host     (make-root! [id])
               captured (atom [])
               k        (str (gensym "stream-idtype-cb"))]
-          (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+          (rf.trace.tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
           (try
             ;; A failed-boundary chunk → process-resolved-template! emits
             ;; :rf.ssr/suspense-boundary-failed with :id (read-boundary-id …).
@@ -761,7 +761,7 @@
             (append-chunk!
               host
               (failed-chunk-html id "<div class=\"card card-failed\">unavailable</div>"))
-            (let [stop! (streaming-client/install! {:frame fid :root host})]
+            (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
               (try
                 ;; The boundary id lands in the trace envelope's PAYLOAD —
                 ;; `[:tags :id]` — not the top-level `:id` (a trace-sequence
@@ -778,7 +778,7 @@
                            (pr-str (type ev-id)))))
                 (finally (stop!))))
             (finally
-              (trace-tooling/unregister-listener! k)
+              (rf.trace.tooling/unregister-listener! k)
               (remove-root! host))))))))
 
 (deftest async-observer-applies-late-chunk
@@ -791,7 +791,7 @@
         done
         (let [fid   (make-client-frame!)
               host  (make-root! [:card.late])
-              stop! (streaming-client/install! {:frame fid :root host})]
+              stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
           ;; Before the chunk: the fallback is materialised + visible.
           (is (true? (showing-fallback? host :card.late)) "late card starts as a visible skeleton")
           ;; Chunk arrives after install → the observer fires (microtask).
@@ -836,9 +836,9 @@
           ;; its delta <script> has NOT streamed in yet.
           (append-chunk!
             host
-            (ssr/streaming-resolved-template
+            (rf.ssr/streaming-resolved-template
               :card.revenue "<div class=\"card resolved-revenue\">Revenue 42375</div>"))
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             ;; After the synchronous initial sweep: the template swapped in,
             ;; but app-db is still empty — the delta is in a later chunk.
             (is (= 1 (card-count host "resolved-revenue"))
@@ -851,7 +851,7 @@
             ;; swapped + removed. The observer fires a fresh sweep.
             (append-chunk!
               host
-              (ssr/streaming-hydrate-delta-script
+              (rf.ssr/streaming-hydrate-delta-script
                 :card.revenue (pr-str {:cards {:revenue {:title "Revenue" :value 42375}}})))
             ;; `setTimeout 0` (macrotask) runs after the observer microtask,
             ;; so the second-batch sweep has definitely run by the continuation.
@@ -861,7 +861,7 @@
                        @(rf/subscribe [:sct/card :revenue] {:frame fid}))
                     "the delta merged even though it arrived in a LATER batch than its template")
                 (is (zero? (count (array-seq
-                                    (.querySelectorAll host (str "[" wire/attr-suspense-hydrate "]")))))
+                                    (.querySelectorAll host (str "[" rf.ssr.streaming.constants/attr-suspense-hydrate "]")))))
                     "the delta <script> was consumed (DOM left script-free)")
                 (stop!)
                 (remove-root! host)
@@ -887,9 +887,9 @@
           ;; resolved <template> has NOT streamed in yet.
           (append-chunk!
             host
-            (ssr/streaming-hydrate-delta-script
+            (rf.ssr/streaming-hydrate-delta-script
               :card.revenue (pr-str {:cards {:revenue {:title "Revenue" :value 42375}}})))
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             ;; After the synchronous initial sweep: no resolved template yet,
             ;; so the boundary is not `seen` and the delta is HELD (not applied).
             (is (nil? @(rf/subscribe [:sct/card :revenue] {:frame fid}))
@@ -897,13 +897,13 @@
             (is (true? (showing-fallback? host :card.revenue))
                 "the boundary still shows its fallback — no resolved template yet")
             (is (= 1 (count (array-seq
-                              (.querySelectorAll host (str "[" wire/attr-suspense-hydrate "]")))))
+                              (.querySelectorAll host (str "[" rf.ssr.streaming.constants/attr-suspense-hydrate "]")))))
                 "the delta <script> waits in the DOM (not consumed before its swap)")
             ;; Batch 2: the resolved <template> arrives. The observer fires;
             ;; the swap marks the id `seen`, then the still-present delta merges.
             (append-chunk!
               host
-              (ssr/streaming-resolved-template
+              (rf.ssr/streaming-resolved-template
                 :card.revenue "<div class=\"card resolved-revenue\">Revenue 42375</div>"))
             (js/setTimeout
               (fn []
@@ -913,7 +913,7 @@
                        @(rf/subscribe [:sct/card :revenue] {:frame fid}))
                     "the delta (which arrived FIRST) merged once its template swapped")
                 (is (zero? (count (array-seq
-                                    (.querySelectorAll host (str "[" wire/attr-suspense-hydrate "]")))))
+                                    (.querySelectorAll host (str "[" rf.ssr.streaming.constants/attr-suspense-hydrate "]")))))
                     "the delta <script> was consumed once applied")
                 (stop!)
                 (remove-root! host)
@@ -960,11 +960,11 @@
           ;; before any live mount exists.
           (set! (.-innerHTML host) "<div id=\"app\"><main></main></div>")
           (.appendChild (.-body js/document) host)
-          (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+          (rf.trace.tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
           (append-chunk!
             host
             (failed-chunk-html id "<div class=\"card card-failed\">unavailable</div>"))
-          (let [stop! (streaming-client/install! {:frame fid :root host})]
+          (let [stop! (rf.ssr.streaming.client/install! {:frame fid :root host})]
             ;; Sweep 1 (synchronous initial sweep): no mount → swapped? false
             ;; → the failed arm is gated → NO trace, and the failed <template>
             ;; stays retryable.
@@ -982,7 +982,7 @@
                 ;; retryable failed chunk → swap succeeds → EXACTLY ONE trace.
                 (append-chunk!
                   host
-                  (ssr/streaming-fallback-template
+                  (rf.ssr/streaming-fallback-template
                     id "<div class=\"card skeleton\">loading</div>"))
                 (js/setTimeout
                   (fn []

--- a/implementation/ssr/test/re_frame/ssr/streaming_component_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/streaming_component_cljs_test.cljc
@@ -16,11 +16,11 @@
   `re-frame.ssr.streaming-hydration-lifecycle-dom-cljs-test`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.suspense :as suspense :refer [boundary]]
-            [re-frame.ssr.install :as install]
-            [re-frame.test-support :as test-support]
-            #?(:cljs [re-frame.adapter.reagent-slim :as reagent-slim-adapter])))
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.suspense :as rf.ssr.suspense :refer [boundary]]
+            [re-frame.ssr.install :as rf.ssr.install]
+            [re-frame.test-support :as rf.test-support]
+            #?(:cljs [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim])))
 
 ;; `installed-payloads` is a process-global `defonce` ledger that neither
 ;; `clear-all!` nor a frames reset touches — reset it so nothing this
@@ -34,11 +34,11 @@
 ;; unset so `make-reset-runtime-fixture` also returns its fn form.
 (use-fixtures :each
   (fn [f]
-    (install/reset-installed-payloads!)
-    (suspense/reset-failed-boundaries!)
+    (rf.ssr.install/reset-installed-payloads!)
+    (rf.ssr.suspense/reset-failed-boundaries!)
     (f))
-  (test-support/make-reset-runtime-fixture
-    {:adapter #?(:clj ssr/adapter :cljs reagent-slim-adapter/adapter)
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter #?(:clj rf.ssr/adapter :cljs rf.adapter.reagent-slim/adapter)
      :ambient-frame nil}))
 
 ;; Server-side fixture components. JVM-only: every reference is inside a
@@ -70,14 +70,14 @@
 (deftest the-failed-set-path-is-under-the-reserved-ssr-key
   (testing "the slot lives under the already-reserved :rf.runtime/ssr
             runtime-db key, a sibling of the :hydration metadata"
-    (is (= :rf.runtime/ssr (first suspense/failed-boundaries-path)))
+    (is (= :rf.runtime/ssr (first rf.ssr.suspense/failed-boundaries-path)))
     (is (= [:rf.runtime/ssr :streaming :failed-boundaries]
-           suspense/failed-boundaries-path))))
+           rf.ssr.suspense/failed-boundaries-path))))
 
 (deftest frame-failed-boundaries-reads-empty-for-an-unknown-frame
   (testing "never throws for an absent / destroyed frame — absence is the
             ordinary no-recorded-outcome case, not an error"
-    (is (= #{} (suspense/frame-failed-boundaries :no/such-frame)))))
+    (is (= #{} (rf.ssr.suspense/frame-failed-boundaries :no/such-frame)))))
 
 ;; ---- server host -----------------------------------------------------------
 
@@ -109,7 +109,7 @@
                       [boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
                        [card-view :revenue]]]
                {:keys [shell-html continuations]}
-               (rf/with-frame fid (ssr/streaming-render-shell tree))]
+               (rf/with-frame fid (rf.ssr/streaming-render-shell tree))]
            (is (= 1 (count continuations)))
            (is (= :card.revenue (:id (first continuations))))
            (is (clojure.string/includes? shell-html "data-rf2-suspense-fallback=\"1\"")
@@ -121,7 +121,7 @@
            (testing "draining the continuation renders the deferred body"
              (let [{:keys [html failed?]}
                    (rf/with-frame fid
-                     (ssr/streaming-render-continuation fid (first continuations)))]
+                     (rf.ssr/streaming-render-continuation fid (first continuations)))]
                (is (false? failed?))
                (is (clojure.string/includes? html "42375")))))))))
 
@@ -136,29 +136,29 @@
          (let [tree      [:section.cards
                           [boundary {:id :card.flaky :fallback [card-skeleton :flaky]}
                            [throwing-card]]]
-               {:keys [continuations]} (rf/with-frame fid (ssr/streaming-render-shell tree))
-               outcomes  (mapv #(rf/with-frame fid (ssr/streaming-render-continuation fid %))
+               {:keys [continuations]} (rf/with-frame fid (rf.ssr/streaming-render-shell tree))
+               outcomes  (mapv #(rf/with-frame fid (rf.ssr/streaming-render-continuation fid %))
                                continuations)
                failed    (into #{} (comp (filter :failed?) (map :id)) outcomes)]
            (is (= #{:card.flaky} failed) "the drain reports the failure")
            (testing "the set lands in the payload's runtime-db slice"
              (let [payload (rf/with-frame fid
-                             (ssr/streaming-build-final-payload
+                             (rf.ssr/streaming-build-final-payload
                                fid "deadbeef"
                                {:version 1
                                 :payload :rf.ssr.payload/whole-app-db
                                 :failed-boundaries failed}))]
                (is (= #{:card.flaky}
-                      (get-in (:rf/runtime-db payload) suspense/failed-boundaries-path)))))
+                      (get-in (:rf/runtime-db payload) rf.ssr.suspense/failed-boundaries-path)))))
            (testing "nothing failed contributes NO key — an ordinary page
                      carries nothing extra on the wire"
              (let [payload (rf/with-frame fid
-                             (ssr/streaming-build-final-payload
+                             (rf.ssr/streaming-build-final-payload
                                fid "deadbeef"
                                {:version 1
                                 :payload :rf.ssr.payload/whole-app-db
                                 :failed-boundaries #{}}))]
-               (is (nil? (get-in (:rf/runtime-db payload) suspense/failed-boundaries-path))))))))))
+               (is (nil? (get-in (:rf/runtime-db payload) rf.ssr.suspense/failed-boundaries-path))))))))))
 
 #?(:clj
    (deftest one-tree-hashes-identically-for-both-hosts
@@ -171,8 +171,8 @@
          (let [tree [:section.cards
                      [boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
                       [card-view :revenue]]]
-               h1   (rf/with-frame fid (ssr/render-tree-hash tree))
-               h2   (rf/with-frame fid (ssr/render-tree-hash tree))]
+               h1   (rf/with-frame fid (rf.ssr/render-tree-hash tree))
+               h2   (rf/with-frame fid (rf.ssr/render-tree-hash tree))]
            (is (string? h1))
            (is (= h1 h2) "hashing is deterministic over the component head")
            (testing "a DIFFERENT boundary id changes the hash (the hash is
@@ -180,7 +180,7 @@
              (let [other [:section.cards
                           [boundary {:id :card.other :fallback [card-skeleton :revenue]}
                            [card-view :revenue]]]]
-               (is (not= h1 (rf/with-frame fid (ssr/render-tree-hash other)))))))))))
+               (is (not= h1 (rf/with-frame fid (rf.ssr/render-tree-hash other)))))))))))
 
 ;; ---- client host -----------------------------------------------------------
 
@@ -198,7 +198,7 @@
    (deftest client-renders-the-declared-fallback-for-a-failed-boundary
      (testing "SS2: a boundary in the failed set renders its DECLARED
                fallback — the markup the failed chunk left in the DOM"
-       (suspense/record-failed-boundaries! #{:card.flaky})
+       (rf.ssr.suspense/record-failed-boundaries! #{:card.flaky})
        (is (= [:p "loading"]
               (boundary {:id :card.flaky :fallback [:p "loading"]} [:div "body"]))
            "the failed boundary renders its fallback")
@@ -212,7 +212,7 @@
                fn cannot read the enclosing provider's frame from React
                context — so the render-time record is deliberately
                frame-free and works with no scope established at all"
-       (suspense/record-failed-boundaries! #{:card.flaky})
+       (rf.ssr.suspense/record-failed-boundaries! #{:card.flaky})
        (is (= [:p "loading"]
               (boundary {:id :card.flaky :fallback [:p "loading"]} [:div "body"])))
        (is (= [:div "body"]
@@ -228,10 +228,10 @@
          (rf/dispatch-sync
            [:rf/hydrate {:rf/version 1
                          :rf/app-db  {}
-                         :rf/runtime-db (assoc-in {} suspense/failed-boundaries-path
+                         :rf/runtime-db (assoc-in {} rf.ssr.suspense/failed-boundaries-path
                                                   #{:card.flaky})}]
            {:frame fid})
-         (is (= #{:card.flaky} (suspense/frame-failed-boundaries fid)))))))
+         (is (= #{:card.flaky} (rf.ssr.suspense/frame-failed-boundaries fid)))))))
 
 #?(:cljs
    (deftest client-wraps-multiple-children-in-a-fragment

--- a/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
@@ -54,14 +54,14 @@
             ["react-dom/client" :as react-dom-client]
             [reagent2.core :as r2]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.suspense :as suspense :refer [boundary]]
-            [re-frame.ssr.constants :as constants]
-            [re-frame.ssr.install :as install]
-            [re-frame.ssr.streaming.constants :as wire]
-            [re-frame.ssr.streaming.client :as streaming-client]
-            [re-frame.test-support :as test-support]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.suspense :as rf.ssr.suspense :refer [boundary]]
+            [re-frame.ssr.constants :as rf.ssr.constants]
+            [re-frame.ssr.install :as rf.ssr.install]
+            [re-frame.ssr.streaming.constants :as rf.ssr.streaming.constants]
+            [re-frame.ssr.streaming.client :as rf.ssr.streaming.client]
+            [re-frame.test-support :as rf.test-support]
             ;; Publishes the React-context tier `frame-provider` resolves
             ;; through. Without it the provider renders nothing and every
             ;; assertion below would read an empty container.
@@ -78,10 +78,10 @@
 ;; on the page. A test that streams a failure MUST clear it.
 (use-fixtures :each
   {:before (fn []
-             (install/reset-installed-payloads!)
-             (suspense/reset-failed-boundaries!))}
-  (test-support/make-reset-runtime-fixture
-    {:adapter reagent-slim-adapter/adapter :async? true :ambient-frame nil}))
+             (rf.ssr.install/reset-installed-payloads!)
+             (rf.ssr.suspense/reset-failed-boundaries!))}
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent-slim/adapter :async? true :ambient-frame nil}))
 
 (defn- browser? []
   (and (exists? js/document)
@@ -182,15 +182,15 @@
     (rf/make-frame {:id fid :platform :server})
     (rf/dispatch-sync [:test/seed] {:frame fid})
     (let [{:keys [shell-html continuations]}
-          (rf/with-frame fid (ssr/streaming-render-shell [server-dashboard]))
-          outcomes (mapv #(rf/with-frame fid (ssr/streaming-render-continuation fid %))
+          (rf/with-frame fid (rf.ssr/streaming-render-shell [server-dashboard]))
+          outcomes (mapv #(rf/with-frame fid (rf.ssr/streaming-render-continuation fid %))
                          continuations)
           chunks   (mapv (fn [{:keys [id html delta failed?]}]
                            (str (if failed?
-                                  (ssr/streaming-failed-template id html)
-                                  (ssr/streaming-resolved-template id html))
+                                  (rf.ssr/streaming-failed-template id html)
+                                  (rf.ssr/streaming-resolved-template id html))
                                 (when (and (not failed?) (some? delta))
-                                  (ssr/streaming-hydrate-delta-script id (pr-str delta)))))
+                                  (rf.ssr/streaming-hydrate-delta-script id (pr-str delta)))))
                          outcomes)
           failed   (into #{} (comp (filter :failed?) (map :id)) outcomes)]
       (rf/destroy-frame! fid)
@@ -205,8 +205,8 @@
   (let [fid :test/expected]
     (rf/make-frame {:id fid :platform :server})
     (rf/dispatch-sync [:test/seed] {:frame fid})
-    (suspense/record-failed-boundaries! #{:card.flaky})
-    (let [html (rf/with-frame fid (ssr/render-to-string [dashboard] nil))]
+    (rf.ssr.suspense/record-failed-boundaries! #{:card.flaky})
+    (let [html (rf/with-frame fid (rf.ssr/render-to-string [dashboard] nil))]
       (rf/destroy-frame! fid)
       html)))
 
@@ -216,13 +216,13 @@
   the JVM half of that assembly is pinned in
   `streaming_component_cljs_test`."
   [failed]
-  (str "<script id=\"" constants/payload-script-id "\" type=\"application/edn\">"
+  (str "<script id=\"" rf.ssr.constants/payload-script-id "\" type=\"application/edn\">"
        (pr-str (cond-> {:rf/version   1
                         :rf/app-db    {:cards {:revenue {:title "Revenue" :value 42375}}}
                         :rf/render-hash "00000000"}
                  (seq failed)
                  (assoc :rf/runtime-db
-                        (assoc-in {} suspense/failed-boundaries-path (set failed)))))
+                        (assoc-in {} rf.ssr.suspense/failed-boundaries-path (set failed)))))
        "</script>"))
 
 ;; ---- DOM scaffolding -------------------------------------------------------
@@ -248,7 +248,7 @@
     (.removeChild p host)))
 
 (defn- mounts [host]
-  (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-mount "]"))))
+  (array-seq (.querySelectorAll host (str "[" rf.ssr.streaming.constants/attr-suspense-mount "]"))))
 
 (defn- normalise-html
   "Collapse insignificant whitespace so a structural comparison is not
@@ -358,7 +358,7 @@
             "the shell walk registered both boundaries in document order")
         (is (= #{:card.flaky} failed)
             "the drain reported the throwing boundary as failed")
-        (streaming-client/install!
+        (rf.ssr.streaming.client/install!
           {:frame frame-id :root host :on-ready #(reset! ready %)})
         ;; Fallbacks are now LIVE mounts — the page paints its skeletons.
         (is (= 2 (count (mounts host)))
@@ -397,7 +397,7 @@
                       ;; The public boot path: read `__rf_payload`, validate
                       ;; it, dispatch `:rf/hydrate` into the explicit frame.
                       ;; State only — it never touches the DOM.
-                      (is (some? (ssr/hydrate! {:frame frame-id}))
+                      (is (some? (rf.ssr/hydrate! {:frame frame-id}))
                           "the final payload is readable and hydrates the frame")
                       (let [tree [rf/frame-provider {:frame frame-id} [dashboard]]
                             {:keys [complaints html]} (hydrate-capturing! (app-el host) tree)]
@@ -438,15 +438,15 @@
         (rf/dispatch-sync
           [:rf/hydrate {:rf/version 1
                         :rf/app-db  {:cards {:revenue {:title "Revenue" :value 42375}}}
-                        :rf/runtime-db (assoc-in {} suspense/failed-boundaries-path
+                        :rf/runtime-db (assoc-in {} rf.ssr.suspense/failed-boundaries-path
                                                  #{:card.flaky})}]
           {:frame frame-id})
-        (is (= #{:card.flaky} (suspense/frame-failed-boundaries frame-id))
+        (is (= #{:card.flaky} (rf.ssr.suspense/frame-failed-boundaries frame-id))
             "the DURABLE set survives the hydration round-trip into runtime-db")
         ;; The RENDER-TIME record — what the component consults. On a real
         ;; page the streaming client writes this at finalization; here we
         ;; stand in for it directly.
-        (suspense/record-failed-boundaries! #{:card.flaky})
+        (rf.ssr.suspense/record-failed-boundaries! #{:card.flaky})
         ;; Hydrate the SAME tree against the markup the finalised stream
         ;; leaves behind — which is, by construction, what the equivalent
         ;; non-streamed render of the same tree produces.
@@ -478,7 +478,7 @@
                          (register-app! frame-id))
             {:keys [shell chunks failed]} (server-render!)
             host     (make-host! shell)]
-        (streaming-client/install! {:frame frame-id :root host})
+        (rf.ssr.streaming.client/install! {:frame frame-id :root host})
         (doseq [c chunks] (append-chunk! host c))
         (async done
           (js/setTimeout
@@ -513,7 +513,7 @@
         ;; Everything arrived before the bundle booted.
         (doseq [c chunks] (append-chunk! host c))
         (append-chunk! host (payload-chunk failed))
-        (streaming-client/install!
+        (rf.ssr.streaming.client/install!
           {:frame frame-id :root host :on-ready (fn [_] (swap! calls inc))})
         (is (= 1 @calls) ":on-ready fires synchronously during install!")
         (is (zero? (count (mounts host)))
@@ -538,7 +538,7 @@
             {:keys [shell chunks]} (server-render!)
             host     (make-host! shell)
             ready    (atom false)]
-        (streaming-client/install!
+        (rf.ssr.streaming.client/install!
           {:frame frame-id :root host :on-ready (fn [_] (reset! ready true))})
         (append-chunk! host (first chunks))
         (async done
@@ -547,7 +547,7 @@
               (is (false? @ready) "no readiness before the final payload")
               (is (pos? (count (mounts host)))
                   "mounts are still present pre-readiness — this is precisely why hydration must wait")
-              (is (some? (.querySelector host (str "[" wire/attr-suspense-mount "] > div.card")))
+              (is (some? (.querySelector host (str "[" rf.ssr.streaming.constants/attr-suspense-mount "] > div.card")))
                   "the resolved card is nested inside its mount pre-readiness — the o4rbh mismatch shape")
               (remove-host! host)
               (done))

--- a/implementation/ssr/test/re_frame/ssr/test_fixture.clj
+++ b/implementation/ssr/test/re_frame/ssr/test_fixture.clj
@@ -52,15 +52,15 @@
     divergence is an immediate signal that either the tests are
     cheating or the teardown is incomplete."
   (:require [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.error-listener :as error-listener]
-            [re-frame.ssr.install :as install]
-            [re-frame.ssr.request :as request]
-            [re-frame.ssr.response :as response]))
+            [re-frame.flows :as rf.flows]
+            [re-frame.frame :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.error-listener :as rf.ssr.error-listener]
+            [re-frame.ssr.install :as rf.ssr.install]
+            [re-frame.ssr.request :as rf.ssr.request]
+            [re-frame.ssr.response :as rf.ssr.response]))
 
 (defn reset-runtime
   "The canonical `:each` fixture for ssr-artefact JVM tests. Wipes the
@@ -69,27 +69,27 @@
 
   Call shape — `(use-fixtures :each reset-runtime)`."
   [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf.flows/reset-flows!)
+  (rf.schemas/clear-schemas-by-frame!)
   ;; SSR side-channel atoms — direct refs into the producing sub-ns
   ;; rather than the (private) façade aliases. Same atoms either way;
   ;; this avoids the `(resolve ...)` reflective dance the legacy
   ;; per-file fixtures used to reach the ^:private façade vars.
-  (reset! request/request-slots {})
-  (reset! response/response-slots {})
-  (reset! error-listener/pending-error-traces {})
+  (reset! rf.ssr.request/request-slots {})
+  (reset! rf.ssr.response/response-slots {})
+  (reset! rf.ssr.error-listener/pending-error-traces {})
   ;; S5 — the hydration-payload install ledger. Keyed by payload id (a
   ;; frame id), so a claim left by a prior test would make the next test's
   ;; first hydrate look like a sibling root's second one.
-  (install/reset-installed-payloads!)
+  (rf.ssr.install/reset-installed-payloads!)
   ;; Per rf2-4gvb4 — the flows artefact's per-frame `last-inputs` memo
   ;; table is reset through the public `flows/reset-last-inputs!` seam
   ;; (the atom itself is now private to the flows artefact). Spec 013
   ;; §Flow re-evaluation trigger.
-  (flows/reset-last-inputs!)
-  (rf/init! ssr/adapter)
+  (rf.flows/reset-last-inputs!)
+  (rf/init! rf.ssr/adapter)
   ;; Namespace-load-time registrations get wiped by clear-all!; reload
   ;; so :rf/hydrate, :rf.route/navigate, :rf.server/* fxs, the
   ;; :rf.server/request cofx, the head late-bind hooks, AND the

--- a/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
@@ -25,8 +25,8 @@
   the head emitter, and the streaming emitter)."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.ssr.html-helpers :as html]
-            [re-frame.ssr.emit :as emit]))
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]
+            [re-frame.ssr.emit :as rf.ssr.emit]))
 
 (deftest attr-string-strips-event-handler-props
   (testing "rf2-dwds9 — structural `on*` handler spellings the re-frame
@@ -34,28 +34,28 @@
             emit time: camelCase `on[A-Z]…` and kebab `on-…`."
     (testing ":on-click (kebab) is stripped"
       (is (= " id=\"x\""
-             (html/attr-string {:on-click "alert(1)" :id "x"}))))
+             (rf.ssr.html-helpers/attr-string {:on-click "alert(1)" :id "x"}))))
 
     (testing ":onClick (camelCase) is stripped"
       (is (= " id=\"x\""
-             (html/attr-string {:onClick "alert(1)" :id "x"}))))
+             (rf.ssr.html-helpers/attr-string {:onClick "alert(1)" :id "x"}))))
 
     (testing ":onMouseDown (camelCase, multi-word) is stripped"
       (is (= " id=\"x\""
-             (html/attr-string {:onMouseDown "alert(1)" :id "x"}))))
+             (rf.ssr.html-helpers/attr-string {:onMouseDown "alert(1)" :id "x"}))))
 
     (testing ":onCustomEvent (camelCase, framework-shaped non-HTML name)
               is stripped by the structural matcher"
       (is (= " id=\"x\""
-             (html/attr-string {:onCustomEvent "alert(1)" :id "x"}))))
+             (rf.ssr.html-helpers/attr-string {:onCustomEvent "alert(1)" :id "x"}))))
 
     (testing "`true`-valued on* boolean prop is also stripped (no bare attr)"
       (is (= " id=\"x\""
-             (html/attr-string {:on-load true :id "x"}))))
+             (rf.ssr.html-helpers/attr-string {:on-load true :id "x"}))))
 
     (testing "a map whose every entry is a stripped on* prop yields the
               empty string — no stray leading space"
-      (is (= "" (html/attr-string {:on-click "f" :onScroll "g"})))))
+      (is (= "" (rf.ssr.html-helpers/attr-string {:on-click "f" :onScroll "g"})))))
 
   (testing "rf2-1uex4 — canonical all-lowercase HTML event-handler names
             are stripped. HTML attribute names are case-insensitive, so the
@@ -66,7 +66,7 @@
     (doseq [k [:onclick :onload :onerror :onmouseover :onsubmit :onfocus]]
       (testing (str k " (lowercase canonical) is stripped")
         (is (= " id=\"x\""
-               (html/attr-string {k "steal()" :id "x"}))
+               (rf.ssr.html-helpers/attr-string {k "steal()" :id "x"}))
             (str (name k) " must not survive to wire output")))))
 
   (testing "rf2-1uex4 — arbitrary casings of a real handler name are
@@ -74,14 +74,14 @@
     (doseq [k [:ONLOAD :OnClick :OnLoad :ONCLICK :onCLICK]]
       (testing (str k " (mixed/upper casing) is stripped")
         (is (= " id=\"x\""
-               (html/attr-string {k "steal()" :id "x"}))
+               (rf.ssr.html-helpers/attr-string {k "steal()" :id "x"}))
             (str (name k) " must not survive to wire output")))))
 
   (testing "rf2-1uex4 — the allowlist does NOT over-reach onto innocuous
             keys that merely begin with the letters `on`. `online` / `once`
             / `only` / `on` / `data-on` are legitimate attributes and MUST
             round-trip (a blind `starts-with? \"on\"` would eat them)."
-    (let [out (html/attr-string {:data-on "ok" :one "1" :once "2"
+    (let [out (rf.ssr.html-helpers/attr-string {:data-on "ok" :one "1" :once "2"
                                  :online "3" :only "4" :on "5"})]
       (is (str/includes? out "data-on=\"ok\""))
       (is (str/includes? out "one=\"1\""))
@@ -94,11 +94,11 @@
   (testing "rf2-dwds9 — function-valued props have no HTML serialisation
             and are dropped (a fn can only be a handler/callback)"
     (is (= " id=\"x\""
-           (html/attr-string {:title (fn [_] :handler) :id "x"})))
+           (rf.ssr.html-helpers/attr-string {:title (fn [_] :handler) :id "x"})))
 
     (testing "fn value is stripped even when the key itself is innocuous"
       (is (= ""
-             (html/attr-string {:data-cb (fn [] nil)}))))))
+             (rf.ssr.html-helpers/attr-string {:data-cb (fn [] nil)}))))))
 
 (deftest attr-string-drops-prototype-pollution-keys
   (testing "rf2-dwds9 — reserved prototype-pollution keys are dropped
@@ -106,16 +106,16 @@
     (doseq [k ["__proto__" "constructor" "prototype"]]
       (testing (str "`" k "` is dropped")
         (is (= " id=\"x\""
-               (html/attr-string {(keyword k) "polluted" :id "x"}))
+               (rf.ssr.html-helpers/attr-string {(keyword k) "polluted" :id "x"}))
             (str k " must not survive to wire output"))))
 
     (testing "the match is case-insensitive on the normalised name"
       (is (= " id=\"x\""
-             (html/attr-string {(keyword "Constructor") "polluted" :id "x"}))))))
+             (rf.ssr.html-helpers/attr-string {(keyword "Constructor") "polluted" :id "x"}))))))
 
 (deftest attr-string-normal-attrs-still-emit
   (testing "the filter does not over-reach — ordinary attrs round-trip"
-    (let [out (html/attr-string {:id "main" :class "a b" :data-x "1"})]
+    (let [out (rf.ssr.html-helpers/attr-string {:id "main" :class "a b" :data-x "1"})]
       (is (str/includes? out "id=\"main\""))
       (is (str/includes? out "class=\"a b\""))
       (is (str/includes? out "data-x=\"1\""))))
@@ -124,7 +124,7 @@
             that would otherwise throw `:rf.error/ssr-invalid-attribute-name`
             is silently dropped rather than raising"
     (is (= " id=\"x\""
-           (html/attr-string {(keyword "onClick=alert(1) data-x") "v"
+           (rf.ssr.html-helpers/attr-string {(keyword "onClick=alert(1) data-x") "v"
                               :id "x"})))))
 
 (deftest attr-string-serialises-style-map
@@ -135,64 +135,64 @@
             logged a hydration attribute mismatch on every SSR app's first load."
     (testing "the reported repro: a single string-valued declaration"
       (is (= " style=\"margin:0 1em\""
-             (html/attr-string {:style {:margin "0 1em"}})))
-      (is (not (str/includes? (html/attr-string {:style {:margin "0 1em"}})
+             (rf.ssr.html-helpers/attr-string {:style {:margin "0 1em"}})))
+      (is (not (str/includes? (rf.ssr.html-helpers/attr-string {:style {:margin "0 1em"}})
                               "{:margin"))
           "the raw EDN map text must never reach the wire"))
 
     (testing "camelCase property names → kebab CSS names (React's rule)"
       (is (= " style=\"margin-top:4px\""
-             (html/attr-string {:style {:marginTop "4px"}}))))
+             (rf.ssr.html-helpers/attr-string {:style {:marginTop "4px"}}))))
 
     (testing "an already-kebab property name is unchanged"
       (is (= " style=\"background-color:red\""
-             (html/attr-string {:style {:background-color "red"}}))))
+             (rf.ssr.html-helpers/attr-string {:style {:background-color "red"}}))))
 
     (testing "a keyword value renders bare (its name)"
       (is (= " style=\"display:flex\""
-             (html/attr-string {:style {:display :flex}}))))
+             (rf.ssr.html-helpers/attr-string {:style {:display :flex}}))))
 
     (testing "a numeric value on a non-unitless property gets a px suffix"
       (is (= " style=\"width:10px\""
-             (html/attr-string {:style {:width 10}}))))
+             (rf.ssr.html-helpers/attr-string {:style {:width 10}}))))
 
     (testing "a numeric value of 0 is bare (no px)"
       (is (= " style=\"margin:0\""
-             (html/attr-string {:style {:margin 0}}))))
+             (rf.ssr.html-helpers/attr-string {:style {:margin 0}}))))
 
     (testing "a numeric value on a unitless property is bare (no px)"
       (is (= " style=\"flex-grow:1\""
-             (html/attr-string {:style {:flex-grow 1}})))
+             (rf.ssr.html-helpers/attr-string {:style {:flex-grow 1}})))
       (is (= " style=\"z-index:100\""
-             (html/attr-string {:style {:z-index 100}}))))
+             (rf.ssr.html-helpers/attr-string {:style {:z-index 100}}))))
 
     (testing "nil / boolean / empty-string entries are omitted entirely"
       (is (= " style=\"color:red\""
-             (html/attr-string {:style {:color "red" :top nil
+             (rf.ssr.html-helpers/attr-string {:style {:color "red" :top nil
                                         :bottom false :left ""}}))))
 
     (testing "CSS custom properties (--foo) pass through verbatim, no px"
       (is (= " style=\"--gap:8\""
-             (html/attr-string {:style {:--gap 8}}))))
+             (rf.ssr.html-helpers/attr-string {:style {:--gap 8}}))))
 
     (testing "the CSS string is attribute-escaped (double-quote in a value)"
       (is (= " style=\"font-family:&quot;My Font&quot;, sans-serif\""
-             (html/attr-string {:style {:font-family "\"My Font\", sans-serif"}}))))
+             (rf.ssr.html-helpers/attr-string {:style {:font-family "\"My Font\", sans-serif"}}))))
 
     (testing "a STRING :style value is already CSS and rides through untouched"
       (is (= " style=\"margin:0 1em\""
-             (html/attr-string {:style "margin:0 1em"}))))
+             (rf.ssr.html-helpers/attr-string {:style "margin:0 1em"}))))
 
     (testing "multiple declarations join with `;` in map order"
       (is (= " style=\"margin:0;padding:4px\""
-             (html/attr-string {:style (array-map :margin 0 :padding "4px")}))))))
+             (rf.ssr.html-helpers/attr-string {:style (array-map :margin 0 :padding "4px")}))))))
 
 (deftest render-to-string-serialises-style-map-through-full-emit
   (testing "rf2-l6h6a — the style-map → CSS serialisation survives the FULL
             `render-to-string` emit composition (not just `attr-string` in
             isolation), so the wire markup for a `:style` map is CSS and the
             server/client render agree (no hydration attribute mismatch)."
-    (let [html-out (emit/render-to-string
+    (let [html-out (rf.ssr.emit/render-to-string
                      [:div {:style {:margin "0 1em" :color :red}} "hi"] {})]
       (is (= "<div style=\"margin:0 1em;color:red\">hi</div>" html-out))
       (is (not (str/includes? html-out "{:margin"))
@@ -204,7 +204,7 @@
             emitter. The verified repro was `[:img {:src \"x\" :onerror
             \"alert(document.cookie)\"}]` rendering the live handler on a
             void element; the wire output MUST carry no `onerror`."
-    (let [out (emit/render-to-string
+    (let [out (rf.ssr.emit/render-to-string
                [:img {:src "x" :onerror "alert(document.cookie)"}] {})]
       (is (str/includes? out "src=\"x\"") "the legitimate attr survives")
       (is (not (str/includes? (str/lower-case out) "onerror"))
@@ -213,7 +213,7 @@
           "no live handler payload on the wire"))
 
     (testing "uppercase casing through the emitter is also stripped"
-      (let [out (emit/render-to-string
+      (let [out (rf.ssr.emit/render-to-string
                  [:img {:src "x" :ONLOAD "steal()"}] {})]
         (is (not (str/includes? (str/lower-case out) "onload")))
         (is (not (str/includes? out "steal()")))))))

--- a/implementation/ssr/test/re_frame/ssr_boundary_rejection_400_production_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_boundary_rejection_400_production_test.clj
@@ -62,10 +62,10 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.error-listener :as error-listener]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.error-listener :as rf.ssr.error-listener]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
 ;; NOTE the fixture does NOT clear the always-on error-listener registry.
 ;; `re-frame.ssr` installs its own `::error-projection` listener there at
@@ -73,7 +73,7 @@
 ;; this suite exercises; wiping the registry would silently disarm every 400
 ;; assertion below into a vacuous 200. Each test unregisters only the shipper
 ;; stand-in it registered.
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -113,7 +113,7 @@
   unless a test names its own)."
   ([] (server-frame :rf.ssr/default-error-projector))
   ([projector-id]
-   (frame/make-anon-frame-record!
+   (rf.frame/make-anon-frame-record!
      {:platform :server
       :ssr      {:public-error-id   projector-id
                  :dev-error-detail? false}})))
@@ -156,7 +156,7 @@
             `-Dre-frame.debug=false` — a malformed request body answered with
             a success code."
     (let [{:keys [frame]} (ingest! bad-payload)
-          {:keys [response public-error]} (ssr/flush-response-result! frame)]
+          {:keys [response public-error]} (rf.ssr/flush-response-result! frame)]
       (is (= 400 (:status response))
           "the drain projects the boundary rejection onto :status — 400, not
            a silent 200 over a handler that never ran")
@@ -177,7 +177,7 @@
             conforming payload ships no record, keeps the 200, and — the part
             that proves the pipeline really ran — lands the handler's write."
     (let [{:keys [frame records]} (ingest! good-payload)
-          {:keys [response public-error]} (ssr/flush-response-result! frame)]
+          {:keys [response public-error]} (rf.ssr/flush-response-result! frame)]
       (is (empty? (boundary-records records))
           "no boundary record on the happy path")
       (is (= 200 (:status response))
@@ -236,17 +236,17 @@
             through too — the arm is opt-in on the discriminator (fail-safe),
             symmetric with the `:kind`-gated 404."
     (is (= {:status 400 :code :bad-request :message "Invalid input" :retryable? false}
-           (ssr/default-error-projector-fn
+           (rf.ssr/default-error-projector-fn
              {:operation :rf.error/schema-validation-failure
               :tags      {:where :event :source :boundary}}))
         ":where :event → 400")
-    (is (= ssr/fallback-public-error
-           (ssr/default-error-projector-fn
+    (is (= rf.ssr/fallback-public-error
+           (rf.ssr/default-error-projector-fn
              {:operation :rf.error/schema-validation-failure
               :tags      {:where :fx-args}}))
         ":where :fx-args (a server-side surface) → the locked 500")
-    (is (= ssr/fallback-public-error
-           (ssr/default-error-projector-fn
+    (is (= rf.ssr/fallback-public-error
+           (rf.ssr/default-error-projector-fn
              {:operation :rf.error/schema-validation-failure :tags {}}))
         "no :where → 500; the 400 arm never fires on an unclassified failure")))
 
@@ -313,9 +313,9 @@
           accepted (server-frame)]
       (rf/dispatch-sync [:api/ingest bad-payload]  {:frame refused})
       (rf/dispatch-sync [:api/ingest good-payload] {:frame accepted})
-      (is (= 400 (:status (ssr/flush-response! refused)))
+      (is (= 400 (:status (rf.ssr/flush-response! refused)))
           "the frame that refused carries the 400")
-      (is (= 200 (:status (ssr/flush-response! accepted)))
+      (is (= 200 (:status (rf.ssr/flush-response! accepted)))
           "its concurrent sibling, which conformed, is untouched"))))
 
 (deftest a-client-frame-rejection-stamps-no-status
@@ -325,12 +325,12 @@
             is no request to fail."
     (register-ingest!)
     (let [seen     (capture-always-on! ::client)
-          client-f (frame/make-anon-frame-record! {:platform :client})]
+          client-f (rf.frame/make-anon-frame-record! {:platform :client})]
       (rf/dispatch-sync [:api/ingest bad-payload] {:frame client-f})
       (rf/unregister-listener! :errors ::client)
       (is (= [:rf.error/schema-validation-failure] (mapv :error @seen))
           "the always-on record still fans")
-      (is (= 200 (:status (ssr/get-response client-f)))
+      (is (= 200 (:status (rf.ssr/get-response client-f)))
           "but no status is stamped: a client frame has no HTTP response"))))
 
 ;; ===========================================================================
@@ -354,8 +354,8 @@
     (register-ingest!)
     (let [f (server-frame)]
       (rf/dispatch-sync [:api/ingest bad-payload] {:frame f})
-      (let [buffered (get @error-listener/pending-error-traces
-                          (frame/frame-address f))]
+      (let [buffered (get @rf.ssr.error-listener/pending-error-traces
+                          (rf.frame/frame-address f))]
         (is (seq buffered)
             "the rejection buffered for projection — non-vacuity for the
              agreement assertion below, and the load-bearing half under the
@@ -364,7 +364,7 @@
                (set (map :operation buffered)))
             "every buffered entry is the boundary category")
         (is (= #{400}
-               (set (map #(:status (ssr/default-error-projector-fn %)) buffered)))
+               (set (map #(:status (rf.ssr/default-error-projector-fn %)) buffered)))
             "and every one of them projects 400, so last-write-wins cannot
              pick a different status in one posture than the other")))))
 
@@ -376,14 +376,14 @@
     (register-ingest!)
     (let [f (server-frame)]
       (rf/dispatch-sync [:api/ingest bad-payload] {:frame f})
-      (let [first-flush (ssr/flush-response-result! f)]
+      (let [first-flush (rf.ssr/flush-response-result! f)]
         (is (= 400 (:status (:response first-flush))))
         (is (some? (:public-error first-flush))
             "the first drain is the one that projected")
-        (is (empty? (get @error-listener/pending-error-traces
-                         (frame/frame-address f)))
+        (is (empty? (get @rf.ssr.error-listener/pending-error-traces
+                         (rf.frame/frame-address f)))
             "and it consumed the entire buffer in a single pass"))
-      (let [second-flush (ssr/flush-response-result! f)]
+      (let [second-flush (rf.ssr/flush-response-result! f)]
         (is (nil? (:public-error second-flush))
             "the second drain finds nothing to project")
         (is (= 400 (:status (:response second-flush)))

--- a/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
@@ -40,17 +40,17 @@
       this surface a production server ever experiences."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.fx :as fx]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fx :as rf.fx]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; Shared reset fixture lives in `re-frame.ssr.test-fixture` (rf2-i3qc0).
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -75,7 +75,7 @@
             production per Spec 001 §Production elision contract) and it is
             what decides whether the fx runs at all."
     (doseq [id [:rf.ssr/check-version :rf.ssr/check-schema-digest]]
-      (let [meta (registrar/lookup :fx id)]
+      (let [meta (rf.registrar/lookup :fx id)]
         (is (some? meta) (str id " resolves in the :fx registry"))
         (is (fn? (:handler-fn meta)) (str id " carries a :handler-fn"))
         (is (= #{:client} (:platforms meta))
@@ -91,7 +91,7 @@
     (let [ran (atom [])]
       ;; A marker fx queued AFTER both checks. If a mismatching check threw,
       ;; or aborted the drain, this never runs.
-      (fx/reg-fx ::after-checks
+      (rf.fx/reg-fx ::after-checks
                  {:platforms #{:client}}
                  (fn [_ v] (swap! ran conj v)))
       (rf/reg-event ::probe-best-effort
@@ -103,10 +103,10 @@
                                               :actual   "sha256:bbbb"}]
                 [::after-checks :marker]]}))
 
-      (let [f (frame/make-anon-frame-record! {:platform :client})]
+      (let [f (rf.frame/make-anon-frame-record! {:platform :client})]
         (is (nil? (rf/dispatch-sync [::probe-best-effort] {:frame f}))
             "a double mismatch does not throw out of dispatch-sync")
-        (is (true? (:probe/handler-ran (frame/frame-app-db-value f)))
+        (is (true? (:probe/handler-ran (rf.frame/frame-app-db-value f)))
             "the handler's :db write committed alongside the failing checks")
         (is (= [:marker] @ran)
             "the effect queued AFTER both mismatching checks still ran —
@@ -131,13 +131,13 @@
         ;; check-version probes compare integers, not semver strings.
         {:fx [[:rf.ssr/check-version {:expected 1 :actual 1}]]}))
 
-    (let [f (frame/make-anon-frame-record! {:platform :client})]
+    (let [f (rf.frame/make-anon-frame-record! {:platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [::probe-check-version-match] {:frame f})
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). BOTH of
         ;; these are negatives over the trace ring, and both pass vacuously
         ;; under the gate, where the ring is empty whatever the fx did.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (empty? (traces-of @traces :rf.ssr/version-mismatch))
               "matching version → no mismatch trace")
           (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
@@ -150,14 +150,14 @@
       (fn [_ _]
         {:fx [[:rf.ssr/check-version {:expected 1 :actual 2}]]}))
 
-    (let [f (frame/make-anon-frame-record! {:platform :client})]
+    (let [f (rf.frame/make-anon-frame-record! {:platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [::probe-check-version-mismatch] {:frame f})
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The trace
         ;; is this fx's ONLY output; its production behaviour — do not throw,
         ;; do not halt the drain — is pinned by
         ;; `compatibility-checks-are-best-effort-and-never-halt-the-drain`.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (let [hits (traces-of @traces :rf.ssr/version-mismatch)]
             (is (= 1 (count hits))
                 (str "expected one :rf.ssr/version-mismatch trace; saw: "
@@ -191,12 +191,12 @@
                {:expected "sha256:deadbeefcafef00d"
                 :actual   "sha256:deadbeefcafef00d"}]]}))
 
-    (let [f (frame/make-anon-frame-record! {:platform :client})]
+    (let [f (rf.frame/make-anon-frame-record! {:platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [::probe-check-digest-match] {:frame f})
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
         ;; under the gate — both are negatives over an empty ring.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (empty? (traces-of @traces :rf.ssr/schema-digest-mismatch))
               "matching digest → no mismatch trace")
           (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
@@ -211,11 +211,11 @@
                {:expected "sha256:deadbeefcafef00d"
                 :actual   "sha256:0000000000000000"}]]}))
 
-    (let [f (frame/make-anon-frame-record! {:platform :client})]
+    (let [f (rf.frame/make-anon-frame-record! {:platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [::probe-check-digest-mismatch] {:frame f})
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (let [hits (traces-of @traces :rf.ssr/schema-digest-mismatch)]
             (is (= 1 (count hits))
                 (str "expected one :rf.ssr/schema-digest-mismatch trace; saw: "
@@ -254,14 +254,14 @@
     (rf/reg-event ::probe-check-version-scalar-matches
       {:platforms #{:client}}
       (fn [_ _]
-        {:fx [[:rf.ssr/check-version payload-policy/pattern-protocol-version]]}))
+        {:fx [[:rf.ssr/check-version rf.ssr.payload-policy/pattern-protocol-version]]}))
 
-    (let [f (frame/make-anon-frame-record! {:platform :client})]
+    (let [f (rf.frame/make-anon-frame-record! {:platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [::probe-check-version-scalar-matches] {:frame f})
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
         ;; under the gate — both are negatives over an empty ring.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
               "version scalar resolves via the SSR constant → never skipped")
           (is (empty? (traces-of @traces :rf.ssr/version-mismatch))
@@ -273,17 +273,17 @@
     ;; SSR artefact's compiled-in constant. A scalar (server value) that
     ;; differs from it is genuine skew and emits :rf.ssr/version-mismatch,
     ;; proving the SSR constant is the "actual" the comparison runs against.
-    (let [server-version (inc payload-policy/pattern-protocol-version)]
+    (let [server-version (inc rf.ssr.payload-policy/pattern-protocol-version)]
       (rf/reg-event ::probe-check-version-scalar-differs
         {:platforms #{:client}}
         (fn [_ _]
           {:fx [[:rf.ssr/check-version server-version]]}))
 
-      (let [f (frame/make-anon-frame-record! {:platform :client})]
+      (let [f (rf.frame/make-anon-frame-record! {:platform :client})]
         (with-trace-recorder! [traces]
           (rf/dispatch-sync [::probe-check-version-scalar-differs] {:frame f})
           ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (let [hits (traces-of @traces :rf.ssr/version-mismatch)]
               (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
                   "version scalar resolves via the SSR constant → never skipped")
@@ -294,7 +294,7 @@
                 (let [ev (first hits)]
                   (is (= server-version (-> ev :tags :expected))
                       "scalar arg is :expected (server side)")
-                  (is (= payload-policy/pattern-protocol-version (-> ev :tags :actual))
+                  (is (= rf.ssr.payload-policy/pattern-protocol-version (-> ev :tags :actual))
                       ":actual sourced from the SSR-owned pattern-protocol constant"))))))))))
 
 (deftest check-schema-digest-scalar-with-no-hook-emits-skipped
@@ -302,19 +302,19 @@
     ;; Test deps pull `re-frame.schemas` onto the classpath so its ns-load
     ;; registers `:schemas/app-schemas-digest`; explicitly clear the hook
     ;; for this test so we can pin the missing-hook path. Restore on exit.
-    (let [prior-hook (late-bind/get-fn :schemas/app-schemas-digest)]
-      (swap! late-bind/hooks dissoc :schemas/app-schemas-digest)
+    (let [prior-hook (rf.late-bind/get-fn :schemas/app-schemas-digest)]
+      (swap! rf.late-bind/hooks dissoc :schemas/app-schemas-digest)
       (try
         (rf/reg-event ::probe-check-digest-scalar-no-hook
           {:platforms #{:client}}
           (fn [_ _]
             {:fx [[:rf.ssr/check-schema-digest "sha256:deadbeefcafef00d"]]}))
 
-        (let [f (frame/make-anon-frame-record! {:platform :client})]
+        (let [f (rf.frame/make-anon-frame-record! {:platform :client})]
           (with-trace-recorder! [traces]
             (rf/dispatch-sync [::probe-check-digest-scalar-no-hook] {:frame f})
             ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-            (when interop/debug-enabled?
+            (when rf.interop/debug-enabled?
               (let [hits (traces-of @traces :rf.ssr/compatibility-check-skipped)]
                 (is (= 1 (count hits)))
                 (when (seq hits)
@@ -324,4 +324,4 @@
                     (is (= :skipped                    (:recovery ev)))))))))
         (finally
           (when prior-hook
-            (late-bind/set-fn! :schemas/app-schemas-digest prior-hook)))))))
+            (rf.late-bind/set-fn! :schemas/app-schemas-digest prior-hook)))))))

--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -142,21 +142,21 @@
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [re-frame.conformance :as conformance]
+            [re-frame.conformance :as rf.conformance]
             [re-frame.core :as rf]
-            [re-frame.events :as events]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.registrar :as registrar]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.head :as ssr-head]
-            [re-frame.ssr.test-fixture :as tf]
-            [re-frame.subs :as subs]
-            [re-frame.trace :as trace]))
+            [re-frame.events :as rf.events]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.head :as rf.ssr.head]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
+            [re-frame.subs :as rf.subs]
+            [re-frame.trace :as rf.trace]))
 
 ;; The shared reset fixture is `:each` — every fixture in the corpus
 ;; runs against a clean registrar / frame table / side-channel slot.
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---- fixture discovery ----------------------------------------------------
 
@@ -311,12 +311,12 @@
   to the frame's app-db via the substrate adapter and to the dispatch
   surface. Mirrors core's runner shape."
   []
-  {:read-db!  (fn [frame-id] (frame/frame-app-db-value frame-id))
+  {:read-db!  (fn [frame-id] (rf.frame/frame-app-db-value frame-id))
    ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION via swap-frame-db! —
    ;; app-db-container is now a read-only projection over the one physical
    ;; frame-state container.
    :write-db! (fn [frame-id new-db]
-                (frame/swap-frame-db! frame-id (constantly new-db)))
+                (rf.frame/swap-frame-db! frame-id (constantly new-db)))
    :dispatch! (fn [event frame-id] (rf/dispatch event {:frame frame-id}))})
 
 (defn- collect-cofx-keys
@@ -414,7 +414,7 @@
     ;; on a kind (rf2-hl4bdk).
     (doseq [[id steps] (:event hmap)]
       (let [handler   (normalize-event-handler
-                        (conformance/realise-event-handler steps))
+                        (rf.conformance/realise-event-handler steps))
             base-meta (get event-meta id {})
             ks        (collect-cofx-keys steps)
             cofx-ids  (vec (filter cofx-registry ks))
@@ -424,18 +424,18 @@
           ;; FN form (nil provenance): a fixture overriding a framework
           ;; event id (e.g. :rf/hydrate) must REPLACE its source-store slot,
           ;; not collide at default-image assembly (rf2-h1vqa4).
-          (events/reg-event id meta handler)
-          (events/reg-event id handler))))
+          (rf.events/reg-event id meta handler)
+          (rf.events/reg-event id handler))))
     ;; ---- subs ----------------------------------------------------------
     (doseq [[id steps] (:sub hmap)]
-      (let [{:keys [kind inputs body]} (conformance/realise-sub steps)
+      (let [{:keys [kind inputs body]} (rf.conformance/realise-sub steps)
             meta                       (get sub-meta id {})]
         (case kind
           :layer-1 (if (seq meta) (rf/reg-sub id meta body) (rf/reg-sub id body))
           ;; Use the fn-form `subs/reg-sub` — the public `rf/reg-sub`
           ;; is a JVM macro (Spec 001 §Source-coordinate capture); a
           ;; macro var isn't `apply`-able.
-          :layer-2 (apply subs/reg-sub id
+          :layer-2 (apply rf.subs/reg-sub id
                           (concat (when (seq meta) [meta])
                                   (interleave (repeat :<-) inputs)
                                   [body])))))
@@ -446,13 +446,13 @@
       (doseq [id all-ids]
         (let [body    (get fx-bodies id [[:noop]])
               meta    (get fx-registry id {})
-              handler (conformance/realise-fx-handler id body helpers)]
+              handler (rf.conformance/realise-fx-handler id body helpers)]
           (rf/reg-fx id (assoc meta :handler-fn handler) handler))))
     ;; ---- views ---------------------------------------------------------
     (doseq [[id steps] (:view hmap)]
-      (registrar/register!
+      (rf.registrar/register!
         :view id
-        {:handler-fn (conformance/realise-view-handler steps)}))
+        {:handler-fn (rf.conformance/realise-view-handler steps)}))
     ;; ---- heads ---------------------------------------------------------
     ;; The head ns's `reg-head` is the public registration surface;
     ;; here we wire the head handler-fn the fixture's :return-head body
@@ -484,7 +484,7 @@
   is why the always-on captures below exist alongside it."
   [fixture-id]
   (let [traces (atom [])]
-    (trace/register-listener! [fixture-id]
+    (rf.trace/register-listener! [fixture-id]
                               (fn [ev] (swap! traces conj ev)))
     traces))
 
@@ -659,10 +659,10 @@
   ;; actually render (rf2-j81hs — a keyword head is a DOM element on every
   ;; host, so EDN cannot name a view as a head). Recurses into maps, which
   ;; is what reaches the `:subtree` inside a render-continuation input.
-  (let [call (update call :input conformance/realise-view-refs)]
+  (let [call (update call :input rf.conformance/realise-view-refs)]
   (case (:call call)
     :render-to-string
-    (let [out  (try (ssr/render-to-string (:input call) (or (:opts call) {}))
+    (let [out  (try (rf.ssr/render-to-string (:input call) (or (:opts call) {}))
                     (catch Throwable e (str "<error: " (.getMessage e) ">")))
           want (:expect call)]
       {:passed? (= want out)
@@ -679,7 +679,7 @@
     ;; corpus plus same-hash LAW pairs; the value branch is per-host, the
     ;; law pairs are pattern-level.
     :render-tree-hash
-    (let [out  (try (ssr/render-tree-hash (:input call))
+    (let [out  (try (rf.ssr/render-tree-hash (:input call))
                     (catch Throwable e (str "<error: " (.getMessage e) ">")))
           want (:expect call)]
       {:passed? (= want out)
@@ -694,7 +694,7 @@
 
     :ssr.streaming/render-shell
     (let [{:keys [shell-html continuations]}
-          (try (ssr/streaming-render-shell (:input call))
+          (try (rf.ssr/streaming-render-shell (:input call))
                (catch Throwable e {:shell-html (str "<error: " (.getMessage e) ">")
                                    :continuations []}))
           want (:expect call)
@@ -714,7 +714,7 @@
                               "    continuations actual:   " (pr-str conts-actual) "\n"))))})
 
     :ssr.streaming/render-continuation
-    (let [out  (try (ssr/streaming-render-continuation
+    (let [out  (try (rf.ssr/streaming-render-continuation
                       :rf/default (:input call))
                     (catch Throwable e {:html (str "<error: " (.getMessage e) ">")
                                         :failed? true}))
@@ -740,7 +740,7 @@
                               "    failed? actual:   " (:failed? out) "\n"))))})
 
     :ssr.streaming/build-final-payload
-    (let [payload (try (ssr/streaming-build-final-payload
+    (let [payload (try (rf.ssr/streaming-build-final-payload
                          :rf/default
                          (:render-hash (:input call))
                          ;; rf2-lm2yzy — the WIRE :rf/frame-id is decoupled from
@@ -896,7 +896,7 @@
               server-hash     (:rf/render-hash payload)
               frame-id        (:rf/frame-id payload :rf/default)]
           (when (and client-hash server-hash)
-            (ssr/verify-hydration!
+            (rf.ssr/verify-hydration!
               frame-id client-hash
               {:first-diff-path first-diff-path
                :server-hash     server-hash}))))
@@ -914,8 +914,8 @@
       ;; :status onto the per-frame response slot. We flush before
       ;; reading final-app-db / request-result so the assertions see
       ;; the post-drain state.
-      (doseq [fid (frame/frame-ids)]
-        (try (ssr/apply-error-projection! fid)
+      (doseq [fid (rf.frame/frame-ids)]
+        (try (rf.ssr/apply-error-projection! fid)
              (catch Throwable _ nil)))
       ;; ---- assertion gathering -----------------------------------------
       (let [expect        (or (:fixture/expect fixture) {})
@@ -940,10 +940,10 @@
             ;;
             ;; The production counterpart is `always-on-failures` below; the
             ;; two are complementary, not a substitution.
-            trace-failures (when interop/debug-enabled?
+            trace-failures (when rf.interop/debug-enabled?
                              (check-trace-emissions @traces
                                                     (:trace-emissions expect)))
-            not-emit-failures (when interop/debug-enabled?
+            not-emit-failures (when rf.interop/debug-enabled?
                                 (check-trace-not-emitted @traces
                                                          (:trace-not-emitted expect)))
             ;; ---- the always-on counterpart (rf2-lwtlk) ----------------
@@ -974,7 +974,7 @@
             pe-check
             (when expected-pe
               (if last-error
-                (let [actual (ssr/project-error :rf/default last-error)]
+                (let [actual (rf.ssr/project-error :rf/default last-error)]
                   {:expected expected-pe
                    :actual   actual
                    :passed?  (= expected-pe actual)})
@@ -1000,7 +1000,7 @@
             expected-rr   (:ssr/request-result expect)
             req-check
             (when expected-rr
-              (let [response (ssr/get-response :rf/default)
+              (let [response (rf.ssr/get-response :rf/default)
                     rr       {:response response
                               :html     :absent
                               :payload  :absent}]
@@ -1017,7 +1017,7 @@
                 {:misses misses
                  :html   html
                  :passed? (empty? misses)}))]
-        (trace/clear-listeners!)
+        (rf.trace/clear-listeners!)
         {:fixture-id        fid
          :passed?           (and (or (nil? expected-db) (submap? expected-db final-db))
                                  (every? #(= (:expected %) (:actual %)) sub-checks)

--- a/implementation/ssr/test/re_frame/ssr_doc_example_projector_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_doc_example_projector_test.clj
@@ -48,16 +48,16 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
 ;; The fixture must NOT clear the always-on error-listener registry:
 ;; `re-frame.ssr` installs its `::error-projection` listener at ns-load
 ;; time and that listener IS the production status-projection path these
 ;; assertions exercise. Wiping it would turn every 404 below into a
 ;; vacuous 200. Same note as `re-frame.ssr-route-miss-404-production-test`.
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---------------------------------------------------------------------------
 ;; Reading the documented example out of the page
@@ -125,7 +125,7 @@
 
 (defn- server-frame-using-the-documented-projector []
   (rf/reg-error-projector :app/public-error @documented-projector-fn)
-  (frame/make-anon-frame-record!
+  (rf.frame/make-anon-frame-record!
     {:platform :server
      :ssr      {:public-error-id   :app/public-error
                 :dev-error-detail? false}}))
@@ -143,7 +143,7 @@
     (register-routes!)
     (let [f (server-frame-using-the-documented-projector)]
       (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"] {:frame f})
-      (let [{:keys [response public-error]} (ssr/flush-response-result! f)]
+      (let [{:keys [response public-error]} (rf.ssr/flush-response-result! f)]
         (is (= 404 (:status response))
             "the documented projector's 404 reached the response accumulator")
         (is (= :not-found (:code public-error))
@@ -152,7 +152,7 @@
             "the example's own message proves the four-key shape passed
              conformance — a non-conforming return would have been replaced
              by fallback-public-error's \"Something went wrong\"")
-        (is (= ssr/public-error-keys (set (keys public-error)))
+        (is (= rf.ssr/public-error-keys (set (keys public-error)))
             "exactly the four locked keys, none extra (:dev-error-detail?
              is false, so the runtime appended no :details)")))))
 
@@ -170,7 +170,7 @@
     (register-routes!)
     (let [f (server-frame-using-the-documented-projector)]
       (rf/dispatch-sync [:never/registered] {:frame f})
-      (is (= 500 (:status (ssr/flush-response! f)))
+      (is (= 500 (:status (rf.ssr/flush-response! f)))
           "an unregistered EVENT dispatch is a server defect — generic 500"))
     (let [project @documented-projector-fn]
       (is (= 404 (:status (project {:operation :rf.error/no-such-handler
@@ -201,10 +201,10 @@
                       second
                       edn/read-string)]
       (is (some? claimed) "the example still carries a `;; =>` result comment")
-      (is (= ssr/public-error-keys (set (keys claimed)))
+      (is (= rf.ssr/public-error-keys (set (keys claimed)))
           "the documented result names exactly the four locked keys")
       (is (= claimed
-             (ssr/default-error-projector-fn {:operation :rf.error/no-such-handler
+             (rf.ssr/default-error-projector-fn {:operation :rf.error/no-such-handler
                                               :tags      {:kind :route}}))
           "and it is byte-for-byte what the default projector returns for the
            route miss the example describes"))))

--- a/implementation/ssr/test/re_frame/ssr_drain_facade_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_drain_facade_test.clj
@@ -33,8 +33,8 @@
   the settled-shape, and (b) installing a RECORDING stub hook and asserting the
   exact opts map the façade forwards."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.ssr :as ssr]))
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.ssr :as rf.ssr]))
 
 (def ^:private drain-key :resources/drain-blocking-ssr!)
 
@@ -43,17 +43,17 @@
 ;; a fresh `default-blocking-pump!` fn object, so an `identical?` compare must
 ;; read the CURRENT var root the façade also resolves — a load-time snapshot
 ;; would go stale after any such reload.
-(defn- default-pump [] @#'ssr/default-blocking-pump!)
-(defn- default-timeout [] @#'ssr/default-ssr-blocking-timeout-ms)
+(defn- default-pump [] @#'rf.ssr/default-blocking-pump!)
+(defn- default-timeout [] @#'rf.ssr/default-ssr-blocking-timeout-ms)
 
 (defn- restore-hook!
   "Restore the drain hook to its pre-test registration (or remove it when it
   was absent), keeping the late-bind resolution cache consistent."
   [prev]
   (if prev
-    (late-bind/set-fn! drain-key prev)
-    (do (swap! late-bind/hooks dissoc drain-key)
-        (late-bind/invalidate-cache! drain-key)))
+    (rf.late-bind/set-fn! drain-key prev)
+    (do (swap! rf.late-bind/hooks dissoc drain-key)
+        (rf.late-bind/invalidate-cache! drain-key)))
   nil)
 
 ;; ---- (1) hook-absent no-op fast path ---------------------------------------
@@ -69,18 +69,18 @@
   blocking-ssr!` hook unregistered — the default for every no-resources SSR
   app) the façade is a no-op returning the exact settled-shape the Ring host
   consults: {:settled? true :timed-out [] :route-blocking-failure nil}"
-    (let [prev (late-bind/get-fn drain-key)]
+    (let [prev (rf.late-bind/get-fn drain-key)]
       (try
-        (swap! late-bind/hooks dissoc drain-key)
-        (late-bind/invalidate-cache! drain-key)
-        (is (nil? (late-bind/get-fn drain-key))
+        (swap! rf.late-bind/hooks dissoc drain-key)
+        (rf.late-bind/invalidate-cache! drain-key)
+        (is (nil? (rf.late-bind/get-fn drain-key))
             "precondition: the drain hook is absent in the ssr slice")
         (testing "1-arity (the host's default call — no opts)"
-          (is (= settled-shape (ssr/drain-blocking-resources! :ssr/some-frame))
+          (is (= settled-shape (rf.ssr/drain-blocking-resources! :ssr/some-frame))
               "hook-absent 1-arity returns the settled-shape"))
         (testing "2-arity opts are IGNORED on the absent path — still settled-shape"
           (is (= settled-shape
-                 (ssr/drain-blocking-resources!
+                 (rf.ssr/drain-blocking-resources!
                    :ssr/some-frame {:ssr-blocking-timeout-ms 123 :pump! nil :tick-ms 9}))
               "even with opts, the hook-absent path short-circuits to settled-shape"))
         (finally
@@ -91,23 +91,23 @@
 (deftest hook-present-forwards-resolved-opts-and-return
   (testing "rf2-zplpsp — with the drain hook PRESENT the façade forwards the
   frame-id and a normalised opts map, and returns the hook's result verbatim"
-    (let [prev     (late-bind/get-fn drain-key)
+    (let [prev     (rf.late-bind/get-fn drain-key)
           captured (atom nil)
           sentinel {:settled? false :timed-out #{[:x]} :route-blocking-failure {:route :r}}]
       (try
-        (late-bind/set-fn! drain-key
+        (rf.late-bind/set-fn! drain-key
           (fn [frame-id opts]
             (reset! captured {:frame-id frame-id :opts opts})
             sentinel))
 
         (testing "the hook's return rides back verbatim"
-          (is (= sentinel (ssr/drain-blocking-resources! :ssr/f))
+          (is (= sentinel (rf.ssr/drain-blocking-resources! :ssr/f))
               "the façade does not reshape the resources drain result"))
 
         (testing "DEFAULTS (1-arity / no opts): :deadline-ms = default 5000,
                   :pump! = default host-yield pump, :tick-ms = 5"
           (reset! captured nil)
-          (ssr/drain-blocking-resources! :ssr/f)
+          (rf.ssr/drain-blocking-resources! :ssr/f)
           (let [{:keys [frame-id opts]} @captured]
             (is (= :ssr/f frame-id) "frame-id is forwarded")
             (is (= (default-timeout) (:deadline-ms opts))
@@ -121,7 +121,7 @@
                   not an `or`) — a sync test stub drives a never-settling resource
                   straight to the deadline"
           (reset! captured nil)
-          (ssr/drain-blocking-resources! :ssr/f {:pump! nil})
+          (rf.ssr/drain-blocking-resources! :ssr/f {:pump! nil})
           (let [opts (:opts @captured)]
             (is (contains? opts :pump!) ":pump! key is present in the forwarded opts")
             (is (nil? (:pump! opts))
@@ -133,7 +133,7 @@
                   :deadline-ms, a custom :pump!, and :tick-ms"
           (reset! captured nil)
           (let [my-pump (fn [_tick] :pumped)]
-            (ssr/drain-blocking-resources! :ssr/f
+            (rf.ssr/drain-blocking-resources! :ssr/f
               {:ssr-blocking-timeout-ms 250 :pump! my-pump :tick-ms 7})
             (let [opts (:opts @captured)]
               (is (= 250 (:deadline-ms opts)) "explicit :ssr-blocking-timeout-ms → :deadline-ms")

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -32,12 +32,12 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.ssr.emit :as emit]
-            [re-frame.ssr.streaming :as streaming]
-            [re-frame.ssr.test-fixture :as tf]
-            [re-frame.ssr.ui-tree :as ui-tree]))
+            [re-frame.ssr.emit :as rf.ssr.emit]
+            [re-frame.ssr.streaming :as rf.ssr.streaming]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
+            [re-frame.ssr.ui-tree :as rf.ssr.ui-tree]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-xbvzh — shared raw-text emission across ALL three SSR paths.
@@ -58,12 +58,12 @@
   [tag content expected-inner]
   (let [tag-name (name tag)
         expected (str "<" tag-name ">" expected-inner "</" tag-name ">")]
-    (is (= expected (emit/render-to-string [tag content] {}))
+    (is (= expected (rf.ssr.emit/render-to-string [tag content] {}))
         (str "sync render-to-string byte-mismatch for <" tag-name ">"))
-    (is (str/includes? (:shell-html (streaming/render-shell [:div [tag content]]))
+    (is (str/includes? (:shell-html (rf.ssr.streaming/render-shell [:div [tag content]]))
                        expected)
         (str "streaming render-shell byte-mismatch for <" tag-name ">"))
-    (is (= expected (ui-tree/emit-ui-tree (v1 {:tag tag :children [content]})))
+    (is (= expected (rf.ssr.ui-tree/emit-ui-tree (v1 {:tag tag :children [content]})))
         (str "emit-ui-tree byte-mismatch for <" tag-name ">"))))
 
 ;; ===========================================================================
@@ -77,15 +77,15 @@
             that the strip survives `emit-element`'s attr path."
     (testing ":on-click (kebab) is stripped through render-to-string"
       (is (= "<div id=\"x\"></div>"
-             (emit/render-to-string [:div {:on-click "alert(1)" :id "x"}] {}))))
+             (rf.ssr.emit/render-to-string [:div {:on-click "alert(1)" :id "x"}] {}))))
 
     (testing ":onClick (camelCase) is stripped through render-to-string"
       (is (= "<div id=\"x\"></div>"
-             (emit/render-to-string [:div {:onClick "alert(1)" :id "x"}] {}))))
+             (rf.ssr.emit/render-to-string [:div {:onClick "alert(1)" :id "x"}] {}))))
 
     (testing "the stripped handler value never appears in the output
               string — belt-and-braces against a partial-emit leak"
-      (let [html (emit/render-to-string
+      (let [html (rf.ssr.emit/render-to-string
                    [:div {:onMouseDown "steal()" :id "x"}] {})]
         (is (not (str/includes? html "steal"))
             "the handler body must not survive anywhere in the markup")
@@ -95,7 +95,7 @@
     (testing "a div whose ONLY attr is a stripped handler emits a clean
               open tag — no stray space, no bare attr"
       (is (= "<div></div>"
-             (emit/render-to-string [:div {:on-click "f"}] {}))))))
+             (rf.ssr.emit/render-to-string [:div {:on-click "f"}] {}))))))
 
 (deftest render-to-string-strips-lowercase-touch-handlers
   (testing "rf2-cv165 — the lower-case W3C Touch Events L2 GlobalEventHandlers
@@ -108,7 +108,7 @@
             security tier's render-to-string assertion)."
     (doseq [k [:ontouchstart :ontouchmove :ontouchend :ontouchcancel]]
       (testing (str k " is stripped through render-to-string")
-        (let [html (emit/render-to-string
+        (let [html (rf.ssr.emit/render-to-string
                      [:div {k "alert(document.cookie)" :id "x"} [:p "body"]] {})]
           (is (str/includes? html "id=\"x\"")
               (str "the legit attr should survive for " k))
@@ -125,11 +125,11 @@
             serialisation and is dropped through the full emit
             composition."
     (is (= "<div id=\"x\"></div>"
-           (emit/render-to-string [:div {:title (fn [_] :handler) :id "x"}] {})))
+           (rf.ssr.emit/render-to-string [:div {:title (fn [_] :handler) :id "x"}] {})))
 
     (testing "fn value is stripped even on an innocuous key name"
       (is (= "<span></span>"
-             (emit/render-to-string [:span {:data-cb (fn [] nil)}] {}))))))
+             (rf.ssr.emit/render-to-string [:span {:data-cb (fn [] nil)}] {}))))))
 
 (deftest render-to-string-drops-prototype-pollution-keys
   (testing "rf2-usio0 / rf2-dwds9 — reserved prototype-pollution keys
@@ -139,13 +139,13 @@
     (doseq [k ["__proto__" "constructor" "prototype"]]
       (testing (str "`" k "` is dropped through render-to-string")
         (is (= "<div id=\"x\"></div>"
-               (emit/render-to-string
+               (rf.ssr.emit/render-to-string
                  [:div {(keyword k) "polluted" :id "x"}] {}))
             (str k " must not survive to wire output via the emit path"))))
 
     (testing "the match is case-insensitive at the composed callsite too"
       (is (= "<div id=\"x\"></div>"
-             (emit/render-to-string
+             (rf.ssr.emit/render-to-string
                [:div {(keyword "Constructor") "polluted" :id "x"}] {}))))))
 
 (deftest render-to-string-strips-props-on-void-element
@@ -154,9 +154,9 @@
             open/close branch. An `on*` handler on an <input> is dropped
             and the void tag self-closes cleanly."
     (is (= "<input id=\"x\">"
-           (emit/render-to-string
+           (rf.ssr.emit/render-to-string
              [:input {:on-change "x()" :id "x"}] {})))
-    (let [html (emit/render-to-string
+    (let [html (rf.ssr.emit/render-to-string
                  [:img {:onError "alert(1)" :src "/a.png"}] {})]
       (is (str/includes? html "src=\"/a.png\"") "the legit attr survives")
       (is (not (str/includes? html "onError")) "the handler is stripped")
@@ -170,7 +170,7 @@
     (rf/reg-view ^{:rf/id :test/hostile-root} hostile-root-view []
       [:div {:on-click "alert(document.cookie)" :id "v"}
        [:p "safe body"]])
-    (let [html (emit/render-to-string [(rf/view :test/hostile-root)] {})]
+    (let [html (rf.ssr.emit/render-to-string [(rf/view :test/hostile-root)] {})]
       (is (str/includes? html "<p>safe body</p>")
           "the view body still renders")
       (is (str/includes? html "id=\"v\"")
@@ -186,7 +186,7 @@
             `data-rf-render-hash` lands while the user's hostile handler
             on the SAME root element is dropped — `merge-root-attrs`
             feeds into the same `attr-string` strip."
-    (let [html (emit/render-to-string
+    (let [html (rf.ssr.emit/render-to-string
                  [:div {:onClick "alert(1)" :id "root"} [:p "x"]]
                  {:render-hash "deadbeef"})]
       (is (str/includes? html "data-rf-render-hash=")
@@ -202,7 +202,7 @@
   (testing "rf2-usio0 — the strip runs at EVERY emit-element descent, not
             only the root. A handler buried several levels deep is
             dropped — `emit-children` re-enters `emit-element` per child."
-    (let [html (emit/render-to-string
+    (let [html (rf.ssr.emit/render-to-string
                  [:div
                   [:section
                    [:ul
@@ -225,7 +225,7 @@
             just through the non-streaming `render-to-string`."
     (let [tree [:div {:on-click "alert(1)" :id "x"}
                 [:p "shell body"]]
-          {:keys [shell-html]} (streaming/render-shell tree)]
+          {:keys [shell-html]} (rf.ssr.streaming/render-shell tree)]
       (is (str/includes? shell-html "<p>shell body</p>")
           "the shell body renders")
       (is (str/includes? shell-html "id=\"x\"")
@@ -242,7 +242,7 @@
                       :__proto__ "polluted"
                       :id "x"}
                 [:span "ok"]]
-          {:keys [shell-html]} (streaming/render-shell tree)]
+          {:keys [shell-html]} (rf.ssr.streaming/render-shell tree)]
       (is (str/includes? shell-html "id=\"x\"") "the legit attr survives")
       (is (str/includes? shell-html "<span>ok</span>") "body renders")
       (is (not (str/includes? shell-html "__proto__"))
@@ -256,7 +256,7 @@
             an <input> in the shell is dropped."
     (let [tree [:form
                 [:input {:onChange "steal()" :name "q"}]]
-          {:keys [shell-html]} (streaming/render-shell tree)]
+          {:keys [shell-html]} (rf.ssr.streaming/render-shell tree)]
       (is (str/includes? shell-html "name=\"q\"") "the legit attr survives")
       (is (not (str/includes? shell-html "onChange")) "the handler is stripped")
       (is (not (str/includes? shell-html "steal")) "the handler body is gone"))))
@@ -271,7 +271,7 @@
                 [:rf/suspense-boundary
                  {:id :sb :fallback [:p "loading"]}
                  [:p "body"]]]
-          {:keys [shell-html continuations]} (streaming/render-shell tree)]
+          {:keys [shell-html continuations]} (rf.ssr.streaming/render-shell tree)]
       (is (= 1 (count continuations))
           "the boundary still registered its continuation")
       (is (str/includes? shell-html "id=\"outer\"")
@@ -324,11 +324,11 @@
             in the emitted markup), so its literal `<` is NOT entity-escaped."
     (doseq [tag [:SCRIPT :Script :sCrIpT]]
       (is (= (str "<" (name tag) ">if (a < b)</" (name tag) ">")
-             (emit/render-to-string [tag "if (a < b)"] {}))
+             (rf.ssr.emit/render-to-string [tag "if (a < b)"] {}))
           (str tag " body emitted as raw text, not escaped")))
     (doseq [tag [:STYLE :Style]]
       (is (= (str "<" (name tag) ">a > .b { }</" (name tag) ">")
-             (emit/render-to-string [tag "a > .b { }"] {}))
+             (rf.ssr.emit/render-to-string [tag "a > .b { }"] {}))
           (str tag " body emitted as raw text, not escaped")))))
 
 (deftest raw-text-json-island-round-trips-through-json-parse
@@ -338,7 +338,7 @@
             `\\u0073` is ALSO a valid JSON string escape the payload round-trips
             back through JSON.parse."
     (let [json "{\"@type\":\"WebSite\",\"u\":\"a</script>b\"}"
-          out  (emit/render-to-string
+          out  (rf.ssr.emit/render-to-string
                  [:script {:type "application/ld+json"} json] {})]
       (is (= (str "<script type=\"application/ld+json\">"
                   "{\"@type\":\"WebSite\",\"u\":\"a</\\u0073cript>b\"}"
@@ -375,13 +375,13 @@
   (testing "rf2-xbvzh — a raw-text tag with NO string child is inert and emits
             unchanged; the raw-text emission only applies to string content."
     (is (= "<script></script>"
-           (emit/render-to-string [:script] {}))
+           (rf.ssr.emit/render-to-string [:script] {}))
         "empty <script> is fine")
     (is (= "<style></style>"
-           (emit/render-to-string [:style {}] {}))
+           (rf.ssr.emit/render-to-string [:style {}] {}))
         "empty <style> with an attrs map is fine")
     (is (= "<script src=\"/main.js\"></script>"
-           (emit/render-to-string [:script {:src "/main.js"}] {}))
+           (rf.ssr.emit/render-to-string [:script {:src "/main.js"}] {}))
         "an attribute-only <script> (the common external-script shape) is fine")))
 
 ;; ===========================================================================
@@ -399,21 +399,21 @@
             as void and self-closes; it must NOT emit a spurious closing tag.
             HTML5 tag names are case-insensitive."
     (testing "[:BR] self-closes (no </BR>)"
-      (let [html (emit/render-to-string [:BR] {})]
+      (let [html (rf.ssr.emit/render-to-string [:BR] {})]
         (is (= "<BR>" html)
             "void classification is case-insensitive; author case preserved")
         (is (not (str/includes? html "</BR>"))
             "no spurious closing tag for an upper-case void element")))
     (testing "[:Img …] self-closes with its attrs"
-      (let [html (emit/render-to-string [:Img {:src "/a.png"}] {})]
+      (let [html (rf.ssr.emit/render-to-string [:Img {:src "/a.png"}] {})]
         (is (= "<Img src=\"/a.png\">" html))
         (is (not (str/includes? html "</Img>")))))
     (testing "[:INPUT …] self-closes"
       (is (= "<INPUT name=\"q\">"
-             (emit/render-to-string [:INPUT {:name "q"}] {}))))
+             (rf.ssr.emit/render-to-string [:INPUT {:name "q"}] {}))))
     (testing "a non-void upper-case tag still emits an open+close pair"
       (is (= "<DIV>x</DIV>"
-             (emit/render-to-string [:DIV "x"] {}))
+             (rf.ssr.emit/render-to-string [:DIV "x"] {}))
           "case-folding only affects the void/raw-text classification, not
            which tags are void"))))
 
@@ -421,7 +421,7 @@
   (testing "rf2-hzttr finding 3 — the streaming walker mirrors the
             case-insensitive void classification (streaming.cljc:284). A
             `[:BR]` in the shell must self-close, not emit <BR></BR>."
-    (let [{:keys [shell-html]} (streaming/render-shell
+    (let [{:keys [shell-html]} (rf.ssr.streaming/render-shell
                                  [:div [:BR] [:Img {:src "/a.png"}]])]
       (is (str/includes? shell-html "<BR>"))
       (is (not (str/includes? shell-html "</BR>"))
@@ -434,7 +434,7 @@
             case-insensitively too: an UPPER/MIXED-case <STYLE>/<SCRIPT> body
             is emitted as raw text (author case preserved), NOT entity-escaped
             and NOT refused."
-    (let [{:keys [shell-html]} (streaming/render-shell
+    (let [{:keys [shell-html]} (rf.ssr.streaming/render-shell
                                  [:div
                                   [:STYLE "p > a { margin: 0 }"]
                                   [:Script "if (a < b) { x() }"]])]
@@ -458,10 +458,10 @@
     (let [some-component (fn [_props] [:div "react"])]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #":rf.error/ssr-reagent-native-head"
-                            (emit/render-to-string
+                            (rf.ssr.emit/render-to-string
                               [:> some-component {:prop "v"} [:span "child"]] {})))
       (testing "the props map is never emitted as raw text on the wire"
-        (let [thrown (try (emit/render-to-string
+        (let [thrown (try (rf.ssr.emit/render-to-string
                             [:> some-component {:secret "leak-me"}] {})
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (instance? clojure.lang.ExceptionInfo thrown))
@@ -474,14 +474,14 @@
     (let [some-component (fn [_props] [:div "react"])]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #":rf.error/ssr-reagent-native-head"
-                            (streaming/render-shell
+                            (rf.ssr.streaming/render-shell
                               [:div [:> some-component {:prop "v"}]]))))))
 
 (deftest render-to-string-still-handles-fragment-head
   (testing "rf2-ee38b.10 — splitting `:>` out of the `:<>` branch leaves
             the fragment head working: children splice with no wrapper."
     (is (= "<p>a</p><p>b</p>"
-           (emit/render-to-string [:<> [:p "a"] [:p "b"]] {})))))
+           (rf.ssr.emit/render-to-string [:<> [:p "a"] [:p "b"]] {})))))
 
 (deftest render-hash-threads-through-fragment-root
   (testing "rf2-58zvy1 finding 2 — root-attrs (the render-hash marker)
@@ -491,7 +491,7 @@
             tree lost the `data-rf-render-hash` the emitter docstring
             promises (and that the emitter/Ring hash contract depends on)."
     (testing "the marker lands on the FIRST DOM child only, not every child"
-      (let [html (emit/render-to-string [:<> [:div "a"] [:div "b"]] {:render-hash "deadbeef"})]
+      (let [html (rf.ssr.emit/render-to-string [:<> [:div "a"] [:div "b"]] {:render-hash "deadbeef"})]
         (is (re-matches #"<div data-rf-render-hash=\"[0-9a-f]+\">a</div><div>b</div>"
                         html)
             (str "exactly one data-rf-render-hash, on the first div; got: " html))
@@ -499,15 +499,15 @@
             "marker appears exactly once across the fragment's children")))
     (testing "an explicit :render-hash threads through the fragment root"
       (is (= "<div data-rf-render-hash=\"deadbeef\">x</div>"
-             (emit/render-to-string [:<> [:div "x"]] {:render-hash "deadbeef"}))
+             (rf.ssr.emit/render-to-string [:<> [:div "x"]] {:render-hash "deadbeef"}))
           "the supplied hash drives the root-attr marker through the fragment"))
     (testing "nested fragments keep threading the marker down to the first DOM tag"
       (is (re-matches #"<div data-rf-render-hash=\"[0-9a-f]+\">y</div>"
-                      (emit/render-to-string [:<> [:<> [:div "y"]]] {:render-hash "deadbeef"}))
+                      (rf.ssr.emit/render-to-string [:<> [:<> [:div "y"]]] {:render-hash "deadbeef"}))
           "a fragment whose first child is a fragment still places the marker"))
     (testing "no opts → no marker (fragment branch unchanged when root-attrs nil)"
       (is (= "<div>x</div>"
-             (emit/render-to-string [:<> [:div "x"]] {}))
+             (rf.ssr.emit/render-to-string [:<> [:div "x"]] {}))
           "without :render-hash the fragment root emits no marker"))))
 
 (deftest render-hash-threads-through-lazy-seq-root
@@ -520,21 +520,21 @@
             data-rf-render-hash marker."
     (testing "the marker lands on a (map …) lazy-seq root"
       (is (re-matches #"<div data-rf-render-hash=\"[0-9a-f]+\">1</div>"
-                      (emit/render-to-string (map (fn [i] [:div i]) [1]) {:render-hash "deadbeef"}))
+                      (rf.ssr.emit/render-to-string (map (fn [i] [:div i]) [1]) {:render-hash "deadbeef"}))
           "a lazy-seq produced by map gets the marker on its first DOM child"))
     (testing "the marker lands on the FIRST DOM child only across a multi-child seq"
-      (let [html (emit/render-to-string (for [i [1 2]] [:p i]) {:render-hash "deadbeef"})]
+      (let [html (rf.ssr.emit/render-to-string (for [i [1 2]] [:p i]) {:render-hash "deadbeef"})]
         (is (re-matches #"<p data-rf-render-hash=\"[0-9a-f]+\">1</p><p>2</p>" html)
             (str "exactly one marker, on the first <p>; got: " html))
         (is (= 1 (count (re-seq #"data-rf-render-hash=" html)))
             "marker appears exactly once across the seq's children")))
     (testing "an explicit :render-hash threads through the lazy-seq root"
       (is (= "<div data-rf-render-hash=\"deadbeef\">x</div>"
-             (emit/render-to-string (list [:div "x"]) {:render-hash "deadbeef"}))
+             (rf.ssr.emit/render-to-string (list [:div "x"]) {:render-hash "deadbeef"}))
           "the supplied hash drives the marker through the seq root"))
     (testing "no opts → no marker (seq branch unchanged when root-attrs nil)"
       (is (= "<div>x</div>"
-             (emit/render-to-string (list [:div "x"]) {}))
+             (rf.ssr.emit/render-to-string (list [:div "x"]) {}))
           "without :render-hash the lazy-seq root emits no marker"))))
 
 ;; ===========================================================================
@@ -552,14 +552,14 @@
             emitting a phantom <suspense-boundary> DOM element."
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf.error/ssr-suspense-boundary-outside-stream"
-                          (emit/render-to-string
+                          (rf.ssr.emit/render-to-string
                             [:rf/suspense-boundary
                              {:id :b1 :fallback [:span "loading"]}
                              [:div "resolved"]]
                             {})))
     (testing "the marker's id/fallback/subtree never reach the wire as
               a bogus <suspense-boundary> element"
-      (let [thrown (try (emit/render-to-string
+      (let [thrown (try (rf.ssr.emit/render-to-string
                           [:rf/suspense-boundary
                            {:id :secret-boundary :fallback [:span "spin"]}
                            [:div "leak-me"]]
@@ -572,7 +572,7 @@
               (emit-children recurses into it)"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #":rf.error/ssr-suspense-boundary-outside-stream"
-                            (emit/render-to-string
+                            (rf.ssr.emit/render-to-string
                               [:div [:section
                                      [:rf/suspense-boundary
                                       {:id :b :fallback [:span "…"]}
@@ -585,7 +585,7 @@
             the NON-streaming path); render-shell materialises the
             fallback as a <template> and does NOT throw."
     (let [{:keys [shell-html continuations]}
-          (streaming/render-shell
+          (rf.ssr.streaming/render-shell
             [:div
              [:rf/suspense-boundary
               {:id :card-1 :fallback [:span "loading…"]}
@@ -613,13 +613,13 @@
   (testing "rf2-ynjts.13 — a number child renders as its `str` form, not
             dropped, not escaped (emit-element number? branch)."
     (is (= "<span>42</span>"
-           (emit/render-to-string [:span 42] {}))
+           (rf.ssr.emit/render-to-string [:span 42] {}))
         "integer child stringifies")
     (is (= "<span>3.14</span>"
-           (emit/render-to-string [:span 3.14] {}))
+           (rf.ssr.emit/render-to-string [:span 3.14] {}))
         "double child stringifies")
     (is (= "<p>count=7</p>"
-           (emit/render-to-string [:p "count=" 7] {}))
+           (rf.ssr.emit/render-to-string [:p "count=" 7] {}))
         "a number sits inline alongside a string child")))
 
 (deftest render-to-string-boolean-child-is-dropped
@@ -630,16 +630,16 @@
             `false`. Distinct from a boolean ATTR VALUE (which `attr-string`
             renders as a bare attr name) — this is the child position."
     (is (= "<div></div>"
-           (emit/render-to-string [:div true] {}))
+           (rf.ssr.emit/render-to-string [:div true] {}))
         "a lone `true` child is dropped")
     (is (= "<div></div>"
-           (emit/render-to-string [:div false] {}))
+           (rf.ssr.emit/render-to-string [:div false] {}))
         "a lone `false` child is dropped")
     (is (= "<div><p>shown</p></div>"
-           (emit/render-to-string [:div (when true [:p "shown"]) (when false [:p "hidden"])] {}))
+           (rf.ssr.emit/render-to-string [:div (when true [:p "shown"]) (when false [:p "hidden"])] {}))
         "the false arm of a (when …) yields nil → dropped; the true arm renders")
     (is (= "<p>ab</p>"
-           (emit/render-to-string [:p "a" true "b" false nil] {}))
+           (rf.ssr.emit/render-to-string [:p "a" true "b" false nil] {}))
         "booleans + nil interleaved with strings drop, strings survive")))
 
 (deftest render-to-string-fn-headed-component
@@ -650,17 +650,17 @@
             emitter's fn-head branch had no direct assertion."
     (let [greeting (fn [name] [:h1 "Hello, " name])]
       (is (= "<h1>Hello, world</h1>"
-             (emit/render-to-string [greeting "world"] {}))
+             (rf.ssr.emit/render-to-string [greeting "world"] {}))
           "the component fn is called with the trailing args; its hiccup emits"))
     (testing "a fn-headed component nested as a child is resolved too"
       (let [item (fn [label] [:li label])]
         (is (= "<ul><li>a</li><li>b</li></ul>"
-               (emit/render-to-string [:ul [item "a"] [item "b"]] {}))
+               (rf.ssr.emit/render-to-string [:ul [item "a"] [item "b"]] {}))
             "fn-heads in child position resolve via emit-children → emit-element")))
     (testing "a fn-headed component returning a string renders the string escaped"
       (let [raw (fn [] "a < b")]
         (is (= "<p>a &lt; b</p>"
-               (emit/render-to-string [:p [raw]] {}))
+               (rf.ssr.emit/render-to-string [:p [raw]] {}))
             "the fn's string output flows back through escape-html")))))
 
 ;; ===========================================================================
@@ -678,10 +678,10 @@
   (testing "rf2-ynjts.13 — a text-node child escapes `& < > \" '` so no
             raw markup or quote can break out of text position."
     (is (= "<p>&amp;&lt;&gt;&quot;&#39;</p>"
-           (emit/render-to-string [:p "&<>\"'"] {}))
+           (rf.ssr.emit/render-to-string [:p "&<>\"'"] {}))
         "all five escapable entities are rewritten in text position")
     (is (= "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>"
-           (emit/render-to-string [:p "<script>alert(1)</script>"] {}))
+           (rf.ssr.emit/render-to-string [:p "<script>alert(1)</script>"] {}))
         "a literal <script> in text cannot inject a real tag")))
 
 (deftest render-to-string-attr-value-escapes-only-amp-and-quote
@@ -691,17 +691,17 @@
             text-node escaping is deliberate — over-escaping attrs corrupts
             legit values."
     (is (= "<div data-x=\"a&amp;b\"></div>"
-           (emit/render-to-string [:div {:data-x "a&b"}] {}))
+           (rf.ssr.emit/render-to-string [:div {:data-x "a&b"}] {}))
         "`&` in an attr value is escaped to &amp;")
     (is (= "<div data-x=\"&quot;q&quot;\"></div>"
-           (emit/render-to-string [:div {:data-x "\"q\""}] {}))
+           (rf.ssr.emit/render-to-string [:div {:data-x "\"q\""}] {}))
         "a double-quote in an attr value is escaped to &quot; (else it would
          close the value)")
     (is (= "<div data-x=\"a<b>c\"></div>"
-           (emit/render-to-string [:div {:data-x "a<b>c"}] {}))
+           (rf.ssr.emit/render-to-string [:div {:data-x "a<b>c"}] {}))
         "`<` and `>` are NOT escaped in an attr value — legal per HTML5")
     (is (= "<div data-x=\"it's\"></div>"
-           (emit/render-to-string [:div {:data-x "it's"}] {}))
+           (rf.ssr.emit/render-to-string [:div {:data-x "it's"}] {}))
         "a single-quote is NOT escaped — the value is double-quoted")))
 
 ;; ===========================================================================
@@ -718,13 +718,13 @@
             and `nil` attr values → omitted entirely, through the full
             render-to-string composition."
     (is (= "<input disabled required>"
-           (emit/render-to-string [:input {:disabled true :required true}] {}))
+           (rf.ssr.emit/render-to-string [:input {:disabled true :required true}] {}))
         "`true` boolean attrs emit as bare names on a void element")
     (is (= "<input>"
-           (emit/render-to-string [:input {:disabled false :hidden nil}] {}))
+           (rf.ssr.emit/render-to-string [:input {:disabled false :hidden nil}] {}))
         "`false` and `nil` attrs are omitted — no bare name, no empty value")
     (is (= "<button disabled>Go</button>"
-           (emit/render-to-string [:button {:disabled true :title nil} "Go"] {}))
+           (rf.ssr.emit/render-to-string [:button {:disabled true :title nil} "Go"] {}))
         "boolean + nil attrs compose on a non-void element alongside text")))
 
 ;; ===========================================================================
@@ -751,14 +751,14 @@
   (testing "rf2-wtd8z finding 2 — a Var-headed component `[#'component & args]`
             is invoked and its hiccup emitted (NOT stringified as EDN)"
     (is (= "<span>ok</span>"
-           (emit/render-to-string [#'var-component "ok"] {}))
+           (rf.ssr.emit/render-to-string [#'var-component "ok"] {}))
         "the Var head resolves: invoked with its args, returned hiccup emits")
     (testing "a Var-headed component nested as a child resolves too"
       (is (= "<ul><span>a</span><span>b</span></ul>"
-             (emit/render-to-string [:ul [#'var-component "a"] [#'var-component "b"]] {}))
+             (rf.ssr.emit/render-to-string [:ul [#'var-component "a"] [#'var-component "b"]] {}))
           "Var-heads in child position resolve via emit-children → emit-element"))
     (testing "root render-hash threads through the Var head onto the resolved DOM root"
-      (let [html (emit/render-to-string [#'var-component "ok"] {:render-hash "deadbeef"})]
+      (let [html (rf.ssr.emit/render-to-string [#'var-component "ok"] {:render-hash "deadbeef"})]
         (is (re-find #"<span [^>]*data-rf-render-hash=\"[^\"]+\">ok</span>" html)
             (str "the root data-rf-render-hash lands on the Var head's resolved"
                  " <span> root; got: " html))))))
@@ -772,12 +772,12 @@
             Var-headed."
     (rf/reg-view ^{:rf/id :rf.ssr-emit-test/var-view} var-view []
       [#'var-component "v"])
-    (let [html (emit/render-to-string [(rf/view :rf.ssr-emit-test/var-view)] {})]
+    (let [html (rf.ssr.emit/render-to-string [(rf/view :rf.ssr-emit-test/var-view)] {})]
       (is (= "<span>v</span>" html)
           (str "the Var head resolved to <span>v</span> (NOT EDN text); "
                "got: " html)))
     (testing "render-hash threads through the Var-headed view root onto the resolved DOM root"
-      (let [html (emit/render-to-string [(rf/view :rf.ssr-emit-test/var-view)] {:render-hash "deadbeef"})]
+      (let [html (rf.ssr.emit/render-to-string [(rf/view :rf.ssr-emit-test/var-view)] {:render-hash "deadbeef"})]
         (is (re-find #"<span [^>]*data-rf-render-hash=\"[^\"]+\">v</span>" html)
             (str "the root data-rf-render-hash threads through the view-ref AND "
                  "the Var head onto the resolved <span> root; got: " html))))))
@@ -786,12 +786,12 @@
   (testing "rf2-wtd8z finding 2 — the streaming shell walker resolves a
             Var-headed component just like the non-streaming emitter
             (ifn?, not fn?), recursing on its returned hiccup"
-    (let [{:keys [shell-html]} (streaming/render-shell [#'var-component "streamed"])]
+    (let [{:keys [shell-html]} (rf.ssr.streaming/render-shell [#'var-component "streamed"])]
       (is (= "<span>streamed</span>" shell-html)
           (str "the streaming walker resolved the Var head + recursed on its"
                " body; got: " shell-html)))
     (testing "a Var head nested in a DOM tree streams resolved too"
-      (let [{:keys [shell-html]} (streaming/render-shell
+      (let [{:keys [shell-html]} (rf.ssr.streaming/render-shell
                                    [:section [#'var-component "x"]])]
         (is (= "<section><span>x</span></section>" shell-html)
             (str "nested Var head resolved in the shell walk; got: "
@@ -817,14 +817,14 @@
                 [true "<script>y</script>"]]]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #":rf.error/invalid-hiccup-head"
-                            (emit/render-to-string el {}))
+                            (rf.ssr.emit/render-to-string el {}))
           (str "malformed-head vector must fail loud, not emit raw: " (pr-str el)))))
 
   (testing "rf2-y1jbaq — no raw `<script>` / `<img onerror>` survives to output
             for a malformed-head vector (the throw prevents any emission)"
     (doseq [el [[nil "<script>alert(1)</script>"]
                 ["x" "<img src=x onerror=alert(1)>"]]]
-      (let [out (try (emit/render-to-string el {}) (catch Throwable _ ::threw))]
+      (let [out (try (rf.ssr.emit/render-to-string el {}) (catch Throwable _ ::threw))]
         (is (= ::threw out)
             (str "no wire output produced for malformed head: " (pr-str el)))))))
 
@@ -836,7 +836,7 @@
                 ["x" "<img src=x onerror=alert(1)>"]]]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #":rf.error/invalid-hiccup-head"
-                            (streaming/render-shell el))
+                            (rf.ssr.streaming/render-shell el))
           (str "streaming path must fail loud on malformed head: " (pr-str el))))))
 
 ;; ===========================================================================
@@ -859,19 +859,19 @@
     (let [form2-closed (fn [value] (fn [] [:div value]))
           form2-arg    (fn [_outer-value]
                          (fn [value] [:p (str "v=" value)]))]
-      (is (= "<div>hello</div>" (emit/emit-element [form2-closed "hello"]))
+      (is (= "<div>hello</div>" (rf.ssr.emit/emit-element [form2-closed "hello"]))
           "sync emit renders the 0-arity-inner Form-2 output")
       (is (= "<div>hello</div>"
-             (:shell-html (streaming/render-shell [form2-closed "hello"])))
+             (:shell-html (rf.ssr.streaming/render-shell [form2-closed "hello"])))
           "streaming renders the 0-arity-inner Form-2 output")
-      (is (= "<p>v=7</p>" (emit/emit-element [form2-arg 7]))
+      (is (= "<p>v=7</p>" (rf.ssr.emit/emit-element [form2-arg 7]))
           "sync emit renders the same-arity-inner Form-2 output")
       (is (= "<p>v=7</p>"
-             (:shell-html (streaming/render-shell [form2-arg 7])))
+             (:shell-html (rf.ssr.streaming/render-shell [form2-arg 7])))
           "streaming renders the same-arity-inner Form-2 output")
       ;; Belt-and-braces: no fn-identity toString leaks into the output.
-      (doseq [out [(emit/emit-element [form2-closed "hello"])
-                   (:shell-html (streaming/render-shell [form2-closed "hello"]))]]
+      (doseq [out [(rf.ssr.emit/emit-element [form2-closed "hello"])
+                   (:shell-html (rf.ssr.streaming/render-shell [form2-closed "hello"]))]]
         (is (not (str/includes? out "fn__"))
             "no inner-fn .toString (`…fn__…@…`) leaks as page text")
         (is (not (str/includes? out "@"))
@@ -882,11 +882,11 @@
     (let [deep (fn [x] (fn [] (fn [] [:div x])))]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #":rf.error/ssr-nonrenderable-component"
-                            (emit/emit-element [deep "z"]))
+                            (rf.ssr.emit/emit-element [deep "z"]))
           "sync emit fails loud on a deeper-than-Form-2 component")
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #":rf.error/ssr-nonrenderable-component"
-                            (streaming/render-shell [deep "z"]))
+                            (rf.ssr.streaming/render-shell [deep "z"]))
           "streaming fails loud on a deeper-than-Form-2 component"))))
 
 ;; ===========================================================================
@@ -933,10 +933,10 @@
     ;; the JVM used to try 2 args, catch, retry at 0, and throw.
     (let [form2-partial (fn [_outer-value _ignored]
                           (fn [kept] [:p kept]))]
-      (is (= "<p>kept</p>" (emit/emit-element [form2-partial "kept" "ignored"]))
+      (is (= "<p>kept</p>" (rf.ssr.emit/emit-element [form2-partial "kept" "ignored"]))
           "sync emit passes the inner the longest prefix it accepts")
       (is (= "<p>kept</p>"
-             (:shell-html (streaming/render-shell [form2-partial "kept" "ignored"])))
+             (:shell-html (rf.ssr.streaming/render-shell [form2-partial "kept" "ignored"])))
           "streaming passes the inner the longest prefix it accepts"))))
 
 (deftest emit-form-2-inner-body-arity-exception-propagates-once
@@ -963,14 +963,14 @@
                                      (needs-two "x")]))]
       (reset! calls 0)
       (is (thrown? clojure.lang.ArityException
-                   (emit/emit-element [form2-buggy]))
+                   (rf.ssr.emit/emit-element [form2-buggy]))
           "sync emit propagates the inner body's own ArityException")
       (is (= 1 @calls)
           "sync emit invoked the inner render EXACTLY once (the old
            catch-and-retry reached 2)")
       (reset! calls 0)
       (is (thrown? clojure.lang.ArityException
-                   (streaming/render-shell [form2-buggy]))
+                   (rf.ssr.streaming/render-shell [form2-buggy]))
           "streaming propagates the inner body's own ArityException")
       (is (= 1 @calls)
           "streaming invoked the inner render EXACTLY once (the old
@@ -996,14 +996,14 @@
       (reset! calls 0)
       (is (thrown-with-msg? clojure.lang.ArityException
                             #"Wrong number of args \(1\)"
-                            (emit/emit-element [form2-buggy "x"]))
+                            (rf.ssr.emit/emit-element [form2-buggy "x"]))
           "sync emit surfaces the render's own failing call, not a
            fabricated zero-arity retry")
       (is (= 1 @calls) "sync emit invoked the inner render exactly once")
       (reset! calls 0)
       (is (thrown-with-msg? clojure.lang.ArityException
                             #"Wrong number of args \(1\)"
-                            (streaming/render-shell [form2-buggy "x"]))
+                            (rf.ssr.streaming/render-shell [form2-buggy "x"]))
           "streaming surfaces the render's own failing call, not a
            fabricated zero-arity retry")
       (is (= 1 @calls) "streaming invoked the inner render exactly once"))))
@@ -1026,11 +1026,11 @@
                                       (needs-two x)]
                                 [:p "zero-arity retry reached this"])))]
       (is (thrown? clojure.lang.ArityException
-                   (emit/emit-element [form2 "x"]))
+                   (rf.ssr.emit/emit-element [form2 "x"]))
           "sync emit surfaces the render's own failure rather than
            re-entering the variadic inner with no args")
       (is (thrown? clojure.lang.ArityException
-                   (streaming/render-shell [form2 "x"]))
+                   (rf.ssr.streaming/render-shell [form2 "x"]))
           "streaming surfaces the render's own failure rather than
            re-entering the variadic inner with no args"))))
 
@@ -1048,7 +1048,7 @@
                               [:p (str/join "," xs)]))]
       (reset! calls 0)
       (reset! seen nil)
-      (is (= "<p>a,b</p>" (emit/emit-element [form2 "a" "b"]))
+      (is (= "<p>a,b</p>" (rf.ssr.emit/emit-element [form2 "a" "b"]))
           "sync emit renders the variadic inner's output")
       (is (= ["a" "b"] @seen)
           "sync emit passed the variadic inner the complete arg sequence")
@@ -1056,7 +1056,7 @@
           "sync emit invoked the variadic inner exactly once")
       (reset! calls 0)
       (reset! seen nil)
-      (is (= "<p>a,b</p>" (:shell-html (streaming/render-shell [form2 "a" "b"])))
+      (is (= "<p>a,b</p>" (:shell-html (rf.ssr.streaming/render-shell [form2 "a" "b"])))
           "streaming renders the variadic inner's output")
       (is (= ["a" "b"] @seen)
           "streaming passed the variadic inner the complete arg sequence")
@@ -1104,35 +1104,35 @@
           multi-0-1 (fn [& _] (fn ([]  [:p "m0"])
                                   ([x] [:p (str "m1|" x)])))]
       (is (thrown? clojure.lang.ArityException
-                   (emit/emit-element [multi-1-2 "a" "b" "c"]))
+                   (rf.ssr.emit/emit-element [multi-1-2 "a" "b" "c"]))
           "sync emit refuses a 1-or-2-arity inner handed 3 args")
       (is (thrown? clojure.lang.ArityException
-                   (streaming/render-shell [multi-1-2 "a" "b" "c"]))
+                   (rf.ssr.streaming/render-shell [multi-1-2 "a" "b" "c"]))
           "streaming refuses a 1-or-2-arity inner handed 3 args")
       (is (thrown? clojure.lang.ArityException
-                   (emit/emit-element [multi-0-1 "a" "b"]))
+                   (rf.ssr.emit/emit-element [multi-0-1 "a" "b"]))
           "sync emit refuses a 0-or-1-arity inner handed 2 args")
       (is (thrown? clojure.lang.ArityException
-                   (streaming/render-shell [multi-0-1 "a" "b"]))
+                   (rf.ssr.streaming/render-shell [multi-0-1 "a" "b"]))
           "streaming refuses a 0-or-1-arity inner handed 2 args")
 
       ;; NON-VACUITY. The same two inners must still render through every arm
       ;; they DO declare — otherwise the rows above would be satisfied by a
       ;; blanket refusal of multi-arity inners, which is a different (and
       ;; worse) behaviour wearing the same green.
-      (is (= "<p>m2|a|b</p>" (emit/emit-element [multi-1-2 "a" "b"]))
+      (is (= "<p>m2|a|b</p>" (rf.ssr.emit/emit-element [multi-1-2 "a" "b"]))
           "sync emit selects the exact 2-arity arm")
       (is (= "<p>m2|a|b</p>"
-             (:shell-html (streaming/render-shell [multi-1-2 "a" "b"])))
+             (:shell-html (rf.ssr.streaming/render-shell [multi-1-2 "a" "b"])))
           "streaming selects the exact 2-arity arm")
-      (is (= "<p>m1|a</p>" (emit/emit-element [multi-1-2 "a"]))
+      (is (= "<p>m1|a</p>" (rf.ssr.emit/emit-element [multi-1-2 "a"]))
           "sync emit selects the exact 1-arity arm")
       (is (= "<p>m1|a</p>"
-             (:shell-html (streaming/render-shell [multi-1-2 "a"])))
+             (:shell-html (rf.ssr.streaming/render-shell [multi-1-2 "a"])))
           "streaming selects the exact 1-arity arm")
-      (is (= "<p>m0</p>" (emit/emit-element [multi-0-1]))
+      (is (= "<p>m0</p>" (rf.ssr.emit/emit-element [multi-0-1]))
           "sync emit selects the exact 0-arity arm")
-      (is (= "<p>m0</p>" (:shell-html (streaming/render-shell [multi-0-1])))
+      (is (= "<p>m0</p>" (:shell-html (rf.ssr.streaming/render-shell [multi-0-1])))
           "streaming selects the exact 0-arity arm")))
 
   (testing "rf2-mocn3 — a fixed+variadic inner routes by the same rules: the
@@ -1145,14 +1145,14 @@
     (let [mixed (fn [& _] (fn ([a] [:p (str "mx1|" a)])
                               ([a b & r] [:p (str "mxv|" a "|" b "|"
                                                   (str/join "," r))])))]
-      (is (= "<p>mxv|a|b|c</p>" (emit/emit-element [mixed "a" "b" "c"]))
+      (is (= "<p>mxv|a|b|c</p>" (rf.ssr.emit/emit-element [mixed "a" "b" "c"]))
           "sync emit hands the satisfied variadic arm every arg")
       (is (= "<p>mxv|a|b|c</p>"
-             (:shell-html (streaming/render-shell [mixed "a" "b" "c"])))
+             (:shell-html (rf.ssr.streaming/render-shell [mixed "a" "b" "c"])))
           "streaming hands the satisfied variadic arm every arg")
-      (is (= "<p>mx1|a</p>" (emit/emit-element [mixed "a"]))
+      (is (= "<p>mx1|a</p>" (rf.ssr.emit/emit-element [mixed "a"]))
           "sync emit prefers the exact fixed arm")
-      (is (= "<p>mx1|a</p>" (:shell-html (streaming/render-shell [mixed "a"])))
+      (is (= "<p>mx1|a</p>" (:shell-html (rf.ssr.streaming/render-shell [mixed "a"])))
           "streaming prefers the exact fixed arm"))))
 
 ;; ===========================================================================
@@ -1194,27 +1194,27 @@
   (testing "rf2-r9kf — an `aria-*` boolean stringifies in BOTH directions;
             `false` is a state, never an omission"
     (is (= "<button aria-expanded=\"true\">x</button>"
-           (emit/render-to-string [:button {:aria-expanded true} "x"] {}))
+           (rf.ssr.emit/render-to-string [:button {:aria-expanded true} "x"] {}))
         "aria-expanded true → aria-expanded=\"true\", never a bare name")
     (is (= "<button aria-expanded=\"false\">x</button>"
-           (emit/render-to-string [:button {:aria-expanded false} "x"] {}))
+           (rf.ssr.emit/render-to-string [:button {:aria-expanded false} "x"] {}))
         "aria-expanded false → aria-expanded=\"false\", never absent")
     (is (= "<div aria-hidden=\"false\"></div>"
-           (emit/render-to-string [:div {:aria-hidden false}] {}))
+           (rf.ssr.emit/render-to-string [:div {:aria-hidden false}] {}))
         "aria-hidden false survives — absent would mean the opposite")
     (is (= "<div aria-checked=\"false\"></div>"
-           (emit/render-to-string [:div {:aria-checked false}] {}))
+           (rf.ssr.emit/render-to-string [:div {:aria-checked false}] {}))
         "aria-checked false survives")
     (is (= "<div aria-disabled=\"false\"></div>"
-           (emit/render-to-string [:div {:aria-disabled false}] {}))
+           (rf.ssr.emit/render-to-string [:div {:aria-disabled false}] {}))
         "aria-disabled false survives"))
 
   (testing "rf2-r9kf — `data-*` booleans stringify the same way"
     (is (= "<div data-open=\"true\"></div>"
-           (emit/render-to-string [:div {:data-open true}] {}))
+           (rf.ssr.emit/render-to-string [:div {:data-open true}] {}))
         "data-* true → data-open=\"true\"")
     (is (= "<div data-open=\"false\"></div>"
-           (emit/render-to-string [:div {:data-open false}] {}))
+           (rf.ssr.emit/render-to-string [:div {:data-open false}] {}))
         "data-* false → data-open=\"false\"")))
 
 (deftest render-to-string-booleanish-attrs-stringify-both-ways
@@ -1224,7 +1224,7 @@
     (is (= (str "<div contentEditable=\"true\">"
                 "<section contentEditable=\"false\">locked</section>"
                 "</div>")
-           (emit/render-to-string
+           (rf.ssr.emit/render-to-string
             [:div {:contentEditable true}
              [:section {:contentEditable false} "locked"]]
             {}))
@@ -1235,7 +1235,7 @@
     (doseq [attribute-key [:contentEditable :draggable :spellCheck]
             [value expected] [[true "true"] [false "false"]]]
       (is (= (str "<div " (name attribute-key) "=\"" expected "\"></div>")
-             (emit/render-to-string [:div {attribute-key value}] {}))
+             (rf.ssr.emit/render-to-string [:div {attribute-key value}] {}))
           (str "booleanish " attribute-key " " value
                " → " (name attribute-key) "=\"" expected "\"")))))
 
@@ -1244,34 +1244,34 @@
             semantics. `disabled=\"false\"` is truthy to a browser, so
             emitting the false value here would disable the control"
     (is (= "<input disabled required>"
-           (emit/render-to-string [:input {:disabled true :required true}] {}))
+           (rf.ssr.emit/render-to-string [:input {:disabled true :required true}] {}))
         "true boolean attrs stay bare names")
     (is (= "<input>"
-           (emit/render-to-string [:input {:disabled false :hidden nil}] {}))
+           (rf.ssr.emit/render-to-string [:input {:disabled false :hidden nil}] {}))
         "a false boolean attr stays OMITTED — never disabled=\"false\"")
     (is (= "<input>"
-           (emit/render-to-string [:input {:checked false :readonly false}] {}))
+           (rf.ssr.emit/render-to-string [:input {:checked false :readonly false}] {}))
         "checked/readonly false stay omitted"))
 
   (testing "rf2-r9kf CONTROL — overloaded booleans keep their own shape:
             true → presence, false → omitted, any other value stringifies"
     (is (= "<a download>d</a>"
-           (emit/render-to-string [:a {:download true} "d"] {}))
+           (rf.ssr.emit/render-to-string [:a {:download true} "d"] {}))
         "download true → bare presence")
     (is (= "<a>d</a>"
-           (emit/render-to-string [:a {:download false} "d"] {}))
+           (rf.ssr.emit/render-to-string [:a {:download false} "d"] {}))
         "download false → omitted")
     (is (= "<a download=\"report.pdf\">d</a>"
-           (emit/render-to-string [:a {:download "report.pdf"} "d"] {}))
+           (rf.ssr.emit/render-to-string [:a {:download "report.pdf"} "d"] {}))
         "a string download stringifies"))
 
   (testing "rf2-r9kf CONTROL — a boolean on an ORDINARY attribute never
             becomes a bare attribute (react-dom drops it)"
     (is (= "<div>x</div>"
-           (emit/render-to-string [:div {:title true} "x"] {}))
+           (rf.ssr.emit/render-to-string [:div {:title true} "x"] {}))
         "true on an ordinary attribute is dropped, not emitted bare")
     (is (= "<div>x</div>"
-           (emit/render-to-string [:div {:role false} "x"] {}))
+           (rf.ssr.emit/render-to-string [:div {:role false} "x"] {}))
         "false on an ordinary attribute is dropped")))
 
 (deftest render-shell-applies-the-same-boolean-classes
@@ -1280,7 +1280,7 @@
             landing on one hiccup mode only is the drift this pins"
     (let [tree [:div {:aria-expanded false :contentEditable false}
                 [:button {:disabled true :aria-disabled false} "go"]]
-          {:keys [shell-html]} (streaming/render-shell tree)]
+          {:keys [shell-html]} (rf.ssr.streaming/render-shell tree)]
       (is (str/includes? shell-html "aria-expanded=\"false\"")
           "streaming keeps a false aria-* value")
       (is (str/includes? shell-html "contentEditable=\"false\"")
@@ -1324,8 +1324,8 @@
                                    [:download true]        [:download false]
                                    [:title true]           [:role false]]]
       (let [attribute-name (name attribute-key)
-            hiccup-html    (emit/render-to-string [:div {attribute-key value}] {})
-            tree-html      (ui-tree/emit-ui-tree
+            hiccup-html    (rf.ssr.emit/render-to-string [:div {attribute-key value}] {})
+            tree-html      (rf.ssr.ui-tree/emit-ui-tree
                             (v1 {:tag :div :attrs {attribute-key value}}))]
         (is (= (boolean-attr-class-signature attribute-name tree-html)
                (boolean-attr-class-signature attribute-name hiccup-html))

--- a/implementation/ssr/test/re_frame/ssr_emitter_reinit_lifecycle_jvm_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emitter_reinit_lifecycle_jvm_test.clj
@@ -20,45 +20,45 @@
   path armed."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind :as rf.late-bind]
             [re-frame.ssr]
-            [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
 (use-fixtures :each
   (fn [f]
-    (substrate-adapter/reset-lifecycle-state-for-tests!)
+    (rf.substrate.adapter/reset-lifecycle-state-for-tests!)
     (try
       (f)
       (finally
         (rf/destroy-adapter!)
-        (substrate-adapter/reset-lifecycle-state-for-tests!)))))
+        (rf.substrate.adapter/reset-lifecycle-state-for-tests!)))))
 
 (defn- render! []
-  (substrate-adapter/render-to-string [:div "ok"] {}))
+  (rf.substrate.adapter/render-to-string [:div "ok"] {}))
 
 (deftest ssr-load-published-the-durable-emitter-on-the-jvm-too
-  (is (fn? (late-bind/get-fn :ssr/current-hiccup-emitter))
+  (is (fn? (rf.late-bind/get-fn :ssr/current-hiccup-emitter))
       "re-frame.ssr ns-load published :ssr/current-hiccup-emitter on the JVM"))
 
 (deftest jvm-plain-atom-emitter-is-retained-across-destroy-and-reinit
-  (is (nil? (rf/init! plain-atom/adapter)))
+  (is (nil? (rf/init! rf.substrate.plain-atom/adapter)))
   (testing "first install renders through the SSR emitter"
     (is (re-find #"<div>ok</div>" (render!))))
 
   (is (nil? (rf/destroy-adapter!)))
-  (is (true? (substrate-adapter/adapter-disposed?)))
+  (is (true? (rf.substrate.adapter/adapter-disposed?)))
 
-  (is (nil? (rf/init! plain-atom/adapter)) "a fresh init is legal after disposal")
+  (is (nil? (rf/init! rf.substrate.plain-atom/adapter)) "a fresh init is legal after disposal")
   (testing "the JVM emitter survived the no-op dispose — re-init still renders"
     (is (re-find #"<div>ok</div>" (render!))
         "plain-atom retains its hiccup-emitter across the dispose/re-init cycle")))
 
 (deftest jvm-lifecycle-is-repeatable-and-does-not-duplicate-publication
-  (let [emitter-before (late-bind/get-fn :ssr/current-hiccup-emitter)]
+  (let [emitter-before (rf.late-bind/get-fn :ssr/current-hiccup-emitter)]
     (dotimes [_ 5]
-      (is (nil? (rf/init! plain-atom/adapter)))
+      (is (nil? (rf/init! rf.substrate.plain-atom/adapter)))
       (is (re-find #"<div>ok</div>" (render!)))
       (is (nil? (rf/destroy-adapter!))))
-    (is (identical? emitter-before (late-bind/get-fn :ssr/current-hiccup-emitter))
+    (is (identical? emitter-before (rf.late-bind/get-fn :ssr/current-hiccup-emitter))
         "the durable emitter slot holds the SAME single publication after every cycle")))

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -78,18 +78,18 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.response :as response]
-            [re-frame.ssr.test-fixture :as tf]
-            [re-frame.trace :as trace]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.response :as rf.ssr.response]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
+            [re-frame.trace :as rf.trace]))
 
 ;; The canonical reset-runtime fixture lives in `re-frame.ssr.test-fixture`
 ;; (rf2-i3qc0) — one source of truth for the registrar/side-channel/ns-
 ;; reload cycle that every ssr-artefact JVM test needs between :each.
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---- helpers --------------------------------------------------------------
 
@@ -176,7 +176,7 @@
               ^{:key id} [:li [:h3 title] [:p body]])]])))
 
     ;; ---- (1) per-request server frame -------------------------------------
-    (let [server-frame (frame/make-anon-frame-record!
+    (let [server-frame (rf.frame/make-anon-frame-record!
                          {:doc          "SSR request frame"
                           :platform     :server
                           :initial-events    [[:rf/server-init {:uri "/articles"}]]
@@ -225,7 +225,7 @@
               "payload carries the resolved render-tree hash")
 
           ;; ---- (6) hydration on a separate "client" frame ---------------
-          (let [client-frame (frame/make-anon-frame-record!
+          (let [client-frame (rf.frame/make-anon-frame-record!
                                {:doc      "Hydrated client frame"
                                 :platform :client})
                 ;; rf2-nv3mua: in a real SSR deployment the server and client
@@ -262,7 +262,7 @@
                                   (resolve-tree client-frame render-tree))
                   match-traces  (atom [])]
               (rf/register-listener! :trace ::match (fn [ev] (swap! match-traces conj ev)))
-              (ssr/verify-hydration!
+              (rf.ssr/verify-hydration!
                 client-frame client-hash-1)
               (rf/unregister-listener! :trace ::match)
               (is (= server-hash client-hash-1)
@@ -276,7 +276,7 @@
               ;; the positive it discriminates against, not outside it. The
               ;; hash equality above is the posture-independent half and stays
               ;; in this lane.
-              (when interop/debug-enabled?
+              (when rf.interop/debug-enabled?
                 (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %))
                               @match-traces)
                     "no :rf.ssr/hydration-mismatch trace when hashes agree")))
@@ -294,7 +294,7 @@
                                      (resolve-tree client-frame render-tree))
                   mismatch-traces (atom [])]
               (rf/register-listener! :trace ::mismatch (fn [ev] (swap! mismatch-traces conj ev)))
-              (ssr/verify-hydration!
+              (rf.ssr/verify-hydration!
                 client-frame client-hash-2)
               (rf/unregister-listener! :trace ::mismatch)
 
@@ -304,7 +304,7 @@
               ;; production-visible half is the hash inequality asserted just
               ;; above: the framework computes the divergence in every build,
               ;; and only the telling-you-about-it is dev-gated.
-              (when interop/debug-enabled?
+              (when rf.interop/debug-enabled?
                 (is (some (fn [ev]
                             (and (= :rf.ssr/hydration-mismatch (:operation ev))
                                  (= :error (:op-type ev))
@@ -327,7 +327,7 @@
 (defn- get-response
   "Read the resolved response accumulator for a frame."
   [frame-id]
-  (ssr/get-response frame-id))
+  (rf.ssr/get-response frame-id))
 
 (deftest ssr-set-status-precedence
   (testing "two :rf.server/set-status fx → last write wins + :rf.warning/multiple-status-set"
@@ -337,7 +337,7 @@
           {:fx [[:rf.server/set-status 401]
                 [:rf.server/set-status 403]]}))                          ;; second write replaces
 
-      (let [f (frame/make-anon-frame-record! {:platform :server})]
+      (let [f (rf.frame/make-anon-frame-record! {:platform :server})]
         (rf/register-listener! :trace ::status (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:auth/forbid] {:frame f})
         (rf/unregister-listener! :trace ::status)
@@ -350,7 +350,7 @@
         ;; last-write-wins and the warning is advice to the programmer, not
         ;; part of the response. The policy itself is asserted above and runs
         ;; in this lane; only the advice is gated.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (some (fn [ev]
                       (and (= :rf.warning/multiple-status-set (:operation ev))
                            (= [401 403] (:writes (:tags ev)))
@@ -382,7 +382,7 @@
                                       :value   "off"
                                       :max-age 0}]]}))
 
-    (let [f (frame/make-anon-frame-record! {:platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:platform :server})]
       (rf/dispatch-sync [:auth/establish] {:frame f})
 
       (let [cookies (:cookies (get-response f))]
@@ -416,7 +416,7 @@
       (fn [_ _]
         {:fx [[:rf.server/delete-cookie {:name "session" :path "/"}]]}))
 
-    (let [f (frame/make-anon-frame-record! {:platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:platform :server})]
       (rf/dispatch-sync [:auth/logout] {:frame f})
       (let [[c] (:cookies (get-response f))]
         (is (= "session" (:name c)))
@@ -442,7 +442,7 @@
         {:fx [[:rf.server/append-header {:name "Set-Cookie" :value "a=1"}]
               [:rf.server/append-header {:name "Set-Cookie" :value "b=2"}]]}))
 
-    (let [f (frame/make-anon-frame-record! {:platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:platform :server})]
       (rf/dispatch-sync [:hdr/set-then-replace] {:frame f})
       (rf/dispatch-sync [:hdr/append-twice]     {:frame f})
       (let [hdrs  (:headers (get-response f))
@@ -564,7 +564,7 @@
                {:name  "X-Forwarded-For"
                 :value "1.2.3.4\r\nSet-Cookie: admin=1"}]]}))
 
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/inject-crlf] {:frame f})))]
       (expect-fx-error-keyword!
@@ -576,7 +576,7 @@
       (rf/reg-event :hdr/probe-injection
         (fn [_ _]
           {:fx [[:rf.server/set-header {:name "X-Probe" :value hostile}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:hdr/probe-injection] {:frame f})))]
         (expect-fx-error-keyword!
@@ -591,7 +591,7 @@
         {:fx [[:rf.server/append-header
                {:name  "X-Audit"
                 :value "ok\r\nSet-Cookie: forged=1"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/append-crlf] {:frame f})))]
       (expect-fx-error-keyword!
@@ -607,7 +607,7 @@
       (fn [_ _]
         {:fx [[:rf.server/redirect
                {:location "https://example.com\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:redirect/crlf-in-location] {:frame f})))]
       (expect-fx-error-keyword!
@@ -627,7 +627,7 @@
       (fn [_ _]
         {:fx [[:rf.server/redirect {:to "/ok"}]]}))
     (doseq [ev [:redirect/via-url :redirect/via-to]]
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [ev] {:frame f})))]
         (expect-fx-error-keyword!
@@ -643,7 +643,7 @@
     (rf/reg-event :redirect/retired-spelling
       (fn [_ _]
         {:fx [[:rf.server/redirect {:url "/login"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:redirect/retired-spelling] {:frame f})))
           ex     (some (fn [ev]
@@ -679,7 +679,7 @@
       (rf/reg-event :redirect/shape-quirk
         (fn [_ _]
           {:fx [[:rf.server/redirect {:location loc}]]}))
-      (let [f    (frame/make-anon-frame-record! {:platform :server :initial-events [[:redirect/shape-quirk]]})
+      (let [f    (rf.frame/make-anon-frame-record! {:platform :server :initial-events [[:redirect/shape-quirk]]})
             resp (get-response f)]
         (is (= loc (-> resp :redirect :location))
             (str "raw URL-shape quirk passes through the caller-trusted "
@@ -699,7 +699,7 @@
       (rf/reg-event :redirect/well-formed
         (fn [_ _]
           {:fx [[:rf.server/redirect {:location loc}]]}))
-      (let [f    (frame/make-anon-frame-record! {:platform :server :initial-events [[:redirect/well-formed]]})
+      (let [f    (rf.frame/make-anon-frame-record! {:platform :server :initial-events [[:redirect/well-formed]]})
             resp (get-response f)]
         (is (= loc (-> resp :redirect :location))
             (str "well-formed redirect :location flows through: " loc))))))
@@ -716,7 +716,7 @@
       (rf/reg-event :redirect/crlf-nul
         (fn [_ _]
           {:fx [[:rf.server/redirect {:location loc}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:redirect/crlf-nul] {:frame f})))]
         (expect-fx-error-keyword!
@@ -733,7 +733,7 @@
       (rf/reg-event :safe-redirect/crlf-nul
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect {:location loc}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:safe-redirect/crlf-nul] {:frame f})))]
         (expect-fx-error-keyword!
@@ -751,7 +751,7 @@
               [:rf.server/set-header {:name "X-Whitespace"
                                       :value "tab\there space"}]
               [:rf.server/redirect    {:location "https://example.com/path?q=1&r=2"}]]}))
-    (let [f (frame/make-anon-frame-record! {:platform :server :initial-events [[:hdr/clean]]})
+    (let [f (rf.frame/make-anon-frame-record! {:platform :server :initial-events [[:hdr/clean]]})
           resp (get-response f)
           hdrs (:headers resp)]
       (is (some (fn [[k v]]
@@ -773,7 +773,7 @@
       (fn [_ _]
         {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
 
-    (let [f (frame/make-anon-frame-record! {:platform     :server
+    (let [f (rf.frame/make-anon-frame-record! {:platform     :server
                             :initial-events    [[:auth/check-session]]})]
       (let [resp     (get-response f)
             redirect (:redirect resp)]
@@ -802,7 +802,7 @@
     (rf/reg-event :auth/check-no-status
       (fn [_ _]
         {:fx [[:rf.server/redirect {:location "/login"}]]}))
-    (let [f (frame/make-anon-frame-record! {:platform  :server
+    (let [f (rf.frame/make-anon-frame-record! {:platform  :server
                             :initial-events [[:auth/check-no-status]]})]
       (is (= 302 (-> (get-response f) :redirect :status))
           ":rf.server/redirect defaults :status to 302 per Spec 011 §Redirect"))))
@@ -872,8 +872,8 @@
 (deftest ssr-default-error-projector-no-such-handler
   (testing "routing's :rf.error/no-such-handler → default projector → 404"
     (rf/reg-route :route/home {} "/")
-    (let [project-error  ssr/project-error
-          f              (frame/make-anon-frame-record!
+    (let [project-error  rf.ssr/project-error
+          f              (rf.frame/make-anon-frame-record!
                            {:platform :server
                             :ssr {:public-error-id   :rf.ssr/default-error-projector
                                   :dev-error-detail? false}})
@@ -921,8 +921,8 @@
     (rf/reg-event :rf/server-init
       (fn [_ _] {}))
 
-    (let [project-error  ssr/project-error
-          f              (frame/make-anon-frame-record!
+    (let [project-error  rf.ssr/project-error
+          f              (rf.frame/make-anon-frame-record!
                            {:platform :server
                             :initial-events [[:rf/server-init]]
                             :ssr {:public-error-id   :rf.ssr/default-error-projector
@@ -947,8 +947,8 @@
 
 (deftest ssr-error-projector-dev-mode-includes-details
   (testing ":dev-error-detail? true puts the raw trace under :details"
-    (let [project-error ssr/project-error
-          f             (frame/make-anon-frame-record!
+    (let [project-error rf.ssr/project-error
+          f             (rf.frame/make-anon-frame-record!
                           {:platform :server
                            :ssr {:public-error-id   :rf.ssr/default-error-projector
                                  :dev-error-detail? true}})
@@ -984,8 +984,8 @@
            :message "Custom 500"
            :retryable? false})))
 
-    (let [project-error ssr/project-error
-          f             (frame/make-anon-frame-record!
+    (let [project-error rf.ssr/project-error
+          f             (rf.frame/make-anon-frame-record!
                           {:platform :server
                            :ssr {:public-error-id   :myapp/public-error
                                  :dev-error-detail? false}})]
@@ -1011,8 +1011,8 @@
       (fn [_trace-event]
         (throw (ex-info "projector bug" {}))))
 
-    (let [project-error ssr/project-error
-          f             (frame/make-anon-frame-record!
+    (let [project-error rf.ssr/project-error
+          f             (rf.frame/make-anon-frame-record!
                           {:platform :server
                            :ssr {:public-error-id   :myapp/buggy-projector
                                  :dev-error-detail? false}})
@@ -1034,8 +1034,8 @@
     (rf/reg-error-projector :myapp/bad-shape
       (fn [_trace-event] {:wrong :shape}))
 
-    (let [project-error ssr/project-error
-          f             (frame/make-anon-frame-record!
+    (let [project-error rf.ssr/project-error
+          f             (rf.frame/make-anon-frame-record!
                           {:platform :server
                            :ssr {:public-error-id   :myapp/bad-shape}})
           {public :result
@@ -1055,9 +1055,9 @@
             of silently downgrading the projector's intended mapping to the
             generic 500. Pre-rf2-mlodrn this fell back with NO dev trace and
             NO always-on record."
-    (let [project-error ssr/project-error
+    (let [project-error rf.ssr/project-error
           ;; A :public-error-id that was NEVER reg-error-projector'd.
-          f             (frame/make-anon-frame-record!
+          f             (rf.frame/make-anon-frame-record!
                           {:platform :server
                            :ssr {:public-error-id   :myapp/never-registered
                                  :dev-error-detail? false}})
@@ -1090,8 +1090,8 @@
             there is no missing-projector diagnostic (the change is surgical
             to the CONFIGURED-but-unregistered case, not noisy on the default
             path)."
-    (let [project-error ssr/project-error
-          f             (frame/make-anon-frame-record! {:platform :server})
+    (let [project-error rf.ssr/project-error
+          f             (rf.frame/make-anon-frame-record! {:platform :server})
           ;; rf2-ov56u: the 404 arm is gated on `:kind :route` — the
           ;; URL-driven miss. `:tags {}` now projects 500, so the
           ;; honoured-vs-fallen-back distinction this deftest is about
@@ -1134,18 +1134,18 @@
               :kind :event / :kind :frame / kind-less cases are pinned in
               re-frame.ssr-route-miss-404-production-test)"
       (is (= {:status 404 :code :not-found :message "Page not found" :retryable? false}
-             (ssr/default-error-projector-fn {:operation :rf.error/no-such-handler
+             (rf.ssr/default-error-projector-fn {:operation :rf.error/no-such-handler
                                               :tags      {:kind :route}}))))
     (testing ":rf.error/no-such-route → 404 :not-found (the second 404 arm —
               previously untested)"
       (is (= {:status 404 :code :not-found :message "Page not found" :retryable? false}
-             (ssr/default-error-projector-fn {:operation :rf.error/no-such-route}))
+             (rf.ssr/default-error-projector-fn {:operation :rf.error/no-such-route}))
           "no-such-route shares the 404 :not-found mapping with no-such-handler"))
     (testing ":rf.error/cofx-value-invalid → 400 :bad-request
               UNCONDITIONALLY (rf2-57ehvw — a bad client-supplied request
               coeffect is client input, never a server-fault 500)"
       (is (= {:status 400 :code :bad-request :message "Invalid input" :retryable? false}
-             (ssr/default-error-projector-fn
+             (rf.ssr/default-error-projector-fn
                {:operation :rf.error/cofx-value-invalid
                 :tags      {:reason :non-edn-recordable-value}}))
           "a non-recordable request coeffect (the category that REPLACED the
@@ -1153,7 +1153,7 @@
            a client-facing 400 — the regression this bead fixes was that it
            projected 500")
       (is (= {:status 400 :code :bad-request :message "Invalid input" :retryable? false}
-             (ssr/default-error-projector-fn
+             (rf.ssr/default-error-projector-fn
                {:operation :rf.error/cofx-value-invalid}))
           "the 400 arm is UNCONDITIONAL — it does not depend on a :where tag
            (unlike schema-validation-failure); the dispatch boundary is the
@@ -1161,7 +1161,7 @@
     (testing ":rf.error/schema-validation-failure with a CLIENT-surface
               :where (:event) → 400 :bad-request (rf2-37o5by)"
       (is (= {:status 400 :code :bad-request :message "Invalid input" :retryable? false}
-             (ssr/default-error-projector-fn
+             (rf.ssr/default-error-projector-fn
                {:operation :rf.error/schema-validation-failure
                 :tags      {:where :event}}))
           "an inbound-event payload failure is client-facing → 400"))
@@ -1170,40 +1170,40 @@
               path was retired; a bad request coeffect now rides its own
               :rf.error/cofx-value-invalid category, so this stale shape is no
               longer a client 400)"
-      (is (= ssr/fallback-public-error
-             (ssr/default-error-projector-fn
+      (is (= rf.ssr/fallback-public-error
+             (rf.ssr/default-error-projector-fn
                {:operation :rf.error/schema-validation-failure
                 :tags      {:where :cofx}}))
           "the retired :where :cofx shape falls through to the locked
            generic-500 — the live client-cofx 400 is :rf.error/cofx-value-invalid"))
     (testing ":rf.error/schema-validation-failure with a SERVER-surface
               :where (:fx-args) → 500 (rf2-37o5by — gated 400 arm)"
-      (is (= ssr/fallback-public-error
-             (ssr/default-error-projector-fn
+      (is (= rf.ssr/fallback-public-error
+             (rf.ssr/default-error-projector-fn
                {:operation :rf.error/schema-validation-failure
                 :tags      {:where :fx-args}}))
           "a server-fx arg-schema failure is a SERVER-side defect, not bad
            client input — it falls through to the locked generic-500 rather
            than mislabelling a server bug as a client 400")
-      (is (= ssr/fallback-public-error
-             (ssr/default-error-projector-fn
+      (is (= rf.ssr/fallback-public-error
+             (rf.ssr/default-error-projector-fn
                {:operation :rf.error/schema-validation-failure}))
           "a schema-validation-failure with NO :where tag also falls through
            to 500 — the 400 arm is opt-in on a client-surface :where, fail-safe")
-      (is (= ssr/fallback-public-error
-             (ssr/default-error-projector-fn
+      (is (= rf.ssr/fallback-public-error
+             (rf.ssr/default-error-projector-fn
                {:operation :rf.error/schema-validation-failure
                 :tags      {:where :sub-return}}))
           "a sub-return failure is likewise non-client → 500"))
     (testing "any other category → the locked generic-500 fallback"
-      (is (= ssr/fallback-public-error
-             (ssr/default-error-projector-fn {:operation :rf.error/handler-exception}))
+      (is (= rf.ssr/fallback-public-error
+             (rf.ssr/default-error-projector-fn {:operation :rf.error/handler-exception}))
           "handler-exception falls through to the 500 default")
-      (is (= ssr/fallback-public-error
-             (ssr/default-error-projector-fn {:operation :totally/unknown-future-category}))
+      (is (= rf.ssr/fallback-public-error
+             (rf.ssr/default-error-projector-fn {:operation :totally/unknown-future-category}))
           "an unenumerated future category also falls through — no case arm needed")
-      (is (= ssr/fallback-public-error
-             (ssr/default-error-projector-fn {}))
+      (is (= rf.ssr/fallback-public-error
+             (rf.ssr/default-error-projector-fn {}))
           "an event with no :operation falls through to 500 too"))))
 
 ;; ===========================================================================
@@ -1220,7 +1220,7 @@
             peek-response (pure read) and only stamps :status when
             flush-response! / get-response drains it."
     (rf/reg-route :route/home {} "/")
-    (let [f (frame/make-anon-frame-record!
+    (let [f (rf.frame/make-anon-frame-record!
               {:platform :server
                :ssr {:public-error-id   :rf.ssr/default-error-projector
                      :dev-error-detail? false}})]
@@ -1229,22 +1229,22 @@
 
       (testing "peek-response reads the un-projected response (still 200) and
                 does NOT consume the buffered trace"
-        (is (= 200 (:status (ssr/peek-response f)))
+        (is (= 200 (:status (rf.ssr/peek-response f)))
             "peek leaves :status at the default 200 — the projector buffer
              is NOT drained by a pure read"))
 
       (testing "a SECOND peek still sees 200 — peek is idempotent + side-effect-free"
-        (is (= 200 (:status (ssr/peek-response f)))
+        (is (= 200 (:status (rf.ssr/peek-response f)))
             "the pending trace survived the first peek, so the second peek
              still reads the un-projected status"))
 
       (testing "flush-response! drains the buffer and stamps the projector's status"
-        (is (= 404 (:status (ssr/flush-response! f)))
+        (is (= 404 (:status (rf.ssr/flush-response! f)))
             "flush projects the buffered :no-such-handler → 404 onto :status"))
 
       (testing "after the drain the buffer is empty — a subsequent peek reads 404
                 (the stamped value persists; nothing left to re-project)"
-        (is (= 404 (:status (ssr/peek-response f)))
+        (is (= 404 (:status (rf.ssr/peek-response f)))
             "the stamped 404 persists on the accumulator post-drain")))))
 
 (deftest peek-and-get-response-strip-bookkeeping-keys
@@ -1256,10 +1256,10 @@
       (fn [_ _]
         {:fx [[:rf.server/set-status 201]
               [:rf.server/set-status 202]]}))
-    (let [f (frame/make-anon-frame-record! {:platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:platform :server})]
       (rf/dispatch-sync [:resp/multi-status] {:frame f})
-      (doseq [[label resp] [["peek-response"  (ssr/peek-response f)]
-                            ["get-response"   (ssr/get-response f)]]]
+      (doseq [[label resp] [["peek-response"  (rf.ssr/peek-response f)]
+                            ["get-response"   (rf.ssr/get-response f)]]]
         (is (= 202 (:status resp))
             (str label ": last-write-wins status surfaces"))
         (is (not (contains? resp :rf.server/_status-writes))
@@ -1274,7 +1274,7 @@
     ;; project. (The trace still fires; the projector just isn't called
     ;; for a client frame's response slot.)
     (rf/reg-route :route/home {} "/")
-    (let [client-f (frame/make-anon-frame-record! {:platform :client})]
+    (let [client-f (rf.frame/make-anon-frame-record! {:platform :client})]
       (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"]
                         {:frame client-f})
       (let [resp (get-response client-f)]
@@ -1295,7 +1295,7 @@
           {:fx [[:rf.server/redirect {:status 302 :location "/login"}]
                 [:rf.server/redirect {:status 301 :location "/canonical"}]]}))
 
-      (let [f (frame/make-anon-frame-record! {:platform :server})]
+      (let [f (rf.frame/make-anon-frame-record! {:platform :server})]
         (rf/register-listener! :trace ::redir (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:auth/double-redirect] {:frame f})
         (rf/unregister-listener! :trace ::redir)
@@ -1308,7 +1308,7 @@
         ;; above: the last-write-wins POLICY is the contract and is asserted
         ;; posture-independently just above; the warning is programmer advice
         ;; and is dev-only by design.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (some (fn [ev]
                       (and (= :rf.warning/multiple-redirects (:operation ev))
                            (= 2 (count (:writes (:tags ev))))
@@ -1337,7 +1337,7 @@
 
 (deftest host-supplied-failing-id-surfaced-on-unified-channel
   (testing "a host-supplied :failing-id override flows through verify-hydration! to the trace on the unified render-hash channel"
-    (let [verify-fn ssr/verify-hydration!
+    (let [verify-fn rf.ssr/verify-hydration!
           ;; Hydration payload carries the SERVER's render-hash. v1's
           ;; unified channel covers head + body; the bundled runtime emits
           ;; only :failing-id :rf/hydrate. Here the HOST supplies its own
@@ -1354,7 +1354,7 @@
                      :rf/runtime-db  {:rf.runtime/routing {:current {:route-id :route/article :params {:id "123"}}}}
                      :rf/render-hash "head-hash-server-A"}
           traces    (atom [])
-          f         (frame/make-anon-frame-record! {:platform :client})]
+          f         (rf.frame/make-anon-frame-record! {:platform :client})]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame f})
       (is (= "head-hash-server-A"
              (get-in (:rf.db/runtime (rf/frame-state-value f)) [:rf.runtime/ssr :hydration :server-hash]))
@@ -1379,7 +1379,7 @@
       ;; the runtime-db partition in every build, and that assertion runs in
       ;; this lane — which is why guarding here does not leave the deftest
       ;; executing nothing under the gate.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (some (fn [ev]
                     (and (= :rf.ssr/hydration-mismatch (:operation ev))
                          (= "head-hash-server-A" (:server-hash (:tags ev)))
@@ -1410,7 +1410,7 @@
 
 (deftest default-response-canonical-shape
   (testing "(ssr/default-response) returns the canonical initial response map"
-    (let [r (ssr/default-response)]
+    (let [r (rf.ssr/default-response)]
       (is (map? r) "default-response returns a map")
       ;; Per Spec 011 §HTTP response contract / §Status defaults:
       (is (= 200 (:status r))
@@ -1433,8 +1433,8 @@
 
 (deftest default-response-returns-fresh-map
   (testing "each call to default-response returns a fresh map (not shared state)"
-    (let [r1 (ssr/default-response)
-          r2 (ssr/default-response)]
+    (let [r1 (rf.ssr/default-response)
+          r2 (rf.ssr/default-response)]
       (is (= r1 r2) "the value shape is consistent across calls")
       ;; If they share state, mutating one (e.g. updating :status) would
       ;; affect the other. Persistent maps in Clojure are immutable, so
@@ -1484,17 +1484,17 @@
             get-response flushes → :status carries the default projector's 500.
             This is the production path: in a release build this listener, not
             the trace-cb one, is what produces the status."
-    (let [f (frame/make-anon-frame-record!
+    (let [f (rf.frame/make-anon-frame-record!
               {:platform :server
                :ssr      {:public-error-id   :rf.ssr/default-error-projector
                           :dev-error-detail? false}})]
       ;; The EP-0008 union record shape `{:error <kw> :frame <id> :time <ms>
       ;; + flat category keys}` — what `dispatch-error-record!` fans to every
       ;; always-on listener, including SSR's `::error-projection`.
-      (error-emit/dispatch-error-record!
+      (rf.error-emit/dispatch-error-record!
         {:error             :rf.error/view-time-exception
          :frame             f
-         :time              (interop/now-ms)
+         :time              (rf.interop/now-ms)
          :exception-message "synthetic view-time boom"
          :failing-id        :pages/articles
          :recovery          :warned-and-projected})
@@ -1504,12 +1504,12 @@
         (is (nil? (:redirect resp))
             "no redirect was set; the projector overwrites the status freely"))))
 
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (testing "rf2-dl9yg TC9 (dev arm) — the trace-cb buffering path. Kept
               VERBATIM: `trace/emit!` cannot fire under the production gate,
               so this half is a genuine dev-posture contract rather than a
               dev-posture SPELLING of one."
-      (let [f (frame/make-anon-frame-record!
+      (let [f (rf.frame/make-anon-frame-record!
                 {:platform :server
                  :ssr      {:public-error-id   :rf.ssr/default-error-projector
                             :dev-error-detail? false}})]
@@ -1517,7 +1517,7 @@
         ;; the listener contract (`error_listener.cljc:103-115`) it
         ;; gates on :op-type :error and the frame being a server frame;
         ;; either condition failing → silent.
-        (trace/emit! :error :rf.error/view-time-exception
+        (rf.trace/emit! :error :rf.error/view-time-exception
                      {:frame             f
                       :exception-message "synthetic view-time boom"
                       :failing-id        :pages/articles
@@ -1543,7 +1543,7 @@
 (deftest adapter-installs-ssr-render-to-string
   (testing "ssr/adapter wires re-frame.ssr/render-to-string into the
             :render-to-string slot"
-    (let [adapter ssr/adapter]
+    (let [adapter rf.ssr/adapter]
       (is (= :rf.adapter/ssr (:kind adapter))
           ":kind identifies the SSR substrate")
       (is (fn? (:render-to-string adapter))
@@ -1564,7 +1564,7 @@
 (deftest adapter-render-throws-rf-error-render-on-headless-adapter
   (testing "ssr/adapter :render slot throws :rf.error/render-on-headless-adapter
             — SSR uses render-to-string exclusively (Spec 006 §Plain-atom adapter)"
-    (let [render-fn (:render ssr/adapter)]
+    (let [render-fn (:render rf.ssr/adapter)]
       (is (fn? render-fn))
       (try
         (render-fn [:div] nil nil)
@@ -1603,7 +1603,7 @@
     (rf/reg-event :retired/url-redirect
       (fn [_ _]
         {:fx [[:rf.server/redirect {:url "/dashboard"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:retired/url-redirect] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1619,7 +1619,7 @@
     (rf/reg-event :retired/to-redirect
       (fn [_ _]
         {:fx [[:rf.server/redirect {:to "/welcome" :status 301}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:retired/to-redirect] {:frame f})))]
       (expect-fx-error-keyword!
@@ -1656,7 +1656,7 @@
     ;; the projector's drain-time domain; were this a construction setup step,
     ;; the now-STRICT :initial-events teardown (EP-0027 §Failure) would tear
     ;; the frame down and raise :rf.error/initial-events-step-failed instead.
-    (let [f      (frame/make-anon-frame-record!
+    (let [f      (rf.frame/make-anon-frame-record!
                    {:platform  :server
                     :ssr       {:public-error-id   :rf.ssr/default-error-projector
                                 :dev-error-detail? false}})
@@ -1790,7 +1790,7 @@
         ;; not a legal scheme-specific character).
         {:fx [[:rf.server/safe-redirect
                {:location "https://example.com/path with space"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/unparseable] {:frame f})))
           resp   (get-response f)]
@@ -1809,7 +1809,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "javascript:alert(1)"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/javascript] {:frame f})))
           hits   (filter #(= :rf.error/safe-redirect-scheme-rejected
@@ -1829,7 +1829,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "data:text/html,<script>alert(1)</script>"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/data] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1843,7 +1843,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "vbscript:msgbox(\"x\")"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/vbscript] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1858,7 +1858,7 @@
       (rf/reg-event :sr/probe-case
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect {:location hostile}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-safe-redirect-traces!
                      (fn [] (rf/dispatch-sync [:sr/probe-case] {:frame f})))]
         (is (some #(= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -1875,7 +1875,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location       "https://evil.example.com/phish"
                 :relative-only? true}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/abs-with-relative-only] {:frame f})))
           hits   (filter #(= :rf.error/safe-redirect-host-disallowed
@@ -1897,10 +1897,10 @@
 
     ;; rf2-lwtlk DEV ARM — `:host` on axis 2, where the diagnostics arrive
     ;; whole and the reader is standing at their own process.
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (testing "rf2-2brsn step 3 (dev diagnostics): the dev trace names the
                 rejected host itself"
-        (let [f      (frame/make-anon-frame-record! {:platform :server})
+        (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
               traces (capture-safe-redirect-dev-traces!
                        (fn [] (rf/dispatch-sync [:sr/abs-with-relative-only] {:frame f})))]
           (is (some #(= "evil.example.com" (-> % :tags :host)) traces)
@@ -1914,7 +1914,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location       "/dashboard"
                 :relative-only? true}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/relative-ok] {:frame f})))
           resp   (get-response f)]
@@ -1935,7 +1935,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://evil.example.com/phish"
                 :allow    ["app.example.com" "alt.example.com"]}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/not-in-allow] {:frame f})))
           hits   (filter #(= :rf.error/safe-redirect-host-disallowed
@@ -1962,7 +1962,7 @@
     ;; construction a name the app did not authorise. `:reason
     ;; :not-in-allowlist` discriminates the arm without either. Read off axis
     ;; 2, where the diagnostics arrive whole.
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (testing "rf2-2brsn step 4 (dev diagnostics): the dev trace carries the
                 rejected host and the allowlist vector itself, for the
                 programmer reading a log"
@@ -1971,7 +1971,7 @@
             {:fx [[:rf.server/safe-redirect
                    {:location "https://evil.example.com/phish"
                     :allow    ["app.example.com" "alt.example.com"]}]]}))
-        (let [f      (frame/make-anon-frame-record! {:platform :server})
+        (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
               traces (capture-safe-redirect-dev-traces!
                        (fn [] (rf/dispatch-sync [:sr/not-in-allow-dev] {:frame f})))
               ev     (first (filter #(= :rf.error/safe-redirect-host-disallowed
@@ -1991,7 +1991,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://app.example.com/dashboard"
                 :allow    ["app.example.com" "alt.example.com"]}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/in-allow] {:frame f})))
           resp   (get-response f)]
@@ -2010,7 +2010,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://APP.Example.COM/dashboard"
                 :allow    ["app.example.com" "alt.example.com"]}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/in-allow-mixed-case] {:frame f})))
           resp   (get-response f)]
@@ -2032,7 +2032,7 @@
         ;; parser-fail must fire FIRST because step 1 runs before step 2.
         {:fx [[:rf.server/safe-redirect
                {:location "javascript: not a real url "}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/order-parse-first] {:frame f})))
           ops    (mapv :operation traces)]
@@ -2050,7 +2050,7 @@
     (rf/reg-event :sr/empty
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location ""}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/empty] {:frame f})))]
       (is (some #(= :rf.error/safe-redirect-invalid-url (:operation %))
@@ -2084,7 +2084,7 @@
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect
                  (merge {:location "http:evil.example.com"} policy)]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-safe-redirect-traces!
                      (fn [] (rf/dispatch-sync [:sr/opaque-http] {:frame f})))]
         (is (seq traces)
@@ -2101,7 +2101,7 @@
     (rf/reg-event :sr/opaque-https
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "https:evil.example.com"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/opaque-https] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-invalid-url (:operation %))
@@ -2118,7 +2118,7 @@
     (rf/reg-event :sr/mailto
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "mailto:user@example.com"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/mailto] {:frame f})))]
       (is (some #(and (= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -2131,7 +2131,7 @@
                       (= :scheme-not-allowed (-> % :tags :reason)))
                 traces)
           "mailto: rejected as :scheme-not-allowed, classed :other")
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (some #(= "mailto" (-> % :tags :scheme))
                   (capture-safe-redirect-dev-traces!
                     (fn [] (rf/dispatch-sync [:sr/mailto] {:frame f}))))
@@ -2145,7 +2145,7 @@
     (rf/reg-event :sr/ftp
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect {:location "ftp:example.com"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/ftp] {:frame f})))]
       (is (some #(= :rf.error/safe-redirect-scheme-rejected (:operation %))
@@ -2165,7 +2165,7 @@
         (fn [_ _]
           {:fx [[:rf.server/safe-redirect
                  (merge {:location "//evil.example.com/path"} policy)]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-safe-redirect-traces!
                      (fn [] (rf/dispatch-sync [:sr/protocol-relative] {:frame f})))]
         (is (some #(and (= :rf.error/safe-redirect-host-disallowed (:operation %))
@@ -2184,7 +2184,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "/account/settings" :relative-only? true}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/relative-control] {:frame f})))
           resp   (get-response f)]
@@ -2204,7 +2204,7 @@
         {:fx [[:rf.server/safe-redirect
                {:location "https://app.example.com/dashboard"
                 :allow    ["app.example.com"]}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-safe-redirect-traces!
                    (fn [] (rf/dispatch-sync [:sr/abs-control] {:frame f})))
           resp   (get-response f)]
@@ -2224,7 +2224,7 @@
       (fn [_ _]
         {:fx [[:rf.server/safe-redirect
                {:location "/path\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:sr/crlf] {:frame f})))]
       (expect-fx-error-keyword!
@@ -2328,7 +2328,7 @@
         {:fx [[:rf.server/set-header
                {:name  "X-Test\r\nSet-Cookie: evil=1"
                 :value "ok"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/crlf-in-name] {:frame f})))]
       (expect-fx-error-keyword!
@@ -2341,7 +2341,7 @@
       (rf/reg-event :hdr/probe-name
         (fn [_ _]
           {:fx [[:rf.server/set-header {:name hostile :value "ok"}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:hdr/probe-name] {:frame f})))]
         (expect-fx-error-keyword!
@@ -2356,7 +2356,7 @@
         {:fx [[:rf.server/append-header
                {:name  "X-Audit\r\nSet-Cookie: forged=1"
                 :value "ok"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:hdr/append-crlf-name] {:frame f})))]
       (expect-fx-error-keyword!
@@ -2371,7 +2371,7 @@
         {:fx [[:rf.server/set-cookie
                {:name  "session\r\nSet-Cookie: stolen=1"
                 :value "abc"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-name] {:frame f})))]
       (expect-fx-error-keyword!
@@ -2386,7 +2386,7 @@
         {:fx [[:rf.server/set-cookie
                {:name  "session"
                 :value "abc\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-value] {:frame f})))]
       (expect-fx-error-keyword!
@@ -2403,7 +2403,7 @@
                {:name  "session"
                 :value "abc"
                 :path  "/\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-path] {:frame f})))]
       (expect-fx-error-keyword!
@@ -2420,7 +2420,7 @@
                {:name   "session"
                 :value  "abc"
                 :domain "example.com\r\nSet-Cookie: stolen=1"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/crlf-in-domain] {:frame f})))]
       (expect-fx-error-keyword!
@@ -2436,7 +2436,7 @@
       (fn [_ _]
         {:fx [[:rf.server/delete-cookie
                {:name "session" :path "/admin\r\nbad"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/del-crlf-path] {:frame f})))]
       (expect-fx-error-keyword!
@@ -2461,7 +2461,7 @@
                  {:name    "session"
                   :value   "x"
                   :max-age "3600\r\nSet-Cookie: admin=1; Path=/"}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:ck/crlf-in-max-age] {:frame f})))]
         (expect-fx-error-keyword!
@@ -2479,7 +2479,7 @@
                  {:name      "session"
                   :value     "x"
                   :same-site "Lax\r\nSet-Cookie: admin=1"}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:ck/crlf-in-same-site] {:frame f})))]
         (expect-fx-error-keyword!
@@ -2500,7 +2500,7 @@
                  {:name    "session"
                   :value   "x"
                   :expires "Wed, 09 Jun 2027 10:18:14 GMT\r\nSet-Cookie: admin=1"}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:ck/crlf-in-expires] {:frame f})))]
         (expect-fx-error-keyword!
@@ -2520,7 +2520,7 @@
           (fn [_ _]
             {:fx [[:rf.server/set-cookie
                    {:name "s" :value "x" :max-age hostile}]]}))
-        (let [f      (frame/make-anon-frame-record! {:platform :server})
+        (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
               traces (capture-fx-traces!
                        (fn [] (rf/dispatch-sync [:ck/probe-max-age] {:frame f})))]
           (expect-fx-error-keyword!
@@ -2550,7 +2550,7 @@
         (fn [_ _]
           {:fx [[:rf.server/set-cookie
                  (assoc {:name "sid" :value "abc"} attr hostile)]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:ck/semicolon-attr] {:frame f})))]
         (expect-fx-error-keyword!
@@ -2568,7 +2568,7 @@
     (rf/reg-event :ck/semicolon-value
       (fn [_ _]
         {:fx [[:rf.server/set-cookie {:name "sid" :value "a;b" :path "/"}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-fx-traces!
                    (fn [] (rf/dispatch-sync [:ck/semicolon-value] {:frame f})))
           cookies (:cookies (get-response f))]
@@ -2585,7 +2585,7 @@
         (fn [_ _]
           {:fx [[:rf.server/delete-cookie
                  (assoc {:name "sid"} attr "x; Secure")]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
+      (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
             traces (capture-fx-traces!
                      (fn [] (rf/dispatch-sync [:ck/del-semicolon] {:frame f})))]
         (expect-fx-error-keyword!
@@ -2604,24 +2604,24 @@
             `(name n)` on a non-Named value would otherwise throw a bare host
             exception with nil ex-data, bypassing the structured-error
             contract and reaching adapter / :on-error code."
-    (let [f (frame/make-anon-frame-record! {:platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:platform :server})]
       (doseq [bad-name [42 3.14 [:not :a :name] {:cookie :map} true]]
         (is (thrown-with-msg?
               clojure.lang.ExceptionInfo
               #":rf\.error/cookie-invalid-name"
-              (response/set-cookie-fx {:frame f} {:name bad-name :value "x"}))
+              (rf.ssr.response/set-cookie-fx {:frame f} {:name bad-name :value "x"}))
             (str "set-cookie-fx with a non-string/non-Named :name "
                  (pr-str bad-name)
                  " must throw :rf.error/cookie-invalid-name, not a raw host"
                  " exception"))
-        (is (empty? (:cookies (response/response-of f)))
+        (is (empty? (:cookies (rf.ssr.response/response-of f)))
             (str "the rejected cookie (" (pr-str bad-name)
                  ") never lands on the accumulator")))
       ;; delete-cookie is sugar over the same validator — same TYPE guard.
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
             #":rf\.error/cookie-invalid-name"
-            (response/delete-cookie-fx {:frame f} {:name 99 :path "/"}))
+            (rf.ssr.response/delete-cookie-fx {:frame f} {:name 99 :path "/"}))
           "delete-cookie-fx runs the same cookie-name type guard")))
 
   (testing "rf2-9t17id regression guard — the type gate still separates a
@@ -2636,17 +2636,17 @@
             reached host adapters as a keyword. Same ordering as set-header:
             grammar gate first with its own catalogued id, shape gate second.
             The full contract lives in `re-frame.ssr-reserved-fx-guards-test`."
-    (let [f (frame/make-anon-frame-record! {:platform :server})]
-      (response/set-cookie-fx {:frame f} {:name "session" :value "a"})
+    (let [f (rf.frame/make-anon-frame-record! {:platform :server})]
+      (rf.ssr.response/set-cookie-fx {:frame f} {:name "session" :value "a"})
       (doseq [named-name [:csrf 'tracker]]
         (is (thrown-with-msg?
               clojure.lang.ExceptionInfo
               #":rf\.error/server-fx-args-invalid"
-              (response/set-cookie-fx {:frame f} {:name named-name :value "b"}))
+              (rf.ssr.response/set-cookie-fx {:frame f} {:name named-name :value "b"}))
             (str "a " (pr-str named-name) " :name is refused by the shape gate,"
                  " not by the type gate — it is a well-formed token of the"
                  " wrong published type")))
-      (is (= ["session"] (mapv :name (:cookies (response/response-of f))))
+      (is (= ["session"] (mapv :name (:cookies (rf.ssr.response/response-of f))))
           "only the string-named cookie landed, and its :name is a string"))))
 
 (deftest ssr-set-cookie-clean-attributes-still-accepted
@@ -2663,7 +2663,7 @@
                 :same-site "Strict"
                 :path      "/"
                 :expires   "Wed, 09 Jun 2027 10:18:14 GMT"}]]}))
-    (let [f       (frame/make-anon-frame-record! {:platform :server :initial-events [[:ck/clean-attrs]]})
+    (let [f       (rf.frame/make-anon-frame-record! {:platform :server :initial-events [[:ck/clean-attrs]]})
           cookies (:cookies (get-response f))]
       (is (= 1 (count cookies))
           "the clean cookie lands on the accumulator")
@@ -2686,7 +2686,7 @@
                                        :path    "/"
                                        :domain  "example.com"}]
               [:rf.server/delete-cookie {:name "stale" :path "/"}]]}))
-    (let [f (frame/make-anon-frame-record! {:platform :server :initial-events [[:clean/all]]})
+    (let [f (rf.frame/make-anon-frame-record! {:platform :server :initial-events [[:clean/all]]})
           resp (get-response f)]
       (is (some (fn [[k _]] (= "Cache-Control"   k)) (:headers resp)))
       (is (some (fn [[k _]] (= "X-Forwarded-For" k)) (:headers resp)))
@@ -2826,7 +2826,7 @@
   dev `:rf.error/schema-validation-failure` trace, and every record the
   ALWAYS-ON `:errors` axis saw. One drive, read by all three sections below."
   [fx-vec]
-  (let [f       (frame/make-anon-frame-record! {:platform :server})
+  (let [f       (rf.frame/make-anon-frame-record! {:platform :server})
         ev-id   (keyword "rf2-lwtlk" (str "attempt-" (name (gensym "e"))))
         tag     (keyword "rf2-lwtlk" (str "sfx-cap-" (name (gensym "c"))))
         dev     (atom [])
@@ -2962,7 +2962,7 @@
   ;; -------------------------------------------------------------------------
   ;; §2 — DEV ARM. The rich step-5 diagnostic, kept VERBATIM.
   ;; -------------------------------------------------------------------------
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (testing "rf2-lwtlk DEV ARM — with schemas live the Spec 010 §step-5
               boundary rejects FIRST, so the programmer gets the RICH
               diagnostic: :rf.error/schema-validation-failure :where :fx-args,
@@ -2994,7 +2994,7 @@
   ;; §3 — PRODUCTION ARM. The always-on witness that makes §1 true in a
   ;;      release build, and the one an off-box shipper actually receives.
   ;; -------------------------------------------------------------------------
-  (when-not interop/debug-enabled?
+  (when-not rf.interop/debug-enabled?
     (testing "rf2-lwtlk PRODUCTION ARM — with step-5 compiled out, the
               reserved fx's OWN guard (rf2-dtpfv, re-frame.ssr.response)
               throws, `re-frame.fx` containment catches it, and
@@ -3031,7 +3031,7 @@
                                        :secure true :http-only true}]
               [:rf.server/delete-cookie {:name "stale" :path "/"}]
               [:rf.server/redirect    {:location "/dashboard" :status 302}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-schema-failures!
                    (fn [] (rf/dispatch-sync [:good/all] {:frame f})))
           resp   (get-response f)]
@@ -3042,7 +3042,7 @@
       ;; POSTURE-INDEPENDENT half of the same claim is the accumulator reads
       ;; below: they prove admission by showing the effects LANDED, which is
       ;; the non-vacuous form and needs no arm.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (empty? (filter (fn [ev] (= :fx-args (-> ev :tags :where))) traces))
             (str "no :fx-args schema failure for well-formed args; saw: "
                  (pr-str (mapv (comp :failing-id :tags) traces)))))
@@ -3069,14 +3069,14 @@
                 :status         302
                 :relative-only? false
                 :allow          ["app.example.com"]}]]}))
-    (let [f      (frame/make-anon-frame-record! {:platform :server})
+    (let [f      (rf.frame/make-anon-frame-record! {:platform :server})
           traces (capture-schema-failures!
                    (fn [] (rf/dispatch-sync [:good/safe-redirect] {:frame f})))
           resp   (get-response f)]
       ;; rf2-lwtlk — DEV ARM, same reasoning as its sibling above: a negative
       ;; over an empty ring. The landing assertions that follow carry the
       ;; posture-independent half.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (empty? (filter (fn [ev] (and (= :fx-args (-> ev :tags :where))
                                           (= :rf.server/safe-redirect
                                              (-> ev :tags :failing-id))))
@@ -3128,7 +3128,7 @@
 
       (let [traces (atom [])]
         (rf/register-listener! :trace ::ssr (fn [ev] (swap! traces conj ev)))
-        (let [f  (frame/make-anon-frame-record!
+        (let [f  (rf.frame/make-anon-frame-record!
                    {:initial-events    [[:rf/server-init {:uri "/articles"}]]
                     :fx-overrides {:http/get :http/get.canned-articles}})
               db (rf/app-db-value f)]

--- a/implementation/ssr/test/re_frame/ssr_error_drain_concurrency_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_drain_concurrency_test.clj
@@ -36,15 +36,15 @@
   (`swap-vals!` exists on both runtimes); this test pins the JVM
   concurrency contract."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.ssr.error-listener :as error-listener]))
+            [re-frame.ssr.error-listener :as rf.ssr.error-listener]))
 
 ;; Private fns reached via their vars — the same internal surface the
 ;; runtime drives (buffer on the listener path, drain on the projection
 ;; path).
-(def ^:private consume! #'error-listener/consume-pending-traces!)
+(def ^:private consume! #'rf.ssr.error-listener/consume-pending-traces!)
 
 (defn- buffer! [frame-id trace]
-  (swap! error-listener/pending-error-traces
+  (swap! rf.ssr.error-listener/pending-error-traces
          update frame-id (fnil conj []) trace))
 
 (deftest consume-pending-traces-loses-no-trace-under-concurrent-append
@@ -54,7 +54,7 @@
     (let [frame-id      :rf.test/drain-race
           appends       2000
           ;; Clean slate for this frame.
-          _             (swap! error-listener/pending-error-traces
+          _             (swap! rf.ssr.error-listener/pending-error-traces
                                dissoc frame-id)
           drained       (atom [])
           appended      (atom 0)
@@ -102,12 +102,12 @@
             frame's key (the clear half of the atomic pull-and-clear), so a
             subsequent drain on the same frame returns empty."
     (let [frame-id :rf.test/drain-clear]
-      (swap! error-listener/pending-error-traces dissoc frame-id)
+      (swap! rf.ssr.error-listener/pending-error-traces dissoc frame-id)
       (buffer! frame-id {:op-type :error :operation :rf.error/probe :seq 0})
       (buffer! frame-id {:op-type :error :operation :rf.error/probe :seq 1})
       (let [pulled (consume! frame-id)]
         (is (= 2 (count pulled)) "the drain pulls both buffered traces")
-        (is (not (contains? @error-listener/pending-error-traces frame-id))
+        (is (not (contains? @rf.ssr.error-listener/pending-error-traces frame-id))
             "the frame key is removed in the same transition")
         (is (= [] (consume! frame-id))
             "a second drain returns empty — the buffer was cleared")))))
@@ -117,7 +117,7 @@
             returns [] and does not introduce a spurious frame key
             (swap-vals! dissoc of an absent key is a no-op)."
     (let [frame-id :rf.test/drain-empty]
-      (swap! error-listener/pending-error-traces dissoc frame-id)
+      (swap! rf.ssr.error-listener/pending-error-traces dissoc frame-id)
       (is (= [] (consume! frame-id)))
-      (is (not (contains? @error-listener/pending-error-traces frame-id))
+      (is (not (contains? @rf.ssr.error-listener/pending-error-traces frame-id))
           "no spurious key added for an empty drain"))))

--- a/implementation/ssr/test/re_frame/ssr_error_emit_promotion_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_emit_promotion_test.clj
@@ -40,21 +40,21 @@
   there does not flip the wire — the rf2-hhutya conformance leg."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.boot :as boot]
-            [re-frame.ssr.error-listener :as error-listener]
-            [re-frame.ssr.error-projector :as error-projector]
-            [re-frame.ssr.test-fixture :as tf]
-            [re-frame.subs :as subs]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.boot :as rf.ssr.boot]
+            [re-frame.ssr.error-listener :as rf.ssr.error-listener]
+            [re-frame.ssr.error-projector :as rf.ssr.error-projector]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
+            [re-frame.subs :as rf.subs]))
 
 (use-fixtures :each
   (fn [t]
-    (tf/reset-runtime
+    (rf.ssr.test-fixture/reset-runtime
       (fn []
-        (error-emit/clear-error-listeners!)
+        (rf.error-emit/clear-error-listeners!)
         (t)))))
 
 (def ^:private server-frame :ssr/promotion-acceptance-frame)
@@ -105,7 +105,7 @@
   (rf/reg-sub :count (fn [db _] (or (:count db) 0)))
   (rf/reg-sub :title (fn [db _] (or (:title db) "untitled")))
   ;; EP-0001 (rf2-vzld77): hydration metadata is durable runtime-db state.
-  (subs/reg-runtime-sub :hydrated?
+  (rf.subs/reg-runtime-sub :hydrated?
     (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration])))))
 
 ;; ===========================================================================
@@ -121,8 +121,8 @@
             is the projector's 500, unchanged by promotion."
     (let [fid  (make-server-frame)
           seen (capture-always-on!)]
-      (with-redefs [interop/debug-enabled? false]
-        (let [public-error (error-listener/project-render-exception!
+      (with-redefs [rf.interop/debug-enabled? false]
+        (let [public-error (rf.ssr.error-listener/project-render-exception!
                              fid (ex-info "render boom" {}))]
           ;; (A) off-box record reached the listener
           (is (some #{:rf.error/ssr-render-failed} @seen)
@@ -130,7 +130,7 @@
           ;; (B) wire-unchanged — the direct projection stamps 5xx
           (is (= 500 (:status public-error))
               "project-render-exception! returned the projector's 500")
-          (is (= 500 (:status (ssr/get-response fid)))
+          (is (= 500 (:status (rf.ssr/get-response fid)))
               "the response status is the projector's 500 — promotion did
                NOT double-stamp or re-project (the buffered duplicate was
                cleared)")
@@ -152,8 +152,8 @@
       (rf/make-frame {:id server-frame :platform :server
                       :ssr      {:public-error-id   :test/throwing-projector
                                  :dev-error-detail? false}})
-      (with-redefs [interop/debug-enabled? false]
-        (let [public-error (error-projector/project-error
+      (with-redefs [rf.interop/debug-enabled? false]
+        (let [public-error (rf.ssr.error-projector/project-error
                             fid {:op-type   :error
                                  :operation :rf.error/ssr-render-failed
                                  :tags      {:frame fid}})]
@@ -168,7 +168,7 @@
               "the fallback locked generic-500 public-error shipped — the
                projector's throw did not bypass the boundary")
           ;; the always-on record was NOT buffered for re-projection
-          (is (empty? (get @error-listener/pending-error-traces fid))
+          (is (empty? (get @rf.ssr.error-listener/pending-error-traces fid))
               "NON-PROJECTING + re-entry guard: the sanitised record was
                NOT buffered (the projection listener skips it), so it cannot
                re-enter the projector it reports on"))))))
@@ -184,12 +184,12 @@
       (rf/register-listener! :errors
         ::acceptance-recorder
         (fn [record] (swap! seen-records conj record)))
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         ;; Drive the FRAMELESS always-on emit exactly as
         ;; boot/read-server-payload's catch arm does (the JVM path has no
         ;; DOM, so we exercise the record shape the late-bind hook fans;
         ;; the CLJS DOM read is covered by ssr_hydration_test).
-        (boot/dispatch-malformed-hydration-frameless!
+        (rf.ssr.boot/dispatch-malformed-hydration-frameless!
           'rf.ssr/read-server-payload
           "__rf_payload"
           "the __rf_payload hydration script did not parse as EDN")
@@ -204,8 +204,8 @@
                EP-0002 resolution-6 frameless precedent")
           ;; WIRE-UNCHANGED: a frameless record never routes to a server
           ;; frame's projector (no status to move).
-          (error-listener/error-emit-projection-listener rec)
-          (is (empty? @error-listener/pending-error-traces)
+          (rf.ssr.error-listener/error-emit-projection-listener rec)
+          (is (empty? @rf.ssr.error-listener/pending-error-traces)
               "a frameless record is not buffered for any frame's
                projection — no status moved"))))))
 
@@ -239,13 +239,13 @@
                           :rf/runtime-db [:runtime :is :a :vector]}]]
       (let [seen-records (capture-records!)]
         (register-hydration-handlers!)
-        (let [client-frame (frame/make-anon-frame-record! {:doc "ep0008-hguive client frame"
+        (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ep0008-hguive client frame"
                                            :platform :client})]
           ;; Seed a recognisable pre-hydration client slice so we can prove
           ;; the rejection left both partitions untouched (fail-closed).
           (rf/dispatch-sync [::set-title "pre-hydration"] {:frame client-frame})
           (rf/dispatch-sync [::inc]                       {:frame client-frame}) ;; 0 → 1
-          (with-redefs [interop/debug-enabled? false]
+          (with-redefs [rf.interop/debug-enabled? false]
             (rf/dispatch-sync [:rf/hydrate bad-payload] {:frame client-frame}))
 
           ;; (A) the FRAMEFUL always-on record reached the off-box listener
@@ -309,16 +309,16 @@
         (rf/make-frame {:id fid :platform :server
                         :ssr      {:public-error-id   :rf.ssr/default-error-projector
                                    :dev-error-detail? false}})
-        (with-redefs [interop/debug-enabled? false]
-          (error-listener/error-emit-projection-listener
+        (with-redefs [rf.interop/debug-enabled? false]
+          (rf.ssr.error-listener/error-emit-projection-listener
             {:error     cat
              :frame     fid
              :time      0
              :exception (ex-info "synthetic" {})
              :recovery  :no-recovery})
-          (is (empty? (get @error-listener/pending-error-traces fid))
+          (is (empty? (get @rf.ssr.error-listener/pending-error-traces fid))
               (str cat ": NON-PROJECTING — not buffered on the always-on axis"))
-          (is (= 200 (:status (ssr/get-response fid)))
+          (is (= 200 (:status (rf.ssr/get-response fid)))
               (str cat ": status stays 200 — the always-on record did not
                    flip the wire")))))))
 
@@ -330,15 +330,15 @@
             no-op, and that the projection-eligible promotion still drives
             the status under production hardening."
     (let [fid (make-server-frame)]
-      (with-redefs [interop/debug-enabled? false]
-        (error-listener/error-emit-projection-listener
+      (with-redefs [rf.interop/debug-enabled? false]
+        (rf.ssr.error-listener/error-emit-projection-listener
           {:error     :rf.error/ssr-render-failed
            :frame     fid
            :time      0
            :exception (ex-info "render boom" {})
            :recovery  :projected-to-public-error})
-        (is (seq (get @error-listener/pending-error-traces fid))
+        (is (seq (get @rf.ssr.error-listener/pending-error-traces fid))
             "ssr-render-failed IS buffered on the always-on axis")
-        (is (= 500 (:status (ssr/get-response fid)))
+        (is (= 500 (:status (rf.ssr/get-response fid)))
             "and projects a 5xx — the projection-eligible promotion drives
              the status under debug-off")))))

--- a/implementation/ssr/test/re_frame/ssr_error_projector_substrate_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_projector_substrate_test.clj
@@ -33,12 +33,12 @@
   same substrate."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 (deftest ssr-error-projector-fires-under-production-hardening-rf2-fb598
   (testing "Spec 011 §Server error projection holds when
@@ -60,14 +60,14 @@
     (rf/reg-event :rf/server-init
       (fn [_ _] {}))
 
-    (with-redefs [interop/debug-enabled? false]
-      (let [f (frame/make-anon-frame-record!
+    (with-redefs [rf.interop/debug-enabled? false]
+      (let [f (rf.frame/make-anon-frame-record!
                 {:platform  :server
                  :initial-events [[:rf/server-init]]
                  :ssr       {:public-error-id   :rf.ssr/default-error-projector
                              :dev-error-detail? false}})
             _ (rf/dispatch-sync [:load/article] {:frame f})
-            response (ssr/get-response f)]
+            response (rf.ssr/get-response f)]
         (is (= 500 (:status response))
             "Spec 011 §Server error projection — the default projector
              stamps :status 500 on :rf/response even with the dev trace
@@ -82,7 +82,7 @@
             framework-private id used by both substrate installs). A
             tight error-record delivered through the substrate routes
             to the SSR projector buffer and stamps the response."
-    (let [f (frame/make-anon-frame-record!
+    (let [f (rf.frame/make-anon-frame-record!
               {:platform :server
                :ssr      {:public-error-id   :rf.ssr/default-error-projector
                           :dev-error-detail? false}})]
@@ -94,7 +94,7 @@
       (let [dispatch-on-error!
             (requiring-resolve 're-frame.error-emit/dispatch-on-error!)
             ex (ex-info "boom" {})]
-        (with-redefs [interop/debug-enabled? false]
+        (with-redefs [rf.interop/debug-enabled? false]
           (dispatch-on-error!
             :rf.error/handler-exception
             [:boom]                            ;; event
@@ -103,7 +103,7 @@
             ex                                 ;; exception
             0                                  ;; elapsed-ms
             (System/currentTimeMillis))        ;; time
-          (is (= 500 (:status (ssr/get-response f)))
+          (is (= 500 (:status (rf.ssr/get-response f)))
               "The framework's own error-emit listener
                (`::error-projection`) routed the record to the buffer,
                flush-response! drained it, and the default projector

--- a/implementation/ssr/test/re_frame/ssr_error_two_frame_attribution_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_two_frame_attribution_test.clj
@@ -69,13 +69,13 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.fx :as fx]
-            [re-frame.interop :as interop]
-            [re-frame.schemas :as schemas]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.fx :as rf.fx]
+            [re-frame.interop :as rf.interop]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---------------------------------------------------------------------------
 ;; Stub validator — interpret a `:params` schema as a Clojure predicate
@@ -84,7 +84,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- with-stub-validator []
-  (let [snap     (schemas/snapshot-schema-fns)
+  (let [snap     (rf.schemas/snapshot-schema-fns)
         ;; rf2-ps05ug: the stub is process-global, so while installed EVERY
         ;; schema-validating boundary uses it — including the routing
         ;; recordable allocation cofx, whose `:schema` is a real Malli VECTOR
@@ -103,8 +103,8 @@
         explain  (fn [schema value]
                    (when (fn? schema)
                      {:reason :stub-explainer :value value}))]
-    (schemas/set-schema-fns! {:validate validate :explain explain})
-    (fn [] (schemas/restore-schema-fns! snap))))
+    (rf.schemas/set-schema-fns! {:validate validate :explain explain})
+    (fn [] (rf.schemas/restore-schema-fns! snap))))
 
 (def ^:private frame-a :ssr/req-a)
 (def ^:private frame-b :ssr/req-b)
@@ -119,7 +119,7 @@
                            (str/starts-with? (or id "") "a"))} "/articles/:id")
   ;; Server-platform push-url so the navigate fx assembly resolves on a
   ;; `:platform :server` frame (no-op sink — the reject path never pushes).
-  (fx/reg-fx :rf.nav/push-url
+  (rf.fx/reg-fx :rf.nav/push-url
              {:platforms #{:server :client}}
              (fn [_ _url] nil)))
 
@@ -152,7 +152,7 @@
     ;; (Spec 010 §Production builds): under the gate the params validate
     ;; vacuously, nothing is rejected, and both frames would sit at 200. The
     ;; production-posture pin for this same contract is test (4).
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (let [restore (with-stub-validator)]
         (try
           (register-routes-and-fx!)
@@ -165,11 +165,11 @@
             (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:id "zoo"}}]
                               {:frame fa})
 
-            (is (= 400 (:status (ssr/get-response fa)))
+            (is (= 400 (:status (rf.ssr/get-response fa)))
                 "frame-a's navigate-reject is projected to 400 on frame-a's
                  response — the `:frame` stamp routed the trace to the
                  emitting frame even with a sibling server frame live")
-            (is (= 200 (:status (ssr/get-response fb)))
+            (is (= 200 (:status (rf.ssr/get-response fb)))
                 "frame-b's response stays at the default 200 (Spec 011
                  §Status defaults) — the error did not bleed onto the
                  sibling. The removed single-frame fallback would have
@@ -189,7 +189,7 @@
             (not a fixed/first-registered server frame)."
     ;; rf2-lwtlk — DEV ARM, same reason as test (1). Test (4) mirrors this
     ;; symmetry check on the always-on axis.
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (let [restore (with-stub-validator)]
         (try
           (register-routes-and-fx!)
@@ -197,9 +197,9 @@
                 fb (make-server-frame frame-b)]
             (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:id "zoo"}}]
                               {:frame fb})
-            (is (= 400 (:status (ssr/get-response fb)))
+            (is (= 400 (:status (rf.ssr/get-response fb)))
                 "frame-b (the emitting frame) gets the projected 400")
-            (is (= 200 (:status (ssr/get-response fa)))
+            (is (= 200 (:status (rf.ssr/get-response fa)))
                 "frame-a stays at the default 200 — clean"))
           (finally (restore)))))))
 
@@ -223,7 +223,7 @@
     ;; the assertions read the DEV trace bus, whose subject here (epoch /
     ;; Xray capture) is dev tooling. Nothing about this test has a
     ;; production counterpart, and that is correct rather than a gap.
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (let [restore (with-stub-validator)
             traces  (atom [])]
         (try
@@ -272,15 +272,15 @@
     (let [fa (make-server-frame frame-a)
           fb (make-server-frame frame-b)]
       (rf/dispatch-sync [:boom/throw] {:frame fa})
-      (is (= 500 (:status (ssr/get-response fa)))
+      (is (= 500 (:status (rf.ssr/get-response fa)))
           "frame-a's handler exception is projected to 500 on frame-a's
            response — the always-on record carried the emitting frame")
-      (is (= 200 (:status (ssr/get-response fb)))
+      (is (= 200 (:status (rf.ssr/get-response fb)))
           "frame-b's response stays at the default 200 — no bleed onto the
            concurrent sibling")
 
       (rf/dispatch-sync [:boom/throw] {:frame fb})
-      (is (= 500 (:status (ssr/get-response fb)))
+      (is (= 500 (:status (rf.ssr/get-response fb)))
           "and the mirror: frame-b now carries its OWN 500, so attribution
            follows the emitting frame in both directions rather than a
            fixed / first-registered server frame"))))

--- a/implementation/ssr/test/re_frame/ssr_error_view_failed_no_project_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_view_failed_no_project_test.clj
@@ -65,13 +65,13 @@
   adjudicated for real under the gate rather than only in dev."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.error-listener :as error-listener]
-            [re-frame.ssr.test-fixture :as tf]
-            [re-frame.trace :as trace]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.error-listener :as rf.ssr.error-listener]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
+            [re-frame.trace :as rf.trace]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 (def ^:private server-frame :ssr/error-view-failed-no-project-frame)
 
@@ -104,18 +104,18 @@
       ;; the listener ripped out: a negative over a bus that emitted
       ;; nothing. The production counterpart is test (3), which calls the
       ;; always-on listener directly and is posture-independent.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         ;; Stamp the frame exactly as resolve-error-body's catch arm does.
-        (trace/emit-error! :rf.error/ssr-ring-error-view-failed
+        (rf.trace/emit-error! :rf.error/ssr-ring-error-view-failed
                            {:frame     fid
                             :exception "synthetic error-view failure"
                             :ex-class  "clojure.lang.ExceptionInfo"
                             :recovery  :fell-back-to-default-error-template})
-        (is (empty? (get @error-listener/pending-error-traces fid))
+        (is (empty? (get @rf.ssr.error-listener/pending-error-traces fid))
             "the error-view-failed trace was SKIPPED — not buffered into
              pending-error-traces (so a later get-response / re-flush can't
              re-project it and flip the already-stamped status)")
-        (is (= 200 (:status (ssr/get-response fid)))
+        (is (= 200 (:status (rf.ssr/get-response fid)))
             "status stays 200 — the error-view failure degraded gracefully
              to the locked default template; the default projector (→ 500)
              never ran for this category")))))
@@ -139,14 +139,14 @@
       ;; production gate this control observes an empty buffer. The category
       ;; itself DOES reach production, so the control is not lost — it is
       ;; re-run on the always-on axis by test (4).
-      (when interop/debug-enabled?
-        (trace/emit-error! :rf.error/sub-exception
+      (when rf.interop/debug-enabled?
+        (rf.trace/emit-error! :rf.error/sub-exception
                            {:frame     fid
                             :exception (ex-info "sub boom" {})
                             :recovery  :no-recovery})
-        (is (seq (get @error-listener/pending-error-traces fid))
+        (is (seq (get @rf.ssr.error-listener/pending-error-traces fid))
             "a genuine drain-time failure IS buffered for projection")
-        (is (not= 200 (:status (ssr/get-response fid)))
+        (is (not= 200 (:status (rf.ssr/get-response fid)))
             "and it projects a non-200 — the listener is doing real work;
              the error-view-failed skip in (1) is therefore meaningful and
              does NOT over-skip a real failure's fail-closed status")))))
@@ -178,7 +178,7 @@
       ;; real; that is the evidence.
       ;;
       ;; The error-emit record shape per `error-emit/dispatch-on-error!`.
-      (error-listener/error-emit-projection-listener
+      (rf.ssr.error-listener/error-emit-projection-listener
         {:error      :rf.error/ssr-ring-error-view-failed
          :event      nil
          :event-id   nil
@@ -186,10 +186,10 @@
          :time       0
          :exception  (ex-info "synthetic error-view failure" {})
          :elapsed-ms 0})
-      (is (empty? (get @error-listener/pending-error-traces fid))
+      (is (empty? (get @rf.ssr.error-listener/pending-error-traces fid))
           "the always-on listener also skips the error-view-failed
            category — not buffered")
-      (is (= 200 (:status (ssr/get-response fid)))
+      (is (= 200 (:status (rf.ssr/get-response fid)))
           "status stays 200 on the production substrate too"))))
 
 ;; ===========================================================================
@@ -209,7 +209,7 @@
             posture that ships: an over-broad skip would silently turn an
             unusable page into a 200 on a real server."
     (let [fid (make-server-frame)]
-      (error-listener/error-emit-projection-listener
+      (rf.ssr.error-listener/error-emit-projection-listener
         {:error      :rf.error/sub-exception
          :event      nil
          :event-id   nil
@@ -217,9 +217,9 @@
          :time       0
          :exception  (ex-info "sub boom" {})
          :elapsed-ms 0})
-      (is (seq (get @error-listener/pending-error-traces fid))
+      (is (seq (get @rf.ssr.error-listener/pending-error-traces fid))
           "a genuine drain-time failure IS buffered by the always-on listener")
-      (is (= 500 (:status (ssr/get-response fid)))
+      (is (= 500 (:status (rf.ssr/get-response fid)))
           "and it projects the default projector's fail-closed 500 — the
            always-on listener is doing real work in this posture, so the
            error-view-failed skip in (3) is targeted and does not swallow a

--- a/implementation/ssr/test/re_frame/ssr_flush_response_result_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_flush_response_result_test.clj
@@ -22,12 +22,12 @@
   `re-frame.ssr.ring-draintime-error-view-test`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error-emit :as error-emit]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]
-            [re-frame.trace :as trace]))
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
+            [re-frame.trace :as rf.trace]))
 
 ;; rf2-lwtlk — ORDER MATTERS. The wholesale `clear-error-listeners!` used to
 ;; run INSIDE `reset-runtime`'s body, i.e. AFTER it. `reset-runtime` re-installs
@@ -39,8 +39,8 @@
 ;; reset arm the projector.
 (use-fixtures :each
   (fn [t]
-    (error-emit/clear-error-listeners!)
-    (tf/reset-runtime t)))
+    (rf.error-emit/clear-error-listeners!)
+    (rf.ssr.test-fixture/reset-runtime t)))
 
 (defn- make-server-frame
   "A `:server`-platform frame using the default projector (no-such-handler →
@@ -88,9 +88,9 @@
   ([frame-id operation] (buffer-error! frame-id operation nil))
   ([frame-id operation extra-tags]
    (let [tags (merge {:frame frame-id :recovery :for-test} extra-tags)]
-     (trace/emit-error! operation tags)
-     (error-emit/dispatch-error-record!
-       (merge {:error operation :time (interop/now-ms)} tags)))))
+     (rf.trace/emit-error! operation tags)
+     (rf.error-emit/dispatch-error-record!
+       (merge {:error operation :time (rf.interop/now-ms)} tags)))))
 
 ;; ===========================================================================
 ;; flush-response-result! — returns the projected public-error alongside resp
@@ -102,7 +102,7 @@
             :response — one drain, both facts."
     (let [fid (make-server-frame :ssr/frr-500)]
       (buffer-error! fid :rf.error/handler-exception)
-      (let [{:keys [response public-error]} (ssr/flush-response-result! fid)]
+      (let [{:keys [response public-error]} (rf.ssr/flush-response-result! fid)]
         (is (= 500 (:status public-error))
             "the projected public-error is returned for classification")
         (is (= :internal-error (:code public-error)))
@@ -114,7 +114,7 @@
             host keeps the app arm; only 500..599 diverts to the error page."
     (let [fid (make-server-frame :ssr/frr-404)]
       (buffer-error! fid :rf.error/no-such-handler {:kind :route})
-      (let [{:keys [public-error]} (ssr/flush-response-result! fid)]
+      (let [{:keys [public-error]} (rf.ssr/flush-response-result! fid)]
         (is (= 404 (:status public-error)))
         (is (<= 400 (:status public-error) 499)
             "a 404 is the client-fault / app-renderable arm")))))
@@ -124,7 +124,7 @@
             A host that reads a 200 with nil public-error stays on the app arm
             (status alone is not proof of a projection)."
     (let [fid (make-server-frame :ssr/frr-clean)
-          {:keys [response public-error]} (ssr/flush-response-result! fid)]
+          {:keys [response public-error]} (rf.ssr/flush-response-result! fid)]
       (is (nil? public-error) "no projection fired")
       (is (= 200 (:status response))))))
 
@@ -134,10 +134,10 @@
             the response keeps the stamped status."
     (let [fid (make-server-frame :ssr/frr-consume)]
       (buffer-error! fid :rf.error/handler-exception)
-      (let [first-flush (ssr/flush-response-result! fid)]
+      (let [first-flush (rf.ssr/flush-response-result! fid)]
         (is (= 500 (:status (:public-error first-flush)))
             "first flush projects the buffered error"))
-      (let [second-flush (ssr/flush-response-result! fid)]
+      (let [second-flush (rf.ssr/flush-response-result! fid)]
         (is (nil? (:public-error second-flush))
             "second flush finds the buffer empty → nil public-error")
         (is (= 500 (:status (:response second-flush)))
@@ -151,8 +151,8 @@
           f404 (make-server-frame :ssr/frr-b-404)]
       (buffer-error! f500 :rf.error/handler-exception)
       (buffer-error! f404 :rf.error/no-such-handler {:kind :route})
-      (let [a (ssr/flush-response-result! f500)
-            b (ssr/flush-response-result! f404)]
+      (let [a (rf.ssr/flush-response-result! f500)
+            b (rf.ssr/flush-response-result! f404)]
         (is (= 500 (:status (:public-error a))) "frame A keeps its 500")
         (is (= 404 (:status (:public-error b))) "frame B keeps its 404")
         (is (= 500 (:status (:response a))))
@@ -167,7 +167,7 @@
       ((requiring-resolve 're-frame.ssr.response/redirect-fx)
        {:frame fid} {:location "/login"})
       (buffer-error! fid :rf.error/handler-exception)
-      (let [{:keys [response public-error]} (ssr/flush-response-result! fid)]
+      (let [{:keys [response public-error]} (rf.ssr/flush-response-result! fid)]
         (is (some? (:redirect response)) "the redirect stands")
         (is (= 302 (:status response))
             "redirect status locked through — the 500 did NOT overwrite it")
@@ -185,11 +185,11 @@
   ([projector-fn] (project-with projector-fn false))
   ([projector-fn dev-detail?]
    (rf/reg-error-projector :test/shape-projector projector-fn)
-   (let [f (frame/make-anon-frame-record!
+   (let [f (rf.frame/make-anon-frame-record!
              {:platform :server
               :ssr      {:public-error-id   :test/shape-projector
                          :dev-error-detail? dev-detail?}})]
-     (ssr/project-error f {:op-type   :error
+     (rf.ssr/project-error f {:op-type   :error
                            :operation :rf.error/handler-exception
                            :tags      {:frame f}}))))
 

--- a/implementation/ssr/test/re_frame/ssr_hash_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hash_test.clj
@@ -19,47 +19,47 @@
   pruning-equivalence."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.ssr.emit :as emit]
-            [re-frame.ssr.hash :as hash]))
+            [re-frame.ssr.emit :as rf.ssr.emit]
+            [re-frame.ssr.hash :as rf.ssr.hash]))
 
 ;; ---- canonical-edn ---------------------------------------------------------
 
 (deftest canonical-edn-prunes-nil-from-maps
   (testing "map entries with nil values are pruned — {:class nil} ≡ {}"
-    (is (= (hash/canonical-edn {})
-           (hash/canonical-edn {:class nil}))
+    (is (= (rf.ssr.hash/canonical-edn {})
+           (rf.ssr.hash/canonical-edn {:class nil}))
         "lone nil-valued entry is pruned")
-    (is (= (hash/canonical-edn {:id "x"})
-           (hash/canonical-edn {:id "x" :class nil}))
+    (is (= (rf.ssr.hash/canonical-edn {:id "x"})
+           (rf.ssr.hash/canonical-edn {:id "x" :class nil}))
         "nil-valued entry pruned alongside live entries")
-    (is (= (hash/canonical-edn {:id "x"})
-           (hash/canonical-edn {:id "x" :class nil :title nil :hidden nil}))
+    (is (= (rf.ssr.hash/canonical-edn {:id "x"})
+           (rf.ssr.hash/canonical-edn {:id "x" :class nil :title nil :hidden nil}))
         "multiple nil-valued entries all pruned"))
 
   (testing "nil map keys ARE preserved (the spec prunes nil VALUES, not keys)"
     ;; Hiccup attribute maps don't have nil keys in practice, but the
     ;; spec is explicit about pruning nil values — leaves keys alone.
-    (is (not= (hash/canonical-edn {})
-              (hash/canonical-edn {nil "x"}))
+    (is (not= (rf.ssr.hash/canonical-edn {})
+              (rf.ssr.hash/canonical-edn {nil "x"}))
         "nil-keyed entry is NOT pruned")))
 
 (deftest canonical-edn-prunes-nil-from-sequences
   (testing "vectors: nil child elements are pruned"
-    (is (= (hash/canonical-edn [:p "text"])
-           (hash/canonical-edn [:p "text" nil]))
+    (is (= (rf.ssr.hash/canonical-edn [:p "text"])
+           (rf.ssr.hash/canonical-edn [:p "text" nil]))
         "trailing nil element pruned")
-    (is (= (hash/canonical-edn [:p "text"])
-           (hash/canonical-edn [:p nil "text" nil]))
+    (is (= (rf.ssr.hash/canonical-edn [:p "text"])
+           (rf.ssr.hash/canonical-edn [:p nil "text" nil]))
         "interior + trailing nil elements pruned"))
 
   (testing "lists: nil child elements are pruned"
-    (is (= (hash/canonical-edn '(:p "text"))
-           (hash/canonical-edn '(:p "text" nil)))
+    (is (= (rf.ssr.hash/canonical-edn '(:p "text"))
+           (rf.ssr.hash/canonical-edn '(:p "text" nil)))
         "trailing nil element pruned in a list")))
 
 (deftest canonical-edn-returns-nil-for-nil
   (testing "bare nil input — sentinel for parent pruning"
-    (is (nil? (hash/canonical-edn nil))
+    (is (nil? (rf.ssr.hash/canonical-edn nil))
         "canonical-edn returns nil for nil input — parent's keep/remove prunes it")))
 
 (deftest canonical-edn-non-nil-fast-path-unchanged
@@ -68,27 +68,27 @@
             parity test (hash_check_cljs_test.cljs) pins '9d7457ef' for
             [:div {:class \"x\"} [:p \"hi\"]]."
     (is (= "[:div {:class \"x\"} [:p \"hi\"]]"
-           (hash/canonical-edn [:div {:class "x"} [:p "hi"]]))
+           (rf.ssr.hash/canonical-edn [:div {:class "x"} [:p "hi"]]))
         "no-nil tree serialises to the pre-fix canonical form")))
 
 ;; ---- render-tree-hash ------------------------------------------------------
 
 (deftest render-tree-hash-equates-nil-attr-with-absent-attr
   (testing "{:class nil} and {} hash identically per Spec 011 §Hydration-mismatch"
-    (is (= (hash/render-tree-hash [:div {:class nil}])
-           (hash/render-tree-hash [:div {}]))
+    (is (= (rf.ssr.hash/render-tree-hash [:div {:class nil}])
+           (rf.ssr.hash/render-tree-hash [:div {}]))
         "the common (when condition? :class) shape no longer triggers spurious mismatch")
-    (is (= (hash/render-tree-hash [:div {:id "x" :class nil}])
-           (hash/render-tree-hash [:div {:id "x"}]))
+    (is (= (rf.ssr.hash/render-tree-hash [:div {:id "x" :class nil}])
+           (rf.ssr.hash/render-tree-hash [:div {:id "x"}]))
         "nil-valued attr pruned alongside live attrs")))
 
 (deftest render-tree-hash-equates-nil-child-with-absent-child
   (testing "nil children are pruned — [:p \"text\" nil] ≡ [:p \"text\"]"
-    (is (= (hash/render-tree-hash [:p "text" nil])
-           (hash/render-tree-hash [:p "text"]))
+    (is (= (rf.ssr.hash/render-tree-hash [:p "text" nil])
+           (rf.ssr.hash/render-tree-hash [:p "text"]))
         "trailing nil child pruned")
-    (is (= (hash/render-tree-hash [:div [:p "a"] nil [:p "b"]])
-           (hash/render-tree-hash [:div [:p "a"] [:p "b"]]))
+    (is (= (rf.ssr.hash/render-tree-hash [:div [:p "a"] nil [:p "b"]])
+           (rf.ssr.hash/render-tree-hash [:div [:p "a"] [:p "b"]]))
         "interior nil child pruned")))
 
 ;; ===========================================================================
@@ -112,12 +112,12 @@
           colon-first (array-map ":a" 2 :a 1)]
       (is (= a-first colon-first)
           "the two maps are Clojure-= (sanity: same logical map)")
-      (is (= (hash/render-tree-hash a-first)
-             (hash/render-tree-hash colon-first))
+      (is (= (rf.ssr.hash/render-tree-hash a-first)
+             (rf.ssr.hash/render-tree-hash colon-first))
           "render-tree-hash is insertion-order-independent for
            str-colliding keys")
-      (is (= (hash/canonical-edn a-first)
-             (hash/canonical-edn colon-first))
+      (is (= (rf.ssr.hash/canonical-edn a-first)
+             (rf.ssr.hash/canonical-edn colon-first))
           "canonical EDN is byte-identical regardless of construction order"))
 
     (testing "the canonical form distinguishes the two key shapes (the
@@ -125,22 +125,22 @@
       ;; The keyword sorts before the quoted string (`:` 0x3A < `\"` 0x22?
       ;; no — `"` is 0x22, `:` is 0x3A, so the quoted string sorts first).
       ;; We assert byte-equality across orders, not the absolute position.
-      (is (str/includes? (hash/canonical-edn (array-map :a 1 ":a" 2))
+      (is (str/includes? (rf.ssr.hash/canonical-edn (array-map :a 1 ":a" 2))
                          "\":a\"")
           "the string key keeps its quotes in canonical form")
-      (is (str/includes? (hash/canonical-edn (array-map :a 1 ":a" 2))
+      (is (str/includes? (rf.ssr.hash/canonical-edn (array-map :a 1 ":a" 2))
                          ":a 1")
           "the keyword key is bare in canonical form"))))
 
 (deftest render-tree-hash-prunes-nil-deeply
   (testing "pruning is recursive — nil-pruning applies at every level"
-    (is (= (hash/render-tree-hash
+    (is (= (rf.ssr.hash/render-tree-hash
              [:section {:class "wrap"}
               [:header {:role "banner" :hidden nil}
                [:h1 "Title" nil]]
               [:article {:class nil}
                [:p "Body" nil]]])
-           (hash/render-tree-hash
+           (rf.ssr.hash/render-tree-hash
              [:section {:class "wrap"}
               [:header {:role "banner"}
                [:h1 "Title"]]
@@ -164,8 +164,8 @@
             <!DOCTYPE html> followed by <root data-rf-render-hash=\"...\"> —
             the hash rides on the root element, not on the doctype"
     (let [tree [:div {:class "page"} [:h1 "Hello"]]
-          h    (hash/render-tree-hash tree)
-          html (emit/render-to-string tree {:doctype? true :render-hash h})]
+          h    (rf.ssr.hash/render-tree-hash tree)
+          html (rf.ssr.emit/render-to-string tree {:doctype? true :render-hash h})]
       (is (str/starts-with? html "<!DOCTYPE html>")
           ":doctype? prepended")
       (is (re-find (re-pattern (str "<!DOCTYPE html><div[^>]*data-rf-render-hash=\"" h "\""))
@@ -180,7 +180,7 @@
   (testing ":render-hash / :doctype? false → root element carries the hash;
             no doctype prefix"
     (let [tree [:section [:p "x"]]
-          html (emit/render-to-string tree {:render-hash (hash/render-tree-hash tree)})]
+          html (rf.ssr.emit/render-to-string tree {:render-hash (rf.ssr.hash/render-tree-hash tree)})]
       (is (not (str/starts-with? html "<!DOCTYPE"))
           "no doctype emitted")
       (is (re-find #"^<section[^>]*data-rf-render-hash=\"[0-9a-f]{8}\""
@@ -190,7 +190,7 @@
 (deftest doctype-without-render-hash-omits-hash-attribute
   (testing ":doctype? true, no :render-hash → doctype emitted; no hash attr"
     (let [tree [:div "no-hash"]
-          html (emit/render-to-string tree {:doctype? true})]
+          html (rf.ssr.emit/render-to-string tree {:doctype? true})]
       (is (str/starts-with? html "<!DOCTYPE html>"))
       (is (not (str/includes? html "data-rf-render-hash"))
           "no hash attribute without :render-hash"))))
@@ -199,10 +199,10 @@
   (testing "the retired `:emit-hash?` opt is now an ordinary unknown key —
             no marker, no throw (the emitter does not validate its opts)"
     (let [tree [:div "x"]]
-      (is (= "<div>x</div>" (emit/render-to-string tree {:emit-hash? true}))
+      (is (= "<div>x</div>" (rf.ssr.emit/render-to-string tree {:emit-hash? true}))
           ":emit-hash? true stamps nothing")
       (is (= "<!DOCTYPE html><div>x</div>"
-             (emit/render-to-string tree {:doctype? true :emit-hash? true}))
+             (rf.ssr.emit/render-to-string tree {:doctype? true :emit-hash? true}))
           ":emit-hash? does not disturb the other opts"))))
 
 ;; ---- rf2-jsa2ml: raw-fn hiccup heads hash identity-free -------------------
@@ -219,7 +219,7 @@
             raw fn head to the fixed identity-free token `#fn[]`."
     (let [f1 (fn [_] [:span "a"])
           f2 (fn [_] [:span "a"])]
-      (is (= "#fn[]" (hash/canonical-edn f1))
+      (is (= "#fn[]" (rf.ssr.hash/canonical-edn f1))
           "a raw fn serialises to the identity-free token, not #fn[<toString>]")
       ;; The decisive property: two DISTINCT fn objects standing for the same
       ;; logical view (server's deref'd defn vs client's) hash identically.
@@ -227,18 +227,18 @@
       ;; toString → different canonical EDN → different hashes → false mismatch.
       (is (not= (.toString f1) (.toString f2))
           "sanity: the two fn objects DO have divergent toStrings (the trap)")
-      (is (= (hash/render-tree-hash [:div [f1 {:x 1}]])
-             (hash/render-tree-hash [:div [f2 {:x 1}]]))
+      (is (= (rf.ssr.hash/render-tree-hash [:div [f1 {:x 1}]])
+             (rf.ssr.hash/render-tree-hash [:div [f2 {:x 1}]]))
           "distinct fn objects for the same tree hash identically — no spurious mismatch")
       ;; The fn's props still discriminate: a different prop → a different hash.
-      (is (not= (hash/render-tree-hash [:div [f1 {:x 1}]])
-                (hash/render-tree-hash [:div [f1 {:x 2}]]))
+      (is (not= (rf.ssr.hash/render-tree-hash [:div [f1 {:x 1}]])
+                (rf.ssr.hash/render-tree-hash [:div [f1 {:x 2}]]))
           "the head is identity-free but the props are still hashed")))
   (testing "a Var head stays identity-stable — a Var is NOT fn? on the JVM, so
             `[#'ns/view …]` falls to :else → pr-str → #'ns/name (identical
             both runtimes)"
     (is (= "#'clojure.core/identity"
-           (hash/canonical-edn #'clojure.core/identity))
+           (rf.ssr.hash/canonical-edn #'clojure.core/identity))
         "a Var reference keeps its stable #'ns/name print form")))
 
 ;; ---- rf2-0ypnnk: whole-valued doubles canonicalise cross-runtime ----------
@@ -251,21 +251,21 @@
             the hash passes while the server/client DOM diverges (and, under
             :on-mismatch :hard-error, hydration crashes)."
     ;; hash side — canonical EDN drops the .0 for a child AND an attr value.
-    (is (= "[:span 9]" (hash/canonical-edn [:span 9.0]))
+    (is (= "[:span 9]" (rf.ssr.hash/canonical-edn [:span 9.0]))
         "whole-double child → `9` in the canonical EDN")
     (is (= "[:progress {:max 1,:value 0}]"
-           (hash/canonical-edn [:progress {:value 0.0 :max 1.0}]))
+           (rf.ssr.hash/canonical-edn [:progress {:value 0.0 :max 1.0}]))
         "whole-double attr values → `0`/`1` in the canonical EDN")
     ;; HTML side — the emitter applies the SAME normalisation, child + attr.
-    (is (= "<span>9</span>" (emit/render-to-string [:span 9.0] {}))
+    (is (= "<span>9</span>" (rf.ssr.emit/render-to-string [:span 9.0] {}))
         "whole-valued double CHILD renders `9`, not the JVM `9.0`")
-    (let [html (emit/render-to-string [:progress {:value 0.0 :max 1.0}] {})]
+    (let [html (rf.ssr.emit/render-to-string [:progress {:value 0.0 :max 1.0}] {})]
       (is (str/includes? html "value=\"0\"") "whole-double attr renders value=\"0\"")
       (is (str/includes? html "max=\"1\"")   "whole-double attr renders max=\"1\"")
       (is (not (str/includes? html ".0"))    "no trailing .0 leaks into the HTML"))
     ;; integers, non-whole doubles, and ratios behave as documented.
-    (is (= "42"   (hash/canonical-number 42))   "an integer is unchanged")
-    (is (= "3.14" (hash/canonical-number 3.14)) "a non-whole double is unchanged")
-    (is (= "0.5"  (hash/canonical-number 1/2))  "a ratio coerces to its IEEE-double form")
-    (is (= "<span>3.14</span>" (emit/render-to-string [:span 3.14] {}))
+    (is (= "42"   (rf.ssr.hash/canonical-number 42))   "an integer is unchanged")
+    (is (= "3.14" (rf.ssr.hash/canonical-number 3.14)) "a non-whole double is unchanged")
+    (is (= "0.5"  (rf.ssr.hash/canonical-number 1/2))  "a ratio coerces to its IEEE-double form")
+    (is (= "<span>3.14</span>" (rf.ssr.emit/render-to-string [:span 3.14] {}))
         "a non-whole double child is unchanged")))

--- a/implementation/ssr/test/re_frame/ssr_head_resolution_no_project_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_resolution_no_project_test.clj
@@ -55,13 +55,13 @@
   proved could ever be positive."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.error-listener :as error-listener]
-            [re-frame.ssr.test-fixture :as tf]
-            [re-frame.trace :as trace]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.error-listener :as rf.ssr.error-listener]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
+            [re-frame.trace :as rf.trace]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 (def ^:private server-frame :ssr/head-no-project-frame)
 
@@ -94,16 +94,16 @@
       ;; the listener ripped out: a negative over a bus that emitted
       ;; nothing. The production counterpart is test (3), which calls the
       ;; always-on listener directly and is posture-independent.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         ;; Stamp the frame exactly as resolve-head's catch arm does.
-        (trace/emit-error! :rf.error/ssr-head-resolution-failed
+        (rf.trace/emit-error! :rf.error/ssr-head-resolution-failed
                            {:frame     fid
                             :exception (ex-info "synthetic head failure" {:reason :test})
                             :recovery  :no-recovery})
-        (is (empty? (get @error-listener/pending-error-traces fid))
+        (is (empty? (get @rf.ssr.error-listener/pending-error-traces fid))
             "the head trace was SKIPPED — not buffered into
              pending-error-traces (so a later get-response can't project it)")
-        (is (= 200 (:status (ssr/get-response fid)))
+        (is (= 200 (:status (rf.ssr/get-response fid)))
             "status stays 200 — the head failure degraded gracefully; the
              default projector (→ 500) never ran for this category")))))
 
@@ -126,14 +126,14 @@
       ;; production-elided (Spec 010 §Production builds), so no production
       ;; reject exists for this control to observe. The always-on control
       ;; is test (4).
-      (when interop/debug-enabled?
-        (trace/emit-error! :rf.error/schema-validation-failure
+      (when rf.interop/debug-enabled?
+        (rf.trace/emit-error! :rf.error/schema-validation-failure
                            {:frame     fid
                             :exception (ex-info "schema boom" {})
                             :recovery  :no-recovery})
-        (is (seq (get @error-listener/pending-error-traces fid))
+        (is (seq (get @rf.ssr.error-listener/pending-error-traces fid))
             "a non-degradation category IS buffered for projection")
-        (is (not= 200 (:status (ssr/get-response fid)))
+        (is (not= 200 (:status (rf.ssr/get-response fid)))
             "and it projects a non-200 — the listener is doing real work;
              the head-category skip in (1) is therefore meaningful")))))
 
@@ -166,7 +166,7 @@
       ;; the property is false for real; that is the evidence.
       ;;
       ;; The error-emit record shape per `error-emit/dispatch-on-error!`.
-      (error-listener/error-emit-projection-listener
+      (rf.ssr.error-listener/error-emit-projection-listener
         {:error      :rf.error/ssr-head-resolution-failed
          :event      nil
          :event-id   nil
@@ -174,10 +174,10 @@
          :time       0
          :exception  (ex-info "synthetic head failure" {})
          :elapsed-ms 0})
-      (is (empty? (get @error-listener/pending-error-traces fid))
+      (is (empty? (get @rf.ssr.error-listener/pending-error-traces fid))
           "the always-on listener also skips the head category — not
            buffered")
-      (is (= 200 (:status (ssr/get-response fid)))
+      (is (= 200 (:status (rf.ssr/get-response fid)))
           "status stays 200 on the production substrate too"))))
 
 ;; ===========================================================================
@@ -198,7 +198,7 @@
             it really does reach production (via `dispatch-on-error!`), so
             this control has a live producer in the posture that ships."
     (let [fid (make-server-frame)]
-      (error-listener/error-emit-projection-listener
+      (rf.ssr.error-listener/error-emit-projection-listener
         {:error      :rf.error/handler-exception
          :event      [:load/article]
          :event-id   :load/article
@@ -206,9 +206,9 @@
          :time       0
          :exception  (ex-info "handler boom" {})
          :elapsed-ms 0})
-      (is (seq (get @error-listener/pending-error-traces fid))
+      (is (seq (get @rf.ssr.error-listener/pending-error-traces fid))
           "a non-degradation category IS buffered by the always-on listener")
-      (is (= 500 (:status (ssr/get-response fid)))
+      (is (= 500 (:status (rf.ssr/get-response fid)))
           "and it projects the default projector's generic 500 — the
            always-on listener is doing real work in this posture, so the
            head-category skip in (3) is a targeted skip and not a listener

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -34,15 +34,15 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.registrar :as registrar]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.head :as head]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.head :as rf.ssr.head]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
 ;; Shared reset fixture lives in `re-frame.ssr.test-fixture` (rf2-i3qc0).
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ===========================================================================
 ;; reg-head — registry kind :head with handler-fn
@@ -53,7 +53,7 @@
             with the head-fn under :handler-fn"
     (let [head-fn (fn [_db _route] {:title "Hello"})]
       (rf/reg-head :head/static head-fn)
-      (let [meta (registrar/lookup :head :head/static)]
+      (let [meta (rf.registrar/lookup :head :head/static)]
         (is (some? meta) "registry slot exists")
         (is (= head-fn (:handler-fn meta))
             "the head-fn is stored under :handler-fn")))))
@@ -68,7 +68,7 @@
     (rf/reg-head :head/with-meta
                  {:doc "Article-page head model"}
                  (fn [_db _route] {:title "x"}))
-    (let [m (registrar/lookup :head :head/with-meta)]
+    (let [m (rf.registrar/lookup :head :head/with-meta)]
       ;; SEMANTIC, posture-independent (rf2-lwtlk): the 3-arity is above all a
       ;; REGISTRATION arity — the extra metadata argument must not displace
       ;; the head-fn, and the slot must be usable.
@@ -82,14 +82,14 @@
       ;; pure-documentation key, dropped by
       ;; `registrar/strip-pure-documentation` under the production gate per
       ;; Spec 001 §Production elision contract.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (= "Article-page head model" (:doc m))
             ":doc metadata is preserved on the registry slot"))
 
       ;; rf2-lwtlk — the REAL-gate arm: the elision itself, witnessed on a JVM
       ;; actually started with `-Dre-frame.debug=false` rather than through a
       ;; `with-redefs` rebind that a load-time gate cannot see (rf2-9c2jf).
-      (when-not interop/debug-enabled?
+      (when-not rf.interop/debug-enabled?
         (is (nil? (:doc m))
             ":doc is elided from the registry slot in production builds
              (Spec 001 §Production elision contract)")))))
@@ -100,7 +100,7 @@
           second-fn (fn [_ _] {:title "second"})]
       (rf/reg-head :head/redo first-fn)
       (rf/reg-head :head/redo second-fn)
-      (is (= second-fn (:handler-fn (registrar/lookup :head :head/redo)))
+      (is (= second-fn (:handler-fn (rf.registrar/lookup :head :head/redo)))
           "second registration wins"))))
 
 ;; ===========================================================================
@@ -115,7 +115,7 @@
                    (let [{:keys [title summary]} (get-in db [:articles (:id params)])]
                      {:title title
                       :meta  [{:name "description" :content summary}]})))
-    (let [f (frame/make-anon-frame-record!
+    (let [f (rf.frame/make-anon-frame-record!
               {:doc       "head test frame"
                :platform  :server
                :initial-events [[:set-test-state]]})]
@@ -138,14 +138,14 @@
   (testing "(render-head head-id frame-id) is sugar for (render-head head-id
             {:frame frame-id})"
     (rf/reg-head :head/simple (fn [_ _] {:title "bare"}))
-    (let [f (frame/make-anon-frame-record! {:doc "shorthand frame" :platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:doc "shorthand frame" :platform :server})]
       (is (= {:title "bare"} (rf/render-head :head/simple f))))))
 
 (deftest render-head-accepts-explicit-route-override
   (testing ":route opt overrides the slice read from app-db — useful for
             tools that want a hypothetical-route preview"
     (rf/reg-head :head/echo (fn [_ route] {:title (str (:route-id route))}))
-    (let [f (frame/make-anon-frame-record! {:doc "explicit-route frame" :platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:doc "explicit-route frame" :platform :server})]
       (is (= ":route/explicit"
              (:title (rf/render-head :head/echo
                                      {:frame f
@@ -153,7 +153,7 @@
 
 (deftest render-head-raises-on-unregistered-id
   (testing "render-head against an unknown id throws :rf.error/no-such-head"
-    (let [f (frame/make-anon-frame-record! {:doc "missing-head frame" :platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:doc "missing-head frame" :platform :server})]
       (try
         (rf/render-head :head/nope {:frame f})
         (is false "expected exception")
@@ -169,7 +169,7 @@
             and the second call's return is the second head's model"
     (rf/reg-head :head/a (fn [_ _] {:title "A"}))
     (rf/reg-head :head/b (fn [_ _] {:title "B"}))
-    (let [f (frame/make-anon-frame-record! {:doc "render-head frame" :platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:doc "render-head frame" :platform :server})]
       (is (= {:title "A"} (rf/render-head :head/a {:frame f}))
           "the first call returns the first head's model")
       (is (= {:title "B"} (rf/render-head :head/b {:frame f}))
@@ -190,7 +190,7 @@
     (rf/reg-route :route/article
                   {:doc  "Article page"
                    :head :head/article} "/articles/:id")
-    (let [f (frame/make-anon-frame-record! {:doc "active-route frame" :platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:doc "active-route frame" :platform :server})]
       (rf/dispatch-sync
         [::seed-route] {:frame f})
       ;; The test sub-handler isn't registered; instead seed the runtime-db
@@ -209,7 +209,7 @@
   (testing "no :head on the route → default-head fires (viewport only)"
     (rf/reg-route :route/no-head
                   {:doc  "Bare route"} "/")
-    (let [f (frame/make-anon-frame-record! {:doc "Default-head probe" :platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:doc "Default-head probe" :platform :server})]
       (rf/reg-event ::seed-route-no-head
                        (fn [{rt :rf.db/runtime} _]
                          {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:route-id :route/no-head})}))
@@ -225,7 +225,7 @@
 
 (deftest active-head-uses-default-when-no-route-at-all
   (testing "no route slice (e.g. a frame that hasn't routed yet) → default"
-    (let [f (frame/make-anon-frame-record! {:doc "Bare" :platform :server})
+    (let [f (rf.frame/make-anon-frame-record! {:doc "Bare" :platform :server})
           model (rf/active-head f)]
       (is (= "Bare" (:title model)))
       (is (seq (:meta model))))))
@@ -569,7 +569,7 @@
     (rf/reg-route :route/article
                   {:doc  "Article page"
                    :head :head/article} "/articles/:id")
-    (let [f (frame/make-anon-frame-record! {:doc "article frame" :platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:doc "article frame" :platform :server})]
       (rf/dispatch-sync [:seed-article] {:frame f})
       (let [model (rf/active-head f)
             html  (rf/head-model->html model)]
@@ -612,7 +612,7 @@
                      (fn [{rt :rf.db/runtime} _]
                        {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current]
                                                  {:route-id :route/article-fr :params {:id "1"}})}))
-    (let [f (frame/make-anon-frame-record! {:platform :server})]
+    (let [f (rf.frame/make-anon-frame-record! {:platform :server})]
       (rf/dispatch-sync [:seed-fr] {:frame f})
       (let [model (rf/active-head f)]
         (is (= "Article — fr-FR" (:title model)))

--- a/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
@@ -78,15 +78,15 @@
       error id — in the strict-mode throw's `ex-data`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.error :as error]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.subs :as subs]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.error :as rf.error]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.subs :as rf.subs]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; The payload the testbed's `<script id=\"__rf_payload\">` bakes verbatim
 ;; (testbeds/ssr_hydration_mismatch/index.html lines 49-54). The
@@ -110,7 +110,7 @@
     (fn [{:keys [db]} _ev] {:db (update db :count (fnil inc 0))}))
   (rf/reg-sub :count     (fn [db _] (or (:count db) 0)))
   ;; EP-0001 (rf2-vzld77): the SSR hydration metadata is durable runtime-db state.
-  (subs/reg-runtime-sub :hydrated? (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration])))))
+  (rf.subs/reg-runtime-sub :hydrated? (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration])))))
 
 (def ^:private hex-8-pattern #"^[0-9a-f]{8}$")
 
@@ -128,7 +128,7 @@
             The mismatch is a downstream trace, not a hydration
             blocker (Spec 011 — degraded-but-running posture)."
     (register-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
 
@@ -154,7 +154,7 @@
             hoisted to the trace envelope's top level (per Spec 009
             §Error event shape's recovery-hoist branch)."
     (register-handlers!)
-    (let [client-frame   (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
+    (let [client-frame   (rf.frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                          :platform :client})
           ;; A second 8-hex string — anything other than \"deadbeef\".
           client-hash    "0badf00d"]
@@ -163,9 +163,9 @@
       ;; identical payload map is observable in production through the
       ;; strict-mode throw's ex-data, pinned by
       ;; `mismatch-strict-mode-throws-with-structured-payload`.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (with-trace-recorder! [traces]
-          (ssr/verify-hydration! client-frame client-hash)
+          (rf.ssr/verify-hydration! client-frame client-hash)
           (let [mismatches (filter #(= :rf.ssr/hydration-mismatch (:operation %))
                                    @traces)]
             (is (= 1 (count mismatches))
@@ -198,7 +198,7 @@
             input and lock the shape + the not-equal-deadbeef
             invariant."
     (register-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                        :platform :client})
           ;; A non-trivial hiccup tree — its computed hash is whatever
           ;; FNV-1a resolves to; we lock the shape and the not-equal
@@ -226,9 +226,9 @@
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). What is
       ;; left here that is genuinely ABOUT the trace: that the tag echoes
       ;; the same value `render-tree-hash` computes directly.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (with-trace-recorder! [traces]
-          (ssr/verify-hydration! client-frame render-tree)
+          (rf.ssr/verify-hydration! client-frame render-tree)
           (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch
                                             (:operation %))
                                         @traces))]
@@ -263,7 +263,7 @@
             error-emit path is the producer site — see
             `re-frame.ssr.hydrate/verify-hydration!`)."
     (register-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
 
@@ -272,12 +272,12 @@
       ;; escalated, carries an `:rf.error/id` (not a `:rf.warning/…` id) in
       ;; the strict-mode throw's ex-data. Spec 009 categorisation is
       ;; therefore witnessed in both postures, not only on the trace bus.
-      (let [strict-frame (frame/make-anon-frame-record!
+      (let [strict-frame (rf.frame/make-anon-frame-record!
                            {:doc      "ssr-mismatch severity frame"
                             :platform :client
                             :ssr      {:on-mismatch :hard-error}})]
         (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame strict-frame})
-        (let [thrown (try (ssr/verify-hydration! strict-frame "0badf00d")
+        (let [thrown (try (rf.ssr/verify-hydration! strict-frame "0badf00d")
                           nil
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown) "the mismatch escalates when strict")
@@ -286,9 +286,9 @@
                severity, matching the trace's :op-type :error")))
 
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (with-trace-recorder! [traces]
-          (ssr/verify-hydration! client-frame "0badf00d")
+          (rf.ssr/verify-hydration! client-frame "0badf00d")
           (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch
                                             (:operation %))
                                         @traces))]
@@ -311,7 +311,7 @@
             assertion here drives ::inc through `dispatch-sync`
             and reads :count via `subscribe-once`."
     (register-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
 
@@ -324,7 +324,7 @@
       ;; vacuously — we want to assert the dispatch survives
       ;; the recovery, not just that it works without one).
       (with-trace-recorder! [_traces]
-        (ssr/verify-hydration! client-frame "0badf00d"))
+        (rf.ssr/verify-hydration! client-frame "0badf00d"))
 
       (rf/dispatch-sync [::inc] {:frame client-frame})
       (is (= 1 (rf/subscribe-once [:count] {:frame client-frame}))
@@ -346,11 +346,11 @@
             hash + failing-id payload as the trace, and :recovery is
             :hard-error."
     (register-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr strict-mode frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr strict-mode frame"
                                        :platform :client
                                        :ssr {:on-mismatch :hard-error}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
-      (let [thrown (try (ssr/verify-hydration! client-frame "0badf00d")
+      (let [thrown (try (rf.ssr/verify-hydration! client-frame "0badf00d")
                         nil
                         (catch clojure.lang.ExceptionInfo e e))]
         (is (some? thrown)
@@ -368,11 +368,11 @@
           ;; the message LEADS with the human :reason sentence and TRAILS with
           ;; the [:rf.ssr/hydration-mismatch] greppability token (rule 4), and
           ;; the ex-data now carries :where like the frame/events sibling throws.
-          (is (error/message-has-id-token? msg)
+          (is (rf.error/message-has-id-token? msg)
               "the message carries the trailing greppability token (rule 4)")
-          (is (not (error/keyword-only-message? msg))
+          (is (not (rf.error/keyword-only-message? msg))
               "the message is the human sentence, not a bare keyword (rule 1)")
-          (is (= (error/human-message :rf.ssr/hydration-mismatch (:reason data)) msg)
+          (is (= (rf.error/human-message :rf.ssr/hydration-mismatch (:reason data)) msg)
               "the message is derived from the payload's own :rf.error/id + :reason")
           (is (= 'rf/verify-hydration! (:where data))
               ":where names the throwing helper (was absent before rf2-ya3iqg)"))))))
@@ -382,7 +382,7 @@
             trace (monitoring integrations rely on it) AND throws — the
             two are not mutually exclusive."
     (register-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr strict-mode frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr strict-mode frame"
                                        :platform :client
                                        :ssr {:on-mismatch :hard-error}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
@@ -390,9 +390,9 @@
       ;; deftest's subject is the TRACE half of the emit-then-throw pair; the
       ;; throw half is `mismatch-strict-mode-throws-with-structured-payload`,
       ;; which runs in both postures.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (with-trace-recorder! [traces]
-          (try (ssr/verify-hydration! client-frame "0badf00d")
+          (try (rf.ssr/verify-hydration! client-frame "0badf00d")
                (catch clojure.lang.ExceptionInfo _ nil))
           (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch (:operation %))
                                         @traces))]
@@ -406,11 +406,11 @@
             short-circuits the hash comparison entirely (Spec 011 item 4):
             no trace, no throw, even when the hashes diverge."
     (register-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr detection-off frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr detection-off frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? false}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
-      (is (nil? (ssr/verify-hydration! client-frame "0badf00d"))
+      (is (nil? (rf.ssr/verify-hydration! client-frame "0badf00d"))
           "verify-hydration! is a no-op when detection is off")
 
       ;; SEMANTIC, posture-independent (rf2-lwtlk): a no-op return value is
@@ -419,22 +419,22 @@
       ;; on a frame that ALSO asks for `:on-mismatch :hard-error`: with
       ;; detection off there is nothing to escalate, so it must not throw.
       ;; That reaches the always-on channel and holds in either posture.
-      (let [off-strict (frame/make-anon-frame-record!
+      (let [off-strict (rf.frame/make-anon-frame-record!
                          {:doc      "ssr detection-off strict frame"
                           :platform :client
                           :ssr      {:detect-mismatch? false
                                      :on-mismatch      :hard-error}})]
         (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame off-strict})
-        (is (nil? (ssr/verify-hydration! off-strict "0badf00d"))
+        (is (nil? (rf.ssr/verify-hydration! off-strict "0badf00d"))
             ":detect-mismatch? false short-circuits BEFORE the comparison —
              even :on-mismatch :hard-error has nothing to escalate"))
 
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). A NEGATIVE
       ;; over the trace ring: vacuous under the gate, where no mismatch
       ;; trace fires whether detection ran or not.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (with-trace-recorder! [traces]
-          (ssr/verify-hydration! client-frame "0badf00d")
+          (rf.ssr/verify-hydration! client-frame "0badf00d")
           (let [mismatches (filter #(= :rf.ssr/hydration-mismatch (:operation %))
                                    @traces)]
             (is (empty? mismatches)
@@ -446,7 +446,7 @@
             warns. Pins the default so a future refactor can't silently
             flip detection off."
     (register-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr default frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr default frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
 
@@ -458,12 +458,12 @@
       ;; throw. The throw is always-on, so the default is now pinned in both
       ;; postures — which is precisely the refactor this deftest guards
       ;; against.
-      (let [default-strict (frame/make-anon-frame-record!
+      (let [default-strict (rf.frame/make-anon-frame-record!
                              {:doc      "ssr default-detection strict frame"
                               :platform :client
                               :ssr      {:on-mismatch :hard-error}})]
         (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame default-strict})
-        (let [thrown (try (ssr/verify-hydration! default-strict "0badf00d")
+        (let [thrown (try (rf.ssr/verify-hydration! default-strict "0badf00d")
                           nil
                           (catch clojure.lang.ExceptionInfo e e))]
           (is (some? thrown)
@@ -476,9 +476,9 @@
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The default
       ;; RECOVERY (`:warned-and-replaced` rather than `:hard-error`) is only
       ;; observable on the trace: the warn path throws nothing by definition.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (with-trace-recorder! [traces]
-          (ssr/verify-hydration! client-frame "0badf00d")
+          (rf.ssr/verify-hydration! client-frame "0badf00d")
           (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch (:operation %))
                                         @traces))]
             (is (some? mismatch) "detection defaults on")

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -96,17 +96,17 @@
   `(when dev-trace …)`. It is the shape the rest of this file now follows."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.fx :as fx]
-            [re-frame.interop :as interop]
-            [re-frame.registrar :as registrar]
-            [re-frame.subs :as subs]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fx :as rf.fx]
+            [re-frame.interop :as rf.interop]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.subs :as rf.subs]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; rf2-lwtlk — a production-visible probe for "were the compatibility-check
 ;; fxs ENQUEUED?".  Re-registers the two `:rf.ssr/check-*` fx ids with a
@@ -126,9 +126,9 @@
 (defn- record-check-fx-dispatches! []
   (let [seen (atom [])]
     (doseq [id [:rf.ssr/check-version :rf.ssr/check-schema-digest]]
-      (let [slot (registrar/lookup :fx id)
+      (let [slot (rf.registrar/lookup :fx id)
             real (:handler-fn slot)]
-        (fx/reg-fx id
+        (rf.fx/reg-fx id
                    (select-keys slot [:platforms :schema])
                    (fn [frame-id v]
                      (swap! seen conj [id v])
@@ -180,7 +180,7 @@
   (rf/reg-sub :server-resp (fn [db _] (:server-response db)))
   ;; EP-0001 (rf2-vzld77): the SSR hydration metadata is durable runtime-db
   ;; state, so :hydrated? is a runtime-db sub.
-  (subs/reg-runtime-sub :hydrated? (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration])))))
+  (rf.subs/reg-runtime-sub :hydrated? (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration])))))
 
 (defn- materialise-response
   "Mirror of testbeds/ssr_basic/core.cljs's `materialise-response` —
@@ -209,7 +209,7 @@
             post-hydrate values via subscribe-once (no view re-render
             machinery needed; the contract is the app-db state)."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -244,7 +244,7 @@
             observed the same via DOM re-render; subscribe-once reads
             the post-drain app-db directly)."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -276,7 +276,7 @@
             (resp-status, resp-ct, resp-cookies-count,
             resp-cookie-name)."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -309,9 +309,9 @@
     (register-baseline-handlers!)
     ;; The baseline payload's version is the SSR-owned constant (the wire
     ;; shape the testbed baked), so the scalar version check compares equal.
-    (is (= payload-policy/pattern-protocol-version (:rf/version baseline-payload))
+    (is (= rf.ssr.payload-policy/pattern-protocol-version (:rf/version baseline-payload))
         "the baseline payload ships the v1 pattern-protocol version")
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (with-trace-recorder! [traces]
@@ -319,7 +319,7 @@
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). BOTH are
         ;; negatives over the trace ring: vacuous under the gate, where a
         ;; skewed version would look identical to a matching one.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (empty? (filter #(= :rf.ssr/compatibility-check-skipped (:operation %)) @traces))
               (str "version check resolves via the SSR constant → never skipped; "
                    "saw operations: " (pr-str (mapv :operation @traces))))
@@ -344,7 +344,7 @@
             :rf.fx/skipped-on-platform warning per check on every server-
             side hydrate. The handler-level gate prevents that noise."
     (register-baseline-handlers!)
-    (let [server-frame (frame/make-anon-frame-record! {:doc "ssr-basic server frame"
+    (let [server-frame (rf.frame/make-anon-frame-record! {:doc "ssr-basic server frame"
                                        :platform :server})
           ;; Add a :rf/schema-digest so BOTH checks would fire if the
           ;; handler enqueued them; otherwise only :rf.ssr/check-version
@@ -368,7 +368,7 @@
           (is (= 7 (rf/subscribe-once [:count] {:frame server-frame}))
               ":rf/app-db still applied on the server-side run")
           ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (let [skipped-checks
                   (filter (fn [ev]
                             (and (= :rf.fx/skipped-on-platform (:operation ev))
@@ -393,12 +393,12 @@
             Without this counter-assertion the server-side gate could
             silently strip the client code path."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           ;; Skew the payload version away from the SSR constant so the
           ;; version check has something to report on the client frame.
           payload      (-> baseline-payload
-                           (assoc :rf/version (inc payload-policy/pattern-protocol-version))
+                           (assoc :rf/version (inc rf.ssr.payload-policy/pattern-protocol-version))
                            materialise-response)]
       (let [dispatched (record-check-fx-dispatches!)]
         (with-trace-recorder! [traces]
@@ -411,11 +411,11 @@
           (is (contains? (set (map first @dispatched)) :rf.ssr/check-version)
               (str "on :client the handler still enqueued :rf.ssr/check-version; "
                    "saw: " (pr-str @dispatched)))
-          (is (= (inc payload-policy/pattern-protocol-version)
+          (is (= (inc rf.ssr.payload-policy/pattern-protocol-version)
                  (some (fn [[id v]] (when (= :rf.ssr/check-version id) v)) @dispatched))
               "…carrying the payload's skewed :rf/version as its argument")
           ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (let [mismatch (filter #(= :rf.ssr/version-mismatch (:operation %)) @traces)]
               (is (seq mismatch)
                   (str "on :client the :rf.ssr/check-version fx still fires and "
@@ -430,7 +430,7 @@
             :rf.ssr/hydration-mismatch trace fires on the baseline
             surface (its payload's :rf/render-hash is nil)."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                        :platform :client})
           payload      (materialise-response baseline-payload)]
       (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
@@ -444,11 +444,11 @@
         ;; the call a no-op regardless of the client
         ;; value (Spec 011 — `(when (and server-hash
         ;; client-hash ...) ...)` short-circuits).
-        (ssr/verify-hydration! client-frame "abcdef01")
+        (rf.ssr/verify-hydration! client-frame "abcdef01")
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). A NEGATIVE
         ;; over the trace ring, and this deftest's ONLY assertion: under the
         ;; gate it would have passed without the short-circuit existing.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
               (str "no :rf.ssr/hydration-mismatch on the baseline (server-"
                    "hash was nil); saw: "
@@ -460,13 +460,13 @@
       ;; since hydrate.cljc builds one shared payload for the trace and the
       ;; throw alike. Nothing thrown means the comparison genuinely
       ;; short-circuited rather than merely failing to announce itself.
-      (let [strict-frame (frame/make-anon-frame-record!
+      (let [strict-frame (rf.frame/make-anon-frame-record!
                            {:doc      "nil-server-hash strict frame"
                             :platform :client
                             :ssr      {:on-mismatch :hard-error}})]
         (rf/dispatch-sync [:rf/hydrate (materialise-response baseline-payload)]
                           {:frame strict-frame})
-        (is (nil? (ssr/verify-hydration! strict-frame "abcdef01"))
+        (is (nil? (rf.ssr/verify-hydration! strict-frame "abcdef01"))
             "a nil server-hash short-circuits BEFORE the comparison — even
              :on-mismatch :hard-error has nothing to escalate")))))
 
@@ -498,7 +498,7 @@
                          {:rf/app-db "slice-is-a-string"}
                          {:rf/app-db [:slice :is :a :vector]}
                          {:rf/app-db 99}]]
-      (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-basic client frame"
+      (let [client-frame (rf.frame/make-anon-frame-record! {:doc "ssr-basic client frame"
                                          :platform :client})]
         ;; Seed a recognisable pre-hydration client slice so we can prove
         ;; it SURVIVES (was not replaced by the malformed payload).
@@ -519,7 +519,7 @@
           ;; CLOSED is the contract and is pinned by the three assertions
           ;; above, all posture-independent; the diagnostic is how a
           ;; developer learns which payload was rejected and why.
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (is (some #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
                 (str (pr-str bad-payload)
                      " must emit :rf.error/malformed-hydration-payload; saw: "
@@ -533,7 +533,7 @@
             neither emits the malformed diagnostic."
     (register-baseline-handlers!)
     ;; (a) full server slice → replaces app-db, no diagnostic.
-    (let [client-frame (frame/make-anon-frame-record! {:doc "client frame a" :platform :client})]
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "client frame a" :platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [:rf/hydrate {:rf/app-db {:count 7 :title "seeded"}}]
                           {:frame client-frame})
@@ -542,11 +542,11 @@
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
         ;; under the gate; the PRECISION this deftest is for — the payload
         ;; was accepted — is pinned by the installed slice above.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
               "no malformed diagnostic on a well-formed payload"))))
     ;; (b) map payload with no app-db slice → existing client data survives.
-    (let [client-frame (frame/make-anon-frame-record! {:doc "client frame b" :platform :client})]
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "client frame b" :platform :client})]
       (rf/dispatch-sync [::set-title "kept"] {:frame client-frame})
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [:rf/hydrate {:rf/version 1}] {:frame client-frame})
@@ -554,7 +554,7 @@
             "no-slice payload preserves the existing client slice")
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
         ;; under the gate.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
               "a no-slice map payload is the legitimate client-only fallback, not malformed"))))))
 
@@ -593,13 +593,13 @@
         {:db db
          :rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/machines :snapshots]
                                   {:m {:value :idle}})}))
-    (subs/reg-runtime-sub :machine-snapshots
+    (rf.subs/reg-runtime-sub :machine-snapshots
       (fn [rt _] (get-in rt [:rf.runtime/machines :snapshots])))
     (doseq [bad-rt ["runtime-is-a-string"
                     [:runtime :is :a :vector]
                     42
                     false]]
-      (let [client-frame (frame/make-anon-frame-record! {:doc "non-map-runtime-db client frame"
+      (let [client-frame (rf.frame/make-anon-frame-record! {:doc "non-map-runtime-db client frame"
                                          :platform :client})]
         ;; Seed recognisable pre-hydration state in BOTH partitions.
         (rf/dispatch-sync [::set-title "pre-hydration"] {:frame client-frame})
@@ -632,7 +632,7 @@
             ;; a negative over the same empty ring, so it would have PASSED
             ;; without the rejection short-circuit existing. The rejection
             ;; itself is pinned by the four partition assertions above.
-            (when interop/debug-enabled?
+            (when rf.interop/debug-enabled?
               ;; the malformed diagnostic fires.
               (is (some #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
                   (str (pr-str bad-rt)
@@ -652,10 +652,10 @@
             through the router, and a wholly-absent :rf/runtime-db key is
             the legitimate no-server-runtime fallback (neither is malformed)."
     (register-baseline-handlers!)
-    (subs/reg-runtime-sub :route-current
+    (rf.subs/reg-runtime-sub :route-current
       (fn [rt _] (get-in rt [:rf.runtime/routing :current])))
     ;; (a) map runtime-db slice → installs the runtime-db partition.
-    (let [client-frame (frame/make-anon-frame-record! {:doc "rt-ok client frame" :platform :client})
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "rt-ok client frame" :platform :client})
           payload {:rf/app-db     {:count 7 :title "seeded"}
                    :rf/runtime-db {:rf.runtime/routing {:current {:route-id :home}}}}]
       (with-trace-recorder! [traces]
@@ -665,17 +665,17 @@
             "the runtime-db route slice rode the payload and installed")
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
         ;; under the gate; the installed route slice above is the acceptance.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
               "no malformed diagnostic on a well-formed two-partition payload"))))
     ;; (b) wholly-absent :rf/runtime-db key → no-server-runtime fallback.
-    (let [client-frame (frame/make-anon-frame-record! {:doc "rt-absent client frame" :platform :client})]
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "rt-absent client frame" :platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [:rf/hydrate {:rf/app-db {:count 3}}] {:frame client-frame})
         (is (= 3 (rf/subscribe-once [:count] {:frame client-frame})) "app-db slice installed")
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
         ;; under the gate.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
               "an absent :rf/runtime-db key is the no-server-runtime fallback, not malformed"))))))
 
@@ -702,7 +702,7 @@
             a retired alias that stays dead. It behaves as an unknown no-slice
             payload (app-db unchanged, client-only fallback), not as an alias."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "alias-dead client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "alias-dead client frame"
                                        :platform :client})]
       ;; Seed a recognisable pre-hydration client slice so we can prove it
       ;; SURVIVES (was not replaced by the :app-db-keyed payload).
@@ -724,7 +724,7 @@
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
         ;; under the gate; the alias-stays-dead claim is pinned by the three
         ;; posture-independent assertions above.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
               (str "a {:app-db {…}} payload is a map with no :rf/app-db key — the "
                    "legitimate client-only no-slice fallback, NOT malformed; saw: "
@@ -748,9 +748,9 @@
   `re-frame.ssr.ring.payload/build-payload` uses. `render-hash` is the
   FNV-1a hash of the render-tree the server stringified."
   [frame-id app-db render-hash policy-opts]
-  (payload-policy/build-payload
+  (rf.ssr.payload-policy/build-payload
     frame-id
-    (payload-policy/apply-policy app-db policy-opts)
+    (rf.ssr.payload-policy/apply-policy app-db policy-opts)
     render-hash
     policy-opts))
 
@@ -760,7 +760,7 @@
             sub reflects the seeded slice — the server-build → hydrate! →
             sub round-trip. hydrate! returns the applied payload."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "boot-helper client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "boot-helper client frame"
                                        :platform :client})
           ;; Server side: build the payload from the authoritative app-db
           ;; slice via the same payload-policy path the Ring adapter uses.
@@ -774,7 +774,7 @@
                           client-frame server-app-db "deadbeef"
                           {:version 1 :payload [:count :title]})
           ;; Client side: the symmetric boot call.
-          returned      (ssr/hydrate! {:frame   client-frame
+          returned      (rf.ssr/hydrate! {:frame   client-frame
                                        :payload payload})]
       (is (= payload returned)
           "hydrate! returns the applied payload so the caller can branch
@@ -796,9 +796,9 @@
             first-load shape) does NOT dispatch :rf/hydrate and returns
             nil. The caller renders against the empty app-db."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "boot-helper client-only frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "boot-helper client-only frame"
                                        :platform :client})
-          returned     (ssr/hydrate! {:frame client-frame :payload nil})]
+          returned     (rf.ssr/hydrate! {:frame client-frame :payload nil})]
       (is (nil? returned)
           "nil payload → hydrate! returns nil (client-only first load)")
       (is (false? (rf/subscribe-once [:hydrated?] {:frame client-frame}))
@@ -817,7 +817,7 @@
             server's :render-hash marker."
     (register-baseline-handlers!)
     (rf/reg-view* ::boot-root (fn [] [:div.app [:span "client-render"]]))
-    (let [client-frame (frame/make-anon-frame-record! {:doc "boot-helper verify frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "boot-helper verify frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           ;; Server hash is a DELIBERATELY divergent value so the verify
@@ -828,12 +828,12 @@
                           "server00"                 ;; != the client tree hash
                           {:version 1 :payload [:count :title]})]
       (with-trace-recorder! [traces]
-        (ssr/hydrate!
+        (rf.ssr/hydrate!
           {:frame          client-frame
            :payload        payload
            :render-tree-fn (fn [] [:div.app [:span "client-render"]])})
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (some #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
               (str "verify step fired a :rf.ssr/hydration-mismatch (server hash "
                    "'server00' != client render-tree hash); saw: "
@@ -846,7 +846,7 @@
       ;; ex-data must name the server hash the payload carried and the hash of
       ;; the tree `:render-tree-fn` actually returned. Nothing else in this
       ;; deftest proves the verify step ran.
-      (let [strict-frame (frame/make-anon-frame-record!
+      (let [strict-frame (rf.frame/make-anon-frame-record!
                            {:doc      "boot-helper verify strict frame"
                             :platform :client
                             :ssr      {:detect-mismatch? true
@@ -856,7 +856,7 @@
                            strict-frame {:count 7 :title "seeded"}
                            "server00"
                            {:version 1 :payload [:count :title]})
-            thrown       (try (ssr/hydrate!
+            thrown       (try (rf.ssr/hydrate!
                                 {:frame          strict-frame
                                  :payload        strict-pl
                                  :render-tree-fn (fn [] client-tree)})
@@ -867,7 +867,7 @@
         (is (= :rf.ssr/hydration-mismatch (:rf.error/id (ex-data thrown))))
         (is (= "server00" (:server-hash (ex-data thrown)))
             "the payload's server hash reached the comparison")
-        (is (= (ssr/render-tree-hash client-tree) (:client-hash (ex-data thrown)))
+        (is (= (rf.ssr/render-tree-hash client-tree) (:client-hash (ex-data thrown)))
             "…and it was compared against the hash of the tree
              :render-tree-fn returned, so the verify step really rendered")))))
 
@@ -877,27 +877,27 @@
             successful hydration. Counter-test to the divergent-render case
             so the verify step can't be a false-positive generator."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "boot-helper verify-match frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "boot-helper verify-match frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           client-tree   [:div.app [:span "client-render"]]
           ;; Compute the server hash from the SAME tree so the round-trip
           ;; hashes agree — the happy path.
-          matched-hash  (ssr/render-tree-hash client-tree)
+          matched-hash  (rf.ssr/render-tree-hash client-tree)
           ;; EP-0002 (rf2-acjknb): payload :rf/frame-id == the client target.
           payload       (build-server-payload
                           client-frame {:count 7 :title "seeded"}
                           matched-hash
                           {:version 1 :payload [:count :title]})]
       (with-trace-recorder! [traces]
-        (ssr/hydrate!
+        (rf.ssr/hydrate!
           {:frame          client-frame
            :payload        payload
            :render-tree-fn (fn [] client-tree)})
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). A NEGATIVE
         ;; over the trace ring: vacuous under the gate, where a DIVERGENT
         ;; render would look identical to a matching one.
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
               (str "matching hashes → no :rf.ssr/hydration-mismatch; saw: "
                    (pr-str (mapv :operation @traces)))))
@@ -909,7 +909,7 @@
       ;; this deftest exists to be needs an always-on channel too. Same
       ;; matching-hash boot on an `:on-mismatch :hard-error` frame: it must
       ;; NOT throw, which the divergent case above proves it would.
-      (let [strict-frame (frame/make-anon-frame-record!
+      (let [strict-frame (rf.frame/make-anon-frame-record!
                            {:doc      "boot-helper verify-match strict frame"
                             :platform :client
                             :ssr      {:detect-mismatch? true
@@ -918,7 +918,7 @@
                            strict-frame {:count 7 :title "seeded"}
                            matched-hash
                            {:version 1 :payload [:count :title]})]
-        (is (some? (ssr/hydrate! {:frame          strict-frame
+        (is (some? (rf.ssr/hydrate! {:frame          strict-frame
                                   :payload        strict-pl
                                   :render-tree-fn (fn [] client-tree)}))
             "matching hashes do not escalate even under :on-mismatch
@@ -941,7 +941,7 @@
             :rf.ssr/hydration-mismatch, proving the subscribing tree actually
             computed under scope."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "0vk7b scope frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "0vk7b scope frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           ;; Divergent server hash so a successful verify FIRES the mismatch —
@@ -966,8 +966,8 @@
         ;; by resolving the subscribe to `:rf/default`. `run`/`^:export run` in a
         ;; browser has no such scope, so unbind it here — only then does the
         ;; unwrapped render-tree-fn face the real no-frame-context condition.
-        (binding [frame/*current-frame* nil]
-          (let [returned (ssr/hydrate! {:frame          client-frame
+        (binding [rf.frame/*current-frame* nil]
+          (let [returned (rf.ssr/hydrate! {:frame          client-frame
                                         :payload        payload
                                         :render-tree-fn render-tree-fn})]
             (is (some? returned)
@@ -983,7 +983,7 @@
                 "hydrate! invoked :render-tree-fn exactly once, under the
                  target frame's scope")
             ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-            (when interop/debug-enabled?
+            (when rf.interop/debug-enabled?
               (is (some #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
                   (str "verify ran the subscribing render-tree-fn under frame scope "
                        "(server hash 'server00' != client render-tree hash); saw: "
@@ -1002,7 +1002,7 @@
             The malformed-payload guard never runs (the absence fails first
             at the boundary)."
     (register-baseline-handlers!)
-    (let [ex (try (ssr/hydrate! {:payload {:rf/app-db {:count 1}}})
+    (let [ex (try (rf.ssr/hydrate! {:payload {:rf/app-db {:count 1}}})
                   nil
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex) "hydrate! with no :frame must throw")
@@ -1017,15 +1017,15 @@
             :rf.error/hydration-frame-id-mismatch — the runtime never
             silently picks a side, and app-db is NOT replaced."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "mismatch client frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "mismatch client frame"
                                        :platform :client})
           ;; Payload stamped with a DIFFERENT frame id than the client target.
-          other-frame  (frame/make-anon-frame-record! {:doc "the server's other frame"
+          other-frame  (rf.frame/make-anon-frame-record! {:doc "the server's other frame"
                                        :platform :server})
           payload      (build-server-payload
                          other-frame {:count 7 :title "seeded"} "deadbeef"
                          {:version 1 :payload [:count :title]})
-          ex           (try (ssr/hydrate! {:frame client-frame :payload payload})
+          ex           (try (rf.ssr/hydrate! {:frame client-frame :payload payload})
                             nil
                             (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex) "a payload/target frame-id conflict must throw")
@@ -1044,11 +1044,11 @@
             conflict — there is nothing to disagree with, so the explicit
             client target stands and hydration proceeds normally."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "no-payload-frame-id client"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "no-payload-frame-id client"
                                        :platform :client})
           ;; A hand-built payload deliberately WITHOUT :rf/frame-id.
           payload      {:rf/version 1 :rf/app-db {:count 7 :title "seeded"}}
-          returned     (ssr/hydrate! {:frame client-frame :payload payload})]
+          returned     (rf.ssr/hydrate! {:frame client-frame :payload payload})]
       (is (= payload returned) "hydration proceeded (no frame-id to conflict)")
       (is (= 7 (rf/subscribe-once [:count] {:frame client-frame}))
           "the seeded slice landed — an absent payload :rf/frame-id is no conflict"))))
@@ -1070,7 +1070,7 @@
             This is the bypass the bead names: hydrate! throws pre-dispatch,
             but a direct dispatch hits ONLY the handler."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "nv3mua direct-dispatch client"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "nv3mua direct-dispatch client"
                                        :platform :client})]
       ;; Seed a recognisable pre-hydration client slice so we can prove it
       ;; SURVIVES (was not replaced by the wrong-frame payload).
@@ -1100,7 +1100,7 @@
           ;; posture-independent. The always-on fan-out of this same category
           ;; is pinned on the `:errors` axis by the b5- deftest below, which
           ;; has been green under the gate throughout.
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             ;; the structured mismatch surfaced, carrying the two frames.
             (let [mismatch (first (filter #(= :rf.error/hydration-frame-id-mismatch
                                               (:operation %))
@@ -1141,7 +1141,7 @@
       (fn [_ _] {:sensitive [[:payload-frame-id]]}))
     (let [;; the rejected client frame declares the untrusted payload slot
           ;; :sensitive — so project-egress redacts it on the off-box leg.
-          client-frame (frame/make-anon-frame-record!
+          client-frame (rf.frame/make-anon-frame-record!
                          {:doc            "B5 sensitive payload-frame-id client"
                           :platform       :client
                           :initial-events [[:rf.b5/classify]]})
@@ -1190,7 +1190,7 @@
             dispatch target installs the slice normally (the validation is
             precise — it rejects only present-and-DIFFERENT, never a match)."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "nv3mua matching-frame client"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "nv3mua matching-frame client"
                                        :platform :client})
           ;; Stamp the payload's :rf/frame-id with the SAME frame we hydrate
           ;; into — server + client agree, so the slice lands. A render-hash
@@ -1212,7 +1212,7 @@
             slice installs (the documented client-only / no-server-slice
             fallback shape). This is the path the baseline tests rely on."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "nv3mua absent-frame-id client"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "nv3mua absent-frame-id client"
                                        :platform :client})
           ;; Deliberately NO :rf/frame-id key.
           payload      {:rf/app-db {:count 5 :title "no-frame-id"}}]
@@ -1231,7 +1231,7 @@
             host render happens between :rf/hydrate and the call. This locks
             the chosen contract in maintainer-visible terms."
     (register-baseline-handlers!)
-    (let [client-frame (frame/make-anon-frame-record! {:doc "boot-helper sync-contract frame"
+    (let [client-frame (rf.frame/make-anon-frame-record! {:doc "boot-helper sync-contract frame"
                                        :platform :client
                                        :ssr {:detect-mismatch? true}})
           ;; Records WHEN render-tree-fn ran + WHAT app-db it saw.
@@ -1245,7 +1245,7 @@
                           client-frame {:count 11 :title "seeded"}
                           "server00"
                           {:version 1 :payload [:count :title]})
-          returned      (ssr/hydrate!
+          returned      (rf.ssr/hydrate!
                           {:frame          client-frame
                            :payload        payload
                            :render-tree-fn (fn []

--- a/implementation/ssr/test/re_frame/ssr_keyword_head_contract_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_keyword_head_contract_test.clj
@@ -65,10 +65,10 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [are deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.ssr.emit :as emit]
-            [re-frame.ssr.streaming :as streaming]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr.emit :as rf.ssr.emit]
+            [re-frame.ssr.streaming :as rf.ssr.streaming]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
 ;; The view body, held as a plain fn so the SAME implementation backs all
 ;; three spellings under test (keyword head, Var head, `(rf/view :id)`).
@@ -86,7 +86,7 @@
   (rf/reg-view* :dashboard/card {} card-view)
   (test-fn))
 
-(use-fixtures :each tf/reset-runtime with-registered-card)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime with-registered-card)
 
 ;; ===========================================================================
 ;; The standard emitter — `render-to-string`
@@ -105,7 +105,7 @@
             (measured, and pinned as a cross-host equality in the CLJS
             twin)."
     (is (= "<card>revenue</card>"
-           (emit/render-to-string [:dashboard/card :revenue] nil))))
+           (rf.ssr.emit/render-to-string [:dashboard/card :revenue] nil))))
 
   (testing "the registration is genuinely present — this test would be
             vacuous if `:dashboard/card` were simply unregistered, which
@@ -119,7 +119,7 @@
             registration state does not change the head's meaning, which
             is the whole content of the one-grammar rule"
     (is (= "<card>revenue</card>"
-           (emit/render-to-string [:never-registered/card :revenue] nil)))))
+           (rf.ssr.emit/render-to-string [:never-registered/card :revenue] nil)))))
 
 (deftest scalar-children-are-spelled-by-name
   (testing "rf2-53lsj — a keyword or symbol CHILD is spelled by its `name`:
@@ -131,7 +131,7 @@
             Every expectation here was measured against Reagent +
             react-dom/server before it was written; the CLJS twin asserts
             the same strings from the other side."
-    (are [expected tree] (= expected (emit/render-to-string tree nil))
+    (are [expected tree] (= expected (rf.ssr.emit/render-to-string tree nil))
       "<div>revenue</div>" [:div :revenue]
       "<div>b</div>"       [:div :a/b]
       "<div>leaf</div>"    [:div :ns.deep/leaf]
@@ -144,15 +144,15 @@
             colon-stripping fix would have got wrong. `:a/b` paints `b`,
             never `a/b`, because Reagent routes a named child through
             `(name x)` rather than trimming the printed form."
-    (is (= "<div>b</div>" (emit/render-to-string [:div :a/b] nil)))
-    (is (not= "<div>a/b</div>" (emit/render-to-string [:div :a/b] nil))))
+    (is (= "<div>b</div>" (rf.ssr.emit/render-to-string [:div :a/b] nil)))
+    (is (not= "<div>a/b</div>" (rf.ssr.emit/render-to-string [:div :a/b] nil))))
 
   (testing "escaping still applies to the NAME — spelling a child by
             `name` must not become an escape bypass"
-    (is (= "<div>x&lt;y</div>" (emit/render-to-string [:div :x<y] nil))))
+    (is (= "<div>x&lt;y</div>" (rf.ssr.emit/render-to-string [:div :x<y] nil))))
 
   (testing "the classes that already agreed are unchanged"
-    (are [expected tree] (= expected (emit/render-to-string tree nil))
+    (are [expected tree] (= expected (rf.ssr.emit/render-to-string tree nil))
       "<div>plain</div>" [:div "plain"]
       "<div>9</div>"     [:div 9]
       "<div></div>"      [:div nil]
@@ -162,8 +162,8 @@
             standard emitter, so this is a delegation pin, not a second
             implementation"
     (doseq [tree [[:div :revenue] [:div :a/b] [:div 'a/b] [:dashboard/card :revenue]]]
-      (is (= (emit/render-to-string tree nil)
-             (:shell-html (streaming/render-shell tree)))
+      (is (= (rf.ssr.emit/render-to-string tree nil)
+             (:shell-html (rf.ssr.streaming/render-shell tree)))
           (str "emitter/walker divergence on " (pr-str tree))))))
 
 (deftest keyword-head-carries-ordinary-element-syntax
@@ -172,7 +172,7 @@
             `.class`/`#id` sugar, an attrs map, and child recursion. It is
             not a special case, it is the same case."
     (is (= "<card class=\"revenue\" data-x=\"1\"><b>hi</b></card>"
-           (emit/render-to-string [:dashboard/card.revenue {:data-x "1"} [:b "hi"]] nil)))))
+           (rf.ssr.emit/render-to-string [:dashboard/card.revenue {:data-x "1"} [:b "hi"]] nil)))))
 
 (deftest views-are-referenced-by-callable-head
   (testing "rf2-j81hs — the two supported spellings both RESOLVE the view
@@ -186,11 +186,11 @@
     (testing "a bare fn Var resolves the view — UNANNOTATED (it is the raw
               render fn, not the registered handle)"
       (is (= "<div class=\"card\"><h3>:revenue</h3></div>"
-             (emit/render-to-string [card-view :revenue] nil))))
+             (rf.ssr.emit/render-to-string [card-view :revenue] nil))))
 
     ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The registered
     ;; handle carries the annotations only under `interop/debug-enabled?`.
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (testing "`(rf/view :id)` — the REGISTERED handle — resolves the view AND
                 carries both dev annotations (rf2-8vi4q). In idiomatic usage
                 the symbol `reg-view` defs IS `(rf/view id)`, so THIS is what a
@@ -199,30 +199,30 @@
                     " data-rf2-source-coord=\"dashboard:card:?:?\""
                     " data-rf-view=\":dashboard/card\">"
                     "<h3>:revenue</h3></div>")
-               (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)))))
+               (rf.ssr.emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)))))
 
     (testing "both spellings resolve to the SAME view subtree — the class and
               child agree; the registered handle merely adds the debug-gated
               annotation attributes on the root"
-      (is (str/includes? (emit/render-to-string [card-view :revenue] nil)
+      (is (str/includes? (rf.ssr.emit/render-to-string [card-view :revenue] nil)
                          "class=\"card\""))
-      (is (str/includes? (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)
+      (is (str/includes? (rf.ssr.emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)
                          "class=\"card\""))
-      (is (str/includes? (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)
+      (is (str/includes? (rf.ssr.emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)
                          "<h3>:revenue</h3>")))
 
     ;; rf2-lwtlk — the REAL-gate arm. With no annotation wrapper installed the
     ;; two spellings are not merely "the same subtree modulo attributes", they
     ;; are byte-identical — which is the head-grammar claim in its purest
     ;; form, and is only observable in this posture.
-    (when-not interop/debug-enabled?
+    (when-not rf.interop/debug-enabled?
       (testing "under -Dre-frame.debug=false the registered handle and the bare
                 Var render byte-identically — nothing but the debug-gated
                 attributes ever separated them"
-        (is (= (emit/render-to-string [card-view :revenue] nil)
-               (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)))
+        (is (= (rf.ssr.emit/render-to-string [card-view :revenue] nil)
+               (rf.ssr.emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)))
         (is (= "<div class=\"card\"><h3>:revenue</h3></div>"
-               (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)))))))
+               (rf.ssr.emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)))))))
 
 ;; ===========================================================================
 ;; The streaming shell walker — `render-shell`
@@ -233,13 +233,13 @@
             had its OWN `(registrar/lookup :view head)` probe, so fixing
             only the standard emitter would have left the streaming path
             diverging from every client substrate."
-    (let [{:keys [shell-html]} (streaming/render-shell [:dashboard/card :revenue])]
+    (let [{:keys [shell-html]} (rf.ssr.streaming/render-shell [:dashboard/card :revenue])]
       (is (= "<card>revenue</card>" shell-html))))
 
   (testing "and still recurses through the element into nested children,
             so a suspense boundary underneath a keyword head is reachable"
     (let [{:keys [shell-html continuations]}
-          (streaming/render-shell
+          (rf.ssr.streaming/render-shell
             [:dashboard/card
              [:rf/suspense-boundary {:id :b1 :fallback [:span "loading"]}
               [card-view :revenue]]])]
@@ -250,7 +250,7 @@
 
   (testing "callable heads resolve in the walker exactly as in the
             standard emitter"
-    (let [{:keys [shell-html]} (streaming/render-shell [card-view :revenue])]
+    (let [{:keys [shell-html]} (rf.ssr.streaming/render-shell [card-view :revenue])]
       (is (= "<div class=\"card\"><h3>:revenue</h3></div>" shell-html)))))
 
 ;; ===========================================================================
@@ -269,7 +269,7 @@
             nothing: `:rf/suspense-boundry` has a `name` that passes the
             DOM tag grammar. That is the very failure this bead removes,
             displaced by one keystroke, so the reserved scheme fails loud."
-    (let [data (head-error #(emit/render-to-string % nil)
+    (let [data (head-error #(rf.ssr.emit/render-to-string % nil)
                            [:rf/suspense-boundry {:id :x} [:p "hi"]])]
       (is (some? data) "an unrecognised :rf/* head must throw")
       (is (= :rf.error/invalid-hiccup-head (:rf.error/id data))
@@ -283,12 +283,12 @@
       (is (some? (:element data)))))
 
   (testing "the dotted `:rf.<area>/*` sub-namespaces are reserved too"
-    (is (some? (head-error #(emit/render-to-string % nil) [:rf.ssr/nope]))))
+    (is (some? (head-error #(rf.ssr.emit/render-to-string % nil) [:rf.ssr/nope]))))
 
   (testing "the streaming walker rejects it identically — it carried its
             own keyword branch, so a one-sided guard would re-fork the
             hosts"
-    (let [data (head-error #(:shell-html (streaming/render-shell %))
+    (let [data (head-error #(:shell-html (rf.ssr.streaming/render-shell %))
                            [:rf/suspense-boundry {:id :x}])]
       (is (= :rf.error/invalid-hiccup-head (:rf.error/id data)))
       (is (= :use-a-recognised-reserved-head-or-an-unreserved-keyword
@@ -298,17 +298,17 @@
             not swallow the markers it sits next to"
     (testing ":<> fragment still splices"
       (is (= "<p>a</p><p>b</p>"
-             (emit/render-to-string [:<> [:p "a"] [:p "b"]] nil))))
+             (rf.ssr.emit/render-to-string [:<> [:p "a"] [:p "b"]] nil))))
 
     (testing ":rf/suspense-boundary still raises its OWN distinct error
               from the standard emitter, not the reserved-head one"
       (is (= :rf.error/ssr-suspense-boundary-outside-stream
-             (:rf.error/id (head-error #(emit/render-to-string % nil)
+             (:rf.error/id (head-error #(rf.ssr.emit/render-to-string % nil)
                                        [:rf/suspense-boundary {:id :b}])))))
 
     (testing ":rf/suspense-boundary still WORKS in the streaming walker"
       (let [{:keys [continuations]}
-            (streaming/render-shell
+            (rf.ssr.streaming/render-shell
               [:rf/suspense-boundary {:id :b1 :fallback [:span "…"]}
                [card-view :revenue]])]
         (is (= 1 (count continuations))))))
@@ -317,9 +317,9 @@
             scoped to `:rf/*` and must not capture app namespaces, which
             are exactly the heads that now render as custom elements"
     (is (= "<card>revenue</card>"
-           (emit/render-to-string [:dashboard/card :revenue] nil)))
+           (rf.ssr.emit/render-to-string [:dashboard/card :revenue] nil)))
     (is (= "<widget></widget>"
-           (emit/render-to-string [:rfid/widget] nil))
+           (rf.ssr.emit/render-to-string [:rfid/widget] nil))
         "`:rfid/widget` starts with `rf` but is NOT the reserved scheme —
          the check must match the `rf` namespace exactly or an `rf.` dotted
          prefix, not a bare string prefix")))
@@ -332,6 +332,6 @@
                   [:never-registered/card :revenue]
                   [card-view :revenue]
                   [(rf/view :dashboard/card) :revenue]]]
-      (is (= (emit/render-to-string tree nil)
-             (:shell-html (streaming/render-shell tree)))
+      (is (= (rf.ssr.emit/render-to-string tree nil)
+             (:shell-html (rf.ssr.streaming/render-shell tree)))
           (str "emitter/walker divergence on " (pr-str tree))))))

--- a/implementation/ssr/test/re_frame/ssr_machine_snapshot_projection_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_machine_snapshot_projection_test.clj
@@ -39,10 +39,10 @@
             [re-frame.machines]
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 (def ^:private auth-id :rf.ssr-machine/auth)
 
@@ -112,7 +112,7 @@
             projection; the large path elides; the plain sibling rides verbatim"
     (reg-auth-machine!)
     (declare-frame-marks!)
-    (let [slice    (payload-policy/project-runtime-db
+    (let [slice    (rf.ssr.payload-policy/project-runtime-db
                      (runtime-db-with-secret-snapshot))
           snapshot (get-in slice [:rf.runtime/machines :snapshots auth-id])]
       (is (= :rf/redacted (get-in snapshot [:data :token]))
@@ -133,9 +133,9 @@
             redacted/elided machine :data, not the raw classified fields"
     (reg-auth-machine!)
     (declare-frame-marks!)
-    (let [rt-slice (payload-policy/project-runtime-db
+    (let [rt-slice (rf.ssr.payload-policy/project-runtime-db
                      (runtime-db-with-secret-snapshot))
-          payload  (payload-policy/build-payload
+          payload  (rf.ssr.payload-policy/build-payload
                      auth-id {:public/page :dashboard} "h1"
                      {:version 1 :runtime-db rt-slice})
           snap     (get-in payload [:rf/runtime-db :rf.runtime/machines
@@ -154,7 +154,7 @@
     (let [rt    {:rf.runtime/machines
                  {:snapshots {:rf.ssr-machine/plain
                               {:state :idle :data {:public "ok"}}}}}
-          slice (payload-policy/project-runtime-db rt)
+          slice (rf.ssr.payload-policy/project-runtime-db rt)
           snap  (get-in slice [:rf.runtime/machines :snapshots
                                :rf.ssr-machine/plain])]
       (is (= "ok" (get-in snap [:data :public]))

--- a/implementation/ssr/test/re_frame/ssr_multi_frame_isolation_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_multi_frame_isolation_test.clj
@@ -48,10 +48,10 @@
   smokes per the audit's §Drop-or-keep recommendation)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.subs :as subs]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.subs :as rf.subs]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; Frame ids mirror testbeds/ssr_multi_frame/core.cljs lines 48-50.
 (def ^:private frame-a   :counter/a)
@@ -85,7 +85,7 @@
   (rf/reg-sub :entries   (fn [db _] (:entries db)))
   ;; EP-0001 (rf2-vzld77): the SSR hydration metadata is durable runtime-db
   ;; state, so :hydration is a runtime-db sub (reads the runtime-db projection).
-  (subs/reg-runtime-sub :hydration (fn [rt _] (get-in rt [:rf.runtime/ssr :hydration]))))
+  (rf.subs/reg-runtime-sub :hydration (fn [rt _] (get-in rt [:rf.runtime/ssr :hydration]))))
 
 (defn- register-three-frames! []
   (rf/make-frame {:id frame-a :initial-events [[::counter-init]]})

--- a/implementation/ssr/test/re_frame/ssr_prod_gate_lane_pin_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_prod_gate_lane_pin_test.clj
@@ -45,7 +45,7 @@
   PROPERTY did not arrive; the second when it arrived but the framework did not
   read it. They are different defects and they get different messages."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.interop :as interop]))
+            [re-frame.interop :as rf.interop]))
 
 (deftest ^:prod-gate the-property-really-reached-this-jvm
   (testing "rf2-hnrwo — `-Dre-frame.debug=false` is on THIS JVM's command line.
@@ -62,5 +62,5 @@
             assertion above green means the property arrived but
             `re-frame.interop` did not honour it, which is the load-order defect
             class rf2-9c2jf belonged to."
-    (is (false? interop/debug-enabled?)
+    (is (false? rf.interop/debug-enabled?)
         "re-frame.interop/debug-enabled? must be false under the production gate")))

--- a/implementation/ssr/test/re_frame/ssr_render_failed_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_render_failed_test.clj
@@ -47,12 +47,12 @@
   original Throwable instead of returning a public-error map."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 (deftest project-render-exception-emits-ssr-render-failed-trace
   (testing "rf2-260pg / rf2-zwgsv: `project-render-exception!` against a
@@ -66,13 +66,13 @@
                                               (:operation ev))
                                        (swap! traces conj ev))))
       (try
-        (let [f  (frame/make-anon-frame-record!
+        (let [f  (rf.frame/make-anon-frame-record!
                    {:platform :server
                     :ssr      {:public-error-id   :rf.ssr/default-error-projector
                                :dev-error-detail? false}})
               t  (ex-info "synthetic render-time failure"
                           {:reason :test})
-              public (ssr/project-render-exception! f t)]
+              public (rf.ssr/project-render-exception! f t)]
 
           (testing "projector returned a public-error map (the
                     status-stamping path executed)"
@@ -84,7 +84,7 @@
           ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
           ;; projection above is the production-real half and is asserted
           ;; outside it; everything from here down is the trace envelope.
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (testing "exactly one `:rf.error/ssr-render-failed` trace
                       fired (Spec 009 §Error event catalogue)"
               (is (= 1 (count @traces))
@@ -139,9 +139,9 @@
       (try
         ;; Default platform is :client; project-render-exception! checks
         ;; `server-frame?` and short-circuits.
-        (let [f      (frame/make-anon-frame-record! {})
+        (let [f      (rf.frame/make-anon-frame-record! {})
               t      (ex-info "should not fire" {})
-              result (ssr/project-render-exception! f t)]
+              result (rf.ssr/project-render-exception! f t)]
           ;; SEMANTIC, posture-independent (rf2-lwtlk): `nil` rather than a
           ;; public-error map IS the short-circuit, observable in production.
           (is (nil? result)
@@ -149,7 +149,7 @@
           ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
           ;; under the gate: the ring is empty for every input there, so
           ;; `zero?` cannot distinguish a short-circuit from a full run.
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (is (zero? (count @traces))
                 "no `:rf.error/ssr-render-failed` trace fires for a
                  non-server frame")))
@@ -168,7 +168,7 @@
                                         (:operation ev))
                                  (swap! traces conj ev))))
       (try
-        (let [f (frame/make-anon-frame-record!
+        (let [f (rf.frame/make-anon-frame-record!
                   {:platform :server
                    :ssr      {:public-error-id   :rf.ssr/default-error-projector
                               :on-view-exception :throw}})
@@ -179,11 +179,11 @@
           ;; projection path was skipped — no public-error map came back.
           (is (thrown-with-msg? clojure.lang.ExceptionInfo
                                 #"eager dev failure"
-                                (ssr/project-render-exception! f t))
+                                (rf.ssr/project-render-exception! f t))
               "the original throwable surfaces unchanged to the host")
           ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
           ;; under the gate, where no trace fires on any path.
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (is (zero? (count @traces))
                 "the projection path (and its trace) is skipped when the
                  dev escape-hatch is on — the host's outer handler owns it")))
@@ -195,11 +195,11 @@
             production default) project-render-exception! projects as
             normal. Pins the default so the escape-hatch can't silently
             become the default."
-    (let [f (frame/make-anon-frame-record!
+    (let [f (rf.frame/make-anon-frame-record!
               {:platform :server
                :ssr      {:public-error-id :rf.ssr/default-error-projector}})
           t (ex-info "normal failure" {})
-          public (ssr/project-render-exception! f t)]
+          public (rf.ssr/project-render-exception! f t)]
       (is (map? public) "projection path runs by default")
       (is (= 500 (:status public))
           "the default projector maps to 500 — no re-throw"))))

--- a/implementation/ssr/test/re_frame/ssr_render_state_jvm_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_render_state_jvm_test.clj
@@ -19,11 +19,11 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.ssr.render-state :as render-state]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.ssr.render-state :as rf.ssr.render-state]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 (defn- thrown-data [f]
   (try (f) nil
@@ -45,11 +45,11 @@
   (let [sfid (server-frame! :rf.ssrrs/server-route)]
     (rf/dispatch-sync [:rf.route/handle-url-change "/article?token=secret-query-token&tab=x"]
                       {:frame sfid})
-    (let [live (get-in (frame/frame-runtime-db-value sfid) [:rf.runtime/routing :current])]
+    (let [live (get-in (rf.frame/frame-runtime-db-value sfid) [:rf.runtime/routing :current])]
       (is (= :route/article (:route-id live)) "precondition: the navigation settled")
       (is (= "secret-query-token" (get-in live [:query :token]))
           "precondition: the live frame holds the raw query on the server"))
-    (let [projected (render-state/project sfid {:render-state {:runtime-db [:rf.runtime/routing]}})
+    (let [projected (rf.ssr.render-state/project sfid {:render-state {:runtime-db [:rf.runtime/routing]}})
           current   (get-in projected [:rf/runtime-db :rf.runtime/routing :current])]
       (is (= :route/article (:route-id current)))
       (is (= :rf/redacted (get-in current [:query :token]))
@@ -59,7 +59,7 @@
           "only the durable :current slice rides")
       (is (not (str/includes? (pr-str projected) "secret-query-token")))
       (let [cfid (server-frame! :rf.ssrrs/fresh-route)]
-        (render-state/restore! cfid (render-state/deserialize (render-state/serialize projected)))
+        (rf.ssr.render-state/restore! cfid (rf.ssr.render-state/deserialize (rf.ssr.render-state/serialize projected)))
         (is (= current (rf/subscribe-once [:rf/route] {:frame cfid}))
             "the routing artefact's own [:rf/route] sub reads the restored slice on the fresh frame")))))
 
@@ -78,14 +78,14 @@
                               ["a float"              (float 0.1)               0.1]
                               ["an integer past 2^53" 9007199254740993          9007199254740991]
                               ["an atom"              (atom 1)                  1]]]
-      (frame/replace-frame-state! sfid {frame/app-partition-key {:value bad}})
-      (let [data (thrown-data #(render-state/project sfid {:render-state {:app-db [:value]}}))]
+      (rf.frame/replace-frame-state! sfid {rf.frame/app-partition-key {:value bad}})
+      (let [data (thrown-data #(rf.ssr.render-state/project sfid {:render-state {:app-db [:value]}}))]
         (is (= :rf.error/ssr-render-state-invalid (:rf.error/id data)) label)
         (is (= :unserialisable (:invalid data)) label)
         (is (= :value (:key data)) label)
         (is (= :value (:half data)) label))
       ;; CONTROL — the in-domain twin under the same key rides and round-trips.
-      (frame/replace-frame-state! sfid {frame/app-partition-key {:value good}})
-      (let [projected (render-state/project sfid {:render-state {:app-db [:value]}})]
+      (rf.frame/replace-frame-state! sfid {rf.frame/app-partition-key {:value good}})
+      (let [projected (rf.ssr.render-state/project sfid {:render-state {:app-db [:value]}})]
         (is (= {:rf/app-db {:value good} :rf/runtime-db {}} projected) label)
-        (is (= projected (render-state/deserialize (render-state/serialize projected))) label)))))
+        (is (= projected (rf.ssr.render-state/deserialize (rf.ssr.render-state/serialize projected))) label)))))

--- a/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
@@ -44,15 +44,15 @@
   behaviour the trace merely narrates."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.registrar :as registrar]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
 ;; Shared reset fixture lives in `re-frame.ssr.test-fixture` (rf2-i3qc0).
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---- registration -----------------------------------------------------------
 ;;
@@ -61,7 +61,7 @@
 
 (deftest cofx-is-registered-after-namespace-load
   (testing ":rf.server/request resolves in the cofx registry"
-    (let [meta (registrar/lookup :cofx :rf.server/request)]
+    (let [meta (rf.registrar/lookup :cofx :rf.server/request)]
       (is (some? meta)
           "the cofx registry holds an entry under :rf.server/request")
       (is (fn? (:handler-fn meta))
@@ -71,12 +71,12 @@
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). `:doc` is a
       ;; pure-documentation key and is stripped in production builds; the
       ;; three RETAINED keys above are the ones the runtime acts on.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (string? (:doc meta))
             "the registration carries a :doc string"))
       ;; rf2-lwtlk — the REAL-gate arm: the elision itself, witnessed on a
       ;; JVM actually started with `-Dre-frame.debug=false`.
-      (when-not interop/debug-enabled?
+      (when-not rf.interop/debug-enabled?
         (is (nil? (:doc meta))
             ":doc is elided from the registry slot in production builds
              (Spec 001 §Production elision contract)")))))
@@ -89,7 +89,7 @@
 
 (deftest cofx-reads-populated-request
   (testing "(set-request! frame req) → :rf.cofx/requires [:rf.server/request] → handler reads req"
-    (let [server-frame (frame/make-anon-frame-record!
+    (let [server-frame (rf.frame/make-anon-frame-record!
                          {:doc      "SSR request frame"
                           :platform :server})
           request      {:request-method :get
@@ -101,7 +101,7 @@
                         :scheme         :https}
           observed     (atom :unset)]
       ;; Host adapter populates the slot.
-      (ssr/set-request! server-frame request)
+      (rf.ssr/set-request! server-frame request)
       ;; A server-side handler reads it via the cofx.
       (rf/reg-event :req-test/read
         {:rf.cofx/requires [:rf.server/request]}
@@ -115,12 +115,12 @@
 
 (deftest get-request-mirrors-cofx
   (testing "ssr/get-request is the public read surface — same value as the cofx"
-    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
+    (let [server-frame (rf.frame/make-anon-frame-record! {:platform :server})
           request      {:request-method :post
                         :uri            "/api/articles"
                         :body           "{\"title\":\"new\"}"}]
-      (ssr/set-request! server-frame request)
-      (is (= request (ssr/get-request server-frame))
+      (rf.ssr/set-request! server-frame request)
+      (is (= request (rf.ssr/get-request server-frame))
           "get-request returns the host-supplied map verbatim"))))
 
 ;; ---- unpopulated slot ------------------------------------------------------
@@ -131,7 +131,7 @@
 
 (deftest cofx-injects-nil-when-slot-unpopulated
   (testing "cofx returns nil when no host adapter has populated the slot"
-    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
+    (let [server-frame (rf.frame/make-anon-frame-record! {:platform :server})
           observed     (atom :unset)]
       (rf/reg-event :req-test/read-empty
         {:rf.cofx/requires [:rf.server/request]}
@@ -159,7 +159,7 @@
 (deftest cofx-is-skipped-on-client-frame
   (testing ":rf.server/request is skipped on a :platform :client frame
             and emits :rf.cofx/skipped-on-platform"
-    (let [client-frame (frame/make-anon-frame-record! {:platform :client})
+    (let [client-frame (rf.frame/make-anon-frame-record! {:platform :client})
           observed     (atom :unset)]
       (with-trace-recorder! [traces]
         (rf/reg-event :req-test/read-on-client
@@ -180,7 +180,7 @@
             "the cofx did NOT run — :rf.server/request is absent from coeffects")
 
         ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-        (when interop/debug-enabled?
+        (when rf.interop/debug-enabled?
           (let [skips (filter #(= :rf.cofx/skipped-on-platform (:operation %))
                               @traces)]
             (is (= 1 (count skips))
@@ -204,14 +204,14 @@
 
 (deftest two-frames-carry-independent-request-data
   (testing "two simultaneous per-request frames have isolated request slots"
-    (let [frame-a    (frame/make-anon-frame-record! {:platform :server :doc "request A"})
-          frame-b    (frame/make-anon-frame-record! {:platform :server :doc "request B"})
+    (let [frame-a    (rf.frame/make-anon-frame-record! {:platform :server :doc "request A"})
+          frame-b    (rf.frame/make-anon-frame-record! {:platform :server :doc "request B"})
           request-a  {:uri "/articles/aaa" :headers {"cookie" "session=user-a"}}
           request-b  {:uri "/articles/bbb" :headers {"cookie" "session=user-b"}}
           observed-a (atom :unset)
           observed-b (atom :unset)]
-      (ssr/set-request! frame-a request-a)
-      (ssr/set-request! frame-b request-b)
+      (rf.ssr/set-request! frame-a request-a)
+      (rf.ssr/set-request! frame-b request-b)
 
       (rf/reg-event :req-test/read-isolated
         {:rf.cofx/requires [:rf.server/request]}
@@ -231,17 +231,17 @@
       (is (= request-b @observed-b)
           "frame B's handler saw frame B's request — no leak from A")
       ;; Independent reads via the public surface.
-      (is (= request-a (ssr/get-request frame-a)))
-      (is (= request-b (ssr/get-request frame-b))))))
+      (is (= request-a (rf.ssr/get-request frame-a)))
+      (is (= request-b (rf.ssr/get-request frame-b))))))
 
 (deftest clear-request-removes-the-slot
   (testing "clear-request! removes the per-frame slot — subsequent reads return nil"
-    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
+    (let [server-frame (rf.frame/make-anon-frame-record! {:platform :server})
           request      {:uri "/x"}]
-      (ssr/set-request! server-frame request)
-      (is (= request (ssr/get-request server-frame)))
-      (ssr/clear-request! server-frame)
-      (is (nil? (ssr/get-request server-frame))
+      (rf.ssr/set-request! server-frame request)
+      (is (= request (rf.ssr/get-request server-frame)))
+      (rf.ssr/clear-request! server-frame)
+      (is (nil? (rf.ssr/get-request server-frame))
           "the slot was cleared")
 
       ;; The cofx now injects nil.
@@ -266,10 +266,10 @@
 (deftest set-request-is-the-test-seam
   (testing "set-request! supplies the request for a harness-driven drain; the
             declared cofx reads it (replacing the retired 2-arity override)"
-    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
+    (let [server-frame (rf.frame/make-anon-frame-record! {:platform :server})
           explicit     {:uri "/explicit" :headers {"x-test" "1"}}
           observed     (atom :unset)]
-      (ssr/set-request! server-frame explicit)
+      (rf.ssr/set-request! server-frame explicit)
       (rf/reg-event :req-test/read-explicit
         {:rf.cofx/requires [:rf.server/request]}
         (fn [{:keys [rf.server/request]} _]
@@ -288,10 +288,10 @@
 
 (deftest cofx-works-under-ssr-server-preset
   (testing "the cofx surfaces the request under a :preset :ssr-server frame"
-    (let [server-frame (frame/make-anon-frame-record! {:preset :ssr-server})
+    (let [server-frame (rf.frame/make-anon-frame-record! {:preset :ssr-server})
           request      {:uri "/preset" :request-method :get}
           observed     (atom :unset)]
-      (ssr/set-request! server-frame request)
+      (rf.ssr/set-request! server-frame request)
       (rf/reg-event :req-test/read-preset
         {:rf.cofx/requires [:rf.server/request]}
         (fn [{:keys [rf.server/request]} _]

--- a/implementation/ssr/test/re_frame/ssr_request_durable_fact_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_durable_fact_test.clj
@@ -41,13 +41,13 @@
   the two negatives cannot pass by the record being absent altogether."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---- shape 1: event payload (the sanitized fact rides :event) -------------
 
@@ -55,7 +55,7 @@
   (testing "a setup handler writes durable app-db from a request-derived fact
             supplied as EVENT PAYLOAD — the fact rides :event (recorded), the
             handler never reads the ambient request cofx"
-    (let [server-frame (frame/make-anon-frame-record! {:platform :server})]
+    (let [server-frame (rf.frame/make-anon-frame-record! {:platform :server})]
       ;; The handler reads the SANITIZED session off its event arg, NOT off the
       ;; ambient :rf.server/request cofx — so the durable write folds a recorded
       ;; fact (the event), replay-stable.
@@ -67,7 +67,7 @@
       ;; Host adapter sanitizes the request and dispatches WITH the fact.
       (rf/dispatch-sync [:auth/server-init {:user "alice" :authed? true}]
                         {:frame server-frame})
-      (let [db (frame/frame-app-db-value server-frame)]
+      (let [db (rf.frame/frame-app-db-value server-frame)]
         (is (= "alice" (:auth/user db))
             "durable app-db carries the request-derived user from event payload")
         (is (= :authed (:auth/state db)))))))
@@ -78,7 +78,7 @@
   (testing "a setup handler writes durable app-db from a PROVIDED recordable
             :rf.cofx leaf the host stamped onto the token after sanitizing the
             request — the value is recorded + replay-stable, delivered flat"
-    (let [server-frame (frame/make-anon-frame-record! {:platform :server})]
+    (let [server-frame (rf.frame/make-anon-frame-record! {:platform :server})]
       (rf/reg-cofx :auth.session/user
         {:recordable? true :provided? true
          :doc "Sanitized session user, stamped by the SSR host adapter."})
@@ -92,7 +92,7 @@
       (rf/dispatch-sync [:auth/server-init-cofx]
                         {:frame   server-frame
                          :rf.cofx {:auth.session/user "bob"}})
-      (let [db (frame/frame-app-db-value server-frame)]
+      (let [db (rf.frame/frame-app-db-value server-frame)]
         (is (= "bob" (:auth/user db))
             "durable app-db carries the request-derived user from the recorded :rf.cofx leaf")
         (is (= :authed (:auth/state db)))))))
@@ -101,7 +101,7 @@
   (testing "a PROVIDED recordable request fact absent from the token fails
             LOUDLY with :rf.error/missing-required-cofx — NOT a silent
             fall-back to get-request / nil (the strict-replay contract)"
-    (let [server-frame (frame/make-anon-frame-record! {:platform :server})]
+    (let [server-frame (rf.frame/make-anon-frame-record! {:platform :server})]
       (with-trace-recorder! [traces]
         (rf/reg-cofx :auth.session/user
           {:recordable? true :provided? true
@@ -122,11 +122,11 @@
           ;; fail-closed contract is pinned by the throw and its
           ;; `:rf.error/id` above, both production-real; this is the dev
           ;; trace restating the same category on the trace bus.
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (is (seq (filter #(= :rf.error/missing-required-cofx (:operation %)) @traces))
                 "a :rf.error/missing-required-cofx error trace was emitted"))
           ;; And no durable write landed.
-          (is (nil? (:auth/user (frame/frame-app-db-value server-frame)))
+          (is (nil? (:auth/user (rf.frame/frame-app-db-value server-frame)))
               "no durable app-db slice was written from a missing provided fact"))))))
 
 ;; ---- contrast: the ambient :rf.server/request value is NOT recorded -------
@@ -136,9 +136,9 @@
             token's :rf.cofx record — proving it is unrecorded (replay re-runs
             the supplier), which is exactly why a DURABLE write must not fold it
             (it would diverge on replay / read nil after teardown)"
-    (let [server-frame (frame/make-anon-frame-record! {:platform :server})
+    (let [server-frame (rf.frame/make-anon-frame-record! {:platform :server})
           seen-cofx    (atom ::unset)]
-      (ssr/set-request! server-frame {:request-method :get :uri "/x"
+      (rf.ssr/set-request! server-frame {:request-method :get :uri "/x"
                                       :headers {"cookie" "session=raw-secret"}})
       ;; A handler that READS the ambient request (a legal NON-durable use:
       ;; here just to capture the recorded :rf.cofx for the assertion).

--- a/implementation/ssr/test/re_frame/ssr_reserved_fx_guards_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_reserved_fx_guards_test.clj
@@ -66,21 +66,21 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [malli.core :as m]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.response :as response]
-            [re-frame.ssr.server-fx-schemas :as fx-schemas]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.response :as rf.ssr.response]
+            [re-frame.ssr.server-fx-schemas :as rf.ssr.server-fx-schemas]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
 ;; ---------------------------------------------------------------------------
 
 (defn- server-frame []
-  (frame/make-anon-frame-record!
+  (rf.frame/make-anon-frame-record!
     {:platform :server
      :ssr      {:public-error-id   :rf.ssr/default-error-projector
                 :dev-error-detail? false}}))
@@ -113,12 +113,12 @@
     (rf/reg-event ::attempt (fn [_ [_ fx]] {:fx [fx sibling-fx]}))
     (try
       (rf/dispatch-sync [::attempt fx-vec] {:frame f})
-      (let [raw      (ssr/peek-response f)
-            bookkept (response/response-of f)]
+      (let [raw      (rf.ssr/peek-response f)
+            bookkept (rf.ssr.response/response-of f)]
         {:frame    f
          :raw      raw
          :bookkept bookkept
-         :response (ssr/get-response f)
+         :response (rf.ssr/get-response f)
          :records  @seen})
       (finally
         (rf/unregister-listener! :errors id)))))
@@ -154,156 +154,156 @@
 (def ^:private acceptance-corpus
   [;; ---- :rf.server/set-status ------------------------------------------
    ["set-status 200"           :rf.server/set-status
-    fx-schemas/set-status-args 200                                  true]
+    rf.ssr.server-fx-schemas/set-status-args 200                                  true]
    ["set-status 404"           :rf.server/set-status
-    fx-schemas/set-status-args 404                                  true]
+    rf.ssr.server-fx-schemas/set-status-args 404                                  true]
    ["set-status 599 (top)"     :rf.server/set-status
-    fx-schemas/set-status-args 599                                  true]
+    rf.ssr.server-fx-schemas/set-status-args 599                                  true]
    ["set-status 100 (bottom)"  :rf.server/set-status
-    fx-schemas/set-status-args 100                                  true]
+    rf.ssr.server-fx-schemas/set-status-args 100                                  true]
    ["set-status string"        :rf.server/set-status
-    fx-schemas/set-status-args "not-an-int"                         false]
+    rf.ssr.server-fx-schemas/set-status-args "not-an-int"                         false]
    ["set-status below range"   :rf.server/set-status
-    fx-schemas/set-status-args 99                                   false]
+    rf.ssr.server-fx-schemas/set-status-args 99                                   false]
    ["set-status above range"   :rf.server/set-status
-    fx-schemas/set-status-args 600                                  false]
+    rf.ssr.server-fx-schemas/set-status-args 600                                  false]
    ["set-status nil"           :rf.server/set-status
-    fx-schemas/set-status-args nil                                  false]
+    rf.ssr.server-fx-schemas/set-status-args nil                                  false]
 
    ;; ---- :rf.server/set-header -------------------------------------------
    ["set-header well-formed"   :rf.server/set-header
-    fx-schemas/set-header-args {:name "X-Foo" :value "bar"}          true]
+    rf.ssr.server-fx-schemas/set-header-args {:name "X-Foo" :value "bar"}          true]
    ["set-header no :value"     :rf.server/set-header
-    fx-schemas/set-header-args {:name "X-Foo"}                       false]
+    rf.ssr.server-fx-schemas/set-header-args {:name "X-Foo"}                       false]
    ["set-header int :value"    :rf.server/set-header
-    fx-schemas/set-header-args {:name "X-Foo" :value 42}             false]
+    rf.ssr.server-fx-schemas/set-header-args {:name "X-Foo" :value 42}             false]
    ["set-header symbol :name"  :rf.server/set-header
-    fx-schemas/set-header-args {:name 'x-foo :value "bar"}           false]
+    rf.ssr.server-fx-schemas/set-header-args {:name 'x-foo :value "bar"}           false]
 
    ;; ---- :rf.server/append-header ----------------------------------------
    ["append-header well-formed" :rf.server/append-header
-    fx-schemas/append-header-args {:name "Vary" :value "Accept"}     true]
+    rf.ssr.server-fx-schemas/append-header-args {:name "Vary" :value "Accept"}     true]
    ["append-header int :value"  :rf.server/append-header
-    fx-schemas/append-header-args {:name "Vary" :value 42}           false]
+    rf.ssr.server-fx-schemas/append-header-args {:name "Vary" :value 42}           false]
 
    ;; ---- :rf.server/set-cookie -------------------------------------------
    ["set-cookie minimal"       :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "session" :value "abc"}        true]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "session" :value "abc"}        true]
    ["set-cookie canonical"     :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "session" :value "abc"
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "session" :value "abc"
                                 :max-age 3600 :same-site :lax
                                 :secure true :http-only true
                                 :path "/" :domain "example.com"}     true]
    ["set-cookie string attrs (documented ingress tolerance)"
     :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "session" :value "abc"
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "session" :value "abc"
                                 :max-age "3600" :expires "1700000000000"
                                 :same-site "Strict"}                 true]
    ["set-cookie no :value"     :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "session"}                     false]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "session"}                     false]
    ["set-cookie int :value"    :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "session" :value 42}           false]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "session" :value 42}           false]
    ["set-cookie bogus :same-site keyword" :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "s" :value "v" :same-site :bogus} false]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "s" :value "v" :same-site :bogus} false]
    ["set-cookie non-boolean :secure" :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "s" :value "v" :secure "yes"}  false]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "s" :value "v" :secure "yes"}  false]
 
    ;; ---- :rf.server/delete-cookie ----------------------------------------
    ["delete-cookie well-formed" :rf.server/delete-cookie
-    fx-schemas/delete-cookie-args {:name "stale" :path "/"}          true]
+    rf.ssr.server-fx-schemas/delete-cookie-args {:name "stale" :path "/"}          true]
    ["delete-cookie no :name"    :rf.server/delete-cookie
-    fx-schemas/delete-cookie-args {:path "/"}                        false]
+    rf.ssr.server-fx-schemas/delete-cookie-args {:path "/"}                        false]
    ["delete-cookie int :path"   :rf.server/delete-cookie
-    fx-schemas/delete-cookie-args {:name "stale" :path 42}           false]
+    rf.ssr.server-fx-schemas/delete-cookie-args {:name "stale" :path 42}           false]
 
    ;; ---- :rf.server/redirect ---------------------------------------------
    ["redirect well-formed"     :rf.server/redirect
-    fx-schemas/redirect-args {:location "/dashboard" :status 302}    true]
+    rf.ssr.server-fx-schemas/redirect-args {:location "/dashboard" :status 302}    true]
    ;; The documented no-target graceful path: NOT a structural error, so both
    ;; halves must ACCEPT it and let the adapter's warn→3xx take over.
    ["redirect no target"       :rf.server/redirect
-    fx-schemas/redirect-args {:status 302}                           true]
+    rf.ssr.server-fx-schemas/redirect-args {:status 302}                           true]
    ["redirect non-int :status" :rf.server/redirect
-    fx-schemas/redirect-args {:location "/x" :status "oops"}         false]
+    rf.ssr.server-fx-schemas/redirect-args {:location "/x" :status "oops"}         false]
    ["redirect keyword :location" :rf.server/redirect
-    fx-schemas/redirect-args {:location :dashboard}                  false]
+    rf.ssr.server-fx-schemas/redirect-args {:location :dashboard}                  false]
 
    ;; ---- :rf.server/safe-redirect ----------------------------------------
    ["safe-redirect well-formed" :rf.server/safe-redirect
-    fx-schemas/safe-redirect-args {:location "/dashboard"
+    rf.ssr.server-fx-schemas/safe-redirect-args {:location "/dashboard"
                                    :status 302
                                    :relative-only? true
                                    :allow ["app.example.com"]}       true]
    ["safe-redirect no :location" :rf.server/safe-redirect
-    fx-schemas/safe-redirect-args {:status 302}                      false]
+    rf.ssr.server-fx-schemas/safe-redirect-args {:status 302}                      false]
    ["safe-redirect non-int :status" :rf.server/safe-redirect
-    fx-schemas/safe-redirect-args {:location "/ok" :status "not-int"} false]
+    rf.ssr.server-fx-schemas/safe-redirect-args {:location "/ok" :status "not-int"} false]
    ["safe-redirect scalar :allow" :rf.server/safe-redirect
-    fx-schemas/safe-redirect-args {:location "/ok"
+    rf.ssr.server-fx-schemas/safe-redirect-args {:location "/ok"
                                    :allow "app.example.com"}         false]
    ["safe-redirect non-boolean :relative-only?" :rf.server/safe-redirect
-    fx-schemas/safe-redirect-args {:location "/ok" :relative-only? "yes"} false]
+    rf.ssr.server-fx-schemas/safe-redirect-args {:location "/ok" :relative-only? "yes"} false]
 
    ;; ---- AUDIT (a): every optional key, explicitly nil — ACCEPTED by both --
    ;; `{:path nil}` and `{}` say the same thing in Clojure, and code that
    ;; builds a cookie from an options map writes the first meaning the second.
    ["set-cookie nil :path"      :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "s" :value "v" :path nil}      true]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "s" :value "v" :path nil}      true]
    ["set-cookie nil :domain"    :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "s" :value "v" :domain nil}    true]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "s" :value "v" :domain nil}    true]
    ["set-cookie nil :max-age"   :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "s" :value "v" :max-age nil}   true]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "s" :value "v" :max-age nil}   true]
    ["set-cookie nil :expires"   :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "s" :value "v" :expires nil}   true]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "s" :value "v" :expires nil}   true]
    ["set-cookie nil :same-site" :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "s" :value "v" :same-site nil} true]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "s" :value "v" :same-site nil} true]
    ["set-cookie nil :secure"    :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "s" :value "v" :secure nil}    true]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "s" :value "v" :secure nil}    true]
    ["set-cookie nil :http-only" :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "s" :value "v" :http-only nil} true]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "s" :value "v" :http-only nil} true]
    ["set-cookie every optional nil at once" :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "s" :value "v"
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "s" :value "v"
                                 :path nil :domain nil :max-age nil
                                 :expires nil :same-site nil
                                 :secure nil :http-only nil}          true]
    ["delete-cookie nil :path"   :rf.server/delete-cookie
-    fx-schemas/delete-cookie-args {:name "stale" :path nil}          true]
+    rf.ssr.server-fx-schemas/delete-cookie-args {:name "stale" :path nil}          true]
    ["delete-cookie nil :domain" :rf.server/delete-cookie
-    fx-schemas/delete-cookie-args {:name "stale" :domain nil}        true]
+    rf.ssr.server-fx-schemas/delete-cookie-args {:name "stale" :domain nil}        true]
    ["redirect nil :status"      :rf.server/redirect
-    fx-schemas/redirect-args {:location "/x" :status nil}            true]
+    rf.ssr.server-fx-schemas/redirect-args {:location "/x" :status nil}            true]
    ;; The no-target path spelled with an explicit nil rather than by omission.
    ["redirect nil :location"    :rf.server/redirect
-    fx-schemas/redirect-args {:location nil :status 302}             true]
+    rf.ssr.server-fx-schemas/redirect-args {:location nil :status 302}             true]
    ["safe-redirect nil :status" :rf.server/safe-redirect
-    fx-schemas/safe-redirect-args {:location "/ok" :status nil}      true]
+    rf.ssr.server-fx-schemas/safe-redirect-args {:location "/ok" :status nil}      true]
    ["safe-redirect nil :relative-only?" :rf.server/safe-redirect
-    fx-schemas/safe-redirect-args {:location "/ok" :relative-only? nil} true]
+    rf.ssr.server-fx-schemas/safe-redirect-args {:location "/ok" :relative-only? nil} true]
    ["safe-redirect nil :allow"  :rf.server/safe-redirect
-    fx-schemas/safe-redirect-args {:location "/ok" :allow nil}       true]
+    rf.ssr.server-fx-schemas/safe-redirect-args {:location "/ok" :allow nil}       true]
    ["safe-redirect every optional nil at once" :rf.server/safe-redirect
-    fx-schemas/safe-redirect-args {:location "/ok" :status nil
+    rf.ssr.server-fx-schemas/safe-redirect-args {:location "/ok" :status nil
                                    :relative-only? nil :allow nil}   true]
 
    ;; A REQUIRED key is not an optional one: nil is the violation it looks
    ;; like. These are the control rows for AUDIT (a) — without them `[:maybe …]`
    ;; on the optional slots could have been read as nil-tolerance at large.
    ["set-cookie nil :value (required)" :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name "s" :value nil}                false]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name "s" :value nil}                false]
    ["set-cookie nil :name (required)"  :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name nil :value "v"}                false]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name nil :value "v"}                false]
    ["set-header nil :value (required)" :rf.server/set-header
-    fx-schemas/set-header-args {:name "X-Foo" :value nil}            false]
+    rf.ssr.server-fx-schemas/set-header-args {:name "X-Foo" :value nil}            false]
    ["safe-redirect nil :location (required)" :rf.server/safe-redirect
-    fx-schemas/safe-redirect-args {:location nil}                    false]
+    rf.ssr.server-fx-schemas/safe-redirect-args {:location nil}                    false]
 
    ;; ---- AUDIT (b): a cookie `:name` is the published `:string` ---------
    ["set-cookie keyword :name"  :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name :csrf :value "v"}              false]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name :csrf :value "v"}              false]
    ["set-cookie symbol :name"   :rf.server/set-cookie
-    fx-schemas/set-cookie-args {:name 'tracker :value "v"}           false]
+    rf.ssr.server-fx-schemas/set-cookie-args {:name 'tracker :value "v"}           false]
    ["delete-cookie keyword :name" :rf.server/delete-cookie
-    fx-schemas/delete-cookie-args {:name :stale :path "/"}           false]])
+    rf.ssr.server-fx-schemas/delete-cookie-args {:name :stale :path "/"}           false]])
 
 ;; ===========================================================================
 ;; (1) THE DEFECT — the four measured malformations, closed under BOTH postures
@@ -421,7 +421,7 @@
               [:rf.server/delete-cookie {:name "stale" :path "/"}]]}))
     (let [f (server-frame)]
       (rf/dispatch-sync [::good] {:frame f})
-      (let [raw (ssr/peek-response f)]
+      (let [raw (rf.ssr/peek-response f)]
         (is (= 201 (:status raw)) "set-status landed")
         (is (some (fn [[k _]] (= "Cache-Control" k)) (:headers raw))
             "set-header landed")
@@ -448,7 +448,7 @@
                                         :expires   "1700000000000"
                                         :same-site "Strict"}]]}))
       (rf/dispatch-sync [::tolerant] {:frame f})
-      (is (= 1 (count (:cookies (ssr/peek-response f))))
+      (is (= 1 (count (:cookies (rf.ssr/peek-response f))))
           "the string-attr cookie still lands at the fx boundary")))
 
   (testing "rf2-dtpfv: `:rf.server/redirect`'s documented NO-TARGET graceful
@@ -460,7 +460,7 @@
       (rf/reg-event ::no-target
         (fn [_ _] {:fx [[:rf.server/redirect {:status 302}]]}))
       (rf/dispatch-sync [::no-target] {:frame f})
-      (is (= {:status 302} (:redirect (ssr/peek-response f)))
+      (is (= {:status 302} (:redirect (rf.ssr/peek-response f)))
           "the target-less redirect passed the guard and set :redirect")))
 
   (testing "rf2-dtpfv taxonomy: an untrusted-INPUT policy rejection stays the
@@ -550,7 +550,7 @@
           {:fx [[:rf.server/set-cookie    {:name "session" :value "abc"}]
                 [:rf.server/delete-cookie {:name "stale" :path "/"}]]}))
       (rf/dispatch-sync [::named] {:frame f})
-      (let [cookies (:cookies (ssr/peek-response f))]
+      (let [cookies (:cookies (rf.ssr/peek-response f))]
         (is (= 2 (count cookies)) "both string-named cookies landed")
         (is (every? string? (map :name cookies))
             "and every :name on the accumulator is a string")))))
@@ -568,7 +568,7 @@
   [fx-id args {:keys [raw bookkept]}]
   (case fx-id
     :rf.server/set-status
-    (boolean (seq (get bookkept response/status-writes-key)))
+    (boolean (seq (get bookkept rf.ssr.response/status-writes-key)))
 
     (:rf.server/set-header :rf.server/append-header)
     (boolean (some (fn [[k _]] (= (:name args) k)) (:headers raw)))
@@ -613,7 +613,7 @@
 ;; ===========================================================================
 
 (deftest the-production-diagnostic-is-always-on
-  (when-not interop/debug-enabled?
+  (when-not rf.interop/debug-enabled?
     (testing "rf2-dtpfv: in a release build the guard's throw is contained by
               `re-frame.fx`, which fans an ALWAYS-ON
               `:rf.error/fx-handler-exception` — so the defect is visible to
@@ -632,7 +632,7 @@
              status")))))
 
 (deftest the-dev-diagnostic-is-the-richer-schema-failure
-  (when interop/debug-enabled?
+  (when rf.interop/debug-enabled?
     (testing "rf2-dtpfv: with schemas live in a dev build the Spec 010 step-5
               boundary rejects FIRST, so the guard never runs and the
               programmer gets the richer `:where :fx-args` diagnostic with the
@@ -655,7 +655,7 @@
                          @traces))
             (str "a :where :fx-args schema failure named the fx; saw: "
                  (pr-str (mapv (comp :failing-id :tags) @traces))))
-        (is (= 200 (:status (ssr/peek-response f)))
+        (is (= 200 (:status (rf.ssr/peek-response f)))
             "the fx was skipped and the app's status is untouched — the dev
              recovery is `:skipped`, not a 500")))))
 
@@ -689,7 +689,7 @@
       (try
         (rf/dispatch-sync [::user-attempt] {:frame f})
         (finally (rf/unregister-listener! :trace tag)))
-      (if interop/debug-enabled?
+      (if rf.interop/debug-enabled?
         (do (is (empty? @ran)
                 "dev: the user fx was SKIPPED — its handler never ran")
             (is (seq @traces)
@@ -748,31 +748,31 @@
    ;; cookie `:value` is LEGAL and never reaches the guard, so the token is
    ;; routed through `:status` and the boolean `:secure` instead.
    ["status — a SHORT token (under the old 24-char head, so returned verbatim)"
-    response/set-status-fx (subs sentinel 0 16)]
+    rf.ssr.response/set-status-fx (subs sentinel 0 16)]
    ["status — a long token whose first 24 chars ARE the sentinel"
-    response/set-status-fx (str sentinel "-tail-0123456789")]
+    rf.ssr.response/set-status-fx (str sentinel "-tail-0123456789")]
    ["cookie :secure — a raw token where a boolean was published"
-    response/set-cookie-fx {:name "session" :value "v" :secure (str sentinel "-x")}]
+    rf.ssr.response/set-cookie-fx {:name "session" :value "v" :secure (str sentinel "-x")}]
    ;; Non-string values in the session-token slot itself.
    ["cookie :value — a keyword, which the old head bounded not at all"
-    response/set-cookie-fx {:name "session" :value (keyword sentinel)}]
+    rf.ssr.response/set-cookie-fx {:name "session" :value (keyword sentinel)}]
    ["cookie :value — a number that IS the secret"
-    response/set-cookie-fx {:name "session" :value 4111111111111111}]
+    rf.ssr.response/set-cookie-fx {:name "session" :value 4111111111111111}]
    ["cookie :value — a MAP, whose keys the old `:keys` leg reproduced"
-    response/set-cookie-fx {:name "session" :value {sentinel "v" (keyword sentinel) 2}}]
+    rf.ssr.response/set-cookie-fx {:name "session" :value {sentinel "v" (keyword sentinel) 2}}]
    ["header :value — a map with sentinel-bearing keys"
-    response/set-header-fx {:name "X-Auth" :value {sentinel "v"}}]
+    rf.ssr.response/set-header-fx {:name "X-Auth" :value {sentinel "v"}}]
    ["header :value — a vector carrying the token"
-    response/set-header-fx {:name "X-Auth" :value [sentinel]}]
+    rf.ssr.response/set-header-fx {:name "X-Auth" :value [sentinel]}]
    ["header :value — an attacker-sized map (the old `:keys` leg grew unbounded)"
-    response/set-header-fx {:name "X-Auth"
+    rf.ssr.response/set-header-fx {:name "X-Auth"
                             :value (into {} (map (fn [i] [(str sentinel "-" i) i]))
                                          (range 500))}]
    ;; The args value is not a map at all — `validate-args-map!`'s own leg.
    ["args map — a bare token string where a map was required"
-    response/set-cookie-fx (str sentinel "-not-a-map")]
+    rf.ssr.response/set-cookie-fx (str sentinel "-not-a-map")]
    ["args map — a token-bearing vector where a map was required"
-    response/set-header-fx [sentinel]]])
+    rf.ssr.response/set-header-fx [sentinel]]])
 
 (deftest a-rejection-carries-no-fragment-of-the-value-it-rejected
   (doseq [[label handler-fn args] token-bearing-malformations]
@@ -792,7 +792,7 @@
             argument failed ride explicitly trusted ex-data slots the emit
             site controls — never a guess recovered from the value — and the
             shape summary still answers 'what did I actually get?'"
-    (let [e    (rejection-of response/set-cookie-fx
+    (let [e    (rejection-of rf.ssr.response/set-cookie-fx
                              {:name "session" :value {sentinel "v"}})
           data (ex-data e)]
       (is (= :rf.server/set-cookie (:fx-id data)) "the trusted fx-id slot")
@@ -807,9 +807,9 @@
             map's key set, so an attacker-sized value inflated a message
             headed for an SSR host log. The summary is now fixed-size, so the
             message length no longer tracks the input's"
-    (let [small (ex-message (rejection-of response/set-header-fx
+    (let [small (ex-message (rejection-of rf.ssr.response/set-header-fx
                                           {:name "X-Auth" :value {:a 1}}))
-          huge  (ex-message (rejection-of response/set-header-fx
+          huge  (ex-message (rejection-of rf.ssr.response/set-header-fx
                                           {:name "X-Auth"
                                            :value (into {} (map (fn [i]
                                                                   [(str sentinel "-" i) i]))

--- a/implementation/ssr/test/re_frame/ssr_route_miss_404_production_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_route_miss_404_production_test.clj
@@ -50,9 +50,9 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
 ;; NOTE the fixture does NOT clear the always-on error-listener registry.
 ;; `re-frame.ssr` installs its own `::error-projection` listener there at
@@ -60,7 +60,7 @@
 ;; path this suite exercises; wiping the registry would silently disarm
 ;; every 404 assertion below into a vacuous 200. Each test unregisters
 ;; only the shipper stand-in it registered.
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -82,7 +82,7 @@
   default unless a test names its own)."
   ([] (server-frame :rf.ssr/default-error-projector))
   ([projector-id]
-   (frame/make-anon-frame-record!
+   (rf.frame/make-anon-frame-record!
      {:platform :server
       :ssr      {:public-error-id   projector-id
                  :dev-error-detail? false}})))
@@ -110,7 +110,7 @@
     (let [f (server-frame)]
       (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"] {:frame f})
 
-      (let [{:keys [response public-error]} (ssr/flush-response-result! f)]
+      (let [{:keys [response public-error]} (rf.ssr/flush-response-result! f)]
         (is (= 404 (:status response))
             "the drain projects the route miss onto :status — 404, not a soft-404 200")
         (is (nil? (:redirect response))
@@ -137,7 +137,7 @@
       (is (str/includes? html "No such page")
           "the app's not-found body rendered — the projection did not
            short-circuit the render")
-      (is (= 404 (:status (ssr/flush-response! f)))
+      (is (= 404 (:status (rf.ssr/flush-response! f)))
           "and the response still carries the 404"))))
 
 (deftest the-route-slice-records-the-miss-alongside-the-404
@@ -152,7 +152,7 @@
              (get-in (rf/frame-state-value f)
                      [:rf.db/runtime :rf.runtime/routing :current :route-id]))
           "the navigation slice committed the not-found fallback")
-      (is (= 404 (:status (ssr/flush-response! f)))
+      (is (= 404 (:status (rf.ssr/flush-response! f)))
           "and the response accumulator carries the projected 404"))))
 
 ;; ===========================================================================
@@ -252,7 +252,7 @@
         (is (= :rf.error/no-such-handler (:error record)))
         (is (= :malformed-url (:reason record))
             "the malformed percent-encoding is named on the production record")
-        (is (= 404 (:status (ssr/flush-response! f)))
+        (is (= 404 (:status (rf.ssr/flush-response! f)))
             "and it is still a 404 on the wire — a malformed URL matches no
              route")))))
 
@@ -271,7 +271,7 @@
     (register-routes!)
     (let [f (server-frame)]
       (rf/dispatch-sync [:never/registered] {:frame f})
-      (is (= 500 (:status (ssr/flush-response! f)))
+      (is (= 500 (:status (rf.ssr/flush-response! f)))
           "the event-kind miss falls through to the locked generic-500"))))
 
 (deftest default-projector-gates-the-404-arm-on-kind-route
@@ -280,23 +280,23 @@
             is opt-in on the route discriminator (fail-safe), symmetric with
             the `:where`-gated schema-validation-failure arm."
     (is (= {:status 404 :code :not-found :message "Page not found" :retryable? false}
-           (ssr/default-error-projector-fn
+           (rf.ssr/default-error-projector-fn
              {:operation :rf.error/no-such-handler :tags {:kind :route}}))
         ":kind :route → 404")
-    (is (= ssr/fallback-public-error
-           (ssr/default-error-projector-fn
+    (is (= rf.ssr/fallback-public-error
+           (rf.ssr/default-error-projector-fn
              {:operation :rf.error/no-such-handler :tags {:kind :event}}))
         ":kind :event (an unregistered event id) → the locked 500")
-    (is (= ssr/fallback-public-error
-           (ssr/default-error-projector-fn
+    (is (= rf.ssr/fallback-public-error
+           (rf.ssr/default-error-projector-fn
              {:operation :rf.error/no-such-handler :tags {:kind :frame}}))
         ":kind :frame (a Tool-Pair surface naming an unknown frame) → 500")
-    (is (= ssr/fallback-public-error
-           (ssr/default-error-projector-fn
+    (is (= rf.ssr/fallback-public-error
+           (rf.ssr/default-error-projector-fn
              {:operation :rf.error/no-such-handler :tags {}}))
         "no :kind → 500; the 404 arm never fires on an unclassified miss")
     (is (= {:status 404 :code :not-found :message "Page not found" :retryable? false}
-           (ssr/default-error-projector-fn {:operation :rf.error/no-such-route}))
+           (rf.ssr/default-error-projector-fn {:operation :rf.error/no-such-route}))
         ":rf.error/no-such-route keeps its UNCONDITIONAL 404 — one failure
          mode, no :kind discriminator")))
 
@@ -320,7 +320,7 @@
 
     (let [f (server-frame :myapp/route-miss-projector)]
       (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"] {:frame f})
-      (let [{:keys [response public-error]} (ssr/flush-response-result! f)]
+      (let [{:keys [response public-error]} (rf.ssr/flush-response-result! f)]
         (is (= 410 (:status response))
             "the custom projector's status reaches the wire — the runtime
              default did not shadow it")
@@ -337,7 +337,7 @@
     (let [f (server-frame)]
       (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"] {:frame f})
       (rf/dispatch-sync [:auth/bounce] {:frame f})
-      (let [response (ssr/get-response f)]
+      (let [response (rf.ssr/get-response f)]
         (is (= {:status 302 :location "/login"} (:redirect response))
             "the redirect survived the drain")
         (is (not= 404 (:status response))
@@ -361,9 +361,9 @@
       (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"]
                         {:frame miss-frame})
       (rf/dispatch-sync [:rf.route/handle-url-change "/"] {:frame ok-frame})
-      (is (= 404 (:status (ssr/flush-response! miss-frame)))
+      (is (= 404 (:status (rf.ssr/flush-response! miss-frame)))
           "the frame that missed carries the 404")
-      (is (= 200 (:status (ssr/flush-response! ok-frame)))
+      (is (= 200 (:status (rf.ssr/flush-response! ok-frame)))
           "its concurrent sibling, which routed fine, is untouched"))))
 
 (deftest a-client-frame-route-miss-stamps-no-status
@@ -373,12 +373,12 @@
             no request to fail."
     (register-routes!)
     (let [seen     (capture-always-on! ::client)
-          client-f (frame/make-anon-frame-record! {:platform :client})]
+          client-f (rf.frame/make-anon-frame-record! {:platform :client})]
       (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"]
                         {:frame client-f})
       (rf/unregister-listener! :errors ::client)
       (is (= [:rf.error/no-such-handler] (mapv :error @seen))
           "the always-on record still fans — a CLJS production build's error
            shipper sees the client-side route miss too")
-      (is (= 200 (:status (ssr/get-response client-f)))
+      (is (= 200 (:status (rf.ssr/get-response client-f)))
           "but no status is stamped: a client frame has no HTTP response"))))

--- a/implementation/ssr/test/re_frame/ssr_route_slice_projection_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_route_slice_projection_test.clj
@@ -34,16 +34,16 @@
   uses a NON-sensitive sample route, so the leak was invisible there — this is
   the sensitive-route regression that gap called for (rf2-ugoxyv)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.elision :as elision]
-            [re-frame.frame :as frame]
+            [re-frame.elision :as rf.elision]
+            [re-frame.frame :as rf.frame]
             ;; Loading routing publishes the route classification machinery
             ;; and the routing fxs; the reset fixture reloads it.
             [re-frame.routing]
-            [re-frame.routing.classification :as route-class]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.routing.classification :as rf.routing.classification]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---- the route under test -------------------------------------------------
 ;;
@@ -69,13 +69,13 @@
   time. Mirrors the machines test's commit-plane-effect install, but exercises
   the real route classification path."
   []
-  (let [lowered (route-class/apply-route-classification
+  (let [lowered (rf.routing.classification/apply-route-classification
                   {}
-                  (route-class/validate+extract route-id route-classification))
+                  (rf.routing.classification/validate+extract route-id route-classification))
         reg     (get lowered :rf.runtime/elision)]
     ;; Write the lowered route-sourced registry into the live frame's runtime-db
     ;; partition — the canonical durable home of `[:rf.runtime/elision]`.
-    (elision/swap-elision-slot! :rf/default (constantly reg))))
+    (rf.elision/swap-elision-slot! :rf/default (constantly reg))))
 
 (defn- runtime-db-with-secret-route
   "A runtime-db carrying the durable `:current` route slice the SSR hydration
@@ -99,7 +99,7 @@
             the plain :query sibling rides verbatim; the transient
             :pending-navigation is stripped"
     (install-route-classification!)
-    (let [slice   (payload-policy/project-runtime-db (runtime-db-with-secret-route))
+    (let [slice   (rf.ssr.payload-policy/project-runtime-db (runtime-db-with-secret-route))
           current (get-in slice [:rf.runtime/routing :current])]
       (is (= :rf/redacted (get-in current [:query :token]))
           "route-declared sensitive :query :token redacted in the hydration slice")
@@ -121,8 +121,8 @@
             redacted/elided route :query / :params, not the raw classified
             values"
     (install-route-classification!)
-    (let [rt-slice (payload-policy/project-runtime-db (runtime-db-with-secret-route))
-          payload  (payload-policy/build-payload
+    (let [rt-slice (rf.ssr.payload-policy/project-runtime-db (runtime-db-with-secret-route))
+          payload  (rf.ssr.payload-policy/build-payload
                      :rf/default {:public/page :callback} "h1"
                      {:version 1 :runtime-db rt-slice})
           current  (get-in payload [:rf/runtime-db :rf.runtime/routing :current])]
@@ -139,7 +139,7 @@
     (let [rt      {:rf.runtime/routing
                    {:current {:route-id :route/home
                               :query    {:token "still-here"}}}}
-          slice   (payload-policy/project-runtime-db rt)
+          slice   (rf.ssr.payload-policy/project-runtime-db rt)
           current (get-in slice [:rf.runtime/routing :current])]
       (is (= "still-here" (get-in current [:query :token]))
           "an unclassified route query rides the hydration wire verbatim")
@@ -152,7 +152,7 @@
             (`[:rf.runtime/routing :current :query :token]`) into the live
             frame's elision registry — the path the SSR egress walk matches"
     (install-route-classification!)
-    (let [reg (get (frame/frame-runtime-db-value :rf/default) :rf.runtime/elision)]
+    (let [reg (get (rf.frame/frame-runtime-db-value :rf/default) :rf.runtime/elision)]
       (is (contains? (:sensitive-declarations reg)
                      [:rf.runtime/routing :current :query :token])
           "sensitive :query :token re-rooted to its absolute runtime-db path")

--- a/implementation/ssr/test/re_frame/ssr_routing_egress_production_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_routing_egress_production_test.clj
@@ -46,15 +46,15 @@
   recommendation is recorded on rf2-u2x6w."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.frame :as frame]
+            [re-frame.elision :as rf.elision]
+            [re-frame.frame :as rf.frame]
             ;; Loading routing publishes the route classification machinery and
             ;; the routing events; the reset fixture reloads it.
             [re-frame.routing]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 (def ^:private token-secret "secret-oauth-token-u2x6w")
 (def ^:private blob-secret "huge-callback-blob-value-u2x6w")
@@ -85,7 +85,7 @@
   "`:rf/default`'s ACTUAL runtime-db — the state a request frame would be
   holding when the hydration payload is built, not a hand-written fixture map."
   []
-  (frame/frame-runtime-db-value :rf/default))
+  (rf.frame/frame-runtime-db-value :rf/default))
 
 ;; ===========================================================================
 ;; (1) The always-on precondition — activation really lowers, in this posture
@@ -126,11 +126,11 @@
             the registry's re-rooted absolute route paths match and the
             classified values never reach the wire."
     (navigate-to-classified-route!)
-    (let [slice   (payload-policy/project-runtime-db (live-runtime-db) :rf/default)
+    (let [slice   (rf.ssr.payload-policy/project-runtime-db (live-runtime-db) :rf/default)
           current (get-in slice [:rf.runtime/routing :current])]
       (is (= :rf/redacted (get-in current [:query :token]))
           "the `:sensitive` query value redacts in the hydration slice")
-      (is (elision/marker? (get-in current [:query :payload]))
+      (is (rf.elision/marker? (get-in current [:query :payload]))
           "the `:large` one elides to the size marker")
       (is (= "/dashboard" (get-in current [:query :return-to]))
           "the unclassified sibling rides verbatim — path-precise, not a
@@ -148,13 +148,13 @@
             becomes the serialized hydration blob; asserting on the projector's
             return value alone would leave the last hop unwitnessed."
     (navigate-to-classified-route!)
-    (let [rt-slice (payload-policy/project-runtime-db (live-runtime-db) :rf/default)
-          payload  (payload-policy/build-payload
+    (let [rt-slice (rf.ssr.payload-policy/project-runtime-db (live-runtime-db) :rf/default)
+          payload  (rf.ssr.payload-policy/build-payload
                      :rf/default {:public/page :callback} "h1"
                      {:version 1 :runtime-db rt-slice})
           current  (get-in payload [:rf/runtime-db :rf.runtime/routing :current])]
       (is (= :rf/redacted (get-in current [:query :token])))
-      (is (elision/marker? (get-in current [:query :payload])))
+      (is (rf.elision/marker? (get-in current [:query :payload])))
       (is (not (.contains (pr-str payload) token-secret))
           "GUARD: the blob the client receives carries no raw secret")
       (is (not (.contains (pr-str payload) blob-secret))))))
@@ -171,7 +171,7 @@
             be a different framework."
     (rf/reg-route :route/home {:query [:map [:token :string]]} "/home")
     (rf/dispatch-sync [:rf.route/transitioned "/home?token=not-classified"])
-    (let [slice   (payload-policy/project-runtime-db (live-runtime-db) :rf/default)
+    (let [slice   (rf.ssr.payload-policy/project-runtime-db (live-runtime-db) :rf/default)
           current (get-in slice [:rf.runtime/routing :current])]
       (is (= "not-classified" (get-in current [:query :token]))
           "an unclassified route query rides the hydration wire verbatim")

--- a/implementation/ssr/test/re_frame/ssr_runtime_db_explicit_frame_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_runtime_db_explicit_frame_test.clj
@@ -41,22 +41,22 @@
   is ambient, so ambient == explicit and the bug is invisible."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
+            [re-frame.elision :as rf.elision]
+            [re-frame.frame :as rf.frame]
+            [re-frame.late-bind :as rf.late-bind]
             ;; Loading routing / machines publishes the route classification
             ;; machinery and the `:machines/project-ssr-runtime-db` hook; the
             ;; reset fixture reloads both.
             [re-frame.machines]
             [re-frame.routing]
-            [re-frame.routing.classification :as route-class]
+            [re-frame.routing.classification :as rf.routing.classification]
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.streaming :as streaming]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.ssr.streaming :as rf.ssr.streaming]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---- the target frame + its classified runtime state ----------------------
 ;;
@@ -87,9 +87,9 @@
   Every classified path is declared ONLY in frame A's registry — frame B
   (`:rf/default`) declares nothing, so a projection run under B leaks."
   []
-  (-> (route-class/apply-route-classification
-        {} (route-class/validate+extract route-id route-classification))
-      (elision/apply-classification-effects
+  (-> (rf.routing.classification/apply-route-classification
+        {} (rf.routing.classification/validate+extract route-id route-classification))
+      (rf.elision/apply-classification-effects
         {:sensitive [[:secret]
                      [:rf.runtime/machines :snapshots machine-id :data :token]]
          :large     [[:rf.runtime/machines :snapshots machine-id :data :blob]]})
@@ -124,7 +124,7 @@
      :data    {:retries 0 :token nil :blob nil}
      :schemas {:data auth-schema}
      :states  {:anon {:on {:login :authed}} :authed {}}})
-  (frame/swap-runtime-db! server-frame (constantly (frame-a-runtime-db))))
+  (rf.frame/swap-runtime-db! server-frame (constantly (frame-a-runtime-db))))
 
 ;; ---- AC#1: leak with NO ambient scope -------------------------------------
 
@@ -136,8 +136,8 @@
     ;; Escape the fixture's `(with-frame :rf/default …)` scope: no ambient frame
     ;; at all. On the buggy one-arity projector `resolve-current-frame` → nil,
     ;; `project-routing-egress` fails OPEN, and the raw token rides the wire.
-    (let [payload (binding [frame/*current-frame* nil]
-                    (streaming/build-final-payload
+    (let [payload (binding [rf.frame/*current-frame* nil]
+                    (rf.ssr.streaming/build-final-payload
                       server-frame "hash"
                       {:payload :rf.ssr.payload/whole-app-db}))
           current (get-in payload [:rf/runtime-db :rf.runtime/routing :current])
@@ -177,7 +177,7 @@
     (setup-frame-a!)
     (let [captured-hook-frame   (atom :unset)
           captured-hook-ambient (atom :unset)
-          orig-hook (late-bind/get-fn :ssr/extend-runtime-db-projection)]
+          orig-hook (rf.late-bind/get-fn :ssr/extend-runtime-db-projection)]
       (try
         ;; A stub resource-extension hook records BOTH the frame-id PARAMETER it
         ;; is threaded AND the ambient scope in effect when it runs — proving the
@@ -187,15 +187,15 @@
         ;; so we stub its seam). A one-arity stub here would ARITY-ERROR against
         ;; the consumer's `(extend-fn runtime-db frame-id)` — the two args ARE
         ;; the proof the frame is threaded.
-        (late-bind/set-fn! :ssr/extend-runtime-db-projection
+        (rf.late-bind/set-fn! :ssr/extend-runtime-db-projection
                            (fn [_runtime-db frame-id]
                              (reset! captured-hook-frame frame-id)
-                             (reset! captured-hook-ambient (frame/resolve-current-frame))
+                             (reset! captured-hook-ambient (rf.frame/resolve-current-frame))
                              {}))
         ;; Ambient is frame B (the fixture's `:rf/default` scope); we pass A.
-        (is (= :rf/default (frame/resolve-current-frame))
+        (is (= :rf/default (rf.frame/resolve-current-frame))
             "sanity: the ambient frame is B (:rf/default), NOT A")
-        (let [payload (streaming/build-final-payload
+        (let [payload (rf.ssr.streaming/build-final-payload
                         server-frame "hash"
                         {:payload :rf.ssr.payload/whole-app-db})
               current (get-in payload [:rf/runtime-db :rf.runtime/routing :current])
@@ -227,7 +227,7 @@
           (is (not (.contains (pr-str payload) "app-db-secret"))
               "no raw app-db secret survives"))
         (finally
-          (late-bind/set-fn! :ssr/extend-runtime-db-projection orig-hook))))))
+          (rf.late-bind/set-fn! :ssr/extend-runtime-db-projection orig-hook))))))
 
 ;; ---- AC#4 (unit): explicit precedence at the projector seam ---------------
 
@@ -236,9 +236,9 @@
             frame-id argument even under a mismatched ambient frame; the
             one-arity falls back to ambient only when no target is carried"
     (setup-frame-a!)
-    (let [rt (frame/frame-runtime-db-value server-frame)]
+    (let [rt (rf.frame/frame-runtime-db-value server-frame)]
       ;; Ambient is B (:rf/default, no route decls). Explicit A ⇒ redacted.
-      (let [slice   (payload-policy/project-runtime-db rt server-frame)
+      (let [slice   (rf.ssr.payload-policy/project-runtime-db rt server-frame)
             current (get-in slice [:rf.runtime/routing :current])]
         (is (= :rf/redacted (get-in current [:query :token]))
             "explicit A wins: route token redacted despite ambient B")
@@ -247,7 +247,7 @@
       ;; This documents the sanctioned ambient-fallback path (a caller inside a
       ;; MATCHING with-frame gets correct behaviour); the security-critical
       ;; builders always pass the explicit target.
-      (let [slice   (payload-policy/project-runtime-db rt)
+      (let [slice   (rf.ssr.payload-policy/project-runtime-db rt)
             current (get-in slice [:rf.runtime/routing :current])]
         (is (= "secret-oauth-token" (get-in current [:query :token]))
             "one-arity under ambient B applies B's (absent) policy — the
@@ -274,23 +274,23 @@
             LIVE fails closed once A is destroyed, and is distinguished from the
             live-frame precise projection and the frameless-nil passthrough"
     (setup-frame-a!)
-    (let [slice (select-keys (:rf.runtime/routing (frame/frame-runtime-db-value server-frame))
+    (let [slice (select-keys (:rf.runtime/routing (rf.frame/frame-runtime-db-value server-frame))
                              [:current])]
       ;; Acceptance #6, first clause: a LIVE frame with declarations projects
       ;; PRECISELY — the sensitive token redacts, the unclassified sibling rides.
-      (let [live (payload-policy/project-routing-egress slice server-frame)]
+      (let [live (rf.ssr.payload-policy/project-routing-egress slice server-frame)]
         (is (= :rf/redacted (get-in live [:current :query :token]))
             "LIVE frame A: declared sensitive :query :token redacts precisely")
         (is (= "/dashboard" (get-in live [:current :query :return-to]))
             "LIVE frame A: unclassified sibling rides verbatim"))
       ;; Acceptance #6, frameless clause: a NIL frame-id is the frameless
       ;; convenience — no frame policy to lose, so the slice rides verbatim.
-      (is (= slice (payload-policy/project-routing-egress slice nil))
+      (is (= slice (rf.ssr.payload-policy/project-routing-egress slice nil))
           "NIL frame: frameless passthrough (NOT fail-closed)")
       ;; The teardown race: destroy A, then re-project the ALREADY-captured slice
       ;; under the same EXPLICIT id. Acceptance #1 — fail closed.
       (rf/destroy-frame! server-frame)
-      (let [dead (payload-policy/project-routing-egress slice server-frame)]
+      (let [dead (rf.ssr.payload-policy/project-routing-egress slice server-frame)]
         (is (= :rf/redacted dead)
             "DESTROYED explicit frame: the whole :current slice fails closed")
         (is (not (.contains (pr-str dead) "secret-oauth-token"))
@@ -302,16 +302,16 @@
             snapshot :data and the routing :current slice; no raw classified
             value survives, while a LIVE frame still projects them precisely"
     (setup-frame-a!)
-    (let [rt (frame/frame-runtime-db-value server-frame)]
+    (let [rt (rf.frame/frame-runtime-db-value server-frame)]
       ;; sanity — LIVE A projects machine :data + route precisely
-      (let [live (payload-policy/project-runtime-db rt server-frame)]
+      (let [live (rf.ssr.payload-policy/project-runtime-db rt server-frame)]
         (is (= :rf/redacted (get-in live [:rf.runtime/machines :snapshots machine-id :data :token]))
             "LIVE frame A: machine snapshot :data :token redacts")
         (is (= :rf/redacted (get-in live [:rf.runtime/routing :current :query :token]))
             "LIVE frame A: route :current :query :token redacts"))
       ;; teardown race
       (rf/destroy-frame! server-frame)
-      (let [dead (payload-policy/project-runtime-db rt server-frame)]
+      (let [dead (rf.ssr.payload-policy/project-runtime-db rt server-frame)]
         (is (= :rf/redacted (:rf.runtime/machines dead))
             "DESTROYED frame: the machines slice fails closed whole (the hook is
              not invoked with a dead frame)")
@@ -330,8 +330,8 @@
             is still stamped for A; no classified route / machine / app-db value
             survives."
     (setup-frame-a!)
-    (let [orig    frame/frame-runtime-db-value
-          payload (with-redefs [frame/frame-runtime-db-value
+    (let [orig    rf.frame/frame-runtime-db-value
+          payload (with-redefs [rf.frame/frame-runtime-db-value
                                 (fn [fid]
                                   ;; DR#4 interposition: capture the live
                                   ;; runtime-db, THEN tear the frame down before
@@ -339,7 +339,7 @@
                                   (let [v (orig fid)]
                                     (rf/destroy-frame! server-frame)
                                     v))]
-                    (streaming/build-final-payload
+                    (rf.ssr.streaming/build-final-payload
                       server-frame "hash"
                       {:payload :rf.ssr.payload/whole-app-db}))]
       ;; rf2-lm2yzy — wire :rf/frame-id decoupled from the projection frame;
@@ -364,8 +364,8 @@
             check fails closed rather than shipping A-old's token under A-new's
             wide-open registry."
     (setup-frame-a!)
-    (let [orig    frame/frame-runtime-db-value
-          payload (with-redefs [frame/frame-runtime-db-value
+    (let [orig    rf.frame/frame-runtime-db-value
+          payload (with-redefs [rf.frame/frame-runtime-db-value
                                 (fn [fid]
                                   (let [v (orig fid)]
                                     ;; destroy A, then re-register a FRESH A that
@@ -374,7 +374,7 @@
                                     (rf/destroy-frame! server-frame)
                                     (rf/make-frame {:id server-frame :platform :server})
                                     v))]
-                    (streaming/build-final-payload
+                    (rf.ssr.streaming/build-final-payload
                       server-frame "hash"
                       {:payload :rf.ssr.payload/whole-app-db}))]
       ;; rf2-lm2yzy — wire :rf/frame-id decoupled from the projection frame;

--- a/implementation/ssr/test/re_frame/ssr_safe_redirect_production_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_safe_redirect_production_test.clj
@@ -75,25 +75,25 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.privacy.url :as url-egress]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.egress :as egress]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.frame :as rf.frame]
+            [re-frame.privacy.url :as rf.privacy.url]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.egress :as rf.ssr.egress]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
 ;; NOTE the fixture does NOT clear the always-on error-listener registry.
 ;; `re-frame.ssr` installs its own `::error-projection` listener there at
 ;; ns-load time, and (5) below is precisely a claim about what that listener
 ;; does with these categories. Each test unregisters only the shipper
 ;; stand-in it registered.
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
 ;; ---------------------------------------------------------------------------
 
 (defn- server-frame []
-  (frame/make-anon-frame-record!
+  (rf.frame/make-anon-frame-record!
     {:platform :server
      :ssr      {:public-error-id   :rf.ssr/default-error-projector
                 :dev-error-detail? false}}))
@@ -120,7 +120,7 @@
     (rf/unregister-listener! :errors id)
     {:frame    f
      :records  @seen
-     :response (ssr/flush-response! f)}))
+     :response (rf.ssr/flush-response! f)}))
 
 (defn- safe-redirect-records [records]
   (filter #(str/starts-with? (name (:error %)) "safe-redirect-") records))
@@ -408,16 +408,16 @@
             Read the two together and the EP-0015 relationship is the point:
             the dev operator sees their own process in full detail, and the
             production record is a strict projection of it."
-    (is (nil? (url-egress/redact-url-carriers nil)))
-    (is (= 42 (url-egress/redact-url-carriers 42)))
-    (is (= "" (url-egress/redact-url-carriers "")))
-    (is (= "/plain/path" (url-egress/redact-url-carriers "/plain/path"))
+    (is (nil? (rf.privacy.url/redact-url-carriers nil)))
+    (is (= 42 (rf.privacy.url/redact-url-carriers 42)))
+    (is (= "" (rf.privacy.url/redact-url-carriers "")))
+    (is (= "/plain/path" (rf.privacy.url/redact-url-carriers "/plain/path"))
         "a bare path is not a carrier this policy targets")
-    (is (= "javascript:alert(1)" (url-egress/redact-url-carriers "javascript:alert(1)"))
+    (is (= "javascript:alert(1)" (rf.privacy.url/redact-url-carriers "javascript:alert(1)"))
         "the attack string itself survives intact when it carries no
          query / fragment — the common case, and the one a responder needs")
     (is (= "/x?a=rf/redacted&flag#rf/redacted"
-           (url-egress/redact-url-carriers "/x?a=1&flag#frag"))
+           (rf.privacy.url/redact-url-carriers "/x?a=1&flag#frag"))
         "values redacted, keys kept, value-less flag key kept, fragment whole")))
 
 ;; ===========================================================================
@@ -563,16 +563,16 @@
             over a set the framework owns."
     (let [classes (into #{}
                         (map (fn [scheme]
-                               (egress/safe-redirect-scheme-class scheme)))
+                               (rf.ssr.egress/safe-redirect-scheme-class scheme)))
                         ["javascript" "DATA" "vbscript" "http" "https"
                          "mailto" "ftp" "file" "tel" "s3cr3t-probe-token"
                          (apply str (repeat 5000 "z"))])]
       (is (= #{:javascript :data :vbscript :http :https :other} classes)
           "every scheme the gate can meet lands in the six-member vocabulary")
-      (is (nil? (egress/safe-redirect-scheme-class nil))
+      (is (nil? (rf.ssr.egress/safe-redirect-scheme-class nil))
           "no scheme to classify yields nil, so the slot is omitted rather
            than carried as nil")
-      (is (= :other (egress/safe-redirect-scheme-class
+      (is (= :other (rf.ssr.egress/safe-redirect-scheme-class
                       (apply str (repeat 50000 "q"))))
           "an oversized scheme is classified without being copied"))))
 
@@ -585,13 +585,13 @@
             is that failure, made loud."
     (let [gate-schemes (into (deref #'re-frame.ssr.response/rejected-schemes)
                              (deref #'re-frame.ssr.response/allowed-schemes))]
-      (is (= gate-schemes (set (keys egress/scheme-classes)))
+      (is (= gate-schemes (set (keys rf.ssr.egress/scheme-classes)))
           "the class map's domain IS the gate's closed vocabulary")
       (is (= (into #{} (map keyword) gate-schemes)
-             (set (vals egress/scheme-classes)))
+             (set (vals rf.ssr.egress/scheme-classes)))
           "and each maps to the keyword of its own name — no re-spelling, so
            a reader of the sink and a reader of the gate use one word")
-      (is (not (contains? (set (vals egress/scheme-classes)) :other))
+      (is (not (contains? (set (vals rf.ssr.egress/scheme-classes)) :other))
           ":other is the fallback for everything OUTSIDE the vocabulary; a
            scheme mapping TO it would make the fallback ambiguous"))))
 
@@ -696,11 +696,11 @@
             a routing-free host would take the unbound branch and ship the raw
             URL."
     (is (= "/cb?code=rf/redacted#rf/redacted"
-           (url-egress/redact-url-carriers "/cb?code=secret#access_token=leak"))
+           (rf.privacy.url/redact-url-carriers "/cb?code=secret#access_token=leak"))
         "the scrub runs here, on ssr's classpath, with nothing routing-shaped
          loaded on its behalf")
     (is (= "/cb?code=rf/redacted#rf/redacted"
-           (:location (url-egress/redact-url-tag
+           (:location (rf.privacy.url/redact-url-tag
                         {:location "/cb?code=secret#access_token=leak"}
                         :location)))
         "and the `:location` slot the rejection arms build reaches it")))
@@ -723,10 +723,10 @@
             built FROM its slot set rather than filtered down to it, so an
             unrecognised tag has no path into the record even in principle."
     (is (= #{:frame :recovery :reason :scheme-class}
-           egress/safe-redirect-record-slots)
+           rf.ssr.egress/safe-redirect-record-slots)
         "the closed set, unchanged by the consolidation")
     (is (= {:scheme-class :https}
-           (egress/safe-redirect-record-tags
+           (rf.ssr.egress/safe-redirect-record-tags
              {:scheme    "https"
               :host      "evil.example.com"
               :location  "https://alice:pw@evil.example.com/reset/tok-abc"

--- a/implementation/ssr/test/re_frame/ssr_source_coord_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_source_coord_test.clj
@@ -58,13 +58,13 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.streaming :as streaming]
-            [re-frame.ssr.test-fixture :as tf]
-            [re-frame.views.jvm-source-coord-annotation :as jvm-annot]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.streaming :as rf.ssr.streaming]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
+            [re-frame.views.jvm-source-coord-annotation :as rf.views.jvm-source-coord-annotation]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 (defn- source-coord? [html] (str/includes? html "data-rf2-source-coord="))
 (defn- view-id?      [html] (str/includes? html "data-rf-view="))
@@ -87,28 +87,28 @@
     ;; to the dev attributes that happen to sit on that root in dev posture.
     (testing "both head shapes render the registered view's own <h1> root"
       (doseq [[label html] [["Var head"
-                             (ssr/render-to-string [banner-view] {})]
+                             (rf.ssr/render-to-string [banner-view] {})]
                             ["`(rf/view :id)` head"
-                             (ssr/render-to-string
+                             (rf.ssr/render-to-string
                                [(rf/view :ssr-coord-test/banner)] {})]]]
         (is (str/starts-with? html "<h1") label)
         (is (str/ends-with? html ">hi</h1>") label)))
 
     ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (testing "Var head"
-        (is (both-annotations? (ssr/render-to-string [banner-view] {}))))
+        (is (both-annotations? (rf.ssr/render-to-string [banner-view] {}))))
 
       (testing "`(rf/view :id)` head"
         (is (both-annotations?
-              (ssr/render-to-string [(rf/view :ssr-coord-test/banner)] {}))))
+              (rf.ssr/render-to-string [(rf/view :ssr-coord-test/banner)] {}))))
 
       (testing "the data-rf-view value is `(str id)`"
-        (is (str/includes? (ssr/render-to-string [banner-view] {})
+        (is (str/includes? (rf.ssr/render-to-string [banner-view] {})
                            "data-rf-view=\":ssr-coord-test/banner\"")))
 
       (testing "the view genuinely rendered its own root — not swallowed"
-        (is (str/starts-with? (ssr/render-to-string [banner-view] {}) "<h1 "))))))
+        (is (str/starts-with? (rf.ssr/render-to-string [banner-view] {}) "<h1 "))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Exact byte shape for a programmatic (coordless) registration — degrade
@@ -119,7 +119,7 @@
             annotates, degrading the source-coord to <ns>:<sym>:?:? so both
             hosts match on the programmatic path too."
     (rf/reg-view* :ssr-coord-test/prog {} (fn [] [:div "prog"]))
-    (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/prog)] {})]
+    (let [html (rf.ssr/render-to-string [(rf/view :ssr-coord-test/prog)] {})]
       ;; SEMANTIC, posture-independent (rf2-lwtlk): a programmatic
       ;; registration renders at all, and renders its own root and body.
       ;; The gate removes the ATTRIBUTES, never the element.
@@ -129,7 +129,7 @@
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The exact
       ;; byte shape of the `?:?` degrade is the whole point of this deftest
       ;; and is a statement about the dev annotation dialect.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (= (str "<div data-rf2-source-coord=\"ssr-coord-test:prog:?:?\""
                     " data-rf-view=\":ssr-coord-test/prog\">prog</div>")
                html)
@@ -147,7 +147,7 @@
     (rf/reg-view* :ssr-coord-test/authored {}
                   (fn [] [:div {:data-rf-view "author-owned"
                                 :id           "x"} "a"]))
-    (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/authored)] {})]
+    (let [html (rf.ssr/render-to-string [(rf/view :ssr-coord-test/authored)] {})]
       ;; SEMANTIC, posture-independent (rf2-lwtlk): the author's OWN attribute
       ;; map is emitted whatever the posture — `data-rf-view` here is an
       ;; author-owned attribute that merely shares a name with the framework's,
@@ -161,7 +161,7 @@
       ;; are about the WRAPPER: that it declined to overwrite, and that it
       ;; filled the key the author left out. Under the gate no wrapper exists,
       ;; so "did not overwrite" would pass vacuously.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (not (str/includes? html "data-rf-view=\":ssr-coord-test/authored\""))
             "the wrapper did not overwrite it")
         (is (source-coord? html)
@@ -178,7 +178,7 @@
             branch re-wraps so the inner hiccup gets the attributes."
     (rf/reg-view* :ssr-coord-test/form2 {}
                   (fn [] (fn [] [:section "inner"])))
-    (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/form2)] {})]
+    (let [html (rf.ssr/render-to-string [(rf/view :ssr-coord-test/form2)] {})]
       ;; SEMANTIC, posture-independent (rf2-lwtlk): the emitter unwraps the
       ;; outer fn and renders the INNER fn's hiccup. That is Form-2 support
       ;; itself, and it holds with or without the annotation wrapper.
@@ -188,7 +188,7 @@
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The wrapper's
       ;; Form-2 branch re-wraps so the INNER hiccup gets the attributes; the
       ;; trailing space in "<section " is what proves an attribute landed.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (both-annotations? html)
             (str "Form-2 inner output must be annotated; got: " (pr-str html)))
         (is (str/starts-with? html "<section "))))))
@@ -203,7 +203,7 @@
             fragment's children emit unwrapped."
     (rf/reg-view* :ssr-coord-test/frag {}
                   (fn [] [:<> [:p "a"] [:p "b"]]))
-    (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/frag)] {})]
+    (let [html (rf.ssr/render-to-string [(rf/view :ssr-coord-test/frag)] {})]
       ;; SEMANTIC, posture-independent (rf2-lwtlk): a `:<>` root emits its
       ;; children and nothing else — no wrapper element is invented for it.
       (is (= "<p>a</p><p>b</p>" html))
@@ -213,7 +213,7 @@
       ;; annotated; it only says something where the wrapper exists and
       ;; deliberately skipped a non-DOM root. The `=` above already pins the
       ;; byte shape in both postures.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (not (both-annotations? html)))))))
 
 (deftest nested-view-ref-root-is-not-doubly-annotated
@@ -224,7 +224,7 @@
     (rf/reg-view* :ssr-coord-test/inner {} (fn [] [:span "in"]))
     (rf/reg-view* :ssr-coord-test/outer {}
                   (fn [] [(rf/view :ssr-coord-test/inner)]))
-    (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/outer)] {})]
+    (let [html (rf.ssr/render-to-string [(rf/view :ssr-coord-test/outer)] {})]
       ;; SEMANTIC, posture-independent (rf2-lwtlk): a view whose root is
       ;; another view-ref resolves through to the inner view and emits the
       ;; inner view's element ONCE — no wrapper element, no duplication.
@@ -237,7 +237,7 @@
       ;; original assertions are about WHICH element carries the stamp; under
       ;; the gate no element does, so the two negatives pass vacuously and the
       ;; count is trivially 0.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (str/includes? html "data-rf-view=\":ssr-coord-test/inner\"")
             "the inner view annotated its own root")
         (is (not (str/includes? html "data-rf-view=\":ssr-coord-test/outer\""))
@@ -257,8 +257,8 @@
             worried about is gone: one wrapper, both paths."
     (rf/reg-view ^{:rf/id :ssr-coord-test/shell} shell-view []
       [:main "shell"])
-    (let [{:keys [shell-html]} (streaming/render-shell [shell-view])
-          sync-html            (ssr/render-to-string [shell-view] {})]
+    (let [{:keys [shell-html]} (rf.ssr.streaming/render-shell [shell-view])
+          sync-html            (rf.ssr/render-to-string [shell-view] {})]
       ;; SEMANTIC, posture-independent (rf2-lwtlk), and a STRONGER statement
       ;; of this deftest's actual claim: the streaming walker carries no
       ;; annotation logic of its own because it resolves callable heads
@@ -272,7 +272,7 @@
       (is (str/ends-with? shell-html ">shell</main>") (pr-str shell-html))
 
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (both-annotations? shell-html)
             (str "streamed shell must be annotated; got: " (pr-str shell-html)))
         (is (str/includes? shell-html
@@ -287,7 +287,7 @@
             on every host (rf2-j81hs), never a view, so it carries no
             annotation even when a view of the same id is registered."
     (rf/reg-view* :coord-demo/card {} (fn [_] [:div.card "x"]))
-    (let [html (ssr/render-to-string [:coord-demo/card :revenue] {})]
+    (let [html (rf.ssr/render-to-string [:coord-demo/card :revenue] {})]
       ;; SEMANTIC, posture-independent (rf2-lwtlk): the keyword head is
       ;; emitted as a CUSTOM ELEMENT with its argument as a child, and the
       ;; identically-named registered view is NOT invoked (no `.card` div).
@@ -297,7 +297,7 @@
 
       ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous under
       ;; the gate, where nothing anywhere is annotated.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (not (both-annotations? html)))))))
 
 (deftest plain-hiccup-not-annotated
@@ -307,11 +307,11 @@
     ;; gate at all — `not annotated` is trivially true when the wrapper does
     ;; not exist.
     (is (= "<div><span>x</span></div>"
-           (ssr/render-to-string [:div [:span "x"]] {})))
+           (rf.ssr/render-to-string [:div [:span "x"]] {})))
 
     ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-    (when interop/debug-enabled?
-      (is (not (both-annotations? (ssr/render-to-string [:div [:span "x"]] {})))))))
+    (when rf.interop/debug-enabled?
+      (is (not (both-annotations? (rf.ssr/render-to-string [:div [:span "x"]] {})))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Production gate (rf2-wtd8z finding 3) — reinstated at the new site
@@ -335,19 +335,19 @@
     ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Under the real
     ;; `-Dre-frame.debug=false` gate there is no "debug ON at registration"
     ;; to have: the flag was read before this namespace loaded.
-    (when interop/debug-enabled?
+    (when rf.interop/debug-enabled?
       (testing "debug ON at registration — annotated (the load-bearing arm)"
         (rf/reg-view* :ssr-coord-test/gated-dev {} (fn [] [:h2 "g"]))
-        (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/gated-dev)] {})]
+        (let [html (rf.ssr/render-to-string [(rf/view :ssr-coord-test/gated-dev)] {})]
           (is (str/starts-with? html "<h2 "))
           (is (both-annotations? html)))))
 
     (testing "debug OFF at registration — NOT annotated"
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         (rf/reg-view* :ssr-coord-test/gated-prod {} (fn [] [:h2 "g"])))
       ;; render with debug back at its default — the wrap decision was made
       ;; at registration, so the markup is unannotated regardless.
-      (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/gated-prod)] {})]
+      (let [html (rf.ssr/render-to-string [(rf/view :ssr-coord-test/gated-prod)] {})]
         (is (= "<h2>g</h2>" html))
         (is (not (both-annotations? html)))))
 
@@ -358,17 +358,17 @@
     ;; branch and nothing about the documented production posture. This arm
     ;; runs only when the JVM was actually started with
     ;; `-Dre-frame.debug=false`, and registers under it for real.
-    (when-not interop/debug-enabled?
+    (when-not rf.interop/debug-enabled?
       (testing "-Dre-frame.debug=false on the JVM — NOT annotated, for real"
         (rf/reg-view* :ssr-coord-test/real-gate {} (fn [] [:h2 "g"]))
-        (let [html (ssr/render-to-string
+        (let [html (rf.ssr/render-to-string
                      [(rf/view :ssr-coord-test/real-gate)] {})]
           (is (= "<h2>g</h2>" html)
               (str "the real production gate must elide both annotations; got: "
                    (pr-str html))))
         (rf/reg-view ^{:rf/id :ssr-coord-test/real-gate-macro} real-gate-macro []
           [:h3 "m"])
-        (let [html (ssr/render-to-string [real-gate-macro] {})]
+        (let [html (rf.ssr/render-to-string [real-gate-macro] {})]
           (is (= "<h3>m</h3>" html)
               (str "…including on the macro path, which is where the coords "
                    "would have come from; got: " (pr-str html))))))))
@@ -382,7 +382,7 @@
             CLJS one (pinned cross-host in `source-coord-parity-test`). Here
             just confirm the two value shapes directly."
     (is (= "a.b:c:1:2"
-           (jvm-annot/format-source-coord :a.b/c {:line 1 :column 2})))
+           (rf.views.jvm-source-coord-annotation/format-source-coord :a.b/c {:line 1 :column 2})))
     (is (= "a.b:c:?:?"
-           (jvm-annot/format-source-coord :a.b/c {})))
-    (is (= ":a.b/c" (jvm-annot/format-view-id :a.b/c)))))
+           (rf.views.jvm-source-coord-annotation/format-source-coord :a.b/c {})))
+    (is (= ":a.b/c" (rf.views.jvm-source-coord-annotation/format-view-id :a.b/c)))))

--- a/implementation/ssr/test/re_frame/ssr_streaming_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_conformance_test.clj
@@ -17,8 +17,8 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
 (defn- realise-fixture-head
   "Realise a fixture-supplied render tree onto THIS host's head grammar.
@@ -53,7 +53,7 @@
 
 (defn- reset+reg-fixture-handlers
   [test-fn]
-  (tf/reset-runtime
+  (rf.ssr.test-fixture/reset-runtime
     (fn []
       ;; Register the four views the fixture's :fixture/handlers names.
       (rf/reg-view ^{:rf/id :streaming.test/article-list} _al []
@@ -124,7 +124,7 @@
                           (filter #(= :ssr.streaming/render-shell (:call %)))
                           first)
           {:keys [shell-html continuations]}
-          (ssr/streaming-render-shell (realise-fixture-head (:input shell-call)))
+          (rf.ssr/streaming-render-shell (realise-fixture-head (:input shell-call)))
           expect (:expect shell-call)]
       (testing "shell-html includes every fixture-pinned substring"
         (doseq [s (:shell-html-includes expect)]
@@ -145,7 +145,7 @@
           ;; views. We drain against that frame.
           fid     :rf/default]
       (doseq [{:keys [input expect]} cont-calls]
-        (let [out (ssr/streaming-render-continuation
+        (let [out (rf.ssr/streaming-render-continuation
                     fid (update input :subtree realise-fixture-head))]
           (doseq [s (:html-includes expect)]
             (is (str/includes? (:html out) s)
@@ -161,7 +161,7 @@
                        first)
           input   (:input fp-call)
           expect  (:expect fp-call)
-          payload (ssr/streaming-build-final-payload
+          payload (rf.ssr/streaming-build-final-payload
                     :rf/default
                     (:render-hash input)
                     ;; rf2-lm2yzy — the WIRE :rf/frame-id is decoupled from the
@@ -226,7 +226,7 @@
                           (filter #(= :ssr.streaming/render-shell (:call %)))
                           first)
           {:keys [shell-html continuations]}
-          (ssr/streaming-render-shell (realise-fixture-head (:input shell-call)))
+          (rf.ssr/streaming-render-shell (realise-fixture-head (:input shell-call)))
           expect     (:expect shell-call)]
       (doseq [s (:shell-html-includes expect)]
         (is (str/includes? shell-html s)
@@ -251,7 +251,7 @@
           inner-call (second cont-calls)
           fid        :rf/default]
       ;; Drain the outer.
-      (let [out    (ssr/streaming-render-continuation
+      (let [out    (rf.ssr/streaming-render-continuation
                      fid (update (:input outer-call) :subtree realise-fixture-head))
             expect (:expect outer-call)]
         (is (= (:failed? expect) (:failed? out))
@@ -267,7 +267,7 @@
                (mapv :id (:continuations out)))
             "outer drain returns the inner continuation at the FIFO tail"))
       ;; Drain the inner.
-      (let [in     (ssr/streaming-render-continuation
+      (let [in     (rf.ssr/streaming-render-continuation
                      fid (update (:input inner-call) :subtree realise-fixture-head))
             expect (:expect inner-call)]
         (is (= (:failed? expect) (:failed? in)))

--- a/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
@@ -43,15 +43,15 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.ssr.streaming :as streaming]
-            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr.streaming :as rf.ssr.streaming]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (defn- reset+reg
   [test-fn]
-  (tf/reset-runtime
+  (rf.ssr.test-fixture/reset-runtime
     (fn []
       (rf/reg-event :rf.test/seed-db
                     (fn [_coeffects [_event-id seed-db]]
@@ -86,7 +86,7 @@
                 [:rf/suspense-boundary
                  {:id :empty/body :fallback [:p "loading"]}]]
           {:keys [shell-html continuations]}
-          (streaming/render-shell tree)]
+          (rf.ssr.streaming/render-shell tree)]
       (is (= 1 (count continuations))
           "even a zero-body boundary registers a continuation")
       (is (str/includes? shell-html "<p>loading</p>")
@@ -99,7 +99,7 @@
       ;; by hand re-introduces exactly the mask the rf2-405ld fix removed.
       (let [fid    (make-server-frame)
             entry  (first continuations)
-            result (streaming/render-continuation fid entry)]
+            result (rf.ssr.streaming/render-continuation fid entry)]
         (is (= [:p "loading"] (:fallback entry))
             "record-continuation! stored the declared :fallback on the
              zero-body entry (drained verbatim, not re-injected)")
@@ -123,7 +123,7 @@
                  [:p "first"]
                  [:p "second"]
                  [:p "third"]]]
-          {:keys [continuations]} (streaming/render-shell tree)]
+          {:keys [continuations]} (rf.ssr.streaming/render-shell tree)]
       (is (= 1 (count continuations))
           "multi-child body still registers ONE continuation — the
            fragment wraps all children")
@@ -131,7 +131,7 @@
       ;; must ride from `record-continuation!`, not be re-injected here.
       (let [fid    (make-server-frame)
             entry  (first continuations)
-            result (streaming/render-continuation fid entry)]
+            result (rf.ssr.streaming/render-continuation fid entry)]
         (is (= [:p "loading"] (:fallback entry))
             "record-continuation! stored the declared :fallback on the
              multi-child entry")
@@ -164,7 +164,7 @@
                   [:rf/suspense-boundary
                    {:id :inner :fallback [:p "inner loading"]}
                    [:p "inner body"]]]]]
-          {:keys [shell-html continuations]} (streaming/render-shell tree)]
+          {:keys [shell-html continuations]} (rf.ssr.streaming/render-shell tree)]
       ;; The SHELL walk only sees the outer boundary — the inner is
       ;; buried inside the outer's subtree and registers when the outer
       ;; continuation later drains.
@@ -187,7 +187,7 @@
       (let [fid    (make-server-frame)
             entry  (first continuations)
             result (with-trace-recorder! [captured]
-                     (let [result (streaming/render-continuation fid entry)]
+                     (let [result (rf.ssr.streaming/render-continuation fid entry)]
                        (is (= [:p "outer loading"] (:fallback entry))
                            "record-continuation! stored the outer boundary's declared
                             :fallback on the entry")
@@ -228,7 +228,7 @@
         ;; Draining the inner continuation now resolves the inner body.
         ;; (post-capture: the inner render is not part of the outer's trace window)
         (let [inner-entry  (-> result :continuations first)
-              inner-result (streaming/render-continuation fid inner-entry)]
+              inner-result (rf.ssr.streaming/render-continuation fid inner-entry)]
           (is (not (:failed? inner-result)))
           (is (str/includes? (:html inner-result) "inner body")
               "the inner continuation's resolved chunk carries the inner
@@ -252,12 +252,12 @@
                    [:rf/suspense-boundary
                     {:id :lvl3 :fallback [:p "l3 loading"]}
                     [:p "deepest body"]]]]]]
-          {:keys [continuations]} (streaming/render-shell tree)
+          {:keys [continuations]} (rf.ssr.streaming/render-shell tree)
           fid (make-server-frame)]
       (is (= [:lvl1] (mapv :id continuations))
           "shell sees only level-1; deeper levels are buried")
       ;; Drain level-1 → registers level-2.
-      (let [r1 (streaming/render-continuation fid (first continuations))]
+      (let [r1 (rf.ssr.streaming/render-continuation fid (first continuations))]
         (is (not (:failed? r1)))
         (is (str/includes? (:html r1) "data-rf2-suspense-id=\":lvl2\"")
             "level-1 chunk carries level-2's fallback template")
@@ -266,14 +266,14 @@
         (is (= [:lvl2] (mapv :id (:continuations r1)))
             "level-1 drain registers exactly level-2 at the tail")
         ;; Drain level-2 → registers level-3.
-        (let [r2 (streaming/render-continuation fid (-> r1 :continuations first))]
+        (let [r2 (rf.ssr.streaming/render-continuation fid (-> r1 :continuations first))]
           (is (not (:failed? r2)))
           (is (str/includes? (:html r2) "data-rf2-suspense-id=\":lvl3\"")
               "level-2 chunk carries level-3's fallback template")
           (is (= [:lvl3] (mapv :id (:continuations r2)))
               "level-2 drain registers exactly level-3 at the tail")
           ;; Drain level-3 → resolves the deepest body, no further nesting.
-          (let [r3 (streaming/render-continuation fid (-> r2 :continuations first))]
+          (let [r3 (rf.ssr.streaming/render-continuation fid (-> r2 :continuations first))]
             (is (not (:failed? r3)))
             (is (str/includes? (:html r3) "deepest body")
                 "level-3 resolves the deepest body")
@@ -293,7 +293,7 @@
         {:id :buried/in-view :fallback [:p "buried loading"]}
         [:p "buried body"]]])
     (let [tree [:main [(rf/view :test/wrapper)]]
-          {:keys [shell-html continuations]} (streaming/render-shell tree)]
+          {:keys [shell-html continuations]} (rf.ssr.streaming/render-shell tree)]
       (is (= 1 (count continuations))
           "the walker recursed into the registered view and found the
            boundary")
@@ -318,7 +318,7 @@
                   {:id :in-fragment :fallback [:p "fragment loading"]}
                   [:p "fragment body"]]
                  [:p "footer in fragment"]]]
-          {:keys [shell-html continuations]} (streaming/render-shell tree)]
+          {:keys [shell-html continuations]} (rf.ssr.streaming/render-shell tree)]
       (is (= 1 (count continuations))
           "the walker spliced the fragment and reached the boundary")
       (is (= :in-fragment (-> continuations first :id)))
@@ -346,7 +346,7 @@
                  [:p "third body"]]]
           {:keys [continuations captured-traces]}
           (with-trace-recorder! [captured]
-            (let [{:keys [continuations]} (streaming/render-shell tree)]
+            (let [{:keys [continuations]} (rf.ssr.streaming/render-shell tree)]
               {:continuations continuations :captured-traces @captured}))]
       (is (= 1 (count continuations))
           "only one continuation survives dedup across three duplicates")
@@ -357,7 +357,7 @@
       ;; through `record-continuation!` (not re-injected by hand).
       (let [fid    (make-server-frame)
             entry  (first continuations)
-            result (streaming/render-continuation fid entry)]
+            result (rf.ssr.streaming/render-continuation fid entry)]
         (is (= [:p "third fallback"] (:fallback entry))
             "the surviving entry carries the LAST registration's declared
              :fallback — last-write-wins applies to :fallback too")
@@ -371,7 +371,7 @@
       ;; entry's `:fallback` and the drained chunk's body, both
       ;; posture-independent; a duplicate boundary id is a programmer error
       ;; the framework ANNOUNCES in dev and silently applies in production.
-      (when interop/debug-enabled?
+      (when rf.interop/debug-enabled?
         (is (some #(= :rf.error/suspense-boundary-duplicate-id (:operation %))
                   captured-traces)
             "the duplicate-id trace still fires across N=3 duplicates")
@@ -411,11 +411,11 @@
           tree   [:rf/suspense-boundary {:id :double-throw
                                          :fallback [:p "ok in shell"]}
                   [throws-sub]]
-          {:keys [continuations]} (streaming/render-shell tree)
+          {:keys [continuations]} (rf.ssr.streaming/render-shell tree)
           fid (make-server-frame)
           entry (assoc (first continuations) :fallback [throws-fb])]
       (with-trace-recorder! [captured]
-        (let [result (streaming/render-continuation fid entry)]
+        (let [result (rf.ssr.streaming/render-continuation fid entry)]
           (is (:failed? result)
               ":failed? is true when the subtree throws — even though
                the fallback render also throws")
@@ -430,7 +430,7 @@
           ;; posture-independently above: `render-continuation` returned at
           ;; all, with `:failed? true` and empty `:html`, despite BOTH the
           ;; subtree and the fallback throwing.
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
                       @captured)
                 "the suspense-boundary-failed trace still fires for the
@@ -454,9 +454,9 @@
           tree    [:rf/suspense-boundary
                    {:id :mutator :fallback [:p "loading"]}
                    [(rf/view :test/mutating)]]
-          {:keys [continuations]} (streaming/render-shell tree)
+          {:keys [continuations]} (rf.ssr.streaming/render-shell tree)
           entry   (first continuations)
-          result  (streaming/render-continuation fid entry)]
+          result  (rf.ssr.streaming/render-continuation fid entry)]
       (is (not (:failed? result)))
       (is (str/includes? (:html result) "mutated")
           "the resolved chunk's html carries the view's rendered output")
@@ -480,7 +480,7 @@
           tree [:rf/suspense-boundary
                 {:id :after-destroy :fallback [:p "loading"]}
                 [:p "body"]]
-          {:keys [continuations]} (streaming/render-shell tree)
+          {:keys [continuations]} (rf.ssr.streaming/render-shell tree)
           ;; rf2-usio0 — drain the entry verbatim; the declared :fallback
           ;; rides from `record-continuation!`. Re-injecting it masks an
           ;; empty-fallback regression on the fail-soft path.
@@ -496,7 +496,7 @@
       ;; §Failure semantics; what is NOT acceptable is an uncaught
       ;; throw.
       (with-trace-recorder! [_captured-traces]
-        (let [result (streaming/render-continuation fid entry)]
+        (let [result (rf.ssr.streaming/render-continuation fid entry)]
           (is (map? result)
               "render-continuation returned a result map — did NOT
                escape with an uncaught exception even though the frame
@@ -520,7 +520,7 @@
     (let [fid (make-server-frame {:public/articles [{:id "a"}]
                                   :server-only/auth-token "RF2_U91HB_LEAK_PROBE_xyz"
                                   :server-only/admin-flag true})
-          payload (streaming/build-final-payload
+          payload (rf.ssr.streaming/build-final-payload
                     fid "deadbeef"
                     {:version 1
                      :payload [:public/articles]})]
@@ -589,7 +589,7 @@
       (rf/make-frame {:id fid :doc       "privacy-invariant frame"
                       :platform  :server
                       :initial-events [[:test/server-write]]})
-      (let [app-db (frame/frame-app-db-value fid)]
+      (let [app-db (rf.frame/frame-app-db-value fid)]
         ;; Spec 011 §Response storage substrate: NO app-db key may
         ;; carry the accumulator. Pin both the published reserved key and the
         ;; old sentinel spelling.
@@ -626,7 +626,7 @@
                             :headers        {"authorization" "Bearer SECRET_TOKEN"
                                              "cookie"        "session=hot"}}]
         ((requiring-resolve 're-frame.ssr.request/set-request!) fid secret-request)
-        (let [app-db (frame/frame-app-db-value fid)]
+        (let [app-db (rf.frame/frame-app-db-value fid)]
           (is (not (contains? app-db :rf.server/request))
               "app-db MUST NOT carry :rf.server/request")
           (is (not (contains? app-db :request))

--- a/implementation/ssr/test/re_frame/ssr_streaming_hydration_egress_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_hydration_egress_test.clj
@@ -18,11 +18,11 @@
   rf2-bt9kct) through the actual `build-final-payload` path."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.privacy :as privacy]
-            [re-frame.ssr.streaming :as streaming]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.privacy :as rf.privacy]
+            [re-frame.ssr.streaming :as rf.ssr.streaming]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 (def ^:private sframe :rf.uc3cs4/server)
 
@@ -56,7 +56,7 @@
           raw-delta {:secret {:api-key "leak-me"}
                      :public {:page :dashboard}}
           projected (rf/with-frame sframe
-                      (streaming/project-delta raw-delta sframe {:payload [:public]}))]
+                      (rf.ssr.streaming/project-delta raw-delta sframe {:payload [:public]}))]
       (is (not (contains? projected :secret))
           ":secret (off-allowlist) is dropped from the streaming delta")
       (is (= {:page :dashboard} (:public projected))
@@ -71,8 +71,8 @@
     (reg-sensitive-server-frame! {})
     (let [raw-delta {:session {:token "secret-jwt" :user "bob"}}
           projected (rf/with-frame sframe
-                      (streaming/project-delta raw-delta sframe {:payload [:session]}))]
-      (is (= privacy/redacted-sentinel (get-in projected [:session :token]))
+                      (rf.ssr.streaming/project-delta raw-delta sframe {:payload [:session]}))]
+      (is (= rf.privacy/redacted-sentinel (get-in projected [:session :token]))
           "the frame-sensitive nested :token is redacted in the streamed delta")
       (is (= "bob" (get-in projected [:session :user]))
           "the public sibling rides verbatim")
@@ -86,9 +86,9 @@
     (let [raw-delta {:session {:token "secret-jwt" :user "bob"}
                      :secret  {:api-key "x"}}
           projected (rf/with-frame sframe
-                      (streaming/project-delta
+                      (rf.ssr.streaming/project-delta
                         raw-delta sframe {:payload :rf.ssr.payload/whole-app-db}))]
-      (is (= privacy/redacted-sentinel (get-in projected [:session :token])))
+      (is (= rf.privacy/redacted-sentinel (get-in projected [:session :token])))
       (is (contains? projected :secret)
           "whole-app-db keeps the changed :secret key (no allowlist filtering)")
       (is (not (.contains (pr-str projected) "secret-jwt"))))))
@@ -98,9 +98,9 @@
             off-allowlist, both project to {} so the host emits no delta script"
     (reg-sensitive-server-frame! {})
     (rf/with-frame sframe
-      (is (= {} (streaming/project-delta {} sframe {:payload [:public]}))
+      (is (= {} (rf.ssr.streaming/project-delta {} sframe {:payload [:public]}))
           "empty delta → {}")
-      (is (= {} (streaming/project-delta {:secret {:k 1}} sframe {:payload [:public]}))
+      (is (= {} (rf.ssr.streaming/project-delta {:secret {:k 1}} sframe {:payload [:public]}))
           "all-off-allowlist delta → {} (no :rf/redacted scalar)"))))
 
 ;; ---- the streaming arm of rf2-bt9kct: build-final-payload's :rf/app-db -----
@@ -114,10 +114,10 @@
        :public  {:page :home}
        :secrets {:api-key "internal"}})
     (let [payload (rf/with-frame sframe
-                    (streaming/build-final-payload
+                    (rf.ssr.streaming/build-final-payload
                       sframe "h1" {:version 1 :payload [:session :public]}))
           db      (:rf/app-db payload)]
-      (is (= privacy/redacted-sentinel (get-in db [:session :token]))
+      (is (= rf.privacy/redacted-sentinel (get-in db [:session :token]))
           "the frame-sensitive :token redacts in the streaming final payload")
       (is (= "carol" (get-in db [:session :user])))
       (is (= {:page :home} (:public db)))

--- a/implementation/ssr/test/re_frame/ssr_streaming_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_test.clj
@@ -27,20 +27,20 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.html-helpers :as html]
-            [re-frame.ssr.payload-policy :as payload-policy]
-            [re-frame.ssr.streaming :as streaming]
-            [re-frame.ssr.streaming.constants :as wire]
-            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]
+            [re-frame.ssr.payload-policy :as rf.ssr.payload-policy]
+            [re-frame.ssr.streaming :as rf.ssr.streaming]
+            [re-frame.ssr.streaming.constants :as rf.ssr.streaming.constants]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (defn- reset+reg-test-handlers
   "Reset the runtime via the canonical fixture, then re-register the
   test-local event handlers that the fixture's `clear-all!` step wiped."
   [test-fn]
-  (tf/reset-runtime
+  (rf.ssr.test-fixture/reset-runtime
     (fn []
       (rf/reg-event :rf.test/noop     (fn [{:keys [db]} _] {:db db}))
       (rf/reg-event :rf.test/seed-db  (fn [_coeffects [_event-id new-db]]
@@ -75,7 +75,7 @@
                    {:id :test/comments :fallback [:p "Loading…"]}
                    [:section.comments "Body"]]
                   [:footer "Footer"]]
-          {:keys [shell-html continuations]} (streaming/render-shell tree)]
+          {:keys [shell-html continuations]} (rf.ssr.streaming/render-shell tree)]
       (is (= 1 (count continuations)) "one continuation registered")
       (is (= :test/comments (-> continuations first :id)) "id propagates")
       (is (str/includes? shell-html "<h1>Header</h1>") "shell content above boundary preserved")
@@ -99,7 +99,7 @@
                   [:rf/suspense-boundary
                    {:id :news/comments :fallback [:p.skeleton "Loading comments…"]}
                    [:section.comments "Body"]]]
-          {:keys [shell-html]} (streaming/render-shell tree)
+          {:keys [shell-html]} (rf.ssr.streaming/render-shell tree)
           ;; Strip every <template …>…</template> block; whatever fallback
           ;; markup the server painted OUTSIDE a template survives.
           painted (str/replace shell-html
@@ -123,7 +123,7 @@
                 [:rf/suspense-boundary {:id :a :fallback [:p "A loading"]} [:p "A body"]]
                 [:rf/suspense-boundary {:id :b :fallback [:p "B loading"]} [:p "B body"]]
                 [:rf/suspense-boundary {:id :c :fallback [:p "C loading"]} [:p "C body"]]]
-          {:keys [continuations]} (streaming/render-shell tree)]
+          {:keys [continuations]} (rf.ssr.streaming/render-shell tree)]
       (is (= [:a :b :c] (mapv :id continuations)) "FIFO registration in document order"))))
 
 (deftest render-shell-handles-nested-boundaries
@@ -132,7 +132,7 @@
                 [:section
                  [:rf/suspense-boundary {:id :nested :fallback [:p "nested loading"]}
                   [:p "nested body"]]]]
-          {:keys [shell-html continuations]} (streaming/render-shell tree)]
+          {:keys [shell-html continuations]} (rf.ssr.streaming/render-shell tree)]
       (is (= 1 (count continuations)))
       (is (= :nested (-> continuations first :id)))
       (is (str/includes? shell-html "<section>"))
@@ -144,16 +144,16 @@
                [:p "body"]]]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #":rf.error/suspense-boundary-invalid-attrs"
-                            (streaming/render-shell bad))))))
+                            (rf.ssr.streaming/render-shell bad))))))
 
 (deftest render-continuation-resolves-and-deltas
   (testing "Continuation render returns subtree HTML + (empty) delta when db is unchanged across render"
     (let [fid (make-frame {:db {:initial true}})
           tree [:rf/suspense-boundary {:id :c :fallback [:p "..."]}
                 [:ul [:li "comment"]]]
-          {:keys [continuations]} (streaming/render-shell tree)
+          {:keys [continuations]} (rf.ssr.streaming/render-shell tree)
           entry (first continuations)
-          {:keys [id html delta failed?]} (streaming/render-continuation fid entry)]
+          {:keys [id html delta failed?]} (rf.ssr.streaming/render-continuation fid entry)]
       (is (= :c id))
       (is (not failed?))
       (is (= "<ul><li>comment</li></ul>" html))
@@ -179,9 +179,9 @@
                     [:p "mutated"])
           tree    [:rf/suspense-boundary {:id :n :fallback [:p "..."]}
                    [(rf/view :rf.test/nested-mutator)]]
-          {:keys [continuations]} (streaming/render-shell tree)
+          {:keys [continuations]} (rf.ssr.streaming/render-shell tree)
           entry   (first continuations)
-          {:keys [delta]} (streaming/render-continuation fid entry)]
+          {:keys [delta]} (rf.ssr.streaming/render-continuation fid entry)]
       (is (contains? delta :user)
           ":user is a changed top-level key, so it is in the delta")
       (is (= {:name "after" :role "admin"} (:user delta))
@@ -204,7 +204,7 @@
           ;; Attach a fn-headed component that throws during render
           tree   [:rf/suspense-boundary {:id :flaky :fallback [:p "Loading…"]}
                   [throws]]
-          {:keys [continuations]} (streaming/render-shell tree)
+          {:keys [continuations]} (rf.ssr.streaming/render-shell tree)
           ;; rf2-405ld — exercise the REAL record→fail path: the
           ;; continuation entry must already carry its declared :fallback
           ;; from `record-continuation!`. Previously this test masked the
@@ -213,7 +213,7 @@
           ;; bug) would surface here as a "" :html.
           entry  (first continuations)]
       (with-trace-recorder! [captured]
-        (let [result (streaming/render-continuation fid entry)]
+        (let [result (rf.ssr.streaming/render-continuation fid entry)]
           (is (= [:p "Loading…"] (:fallback entry))
               "record-continuation! stored the declared :fallback on the entry")
           (is (:failed? result) ":failed? truthy")
@@ -223,7 +223,7 @@
           ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
           ;; failure's production face is `:failed?` + the materialised
           ;; fallback above; this is how a developer hears about it.
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
                       @captured)
                 ":rf.ssr/suspense-boundary-failed trace emitted")))))))
@@ -234,7 +234,7 @@
                 [:rf/suspense-boundary {:id :dup :fallback [:p "first"]} [:p "first body"]]
                 [:rf/suspense-boundary {:id :dup :fallback [:p "second"]} [:p "second body"]]]]
       (with-trace-recorder! [captured]
-        (let [{:keys [continuations]} (streaming/render-shell tree)]
+        (let [{:keys [continuations]} (rf.ssr.streaming/render-shell tree)]
           (is (= 1 (count continuations)) "only one continuation survives dedup")
           ;; SEMANTIC, posture-independent (rf2-lwtlk): last-write-wins is the
           ;; recovery the trace merely NAMES, and it applies in both postures.
@@ -242,7 +242,7 @@
           (is (= [:p "second"] (:fallback (first continuations)))
               "the surviving continuation is the LAST registration")
           ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (is (some #(= :rf.error/suspense-boundary-duplicate-id (:operation %))
                       @captured)
                 ":rf.error/suspense-boundary-duplicate-id trace emitted")))))))
@@ -271,10 +271,10 @@
                 [:rf/suspense-boundary {:id :a :fallback [:p "first"]} [:p "first body"]]
                 [:rf/suspense-boundary {:id ":a" :fallback [:p "second"]} [:p "second body"]]]]
       (with-trace-recorder! [captured]
-        (let [{:keys [continuations shell-html]} (streaming/render-shell tree)]
+        (let [{:keys [continuations shell-html]} (rf.ssr.streaming/render-shell tree)]
           ;; The wire surface: both boundaries stamp the SAME wire id, so the
           ;; client cannot tell them apart — the collision is real.
-          (is (= 2 (count (re-seq (re-pattern (str wire/attr-suspense-id "=\":a\""))
+          (is (= 2 (count (re-seq (re-pattern (str rf.ssr.streaming.constants/attr-suspense-id "=\":a\""))
                                   shell-html)))
               "both fallback templates stamp the same wire id `:a` — the
                collision the client would face")
@@ -293,7 +293,7 @@
           ;; COLLISION and the last-write-wins recovery it names are pinned
           ;; posture-independently above, on the wire attributes and the
           ;; surviving entry.
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (let [dup-traces (filterv #(= :rf.error/suspense-boundary-duplicate-id
                                           (:operation %))
                                       @captured)]
@@ -317,13 +317,13 @@
                 [:rf/suspense-boundary {:id :a :fallback [:p "fa"]} [:p "ba"]]
                 [:rf/suspense-boundary {:id :b :fallback [:p "fb"]} [:p "bb"]]]]
       (with-trace-recorder! [captured]
-        (let [{:keys [continuations]} (streaming/render-shell tree)]
+        (let [{:keys [continuations]} (rf.ssr.streaming/render-shell tree)]
           (is (= 2 (count continuations))
               "distinct wire ids both survive — no false collapse")
           ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). A
           ;; NEGATIVE over the trace ring: vacuous under the gate, where the
           ;; ring is empty for colliding and distinct ids alike.
-          (when interop/debug-enabled?
+          (when rf.interop/debug-enabled?
             (is (empty? (filterv #(= :rf.error/suspense-boundary-duplicate-id
                                      (:operation %))
                                  @captured))
@@ -337,7 +337,7 @@
           ;; app-db so the existing :rf/app-db assertion still holds.
           ;; rf2-lm2yzy: `:client-frame-id` names the stable WIRE :rf/frame-id;
           ;; the per-request projection frame `fid` never rides the wire.
-          payload (streaming/build-final-payload fid "deadbeef"
+          payload (rf.ssr.streaming/build-final-payload fid "deadbeef"
                                                  {:version         7
                                                   :schema-digest   "abc123"
                                                   :payload         :rf.ssr.payload/whole-app-db
@@ -353,7 +353,7 @@
             projection frame is OMITTED from the wire payload (never stamped as
             a per-request gensym the client hydrate guard would reject)"
     (let [fid     (make-frame {:db {:articles [{:id "a"}]}})
-          payload (streaming/build-final-payload fid "deadbeef"
+          payload (rf.ssr.streaming/build-final-payload fid "deadbeef"
                                                  {:payload :rf.ssr.payload/whole-app-db})]
       (is (not (contains? payload :rf/frame-id))
           "streaming final-payload omits :rf/frame-id when no stable wire id is named"))))
@@ -369,14 +369,14 @@
             :rf.ssr/version-mismatch check."
     (let [fid (make-frame {:db {:k 1}})]
       (testing "no explicit :version → the SSR-owned pattern-protocol constant"
-        (let [payload (streaming/build-final-payload
+        (let [payload (rf.ssr.streaming/build-final-payload
                         fid "hash"
                         {:payload :rf.ssr.payload/whole-app-db})]
-          (is (= payload-policy/pattern-protocol-version (:rf/version payload))
+          (is (= rf.ssr.payload-policy/pattern-protocol-version (:rf/version payload))
               "absent :version opt → the SSR artefact's compiled-in constant")))
 
       (testing "explicit :version opt wins over the SSR constant"
-        (let [payload (streaming/build-final-payload
+        (let [payload (rf.ssr.streaming/build-final-payload
                         fid "hash"
                         {:version 42
                          :payload :rf.ssr.payload/whole-app-db})]
@@ -385,9 +385,9 @@
 
 (deftest facade-exposes-streaming-surface
   (testing "`re-frame.ssr` re-exports the streaming public surface"
-    (is (= streaming/render-shell        ssr/streaming-render-shell))
-    (is (= streaming/render-continuation ssr/streaming-render-continuation))
-    (is (= streaming/build-final-payload ssr/streaming-build-final-payload))))
+    (is (= rf.ssr.streaming/render-shell        rf.ssr/streaming-render-shell))
+    (is (= rf.ssr.streaming/render-continuation rf.ssr/streaming-render-continuation))
+    (is (= rf.ssr.streaming/build-final-payload rf.ssr/streaming-build-final-payload))))
 
 ;; ===========================================================================
 ;; rf2-3w6dmy finding 2 — streaming wire-attribute single-source parity
@@ -412,35 +412,35 @@
             emitter reads the wire constants, so a divergent literal cannot
             slip in unnoticed"
     (let [id        :card/revenue
-          fallback  (streaming/fallback-template id "<div>fb</div>")
-          resolved  (streaming/resolved-template id "<div>ok</div>")
-          failed    (streaming/failed-template   id "<div>fb</div>")
-          delta     (streaming/hydrate-delta-script id (pr-str {:k 1}))]
+          fallback  (rf.ssr.streaming/fallback-template id "<div>fb</div>")
+          resolved  (rf.ssr.streaming/resolved-template id "<div>ok</div>")
+          failed    (rf.ssr.streaming/failed-template   id "<div>fb</div>")
+          delta     (rf.ssr.streaming/hydrate-delta-script id (pr-str {:k 1}))]
       ;; The boundary-id attribute anchors every template chunk + the delta
       ;; script — the client matches on it, so server + client MUST agree.
-      (is (str/includes? fallback (str wire/attr-suspense-id "="))
+      (is (str/includes? fallback (str rf.ssr.streaming.constants/attr-suspense-id "="))
           "fallback template stamps the wire id attribute")
-      (is (str/includes? resolved (str wire/attr-suspense-id "="))
+      (is (str/includes? resolved (str rf.ssr.streaming.constants/attr-suspense-id "="))
           "resolved template stamps the wire id attribute")
-      (is (str/includes? failed   (str wire/attr-suspense-id "="))
+      (is (str/includes? failed   (str rf.ssr.streaming.constants/attr-suspense-id "="))
           "failed template stamps the wire id attribute")
-      (is (str/includes? delta    (str wire/attr-suspense-hydrate "="))
+      (is (str/includes? delta    (str rf.ssr.streaming.constants/attr-suspense-hydrate "="))
           "delta script stamps the wire hydrate attribute")
       ;; The per-kind markers the client branches on.
-      (is (str/includes? fallback (str wire/attr-suspense-fallback "=\"1\""))
+      (is (str/includes? fallback (str rf.ssr.streaming.constants/attr-suspense-fallback "=\"1\""))
           "fallback template stamps the wire fallback marker")
-      (is (str/includes? resolved (str wire/attr-suspense-resolved "=\"1\""))
+      (is (str/includes? resolved (str rf.ssr.streaming.constants/attr-suspense-resolved "=\"1\""))
           "resolved template stamps the wire resolved marker")
-      (is (str/includes? failed   (str wire/attr-suspense-resolved "=\"1\""))
+      (is (str/includes? failed   (str rf.ssr.streaming.constants/attr-suspense-resolved "=\"1\""))
           "failed template is a resolved chunk (carries the resolved marker)")
-      (is (str/includes? failed   (str wire/attr-suspense-failed "=\"1\""))
+      (is (str/includes? failed   (str rf.ssr.streaming.constants/attr-suspense-failed "=\"1\""))
           "failed template adds the wire failed marker")
       ;; Belt-and-braces: NO server-emitted chunk may carry a stale literal
       ;; that diverges from the wire constants (catches a hard-coded rename
       ;; on one side only).
-      (is (not (str/includes? failed wire/attr-suspense-fallback))
+      (is (not (str/includes? failed rf.ssr.streaming.constants/attr-suspense-fallback))
           "failed chunk is NOT a fallback (markers don't bleed across kinds)")
-      (is (not (str/includes? resolved wire/attr-suspense-failed))
+      (is (not (str/includes? resolved rf.ssr.streaming.constants/attr-suspense-failed))
           "a non-failed resolved chunk carries no failed marker"))))
 
 ;; ===========================================================================
@@ -469,7 +469,7 @@
     (let [delta   {:public/title "</script><script>alert('xss')</script>"
                    :a<b 1
                    :tag :<}
-          script  (streaming/hydrate-delta-script :boundary/x (pr-str delta))
+          script  (rf.ssr.streaming/hydrate-delta-script :boundary/x (pr-str delta))
           body    (delta-script-body script)]
       ;; (a) no breakout — the raw closing-tag pattern must not survive.
       (is (not (str/includes? (str/lower-case body) "</script"))
@@ -495,7 +495,7 @@
     ;; — `<{`, not `</` — and is safe.)
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf.error/ssr-edn-script-breakout"
-                          (streaming/hydrate-delta-script
+                          (rf.ssr.streaming/hydrate-delta-script
                             :boundary/x (pr-str {:k (symbol "a</script>b")}))))))
 
 ;; ===========================================================================
@@ -522,7 +522,7 @@
             round-trips through the EDN reader"
     (let [value {:x (char 34) :y "</script>"}
           edn-doc (pr-str value)
-          body  (html/escape-edn-script-body edn-doc)]
+          body  (rf.ssr.html-helpers/escape-edn-script-body edn-doc)]
       ;; The pre-fix behaviour THREW here; the fix must produce a body.
       (is (string? body) "escaper returns a body (no false-positive throw)")
       (is (not (str/includes? (str/lower-case body) "</script"))
@@ -536,7 +536,7 @@
             by pr-str, so they round-trip without a false breakout"
     (doseq [v [(char 60) (char 47) (char 33)]]
       (let [value {:c v :s "safe"}
-            body  (html/escape-edn-script-body (pr-str value))]
+            body  (rf.ssr.html-helpers/escape-edn-script-body (pr-str value))]
         (is (= value (edn/read-string body))
             (str "char literal " (pr-str v) " round-trips")))))
 
@@ -545,7 +545,7 @@
             relaxation does not weaken the breakout guard"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #":rf.error/ssr-edn-script-breakout"
-                          (html/escape-edn-script-body
+                          (rf.ssr.html-helpers/escape-edn-script-body
                             (pr-str {:k (symbol "a</script>b")}))))))
 
 (deftest hydrate-delta-script-char-literal-round-trips
@@ -554,7 +554,7 @@
             literal `(char 34)` alongside a string carrying `</script>`
             emits cleanly and round-trips"
     (let [delta  {:x (char 34) :y "</script>"}
-          script (streaming/hydrate-delta-script :boundary/x (pr-str delta))
+          script (rf.ssr.streaming/hydrate-delta-script :boundary/x (pr-str delta))
           body   (delta-script-body script)]
       (is (not (str/includes? (str/lower-case body) "</script"))
           "delta body carries no literal </script breakout")

--- a/implementation/ssr/test/re_frame/ssr_sub_exception_two_frame_attribution_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_sub_exception_two_frame_attribution_test.clj
@@ -70,11 +70,11 @@
       could NOT prove (rf2-c0bq1)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.interop :as interop]
-            [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.interop :as rf.interop]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 (def ^:private frame-a :ssr/sub-req-a)
 (def ^:private frame-b :ssr/sub-req-b)
@@ -121,7 +121,7 @@
     (register-subs!)
     (let [fa (make-server-frame frame-a)
           fb (make-server-frame frame-b)]
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         ;; Both frames are live registered server frames — the exact
         ;; >1-server-frame shape the removed fallback could not handle.
         ;; frame-a derefs the throwing sub; frame-b derefs the clean one.
@@ -134,13 +134,13 @@
         (rf/subscribe-once [:throwing-sub] {:frame fa})
         (rf/subscribe-once [:clean-sub] {:frame fb})
 
-        (is (= 500 (:status (ssr/get-response fa)))
+        (is (= 500 (:status (rf.ssr/get-response fa)))
             "frame-a's sub-exception fails closed to 500 on frame-a's
              response — the always-on substrate carried the projection
              under the disabled dev gate (the dev-only trace path is
              elided here), and the `:frame` stamp routed it to the
              emitting frame even with a sibling server frame live")
-        (is (= 200 (:status (ssr/get-response fb)))
+        (is (= 200 (:status (rf.ssr/get-response fb)))
             "frame-b's response stays at the default 200 — frame-a's
              sub-throw did not bleed onto the sibling. The removed
              single-frame fallback would have no-op'd with >1 server
@@ -158,12 +158,12 @@
     (register-subs!)
     (let [fa (make-server-frame frame-a)
           fb (make-server-frame frame-b)]
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         (rf/subscribe-once [:throwing-sub] {:frame fb})
         (rf/subscribe-once [:clean-sub] {:frame fa})
-        (is (= 500 (:status (ssr/get-response fb)))
+        (is (= 500 (:status (rf.ssr/get-response fb)))
             "frame-b (the emitting frame) fails closed to 500")
-        (is (= 200 (:status (ssr/get-response fa)))
+        (is (= 200 (:status (rf.ssr/get-response fa)))
             "frame-a stays at the default 200 — clean")))))
 
 ;; ===========================================================================
@@ -181,11 +181,11 @@
             is false (the prod default) so no `:details` slot leaks the
             raw trace."
     (register-subs!)
-    (let [project-error ssr/project-error
+    (let [project-error rf.ssr/project-error
           fa            (make-server-frame frame-a)]
-      (with-redefs [interop/debug-enabled? false]
+      (with-redefs [rf.interop/debug-enabled? false]
         (rf/subscribe-once [:throwing-sub] {:frame fa})
-        (let [resp (ssr/get-response fa)]
+        (let [resp (rf.ssr/get-response fa)]
           (is (= 500 (:status resp))
               "sub-exception fails closed to 500 under production hardening")
           ;; The wire response carries the public-error status, not the

--- a/implementation/ssr/test/re_frame/ssr_teardown_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_teardown_corner_test.clj
@@ -28,13 +28,13 @@
   bundle that doesn't pull in re-frame.ssr.head); destroy still completes
   (test 4)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.ssr.error-listener :as error-listener]
-            [re-frame.ssr.install :as install]
-            [re-frame.ssr.request :as request]
-            [re-frame.ssr.response :as response]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.error-listener :as rf.ssr.error-listener]
+            [re-frame.ssr.install :as rf.ssr.install]
+            [re-frame.ssr.request :as rf.ssr.request]
+            [re-frame.ssr.response :as rf.ssr.response]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ===========================================================================
 ;; Composition — one destroy clears every side-channel
@@ -52,37 +52,37 @@
             there is no fourth head channel to clear.)"
     (let [fid :rf.test/composition-target]
       ;; Populate every side-channel slot for fid.
-      (request/set-request! fid {:uri "/comp" :request-method :get})
-      (response/swap-response! fid (fn [r] (assoc r :status 200)))
+      (rf.ssr.request/set-request! fid {:uri "/comp" :request-method :get})
+      (rf.ssr.response/swap-response! fid (fn [r] (assoc r :status 200)))
       ;; Plant a synthetic pending error trace.
-      (swap! error-listener/pending-error-traces
+      (swap! rf.ssr.error-listener/pending-error-traces
              update fid (fnil conj [])
              {:op-type :error :operation :rf.error/composition-probe})
       ;; Plant a hydration-payload install claim under the frame's id
       ;; (payload ids ARE frame ids, 004C §6).
-      (swap! install/installed-payloads
-             assoc fid (install/claim-record "digest-probe" :rf.test/root))
+      (swap! rf.ssr.install/installed-payloads
+             assoc fid (rf.ssr.install/claim-record "digest-probe" :rf.test/root))
 
-      (is (some? (request/get-request fid))
+      (is (some? (rf.ssr.request/get-request fid))
           "request-slot populated (sanity)")
-      (is (contains? @response/response-slots fid)
+      (is (contains? @rf.ssr.response/response-slots fid)
           "response-slot populated (sanity)")
-      (is (contains? @error-listener/pending-error-traces fid)
+      (is (contains? @rf.ssr.error-listener/pending-error-traces fid)
           "pending-error-traces populated (sanity)")
-      (is (some? (install/installed-payload fid))
+      (is (some? (rf.ssr.install/installed-payload fid))
           "payload claim populated (sanity)")
 
       ;; Drive the destroy hook directly — this is the single call the
       ;; spec contract pins as the load-bearing release point.
-      (request/on-frame-destroyed! fid)
+      (rf.ssr.request/on-frame-destroyed! fid)
 
-      (is (nil? (request/get-request fid))
+      (is (nil? (rf.ssr.request/get-request fid))
           "request-slot released by on-frame-destroyed!")
-      (is (not (contains? @response/response-slots fid))
+      (is (not (contains? @rf.ssr.response/response-slots fid))
           "response-slot released by on-frame-destroyed!")
-      (is (not (contains? @error-listener/pending-error-traces fid))
+      (is (not (contains? @rf.ssr.error-listener/pending-error-traces fid))
           "pending-error-traces released by on-frame-destroyed!")
-      (is (nil? (install/installed-payload fid))
+      (is (nil? (rf.ssr.install/installed-payload fid))
           "payload claim released by on-frame-destroyed!"))))
 
 ;; ===========================================================================
@@ -97,23 +97,23 @@
             twice (e.g. via a defensive try/destroy AND a finally
             destroy) MUST NOT throw or corrupt state."
     (let [fid :rf.test/idempotence-target]
-      (request/set-request! fid {:uri "/i" :request-method :get})
-      (response/swap-response! fid (fn [r] (assoc r :status 201)))
-      (swap! install/installed-payloads
-             assoc fid (install/claim-record "digest-idem" :rf.test/root))
+      (rf.ssr.request/set-request! fid {:uri "/i" :request-method :get})
+      (rf.ssr.response/swap-response! fid (fn [r] (assoc r :status 201)))
+      (swap! rf.ssr.install/installed-payloads
+             assoc fid (rf.ssr.install/claim-record "digest-idem" :rf.test/root))
 
       ;; First destroy releases everything.
-      (request/on-frame-destroyed! fid)
-      (is (nil? (request/get-request fid)))
-      (is (nil? (install/installed-payload fid)))
+      (rf.ssr.request/on-frame-destroyed! fid)
+      (is (nil? (rf.ssr.request/get-request fid)))
+      (is (nil? (rf.ssr.install/installed-payload fid)))
 
       ;; Second destroy MUST be a no-op — no throw, no spurious state
       ;; change, no extra trace emission.
-      (is (nil? (request/on-frame-destroyed! fid))
+      (is (nil? (rf.ssr.request/on-frame-destroyed! fid))
           "second destroy returns nil cleanly")
-      (is (nil? (request/get-request fid))
+      (is (nil? (rf.ssr.request/get-request fid))
           "request-slot still empty after second destroy")
-      (is (nil? (install/installed-payload fid))
+      (is (nil? (rf.ssr.install/installed-payload fid))
           "payload claim still released after second destroy"))))
 
 ;; ===========================================================================
@@ -132,30 +132,30 @@
           fid-b :rf.test/iso-frame-b]
       ;; Populate both frames identically.
       (doseq [fid [fid-a fid-b]]
-        (request/set-request! fid {:uri (str "/" (name fid))
+        (rf.ssr.request/set-request! fid {:uri (str "/" (name fid))
                                    :request-method :get})
-        (response/swap-response! fid (fn [r] (assoc r :status 200)))
-        (swap! error-listener/pending-error-traces
+        (rf.ssr.response/swap-response! fid (fn [r] (assoc r :status 200)))
+        (swap! rf.ssr.error-listener/pending-error-traces
                update fid (fnil conj [])
                {:op-type :error :operation :rf.error/iso-probe})
-        (swap! install/installed-payloads
-               assoc fid (install/claim-record "digest-iso" :rf.test/root)))
+        (swap! rf.ssr.install/installed-payloads
+               assoc fid (rf.ssr.install/claim-record "digest-iso" :rf.test/root)))
 
       ;; Destroy ONLY fid-a.
-      (request/on-frame-destroyed! fid-a)
+      (rf.ssr.request/on-frame-destroyed! fid-a)
 
       ;; fid-a cleared.
-      (is (nil? (request/get-request fid-a)))
-      (is (not (contains? @response/response-slots fid-a)))
-      (is (not (contains? @error-listener/pending-error-traces fid-a)))
-      (is (nil? (install/installed-payload fid-a)))
+      (is (nil? (rf.ssr.request/get-request fid-a)))
+      (is (not (contains? @rf.ssr.response/response-slots fid-a)))
+      (is (not (contains? @rf.ssr.error-listener/pending-error-traces fid-a)))
+      (is (nil? (rf.ssr.install/installed-payload fid-a)))
 
       ;; fid-b untouched.
-      (is (some? (request/get-request fid-b))
+      (is (some? (rf.ssr.request/get-request fid-b))
           "fid-b's request-slot survived fid-a's destroy")
-      (is (contains? @response/response-slots fid-b)
+      (is (contains? @rf.ssr.response/response-slots fid-b)
           "fid-b's response-slot survived fid-a's destroy")
-      (is (contains? @error-listener/pending-error-traces fid-b)
+      (is (contains? @rf.ssr.error-listener/pending-error-traces fid-b)
           "fid-b's pending-error-traces survived fid-a's destroy")
-      (is (some? (install/installed-payload fid-b))
+      (is (some? (rf.ssr.install/installed-payload fid-b))
           "fid-b's payload claim survived fid-a's destroy"))))

--- a/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
@@ -56,9 +56,9 @@
                                    laptop."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core             :as rf]
-            [re-frame.frame            :as frame]
-            [re-frame.ssr              :as ssr]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.frame            :as rf.frame]
+            [re-frame.ssr              :as rf.ssr]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]))
 
 ;; ---- runtime reset --------------------------------------------------------
 ;;
@@ -66,7 +66,7 @@
 ;; (rf2-i3qc0). One source of truth for the registrar/side-channel/ns-reload
 ;; cycle every ssr-artefact JVM test runs between :each.
 
-(use-fixtures :each tf/reset-runtime)
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---- side-channel probes --------------------------------------------------
 
@@ -120,7 +120,7 @@
   frames are gensym'd under `:rf.frame/*`; if any survive past their
   request's `destroy-frame!`, the count grows here."
   []
-  (disj (frame/frame-ids) :rf/default))
+  (disj (rf.frame/frame-ids) :rf/default))
 
 ;; ---- the per-request SSR flow under test ---------------------------------
 
@@ -142,13 +142,13 @@
   Returns the rendered HTML for sanity-check assertions."
   [i]
   (let [server-frame
-        (frame/make-anon-frame-record!
+        (rf.frame/make-anon-frame-record!
           {:doc       (str "load-test request " i)
            :platform  :server
            :initial-events [[:load-test/server-init {:i i}]]})]
     ;; Step 2 — populate the per-frame request slot. Exercises the SSR
     ;; side-channel atom we just wired the destroy hook for.
-    (ssr/set-request! server-frame
+    (rf.ssr/set-request! server-frame
                       {:uri            (str "/load/" i)
                        :request-method :get
                        :headers        {"user-agent" "load-test"}})
@@ -157,7 +157,7 @@
                  (rf/render-to-string tree {:render-hash (rf/render-tree-hash tree)}))]
       ;; Step 4 — flush the response accumulator (also triggers any
       ;; pending-error-trace drain).
-      (ssr/get-response server-frame)
+      (rf.ssr/get-response server-frame)
       ;; Step 7 — destroy. Intentionally NO clear-request! call.
       (rf/destroy-frame! server-frame)
       html)))
@@ -309,7 +309,7 @@
     ;; trace-emit so we don't have to engineer a real handler failure
     ;; — the cleanup contract is the same).
     (dotimes [i 50]
-      (let [fid (frame/make-anon-frame-record!
+      (let [fid (rf.frame/make-anon-frame-record!
                   {:doc       (str "error-buffer test " i)
                    :platform  :server
                    :initial-events [[:load-test/server-init {:i i}]]})]

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -42,8 +42,8 @@
   (:require
     [clojure.string :as str]
     [re-frame.test-quiet]
-    [re-frame.test-quiet.shadow-node-cli :as cli]
-    [re-frame.test-quiet.warn-buffer :as wb]
+    [re-frame.test-quiet.shadow-node-cli :as rf.test-quiet.shadow-node-cli]
+    [re-frame.test-quiet.warn-buffer :as rf.test-quiet.warn-buffer]
     [shadow.test.env :as env]
     [shadow.test :as st]
     [cljs.test :as ct]))
@@ -67,7 +67,7 @@
   window into a fresh vector — so discarded warnings are not retained via
   a shared `subvec` backing."
   [warning-args]
-  (swap! warn-buffer wb/bound-conj warning-args))
+  (swap! warn-buffer rf.test-quiet.warn-buffer/bound-conj warning-args))
 
 (defn- replay-buffered-warnings!
   "Replay the buffered warnings to stderr, prefixed so they are
@@ -190,7 +190,7 @@
   and that copy drifted silently for as long as it existed (rf2-6r9j.76).
   What stays here is the registry lookup the cycle actually forces."
   [test-selectors]
-  (cli/select-matching-test-vars test-selectors (env/get-test-vars)))
+  (rf.test-quiet.shadow-node-cli/select-matching-test-vars test-selectors (env/get-test-vars)))
 
 (def ^:private min-tests-env-var
   "Environment variable naming this lane's test-count floor. ONE name across
@@ -204,7 +204,7 @@
 (defn- resolve-min-tests
   "`cli/parse-min-tests` over the live `process.env`, or `::cli/invalid`."
   []
-  (cli/parse-min-tests
+  (rf.test-quiet.shadow-node-cli/parse-min-tests
     (when (exists? js/process)
       (unchecked-get js/process.env min-tests-env-var))))
 
@@ -220,12 +220,12 @@
   malformed floor (configuration), 1 an under-floor lane (red)."
   [min-tests discovered-test-count]
   (cond
-    (= ::cli/invalid min-tests)
+    (= ::rf.test-quiet.shadow-node-cli/invalid min-tests)
     (do (println (str "ERROR: " min-tests-env-var " is not a non-negative"
                       " integer."))
         (println (str "  " min-tests-env-var " is the minimum number of tests"
                       " this build must run; leave it unset for the default"
-                      " of " cli/default-min-tests "."))
+                      " of " rf.test-quiet.shadow-node-cli/default-min-tests "."))
         (js/process.exit 2)
         true)
 
@@ -275,7 +275,7 @@
 
       (seq test-selectors)
       (let [matched-test-vars    (find-matching-test-vars test-selectors)
-            unmatched-selectors (cli/unmatched-selectors test-selectors
+            unmatched-selectors (rf.test-quiet.shadow-node-cli/unmatched-selectors test-selectors
                                                          matched-test-vars)]
         ;; A `--test=` selection that matches no test var must not be a
         ;; false green: `run-test-vars` over an empty set reports a 0-test
@@ -303,5 +303,5 @@
   (reset-test-data!)
   (if env/UI-DRIVEN
     (js/console.log "Waiting for UI ...")
-    (let [cli-options (cli/parse-args args)]
+    (let [cli-options (rf.test-quiet.shadow-node-cli/parse-args args)]
       (execute-cli cli-options))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_discovery_integrity_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_discovery_integrity_test.clj
@@ -35,7 +35,7 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [clojure.tools.namespace.find :as ns-find]
-            [re-frame.test-quiet.runner :as runner]))
+            [re-frame.test-quiet.runner :as rf.test-quiet.runner]))
 
 ;; ----------------------------------------------------------------------
 ;; Fixtures
@@ -87,19 +87,19 @@
   (testing "the guard reads `-d` with cognitect's own option spec and
             default, so there is no second reading to disagree with the
             first"
-    (is (= #{"test"} (runner/discovery-dirs []))
+    (is (= #{"test"} (rf.test-quiet.runner/discovery-dirs []))
         "no -d means cognitect's `(or (:dir options) #{\"test\"})`")
-    (is (= #{"test" "extra"} (runner/discovery-dirs ["-d" "test" "-d" "extra"]))
+    (is (= #{"test" "extra"} (rf.test-quiet.runner/discovery-dirs ["-d" "test" "-d" "extra"]))
         "-d accumulates, exactly as cognitect's :assoc-fn does")
-    (is (= #{"other"} (runner/discovery-dirs ["--dir=other"]))
+    (is (= #{"other"} (rf.test-quiet.runner/discovery-dirs ["--dir=other"]))
         "the long form with = is the same option")
-    (is (= #{"test"} (runner/discovery-dirs ["-n" "some.ns-test" "-e" ":slow"]))
+    (is (= #{"test"} (rf.test-quiet.runner/discovery-dirs ["-n" "some.ns-test" "-e" ":slow"]))
         "selectors narrow what RUNS, never what must be discoverable"))
 
   (testing "unparseable args stand the guard down: cognitect owns its parse
             diagnostics and exits before discovery, so there is nothing yet
             to guard"
-    (is (nil? (runner/discovery-dirs ["--no-such-flag"])))))
+    (is (nil? (rf.test-quiet.runner/discovery-dirs ["--no-such-flag"])))))
 
 ;; ----------------------------------------------------------------------
 ;; The rule
@@ -118,7 +118,7 @@
                    " left to notice. Discovered: " (pr-str discovered)))))
 
       (testing "THE GUARD: it is named, and only it"
-        (let [defects (runner/discovery-defects [(.getPath dir)])]
+        (let [defects (rf.test-quiet.runner/discovery-defects [(.getPath dir)])]
           (is (= ["unreadable_test.clj"] (defect-paths defects)))
           (is (str/includes? (complaint-for defects "unreadable_test.clj")
                              "the reader cannot read it")
@@ -146,7 +146,7 @@
             "and nothing lives there"))
 
       (testing "THE GUARD: named, with the path its declaration resolves to"
-        (let [defects (runner/discovery-defects [(.getPath dir)])]
+        (let [defects (rf.test-quiet.runner/discovery-defects [(.getPath dir)])]
           (is (= ["mislabelled_test.clj"] (defect-paths defects)))
           (is (str/includes? (complaint-for defects "mislabelled_test.clj")
                              "probe/elsewhere_test.clj")
@@ -169,7 +169,7 @@
       (testing "THE GUARD: two files cannot both spell one namespace,
                 because their paths differ"
         (is (= ["shadow_test.clj"]
-               (defect-paths (runner/discovery-defects [(.getPath dir)]))))))))
+               (defect-paths (rf.test-quiet.runner/discovery-defects [(.getPath dir)]))))))))
 
 (def ^:private duplicate-body
   (str "  (:require [clojure.test :refer [deftest is]]))\n"
@@ -191,7 +191,7 @@
             "one namespace, two files, two entries in the discovered seq"))
 
       (testing "THE GUARD: both files are named, each pointing at the other"
-        (let [defects (runner/discovery-defects [(.getPath dir)])]
+        (let [defects (rf.test-quiet.runner/discovery-defects [(.getPath dir)])]
           (is (= ["duplicate_test.clj" "duplicate_test.cljc"]
                  (defect-paths defects))
               "every colliding file is named, not just one of them")
@@ -218,10 +218,10 @@
 
           (testing "THE GUARD: uniqueness is global to the selected roots"
             (is (= ["duplicate_test.clj" "duplicate_test.clj"]
-                   (defect-paths (runner/discovery-defects
+                   (defect-paths (rf.test-quiet.runner/discovery-defects
                                    [(.getPath a) (.getPath b)])))
                 "both copies are named")
-            (is (= [] (runner/discovery-defects [(.getPath a)]))
+            (is (= [] (rf.test-quiet.runner/discovery-defects [(.getPath a)]))
                 "and either root ALONE is clean: the defect is the pairing,
                  so a single-root lane must not be reddened by it")))))))
 
@@ -233,7 +233,7 @@
     (with-tree {"probe/good_test.clj" well-formed}
       (fn [dir]
         (let [p (.getPath dir)]
-          (is (= [] (runner/discovery-defects [p (str p "/.")]))))))))
+          (is (= [] (rf.test-quiet.runner/discovery-defects [p (str p "/.")]))))))))
 
 (deftest a-well-formed-tree-has-nothing-to-say
   (testing "silent on success: the rule is a refusal, not a report"
@@ -245,13 +245,13 @@
                 "probe/not_a_test.clj"
                 (str "(ns probe.not-a-test)\n")}
       (fn [dir]
-        (is (= [] (runner/discovery-defects [(.getPath dir)]))
+        (is (= [] (rf.test-quiet.runner/discovery-defects [(.getPath dir)]))
             "nested paths, and a file the `-test` selector will skip, are
              both ordinary"))))
 
   (testing "a directory that does not exist contributes nothing, exactly as
             it does to cognitect"
-    (is (= [] (runner/discovery-defects ["no-such-directory-anywhere"]))))
+    (is (= [] (rf.test-quiet.runner/discovery-defects ["no-such-directory-anywhere"]))))
 
   (testing "and this artefact's own test tree is clean"
-    (is (= [] (runner/discovery-defects ["test"])))))
+    (is (= [] (rf.test-quiet.runner/discovery-defects ["test"])))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -48,8 +48,8 @@
   ;; anyway because shadow-node is the :node-test build's :main.
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
-            [re-frame.test-quiet.shadow-node-cli :as cli]
-            [re-frame.test-quiet.warn-buffer :as wb]))
+            [re-frame.test-quiet.shadow-node-cli :as rf.test-quiet.shadow-node-cli]
+            [re-frame.test-quiet.warn-buffer :as rf.test-quiet.warn-buffer]))
 
 ;; ----------------------------------------------------------------------
 ;; --test= selection / flag parsing.
@@ -57,27 +57,27 @@
 (deftest parse-args-test-selection
   (testing "--test= splits on comma into symbols"
     (is (= {:test-syms '[my.ns]}
-           (cli/parse-args ["--test=my.ns"]))
+           (rf.test-quiet.shadow-node-cli/parse-args ["--test=my.ns"]))
         "a single simple symbol selects a whole namespace")
     (is (= {:test-syms '[my.ns other.ns]}
-           (cli/parse-args ["--test=my.ns,other.ns"]))
+           (rf.test-quiet.shadow-node-cli/parse-args ["--test=my.ns,other.ns"]))
         "comma-separated values become multiple symbols")
     (is (= {:test-syms '[my.ns/a-test]}
-           (cli/parse-args ["--test=my.ns/a-test"]))
+           (rf.test-quiet.shadow-node-cli/parse-args ["--test=my.ns/a-test"]))
         "a qualified symbol selects a single var")
     (is (= {:test-syms '[my.ns my.ns/a-test]}
-           (cli/parse-args ["--test=my.ns,my.ns/a-test"]))
+           (rf.test-quiet.shadow-node-cli/parse-args ["--test=my.ns,my.ns/a-test"]))
         "ns and fqn selectors coexist")
     (is (= {:test-syms '[a b c d]}
-           (cli/parse-args ["--test=a,b" "--test=c,d"]))
+           (rf.test-quiet.shadow-node-cli/parse-args ["--test=a,b" "--test=c,d"]))
         "repeated --test= flags accumulate into one list")))
 
 (deftest parse-args-flags
   (testing "--list and --help set their flags and default an empty test-syms"
-    (is (= {:test-syms [] :list true} (cli/parse-args ["--list"])))
-    (is (= {:test-syms [] :help true} (cli/parse-args ["--help"]))))
+    (is (= {:test-syms [] :list true} (rf.test-quiet.shadow-node-cli/parse-args ["--list"])))
+    (is (= {:test-syms [] :help true} (rf.test-quiet.shadow-node-cli/parse-args ["--help"]))))
   (testing "no args yields the run-all default (empty test-syms, no flags)"
-    (is (= {:test-syms []} (cli/parse-args []))))
+    (is (= {:test-syms []} (rf.test-quiet.shadow-node-cli/parse-args []))))
   (testing "unknown args are collected (not printed); the pure parser does not abort"
     ;; The pure parser must NOT print on an unknown arg — it collects
     ;; them into `:unknown-args` and the real CLI path (`execute-cli`)
@@ -87,12 +87,12 @@
     ;; `(println \"Unknown arg: ...\")` here would leak a non-summary line
     ;; into every consolidated `npm run test:cljs` run.
     (is (= {:test-syms '[ok.ns] :unknown-args ["--bogus"]}
-           (cli/parse-args ["--bogus" "--test=ok.ns"]))
+           (rf.test-quiet.shadow-node-cli/parse-args ["--bogus" "--test=ok.ns"]))
         "an unknown flag is collected; later valid flags still parse")
     (is (= {:test-syms '[ok.ns] :unknown-args ["--bogus" "--nope"]}
-           (cli/parse-args ["--bogus" "--test=ok.ns" "--nope"]))
+           (rf.test-quiet.shadow-node-cli/parse-args ["--bogus" "--test=ok.ns" "--nope"]))
         "multiple unknown flags accumulate in input order")
-    (is (not (contains? (cli/parse-args ["--test=ok.ns"]) :unknown-args))
+    (is (not (contains? (rf.test-quiet.shadow-node-cli/parse-args ["--test=ok.ns"]) :unknown-args))
         "a clean arg set carries no :unknown-args key at all")))
 
 ;; ----------------------------------------------------------------------
@@ -115,7 +115,7 @@
     ;; underlying vector).
     (let [capacity 4
           buffer   (reduce (fn [current-buffer entry]
-                             (wb/bound-conj current-buffer [entry] capacity))
+                             (rf.test-quiet.warn-buffer/bound-conj current-buffer [entry] capacity))
                            []
                            (range 1000))]
       (is (= capacity (count buffer))
@@ -130,7 +130,7 @@
           "the trimmed ring is a materialised PersistentVector, not a view")))
   (testing "below the cap the ring is a plain growing vector (no trim, no Subvec)"
     (let [buffer (reduce (fn [current-buffer entry]
-                           (wb/bound-conj current-buffer [entry] 10))
+                           (rf.test-quiet.warn-buffer/bound-conj current-buffer [entry] 10))
                          []
                          (range 3))]
       (is (= [[0] [1] [2]] buffer))
@@ -141,10 +141,10 @@
     ;; so a regression that dropped the materialisation (or the cap) is caught
     ;; against the production constant, not just a synthetic tiny cap.
     (let [buffer (reduce (fn [current-buffer entry]
-                           (wb/bound-conj current-buffer [entry]))
+                           (rf.test-quiet.warn-buffer/bound-conj current-buffer [entry]))
                          []
-                         (range (* 4 wb/warn-buffer-cap)))]
-      (is (= wb/warn-buffer-cap (count buffer))
+                         (range (* 4 rf.test-quiet.warn-buffer/warn-buffer-cap)))]
+      (is (= rf.test-quiet.warn-buffer/warn-buffer-cap (count buffer))
           "the ring stays capped at the production warn-buffer-cap")
       (is (not (instance? cljs.core/Subvec buffer))
           "the production-cap ring must not degrade into a retaining Subvec"))))
@@ -174,7 +174,7 @@
                      (fake-var 'my.ns 'b-test)
                      (fake-var 'other.ns 'c-test)]
         select-syms (fn [test-selectors]
-                      (->> (cli/select-matching-test-vars test-selectors
+                      (->> (rf.test-quiet.shadow-node-cli/select-matching-test-vars test-selectors
                                                           test-vars)
                            (map (fn [test-var]
                                   (let [{test-namespace :ns test-name :name}
@@ -208,7 +208,7 @@
                (mapv (fn [test-var]
                        (let [{test-namespace :ns test-name :name} (meta test-var)]
                          (symbol (str test-namespace) (str test-name))))
-                     (cli/select-matching-test-vars many-syms many-vars)))
+                     (rf.test-quiet.shadow-node-cli/select-matching-test-vars many-syms many-vars)))
             "nine qualified selectors must select all nine of their vars")))))
 
 ;; ----------------------------------------------------------------------
@@ -231,19 +231,19 @@
         all-vars  [a-test b-test]]
     (testing "a fully-matched selection has no unmatched selectors -> runs (no exit)"
       ;; ns selector matches: my.ns has matched vars.
-      (is (= '() (cli/unmatched-selectors '[my.ns] all-vars)))
+      (is (= '() (rf.test-quiet.shadow-node-cli/unmatched-selectors '[my.ns] all-vars)))
       ;; fqn selector matches: my.ns/a-test is in the matched set.
-      (is (= '() (cli/unmatched-selectors '[my.ns/a-test] [a-test]))))
+      (is (= '() (rf.test-quiet.shadow-node-cli/unmatched-selectors '[my.ns/a-test] [a-test]))))
     (testing "--test=missing.ns (absent namespace) is reported unmatched -> guard exits nonzero"
       ;; A typo'd namespace produces a non-empty unmatched set, which the
       ;; process-level branch rejects.
-      (let [unmatched (cli/unmatched-selectors '[missing.ns] [])]
+      (let [unmatched (rf.test-quiet.shadow-node-cli/unmatched-selectors '[missing.ns] [])]
         (is (= '[missing.ns] unmatched)
             "an absent namespace selector matches nothing -> unmatched")
         (is (seq unmatched)
             "non-empty unmatched -> execute-cli takes the exit-1 branch, NOT run-test-vars")))
     (testing "--test=missing.ns/a-test (absent var) is reported unmatched -> guard exits nonzero"
-      (let [unmatched (cli/unmatched-selectors '[missing.ns/a-test] [])]
+      (let [unmatched (rf.test-quiet.shadow-node-cli/unmatched-selectors '[missing.ns/a-test] [])]
         (is (= '[missing.ns/a-test] unmatched)
             "an absent fully-qualified selector matches nothing -> unmatched")
         (is (seq unmatched)
@@ -254,11 +254,11 @@
       ;; OTHER matched vars. This is the subtle false-green: the matched-var
       ;; set is non-empty (a-test/b-test), but the SELECTOR matched nothing.
       (is (= '[my.ns/c-test]
-             (cli/unmatched-selectors '[my.ns/c-test] all-vars))
+             (rf.test-quiet.shadow-node-cli/unmatched-selectors '[my.ns/c-test] all-vars))
           "a qualified selector for an absent var is unmatched even when its ns has other matches"))
     (testing "a mix of matched + unmatched reports only the unmatched, in input order"
       (is (= '[gone.ns missing.ns/x]
-             (cli/unmatched-selectors '[my.ns gone.ns my.ns/a-test missing.ns/x]
+             (rf.test-quiet.shadow-node-cli/unmatched-selectors '[my.ns gone.ns my.ns/a-test missing.ns/x]
                                       [a-test]))
           "matched selectors drop out; unmatched ones survive in order"))))
 
@@ -282,21 +282,21 @@
   (testing "an unset or blank RF2_MIN_TESTS resolves to the default floor"
     ;; Default 1, not 0: the bound that can never go stale, since no build
     ;; legitimately ships zero tests.
-    (is (= 1 cli/default-min-tests))
-    (is (= cli/default-min-tests (cli/parse-min-tests nil)))
-    (is (= cli/default-min-tests (cli/parse-min-tests "")))
-    (is (= cli/default-min-tests (cli/parse-min-tests "   "))))
+    (is (= 1 rf.test-quiet.shadow-node-cli/default-min-tests))
+    (is (= rf.test-quiet.shadow-node-cli/default-min-tests (rf.test-quiet.shadow-node-cli/parse-min-tests nil)))
+    (is (= rf.test-quiet.shadow-node-cli/default-min-tests (rf.test-quiet.shadow-node-cli/parse-min-tests "")))
+    (is (= rf.test-quiet.shadow-node-cli/default-min-tests (rf.test-quiet.shadow-node-cli/parse-min-tests "   "))))
   (testing "a non-negative integer is honoured, with surrounding whitespace trimmed"
-    (is (= 0 (cli/parse-min-tests "0")) "0 explicitly disables the floor")
-    (is (= 1 (cli/parse-min-tests "1")))
-    (is (= 3000 (cli/parse-min-tests "3000")))
-    (is (= 3000 (cli/parse-min-tests " 3000 "))))
+    (is (= 0 (rf.test-quiet.shadow-node-cli/parse-min-tests "0")) "0 explicitly disables the floor")
+    (is (= 1 (rf.test-quiet.shadow-node-cli/parse-min-tests "1")))
+    (is (= 3000 (rf.test-quiet.shadow-node-cli/parse-min-tests "3000")))
+    (is (= 3000 (rf.test-quiet.shadow-node-cli/parse-min-tests " 3000 "))))
   (testing "a malformed value is ::invalid, never a silent fall back to the default"
     ;; The whole point of the gate is catching silent non-execution; a typo'd
     ;; floor quietly disabling it would be the same bug in a new place.
     (doseq [bad ["1O" "abc" "1.5" "-1" "1e3x" "٣"]]
       (is (= :re-frame.test-quiet.shadow-node-cli/invalid
-             (cli/parse-min-tests bad))
+             (rf.test-quiet.shadow-node-cli/parse-min-tests bad))
           (str (pr-str bad) " must be rejected, not coerced")))))
 
 ;; ----------------------------------------------------------------------

--- a/scripts/require-alias-baseline.edn
+++ b/scripts/require-alias-baseline.edn
@@ -14,7 +14,7 @@
 ;; observes. It is not a style rule: it is what stops the checker
 ;; reporting a confident zero over a corpus it has stopped being able
 ;; to read.
-{:min-edges 9784
+{:min-edges 9795
 
  :surfaces
  {
@@ -34,13 +34,13 @@
   "implementation/reply-conformance"      0
   "implementation/resources"              0
   "implementation/routing"                0
-  "implementation/schemas"                112
-  "implementation/scripts"                46
-  "implementation/security"               45
+  "implementation/schemas"                0
+  "implementation/scripts"                0
+  "implementation/security"               0
   "implementation/spec-resource"          0
-  "implementation/ssr"                    392
-  "implementation/ssr-ring"               128
-  "implementation/test-quiet"             5
+  "implementation/ssr"                    0
+  "implementation/ssr-ring"               0
+  "implementation/test-quiet"             0
   "migration"                             0
   "skills"                                0
   "testbeds"                              0


### PR DESCRIPTION
**rf2-7sx1** — slice two of the require-alias walk. Six surfaces to zero, floors lowered in the same commit.

## Per-surface floors

| surface | before | after |
|---|---:|---:|
| `implementation/ssr` | 392 | **0** |
| `implementation/ssr-ring` | 128 | **0** |
| `implementation/schemas` | 112 | **0** |
| `implementation/scripts` | 46 | **0** |
| `implementation/security` | 45 | **0** |
| `implementation/test-quiet` | 5 | **0** |
| `implementation/adapters` | 2 | 2 *(left — see below)* |

Repo-wide non-canonical **730 → 2**. Files (2801) and re-frame require edges (10884) are **identical before and after**, and the diff is 4860 insertions / 4860 deletions with no line added or removed anywhere — the shape a pure rename should have. 732 libspec sites plus 4185 use sites across 197 files.

`--write-baseline` moved exactly seven lines: the six floors, plus `:min-edges` 9784 → 9795. That rise tracks the trunk's own growth (`int(edges * 0.9)`; this rename moves the edge count by zero) and **tightens** the anti-blindness guard, which is checked as `total < min_edges -> fail`. Diffed hunk by hunk before committing; the `adapters` row and every other row are untouched.

## What I left, and why

**`implementation/adapters` stays at 2.** Those two sites are `uix_component_recipe_dom_cljs_test.cljs`, pinned byte-for-byte to a fenced block in `docs/core/testing/views.md` by `uix_component_recipe_docs_pin_test.clj`. Clearing them needs the guide in the same fence, which this change does not hold.

**Prose is out of scope; this walk is code only.** The rewrite reuses the checker's own reader-level `mask_source`, so docstrings and comments are *classified* rather than guessed at: 427 non-code hits were reported and left. That matches what the four surfaces walked before this one did — `implementation/hicasso`, walked to zero in #9334, carries 372 bare-leaf prose references against 40 canonical; `flows` 78 vs 4; `adapters` 67 vs 11. Whether the campaign should also walk prose is a separate question, and the measurement is on the bead so it can be ruled on rather than drifting.

Three literal shapes checked, each against a control sharing its shape: literal `:alias/key` keywords are values and stay (the checker's own failure hint states the rule); auto-resolved `::alias/kw` keywords denote the aliased namespace and move; **string literals were reported and none was rewritten** — and one of them shows why that is right, because `ssr_conformance_test.clj` carries `"ssr/streaming/render-shell"` as a *conformance-corpus id*, which an alias rewriter would have silently corrupted.

## Findings carried in from #9334

**Read the step list of every CI job covering the surface.** The gate that reddened #9334 lives only in a workflow job's steps and is reached by no `scripts/` sweep. For these surfaces that turned up `lint.yml :: api-manifest` (eight steps from `implementation/scripts/api-manifest`, the gate for the `scripts` surface), `test.yml :: jvm-ssr-prod-gate`, `jvm-node-crossing`, `node-ssr-node`, `js-harness-self-tests` and `cljs-bundle-isolation` — the last of which release-compiles `bundle-isolation-positive-control`, 15 of the files changed here. All were run; none is reachable from an artefact test alias.

**A chained gate reports only its first failure**, so the eight api-manifest steps were run individually rather than `&&`-chained.

**Literal source-string rosters break on rename** — `git grep -l -F 'premise:'` returns five files repo-wide, all hicasso-related, none on these surfaces. The seven `jvm-repo-source-walks` namespaces do read repo source as text, but each matches alias-*agnostically* (`egress-chokepoint` uses `(?:[a-zA-Z0-9_.-]+/)?`; `prod-gate-naming-drift` matches `^:prod-gate` / `-Dre-frame.debug=false`), and `warn-once-clear-governance` already spells its regex `(?:(?:rf\.)?late-bind/)` to accept both. All seven were run and are green; no file outside the fence needed changing.

**The apostrophe is not a symbol constituent for this rewrite.** `'alias/foo` and `#'alias/foo` are genuine references and must move, while `foo'alias/bar` must not — so the apostrophe is *walked* rather than classed. The lookbehind was exercised in both directions on a fixture before anything was rewritten: 12/12 positives found (`'`, `#'`, `@`, `~`, `` ` ``, `::`), 8/8 negatives skipped (`:alias/key`, fully-qualified, `myalias/`, `my-alias/`, `my.alias/`, `foo'h/bar`, `a/alias/b`).

## Gates

Every exit code below was captured on the same command line as its redirect, and **all were re-run on the final rebased base** — the rebase brought in `.beads/issues.jsonl` only, but a pre-rebase green is evidence about a tree that no longer exists.

| gate | exit | result |
|---|---:|---|
| `check_require_alias_dialect.py --self-test` | 0 | 79 passed, 0 failed |
| `check_require_alias_dialect.py --verbose` | 0 | 2801 files, 10884 edges, 2 non-canonical, every surface at or under floor |
| JVM `implementation/ssr` | 0 | 634 tests / 4170 assertions |
| JVM `implementation/ssr-ring` | 0 | 231 tests / 1164 assertions |
| JVM `implementation/schemas` | 0 | 381 tests / 19283 assertions |
| JVM `implementation/security` | 0 | 92 tests / 725 assertions |
| JVM `implementation/test-quiet` | 0 | 53 tests / 275 assertions |
| `jvm-ssr-prod-gate` (`-Dre-frame.debug=false`) | 0 | 636 tests / 4004 assertions, whole suite, no exclusions |
| `jvm-node-crossing` (`-M:crossing-test`) | 0 | 10 tests / 107 assertions |
| `lint.yml :: api-manifest`, 7 mains + `-M:test` | 0 ×8 | manifest in sync (538 vars); API.md 174; story 69; xray 23; skills 578; doc-guide 820; doc-api 317; 98 tests / 194 assertions |
| `jvm-repo-source-walks`, 7 namespaces | 0 ×7 | 50 tests / 881 assertions |
| node-test compile | 0 | 1907 files, **0 warnings** |
| node-test run | 0 | 11300 tests / 57023 assertions |
| `test:ssr-node` | 0 | 9 suites green |
| `test:scripts` | 0 | 123 tests, 123 pass, 0 fail |
| `test:bundle-isolation` | 0 | 23 artefacts; 40 positive-control sentinels present; 83 example sources isolated |
| `test:schemas-bundle` | 0 | margin 39.8 KB within 20.0–44.0 KB |
| `test:elision` | 0 | production 56/56 absent, control 56/56 present |
| all 43 `scripts/*.py` gates | 0 ×43 | 43 green |
| `check-ai-tracking-ratchet.sh` | 0 | nothing under `ai/` tracked |
| `check-no-hardcoded-paths.sh` | 0 | clean |
| `check-beads-pr-boundary.sh` | 0 | no beads-database paths in this diff |
| `clj-kondo` (implementation, examples, testbeds) | 3 | **unchanged from main** — see below |
| `clojure -M:splint --fail-on-errors` | 0 | 2561 files |

**clj-kondo needs its own sentence, because a raw exit code misreads it.** It exits 3 on this branch *and on unmodified main*, from two pre-existing errors in files this change does not touch (`spine_dispose_cljs_test.cljs`, `epoch_egress_redaction_cljs_test.cljc` — both byte-identical to `origin/main` here). Run on both trees: **1566 findings before, 1566 after**, `errors: 2, warnings: 1564` either way. Diffing the two sets, the 22 lines that differ are one-to-one the *same* findings re-reported under the new alias with shifted columns (`ssr-ring/stream-handler` → `rf.ssr.ring/stream-handler`; `Unresolved symbol: port` at col 23 → col 45). Zero new findings from 4860 renamed lines.

## How each gate was proved to have read this branch's tree

Two routes, per what each gate affords.

**It printed its root.** shadow-cljs named the config path under this branch's checkout on every compile; `check-bundle-isolation`, `check-uix-reagent-free`, `check-login-bundle-isolation` and `check-elision` each printed the `out/` bundle path under it.

**A planted fault came back red naming what was planted.** Three plants, each restored and each restore verified by git *blob* hash against the committed object rather than by reading a diff:

1. Reverting one libspec to `[re-frame.ssr.boot :as boot]` reddened the ratchet at exit 1, naming file, line and libspec — **against a floor of 0 that exists only on this branch**. On main, where that floor is 392, the identical plant is green, so this discriminates rather than merely correlates.
2. A typo'd use site reddened the node-test compile at exit 1 naming `rf.test-quiet.warn-bufferXX/bound-conj` at its line.
3. A typo'd use site in the JVM-loaded `.clj` reddened `implementation/test-quiet`'s JVM lane at exit 1 with `ClassNotFoundException ... rf.test-quiet.runnerXX`.

**Plant 2 exists because plant 3's first attempt came back green, and that is worth recording.** The first JVM plant was placed in a `.cljs` file: the hash proved the source changed, the lane ran green, and the reason is that the JVM lane never reads that file. A green sabotage run is a stop signal, so the plant was re-aimed at the runtime that does see it. The hash alone would not have caught this.

## Revert-shape check

`git diff --name-only <merge-base> origin/main` reports **one** path since this branch's base — `.beads/issues.jsonl` — against 198 here, intersection 0. `comm` against itself returns 1 of 1 and both inputs pass `sort -c`, so the zero is measured rather than an artefact of unsorted input. Nothing a sibling landed is reverted here.
