### PR TITLE
fix(hicasso): a disposed cell retires its cached subscribe; an open popover follows :anchor

### DIFF
--- a/docs/core/hicasso/13-overlays-and-focus.md
+++ b/docs/core/hicasso/13-overlays-and-focus.md
@@ -72,7 +72,9 @@ The options have direct responsibilities:
   frame above it; with none, it refuses at render rather than rendering a panel
   the platform may close behind app-db's back.
 - **`:anchor`** is the unique DOM id of the trigger. The module positions the
-  panel before first paint.
+  panel before first paint, and it is an ordinary prop: change it while the
+  panel is open — one shared menu reused for a newly selected row — and the
+  panel re-anchors in that same commit, without leaving the top layer.
 - **`:placement`** accepts positions such as `:bottom-start`, `:bottom-end`,
   `:top-start`, and `:right`.
 

--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -151,7 +151,7 @@
   retirement)."
   ::cell-watch)
 
-(declare flush!)
+(declare flush! retire-entries-naming!)
 
 (defn- mark-dirty! [^js cell]
   (when-not (.-disposed cell)
@@ -163,7 +163,32 @@
     (set! (.-disposed cell) true)
     (when-some [r (.-reaction cell)] (remove-watch r cell-watch-key))
     (swap! !cells dissoc (.-subKey cell))
-    (rf.subs/unsubscribe (.-frameKw cell) (.-queryV cell)))
+    (rf.subs/unsubscribe (.-frameKw cell) (.-queryV cell))
+    ;; A cell disposed while registrations STILL HOLD IT — the frame did not
+    ;; come back, so `invalidate-cell!`'s deferred phase chose disposal over
+    ;; a rewire — leaves every one of those memberships attached to a table
+    ;; slot that no longer exists. Nothing React does on its own repairs
+    ;; that: `subscribe` is cached per read-set entry, so a mounted boundary
+    ;; re-rendering the SAME read set is handed the same closure, React
+    ;; compares it by identity, does not call it again, and no
+    ;; `acquire-cell!` ever runs. The cold probe still answers a LATER
+    ;; incarnation's value on that render — which is why the paint looks
+    ;; recovered — but the boundary holds no cell, no watch and no reader
+    ;; edge, so the next write to the successor notifies nothing and the
+    ;; value freezes (rf2-3awu).
+    ;;
+    ;; So retire the cached subscribe identity: the entries naming this key
+    ;; are evicted, the next real render mints a fresh entry, and React's
+    ;; own re-subscribe is what re-acquires. The registrations themselves
+    ;; are NOT touched here — React releases each one exactly once through
+    ;; the cleanup it is already holding, which is what keeps teardown
+    ;; symmetric with mount whatever it did in between (`make-subscribe`).
+    ;;
+    ;; Guarded on the readers, so the reaper's own path — a cell whose LAST
+    ;; reader already left, disposed for idleness — keeps its entry and with
+    ;; it the keyed-reorder reuse the grace macrotask exists to buy.
+    (when (pos? (alength (.-readers cell)))
+      (retire-entries-naming! (.-subKey cell))))
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -650,6 +675,34 @@
                  (assoc entries-by-bucket bucket-key remaining-entries)
                  (dissoc entries-by-bucket bucket-key)))))
     nil))
+
+(defn- retire-entries-naming!
+  "Evict every cached read-set entry whose key set names `sub-key` — the
+  ownership half of `dispose-cell!`'s no-successor branch, and the whole
+  of it, because the cache is the only thing that could hand a mounted
+  boundary a subscription it can no longer be notified through.
+
+  Eviction and NOT a rebuild: nothing here subscribes, acquires or
+  notifies. A retired entry keeps working for as long as React holds its
+  cleanup — the closure is unaffected, only the table stops answering
+  with it — so the release still runs exactly once, from React's own
+  hand, and a boundary whose read set spans several keys is retired once
+  however many of its keys the same teardown disposes. What changes is
+  the NEXT render: `entry-for` misses, mints a fresh entry with a fresh
+  `subscribe`, React sees an identity it has not subscribed through, and
+  the commit re-acquires against whatever incarnation is live then.
+
+  Scans the whole cache rather than an index from key to entry. The cache
+  is a per-page render-set cache, this runs once per disposed cell with
+  live readers — a frame that was destroyed and did not come back — and a
+  reverse index would be a second structure to keep in step with
+  `entry-for`'s minting for no measured gain."
+  [sub-key]
+  (run! drop-entry!
+        (into []
+              (comp cat (filter (fn [^js entry] (contains? (.-set entry) sub-key))))
+              (vals @!entries)))
+  nil)
 
 (def entry-reap-horizon-ms
   "The provisional-entry reaper's delay: 4 ms, not 0. An entry is minted

--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -3,25 +3,29 @@
   an element into the browser's top layer and take it out again. The
   posture and the vocabulary are the door's; this file is the mechanism.
 
-  Each component spends two hooks. A `useContext` for the frame, because
+  Each component spends three hooks. A `useContext` for the frame, because
   an overlay's children are hiccup written in the parent boundary's body
   and lowered in THIS component's render, after that body's extent has
   unwound, so the frame the codec's intent lowering reads has to be
-  re-established around the walk. And a `useRef` for the instance cell,
+  re-established around the walk. A `useRef` for the instance cell,
   because a ref callback whose identity changed between renders is one
   React detaches and re-attaches, which for an open dialog is
-  close-then-reopen on every parent render. Neither component is a
-  boundary shell, so HD-020's shell budget is not the ceiling
+  close-then-reopen on every parent render. And a `useLayoutEffect` for
+  the one thing a stable ref cannot see — a changed `:anchor` on an
+  overlay that is already open (`reconcile-anchor!`). Neither component is
+  a boundary shell, so HD-020's shell budget is not the ceiling
   (`docs/design/hicasso/decisions.md`);
-  `overlay-dom-cljs-test/an-overlay-costs-two-hooks-and-the-shell-still-costs-two`
+  `overlay-dom-cljs-test/an-overlay-costs-three-hooks-and-the-shell-still-costs-two`
   counts them.
 
-  All of the work is in the ref callback and none of it in an effect:
-  `showModal` / `showPopover` and both halves of the anchor claim run
-  during the commit, after the node is in the document and before the
-  browser paints, and the callback's cleanup closes through the platform
+  Every one of those runs in the COMMIT, before the browser paints:
+  `showModal` / `showPopover` and the anchor claim from the ref callback,
+  after the node is in the document; the anchor's reconciliation from a
+  layout effect, which React runs in the same phase and after the panel's
+  ref has attached. The ref callback's cleanup closes through the platform
   door while the node is still connected, which is what makes the
-  platform's own focus restoration reachable. The modal alone carries a
+  platform's own focus restoration reachable. Nothing here is a passive
+  effect, and nothing waits for a frame. The modal alone carries a
   keyboard handler, `wrap-tab!`, closing the two Tab edges the engine's
   inert-document trap leaves open; a popover is deliberately not a trap.
 
@@ -327,37 +331,107 @@
    :closed-only? true})
 
 ;; ---------------------------------------------------------------------------
