### PR TITLE
fix(examples): three app-state defects — late settings replies, double tag parse, temp-id writes

### DIFF
--- a/examples/capabilities/resources/linearlite/README.md
+++ b/examples/capabilities/resources/linearlite/README.md
@@ -95,7 +95,16 @@ which restore captured context unconditionally — fine until two writes overlap
 Overlapping writes commit at the granularity they wrote at. Nothing stops you
 adding a card while a retitle is still saving, or moving one card while another
 is in flight — the controls stay live, and each write runs under its own
-mutation instance (`[:create tmp-id]`, `[:edit id]`, `[:status id]`). So the
+mutation instance (`[:create tmp-id]`, `[:edit id]`, `[:status id]`). With one
+exception, and it is worth knowing why it is an exception rather than a policy:
+a card whose *create* is still in flight has only the client-minted `tmp-N`
+placeholder, and the server has never heard of that id. A retitle or a move
+would `PUT /api/issues/tmp-N` at a row that does not exist — answered as a
+success that changed nothing, and then overwritten on screen when the create's
+reply swaps the placeholder for the server's row. So that card's own two
+controls wait for its create to reply, which is the moment its id becomes real.
+Every other card stays live throughout. The limit is identity, not concurrency:
+you cannot address an object the server has not named yet. So the
 success consequences have to be disjoint, or one write's commit would undo
 another's. That is why each mutation declares
 [`:patches`](../../../../docs/resources/glossary.md#mutation) and not

--- a/examples/capabilities/resources/linearlite/core.cljs
+++ b/examples/capabilities/resources/linearlite/core.cljs
@@ -622,9 +622,11 @@
         [:button {:type :submit :data-testid (str "edit-save-" id)} "Save"]
         [:button {:type :button :on-click #(dispatch [:linearlite/cancel-edit])} "Cancel"]]
        [:div.issue-row
-        [:span.issue-title (cond-> {:data-testid (str "title-" id)}
-                             creating?       (assoc :title "Waiting for the server to name this card…")
-                             (not creating?) (assoc :on-click #(dispatch [:linearlite/begin-edit id title])))
+        [:span.issue-title
+         (merge {:data-testid (str "title-" id)}
+                (if creating?
+                  {:title "Waiting for the server to name this card…"}
+                  {:on-click #(dispatch [:linearlite/begin-edit id title])}))
          title]
         (when pending? [:span.badge {:data-testid (str "pending-" id)} "saving…"])
         (when errored? [:span.badge.error {:data-testid (str "errored-" id)} "failed — reverted"])])

--- a/examples/capabilities/resources/linearlite/core.cljs
+++ b/examples/capabilities/resources/linearlite/core.cljs
@@ -569,11 +569,12 @@
               :on-change   #(dispatch [:linearlite/set-new-issue-draft (.. % -target -value)])}]
      [:button {:type :submit :data-testid "new-issue-submit"} "Add issue"]]))
 
-(rf/reg-view status-picker [{:keys [id status]}]
+(rf/reg-view status-picker [{:keys [id status disabled?]}]
   ;; Pick a new column. This fires the optimistic change-status mutation: the
   ;; card jumps right away, then commits or rolls back when the reply lands.
   [:select {:data-testid (str "status-" id)
             :value       (name status)
+            :disabled    (boolean disabled?)
             :on-change   #(dispatch [:linearlite/change-status
                                      id (keyword (.. % -target -value))])}
    (for [{s-id :id s-label :label} statuses]
@@ -591,7 +592,19 @@
         pending?      (or optimistic?
                           (:optimistic? edit-state) (:optimistic? status-state)
                           (:optimistic? create-state))
-        errored?      (or (:error? edit-state) (:error? status-state) (:error? create-state))]
+        errored?      (or (:error? edit-state) (:error? status-state) (:error? create-state))
+        ;; The one overlap this board cannot offer, and it isn't a policy
+        ;; choice. While a create is in flight the card is wearing the
+        ;; client-minted `tmp-N` placeholder; the server has never heard of that
+        ;; id, so a retitle or a move would `PUT /api/issues/tmp-N` at a row that
+        ;; does not exist. The write would come back a cheerful success having
+        ;; changed nothing, and then the create's own reply would swap the
+        ;; placeholder card for the server's row and the change would be gone
+        ;; from the screen too. So this card's own controls wait for its create
+        ;; — that reply is the moment the id becomes real. Every OTHER card stays
+        ;; live throughout, including one being retitled while this one is
+        ;; created: those have server ids to address.
+        creating?     (boolean (:pending? create-state))]
     [:li.issue-card {:data-testid (str "issue-" id)
                      :class       (str (when pending? "pending ") (when errored? "errored"))}
      (if editing-this?
@@ -609,13 +622,14 @@
         [:button {:type :submit :data-testid (str "edit-save-" id)} "Save"]
         [:button {:type :button :on-click #(dispatch [:linearlite/cancel-edit])} "Cancel"]]
        [:div.issue-row
-        [:span.issue-title {:data-testid (str "title-" id)
-                            :on-click    #(dispatch [:linearlite/begin-edit id title])}
+        [:span.issue-title (cond-> {:data-testid (str "title-" id)}
+                             creating?       (assoc :title "Waiting for the server to name this card…")
+                             (not creating?) (assoc :on-click #(dispatch [:linearlite/begin-edit id title])))
          title]
         (when pending? [:span.badge {:data-testid (str "pending-" id)} "saving…"])
         (when errored? [:span.badge.error {:data-testid (str "errored-" id)} "failed — reverted"])])
      [:div.issue-actions
-      [status-picker {:id id :status status}]]]))
+      [status-picker {:id id :status status :disabled? creating?}]]]))
 
 (rf/reg-view board-column [{:keys [status issues editing]}]
   [:div.column {:data-testid (str "column-" (:id status))}

--- a/examples/real-apps/realworld_http/auth.cljs
+++ b/examples/real-apps/realworld_http/auth.cljs
@@ -130,6 +130,47 @@
       (assoc-in [:auth :user] (dissoc user :token))
       (assoc-in [:auth :token] (:token user))))
 
+;; The identity half of the session, and the one question a completion that
+;; OUTLIVES its session has to ask before it acts.
+;;
+;; A request issued while signed in can reply after the sign-out: it is already
+;; on the wire, and logging out does not unsend it. Nothing below the app
+;; catches that. The frame is the same one, so the frame-teardown fence does not
+;; fire; the request was never superseded, so stale suppression has nothing to
+;; suppress. Both are working as specified — each is asking a question about the
+;; WORK, and this one is about the SESSION. A settings completion that folds its
+;; reply in regardless would put the departed user's User and token straight
+;; back into the auth slice.
+;;
+;; So a session-scoped write records who it was issued for, and its completion
+;; refuses to act once that identity is no longer the one signed in. It is the
+;; app-level twin of the framework's nav-token fence for route loaders
+;; (Spec 012 §Threading — "carry the captured facts in the follow-up event
+;; payload"), spelled here because WHO IS SIGNED IN is the app's fact, not the
+;; router's or the transport's.
+(defn session-owner
+  "Who the app is signed in as right now — the username, or nil for nobody.
+   PURE: takes an app-db value, reads nothing ambient."
+  [db]
+  (get-in db [:auth :user :username]))
+
+(defn owns-session?
+  "True when `owner` — a `session-owner` captured when a write was issued — is
+   still the identity signed in. False after a logout (nobody is) and after an
+   account switch (somebody else is).
+
+   A nil `owner` is false, and that clause is load-bearing rather than
+   defensive: `(= nil nil)` would read an unrecorded owner as 'matches the
+   anonymous session', so the guard would fail OPEN on precisely the logout it
+   exists to catch.
+
+   A settings save that RENAMES the user still matches. The comparison is
+   against the session as it stands when the reply LANDS, and the rename only
+   takes effect when that reply is folded in — so the live username is still
+   the pre-save one the owner was captured from."
+  [db owner]
+  (and (some? owner) (= owner (session-owner db))))
+
 (rf/reg-event :auth/store-session
   {:doc "Stash the authenticated session — the standalone, directly-dispatchable
          form of `store-session-db` (test fixtures and any external caller

--- a/examples/real-apps/realworld_http/schema.cljs
+++ b/examples/real-apps/realworld_http/schema.cljs
@@ -144,15 +144,19 @@
   "The `:data` slot of the `:settings/form` machine's snapshot — the case where
    the whole FORM lifecycle lives in the machine. The state-keyword is the
    lifecycle (`:neutral` / `:incorrect` / `:correct` + `:submitting`), and
-   `:data` holds the draft, the per-field validation state, and the projected
-   submit-error string."
+   `:data` holds the draft, the per-field validation state, the projected
+   submit-error string, and `:session-owner` — the username the in-flight
+   submission was issued under, which the two reply handlers compare against
+   the live session before acting on a reply (settings.cljs §SESSION
+   OWNERSHIP)."
   [:map
-   [:draft        :map]
-   [:submitted    [:maybe :map]]
-   [:errors       [:map-of :keyword [:vector :string]]]
-   [:touched      [:set :keyword]]
-   [:submit-error [:maybe :string]]
-   [:loaded-at    [:maybe :int]]])
+   [:draft         :map]
+   [:submitted     [:maybe :map]]
+   [:errors        [:map-of :keyword [:vector :string]]]
+   [:touched       [:set :keyword]]
+   [:submit-error  [:maybe :string]]
+   [:loaded-at     [:maybe :int]]
+   [:session-owner [:maybe :string]]])
 
 (def FormSlice
   [:map

--- a/examples/real-apps/realworld_http/settings.cljs
+++ b/examples/real-apps/realworld_http/settings.cljs
@@ -53,12 +53,23 @@
    :password ""})
 
 (def initial-data
-  {:draft        (draft-from-user nil)
-   :submitted    nil
-   :errors       {}
-   :touched      #{}
-   :submit-error nil
-   :loaded-at    nil})
+  {:draft         (draft-from-user nil)
+   :submitted     nil
+   :errors        {}
+   :touched       #{}
+   :submit-error  nil
+   :loaded-at     nil
+   ;; Whose session the in-flight submission was issued under — recorded by
+   ;; :begin-submit, read back by the two reply handlers. See the SESSION
+   ;; OWNERSHIP note above :settings/submit-success.
+   :session-owner nil})
+
+(defn- machine-data
+  "The `:settings/form` snapshot's `:data`, read out of runtime-db. The snapshot
+   lives at [:rf.runtime/machines :snapshots :settings/form]; naming that path
+   once here keeps the three handlers that need it from each spelling it out."
+  [runtime-db]
+  (get-in runtime-db [:rf.runtime/machines :snapshots :settings/form :data]))
 
 ;; ============================================================================
 ;; THE MACHINE — :settings/form  (one region; the form lifecycle)
@@ -165,9 +176,17 @@
     ;; examples/core/login's submit-form. Wipe :errors and :submit-error so
     ;; nothing lingers from a previous failed attempt while this one's in
     ;; flight.
-    (fn action-begin-submit [{data :data [_ {:keys [submitted]}] :event}]
+    ;;
+    ;; It also carries :session-owner — the identity the PUT is being sent as.
+    ;; THIS is the recording point rather than :load, because :load is only
+    ;; accepted from :neutral: a form sitting in :correct or :incorrect from an
+    ;; earlier attempt ignores a re-entry's :load, and an owner recorded there
+    ;; would still name whoever loaded the form last. A submit can only be made
+    ;; from :neutral or :incorrect, and it is the moment the request goes out.
+    (fn action-begin-submit [{data :data [_ {:keys [submitted session-owner]}] :event}]
       {:data (-> data
                  (assoc :submitted submitted)
+                 (assoc :session-owner session-owner)
                  (assoc-in [:draft :password] "")
                  (assoc :errors {})
                  (assoc :submit-error nil))})
@@ -317,11 +336,13 @@
          :settings/submit-success / :settings/submit-error broadcast
          :submit-succeeded / :submit-failed in turn."
    :rf.http/decode-schemas [schema/UserResponse]}
-  ;; The machine snapshot lives in runtime-db.
-  (fn handler-settings-submit [{rt :rf.db/runtime} _]
-    (let [draft (get-in rt [:rf.runtime/machines :snapshots :settings/form :data :draft])]
+  ;; The machine snapshot lives in runtime-db; the session identity lives in
+  ;; app-db, so this handler reads both partitions.
+  (fn handler-settings-submit [{:keys [db] rt :rf.db/runtime} _]
+    (let [draft (:draft (machine-data rt))]
       {:fx [[:dispatch [:settings/form
-                        [:submit-valid {:submitted draft}]]]
+                        [:submit-valid {:submitted     draft
+                                        :session-owner (auth/session-owner db)}]]]
             [:rf.http/managed
              (rh/request {:method     :put
                           :path       "/user"
@@ -333,39 +354,62 @@
                           :on-success [:settings/submit-success]
                           :on-failure [:settings/submit-error]})]]})))
 
+;; ----------------------------------------------------------------------------
+;; SESSION OWNERSHIP — the two reply handlers below ask one question first
+;; ----------------------------------------------------------------------------
+;;
+;; Both Logout buttons — the one on this page and the one in the navbar — stay
+;; live while a save is in flight, and they should: waiting is not what a user
+;; who wants out is asking for. But the PUT is already on the wire, and logging
+;; out does not unsend it. So either reply can land on a signed-out app.
+;;
+;; `:begin-submit` recorded who the request was sent as; these two handlers
+;; compare that against the live session (auth.cljs's `owns-session?`, which
+;; carries the full why) and refuse to act for any other. Refusal is not a
+;; no-op: the machine is sitting in :submitting, whose only way out is a reply,
+;; so a refused one broadcasts :reset instead — which settles the form AND
+;; scrubs the departed user's draft out of the snapshot on the way past.
 (rf/reg-event :settings/submit-success
   {:doc "Server said yes. Three things follow: fold the returned user into the
          machine's :data via :store-user (region lands in :correct), store the
          session (durable [:auth :token] + [:auth :user]) so the rest of the
-         app sees the update, and navigate off to the user's profile page.
-         The reply rides a map payload classified :sensitive — RealWorld's
-         PUT /user reply carries a fresh User (and therefore a fresh token,
-         just like login/register)."
+         app sees the update, and navigate off to the user's profile page —
+         unless the session that issued the save is gone, in which case the
+         form resets and none of it happens (storing the reply would restore
+         the logged-out user's credentials). The reply rides a map payload
+         classified :sensitive — RealWorld's PUT /user reply carries a fresh
+         User (and therefore a fresh token, just like login/register)."
    :sensitive [[:value :user :token]]}
-  (fn handler-settings-submit-success [{:keys [db]} [_ {:keys [value]}]]
-    (let [user (:user value)]
-      ;; `store-session-db` is called DIRECTLY (not via a nested
-      ;; `[:dispatch [:auth/store-session user]]`) for the same reason
-      ;; auth.cljs's own reply events do — see that fn's doc. The
-      ;; machine-routed :submit-succeeded sub-event never needs the token at
-      ;; all (:store-user's `draft-from-user` never reads it), so it is
-      ;; `dissoc`'d before crossing into the machine — the token is never
-      ;; even offered to that nested dispatch, not merely classified after
-      ;; the fact.
-      {:db (auth/store-session-db db user)
-       :fx [[:dispatch [:settings/form
-                        [:submit-succeeded {:user (dissoc user :token)}]]]
-            [:dispatch [:rf.route/navigate {:to :realworld.profile/show :params {:username (:username user)}}]]]})))
+  (fn handler-settings-submit-success [{:keys [db] rt :rf.db/runtime} [_ {:keys [value]}]]
+    (if-not (auth/owns-session? db (:session-owner (machine-data rt)))
+      {:fx [[:dispatch [:settings/form [:reset]]]]}
+      (let [user (:user value)]
+        ;; `store-session-db` is called DIRECTLY (not via a nested
+        ;; `[:dispatch [:auth/store-session user]]`) for the same reason
+        ;; auth.cljs's own reply events do — see that fn's doc. The
+        ;; machine-routed :submit-succeeded sub-event never needs the token at
+        ;; all (:store-user's `draft-from-user` never reads it), so it is
+        ;; `dissoc`'d before crossing into the machine — the token is never
+        ;; even offered to that nested dispatch, not merely classified after
+        ;; the fact.
+        {:db (auth/store-session-db db user)
+         :fx [[:dispatch [:settings/form
+                          [:submit-succeeded {:user (dissoc user :token)}]]]
+              [:dispatch [:rf.route/navigate {:to :realworld.profile/show :params {:username (:username user)}}]]]}))))
 
 (rf/reg-event :settings/submit-error
   {:doc "Server said no. Folds a readable error message into the machine's
          :data via :set-submit-error; the region lands in :incorrect — the very
          same surface the client-side validation path uses, since both show up
          through :submit-error / :errors. One place to render \"something's
-         wrong\", however it went wrong."}
-  (fn handler-settings-submit-error [_ [_ {:keys [error]}]]
-    {:fx [[:dispatch [:settings/form
-                      [:submit-failed {:submit-error (rh/failure->message error)}]]]]}))
+         wrong\", however it went wrong. Unless the session that issued the save
+         is gone: there is nobody left to show it to, and the message would sit
+         in the snapshot waiting for the next user, so the form resets instead."}
+  (fn handler-settings-submit-error [{:keys [db] rt :rf.db/runtime} [_ {:keys [error]}]]
+    (if-not (auth/owns-session? db (:session-owner (machine-data rt)))
+      {:fx [[:dispatch [:settings/form [:reset]]]]}
+      {:fx [[:dispatch [:settings/form
+                        [:submit-failed {:submit-error (rh/failure->message error)}]]]]})))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/real-apps/realworld_resources/article_editor.cljs
+++ b/examples/real-apps/realworld_resources/article_editor.cljs
@@ -74,7 +74,15 @@
    :body        (:body article)
    :tagList     (str/join ", " (:tagList article))})
 
-(defn- parse-tag-list [s]
+(defn- parse-tag-list
+  "The form's comma-separated tag STRING → the vector of tags the wire wants.
+   Called at exactly one place — `:editor/submit`, the form-to-mutation
+   boundary — because that is where the draft stops being text the user is
+   typing and becomes the mutation's declared `[:vector :string]` params. Run it
+   a second time on the result and CLJS does not complain: `str/split` coerces
+   its argument with `str` first, so a vector is split as its own PRINTED form
+   and `[]` comes back as the single tag `\"[]\"`."
+  [s]
   (->> (str/split (or s "") #",")
        (map str/trim)
        (remove str/blank?)
@@ -128,11 +136,16 @@
     (str/blank? description) (assoc :description "Description is required.")
     (str/blank? body)        (assoc :body "Body is required.")))
 
-(defn- article-body [draft]
-  {:article {:title       (:title draft)
-             :description (:description draft)
-             :body        (:body draft)
-             :tagList     (parse-tag-list (:tagList draft))}})
+(defn- article-body
+  "The RealWorld `{:article …}` request envelope, built from the mutation's
+   PARAMS — already normalised and already schema-checked against
+   `:params-schema` by the time the request function runs. `:tagList` arrives as
+   the vector that schema declares, so it travels through untouched: the one
+   string→vector conversion happened at the form-to-mutation boundary
+   (`:editor/submit`), which is the only place that knows about comma-separated
+   text at all."
+  [params]
+  {:article (select-keys params [:title :description :body :tagList])})
 
 (def save-instance
   "The one stable instance id the editor form watches for the save write."
@@ -214,12 +227,12 @@
                       :tags  #{[:feed]}}
                      {:scope {:from-db :realworld/viewer}
                       :tags  #{[:author-articles (get-in result [:article :author :username])]}}])}
-  (fn [{:keys [slug] :as draft} _ctx]
+  (fn [{:keys [slug] :as params} _ctx]
     {:request {:method (if slug :put :post)
                :url    (rh/full-url (if slug
                                       (str "/articles/" slug)
                                       "/articles"))
-               :body   (article-body (select-keys draft [:title :description :body :tagList]))}
+               :body   (article-body params)}
      :decode  schema/ArticleResponse}))
 
 (rf/reg-mutation :realworld/delete-article
@@ -391,8 +404,13 @@
         {:db (assoc-in db [:editor :submit-attempted?] true)
          :fx [[:dispatch [:rf.mutation/execute
                           {:mutation :realworld/save-article
-                           :params   (cond-> (select-keys draft [:title :description :body])
-                                       true (assoc :tagList (parse-tag-list (:tagList draft)))
+                           ;; The one place the comma-separated tag STRING the
+                           ;; user typed becomes the `[:vector :string]` the
+                           ;; mutation's `:params-schema` declares. Downstream —
+                           ;; the request builder included — sees only the
+                           ;; vector.
+                           :params   (cond-> (-> (select-keys draft [:title :description :body])
+                                                 (assoc :tagList (parse-tag-list (:tagList draft))))
                                        slug (assoc :slug slug))
                            :instance save-instance
                            ;; The save-success continuation is the call-site

--- a/examples/real-apps/realworld_resources/auth.cljs
+++ b/examples/real-apps/realworld_resources/auth.cljs
@@ -150,6 +150,48 @@
       (assoc-in [:auth :user] (dissoc user :token))
       (assoc-in [:auth :token] (:token user))))
 
+;; The identity half of the session, and the one question a completion that
+;; OUTLIVES its session has to ask before it acts.
+;;
+;; A write issued while signed in can reply after the sign-out: the request is
+;; already on the wire, and logging out does not unsend it. Nothing below the
+;; app catches that. The frame is the same one, so the frame fence does not
+;; fire; the mutation instance is the same live instance, so the reply-slot
+;; check accepts the reply as current; and clearing a resource SCOPE retires
+;; cached reads, not a write in flight. All of those are working as specified —
+;; each is asking a question about the WORK, and this one is about the SESSION.
+;; A settings completion that folds its reply in regardless would put the
+;; departed user's User and token straight back into the auth slice.
+;;
+;; So a session-scoped write records who it was issued for, and its
+;; continuation refuses to act once that identity is no longer the one signed
+;; in. It is the app-level twin of the framework's nav-token fence for route
+;; loaders (Spec 012 §Threading — "carry the captured facts in the follow-up
+;; event payload"), spelled here because WHO IS SIGNED IN is the app's fact,
+;; not the router's or the runtime's.
+(defn session-owner
+  "Who the app is signed in as right now — the username, or nil for nobody.
+   PURE: takes an app-db value, reads nothing ambient."
+  [db]
+  (get-in db [:auth :user :username]))
+
+(defn owns-session?
+  "True when `owner` — a `session-owner` captured when a write was issued — is
+   still the identity signed in. False after a logout (nobody is) and after an
+   account switch (somebody else is).
+
+   A nil `owner` is false, and that clause is load-bearing rather than
+   defensive: `(= nil nil)` would read an unrecorded owner as 'matches the
+   anonymous session', so the guard would fail OPEN on precisely the logout it
+   exists to catch.
+
+   A settings save that RENAMES the user still matches. The comparison is
+   against the session as it stands when the reply LANDS, and the rename only
+   takes effect when that reply is folded in — so the live username is still
+   the pre-save one the owner was captured from."
+  [db owner]
+  (and (some? owner) (= owner (session-owner db))))
+
 ;; ONE definition of "we don't know who this is yet", used from three places that
 ;; must not be allowed to drift: the `:auth/viewer-resolving?` sub (the app shell),
 ;; the `:realworld/viewer` scope resolver's fail-closed branch (scope.cljs), and

--- a/examples/real-apps/realworld_resources/schema.cljs
+++ b/examples/real-apps/realworld_resources/schema.cljs
@@ -77,11 +77,19 @@
   "The standard form-draft slice, shared by the login / register / settings
    drafts in app-db. The submission lifecycle isn't here — that's a mutation
    instance (`:rf/mutation`) — so this slice carries only the editable draft
-   plus a little touched-field bookkeeping."
+   plus a little touched-field bookkeeping.
+
+   `:session-owner` is the settings form's alone (hence optional): the username
+   the draft was seeded from, which `:settings/replied` compares against the
+   live session before folding a reply in — a save can reply after a logout, and
+   the departed user's credentials must not come back with it. The login and
+   register drafts are filled in by a visitor who has no session yet, so they
+   have nothing to own."
   [:map
    [:draft   :map]
    [:touched [:set :keyword]]
-   [:submit-attempted? {:optional true} :boolean]])
+   [:submit-attempted? {:optional true} :boolean]
+   [:session-owner {:optional true} [:maybe :string]]])
 
 (def AuthFlowData
   "The :data slot of the :auth/flow machine snapshot."

--- a/examples/real-apps/realworld_resources/settings.cljs
+++ b/examples/real-apps/realworld_resources/settings.cljs
@@ -10,9 +10,10 @@
    the mutation's `:invalidates` clears the public profile read so a later visit
    re-reads the new bio.
 
-   The only thing app-db holds is the editable draft — the live field values. The
-   lifecycle (`:idle` / `:pending` / `:success` / `:error`) is the mutation
-   instance, not a `:status` field you maintain.
+   The only thing app-db holds is the editable draft — the live field values,
+   plus the `:session-owner` recording whose settings they are. The lifecycle
+   (`:idle` / `:pending` / `:success` / `:error`) is the mutation instance, not a
+   `:status` field you maintain.
 
    The success continuation is a call-site `:reply-to`, and it's worth a beat. The
    submit passes `:reply-to [:settings/replied]` to `:rf.mutation/execute`; when
@@ -70,11 +71,23 @@
          write (classify-before-write, mirroring :auth/classify-token), so the
          new-password the user types reads :rf/redacted at every app-db egress
          while the submit handler still reads the live value. See keep-secrets:
-         ../../../docs/core/how-to/keep-secrets-out-of-traces.md"}
+         ../../../docs/core/how-to/keep-secrets-out-of-traces.md
+
+         The seed records `:session-owner` — WHOSE settings these are — beside
+         the draft it seeds from that same user. `:settings/replied` compares it
+         against the live session before folding a reply in, so a save that
+         replies after a logout cannot restore the departed user's credentials
+         (auth.cljs's `owns-session?` carries the full why). Recording it HERE,
+         where the slice is built, rather than at submit is what keeps it right
+         across a mid-save detour: leaving the page and coming back re-seeds the
+         slice, and a submit-time record would be dropped by that re-seed and
+         the returning user's own save then refused."}
   (fn [{:keys [db]} _]
-    {:db        (assoc-in db [:settings-form] {:draft   (draft-from-user (get-in db [:auth :user]))
-                                               :touched #{}})
-     :sensitive [[:settings-form :draft :password]]}))
+    (let [user (get-in db [:auth :user])]
+      {:db        (assoc-in db [:settings-form] {:draft         (draft-from-user user)
+                                                 :touched       #{}
+                                                 :session-owner (:username user)})
+       :sensitive [[:settings-form :draft :password]]})))
 
 (rf/reg-event :settings/edit-field
   {:doc    "Controlled-input edit for a NON-SECRET field (image / username /
@@ -130,8 +143,10 @@
   {:doc "The update-settings completion continuation (the `:reply-to` target). It
          receives the canonical reply map as its final arg, observed AFTER the
          mutation's `:invalidates` cleared the public profile read and the instance
-         settled. On `:ok`, push the saved User (the reply `:value`) into the auth
-         slice, clear the instance, and navigate to the user's profile. On
+         settled. It answers one question first — is the session that issued this
+         save still the one signed in? — and only then, on `:ok`, pushes the saved
+         User (the reply `:value`) into the auth slice, clears the instance, and
+         navigates to the user's profile. On
          `:error` there's nothing to do here — the form already shows it off the
          instance state. Clearing the instance also keeps the dispatch
          idempotent. The reply rides a map payload classified :sensitive — the
@@ -139,7 +154,19 @@
          token, just like login/register)."
    :sensitive [[:value :user :token]]}
   (fn [{:keys [db]} [_ {:keys [status value]}]]
-    (if (= :ok status)
+    (cond
+      ;; The session this save was issued for is gone — logged out, or a
+      ;; different account signed in while the PUT was in flight. Both replies
+      ;; are refused, not just the successful one: folding an :ok would restore
+      ;; the departed user's User and token (auth.cljs's `owns-session?`), and
+      ;; surfacing an :error would settle a form that belongs to nobody. Retire
+      ;; the instance and stop there — the write itself already happened on the
+      ;; server, and the next reader of that profile reads it fresh, because the
+      ;; mutation's `:invalidates` ran before this continuation did.
+      (not (auth/owns-session? db (get-in db [:settings-form :session-owner])))
+      {:fx [[:dispatch [:rf.mutation/clear {:instance settings-instance}]]]}
+
+      (= :ok status)
       (let [user (:user value)]
         ;; `store-session-db` is called DIRECTLY (not via a nested
         ;; `[:dispatch [:auth/store-session user]]`) — see that fn's doc
@@ -149,7 +176,8 @@
         {:db (auth/store-session-db db user)
          :fx [[:dispatch [:rf.mutation/clear {:instance settings-instance}]]
               [:dispatch [:rf.route/navigate {:to :realworld.profile/show :params {:username (:username user)}}]]]})
-      {})))
+
+      :else {})))
 
 (rf/reg-sub :settings/draft (fn [db _] (get-in db [:settings-form :draft])))
 

--- a/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
@@ -509,6 +509,90 @@
     (is (= "Beta" (:title (issue-by-id "srv-2"))) "the title reverted to its prior value (rollback)")
     (is (= demo-board (board-data)) "the board is restored to its pre-edit value")))
 
+;; ============================================================================
+;; 4b. THE TEMP-ID WINDOW — a card the server has not named yet (rf2-mmos)
+;; ============================================================================
+;;
+;; The board's overlapping writes are the example's headline: adding a card
+;; while a retitle saves, moving one while another is in flight. There is one
+;; thing it cannot offer, and it is a limit of IDENTITY rather than of
+;; concurrency. While a create is in flight its card wears the client-minted
+;; `tmp-N` placeholder, which addresses nothing on the server: a retitle or a
+;; move would `PUT /api/issues/tmp-N` at a row that does not exist, come back a
+;; success having changed nothing, and then lose its on-screen value too when
+;; the create's own reply swaps the placeholder for the server's row. So that
+;; card's own two controls wait for its create; every other card keeps them.
+;;
+;; This row reads the card's RENDERED props, because withholding a control is a
+;; view-level fact — the events remain perfectly dispatchable, and should: the
+;; view is the gate.
+
+(defn- card-hiccup
+  "Render `issue`'s card the way the board does, and return the hiccup. The
+   view's auto-injected `subscribe` binds to the surrounding frame, so this
+   runs inside `with-frame` (the same shape realworld-resources' route-link
+   egress row uses for `route-link-render`)."
+  [issue]
+  (rf/with-frame :rf/default
+    (linearlite.core/issue-card {:issue issue :editing nil})))
+
+(defn- hiccup-nodes
+  "Every hiccup node in `tree`. The branch test excludes MAPS deliberately:
+   descending into a props map would yield its entries, which are vectors too,
+   and a `[k {…}]` entry would then read as a node with props."
+  [tree]
+  (filter vector? (tree-seq #(and (coll? %) (not (map? %))) seq tree)))
+
+(defn- props-of
+  "The props map of the first node whose props satisfy `pred?`."
+  [tree pred?]
+  (some (fn [node]
+          (let [props (second node)]
+            (when (and (map? props) (pred? props)) props)))
+        (hiccup-nodes tree)))
+
+(defn- picker-props [card] (props-of card #(contains? % :disabled?)))
+(defn- title-props  [card] (props-of card #(re-find #"^title-" (str (:data-testid %)))))
+
+(deftest a-cards-own-controls-wait-until-the-server-has-named-it
+  (testing "examples/capabilities/resources/linearlite — while its create is in flight a
+            card carries only the client-minted tmp id, so ITS retitle and move
+            controls are withheld; a card the server has already named keeps
+            both, and the new card gets them the moment the create replies
+            (rf2-mmos)"
+    (load-board!)
+    (rf/dispatch-sync [:linearlite/create-issue "Gamma"])
+    (let [tmp    (issue-by-title "Gamma")
+          tmp-id (:id tmp)]
+      (is (string? tmp-id))
+      (is (true? (:pending? (mutation-state [:create tmp-id])))
+          "the create is in flight — the fact the card gates on")
+
+      (testing "the not-yet-named card withholds its own two controls"
+        (let [card (card-hiccup tmp)]
+          (is (true? (:disabled? (picker-props card)))
+              "the status picker is disabled while the id is a placeholder")
+          (is (nil? (:on-click (title-props card)))
+              "the title offers no retitle click while the id is a placeholder")
+          (is (string? (:title (title-props card)))
+              "and says why, rather than silently ignoring the click")))
+
+      (testing "every OTHER card stays live throughout"
+        (let [card (card-hiccup (issue-by-id "srv-1"))]
+          (is (false? (:disabled? (picker-props card)))
+              "a server-named card's status picker stays live")
+          (is (fn? (:on-click (title-props card)))
+              "a server-named card's title stays clickable")))
+
+      (testing "and the new card gets its controls the moment the create replies"
+        (reply-success! {:issues [{:id "srv-3" :title "Gamma" :status :backlog}]})
+        (let [card (card-hiccup (issue-by-id "srv-3"))]
+          (is (nil? (issue-by-id tmp-id)) "the placeholder is gone")
+          (is (false? (:disabled? (picker-props card)))
+              "the committed card's status picker is live")
+          (is (fn? (:on-click (title-props card)))
+              "the committed card's title is clickable"))))))
+
 
 ;; ============================================================================
 ;; 5. THE ARMED DEMO BACKEND — fail-next-write answers a REAL 503 (rf2-pqt5f)

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -133,6 +133,23 @@
 ;; survives the per-test reset.
 (reg-canned-success! :realworld.test/canned-success-empty {})
 
+;; A stub that PARKS the request instead of answering it: it records the args
+;; and returns, so the test decides when — and whether — the reply lands. The
+;; canned stubs above resolve inside the dispatch that issued the request, which
+;; is exactly the window a late-reply row needs to keep open.
+(def ^:private parked-managed-args (atom nil))
+
+(rf/reg-fx :realworld.test/park-managed
+  {:platforms #{:client :server}}
+  (fn [_frame-ctx args] (reset! parked-managed-args args) nil))
+
+(defn- reply-parked-success!
+  "Replay a parked request's `:on-success` with the transport's result appended
+   as the LAST arg — the shape the live managed-HTTP transport produces
+   (Spec 014 §Reply addressing)."
+  [args value frame]
+  (rf/dispatch-sync (conj (:on-success args) {:status :ok :value value}) {:frame frame}))
+
 (use-fixtures :each
   (rf.test-support/make-reset-runtime-fixture
     ;; EP-0002 (rf2-9o48ih): each helper spins its OWN top-level frame via
@@ -749,6 +766,78 @@
       (is (= :neutral (:state snap)))
       (is (false? (settings-machine-has-tag? f :form/invalid)))
       (is (not (contains? (get-in snap [:data :errors]) :email))))))
+
+(defn- park-a-settings-save!
+  "Sign `username` in, open Settings, edit the bio and submit — returning the
+   lowered PUT's args, still unanswered. The stub PARKS the request, so the test
+   owns the window between submitting and replying, which is the window Logout
+   lives in."
+  [f username]
+  (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
+                                          :token "jwt-1"
+                                          :username username
+                                          :bio nil
+                                          :image nil}]
+                    {:frame f})
+  (rf/dispatch-sync [:settings/load] {:frame f})
+  (rf/dispatch-sync [:settings/edit-field :bio "New bio"] {:frame f})
+  (reset! parked-managed-args nil)
+  (rf/dispatch-sync [:settings/submit] {:frame f})
+  @parked-managed-args)
+
+(defn- settings-logout-race-test []
+  ;; rf2-2ape. Logout stays live while the save is in flight — the button on
+  ;; this page and the navbar's — and the PUT is already on the wire, so its
+  ;; reply can land on a signed-out app. Nothing below the app rejects it: same
+  ;; frame, never superseded. :settings/submit-success is where the session
+  ;; question gets asked, and a reply from a session that has gone is refused.
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+                                 :fx-overrides {:rf.http/managed      :realworld.test/park-managed
+                                                :auth.session/persist :rf/no-op}})]
+    (let [save-args (park-a-settings-save! f "alice")]
+      (is (some? save-args) "the settings PUT lowered a request and parked")
+      (is (= :submitting (:state (settings-snapshot (rf/frame-state-value f))))
+          "the form is in flight")
+
+      ;; Log out while it is parked.
+      (rf/dispatch-sync [:auth/clear-session] {:frame f})
+      (is (nil? (get-in (rf/frame-state-value f) [:rf.db/app :auth :user])) "signed out")
+
+      ;; The server accepts the save and answers with a fresh User + token.
+      (reply-parked-success! save-args
+                             {:user {:email "alice@example.com" :token "jwt-2"
+                                     :username "alice" :bio "New bio" :image nil}}
+                             f)
+      (let [db (rf/frame-state-value f)]
+        (is (nil? (get-in db [:rf.db/app :auth :user]))
+            "the late reply does NOT restore the logged-out user")
+        (is (nil? (get-in db [:rf.db/app :auth :token]))
+            "the late reply does NOT restore the logged-out user's token")
+        (is (= :neutral (:state (settings-snapshot db)))
+            "the refused reply still settles the form out of :submitting (:reset)")
+        (is (= "" (get-in (settings-snapshot db) [:data :draft :bio]))
+            "and scrubs the departed user's draft on the way past")))))
+
+(defn- settings-account-switch-test []
+  ;; The same refusal covers an account SWITCH, which is the case a bare
+  ;; "is anybody signed in?" test would let through.
+  (with-new-frame [f (rf.frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+                                 :fx-overrides {:rf.http/managed      :realworld.test/park-managed
+                                                :auth.session/persist :rf/no-op}})]
+    (let [alice-args (park-a-settings-save! f "alice")]
+      (rf/dispatch-sync [:auth/clear-session] {:frame f})
+      (rf/dispatch-sync [:auth/store-session {:email "bob@example.com" :token "bob-jwt"
+                                              :username "bob" :bio nil :image nil}]
+                        {:frame f})
+      (reply-parked-success! alice-args
+                             {:user {:email "alice@example.com" :token "jwt-2"
+                                     :username "alice" :bio "New bio" :image nil}}
+                             f)
+      (let [db (rf/frame-state-value f)]
+        (is (= "bob" (get-in db [:rf.db/app :auth :user :username]))
+            "bob is still the signed-in user")
+        (is (= "bob-jwt" (get-in db [:rf.db/app :auth :token]))
+            "bob's token is untouched by the old account's reply")))))
 
 ;; ============================================================================
 ;; tags — route query helpers + the :realworld/tags machine
@@ -1529,7 +1618,11 @@
   (testing ":settings/form machine — failure path lands in :incorrect (rf2-6d3x)"
     (settings-failure-test))
   (testing ":settings/form machine — :submit-invalid / :edit cycle (rf2-6d3x)"
-    (settings-validation-test)))
+    (settings-validation-test))
+  (testing "a save that replies after logout does not restore the session (rf2-2ape)"
+    (settings-logout-race-test))
+  (testing "a save that replies after an account switch does not overwrite it (rf2-2ape)"
+    (settings-account-switch-test)))
 
 (deftest realworld-tags
   (testing "tag filter and feed-kind round-trip via :rf.route/query"

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -650,6 +650,57 @@
         (is (false? (rf/compute-sub [:editor/dirty?] (state-value f)))
             "the saved draft is no longer dirty")))))
 
