### PR TITLE
fix(mcp): four MCP tooling repairs

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -310,6 +310,19 @@ first. Cache lifetime is the MCP server process (= one MCP
 session per the [persistent-socket principle](Principles.md#single-persistent-nrepl-socket));
 no cross-process leak, no manual invalidation.
 
+**A cache-hit is only ever claimed for a payload that was DELIVERED**
+(rf2-gov3). The cache check runs before the wire cap, so a response can
+be hashed and then replaced by `:rf.mcp/overflow` — withheld, never
+sent. Reporting a hit against that hash would tell the agent to re-use
+bytes it never received, and would erase the actionable size-limit
+diagnosis on every repeat of the same oversized read. The cap therefore
+withdraws the candidate entry when it withholds the payload: two
+identical oversized reads both return the honest overflow marker (the
+recovery is a larger `max-tokens`, which is a different cache key), and
+a delivered under-cap payload keeps its entry and the fast
+hit-before-cap path. An overflow marker is never itself cached as if it
+were the source payload.
+
 Action tools (`dispatch`, `eval-cljs`, `tail-build`)
 bypass the cache — their return value is the
 result of an action,
@@ -1639,10 +1652,15 @@ the injection.
 `restore-epoch`). Default OFF.
 
 **`db` is EDN data, not host source**: parsed as EDN and emitted into
-the runtime call via the normal `pr-str` path (no `rt-raw` splice) —
-the same injection-closing posture `dispatch` takes (rf2-vflrg). A
-prompt-injected `(println :pwn)` string reads as a list literal (data),
-never executed.
+the runtime call as a `(quote <datum>)` literal (no `rt-raw` splice) —
+the same injection-closing posture `dispatch` takes (rf2-vflrg,
+rf2-olqo). A prompt-injected `(println :pwn)` string reads as a list
+literal (data), never executed. The `pr-str` path this argument used to
+take was not that guarantee: printing renders a value as SOURCE, so a
+list inside the app-db value was a call and a symbol a name lookup, and
+a value shaped like one of the emitter's own tagged vectors was spliced
+in as raw source. Quoting is the emission that evaluates to its datum
+for every EDN value (rf2-j2wz is the same repair on `dispatch`).
 
 **Args**: `db` (string, required — EDN app-db value), `frame` (string,
 e.g. `":foo"`; defaults to the operating frame), `build` (string).

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/cache.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/cache.cljs
@@ -239,6 +239,16 @@
   (swap! state update :order touch k)
   (get-in @state [:entries k]))
 
