### PR TITLE
fix(story,xray): three tooling repairs

### DIFF
--- a/tools/story/src/re_frame/story/review_dialog.cljc
+++ b/tools/story/src/re_frame/story/review_dialog.cljc
@@ -268,24 +268,36 @@
 ;; ---------------------------------------------------------------------------
 ;; CLJS-only: copy-to-clipboard shim
 ;;
-;; Wraps `navigator.clipboard.writeText`. Single helper both save-as
-;; flows consume — pre-extract each flow carried its own try/catch
-;; copy. Returns nil; failures are swallowed silently (no clipboard
-;; on JSDOM / older browsers / non-secure contexts is the expected
-;; case).
+;; Wraps `navigator.clipboard.writeText`. Single helper every save-as /
+;; copy flow consumes — pre-extract each flow carried its own try/catch
+;; copy.
+;;
+;; Returns a `js/Promise` of a BOOLEAN OUTCOME (rf2-jgn8): `true` only
+;; once the write has actually FULFILLED, `false` when there is no
+;; clipboard API (JSDOM / older browsers / a non-secure dev host), when
+;; the call throws, or when the write PROMISE REJECTS (the ordinary
+;; permission denial). It never rejects, so a fire-and-forget
+;; `:on-copy` caller cannot leak an unhandled rejection, and a caller
+;; that wants to report completion — `re-frame.story.ui.share` — can
+;; await the real outcome instead of assuming one. Every caller still
+;; has the snippet on screen for manual copy.
 ;; ---------------------------------------------------------------------------
 
 #?(:cljs
    (defn copy-to-clipboard!
-     "Copy `text` to the system clipboard via the navigator API.
-     No-op on hosts without `navigator.clipboard`. Swallows failures
-     silently — the modal still surfaces the snippet for manual copy."
+     "Copy `text` to the system clipboard via the navigator API. Returns a
+     `js/Promise` resolving `true` iff the write FULFILLED, else `false`
+     (no `navigator.clipboard`, a throw, or a rejected `writeText` — the
+     ordinary permission denial). Never rejects; the modal still surfaces
+     the snippet for manual copy on a `false`."
      [text]
      (try
-       (when (and (exists? js/navigator) (.-clipboard js/navigator))
-         (.writeText (.-clipboard js/navigator) text))
-       (catch :default _ nil))
-     nil))
+       (if-let [clipboard (and (exists? js/navigator) (.-clipboard js/navigator))]
+         (-> (.writeText clipboard text)
+             (.then (fn [_] true))
+             (.catch (fn [_] false)))
+         (js/Promise.resolve false))
+       (catch :default _ (js/Promise.resolve false)))))
 
 ;; ---------------------------------------------------------------------------
 ;; CLJS-only: presentational modal renderer

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -552,12 +552,27 @@
   (when (exists? js/window)
     (some-> js/window .-location .-href)))
 
-(defn- copy-text!
-  "Copy `text` to the clipboard via the shared review-dialog shim, then
-  flash the `cmd` confirmation."
+(defn copy-text!
+  "Copy `text` to the clipboard via the shared review-dialog shim and flash
+  the `cmd` confirmation ONLY once the write has actually fulfilled.
+
+  rf2-jgn8: the previous body called the shim and marked copied on the very
+  next line, so a missing `navigator.clipboard` (an insecure dev host, JSDOM),
+  a denied permission, or a still-pending write all displayed a false
+  'copied ✓'. The shim now resolves a boolean outcome, so the text commands
+  get the SAME honesty the screenshot path already had — `mark-error!` with a
+  human reason on a no-op or a rejection, and the dialog keeps the snippet /
+  URL field on screen as the manual-copy fallback.
+
+  Returns the `js/Promise` of the outcome (never rejects) so tests can await
+  it; the `:on-click` callers are fire-and-forget."
   [cmd text]
-  (rf.story.review-dialog/copy-to-clipboard! text)
-  (mark-copied! cmd))
+  (-> (rf.story.review-dialog/copy-to-clipboard! text)
+      (.then (fn [ok?]
+               (if ok?
+                 (mark-copied! cmd)
+                 (mark-error! cmd "clipboard write did not complete — copy it by hand"))
+               (boolean ok?)))))
 
 ;; ---- screenshot ----------------------------------------------------------
 