-;; The instance cell, and the one ref callback that ever attaches
+;; The instance cell, the one ref callback that ever attaches, and the one
+;; reconciliation that follows a changed `:anchor`
 ;; ---------------------------------------------------------------------------
+
+(defn- take-anchor!
+  "Claim the trigger the cell's CURRENT `:anchor` names, point `panel` at
+  the claim, and record which anchor id the claim was taken for. The one
+  place a claim is ever taken — the ref callback's attach and
+  `reconcile-anchor!` both come through here, so the trigger's
+  `anchor-name`, the panel's `position-anchor` and the id they were taken
+  for cannot drift apart."
+  [^js cell ^js panel]
+  (let [ident     (unchecked-get cell "ident")
+        anchor-id (unchecked-get cell "anchorId")
+        claimed   (claim-anchor! anchor-id ident)]
+    (unchecked-set cell "claimed" claimed)
+    (unchecked-set cell "claimedFor" anchor-id)
+    ;; Both halves of one claim, or neither. `claim-anchor!` answers
+    ;; nil for exactly one case — no `:anchor` at all — since a
+    ;; missing element raises rather than returns, so this guard
+    ;; reads "the author asked for no anchor" and nothing else.
+    (when claimed
+      (anchor-panel! panel ident)))
+  nil)
+
+(defn- drop-anchor!
+  "Hand back whatever `take-anchor!` claimed, and forget it. The exact
+  inverse, in one place for the same reason: the ref callback's cleanup
+  and `reconcile-anchor!`'s release half are the same act."
+  [^js cell]
+  (when-some [claimed (unchecked-get cell "claimed")]
+    (release-anchor! claimed (unchecked-get cell "ident")))
+  (unchecked-set cell "claimed" nil)
+  (unchecked-set cell "claimedFor" nil)
+  nil)
+
+(defn- reconcile-anchor!
+  "Follow a changed `:anchor` on an overlay that is ALREADY OPEN: hand the
+  previous trigger back what it had, and claim the new one, keeping the
+  panel and its top-layer entry exactly where they are.
+
+  `:anchor` is the DOM id of the trigger to position against, and neither
+  the door's contract nor the guide makes it initial-only — a single
+  shared menu moved from row A to row B is the ordinary caller. But the
+  claim is imperative, and the only commit-phase door the module had was
+  the ref callback, which React calls on ATTACHMENT and not on an
+  ordinary prop update: the panel kept the fiber, the ref kept its
+  identity, and the claim stayed on A while the panel went on resolving
+  `position-anchor` against it (rf2-kx9f).
+
+  Release before claim, and both through the shared doors above, because
+  a trigger may carry an author's own `anchor-name` and two overlays may
+  share one trigger: `release-anchor!` restores only while this overlay's
+  ident is still the name on the element, so an out-of-order reconcile
+  leaves the other panel's claim standing rather than unanchoring it.
+
+  Idempotent by `claimedFor`, which is the anchor id the standing claim
+  was taken for. That is what makes it safe to run on the render that
+  MOUNTS the panel — the ref callback attached first and has already
+  claimed, so this sees no change and touches nothing — and what keeps an
+  unrelated re-render from churning a live claim."
+  [^js cell]
+  (let [^js panel (unchecked-get cell "panel")]
+    (when (and (some? panel)
+               (not= (unchecked-get cell "anchorId")
+                     (unchecked-get cell "claimedFor")))
+      (drop-anchor! cell)
+      (take-anchor! cell panel)))
+  nil)
 
 (defn- make-cell
   "The per-instance state: an anchor ident minted once, the trigger this
-  overlay claimed, and the stable ref callback that owns both. Every use
-  of the ident is inside that callback, which is what keeps it out of the
-  server bytes (see `anchor-panel!`)."
+  overlay claimed and the id it was claimed for, the panel node while one
+  is attached, and the stable ref callback that owns all of them. Every
+  use of the ident is inside that callback or inside
+  `reconcile-anchor!`, both of which run at the commit against a document
+  — which is what keeps it out of the server bytes (see `anchor-panel!`).
+
+  The ref's identity is STABLE across every render, deliberately: React
+  detaches and re-attaches a ref whose identity changed, which for an
+  open overlay would be `hidePopover()`/`showPopover()` — a real platform
+  dismissal, `beforetoggle` and all — on every render that moved the
+  anchor. Following a changed `:anchor` is therefore
+  `reconcile-anchor!`'s job and not the ref's."
   [{:keys [show! hide!]}]
-  (let [cell #js {"ident"    (next-anchor-ident)
-                  "anchorId" nil
-                  "claimed"  nil}]
+  (let [cell #js {"ident"      (next-anchor-ident)
+                  "anchorId"   nil
+                  "claimed"    nil
+                  "claimedFor" nil
+                  "panel"      nil}]
     (unchecked-set
       cell "ref"
       (fn [node]
         (when node
-          (let [ident   (unchecked-get cell "ident")
-                claimed (claim-anchor! (unchecked-get cell "anchorId") ident)]
-            (unchecked-set cell "claimed" claimed)
-            ;; Both halves of one claim, or neither. `claim-anchor!` answers
-            ;; nil for exactly one case — no `:anchor` at all — since a
-            ;; missing element raises rather than returns, so this guard
-            ;; reads "the author asked for no anchor" and nothing else.
-            (when claimed
-              (anchor-panel! node ident)))
+          (unchecked-set cell "panel" node)
+          (take-anchor! cell node)
           (show! node)
           (fn []
             (hide! node)
-            (when-some [claimed (unchecked-get cell "claimed")]
-              (release-anchor! claimed (unchecked-get cell "ident")))
-            (unchecked-set cell "claimed" nil)
+            (drop-anchor! cell)
+            (unchecked-set cell "panel" nil)
             nil))))
     cell))
 
