### PR TITLE
fix(adapters): three correctness bugs across uix, reagent-slim and test-react

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -946,13 +946,30 @@
   A static render has no instance, so there is no inner-fn cache (the
   live path caches on `.-cljsRenderFn`); each static render re-runs the
   setup. That is correct for static markup — output is a function of the
-  args only."
+  args only.
+
+  Form-3 FACTORY (rf2-oyrj): `f` may be a plain factory whose body
+  RETURNS a `create-class` result — `FORM-3.md`'s supported per-instance
+  shape. That class is a JS function, so it matches the same `fn?` test
+  that detects a Form-2 inner render fn, and applying it would invoke the
+  constructor rather than render. Detect it FIRST and re-enter the
+  element walk with the class as a hiccup HEAD, where
+  `emit-hiccup-vector`'s existing `reagent-class?` dispatch renders its
+  `:reagent-render` — keeping static markup free of lifecycle execution,
+  exactly as for a class written directly in the head."
   [^StringBuffer sb f args]
   (let [out (apply f args)]
-    (if (fn? out)
+    (cond
+      ;; Form-3 factory output: mount-shaped, not call-shaped.
+      (component/reagent-class? out)
+      (emit-element sb (into [out] args))
+
       ;; Form-2: `out` is the inner render closure. Recall with the same
       ;; args (matches wrap-render's `(apply inner args)`).
+      (fn? out)
       (emit-element sb (apply out args))
+
+      :else
       (emit-element sb out))))
 
 (defn- emit-user-fn

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -259,6 +259,39 @@
   [render-fn]
   (some-> render-fn meta :reagent2/form))
 
+(defn- class-mounting-render-fn
+  "Wrap a factory-returned Reagent class `klass` in a render fn that MOUNTS
+  it (rf2-oyrj).
+
+  A class made by `create-class*` is a JS function, so the bare `fn?`
+  test that classifies a Form-2 inner render fn also matches it. Calling
+  it is NOT mounting it: the constructor assigns instance fields and
+  returns `this`, while the real render lives on the prototype and the
+  lifecycle methods are installed separately. The supported Form-3
+  FACTORY shape — a plain `defn` whose body returns `create-class` (see
+  `FORM-3.md`'s google-map recipe) — therefore never reached its class.
+
+  Returning `[klass & args]` instead hands the class back as a hiccup
+  HEAD, which `template/vec-to-elem` already routes through
+  `react-component-element` → `React.createElement`. React then owns the
+  instance: the class type is stable across renders, so an update
+  reconciles in place and the factory's per-mount closure survives.
+  Mirrors stock Reagent's `reagent.impl.component/wrap-render`, which
+  caches exactly this wrapper for a `reagent-class?` render result."
+  [klass]
+  (fn mount-class [& args]
+    (into [klass] args)))
+
+(defn- form-2-inner-fn
+  "Classify a render fn's fn-valued output for caching as the Form-2 inner
+  render fn. A factory-returned Reagent class is wrapped so it is MOUNTED
+  rather than invoked (rf2-oyrj); a genuine inner render closure is cached
+  unchanged."
+  [out]
+  (if (reagent-class? out)
+    (class-mounting-render-fn out)
+    out))
+
 (defn wrap-render
   "Runtime Form-1/Form-2 detection on the user render fn `render-fn`,
   invoked on `c` (the React component instance). Returns the resulting
@@ -279,7 +312,14 @@
 
   Form-3 dispatches via the `:reagent-render` key in the spec map and
   reaches this fn directly with the user's render fn (the spec's
-  `:reagent-render` value)."
+  `:reagent-render` value).
+
+  Form-3 FACTORY (rf2-oyrj): when `render-fn` is a plain factory whose
+  body RETURNS a `create-class` result — `FORM-3.md`'s supported
+  per-instance shape — the returned class is a JS function and so
+  matches the same `fn?` test that detects a Form-2 inner render fn.
+  `form-2-inner-fn` discriminates it and caches a wrapper that mounts
+  the class (`[klass & args]`) instead of invoking its constructor."
   [^js c render-fn]
   (let [args   (argv-args c)
         cached (.-cljsRenderFn c)]
@@ -305,8 +345,9 @@
       (= :reagent2/form-1 (form-tag render-fn))
       (let [out (apply render-fn args)]
         (if (fn? out)
-          (do (set! (.-cljsRenderFn c) out)
-              (apply out args))
+          (let [inner (form-2-inner-fn out)]
+            (set! (.-cljsRenderFn c) inner)
+            (apply inner args))
           out))
 
       :else
@@ -319,10 +360,12 @@
 
           ;; Form-2: render-fn returned a fn. Cache it and recall with
           ;; the current args so this render produces actual hiccup.
+          ;; A factory-returned Reagent CLASS is also a fn — `form-2-inner-fn`
+          ;; wraps that case so the class is mounted, not called (rf2-oyrj).
           (fn? out)
-          (do
-            (set! (.-cljsRenderFn c) out)
-            (apply out args))
+          (let [inner (form-2-inner-fn out)]
+            (set! (.-cljsRenderFn c) inner)
+            (apply inner args))
 
           ;; Seq-as-fragment shape — coerce to a vector for React's
           ;; children-of-a-fragment handling.

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/form3_factory_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/form3_factory_dom_cljs_test.cljs
@@ -1,0 +1,179 @@
+(ns reagent2.impl.form3-factory-dom-cljs-test
+  "rf2-oyrj — the per-instance Form-3 FACTORY mount witness.
+
+  WHAT IT PROVES. `FORM-3.md` §\"A complete example\" documents the
+  supported Form-3 shape as a plain factory `defn` whose body returns a
+  `create-class` result:
+
+      (defn google-map [_initial-props]
+        (let [el-ref (atom nil) ...]
+          (r/create-class {...})))
+
+  and the section under it states that each `[google-map ...]` mount
+  owns its own closure atoms. That is the adapter's principal
+  imperative-widget recipe (maps, charts, popovers, cleanup-owning
+  widgets).
+
+  The defect: `reagent2.impl.component/wrap-render` classified the
+  factory's OUTPUT with a bare `fn?` test. A reagent-slim class made by
+  `create-class*` IS a JS function, so it took the Form-2 branch and the
+  CLASS CONSTRUCTOR was cached as `cljsRenderFn` and applied with the
+  render args. No Form-3 instance was mounted and its render/lifecycle
+  methods were never reached. `reagent2.dom.server/emit-render-fn`
+  mirrored the same mistake at the static-markup factory-output
+  boundary — the class dispatch there covered only a class sitting
+  directly in the hiccup HEAD.
+
+  WHY A REAL MOUNT. A test that hand-invokes `new` on the returned class
+  (or walks its prototype) proves the class is well formed, not that the
+  renderer mounts one. Only a `react-dom/client` root driving the
+  ordinary `[factory args...]` hiccup path exercises the classification
+  seam this bug lives in, so the live assertions here go through
+  `rdc/render`.
+
+  TEST-ONLY. The ns ends in `-dom-cljs-test` so shadow-cljs's
+  `:browser-test` discovers it for the real-DOM assertions; the
+  `:node-test` runner also loads it (`cljs-test$` matches), where the
+  live bodies gate on `(browser?)` and no-op cleanly. The
+  static-markup deftest is NOT gated — `render-to-static-markup` is
+  pure string building, so it runs on both lanes."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent2.core :as r]
+            [reagent2.dom.client :as rdc]
+            [reagent2.dom.server :as server]
+            ["react-dom" :as react-dom]))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (when (browser?)
+    (.createElement js/document "div")))
+
+;; ---------------------------------------------------------------------------
+;; The probe factory. Deliberately the documented shape: a plain `defn`
+;; whose body closes over per-mount state and returns `create-class`.
+;; `lifecycle` is passed IN so each deftest owns its own log; the closure
+;; token proves per-mount closure ownership.
+
+(defn- make-probe-factory
+  "Returns a Form-3 FACTORY fn. Each invocation of the returned factory
+  (i.e. each mount of `[factory ...]`) creates a fresh closure token and
+  a fresh class, exactly as `FORM-3.md`'s google-map recipe does."
+  [lifecycle]
+  (fn probe-factory [_initial-label]
+    (let [token (gensym "instance")]
+      (r/create-class
+        {:display-name "form3-factory-probe"
+         :reagent-render
+         (fn [label] [:div {:class "factory-panel"} label])
+         :component-did-mount
+         (fn [_this] (swap! lifecycle conj [:mount token]))
+         :component-will-unmount
+         (fn [_this] (swap! lifecycle conj [:unmount token]))}))))
+
+(defn- phases [lifecycle phase]
+  (filterv #(= phase (first %)) @lifecycle))
+
+;; ---------------------------------------------------------------------------
+
+(deftest factory-returned-class-mounts-updates-and-unmounts
+  (testing "reagent-slim — a plain factory returning create-class mounts its class, keeps closure identity across an update, and runs mount/unmount exactly once (rf2-oyrj)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [lifecycle  (atom [])
+            factory    (make-probe-factory lifecycle)
+            mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node)]
+        (try
+          ;; Initial mount. Pre-fix this rendered nothing usable: the
+          ;; class CONSTRUCTOR was applied as a Form-2 inner render fn.
+          (react-dom/flushSync (fn [] (rdc/render root [factory "hello"])))
+          (is (= "hello" (.-textContent mount-node))
+              "initial mount rendered the class's :reagent-render output")
+          (is (some? (.querySelector mount-node ".factory-panel"))
+              "the class's own render produced the panel element")
+          (is (= 1 (count (phases lifecycle :mount)))
+              ":component-did-mount fired exactly once — the class really mounted")
+
+          (let [token-after-mount (second (first (phases lifecycle :mount)))]
+            ;; Update with fresh args. Same class type → React reconciles
+            ;; in place: no remount, closure token unchanged.
+            (react-dom/flushSync (fn [] (rdc/render root [factory "updated"])))
+            (is (= "updated" (.-textContent mount-node))
+                "the update reached the class's render with the fresh arg")
+            (is (= 1 (count (phases lifecycle :mount)))
+                "no second :component-did-mount — the factory's class instance was reused")
+
+            (rdc/unmount root)
+            (is (= 1 (count (phases lifecycle :unmount)))
+                ":component-will-unmount fired exactly once")
+            (is (= token-after-mount (second (first (phases lifecycle :unmount))))
+                "unmount saw the SAME closure token as mount — per-mount closure ownership held"))
+          (finally
+            (try (rdc/unmount root) (catch :default _ nil))))))))
+
+(deftest sibling-factory-instances-own-separate-closures
+  (testing "reagent-slim — two sibling mounts of one factory each own a separate closure and class (rf2-oyrj)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [lifecycle  (atom [])
+            factory    (make-probe-factory lifecycle)
+            mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node)]
+        (try
+          (react-dom/flushSync
+            (fn [] (rdc/render root [:div [factory "a"] [factory "b"]])))
+          (is (= "ab" (.-textContent mount-node))
+              "both sibling factory mounts rendered")
+          (let [tokens (mapv second (phases lifecycle :mount))]
+            (is (= 2 (count tokens))
+                "two :component-did-mount calls — one per sibling mount")
+            (is (= 2 (count (set tokens)))
+                "the two siblings own DISTINCT closure tokens (FORM-3.md: each mount gets its own atoms)"))
+          (finally
+            (try (rdc/unmount root) (catch :default _ nil))))))))
+
+(deftest genuine-form-2-and-direct-class-head-unchanged
+  (testing "reagent-slim — the Form-2 inner-fn path and a direct class head still behave (rf2-oyrj control)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [setup-calls (atom 0)
+            form-2      (fn form-2-probe [_label]
+                          (swap! setup-calls inc)
+                          (fn [label] [:div {:class "form2"} "f2-" label]))
+            direct      (r/create-class
+                          {:display-name "direct-class-head"
+                           :reagent-render (fn [label] [:div {:class "direct"} "d-" label])})
+            mount-node  (make-mount-node!)
+            root        (rdc/create-root mount-node)]
+        (try
+          (react-dom/flushSync (fn [] (rdc/render root [form-2 "x"])))
+          (is (= "f2-x" (.-textContent mount-node))
+              "Form-2 control: inner fn cached and called with the args")
+          (react-dom/flushSync (fn [] (rdc/render root [form-2 "y"])))
+          (is (= "f2-y" (.-textContent mount-node))
+              "Form-2 control: cached inner fn recalled with fresh args")
+          (is (= 1 @setup-calls)
+              "Form-2 control: the setup fn ran exactly once (inner fn was cached, not re-derived)")
+
+          (react-dom/flushSync (fn [] (rdc/render root [direct "z"])))
+          (is (= "d-z" (.-textContent mount-node))
+              "direct class head control: a create-class result in HEAD position still mounts")
+          (finally
+            (try (rdc/unmount root) (catch :default _ nil))))))))
+
+(deftest static-markup-of-a-factory-emits-content-without-lifecycle
+  (testing "reagent-slim — render-to-static-markup of a factory-returned class emits the class's markup and runs no lifecycle (rf2-oyrj)"
+    ;; NOT browser-gated: the static serializer is pure string building,
+    ;; so this assertion runs on the :node-test lane too.
+    (let [lifecycle (atom [])
+          factory   (make-probe-factory lifecycle)
+          html      (server/render-to-static-markup [factory "hello"])]
+      (is (re-find #"hello" html)
+          "static markup carried the class's :reagent-render content")
+      (is (re-find #"factory-panel" html)
+          "static markup carried the class's own element, not a Form-2 misread")
+      (is (empty? @lifecycle)
+          "no lifecycle ran under static markup (matches renderToStaticMarkup)"))))

--- a/implementation/adapters/test-react/README.md
+++ b/implementation/adapters/test-react/README.md
@@ -71,7 +71,7 @@ The `mount!` / `trigger-update!` / `unmount!` trio drive the simulator. The test
 
 A render tree may be plain opaque data (`[:div "hi"]` — most tests) or declare an imperative render body via the node shape `{:rf/component (fn [mount] ...)}`. The body runs during the render phase, while a render is in flight. From inside it you can:
 
-- mount children with `(test-react/mount-child! child-tree)` — the child runs its own `constructor → render → did-mount` lifecycle, is recorded under the parent (`test-react/mounted-children`), and is torn down children-first when the parent unmounts
+- mount children with `(test-react/mount-child! child-tree)` — the child runs its own `constructor → render → did-mount` lifecycle, is recorded under the parent (`test-react/mounted-children`), and is torn down when the parent unmounts, with the parent's `:will-unmount` logged first (React's order — see *Teardown order* below)
 - issue an `unmount!` of any root — and if you unmount an ancestor or a separately-tracked sibling while the render is in flight, the guard fires `:rf.error/sync-unmount-during-render`
 
 ```clojure
@@ -96,6 +96,21 @@ A render tree may be plain opaque data (`[:div "hi"]` — most tests) or declare
 | `:did-update` | Immediately after each subsequent `:render`. |
 | `:will-unmount` | The unmount thunk fires. |
 | `:forced-teardown` | A mount was torn down bypassing the render-depth unmount guard. Three paths log it: `dispose-adapter!` draining a still-mounted root, a failed **initial** mount rolling back its speculatively-mounted children, or a failed **update** tearing down the whole live root (see *Transactional render failures* below). |
+
+### Teardown order
+
+A normal unmount logs the mount's own `:will-unmount` **before** cascading into
+its children, so a `parent → child → grandchild` tree records
+`parent, child, grandchild`. That is React's own order: the ClassComponent case
+of `commitDeletionEffectsOnFiber` calls `safelyCallComponentWillUnmount` on the
+deleted fiber and only then runs `recursivelyTraverseDeletionEffects` over its
+children (verified against react-dom 19.2.0). An ancestor therefore learns it is
+going away before any descendant does, which is what cleanup code that tears
+down shared resources relies on.
+
+`:forced-teardown` is a separate, simulator-only path (see *Transactional render
+failures* below) and deliberately drains grandchildren-first; React has no
+analogue of it, so that ordering is not a parity claim.
 
 The simulator throws `:rf.error/sync-unmount-during-render` if `unmount!` is
 called while a render is in flight anywhere in the tree. A global counter,
@@ -130,7 +145,7 @@ normative contract.
 - no automatic re-render on app-db change. Tests drive re-renders explicitly via `trigger-update!`. Children re-render only when a test re-runs the parent's render body or drives the child directly; there is no automatic propagation from a `subscribe-container` change
 - no React context provider. Frame-routing under this adapter is via the dynamic-var tier (`re-frame.frame/current-frame`); the React-context tier is degenerate
 - no `data-rf2-source-coord` annotation. Spec 006 makes source-coord injection a normative entry on the adapter contract, but it lives "on the rendered root DOM element." This adapter has no DOM root — the render tree is opaque data — so per the spec's non-DOM-root exemption the annotation is N/A here
-- no real reconciliation. Children declared by `mount-child!` are imperative mounts, not a diffed child list. The simulator does not reconcile a render tree's child vector across updates — that fidelity belongs to a real React adapter / Playwright. The class-3 invariants (constructor/render/did-mount ordering, children-before-parent teardown, the sync-unmount-during-render guard) are what this adapter verifies
+- no real reconciliation. Children declared by `mount-child!` are imperative mounts, not a diffed child list. The simulator does not reconcile a render tree's child vector across updates — that fidelity belongs to a real React adapter / Playwright. The class-3 invariants (constructor/render/did-mount ordering, parent-before-children teardown, the sync-unmount-during-render guard) are what this adapter verifies
 
 ## Where this adapter sits in the family
 

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -70,8 +70,8 @@
 ;;   :children        — atom<vector<MountedComponent>>; child roots this mount
 ;;                      mounted from inside its own render body via
 ;;                      `mount-child!`. Unmounting a parent cascades to its
-;;                      children (will-unmount fires children-first, mirroring
-;;                      React's child-before-parent teardown order).
+;;                      children (will-unmount fires parent-first, mirroring
+;;                      React's parent-before-child teardown order).
 ;;   :unmount-fn      — the unmount thunk for this mount; `unmount!` calls it.
 
 (defrecord ^:no-doc MountedComponent
@@ -148,8 +148,10 @@
 
 (defn- unmount-thunk
   "Build the unmount thunk for `mount`. Idempotent (a second call on an
-  already-unmounted mount is a no-op). Cascades to children first (React tears
-  children down before their parent). Throws
+  already-unmounted mount is a no-op). Logs the mount's own `:will-unmount`
+  BEFORE cascading into its children, mirroring React's ClassComponent
+  deletion effect (`componentWillUnmount` on the deleted fiber, then the
+  recursive descendant traversal — rf2-ytyq). Throws
   `:rf.error/sync-unmount-during-render` if called while a render is in flight
   anywhere in the tree — keyed off the global
   `render-depth`, so a parent re-render that synchronously unmounts a separate
@@ -178,11 +180,17 @@
                  " defer the unmount until rendering settles.")
             {:recovery :defer-the-unmount-until-render-settles
              :extra    {:mount-id (:id mount)}}))
-        ;; Children-first teardown (mirrors React). Each child's own thunk runs
-        ;; the same guard + cascade, so a deep tree unwinds leaf-upward.
+        ;; PARENT-FIRST :will-unmount, then the descendant cascade — React's
+        ;; own order (rf2-ytyq). `commitDeletionEffectsOnFiber`'s
+        ;; ClassComponent case calls `safelyCallComponentWillUnmount` on the
+        ;; deleted fiber's instance and only THEN
+        ;; `recursivelyTraverseDeletionEffects` over its children
+        ;; (react-dom 19.2.0), so an ancestor learns it is going away before
+        ;; any descendant does. Each child's own thunk runs the same guard +
+        ;; cascade, so a deep tree unwinds root-downward.
+        (log-phase! mount :will-unmount)
         (doseq [child @(:children mount)]
           ((:unmount-fn child)))
-        (log-phase! mount :will-unmount)
         (reset! (:mounted? mount) false)
         (reset! (:render-tree mount) nil)
         (swap! active-mounts disj mount)))
@@ -209,8 +217,12 @@
     (swap! active-mounts disj mount)))
 
 (defn- force-teardown-descendants!
-  "Force-tear every descendant of `parent` down GRANDCHILDREN-first, mirroring
-  React's leaf-upward teardown. The descendants may be speculative mounts from
+  "Force-tear every descendant of `parent` down GRANDCHILDREN-first. This is a
+  SIMULATOR-ONLY drain order and deliberately NOT a React-parity claim — React
+  has no analogue of forced teardown, and its normal deletion effect runs
+  parent-first (which is what the `:will-unmount` path mirrors — rf2-ytyq).
+  Draining deepest-first here keeps a descendant from being evicted while an
+  ancestor still lists it. The descendants may be speculative mounts from
   a render that threw or pre-existing children of an already-committed mount;
   this function deliberately leaves `parent` itself untouched.
 
@@ -514,9 +526,9 @@
   mount)
 
 (defn unmount!
-  "Unmount `mount`, cascading to its children first (React tears children down
-  before their parent). Records a `:will-unmount` phase entry per torn-down
-  mount. Throws `:rf.error/sync-unmount-during-render` if called while a render
+  "Unmount `mount`, logging its own `:will-unmount` before cascading into its
+  children (React tears a parent down before its children — rf2-ytyq). Records
+  a `:will-unmount` phase entry per torn-down mount. Throws `:rf.error/sync-unmount-during-render` if called while a render
   is in flight anywhere in the tree, including the
   organic case where a parent's render body synchronously unmounts a separate
   sibling/child root. Idempotent: a second call on the same mount is a no-op."

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
@@ -241,8 +241,8 @@
 (deftest child-mounts-recurse-through-their-own-lifecycle
   (testing "a parent's render body mounts a child via mount-child!; the child
             runs its own constructor → render → did-mount, is tracked as a
-            child of the parent, and is torn down children-first when the
-            parent unmounts"
+            child of the parent, and is torn down when the parent unmounts —
+            with the PARENT's :will-unmount logged first, as React does"
     (let [child-ref (atom nil)
           parent    (rf.adapter.test-react/mount!
                       {:rf/component
@@ -262,7 +262,7 @@
         (is (and (true? (:deprecated (meta #'rf.adapter.test-react/children)))
                  (= [@child-ref] (legacy-children parent)))
             "the deprecated alias remains callable and returns the live child"))
-      ;; Unmounting the parent cascades to the child, children-first.
+      ;; Unmounting the parent cascades to the child, parent-first.
       (rf.adapter.test-react/unmount! parent)
       (is (zero? (count (rf.adapter.test-react/mounted-components)))
           "parent unmount cascaded to the child — nothing leaks")
@@ -270,10 +270,13 @@
           "the child saw its own :will-unmount during the cascade")
       (let [child-unmount-seq  (phase-first-seq @child-ref :will-unmount)
             parent-unmount-seq (phase-first-seq parent :will-unmount)]
-        (is (< child-unmount-seq parent-unmount-seq)
-            "child tears down STRICTLY before its parent — monotonic order-key,
-             so a reversed (parent-first) teardown FAILS here (the old <=-on-ms
-             check passed vacuously because sub-ms timestamps collapsed to equal)")))))
+        (is (< parent-unmount-seq child-unmount-seq)
+            "parent logs :will-unmount STRICTLY before its child (rf2-ytyq) —
+             React's commitDeletionEffectsOnFiber calls
+             safelyCallComponentWillUnmount on a ClassComponent BEFORE
+             recursivelyTraverseDeletionEffects reaches its children
+             (react-dom 19.2.0). Monotonic order-key, so a reversed
+             (child-first) teardown FAILS here")))))
 
 ;; ----------------------------------------------------------------------------
 ;; B.1 — Organic sync-unmount-during-render (the rf2-4l7t2 class)
@@ -1063,15 +1066,15 @@
       (is (nil? (thunk))
           "second thunk call is a silent no-op"))))
 
-;; ---- deep cascade tears down leaf-upward ----------------------------------
+;; ---- deep cascade tears down root-downward --------------------------------
 
-(deftest deep-cascade-tears-down-leaf-upward
-  (testing "a parent → child → grandchild tree unmounts leaf-upward when the
-            root unmounts: the grandchild's :will-unmount fires no later than
-            the child's, which fires no later than the parent's. The A' layer
-            proved one level of children-first teardown; this pins the
-            documented 'deep tree unwinds leaf-upward' invariant across two
-            levels — the recursive cascade real component trees rely on."
+(deftest deep-cascade-tears-down-root-downward
+  (testing "a parent → child → grandchild tree unmounts root-downward when the
+            root unmounts: the parent's :will-unmount fires before the child's,
+            which fires before the grandchild's. The A' layer proved one level
+            of parent-first teardown; this pins the 'deep tree unwinds
+            root-downward' invariant across two levels — the recursive cascade
+            real component trees rely on, in React's own order (rf2-ytyq)."
     (let [grandchild-ref (atom nil)
           child-ref      (atom nil)
           parent (rf.adapter.test-react/mount!
@@ -1109,7 +1112,8 @@
             parent-seq (phase-first-seq parent :will-unmount)]
         (is (and gc-seq child-seq parent-seq)
             "every level recorded a :will-unmount during the cascade")
-        (is (< gc-seq child-seq parent-seq)
-            "teardown order is grandchild < child < parent — leaf-upward unwind
-             (strict monotonic seq: a root-downward regression FAILS this, where
-             the old <=-on-ms check stayed green because the cascade ran sub-ms)")))))
+        (is (< parent-seq child-seq gc-seq)
+            "teardown order is parent < child < grandchild — root-downward
+             unwind, matching React's ClassComponent deletion effect
+             (componentWillUnmount before the descendant traversal). Strict
+             monotonic seq: a leaf-upward regression FAILS this (rf2-ytyq)")))))


### PR DESCRIPTION
Two of the three adapter correctness bugs from the 2026-09-07 Codex surface
review (rf2-djj9). Both fixes are confined to `implementation/adapters/**`.

| Bead | Adapter | State |
|---|---|---|
| rf2-oyrj (P2) | `reagent-slim` | **fixed here** — Form-3 factories now mount their returned class |
| rf2-ytyq (P3) | `test-react` | **fixed here** — normal unmount logs parent before descendants |
| rf2-1frc (P2) | `uix` | **not in this PR** — see *rf2-1frc* below |

All three beads' "unchanged at snapshot" claims were re-verified and all three
still held at this branch's base.

## rf2-oyrj — reagent-slim Form-3 factory mounts its class

`FORM-3.md`'s canonical Google Maps recipe documents the supported per-instance
Form-3 shape as a plain factory `defn` whose body returns `create-class`, and
states that each mount owns separate closure atoms. That shape did not work.

`wrap-render` classified the factory's OUTPUT with a bare `fn?` test. A class
made by `create-class*` IS a JS function, so it took the Form-2 branch: the
class CONSTRUCTOR was cached as `cljsRenderFn` and applied with the render args.
Calling the constructor is not mounting it — it assigns instance fields and
returns `this`, while the real render lives on the prototype and the lifecycle
methods are installed separately — so no Form-3 instance was ever mounted. The
already-cached path then kept calling that constructor on every later render,
and the compile-time-tagged Form-1 fallback carried the same defect. That
fallback is in fact the branch `reg-view` reaches for this shape, since
`classify-form-body` tags a body Form-1 whenever its last form is not a literal
`(fn …)` — which a `(let [...] (create-class ...))` body is not.

`reagent2.dom.server/emit-render-fn` mirrored the mistake at the static
serializer's factory-output boundary; its existing class dispatch handled only a
class sitting directly in the hiccup head.

The repair discriminates a returned Reagent class with the existing
`reagent-class?` predicate before the ordinary Form-2 branch, and caches a
wrapper returning `[klass & args]` — handing the class back as a hiccup HEAD,
which `vec-to-elem`'s existing `reagent-class?` arm already routes through
`react-component-element` to `React.createElement`. React then owns the
instance, so the class type is stable across renders: an update reconciles in
place and the factory's per-mount closure survives. This is stock Reagent's own
shape — `reagent.impl.component/wrap-render` caches exactly this wrapper for a
`reagent-class?` render result — not an invention. The static serializer
re-enters the element walk with the class as a head, where the existing
`reagent-class?` dispatch renders `:reagent-render` and static markup stays free
of lifecycle execution.

Direct class heads and genuine Form-2 inner functions are unchanged, and both
are pinned as controls in the new suite. No new public API, no cap keys, no
renderer redesign, and no `re-frame.core` facade export added or changed.

## rf2-ytyq — test-react unmounts parent-first

`unmount-thunk` invoked each child's unmount thunk BEFORE logging the parent's
`:will-unmount`, so a nested probe emitted `child,parent` and a deep tree emitted
`grandchild,child,parent`. React does the opposite: the ClassComponent case of
`commitDeletionEffectsOnFiber` calls `safelyCallComponentWillUnmount` on the
deleted fiber's stateNode and only THEN runs `recursivelyTraverseDeletionEffects`
over its children — verified against the installed react-dom 19.2.0 package
source. A test reasoning about ancestor/descendant teardown with this fixture was
told the opposite ordering to React, so cleanup assumptions could be falsely
accepted.

The parent's `:will-unmount` log moves to React's pre-descendant position.
Nothing else in the thunk moved — the `mounted?` entry guard, the render-depth
guard, the `reset!`s and the `active-mounts` eviction are untouched, so
exactly-once and idempotent-eviction semantics are unchanged. The two assertions
that pinned the false model are inverted to pin React parity, and the
contradictory README and source statements are corrected; the README gains a
*Teardown order* section stating the invariant and its React provenance.

`:forced-teardown` and the failed-render rollback are deliberately untouched. The
forced path keeps its grandchildren-first drain; only its docstring changed,
which had claimed that order mirrored React's leaf-upward teardown — React has no
analogue of forced teardown, so it now says plainly that this is a
simulator-only order and not a parity claim.

Scope is deliberately narrow: a simulator ordering defect in a local-test-only
fixture, not a step toward React reconciliation.

## rf2-1frc — not in this PR

The UIx adapter file is a thin re-export (`use-subscribe` is
`(:use-subscribe spine-fns)`); every construct that bead names as defective lives
in `implementation/core/src/re_frame/substrate/spine.cljs`, outside this PR's
surface. The mechanism was confirmed real at source and the seam located — the
production-safe one is `re-frame.interop/add-on-dispose!`, **not**
`subs.cache/emit-dispose!`, which is a `rf.trace/emit!` behind `debug-enabled?`
and is dead-code-eliminated from release bundles — but the repair also makes
`unsubscribe-if-reaction`'s Spec-006-scoped docstring wrong and carries a
browser-lane acceptance suite of its own. Landing it half-done would be worse
than not landing it, so it is left open with the full analysis recorded on the
bead for re-dispatch. Nothing in this PR touches `spine.cljs`, `subs.cljc`,
`cache.cljc`, `spec/` or the UIx adapter.

## Quality gates

Every exit code below was captured with the runner's own `$?`, redirected to a
per-worktree, per-attempt log beside it, and quoted from that file — never read
from a pipeline and never taken from a harness report.

| Gate | Result | Exit |
|---|---|---|
| `clojure -M:test` (test-react artefact) — failing-first | 2 failures / 35 tests / 157 assertions | 1 |
| `clojure -M:test` (test-react artefact) — after fix | 0 failures, 0 errors / 35 tests / 157 assertions | 0 |
| `:node-test` focused on the new ns — failing-first | 1 error / 4 tests / 4 assertions | 1 |
| `:node-test` focused on the new ns — after fix | 0 failures, 0 errors / 4 tests / 6 assertions | 0 |
| `npm run test:browser` (`cljs-browser` lane) | 0 failures, 0 errors / 801 tests / 4377 assertions | 0 |
| `npm run test:browser` — deliberate sabotage control | 1 failure, naming the new test | 1 |
| `npm run test:reagent-slim:smoke` | 1 smoke, 0 failures | 0 |
| `npm run test:adapter-smokes` | 2 adapter-smoke specs, 0 failures | 0 |
| `npm run test:cljs` (full `:node-test` suite) | 0 failures, 0 errors / 11320 tests / 57087 assertions | 0 |
| `npm run test:cljs-isolation` (per-ns isolation) | all 16 namespaces pass standalone / 194 tests / 722 assertions | 0 |
| `sh scripts/test-fast-pr.sh` | **wedged — no verdict**, see below | none |
| `python scripts/check_readme_links.py --ci` | clean | 0 |
| `python scripts/check_readme_links.py --ci` — sabotage control | names the planted broken target | 1 |

### The fast-PR spine wedged — what that does and does not mean

`sh scripts/test-fast-pr.sh` was started on the final rebased base and printed
`gate root: …/adapters-b` with `docs=true jvm=true node=true`. It got through the
whole always-on static block, the documentation tier (`mkdocs --strict`,
*Documentation built in 37.15 seconds*) and pinned `clj-kondo`, then stopped
producing output at `==> JVM implementation/core` and wrote nothing further for
eighty minutes. Twenty-two spine processes were live across the fleet at the
time. That is machine contention wedging the run, not a failure — and an absent
exit-code file is **no verdict**, never a pass, so no spine result is claimed
here. The wedged tree was provably this worktree's own
(`adapters-b/scripts/test-fast-pr.sh`) and only it was killed; no peer process
was touched.

Rather than re-queue an hour-long whole-spine run onto a saturated box, the parts
of its tiers that actually grade an adapters-only diff were run directly and are
reported above with their own captured exit codes: the documentation tier had
already passed inside the spine, `clj-kondo` had already passed inside the spine,
the JVM tier's relevant artefact (`test-react`) was run standalone, and the node
tier's two suites — the full `:node-test` run and the per-namespace isolation
gate — were run standalone and are both green. The isolation gate is worth
calling out, since adding a namespace is exactly the shape that can disturb it:
all 16 rostered namespaces still pass standalone.

The one spine component genuinely not exercised is `implementation/core`'s JVM
suite — and this branch changes **no file under `implementation/core`**; it runs
in that tier because core is the substrate every artefact sits on, not because
this diff reaches it. CI runs it regardless.

### Failing-test-first evidence

Both landed bugs were witnessed failing before the fix and passing after.

- **rf2-ytyq.** The two existing assertions pinned child-before-parent.
  Inverting them to React's order against the UNFIXED source gave
  `actual: (not (< 12 11 10))` — grandchild 10, child 11, parent 12, the
  leaf-upward order the bead described, measured rather than inferred — at
  exit 1. After the source fix the same 35 tests / 157 assertions pass at exit 0.
- **rf2-oyrj.** Against the unfixed serializer the new static-markup assertion
  threw `:rf.error/static-markup-bad-element`, *Cannot render {:type :fn} as
  static markup* — the factory-returned class being applied as a Form-2 inner
  render fn and yielding a non-renderable value. Exit 1; exit 0 after the fix.

### Proving the browser assertions actually ran

A green browser suite does not by itself show that a newly added DOM test
executed — a test that never ran looks identical. So the live-mount assertion was
deliberately sabotaged and the lane re-run: it went red at exit 1, naming
`reagent2.impl.form3-factory-dom-cljs-test` /
`factory-returned-class-mounts-updates-and-unmounts`, with
`actual: (not (= "SABOTAGE-adapters-b" "hello"))`. The runtime had rendered
`"hello"` — the factory's class genuinely mounted and produced its
`:reagent-render` output — which is the positive evidence that the fix works on
the real React path and that the runtime observed the plant rather than serving a
warm pre-plant build. Both runs report the same 801 tests / 4377 assertions, so
the new deftests were present in the green run too. The plant was reverted and
the restore verified by git blob hash, not by reading a diff.

### Lanes

- **rf2-ytyq** is covered by the required `jvm-adapters-test-react` job. The
  adapter is local-test-only, has no Maven coordinate and is deliberately
  unsmoked, so its evidence comes from its own unit tests rather than a smoke
  lane — which is where the whole of its coverage lives.
- **rf2-oyrj**'s static-markup assertion runs on the always-on `:node-test` lane;
  its live-mount assertions are `-dom-cljs-test`, run by `cljs-browser`, and
  no-op cleanly under `:node-test` where there is no DOM. Note the roster
  subtlety: `test:adapter-smokes` rosters only `['reagent','uix']`, so
  reagent-slim's client-runtime smoke is the separate `test:reagent-slim:smoke`
  runner — that is the smoke lane covering this change, and it is green.

### Ratchets

Run against the tree carrying the new test file, since a new file is the shape
that trips a per-surface floor. Each was exercised against input it should flag
via its own `--self-test` where it has one.

| Ratchet | Exit | Self-test |
|---|---|---|
| `check_require_alias_dialect.py` | 0 | 0 |
| `check_test_lane_bijection.py` | 0 | 0 |
| `check_jvm_lane_rosters.py` | 0 | 0 |
| `check_adapter_disposition.py` | 0 | n/a |
| `check_readme_inventories.py` | 0 | n/a |
| `check_thrown_error_messages.py` | 0 | n/a |
| `check_retired_spellings.py` | 0 | n/a |
| `check_keyword_catalogue_drift.py` | 0 | n/a |
| `check_architecture_census.py` | 0 | n/a |
| `check-no-hardcoded-paths.sh` | 0 | n/a |
| `check-commit-attribution.sh origin/main` | 0 | n/a |

No new `:require` edge was added in either adapter — `server.cljs` already
required `reagent2.impl.component`, and `reagent-class?` is in-namespace in
`component.cljs` — so the bundle-isolation surfaces are untouched.

### Not run, and why

- **`mkdocs build --strict`.** No page under `docs_dir`, `spec/` or `migration/`
  changed. The one markdown file touched,
  `implementation/adapters/test-react/README.md`, sits beside source and is
  outside `check_doc_slugs.py`'s roots — it is `check_readme_links.py --ci`'s
  surface, which runs unguarded in `verify-readme-links` on every PR and is green
  here, with its own sabotage control confirming it bites on this exact file.
- **Everything else CI runs.** `python scripts/check_fast_pr_gap.py --brief`
  reports **99** required checks the spine does not decide, including
  `cljs-browser` and `adapter-testbed-smokes` — which is why those were run
  explicitly above rather than assumed.