--- a/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
@@ -448,3 +448,94 @@
                       "no false copied ✓ for the failed screenshot egress"))))
             (.finally
               (fn [] (restore! prev) (done))))))))
+
+;; ---- rf2-jgn8 — TEXT copy reports completion, never assumes it -----------
+;;
+;; `copy-text!` backs Copy URL / Copy EDN / Copy static-build command. It used
+;; to call the shared clipboard shim and `mark-copied!` on the very next line,
+;; so an absent `navigator.clipboard` (an insecure dev host, JSDOM), a denied
+;; permission, or a merely PENDING write all displayed "copied ✓". These pin
+;; the same honesty the screenshot path above already had.
+
+(defn- fake-navigator-with-write-text
+  "A `js/navigator.clipboard` whose `writeText` records the text and returns
+  `outcome-fn` applied to it (a resolved or rejected Promise)."
+  [recorder outcome-fn]
+  #js {:clipboard
+       #js {:writeText (fn [text]
+                         (reset! recorder text)
+                         (outcome-fn text))}})
+
+(deftest copy-text-marks-copied-only-after-the-write-fulfils
+  (testing "rf2-jgn8 — a fulfilled writeText flashes :copied and no error"
+    (async done
+      (let [written (atom nil)
+            prev    (install-globals!
+                      {"navigator" (fake-navigator-with-write-text
+                                     written (fn [_] (js/Promise.resolve js/undefined)))})]
+        (-> (rf.story.ui.share/copy-text! :share-url "https://example.test/?variant=x")
+            (.then (fn [ok?]
+                     (is (true? ok?) "the write resolved → success")
+                     (is (= "https://example.test/?variant=x" @written)
+                         "the text actually reached the clipboard API")
+                     (let [snap (rf.story.ui.share/dialog-state-snapshot)]
+                       (is (= :share-url (:copied snap)))
+                       (is (nil? (:error snap)) "no error on the success path"))))
+            (.finally (fn [] (restore! prev) (done))))))))
+
+(deftest copy-text-no-clipboard-api-reports-error-not-false-copied
+  (testing "rf2-jgn8 (adversarial) — no navigator.clipboard at all (an insecure
+            dev host / JSDOM): copy-text! must record an HONEST :error and must
+            NOT flash :copied. This FAILS against the old fire-and-forget body."
+    (async done
+      (let [prev (install-globals! {"navigator" #js {}})]
+        (-> (rf.story.ui.share/copy-text! :copy-edn "(reg-variant …)")
+            (.then (fn [ok?]
+                     (is (false? ok?) "no clipboard API → failure outcome")
+                     (let [snap (rf.story.ui.share/dialog-state-snapshot)]
+                       (is (not= :copy-edn (:copied snap))
+                           "MUST NOT report success on a no-op (the false-success bug)")
+                       (is (= :copy-edn (:cmd (:error snap)))
+                           "records an honest error for THIS command")
+                       (is (string? (:reason (:error snap)))
+                           "the error carries a human reason"))))
+            (.finally (fn [] (restore! prev) (done))))))))
+
+(deftest copy-text-rejected-write-reports-error-not-false-copied
+  (testing "rf2-jgn8 (adversarial) — the ordinary PERMISSION DENIAL: the API is
+            present but writeText REJECTS. The old body never observed the
+            rejected Promise, so it showed copied and leaked an unhandled
+            rejection."
+    (async done
+      (let [prev (install-globals!
+                   {"navigator" (fake-navigator-with-write-text
+                                  (atom nil)
+                                  (fn [_] (js/Promise.reject (js/Error. "NotAllowedError"))))})]
+        (-> (rf.story.ui.share/copy-text! :static-build "npm run story:build")
+            (.then (fn [ok?]
+                     (is (false? ok?) "a rejected write → failure outcome")
+                     (let [snap (rf.story.ui.share/dialog-state-snapshot)]
+                       (is (not= :static-build (:copied snap))
+                           "MUST NOT report success when the write was refused")
+                       (is (= :static-build (:cmd (:error snap)))))))
+            (.finally (fn [] (restore! prev) (done))))))))
+
+(deftest copy-text-does-not-mark-copied-while-the-write-is-pending
+  (testing "rf2-jgn8 — a write that has NOT settled yet must leave the row
+            un-copied; success appears only on fulfilment."
+    (async done
+      (let [resolve-fn (atom nil)
+            prev       (install-globals!
+                         {"navigator" (fake-navigator-with-write-text
+                                        (atom nil)
+                                        (fn [_] (js/Promise. (fn [res _] (reset! resolve-fn res)))))})
+            p          (rf.story.ui.share/copy-text! :share-url "https://example.test/")]
+        (is (not= :share-url (:copied (rf.story.ui.share/dialog-state-snapshot)))
+            "no success flash while the clipboard write is still pending")
+        (@resolve-fn js/undefined)
+        (-> p
+            (.then (fn [ok?]
+                     (is (true? ok?))
+                     (is (= :share-url (:copied (rf.story.ui.share/dialog-state-snapshot)))
+                         "success appears once the write fulfils")))
+            (.finally (fn [] (restore! prev) (done))))))))

--- a/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
@@ -7,7 +7,7 @@
   `re-frame.story-review-dialog-test` arm; this file adds the CLJS-
   only hiccup-renderer assertions that the recorder + save-variant
   flows both depend on."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer [async] :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [re-frame.story.predicates :as rf.story.predicates]
             [re-frame.story.review-dialog :as rf.story.review-dialog]))
