### PR TITLE
fix(ssr): two explicit-target reads answer the question they were asked

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/error_projector.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_projector.cljc
@@ -28,6 +28,7 @@
   (:require [re-frame.frame :as rf.frame]
             [re-frame.interop :as rf.interop]
             [re-frame.late-bind :as rf.late-bind]
+            [re-frame.live-frame :as rf.live-frame]
             [re-frame.registrar :as rf.registrar]
             [re-frame.source-coords :as rf.source-coords]
             [re-frame.trace :as rf.trace]))
@@ -330,7 +331,6 @@
   [frame-id trace-event]
   (let [configured-id (frame-configured-projector-id frame-id)
         projector-id  (frame-projector-id frame-id)
-        projector-fn  (rf.registrar/handler :error-projector projector-id)
         dev-detail?   (frame-dev-error-detail? frame-id)
         ;; Two failure modes for the projector:
         ;;   :threw      — the catch path returns this in `result`
@@ -340,9 +340,21 @@
         ;; sanitisation trace fires AT MOST ONCE per call.
         result
         (try
-          (if projector-fn
-            (projector-fn trace-event)
-            ::no-projector)
+          ;; Resolve AND run the projector through the TARGET FRAME'S
+          ;; generation (rf2-blpg). `frame-id` already selected this frame's
+          ;; `:ssr {:public-error-id …}` config; without this extent the id it
+          ;; named was resolved against the process registrar instead, so a
+          ;; projector registered from another image answered for it — and an
+          ;; error projector decides the STATUS and the public body that leave
+          ;; the server, not merely a label. Resolution and invocation share
+          ;; ONE extent so the fn that was found is the fn that runs. A frame
+          ;; with no sealed generation binds nothing: the unchanged path.
+          (rf.live-frame/call-with-frame-resolution
+            frame-id
+            (fn []
+              (if-let [projector-fn (rf.registrar/handler :error-projector projector-id)]
+                (projector-fn trace-event)
+                ::no-projector)))
           (catch #?(:clj Throwable :cljs :default) e
             (rf.trace/emit-error! :rf.error/sanitised-on-projection
                                {:projector-id      projector-id

--- a/implementation/ssr/src/re_frame/ssr/hash.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hash.cljc
@@ -1,12 +1,48 @@
 (ns re-frame.ssr.hash
-  "Render-tree structural hashing. Per Spec 011 §Hydration-mismatch detection.
+  "SSR structural hashing — TWO canonicalisations over ONE hash function.
+
+  ## `render-tree-hash` — Spec 011 §Hydration-mismatch detection
 
   The server hashes the render-tree at SSR time; the client recomputes
   the hash on first render and compares. Mismatch = the runtime emits
   `:rf.ssr/hydration-mismatch` with both hashes. FNV-1a 32-bit over the
   canonical-EDN traversal of the render tree, output as lowercase hex.
   Same algorithm both sides means byte-identical hashes for byte-identical
-  canonical EDN."
+  canonical EDN.
+
+  Its canonicalisation PRUNES NIL — a nil map value, a nil sequence
+  element and a nil set member all vanish before the bytes are hashed.
+  That rule is correct and load-bearing FOR A RENDER TREE: `[:div {:class
+  nil}]` and `[:div {}]` emit the same HTML, so the common
+  `{:class (when selected? \"on\")}` shape must not manufacture a
+  mismatch. See `canonical-edn`.
+
+  ## `data-hash` — the hydration-payload install ledger (rf2-tax2)
+
+  A DIFFERENT question, and the nil rule inverts with it. The multi-root
+  install ledger (`re-frame.ssr.install`) asks \"is the payload arriving
+  under this id the SAME DATA as the one already installed?\", and for
+  ordinary app data nil is content: `{:x nil}` is not `{}`, `[nil 7]` is
+  not `[7]`, `#{nil 1}` is not `#{1}`. Hashing a payload through the
+  render-tree rules made all three pairs collide DETERMINISTICALLY — not
+  by hash accident, by canonicalisation — so a second root carrying a
+  genuinely different server slice was waved through as
+  `:already-installed` and hydrated index-based content against the wrong
+  data, silently, where the ledger exists to fail loud.
+
+  `data-hash` therefore canonicalises data as DATA: nil preserved
+  everywhere, map insertion order still irrelevant, set order still
+  irrelevant, sequence position significant. It is NOT a replacement for
+  the render-tree rules and does not touch them — the two canonicalisers
+  answer different questions and both are right for their own.
+
+  ## What they share
+
+  `fnv-1a-32` (the bytes → hex step) and `canonical-number` (the
+  cross-runtime numeric print form). Both hashes are therefore
+  byte-identical on JVM and CLJS for the same logical input, which is
+  what lets two roots reading one `__rf_payload` script agree on either
+  host."
   (:require [clojure.string]))
 
 ;; Reflection warnings guard the primitive JVM hash loop against boxing.
@@ -416,3 +452,101 @@
      (let [accumulator (array)]
        (canonical-edn-into accumulator render-tree)
        (fnv-1a-32 (.join accumulator "")))))
+
+;; ---- canonical DATA EDN (rf2-tax2) ----------------------------------------
+;;
+;; The nil-PRESERVING sibling of the render-tree walker above, for callers
+;; asking "is this the same DATA?" rather than "does this render the same?".
+;; See the namespace docstring for why the two rules must differ.
+;;
+;; Deliberately a separate, plain string-building walk rather than a flag
+;; threaded through `canonical-edn-into`:
+;;
+;;   - the render-tree walk is the HOT path (once per server render, once per
+;;     client verify, over a whole tree) and is allocation-tuned around a
+;;     single accumulator; a branch or a dynamic read per node would be paid
+;;     by every node of every tree to serve a caller that runs ONCE PER ROOT
+;;     over one payload map;
+;;   - its output is pinned byte-for-byte by
+;;     `re-frame.ssr.hash-parity-fixtures`, and the cheapest way to keep that
+;;     pin honest is to leave the walk it pins untouched.
+;;
+;; What is shared is what MUST agree cross-runtime: `canonical-number` and
+;; `fnv-1a-32`.
+
+(defn canonical-data-edn
+  "Canonical EDN of a DATA value — nil PRESERVED. -> a string.
+
+  The rules, and each is the DIFFERENCE from `canonical-edn` or the reason
+  it is the same:
+
+    - **nil is content.** `nil` prints as `\"nil\"` wherever it appears —
+      as a map value, a sequence element, a set member or the whole value.
+      `{:x nil}` and `{}` therefore differ, as do `[nil 7]` / `[7]` and
+      `#{nil 1}` / `#{1}`. This is the whole reason the fn exists
+      (rf2-tax2). There is no sentinel and so no sentinel collision: `nil`
+      is an EDN literal and `pr-str` already distinguishes it from the
+      STRING `\"nil\"` (which prints with its quotes).
+
+    - **Map insertion order is not content**, so entries are emitted sorted
+      by the canonical form of their KEY — the same total order
+      `canonical-edn` uses, and for the same reason (rf2-mff1ht): `str`
+      alone collides a keyword `:a` with the string `\":a\"`, while their
+      canonical forms differ.
+
+    - **Set order is not content**, so members are emitted sorted by their
+      own canonical form.
+
+    - **Sequence position IS content**, so vectors and seqs keep their
+      order and are distinguished from each other (`[…]` vs `(…)`).
+
+    - **Numbers go through `canonical-number`**, so a JVM `1.0` and a CLJS
+      `1` — the SAME IEEE double, printed differently by the two hosts —
+      agree. That unification is not a nil-style collision: CLJS cannot
+      represent the two apart at all, so preserving the JVM's distinction
+      would break the cross-host agreement the ledger depends on.
+
+    - **Everything else is `pr-str`**, which is total over EDN. A payload
+      is data — the deserialised `__rf_payload` — so a non-data value in
+      one (a raw fn, a foreign JS object) is a caller error; it hashes by
+      its host print form, which makes two such payloads DISAGREE and fail
+      loud as a conflict rather than alias silently. That is the safe
+      direction for a ledger, and the opposite of what the render-tree
+      walk deliberately does for fns."
+  [value]
+  (cond
+    (map? value)
+    (str "{"
+         (->> value
+              (sort-by (comp canonical-data-edn key))
+              (map (fn [[map-key entry-value]]
+                     (str (canonical-data-edn map-key) " "
+                          (canonical-data-edn entry-value))))
+              (clojure.string/join ","))
+         "}")
+
+    (vector? value)
+    (str "[" (clojure.string/join " " (map canonical-data-edn value)) "]")
+
+    (set? value)
+    (str "#{" (clojure.string/join " " (sort (map canonical-data-edn value))) "}")
+
+    (sequential? value)
+    (str "(" (clojure.string/join " " (map canonical-data-edn value)) ")")
+
+    (number? value)
+    (canonical-number value)
+
+    :else
+    (pr-str value)))
+
+(defn data-hash
+  "A stable structural hash of a DATA value — nil preserved. Lowercase
+  hex, FNV-1a 32-bit over `canonical-data-edn`, byte-identical on JVM and
+  CLJS for the same logical value.
+
+  The install ledger's content digest (`re-frame.ssr.install/payload-content-digest`).
+  Use `render-tree-hash` for hydration-mismatch detection — see the
+  namespace docstring for the one rule that separates them."
+  [value]
+  (fnv-1a-32 (canonical-data-edn value)))

--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -14,9 +14,36 @@
 
   Reading a head is a pure read: the model a caller wants is the value
   `render-head` / `active-head` returned. There is no side-channel
-  register, so there is nothing to clear on frame teardown."
+  register, so there is nothing to clear on frame teardown.
+
+  ## The frame target selects the REGISTRATIONS too (rf2-blpg)
+
+  `render-head` and `active-head` are explicit-target reads — the frame is
+  carried, and they are called OUTSIDE any `with-frame` binding (the
+  public head query, a host that renders a head for a frame it is not
+  running in, a preview inside frame A targeting frame B). They read the
+  target frame's app-db and route slice by id, which needs no ambient
+  scope; but the `:head` and `:route` lookups are ordinary
+  `(kind, id)` resolutions, and those route through
+  `re-frame.registrar/*generation*` — which nothing had bound here.
+
+  So a head id registered from two namespaces, with two frames selecting
+  one each (the image-isolation case
+  `re-frame.source-store/descriptors-for` exists to preserve), resolved to
+  whichever registration reached the registrar ATOM last — and then ran
+  that other image's body against the REQUESTED frame's app-db. Silently:
+  a plausible head model for the wrong page.
+
+  Every read that participates in producing the model therefore runs
+  inside `re-frame.live-frame/call-with-frame-resolution` on the target
+  frame — route metadata selection, head lookup, and the head fn's own
+  invocation, so a coherent generation covers the whole read rather than
+  half of it. A target that names no image-loaded frame binds nothing and
+  takes the registrar-atom path exactly as before, so this changes nothing
+  for the ordinary single-image / default-image application."
   (:require [re-frame.error :as rf.error]
             [re-frame.frame :as rf.frame]
+            [re-frame.live-frame :as rf.live-frame]
             [re-frame.registrar :as rf.registrar]
             [re-frame.source-coords :as rf.source-coords]))
 
@@ -98,32 +125,41 @@
   `:rf.error/no-frame-context` (no `:rf/default`-against-absence
   rendering). Per Spec 002 §Frame target resolution."
   [head-id {:keys [frame] :as opts}]
-  (let [frame    (rf.frame/require-frame-stamp!
-                   frame :rf.ssr/render-head
-                   {:where 'rf/render-head :event-id head-id})
-        route    (if (contains? opts :route)
-                   (:route opts)
-                   (frame-current-route frame))
-        ;; Resolve the `:head` registration from the process registrar
-        ;; (rf2-afdlyr realm collapse: the realm substrate is a single default
-        ;; realm, whose registrar IS the process-global table, so the former
-        ;; per-frame realm-registrar binding was always the no-op default path).
-        head-registration (rf.registrar/lookup :head head-id)]
-    (when-not head-registration
-      (rf.error/throw-error!
-        :rf.error/no-such-head
-        'rf/active-head
-        (str "No head registered under " head-id
-             "; register it with reg-head before rendering, or pass a "
-             "head-id that has been registered.")
-        {:recovery :register-the-head-id
-         :extra    {:head-id head-id}}))
-    (let [head-fn (:handler-fn head-registration)
-          ;; `frame` is a required non-nil stamp here (require-frame-stamp!
-          ;; above), so the app-db read is unconditional.
-          app-db     (rf.frame/frame-app-db-value frame)
-          head-model (head-fn app-db route)]
-      head-model)))
+  (let [frame (rf.frame/require-frame-stamp!
+                frame :rf.ssr/render-head
+                {:where 'rf/render-head :event-id head-id})
+        route (if (contains? opts :route)
+                (:route opts)
+                (frame-current-route frame))]
+    ;; Resolve the `:head` registration THROUGH THE TARGET FRAME'S generation
+    ;; (rf2-blpg). The explicit `:frame` selected the frame's DATA and not its
+    ;; REGISTRATIONS, so a same-id head from another image ran against this
+    ;; frame's app-db. The head fn's invocation is inside the extent too, for
+    ;; the same reason `boot/hydrate!` calls `render-tree-fn` under the target
+    ;; frame's scope: a model produced half in one generation and half in
+    ;; another is not a model of either. A frame with no sealed generation
+    ;; binds nothing — the unchanged registrar-atom path.
+    (rf.live-frame/call-with-frame-resolution
+      frame
+      (fn []
+        (let [head-registration (rf.registrar/lookup :head head-id)]
+          (when-not head-registration
+            (rf.error/throw-error!
+              :rf.error/no-such-head
+              'rf/active-head
+              (str "No head registered under " head-id
+                   " for frame " frame
+                   "; register it with reg-head before rendering, pass a "
+                   "head-id that has been registered, or — if it is "
+                   "registered elsewhere — check that this frame's image "
+                   "selects the namespace it was registered from.")
+              {:recovery :register-the-head-id
+               :extra    {:head-id head-id :frame frame}}))
+          (let [head-fn (:handler-fn head-registration)
+                ;; `frame` is a required non-nil stamp here (require-frame-stamp!
+                ;; above), so the app-db read is unconditional.
+                app-db  (rf.frame/frame-app-db-value frame)]
+            (head-fn app-db route)))))))
 
 (defn render-head
   "Apply the head fn registered under `head-id` against a frame's
@@ -167,10 +203,10 @@
   versioned routes, ...), this fn breaks and must learn the new mapping
   (audit rf2-asmj1 H6 / cluster rf2-sljs1).
 
-  Resolves the `:route` registration from the process registrar (rf2-afdlyr
-  realm collapse: the single default realm's registrar IS the process-global
-  table, so the former per-frame realm-registrar binding was always the no-op
-  default path)."
+  The `:route` lookup is an ordinary generation-routed resolution, and
+  `active-head` calls this INSIDE the target frame's resolution extent
+  (rf2-blpg) so the route metadata and the head it names come from the
+  same image as the app-db they are read against."
   [route]
   (when-let [route-id (:route-id route)]
     (when-let [route-meta (rf.registrar/lookup :route route-id)]
@@ -196,13 +232,22 @@
   [frame-id]
   (let [frame-id (rf.frame/require-frame-stamp!
                    frame-id :rf.ssr/active-head
-                   {:where 'rf/active-head})
-        route    (frame-current-route frame-id)
-        head-id  (route-head-id route)]
-    (if head-id
-      ;; The route declares an id but it may not be registered — surface
-      ;; that as :rf.error/no-such-head per Spec 011, but only when the
-      ;; route explicitly opts in. Routes without :head silently fall
-      ;; back to the default per Spec 011 §Default head.
-      (render-head head-id {:frame frame-id :route route})
-      (default-head frame-id))))
+                   {:where 'rf/active-head})]
+    ;; ONE resolution extent over the whole read (rf2-blpg): the route
+    ;; registration that NAMES the head and the head registration itself must
+    ;; come from the same image, or a route-declared head resolves in one
+    ;; generation and executes in another. `render-head` re-establishes the
+    ;; same binding inside — a no-op rebinding of the same generation, and
+    ;; cheaper than a second entry point that assumes it is already bound.
+    (rf.live-frame/call-with-frame-resolution
+      frame-id
+      (fn []
+        (let [route   (frame-current-route frame-id)
+              head-id (route-head-id route)]
+          (if head-id
+            ;; The route declares an id but it may not be registered — surface
+            ;; that as :rf.error/no-such-head per Spec 011, but only when the
+            ;; route explicitly opts in. Routes without :head silently fall
+            ;; back to the default per Spec 011 §Default head.
+            (render-head head-id {:frame frame-id :route route})
+            (default-head frame-id)))))))

--- a/implementation/ssr/src/re_frame/ssr/install.cljc
+++ b/implementation/ssr/src/re_frame/ssr/install.cljc
@@ -61,12 +61,15 @@
 
   ## Why a digest rather than payload equality
 
-  The digest is `re-frame.ssr.hash/render-tree-hash` — canonical EDN fed
-  through FNV-1a, byte-stable across JVM and CLJS and already
-  parity-pinned by `re-frame.ssr.hash-parity-fixtures`. Comparing digests
+  The digest is `re-frame.ssr.hash/data-hash` — canonical DATA EDN fed
+  through FNV-1a, byte-stable across JVM and CLJS. Comparing digests
   rather than whole payload maps keeps the ledger O(1) in the payload's
   size and makes the recorded evidence small enough to ride an error's
   `ex-data` without dragging a whole app-db into a diagnostic.
+
+  It is deliberately NOT the render-tree hash, whose nil-pruning is right
+  for a render tree and wrong for a data-identity test — see
+  `payload-content-digest` (rf2-tax2).
 
   ## What this namespace deliberately does NOT do
 
@@ -93,17 +96,29 @@
   (atom {}))
 
 (defn payload-content-digest
-  "-> the content digest of a hydration `payload`: the canonical-EDN
-  structural hash, lowercase hex.
+  "-> the content digest of a hydration `payload`: the canonical-DATA
+  structural hash (`re-frame.ssr.hash/data-hash`), lowercase hex.
 
-  Cross-host stable by construction — the same fn the render-tree hash
-  uses, whose JVM/CLJS byte-parity is pinned by
-  `re-frame.ssr.hash-parity-fixtures`. Two roots reading the SAME
-  `__rf_payload` script therefore compute the same digest on either host,
-  which is what makes `:already-installed` a reliable verdict rather than
-  a hopeful one."
+  Cross-host stable by construction — canonical EDN through the same
+  FNV-1a step and the same cross-runtime numeric print form the
+  render-tree hash uses. Two roots reading the SAME `__rf_payload` script
+  therefore compute the same digest on either host, which is what makes
+  `:already-installed` a reliable verdict rather than a hopeful one.
+
+  **Not the render-tree hash (rf2-tax2).** That hash PRUNES NIL, because
+  for a render tree `[:div {:class nil}]` and `[:div {}]` emit the same
+  HTML and must not manufacture a mismatch. A payload is not a render
+  tree: `{:x nil}` is not `{}`, `[nil 7]` is not `[7]`, and `#{nil 1}` is
+  not `#{1}`. Digesting payloads through the render-tree rules aliased all
+  three pairs DETERMINISTICALLY — not by hash accident — so a second root
+  carrying a genuinely different server slice was waved through as
+  `:already-installed` instead of raising
+  `:rf.error/frame-payload-conflict`, and hydrated against data it never
+  received. The render-tree rules are untouched and still right for their
+  own job; this asks a different question, so it uses a different
+  canonicalisation."
   [payload]
-  (rf.ssr.hash/render-tree-hash payload))
+  (rf.ssr.hash/data-hash payload))
 
 (defn installed-payload
   "-> the install record for `payload-id`, or `nil` when nothing is

--- a/implementation/ssr/test/re_frame/ssr/head_image_alpha.clj
+++ b/implementation/ssr/test/re_frame/ssr/head_image_alpha.clj
@@ -1,0 +1,49 @@
+(ns re-frame.ssr.head-image-alpha
+  "Test-support namespace ALPHA for the frame-targeted head/projector
+  resolution tests (rf2-blpg).
+
+  Its whole job is to be a distinct `:rf.provenance/ns` — the provenance
+  source store keys descriptors `[kind id provenance-ns]`, so the SAME
+  `[kind id]` registered from here and from `re-frame.ssr.head-image-beta`
+  produces TWO retained descriptors that two images can select apart. The
+  registrar ATOM keeps only the later of the two; that divergence between
+  the atom and a frame's sealed generation is exactly what the
+  frame-targeted resolution tests measure.
+
+  Provenance is stamped at MACROEXPANSION time by the public `reg-*`
+  macros, so it is a property of the FILE the form is written in, not of
+  the runtime `*ns*` at call time. That is why these are real files rather
+  than `create-ns` calls in a test body, and why the registration lives
+  behind a fn the test calls (the test fixture's `registrar/clear-all!`
+  would otherwise wipe an ns-load-time registration before the test body
+  ran).
+
+  The `-alpha` and `-beta` bodies are deliberately distinguishable by
+  their RETURN VALUE, not by a side effect: a test that cannot tell which
+  body ran cannot detect the wrong-generation defect at all."
+  (:require [re-frame.core :as rf]))
+
+(def head-id
+  "The head id both support namespaces register — the collision the
+  provenance store retains and the two images select apart."
+  :rf.ssr.head-image/shared)
+
+(def projector-id
+  "The error-projector id both support namespaces register."
+  :rf.ssr.head-image/shared-projector)
+
+(defn register!
+  "Register ALPHA's `head-id` head and `projector-id` projector.
+
+  Called from a test body rather than at ns load: the shared `:each`
+  fixture runs `registrar/clear-all!`, which would wipe an ns-load-time
+  registration before the test that needs it."
+  []
+  (rf/reg-head head-id
+    {:doc "ALPHA's body for the shared head id."}
+    (fn [db _route]
+      {:title (str "alpha:" (:marker db))}))
+  (rf/reg-error-projector projector-id
+    {:doc "ALPHA's body for the shared projector id."}
+    (fn [_trace-event]
+      {:status 418 :code :alpha :message "alpha" :retryable? false})))

--- a/implementation/ssr/test/re_frame/ssr/head_image_beta.clj
+++ b/implementation/ssr/test/re_frame/ssr/head_image_beta.clj
@@ -8,16 +8,16 @@
   BETA's body while ALPHA's survives only in the provenance source store —
   reachable through an image that selects ALPHA's namespace."
   (:require [re-frame.core :as rf]
-            [re-frame.ssr.head-image-alpha :as alpha]))
+            [re-frame.ssr.head-image-alpha :as rf.ssr.head-image-alpha]))
 
 (defn register!
   "Register BETA's body for ALPHA's `head-id` and `projector-id`."
   []
-  (rf/reg-head alpha/head-id
+  (rf/reg-head rf.ssr.head-image-alpha/head-id
     {:doc "BETA's body for the shared head id."}
     (fn [db _route]
       {:title (str "beta:" (:marker db))}))
-  (rf/reg-error-projector alpha/projector-id
+  (rf/reg-error-projector rf.ssr.head-image-alpha/projector-id
     {:doc "BETA's body for the shared projector id."}
     (fn [_trace-event]
       {:status 451 :code :beta :message "beta" :retryable? false})))

--- a/implementation/ssr/test/re_frame/ssr/head_image_beta.clj
+++ b/implementation/ssr/test/re_frame/ssr/head_image_beta.clj
@@ -1,0 +1,23 @@
+(ns re-frame.ssr.head-image-beta
+  "Test-support namespace BETA — the provenance twin of
+  `re-frame.ssr.head-image-alpha`. See that namespace's docstring for why
+  these are files rather than runtime-created namespaces.
+
+  BETA registers the SAME ids as ALPHA with different bodies, and it is
+  loaded/registered SECOND in every test, so the registrar atom holds
+  BETA's body while ALPHA's survives only in the provenance source store —
+  reachable through an image that selects ALPHA's namespace."
+  (:require [re-frame.core :as rf]
+            [re-frame.ssr.head-image-alpha :as alpha]))
+
+(defn register!
+  "Register BETA's body for ALPHA's `head-id` and `projector-id`."
+  []
+  (rf/reg-head alpha/head-id
+    {:doc "BETA's body for the shared head id."}
+    (fn [db _route]
+      {:title (str "beta:" (:marker db))}))
+  (rf/reg-error-projector alpha/projector-id
+    {:doc "BETA's body for the shared projector id."}
+    (fn [_trace-event]
+      {:status 451 :code :beta :message "beta" :retryable? false})))

--- a/implementation/ssr/test/re_frame/ssr/multi_root_hydration_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/multi_root_hydration_cljs_test.cljc
@@ -283,6 +283,95 @@
            (rf.ssr.install/payload-content-digest {:rf/version 1 :rf/app-db {:b 2 :a 1}})))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-tax2 — nil is CONTENT in a payload, however it is spelled
+;; ---------------------------------------------------------------------------
+;;
+;; The digest used to be `render-tree-hash`, whose canonicalisation PRUNES
+;; nil — the right rule for a render tree (`[:div {:class nil}]` and
+;; `[:div {}]` emit the same HTML) and the wrong one for a data-identity
+;; test. Each pair below is `not=` as a Clojure value and used to produce
+;; ONE digest, so the second root was waved through as `:already-installed`
+;; and hydrated against a slice it never received.
+;;
+;; The three shapes are the three places the render-tree walk prunes, and
+;; they are asserted separately because they are three different code
+;; paths (map-entry removal, sequence-child skip, set-member keep).
+
+(defn- payload-with-app-db
+  "A payload literal carrying `db` verbatim — NOT the policy-built
+  `payload-for`, whose projection could itself normalise the nils these
+  tests are about. The digest is a function of the payload map it is
+  handed, so the literal is the honest input here."
+  [db]
+  {:rf/version 1 :rf/app-db db})
+
+(deftest nil-differences-in-payload-data-are-digest-differences
+  (testing "map PRESENCE: an explicit nil value is not an absent key"
+    (is (not= (rf.ssr.install/payload-content-digest (payload-with-app-db {:x nil}))
+              (rf.ssr.install/payload-content-digest (payload-with-app-db {})))))
+
+  (testing "vector POSITION: a nil slot is not a shorter vector"
+    (is (not= (rf.ssr.install/payload-content-digest (payload-with-app-db {:items [nil 7]}))
+              (rf.ssr.install/payload-content-digest (payload-with-app-db {:items [7]}))))
+    (is (not= (rf.ssr.install/payload-content-digest (payload-with-app-db {:items [7 nil]}))
+              (rf.ssr.install/payload-content-digest (payload-with-app-db {:items [nil 7]})))
+        "and position within the vector is content too"))
+
+  (testing "set MEMBERSHIP: nil is a member like any other"
+    (is (not= (rf.ssr.install/payload-content-digest (payload-with-app-db {:s #{nil 1}}))
+              (rf.ssr.install/payload-content-digest (payload-with-app-db {:s #{1}}))))))
+
+(deftest the-digest-stays-idempotent-for-genuinely-equal-payloads
+  (testing "preserving nil must not make equal payloads disagree — a digest
+            that never repeats turns every second root into a conflict,
+            which is the opposite failure"
+    (is (= (rf.ssr.install/payload-content-digest (payload-with-app-db {:x nil :items [nil 7] :s #{nil 1}}))
+           (rf.ssr.install/payload-content-digest (payload-with-app-db {:x nil :items [nil 7] :s #{nil 1}}))))
+
+    (testing "map insertion order is still not content"
+      (is (= (rf.ssr.install/payload-content-digest {:rf/app-db {:a nil :b 2} :rf/version 1})
+             (rf.ssr.install/payload-content-digest {:rf/version 1 :rf/app-db {:b 2 :a nil}}))))
+
+    (testing "set order is still not content"
+      (is (= (rf.ssr.install/payload-content-digest (payload-with-app-db {:s #{nil 1 :k}}))
+             (rf.ssr.install/payload-content-digest (payload-with-app-db {:s #{:k nil 1}})))))))
+
+(deftest a-nil-only-payload-difference-reaches-the-conflict-arm
+  (testing "the ledger is what the digest is FOR: two roots whose payloads
+            differ only by a preserved nil must meet
+            :rf.error/frame-payload-conflict, not :already-installed"
+    (let [payload-id :rf.multiroot/tax2-conflict
+          decision   (fn [payload root-id]
+                       (rf.ssr.install/payload-install-decision!
+                         'test payload-id
+                         (rf.ssr.install/payload-content-digest payload)
+                         root-id))]
+      (is (= :install (decision (payload-with-app-db {:items [nil 7]}) :page/a)))
+      (is (= :rf.error/frame-payload-conflict
+             (caught-error-id #(decision (payload-with-app-db {:items [7]}) :page/b))))))
+
+  (testing "and the genuinely identical second root is still the ratified
+            no-op — the guard above must not have been bought by breaking it"
+    (let [payload-id :rf.multiroot/tax2-idempotent
+          decision   (fn [payload root-id]
+                       (rf.ssr.install/payload-install-decision!
+                         'test payload-id
+                         (rf.ssr.install/payload-content-digest payload)
+                         root-id))]
+      (is (= :install (decision (payload-with-app-db {:items [nil 7]}) :page/a)))
+      (is (= :already-installed (decision (payload-with-app-db {:items [nil 7]}) :page/b))))))
+
+(deftest the-render-tree-hash-keeps-pruning-nil
+  (testing "the fix is a SECOND canonicalisation, not a change to the first:
+            Spec 011 §Hydration-mismatch detection still requires
+            [:div {:class nil}] and [:div {}] to hash alike, or the common
+            {:class (when …)} shape manufactures a spurious mismatch"
+    (is (= (rf.ssr/render-tree-hash [:div {:class nil} [:p "hi"]])
+           (rf.ssr/render-tree-hash [:div {} [:p "hi"]])))
+    (is (= (rf.ssr/render-tree-hash [:p "text" nil])
+           (rf.ssr/render-tree-hash [:p "text"])))))
+
+;; ---------------------------------------------------------------------------
 ;; Preflight step 1 — the manifest
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/ssr/test/re_frame/ssr_frame_resolution_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_frame_resolution_test.clj
@@ -35,7 +35,21 @@
   it: `rf/init!` installs only when NO adapter is seated, so in a shared
   runtime the first suite to call it wins and every later `init!` is a
   silent no-op. A test that quietly ran on plain-atom while claiming to
-  exercise SSR would be green for the wrong reason."
+  exercise SSR would be green for the wrong reason.
+
+  ## This namespace also runs under the PRODUCTION gate
+
+  `scripts/test-ssr-prod-gate.sh` re-runs this artefact under
+  `-Dre-frame.debug=false`, and its roster is an EXCLUSION list — a new
+  namespace joins that lane BY DEFAULT. So every assertion here must hold
+  with the dev-only surfaces compiled out, and `clojure -M:test` passing
+  is only half the evidence. The one thing that bit: a descriptor's
+  `:doc` is pure documentation and is stripped before storage under the
+  gate (Spec 001 §Production elision contract), so the divergence between
+  the two images is discriminated by RUNNING the resolved `:handler-fn`
+  rather than by reading a doc string off it. Everything else these tests
+  assert on — a head model, an `:rf.error/*` id, a public error's
+  `:status` — is always-on by contract."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.source-store :as rf.source-store]
@@ -105,13 +119,28 @@
            (set (keys (rf.source-store/descriptors-for :head rf.ssr.head-image-alpha/head-id))))))
 
   (testing "each frame's OWN generation resolves to its OWN image's body —
-            this is the answer the head query has to match"
-    (let [alpha-frame (frame-selecting! "re-frame.ssr.head-image-alpha" {:marker "A"})
-          beta-frame  (frame-selecting! "re-frame.ssr.head-image-beta" {:marker "B"})]
-      (is (= "ALPHA's body for the shared head id."
-             (:doc (rf/handler-meta {:frame alpha-frame :kind :head :id rf.ssr.head-image-alpha/head-id}))))
-      (is (= "BETA's body for the shared head id."
-             (:doc (rf/handler-meta {:frame beta-frame :kind :head :id rf.ssr.head-image-alpha/head-id})))))))
+            this is the answer the head query has to match.
+
+            Discriminated by RUNNING the resolved `:handler-fn`, not by
+            reading a `:doc` off the descriptor. `:doc` is a
+            pure-documentation key that `registrar/strip-pure-documentation`
+            drops BEFORE the metadata is stored when `debug-enabled?` is
+            false (Spec 001 §Production elision contract), so a `:doc`
+            assertion passes in the ordinary lane and reads nil under
+            `scripts/test-ssr-prod-gate.sh` — which is where this one was
+            caught, and the same trap `ssr_head_test`'s docstring records
+            for `reg-head-accepts-metadata-arity`. The handler fn is the
+            executable and is never stripped; it is also the thing this
+            test is actually about, so the elision-proof assertion is the
+            more direct one."
+    (let [alpha-frame  (frame-selecting! "re-frame.ssr.head-image-alpha" {:marker "A"})
+          beta-frame   (frame-selecting! "re-frame.ssr.head-image-beta" {:marker "B"})
+          head-fn-for  (fn [frame]
+                         (:handler-fn (rf/handler-meta {:frame frame
+                                                        :kind  :head
+                                                        :id    rf.ssr.head-image-alpha/head-id})))]
+      (is (= {:title "alpha:probe"} ((head-fn-for alpha-frame) {:marker "probe"} nil)))
+      (is (= {:title "beta:probe"}  ((head-fn-for beta-frame)  {:marker "probe"} nil))))))
 
 ;; ---------------------------------------------------------------------------
 ;; render-head

--- a/implementation/ssr/test/re_frame/ssr_frame_resolution_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_frame_resolution_test.clj
@@ -1,0 +1,176 @@
+(ns re-frame.ssr-frame-resolution-test
+  "rf2-blpg — the explicitly targeted SSR queries resolve their
+  REGISTRATIONS through the target frame's generation, not only its data.
+
+  `render-head`, `active-head` and `project-error` all take an explicit
+  frame and are called OUTSIDE any `with-frame` binding — that is what
+  \"explicit target\" means, and it is how `ssr_head_test` and the Ring
+  host call them. Each read the named frame's app-db / `:ssr` config by
+  id, which needs no ambient scope. The `(kind, id)` lookups they then
+  perform did NOT: they went to the process registrar atom, which is a
+  different question with a different answer.
+
+  ## Why two support namespaces
+
+  The provenance source store keys descriptors `[kind id provenance-ns]`
+  and RETAINS every provenance-distinct one (`source-store/descriptors-for`
+  — \"the image-isolation case the store preserves\"), while the registrar
+  ATOM keeps only the last writer. So a `[kind id]` registered from two
+  namespaces is one entry in the atom and two in the store, and two frames
+  whose images select one namespace each resolve it to two DIFFERENT
+  bodies. That divergence is the whole measurement, and it needs two real
+  files because `reg-*` stamps provenance at MACROEXPANSION time — see
+  `re-frame.ssr.head-image-alpha`.
+
+  ALPHA registers first and BETA second in every test here, so the
+  registrar atom always holds BETA. A read that resolves correctly returns
+  ALPHA's body for ALPHA's frame; the pre-fix behaviour returned BETA's
+  body for BOTH frames, run against whichever frame's app-db was asked
+  for — a plausible head model, or a public error status, for the wrong
+  page.
+
+  ## The adapter these tests run under
+
+  `adapter-under-test-is-the-ssr-adapter` asserts it rather than assuming
+  it: `rf/init!` installs only when NO adapter is seated, so in a shared
+  runtime the first suite to call it wins and every later `init!` is a
+  silent no-op. A test that quietly ran on plain-atom while claiming to
+  exercise SSR would be green for the wrong reason."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.source-store :as rf.source-store]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.error-projector :as rf.ssr.error-projector]
+            [re-frame.ssr.head :as rf.ssr.head]
+            [re-frame.ssr.head-image-alpha :as alpha]
+            [re-frame.ssr.head-image-beta :as beta]
+            [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]))
+
+(use-fixtures :each rf.ssr.test-fixture/reset-runtime)
+
+;; ---------------------------------------------------------------------------
+;; What is actually installed
+;; ---------------------------------------------------------------------------
+
+(deftest adapter-under-test-is-the-ssr-adapter
+  (testing "the shared fixture's (rf/init! ssr/adapter) really seated the SSR
+            adapter in THIS runtime — `init!` is first-wins, so a suite that
+            assumes it can be measuring plain-atom and calling it SSR"
+    (is (= :rf.adapter/ssr (rf.substrate.adapter/current-adapter)))
+    (is (identical? rf.ssr/adapter (rf.substrate.adapter/current-adapter-spec))
+        "and it is this artefact's adapter map, not another :rf.adapter/ssr")))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(def ^:private frame-counter (atom 0))
+
+(defn- register-both!
+  "ALPHA then BETA, so the registrar atom ends up holding BETA."
+  []
+  (alpha/register!)
+  (beta/register!))
+
+(defn- frame-selecting!
+  "A frame whose image selects exactly `ns-glob`, seeded with `db`.
+
+  `:select-ns` SELECTS from what is already registered — it never loads —
+  so `register-both!` must have run first."
+  [ns-glob db]
+  (let [n   (swap! frame-counter inc)
+        fid (keyword "rf.ssr-frame-resolution" (str "f" n))]
+    (rf/make-frame {:id       fid
+                    :platform :server
+                    :images   [(rf/image {:id        (keyword "rf.ssr-frame-resolution" (str "img" n))
+                                          :select-ns {:include [ns-glob]}})]})
+    (rf/dispatch-sync [:rf/set-db db] {:frame fid})
+    fid))
+
+(defn- caught-error-id
+  [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (:rf.error/id (ex-data e)))))
+
+;; ---------------------------------------------------------------------------
+;; The premise: the store really does retain both, and the atom really does
+;; hold only BETA. If either half stops being true the tests below would pass
+;; vacuously, so both are asserted rather than assumed.
+;; ---------------------------------------------------------------------------
+
+(deftest the-two-support-namespaces-produce-a-genuine-divergence
+  (register-both!)
+  (testing "the provenance store retains BOTH descriptors for the shared id"
+    (is (= #{"re-frame.ssr.head-image-alpha" "re-frame.ssr.head-image-beta"}
+           (set (keys (rf.source-store/descriptors-for :head alpha/head-id))))))
+
+  (testing "each frame's OWN generation resolves to its OWN image's body —
+            this is the answer the head query has to match"
+    (let [alpha-frame (frame-selecting! "re-frame.ssr.head-image-alpha" {:marker "A"})
+          beta-frame  (frame-selecting! "re-frame.ssr.head-image-beta" {:marker "B"})]
+      (is (= "ALPHA's body for the shared head id."
+             (:doc (rf/handler-meta {:frame alpha-frame :kind :head :id alpha/head-id}))))
+      (is (= "BETA's body for the shared head id."
+             (:doc (rf/handler-meta {:frame beta-frame :kind :head :id alpha/head-id})))))))
+
+;; ---------------------------------------------------------------------------
+;; render-head
+;; ---------------------------------------------------------------------------
+
+(deftest render-head-runs-the-target-frames-own-registration
+  (register-both!)
+  (let [alpha-frame (frame-selecting! "re-frame.ssr.head-image-alpha" {:marker "A"})
+        beta-frame  (frame-selecting! "re-frame.ssr.head-image-beta" {:marker "B"})]
+    (testing "the frame whose image carries ALPHA's body gets ALPHA's body —
+              not the registrar atom's last writer"
+      (is (= {:title "alpha:A"} (rf.ssr.head/render-head alpha/head-id {:frame alpha-frame}))))
+
+    (testing "and BETA's frame gets BETA's, so the fix is resolution rather
+              than a different fixed answer"
+      (is (= {:title "beta:B"} (rf.ssr.head/render-head alpha/head-id {:frame beta-frame}))))
+
+    (testing "the keyword shorthand carries the same target"
+      (is (= {:title "alpha:A"} (rf.ssr.head/render-head alpha/head-id alpha-frame))))))
+
+(deftest render-head-refuses-a-head-the-target-frames-image-does-not-carry
+  (register-both!)
+  (rf/reg-head ::unselected (fn [_ _] {:title "unselected"}))
+  (let [alpha-frame (frame-selecting! "re-frame.ssr.head-image-alpha" {:marker "A"})]
+    (testing "a head registered outside the frame's image is not that frame's
+              head — resolving it from the process store rendered another
+              application's <title> into this one"
+      (is (= :rf.error/no-such-head
+             (caught-error-id #(rf.ssr.head/render-head ::unselected {:frame alpha-frame})))))))
+
+;; ---------------------------------------------------------------------------
+;; active-head — the route metadata NAMING the head must come from the same
+;; image as the head itself
+;; ---------------------------------------------------------------------------
+
+(deftest active-head-resolves-route-metadata-and-head-in-the-target-generation
+  (register-both!)
+  (let [alpha-frame (frame-selecting! "re-frame.ssr.head-image-alpha" {:marker "A"})]
+    (rf/dispatch-sync [:rf/set-db {:marker "A"}] {:frame alpha-frame})
+    (testing "with no route in the runtime-db slice, active-head is the default
+              head — the arm that must keep working"
+      (is (= "" (:title (rf.ssr.head/active-head alpha-frame)))
+          "the frame carries no :doc, so the default title is the empty string"))))
+
+;; ---------------------------------------------------------------------------
+;; project-error — the same omission, deciding a public status
+;; ---------------------------------------------------------------------------
+
+(deftest project-error-runs-the-target-frames-own-projector
+  (register-both!)
+  (let [n           (swap! frame-counter inc)
+        alpha-frame (keyword "rf.ssr-frame-resolution" (str "err" n))]
+    (rf/make-frame {:id       alpha-frame
+                    :platform :server
+                    :ssr      {:public-error-id alpha/projector-id}
+                    :images   [(rf/image {:id        (keyword "rf.ssr-frame-resolution" (str "errimg" n))
+                                          :select-ns {:include ["re-frame.ssr.head-image-alpha"]}})]})
+    (testing "the frame's :ssr config named ALPHA's projector id and its image
+              carries ALPHA's projector — so ALPHA's status and code leave the
+              server, not the registrar atom's BETA"
+      (is (= {:status 418 :code :alpha :message "alpha" :retryable? false}
+             (rf.ssr.error-projector/project-error alpha-frame {:operation :rf.error/handler-exception}))))))

--- a/implementation/ssr/test/re_frame/ssr_frame_resolution_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_frame_resolution_test.clj
@@ -42,8 +42,8 @@
             [re-frame.ssr :as rf.ssr]
             [re-frame.ssr.error-projector :as rf.ssr.error-projector]
             [re-frame.ssr.head :as rf.ssr.head]
-            [re-frame.ssr.head-image-alpha :as alpha]
-            [re-frame.ssr.head-image-beta :as beta]
+            [re-frame.ssr.head-image-alpha :as rf.ssr.head-image-alpha]
+            [re-frame.ssr.head-image-beta :as rf.ssr.head-image-beta]
             [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
             [re-frame.substrate.adapter :as rf.substrate.adapter]))
 
@@ -70,8 +70,8 @@
 (defn- register-both!
   "ALPHA then BETA, so the registrar atom ends up holding BETA."
   []
-  (alpha/register!)
-  (beta/register!))
+  (rf.ssr.head-image-alpha/register!)
+  (rf.ssr.head-image-beta/register!))
 
 (defn- frame-selecting!
   "A frame whose image selects exactly `ns-glob`, seeded with `db`.
@@ -102,16 +102,16 @@
   (register-both!)
   (testing "the provenance store retains BOTH descriptors for the shared id"
     (is (= #{"re-frame.ssr.head-image-alpha" "re-frame.ssr.head-image-beta"}
-           (set (keys (rf.source-store/descriptors-for :head alpha/head-id))))))
+           (set (keys (rf.source-store/descriptors-for :head rf.ssr.head-image-alpha/head-id))))))
 
   (testing "each frame's OWN generation resolves to its OWN image's body —
             this is the answer the head query has to match"
     (let [alpha-frame (frame-selecting! "re-frame.ssr.head-image-alpha" {:marker "A"})
           beta-frame  (frame-selecting! "re-frame.ssr.head-image-beta" {:marker "B"})]
       (is (= "ALPHA's body for the shared head id."
-             (:doc (rf/handler-meta {:frame alpha-frame :kind :head :id alpha/head-id}))))
+             (:doc (rf/handler-meta {:frame alpha-frame :kind :head :id rf.ssr.head-image-alpha/head-id}))))
       (is (= "BETA's body for the shared head id."
-             (:doc (rf/handler-meta {:frame beta-frame :kind :head :id alpha/head-id})))))))
+             (:doc (rf/handler-meta {:frame beta-frame :kind :head :id rf.ssr.head-image-alpha/head-id})))))))
 
 ;; ---------------------------------------------------------------------------
 ;; render-head
@@ -123,14 +123,14 @@
         beta-frame  (frame-selecting! "re-frame.ssr.head-image-beta" {:marker "B"})]
     (testing "the frame whose image carries ALPHA's body gets ALPHA's body —
               not the registrar atom's last writer"
-      (is (= {:title "alpha:A"} (rf.ssr.head/render-head alpha/head-id {:frame alpha-frame}))))
+      (is (= {:title "alpha:A"} (rf.ssr.head/render-head rf.ssr.head-image-alpha/head-id {:frame alpha-frame}))))
 
     (testing "and BETA's frame gets BETA's, so the fix is resolution rather
               than a different fixed answer"
-      (is (= {:title "beta:B"} (rf.ssr.head/render-head alpha/head-id {:frame beta-frame}))))
+      (is (= {:title "beta:B"} (rf.ssr.head/render-head rf.ssr.head-image-alpha/head-id {:frame beta-frame}))))
 
     (testing "the keyword shorthand carries the same target"
-      (is (= {:title "alpha:A"} (rf.ssr.head/render-head alpha/head-id alpha-frame))))))
+      (is (= {:title "alpha:A"} (rf.ssr.head/render-head rf.ssr.head-image-alpha/head-id alpha-frame))))))
 
 (deftest render-head-refuses-a-head-the-target-frames-image-does-not-carry
   (register-both!)
@@ -166,7 +166,7 @@
         alpha-frame (keyword "rf.ssr-frame-resolution" (str "err" n))]
     (rf/make-frame {:id       alpha-frame
                     :platform :server
-                    :ssr      {:public-error-id alpha/projector-id}
+                    :ssr      {:public-error-id rf.ssr.head-image-alpha/projector-id}
                     :images   [(rf/image {:id        (keyword "rf.ssr-frame-resolution" (str "errimg" n))
                                           :select-ns {:include ["re-frame.ssr.head-image-alpha"]}})]})
     (testing "the frame's :ssr config named ALPHA's projector id and its image

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -737,9 +737,20 @@ one call, returning the verdict), `payload-install-decision!` (the atomic claim)
 `payload-content-digest`, `installed-payload` / `release-payload!`. `re-frame.ssr.boot/hydrate!`
 runs preflight and performs the remaining hydrate step **only** on the `install` verdict;
 it gains `:container` / `:manifest` / `:root-id` opts for the multi-root path. The
-digest is the canonical-EDN structural hash (`re-frame.ssr.hash/render-tree-hash`), whose
-JVM/CLJS byte-parity is already pinned — two roots reading the same script agree on
+digest is the canonical-**data** structural hash (`re-frame.ssr.hash/data-hash`), whose
+JVM/CLJS byte-parity comes from the same FNV-1a step and the same cross-runtime numeric
+print form the render-tree hash uses — two roots reading the same script agree on
 either host.
+
+**The digest is not the render-tree hash, and the difference is nil.** The render-tree
+hash *prunes* nil ([§Hydration-mismatch detection](#hydration-mismatch-detection)):
+`[:div {:class nil}]` and `[:div {}]` emit the same HTML, so they must hash the same or
+the common `{:class (when …)}` shape manufactures a mismatch. A hydration payload is not
+a render tree — it is app data, where `{:x nil}` is not `{}`, `[nil 7]` is not `[7]`, and
+`#{nil 1}` is not `#{1}`. Digesting payloads under the render-tree rules aliased those
+pairs *deterministically*, so the middle row of the table above swallowed a genuinely
+different server slice as the idempotent no-op instead of reaching the third row. The two
+canonicalisations answer different questions and both rules stand.
 
 ### Failed-root isolation
 
@@ -1277,6 +1288,8 @@ Returns the head model map. Pure, JVM-runnable, used by the SSR pipeline to mate
 
 `(rf/active-head frame-id)` is sugar — looks up the active route's `:head` for the given frame, calls `render-head`, returns the model. Useful in dev tools and the SSR pipeline (called inside the request frame's `with-frame` block with the explicit request frame-id). The frame is required; there is no no-arg `(active-head)` form — it would synthesise `:rf/default`.
 
+**The carried frame selects the REGISTRATIONS as well as the data.** The `:head` lookup, the `:route` metadata lookup `active-head` reads the head id from, and the head fn's own invocation all resolve through the target frame's image generation ([002 §Frame target resolution](002-Frames.md#frame-target-resolution--the-carried-invariant)) — the same resolution a dispatch or a subscribe into that frame would get. These are explicit-target reads made *outside* any ambient frame binding, so resolving the app-db per-frame while resolving the registrations against the process store would let one image's head body run against another image's data and return a plausible model for the wrong page. A frame carrying no image generation resolves against the process store exactly as before.
+
 #### Single `:head` per route in v1
 
 Lock: **one registered `:head` per route**. No composition (parent + child route head fragments) in v1 — that's a follow-up if real cases emerge. Routes that want to share head logic do so by referencing the same registered `:head` id, or by registering a head fn that calls a helper.
@@ -1343,6 +1356,8 @@ Lock: **both** a registry-first projector and a per-frame `:ssr` metadata map na
 `reg-error-projector` adds a new registry kind `:error-projector` (per [001 §Registry model](001-Registration.md#registry-model--the-canonical-kind-keyword-set)). The query API surfaces it: `(rf/registrations {:source :store :kind :error-projector})` returns `id → metadata`. The runtime consults exactly one projector per response — the one named in the frame's `:ssr {:public-error-id ...}` metadata. If unset, the runtime uses its **default projector** (below).
 
 `reg-error-projector` returns its `id` argument per the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention).
+
+**The frame that names the projector resolves it.** `project-error` takes an explicit frame and is called outside that frame's binding, so — exactly as for [`render-head`](#render-head) — the `:error-projector` lookup and the projector's invocation run through that frame's image generation. Reading the frame's `:ssr {:public-error-id …}` per-frame and then resolving the id it names against the process store would let another image's projector decide this response's status and public body.
 
 #### Default projector
 


### PR DESCRIPTION
Two SSR reads took an explicit target and then answered a different question with it. Both are "the thing does not do what it says" bugs, so both are repaired in place — no option selecting the old behaviour, no compatibility path.

## rf2-tax2 — the hydration ledger's digest pruned nil

The multi-root install ledger asks *"is the payload arriving under this id the same DATA as the one already installed?"* and answered with `render-tree-hash`, whose canonicalisation **prunes nil**. That rule is correct and load-bearing for a render tree — `[:div {:class nil}]` and `[:div {}]` emit the same HTML, so the common `{:class (when …)}` shape must not manufacture a hydration mismatch — and wrong as a data-identity test.

Measured on the pre-fix tree, all three pairs collide **deterministically**, before any hash accident is involved:

| payload `:rf/app-db` | digest |
|---|---|
| `{:x nil}` / `{}` | both `03a99afc` |
| `{:items [nil 7]}` / `{:items [7]}` | both `85d2011b` |
| `{:s #{nil 1}}` / `{:s #{1}}` | both `bac6f711` |

So a second root carrying a genuinely different server slice received `:already-installed` through preflight, skipped installation, and hydrated index-based content against data it never received — silently, where the ledger exists to raise `:rf.error/frame-payload-conflict`.

**The fix is a second canonicalisation, not a change to the first.** `re-frame.ssr.hash/canonical-data-edn` + `data-hash` preserve nil as a map value, a sequence element and a set member, while keeping map insertion order and set order irrelevant and sequence position significant. They share `canonical-number` and `fnv-1a-32` with the render-tree walk, so both hashes stay byte-identical across JVM and CLJS. The parity-pinned render-tree walker is untouched, and `the-render-tree-hash-keeps-pruning-nil` pins that it still prunes.

There is no sentinel and therefore no sentinel collision: `nil` is an EDN literal and `pr-str` already distinguishes it from the string `"nil"`.

## rf2-blpg — the explicit frame selected the data but not the registrations

`render-head`, `active-head` and `project-error` take an explicit frame and are called *outside* any `with-frame` binding — that is what an explicit-target read is. They read the named frame's app-db, route slice and `:ssr` config by id, which needs no ambient scope; the `:head`, `:route` and `:error-projector` lookups then went to the process registrar atom, which is a different question with a different answer.

The provenance source store retains **every** provenance-distinct descriptor for a `[kind id]` (`source-store/descriptors-for` — "the image-isolation case the store preserves") while the registrar atom keeps only the last writer. So a head id registered from two namespaces, with two frames selecting one namespace each, resolved to the atom's winner and ran **that** image's body against the requested frame's app-db. Measured pre-fix: the frame carrying ALPHA's registration rendered `{:title "beta:A"}` — BETA's body, ALPHA's data — and `project-error` on a frame whose `:ssr {:public-error-id …}` named ALPHA's projector returned BETA's `451`. An error projector decides the status and public body that leave the server, not merely a label.

Each read now runs inside `live-frame/call-with-frame-resolution` on its target: route-metadata selection, head lookup and the head fn's own invocation share one extent (a model produced half in one generation and half in another is a model of neither), and the projector is resolved and invoked in one. A target that names no image-loaded frame binds nothing and takes the registrar-atom path exactly as before, so the ordinary single-image and default-image applications are unchanged.

`render-head` now also raises `:rf.error/no-such-head` for a head the target frame's image does not carry, and its diagnostic names the frame and points at namespace selection.

### One premise on the bead did not hold

rf2-blpg's stated minimal caller registers the head through an inline image section:

```clojure
(rf/image {:id ::page-image :registrations {:reg-head [[::page-head {} (fn [_ _] …)]]}})
```

That is not supported grammar. `:reg-head` appears at the two `image.cljc` sites the bead cites as an explicitly **rejected** inline kind — EP-0026 standardises inline grammar for `:reg-event`, `:reg-sub`, `:reg-fx` and `:reg-cofx` only, and the call fails loud with `:rf.error/invalid-image`. The caller in the bead therefore cannot be run as written, and the `:rf.error/no-such-head` outcome it predicts is unreachable by that door: `register!` writes the registrar atom *and* the source store, so the atom is always a superset of any generation's `:head` view.

The defect itself is real and reachable through the supported door — namespace-authored `reg-head` plus `:select-ns` — and it is the bead's *second* predicted failure, the one that matters more: not a missing head, but a **different image's body executed against the requested frame's data**. The tests use that door.

## Spec

`spec/011-SSR.md` moves in both places: the ledger digest is named as the canonical-**data** hash with the nil difference stated against the decision table, and `#### render-head` / `#### Mechanism — registered projector` state that the carried frame selects the registrations as well as the data.

No `re-frame.core` facade export is added or changed, and `spec/API.md` / the two `api-manifest*.edn` sidecars are untouched — both fixes are behaviour behind existing public names.

## Failing-first evidence

Both regression suites were run against the reverted sources first. `9 failures, 0 errors` out of `25 tests / 57 assertions`:

- **tax2 (5)** — `03a99afc` = `03a99afc`, `85d2011b` = `85d2011b` (twice: absent-slot and reordered-slot), `bac6f711` = `bac6f711`, and the conflict arm returning `nil` instead of `:rf.error/frame-payload-conflict`.
- **blpg (4)** — `{:title "beta:A"}` where `{:title "alpha:A"}` was expected (twice: opts map and keyword shorthand), `nil` instead of `:rf.error/no-such-head` for an unselected head, and `{:status 451 :code :beta …}` instead of `{:status 418 :code :alpha …}`.

The sources were then restored and verified byte-identical by SHA-256 before the green run — "unchanged" and "not attempted" are the same diff.

## Quality gates

Run from this branch rebased onto `d9e8f0628f`, the base it now sits on. The whole set was re-run after each rebase — a pre-rebase green describes a tree that no longer exists. Every exit code below is the runner's own, captured on the same command line, never one reported by a harness — on the first spine run the harness reported `0` for a run whose own capture read `1`, so the captured number is the one quoted.

| gate | exit | result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`; the spine printed its repo root as this worktree |
| `clojure -M:test` in `implementation/ssr` | **0** | 644 tests / 4194 assertions |
| `bash scripts/test-ssr-prod-gate.sh` (`-Dre-frame.debug=false`) | **0** | 646 tests / 4028 assertions, whole suite, no exclusions |
| `clojure -M:test` in `implementation/ssr-ring` | **0** | 231 tests / 1164 assertions |
| `python scripts/check_doc_slugs.py` | **0** | — |
| `python scripts/check_readme_links.py --ci` | **0** | — |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | 2800 files, 10861 re-frame require edges, every surface at or under its floor |

**Assertion counts before and after.** `implementation/ssr` was **634 tests / 4170 assertions** on the base and is **644 / 4194** here — the delta is exactly this PR's new tests (6 / 11 in `re-frame.ssr-frame-resolution-test`, 4 / 13 added to `re-frame.ssr.multi-root-hydration-cljs-test`), so nothing stopped running. `implementation/ssr-ring` is **231 / 1164** on both, unchanged. The baseline was measured by checking the source and test changes back out to the base and running the artefact suite, not quoted from elsewhere.

**The production-gate lane went red first, and the repair was to the TEST, not the code.** `scripts/test-ssr-prod-gate.sh` re-runs this artefact under `-Dre-frame.debug=false`; its roster is an EXCLUSION list, so a new namespace joins that lane by default and `re-frame.ssr-frame-resolution-test` did. Two of its assertions read a descriptor's `:doc` to tell ALPHA's registration from BETA's, and `:doc` is a pure-documentation key that `registrar/strip-pure-documentation` drops *before* the metadata is stored when `debug-enabled?` is false (Spec 001 §Production elision contract) — so both read `nil` under the gate while `clojure -M:test` stayed green. `ssr_head_test`'s own docstring records the identical trap for `reg-head-accepts-metadata-arity`.

The two assertions now resolve each frame's `:handler-fn` through its generation and **call it**, checking the head model each image's body actually produces. That is the more direct assertion, not a weaker one — the handler fn is the executable, is never stripped, and is what the test was always about; the `:doc` was a label standing in for it. Assertion count in the ordinary lane is unchanged at 4194, so nothing was dropped to buy the green. The namespace docstring now records that this file runs under the production gate and what that costs an assertion.

The gap between the two profiles is itself the evidence the lane works: 4194 assertions in the ordinary lane against 4028 under the gate is dev-only instrumentation compiling out, not coverage going missing.

**A ratchet fired and was repaired on its own lines.** `check_require_alias_dialect.py` read three non-canonical aliases against `implementation/ssr`'s floor of 0 — the new support namespaces had taken the bare-leaf form, which `spec/Conventions.md` §Require-alias dialect reserves for application namespaces. Fixed by renaming the aliases (second commit), never by moving the floor.

**What this spine does not decide.** `python scripts/check_fast_pr_gap.py --brief` reports **99 required checks** it does not run, across `test.yml`'s `All required checks passed`, `lint.yml`'s `Lint required` and `docs.yml`'s `Docs required`. Green here is not green in CI — `jvm-ssr-prod-gate` was one of those 99, and it is the one that caught the defect above, so it is now run explicitly here rather than left to CI. Of the four `-Dre-frame.debug=false` lanes in the tree (`core`, `routing`, `ssr`, `epoch`), `ssr` is the only one whose artefact this diff touches; the other three are scheduled by the shared `implementation_jvm` surface flag but test artefacts this PR does not change.

**Gates by path, not by job name.** The diff touches `spec/011-SSR.md`, so `check_doc_slugs.py` is the anchor + repo-relative-target gate for it, and `mkdocs build --strict` (which ran inside the spine's documentation tier, staging `spec/` through `mkdocs_hooks.py`) is the built-site link gate; both are green. Neither looks inside a fenced code block — **every link this PR adds sits in prose, none inside a fence**, checked by hand. No tables were added or changed in the spec.

**Which host and which adapter the new tests actually ran under.** The rf2-blpg tests are JVM (`implementation/ssr`, `clojure -M:test`), and the namespace opens by asserting its own runtime rather than assuming it: `adapter-under-test-is-the-ssr-adapter` pins `(current-adapter)` = `:rf.adapter/ssr` **and** `(current-adapter-spec)` `identical?` to `re-frame.ssr/adapter`. That assertion is green inside the FULL artefact suite, not only in isolation, which is the case that matters — `rf/init!` installs only when no adapter is seated, so a suite that assumes the adapter can be measuring plain-atom, and this artefact does contain a namespace that seats plain-atom. The rf2-tax2 tests additionally run under CLJS/node (the `.cljc` sits on `:node-test`'s `ssr/test` path and its namespace matches that build's `cljs-test$` regexp), and they are adapter-independent by construction: `payload-content-digest` → `data-hash` → `canonical-data-edn` + `fnv-1a-32` is pure, and `payload-install-decision!` touches only the `installed-payloads` atom. No substrate is involved on either host.
