### PR TITLE
refactor(story,machines): one exception collector, one dedup adder (rf2-soie, rf2-3oyn)

### DIFF
--- a/implementation/machines/src/re_frame/machines/cofx_attach.cljc
+++ b/implementation/machines/src/re_frame/machines/cofx_attach.cljc
@@ -500,6 +500,43 @@
 ;; diet` route on it.
 (def ^:private after-elapsed-event-id :rf.machine.timer/after-elapsed)
 
+(defn- dedup-adder
+  "Returns the `add!` closure every ensure-set walk in this namespace
+  shares: conj each entry of a `parse-requires`-shaped `diet` onto `acc`
+  unless its `:id` is already in `seen-ids`.
+
+  THE DEDUP CONTRACT, stated once so all three walks (flat/compound
+  scope, parallel region union, initial-descent birth set) cannot drift
+  apart: THE KEY IS `:id`, AND FIRST OCCURRENCE WINS. A later entry
+  carrying an `:id` already seen is dropped whole — not merged, not
+  replacing the entry already accumulated. That is what makes the
+  ensure-set declaration-order-insensitive, which the walks' own
+  docstrings promise: a fact reachable from two candidate transitions is
+  ensured once, and the set does not depend on which walk order reached
+  it first.
+
+  Mutation note. Both args are `volatile!`s the CALLER binds and reads
+  back (`@acc` at the walk's edge, once, to materialise the result);
+  this closure only ever writes them. They are volatiles rather than
+  atoms because the walk is single-threaded, local and never escapes —
+  and volatiles rather than a bare loop accumulator because `add!` is
+  called from several mutually-recursive helpers that take it as an
+  argument, so there is no single reduction to thread a value through.
+  Note that `acc` and `seen-ids` hold PERSISTENT collections (a vector
+  and a set), so `vswap!` here is threading an ordinary `conj` return;
+  the stricter case — a `volatile!` wrapping a TRANSIENT, where
+  discarding `conj!`/`assoc!`'s return loses writes past the array-map
+  promotion — is the one documented at length in
+  `re-frame.source-coords`. The local `diet` transients built by the
+  callers below are materialised with `persistent!` before they reach
+  `add!`."
+  [seen-ids acc]
+  (fn [diet]
+    (doseq [{:keys [id] :as e} diet]
+      (when-not (contains? @seen-ids id)
+        (vswap! seen-ids conj id)
+        (vswap! acc conj e)))))
+
 (defn- on-done-diet-for-event
   "Add (into `add!`) the `:on-done` guard/action diets of the completed node a
   raised done event targets. `event` is `[:rf.machine/done
@@ -598,11 +635,7 @@
   (let [event-id (when (vector? event) (first event))
         acc      (volatile! [])
         seen-ids (volatile! #{})
-        add!     (fn [diet]
-                   (doseq [{:keys [id] :as e} diet]
-                     (when-not (contains? @seen-ids id)
-                       (vswap! seen-ids conj id)
-                       (vswap! acc conj e))))
+        add!     (dedup-adder seen-ids acc)
         add-always! (fn [tgt] (add! (always-diet-for-state by-entry states tgt)))
         ;; Accumulate a lifecycle (`:entry`/`:exit`) slot's named-action diet
         ;; along a path into a transient, then add! it deduped.
@@ -776,11 +809,7 @@
           ;; separately — `root-on-match` / `root-after-match`), deduped by id.
           (let [acc      (volatile! [])
                 seen-ids (volatile! #{})
-                add!     (fn [diet]
-                           (doseq [{:keys [id] :as e} diet]
-                             (when-not (contains? @seen-ids id)
-                               (vswap! seen-ids conj id)
-                               (vswap! acc conj e))))]
+                add!     (dedup-adder seen-ids acc)]
             (doseq [[region region-state] state
                     :let [body  (get-in machine [:regions region])
                           scope (:states body)
@@ -834,11 +863,7 @@
       []
       (let [acc      (volatile! [])
             seen-ids (volatile! #{})
-            add!     (fn [diet]
-                       (doseq [{:keys [id] :as e} diet]
-                         (when-not (contains? @seen-ids id)
-                           (vswap! seen-ids conj id)
-                           (vswap! acc conj e))))
+            add!     (dedup-adder seen-ids acc)
             add-scope! (fn [scope initial-decl]
                          (when-let [ipath (initial-path-for-scope scope initial-decl)]
                            (let [diet (transient [])]

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -202,6 +202,67 @@
   {:operation  (:operation tev)
    :failing-id (get-in tev [:tags :failing-id])})
 
+(defn- exception-collector
+  "Returns `{:listener _ :drain! _}` for one lifecycle-phase walk over
+  frame `id`: a private pending queue, the trace listener that fills it,
+  and the drain that projects its contents onto `[:rf.story/assertions]`
+  as `:rf.error/exception` records stamped with `phase` (see
+  `phase-exception-record` for the phase keywords).
+
+  WHY A MUTABLE QUEUE, and why it may not be threaded functionally.
+  re-frame's interceptor chain catches handler exceptions internally and
+  emits `:rf.error/handler-exception` trace events rather than
+  re-throwing (per `runtime/capture-phase-errors` and `spec/009` §Error
+  trace), so the projection path has to read failures off the TRACE
+  STREAM. They arrive as a side-channel between dispatches — nothing in
+  `dispatch-sync`'s return carries them — so the walk needs a cell that
+  outlives a single dispatch. The queue is function-local, never escapes,
+  and is drained to empty before the walk returns.
+
+  `:listener` — pass to the walk's `with-*-trace-listener`. It captures
+  every pipeline exception (handler / coeffect / interceptor) targeting
+  `id`, not just handler-exception: a phase event whose cofx injector or
+  user interceptor throws is a first-class failure too.
+
+  `:drain!` — THE ORDERING CONTRACT, which governs every call site.
+  Call it after EVERY dispatch inside the listener-bound walk, and once
+  more after the listener unbinds (belt-and-braces: `dispatch-sync`
+  should have delivered everything already, but the trailing drain costs
+  nothing). Two properties are load-bearing:
+
+  (i) it empties the queue BEFORE projecting, so a capture arriving
+      re-entrantly from the projection dispatch is neither lost nor
+      drained twice;
+
+  (ii) it projects earlier failures BEFORE the next phase event runs, so
+       an event that reads the assertions slot — e.g. an outer
+       decorator's `:teardown` — sees them already landed. That is the
+       spec's \"land in the variant's last `:rf.story/assertions`
+       record\" contract for in-order observability.
+
+  Each captured event keeps its `:operation` / `:failing-id` attribution
+  via `pipeline-event-opts`. A projection dispatch that itself throws is
+  swallowed: the walk records what it can and never aborts
+  `destroy-frame!`."
+  [id phase]
+  (let [pending (atom [])]
+    {:listener (fn [ev]
+                 (when (rf.story.error/pipeline-exception-event? id ev)
+                   (swap! pending conj ev)))
+     :drain!   (fn []
+                 (when-let [evs (seq @pending)]
+                   (reset! pending [])
+                   (doseq [tev evs]
+                     (let [record (phase-exception-record
+                                    id phase
+                                    (get-in tev [:tags :event])
+                                    (get-in tev [:tags :exception])
+                                    (pipeline-event-opts tev))]
+                       (try
+                         (rf/dispatch-sync [::append-teardown-assertion record]
+                                           {:frame id})
+                         (catch #?(:clj Throwable :cljs :default) _ nil))))))}))
+
 ;; ---- :frame-setup decorator application ---------------------------------
 
 ;; Why a trace listener rather than a try/catch: re-frame's interceptor
@@ -246,24 +307,7 @@
   so every setup failure is recorded."
   [frame-id frame-setup-decorators]
   (when (seq frame-setup-decorators)
-    (let [pending  (atom [])
-          drain!   (fn []
-                     (when-let [evs (seq @pending)]
-                       (reset! pending [])
-                       (doseq [tev evs]
-                         (let [orig-event (get-in tev [:tags :event])
-                               err        (get-in tev [:tags :exception])
-                               record     (phase-exception-record
-                                            frame-id :phase-0-setup
-                                            orig-event err
-                                            (pipeline-event-opts tev))]
-                           (try
-                             (rf/dispatch-sync [::append-teardown-assertion record]
-                                               {:frame frame-id})
-                             (catch #?(:clj Throwable :cljs :default) _ nil))))))
-          listener (fn [ev]
-                     (when (rf.story.error/pipeline-exception-event? frame-id ev)
-                       (swap! pending conj ev)))]
+    (let [{:keys [listener drain!]} (exception-collector frame-id :phase-0-setup)]
       (with-setup-trace-listener
         listener
         (fn []
@@ -294,20 +338,7 @@
                                           {:frame frame-id})
                         (catch #?(:clj Throwable :cljs :default) _ nil)))))
                 (drain!))))))
-      ;; Final drain — catch any trace events delivered after the last
-      ;; dispatch inside the listener-bound region (belt-and-braces).
-      (let [collected @pending]
-        (reset! pending [])
-        (doseq [tev collected]
-          (let [orig-event (get-in tev [:tags :event])
-                err        (get-in tev [:tags :exception])
-                record     (phase-exception-record
-                             frame-id :phase-0-setup orig-event err
-                             (pipeline-event-opts tev))]
-            (try
-              (rf/dispatch-sync [::append-teardown-assertion record]
-                                {:frame frame-id})
-              (catch #?(:clj Throwable :cljs :default) _ nil))))))))
+      (drain!))))
 
 ;; ---- :frame-setup decorator teardown -------------------------------------
 
@@ -357,37 +388,7 @@
   outside the interceptor chain — rare) are also caught directly via
   the wrapping `try/catch`."
   [variant-id frame-setup-decorators]
-  (let [pending  (atom [])
-        drain!   (fn []
-                   ;; Drain pending captured exceptions into the
-                   ;; variant frame's [:rf.story/assertions] BEFORE the
-                   ;; next teardown dispatch — so a later teardown event
-                   ;; (e.g. an outer decorator's :teardown) reading the
-                   ;; assertions slot sees earlier failures already
-                   ;; projected. Mirrors the spec's "land in the
-                   ;; variant's last :rf.story/assertions record"
-                   ;; contract for in-order observability.
-                   (when-let [evs (seq @pending)]
-                     (reset! pending [])
-                     (doseq [tev evs]
-                       (let [orig-event (get-in tev [:tags :event])
-                             err        (get-in tev [:tags :exception])
-                             record     (phase-exception-record
-                                          variant-id :phase-teardown
-                                          orig-event err
-                                          (pipeline-event-opts tev))]
-                         (try
-                           (rf/dispatch-sync [::append-teardown-assertion record]
-                                             {:frame variant-id})
-                           (catch #?(:clj Throwable :cljs :default) _ nil))))))
-        listener (fn [ev]
-                   ;; Capture every pipeline exception
-                   ;; (handler / coeffect / interceptor), not just
-                   ;; handler-exception: a teardown event whose cofx
-                   ;; injector or user interceptor throws is a first-class
-                   ;; failure too.
-                   (when (rf.story.error/pipeline-exception-event? variant-id ev)
-                     (swap! pending conj ev)))]
+  (let [{:keys [listener drain!]} (exception-collector variant-id :phase-teardown)]
     (with-teardown-trace-listener
       listener
       (fn []
@@ -407,24 +408,8 @@
                       (rf/dispatch-sync [::append-teardown-assertion record]
                                         {:frame variant-id})
                       (catch #?(:clj Throwable :cljs :default) _ nil)))))
-              ;; Drain after every teardown dispatch so the next
-              ;; teardown event sees the projected record.
               (drain!))))))
-    ;; Final drain — catch any trace events that arrived after the last
-    ;; dispatch inside the listener-bound region. (Shouldn't happen for
-    ;; dispatch-sync, but the belt-and-braces drain costs nothing.)
-    (let [collected @pending]
-      (reset! pending [])
-      (doseq [tev collected]
-        (let [orig-event (get-in tev [:tags :event])
-              err        (get-in tev [:tags :exception])
-              record     (phase-exception-record
-                           variant-id :phase-teardown orig-event err
-                           (pipeline-event-opts tev))]
-          (try
-            (rf/dispatch-sync [::append-teardown-assertion record]
-                              {:frame variant-id})
-            (catch #?(:clj Throwable :cljs :default) _ nil)))))))
+    (drain!)))
 
 ;; ---- variant body :loaders-teardown walk --------------------------------
 ;;
@@ -465,29 +450,7 @@
   Synchronous throws from outside the interceptor chain are caught
   directly. The walk never aborts `destroy-frame!`."
   [variant-id loaders-teardown-events]
-  (let [pending  (atom [])
-        drain!   (fn []
-                   (when-let [evs (seq @pending)]
-                     (reset! pending [])
-                     (doseq [tev evs]
-                       (let [orig-event (get-in tev [:tags :event])
-                             err        (get-in tev [:tags :exception])
-                             record     (phase-exception-record
-                                          variant-id :phase-loaders-teardown
-                                          orig-event err
-                                          (pipeline-event-opts tev))]
-                         (try
-                           (rf/dispatch-sync [::append-teardown-assertion record]
-                                             {:frame variant-id})
-                           (catch #?(:clj Throwable :cljs :default) _ nil))))))
-        listener (fn [ev]
-                   ;; Capture every pipeline exception
-                   ;; (handler / coeffect / interceptor), not just
-                   ;; handler-exception (a loaders-teardown event whose
-                   ;; cofx injector / user interceptor throws is a
-                   ;; first-class failure too).
-                   (when (rf.story.error/pipeline-exception-event? variant-id ev)
-                     (swap! pending conj ev)))]
+  (let [{:keys [listener drain!]} (exception-collector variant-id :phase-loaders-teardown)]
     (with-teardown-trace-listener
       listener
       (fn []
@@ -502,19 +465,7 @@
                                     {:frame variant-id})
                   (catch #?(:clj Throwable :cljs :default) _ nil)))))
           (drain!))))
-    ;; Final drain after the listener unbinds.
-    (let [collected @pending]
-      (reset! pending [])
-      (doseq [tev collected]
-        (let [orig-event (get-in tev [:tags :event])
-              err        (get-in tev [:tags :exception])
-              record     (phase-exception-record
-                           variant-id :phase-loaders-teardown
-                           orig-event err)]
-          (try
-            (rf/dispatch-sync [::append-teardown-assertion record]
-                              {:frame variant-id})
-            (catch #?(:clj Throwable :cljs :default) _ nil)))))))
+    (drain!)))
 
 (defn install-canonical-frame-events!
   "Register Story-internal helper events: `::apply-app-db-patch` for


### PR DESCRIPTION
Two instances of one defect from the 2026-09-07 functional-programming audit
(rf2-5941): **justified local mutation, written out three times**. Both are pure
extractions. In neither case is the mutation the defect — the `atom`, the
`volatile!`s and the callers' `transient`s all stay exactly as they were.

## rf2-soie — `tools/story/src/re_frame/story/frames.cljc`

Three lifecycle-phase walks each carried their own pending-atom + `drain!`
collector. The bead counted three copies; there are **nine**:

| walk | phase | `drain!` | inlined "final drain" | trace listener |
|---|---|---|---|---|
| `apply-frame-setup!` | `:phase-0-setup` | yes | yes | yes |
| `apply-frame-teardown!` | `:phase-teardown` | yes | yes | yes |
| `apply-loaders-teardown!` | `:phase-loaders-teardown` | yes | yes | yes |

The three "final drain" blocks are the same body again, and the three listeners
are identical modulo the frame id. One `exception-collector` factory taking
`[id phase]` and returning `{:listener _ :drain! _}` replaces all nine.

The bead asked for the middle site's phase keyword to be **verified at source**
rather than assumed symmetric. Verified: it is `:phase-teardown`.

**The ordering rationale moved to the factory docstring**, which is the point of
the bead. It was written out at exactly one of the three sites as a nine-line
comment, and it is load-bearing twice over: the queue is emptied *before*
projecting, so a capture arriving re-entrantly from the projection dispatch is
neither lost nor drained twice; and projection happens *before* the next phase
event, so an event reading `[:rf.story/assertions]` sees earlier failures
already landed. A change to that contract previously had to be made three times
with the reasoning findable at one of them.

**The atom stays.** Exceptions reach this path off the *trace stream* —
re-frame's interceptor chain catches handler throws and emits
`:rf.error/handler-exception` rather than re-throwing — so they arrive between
dispatches and there is nothing in `dispatch-sync`'s return to thread them
through. The queue is function-local and drained empty before the walk returns.

### One asymmetry found — the divergence the bead predicted

`apply-loaders-teardown!`'s **final** drain did not pass
`(pipeline-event-opts tev)` to `phase-exception-record`. The other five copies
of that body did, including the in-walk `drain!` of that same function. A
pipeline exception delivered after that walk's listener unbound therefore lost
its `:operation` / `:failing-id` attribution, where the identical event in the
other two phases kept it. Five sites agreed and one did not, so this reads as a
copy-paste omission rather than an intended difference; unifying the six repairs
it. **This is the only behaviour change in the PR.** No test pinned the
divergent shape.

## rf2-3oyn — `implementation/machines/src/re_frame/machines/cofx_attach.cljc`

Three `add!` closures — flat/compound scope, parallel-region union, and the
initial-descent birth set — verified **byte-identical** by pairwise diff. The
bead asked whether any of the three carried an extra clause its reading missed:
none does. One `dedup-adder` helper replaces all three.

The dedup key is `:id` and the rule is **first-occurrence-wins**. Neither was
stated anywhere; both now sit on the one docstring. That matters beyond
tidiness: a partial edit to two of three would have left the walks deduping
inconsistently between the flat and region paths — a silent correctness
divergence rather than a style issue.

**One premise correction.** The bead describes these accumulators as a
"`volatile!` around a `transient`". They are not: `acc` is `(volatile! [])` and
`seen-ids` is `(volatile! #{})` — volatiles around **persistent** collections.
The transients in this namespace are the local `diet` transients built by
`add-lifecycle!` / `add-scope!`, which are `persistent!`-ed before they ever
reach `add!`, and which this PR does not touch. The new docstring says that
accurately, and points at `re-frame.source-coords` as the exemplar for the
*stricter* volatile-around-transient case rather than claiming this is one.

## Quality gates

Every exit code below is the runner's own status, captured with the redirect and
the `echo` on one command line in one shell — never read through a pipe, and
never taken from a harness report about the same run.

| gate | command | exit | result |
|---|---|---|---|
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` |
| Tool JVM suites | `sh scripts/test-jvm-tools.sh` | **0** | `PASS tools JVM artefacts` — 10 artefacts, all green; `tools/story` 1903 tests / 7010 assertions |
| Story JVM suite | `clojure -M:test` in `tools/story/` | **0** | 1903 tests, 7010 assertions, 0 failures, 0 errors |
| Machines JVM suite | `clojure -M:test` in `implementation/machines/` | **0** | 1244 tests, 4528 assertions, 0 failures, 0 errors |
| Require-alias dialect ratchet | `python scripts/check_require_alias_dialect.py` | **0** | no surface over its floor |
| clj-kondo (inside spine) | `clj-kondo --fail-level error` | — | 0 errors, 1920 warnings (unchanged baseline) |

The spine's JVM tier selected `implementation/machines` by construction — its
own PASS line enumerates the artefact suites it *skipped*, and machines is not
among them.

### Assertion counts, before and after

Both changes are pure extraction, so the evidence is that the existing suites
run the *same* namespaces and assertions and still pass. Counts were taken by
reverting the two files to their merge-base content, running, restoring, and
re-running. The restore was verified by **git blob hash**, not by reading a
diff — an unapplied patch and an unchanged file produce the same diff.

| suite | before | after | delta |
|---|---|---|---|
| `tools/story` | 1903 tests / 7010 assertions / 0 failures | 1903 tests / 7010 assertions / 0 failures | none |
| `implementation/machines` | 1244 tests / 4528 assertions / 0 failures | 1244 tests / 4528 assertions / 0 failures | none |

Equal counts are the point: a refactor that silently drops a namespace from a
run also reads as green.

### Evidence the gates read this worktree

Two independent routes, both taken:

* **The spine prints its root**, and it named this checkout — the shadow-cljs
  config line and the path-policy tier's approved-roots line both resolved
  under the worker worktree rather than the primary checkout.
* **Planted faults went red.** A repository-relative path cannot tell two
  checkouts apart, so each suite was run against a deliberate fault on a line
  this PR authored. Swapping `:phase-teardown` for a bogus keyword at
  `exception-collector`'s call site reddened the story suite (**exit 1**, 1
  failure, the assertion text naming the planted keyword); neutering
  `dedup-adder`'s guard reddened the machines suite (**exit 1**, 72 failures).
  Both plants matched exactly one line each — the match count was read *before*
  the run, since a zero-match plant makes a sabotage run come back green about
  nothing. Both sabotage runs held the same 1903/7010 and 1244/4528 totals, so
  neither plant crashed a namespace and truncated the lane. Files were restored
  from `HEAD` and both restores confirmed by blob hash.

### Fast-PR spine coverage gap

`scripts/test-fast-pr.sh`'s header says the tool JVM suites are in **no** tier
of the spine, and `tools/story` is rf2-soie's entire surface — so the spine
alone would have returned a green that inspected nothing in half of this
change. That is why the story suite and `scripts/test-jvm-tools.sh` were run
explicitly.

`python scripts/check_fast_pr_gap.py --brief` reports **99 required checks this
spine does not run**, across three required contexts (`All required checks
passed`, `Lint required`, `Docs required`). Most are surface-gated in CI and
skip on a diff that does not reach them; the narrower claim is that none of them
is decided locally. The spine additionally names three families it did not run
here: the documentation tier (surface unchanged), the JVM artefact suites the
diff did not touch, and the browser / prod-elision / bundle-isolation / perf /
adapter / Xray / mcp-conformance lanes.

## Not touched

No public name moves — both new helpers are `defn-` — so `spec/API.md`, the two
`spec/api-manifest*.edn` sidecars and every other hot-zone document are
untouched.