+(defn- saved-tag-list
+  "The `:tagList` the save actually put on the wire — read off the lowered
+   request body rather than off the mutation params, because the defect this
+   pins lived BETWEEN the two."
+  [args]
+  (get-in args [:request :body :article :tagList]))
+
+(deftest editor-save-parses-its-tag-list-exactly-once
+  (testing "examples/real-apps/realworld_resources — the comma-separated tag string
+            is converted ONCE, at the form-to-mutation boundary; the
+            :realworld/save-article request builder passes the resulting vector
+            through untouched. A second parse would not throw under CLJS —
+            `clojure.string/split` coerces with `str` — it would send the
+            vector's PRINTED form as a single tag (rf2-0mxz)"
+    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      (rf/dispatch-sync [:editor/register-flow] {:frame f})
+
+      (testing "tags left blank → an EMPTY tag list, not the single tag \"[]\""
+        (rf/dispatch-sync [:editor/initialise] {:frame f})
+        (rf/dispatch-sync [:editor/edit-field :title "Untagged"] {:frame f})
+        (rf/dispatch-sync [:editor/edit-field :description "A desc"] {:frame f})
+        (rf/dispatch-sync [:editor/edit-field :body "Some body"] {:frame f})
+        (reset! last-managed-args nil)
+        (rf/dispatch-sync [:editor/submit] {:frame f})
+        (is (= [] (saved-tag-list @last-managed-args))
+            "a blank tag field sends an empty tagList")
+        ;; settle it, so the next arm's submit starts from an idle instance
+        (reply-success! @last-managed-args
+                        {:article {:slug "untagged" :title "Untagged" :description "A desc"
+                                   :body "Some body" :tagList []}}
+                        f))
+
+      (testing "\"clojure, SPA\" → two tags, not one serialized vector"
+        (rf/dispatch-sync [:editor/initialise] {:frame f})
+        (rf/dispatch-sync [:editor/edit-field :title "Tagged"] {:frame f})
+        (rf/dispatch-sync [:editor/edit-field :description "A desc"] {:frame f})
+        (rf/dispatch-sync [:editor/edit-field :body "Some body"] {:frame f})
+        (rf/dispatch-sync [:editor/edit-field :tagList "clojure, SPA"] {:frame f})
+        (reset! last-managed-args nil)
+        (rf/dispatch-sync [:editor/submit] {:frame f})
+        (is (= ["clojure" "SPA"] (saved-tag-list @last-managed-args))
+            "the tags reach the wire trimmed, split and in order")
+        (is (= #{:title :description :body :tagList}
+               (set (keys (get-in @last-managed-args [:request :body :article]))))
+            "the request body carries the four Article fields and nothing else")
+        (reply-success! @last-managed-args
+                        {:article {:slug "tagged" :title "Tagged" :description "A desc"
+                                   :body "Some body" :tagList ["clojure" "SPA"]}}
+                        f)))))
+
 ;; ============================================================================
 ;; 5. LOGOUT TEARDOWN — clear-scope + owner release
 ;; ============================================================================
