### PR TITLE
fix(story): three tools/story correctness bugs (rf2-fjax, rf2-i6v4, rf2-7aqo)

### DIFF
--- a/tools/story/src/re_frame/story/play/dom.cljc
+++ b/tools/story/src/re_frame/story/play/dom.cljc
@@ -122,11 +122,46 @@
                   (.initEvent e type true true)
                   e)))))))
 
+#?(:cljs
+   (defn native-value-setter
+     "Return the `value` SETTER declared on `node`'s DOM PROTOTYPE
+     (`HTMLInputElement` / `HTMLTextAreaElement` / `HTMLSelectElement` …),
+     skipping any own-property setter a framework installed on the node
+     ITSELF. Returns nil when the chain declares no `value` setter.
+
+     WHY THIS EXISTS (rf2-7aqo). React tracks a controlled input's last
+     value by redefining `value` as an OWN accessor on the node
+     (`trackValueOnNode`): its setter records the incoming value in the
+     tracker and THEN forwards to the native setter. A plain
+     `(set! (.-value node) text)` therefore leaves the tracker holding the
+     text we just wrote, so React's `updateValueIfChanged` reports 'value
+     did not change' and DROPS the synthetic `input`/`change` events —
+     the DOM shows the text while the component's `on-change` never
+     fires. Writing through the PROTOTYPE setter leaves the tracker stale,
+     which is exactly the state a real keystroke produces, so React
+     synthesises the change and the controlled component sees it.
+
+     This reads a standard property descriptor; it never mutates React's
+     private tracker fields. Walking the chain (rather than naming
+     `js/HTMLInputElement`) keeps textarea / select / custom elements
+     working through one code path and degrades to nil — and hence to the
+     plain assignment below — in a runtime with no such descriptor."
+     [node]
+     (loop [proto (js/Object.getPrototypeOf node)]
+       (when (some? proto)
+         (let [d (js/Object.getOwnPropertyDescriptor proto "value")]
+           (if (and (some? d) (fn? (.-set d)))
+             (.-set d)
+             (recur (js/Object.getPrototypeOf proto))))))))
+
 (defn type!
   "Simulate the user typing `text` into the input matched by
-  `selector-or-node`. Sets the `value` property and dispatches an
-  `input` event + a `change` event so reagent / onChange handlers
-  observe the new value. Returns true on success. JVM → false."
+  `selector-or-node`. Writes the value through the node's NATIVE
+  prototype setter (see `native-value-setter` — a direct
+  `(set! (.-value node) …)` is swallowed by React's controlled-input
+  value tracker) and dispatches an `input` event + a `change` event so
+  reagent / React / plain-DOM `onChange` handlers observe the new value.
+  Returns true on success. JVM → false."
   [selector-or-node text]
   #?(:clj  false
      :cljs (let [node (cond
@@ -134,7 +169,13 @@
                         (some?  selector-or-node)  selector-or-node
                         :else                      nil)]
              (if (some? node)
-               (do (set! (.-value node) text)
+               (do (if-let [setter (native-value-setter node)]
+                     (.call setter node text)
+                     ;; No prototype-declared setter (a plain object stand-in
+                     ;; in a test harness, an exotic element): fall back to
+                     ;; the ordinary assignment so the plain-DOM path keeps
+                     ;; working.
+                     (set! (.-value node) text))
                    ;; Reagent's onChange is wired to the React synthetic
                    ;; `change` event but reads from the underlying DOM
                    ;; `input` event; we dispatch both to be friendly to

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -74,6 +74,7 @@
             [re-frame.story.ui.author-expectations :as rf.story.ui.author-expectations]
             [re-frame.story.ui.controls-styles :refer [styles]]
             [re-frame.story.ui.save-variant    :as rf.story.ui.save-variant]
+            [re-frame.story.ui.schema-form     :as rf.story.ui.schema-form]
             [re-frame.story.ui.schema-validation :as rf.story.ui.schema-validation]
             [re-frame.story.ui.state           :as rf.story.ui.state]
             [re-frame.story.ui.view-state      :as rf.story.ui.view-state]))
@@ -152,7 +153,10 @@
   - `:string`             → `{:widget :text}`
   - `:int` / `:double`    → `{:widget :number}`
   - `:boolean`            → `{:widget :boolean}`
-  - `:keyword`            → `{:widget :text}` (keyword-coercion at edit)
+  - `:keyword`            → `{:widget :text :coerce :keyword}` (the
+                            `:coerce` tag is what makes the promised
+                            keyword-coercion-at-edit actually happen —
+                            `render-text` reads it, rf2-i6v4)
   - `[:enum a b c]`       → `{:widget :select :options [a b c]}`
 
   Collection shapes:
@@ -176,7 +180,7 @@
     (= :int schema-fragment)     {:widget :number}
     (= :double schema-fragment)  {:widget :number}
     (= :boolean schema-fragment) {:widget :boolean}
-    (= :keyword schema-fragment) {:widget :text}
+    (= :keyword schema-fragment) {:widget :text :coerce :keyword}
 
     (vector? schema-fragment)
     (case (schema-op schema-fragment)
@@ -393,6 +397,43 @@
   [variant-id path]
   (fn [e] (on-change-at-path variant-id path (read-event-value e))))
 
+(defn- on-coerced-change
+  "Text-input on-change handler for a widget carrying a `:coerce` tag —
+  writes the value the DOM string DENOTES rather than the string itself,
+  via the shared `rf.story.ui.schema-form/coerce-input` (the SAME
+  coercion the View-State form applies; there is no second coercion
+  table). `widget-spec` with no `:coerce` coerces to the string
+  unchanged, so this is safe for a plain text field.
+
+  rf2-i6v4: `infer-widget` promises keyword coercion at edit for a
+  `:keyword` schema, but the inferred editor wrote a plain string — so an
+  ordinary keyword argument could not round-trip through its own
+  generated control, and the written `\"loading\"` failed the very schema
+  that produced the widget."
+  [variant-id path widget-spec]
+  (fn [e]
+    (on-change-at-path variant-id path
+                       (rf.story.ui.schema-form/coerce-input
+                         widget-spec (read-event-value e)))))
+
+(defn- option-for-token
+  "Map a `<select>`'s chosen DOM string back to the SOURCE option it
+  names. `<option value>` must be a string, so the renderer prints each
+  option as its token; this reverses that projection so the override
+  carries the original `:large` / `3` rather than `\":large\"` / `\"3\"`.
+
+  The same token round-trip the View-State form's select already
+  performs (`rf.story.ui.view-state/field-widget`) — one idiom, not two.
+
+  Returns a single-element vector `[option]` on a hit and nil on a miss —
+  a BOX rather than the bare option, so a legitimately falsey option
+  (`false` in an `[:enum true false]`) is distinguishable from no match.
+  The caller treats a miss as no edit."
+  [options token]
+  (reduce (fn [_ opt] (when (= (str opt) token) (reduced [opt])))
+          nil
+          options))
+
 (defn- path-label
   "Derive an accessible name for an input from its `path`. The path tail
   is the user-visible label sibling (rendered in the `:label` span at
@@ -406,12 +447,14 @@
   (let [parts (mapv str path)]
     (str/join " / " parts)))
 
-(defn- render-text [variant-id path value _]
+(defn- render-text [variant-id path value widget-spec]
   [:input {:type       "text"
            :style      (:input styles)
            :aria-label (path-label path)
            :value      (if (nil? value) "" (str value))
-           :on-change  (on-string-change variant-id path)}])
+           :on-change  (if (:coerce widget-spec)
+                         (on-coerced-change variant-id path widget-spec)
+                         (on-string-change variant-id path))}])
 
 (defn- render-textarea [variant-id path value _]
   [:textarea {:style      (:textarea styles)
@@ -438,10 +481,20 @@
                                             (read-event-checked e)))}])
 
 (defn- render-select [variant-id path value {:keys [options]}]
+  ;; rf2-i6v4 — the DOM can only carry a STRING as an <option value>, so
+  ;; the chosen token is mapped back to the source option before it is
+  ;; written. Writing the raw string instead (as this did) meant that
+  ;; picking `:large` from a widget the `[:enum :small :large]` schema
+  ;; GENERATED stored `":large"`, which then failed that same schema and
+  ;; never exercised the view's keyword branch; a numeric enum went the
+  ;; same way. The sibling `render-radio` already writes the source
+  ;; option, so the two now agree.
   [:select {:value      (str value)
             :style      (:input styles)
             :aria-label (path-label path)
-            :on-change  (on-string-change variant-id path)}
+            :on-change  (fn [e]
+                          (when-let [[opt] (option-for-token options (read-event-value e))]
+                            (on-change-at-path variant-id path opt)))}
    (for [opt options]
      ^{:key (str opt)}
      [:option {:value (str opt)} (str opt)])])

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -291,25 +291,59 @@
                       :cell-overrides overrides
                       :dropped        dropped})))
 
