### PR TITLE
refactor(adapters): the UIx component-test recipe takes the canonical require-alias dialect (rf2-7sx1)

### DIFF
--- a/docs/core/testing/views.md
+++ b/docs/core/testing/views.md
@@ -106,8 +106,8 @@ Everything above calls a view as a function. A UIx `defui` that reads `use-subsc
             [uix.core :refer [$ defui]]
             [uix.dom :as uix-dom]
             [re-frame.core :as rf]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.test-support :as ts]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; -- The app under test ------------------------------------------------------
 ;; In your project these live in your events / subs / views namespaces —
@@ -124,8 +124,8 @@ Everything above calls a view as a function. A UIx `defui` that reads `use-subsc
   (fn [db _] (:recipe.counter/value db)))
 
 (defui counter []
-  (let [n                  (uix-adapter/use-subscribe [:recipe.counter/value])
-        {:keys [dispatch]} (uix-adapter/use-frame)]
+  (let [n                  (rf.adapter.uix/use-subscribe [:recipe.counter/value])
+        {:keys [dispatch]} (rf.adapter.uix/use-frame)]
     ($ :div
        ($ :span {:data-testid "counter-value"} n)
        ($ :button {:data-testid "counter-inc"
@@ -139,8 +139,8 @@ Everything above calls a view as a function. A UIx `defui` that reads `use-subsc
 ;; `(async done …)` test requires.
 
 (use-fixtures :each
-  (ts/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      :init-fn #(rf/dispatch-sync [:recipe.counter/init])
      :async?  true}))
 
@@ -162,7 +162,7 @@ Everything above calls a view as a function. A UIx `defui` that reads `use-subsc
    rejects with `:rf.error/poll-until-timeout` when it never does."
   [pred label]
   (act-environment! false)
-  (.finally (ts/poll-until pred {:label label})
+  (.finally (rf.test-support/poll-until pred {:label label})
             #(act-environment! true)))
 
 (defn- mount!
@@ -178,9 +178,9 @@ Everything above calls a view as a function. A UIx `defui` that reads `use-subsc
     (.appendChild js/document.body node)
     (try
       (act-environment! true)
-      (uix-adapter/flush-views!
+      (rf.adapter.uix/flush-views!
         #(uix-dom/render-root
-           ($ uix-adapter/frame-provider {:frame :rf/default} element)
+           ($ rf.adapter.uix/frame-provider {:frame :rf/default} element)
            root))
       {:node node :root root :act-prev act-prev}
       (catch :default e
@@ -190,7 +190,7 @@ Everything above calls a view as a function. A UIx `defui` that reads `use-subsc
 
 (defn- unmount! [{:keys [node root act-prev]}]
   (try
-    (uix-adapter/flush-views! #(uix-dom/unmount-root root))
+    (rf.adapter.uix/flush-views! #(uix-dom/unmount-root root))
     (finally
       ;; Even when React's unmount or an effect cleanup throws, the node
       ;; leaves the page and the act flag goes back to what `mount!` found.
@@ -214,7 +214,7 @@ Everything above calls a view as a function. A UIx `defui` that reads `use-subsc
         ;; Drive the dataflow and settle React in one step: `dispatch-sync`
         ;; runs the event now, and act() commits the re-render before
         ;; `flush-views!` returns.
-        (uix-adapter/flush-views! #(rf/dispatch-sync [:recipe.counter/inc]))
+        (rf.adapter.uix/flush-views! #(rf/dispatch-sync [:recipe.counter/inc]))
         (is (= "1" (text node "counter-value")))
         (finally
           (unmount! mounted))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_component_recipe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_component_recipe_dom_cljs_test.cljs
@@ -12,8 +12,8 @@
             [uix.core :refer [$ defui]]
             [uix.dom :as uix-dom]
             [re-frame.core :as rf]
-            [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.test-support :as ts]))
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.test-support :as rf.test-support]))
 
 ;; -- The app under test ------------------------------------------------------
 ;; In your project these live in your events / subs / views namespaces —
@@ -30,8 +30,8 @@
   (fn [db _] (:recipe.counter/value db)))
 
 (defui counter []
-  (let [n                  (uix-adapter/use-subscribe [:recipe.counter/value])
-        {:keys [dispatch]} (uix-adapter/use-frame)]
+  (let [n                  (rf.adapter.uix/use-subscribe [:recipe.counter/value])
+        {:keys [dispatch]} (rf.adapter.uix/use-frame)]
     ($ :div
        ($ :span {:data-testid "counter-value"} n)
        ($ :button {:data-testid "counter-inc"
@@ -45,8 +45,8 @@
 ;; `(async done …)` test requires.
 
 (use-fixtures :each
-  (ts/make-reset-runtime-fixture
-    {:adapter uix-adapter/adapter
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter
      :init-fn #(rf/dispatch-sync [:recipe.counter/init])
      :async?  true}))
 
@@ -68,7 +68,7 @@
    rejects with `:rf.error/poll-until-timeout` when it never does."
   [pred label]
   (act-environment! false)
-  (.finally (ts/poll-until pred {:label label})
+  (.finally (rf.test-support/poll-until pred {:label label})
             #(act-environment! true)))
 
 (defn- mount!
@@ -84,9 +84,9 @@
     (.appendChild js/document.body node)
     (try
       (act-environment! true)
-      (uix-adapter/flush-views!
+      (rf.adapter.uix/flush-views!
         #(uix-dom/render-root
-           ($ uix-adapter/frame-provider {:frame :rf/default} element)
+           ($ rf.adapter.uix/frame-provider {:frame :rf/default} element)
            root))
       {:node node :root root :act-prev act-prev}
       (catch :default e
@@ -96,7 +96,7 @@
 
 (defn- unmount! [{:keys [node root act-prev]}]
   (try
-    (uix-adapter/flush-views! #(uix-dom/unmount-root root))
+    (rf.adapter.uix/flush-views! #(uix-dom/unmount-root root))
     (finally
       ;; Even when React's unmount or an effect cleanup throws, the node
       ;; leaves the page and the act flag goes back to what `mount!` found.
@@ -120,7 +120,7 @@
         ;; Drive the dataflow and settle React in one step: `dispatch-sync`
         ;; runs the event now, and act() commits the re-render before
         ;; `flush-views!` returns.
-        (uix-adapter/flush-views! #(rf/dispatch-sync [:recipe.counter/inc]))
+        (rf.adapter.uix/flush-views! #(rf/dispatch-sync [:recipe.counter/inc]))
         (is (= "1" (text node "counter-value")))
         (finally
           (unmount! mounted))))))

--- a/scripts/require-alias-baseline.edn
+++ b/scripts/require-alias-baseline.edn
@@ -22,7 +22,7 @@
   "bench"                                 0
   "docs"                                  0
   "examples"                              0
-  "implementation/adapters"               2
+  "implementation/adapters"               0
   "implementation/core"                   0
   "implementation/derivation-conformance" 0
   "implementation/epoch"                  0


### PR DESCRIPTION
rf2-7sx1 — the closing slice. Every surface in `scripts/require-alias-baseline.edn` now reads 0 against a floor of 0.

## The two sites, and what shape they turned out to be

Both were in ONE file, `implementation/adapters/uix/test/re_frame/adapter/uix_component_recipe_dom_cljs_test.cljs`, lines 15–16:

| namespace | was | now |
|---|---|---|
| `re-frame.adapter.uix` | `:as uix-adapter` | `:as rf.adapter.uix` |
| `re-frame.test-support` | `:as ts` | `:as rf.test-support` |

Neither is the bare-leaf shape that dominated the earlier slices, and neither is the `:as h` shape a pre-dispatch guess had looked for — one is a hyphenated compound (`uix-adapter`) and the other a two-letter contraction (`ts`). Nine use sites moved with them (7 `uix-adapter/`, 2 `ts/`). Every other file in the same test tree already spells both namespaces the canonical way.

**The gate does not have to be guessed at when a surface is ABOVE its floor.** `check_require_alias_dialect.py`'s above-floor branch prints `path:line`, the offending libspec and the canonical alias — verified by planting one (below). What it does not print is a roster for a surface sitting exactly AT a non-zero floor, which is the state this bead was parked in; that run exits 0 and says nothing. Locating the two therefore meant driving the checker's own `scan_paths` / `violations_of` over the tracked corpus, which is the reliable route and takes seconds.

## The doc pin forced a two-file change

`implementation/adapters/uix/test/re_frame/adapter/uix_component_recipe_docs_pin_test.clj` holds the fenced `clojure` block in `docs/core/testing/views.md` §4 to that recipe file byte for byte (line endings normalised). So the guide's block moves in the same commit; the page's fence body was regenerated from the recipe rather than hand-edited, and the pin re-verified after.

Nothing else on that page changes. The §1–§3 snippets are independent examples that also spell `[re-frame.test-support :as ts]`; they are prose, not scanned by this ratchet, and they belong to rf2-gbuh's open prose question rather than to this slice. Same for `implementation/adapters/uix/README.md`'s `:as uix-adapter` snippet and the `(require '[re-frame.adapter.uix :as uix])` inside the adapter's own docstring — both are masked out of the scan by construction, both deliberately left.

## Baseline

`implementation/adapters` **2 → 0**, written by `--write-baseline` (monotonic since rf2-ydpr) and diffed hunk by hunk: exactly one line changed. Removing the two sites drops the surface below its floor, which reds the ratchet from the other side, so the floor had to come down in this commit.

`:min-edges` is **unchanged at 9795**. A rename moves no edges — 10884 observed, `int(10884 * 0.9)` is still 9795.

Repo-wide after: **2803 files, 10884 re-frame require edges, 0 non-canonical**, every one of the 27 surfaces at 0/0.

The diff is 23 insertions / 23 deletions with no line added or removed anywhere, which is what a pure rename should look like.

## Gates — exit codes captured on the same command line as the redirect

Re-run on the final rebased base unless noted.

| gate | exit |
|---|---|
| `python scripts/check_require_alias_dialect.py` | 0 |
| `python scripts/check_require_alias_dialect.py --self-test` | 0 (79 passed, 0 failed) |
| `clojure -M:test` in `implementation/adapters/uix` (where the doc pin runs) | 0 (4 tests / 34 assertions) |
| `clojure -M:test` in `implementation/adapters/reagent-slim` | 0 (10 tests / 10 assertions) |
| `clojure -M:test` in `implementation/adapters/reagent` | 0 (declared classpath probe) |
| `npm run test:cljs` | 0 (11313 tests / 57074 assertions; compile 1909 files, 0 warnings) |
| `npx shadow-cljs compile browser-test` | 0 (1026 files; 5 pre-existing `:infer-warning`s in an untouched hicasso test, none in the changed file) |
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_readme_links.py --ci` | 0 |
| `python -m mkdocs build --strict` | 0 |
| all 42 `scripts/check_*.py` gates run bare | 0 each |
| `scripts/check-ai-tracking-ratchet.sh` | 0 |
| `scripts/check-no-hardcoded-paths.sh` | 0 |
| `scripts/check-beads-pr-boundary.sh origin/main` | 0 |
| `scripts/check-commit-attribution.sh origin/main` | 0 |
| `python scripts/lint_kondo.py` | 0 (errors 0; no finding names the changed file) |

**Both lanes were exercised with a plant, because one plant cannot speak for two.** Committing first, then:

- **doc pin / JVM lane** — replaced `rf.test-support/poll-until pred` inside the pinned fence of `views.md` (anchor matched exactly 1 line) with `PLANTED-FAULT/poll-until pred`. The uix JVM lane went to **exit 1**, `FAIL in (views-page-shows-the-recipe-verbatim)`, the failure text naming the plant. Restored with `git checkout HEAD --`, blob hash back to `348deab3dae5c958eb77c7d50cd931360390d4c6`.
- **ratchet** — rewrote `re-frame.adapter.uix :as rf.adapter.uix` to `:as planted-uixa` in `implementation/adapters/uix/testbed/adapter_testbed_uix/core.cljs` (anchor matched exactly 1). The ratchet went to **exit 1** on `implementation/adapters: 1 violation(s), floor 0`, naming `core.cljs:14`. Restored, blob hash back to `40bab9e5770dc4c3a9960956fb906db50e944a7b`.

Both plants named the worktree under test, so both gates read this tree.

**Two gates that cover this page do not cover this change, and the doc pin is why that is fine.** `check_doc_slugs.py` and `check_readme_links.py` share an extractor that strips fenced blocks before reading a link, so a change confined to the pinned fence is invisible to both; `mkdocs build --strict` builds the page but grades anchors at INFO. Passing them shows nothing regressed elsewhere on the page. The byte-for-byte pin test is what actually covers the change, and it is the plant above.

Compile evidence that the renamed aliases resolve, rather than merely parse: the file is compiled into both the `:node-test` build (its ns matches `cljs-test$`) and the `:browser-test` build (`.*-dom-cljs-test$`), and the browser-test output resolves `rf.test-support/make-reset-runtime-fixture` → `re_frame.test_support.make_reset_runtime_fixture` and `rf.adapter.uix/flush-views!` → `re_frame.adapter.uix.flush_views_BANG_`, with zero occurrences of the old munged names.

Revert-shape: `origin/main` moved one path since the merge base (`.beads/issues.jsonl`) against this branch's three; intersection empty.

## What this does not close

The ratchet reads only tracked `.clj` / `.cljs` / `.cljc`. A roster of zeros means THE CODE carries one dialect; it says nothing about prose, which is rf2-gbuh. The bead stays open for the mayor to close.