+(defn forget!
+  "Drop the entry for `k` — both the entry and its LRU slot. The inverse
+  of [[store!]], for the case where the payload whose hash was recorded
+  never reached the caller."
+  [k]
+  (swap! state
+         (fn [{:keys [entries order]}]
+           {:entries (dissoc entries k)
+            :order   (filterv #(not= % k) order)})))
+
 (defn size
   "Current number of cached entries — exposed for tests and for the
   health surface."
@@ -331,6 +341,32 @@
         (do (store! k (cond-> {:hash h :sent-at now :tool tool}
                         (some? precheck-hash) (assoc :precheck-hash precheck-hash)))
             result-js)))))
+
+(defn withhold!
+  "Undo the identity [[apply-cache]] just recorded, because the payload it
+  hashed was never delivered to the caller (rf2-gov3).
+
+  A `:rf.mcp/cache-hit` is an instruction: *re-use the response you
+  already have*. `apply-cache` runs BEFORE the wire cap, so on a miss it
+  stores the full response's hash and `:sent-at` and then the cap can
+  replace that response with `:rf.mcp/overflow` — a payload the caller
+  never saw. The next identical read matched the stored hash and was told
+  to re-use bytes that were never sent, and the actionable size-limit
+  diagnosis was erased on every repeat.
+
+  Dropping the candidate entry is the narrow repair: the fast
+  hit-before-cap path is untouched for genuinely delivered responses (an
+  under-cap payload leaves its entry standing), and no overflow marker is
+  ever cached as if it were the source payload. The whole entry goes,
+  `:precheck-hash` included — that hash short-circuits a future call to
+  the very same cache-hit marker, so retaining it would reopen the same
+  false claim through the pre-eval door.
+
+  Takes the same `cache-opts` map `apply-cache` does. A no-op when the
+  cache is off or the tool is not cacheable, since nothing was stored."
+  [{:keys [tool args enabled? build]}]
+  (when (and enabled? (cacheable? tool))
+    (forget! (cache-key tool args build))))
 
 ;; ---------------------------------------------------------------------------
 ;; Precheck — decide cache-hit BEFORE running the tool.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
@@ -262,9 +262,21 @@
 (defn- apply-cap-step
   "Step 3 — wire-boundary token-budget enforcement. When
   `:result` exceeds the per-call cap, replaces it with the
-  `:rf.mcp/overflow` marker."
-  [{:keys [result cap-opts] :as ctx}]
-  (assoc ctx :result (cap/apply-cap result cap-opts)))
+  `:rf.mcp/overflow` marker.
+
+  A replaced payload was NOT delivered, so the identity step 2 recorded
+  for it cannot underwrite a future `:rf.mcp/cache-hit` — that marker
+  tells the caller to re-use bytes it would never have received, and it
+  also erases the actionable overflow diagnosis on every repeat of the
+  same oversized read. So the cap withdraws the candidate entry here
+  (rf2-gov3). Only the withheld case pays anything: `apply-cap` returns
+  the identical result object when the payload fits, and a delivered
+  payload keeps its entry and the fast hit-before-cap path with it."
+  [{:keys [result cap-opts cache-opts] :as ctx}]
+  (let [capped (cap/apply-cap result cap-opts)]
+    (when-not (identical? capped result)
+      (cache/withhold! cache-opts))
+    (assoc ctx :result capped)))
 
 (defn- isError? [result-js]
   (and (some? result-js)
@@ -290,7 +302,9 @@
   Cache before cap is the right order: a cache hit emits a sub-100-
   byte marker that's trivially under any reasonable cap, so flipping
   the order would never change behaviour but would waste a token
-  walk on the hit path.
+  walk on the hit path. The cost of that order is that step 2 records
+  an identity for a payload step 3 may withhold, which `apply-cap-step`
+  settles by withdrawing that entry (rf2-gov3) — see its docstring.
 
   `:skip-when?` is the per-step skip predicate: when it returns true the
   step is skipped and the chain continues to the next step's own

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/replace_app_db.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/replace_app_db.cljs
@@ -21,11 +21,24 @@
   ## db is EDN data, not host source
 
   The `db` arg is parsed as EDN and emitted into the runtime call via
-  the normal `pr-str` path (NO `rt-raw` splice) — the same
-  injection-closing posture `dispatch` takes. A
-  prompt-injected `(println :pwn)` string is data, not code; it would
-  read as a symbol/list literal and be injected verbatim (and almost
-  certainly rejected by the frame's app-schema), never executed.
+  [[re-frame2-pair-mcp.tools.eval-form/rt-quote]] — the literal-data
+  emission path (NO `rt-raw` splice) — the same injection-closing
+  posture `dispatch` takes. A prompt-injected `(println :pwn)` string
+  is data, not code; it reads as a list literal and is injected
+  verbatim (and almost certainly rejected by the frame's app-schema),
+  never executed.
+
+  The `pr-str` path this used to take was NOT that guarantee (rf2-olqo,
+  the sibling of rf2-j2wz on this tool). Printing a value renders it as
+  SOURCE, and source is read as code: a list inside the app-db value is
+  a function call and a symbol is a name lookup, so the value the
+  runtime received was whatever those evaluated to rather than the
+  datum the caller sent — and a value shaped like one of the emitter's
+  own tagged vectors was recognised as IR and its payload spliced in as
+  raw source. `(quote <datum>)` evaluates to its datum for every EDN
+  value, which is the whole of what the paragraph above promises. The
+  `frame` argument is an internally-composed keyword and stays on the
+  default path.
 
   The injection can fail for the documented `:rf.epoch/*` reasons
   (no-such-frame, replace-during-drain, schema-mismatch — see
@@ -87,11 +100,16 @@
         (let [new-db payload
               ;; app-db-reset!'s runtime arglist is ([v] [v frame-id]) —
               ;; the value is FIRST, the frame is the optional SECOND.
-              ;; The value rides the normal pr-str arg path (data, not
-              ;; rt-raw source).
+              ;; The value is EXTERNAL EDN off the wire, so it rides
+              ;; `rt-quote` — the literal-data emission path — and not
+              ;; the default `pr-str` arg path, which prints a value as
+              ;; source and so re-evaluates any list or symbol inside it
+              ;; (rf2-olqo; rf2-j2wz is the same defect on `dispatch`).
+              ;; `frame` is composed here, not supplied, so it stays on
+              ;; the default path.
               call (if frame
-                     (ef/rt-call 'app-db-reset! new-db frame)
-                     (ef/rt-call 'app-db-reset! new-db))
+                     (ef/rt-call 'app-db-reset! (ef/rt-quote new-db) frame)
+                     (ef/rt-call 'app-db-reset! (ef/rt-quote new-db)))
               form (ef/emit call)]
           ;; The signalled prelude lands `signal-runtime!`
           ;; between `ensure-runtime!` and the `app-db-reset!` eval so the

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -1081,7 +1081,9 @@
      ["app-db-reset!"             {:ok? true :frame :rf/default}]
      [:default                    nil]]
     :fixture/eval-form-must-contain
-    ["app-db-reset! {:counter 0}"
+    ;; rf2-olqo — the `db` value is external EDN, so it rides the
+    ;; literal-data emission `(quote <datum>)`, not the print path.
+    ["app-db-reset! (quote {:counter 0})"
      ;; The raw-state tap posture is signalled (the unit suite pins it
      ;; lands BEFORE app-db-reset!; the corpus pins it IS emitted on the
      ;; write path with the gate-OFF posture).

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
@@ -376,41 +376,103 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Phase ordering: cache hit BEFORE cap. The hit marker is sub-100
-;; bytes; even with an absurdly tight cap the marker survives because
-;; the cap walk sees the small marker, not the original oversized
-;; payload. Flipping the order would force the cap to walk the full
-;; (potentially massive) original payload before the cache could
-;; replace it.
+;; Phase ordering: cache hit BEFORE cap, for a payload that was actually
+;; DELIVERED. The hit marker is sub-100 bytes, so it survives the cap
+;; walk; flipping the order would force the cap to walk the full
+;; (potentially massive) original payload before the cache could replace
+;; it. This arm keeps that optimisation pinned.
 ;; ---------------------------------------------------------------------------
 
-(deftest cache-hit-bypasses-cap-walk
+(deftest delivered-payload-still-gets-the-fast-cache-hit
   (async done
-    ;; Cap = 200 tokens: the original payload (~2000 tokens) overflows,
-    ;; but the cache-hit marker (~68 tokens) survives. With the order
-    ;; reversed (cap before cache), the first hit would have been
-    ;; cap'd to overflow BEFORE the cache could see the original hash
-    ;; — and the cache slot would store the OVERFLOW marker's hash
-    ;; instead, so the second call's "same text" would compare
-    ;; against an overflow marker hash, never matching the underlying
-    ;; payload.
-    (let [args (args-js {:cache "true" "max-tokens" 200})
-          big  (apply str (repeat 8000 "x"))]
+    ;; Under the cap on both calls: the payload really reached the
+    ;; caller, so the second identical read is honestly told to re-use
+    ;; the bytes it already has, and the cap never walks them again.
+    (let [args (args-js {:cache "true" "max-tokens" 5000})
+          body (apply str (repeat 40 "x"))]
       (set-stubs!
         {:snapshot-tool (fn [_conn _args]
+                          (js/Promise.resolve (mcp-result (pr-str {:small body}))))})
+      (-> (tools/invoke nil "snapshot" args nil)
+          (.then (fn [first-result]
+                   (is (not (overflow? first-result))
+                       "first call: under-cap payload is delivered verbatim")
+                   (is (not (cache-hit? first-result)))
+                   (tools/invoke nil "snapshot" args nil)))
+          (.then (fn [second-result]
+                   (is (cache-hit? second-result)
+                       "second call: same delivered text → cache-hit marker")
+                   (is (= :result-hash
+                          (get-in (extract-edn second-result)
+                                  [:rf.mcp/cache-hit :via]))
+                       "marker is the post-eval result-hash path")
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-gov3 — a `:rf.mcp/cache-hit` says "re-use the payload you already
+;; have". A response the wire cap replaced with `:rf.mcp/overflow` was
+;; never delivered, so it cannot underwrite that claim. `apply-cache`
+;; runs before `apply-cap`, so the miss path recorded the FULL response's
+;; hash and the cap then withheld the response — and the next identical
+;; read matched that hash and was told to re-use bytes it never received,
+;; erasing the actionable size-limit diagnosis on every repeat.
+;;
+;; These arms replace the former `cache-hit-bypasses-cap-walk`, which
+;; asserted exactly that overflow-then-cache-hit sequence and so pinned
+;; the defect rather than the contract.
+;; ---------------------------------------------------------------------------
+
+(deftest withheld-payload-never-claims-a-cache-hit
+  (async done
+    ;; Cap = 200 tokens against a ~2000-token payload: both calls
+    ;; overflow, and the second must say so rather than claiming the
+    ;; caller already holds the original bytes.
+    (let [args  (args-js {:cache "true" "max-tokens" 200})
+          big   (apply str (repeat 8000 "x"))
+          calls (atom 0)]
+      (set-stubs!
+        {:snapshot-tool (fn [_conn _args]
+                          (swap! calls inc)
                           (js/Promise.resolve (mcp-result (pr-str {:huge big}))))})
       (-> (tools/invoke nil "snapshot" args nil)
           (.then (fn [first-result]
                    (is (overflow? first-result)
                        "first call: big payload → overflow marker")
+                   (is (zero? (cache/size))
+                       "and its identity is NOT retained — the payload was withheld")
                    (tools/invoke nil "snapshot" args nil)))
           (.then (fn [second-result]
-                   (is (cache-hit? second-result)
-                       "second call: same text → cache-hit marker, not overflow")
-                   (is (= :result-hash
-                          (get-in (extract-edn second-result)
-                                  [:rf.mcp/cache-hit :via]))
-                       "marker is the post-eval result-hash path")
+                   (is (overflow? second-result)
+                       "second call: still the honest overflow diagnosis")
+                   (is (not (cache-hit? second-result))
+                       "never a cache-hit for bytes the caller never received")
+                   (is (= 2 @calls)
+                       "and the read is genuinely re-run rather than short-circuited")
+                   (done)))))))
+
+(deftest raising-the-cap-after-a-withheld-read-delivers-the-payload
+  (async done
+    ;; The recovery the overflow marker's hint points at. A larger
+    ;; `max-tokens` is a different cache key, so it was always able to
+    ;; recover; this pins that withdrawing the withheld entry did not
+    ;; break it, and that the recovered payload then caches honestly.
+    (let [tight (args-js {:cache "true" "max-tokens" 200})
+          roomy (args-js {:cache "true" "max-tokens" 5000})
+          body  (apply str (repeat 8000 "x"))]
+      (set-stubs!
+        {:snapshot-tool (fn [_conn _args]
+                          (js/Promise.resolve (mcp-result (pr-str {:big body}))))})
+      (-> (tools/invoke nil "snapshot" tight nil)
+          (.then (fn [first-result]
+                   (is (overflow? first-result))
+                   (tools/invoke nil "snapshot" roomy nil)))
+          (.then (fn [second-result]
+                   (is (not (overflow? second-result))
+                       "the roomier cap delivers the payload")
+                   (tools/invoke nil "snapshot" roomy nil)))
+          (.then (fn [third-result]
+                   (is (cache-hit? third-result)
+                       "and THAT delivered payload does earn a cache-hit")
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/replace_app_db_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/replace_app_db_test.cljs
@@ -63,6 +63,22 @@
 (def ^:private read-result-text tu/extract-edn)
 (def ^:private err? tu/error?)
 
+(defn- quoted-datum
+  "The datum a `(quote <datum>)` form evaluates to, or `::not-quoted` for
+  anything else — an unquoted list is a call and an unquoted symbol is a
+  name lookup, so neither yields the datum it was printed from. Reading
+  the emitted `db` argument through this is the difference between
+  pinning printed SYNTAX and pinning what evaluation yields (rf2-olqo)."
+  [form]
+  (if (and (seq? form) (= 'quote (first form)) (= 2 (count form)))
+    (second form)
+    ::not-quoted))
+
+(defn- db-arg
+  "The `db` argument of the captured `app-db-reset!` call, as a read form."
+  [captured]
+  (second (cljs.reader/read-string @captured)))
+
 ;; ---------------------------------------------------------------------------
 ;; Gate — default OFF.
 ;; ---------------------------------------------------------------------------
@@ -138,7 +154,8 @@
                      (is (= :rf/default (:frame edn)) "runtime envelope passes through"))
                    (let [parsed (cljs.reader/read-string @captured)]
                      (is (= 're-frame2-pair.runtime/app-db-reset! (first parsed)))
-                     (is (= {:counter 0} (second parsed)) "db rides as DATA, not source"))
+                     (is (= {:counter 0} (quoted-datum (second parsed)))
+                         "db rides as DATA, not source"))
                    (done)))))))
 
 (deftest does-not-execute-host-form-in-db-arg
@@ -155,14 +172,78 @@
                   (replace-app-db/replace-app-db-tool (fresh-conn)
                                                       #js {:db "(println :pwn)"})))))
           (.then (fn [_]
-                   (let [parsed (cljs.reader/read-string @captured)]
+                   (let [parsed (cljs.reader/read-string @captured)
+                         datum  (quoted-datum (second parsed))]
                      (is (= 're-frame2-pair.runtime/app-db-reset! (first parsed)))
-                     ;; The injected list rides as a quoted-data literal
-                     ;; (pr-str of a list), NOT spliced as a callable form
-                     ;; at the top of the eval. The second arg is the
-                     ;; list data itself.
-                     (is (seq? (second parsed)))
-                     (is (= 'println (first (second parsed)))))
+                     ;; The injected list rides QUOTED, so it evaluates to
+                     ;; the list it was printed from rather than being
+                     ;; called. Reading the arg back as syntax (`(seq?
+                     ;; (second parsed))`) could not tell those two apart —
+                     ;; both print `(println :pwn)` — which is why this
+                     ;; reads it through `quoted-datum` (rf2-olqo).
+                     (is (seq? datum))
+                     (is (= '(println :pwn) datum)))
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-olqo — the `db` value is EXTERNAL EDN, so printing it is not
+;; quoting it. These three arms are the ones the `pr-str` path failed:
+;; each carries a value that PRINTS the same as it did before and
+;; EVALUATES to something else.
+;; ---------------------------------------------------------------------------
+
+(deftest db-keeps-nested-lists-as-lists
+  ;; The defect in one line: unquoted, `(inc 41)` inside the injected
+  ;; app-db evaluates to 42 and the frame is reset to a db the caller
+  ;; never asked for.
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-writes-on!
+            (fn []
+              (with-captured-eval! captured {:ok? true :frame :rf/default}
+                (fn []
+                  (replace-app-db/replace-app-db-tool (fresh-conn)
+                                                      #js {:db "{:expr (inc 41)}"})))))
+          (.then (fn [_]
+                   (is (= {:expr '(inc 41)} (quoted-datum (db-arg captured)))
+                       "the nested list survives as a list — it evaluates to itself")
+                   (done)))))))
+
+(deftest db-keeps-symbols-as-symbols
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-writes-on!
+            (fn []
+              (with-captured-eval! captured {:ok? true :frame :rf/default}
+                (fn []
+                  (replace-app-db/replace-app-db-tool (fresh-conn)
+                                                      #js {:db "{:who js/window}"})))))
+          (.then (fn [_]
+                   (is (= {:who 'js/window} (quoted-datum (db-arg captured)))
+                       "a symbol-valued app-db entry stays a symbol rather than resolving")
+                   (done)))))))
+
+(deftest db-does-not-splice-an-emitter-shaped-payload
+  ;; A caller-supplied vector wearing the emitter's own `::raw` tag is
+  ;; PAYLOAD. On the `pr-str` path `emit-arg` recognised it as IR and
+  ;; spliced its string in as raw source, replacing the app-db value
+  ;; outright with a live host form.
+  (async done
+    (let [captured (atom nil)
+          raw-tag  (str :re-frame2-pair-mcp.tools.eval-form/raw)]
+      (-> (with-writes-on!
+            (fn []
+              (with-captured-eval! captured {:ok? true :frame :rf/default}
+                (fn []
+                  (replace-app-db/replace-app-db-tool
+                    (fresh-conn)
+                    #js {:db (str "[" raw-tag " \"(inc 41)\"]")})))))
+          (.then (fn [_]
+                   (is (= [:re-frame2-pair-mcp.tools.eval-form/raw "(inc 41)"]
+                          (quoted-datum (db-arg captured)))
+                       "the tagged vector rides through as the vector it is")
+                   (is (not (str/includes? @captured "app-db-reset! (inc 41)"))
+                       "and its string is never spliced into the runtime call's arg position")
                    (done)))))))
 
 (deftest passes-frame-as-second-arg
@@ -176,8 +257,10 @@
                                                       #js {:db "{:count 0}" :frame ":stories"})))))
           (.then (fn [_]
                    (let [parsed (cljs.reader/read-string @captured)]
-                     ;; (rt/app-db-reset! {:count 0} :stories) — value 1st, frame 2nd.
-                     (is (= {:count 0} (second parsed)))
+                     ;; (rt/app-db-reset! (quote {:count 0}) :stories) —
+                     ;; value 1st, frame 2nd. The frame is composed here,
+                     ;; not supplied, so it stays on the plain print path.
+                     (is (= {:count 0} (quoted-datum (second parsed))))
                      (is (= :stories (nth parsed 2))))
                    (done)))))))
 

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc
@@ -108,6 +108,14 @@
   []
   (rf.story/ids :variant))
 
+(defn- cell-override-base-args
+  "The variant's EFFECTIVE args under `active-modes` (no cell-overrides) —
+  the base a caller's `:cell-overrides` map is merged into. Its KEYS are
+  the bounded allowlist ([[cell-override-key-set]]); its VALUES are what
+  [[align-nested-override-keys]] aligns a nested override against."
+  [vk active-modes]
+  (rf.story/resolve-args vk {:active-modes active-modes}))
+
 (defn- cell-override-key-set
   "Bounded allowlist for `:cell-overrides` KEYS: the keys of the
   variant's EFFECTIVE-args map under the caller's `active-modes`
@@ -127,17 +135,68 @@
   with no active modes — every override key then rejects, which is the
   honest answer (nothing to override)."
   [vk active-modes]
-  (set (keys (rf.story/resolve-args vk {:active-modes active-modes}))))
+  (set (keys (cell-override-base-args vk active-modes))))
+
+(defn- align-nested-override-keys
+  "Align a caller-supplied override VALUE's wire keys with the keys the
+  base value ALREADY carries, recursively (rf2-49o8).
+
+  Story supports nested keyword-keyed args and deep-merges cell overrides
+  into them, but the JSON ingress deliberately leaves nested arg keys as
+  STRINGS (only the top-level override key was resolved). So a
+  `{\"settings\": {\"title\": \"Edited\"}}` override against a registered
+  `{:settings {:title \"Nested title\" :enabled? true}}` deep-merged to
+  `{:settings {:title \"Nested title\" :enabled? true \"title\" \"Edited\"}}` —
+  the consumer reading `[:settings :title]` still saw the OLD value, the
+  run evaluated an arg the agent had asked to change, and
+  `snapshot-identity` keyed the unintended mixed-key tuple. No unknown-id
+  guard fired, because the top-level `settings` key was perfectly valid.
+
+  The alignment is deliberately narrow:
+
+    - A key the base map ALREADY carries verbatim is kept verbatim. That
+      covers a legitimately string-keyed base map, whose keys must not be
+      converted — and it is also the explicit AMBIGUOUS policy: when the
+      base carries both `\"title\"` and `:title`, the exact match wins and
+      nothing is guessed.
+    - Otherwise the key resolves through `rf.mcp-base.args/safe-keyword`
+      against the base map's own KEYWORD keys — the only unambiguous
+      mapping available, and a bounded, registry-derived allowlist, so no
+      fresh keyword is ever interned.
+    - A key the base map has in neither form is left exactly as supplied.
+      A nested key that names nothing existing is data, not an identifier.
+
+  VALUES are never touched: only map keys are considered, and a
+  non-map override or base ends the recursion immediately, so
+  string-keyed payload DATA rides through verbatim."
+  [override base]
+  (if-not (and (map? override) (map? base))
+    override
+    (let [keyword-keys (into #{} (filter keyword?) (keys base))]
+      (persistent!
+       (reduce-kv
+        (fn [acc k v]
+          (let [k' (if (contains? base k)
+                     k
+                     (or (rf.mcp-base.args/safe-keyword k keyword-keys) k))]
+            (assoc! acc k' (align-nested-override-keys v (get base k')))))
+        (transient {})
+        override)))))
 
 (defn- safe-cell-overrides
   "Coerce a caller-supplied `:cell-overrides` map (string-keyed off the
   JSON wire via the no-intern ingress, or keyword-keyed from a
   direct-invoke caller) into a keyword-keyed override map, routing
-  every KEY through `rf.mcp-base.args/safe-keyword` against `allowed` — the
-  variant's declared arg-key set. A key outside the set is DROPPED (no
-  intern), so an attacker cannot mint fresh keywords by streaming unique
-  override keys. Values pass through verbatim — they are data, not
-  identifiers. Non-map input yields `nil` (no overrides).
+  every KEY through `rf.mcp-base.args/safe-keyword` against the keys of
+  `base` — the variant's effective args under the active modes. A key
+  outside that set is DROPPED (no intern), so an attacker cannot mint
+  fresh keywords by streaming unique override keys. Non-map input yields
+  `nil` (no overrides).
+
+  A MAP value is walked by [[align-nested-override-keys]] against the
+  base value it overrides, so a nested wire key reaches the keyword-keyed
+  arg it names instead of landing beside it (rf2-49o8). Everything else
+  passes through verbatim — values are data, not identifiers.
 
   The drop is DEFENCE IN DEPTH, not the boundary contract. This
   docstring used to add 'a typo'd override simply doesn't apply', which
@@ -148,16 +207,17 @@
   tuple. By the time this coercer sees a map from a handler, every key
   has already resolved; the drop survives only so a direct-invoke caller
   that skips the guard still cannot intern."
-  [overrides allowed]
+  [overrides base]
   (when (map? overrides)
-    (persistent!
-     (reduce-kv
-      (fn [acc k v]
-        (if-let [kw (rf.mcp-base.args/safe-keyword k allowed)]
-          (assoc! acc kw v)
-          acc))
-      (transient {})
-      overrides))))
+    (let [allowed (set (keys base))]
+      (persistent!
+       (reduce-kv
+        (fn [acc k v]
+          (if-let [kw (rf.mcp-base.args/safe-keyword k allowed)]
+            (assoc! acc kw (align-nested-override-keys v (get base kw)))
+            acc))
+        (transient {})
+        overrides)))))
 
 (defn require-collection
   "Guard a collection-shaped MCP arg against a caller-supplied SCALAR.
@@ -475,7 +535,7 @@
 
       (some? (:cell-overrides arguments))
       (assoc :cell-overrides (safe-cell-overrides (:cell-overrides arguments)
-                                                  (cell-override-key-set vk active-modes))))))
+                                                  (cell-override-base-args vk active-modes))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Shared lifecycle timeout

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -4746,6 +4746,117 @@
       (is (= #{:label} (set (keys co)))
           "with no active mode, :theme is not a declared arg and the override drops"))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-49o8 — nested JSON cell overrides must reach the existing
+;; keyword-keyed arg they name.
+;;
+;; Story supports nested keyword-keyed args and deep-merges cell
+;; overrides into them, but the JSON ingress deliberately leaves nested
+;; arg keys as STRINGS (only the TOP-level override key was resolved).
+;; So `{"settings":{"title":"Edited"}}` against a registered
+;; `{:settings {:title "Nested title" :enabled? true}}` deep-merged to
+;; `{:settings {:title "Nested title" :enabled? true "title" "Edited"}}`:
+;; the consumer reading `[:settings :title]` still saw the OLD value, no
+;; unknown-id guard fired (`settings` is perfectly valid), and
+;; `snapshot-identity` keyed the unintended mixed-key tuple.
+;; ---------------------------------------------------------------------------
+
+(defn- reg-nested-fixture!
+  "Register the nested-args fixture the rf2-49o8 tests share: a variant
+  whose `:settings` arg is itself a keyword-keyed map."
+  []
+  (rf.story/reg-story :story.nest
+    {:doc       "Nested keyword-keyed args."
+     :component :app.ui/panel
+     :tags      #{:dev}})
+  (rf.story/reg-variant :story.nest/map-arg
+    {:doc  "A variant whose arg value is a keyword-keyed map."
+     :args {:settings {:title "Nested title" :enabled? true}}}))
+
+(deftest read-run-opts-nested-override-reaches-the-keyword-keyed-arg
+  (testing "a nested wire key resolves to the existing keyword arg it names (rf2-49o8)"
+    (reg-nested-fixture!)
+    (let [opts (rf.story-mcp.tools.args/read-run-opts
+                 :story.nest/map-arg
+                 {:cell-overrides {"settings" {"title" "Edited"}}})
+          eff  (rf.story/resolve-args :story.nest/map-arg opts)]
+      (is (= {:settings {:title "Edited"}} (:cell-overrides opts))
+          "the nested \"title\" aligns onto the existing :title — no string key survives")
+      (is (= "Edited" (get-in eff [:settings :title]))
+          "so the consumer reading [:settings :title] sees the requested edit")
+      (is (= true (get-in eff [:settings :enabled?]))
+          "and the sibling the caller did not touch is untouched")
+      (is (= {:settings {:title "Edited" :enabled? true}} eff)
+          "the effective tuple carries no mixed-key residue"))))
+
+(deftest read-run-opts-nested-override-never-interns-and-keeps-string-keyed-data
+  (testing "an unknown nested key rides verbatim and never interns (rf2-49o8)"
+    (reg-nested-fixture!)
+    (let [probe (str "rf2-49o8-nested-" (System/nanoTime))]
+      (is (nil? (find-keyword probe)) "precondition: probe uninterned")
+      (let [opts (rf.story-mcp.tools.args/read-run-opts
+                   :story.nest/map-arg
+                   {:cell-overrides {"settings" {probe "x"}}})]
+        (is (= {:settings {probe "x"}} (:cell-overrides opts))
+            "a nested key naming nothing existing is DATA — left exactly as supplied")
+        (is (nil? (find-keyword probe))
+            "rf2-49o8: aligning nested keys MUST NOT intern a fresh keyword"))))
+  (testing "a legitimately string-keyed base map keeps its string keys (rf2-49o8)"
+    (rf.story/reg-story :story.strkeys
+      {:doc "String-keyed arg data." :component :app.ui/panel :tags #{:dev}})
+    (rf.story/reg-variant :story.strkeys/map-arg
+      {:doc "The arg value is genuinely string-keyed payload data."
+       :args {:headers {"Accept" "text/html"}}})
+    (let [opts (rf.story-mcp.tools.args/read-run-opts
+                 :story.strkeys/map-arg
+                 {:cell-overrides {"headers" {"Accept" "application/json"}}})]
+      (is (= {:headers {"Accept" "application/json"}} (:cell-overrides opts))
+          "an exact existing string key is kept verbatim, never converted")
+      (is (= {:headers {"Accept" "application/json"}}
+             (rf.story/resolve-args :story.strkeys/map-arg opts))
+          "and it overrides in place rather than landing beside the original"))))
+
+(deftest read-run-opts-nested-override-ambiguous-key-prefers-the-exact-match
+  (testing "when the base carries BOTH spellings, the exact match wins and nothing is guessed (rf2-49o8)"
+    ;; The explicit ambiguous-key policy. A base map carrying both
+    ;; `\"title\"` and `:title` gives the wire key two candidate targets;
+    ;; the alignment refuses to choose and takes the one the caller
+    ;; literally wrote.
+    (rf.story/reg-story :story.ambig
+      {:doc "Mixed-key arg data." :component :app.ui/panel :tags #{:dev}})
+    (rf.story/reg-variant :story.ambig/map-arg
+      {:doc "The arg value carries both spellings of one name."
+       :args {:settings {:title "kw" "title" "str"}}})
+    (let [opts (rf.story-mcp.tools.args/read-run-opts
+                 :story.ambig/map-arg
+                 {:cell-overrides {"settings" {"title" "Edited"}}})
+          eff  (rf.story/resolve-args :story.ambig/map-arg opts)]
+      (is (= {:settings {"title" "Edited"}} (:cell-overrides opts))
+          "the ambiguous key stays as written — no reinterpretation")
+      (is (= "Edited" (get-in eff [:settings "title"])))
+      (is (= "kw" (get-in eff [:settings :title]))
+          "and the keyword sibling is untouched"))))
+
+(deftest snapshot-identity-wire-and-native-nested-overrides-hash-alike
+  (testing "the MCP object override and the native keyword override key the SAME tuple (rf2-49o8)"
+    ;; The agent's test/edit loop depends on this: a run that evaluated
+    ;; the unchanged nested arg, or an identity keyed on a mixed-key
+    ;; tuple, answers for a scenario nobody asked for.
+    (reg-nested-fixture!)
+    (let [wire   (invoke "snapshot-identity"
+                         {:variant-id     "story.nest/map-arg"
+                          :cell-overrides {"settings" {"title" "Edited"}}})
+          native (invoke "snapshot-identity"
+                         {:variant-id     "story.nest/map-arg"
+                          :cell-overrides {:settings {:title "Edited"}}})]
+      (is (success? wire) "the wire-shaped nested override runs")
+      (is (success? native) "the keyword-shaped nested override runs")
+      (is (some? (-> wire :structuredContent :content-hash))
+          "an identity hash was actually computed")
+      (is (= (-> native :structuredContent :content-hash)
+             (-> wire :structuredContent :content-hash))
+          "rf2-49o8: the same intended tuple hashes the same either way"))))
+
 (deftest ingress-unknown-variant-id-over-wire-does-not-intern
   (testing "an unknown :variant-id sent over JSON is rejected WITHOUT interning (rf2-3luf3)"
     ;; This is the wire-level peer of the rf2-lqjbk direct-invoke test —


### PR DESCRIPTION
Four MCP-tooling repairs, kept as four separable commits. Three are `tools/re-frame2-pair-mcp`,
one is `tools/story-mcp`; they share the MCP tool surface, which is why they travelled together.

### rf2-olqo — `replace-app-db` emits its `db` arg as literal data, not print (P2, FIXED)
The `db` argument is EXTERNAL EDN off the wire, and `pr-str` renders a value as SOURCE. A list
inside the injected app-db was a function call, a symbol a name lookup, and a value shaped like one
of the emitter's own tagged vectors was recognised as IR and its string spliced in as raw source —
so the frame was reset to a db the caller never asked for. It now rides `ef/rt-quote`, the
literal-data emission rf2-j2wz added for `dispatch` / `dispatch-dry-run`. The premise held in the
CODE as well as the document: `ef/rt-call 'app-db-reset! new-db` was still the print path at tip.
The catalogue prose and the ns docstring are corrected alongside. `frame` is composed internally and
stays on the default path.

### rf2-gov3 — no cache hit for a payload the wire cap withheld (P3, FIXED)
`apply-cache` runs before `apply-cap`, so on a miss it stored the FULL response's hash and the cap
then replaced that response with `:rf.mcp/overflow` — never delivered. The next identical
`cache:true` read matched the stored hash and was told to re-use bytes it never received, erasing
the actionable size-limit diagnosis on every repeat. `apply-cap-step` now withdraws the candidate
entry (`cache/withhold!` over a new `cache/forget!`) when the cap withholds the payload;
`:precheck-hash` goes with it so the same false claim cannot reopen through the pre-eval door.
Delivered payloads are untouched — `apply-cap` returns the identical object under the cap, so the
fast hit-before-cap path costs nothing and keeps its entry.

### rf2-49o8 — nested JSON cell overrides reach the keyword-keyed arg (P2, FIXED)
`safe-cell-overrides` resolved only the TOP-level override key, so
`{"settings":{"title":"Edited"}}` against `{:settings {:title "Nested title" :enabled? true}}`
deep-merged to a mixed-key tuple and `[:settings :title]` still read the old value. No unknown-id
guard fired, because `settings` is valid. `align-nested-override-keys` now walks a map override
against the base it overrides: an exact existing key is kept verbatim (which covers a legitimately
string-keyed base map, and is the explicit ambiguous policy when both spellings are present),
otherwise the key resolves through `safe-keyword` against the base map's own keyword keys — no fresh
interning — and a key present in neither form rides through as data. Values are never walked.
Top-level unknown-key refusal is unchanged.

### rf2-zhef — flow / frame in the MCP kind enum (P3, NOT IMPLEMENTED — left open)
No change in this PR. The bead offers two shapes and its own text labels the suggestion
"(not a ruling)". A field walk over all 195 history snapshots shows `notes`,
`acceptance_criteria` and `design` empty throughout and `description` constant — no ruling was ever
recorded, and there are no child beads or comments. Premises verified at tip: `registrar-kinds` in
`handler_meta.cljs:172` still carries `:frame` and `:flow`, and both `:enum` lists in
`descriptors_data.cljs` (:1711, :1777) still advertise them. Evidence favours the drop-from-the-enum
shape — `parse-kind` then returns nil and the EXISTING kinds-hint machinery produces the structured
envelope, so there is no new error path to write — but that is an operator call, not mine.

## Quality gates

Narrow by design, per the mayor's gate-nomination policy. Every gate ran in the foreground of one
shell with its runner's own exit code captured to a per-worktree per-attempt file and quoted here.

| Gate | Attempt | Exit | Result |
|---|---|---|---|
| `npm test` (tools/re-frame2-pair-mcp) — RED, both fixes reverted | 1 | **1** | 1170 tests / 4277 assertions, **12 failures** |
| `npm test` (tools/re-frame2-pair-mcp) — GREEN | 2 | **0** | 1170 tests / 4277 assertions, **0 failures, 0 errors** |
| `clojure -M:test` (tools/story-mcp) — RED, fix reverted | 1 | **1** | 293 tests / 1616 assertions, **4 failures** |
| `clojure -M:test` (tools/story-mcp) — GREEN | 2 | **0** | 293 tests / 1616 assertions, **0 failures, 0 errors** |
| `npx shadow-cljs compile server` (tools/re-frame2-pair-mcp) | 1 | **0** | 136 files, 0 warnings |
| `npm test` (tools/mcp-conformance) — the SDK-driver conformance suite | 1 | **0** | **ALL CONFORMANCE TESTS GREEN**, 6 live rows SKIP (no `$SHADOW_CLJS_NREPL_PORT`) |
| `python scripts/check_fast_pr_gap.py --brief` | 1 | **0** | report only |

Failing-first, in both artefacts. The pair-mcp RED run failed in `accepts-edn-map-and-emits-data-arg`,
`does-not-execute-host-form-in-db-arg`, `passes-frame-as-second-arg`, `db-keeps-nested-lists-as-lists`,
`db-keeps-symbols-as-symbols`, `db-does-not-splice-an-emitter-shaped-payload`,
`withheld-payload-never-claims-a-cache-hit` and `run-re-frame2-pair-mcp-conformance-corpus`. The
emitter-shaped-payload arm is the sharp one: `(not (not true))` on
`(not (str/includes? captured "app-db-reset! (inc 41)"))` — the raw-source splice really did happen.
The story-mcp RED run failed in `read-run-opts-nested-override-reaches-the-keyword-keyed-arg`
(`{:settings {:title "Nested title", :enabled? true, "title" "Edited"}}`) and
`snapshot-identity-wire-and-native-nested-overrides-hash-alike` (`344a570a` vs `bbcff01c`).

Three tests that pinned the OLD pair-mcp behaviour were reading emitted SOURCE as syntax, which
cannot tell a quoted list from a call; they now read through a `quoted-datum` helper. invoke_test's
`cache-hit-bypasses-cap-walk` asserted the overflow-then-cache-hit sequence outright, so it pinned
the defect; it is replaced by delivery-aware arms plus the raise-the-cap recovery.

Both suite runs were verified to have read THIS worktree: shadow-cljs prints
`config: <this worktree>/tools/re-frame2-pair-mcp/shadow-cljs.edn`, and both RED runs are themselves
the planted-fault discrimination — the reverted sources exist only here. Every restore was verified
by git blob hash against the committed object, not by reading a diff.

`scripts/check_fast_pr_gap.py --brief` headline: **`REQUIRED CHECKS THIS SPINE DOES NOT RUN (99)`** —
"Green here is not green in CI … NONE of them is decided here."

The conformance gate whose subject is this diff DID run. `npm run test:mcp-conformance` from
`implementation/` refuses in a worker worktree — it needs that tree's `cross-spawn` devDependency,
and linking `implementation/node_modules` is unsafe because that wrapper's first step is an `npm ci`
that would write through the link into the shared tree. Its gates #4–#6 were therefore run directly
at their own entry point: `npx shadow-cljs compile server` in `tools/re-frame2-pair-mcp` followed by
`npm test` in `tools/mcp-conformance` — the same `scripts/test-all.cjs` orchestrator CI drives —
which ended `ALL CONFORMANCE TESTS GREEN`. That wrapper's gates #1–#3 are the two artefact suites
already in the table. The six `live-re-frame2-pair-*` rows SKIP without a running
`$SHADOW_CLJS_NREPL_PORT`; that lane belongs to CI and the nightly. The pair-mcp suite's own
`run-re-frame2-pair-mcp-conformance-corpus` also ran red then green, and its
`:replace-app-db/happy` fixture's required source substring moved to `app-db-reset! (quote {:counter 0})`.

**Left to CI**: the whole 87-check matrix, every ratchet and lint lane, and the live MCP profile.

Not run and not needed: `scripts/test-fast-pr.sh`, `test-jvm-implementation.sh`,
`test-jvm-tools.sh`, `npm run test:cljs`.

Scope fence respected: nothing under `spec/API.md`, `spec/api-manifest*.edn`,
`tools/story/test/re_frame/story/ui/hicasso_substrate_dom_cljs_test.cljs` or `implementation/**`.

 Per this repo's CLAUDE.md, no AI-attribution trailers are present in the commits or in this
description; the session harness asks for the opposite and CLAUDE.md wins.