-(defn egress-edn-snippet
-  "Build the copyable `(reg-variant …)` EDN form for the focused cell —
-  the variant id, its parent via `:extends`, and the effective args the
-  cell currently shows (the post-control state a recipient pastes to land
-  on the same view). Pure data → string; mirrors the save-as / recorder
-  snippet idiom (source is never written directly — the dev pastes).
+(def ^:const shared-id-prefix
+  "Per-flow prefix for the Copy-EDN snippet's derived variant id — the
+  save-variant flow's `\"saved\"` and the recorder's `\"recorded\"`
+  sibling."
+  "shared")
 
-  `shell` is the shell-state map. Returns nil when no variant is focused.
-  A fn-valued effective arg prints as an unreadable tagged literal; the
+(def ^:const shared-id-fallback
+  "Placeholder id the Copy-EDN snippet emits when the focused variant id
+  is not a qualified keyword and no id can be derived from it. A visible
+  placeholder the dev renames — never the source id, which would
+  reintroduce the self-`:extends` cycle."
+  :story.shared/example)
+
+(defn egress-edn-snippet
+  "Build the copyable `(reg-variant …)` EDN form for the focused cell — a
+  NEW variant id, the focused variant as its `:extends` parent, and the
+  effective args the cell currently shows (the post-control state a
+  recipient pastes to land on the same view). Pure data → string; mirrors
+  the save-as / recorder snippet idiom (source is never written directly
+  — the dev pastes).
+
+  THE REGISTRATION ID IS DERIVED, NOT THE SOURCE'S (rf2-fjax). This form
+  previously registered at the focused variant's OWN id while naming that
+  same id as its `:extends` parent. Pasting it did not recreate the
+  edited cell: `registrar/reg-variant` stores the new body at the SAME
+  id, REPLACING the original, and `plan/variant-plan` then seeds its
+  visited set with that id and throws `:rf.error/story-extends-cycle` on
+  the `:extends` — so the one act the dialog advertises (paste to
+  reproduce this cell) destroyed the source variant instead. The id now
+  comes from the save-as derivation
+  (`review-dialog/default-variant-id-with-prefix`, `\"shared\"` prefix),
+  so the pasted form is a sibling that extends a source which stays
+  registered and renderable.
+
+  `shell` is the shell-state map. `now-ms` seeds the derived id's suffix;
+  the 1-arity reads the wall clock, and the 2-arity exists so callers and
+  tests can pin it. Returns nil when no variant is focused. A fn-valued
+  effective arg prints as an unreadable tagged literal; the
   reproducibility badge already flags that case, so the snippet is emitted
   honestly (it is what the dev would paste) rather than silently dropped."
-  [shell]
-  (when-let [vid (:selected-variant shell)]
-    (let [eff (rf.story.args/resolve-args
-                vid
-                {:active-modes   (:active-modes shell)
-                 :cell-overrides (get-in shell [:cell-overrides vid])})]
-      (rf.story.predicates/reg-variant-form "story" vid [[:extends (pr-str vid)]
-                                          [:args (pr-str eff)]]))))
+  ([shell] (egress-edn-snippet shell (.now js/Date)))
+  ([shell now-ms]
+   (when-let [vid (:selected-variant shell)]
+     (let [eff    (rf.story.args/resolve-args
+                    vid
+                    {:active-modes   (:active-modes shell)
+                     :cell-overrides (get-in shell [:cell-overrides vid])})
+           new-id (or (rf.story.review-dialog/default-variant-id-with-prefix
+                        vid now-ms shared-id-prefix)
+                      shared-id-fallback)]
+       (rf.story.predicates/reg-variant-form "story" new-id
+                                             [[:extends (pr-str vid)]
+                                              [:args (pr-str eff)]])))))
 
 ;; ---- styling -------------------------------------------------------------
 
