### PR TITLE
docs(method): the done-check sweep reads whole commit messages, not subjects

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -853,6 +853,22 @@ reads every open item, so this is where the check belongs in BULK, before a disp
 on it. The sweep is one command — for each open id, search the trunk's merged history for that
 id — and it costs a minute against a backlog of any size.
 
+**Search the whole commit MESSAGE, not the subject line.** Formatting that history to subjects
+alone is the obvious way to write this sweep, and it fails OPEN. A change whose subject describes
+the work without naming the item returns zero — and zero is the answer that causes a dispatch,
+indistinguishable on screen from a correct one. Measured: a sweep in that form reported an item
+outstanding whose work had already merged, and a worker was spent establishing that; re-running it
+over full messages surfaced four further open items already named on the trunk, one of them
+verified done at source minutes later. Where an identifier goes is a house style nobody enforces,
+so assume the body.
+
+**Two mechanics make the corrected form right rather than merely wider.** A body is multi-line, so
+a line-oriented search over full messages splits one change across several records and attributes
+an identifier to a neighbouring commit — flatten each change to one record before matching. And
+where identifiers share a prefix, a fixed-string match for the shorter one also matches every
+longer sibling, inflating a hit count for an item that has none; anchor the match so the
+identifier must end where it ends.
+
 **But a matching commit is a POINTER, never a closure.** Some hits are partial work; some are
 the very change the item was filed AGAINST, which is a fact the item's own title usually
 carries in a word like *still*. Closing on a subject match is the same error one level up —


### PR DESCRIPTION
`loops.md` §3 tells the mayor, in its backlog-reread body, to check whether an open item's work has already landed: *"The sweep is one command — for each open id, search the trunk's merged history for that id."* It does not say **where in the history**, and the obvious reading — format the log to subject lines — **fails open**.

## What was measured, today

A sweep in that form reported `rf2-kuky.5` outstanding. Its work had merged as `f18aa19c7b`, whose subject is *"refactor(egress): explicit :frame nil is sayable and fails closed; rf/sensitive? fails closed"* — naming no bead at all. The id sits in the commit **body**, which `%s` cannot see. A worker was dispatched at the bead and spent its cycle establishing that the premise was false.

Re-running the same sweep over full messages surfaced **four further open beads already named on the trunk**, one of which (`rf2-kuky.56`) was then verified at source — the UIx adapter does publish `client-root` / `render!` / `unmount!` — and closed.

The failure is silent in the way this document warns about generally: zero is the answer that causes a dispatch, and nothing on screen distinguishes it from a correct zero.

## Why the second paragraph is there

Both of its mechanics were hit while correcting the first:

- a line-oriented search over multi-line bodies splits one commit across several records and attributes an id to a **neighbouring** commit;
- a fixed-string match for a prefix id also matches its longer siblings — `rf2-kuky.2` reported ten hits, which belonged to `.20`, `.21` and `.23`.

Widening the search without those two makes the sweep wrong in a new direction rather than right.

## Scope

One file, 16 insertions, 0 deletions. No existing sentence reworded; the correction is additive, immediately beneath the sentence it qualifies. This is §6's own category — *a hazard recorded without the test that discharges it* — and §6 says to fix the document rather than note it.

## Quality gates

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_readme_links.py --ci` | **0** |
| `python -m mkdocs build --strict` | **0** |

`docs/the-mayor-method/` is inside `docs_dir` and is **not** in `mkdocs.yml`'s `exclude_docs`; the strict build's own page list names `the-mayor-method\loops.md`, so the run covers the edited file rather than skipping it. The change adds no links, no anchors and no fenced blocks, so the fence-blindness both link gates share does not apply to it.