@@ -424,6 +498,19 @@
       (set! (.-current ref-cell) (make-cell ops)))
     (let [cell (.-current ref-cell)]
       (unchecked-set cell "anchorId" (:anchor props))
+      ;; Hook 3 — the anchor's commit-phase reconciliation, and the module's
+      ;; only effect. It is a LAYOUT effect for the same reason everything
+      ;; else here is in the ref callback: the claim is a position, and a
+      ;; position corrected after paint is a visible jump from the old
+      ;; trigger to the new one. React attaches the panel's ref before it
+      ;; runs this parent's layout effects, so on the render that opens an
+      ;; overlay the claim is already taken and `reconcile-anchor!` finds
+      ;; nothing to do; on an ordinary re-render the dependency ties and it
+      ;; is not called at all. Unconditional and above the `:open?` branch,
+      ;; because a closed overlay renders nil and hooks may not be
+      ;; conditional — with no panel attached the reconciliation is a no-op.
+      (react/useLayoutEffect (fn [] (reconcile-anchor! cell) js/undefined)
+                             #js [(:anchor props)])
       ;; Zero cost when closed: no element, so no top-layer entry, no
       ;; listener, no anchor claim and no children rendered.
       (when (:open? props)

--- a/implementation/hicasso/src/re_frame/hicasso/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/overlay.cljs
@@ -203,8 +203,11 @@
 
   `:anchor` is the DOM id of the trigger; the module gives that element a
   generated CSS anchor name while the panel is open and puts back whatever
-  it found on the way out. `:placement` is the compass word that becomes a
-  `position-area` against it. With `:on-dismiss` the panel is a
+  it found on the way out. It is an ordinary prop and not an initial-only
+  one: change it on a panel that is already open — one shared menu moved
+  from row A to row B — and the claim moves with it, in the same commit
+  and without the panel leaving the top layer. `:placement` is the compass
+  word that becomes a `position-area` against it. With `:on-dismiss` the panel is a
   `popover=\"auto\"` and takes its place in the platform's LIFO stack;
   without one it is `popover=\"manual\"` and dismisses for nothing, because
   a dismissal with nowhere to go is how an open flag acquires a second

--- a/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
@@ -26,8 +26,12 @@
     nothing is omitted, and no fallback stands in — because none is
     needed.
   - **HS-32, overlays.** The module's whole client mechanism is one ref
-    callback (`impl.overlay/make-cell`), and React does not call refs
-    during `renderToString`. What that omits is the *top-layer entry*,
+    callback (`impl.overlay/make-cell`) and one layout effect that
+    follows a changed `:anchor` (`impl.overlay/reconcile-anchor!`), and
+    `renderToString` calls neither — React does not attach refs on the
+    server, and its server dispatcher's `useLayoutEffect` is `noop`
+    (read off the pinned `react-dom-server.node.development.js` rather
+    than assumed). What that omits is the *top-layer entry*,
     not the markup: an open overlay's panel and all of its children ARE
     in the server bytes. They are invisible there because a `<dialog>`
     without `open` and an unshown `[popover]` are both `display:none` by

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
@@ -34,7 +34,8 @@
   | zero cost when closed | [[a-closed-overlay-has-no-element-no-listener-and-no-rendered-body]] |
   | an intent inside an overlay lowers in the overlay's frame | [[an-intent-on-an-overlay-child-dispatches-in-the-frame-above-it]] |
   | the anchor is claimed while open and put back after | [[the-anchor-is-claimed-while-open-and-handed-back-on-teardown]] |
-  | two hooks here, and still two in the shell | [[an-overlay-costs-two-hooks-and-the-shell-still-costs-two]] |
+  | an OPEN panel's anchor follows the prop that names it | [[an-open-popovers-anchor-follows-the-prop-that-names-it]] |
+  | three hooks here, and still two in the shell | [[an-overlay-costs-three-hooks-and-the-shell-still-costs-two]] |
   | a close request arrives as an intent | [[a-close-request-on-a-modal-arrives-as-an-intent]] |
   | a REAL Escape takes that same door, and a synthetic one takes none | [[a-real-escape-dismisses-the-modal-and-a-synthetic-one-does-nothing]] |
   | the focus one-shot, and which spelling reaches the platform | [[the-focus-one-shot-is-the-platforms-focus-delegate-and-not-reacts-autofocus]] |
@@ -156,6 +157,15 @@
 (rf/reg-event ::retag (fn [{:keys [db]} [_ tag]] {:db (assoc db :dismiss-tag tag)}))
 (rf/reg-event ::clicked (fn [{:keys [db]} [_ k]] {:db (assoc-in db [:clicked k] true)}))
 (rf/reg-sub ::body-read (fn [db _] (:body-read db)))
+;; The moving-anchor row's model: WHICH trigger an open popover is anchored
+;; to is ordinary application state, so a dispatch moves it while the panel
+;; stays open and the row can ask which element carries the claim.
+(rf/reg-sub ::anchor (fn [db _] (:anchor db)))
+(rf/reg-event ::anchored (fn [{:keys [db]} [_ id]] {:db (assoc db :anchor id)}))
+;; A write that changes NOTHING the overlay reads — the churn control's
+;; re-render trigger.
+(rf/reg-sub ::tick (fn [db _] (:tick db 0)))
+(rf/reg-event ::ticked (fn [{:keys [db]} _] {:db (update db :tick (fnil inc 0))}))
 
 ;; MAP fixtures (`:async? true`), and not a preference: this file now
 ;; carries an `(async done …)` row — the trusted-input bridge presses a
@@ -1274,13 +1284,143 @@
                 "and the panel never opened"))
           (finally (rf.hicasso.impl.mount/release! handle)))))))
 
