### PR TITLE
fix(subs): one concrete subscription — generation refresh (rf2-4lp1), mounted-hook reacquisition and exact release (rf2-1frc), explicit-target resolution (rf2-kuky.57)

### DIFF
--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_sub_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_sub_dom_cljs_test.cljs
@@ -325,6 +325,48 @@
          ($ ProbeGapMutator)
          ($ ProbeGapObserver)))))
 
+;; ---- rf2-1frc eviction / reacquisition probes -----------------------------
+;;
+;; Two INDEPENDENT consumers of the same (frame, query). The first is the
+;; ORIGINAL holder whose committed reaction the framework evicts underneath it;
+;; the second mounts afterwards onto the REBUILT entry, so the suite can prove
+;; the original's later cleanup does not decrement the successor's reference.
+;; Both take their frame from `evict-target` (a dedicated atom, so these cases
+;; cannot collide with the refcount probes above).
+
+(def ^:private evict-target                  (atom nil))
+(def ^:private probe-evict-observed          (atom []))
+(def ^:private probe-evict-successor-observed (atom []))
+
+(defui ProbeEvict []
+  (let [target @evict-target
+        v (rf.adapter.uix/use-sub [:rf.uix-evict/n] {:frame target})]
+    (swap! probe-evict-observed conj v)
+    ($ :div (str "n=" v))))
+
+(defui ProbeEvictSuccessor []
+  (let [target @evict-target
+        v (rf.adapter.uix/use-sub [:rf.uix-evict/n] {:frame target})]
+    (swap! probe-evict-successor-observed conj v)
+    ($ :div (str "s=" v))))
+
+;; ---- rf2-kuky.57 explicit-target probe ------------------------------------
+;;
+;; Reads its ENTIRE opts map from a side-channel atom, so one probe covers
+;; `{}`, `{:frame nil}`, a legal keyword target and a legal live frame VALUE
+;; without changing its hook shape between cases — the hook COUNT is identical
+;; on every one of them, which is the property the explicit-only design exists
+;; to preserve.
+
+(def ^:private nil-frame-opts     (atom {}))
+(def ^:private nil-frame-observed (atom []))
+
+(defui ProbeNilFrame []
+  (let [opts @nil-frame-opts
+        v (rf.adapter.uix/use-sub [:rf.uix-nil-frame/v] opts)]
+    (swap! nil-frame-observed conj v)
+    ($ :div (str "v=" v))))
+
 ;; ---- cfg + forwarded deftests ---------------------------------------------
 
 (def ^:private cfg
@@ -448,7 +490,23 @@
    ;; under a fresh isolated frame so it can't collide with the use-sub
    ;; cases above.
    :fr-frame              :rf.uix-flush-render/probe-frame
-   :fr-query              :rf.uix-use-sub-test/n})
+   :fr-query              :rf.uix-use-sub-test/n
+   ;; rf2-1frc — reacquisition after a framework-owned cache eviction, and the
+   ;; ownership edge on the committed release.
+   :probe-evict-element            (fn [] (uix/$ ProbeEvict))
+   :probe-evict-observed           probe-evict-observed
+   :probe-evict-successor-element  (fn [] (uix/$ ProbeEvictSuccessor))
+   :probe-evict-successor-observed probe-evict-successor-observed
+   :evict-target                   evict-target
+   :ev-frame                       :rf.uix-evict/frame
+   :ev-query                       :rf.uix-evict/n
+   ;; rf2-kuky.57 — the explicit arm resolves ONE concrete target before any
+   ;; acquisition; a missing / nil `:frame` refuses and retains nothing.
+   :probe-nil-frame-element        (fn [] (uix/$ ProbeNilFrame))
+   :nil-frame-opts                 nil-frame-opts
+   :nil-frame-observed             nil-frame-observed
+   :nf-frame                       :rf.uix-nil-frame/frame
+   :nf-query                       :rf.uix-nil-frame/v})
 
 (deftest use-sub-tracks-app-db-changes
   (rf.adapter.react-shared-suite/assert-use-sub-tracks-app-db-changes cfg))
@@ -698,3 +756,22 @@
                       "both trailing children rendered (not dropped)")
                   (finally
                     (try (.unmount root) (catch :default _ nil))))))))))))
+
+;; ---- rf2-1frc / rf2-kuky.57 — subscription lifetime -----------------------
+;;
+;; Real React lifecycle regressions: a MOUNTED component whose cached reaction
+;; the framework evicts, and the explicit-target arm's refusal. Neither surface
+;; was exercised by any existing gate — the merged PR that introduced the
+;; explicit arm was green at band with the nil-target leak in it.
+
+(deftest use-sub-reacquires-after-eviction
+  (rf.adapter.react-shared-suite/assert-use-sub-reacquires-after-eviction cfg))
+
+(deftest use-sub-stale-cleanup-does-not-release-a-successor
+  (rf.adapter.react-shared-suite/assert-use-sub-stale-cleanup-does-not-release-a-successor cfg))
+
+(deftest use-sub-nil-explicit-frame-refuses-without-retaining
+  (rf.adapter.react-shared-suite/assert-use-sub-nil-explicit-frame-refuses-without-retaining cfg))
+
+(deftest use-sub-live-frame-value-target-balances
+  (rf.adapter.react-shared-suite/assert-use-sub-live-frame-value-target-balances cfg))

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -149,9 +149,22 @@
             [re-frame.interop        :as rf.interop]
             [re-frame.error          :as rf.error]
             [re-frame.late-bind      :as rf.late-bind]
+            ;; rf2-4lp1 — the targeted subscription refresh at a generation
+            ;; change (§Subscription refresh at a generation change, below).
+            ;; `re-frame.subs.cache` requires `re-frame.frame`, so the frame ns
+            ;; cannot reach the cache; this ns sits ABOVE both. The edge adds NO
+            ;; transitive dependency — `subs.cache`'s whole require closure
+            ;; (frame, interop, late-bind, registrar, trace) is a subset of the
+            ;; one this ns already carries.
+            [re-frame.subs.cache     :as rf.subs.cache]
             [re-frame.trace          :as rf.trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
+
+;; rf2-4lp1: `make-frame` fires the generation-change subscription refresh,
+;; whose definition sits beside `generation-diff` — the fn it is built on —
+;; several hundred lines below it.
+(declare invalidate-subs-for-generation-change!)
 
 ;; ===========================================================================
 ;; The frame VALUE + the ONE registry (EP-0024 §One live frame registry,
@@ -1062,16 +1075,37 @@
        ;; nothing and a FAILED re-construction still preserves the OLD row — and
        ;; because the restore runs while this attempt still OWNS the id, the row
        ;; it restores is still the row it displaced.
-       (rf.frame/call-with-frame-construction-claim!
-         runnable-id :construction
-         (fn []
-           (let [[had-pool-row? prior-pool]
-                 (record-frame-generation-pool! runnable-id descriptors)]
-             (try
-               (rf.frame/upsert-frame! runnable-id record-config token-box)
-               (catch #?(:clj Throwable :cljs :default) e
-                 (restore-frame-generation-pool! runnable-id had-pool-row? prior-pool)
-                 (throw e))))))
+       ;; rf2-4lp1 — the generation this call DISPLACES, read INSIDE the per-id
+       ;; construction claim so it is exactly what `upsert-frame!` is about to
+       ;; replace: nil on a first creation (nothing cached yet), the previous
+       ;; sealed generation on the same-id re-construction path that IS image
+       ;; hot-reload. Reading it outside the claim would race the reprojection
+       ;; writer. The refresh itself fires AFTER the commit — a construction
+       ;; that throws rolls the record back, and evicting against a generation
+       ;; that was never installed would churn a cache for nothing.
+       (let [displaced-generation (volatile! nil)]
+         (rf.frame/call-with-frame-construction-claim!
+           runnable-id :construction
+           (fn []
+             (let [[had-pool-row? prior-pool]
+                   (record-frame-generation-pool! runnable-id descriptors)]
+               (vreset! displaced-generation
+                        (rf.frame/frame-generation runnable-id))
+               (try
+                 (rf.frame/upsert-frame! runnable-id record-config token-box)
+                 (catch #?(:clj Throwable :cljs :default) e
+                   (restore-frame-generation-pool! runnable-id had-pool-row? prior-pool)
+                   (throw e))))))
+         ;; Refresh the frame's cached subscriptions against what actually
+         ;; landed on the record (`frame-generation` re-read, not the local
+         ;; `generation` value) — the `:initial-events` cascade inside
+         ;; `upsert-frame!` can flush a pending reprojection that swaps a
+         ;; different generation on, and the diff must be against the one the
+         ;; next subscribe will resolve through.
+         (invalidate-subs-for-generation-change!
+           runnable-id
+           @displaced-generation
+           (rf.frame/frame-generation runnable-id)))
        ;; rf2-djkr0 — THE INVARIANT: a PARTIALLY-CONSTRUCTED frame is never
        ;; observable as live, so a registration that lands while a frame is
        ;; mid-construction is never lost.
@@ -1199,6 +1233,81 @@
      :changed  changed
      :retained retained}))
 
+;; ---- subscription refresh at a generation change (rf2-4lp1) ---------------
+;;
+;; EP-0023 §Hot Reload preserves "subscription state that remains valid" and
+;; explicitly permits TARGETED invalidation for changed registrations; EP-0024
+;; §Duplicate id policy makes same-id construction refresh configuration and
+;; generation while durable state — the `:sub-cache` atom among it — survives.
+;; Preserving the cache is right; preserving its CONTENTS wholesale was not.
+;;
+;; A cached reaction closes over the `:handler-fn` and input topology resolved
+;; from the descriptor that was current WHEN IT WAS BUILT. `subscribe-in-frame`'s
+;; hit branch bumps the ref-count and hands that reaction back without ever
+;; comparing it against the frame's CURRENT generation, so after a generation
+;; swap an already-materialised query kept running the old body — image
+;; replacement (and Story behaviour replacement) appeared not to take effect
+;; until the caller knew to call `clear-sub-cache!` by hand, which is exactly
+;; the ceremony §Hot Reload says a reload must not require.
+;;
+;; A generation change fires NO `register!`, so `re-frame.subs.cache`'s
+;; registrar replacement hook cannot see it. This is the other half of that
+;; same hook, driven from the registry that DOES move: the diff between the two
+;; sealed generations. `generation-diff` (above) already names it exactly —
+;; `:changed` / `:added` / `:removed` `[kind id]` pairs — and, crucially,
+;; `:retained` names the registrations that are byte-identical across the swap
+;; (an unchanged sub merely selected by a different image composition), which
+;; is what keeps this TARGETED rather than a cache clear: retained slots keep
+;; their reaction identity and their ref-counts.
+;;
+;; `:added` is load-bearing, not defensive. A parent sub declaring an input
+;; that is not registered yet resolves that input to a nil-yielding reaction
+;; whose MISS is deliberately not cached (rf2-l9u5) — but the PARENT is cached,
+;; holding that nil-yielding reaction by closure. First-registering the missing
+;; input reprojects the frame's generation, and the parent is reached through
+;; its declared `:inputs` head even though the added id has no slot of its own.
+;;
+;; WHY HERE AND NOT IN `re-frame.frame`. `re-frame.subs.cache` requires
+;; `re-frame.frame`, so the frame ns cannot statically reach the cache (the
+;; same constraint that puts `:subs/dispose-frame-sub-caches!` in the late-bind
+;; directory). This ns sits ABOVE both — it already requires `rf.frame`, and
+;; `rf.subs.cache`'s whole require closure is a subset of the one this ns
+;; already carries, so the edge adds no transitive dependency — and it is the
+;; ns that owns `generation-diff`. It is also the ns through which BOTH
+;; generation writers pass: `swap-frame-generation!` below (the automatic
+;; `reg-*` reprojection path) and `make-frame`'s `upsert-frame!` call (the
+;; explicit same-id re-construction path). `rf.frame/set-generation!` has no
+;; other production caller.
+
+(defn- invalidate-subs-for-generation-change!
+  "Refresh frame `id`'s cached subscriptions against a generation swap from
+  `old-generation` to `new-generation`.
+
+  Evicts + disposes exactly the cache slots whose `:sub` registration DIFFERS
+  between the two generations — `:changed`, `:added` and `:removed` — plus
+  their transitive declared-input dependent closure, via
+  `rf.subs.cache/invalidate-frame-subs!`. `:retained` subs are left alone, so
+  a swap that moves one registration does not churn the rest of the frame's
+  cache, and other frames are never touched (the generation is per-record).
+
+  A no-op when there was no previous generation (frame CREATION — there is no
+  cache yet), when the generations are `=` (the reprojection path already
+  guards this, and a rolled-back construction restores the old value), or when
+  no `:sub` moved (an `:event`-only image edit leaves every reaction valid).
+  Returns nil."
+  [id old-generation new-generation]
+  (when (and (some? old-generation)
+             (not= old-generation new-generation))
+    (let [{:keys [added changed removed]} (generation-diff old-generation
+                                                          new-generation)
+          sub-ids (into #{}
+                        (comp (filter (fn [[kind _id]] (= :sub kind)))
+                              (map second))
+                        (concat added changed removed))]
+      (when (seq sub-ids)
+        (rf.subs.cache/invalidate-frame-subs! id sub-ids))))
+  nil)
+
 ;; ---- the in-place generation swap (PRESERVES FRAME MEMORY) -----------------
 ;;
 ;; Shared by the automatic `reg-*` reprojection path below. The explicit