@@ -186,8 +186,17 @@
       (is (str/includes? flat ":story.x/example")))))
 
 (deftest copy-to-clipboard!-safe-on-node
-  (testing "the shared copy helper is callable + no-ops without a clipboard API"
-    (is (nil? (rf.story.review-dialog/copy-to-clipboard! "anything")))))
+  (testing "rf2-jgn8 — the shared copy helper is callable without a clipboard
+            API and resolves an HONEST false outcome (it used to return nil,
+            which every caller read as success)"
+    (async done
+      (let [p (rf.story.review-dialog/copy-to-clipboard! "anything")]
+        (is (instance? js/Promise p) "the shim exposes a completion result")
+        (-> p
+            (.then (fn [ok?]
+                     (is (false? ok?)
+                         "no navigator.clipboard on node → not copied")))
+            (.finally done))))))
 
 ;; ---- indent-after (snippet-format helper, rf2-zs0w4) ---------------------
 

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -219,7 +219,12 @@ stacked sections:
    `:stale-at` / `:invalidated-at`, generation, attempt, request id,
    current work id, active owners, owner count, tags, GC eligibility.
    `:stale?` / `:has-data?` are **derived** here (Spec 016 §Status
-   semantics — never stored facts). **The infinite-feed surface (EP-0021,
+   semantics — never stored facts), by the SAME rule
+   `re-frame.resources.state/has-data?` applies: an `:infinite?` entry is
+   `:has-data?` only once its page vector carries **≥1 accumulated page**
+   (the seeded-empty `[]` is a first load, so the §4 live rollup reads
+   `:loading`, never `:fresh`); a scalar entry is `:has-data?` iff its
+   `:data` is non-nil. **The infinite-feed surface (EP-0021,
    R1/R2/R3):** an `:infinite?` entry additionally carries `:page-count`
    (the accumulated page-vector length), the runtime-owned `:cursor`
    (the `:next-page-param` — egress-projected, since a cursor can carry

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -575,9 +575,21 @@
   `:data` is no-data; a value already redacted/elided UPSTREAM (`:rf/redacted`
   / `:rf.size/large-elided`) means data WAS present (the sentinel replaced a
   real value), so it counts as has-data (rf2-tgm1xu — the egress redaction
-  of a payload must not flip the derived `:has-data?` fact)."
-  [data]
-  (some? data))
+  of a payload must not flip the derived `:has-data?` fact).
+
+  EP-0021 R1 (rf2-o5iv): an `:infinite?` feed's `:data` is the ordered PAGE
+  VECTOR, seeded EMPTY (`[]`) before page 0 loads — an empty page vector is
+  NO usable data, so the feed reads first-load (`:loading`), not `:fresh`.
+  This mirrors the SINGLE canonical derivation in
+  `re-frame.resources.state/has-data?`; the projection must agree with it or
+  the row contradicts its own `:status` / `:page-count`. The page-vector rule
+  applies only to an ACTUAL vector: an infinite payload already collapsed to
+  a redaction/elision sentinel upstream keeps the `some?` reading above."
+  [entry]
+  (let [data (:data entry)]
+    (if (and (:infinite? entry) (sequential? data))
+      (boolean (seq data))
+      (some? data))))
 
 (defn instance-row
   "Project ONE live cache entry `[scoped-key entry]` into a render-safe
@@ -641,7 +653,7 @@
               :params         (summarize (eg raw-params :params))
               :status         (:status entry)
               :stale?         (derive-stale? entry now-ms)
-              :has-data?      (entry-has-data? raw-data)
+              :has-data?      (entry-has-data? entry)
               :data           (summarize (eg raw-data :data))
               :error          (when (:error entry) (summarize (eg (:error entry) :error)))
               :refresh-error  (when (:refresh-error entry) (summarize (eg (:refresh-error entry) :refresh-error)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -1312,3 +1312,80 @@
     ;; nil params AND a scope that no entry carries → no match
     (is (empty? (h/select-raw-entries nilparams-entries
                   {:scope :rf.scope/global :params nil})))))
+
+;; ---- (5c) rf2-o5iv — an EMPTY infinite feed is NOT has-data ---------------
+;;
+;; `rf.resources.state/has-data?` (Spec 016 §Status semantics, EP-0021 R1)
+;; defines an infinite feed as has-data ONLY once it carries ≥1 accumulated
+;; page: the seeded-empty page vector `[]` is a FIRST LOAD, not a refresh.
+;; The Xray projection derives the same fact and must agree — an empty feed
+;; reporting `:has-data? true` made `resource-liveness` skip `:loading` and
+;; call a never-loaded feed `:fresh`, contradicting its own `:status :loading`
+;; / `:page-count 0` on the same row.
+
+(deftest empty-infinite-feed-has-no-data-test
+  (let [empty-feed  {:resource/id     :feed/articles
+                     :resource/key    [session-scope :feed/articles {}]
+                     :status          :loading
+                     :infinite?       true
+                     :data            []          ; seeded-empty page vector
+                     :page-params     []
+                     :next-page-param nil
+                     :active-owners   #{[:feed/opened "feed"]}}
+        row         (h/instance-row [(rf.resources.state/key-id [session-scope :feed/articles {}])
+                                     empty-feed]
+                                    now)]
+    (testing "a seeded-empty page vector is NO usable data (EP-0021 R1)"
+      (is (= 0 (:page-count row)))
+      (is (false? (:has-data? row))
+          "an infinite feed with zero accumulated pages has not loaded anything")
+      (is (= :loading (:status row))
+          "the row's own status agrees — the projection no longer self-contradicts"))
+    (testing "the route/resource graph's live rollup reads FIRST LOAD, not :fresh"
+      ;; the rollup is private; exercise it through the public route-graph
+      ;; projection, which is how the panel reads it.
+      (let [graph (h/project-route-graph
+                    {:route/feed {:path      "/feed"
+                                  :resources [{:resource :feed/articles :blocking? false}]}}
+                    {:instance-rows [row]
+                     :work-rows     [{:resource-id :feed/articles :terminal? false}]})
+            live  (:live (first (:resources (first graph))))]
+        (is (false? (:has-data? live)))
+        (is (= :loading (:freshness live))
+            "active work + no accumulated page ⇒ :loading, never :fresh")))
+    (testing "ONE empty page is still a loaded page — has-data"
+      (let [one-page (assoc empty-feed :data [[]] :status :loaded)
+            row'     (h/instance-row [(rf.resources.state/key-id [session-scope :feed/articles {}])
+                                      one-page]
+                                     now)]
+        (is (= 1 (:page-count row')))
+        (is (true? (:has-data? row'))
+            "an accumulated page that happens to be empty is data")))
+    (testing "a SCALAR entry keeps nil/non-nil semantics — `[]` is still data"
+      (let [scalar {:resource/id  :article/by-slug
+                    :resource/key [session-scope :article/by-slug {:slug "x"}]
+                    :status       :loaded
+                    :data         []}
+            row'   (h/instance-row [(rf.resources.state/key-id [session-scope :article/by-slug {:slug "x"}])
+                                    scalar]
+                                   now)]
+        (is (true? (:has-data? row'))
+            "a non-infinite resource whose value IS an empty vector has data")
+        (is (false? (:has-data? (h/instance-row
+                                  [(rf.resources.state/key-id [session-scope :article/by-slug {:slug "y"}])
+                                   (assoc scalar :data nil
+                                          :resource/key [session-scope :article/by-slug {:slug "y"}])]
+                                  now)))
+            "a nil scalar payload is still no-data")))
+    (testing "an UPSTREAM-redacted/elided payload still reads has-data
+              (rf2-tgm1xu — the sentinel replaced a real value)"
+      (doseq [sentinel [:rf/redacted :rf.size/large-elided]]
+        (let [redacted {:resource/id  :article/by-slug
+                        :resource/key [session-scope :article/by-slug {:slug "s"}]
+                        :status       :loaded
+                        :data         sentinel}
+              row'     (h/instance-row [(rf.resources.state/key-id [session-scope :article/by-slug {:slug "s"}])
+                                        redacted]
+                                       now)]
+          (is (true? (:has-data? row'))
+              (str sentinel " means data WAS present — never flipped to no-data")))))))


### PR DESCRIPTION
Two of the three dispatched beads are fixed; the third is untouched and stays open.

## rf2-o5iv — empty infinite feeds reported as having fresh data (P3, tools/xray/panels) — FIXED

Premise verified at source. `resources_helpers.cljc` derived `:has-data?` with a bare
`(some? data)`, so an `:infinite?` feed still carrying its seeded-empty page vector `[]`
read as having data. The private `resource-liveness` rollup then skipped its `:loading`
branch and called a never-loaded feed `:fresh` — on a row that simultaneously carried
`:status :loading` and `:page-count 0`. Reproduced as a failing test before the fix:
`:has-data?` `true` and `:freshness` `:fresh` on an empty feed.

The repair derives the fact from the ENTRY rather than the payload alone, mirroring the
single canonical rule in `re-frame.resources.state/has-data?` (EP-0021 R1): an infinite
feed has data only with >=1 accumulated page. Scalar `nil`/non-nil semantics are unchanged,
and the page-vector branch is guarded on an actual `sequential?` so an upstream-collapsed
`:rf/redacted` / `:rf.size/large-elided` sentinel keeps the rf2-tgm1xu `some?` reading.

Spec: `tools/xray/spec/024-Resources-Panel.md` §2 now states the derivation rule at the
Xray surface (it previously deferred to Spec 016 without spelling out the infinite case,
which is exactly where the projection had drifted).

New tests cover the four acceptance cases: empty page vector => no data + `:loading`
rollup (read through the public `project-route-graph`, since the rollup itself is private);
one empty page `[[]]` => has data; a scalar `[]` => still has data; a `nil` scalar => no
data; and both redaction sentinels => still has data.

## rf2-jgn8 — text clipboard reports completion it never observed (P3, tools/story) — FIXED

Premise verified at source. `share.cljs` `copy-text!` called
`review-dialog/copy-to-clipboard!` and `mark-copied!` on the very next line, for all three
text commands (Copy URL, Copy EDN, Copy static-build command). The shim no-opped without
`navigator.clipboard`, returned `nil` unconditionally, and never observed a rejected
`writeText` promise.

The shared shim now resolves a boolean OUTCOME — `true` only on fulfilment, `false` on an
absent API, a throw, or a rejection — and never rejects, so the eight other fire-and-forget
`:on-copy` callers stay safe from unhandled rejections. `copy-text!` awaits it and routes a
failure through the existing `mark-error!` path, giving the text commands the same honesty
the screenshot path (rf2-ehc5bq) already had. Manual-copy affordances and the trusted-local
unredacted sharing policy are untouched; no privacy gating added. Screenshot behaviour is
unchanged.

## rf2-shx4 — realize authored network fixtures (P2, tools/story/runtime) — NOT ATTEMPTED

Untouched; the bead stays OPEN and now carries the verified trace as a note. The premise was
re-checked at this branch's base rather than taken from the review snapshot, and it holds:
`install-managed-request-stubs!` has exactly one executable call site in `tools/story/src`
(`artifact.cljc` `with-network-stubs!`, the replay path); `[:world :network]` is read only by
`determinism.cljc` when materializing an artifact; registered phase 0 passes only the decorator
stack and the `:sensitive`/`:large` classification to `frames/allocate!`, which has no arity for
the compiled `:fx-overrides`; and inline phase 0 does pass that override while nothing ever
registers its target.

It was not attempted because the acceptance's isolation clause is a DESIGN call rather than an
implementation detail. `plan/lower-network` lowers to the fixed global target
`:rf.http/managed-test-stub`, and the installer re-registers that one id with a route map closed
over at install time (LIFO snapshot/restore, not a merge) — so two concurrently mounted variants
mean the second one's routes answer for both, exactly the silent overwrite the bead forbids. A
fix that installs without solving that ships the regression as the repair. Both routes to
per-frame dispatch leave this dispatch's scope: minting a per-variant stub id changes the
recorded `:fx-decisions` target that spec/017 and the artifact replay path pin, and making
`stub-handler` resolve its map from the calling frame is a seam change in
`implementation/http`. The bead note names both and recommends the next dispatch carry the
ruling.

## Quality gates

| gate | command | captured exit | result |
|---|---|---|---|
| rf2-o5iv failing-first (RED) | `clojure -M:test -n day8.re-frame2-xray.panels.resources-helpers-cljs-test` | `1` | 29 tests / 340 assertions, 3 failures + 1 error — `:has-data?` `true`, `:freshness` `:fresh` |
| rf2-o5iv failing-first (GREEN) | same, after the fix | `0` | 29 tests / 341 assertions, 0 failures, 0 errors |
| tools/xray suite | `cd tools/xray && clojure -M:test` | `0` | 1276 tests / 6118 assertions, 0 failures, 0 errors |
| tools/story suite | `cd tools/story && clojure -M:test` | `0` | 1903 tests / 7010 assertions, 0 failures, 0 errors |

Every exit code above is the runner's own `$?`, captured to a per-worktree, per-attempt
`.exit` file on the same command line as the redirect; nothing was piped through a filter.

**Left to CI, and stated rather than assumed: the rf2-jgn8 tests were NOT run locally.**
They are CLJS (`share.cljs` is Reagent/DOM-only, and the shim's body is a `:cljs` reader
branch), and the only runner for them is the consolidated `npm run test:cljs` node-test
build, which the dispatch explicitly excluded on cost. So rf2-jgn8 has failing-first tests
written to the established rf2-ehc5bq async pattern — four of them, including the pending-write
and rejected-write adversarial cases that fail against the old body — but no locally observed
red or green. CI's `cljs` job is the first thing to read on this PR. The tools/story JVM
suite above does cover that `review_dialog.cljc` still reads and compiles on the JVM arm,
which is the only JVM-visible half of that change.

Also left to CI: the whole 87-check matrix — lint, docs, portability, the examples-compile
sweep, browser/adapter smokes and the Xray feature-matrix gate.

## Verification by hand

`spec/024-Resources-Panel.md`'s edit is prose inside an existing numbered list item; no
table columns and no link targets or anchors were added or moved, so neither
`check_doc_slugs.py` nor `check_readme_links.py` has anything new to grade. Read back in
place to confirm the list numbering and indentation still hold.

## Fence

`spec/API.md`, `spec/api-manifest*.edn` and
`tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs` were not touched;
no fix needed one. `copy-text!` moved from private to public within `re-frame.story.ui.share`,
which is a tool-internal namespace and not a `re-frame.core` facade export, so no manifest
surface moved.

  Per the repository's Git Conventions the AI-attribution trailers ("Co-Authored-By: Claude",
  "Generated with Claude Code") are deliberately absent from every commit here and from this
  description.

