### PR TITLE
fix(xray,pair-mcp): forward the shell embed's own-frame opt, seat before manual init applies its target, emit parsed event EDN as data

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
@@ -247,7 +247,8 @@
 (defn- render-settle-form
   "Build the CLJS source for an `:await-render` dispatch. `fn-sym` is the
   runtime dispatch fn (always a synchronous variant under await-render);
-  `event-vec` + `opts-form` are the dispatch payload. Emits a form whose
+  `event-form` (the parsed event wrapped for literal-data emission, per
+  rf2-j2wz) + `opts-form` are the dispatch payload. Emits a form whose
   synchronous return is a `js/Promise` resolving to the dispatch envelope
   merged with `{:settled? true}` once the substrate has flushed + the
   next paint is scheduled.
@@ -270,8 +271,8 @@
   runtime call rides unwrapped (matching the non-await default). `incl?`
   threads the resolved `:include-sensitive` opt-in INTO the projection
   (app-db sensitive axis only) — never a projection bypass."
-  [fn-sym event-vec opts-form epoch-bearing? incl?]
-  (let [call-src (ef/emit (ef/rt-call fn-sym event-vec opts-form))
+  [fn-sym event-form opts-form epoch-bearing? incl?]
+  (let [call-src (ef/emit (ef/rt-call fn-sym event-form opts-form))
         result-src (if epoch-bearing?
                      (egress/project-dispatch-result-src call-src incl?)
                      call-src)]
@@ -462,7 +463,8 @@
         (js/Promise.resolve (wire/err-text payload))
 
         :ok
-      (let [event-vec payload
+      (let [event-vec  payload
+            event-form (ef/rt-quote event-vec)
             opts-form (cond-> {}
                         frame        (assoc :frame frame)
                         fx-overrides (assoc :fx-overrides fx-overrides)
@@ -492,10 +494,23 @@
                         ;; whether or not a `cofx` token was supplied (a record
                         ;; with no scripted facts still re-drives strict).
                         replay?      (assoc :rf.cofx/mint-policy :strict))
-            ;; The event is a parsed CLJS vector. Pass it through
-            ;; `rt-call`'s normal arg-emit path so it is `pr-str`'d as an
-            ;; EDN literal — the runtime fn receives data, not host source.
-            ;; NO `rt-raw` splice on this surface.
+            ;; The event is a parsed CLJS vector, and it is EXTERNAL data.
+            ;; It rides through `ef/rt-quote` — the literal-data emission
+            ;; path — so the runtime fn receives the datum the caller sent,
+            ;; not whatever its printed form evaluates to (rf2-j2wz). The
+            ;; default `pr-str` arg path is right for the internally-
+            ;; composed `opts-form` below and wrong here: printed unquoted,
+            ;; a nested list in the payload is a function call and a symbol
+            ;; is a name lookup, and a payload shaped like one of the
+            ;; emitter's tagged vectors is spliced in as raw source. All
+            ;; three happen while the call is being CONSTRUCTED — before
+            ;; the runtime dispatch fn validates anything, and regardless
+            ;; of whether `eval-cljs` is enabled.
+            ;;
+            ;; `parse-event-arg` is the other half of the same boundary and
+            ;; is unchanged: it rejects a whole host form at the door. Its
+            ;; check is on the OUTER shape only, so quoting is what carries
+            ;; the guarantee inward. NO `rt-raw` splice on this surface.
             ;;
             ;; The DEFAULT (and explicit `:sync` / `:await-render`) routes
             ;; through
@@ -530,7 +545,7 @@
           ;; redaction the non-await `:trace` / `:settle` path applies
           ;; (rf2-6klf02). The consequence shapes (`:sync` / `:queued`)
           ;; carry no raw app-db, so they ride unwrapped.
-          (let [settle-form (render-settle-form fn-sym event-vec opts-form
+          (let [settle-form (render-settle-form fn-sym event-form opts-form
                                                 (contains? #{:trace :settle} mode)
                                                 incl?)
                 mailbox-id  (await-promise/mailbox-key)
@@ -551,7 +566,7 @@
                 (await-promise/handle-sentinel
                   conn build-id timeout-ms sentinel
                   (await-render-callbacks mode)))))
-          (let [call-src (ef/emit (ef/rt-call fn-sym event-vec opts-form))
+          (let [call-src (ef/emit (ef/rt-call fn-sym event-form opts-form))
                 ;; Only the epoch-bearing modes
                 ;; (`:trace` / `:settle`) carry raw `:epoch` /
                 ;; `:render-events`; wrap their emitted form so the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
@@ -308,6 +308,17 @@
 
       :else
       (let [event-vec payload
+            ;; rf2-j2wz — the parsed event is EXTERNAL data, so it rides
+            ;; through the literal-data emission path rather than the
+            ;; default `pr-str` arg path (which is right for the
+            ;; internally-composed `opts-form` below). Unquoted, a nested
+            ;; list in the payload would be a function call, a symbol a
+            ;; name lookup, and a payload shaped like one of the emitter's
+            ;; tagged vectors a raw-source splice — all evaluated while
+            ;; the call is CONSTRUCTED, before the simulation runs and
+            ;; regardless of whether `eval-cljs` is enabled. Dry-run shares
+            ;; `dispatch`'s parser and emitter, so it shares this seam too.
+            event-form (ef/rt-quote event-vec)
             opts-form (cond-> {}
                         frame        (assoc :frame frame)
                         ;; EP-0017 — thread the scripted
@@ -343,7 +354,7 @@
             form (if walk?
                    (ef/emit
                      (ef/rt-let
-                       ['env      (ef/rt-call 'dispatch-dry-run event-vec opts-form)
+                       ['env      (ef/rt-call 'dispatch-dry-run event-form opts-form)
                         'redacted (ef/rt-raw (str "(" redact-src " env)"))
                         'walked   (ef/rt-raw (str "(" (elide-envelope-src frame-edn elision-opts) " redacted)"))]
                        (ef/rt-raw
@@ -352,7 +363,7 @@
                               "                              (tree-seq coll? seq walked)))}"))))
                    (ef/emit
                      (ef/rt-let
-                       ['env      (ef/rt-call 'dispatch-dry-run event-vec opts-form)
+                       ['env      (ef/rt-call 'dispatch-dry-run event-form opts-form)
                         'redacted (ef/rt-raw (str "(" redact-src " env)"))]
                        (ef/rt-raw "{:value redacted :elided-count 0}"))))]
         (probe/eval-after-runtime-signalled!

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
@@ -20,7 +20,7 @@
       [::call* qsym args]         →  `(<qsym> <emitted arg> ...)`  — fully-qualified
       [::let   bindings body]     →  `(let [<binding-name> <binding-val> ...] <body>)`
       [::raw   source-string]     →  `<source-string>`  — escape hatch
-      [::quote v]                 →  `(quote v)`  — embedded EDN literal
+      [::quote v]                 →  `(quote v)`  — literal DATA
       other value                 →  `(pr-str v)`  — EDN-printed literal
 
   `bindings` is a flat seq `[name form name form ...]`; binding NAMES
@@ -44,6 +44,15 @@
     For raw-source fragments (e.g. referring to a let-bound name, a
     `loop`/`recur`, or a `(if ...)` host form), wrap with
     [[rt-raw]].
+
+  - `pr-str` is a PRINT, not a quotation, and the difference only shows
+    up on values containing lists or symbols — which internally-composed
+    arguments never are, and EXTERNAL EDN parsed off the wire routinely
+    is. Arguments that came from a caller therefore take [[rt-quote]],
+    whose emission evaluates to its datum for every EDN value. This is
+    the boundary `dispatch` / `dispatch-dry-run` sit on (rf2-j2wz); every
+    other call site composes its own arguments and stays on the default
+    path.
 
   - The runtime prefix lives in ONE place — `runtime-ns`. A rename of
     the runtime ns flows to every callsite by editing one string.
@@ -92,9 +101,40 @@
   [source-string]
   [::raw source-string])
 
+(defn rt-quote
+  "Wrap a value so `emit` renders it as `(quote <v>)` — a LITERAL-DATA
+  argument — instead of the bare EDN print `pr-str` produces.
+
+  ## Why this is not the same as the default arg path (rf2-j2wz)
+
+  `pr-str` renders a value as SOURCE, and source is read as code. For
+  the scalar payloads the internal tool sites compose — a keyword, a
+  string, a number, a map of those — printing and quoting agree, which
+  is why the default path is fine there and stays unchanged. They part
+  company the moment the value contains a LIST or a SYMBOL: printed
+  unquoted, a nested list is a function call and a symbol is a name
+  lookup, so the argument the runtime fn receives is whatever those
+  evaluate to rather than the datum it was printed from. Worse, a value
+  that happens to be shaped like one of this DSL's own tagged vectors is
+  recognised by `emit-arg` as IR and its payload spliced in as raw
+  source.
+
+  That is invisible for internally-composed arguments, whose shapes the
+  emitter chose. It is exactly wrong for EXTERNAL EDN parsed off the
+  wire, where lists and symbols are ordinary event data and an
+  emitter-shaped vector is payload, not instruction. Data-only tool
+  surfaces (`dispatch`, `dispatch-dry-run`) therefore wrap their parsed
+  event with this node.
+
+  The payload is NEVER walked: `emit` prints it and stops. A quoted form
+  evaluates to its datum for every EDN value, which is the whole of what
+  this node promises."
+  [v]
+  [::quote v])
+
 (defn- node? [x]
   (and (vector? x)
-       (#{::call ::call* ::let ::raw} (first x))))
+       (#{::call ::call* ::let ::raw ::quote} (first x))))
 
 (declare emit)
 
@@ -175,6 +215,13 @@
     (let [[tag] form]
       (case tag
         ::raw  (let [[_ s] form] s)
+
+        ;; rf2-j2wz — the literal-data path. `pr-str` the payload and
+        ;; STOP: no `emit-arg` recursion, because a caller-supplied
+        ;; value that wears one of this DSL's tags is payload rather
+        ;; than IR, and walking it would hand back the raw-source
+        ;; splice this node exists to close.
+        ::quote (let [[_ v] form] (str "(quote " (pr-str v) ")"))
 
         ::call (let [[_ sym args] form]
                  (str "(" runtime-ns "/" (name sym)

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -767,8 +767,11 @@
                                    :would-fire-effects [{:fx-id :http :args {:url "/checkout"}}]
                                    :db-state-after-simulation {:cart {} :order {:id 1}}}]
      [:default                    nil]]
+    ;; rf2-j2wz — the parsed event rides as a QUOTED literal, so it
+    ;; evaluates to the datum the caller sent rather than to whatever its
+    ;; printed form means as source.
     :fixture/eval-form-must-contain
-    ["dispatch-dry-run [:cart/checkout]"]
+    ["dispatch-dry-run (quote [:cart/checkout])"]
     :fixture/expect
     {:isError? false
      :edn-submap {:ok? true :dry-run? true :rolled-back? true}}}

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_dry_run_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_dry_run_test.cljs
@@ -731,3 +731,84 @@
                  (let [edn (read-result-text r)]
                    (is (= :unexpected-shape (:reason edn))))
                  (done))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-j2wz — the parsed event reaches the runtime as DATA here too.
+;;
+;; `dispatch-dry-run` shares `dispatch`'s parser and its emitter, so it
+;; shared the defect: the vector check guards only the OUTER shape, and
+;; `pr-str` renders what got past it as SOURCE. A nested list evaluated, a
+;; symbol resolved, and a payload wearing the emitter's own IR tag was
+;; spliced in as raw source — all while the runtime call was being built,
+;; ahead of the simulation, and all reachable with `eval-cljs` disabled.
+;;
+;; Dry-run composes its call inside an `rt-let`, so the assertions below
+;; read the inner runtime call out of the emitted form: `read-string`
+;; consumes one balanced form, so slicing at the call's opening paren
+;; yields exactly it.
+;; ---------------------------------------------------------------------------
+
+(defn- quoted-datum
+  "The datum a `(quote <datum>)` form evaluates to, or `::not-quoted` for
+  anything else — an unquoted list is a call and an unquoted symbol is a
+  name lookup, so neither yields the datum it was printed from."
+  [form]
+  (if (and (seq? form) (= 'quote (first form)) (= 2 (count form)))
+    (second form)
+    ::not-quoted))
+
+(defn- runtime-call
+  "The `(re-frame2-pair.runtime/dispatch-dry-run <event> <opts>)` call read
+  out of the emitted `rt-let` form."
+  [forms*]
+  (let [form (dispatch-form forms*)
+        head "(re-frame2-pair.runtime/dispatch-dry-run "
+        i    (str/index-of form head)]
+    (when i (cljs.reader/read-string (subs form i)))))
+
+(deftest dry-run-event-payload-lists-are-not-evaluated
+  (async done
+    (let [forms (atom [])]
+      (-> (with-captured-eval! forms (wrap {:ok? true :dry-run? true :rolled-back? true} 0)
+            (fn []
+              (dry-run/dispatch-dry-run-tool (fresh-conn)
+                                             #js {:event "[:cart/add (inc 41)]"})))
+          (.then (fn [r]
+                   (is (not (err? r)))
+                   (is (= [:cart/add '(inc 41)]
+                          (quoted-datum (second (runtime-call forms))))
+                       "the nested list reaches the runtime as a list")
+                   (done)))))))
+
+(deftest dry-run-event-payload-symbols-are-not-resolved
+  (async done
+    (let [forms (atom [])]
+      (-> (with-captured-eval! forms (wrap {:ok? true :dry-run? true :rolled-back? true} 0)
+            (fn []
+              (dry-run/dispatch-dry-run-tool (fresh-conn)
+                                             #js {:event "[:cart/add js/window]"})))
+          (.then (fn [r]
+                   (is (not (err? r)))
+                   (is (= [:cart/add 'js/window]
+                          (quoted-datum (second (runtime-call forms))))
+                       "a symbol-valued event stays a symbol rather than resolving")
+                   (done)))))))
+
+(deftest dry-run-emitter-shaped-event-payload-is-not-spliced
+  (async done
+    (let [forms   (atom [])
+          raw-tag :re-frame2-pair-mcp.tools.eval-form/raw]
+      (-> (with-captured-eval! forms (wrap {:ok? true :dry-run? true :rolled-back? true} 0)
+            (fn []
+              (dry-run/dispatch-dry-run-tool
+                (fresh-conn)
+                #js {:event "[:re-frame2-pair-mcp.tools.eval-form/raw \"(inc 41)\"]"})))
+          (.then (fn [r]
+                   (is (not (err? r)))
+                   (is (= [raw-tag "(inc 41)"]
+                          (quoted-datum (second (runtime-call forms))))
+                       "the tagged vector rides through as the vector it is")
+                   (is (not (str/includes? (dispatch-form forms)
+                                           "dispatch-dry-run (inc 41)"))
+                       "no raw-source splice in the runtime call")
+                   (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
@@ -118,6 +118,20 @@
 (def ^:private read-result-text tu/extract-edn)
 (def ^:private err? tu/error?)
 
+(defn- quoted-datum
+  "The datum a `(quote <datum>)` form evaluates to, or `::not-quoted` for
+  anything else — an unquoted list is a call, an unquoted symbol is a name
+  lookup, and neither yields the datum it was printed from."
+  [form]
+  (if (and (seq? form) (= 'quote (first form)) (= 2 (count form)))
+    (second form)
+    ::not-quoted))
+
+(defn- event-arg
+  "The event argument of the captured runtime call, as a read form."
+  [captured]
+  (second (cljs.reader/read-string @captured)))
+
 ;; ---------------------------------------------------------------------------
 ;; Narrow integration arms — the exhaustive event-parse matrix (nil / blank
 ;; / unreadable / map / keyword / list / symbol / scalar / vector, with the
@@ -232,9 +246,9 @@
                    (let [form @captured]
                      (is (string? form))
                      ;; The default runtime call is
-                     ;; `(rt/dispatch-consequence! [:cart/checkout] {})`.
-                     ;; The event vector rides as an EDN literal — pinned
-                     ;; via the `pr-str` shape.
+                     ;; `(rt/dispatch-consequence! (quote [:cart/checkout]) {})`.
+                     ;; The event vector rides as a QUOTED literal (rf2-j2wz)
+                     ;; so it evaluates to the datum the caller sent.
                      (is (re-find #"dispatch-consequence!" form))
                      (is (re-find #"\[:cart/checkout\]" form))
                      ;; And critically — NO host-form splice. The form is
@@ -243,8 +257,8 @@
                      (let [parsed (cljs.reader/read-string form)]
                        (is (= 're-frame2-pair.runtime/dispatch-consequence! (first parsed))
                            "first arg is the qualified fn symbol")
-                       (is (= [:cart/checkout] (second parsed))
-                           "second arg is the event vector — DATA, not source")))
+                       (is (= [:cart/checkout] (quoted-datum (second parsed)))
+                           "second arg evaluates to the event vector — DATA, not source")))
                    (done)))))))
 
 (deftest accepts-event-with-args
@@ -259,7 +273,7 @@
           (.then (fn [r]
                    (is (not (err? r)))
                    (let [parsed (cljs.reader/read-string @captured)]
-                     (is (= [:cart/add {:sku "abc"}] (second parsed))))
+                     (is (= [:cart/add {:sku "abc"}] (quoted-datum (second parsed)))))
                    (done)))))))
 
 (deftest sync-mode-routes-to-dispatch-consequence
@@ -825,7 +839,7 @@
                    (let [parsed (cljs.reader/read-string @captured)
                          opts   (nth parsed 2)]
                      (is (= 're-frame2-pair.runtime/dispatch-consequence! (first parsed)))
-                     (is (= [:rf.xray/focus-event 85] (second parsed)))
+                     (is (= [:rf.xray/focus-event 85] (quoted-datum (second parsed))))
                      (is (= :rf/xray (:frame opts))
                          "frame routes to the well-formed :rf/xray keyword")
                      (is (not= ::malformed (:frame opts)))
@@ -1346,7 +1360,7 @@
                    (is (not (err? r)))
                    (let [parsed (cljs.reader/read-string @captured)
                          opts   (nth parsed 2)]
-                     (is (= [:todo/add {:text "buy milk"}] (second parsed)))
+                     (is (= [:todo/add {:text "buy milk"}] (quoted-datum (second parsed))))
                      (is (= {:rf/time-ms 1781078400123} (:rf.cofx opts))
                          "cofx is threaded under the :rf.cofx opts key the router reads")
                      (is (int? (get-in opts [:rf.cofx :rf/time-ms]))
@@ -1685,3 +1699,98 @@
                    (is (= :rf.error/unreplayable-fx-override (:reason edn)))
                    (is (= :http (:target edn))))
                  (done))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-j2wz — the parsed event reaches the runtime as DATA.
+;;
+;; `parse-event-arg`'s vector check stops a whole host form at the door, and
+;; its docstring says why: the payload must be data, never source. But the
+;; check is on the OUTER shape only, and what got past it was emitted with
+;; `pr-str` — which renders a value as source rather than quoting it. So an
+;; event whose payload contained a list or a symbol changed meaning on the
+;; way to the handler, and one shaped like the emitter's own IR was spliced
+;; in as raw source outright. Both happen while the runtime call is being
+;; CONSTRUCTED, ahead of anything the dispatch fn validates, and both are
+;; reachable with `eval-cljs` disabled — the narrow explicit boundary the
+;; parser's own docstring draws.
+;;
+;; These deftests read the emitted argument through `quoted-datum`, which
+;; asks what the form EVALUATES to rather than what it prints as. The old
+;; read-back-as-EDN assertions could not see the defect at all: `pr-str`'d
+;; source and quoted data read back identically as EDN, and only evaluation
+;; tells them apart.
+;; ---------------------------------------------------------------------------
+
+(deftest event-payload-lists-are-not-evaluated-before-dispatch
+  ;; `(inc 41)` inside the payload is ordinary data. Unquoted it evaluates
+  ;; to 42 and the handler is handed a number where the caller sent a list.
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:ok? true :no-op? true}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:cart/add (inc 41)]"})))
+          (.then (fn [r]
+                   (is (not (err? r)))
+                   (is (= [:cart/add '(inc 41)] (quoted-datum (event-arg captured)))
+                       "the nested list reaches the runtime as a list")
+                   (is (not (str/includes? @captured "dispatch-consequence! [:cart/add"))
+                       "the event no longer rides as a bare unquoted literal")
+                   (done)))))))
+
+(deftest event-payload-symbols-are-not-resolved-before-dispatch
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:ok? true :no-op? true}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:cart/add js/window]"})))
+          (.then (fn [r]
+                   (is (not (err? r)))
+                   (is (= [:cart/add 'js/window] (quoted-datum (event-arg captured)))
+                       "a symbol-valued event stays a symbol rather than resolving")
+                   (done)))))))
+
+(deftest emitter-shaped-event-payload-is-not-spliced-as-source
+  ;; The strongest witness: a payload wearing the emitter's own `::raw` tag.
+  ;; Unquoted, `emit` recognised it as IR and inlined its string in the
+  ;; runtime call's argument position, replacing the event outright — an
+  ;; arbitrary-source request through the data-only tool route.
+  (async done
+    (let [captured (atom nil)
+          raw-tag  :re-frame2-pair-mcp.tools.eval-form/raw]
+      (-> (with-captured-eval! captured {:ok? true :no-op? true}
+            (fn []
+              (dispatch/dispatch-tool
+                (fresh-conn)
+                #js {:event "[:re-frame2-pair-mcp.tools.eval-form/raw \"(inc 41)\"]"})))
+          (.then (fn [r]
+                   (is (not (err? r)))
+                   (is (= [raw-tag "(inc 41)"] (quoted-datum (event-arg captured)))
+                       "the tagged vector rides through as the vector it is")
+                   (is (not (str/includes? @captured "dispatch-consequence! (inc 41)"))
+                       "no raw-source splice in the runtime call")
+                   (done)))))))
+
+(deftest await-render-event-payload-is-quoted-too
+  ;; `:await-render` composes the runtime call through `render-settle-form`
+  ;; rather than the plain emit path, so it needs its own arm — the same
+  ;; parsed EDN travels a second route to the same runtime fn.
+  (async done
+    (let [wrap-form*  (atom nil)
+          read-count* (atom 0)]
+      (-> (with-staged-mailbox-eval!
+            {:wrap-form* wrap-form* :read-count* read-count*
+             :pending-polls 0
+             :resolved {:ok? true :epoch-id 9 :settled? true}}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:cart/add (inc 41)]"
+                                           :await-render true})))
+          (.then (fn [_]
+                   (let [form @wrap-form*]
+                     (is (str/includes? form "(quote [:cart/add (inc 41)])")
+                         "the settle form carries the event as quoted data")
+                     (is (not (str/includes? form "dispatch-consequence! [:cart/add"))
+                         "and not as a bare unquoted literal"))
+                   (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_form_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_form_test.cljs
@@ -13,6 +13,7 @@
     contract every tool body relies on."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [cljs.reader]
+            [clojure.string :as str]
             [re-frame2-pair-mcp.tools.eval-form :as ef]))
 
 ;; ---------------------------------------------------------------------------
@@ -171,3 +172,79 @@
   ;; the output for the existing tool sites.
   (is (= "(re-frame2-pair.runtime/foo [1 2 3])"
          (ef/emit (ef/rt-call 'foo [1 2 3])))))
+
+;; ---------------------------------------------------------------------------
+;; rt-quote — the literal-data emission path (rf2-j2wz).
+;;
+;; `pr-str` is not a data quotation. It renders a value as SOURCE, and
+;; source is read as code: a nested EDN list becomes a function call and a
+;; symbol becomes a name lookup. That is invisible for the scalar payloads
+;; the internal tool sites compose — a keyword, a string, a number, a map of
+;; those — which is why the DSL got away with `pr-str` for so long, and it
+;; is exactly wrong for EXTERNAL EDN parsed off the wire, where lists and
+;; symbols are ordinary data the caller expects to reach the handler
+;; unchanged.
+;;
+;; `(quote <datum>)` is the only emission that evaluates to arbitrary EDN
+;; unchanged, so it is the one shape the data-only call sites take. The
+;; node's payload is NEVER walked by `emit-arg`: a caller-supplied vector
+;; that happens to wear an emitter tag is payload, not IR, and quoting it
+;; must not hand it back the splice.
+;; ---------------------------------------------------------------------------
+
+(defn- quoted-datum
+  "The datum a `(quote <datum>)` form evaluates to, or `::not-quoted` for
+  anything else. Reading an emitted arg through this is the difference
+  between pinning printed SYNTAX and pinning what evaluation yields."
+  [form]
+  (if (and (seq? form) (= 'quote (first form)) (= 2 (count form)))
+    (second form)
+    ::not-quoted))
+
+(deftest rt-quote-ir-shape
+  ;; The constructor is the fourth peer of rt-call / rt-raw / rt-let: a
+  ;; tagged vector, pinned as data so a tag rename surfaces here.
+  (is (= [::ef/quote [:cart/checkout]] (ef/rt-quote [:cart/checkout]))))
+
+(deftest rt-quote-emits-a-quoted-literal
+  (is (= "(quote [:cart/checkout])"
+         (ef/emit [::ef/quote [:cart/checkout]])))
+  (is (= "(quote :bare)"
+         (ef/emit [::ef/quote :bare]))))
+
+(deftest rt-quote-keeps-nested-lists-as-lists
+  ;; The defect in one line: unquoted, `(inc 41)` inside the payload
+  ;; evaluates to 42 and the handler never sees the list it was sent.
+  (let [datum [:cart/add '(inc 41)]
+        src   (ef/emit (ef/rt-call 'dispatch-consequence! [::ef/quote datum] {}))
+        arg   (second (cljs.reader/read-string src))]
+    (is (= datum (quoted-datum arg))
+        "the nested list survives as a list — it evaluates to itself")))
+
+(deftest rt-quote-keeps-symbols-as-symbols
+  (let [datum [:cart/add 'js/window]
+        src   (ef/emit (ef/rt-call 'dispatch-consequence! [::ef/quote datum] {}))
+        arg   (second (cljs.reader/read-string src))]
+    (is (= datum (quoted-datum arg))
+        "a symbol-valued event stays a symbol rather than resolving")))
+
+(deftest rt-quote-does-not-splice-an-emitter-shaped-payload
+  ;; A caller-supplied vector wearing the emitter's own `::raw` tag is
+  ;; PAYLOAD. Unquoted it was recognised as IR and its string spliced in
+  ;; as raw source, replacing the event outright.
+  (let [datum [::ef/raw "(inc 41)"]
+        src   (ef/emit (ef/rt-call 'dispatch-consequence! [::ef/quote datum] {}))
+        arg   (second (cljs.reader/read-string src))]
+    (is (= datum (quoted-datum arg))
+        "the tagged vector rides through as the vector it is")
+    (is (not (str/includes? src "dispatch-consequence! (inc 41)"))
+        "and its string is never spliced into the runtime call's arg position")))
+
+(deftest rt-quote-leaves-internal-raw-composition-alone
+  ;; The escape hatch the internal sites depend on is untouched: an
+  ;; `rt-raw` node built by the emitter itself still inlines verbatim.
+  (is (= "(re-frame.core/elide-wire-value db)"
+         (ef/emit (ef/rt-call* 're-frame.core/elide-wire-value
+                               (ef/rt-raw "db")))))
+  (is (= "(re-frame2-pair.runtime/foo [1 bar])"
+         (ef/emit (ef/rt-call 'foo [1 (ef/rt-raw "bar")])))))

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -113,12 +113,22 @@ The full-shell embed exposes exactly two host-visible props:
 | `:frame` | no | `:rf/xray` (Xray-internal default) | The frame the shell's frame-provider wraps. Hosts that need the embedded shell to read a non-default Xray-internal frame pass this through `mount-shell!`'s `opts`; in practice the default is what every shipped host uses. The shell's frame-picker UI is the canonical way to choose which *host* frame Xray observes — that selection lives in `:rf.xray/target-frame` inside `:rf/xray`'s db. |
 | `:height` | no | host-CSS owned | Xray does not read a height prop. The host's stylesheet sizes the mount-point container (typically via `--rf-xray-inline-width` for inline-host width and the host's flex / grid rules for height). Listed here because hosts often think of "height" as part of the embed contract; the contract is "the host owns it". |
 
-Both props are honoured by the **frame-provider convention** (the
-`mount-<panel>!` surface from [`007-UX-IA.md`](./007-UX-IA.md)
-§Mountable panel contract: every mount fn opens with
-`[rf/frame-provider {:frame ...} ...]` and renders into the
-host-supplied mount-point — Xray never sizes its own container). No
-other host-facing props exist.
+`mount-shell!` resolves `:frame` against the Xray-internal default and
+threads it to `shell-view` as its `:frame-id` opt; `shell-view` opens
+its own `[rf/frame-provider {:frame frame-id} ...]` around the 4-layer
+chrome, so the full-shell mount adds no outer provider of its own. The
+requested own frame is seated on the way through — the host is not asked
+to pre-create it. Two embeds given distinct `:frame`s therefore hold
+independent shell state (selected tab, mode, focused epoch, modals)
+rather than sharing one app-db.
+
+This is a different mechanism from the per-panel `mount-<panel>!`
+surface in [`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract,
+where the mount fn itself opens the `[rf/frame-provider {:frame ...}
+...]` wrapper around a panel view that has none. Both render into the
+host-supplied mount-point — Xray never sizes its own container, which is
+the whole of what `:height` means here. No other host-facing props
+exist.
 
 ## What the host owns
 
@@ -380,20 +390,27 @@ chosen one; where a choice is already in the slot, first open preserves
 it and re-seeds `:epoch-history` from that frame.
 
 The collision is new, and that is why the ordering had not needed
-stating: until `set-target-frame!` seated `:rf/xray` itself (below), no
-target could be selected *before* first open, so discovery never met one.
+stating: until the host-config entry points seated `:rf/xray` themselves
+(below), no target could be selected *before* first open, so discovery
+never met one.
 Unordered, the loss was silent both ways — a cold ring resolves to `nil`,
 which `:rf.xray/set-target-frame` writes as a full RESET (clearing
 `:target-frame`, `[:focus :frame]` and `:epoch-history`), and a warm ring
 substitutes whichever frame happens to head the pre-open trace.
 
-`set-target-frame!` **seats `:rf/xray` before it dispatches** (rf2-88f1).
-The own-frame singleton is normally seated the moment the host runtime is
-ready, from the preload's readiness loop (rf2-avi7) — but that loop polls
-on a 50ms tick, and a host whose boot calls `rf/init!` and re-orients the
-target on the same turn reaches the facade inside that window. Without the
-seat the gesture dispatched into a frame that did not exist yet and the
-host got `:rf.error/frame-destroyed` instead of the target it asked for.
+**Both host-config entry points — `set-target-frame!` (rf2-88f1) and
+`init! {:target-frame …}` (rf2-bitb) — seat `:rf/xray` before they
+dispatch.** The own-frame singleton is normally seated the moment the host
+runtime is ready, from the preload's readiness loop (rf2-avi7) — but that
+loop polls on a 50ms tick, and a host whose boot calls `rf/init!` and
+re-orients the target on the same turn reaches the facade inside that
+window. `init!` is the stronger case: it is the MANUAL install, the
+documented alternative to the preload, so on that route the readiness loop
+is not running at all and there is no eventual seat to fall back on.
+Without the seat the gesture dispatched into a frame that did not exist yet
+and the host got `:rf.error/frame-destroyed` instead of the target it asked
+for — and because the rejection happens at dispatch, calling `open!`
+immediately afterwards cannot rescue the choice.
 The seat is idempotent and is itself a no-op until a substrate adapter is
 installed, so it costs a live host nothing. It is the SEAT only — the
 first-mount seed/hydrate fan-out stays at first open, where it can still

--- a/tools/xray/src/day8/re_frame2_xray/core.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/core.cljs
@@ -109,6 +109,37 @@
   non-blocking diagnostic when the default inline host is missing."
   mount/status)
 
+;; ---- the seated target-set (shared by init! and set-target-frame!) ------
+
+(defn- seat-and-set-target-frame!
+  "Seat `:rf/xray`, then dispatch `:rf.xray/set-target-frame` into it.
+
+  The seat is what makes the dispatch land. `:rf/xray` is normally seated
+  by the preload's readiness loop (rf2-avi7), but that loop polls on a
+  50ms tick, and both callers below reach here INSIDE that window on a
+  host whose boot re-orients the target on the same turn as `rf/init!` —
+  and `init!` is the MANUAL install, which deliberately loads no preload
+  and starts no poll at all, so on that route there is no eventual seat
+  to fall back on. Without the seat the dispatch is rejected at the
+  router with `:rf.error/frame-destroyed`, the host's boot target is
+  dropped, and a later `open!` cannot rescue a choice that never landed.
+
+  `mount/ensure-seated!` and NOT `mount/ensure-xray-frame!` (rf2-88f1):
+  the latter also runs the run-once first-mount hook fan-out, whose job
+  is to harvest the trace and epoch rings the user filled BEFORE opening
+  Xray. Firing it from here would spend that one run on an empty
+  boot-time ring. Seating is idempotent and is a no-op until a substrate
+  adapter exists, so it costs a live host nothing.
+
+  Factored out under rf2-bitb: `set-target-frame!` was correct and
+  `init!` — the other supported way a host states its boot target — was
+  not, because it hand-rolled the dispatch instead of taking this seam."
+  [frame-id]
+  (mount/ensure-seated!)
+  (rf/with-frame :rf/xray
+    (rf/dispatch [:rf.xray/set-target-frame frame-id]))
+  nil)
+
 ;; ---- init! (manual install, alternative to :preloads) ------------------
 
 (defn init!
@@ -188,9 +219,11 @@
    ;; Select the explicit inspected target frame in
    ;; Xray's OWN (`:rf/xray`) frame. Absent → leave unselected (the picker
    ;; / mount discovery policy chooses); never a `:rf/default` fallback.
+   ;; Routed through the seated seam (rf2-bitb) — none of the installs
+   ;; above seats `:rf/xray`, and this facade starts no readiness poll, so
+   ;; a raw dispatch here had no frame to land in.
    (when target-frame
-     (rf/with-frame :rf/xray
-       (rf/dispatch [:rf.xray/set-target-frame target-frame])))
+     (seat-and-set-target-frame! target-frame))
    (when theme
      (config/update-setting! :theme nil theme)
      (settings-effects/apply-theme! theme))
@@ -240,22 +273,15 @@
 
   ## Correct at boot instant (rf2-88f1)
 
-  Seats `:rf/xray` before dispatching. `:rf/xray` is normally seated by
-  the preload's readiness loop (rf2-avi7), but that loop polls on a
-  50ms tick and a host whose boot re-orients the target on the same
-  turn as `rf/init!` reaches this fn INSIDE the poll window — the
-  dispatch then landed in a frame that did not exist yet and the host
-  got `:rf.error/frame-destroyed` instead of the target it asked for.
-  Seating here is idempotent and is a no-op until the runtime is ready,
-  so it costs a live host nothing and makes the facade correct for
-  every host rather than for the ones that dispatch late enough.
+  Seats `:rf/xray` before dispatching, through the shared
+  `seat-and-set-target-frame!` seam above — see its docstring for why the
+  seat is load-bearing, and why it is `ensure-seated!` rather than
+  `ensure-xray-frame!`. `init!` takes the same seam (rf2-bitb), so the
+  two supported ways a host states its boot target now behave alike.
 
   Returns nothing."
   [frame-id]
-  (mount/ensure-seated!)
-  (rf/with-frame :rf/xray
-    (rf/dispatch [:rf.xray/set-target-frame frame-id]))
-  nil)
+  (seat-and-set-target-frame! frame-id))
 
 ;; ---- Story → Xray focus -------------------------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -180,10 +180,19 @@
   been dispatching events.
 
   `ensure-xray-frame!` is idempotent, so multiple panel mounts and
-  shadow-cljs reloads collapse to one seed pass."
-  []
-  (registry/register-xray-handlers!)
-  (mount/ensure-xray-frame!))
+  shadow-cljs reloads collapse to one seed pass.
+
+  `frame-id` names the Xray-OWN frame to seat — the shell's own app-db,
+  not the inspected host target. It defaults to `shell/default-frame-id`,
+  which is what every per-panel mount takes; `mount-shell!` passes the
+  own frame its caller asked for (rf2-lffg), so a second embed gets its
+  own seeded frame rather than sharing the first's. The hook table's
+  run-once guard is keyed per `frame-id`, so each instance frame gets
+  exactly one seed pass."
+  ([] (ensure-xray-handlers-installed! shell/default-frame-id))
+  ([frame-id]
+   (registry/register-xray-handlers!)
+   (mount/ensure-xray-frame! frame-id)))
 
 (defn- render-panel!
   "Internal helper. Wraps `panel-view` in `[rf/frame-provider {:frame
@@ -370,10 +379,29 @@
   default in-app `[data-rf-xray-host]` mount; exposing it here lets
   hosts that own their own DOM (Story, custom dev surfaces) mount
   the shell at any element without going through Xray's auto-open
-  preload."
+  preload.
+
+  `opts` carries the two props `008-Embedding-Contract.md` §Embed props
+  inventory publishes:
+
+  - `:mode` — `:inline` (default) / `:overlay`, the shell's chrome mode.
+  - `:frame` — the shell's OWN frame, defaulting to
+    `shell/default-frame-id`. Distinct from the inspected host target,
+    which the frame-picker chooses and which lives in
+    `:rf.xray/target-frame` inside the own frame's db. It is forwarded to
+    `shell-view` as its `:frame-id` opt (rf2-lnluk's de-singleton axis)
+    and the frame is seated on the way through, so two embeds given
+    distinct `:frame`s hold independent tab / mode / focus state instead
+    of colliding on one app-db (rf2-lffg).
+
+  Unlike the per-panel mounts, no outer `frame-provider` is added here:
+  `shell-view` opens its own around `frame-id`."
   ([mount-point]      (mount-shell! mount-point nil))
   ([mount-point opts]
-   (ensure-xray-handlers-installed!)
-   (let [mode (get opts :mode :inline)
-         tree [shell/shell-view {:mode mode}]]
-     (rf.substrate.adapter/render tree mount-point nil))))
+   (let [frame-id (get opts :frame shell/default-frame-id)
+         mode     (get opts :mode :inline)]
+     (ensure-xray-handlers-installed! frame-id)
+     (rf.substrate.adapter/render [shell/shell-view {:mode     mode
+                                                     :frame-id frame-id}]
+                                  mount-point
+                                  nil))))

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -43,6 +43,7 @@
             [day8.re-frame2-xray.panels.routing :as routing]
             [day8.re-frame2-xray.panels.trace :as trace]
             [day8.re-frame2-xray.panels.reactive-panel :as reactive-panel]
+            [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.spine :as spine]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
@@ -213,6 +214,123 @@
     (with-redefs [rf.substrate.adapter/render render-stub]
       (panels/mount-shell! :mount-point {:mode :overlay})
       (is (= :overlay (-> (captured-tree capture) second :mode))))))
+
+;; ---- rf2-lffg — the full-shell embed forwards its own-frame opt --------
+;;
+;; `008-Embedding-Contract.md` §Embed props inventory publishes exactly two
+;; host-visible props on the full-shell embed, and `:frame` is one of them:
+;; the frame the shell's frame-provider wraps — Xray's OWN frame, distinct
+;; from the inspected host target the frame-picker chooses. `shell-view`
+;; has taken that axis as its `:frame-id` opt since rf2-lnluk de-singletoned
+;; the shell, and `two-instance-isolation-cljs-test` pins the isolation it
+;; buys at the data layer by binding the two frames directly.
+;;
+;; `mount-shell!` was the one seam that never carried the option across: it
+;; read `:mode` out of `opts` and dropped `:frame` on the floor, so every
+;; embed — however many, however addressed — resolved to the default
+;; `:rf/xray` and shared one app-db. The source-level singleton guard
+;; (`frame_singleton_guard_test.clj`) cannot see this: there is no literal
+;; `:rf/xray` to find, only a caller option that is never read.
+;;
+;; These deftests sit at the PUBLIC full-shell boundary — through
+;; `mount-shell!`, never `shell-view` directly — which is precisely the
+;; surface the existing coverage stepped around.
+
+(def ^:private embed-cell-a :review/xray-a)
+(def ^:private embed-cell-b :review/xray-b)
+
+(defn- shell-frame-id
+  "The `:frame-id` prop the n'th captured `[shell/shell-view {…}]` tree
+  carries — the shell's own frame."
+  [capture n]
+  (-> @capture (nth n) :tree second :frame-id))
+
+(defn- read-in-frame [frame-id query]
+  (rf/with-frame frame-id (rf/subscribe-once query)))
+
+(defn- dispatch-in-frame! [frame-id event-v]
+  (rf/with-frame frame-id (rf/dispatch-sync event-v)))
+
+(deftest mount-shell-forwards-the-frame-opt-as-the-shells-own-frame-id
+  (testing "rf2-lffg — two full shells mounted through `mount-shell!` into
+            separate roots with DISTINCT `:frame` options each receive the
+            own frame they asked for. Pre-fix both trees carried no
+            `:frame-id` at all, so `shell-view` defaulted both to
+            `shell/default-frame-id` and the two embeds collided."
+    (let [[capture _ render-stub] (make-render-stub)]
+      (with-redefs [rf.substrate.adapter/render render-stub]
+        (panels/mount-shell! :mount-a {:frame embed-cell-a})
+        (panels/mount-shell! :mount-b {:frame embed-cell-b}))
+      (is (= 2 (count @capture))
+          "both mounts delegated to the substrate adapter")
+      (is (= embed-cell-a (shell-frame-id capture 0))
+          "shell A carries the own frame its caller requested")
+      (is (= embed-cell-b (shell-frame-id capture 1))
+          "shell B carries ITS own frame — not A's, and not the default")
+      (is (not= (shell-frame-id capture 0) (shell-frame-id capture 1))
+          "two requested own frames stay two")
+      (is (= :mount-a (-> @capture (nth 0) :mount-point))
+          "mount-points are untouched by the frame plumbing")
+      (is (= :mount-b (-> @capture (nth 1) :mount-point)))
+      (is (some? (rf.frame/frame embed-cell-a))
+          "the requested own frame is SEATED — `shell-view`'s subscribes
+           and its captured dispatchers need a frame to land in, and the
+           embed contract does not ask the host to pre-seat one")
+      (is (some? (rf.frame/frame embed-cell-b))))))
+
+(deftest mount-shell-frame-opt-defaults-and-leaves-mode-intact
+  (testing "rf2-lffg — omitting `:frame` still selects the documented
+            default own frame (`shell/default-frame-id`), and threading the
+            new axis does not disturb `:mode`."
+    (let [[capture _ render-stub] (make-render-stub)]
+      (with-redefs [rf.substrate.adapter/render render-stub]
+        (panels/mount-shell! :mount-default)
+        (panels/mount-shell! :mount-overlay {:mode :overlay})
+        (panels/mount-shell! :mount-both {:mode  :overlay
+                                          :frame embed-cell-a}))
+      (is (= shell/default-frame-id (shell-frame-id capture 0))
+          "omitted :frame shares the documented default")
+      (is (= :inline (-> @capture (nth 0) :tree second :mode))
+          "and the default :mode is unchanged")
+      (is (= shell/default-frame-id (shell-frame-id capture 1))
+          ":mode alone does not disturb the own-frame default")
+      (is (= :overlay (-> @capture (nth 1) :tree second :mode)))
+      (is (= embed-cell-a (shell-frame-id capture 2))
+          "both opts travel together")
+      (is (= :overlay (-> @capture (nth 2) :tree second :mode))))))
+
+(deftest mount-shell-instances-hold-independent-own-frame-state
+  (testing "rf2-lffg — the point of forwarding the option: driving tab,
+            mode and focus in the shell mounted at one root leaves the
+            shell mounted at the other root untouched. The `with-frame`
+            bindings below stand in for the two `[frame-provider {:frame
+            frame-id}]` scopes the mounted `shell-view`s establish — the
+            same standing-in `two-instance-isolation-cljs-test` does, but
+            reached through `mount-shell!` rather than around it. Pre-fix
+            both mounts resolved to one frame and every assertion in the
+            second half of this deftest read back A's value."
+    (let [[_ _ render-stub] (make-render-stub)]
+      (with-redefs [rf.substrate.adapter/render render-stub]
+        (panels/mount-shell! :mount-a {:frame embed-cell-a})
+        (panels/mount-shell! :mount-b {:frame embed-cell-b}))
+      ;; Seed B, then drive A across all three axes.
+      (dispatch-in-frame! embed-cell-b [:rf.xray/select-tab :trace])
+      (dispatch-in-frame! embed-cell-b [:rf.xray/set-mode :static])
+      (dispatch-in-frame! embed-cell-b [:rf.xray/focus-event :b-cascade :rf/default])
+      (dispatch-in-frame! embed-cell-a [:rf.xray/select-tab :app-db])
+      (dispatch-in-frame! embed-cell-a [:rf.xray/focus-event :a-cascade :rf/default])
+      (is (= :app-db (read-in-frame embed-cell-a [:rf.xray/selected-tab]))
+          "shell A holds its own selected tab")
+      (is (= :trace (read-in-frame embed-cell-b [:rf.xray/selected-tab]))
+          "shell B's tab did NOT move when A's did")
+      (is (= :dynamic (read-in-frame embed-cell-a [:rf.xray/mode]))
+          "shell A is still at the default mode")
+      (is (= :static (read-in-frame embed-cell-b [:rf.xray/mode]))
+          "shell B's mode is its own")
+      (is (= :a-cascade (:dispatch-id (read-in-frame embed-cell-a [:rf.xray/focus])))
+          "shell A focused its own epoch")
+      (is (= :b-cascade (:dispatch-id (read-in-frame embed-cell-b [:rf.xray/focus])))
+          "and shell B is STILL focused on its own"))))
 
 ;; ---- contract — frame opt --------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/target_frame_seating_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/target_frame_seating_cljs_test.cljs
@@ -348,3 +348,96 @@
            before rf2-88f1")
       (is (= :other/frame (focus-frame))
           "aligning the focus axis with it"))))
+
+;; ---- (8) rf2-bitb — the MANUAL init route seats before it applies -------
+;;
+;; rf2-88f1 (deftests 4-6) fixed the standalone setter. `core/init!` — the
+;; documented alternative to wiring the preload into `:devtools/preloads` —
+;; is a SEPARATE supported call site that carries the same `:target-frame`
+;; intent and was never routed through the same seam: it installed handlers,
+;; collectors, exports and keys, then dispatched `:rf.xray/set-target-frame`
+;; into `:rf/xray` raw. None of those installs seats that frame, and the
+;; manual facade deliberately does not load the preload or start its
+;; readiness poll (`spec/API.md` §Public CLJS API), so this route has no
+;; eventual seat to fall back on. The dispatch was rejected at the router
+;; with `:rf.error/frame-destroyed` and the boot target was lost — an open!
+;; afterwards cannot rescue a choice that never landed.
+;;
+;; The existing `core-cljs-test` init! deftests miss it structurally: both
+;; call `setup-xray-frame!` before `init!`, and the `:target-frame` one also
+;; redefines `rf/dispatch-impl` to capture the vector, so neither reaches
+;; the real fresh-frame dispatch boundary. This deftest does the opposite of
+;; each — no pre-created `:rf/xray`, no replaced dispatch — and therefore
+;; stands exactly where deftest (1)'s control stands.
+
+(deftest manual-init-seats-xrays-frame-before-applying-its-target
+  (testing "rf2-bitb — on a fresh runtime with an adapter and a host frame
+            but no `:rf/xray` and no preload, the documented manual startup
+            `(init! {:target-frame :app/main})` seats Xray's own frame,
+            emits no `:rf.error/frame-destroyed`, and lands the target once
+            its queue drains."
+    (config/set-auto-open! false)
+    (rf/make-frame {:id :app/main})
+    (is (nil? (rf.frame/frame :rf/xray))
+        "precondition: nothing has seated Xray's frame — the same start
+         state as the control in deftest (1), and NOT what the existing
+         core-cljs-test init! deftests set up")
+    (with-redefs [rf/epoch-history stub-epoch-history]
+      (let [seen (capture-errors!)]
+        (core/init! {:target-frame :app/main})
+        (is (some? (rf.frame/frame :rf/xray))
+            "init! seated Xray's own frame before dispatching into it")
+        (flush-xray-queue!)
+        (is (empty? (frame-destroyed-records seen))
+            "and nothing recovered-but-emitted — a supported manual host
+             integration no longer errors on first startup"))
+      (is (= :app/main (core/target-frame))
+          "the host's boot target landed")
+      (is (= :app/main (focus-frame))
+          "on the `[:focus :frame]` axis the reducer moves with it")
+      (is (= main-epochs (xray-read [:rf.xray/epoch-history]))
+          "and `:epoch-history` reads the target's ring"))))
+
+(deftest manual-init-target-survives-first-open-against-a-competing-candidate
+  (testing "rf2-bitb — the seat is only half the contract. Because the
+            first-mount hook fan-out is still deferred to first OPEN, the
+            explicit target `init!` recorded must outrank whatever the
+            pre-open ring offers discovery — the same deference deftests
+            (5) and (6) pin for the standalone setter, now reached through
+            the manual boot route."
+    (config/set-auto-open! false)
+    (rf/make-frame {:id :app/main})
+    (with-redefs [rf/epoch-history stub-epoch-history]
+      (trace-collector/seed-trace-for-test!
+        (pre-mount-dispatch-event 1 100 :other/frame :other/event))
+      (core/init! {:target-frame :app/main})
+      (flush-xray-queue!)
+      (is (= :app/main (core/target-frame))
+          "precondition: the manual boot target landed")
+      (is (not (contains? (seeded-frame-ids) :rf/xray))
+          "and init! did NOT burn the run-once first-mount seed — it takes
+           `ensure-seated!`, not `ensure-xray-frame!`, for the same reason
+           deftest (5) gives for the setter")
+      (mount/ensure-xray-frame!)
+      (is (= :app/main (core/target-frame))
+          "first open preserves the manual boot target over the head
+           focusable bundle's frame")
+      (is (= :app/main (focus-frame))
+          "on the focus axis too")
+      (is (= main-epochs (xray-read [:rf.xray/epoch-history]))
+          "and the epoch history stays keyed on the surviving target"))))
+
+(deftest manual-init-without-a-target-leaves-the-existing-controls-intact
+  (testing "rf2-bitb control — the seat must not become an eager boot
+            protocol. `init!` with no `:target-frame` leaves the target
+            UNSELECTED (never absence-repaired to `:rf/default`), does not
+            open the shell, and stays idempotent."
+    (config/set-auto-open! false)
+    (core/init!)
+    (is (nil? (core/target-frame))
+        "no :target-frame opt leaves the inspected target unselected")
+    (is (false? (mount/mounted?))
+        "and nothing was opened")
+    (core/init!)
+    (is (nil? (core/target-frame))
+        "a second init! is still a no-op on the target")))


### PR DESCRIPTION
Three "the thing does not do what it says" bugs across two tool artefacts, each with a failing-first regression test. Fixes rf2-lffg, rf2-bitb, rf2-j2wz (all filed by the 2026-09-07 Codex correctness review).

## rf2-lffg — the full-shell embed dropped its own-frame option

`008-Embedding-Contract.md` §Embed props inventory publishes exactly two host-visible props on the full-shell embed, and `:frame` — the shell's OWN frame, distinct from the inspected host target — is one of them. `shell-view` has taken that axis as its `:frame-id` opt since the de-singleton refactor. `panels/mount-shell!` was the one seam that never carried it across: it read `:mode` out of `opts` and dropped `:frame`, so every embed resolved to the default own frame and N shells on one page shared one app-db.

The source-text singleton guard cannot see this — there is no literal `:rf/xray` to find, only a caller option that is never read — and the existing two-instance isolation test binds the two frames directly, stepping around the public mount seam entirely.

`mount-shell!` now resolves `:frame` against `shell/default-frame-id`, seats that own frame through the existing `mount/ensure-xray-frame!` seam (whose run-once hook guard is already keyed per frame-id, so each instance gets exactly one seed pass), and passes it to `shell-view` as `:frame-id`. `:mode`, target selection and teardown semantics are untouched; omitting `:frame` still shares the documented default.

## rf2-bitb — manual init applied its target before anything seated the frame

`core/init!` is the documented manual alternative to the preload. It installs handlers, collectors, browser exports and keys, then dispatched `:rf.xray/set-target-frame` into `:rf/xray` raw. None of those installs seats that frame, and the manual facade deliberately loads no preload and starts no readiness poll — so unlike the preload path there is no eventual seat to fall back on. The dispatch was rejected at the router with `:rf.error/frame-destroyed`, the host's boot target was dropped, and because the rejection lands at dispatch, a following `open!` cannot rescue a choice that never landed.

`set-target-frame!` had already been fixed for exactly this (rf2-88f1). `init!` was a second supported call site that hand-rolled the dispatch instead of taking that seam. The seat-then-dispatch pair is now one private `seat-and-set-target-frame!` both take. It stays `mount/ensure-seated!` rather than `ensure-xray-frame!`, so the run-once first-mount fan-out is still spent on a filled ring at first open rather than an empty boot-time one.

## rf2-j2wz — parsed event EDN was emitted as source, not data

`dispatch` and `dispatch-dry-run` parse their `event` arg as EDN and require a vector, precisely so the payload is data rather than source — `parse-event-arg`'s own docstring says so. But the parsed value was emitted through `pr-str`, which is a print and not a quotation. Three consequences, all of which occur while the runtime call is being CONSTRUCTED — ahead of anything the dispatch fn validates, and regardless of whether `eval-cljs` is enabled:

- a nested EDN list in the payload becomes a function call;
- a symbol becomes a name lookup;
- a payload shaped like one of the emitter's own tagged vectors is recognised as IR and its string spliced in as raw source, replacing the event outright.

The vector check is on the OUTER shape only, so it stops a whole host form at the door and nothing carries the guarantee inward.

The mini-DSL's own namespace docstring already published a `[::quote v]` node for exactly this — `(quote v)`, a literal-data emission — and it had **never been implemented**: no entry in `node?`, no branch in `emit`, no constructor, and the docstring line was its only occurrence in the tree. It is implemented now as `rt-quote`, and the two data-only call sites take it. The payload is never walked by `emit-arg`, so a caller-supplied vector wearing an emitter tag stays payload. Internal `rt-raw` composition and the default `pr-str` arg path are untouched — every other call site composes its own arguments, where printing and quoting agree.

This does not touch the MCP kind enum, so it does not overlap rf2-zhef.

## Xray spec

**Updated** — `tools/xray/spec/008-Embedding-Contract.md`, two places where it described a mechanism it does not have:

- §Embed props inventory claimed both props are honoured by "the frame-provider convention (the `mount-<panel>!` surface ... every mount fn opens with `[rf/frame-provider {:frame ...} ...]`)". That is the per-panel mechanism. `mount-shell!` adds no outer provider — `shell-view` opens its own around `frame-id` — and it was never right for `:height`, which Xray does not read at all. Now states the shell's actual path and contrasts it with the per-panel convention.
- §Frame roles attributed the pre-open seat to `set-target-frame!` alone, while the §host config bullet immediately above lists `init! {:target-frame ...}` and `set-target-frame!` as peer ways to state the same choice. They are peers now; before, only one seated.

The `:frame` prop row and the `init! {:target-frame ...}` contract in `tools/xray/spec/API.md` already promised what the code now does, so neither changed — the gap was implementation, not contract. Nothing else under `tools/xray/spec/` is affected, and no file in `spec/` (the framework spec) or either `spec/api-manifest*.edn` sidecar is touched: no public framework name moves.

`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md` already specifies the `event` arg as an "EDN-encoded event vector", which is what the fix delivers; unchanged.

## Quality gates

Every exit code below is the runner's own, captured on the same command line and read from a file, never one the harness reported. All runs are on the post-rebase base (`origin/main` at the time of the run).

Base for every run below: `origin/main` at `0d2a30ed9b`, after the rebase that picked up PR #9366 (story) and PR #9358 (routing). The branch was deliberately not rebased again afterwards, so every number here describes exactly the tree being merged rather than one that has since moved.

| Gate | Command | Exit | Result |
|---|---|---|---|
| CLJS node-test (`cljs_node_test`) | `npm run test:cljs` | 0 | Ran 11335 tests / 57179 assertions, 0 failures, 0 errors |
| Tool JVM artefacts (`tools_jvm`) | `sh scripts/test-jvm-tools.sh` | 0 | PASS, 10 artefacts; xray 1275 tests / 6107 assertions |
| MCP conformance (`mcp_conformance`) | `npm run test:mcp-conformance` | 0 | DEFAULT PROFILE GREEN, 6/6 gates |
| MCP conformance, live (`mcp_live`) | `npm run test:mcp-conformance -- --live` | 0 | LIVE PROFILE GREEN, 7/7 gates, 6 live rows (run on the pre-rebase base) |
| Xray feature matrix | `npm run test:xray-feature-gate:smoke` | 0 | 5 scenarios, PR-smoke tier, 0 failures, 10 matrix rows |
| Fast PR spine | `sh scripts/test-fast-pr.sh` | 0 | PASS fast PR spine |
| Doc slugs (covers `tools/*/spec`) | `python scripts/check_doc_slugs.py` | 0 | clean |
| README links | `python scripts/check_readme_links.py --ci` | 0 | clean |
| Conformance fixture EDN | `python scripts/check_conformance_fixture_edn.py` | 0 | clean |
| Require-alias dialect | `python scripts/check_require_alias_dialect.py` | 0 | clean |
| Test-lane bijection | `python scripts/check_test_lane_bijection.py` | 0 | PASS, 1575 test-defining files, 44 lanes |
| JVM lane rosters | `python scripts/check_jvm_lane_rosters.py` | 0 | PASS, 31 rostered artefacts |
| Skill/MCP drift | `python scripts/check_skill_mcp_drift.py` | 0 | clean |
| Xray tab inventory drift | `python scripts/check_skill_xray_tab_inventory_drift.py` | 0 | clean |

`python scripts/check_fast_pr_gap.py --brief` reports **99** required checks the spine does not decide, so the spine's green is not CI's. The lanes that actually grade this diff are the five above it, each run explicitly.

Surfaces this diff arms, from `.github/scripts/report-changed-surfaces.sh` given the real merge-base file list: `cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance`, `mcp_live`, `story_xray_browser`. Of these `examples_compile` was not run as a whole sweep locally; its highest-risk member for this diff — `:testbeds/panel-gallery`, the only build composing the Xray panel surface — was compiled clean by the feature-matrix gate (709 files, 708 compiled, 0 warnings). `node implementation/scripts/check-examples-compile.cjs --list` enumerates 58 builds and CI runs the sweep.

Two measurement notes, both places where a local reading disagrees with CI and the local one is wrong:

- Run locally without `GITHUB_EVENT_NAME=pull_request`, `report-changed-surfaces.sh` falls back to `git diff HEAD^ HEAD` — the last COMMIT, not the PR. On this branch that is the docs-only commit, which classifies to `mcp_conformance=false`. Supplying the merge-base file list explicitly gives the CI answer, `mcp_conformance=true`. A local invocation of that script is not evidence about a PR unless the file list is passed in.
- The harness reported exit 0 for two runs whose own captured exit file read 1. Every exit code in the table is the runner's own, echoed on the same command line and read back from a file.

## Failing-first evidence

Each fix was shown to be load-bearing by watching the new tests fail against unfixed source and pass against fixed source, with the test files byte-identical across both runs.

**rf2-lffg + rf2-bitb** — the two xray source files were reverted to `origin/main` with the new tests left in place (controls: both fix markers read 0 occurrences in the reverted source), then restored and verified with `sha256sum -c`.

- RED: `npm run test:cljs` exit **1** — Ran 11311 tests / 57107 assertions, **23 failures**. All 23 were the five new deftests and nothing else.
- GREEN: same command, same tree but for the two restored source files, exit **0** — Ran **11311** tests / **57107** assertions, **0 failures**.
- Identical totals across the two runs, so nothing stopped running; only the outcomes moved.
- The rf2-bitb control deftest — `init!` with no `:target-frame` leaves the target unselected, opens nothing, stays idempotent — passed in BOTH runs, as a control should.

**rf2-j2wz** — the tests were written and run before the fix existed.

- RED: `npm test` in `tools/re-frame2-pair-mcp`, exit **1** — Ran 1164 tests / 4263 assertions, **16 failures**, every one a new deftest.
- GREEN: after the fix, exit **0** — Ran 1165 tests / 4264 assertions, **0 failures**. The +1/+1 is exactly `rt-quote-ir-shape`, the constructor pin added alongside the fix; a new constructor cannot be referenced before it exists, so the DSL-level failing-first tests address the node through its raw IR vector instead.

The doc-slug gate was sabotage-checked rather than trusted: a broken anchor planted in `008-Embedding-Contract.md` took it to exit **1** naming that exact file and line, proving it reads the file this PR edits. The plant was reverted and verified with `sha256sum -c`.


## Notes

- `check_doc_slugs.py` covers `tools/*/spec`, so the `008-Embedding-Contract.md` edit is on its surface. The edited paragraphs are prose, not fenced code; the only links they carry are `./007-UX-IA.md` and the existing intra-page references, verified by hand and by the gate.
- Table column counts in `008-Embedding-Contract.md` are unchanged — neither edit touches a table row.