@@ -742,7 +776,7 @@
              [command-block
               {:test    "copy-edn"
                :name    "Copy EDN"
-               :desc    "A (reg-variant …) snippet of this cell's effective state — paste into your stories ns."
+               :desc    "A (reg-variant …) snippet of this cell's effective state — paste into your stories ns. It registers a NEW variant extending this one, so the source stays as it is."
                :badge   (reproducibility-badge report)
                :copied? (= copied :copy-edn)
                :action       (fn [_] (copy-text! :copy-edn (or edn "")))

--- a/tools/story/test/re_frame/story/play/type_controlled_input_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/type_controlled_input_dom_cljs_test.cljs
@@ -1,0 +1,263 @@
+(ns re-frame.story.play.type-controlled-input-dom-cljs-test
+  "ACCEPTANCE test for the play runner's `:type` step against REAL
+  React-controlled inputs (rf2-7aqo).
+
+  The bug: `rf.story.play.dom/type!` assigned `node.value` directly. React
+  redefines `value` as an OWN accessor on every controlled input
+  (`trackValueOnNode`); that setter records the incoming value in React's
+  value tracker BEFORE forwarding to the native setter, so
+  `updateValueIfChanged` afterwards reports 'value did not change' and
+  React DISCARDS both the `input` and the `change` synthetic events. The
+  DOM showed the text, the component's `on-change` never fired, and
+  `type!` returned true regardless — so a play could type an email and a
+  password and submit empty credentials.
+
+  The repair writes through the node's PROTOTYPE `value` setter, which is
+  the write a real keystroke performs: React's tracker stays stale, so it
+  synthesises the change.
+
+  These assertions cannot be made without a real React render — a hiccup
+  or pure-data test cannot observe the value tracker at all. Hence the
+  `-dom-cljs-test$` suffix (rf2-2hrj8), which opts the file into the
+  `:browser-test` build (Playwright + Chromium, real React via
+  `react-dom/client`). `:node-test` also loads it — its `cljs-test$`
+  regex matches this suffix — where every test self-gates on `(browser?)`
+  and exits early.
+
+  `direct-assignment-is-the-regression` is the load-bearing control: it
+  performs the OLD write on an identical mounted input and asserts the
+  controlled state does NOT update. Restoring the direct assignment in
+  `type!` therefore reds the tests above it AND leaves this one green,
+  which is what pins the seam rather than merely exercising it."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            ["react" :as React]
+            ["react-dom/client" :as react-dom-client]
+            [reagent.core :as r]
+            [re-frame.story.play.dom :as rf.story.play.dom]))
+
+;; ---- browser + act gate (mirrors the sibling DOM suites) -----------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (when (exists? (.-act React)) (.-act React)))
+
+(defn- make-mount-node! []
+  (let [node (js/document.createElement "div")]
+    (js/document.body.appendChild node)
+    node))
+
+(defn- with-browser-act [f]
+  (if-not (browser?)
+    (is true ":node-test: no DOM — the browser-test runner exercises these assertions")
+    (let [act-fn (get-act)]
+      (if (nil? act-fn)
+        (is true "act() not reachable from this runner; skipping")
+        (do (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+            (f act-fn))))))
+
+(defn- mount!
+  "Render `component` (a Reagent form) into a fresh node under `act-fn`.
+  Returns `[mount-node root]`."
+  [act-fn component]
+  (let [mount-node (make-mount-node!)
+        root       (react-dom-client/createRoot mount-node)]
+    (act-fn (fn [] (.render root (r/as-element component))))
+    [mount-node root]))
+
+(defn- unmount! [root]
+  (try (.unmount root) (catch :default _ nil)))
+
+;; ---- 1 · a controlled text input receives the typed text -----------------
+;;
+;; The view is authored the completely ordinary way: `:value` from a
+;; ratom, `:on-change` writing that ratom. It has no idea a play is
+;; driving it.
+
+(defn- controlled-input [state]
+  (fn []
+    [:input {:type      "text"
+             :data-test "typed-email"
+             :value     (:email @state)
+             :on-change #(swap! state assoc :email (.. % -target -value))}]))
+
+(deftest type-step-reaches-controlled-input-on-change
+  (testing "the public :type step delivers text to a React-controlled
+            input's on-change, and the rerender retains it"
+    (with-browser-act
+      (fn [act-fn]
+        (let [state       (r/atom {:email ""})
+              [node root] (mount! act-fn [(controlled-input state)])
+              input       (.querySelector node "[data-test=\"typed-email\"]")]
+          (try
+            (is (some? input) "the controlled input mounted")
+            (is (= "" (:email @state)) "precondition: component state starts empty")
+
+            (act-fn (fn [] (rf.story.play.dom/type! input "ada@example.com")))
+
+            (is (= "ada@example.com" (:email @state))
+                "the component's on-change received the typed text")
+            ;; The rerender retains it: React re-renders from the ratom, so
+            ;; a DOM value still reading the typed text after the flush
+            ;; proves the component OWNS that value rather than the DOM
+            ;; merely displaying an assignment React is about to revert.
+            (is (= "ada@example.com"
+                   (.-value (.querySelector node "[data-test=\"typed-email\"]")))
+                "the controlled rerender kept the typed text on screen")
+            (finally (unmount! root))))))))
+
+;; ---- 2 · textarea takes the same path ------------------------------------
+
+(defn- controlled-textarea [state]
+  (fn []
+    [:textarea {:data-test "typed-notes"
+                :value     (:notes @state)
+                :on-change #(swap! state assoc :notes (.. % -target -value))}]))
+
+(deftest type-step-reaches-controlled-textarea-on-change
+  (testing "a controlled <textarea> receives the typed text too — the
+            prototype-setter walk is not input-specific"
+    (with-browser-act
+      (fn [act-fn]
+        (let [state       (r/atom {:notes ""})
+              [node root] (mount! act-fn [(controlled-textarea state)])
+              area        (.querySelector node "[data-test=\"typed-notes\"]")]
+          (try
+            (is (some? area) "the controlled textarea mounted")
+            (act-fn (fn [] (rf.story.play.dom/type! area "line one")))
+            (is (= "line one" (:notes @state))
+                "the textarea's on-change received the typed text")
+            (is (= "line one"
+                   (.-value (.querySelector node "[data-test=\"typed-notes\"]")))
+                "the controlled rerender kept the typed text")
+            (finally (unmount! root))))))))
+
+;; ---- 3 · the submit snapshot — the symptom the bead names ----------------
+;;
+;; A minimal equivalent of `tools/story/testbeds/login_form/views.cljs`:
+;; controlled email + password whose submit handler reads the RATOM, not
+;; the raw DOM. This is the assertion that fails as "submitted empty
+;; credentials despite visibly filled inputs" under the old write.
+
+(defn- login-form [state submitted]
+  (fn []
+    [:form {:data-test "type-login-form"
+            :on-submit (fn [e]
+                         (.preventDefault e)
+                         (reset! submitted @state))}
+     [:input {:type      "email"
+              :data-test "login-email"
+              :value     (:email @state)
+              :on-change #(swap! state assoc :email (.. % -target -value))}]
+     [:input {:type      "password"
+              :data-test "login-password"
+              :value     (:password @state)
+              :on-change #(swap! state assoc :password (.. % -target -value))}]]))
+
+(deftest typed-credentials-reach-the-submit-snapshot
+  (testing "type email · type password · submit — the handler's snapshot
+            carries both typed values, not the empty initial state"
+    (with-browser-act
+      (fn [act-fn]
+        (let [state       (r/atom {:email "" :password ""})
+              submitted   (atom nil)
+              [node root] (mount! act-fn [(login-form state submitted)])]
+          (try
+            (act-fn
+              (fn []
+                (rf.story.play.dom/type!
+                  (.querySelector node "[data-test=\"login-email\"]") "grace@example.com")))
+            (act-fn
+              (fn []
+                (rf.story.play.dom/type!
+                  (.querySelector node "[data-test=\"login-password\"]") "hopper")))
+            (act-fn
+              (fn []
+                (.dispatchEvent (.querySelector node "[data-test=\"type-login-form\"]")
+                                (js/Event. "submit" #js {:bubbles true :cancelable true}))))
+            (is (= {:email "grace@example.com" :password "hopper"} @submitted)
+                "the submit handler read the typed credentials off component state")
+            (finally (unmount! root))))))))
+
+;; ---- 4 · the plain-DOM path is unchanged ---------------------------------
+
+(deftest type-step-still-drives-a-plain-dom-input
+  (testing "a plain (non-React) input still takes the value and still sees
+            both dispatched events — the repair keeps the plain-DOM path"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — the browser-test runner exercises this")
+      (let [input  (js/document.createElement "input")
+            seen   (atom [])]
+        (set! (.-type input) "text")
+        (js/document.body.appendChild input)
+        (.addEventListener input "input"  (fn [_] (swap! seen conj :input)))
+        (.addEventListener input "change" (fn [_] (swap! seen conj :change)))
+        (try
+          (is (true? (rf.story.play.dom/type! input "plain")))
+          (is (= "plain" (.-value input)) "the plain input carries the value")
+          (is (= [:input :change] @seen)
+              "both events still reach a plain-DOM listener")
+          (finally (.remove input)))))))
+
+;; ---- 5 · the regression control ------------------------------------------
+;;
+;; This is what makes the four tests above load-bearing rather than
+;; merely green. It performs the WRITE `type!` used to perform — a direct
+;; `(set! (.-value node) …)` followed by the same two events — on an
+;; identical mounted input, and asserts the controlled component state
+;; does NOT move. If React ever stops filtering that write, this test
+;; reds and tells us the seam changed; until then it pins exactly why the
+;; repair is necessary.
+
+(deftest direct-assignment-is-the-regression
+  (testing "the OLD write (direct node.value assignment) leaves the
+            controlled component's on-change unfired — the defect rf2-7aqo
+            records"
+    (with-browser-act
+      (fn [act-fn]
+        (let [state       (r/atom {:email ""})
+              [node root] (mount! act-fn [(controlled-input state)])
+              input       (.querySelector node "[data-test=\"typed-email\"]")]
+          (try
+            (act-fn
+              (fn []
+                (set! (.-value input) "swallowed@example.com")
+                (.dispatchEvent input (js/Event. "input"  #js {:bubbles true :cancelable true}))
+                (.dispatchEvent input (js/Event. "change" #js {:bubbles true :cancelable true}))))
+            (is (= "" (:email @state))
+                "React's value tracker swallowed the direct assignment — this is
+                 the bug; `type!` must not write this way")
+            (finally (unmount! root))))))))
+
+;; ---- 6 · the mechanism, asserted directly --------------------------------
+
+(deftest native-value-setter-skips-the-own-property-setter
+  (testing "native-value-setter returns the PROTOTYPE setter, not an
+            own-property setter installed on the node"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — the browser-test runner exercises this")
+      (let [input      (js/document.createElement "input")
+            proto-set  (.-set (js/Object.getOwnPropertyDescriptor
+                                (js/Object.getPrototypeOf input) "value"))
+            calls      (atom [])]
+        ;; Install an own-property accessor exactly the way React's
+        ;; `trackValueOnNode` does, and confirm the walk steps over it.
+        (js/Object.defineProperty
+          input "value"
+          #js {:configurable true
+               :get (fn [] (.call (.-get (js/Object.getOwnPropertyDescriptor
+                                           (js/Object.getPrototypeOf input) "value"))
+                                  input))
+               :set (fn [v] (swap! calls conj v) (.call proto-set input v))})
+        (let [found (rf.story.play.dom/native-value-setter input)]
+          (is (some? found) "a prototype value setter is reachable")
+          (is (identical? proto-set found)
+              "the walk returned the prototype setter, skipping the node's own one")
+          (.call found input "direct")
+          (is (= [] @calls)
+              "writing through it did NOT go via the own-property setter — which
+               is precisely why React's tracker stays stale")
+          (is (= "direct" (.-value input))
+              "and the value still landed on the node"))))))

--- a/tools/story/test/re_frame/story/ui/controls_scalar_widgets_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_scalar_widgets_cljs_test.cljc
@@ -16,7 +16,9 @@
   Runs under shadow's `:node-test` and `:browser-test` targets (the
   `cljs-test$` ns regex picks up this name)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.core :as m]
             #?(:cljs [re-frame.story :as rf.story])
+            #?(:cljs [re-frame.story.args :as rf.story.args])
             #?(:cljs [re-frame.story.ui.controls :as rf.story.ui.controls])
             [re-frame.story.ui.state :as rf.story.ui.state]))
 
@@ -330,3 +332,137 @@
                     :story.x/v [:address :street] "Main St" {:widget :text})]
          (is (re-find #"address" (-> tree second :aria-label)))
          (is (re-find #"street"  (-> tree second :aria-label)))))))
+
+;; ---- rf2-i6v4 · typed values survive the DOM adapter ---------------------
+;;
+;; The controls panel infers its widgets from the variant's Spec 010
+;; schema, so a widget the schema GENERATED must write a value that
+;; schema ACCEPTS. `<option value>` can only carry a string, so a select
+;; whose on-change wrote the raw DOM string turned `:large` into
+;; `":large"` — a value the very `[:enum :small :large]` that produced the
+;; widget rejects, and one that never reaches the view's keyword branch.
+;; The `:radio` renderer above already writes the source option; these
+;; pin the same contract for `:select`, and for the keyword coercion
+;; `infer-widget`'s `:keyword` case has always promised.
+
+#?(:cljs
+   (deftest select-widget-on-change-writes-the-keyword-option
+     (testing ":select on-change writes the SOURCE keyword option, not the
+               stringified DOM token — the value satisfies the enum that
+               generated the widget"
+       (let [tree    (rf.story.ui.controls/scalar-widget
+                       :story.x/v [:size] :small
+                       {:widget :select :options [:small :large]})
+             handler (-> tree second :on-change)]
+         (handler (input-event ":large"))
+         (let [written (get-in (rf.story.ui.state/get-state)
+                               [:cell-overrides :story.x/v :size])]
+           (is (= :large written))
+           (is (keyword? written) "a keyword, not the string \":large\"")
+           (is (m/validate [:enum :small :large] written)
+               "and it satisfies the enum schema the widget was inferred from"))))))
+
+#?(:cljs
+   (deftest select-widget-on-change-writes-the-numeric-option
+     (testing ":select on-change writes a numeric option as a number"
+       (let [tree    (rf.story.ui.controls/scalar-widget
+                       :story.x/v [:cols] 1 {:widget :select :options [1 2 3]})
+             handler (-> tree second :on-change)]
+         (handler (input-event "3"))
+         (let [written (get-in (rf.story.ui.state/get-state)
+                               [:cell-overrides :story.x/v :cols])]
+           (is (= 3 written))
+           (is (number? written) "a number, not the string \"3\"")
+           (is (m/validate [:enum 1 2 3] written)))))))
+
+#?(:cljs
+   (deftest select-widget-leaves-string-options-as-strings
+     (testing ":select does not over-coerce — a string option stays a string"
+       (let [tree    (rf.story.ui.controls/scalar-widget
+                       :story.x/v [:label] "a" {:widget :select :options ["a" "b"]})
+             handler (-> tree second :on-change)]
+         (handler (input-event "b"))
+         (is (= "b" (get-in (rf.story.ui.state/get-state)
+                            [:cell-overrides :story.x/v :label])))))))
+
+#?(:cljs
+   (deftest select-widget-ignores-a-token-naming-no-option
+     (testing ":select writes nothing when the chosen token names no option
+               — no string leaks into the override as a fallback"
+       (let [tree    (rf.story.ui.controls/scalar-widget
+                       :story.x/v [:size] :small
+                       {:widget :select :options [:small :large]})
+             handler (-> tree second :on-change)]
+         (handler (input-event ":enormous"))
+         (is (nil? (get-in (rf.story.ui.state/get-state)
+                           [:cell-overrides :story.x/v :size]))
+             "no override written for an unrecognised token")))))
+
+#?(:cljs
+   (deftest select-widget-nested-path-writes-the-typed-option
+     (testing "the same adapter at a NESTED path also writes the typed
+               option — the fix is in the widget, not in a top-level
+               special case"
+       (let [tree    (rf.story.ui.controls/scalar-widget
+                       :story.x/v [:theme :mode] :light
+                       {:widget :select :options [:light :dark]})
+             handler (-> tree second :on-change)]
+         (handler (input-event ":dark"))
+         (is (= :dark (get-in (rf.story.ui.state/get-state)
+                              [:cell-overrides :story.x/v :theme :mode])))))))
+
+#?(:cljs
+   (deftest infer-widget-keyword-carries-the-coercion-tag
+     (testing "a :keyword schema infers a text widget TAGGED for keyword
+               coercion — the docstring's promise, now carried in data"
+       (is (= {:widget :text :coerce :keyword}
+              (rf.story.ui.controls/infer-widget :keyword))))))
+
+#?(:cljs
+   (deftest keyword-text-widget-on-change-writes-a-keyword
+     (testing "a schema-derived :keyword text field edits to a KEYWORD, so
+               an ordinary keyword argument round-trips through its own
+               inferred editor"
+       (let [spec    (rf.story.ui.controls/infer-widget :keyword)
+             tree    (rf.story.ui.controls/scalar-widget :story.x/v [:status] :idle spec)
+             handler (-> tree second :on-change)]
+         (handler (input-event "loading"))
+         (is (= :loading (get-in (rf.story.ui.state/get-state)
+                                 [:cell-overrides :story.x/v :status])))
+         ;; The user types what the value PRINTS as just as readily.
+         (handler (input-event ":ready"))
+         (is (= :ready (get-in (rf.story.ui.state/get-state)
+                               [:cell-overrides :story.x/v :status])))))))
+
+#?(:cljs
+   (deftest plain-text-widget-still-writes-a-string
+     (testing "an untagged :text widget is untouched — actual string args
+               stay strings"
+       (let [tree    (rf.story.ui.controls/scalar-widget
+                       :story.x/v [:title] "" {:widget :text})
+             handler (-> tree second :on-change)]
+         (handler (input-event "loading"))
+         (is (= "loading" (get-in (rf.story.ui.state/get-state)
+                                  [:cell-overrides :story.x/v :title]))
+             "no coercion tag → the raw string, unchanged")))))
+
+#?(:cljs
+   (deftest typed-select-option-survives-into-effective-args
+     (testing "ACCEPTANCE: the typed option written by the handler is what
+               `resolve-args` hands the view — the override is not
+               re-stringified downstream"
+       (rf.story/reg-variant :story.typed/cell
+                             {:tags #{:dev} :setup [] :args {:size :small}})
+       (let [tree    (rf.story.ui.controls/scalar-widget
+                       :story.typed/cell [:size] :small
+                       {:widget :select :options [:small :large]})
+             handler (-> tree second :on-change)]
+         (handler (input-event ":large"))
+         (let [shell (rf.story.ui.state/get-state)
+               eff   (rf.story.args/resolve-args
+                       :story.typed/cell
+                       {:active-modes   (:active-modes shell)
+                        :cell-overrides (get-in shell [:cell-overrides :story.typed/cell])})]
+           (is (= :large (:size eff)))
+           (is (m/validate [:enum :small :large] (:size eff))
+               "the effective arg satisfies the enum schema"))))))

--- a/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
@@ -8,9 +8,12 @@
   Runs on CLJS under shadow's `:node-test` target (ns suffix
   `-cljs-test`). `share.cljs` is CLJS-only (Reagent / DOM)."
   (:require [clojure.string :as str]
+            [cljs.reader :as reader]
             [cljs.test :refer [deftest is testing use-fixtures async]]
             [goog.object :as gobj]
             [re-frame.story :as rf.story]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.registrar :as rf.story.registrar]
             [re-frame.story.share :as rf.story.share]
             [re-frame.story.ui.share :as rf.story.ui.share]
             [re-frame.story.ui.state :as rf.story.ui.state]))
@@ -86,17 +89,75 @@
       (fn [s] (-> s
                   (assoc :selected-variant :story.egress/counter)
                   (assoc-in [:cell-overrides :story.egress/counter] {:n 7}))))
-    (let [snip (rf.story.ui.share/egress-edn-snippet (rf.story.ui.state/get-state))]
+    (let [snip (rf.story.ui.share/egress-edn-snippet (rf.story.ui.state/get-state) 1700000000000)]
       ;; NOT `rf.story/` — this string pins EMITTED OUTPUT, not this file's
       ;; alias. The snippet is built by `rf.story.predicates/reg-variant-form`,
       ;; whose alias prefix is a plain `"story"` argument (share.cljs), so the
       ;; copyable form a user pastes still reads `(story/reg-variant …)`.
       ;; Renaming the require alias above does not move it.
       (is (str/starts-with? snip "(story/reg-variant "))
-      (is (str/includes? snip ":story.egress/counter"))
-      (is (str/includes? snip ":extends"))
+      (is (str/includes? snip ":extends :story.egress/counter")
+          "the focused variant is the PARENT")
       (is (str/includes? snip ":n 7") "the cell-override beats the variant default")
       (is (str/ends-with? snip "})")))))
+
+;; ---- rf2-fjax — the copied form must not extend itself -------------------
+
+(deftest edn-snippet-registers-a-distinct-id
+  (testing "the snippet's registration id is DERIVED from the focused
+            variant, never the focused variant itself — a form registering
+            at its own :extends parent is an :rf.error/story-extends-cycle"
+    (rf.story/reg-variant :story.egress/counter {:tags #{:dev} :setup [] :args {:n 1}})
+    (rf.story.ui.state/swap-state!
+      (fn [s] (assoc s :selected-variant :story.egress/counter)))
+    (let [snip (rf.story.ui.share/egress-edn-snippet (rf.story.ui.state/get-state) 1700000000000)
+          form (reader/read-string snip)
+          [_ new-id body] form]
+      (is (qualified-keyword? new-id))
+      (is (not= :story.egress/counter new-id)
+          "the registration id differs from the parent")
+      (is (= :story.egress/counter (:extends body))
+          "and the focused variant is what it extends")
+      (is (= "story.egress" (namespace new-id))
+          "the derived id stays in the source variant's namespace")
+      (is (str/starts-with? (name new-id) "shared-")
+          "derived through the save-as id flow, with this flow's prefix"))))
+
+(deftest edn-snippet-round-trips-through-registration
+  (testing "ACCEPTANCE: read the advertised form, register it through the
+            normal API, and compile it — it renders the original source
+            with the edited args, without a cycle, and the ORIGINAL
+            registration stays usable"
+    (rf.story/reg-variant :story.egress/counter
+                          {:tags #{:dev} :setup [] :args {:n 1 :label "base"}})
+    (rf.story.ui.state/swap-state!
+      (fn [s] (-> s
+                  (assoc :selected-variant :story.egress/counter)
+                  (assoc-in [:cell-overrides :story.egress/counter] {:n 7}))))
+    (let [snip           (rf.story.ui.share/egress-edn-snippet
+                           (rf.story.ui.state/get-state) 1700000000000)
+          [_ new-id body] (reader/read-string snip)]
+      ;; The paste, performed for real. `reg-variant` is a MACRO whose
+      ;; expansion is exactly this call, so registering the READ id + body
+      ;; through `reg-variant*` is what compiling the pasted source does —
+      ;; the only form of the paste reachable from a test, since the
+      ;; snippet's id is derived at runtime.
+      (rf.story.registrar/reg-variant* new-id body)
+
+      ;; 1 · the copied variant compiles — no :rf.error/story-extends-cycle.
+      (let [plan (rf.story.plan/variant-plan new-id)]
+        (is (some? plan) "the pasted form compiles")
+        (is (= 7 (get-in plan [:world :effective-args :n]))
+            "it lands on the edited args the cell was showing")
+        (is (= "base" (get-in plan [:world :effective-args :label]))
+            "and inherits the parent's un-overridden args through :extends"))
+
+      ;; 2 · the SOURCE registration is untouched and still renderable — the
+      ;; failure mode was that pasting REPLACED it with a self-cycling body.
+      (let [src (rf.story.plan/variant-plan :story.egress/counter)]
+        (is (some? src) "the source variant still compiles")
+        (is (= 1 (get-in src [:world :effective-args :n]))
+            "the source still carries its own args, unreplaced")))))
 
 (deftest edn-snippet-nil-without-variant
   (testing "no variant focused → no EDN snippet"


### PR DESCRIPTION
Three `tools/story` correctness bugs from the Codex surface review, each an
independent fix. All three premises were re-verified against tip before any
edit; none had drifted.

## rf2-fjax — Copy EDN generated a variant extending itself

`ui.share/egress-edn-snippet` emitted `(story/reg-variant <vid> {:extends <vid> :args …})`.
Pasting that — the one act the dialog instructs — registers the new body at the
SAME id via `registrar/reg-variant*`, replacing the original; `plan/variant-plan`
then seeds its visited set with that id and throws `:rf.error/story-extends-cycle`
on the `:extends`. Copy EDN destroyed the source variant it claimed to reproduce.

The registration id is now derived through the save-as id flow
(`review-dialog/default-variant-id-with-prefix`) under a `"shared"` prefix,
alongside the recorder's `"recorded"` and save-variant's `"saved"`. A source id
that is not a qualified keyword falls back to a visible `:story.shared/example`
placeholder — never the source id.

## rf2-i6v4 — inferred controls wrote DOM strings over typed values

`render-select` stringified options into `<option value>` and wrote the raw
string back, so choosing `:large` from a widget the `[:enum :small :large]`
schema generated stored `":large"` — a value that enum rejects. The chosen
token now maps back to the source option, the same round-trip
`ui.view-state/field-widget`'s select already performs.

`infer-widget`'s `:keyword` case documented keyword-coercion-at-edit but
returned an untyped `{:widget :text}`. It now carries `:coerce :keyword`, and
`render-text` routes a tagged widget through the existing
`ui.schema-form/coerce-input`. Untagged text widgets are untouched.

## rf2-7aqo — `:type` steps bypassed React controlled-input change handlers

`play.dom/type!` assigned `node.value` directly. React redefines `value` as an
own accessor on every controlled input (`trackValueOnNode`): that setter records
the incoming value in React's tracker before forwarding to the native setter, so
the `updateValueIfChanged` check gating synthetic `input`/`change` extraction
reports "value did not change" and both events are discarded. `type!` returned
true regardless, so a play could fill an email and a password and submit empty
credentials.

The write now goes through the `value` setter declared on the node's DOM
prototype, found by walking past any own-property setter a framework installed.
That is the write a real keystroke performs. Plain-DOM inputs are unaffected.

## rf2-shx4 — NOT in this PR

`tools/story/runtime` still does not realize authored `:network` fixtures on
normal runs. The premise is confirmed at tip and the analysis is recorded on the
bead; the repair reaches across `runtime` phase 0, `frames/allocate!`, frame
teardown and per-frame stub ownership, and is larger than the other three
combined. Left for its own dispatch.

## Quality gates

Every exit code below was captured with `echo $? > <file>` on the same command
line as the redirect, and is the number read back from that file. Nothing is
piped through a filter.

| Gate | Before | After | Captured exit |
|---|---|---|---|
| `tools/story` JVM — `clojure -M:test` | 1903 tests / 7010 assertions, 0 failures, 0 errors | 1903 tests / 7010 assertions, 0 failures, 0 errors | `0` |
| `scripts/test-jvm-tools.sh` | — | `PASS tools JVM artefacts` (10 artefact suites, 0 failures, 0 errors) | `0` |
| `npm run test:cljs` (shadow `:node-test`) | — | 11322 tests / 57103 assertions, 0 failures, 0 errors | `0` |
| `npm run test:cljs` — **sabotage control** | — | same 11322 / 57103, **2 failures**, both in the new tests | `1` |
| `npm run test:browser` (shadow `:browser-test`, Playwright + Chromium) | — | 807 tests / 4398 assertions, 0 failures, 0 errors | `0` |
| `npm run test:browser` — **sabotage control** | — | same 807 / 4398, **3 failures**, all in the new DOM suite | `1` |
| `scripts/test-fast-pr.sh` (on the final rebased base) | — | `PASS fast PR spine` | `0` |
| `python scripts/check_fast_pr_gap.py --brief` | — | **99** required checks the spine does not decide | `0` |

### Why the sabotage runs are here

Two of the three fixes live in files no JVM suite can execute, so a green alone
would not show the new tests ran at all. Each green above is paired with a run
that proves the lane sees them:

- **node-test.** A planted fault in `edn-snippet-registers-a-distinct-id` and in
  `select-widget-on-change-writes-the-keyword-option` turned the lane red naming
  both, with `actual: (not (= :story.egress/counter :story.egress/shared-0))` and
  `actual: (not (= :sabotage-story-a :large))` — the derived id and the typed
  keyword, observed.
- **browser-test.** `type!` was reverted to the old `(set! (.-value node) text)`
  and the lane went red on exactly three tests, the third reading
  `actual: (not (= {:email "grace@example.com" :password "hopper"} {:email "" :password ""}))`
  — rf2-7aqo's predicted symptom (a submit handler receiving empty credentials
  while the DOM inputs are visibly filled) reproduced under real React 19. The
  plain-DOM control and the mechanism test stayed green, so the sabotage
  discriminates the controlled path rather than breaking everything.

Both plants were reverted and the restores verified by hashing the bytes — the
raw sha256 of `play/dom.cljc` is identical to its pre-plant value, and the two
test files match their committed blobs byte-for-byte once CRLF normalisation is
accounted for.

### Lane notes

- **`tools/story` is in NO tier of the fast-PR spine.** Its header says the tool
  JVM suites are untiered, and this run's own `NOT RUN` block confirms it skipped
  all JVM artefact suites (`implementation_jvm` surface unchanged). The story JVM
  suite and `test-jvm-tools.sh` were therefore run explicitly rather than relied
  on through the spine. The spine's node tier did run, and its `gate root` line
  names this branch's worktree.
- **rf2-7aqo's covering lane is `browser-test`.** The value-tracker seam does not
  exist without a real React render, so the suite carries the `-dom-cljs-test$`
  suffix. `node-test` also loads the file, where every test self-gates on
  `(browser?)` — a green there is not evidence for this bead and is not offered
  as any. `npm run test:story-play-scripts` is the other browser lane on this
  surface but is not the acceptance lane: its rows assert a play's terminal
  status, not the component state behind it, so it would have stayed green
  through this bug.
- The new `direct-assignment-is-the-regression` test is the permanent form of the
  browser sabotage: it performs the OLD write on an identical mounted input and
  asserts the controlled state does NOT move.

### Surfaces deliberately untouched

- `spec/API.md` and both `api-manifest` sidecars: no public name moved.
- `tools/story/spec/**`: spec unchanged because none of the three bugs is a
  contract change. `017-Testing-Story.md` already promises DOM text input for
  `:dom`/`:browser`; the implementation did not meet a contract that was already
  written correctly.
- No markdown anywhere in the diff, so neither `check_doc_slugs.py` nor
  `check_readme_links.py` has a changed target on this branch.