+;; --- the anchor that MOVES -------------------------------------------------
+
+(rf.hicasso/defview moving-anchor-page [_]
+  [:div
+   ;; TWO persistent triggers with distinct stable ids, both mounted for the
+   ;; whole row, each carrying an author-written `anchor-name` the module
+   ;; must hand back untouched. Neither is unmounted or re-keyed: what moves
+   ;; is the `:anchor` PROP of one open panel.
+   [:button#move-a {:type "button" :style {:anchor-name "--mine-a"}} "A"]
+   [:button#move-b {:type "button" :style {:anchor-name "--mine-b"}} "B"]
+   ;; No `:on-dismiss`, so `popover="manual"`: this row is about the anchor,
+   ;; and a light dismiss firing mid-row would close the panel for a reason
+   ;; that has nothing to do with what is being measured.
+   [rf.hicasso.overlay/popover {:open?     (rf.hicasso/sub [::open? :mv])
+                     :anchor    (rf.hicasso/sub [::anchor])
+                     :placement :bottom-start
+                     :id        "pop-mv"
+                     ;; Read but unused — the churn control's re-render
+                     ;; arrives through the same boundary and must reach
+                     ;; this component's props without moving the claim.
+                     :data-tick (str (rf.hicasso/sub [::tick]))}
+    [:p "Menu"]]
+   ;; Room below the triggers, for the reason `anchored-page` gives.
+   [:div {:style {:height "1200px"}}]])
+
+(deftest an-open-popovers-anchor-follows-the-prop-that-names-it
+  ;; `:anchor` is the DOM id of the trigger to position against, and neither
+  ;; the door's contract nor the guide makes it initial-only. But the claim
+  ;; is imperative and the module's only commit-phase door used to be the ref
+  ;; callback, which React calls on ATTACHMENT — so a shared menu moved from
+  ;; row A to row B kept the claim on A, and the panel went on resolving
+  ;; `position-anchor` against the row the user had just left (rf2-kx9f).
+  ;;
+  ;; Every reading is the ENGINE's: which element carries the name the
+  ;; panel's `position-anchor` resolves, and where the engine actually put
+  ;; the box. An attribute the module just wrote would be green for a
+  ;; runtime that wrote it and anchored nothing.
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (skip! ":node-test resolves no anchors, because it computes no style")
+    (do
+      (fresh!)
+      (rf/with-frame frame-id (rf/dispatch-sync [::anchored "move-a"]))
+      (let [handle (rf.hicasso.impl.mount/root! (rf.hicasso.impl.mount/fresh-container!)
+                                                frame-id [moving-anchor-page {}])]
+        (try
+          (rf.hicasso.impl.mount/settle!)
+          (let [a ($ "#move-a")
+                b ($ "#move-b")]
+            (is (and (= "--mine-a" (.. a -style -anchorName))
+                     (= "--mine-b" (.. b -style -anchorName)))
+                "premise: both triggers carry their author's own anchor name")
+            (.scrollIntoView a #js {"block" "center"})
+
+            (go! [::opened :mv])
+            (let [panel ($ "#pop-mv")]
+              (testing "OPEN ON A: the claim is on the first trigger, the panel
+                        points at it, and the engine put the box there"
+                (is (.matches panel ":popover-open") "premise: the panel is open")
+                (let [claimed (.. a -style -anchorName)]
+                  (is (not= "--mine-a" claimed) "A is claimed")
+                  (is (= claimed (.. panel -style -positionAnchor))
+                      "and the panel's `position-anchor` names that very claim"))
+                (is (= "--mine-b" (.. b -style -anchorName))
+                    "B is untouched — one overlay, one claim")
+                (let [ra (.getBoundingClientRect a)
+                      rp (.getBoundingClientRect panel)]
+                  (is (< (js/Math.abs (- (.-left rp) (.-left ra))) 2)
+                      (str ":bottom-start left-aligns the panel with A. "
+                           "A.left=" (.-left ra) " panel.left=" (.-left rp)))))
+
+              (testing "MOVED TO B: the same open panel, the same node, the
+                        same top-layer entry — and the claim released from A
+                        and taken on B"
+                (go! [::anchored "move-b"])
+                (is (identical? panel ($ "#pop-mv"))
+                    "premise: React kept the node — this is a prop update and
+                     not a remount")
+                (is (.matches panel ":popover-open")
+                    "and the panel never closed and reopened")
+                (is (= "--mine-a" (.. a -style -anchorName))
+                    "A got back exactly what its author wrote")
+                (let [claimed (.. b -style -anchorName)]
+                  (is (not= "--mine-b" claimed) "B is claimed now")
+                  (is (= claimed (.. panel -style -positionAnchor))
+                      "and it is the name the panel's `position-anchor` uses,
+                       which is the whole of what anchoring is"))
+                (let [rb (.getBoundingClientRect b)
+                      rp (.getBoundingClientRect panel)]
+                  (is (< (js/Math.abs (- (.-left rp) (.-left rb))) 2)
+                      (str "so the ENGINE moved the box to B. B.left=" (.-left rb)
+                           " panel.left=" (.-left rp)
+                           " A.left=" (.-left (.getBoundingClientRect a))))))
+
+              (testing "AN UNRELATED RE-RENDER does not churn a live claim: the
+                        panel re-renders for a prop it does not anchor on, and
+                        the name on B is the one that was already there"
+                (let [held (.. b -style -anchorName)]
+                  (go! [::ticked])
+                  (is (= "1" (.getAttribute panel "data-tick"))
+                      "premise: the panel really did re-render")
+                  (is (= held (.. b -style -anchorName))
+                      "and the claim was neither released nor re-taken")))
+
+              (testing "REMOVED WHILE OPEN: dropping `:anchor` releases the
+                        claim rather than leaving it standing, which is the
+                        same defect read from the other end"
+                (go! [::anchored nil])
+                (is (= "--mine-b" (.. b -style -anchorName))
+                    "B got back exactly what its author wrote")
+                (is (= "--mine-a" (.. a -style -anchorName))
+                    "and A is still holding its own")
+                (is (.matches panel ":popover-open")
+                    "with the panel still open, now at the UA's default
+                     position — which is what no anchor means"))
+
+              (testing "and a claim taken after a removal is still a whole
+                        claim, so the module did not merely stop claiming"
+                (go! [::anchored "move-a"])
+                (let [claimed (.. a -style -anchorName)]
+                  (is (not= "--mine-a" claimed) "A is claimed again")
+                  (is (= claimed (.. panel -style -positionAnchor))))))
+
+            (testing "TEARDOWN: closing hands back whatever the last claim
+                      found, and both triggers end the row as their author
+                      wrote them"
+              (go! [::closed :mv])
+              (is (= "--mine-a" (.. a -style -anchorName)))
+              (is (= "--mine-b" (.. b -style -anchorName)))))
+          (finally (rf.hicasso.impl.mount/release! handle)))))))
+
 ;; --- the budget ------------------------------------------------------------
 
 (rf.hicasso/defview budget-page [_]
   [rf.hicasso.overlay/modal {:open? (rf.hicasso/sub [::open? :m]) :on-dismiss [::dismissed :m]}
    [:p "cost"]])
 
-(deftest an-overlay-costs-two-hooks-and-the-shell-still-costs-two
+(deftest an-overlay-costs-three-hooks-and-the-shell-still-costs-two
   (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test does not run this suite's mount")
     (if-not (rf.hicasso.hook-probe/install!)
@@ -1304,16 +1444,21 @@
                   "and the declared shell ledger is still two"))
 
             (let [tail (vec (distinct (drop 2 names)))]
-              (testing "THE MODULE'S OWN ROSTER: two names, and neither is a
+              (testing "THE MODULE'S OWN ROSTER: three names, and none is a
                         subscription. The ≤2-hook ceiling I9 polices is the
                         boundary SHELL's, which this module does not touch —
                         it adds no hook to any boundary at all"
-                (is (= ["useContext" "useRef"] tail)
-                    (str "the frame hook and the instance cell. Raw tail: "
+                (is (= ["useContext" "useRef" "useLayoutEffect"] tail)
+                    (str "the frame hook, the instance cell, and the anchor's
+                          commit-phase reconciliation. Raw tail: "
                          (pr-str (drop 2 names))))
                 (is (empty? (filter #{"useSyncExternalStore" "useState" "useEffect"
-                                      "useLayoutEffect" "useMemo" "useCallback"}
+                                      "useMemo" "useCallback"}
                                     tail))
-                    "no effect, no state, no second store subscription — the
-                     work happens in a ref callback, which is not a hook")))
+                    "no state, no passive effect, no second store subscription
+                     — the show/hide and the anchor claim happen in a ref
+                     callback, which is not a hook, and the one hook that was
+                     unavoidable is a LAYOUT effect, because the thing it
+                     corrects is a position (`impl.overlay/reconcile-anchor!`,
+                     rf2-kx9f)")))
             (finally (when @handle (rf.hicasso.impl.mount/release! @handle)))))))))

--- a/implementation/hicasso/test/re_frame/hicasso/reincarnation_readset_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/reincarnation_readset_dom_cljs_test.cljs
@@ -1,0 +1,377 @@
+(ns re-frame.hicasso.reincarnation-readset-dom-cljs-test
+  "A MOUNTED READ SET ACROSS A LATER-TASK FRAME RECREATION — the value the
+  cold probe recovers, and the ownership it does not.
+
+  `reincarnation_cells_cljs_test` takes the SYNCHRONOUS transition at the
+  commit seam, where `invalidate-cell!`'s deferred phase finds the
+  successor already seated and re-wires the held cell. Its section 3
+  records the other branch in a comment: *a successor seated in a later
+  task now finds the cell disposed and recovers through `cold-read!`'s
+  probe on the next render instead, which is the recovery a key that
+  never had a cell already gets*.
+
+  That recovery is real and it is not enough. A probe answers a VALUE; it
+  takes no reference, records no edge and installs no watch. What the
+  disposal left behind is a committed registration attached to a table
+  slot that no longer exists — and React repairs none of it on its own,
+  because `subscribe` is cached per read-set entry: a mounted boundary
+  re-rendering the same read set is handed the same closure, React
+  compares it by identity, and no `acquire-cell!` ever runs.
+
+  So the boundary paints the successor on the render that recreated the
+  frame, and is deaf to every write after it. **The paint is what makes
+  this dangerous**: a value-only assertion on that first render reads
+  green, which is why every row below asserts the painted value as a
+  PREMISE and then goes on to ask what the runtime is holding (rf2-3awu).
+
+  ## What each row is for
+
+  | row | what it establishes |
+  |---|---|
+  | [[a-mounted-read-set-reacquires-after-a-later-task-recreation]] | the full sequence: mount, destroy, drain, recreate a task later, force a same-head props re-render, then write to the successor. The painted value, the reacquired membership, and the write that has to land. |
+  | [[an-unrelated-re-render-does-not-churn-a-live-membership]] | the negative control. The retirement is reached by a DISPOSAL, not by rendering, so an ordinary re-render inside one incarnation keeps the entry, the cell and the reader it already had. |
+  | [[the-declared-population-was-actually-exercised]] | the roster, asserted rather than described. |
+
+  ## The native hook rides the same entry, and is asserted rather than assumed
+
+  `n/use-sub` hands `useSyncExternalStore` the entry `collector/hook-entry`
+  mints for its one key, and a boundary whose read set IS that one key
+  resolves the same object. So the island in these rows is not a second
+  implementation under test: it is the control that says the boundary's
+  repair reaches the hook door because there is one mechanism, and the
+  residue readings — one cell, TWO readers — are what say it.
+
+  ## The lane
+
+  `:node-test` compiles this namespace too (`cljs-test$` matches
+  `-dom-cljs-test`) and has no document, so every row degrades to an
+  explicit skip there rather than to an assertion that passes because
+  nothing ran. The real run is `npm run test:browser`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [clojure.set :as set]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.hicasso :as rf.hicasso]
+            [re-frame.hicasso.checkpoint-support :as rf.hicasso.checkpoint-support]
+            [re-frame.hicasso.impl.collector :as rf.hicasso.impl.collector]
+            [re-frame.hicasso.impl.mount :as rf.hicasso.impl.mount]
+            [re-frame.hicasso.native :as rf.hicasso.native]
+            [re-frame.hicasso.test.runtime :as rf.hicasso.test.runtime]
+            [re-frame.test-support :as rf.test-support]
+            ["react" :as react]))
+
+(def ^:private frame-id ::reincarnation-readset)
+
+(rf/reg-event :readset/seed (fn [_ [_ who]] {:db {:who who}}))
+(rf/reg-sub   :readset/who  (fn [db _] (:who db)))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rf.hicasso.impl.collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The exercised population — a MEASUREMENT, not a claim
+;; ---------------------------------------------------------------------------
+
+(def ^:private declared-population
+  "The two transitions this file undertakes to reach at runtime. A row
+  that starts returning early fails the last deftest instead of quietly
+  shrinking the evidence."
+  #{:readset/later-task-recreation
+    :readset/unrelated-rerender})
+
+(defonce ^:private !exercised (atom #{}))
+
+(defn- exercised! [mechanism] (swap! !exercised conj mechanism) nil)
+
+;; ---------------------------------------------------------------------------
+;; The page — one boundary and one island, reading one key
+;; ---------------------------------------------------------------------------
+
+(def ^:private sub-key [frame-id [:readset/who]])
+
+(defn- island
+  "A raw React island reading the same key the boundary reads, through
+  `n/use-sub` — the hook door onto the very entry the boundary resolves."
+  [_props]
+  (react/createElement "i" #js {"className" "island"}
+                       (str (rf.hicasso.native/use-sub [:readset/who]))))
+
+(rf.hicasso/defhost island-host island {:server :render})
+
+(rf.hicasso/defview who-page
+  "The mounted view. `:revision` is in the props and NOWHERE in the read
+  set: it exists so a row can force a real re-render of the same head
+  without changing what the body reads, which is the shape the defect
+  needs (`boundary-props=` compares the whole props value, so a changed
+  revision defeats the memo bail-out). It is written to the DOM as well,
+  so a row can prove the re-render happened rather than trusting it."
+  [{:keys [revision]}]
+  [:div
+   [:b.who {:data-revision (str revision)} (rf.hicasso/sub [:readset/who])]
+   [island-host {}]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- skip! [why]
+  (is true (str "a mounted-ownership claim needs a real React DOM — " why)))
+
+(defn- seat!
+  "Create the frame under `frame-id` and seed it — the same three
+  synchronous forms that mount the predecessor and seat the successor,
+  because the transition under test is the ordinary one a tenant or
+  account switch performs."
+  [who]
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:readset/seed who]))
+  (rf.frame/frame-incarnation-token frame-id))
+
+(defn- text [handle] (.-textContent ^js (:container handle)))
+
+(defn- revision-attr [handle]
+  (some-> ^js (.querySelector ^js (:container handle) "b.who")
+          (.getAttribute "data-revision")))
+
+(defn- readers-residue
+  "The residue with `:entries` dropped — cells, memberships, boundaries
+  and edges, which is what a reacquisition has to move."
+  []
+  (dissoc (rf.hicasso.test.runtime/residue) :entries))
+
+(defn- poll [pred label]
+  (rf.test-support/poll-until pred {:label label :timeout-ms 4000}))
+
+(defn- later-task
+  "A promise of `(f)` evaluated in a LATER TASK. The whole transition
+  under test is that the successor arrives after the microtask checkpoint
+  that disposed the predecessor's cell has already run — which a promise
+  turn cannot express, because a task cannot be dequeued inside one."
+  [f]
+  (js/Promise. (fn [resolve] (js/setTimeout (fn [] (resolve (f))) 0))))
+
+(defonce ^:private !minted
+  ;; Every root a row has minted, oldest first; emptied by the single
+  ;; trailing step. `defonce` takes no docstring, hence the comment.
+  (atom []))
+
+(defn- release-minted!
+  "Release every root this row minted, and forget them. Rides the single
+  trailing step, which BOTH arms reach, so a row whose poll timed out or
+  whose body threw cannot leave a live root standing in the document for
+  the next namespace to inherit. `mount/release!` is idempotent."
+  []
+  (run! rf.hicasso.impl.mount/release! @!minted)
+  (reset! !minted [])
+  nil)
+
+(defn- mount-live!
+  "Mount at `revision`, and return only once the read set is provably
+  COMMITTED — two readers on one cell, the boundary's and the island's.
+  `useSyncExternalStore` calls `subscribe` in a passive effect React
+  flushes after the commit, and a row that started before it would be
+  measuring an unsubscribed tree and would stay green through a runtime
+  that reacquired nothing.
+
+  Enrols the root in [[!minted]] the instant it exists, because from that
+  instant until [[release-minted!]] runs there is a live root on the page
+  and this promise is the only thing that could ever name it."
+  [revision]
+  (let [container (rf.hicasso.impl.mount/fresh-container!)
+        handle    (rf.hicasso.impl.mount/root! container frame-id [who-page {:revision revision}])]
+    (swap! !minted conj handle)
+    (-> (poll #(= {:cells 1 :cell-refs 2 :boundaries 2 :edges 2} (readers-residue))
+              "the boundary and the island are both committed on one cell")
+        (.then (fn [_] handle)))))
+
+(defn- report-failure!
+  "Record `label` against THIS row and DELIBERATELY DO NOT finish it. The
+  chain's single trailing step calls `done` and owns the teardown, for
+  the reason `poll-until`'s own docstring gives: `cljs.test/run-block`
+  hands `done` a continuation that runs the whole remainder of the run
+  synchronously, so a `.catch` downstream of `done` claims a foreign
+  failure as this row's and then calls `done` twice."
+  [label handle]
+  (fn [e]
+    (is false (str label " — " (.-message e)
+                   " | DOM was " (pr-str (when handle (text handle)))
+                   " | residue " (pr-str (readers-residue))))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; The row the bead is about
+;; ---------------------------------------------------------------------------
+
+(deftest a-mounted-read-set-reacquires-after-a-later-task-recreation
+  (async done
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (skip! ":node-test has no document to mount into") (done))
+      (do
+        (rf.hicasso.checkpoint-support/leave-act-environment!)
+        (seat! "A")
+        (-> (mount-live! 0)
+            (.then
+              (fn [handle]
+                (testing "the premise: a committed read set, held by two
+                          readers of one key — the boundary's registration and
+                          the island's, which is the SAME entry because a
+                          one-key read set is an ordinary read set"
+                  (is (= "A" (rf/with-frame frame-id @(rf/subscribe [:readset/who])))
+                      "the predecessor holds the value")
+                  (is (some? (rf.hicasso.test.runtime/cell-reaction sub-key))
+                      "and the runtime holds a live cell for the key"))
+
+                ;; 1 — destroy, and let the invalidation microtask RUN. With
+                ;; no successor to rebuild against, the deferred phase
+                ;; disposes: the exact no-successor teardown, unchanged.
+                (rf/destroy-frame! frame-id)
+                (-> (rf.hicasso.checkpoint-support/drain-checkpoint
+                      #(zero? (:cells (readers-residue))))
+                    (.then
+                      (fn [turns]
+                        (testing "inside the checkpoint the cell is DISPOSED —
+                                  the frame did not come back, so this is the
+                                  no-successor branch and not a rewire"
+                          (is (some? turns)
+                              (str "the disposal did not land inside the "
+                                   "microtask checkpoint; residue "
+                                   (pr-str (readers-residue))))
+                          (is (nil? (rf.hicasso.test.runtime/cell-reaction sub-key))))
+
+                        ;; 2 — the successor arrives in a LATER TASK, which is
+                        ;; the whole transition: the disposal has already run.
+                        (later-task
+                          (fn []
+                            (seat! "B")
+                            ;; 3 — a forced same-head props re-render. The read
+                            ;; set is unchanged, so this is exactly the render
+                            ;; React answers without re-subscribing.
+                            (rf.hicasso.impl.mount/render! handle [who-page {:revision 1}])
+                            handle))))
+                    (.then
+                      (fn [handle]
+                        (testing "the premise, and the trap: the re-render
+                                  really happened, and BOTH doors paint the
+                                  successor — `cold-read!`'s probe answers the
+                                  live incarnation, so a value-only assertion
+                                  reads green right here"
+                          (is (= "1" (revision-attr handle))
+                              "the same head re-rendered under new props")
+                          (is (= "BB" (text handle))
+                              (str "the boundary and the island both show the "
+                                   "successor's value; DOM was "
+                                   (pr-str (text handle)))))
+
+                        ;; 4 — what the probe did NOT do.
+                        (poll #(= {:cells 1 :cell-refs 2 :boundaries 2 :edges 2}
+                                  (readers-residue))
+                              "the mounted read set reacquires a cell and both memberships")))
+                    (.then
+                      (fn [_]
+                        (testing "the mounted boundary and island REGAINED
+                                  reactive ownership: one cell under the
+                                  successor, two reader memberships, two
+                                  dependency edges — the probe took none of
+                                  those, so this is the entry retirement being
+                                  spent on React's own re-subscribe"
+                          (is (= {:cells 1 :cell-refs 2 :boundaries 2 :edges 2}
+                                 (readers-residue)))
+                          (is (some? (rf.hicasso.test.runtime/cell-reaction sub-key))
+                              "and the cell holds a live reaction, so a write
+                               has an edge to travel"))
+
+                        ;; 5 — the assertion the impact statement is about: a
+                        ;; write to the SUCCESSOR has to reach the screen.
+                        (rf/with-frame frame-id (rf/dispatch-sync [:readset/seed "C"]))
+                        (rf.hicasso.impl.mount/settle!)
+                        (poll #(= "CC" (text handle))
+                              "a write to the successor repaints both doors")))
+                    (.then
+                      (fn [_]
+                        (testing "so the boundary is LIVE under the successor
+                                  rather than frozen at the value one render
+                                  happened to probe"
+                          (is (= "CC" (text handle))))
+                        (exercised! :readset/later-task-recreation)
+                        (rf.hicasso.impl.mount/unmount! handle)
+                        (.then (rf.hicasso.test.runtime/quiesced!)
+                               (fn [_]
+                                 (testing "and teardown is still exact — the
+                                           retirement evicted a cache, it did
+                                           not leave a membership behind for
+                                           somebody else to release"
+                                   (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0}
+                                          (readers-residue))))
+                                 nil))))
+                    (.catch (report-failure! "later-task reacquisition" handle)))))
+            (.catch (report-failure! "later-task reacquisition" nil))
+            ;; The single trailing step, which BOTH arms reach.
+            (.then (fn [_] (release-minted!) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; The negative control — the repair is reached by a disposal, not by a render
+;; ---------------------------------------------------------------------------
+
+(deftest an-unrelated-re-render-does-not-churn-a-live-membership
+  ;; Without this row the one above is satisfied by a runtime that retired
+  ;; every entry on every render: the read set would be reacquired after the
+  ;; recreation, and also rebuilt on every ordinary re-render in between —
+  ;; a fresh cell, a fresh subscription and a fresh baseline deref for a
+  ;; boundary whose reads did not move. The repair is a DISPOSAL's, and this
+  ;; is what says so.
+  (async done
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (skip! ":node-test has no document to mount into") (done))
+      (do
+        (rf.hicasso.checkpoint-support/leave-act-environment!)
+        (seat! "A")
+        (-> (mount-live! 0)
+            (.then
+              (fn [handle]
+                (let [reaction (rf.hicasso.test.runtime/cell-reaction sub-key)
+                      entry    (rf.hicasso.impl.collector/last-reads)]
+                  (rf.hicasso.impl.mount/render! handle [who-page {:revision 1}])
+                  (testing "the premise: the same head really did re-render
+                            under new props"
+                    (is (= "1" (revision-attr handle))))
+
+                  (testing "and the runtime held everything still: the same
+                            cell, deriving through the SAME reaction, with the
+                            same two memberships on it — no eviction, no
+                            re-subscribe, no rebuilt baseline"
+                    (is (= {:cells 1 :cell-refs 2 :boundaries 2 :edges 2}
+                           (readers-residue)))
+                    (is (identical? reaction
+                                    (rf.hicasso.test.runtime/cell-reaction sub-key))
+                        "the cell was not rebuilt")
+                    (is (identical? entry (rf.hicasso.impl.collector/last-reads))
+                        "and the read-set entry the render resolved is the one
+                         already committed, so React was handed a `subscribe`
+                         it has already subscribed through"))
+
+                  (exercised! :readset/unrelated-rerender)
+                  (rf.hicasso.impl.mount/unmount! handle)
+                  (.then (rf.hicasso.test.runtime/quiesced!)
+                         (fn [_]
+                           (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0}
+                                  (readers-residue))
+                               "teardown is exact")
+                           nil)))))
+            (.catch (report-failure! "unrelated re-render control" nil))
+            (.then (fn [_] (release-minted!) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; The population, asserted rather than described
+;; ---------------------------------------------------------------------------
+
+(deftest the-declared-population-was-actually-exercised
+  (if-not (rf.hicasso.impl.mount/browser?)
+    (skip! ":node-test has no document, so nothing is exercised")
+    (is (= declared-population @!exercised)
+        (str "every declared transition must be reached; missing: "
+             (pr-str (set/difference declared-population @!exercised))))))


### PR DESCRIPTION
Two P2 correctness bugs in `implementation/hicasso`, both of the same family — mounted state that does not follow a change. Both were filed from a source reading with no execution behind them; both are now established by a real-DOM row that was watched failing before the fix and passing after.

## rf2-3awu — a mounted read set reacquires after a later-task frame recreation

Destroy a frame and let the invalidation microtask run with no successor, and `invalidate-cell!`'s deferred phase disposes the cell. That leaves every committed registration on it attached to a table slot that no longer exists, and **React repairs none of it on its own**: `subscribe` is cached per read-set entry, so a mounted boundary re-rendering the *same* read set is handed the same closure, React compares it by identity, and no `acquire-cell!` ever runs.

The value still looks recovered, which is what makes it dangerous. `cold-read!`'s probe answers the live incarnation on that render, so the boundary paints the successor — while holding no cell, no watch and no reader edge, so every write after it is lost.

**The repair is one guarded call in `dispose-cell!`**: a cell disposed *while registrations still hold it* retires the cached read-set entries naming its key (`retire-entries-naming!`). Eviction only — nothing subscribes, acquires or notifies, and React still releases each old registration exactly once through the cleanup it is already holding. The next real render misses the cache, mints a fresh entry with a fresh `subscribe`, and React's own re-subscribe is what re-acquires.

The guard is the readers, so the *reaper's* path — a cell whose last reader already left, disposed for idleness — keeps its entry, and the keyed-reorder reuse the grace macrotask exists to buy is untouched. Synchronous reincarnation is unreached (that branch re-wires and never disposes), and the no-successor teardown still lands on zero cells.

New witness: `reincarnation_readset_dom_cljs_test.cljs`. One boundary and one `n/use-sub` island reading one key — the same entry, so the residue readings are one cell and **two** readers, which is what says the hook door is repaired by the same mechanism rather than by a second implementation. The row asserts the painted value as a *premise* (it is green either way) and then reads what the runtime holds. A negative-control row asserts an unrelated re-render inside one incarnation churns nothing: same cell, same reaction, same entry.

## rf2-kx9f — an open popover follows its `:anchor`

`:anchor` is the DOM id of the trigger to position against, and nothing in the door's contract or the guide makes it initial-only. But the claim ran only in the ref callback, which React calls on *attachment* — so a shared menu moved from row A to row B kept A's `anchor-name`, B never received one, and the panel went on resolving `position-anchor` against the row the user had just left. Removing `:anchor` while open left the claim standing too.

The claim and its inverse are now one pair of doors (`take-anchor!` / `drop-anchor!`), and `reconcile-anchor!` runs them when the anchor id the standing claim was taken for no longer matches the prop. It is driven by a `useLayoutEffect` keyed on the anchor id — commit-phase and before paint, because the thing it corrects is a *position*, and a position corrected after paint is a visible jump.

Why not the ref: React re-attaches a ref whose identity changed, and for an open popover that is `hidePopover()`/`showPopover()` — a real platform dismissal, `beforetoggle` and all — on every render that moved the anchor. The ref's identity therefore stays stable, deliberately.

It is idempotent by `claimedFor`, so the render that *opens* a panel (where the ref has already claimed) and every unrelated re-render touch nothing. Release-before-claim through the shared doors, so `release-anchor!`'s "only while my ident is still the name on it" guard keeps two overlays sharing one trigger correct.

This is the module's **third** hook and its only effect. `an-overlay-costs-three-hooks-and-the-shell-still-costs-two` (renamed) pins the new roster and still pins the *shell* at two — HD-020's ceiling is the boundary shell's and is untouched. On the server the addition is inert: React's server dispatcher has `useLayoutEffect: noop` (read off the pinned `react-dom-server.node.development.js`, not assumed), so the deterministic SSR bytes HS-32 asserts are unchanged.

## Failing-first evidence

The two source files were reverted to their pre-fix bytes with the new tests kept, the browser lane was run, then the bytes were restored and hashed against the committed blobs before re-running. Both directions were measured on the same tree.

**Pre-fix, `npm run test:browser`, exit 1 — 805 tests, 4416 assertions, 8 failures, 0 errors:**

rf2-3awu, and it is the bead's prediction verbatim — the DOM painted the successor while the runtime held nothing:

```
FAIL in (a-mounted-read-set-reacquires-after-a-later-task-recreation)
later-task reacquisition — poll-until timed out — the mounted read set reacquires a cell
and both memberships [:rf.error/poll-until-timeout] | DOM was "BB"
| residue {:cells 0, :cell-refs 0, :boundaries 0, :edges 0}
```

rf2-kx9f, five reds, every one an engine reading rather than an attribute the module just wrote:

```
FAIL ... A got back exactly what its author wrote
  actual: (not (= "--mine-a" "--rf-overlay-34"))
FAIL ... B is claimed now
  actual: (not (not= "--mine-b" "--mine-b"))
FAIL ... and it is the name the panel's `position-anchor` uses
  actual: (not (= "--mine-b" "--rf-overlay-34"))
FAIL ... so the ENGINE moved the box to B. B.left=24.90625 panel.left=0 A.left=0
  actual: (not (< 24.90625 2))
FAIL ... and A is still holding its own
  actual: (not (= "--mine-a" "--rf-overlay-34"))
```

plus the hook roster (`("useContext" "useRef")` against the expected three).

**Post-fix, same base, `npm run test:browser`, exit 0 — 805 tests, 4419 assertions, 0 failures, 0 errors.** The three-assertion rise is the readset row's later steps, which the pre-fix run never reached because its poll rejected first; the test population is identical at 805.

## Quality gates

Run from this branch. Every exit code below is the runner's own, captured on the same command line and read back from a file — never a filtered pipeline's.

The browser lane and the spine were both re-run on the final base after the rebase; the pre-rebase greens are kept below only because the failing-first pair was measured there and has to be quoted against the tree it was measured on.

| gate | exit | result |
|---|---|---|
| `npm run test:browser` (post-rebase, final base `c835b15c6b`) | 0 | 811 tests, 4435 assertions, 0 failures, 0 errors |
| `npm run test:browser` (pre-fix plant) | 1 | 805 tests, 4416 assertions, **8 failures**, 0 errors |
| `npm run test:browser` (post-fix, pre-rebase) | 0 | 805 tests, 4419 assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh` (post-rebase, final base) | 0 | `PASS fast PR spine` — JVM core 2245 tests/11575 assertions, JVM hicasso 3 tests/92 assertions, CLJS node 11333 tests/57167 assertions |
| `npm run test:cljs` (standalone, pre-rebase) | 0 | 11309 tests, 57095 assertions, 0 failures, 0 errors |
| `npm run test:hicasso-invariants` | 0 | reachability + 74 guide verbs at 401 sites across 29 pages |
| `npm run test:hicasso-lint` | 0 | lint export self-test PASS |
| `npm run test:hicasso-compile` | 0 | 11 namespaces, 0 warnings |
| `npm run build:hicasso-release` | 0 | `:advanced` / `goog.DEBUG=false`; production erasure and bundle isolation both OK |
| `npm run test:hicasso-hmr` | 0 | chromium + firefox + webkit, 144 checks each, 45 real shadow reloads |
| `python scripts/check_fast_pr_gap.py --brief` | 0 | **99 required checks the spine does not decide** |

**Which lane covers what.** Both bugs are mounted-state/DOM behaviour, and no tier of the fast-PR spine reaches them: the spine's own PASS line names the browser lanes among what it does not run. `npm run test:browser` (CI's `cljs-browser`) is the lane that decides both — `reincarnation_readset_dom_cljs_test` for rf2-3awu and `overlay_dom_cljs_test`'s new row for rf2-kx9f. The node lane compiles both namespaces and states an explicit skip in each row, so its green is coverage of the *compile*, never of the behaviour.

**One non-coverage worth naming, and it is pre-existing.** No gate compiles `impl/overlay.cljs` under `:advanced`: `check_modules_compile` is a plain warnings-fatal compile, and the `hicasso-release` bundle starts at the public door, which by design does not reach an optional module. The new `react/useLayoutEffect` takes the identical npm-interop path as the `react/useContext` and `react/useRef` already beside it in that file, so nothing new is exposed — but the statement is that it is unexercised there, not that it is gated.

**Verified by hand**, because no gate looks at either: the two new markdown table rows in `overlay_dom_cljs_test`'s claim table have the same column count as their neighbours, and the one prose bullet edited in `docs/core/hicasso/13-overlays-and-focus.md` is outside every fenced block (the guide's fences are untouched, and `check_guide_samples.py` is green).

## Not touched

No facade export is added or changed, so the facade rule has nothing to classify. `spec/API.md`, `spec/api-manifest.edn` and `spec/api-manifest-metadata.edn` are untouched — these are behaviour fixes under an existing public contract, and `:anchor`'s contract is unchanged, only honoured on update as well as on mount. `spec/006-ReactiveSubstrate.md` is untouched. Nothing outside `implementation/hicasso/**` and one guide bullet moves.