@@ -1214,9 +1323,18 @@
   registry; the EP-0023 §Hot Reload contract — \"Hot reload must not be
   implemented by tearing down and recreating the frame\"). The generation lives
   on the ONE record, so an `:id`-bearing frame and any holder of its frame value
-  observe the swap through the same record. Returns nil."
+  observe the swap through the same record. Returns nil.
+
+  rf2-4lp1: the swap is followed by the TARGETED subscription refresh — frame
+  memory continuing across a reload does not mean a cached reaction built
+  against the OLD generation's descriptor continues with it. Read the old
+  generation off the record here rather than trusting a caller's snapshot, so
+  the diff is against what the swap actually displaced."
   [id new-generation]
-  (rf.frame/set-generation! id new-generation))
+  (let [old-generation (rf.frame/frame-generation id)]
+    (rf.frame/set-generation! id new-generation)
+    (invalidate-subs-for-generation-change! id old-generation new-generation))
+  nil)
 
 ;; ---- reload-images! — RETIRED (rf2-lxwpob) ---------------------------------
 ;;

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -639,6 +639,33 @@
     ;; written into the resolver map intentionally stays untouched; the store
     ;; keeps its own provenance-stamped copy.
     (rf.source-store/record-descriptor! kind id metadata)
+    ;; RECORDING THE CHANGE COMPLETES BEFORE ANYTHING REACTS TO IT (rf2-1frc).
+    ;;
+    ;; These two hook batches are not peers. `registration-hooks` finish
+    ;; RECORDING what just happened — `re-frame.live-frame`'s
+    ;; `reproject-on-registration-change!` marks the live-frame projection dirty,
+    ;; which is what makes this registration visible to the next frame-generation
+    ;; resolution — while `replacement-hooks` REACT to it, and the reaction that
+    ;; matters here is `re-frame.subs.cache`'s cache invalidation.
+    ;;
+    ;; They used to run in the other order, and nothing noticed while every
+    ;; invalidated consumer merely dropped its cache entry and rebuilt LATER,
+    ;; past the mark. Since rf2-1frc one rebuilds DURING the invalidation: the
+    ;; React-hook spine reacquires from inside the disposal so a mounted
+    ;; component follows its subscription across the eviction instead of going
+    ;; deaf. Reacquiring before the projection was marked dirty resolved the
+    ;; frame's STALE generation and rebuilt the entry against the very body the
+    ;; re-registration had just replaced — the hot-reload the invalidation
+    ;; exists to serve, defeated by the order in which it was announced.
+    ;;
+    ;; Marking is a flag plus a coalesced `next-tick` schedule (per-frame
+    ;; conditional at flush time, so marking on every `reg-*` is safe by that
+    ;; hook's own contract), and both batches run ISOLATED, so the move changes
+    ;; no failure propagation. What it changes is that a reactor now observes a
+    ;; fully-recorded world.
+    (doseq [f @registration-hooks]
+      (try (f {:kind kind :id id :was previous :now metadata})
+           (catch #?(:clj Throwable :cljs :default) _ nil)))
     (cond
       ;; Re-registration path — fire hooks and emit handler-replaced.
       previous
@@ -710,15 +737,13 @@
     ;; without `:doc` does NOT re-fire the warning.
     (when rf.interop/debug-enabled?
       (maybe-emit-missing-doc! kind id metadata))
-    ;; Always-on registration hooks: fire on BOTH first-time
-    ;; and re-registration so cross-id invariants (e.g. routing's
-    ;; `:url-bound?` exclusivity per Spec 012 §Multi-frame routing) can
-    ;; be validated at the moment of any registration. Hooks run isolated
-    ;; — listener failures don't propagate so a buggy hook can't block
-    ;; the registration.
-    (doseq [f @registration-hooks]
-      (try (f {:kind kind :id id :was previous :now metadata})
-           (catch #?(:clj Throwable :cljs :default) _ nil)))
+    ;; The always-on registration hooks — fired on BOTH first-time and
+    ;; re-registration so cross-id invariants (e.g. routing's `:url-bound?`
+    ;; exclusivity per Spec 012 §Multi-frame routing) are validated at the
+    ;; moment of any registration — now run ABOVE, before the replacement
+    ;; hooks. See the rf2-1frc note there for why the order is load-bearing.
+    ;; Both sites are after the resolver-map and source-store writes, so a hook
+    ;; still inspects the final registry state exactly as it always did.
     {:was previous :now metadata}))
 
 (defn unregister!

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -2477,14 +2477,30 @@
   one reference to `query-v` in `frame-id` **only while the frame's sub-cache
   still holds `reaction`**, then take the ordinary 1 → 0 in-tick disposal.
 
-  Not public API and not an alternative teardown: it exists for the ONE
-  holder whose reference can outlive its slot — the React-hook spine's
-  render-phase provisional acquisition, released either by the commit that
-  adopts it or by a host-macrotask reaper, across a window in which hot
-  reload, `clear-sub-cache!` or `destroy-frame!` may have evicted the entry
-  (Spec 006 §Render-phase provisional acquisition and commit adoption). A
-  stale release then no-ops rather than stealing a successor entry's
-  reference. Every other consumer calls `unsubscribe`.
+  Not public API and not an alternative teardown: it exists for holders
+  whose reference can outlive its slot, and both of them are the React-hook
+  spine's.
+
+    1. The RENDER-PHASE PROVISIONAL acquisition, released either by the
+       commit that adopts it or by a host-macrotask reaper, across a window
+       in which hot reload, `clear-sub-cache!` or `destroy-frame!` may have
+       evicted the entry (Spec 006 §Render-phase provisional acquisition and
+       commit adoption).
+    2. The COMMITTED acquisition a mounted hook holds (rf2-1frc). This was
+       an address-only `unsubscribe`, on the reading that a cache slot could
+       never be replaced under a live holder. It can: hot reload, an explicit
+       `clear-sub-cache!` and a frame generation change (rf2-4lp1) all evict
+       and rebuild, and the hook now REACQUIRES across such an eviction — so
+       what it releases on unmount is the reaction it ended up holding, which
+       need not be the one it first took. After an independent consumer has
+       rebuilt the same (frame, query), an address-only release from a stale
+       holder decremented that SUCCESSOR's reference; the identity guard
+       makes it no-op instead of stealing.
+
+  In both cases a release whose reaction is no longer the cache's no-ops
+  rather than stealing a successor entry's reference; when the slot IS the
+  caller's it takes the ordinary 1 → 0 in-tick disposal, exactly as
+  `unsubscribe` would. Every other consumer calls `unsubscribe`.
 
   Frame resolution and cache-keying are this facade's, exactly as
   `unsubscribe`'s — a frame-id keyword or a live frame value, normalized

--- a/implementation/core/src/re_frame/subs/cache.cljc
+++ b/implementation/core/src/re_frame/subs/cache.cljc
@@ -311,31 +311,54 @@
 ;; reactions hold the OLD input reaction); without invalidating the whole
 ;; transitive dependent closure, a downstream slot like `[:sum]` over `[:a]`
 ;; keeps its stale input reaction and serves the old `:a` body's value.
+;;
+;; rf2-4lp1 — THE REGISTRAR IS NOT THE ONLY REGISTRY A SUB'S DEFINITION CAN
+;; MOVE IN. An image-loaded frame resolves `(kind, id)` through its OWN sealed
+;; generation (EP-0023), so a same-id `make-frame` re-construction or a
+;; source-store reprojection changes what `[:some-sub]` MEANS in that frame
+;; without any `register!` call firing — the replacement hook below never
+;; runs, and the cache (durable frame state, deliberately preserved across the
+;; swap) kept serving the previous generation's body until the caller thought
+;; to `clear-sub-cache!` by hand. Both triggers are one event seen from two
+;; registries, so both funnel through the ONE primitive below
+;; (`invalidate-frame-subs!`); the generation-side trigger lives in
+;; `re-frame.live-frame`, which owns `generation-diff` and can therefore name
+;; exactly the sub-ids that moved.
 
 (defn- transitive-dependent-closure
-  "Given a cache map `m` and a re-registered sub `id`, return the set of
-  cache keys to evict: the re-registered sub's own slots PLUS every slot
-  that depends on it transitively through the declared-input topology recorded in
-  each entry's `:inputs` (the vector of input query-vectors).
+  "Given a cache map `m` and a SET of affected sub `ids`, return the set of
+  cache keys to evict: those subs' own slots PLUS every slot that depends on
+  them transitively through the declared-input topology recorded in each
+  entry's `:inputs` (the vector of input query-vectors).
 
   A slot is a dependent iff any of its `:inputs` query-vectors either
-  (a) has head = `id` — a DIRECT declared input on the re-registered sub — or
+  (a) has head IN `ids` — a DIRECT declared input on an affected sub — or
   (b) equals a key already in the evict set — a TRANSITIVE dependency on
   an already-condemned slot. The fixpoint loop grows the set until no new
   key is added; it only ever ADDS keys not already present, so a cyclic
-  declared-input graph cannot loop forever (each key is admitted at most once)."
-  [m id]
+  declared-input graph cannot loop forever (each key is admitted at most once).
+
+  Clause (a) is what reaches a cached PARENT whose declared input has NO slot
+  of its own — the input was unregistered when the parent was built, so the
+  miss was deliberately not cached (rf2-l9u5) while the parent WAS, holding
+  the nil-yielding input reaction by closure. `ids` is a SET rather than one
+  id (rf2-4lp1) because a frame-generation change condemns a whole BATCH of
+  sub-ids at once — `:added` / `:changed` / `:removed` between two
+  generations — and running the fixpoint once over the batch is not the same
+  as running it per-id: a chain condemned through two different ids
+  converges in one pass."
+  [m ids]
   (let [;; Static index: cache-key → the seq of its input query-vectors.
         inputs-of  (fn [k] (:inputs (get m k)))
         depends-on (fn [k condemned]
-                     ;; k depends on the re-registration iff one of its
-                     ;; inputs targets `id` directly or a condemned slot.
+                     ;; k depends on the change iff one of its inputs targets
+                     ;; an affected id directly or a condemned slot.
                      (boolean
                        (some (fn [input-q]
-                               (or (= id (first input-q))
+                               (or (contains? ids (first input-q))
                                    (contains? condemned input-q)))
                              (inputs-of k))))
-        seed       (into #{} (filter #(= id (first %))) (keys m))]
+        seed       (into #{} (filter #(contains? ids (first %))) (keys m))]
     (loop [condemned seed]
       (let [next-set (into condemned
                            (filter #(depends-on % condemned))
@@ -344,44 +367,73 @@
           condemned
           (recur next-set))))))
 
+(defn invalidate-frame-subs!
+  "Evict + dispose every slot in frame `frame-id`'s sub-cache whose sub-id is
+  in `sub-ids`, PLUS their transitive declared-input dependent closure. The
+  cache ATOM is preserved (durable frame state survives); every slot outside
+  the closure keeps its reaction identity and its ref-count.
+
+  The ONE per-frame invalidation primitive, shared by the two eviction
+  triggers that mean \"this sub's definition moved under a live cache\":
+
+    * `reg-sub` REPLACEMENT — `invalidate-sub-on-replace!` below, over every
+      frame, with a one-element `sub-ids` (Spec 001 §Hot-reload semantics);
+    * a frame's resolved image GENERATION changing — `re-frame.live-frame`'s
+      `invalidate-subs-for-generation-change!`, over the ONE frame that moved,
+      with the `:sub` ids the two generations differ on (rf2-4lp1, EP-0023
+      §Hot Reload).
+
+  Both are the SAME event seen from two registries, so both emit
+  `:rf.sub/dispose` with the closed-enum `:rf.sub/reason :hot-reload` (Spec
+  009 §subs/cache.cljc) and bind the intrinsic `*disposal-cause* :hot-reload`
+  (→ `:hmr`, \"the node WILL rebuild\") rather than minting a second spelling
+  for one meaning.
+
+  Returns the vector of evicted cache keys (empty when nothing matched)."
+  [frame-id sub-ids]
+  (if-let [cache (and (seq sub-ids) (:sub-cache (rf.frame/frame frame-id)))]
+    ;; The swap-fn body is pure — it returns only the new cache map.
+    ;; Reactions to dispose are read from the diff between `old` and
+    ;; `new` AFTER the CAS commits (so a retried `swap!` can't fire
+    ;; dispose 2+ times). The condemned set is the transitive declared-input
+    ;; dependent closure, recomputed inside the swap-fn against the
+    ;; map the CAS actually sees (a retry recomputes against fresh m).
+    (let [ids       (set sub-ids)
+          [old new] (swap-vals! cache
+                                (fn [m]
+                                  (apply dissoc m
+                                         (transitive-dependent-closure m ids))))
+          ;; The keys actually evicted by THIS swap are those present
+          ;; in `old` but absent in `new`. A concurrent evictor that
+          ;; won the CAS race would have removed its keys before our
+          ;; swap saw them, so the diff names ONLY the keys we own.
+          evicted-keys (filterv #(not (contains? new %))
+                                (keys old))]
+      ;; Emit dispose per evicted key BEFORE running the
+      ;; per-reaction `rf.interop/dispose!` teardown. The reason
+      ;; `:hot-reload` discriminates this path from sync 1 → 0 fires
+      ;; (`:no-more-derefers`) and explicit `clear-sub-cache!`
+      ;; (`:cache-clear`).
+      (doseq [k evicted-keys]
+        (emit-dispose! frame-id k :hot-reload))
+      ;; Tag the observation port's synchronous node-disposed notifications
+      ;; with the INTRINSIC :hot-reload cause (→ :hmr) so a former owner is
+      ;; told the node WILL rebuild (re-acquire), not that it is gone
+      ;; (rf2-r8jmdb). Nested `dispose-entry-now!` cascades (a downstream
+      ;; input losing its last derefer) correctly shadow this to :disposed.
+      (binding [*disposal-cause* :hot-reload]
+        (doseq [k evicted-keys]
+          (when-let [r (get-in old [k :reaction])]
+            (try (rf.interop/dispose! r)
+                 (catch #?(:clj Throwable :cljs :default) _ nil)))))
+      evicted-keys)
+    []))
+
 (defn- invalidate-sub-on-replace!
   [{:keys [kind id]}]
   (when (= kind :sub)
     (doseq [frame-id (rf.frame/frame-ids)]
-      (when-let [cache (:sub-cache (rf.frame/frame frame-id))]
-        ;; The swap-fn body is pure — it returns only the new cache map.
-        ;; Reactions to dispose are read from the diff between `old` and
-        ;; `new` AFTER the CAS commits (so a retried `swap!` can't fire
-        ;; dispose 2+ times). The condemned set is the transitive declared-input
-        ;; dependent closure, recomputed inside the swap-fn against the
-        ;; map the CAS actually sees (a retry recomputes against fresh m).
-        (let [[old new] (swap-vals! cache
-                                    (fn [m]
-                                      (apply dissoc m
-                                             (transitive-dependent-closure m id))))
-              ;; The keys actually evicted by THIS swap are those present
-              ;; in `old` but absent in `new`. A concurrent evictor that
-              ;; won the CAS race would have removed its keys before our
-              ;; swap saw them, so the diff names ONLY the keys we own.
-              evicted-keys (filterv #(not (contains? new %))
-                                    (keys old))]
-          ;; Emit dispose per evicted key BEFORE running the
-          ;; per-reaction `rf.interop/dispose!` teardown. The reason
-          ;; `:hot-reload` discriminates this path from sync 1 → 0 fires
-          ;; (`:no-more-derefers`) and explicit `clear-sub-cache!`
-          ;; (`:cache-clear`).
-          (doseq [k evicted-keys]
-            (emit-dispose! frame-id k :hot-reload))
-          ;; Tag the observation port's synchronous node-disposed notifications
-          ;; with the INTRINSIC :hot-reload cause (→ :hmr) so a former owner is
-          ;; told the node WILL rebuild (re-acquire), not that it is gone
-          ;; (rf2-r8jmdb). Nested `dispose-entry-now!` cascades (a downstream
-          ;; input losing its last derefer) correctly shadow this to :disposed.
-          (binding [*disposal-cause* :hot-reload]
-            (doseq [k evicted-keys]
-              (when-let [r (get-in old [k :reaction])]
-                (try (rf.interop/dispose! r)
-                     (catch #?(:clj Throwable :cljs :default) _ nil))))))))))
+      (invalidate-frame-subs! frame-id #{id}))))
 
 (defonce ^:private _hot-reload-hook
   (do (rf.registrar/add-replacement-hook! invalidate-sub-on-replace!)

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -3350,6 +3350,113 @@
                 subscribe-fn
                 (use-callback
                   (fn [on-change]
+                    ;; rf2-1frc — WHAT THIS CLOSURE HOLDS, rather than what
+                    ;; ADDRESS it subscribed to. `held` is `#js [reaction
+                    ;; watch-key]`: the ONE reaction this store-subscription
+                    ;; currently owns a durable +1 on, and the watch key placed
+                    ;; on it. `wire!` (below) replaces both atomically, so a
+                    ;; framework-owned eviction can hand the hook a REBUILT
+                    ;; reaction without React re-running `subscribe-fn` — which
+                    ;; it never will, since the memo is keyed on `[stable-key]`
+                    ;; and the target has not changed.
+                    ;;
+                    ;; Before this, the closure held ONE reaction for the life
+                    ;; of the subscription target and released by ADDRESS. Both
+                    ;; halves were wrong once the cache evicted underneath it:
+                    ;; the disposed reaction has no source watches (so
+                    ;; `on-change` could never fire again — the component went
+                    ;; permanently deaf) while `get-snap` still found a
+                    ;; key-MATCHING entry in `committed-ref` and derefed the
+                    ;; disposed handle (so it kept rendering the OLD sub body);
+                    ;; and the address-only release could later decrement a
+                    ;; SUCCESSOR entry that an independent consumer had
+                    ;; rebuilt under the same (frame, query).
+                    (let [held      (volatile! nil)
+                          released? (volatile! false)
+                          wire!
+                          (fn wire! [reaction]
+                            ;; UNIQUE watch key per ACQUISITION (not merely per
+                            ;; `subscribe-fn` invocation). The key MUST NOT
+                            ;; derive from `(hash reaction)`: subscriptions are
+                            ;; cached/deduped by query, so sibling components
+                            ;; reading the SAME query share the SAME cached
+                            ;; reaction, `add-watch` REPLACES an existing
+                            ;; watcher with the same key, and the last-mounted
+                            ;; sibling's `on-change` would silently overwrite
+                            ;; every earlier sibling's `useSyncExternalStore`
+                            ;; callback — leaving the earlier ones rendering
+                            ;; stale UI until an unrelated parent render
+                            ;; refreshed them. A fresh keyword per acquisition
+                            ;; is cheap and collision-free.
+                            (let [wk (keyword use-sub-watch-ns
+                                              (str (gensym "watch-")))]
+                              (vreset! held #js [reaction wk])
+                              ;; rf2-sqhjtu / rf2-naz09e: publish the durable
+                              ;; reaction KEY-TAGGED with this invocation's
+                              ;; `stable-key` so `get-snap` derefs THIS live
+                              ;; handle (source watches + current sub body) and
+                              ;; never a stale one — but ONLY while the current
+                              ;; render's key matches the tag. The key tag is
+                              ;; what lets `get-snap` reject a stale committed
+                              ;; reaction across a query-v / frame change (the
+                              ;; change-commit reads the render-phase handle for
+                              ;; the NEW target instead).
+                              (set! (.-current committed-ref)
+                                    #js [stable-key reaction])
+                              (when reaction
+                                (add-watch reaction wk (fn [_ _ _ _] (on-change)))
+                                ;; rf2-1frc — THE REACQUISITION SEAM, and the
+                                ;; reason it is THIS one. The obvious hook is
+                                ;; `rf.subs.cache/emit-dispose!`, and it is
+                                ;; unusable: that is an `rf.trace/emit!` behind
+                                ;; `rf.interop/debug-enabled?`, so it is
+                                ;; dead-code-eliminated from production CLJS
+                                ;; bundles — a correctness fix hung off it would
+                                ;; work in development, pass a dev-mode test and
+                                ;; silently not exist in a release build.
+                                ;; `rf.interop/add-on-dispose!` is the
+                                ;; documented cross-substrate teardown contract
+                                ;; (the `:adapter/add-on-dispose!` late-bind
+                                ;; hook, with `re-frame.disposable/
+                                ;; -add-on-dispose` as the CLJS protocol
+                                ;; method); it carries no debug gate and
+                                ;; survives `:advanced` + `goog.DEBUG=false`.
+                                ;;
+                                ;; The callback is GUARDED three ways so it
+                                ;; re-acquires exactly once, for the right
+                                ;; holder, and cannot resurrect a dead frame:
+                                ;;   * `released?` — an unmounted hook takes
+                                ;;     nothing back;
+                                ;;   * identity — this callback fires only for
+                                ;;     the reaction it was registered on, and
+                                ;;     only while that is still the one `held`
+                                ;;     (a later `wire!` supersedes it);
+                                ;;   * frame liveness — `destroy-frame!` flips
+                                ;;     `:destroyed?` (step 4) BEFORE it disposes
+                                ;;     the sub-cache (step 5), so a torn-down
+                                ;;     frame reads nil here and the hook lets go
+                                ;;     rather than emitting a
+                                ;;     `:rf.error/frame-destroyed` recovery per
+                                ;;     mounted component.
+                                (rf.interop/add-on-dispose! reaction
+                                  (fn on-committed-disposed []
+                                    (let [h @held]
+                                      (when (and (not @released?)
+                                                 (some? h)
+                                                 (identical? (aget h 0) reaction)
+                                                 (some? (rf.frame/frame stable-frame-kw)))
+                                        ;; Take the REBUILT entry and re-wire
+                                        ;; onto it, then tell React to re-read
+                                        ;; the snapshot. `subscribe-fn`'s
+                                        ;; IDENTITY is untouched, so React's
+                                        ;; subscribe/unsubscribe contract and
+                                        ;; the same-key steady state are exactly
+                                        ;; what they were.
+                                        (wire! (rf.subs/subscribe
+                                                 stable-query-v
+                                                 {:frame stable-frame-kw}))
+                                        (on-change)))))))
+                            nil)]
                     ;; Take the durable committed ref now (post-commit). This is
                     ;; the ONLY place a lasting +1 is acquired. The returned
                     ;; reaction is the live cached one and its value `=` the
@@ -3379,59 +3486,51 @@
                       ;; already spent, the reaper beat us and the subscribe
                       ;; above was an honest miss + rebuild: today's behaviour,
                       ;; no worse.
-                      (let [held (.-current provisional-ref)]
-                        (when (and (some? held)
-                                   (identical? (aget held 0) stable-key))
+                      (let [tok (.-current provisional-ref)]
+                        (when (and (some? tok)
+                                   (identical? (aget tok 0) stable-key))
                           (set! (.-current provisional-ref) nil)
-                          (release-provisional! (aget held 1))))
-                      ;; rf2-sqhjtu / rf2-naz09e: publish the durable committed
-                      ;; reaction KEY-TAGGED with this invocation's `stable-key`
-                      ;; so `get-snap` derefs THIS live handle (source watches +
-                      ;; current sub body) and never a stale one — but ONLY
-                      ;; while the current render's key matches
-                      ;; the tag. Set post-commit (here), cleared on teardown
-                      ;; below. The key tag is what lets `get-snap` reject a
-                      ;; stale committed reaction across a query-v / frame
-                      ;; change (the change-commit reads the render-phase handle
-                      ;; for the NEW target instead).
-                      (set! (.-current committed-ref) #js [stable-key committed])
-                      ;; UNIQUE watch key per `subscribe-fn` INVOCATION,
-                      ;; closed over by the returned cleanup. The key MUST
-                      ;; NOT derive from `(hash reaction)`: subscriptions are
-                      ;; cached/deduped by query, so sibling UIx
-                      ;; components reading the SAME query share the SAME
-                      ;; cached reaction. A hash-of-reaction key would be
-                      ;; IDENTICAL across those siblings, and `add-watch`
-                      ;; replaces an existing watcher with the same key — so
-                      ;; the last-mounted sibling's `on-change` would silently
-                      ;; overwrite every earlier sibling's `useSyncExternalStore`
-                      ;; callback, leaving the earlier ones rendering stale UI
-                      ;; until an unrelated parent render refreshed them.
-                      ;; `subscribe-fn` is `use-callback`-memoized on
-                      ;; `[stable-key]`, so React calls it once per subscription
-                      ;; target (NOT per render); a fresh keyword per call is
-                      ;; cheap and collision-free.
-                      (let [k (keyword use-sub-watch-ns (str (gensym "watch-")))]
-                        (when committed
-                          (add-watch committed k (fn [_ _ _ _] (on-change))))
-                        (fn unsubscribe []
-                          (when committed (remove-watch committed k))
-                          ;; rf2-sqhjtu / rf2-naz09e: clear the published
-                          ;; committed reaction, but ONLY if it still holds THIS
-                          ;; invocation's handle (compare the tagged reaction at
-                          ;; index 1). A later `subscribe-fn` re-acquire (e.g. a
-                          ;; subscribe-identity / key change) may have already
-                          ;; overwritten `committed-ref` with the NEW tagged
-                          ;; committed reaction before this older cleanup runs;
-                          ;; clobbering it to nil would strand `get-snap` on the
-                          ;; fallback.
-                          (let [stored (.-current committed-ref)]
-                            (when (and stored (identical? (aget stored 1) committed))
-                              (set! (.-current committed-ref) nil)))
-                          ;; Release the durable committed ref — symmetric with
-                          ;; the `rf.subs/subscribe` above. Runs on unmount /
-                          ;; key change / teardown.
-                          (rf.subs/unsubscribe stable-frame-kw stable-query-v)))))
+                          (release-provisional! (aget tok 1))))
+                      ;; Publish + watch + arm the reacquisition seam. Every
+                      ;; later re-acquisition goes through this same `wire!`, so
+                      ;; there is ONE place that decides what this closure holds.
+                      (wire! committed)
+                      (fn unsubscribe []
+                        (vreset! released? true)
+                        (let [h @held]
+                          (vreset! held nil)
+                          (when (some? h)
+                            (let [r (aget h 0)]
+                              (when r (remove-watch r (aget h 1)))
+                              ;; rf2-sqhjtu / rf2-naz09e: clear the published
+                              ;; committed reaction, but ONLY if it still holds
+                              ;; THIS closure's handle (compare the tagged
+                              ;; reaction at index 1). A later `subscribe-fn`
+                              ;; acquire (a subscribe-identity / key change) may
+                              ;; have already overwritten `committed-ref` with
+                              ;; the NEW tagged reaction before this older
+                              ;; cleanup runs; clobbering it to nil would strand
+                              ;; `get-snap` on the fallback.
+                              (let [stored (.-current committed-ref)]
+                                (when (and stored (identical? (aget stored 1) r))
+                                  (set! (.-current committed-ref) nil)))
+                              ;; rf2-1frc — RELEASE THE REACTION WE ACTUALLY
+                              ;; HOLD, not the (frame, query) ADDRESS. The
+                              ;; address-only `rf.subs/unsubscribe` was correct
+                              ;; only while a cache slot could never be replaced
+                              ;; under a live holder. It can: hot reload, an
+                              ;; explicit `clear-sub-cache!` and a frame
+                              ;; generation change all evict and rebuild, and
+                              ;; after an independent consumer has rebuilt the
+                              ;; same key a late cleanup here decremented the
+                              ;; SUCCESSOR's reference — a foreign entry this
+                              ;; hook never acquired. `unsubscribe-if-reaction`
+                              ;; releases under an identity guard, so a stale
+                              ;; holder no-ops instead of stealing; when the
+                              ;; slot IS ours it takes the ordinary 1 → 0
+                              ;; in-tick disposal, byte-identical to before.
+                              (rf.subs/unsubscribe-if-reaction
+                                stable-frame-kw stable-query-v r))))))))
                   #js [stable-key])]
             (React/useSyncExternalStore subscribe-fn get-snap get-snap)))
         use-subscribe
@@ -3499,9 +3598,41 @@
           ;; `:frame` went nil between renders would change its hook COUNT
           ;; mid-life — a rules-of-hooks violation React reports as a
           ;; misordered-hook crash somewhere else entirely. For an ambient read,
-          ;; call the 1-arity. A missing or malformed `:frame` fails loud at the
-          ;; subs layer, on the same bad-/destroyed-frame path any other
-          ;; explicit read takes.
+          ;; call the 1-arity.
+          ;;
+          ;; rf2-kuky.57 (audit reopen) — AND THE REQUIREMENT HAS TO BE ENFORCED
+          ;; HERE, because the layer this arm used to delegate it to does not
+          ;; enforce it. The sentence above once ended "a missing or malformed
+          ;; `:frame` fails loud at the subs layer"; it does not.
+          ;; `rf.subs/subscribe`'s opts arity reads `(if-some [target (:frame
+          ;; opts)] … (subscribe query-v))`, so an ABSENT or nil `:frame` is
+          ;; that layer's spelling for "ambient" and it resolves the ambient
+          ;; frame silently. Passing `(:frame opts)` straight through therefore
+          ;; produced a SPLIT identity in the hook: the acquire resolved the
+          ;; ambient frame and took a real +1 on its reaction, while the hook
+          ;; stored nil in `stable-key` — so `release-provisional!` and the
+          ;; commit cleanup both released against a nil frame, `frame-target->id`
+          ;; normalized it to nil, the registry lookup found nothing, and both
+          ;; no-opped. The reference was never balanced: a leak, invisible,
+          ;; behind a contract that promised a refusal.
+          ;;
+          ;; The repair is to resolve ONE CONCRETE TARGET before any
+          ;; acquisition, with the machinery that already exists for exactly
+          ;; this — `frame-target->id` normalizes the one frame-target grammar
+          ;; (a frame-id keyword or a live frame value) to the id its record is
+          ;; keyed by, and `require-frame-stamp!` is the framework's standing
+          ;; answer to "a token reached a frame-scoped operation carrying no
+          ;; frame": it returns the stamp when present and otherwise emits +
+          ;; throws the always-on `:rf.error/no-frame-context`. No new
+          ;; validation policy, no options schema — we trust the programmer, and
+          ;; the one thing checked here is the invariant this arm's own
+          ;; documented contract already asserted.
+          ;;
+          ;; Normalizing to an id is load-bearing beyond the refusal: it is what
+          ;; makes the acquire and the release name the SAME thing for a live
+          ;; frame VALUE target too, and what lets `unsubscribe-if-reaction`'s
+          ;; identity guard key the exact slot. It is a plain call, not a hook,
+          ;; so the hook count is unchanged on every path.
           ([query-v]
            ;; Hook subscription to provider-value changes (re-render). The
            ;; returned sentinel/keyword is intentionally NOT used as the
@@ -3513,7 +3644,14 @@
                {:where    're-frame.substrate.spine/use-subscribe
                 :event-id (first query-v)})
              query-v))
-          ([query-v opts] (use-subscribe-2 (:frame opts) query-v)))]
+          ([query-v opts]
+           (use-subscribe-2
+             (rf.frame/require-frame-stamp!
+               (rf.frame/frame-target->id (:frame opts))
+               :subscribe
+               {:where    're-frame.substrate.spine/use-sub
+                :event-id (first query-v)})
+             query-v)))]
     ;; rf2-6id3el: the return map exposes ONLY the surfaces the adapter
     ;; assembler consumes. `:warn-cache` is read by `make-react-adapter`
     ;; (the governance arm/armed? probes, :1868). The `:emitter-cell` /

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -5094,7 +5094,25 @@
                                          ;; reaction owns notification through its own
                                          ;; source watches); present only to satisfy
                                          ;; the IWatchable protocol surface. No-op.
-                                         (-notify-watches [_ _old _nu] nil))]
+                                         (-notify-watches [_ _old _nu] nil)
+                                         ;; rf2-1frc — THE PROXY MUST CARRY THE
+                                         ;; DISPOSAL PROTOCOL THROUGH TOO. The spine
+                                         ;; now registers a REACQUISITION callback on
+                                         ;; the reaction it holds, via
+                                         ;; `rf.interop/add-on-dispose!` — so a
+                                         ;; stand-in that answers only IDeref +
+                                         ;; IWatchable stops being a stand-in and
+                                         ;; throws `No protocol method
+                                         ;; IDisposable.-add-on-dispose` the moment
+                                         ;; `subscribe-fn` wires itself up. Delegating
+                                         ;; to the real reaction is the same
+                                         ;; discipline as the un-substitution at the
+                                         ;; identity guard below: a spy is only a spy
+                                         ;; where it is transparent.
+                                         rf.disposable/IDisposable
+                                         (-add-on-dispose [_ f]
+                                           (rf.disposable/-add-on-dispose real f))
+                                         (-dispose [_] (rf.disposable/-dispose real)))]
                                  (swap! proxy->real assoc p real)
                                  p))
             unwrap           (fn [x] (get @proxy->real x x))
@@ -5275,7 +5293,17 @@
                                          (add-watch real k (fn [_ _ old nu] (f k this old nu)))
                                          this)
                                        (-remove-watch [_ k] (remove-watch real k) nil)
-                                       (-notify-watches [_ _o _n] nil))]
+                                       (-notify-watches [_ _o _n] nil)
+                                       ;; rf2-1frc — carry the disposal protocol
+                                       ;; through to the real reaction; the spine
+                                       ;; registers a reacquisition callback via
+                                       ;; `rf.interop/add-on-dispose!` on whatever
+                                       ;; `subscribe` handed it. See the fuller note
+                                       ;; on the rf2-sqhjtu proxy above.
+                                       rf.disposable/IDisposable
+                                       (-add-on-dispose [_ f]
+                                         (rf.disposable/-add-on-dispose real f))
+                                       (-dispose [_] (rf.disposable/-dispose real)))]
                                (swap! proxy->real assoc p real)
                                p))
             unwrap         (fn [x] (get @proxy->real x x))
@@ -6421,7 +6449,17 @@
                                          (add-watch real k (fn [_ _ old nu] (f k this old nu)))
                                          this)
                                        (-remove-watch [_ k] (remove-watch real k) nil)
-                                       (-notify-watches [_ _o _n] nil))]
+                                       (-notify-watches [_ _o _n] nil)
+                                       ;; rf2-1frc — carry the disposal protocol
+                                       ;; through to the real reaction; the spine
+                                       ;; registers a reacquisition callback via
+                                       ;; `rf.interop/add-on-dispose!` on whatever
+                                       ;; `subscribe` handed it. See the fuller note
+                                       ;; on the rf2-sqhjtu proxy above.
+                                       rf.disposable/IDisposable
+                                       (-add-on-dispose [_ f]
+                                         (rf.disposable/-add-on-dispose real f))
+                                       (-dispose [_] (rf.disposable/-dispose real)))]
                                (swap! proxy->real assoc p real)
                                p))
             unwrap         (fn [x] (get @proxy->real x x))
@@ -6521,34 +6559,44 @@
               (finally
                 (try (act-fn (fn [] (.unmount root))) (catch :default _ nil)))))))))))
 
-;; ---- unsubscribe arity contract (rf2-gizlj) -------------------------------
+;; ---- release call-shape contract (rf2-gizlj, retargeted by rf2-1frc) ------
 ;;
-;; The shared spine's `use-sub` useEffect cleanup calls
-;; `rf.subs/unsubscribe` with `[frame-id query-v]` — the canonical 2-arity
-;; form. Per rf2-cmfln (Spec 006 §Reference counting and disposal) the
-;; 3-arity `[frame-id query-v opts]` was retired with the grace-period
-;; mechanism: the cache disposes synchronously on the 1 → 0 transition
-;; and there are no more per-call overrides. The spine cleanup at
-;; `re-frame.substrate.spine/use-subscribe-effect` is the only
-;; production call site whose arity is invisible to the type checker
-;; (it goes through the spy in the rf2-mwft2 stable-deps-key test).
-;; This assertion locks the call-site arity so a future drift — adding
-;; a third arg back, or shifting to a single-arity query-v call — fails
-;; loudly here before reaching the cache layer.
+;; What this pin is FOR has not changed: the spine's commit-owned cleanup is
+;; the one production release site whose call shape no type checker sees (it
+;; goes through the spy in the rf2-mwft2 stable-deps-key test), and two drifts
+;; must fail loudly here rather than at the cache layer — the grace-period
+;; `opts` MAP re-entering the call (retired with the mechanism per rf2-cmfln,
+;; Spec 006 §Reference counting and disposal: the cache disposes synchronously
+;; on the 1 → 0 transition and there are no per-call overrides), and the spine
+;; DROPPING its explicit frame-id pin.
+;;
+;; WHAT CHANGED IS WHICH FN THE SPINE CALLS. Until rf2-1frc the cleanup was
+;; `rf.subs/unsubscribe` with `[frame-id query-v]`, and this assertion pinned
+;; the literal arity 2. That release was by ADDRESS, and a mounted hook's
+;; reaction can be replaced under it — hot reload, `clear-sub-cache!`, a frame
+;; generation change — after which the address names a SUCCESSOR's entry and an
+;; address-only release decrements a reference the hook never took. The cleanup
+;; now calls `rf.subs/unsubscribe-if-reaction` with
+;; `[frame-id query-v reaction]`, releasing under an identity guard.
+;;
+;; So the pin follows the mechanism instead of the number. Arity 3 is now
+;; CORRECT — but only for this fn, and only with a REACTION in the third
+;; position; a third arg that is a MAP is still exactly the grace-period drift
+;; the original pin was placed to catch, and it is now the more likely way to
+;; reintroduce it.
 
 (defn assert-use-sub-cleanup-calls-unsubscribe-with-2-args
-  "rf2-gizlj: the React-hook spine's `use-sub` useEffect cleanup
-  calls `rf.subs/unsubscribe` with exactly 2 args (`[frame-id query-v]`).
-  Per rf2-cmfln the canonical-leaf arity for `rf.subs/unsubscribe` is 2;
-  no `opts` map, no grace-period override. This test mounts a probe,
-  unmounts it, and asserts the spy observed exactly 2 args at the
-  cleanup call — drift here is what introduced the regression bug
-  rf2-gizlj fixed.
+  "rf2-gizlj / rf2-1frc: pin the SHAPE of the React-hook spine's commit-owned
+  release. It must release the reaction it holds, under the identity guard —
+  `rf.subs/unsubscribe-if-reaction` with `[frame-id query-v reaction]` — with a
+  non-nil frame-id pin, and the third argument must be a reaction rather than a
+  grace-period `opts` map. Any plain `rf.subs/unsubscribe` the spine still
+  drives must remain 2-arity.
 
-  cfg keys: re-uses the same stable-deps-key probe surface — the
-  cleanup fires on either parent here."
+  cfg keys: re-uses the same stable-deps-key probe surface — the cleanup fires
+  on either parent here."
   [{:keys [name probe-stable-deps-element stable-deps-set-tick stable-deps-frame stable-deps-query]}]
-  (testing (str name " — use-sub cleanup calls rf.subs/unsubscribe with 2 args (rf2-gizlj, rf2-cmfln contract)")
+  (testing (str name " — use-sub cleanup releases via unsubscribe-if-reaction with a reaction, not an opts map (rf2-gizlj / rf2-1frc)")
     (with-browser-act
      (fn [act-fn]
       (reset! stable-deps-set-tick nil)
@@ -6557,12 +6605,14 @@
       (rf/dispatch-sync [::gizlj-seed] {:frame stable-deps-frame})
       (rf/reg-sub stable-deps-query (fn [db _] (:p db)))
       (let [unsubscribe-arg-counts (atom [])
+            release-calls          (atom [])
             real-unsubscribe       rf.subs/unsubscribe
+            real-unsub-if          rf.subs/unsubscribe-if-reaction
             mount-node             (make-mount-node!)
             root                   (react-dom-client/createRoot mount-node)]
-        ;; Spy records the arg-count at each call site and delegates to
-        ;; the canonical 2-arity body (mirroring the existing spy bypass
-        ;; — see the rf2-mwft2 stable-deps-key spy comment).
+        ;; Spies record the call shape and delegate to the canonical bodies
+        ;; (mirroring the existing spy bypass — see the rf2-mwft2
+        ;; stable-deps-key spy comment).
         (with-redefs [rf.subs/unsubscribe
                       (fn spy-unsubscribe-arity
                         ([query-v]
@@ -6570,25 +6620,44 @@
                          (real-unsubscribe (rf.frame/resolve-current-frame) query-v))
                         ([frame-id query-v]
                          (swap! unsubscribe-arg-counts conj 2)
-                         (real-unsubscribe frame-id query-v)))]
+                         (real-unsubscribe frame-id query-v)))
+                      rf.subs/unsubscribe-if-reaction
+                      (fn spy-unsubscribe-if-reaction [frame-id query-v reaction]
+                        (swap! release-calls conj {:frame-id frame-id
+                                                   :query-v  query-v
+                                                   :third    reaction})
+                        (real-unsub-if frame-id query-v reaction))]
           (try
             (act-fn (fn [] (.render root (probe-stable-deps-element))))
             (act-fn (fn [] (.unmount root)))
-            ;; The spine's useEffect cleanup is the call site under
-            ;; test. There may be additional unsubscribes from layer-2+
-            ;; cascades, but the cleanup fn the spine wires must use
-            ;; the 2-arity form — anything else is a contract violation.
-            (let [arities (set @unsubscribe-arg-counts)]
-              (is (seq @unsubscribe-arg-counts)
-                  "spine fired at least one rf.subs/unsubscribe across mount + unmount")
-              (is (= #{2} arities)
-                  (str "every spine-driven rf.subs/unsubscribe call must be 2-arity "
-                       "(frame-id + query-v) per rf2-cmfln Spec 006 §Reference "
-                       "counting and disposal — observed arities: "
-                       (pr-str @unsubscribe-arg-counts)
-                       ". A 3-arity call here means the grace-period `opts` "
-                       "shape has re-entered the spine; a 1-arity call means "
-                       "the spine is dropping the explicit frame-id pin.")))
+            (is (seq @release-calls)
+                "the spine released through rf.subs/unsubscribe-if-reaction across mount + unmount")
+            (is (every? #(some? (:frame-id %)) @release-calls)
+                (str "every spine-driven release carries an explicit frame-id pin — a nil "
+                     "here means the spine is resolving the frame somewhere the release "
+                     "cannot follow (rf2-kuky.57). Observed: "
+                     (pr-str (mapv :frame-id @release-calls))))
+            (is (every? #(vector? (:query-v %)) @release-calls)
+                "every release names a query VECTOR in the second position")
+            (is (not-any? #(map? (:third %)) @release-calls)
+                (str "no release passes a MAP in the third position — that is the retired "
+                     "grace-period `opts` shape re-entering the spine (rf2-cmfln). "
+                     "Observed third-arg types: "
+                     (pr-str (mapv #(cond (map? (:third %)) :map
+                                          (nil? (:third %)) :nil
+                                          :else             :reaction)
+                                   @release-calls))))
+            (is (every? #(some? (:third %)) @release-calls)
+                "every release names the REACTION it actually holds — a nil third arg
+                 means the identity guard has nothing to compare and the release
+                 degrades to the address-only behaviour rf2-1frc removed")
+            ;; Any plain `unsubscribe` the spine still drives keeps its
+            ;; canonical 2-arity shape.
+            (is (or (empty? @unsubscribe-arg-counts)
+                    (= #{2} (set @unsubscribe-arg-counts)))
+                (str "any remaining spine-driven rf.subs/unsubscribe call is 2-arity "
+                     "(frame-id + query-v) — observed: "
+                     (pr-str @unsubscribe-arg-counts)))
             (finally
               (try (.unmount root) (catch :default _ nil))))))))))
 
@@ -6764,3 +6833,345 @@
                 "the name read off the fiber is the measure's own id"))
           (finally
             (try (.unmount root) (catch :default _ nil)))))))))
+
+;; ===========================================================================
+;; rf2-1frc / rf2-kuky.57 — subscription LIFETIME across a framework-owned
+;; eviction, and the explicit-target refusal.
+;; ===========================================================================
+;;
+;; Three defects, one mechanism: what a mounted hook HOLDS and what it later
+;; RELEASES have to be the same concrete thing.
+;;
+;;   * `use-sub` memoizes `subscribe-fn` on `[stable-key]`, so React calls it
+;;     exactly ONCE per (frame, query) target and never again for the life of
+;;     that target. It took one reaction there and kept it. When the framework
+;;     evicted and disposed that reaction — `reg-sub` re-registration,
+;;     `clear-sub-cache!`, or (rf2-4lp1) a frame generation change — the
+;;     disposed handle held no source watches, so `on-change` could never fire
+;;     again and the component went permanently DEAF; meanwhile `get-snap`
+;;     still found a key-matching entry and derefed it, so the component kept
+;;     rendering the OLD sub body. `assert-use-sub-reacquires-after-eviction`.
+;;
+;;   * The commit cleanup released by (frame, query) ADDRESS. After an
+;;     eviction, once an independent consumer had rebuilt the same key, that
+;;     address named the SUCCESSOR's entry — so unmounting the original
+;;     decremented a reference it never acquired.
+;;     `assert-use-sub-stale-cleanup-does-not-release-a-successor`.
+;;
+;;   * The explicit `[query-v opts]` arm passed `(:frame opts)` straight
+;;     through, and `rf.subs/subscribe`'s opts arity treats a nil target as
+;;     "ambient". So `(use-sub [:q] {})` under a provider ACQUIRED the ambient
+;;     frame's reaction while the hook stored nil in its stable key — and every
+;;     release then resolved nil, found no frame, and no-opped. An unbalanced
+;;     reference behind a contract that promised a refusal.
+;;     `assert-use-sub-nil-explicit-frame-refuses-without-retaining`.
+
+(defn assert-use-sub-reacquires-after-eviction
+  "rf2-1frc: a MOUNTED `use-sub` must follow its (frame, query) target across a
+  framework-owned cache eviction — the ordinary live-reload path. After
+  re-registering the sub body under a mounted, unchanged component:
+
+    (a) an unrelated parent re-render must read the NEW body (not the disposed
+        reaction's old one), and
+    (b) a subsequent app-db write must still NOTIFY it — the component stays
+        reactive rather than going silently deaf,
+
+  while the hook holds exactly ONE durable reference on the REBUILT entry (no
+  leak, no double-take), and unmount still returns it.
+
+  The two `is` forms marked THE BUG are the pre-fix control: without
+  reacquisition (a) reads the v1 value and (b) never fires at all.
+
+  cfg keys:
+    :probe-evict-element   thunk -> a probe calling
+                           `(use-sub [ev-query] {:frame @evict-target})`
+    :probe-evict-observed  atom the probe pushes every observed value into
+    :evict-target          atom the probe reads its target frame-id from
+    :ev-frame / :ev-query  frame-id + query-id keywords for this probe"
+  [{:keys [name probe-evict-element probe-evict-observed evict-target
+           ev-frame ev-query]}]
+  (testing (str name " — use-sub reacquires its subscription after the cached reaction is evicted (rf2-1frc)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! evict-target ev-frame)
+      (reset! probe-evict-observed [])
+      (rf/make-frame {:id ev-frame :doc "rf2-1frc eviction/reacquisition probe frame"})
+      (rf/reg-event ::ev-seed (fn [{:keys [db]} _] {:db {:n 1}}))
+      (rf/dispatch-sync [::ev-seed] {:frame ev-frame})
+      (rf/reg-event ::ev-set  (fn [{:keys [db]} [_ n]] {:db {:n n}}))
+      ;; v1 body.
+      (rf/reg-sub ev-query (fn [db _] (:n db)))
+      (let [k          [ev-query]
+            cache      (:sub-cache (rf.frame/frame ev-frame))
+            mount-node (make-mount-node!)
+            root       (react-dom-client/createRoot mount-node)]
+        (try
+          (act-fn (fn [] (.render root (probe-evict-element))))
+          (is (= 1 (last @probe-evict-observed))
+              "mounted probe reads the v1 body")
+          (let [committed-1 (get-in @cache [k :reaction])]
+            (is (some? committed-1) "the mount pinned a committed cached reaction")
+            (is (= 1 (or (get-in @cache [k :ref-count]) 0))
+                "exactly one durable committed ref before the eviction")
+
+            ;; THE EVICTION. Re-registering the sub fires the registrar
+            ;; replacement hook, which evicts the slot and disposes
+            ;; `committed-1` — under a component that has NOT unmounted and
+            ;; whose frame and query are unchanged.
+            (reset! probe-evict-observed [])
+            (rf/reg-sub ev-query (fn [db _] (+ 100 (:n db))))
+
+            (is (not (identical? committed-1 (get-in @cache [k :reaction])))
+                "the cache no longer holds the reaction the hook first took")
+
+            ;; (a) An unrelated parent re-render of the SAME mounted component.
+            ;; React re-reads `get-snap`; the `[stable-key]`-keyed memo does not
+            ;; re-run and `subscribe-fn` is not re-invoked.
+            (act-fn (fn [] (.render root (probe-evict-element))))
+            (is (= 101 (last @probe-evict-observed))
+                "THE BUG (rf2-1frc): a re-render must read the REPLACEMENT body — pre-fix `get-snap` derefed the disposed v1 handle and read 1")
+
+            ;; (b) Still REACTIVE. A disposed reaction has no source watches, so
+            ;; pre-fix this dispatch produced no notification at all.
+            (reset! probe-evict-observed [])
+            (act-fn (fn [] (rf/dispatch-sync [::ev-set 2] {:frame ev-frame})))
+            (is (= 102 (last @probe-evict-observed))
+                "THE BUG (rf2-1frc): the component must still be notified by an app-db write after the eviction — pre-fix it was permanently deaf")
+
+            ;; Exactly one durable ref on the REBUILT entry: reacquisition takes
+            ;; one reference, not zero (a leak of the component's liveness) and
+            ;; not two (a leaked reference).
+            (is (= 1 (or (get-in @cache [k :ref-count]) 0))
+                "the hook holds exactly ONE durable ref on the rebuilt entry")
+
+            ;; And unmount still balances it.
+            (act-fn (fn [] (.unmount root)))
+            (is (or (nil? (get @cache k))
+                    (zero? (or (get-in @cache [k :ref-count]) 0)))
+                "unmount released the REACQUIRED reference (entry dropped or ref-count 0)"))
+          (finally
+            (try (.unmount root) (catch :default _ nil)))))))))
+
+(defn assert-use-sub-stale-cleanup-does-not-release-a-successor
+  "rf2-1frc, the ownership edge. After an eviction and a SUCCESSOR consumer
+  acquiring the rebuilt entry, unmounting the ORIGINAL consumer must release
+  only what it holds — never the successor's reference.
+
+  The committed cleanup released by (frame, query) ADDRESS, which after a
+  rebuild names the successor's entry. With two mounted consumers of the same
+  key, unmounting one must leave ref-count 1 and the survivor still reactive.
+
+  cfg keys: reuses the eviction probe surface, plus a second INDEPENDENT
+  consumer of the same (frame, query)
+    :probe-evict-element / :probe-evict-observed / :evict-target
+    :probe-evict-successor-element / :probe-evict-successor-observed
+    :ev-frame / :ev-query"
+  [{:keys [name probe-evict-element probe-evict-observed evict-target
+           probe-evict-successor-element probe-evict-successor-observed
+           ev-frame ev-query]}]
+  (testing (str name " — a stale committed cleanup does not release a successor's reference (rf2-1frc)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! evict-target ev-frame)
+      (reset! probe-evict-observed [])
+      (reset! probe-evict-successor-observed [])
+      (rf/make-frame {:id ev-frame :doc "rf2-1frc successor-ownership probe frame"})
+      (rf/reg-event ::so-seed (fn [{:keys [db]} _] {:db {:n 1}}))
+      (rf/dispatch-sync [::so-seed] {:frame ev-frame})
+      (rf/reg-event ::so-set  (fn [{:keys [db]} [_ n]] {:db {:n n}}))
+      (rf/reg-sub ev-query (fn [db _] (:n db)))
+      (let [k              [ev-query]
+            cache          (:sub-cache (rf.frame/frame ev-frame))
+            node-original  (make-mount-node!)
+            node-successor (make-mount-node!)
+            root-original  (react-dom-client/createRoot node-original)
+            root-successor (react-dom-client/createRoot node-successor)]
+        (try
+          ;; The ORIGINAL consumer mounts and pins the v1 entry.
+          (act-fn (fn [] (.render root-original (probe-evict-element))))
+          (is (= 1 (or (get-in @cache [k :ref-count]) 0))
+              "one consumer, one durable ref")
+
+          ;; Evict + dispose that entry under the mounted original.
+          (rf/reg-sub ev-query (fn [db _] (+ 200 (:n db))))
+
+          ;; A SECOND, INDEPENDENT consumer mounts on the rebuilt entry.
+          (reset! probe-evict-successor-observed [])
+          (act-fn (fn [] (.render root-successor (probe-evict-successor-element))))
+          (is (= 201 (last @probe-evict-successor-observed))
+              "the independent successor consumer reads the replacement body")
+          (let [successor (get-in @cache [k :reaction])]
+            (is (some? successor))
+            (is (= 2 (or (get-in @cache [k :ref-count]) 0))
+                "both consumers hold the SAME rebuilt entry — two durable refs")
+
+            ;; Unmount the ORIGINAL. Its cleanup must release the reaction it
+            ;; actually holds and leave the successor's reference alone.
+            (reset! probe-evict-successor-observed [])
+            (act-fn (fn [] (.unmount root-original)))
+
+            (is (identical? successor (get-in @cache [k :reaction]))
+                "THE BUG (rf2-1frc): the successor's entry survives the original's unmount — an address-only release could dispose it out from under a live holder")
+            (is (= 1 (or (get-in @cache [k :ref-count]) 0))
+                "exactly ONE reference remains — the survivor's; the stale cleanup neither stole it nor left its own behind")
+
+            ;; And the survivor is still live.
+            (act-fn (fn [] (rf/dispatch-sync [::so-set 5] {:frame ev-frame})))
+            (is (= 205 (last @probe-evict-successor-observed))
+                "the surviving consumer is still notified after the other unmounted"))
+          (finally
+            (try (.unmount root-original) (catch :default _ nil))
+            (try (.unmount root-successor) (catch :default _ nil)))))))))
+
+(defn assert-use-sub-nil-explicit-frame-refuses-without-retaining
+  "rf2-kuky.57 (audit reopen): the explicit `(use-sub query-v opts)` arm must
+  resolve ONE concrete frame target BEFORE any subscription acquisition. A
+  missing `:frame` (`{}`) or an explicitly nil one (`{:frame nil}`), under a
+  perfectly valid AMBIENT provider, must REFUSE with
+  `:rf.error/no-frame-context` and retain NOTHING.
+
+  Pre-fix, `(:frame opts)` went straight through to `rf.subs/subscribe`, whose
+  opts arity spells a nil target as ambient — so the hook acquired the ambient
+  frame's reaction (ref-count 1) while storing nil in its stable key, and every
+  later release resolved nil, found no frame and no-opped. The ref-count
+  assertion below is the load-bearing one: a refusal that leaks is not a
+  refusal.
+
+  The legal explicit target is exercised as a CONTROL in the same frame, so a
+  green here cannot come from the arm having stopped working altogether.
+
+  cfg keys:
+    :substrate-kw                     keyword fragment for the listener key
+    :probe-nil-frame-element          thunk -> a probe calling
+                                      `(use-sub [nf-query] @nil-frame-opts)`
+    :nil-frame-opts                   atom holding the opts map the probe passes
+    :nil-frame-observed               atom the probe pushes observed values into
+    :nf-frame / :nf-query             frame-id + query-id keywords
+    :frame-provider-mount-element     (fn [frame-kw child-el] …) — the native
+                                      frame-provider element factory"
+  [{:keys [name substrate-kw probe-nil-frame-element nil-frame-opts
+           nil-frame-observed nf-frame nf-query frame-provider-mount-element]}]
+  (testing (str name " — a missing/nil explicit :frame refuses and retains nothing (rf2-kuky.57)")
+    (with-browser-act
+     (fn [act-fn]
+      (rf/make-frame {:id nf-frame :doc "rf2-kuky.57 nil-explicit-frame probe frame"})
+      (rf/reg-event ::nf-seed (fn [{:keys [db]} _] {:db {:v 7}}))
+      (rf/dispatch-sync [::nf-seed] {:frame nf-frame})
+      (rf/reg-sub nf-query (fn [db _] (:v db)))
+      (let [k     [nf-query]
+            cache (:sub-cache (rf.frame/frame nf-frame))]
+        (doseq [[label opts] [["missing :frame" {}]
+                              ["explicit nil :frame" {:frame nil}]]]
+          (let [lk     (keyword "re-frame.adapter.react-shared-suite"
+                                (str "nil-frame-" (clojure.core/name substrate-kw)
+                                     "-" (str/replace label #"[^a-zA-Z0-9]+" "-")))
+                traces (atom [])]
+            (rf.trace.tooling/register-listener! lk (fn [ev] (swap! traces conj ev)))
+            (reset! nil-frame-opts opts)
+            (reset! nil-frame-observed [])
+            (let [mount-node (make-mount-node!)
+                  root       (react-dom-client/createRoot mount-node)]
+              (try
+                ;; Mounted UNDER a valid ambient provider for `nf-frame`, so the
+                ;; ONLY thing wrong is the explicit target. Pre-fix that ambient
+                ;; frame is exactly what got acquired and never released.
+                (try
+                  (act-fn (fn [] (.render root
+                                   (frame-provider-mount-element
+                                     nf-frame (probe-nil-frame-element)))))
+                  (catch :default _ nil))
+                (is (pos? (count (filterv #(= :rf.error/no-frame-context (:operation %))
+                                          @traces)))
+                    (str label " — the explicit arm refused with :rf.error/no-frame-context rather than silently resolving an ambient frame"))
+                ;; The refusal happens BEFORE the hook returns, so the probe
+                ;; never records anything. Pre-fix it rendered and recorded the
+                ;; ambient frame's value for this query.
+                (is (empty? @nil-frame-observed)
+                    (str label " — THE BUG (rf2-kuky.57): the hook refused instead of returning an ambient read; pre-fix it rendered and recorded "
+                         (pr-str @nil-frame-observed)))
+                ;; THE LEAK ASSERTION, and it sweeps EVERY live frame rather
+                ;; than the provider's alone. Which frame the pre-fix code
+                ;; leaked INTO is not fixed: `{:frame nil}` falls through to the
+                ;; ambient 1-arity, whose chain is dynamic-var FIRST and React
+                ;; context second — so under a `with-frame` scope it acquires
+                ;; there, and under a bare provider it acquires the provider's
+                ;; frame. Either way the reference is unbalanced, because the
+                ;; hook stored nil in its stable key and every release resolved
+                ;; nil, found no frame and no-opped. `nf-query` is unique to
+                ;; this assertion, so ANY cache holding a slot for it is a
+                ;; retained reference this refused read is responsible for.
+                (let [retained (into []
+                                     (comp (keep (fn [fid]
+                                                   (when-let [c (:sub-cache (rf.frame/frame fid))]
+                                                     (when-let [e (get @c k)]
+                                                       [fid (:ref-count e)]))))
+                                           (filter (fn [[_ rc]] (pos? (or rc 0)))))
+                                     (rf.frame/frame-ids))]
+                  (is (empty? retained)
+                      (str label " — THE BUG (rf2-kuky.57): a refused read must retain NO sub-cache reference in ANY frame; found "
+                           (pr-str retained))))
+                (finally
+                  (rf.trace.tooling/unregister-listener! lk)
+                  (try (.unmount root) (catch :default _ nil)))))))
+        ;; CONTROL: the LEGAL explicit keyword target still works, still
+        ;; updates, and still releases on unmount — so the refusal above is
+        ;; a refusal and not a broken arm.
+        (reset! nil-frame-opts {:frame nf-frame})
+        (reset! nil-frame-observed [])
+        (let [mount-node (make-mount-node!)
+              root       (react-dom-client/createRoot mount-node)]
+          (try
+            (act-fn (fn [] (.render root (probe-nil-frame-element))))
+            (is (= 7 (last @nil-frame-observed))
+                "CONTROL — the legal explicit keyword target reads its frame's value")
+            (is (= 1 (or (get-in @cache [k :ref-count]) 0))
+                "CONTROL — and holds exactly one durable reference")
+            (rf/reg-event ::nf-set (fn [{:keys [db]} [_ v]] {:db {:v v}}))
+            (act-fn (fn [] (rf/dispatch-sync [::nf-set 9] {:frame nf-frame})))
+            (is (= 9 (last @nil-frame-observed))
+                "CONTROL — a legal explicit target still updates on an app-db write")
+            (act-fn (fn [] (.unmount root)))
+            (is (or (nil? (get @cache k))
+                    (zero? (or (get-in @cache [k :ref-count]) 0)))
+                "CONTROL — and releases on unmount")
+            (finally
+              (try (.unmount root) (catch :default _ nil))))))))))
+
+(defn assert-use-sub-live-frame-value-target-balances
+  "rf2-kuky.57, the other half of resolving ONE concrete target: a live frame
+  VALUE (`make-frame`'s return token) is a legal explicit target, and it must
+  acquire and release the SAME entry a keyword target does. The arm normalizes
+  through `rf.frame/frame-target->id` before acquisition, so the hook's stable
+  key, its escrow token and its release all name the record's id.
+
+  cfg keys: reuses the nil-frame probe surface
+    :probe-nil-frame-element / :nil-frame-opts / :nil-frame-observed
+    :nf-frame / :nf-query"
+  [{:keys [name probe-nil-frame-element nil-frame-opts nil-frame-observed
+           nf-frame nf-query]}]
+  (testing (str name " — a live frame VALUE explicit target acquires and releases the same entry (rf2-kuky.57)")
+    (with-browser-act
+     (fn [act-fn]
+      (let [frame-value (rf/make-frame {:id nf-frame
+                                        :doc "rf2-kuky.57 frame-value target probe frame"})]
+        (rf/reg-event ::fv-seed (fn [{:keys [db]} _] {:db {:v 3}}))
+        (rf/dispatch-sync [::fv-seed] {:frame nf-frame})
+        (rf/reg-sub nf-query (fn [db _] (:v db)))
+        (reset! nil-frame-opts {:frame frame-value})
+        (reset! nil-frame-observed [])
+        (let [k          [nf-query]
+              cache      (:sub-cache (rf.frame/frame nf-frame))
+              mount-node (make-mount-node!)
+              root       (react-dom-client/createRoot mount-node)]
+          (try
+            (act-fn (fn [] (.render root (probe-nil-frame-element))))
+            (is (= 3 (last @nil-frame-observed))
+                "the frame-VALUE target reads its record's value")
+            (is (= 1 (or (get-in @cache [k :ref-count]) 0))
+                "and pins exactly one durable reference in THAT record's cache")
+            (act-fn (fn [] (.unmount root)))
+            (is (or (nil? (get @cache k))
+                    (zero? (or (get-in @cache [k :ref-count]) 0)))
+                "unmount releases it — the release names the same normalized id the acquire did")
+            (finally
+              (try (.unmount root) (catch :default _ nil))))))))))

--- a/implementation/core/test/re_frame/subs_generation_refresh_cljs_test.cljc
+++ b/implementation/core/test/re_frame/subs_generation_refresh_cljs_test.cljc
@@ -1,0 +1,291 @@
+(ns re-frame.subs-generation-refresh-cljs-test
+  "rf2-4lp1 — a frame's cached subscriptions REFRESH when its resolved image
+  generation changes.
+
+  ## The defect
+
+  `re-frame.live-frame/make-frame` against an EXISTING `:id` is the supported
+  image hot-reload verb (EP-0023 §Hot Reload, rf2-lxwpob retired
+  `reload-images!` in its favour): it seals a fresh generation and installs it
+  via `rf.frame/upsert-frame!`'s surgical-update path, preserving durable frame
+  state — the `:sub-cache` atom among it. The automatic `reg-*` reprojection
+  path (`reproject-live-frame!` / `reproject-live-frames!`) swaps a generation
+  in place through `rf.frame/set-generation!` for the same reason.
+
+  Both preserved the sub-cache and neither invalidated ANY of it. A query that
+  was already materialised stayed a cache HIT — `subscribe-in-frame`'s hit
+  branch bumps the ref-count and returns the cached reaction without ever
+  comparing that entry against the current generation — so it kept running the
+  OLD generation's body. Image replacement (and Story behaviour replacement)
+  appeared not to take effect until the caller knew to call `clear-sub-cache!`
+  by hand, which is exactly the ceremony EP-0023 §Hot Reload says a reload must
+  not require.
+
+  The second face of the same gap is a LATE dependency: a parent sub declaring
+  an input that is not registered yet resolves that input to a nil-yielding
+  reaction, and the miss is deliberately not cached (rf2-l9u5). But the PARENT
+  is cached, holding the nil-yielding input by closure — so first-registering
+  the missing input, which reprojects the frame's generation, left the cached
+  parent permanently nil while `compute-sub` inside the frame's resolution
+  returned the real value.
+
+  ## The repair under test
+
+  `re-frame.frame` now fires a generation-change hook from the TWO (and only
+  two) writers of the `:generation` slot — `set-generation!` and
+  `upsert-frame!`'s re-registration branch — and `re-frame.subs.cache` installs
+  `invalidate-subs-on-generation-change!` on it. That handler diffs the two
+  generations with the already-public `re-frame.live-frame/generation-diff`,
+  keeps the `:sub` `[kind id]` pairs that were `:added` / `:changed` /
+  `:removed`, and evicts exactly those slots plus their transitive
+  declared-input dependent closure from THAT frame's cache — the same
+  `transitive-dependent-closure` + dispose machinery the `reg-sub` replacement
+  hook already uses. `:retained` registrations (present in both generations
+  with an `=` descriptor — an unchanged sub merely selected by a different
+  image composition) are NOT evicted, so unchanged entries keep their identity
+  and ref-counts.
+
+  ## Posture split (rf2-d2841)
+
+  Every assertion here is posture-independent: it holds in the ordinary
+  `clojure -M:test` suite AND under the real production gate
+  (`scripts/test-core-prod-gate.sh`, `-Dre-frame.debug=false`). Nothing here
+  observes the `:trace` stream, and the invalidation seam itself is deliberately
+  NOT behind `rf.interop/debug-enabled?` — a correctness fix hung off the trace
+  surface would DCE out of release bundles.
+
+  `.cljc` — runs under both `clojure -M:test` (JVM) and `npm run test:cljs`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.flows :as rf.flows]
+            [re-frame.frame :as rf.frame]
+            [re-frame.image :as rf.image]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.subs :as rf.subs]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf.flows/reset-flows!)
+  (rf.schemas/clear-schemas-by-frame!)
+  (rf/init! rf.substrate.plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- constant-sub-image
+  "An image whose only registration is an inline layer-1 `:reg-sub` under `id`
+  returning the constant `value`. The inline descriptor goes through the REAL
+  normalize + lower path when the frame's generation is sealed."
+  [image-id id value]
+  (rf.image/image {:id            image-id
+                 :registrations {:reg-sub [[id (fn [_db _q] value)]]}}))
+
+(defn- install!
+  "Create — or, on a repeat call with the same `frame-id`, SURGICALLY REPLACE the
+  generation of — a runnable frame sealed from `image`. The empty descriptor
+  pool keeps the generation to the image's OWN inline registrations, so the
+  live source store cannot contaminate the reading."
+  [frame-id image]
+  (rf.live-frame/make-frame {:id frame-id :images [image]} []))
+
+(defn- cache-keys
+  [frame-id]
+  (set (keys @(:sub-cache (rf.frame/frame frame-id)))))
+
+(defn- ref-count
+  [frame-id query-v]
+  (get-in @(:sub-cache (rf.frame/frame frame-id)) [query-v :ref-count]))
+
+;; ---- 1. same-id re-construction refreshes a changed sub -------------------
+
+(deftest same-id-remake-refreshes-a-changed-inline-sub
+  (testing "a same-id make-frame that changes an inline sub body is observed by
+            the next subscribe, with NO clear-sub-cache!"
+    (install! :gen/frame (constant-sub-image :gen/v1 :gen/value 1))
+    (let [r1 (rf.subs/subscribe [:gen/value] {:frame :gen/frame})]
+      (is (= 1 @r1) "generation 1 yields the first body's value")
+
+      ;; The supported image hot-reload verb: re-call make-frame on the SAME id
+      ;; with a new image. Durable frame state (the sub-cache atom) is preserved
+      ;; by design; the ENTRY for the changed sub must not be.
+      (install! :gen/frame (constant-sub-image :gen/v2 :gen/value 2))
+
+      (let [r2 (rf.subs/subscribe [:gen/value] {:frame :gen/frame})]
+        (is (= 2 @r2)
+            "THE BUG (rf2-4lp1): the next subscribe must resolve the NEW
+             generation's body — pre-fix this read 1, because the hit branch
+             returned the cached reaction built against generation 1")
+        (is (not (identical? r1 r2))
+            "a sub whose definition CHANGED does not keep its reaction identity
+             (the bead explicitly does not require preserving it)")))
+
+    ;; `subscribe-once` reads through the same seam.
+    (is (= 2 (rf.subs/subscribe-once [:gen/value] {:frame :gen/frame}))
+        "subscribe-once sees the new generation too")))
+
+(deftest same-id-remake-refreshes-a-changed-declared-input-parent
+  (testing "a cached PARENT rebuilds when the child it declares as an input changes"
+    (let [image-1 (rf.image/image
+                    {:id            :gen/p1
+                     :registrations {:reg-sub [[:gen/child (fn [_db _q] 1)]
+                                               [:gen/parent
+                                                {:inputs [[:gen/child]]}
+                                                (fn [[c] _q] (* 10 c))]]}})
+          image-2 (rf.image/image
+                    {:id            :gen/p2
+                     :registrations {:reg-sub [[:gen/child (fn [_db _q] 5)]
+                                               [:gen/parent
+                                                {:inputs [[:gen/child]]}
+                                                (fn [[c] _q] (* 10 c))]]}})]
+      (install! :gen/pframe image-1)
+      (is (= 10 @(rf.subs/subscribe [:gen/parent] {:frame :gen/pframe}))
+          "generation 1: parent derives from the first child body")
+
+      (install! :gen/pframe image-2)
+      (is (= 50 @(rf.subs/subscribe [:gen/parent] {:frame :gen/pframe}))
+          "THE BUG (rf2-4lp1): the parent's TRANSITIVE dependent closure must be
+           evicted too — pre-fix the cached parent kept the generation-1 child
+           reaction by closure and stayed 10"))))
+
+;; ---- 2. a first-registered late input reaches a cached parent -------------
+
+(deftest first-registered-late-input-reaches-a-cached-parent
+  (testing "first-registering a previously-missing declared input refreshes the
+            already-cached parent that resolved it to nil"
+    ;; A DEFAULT-image frame: its generation reprojects off the live source
+    ;; store, so a later `reg-sub` moves it.
+    (rf/reg-sub :gen/parent-late {:inputs [[:gen/late]]} (fn [[x] _q] x))
+    (rf.live-frame/make-frame {:id :gen/lframe})
+
+    (let [r1 (rf.subs/subscribe [:gen/parent-late] {:frame :gen/lframe})]
+      (is (nil? @r1)
+          "the missing input resolves to a nil-yielding reaction (rf2-l9u5); the
+           MISS is not cached but the PARENT is")
+      (is (contains? (cache-keys :gen/lframe) [:gen/parent-late])
+          "the parent IS cached, holding the nil-yielding input by closure"))
+
+    ;; First registration of the missing input. This fires no registrar
+    ;; REPLACEMENT hook (there is nothing to replace) — but it DOES dirty the
+    ;; live-frame projection, so the frame's generation moves on the next read.
+    (rf/reg-sub :gen/late (fn [_db _q] 7))
+
+    (is (= 7 @(rf.subs/subscribe [:gen/parent-late] {:frame :gen/lframe}))
+        "THE BUG (rf2-4lp1), second face: the :added registration must evict the
+         cached parent that declares it as an input — pre-fix the parent stayed
+         nil while compute-sub inside the frame's resolution returned 7")))
+
+;; ---- 3. unaffected entries and other frames are UNTOUCHED -----------------
+
+(deftest unchanged-entries-keep-identity-and-ref-counts
+  (testing "a generation change evicts ONLY affected entries: an unchanged sub
+            keeps its reaction identity and its ref-count"
+    ;; `:gen/stable` lives in a SHARED image value carried into BOTH
+    ;; compositions, so its resolved descriptor is byte-identical across the
+    ;; swap and `generation-diff` classes it `:retained`. (Re-declaring the
+    ;; same body inline in two SEPARATE images would not be retained, and
+    ;; correctly so: the lowered descriptors differ on
+    ;; `:rf.provenance/image`, which is a real difference in where the
+    ;; registration came from — measured, not assumed.)
+    (let [shared  (rf.image/image
+                    {:id            :gen/shared
+                     :registrations {:reg-sub [[:gen/stable (fn [_db _q] :stable)]]}})
+          image-1 (rf.image/image
+                    {:id            :gen/s1
+                     :registrations {:reg-sub [[:gen/moving (fn [_db _q] :before)]]}})
+          image-2 (rf.image/image
+                    {:id            :gen/s2
+                     :registrations {:reg-sub [[:gen/moving (fn [_db _q] :after)]]}})
+          install-pair! (fn [moving-image]
+                          (rf.live-frame/make-frame
+                            {:id :gen/sframe :images [shared moving-image]} []))]
+      (install-pair! image-1)
+      (let [moving-1 (rf.subs/subscribe [:gen/moving] {:frame :gen/sframe})
+            stable-1 (rf.subs/subscribe [:gen/stable] {:frame :gen/sframe})]
+        ;; A second holder, so the ref-count is observably 2 rather than 1.
+        (rf.subs/subscribe [:gen/stable] {:frame :gen/sframe})
+        (is (= :before @moving-1))
+        (is (= :stable @stable-1))
+        (is (= 2 (ref-count :gen/sframe [:gen/stable]))
+            "two holders → ref-count 2 before the swap")
+
+        (install-pair! image-2)
+
+        (is (= 2 (ref-count :gen/sframe [:gen/stable]))
+            "the RETAINED entry's ref-count survives the generation change
+             untouched — the invalidation is targeted, not a cache clear")
+        (is (identical? stable-1
+                        (rf.subs/subscribe [:gen/stable] {:frame :gen/sframe}))
+            "the RETAINED entry keeps its reaction IDENTITY")
+        (is (not (contains? (cache-keys :gen/sframe) [:gen/moving]))
+            "the CHANGED entry was evicted")
+        (is (= :after @(rf.subs/subscribe [:gen/moving] {:frame :gen/sframe}))
+            "and rebuilds against the new generation")))))
+
+(deftest other-frames-are-untouched-by-a-generation-change
+  (testing "swapping frame A's generation does not disturb frame B's cache"
+    (install! :gen/a (constant-sub-image :gen/a1 :gen/value 1))
+    (install! :gen/b (constant-sub-image :gen/b1 :gen/value 100))
+    (let [a1 (rf.subs/subscribe [:gen/value] {:frame :gen/a})
+          b1 (rf.subs/subscribe [:gen/value] {:frame :gen/b})]
+      (is (= 1 @a1))
+      (is (= 100 @b1))
+
+      (install! :gen/a (constant-sub-image :gen/a2 :gen/value 2))
+
+      (is (identical? b1 (rf.subs/subscribe [:gen/value] {:frame :gen/b}))
+          "frame B's entry — same query-v, different frame — keeps its identity")
+      (is (= 100 @b1) "and its value")
+      (is (= 2 @(rf.subs/subscribe [:gen/value] {:frame :gen/a}))
+          "while frame A refreshed"))))
+
+;; ---- 4. durable frame state survives -------------------------------------
+
+(deftest durable-frame-state-survives-the-refresh
+  (testing "the app-db a frame accumulated is preserved across the generation
+            change the invalidation rides on"
+    (let [image-of (fn [image-id n]
+                     (rf.image/image
+                       {:id            image-id
+                        :registrations {:reg-event [[:gen/bump
+                                                     (fn [{:keys [db]} _]
+                                                       {:db (assoc db :bumped true)})]]
+                                        :reg-sub   [[:gen/db-read
+                                                     (fn [db _q] [n (:bumped db)])]]}}))]
+      (install! :gen/dframe (image-of :gen/d1 1))
+      (rf/dispatch-sync [:gen/bump] {:frame :gen/dframe})
+      (is (= [1 true] @(rf.subs/subscribe [:gen/db-read] {:frame :gen/dframe})))
+
+      (install! :gen/dframe (image-of :gen/d2 2))
+      (is (= [2 true] @(rf.subs/subscribe [:gen/db-read] {:frame :gen/dframe}))
+          "the sub body is the NEW generation's; the app-db is the SAME frame's
+           durable state (`:bumped` survived)"))))
+
+;; ---- 5. a removed registration releases exactly its own refs -------------
+
+(deftest a-removed-sub-is-evicted-and-recovers-as-a-miss
+  (testing "a registration REMOVED by the new generation is evicted, and the
+            next subscribe takes the ordinary no-such-sub recovery"
+    (let [image-1 (rf.image/image
+                    {:id            :gen/r1
+                     :registrations {:reg-sub [[:gen/kept  (fn [_db _q] :kept)]
+                                               [:gen/gone  (fn [_db _q] :here)]]}})
+          image-2 (rf.image/image
+                    {:id            :gen/r2
+                     :registrations {:reg-sub [[:gen/kept  (fn [_db _q] :kept)]]}})]
+      (install! :gen/rframe image-1)
+      (is (= :here @(rf.subs/subscribe [:gen/gone] {:frame :gen/rframe})))
+      (is (contains? (cache-keys :gen/rframe) [:gen/gone]))
+
+      (install! :gen/rframe image-2)
+
+      (is (not (contains? (cache-keys :gen/rframe) [:gen/gone]))
+          "the REMOVED registration's slot is evicted")
+      (is (nil? @(rf.subs/subscribe [:gen/gone] {:frame :gen/rframe}))
+          "and the next subscribe is an honest no-such-sub miss, not a stale hit"))))


### PR DESCRIPTION
Three subscription-lifetime defects across two layers of one mechanism. Delivered
together because they share `subs/cache.cljc`, `live_frame.cljc`, `subs.cljc` and
`substrate/spine.cljs`, and because two of the three have one root cause.

- **rf2-4lp1** — a frame's cached subscriptions were never refreshed when its
  resolved image generation changed.
- **rf2-1frc** — a mounted `use-sub` never reacquired after its cached reaction was
  evicted, and released by address rather than by what it held.
- **rf2-kuky.57** (audit reopen) — the explicit `[query-v opts]` arm acquired against
  one frame and released against another, leaking on every mount.

## Do they share a root cause?

**rf2-1frc and rf2-kuky.57 do, and it is fixed once**: what the React-hook spine
ACQUIRES and what it later RELEASES must be the same concrete thing. rf2-1frc's
holder changed under it (eviction) while the release named a stale address;
rf2-kuky.57's acquire resolved an ambient frame while the release named nil. One
repair — release the reaction actually held, under `unsubscribe-if-reaction`'s
identity guard, having resolved one concrete target up front — closes both.

**rf2-4lp1 is a different layer** and stays a separate commit: it is about
invalidation never *firing*, where the other two are about what happens *after* it
fires. They compose — a generation change now evicts, and the mounted hook now
follows the rebuild — which is why one PR is the right shape and one commit is not.

## rf2-4lp1 — refresh cached subs on a generation change

A same-id `make-frame` is the supported image hot-reload verb (EP-0023 §Hot Reload,
since rf2-lxwpob retired `reload-images!`), and `reg-*` reprojection swaps a
generation in place. Both preserve durable frame state — the `:sub-cache` atom among
it — and neither invalidated any of its contents. `subscribe-in-frame`'s hit branch
bumps the ref-count and returns the cached reaction without ever comparing it against
the frame's current generation, so an already-materialised query kept running the
previous generation's body until the caller called `clear-sub-cache!` by hand — the
ceremony §Hot Reload says a reload must not require.

A generation change fires no `register!`, so the registrar's replacement hook cannot
see it. This is that hook's other half, driven from the registry that does move.
`re-frame.live-frame` owns `generation-diff`, so it names exactly the `:sub` ids that
differ (`:changed`, `:removed`, and `:added` — load-bearing: a cached parent holding
a nil-yielding unregistered input is reached through its declared `:inputs` head) and
hands them to one per-frame primitive in `re-frame.subs.cache`. `:retained`
registrations are left alone, so unchanged slots keep their reaction identity and
ref-counts, other frames are untouched, and app-db survives.

Both triggers are one event seen from two registries, so the generation path reuses
`:rf.sub/reason :hot-reload` rather than widening a closed enum that `spec/009`,
`spec/006` and Xray all pin.

## rf2-1frc — reacquisition, and exact ownership

`use-sub` memoizes `subscribe-fn` on `[stable-key]`, so React calls it once per
(frame, query) target and never again. It took one reaction and kept it. After an
eviction the disposed handle held no source watches — `on-change` could never fire,
the component went permanently deaf — while `get-snap` still found a key-matching
entry and derefed it, so it kept rendering the old body. The closure now holds
`#js [reaction watch-key]` and re-wires onto the rebuilt entry from an
`rf.interop/add-on-dispose!` callback, guarded on release, identity and frame
liveness. `subscribe-fn`'s own identity is untouched, so React's subscribe/unsubscribe
contract and the same-key steady state are unchanged.

**The seam matters more than the repair.** `rf.subs.cache/emit-dispose!` is the
obvious hook and is unusable: an `rf.trace/emit!` behind `rf.interop/debug-enabled?`,
dead-code-eliminated from release bundles. Measured on this PR's `:advanced` bundle —
`adapter/add-on-dispose!` present, `rf.sub/dispose` absent (table below).

The cleanup released by (frame, query) **address**, which after an eviction and a
successor's rebuild names the successor's entry. Measured pre-fix: unmounting the
original **disposed the survivor's reaction out from under it** and left the survivor
deaf. It now releases through `unsubscribe-if-reaction`.

## rf2-kuky.57 — one concrete target before any acquisition

The explicit arm passed `(:frame opts)` straight through, and `rf.subs/subscribe`'s
opts arity spells a nil target as "ambient". So `(use-sub [:q] {})` acquired the
ambient frame's reaction while the hook stored nil in its stable key, and every
release resolved nil, found no frame and no-opped — behind an arm whose own
documented contract promised a refusal.

It now resolves through `rf.frame/frame-target->id` and
`rf.frame/require-frame-stamp!` before any acquisition: existing frame/error
machinery, no parallel validation policy, and a plain call rather than a hook — the
hook count is identical on every path, so the rules-of-hooks constraint that made
`:frame` required is preserved. Normalizing is load-bearing beyond the refusal: it is
what makes acquire and release name the same thing for a frame VALUE target.

## Registrar hook order

`registration-hooks` finish RECORDING a registration — live-frame's marks the
projection dirty, which is what makes it visible to the next generation resolution —
while `replacement-hooks` REACT to it. They ran in the other order, and nothing
noticed while every invalidated consumer merely dropped its entry and rebuilt later,
past the mark. One now rebuilds DURING the invalidation, and reacquiring against the
stale generation rebuilt the entry against the very body the re-registration had just
replaced. Both batches run isolated, so the move changes no failure propagation.

## Tests

Four real React lifecycle regressions in the shared adapter suite, forwarded from
UIx, plus a JVM/CLJS namespace for the generation refresh. Existing CI could not see
any of the hook defects — PR #9365 merged green at band with the nil-target leak in
it.

Two existing test surfaces moved with the mechanism, and both are narrowed rather
than relaxed:

- the suite's deref-recording proxies now carry `IDisposable` through to the real
  reaction (they answered only `IDeref`/`IWatchable`, on the stated assumption that
  release is by address — no longer true);
- the rf2-gizlj release pin follows the mechanism instead of the arity number. A MAP
  in the third position is still exactly the retired grace-period shape it was placed
  to catch, and the frame-id pin is still asserted non-nil.

Anchors and table column counts in this body were checked by hand; no `spec/`,
`spec/API.md` or `api-manifest` file is touched, and no `re-frame.core` facade export
is added or changed.

## Quality gates

Every exit code below was captured on the runner's own command line and read from the
exit file, not from a harness report.

| lane | exit | result |
|---|---|---|
| `npm run test:browser` — failing-first, pre-fix | **1** | 815 tests / 4462 assertions, **13 failures**, 0 errors |
| `npm run test:browser` — post-fix | **0** | 815 tests / 4466 assertions, 0 failures, 0 errors |
| `npm run test:browser-prod-elision` | **0** | 92 tests / 292 assertions, 0 failures; positive control present |
| `npm run test:adapter-smokes` | **0** | 2 adapter-smoke specs, 0 failures |
| `bash scripts/test-core-prod-gate.sh` (`-Dre-frame.debug=false`) | **0** | 1976 tests / 8429 assertions, 0 failures, 187 namespaces |
| `clojure -M:test -n re-frame.subs-generation-refresh-cljs-test` — failing-first | **1** | 7 tests / 27 assertions, **11 failures**, 0 errors |
| `clojure -M:test -n …` — post-fix | **0** | 7 tests / 27 assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`; JVM core 2255/11635, node-test 11353/57266, clj-kondo 2026.04.15 errors: 0 |

`python scripts/check_fast_pr_gap.py --brief` reports **99 required checks the spine
does not decide**, which is why the browser, prod-elision, adapter-smoke and JVM
production-gate lanes were run explicitly. The remaining required matrix is left to
CI, which is authoritative for it.

### Failing-first evidence

Both fixes were proved by watching the tests fail first. For the spine fixes the
source was reverted to `HEAD` with the new tests in place, the lane run, then the
fixed sources restored and verified by SHA-256 against a saved copy before the green
run.

Pre-fix failures were the defects themselves, not incidental:

- a re-render after re-registration read `1` where the replacement body gives `101`;
- an app-db write after the eviction produced **no notification at all** (`nil`);
- unmounting the original consumer left the successor's cache slot **`nil`** — its
  reaction disposed under a live holder — and the survivor unnotified;
- the nil-target read retained `[[:rf/default 2]]`, then `[[:rf/default 4]]` —
  **two unbalanced references per mount** (the render-phase escrow token and the
  committed ref, both no-opping on the nil target), accumulating across cases. The
  audit's seam probe could see one; the React lifecycle shows both.

### DCE proof for the reacquisition seam

Measured on `out/browser-test-prod-elision/js/test.js` (`:advanced`, `goog.DEBUG`
false), in both directions and with controls:

| needle | occurrences |
|---|---|
| `adapter/add-on-dispose!` — the seam used | **1 (present)** |
| `rf.sub/dispose` — the tag `emit-dispose!` emits | **0 (eliminated)** |
| `rf.error/no-frame-context` — live-search control | 1 |
| a nonsense needle — instrument control | 0 |

The obvious seam genuinely is not in the release bundle; the one used is.