@@ -1639,6 +1690,76 @@
           ":settings/replied navigates to the user's profile on :ok")
       (is (= "alice" (:username (route-params f)))
           "the profile route carries the saved username"))))
+
+;; ----------------------------------------------------------------------------
+;; …and the same continuation when the session it was issued for has gone
+;; (rf2-2ape). Logout stays live while the save is in flight — both the form's
+;; own button and the navbar's — and the PUT is already on the wire, so its
+;; reply can land on a signed-out app. Nothing below the app rejects it: the
+;; frame is the same one and the mutation instance is the same live instance,
+;; so the reply is accepted as current and reaches `:settings/replied`. The
+;; continuation is where the session question gets asked.
+;; ----------------------------------------------------------------------------
+
+(defn- park-a-settings-save!
+  "Sign `username` in, open Settings, edit the bio and submit — returning the
+   lowered PUT's args, still unanswered."
+  [f username]
+  (rf/dispatch-sync [:auth/store-session {:username username :email "a@b.c" :token "jwt"
+                                          :bio nil :image nil}] {:frame f})
+  (rf/dispatch-sync [:settings/load] {:frame f})
+  (rf/dispatch-sync [:settings/edit-field :bio "A brand new bio"] {:frame f})
+  (reset! last-managed-args nil)
+  (rf/dispatch-sync [:settings/submit] {:frame f})
+  @last-managed-args)
+
+(defn- settings-frame! []
+  (rf.frame/make-anon-frame-record!
+    {:url-bound?   true
+     :fx-overrides {:rf.nav/push-url :rf/no-op
+                    :realworld-resources.session/persist :rf/no-op}}))
+
+(deftest settings-reply-after-logout-does-not-restore-the-session
+  (testing "examples/real-apps/realworld_resources — a settings save that replies
+            AFTER the user logged out is refused by :settings/replied: the
+            departed user's User and token do not come back, and there is no
+            stale navigation to their profile (rf2-2ape)"
+    (with-new-frame [f (settings-frame!)]
+      (let [save-args (park-a-settings-save! f "alice")]
+        (is (some? save-args) "the settings PUT lowered a write")
+        ;; Logout, while the save is parked.
+        (rf/dispatch-sync [:auth/clear-session] {:frame f})
+        (rf/dispatch-sync [:rf.route/navigate {:to :realworld/home}] {:frame f})
+        (is (nil? (get-in (rf/app-db-value f) [:auth :user])) "signed out")
+        ;; The server accepts the save and answers with a fresh User + token.
+        (reply-success! save-args
+                        {:user {:username "alice" :email "a@b.c" :token "jwt2"
+                                :bio "A brand new bio" :image nil}}
+                        f)
+        (is (nil? (get-in (rf/app-db-value f) [:auth :user]))
+            "the late reply does NOT restore the logged-out user")
+        (is (nil? (get-in (rf/app-db-value f) [:auth :token]))
+            "the late reply does NOT restore the logged-out user's token")
+        (is (not= :realworld.profile/show (route-id f))
+            "no stale navigation to the departed user's profile")))))
+
+(deftest settings-reply-from-an-old-account-does-not-overwrite-the-new-one
+  (testing "examples/real-apps/realworld_resources — the same refusal covers an
+            account SWITCH: alice's parked save replying after bob has signed in
+            must not put alice's credentials over bob's session (rf2-2ape)"
+    (with-new-frame [f (settings-frame!)]
+      (let [alice-args (park-a-settings-save! f "alice")]
+        (rf/dispatch-sync [:auth/clear-session] {:frame f})
+        (rf/dispatch-sync [:auth/store-session {:username "bob" :email "b@b.c" :token "bob-jwt"
+                                                :bio nil :image nil}] {:frame f})
+        (reply-success! alice-args
+                        {:user {:username "alice" :email "a@b.c" :token "jwt2"
+                                :bio "A brand new bio" :image nil}}
+                        f)
+        (is (= "bob" (get-in (rf/app-db-value f) [:auth :user :username]))
+            "bob is still the signed-in user")
+        (is (= "bob-jwt" (get-in (rf/app-db-value f) [:auth :token]))
+            "bob's token is untouched by the old account's reply")))))
 
 (deftest follow-author-continuation-restales-the-detail-article
   (testing "examples/real-apps/realworld_resources — :ui/follow-author fires the follow


### PR DESCRIPTION
Three app-state defects in the example apps: rf2-2ape, rf2-0mxz, rf2-mmos.

## rf2-2ape — a settings reply that outlives its session restores its credentials

**Both** RealWorld twins carry it, independently: `realworld_http` (managed
HTTP) and `realworld_resources` (mutations). Logout stays live while an Update
Settings save is in flight — deliberately — and the PUT is already on the wire,
so its reply can land on a signed-out app. Neither completion asked whose
session it belonged to, so both folded the returned User and token back into the
auth slice and navigated to that user's profile, resurrecting exactly the
credentials the logout had cleared.

Nothing below the app catches it: the frame is the same one, the mutation
instance is the same live instance, and clearing a resource scope retires cached
reads rather than a write in flight. Each of those asks a question about the
*work*; this one is about the *session*.

A session-scoped write now records who it was issued for, and its continuation
refuses to act for any other identity — the app-level twin of the framework's
nav-token fence for route loaders. Success and error alike are refused, and each
app settles its own form: the resources app retires the mutation instance, the
HTTP app broadcasts `:reset`, which is the machine's only way out of
`:submitting` and scrubs the departed user's draft on the way past.

The two apps record the owner at the point each one can, and the difference is
forced by their shapes: the resources app seeds it where the settings slice is
built, so a mid-save detour away from the page and back cannot disown the save;
the HTTP app records it in the machine's `:begin-submit`, because its `:load` is
accepted only from `:neutral` and would leave a stale owner behind after any
earlier attempt.

## rf2-0mxz — the resources editor parsed its tag list twice

`:editor/submit` converted the form's comma-separated string into the
`[:vector :string]` the mutation's `:params-schema` declares, and the request
builder then ran `parse-tag-list` over that vector again. Under ClojureScript
that does not throw — `clojure.string/split` coerces with `str` first — so every
ordinary Publish or Update sent `[]` as the single tag `"[]"`, and
`["clojure" "SPA"]` as one tag spelled `["clojure" "SPA"]`. Editing an existing
article ran the same builder, so it corrupted tags that were previously fine.
The one conversion now stays at the form-to-mutation boundary.

The managed-HTTP twin does **not** have this defect: its `article-body` takes
the raw draft and parses once, correctly.

## rf2-mmos — Linearlite lost edits made before a card had a server id

A card whose create is in flight wears the client-minted `tmp-N` placeholder.
Retitling or moving it sent `PUT /api/issues/tmp-N` at a row the server has
never heard of; the write settled as a success having changed nothing, and the
create's own reply then replaced the placeholder card, taking the visible change
with it and leaving no failed indicator. That card's own two controls now wait
for its create; every other card stays live throughout. The limit is identity,
not concurrency, and the README's overlapping-writes paragraph now says so.

## Quality gates

Every number below is a captured exit code from the runner's own `$?`, redirected
to its own attempt-numbered file — never a figure the harness reported.

**Ran locally, green:**

| gate | exit | result |
|---|---|---|
| `node implementation/scripts/check-examples-compile.cjs` | **0** | all 58 swept builds compiled, zero warnings — `examples/linearlite`, `examples/realworld` and `examples/realworld-resources` among them |
| `npm run test:cljs` (shadow-cljs `:node-test`) | **0** | `Ran 11350 tests containing 57277 assertions. 0 failures, 0 errors.` |
| `python scripts/check_readme_links.py --ci` | **0** | the gate that owns `examples/**/README.md` (the docs slug gate's roots do not reach `examples/`) |

**Red-then-green, one gate, two runs.** With the three example fixes reverted to
`origin/main` and the new tests left in place, the same suite returns **exit 1**,
`18 failures, 0 errors` — and every failure is one of the five new rows:

```
6 FAIL in (realworld-settings)                                     <- rf2-2ape, managed-HTTP twin
3 FAIL in (settings-reply-after-logout-does-not-restore-the-session) <- rf2-2ape, resources twin
2 FAIL in (settings-reply-from-an-old-account-does-not-overwrite-the-new-one)
2 FAIL in (editor-save-parses-its-tag-list-exactly-once)            <- rf2-0mxz
5 FAIL in (a-cards-own-controls-wait-until-the-server-has-named-it) <- rf2-mmos
```

The fixes were then restored and verified by hashing the bytes rather than by
reading a diff.

**Left to CI, deliberately.** The changed-surface classifier arms twelve surfaces
off this diff; the browser lanes, bundle-isolation, prod-elision, adapter smokes,
the Xray feature matrix, mcp-conformance and the JVM tool suites are CI's, and CI
runs them in parallel where a local spine runs them one at a time. `scripts/check_fast_pr_gap.py --brief`
reports **99** required checks the local spine does not decide, so a local green
was never the merge criterion here.

One local run was **aborted by hand rather than failed**: `scripts/test-fast-pr.sh`
reached `FAIL JVM implementation/core` only because its JVM was killed at 58
minutes in that one tier, under a policy decision to stop running the full local
matrix. Its documentation tier (`mkdocs build --strict`) and its pinned clj-kondo
step had already passed inside that same run. No `implementation/**` source is in
this diff.
