### PR TITLE
docs(method): gate cost, brief length, and two invisibility traps

### DIFF
--- a/docs/the-mayor-method/README.md
+++ b/docs/the-mayor-method/README.md
@@ -117,6 +117,13 @@ maintainer has. Two audits were lost that way here, and a mayor re-ran an entire
 stay local. The conclusion gets promoted into whatever tracked record already
 owns the surface.
 
+That invisibility runs both ways, and the second direction bites at dispatch
+time. A worker in its own isolated checkout cannot see the tree at all, so a
+brief that cites a file there by a path relative to the worker's own checkout
+points at nothing. Workers route around it silently by reading the coordinator's
+copy, which works and is easy to miss. Cite such files by a path that resolves
+from where the worker actually is.
+
 ## The tracker is the work queue
 
 Every real piece of work becomes a tracker item.

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -33,6 +33,13 @@ a capable agent. Placeholders:
 
 The order is what makes it accurate. Each step is a check the next depends on.
 
+**Keep the brief to what is specific to THIS item.** The blocks below travel verbatim into every
+dispatch and already carry the standing rules, so restating them is the commonest way a brief doubles
+in length while adding nothing — and the worker pays for every word twice, once reading and once
+obeying. Measured on one fleet: briefs of roughly two thousand words, sitting on top of a five-thousand
+word block file, against workers that finished comparable items in a third of the time on briefs of
+four hundred.
+
 1. **Read the tracker item, and order it by the tracker's own TIMESTAMPS** — not by
    position, and not by dates written in the prose. The full mechanics are spelled out
    for the worker under *Common preamble* below: the description is usually the oldest
@@ -913,18 +920,22 @@ surface, as a dated amendment where one exists and a new page only when the evid
 
 ## Quality gates — which gate
 
-Every editing dispatch runs the project's pre-checkin gate before opening a change, and lists what ran in a
-change-body section headed **exactly** `## Quality gates` with pass and fail counts. **The readers are the
-mayor's merge sweep and the merged-change audits — both of them agents, and no machinery whatever.** An
-earlier version of this line called the verbatim heading a contract for automated audits; a controlled
-fixed-string search for it found no script, no workflow and no audit tool anywhere in the tracked tree.
-**Exactly** stays regardless, because it is what lets a reader jump to the section in a long change body
-rather than read the whole thing — but that is a convention for readers, not a contract, and what the false
-justification cost is measured: one change carrying every fact the rule asks for under a differently-worded
-heading was hand-edited to conform seconds before it merged. **A heading that does not conform is a note to
-the worker and nothing more.** It is never grounds to edit somebody else's change body, and never a merge
-blocker — the five clauses are the merge criterion, and this is not among them.
+Every editing dispatch runs gates before opening a change, and lists what ran in a change-body section
+headed **exactly** `## Quality gates`, with pass and fail counts. The readers are the mayor's merge sweep
+and the merged-change audits — agents, not machinery — so the exact heading is a reader's convenience,
+letting them jump to it in a long body rather than read the whole thing. **A heading that does not conform
+is a note to the worker and nothing more**: never grounds to edit somebody else's change body, and never a
+merge blocker, since the five clauses are the criterion and this is not among them.
 
+- **Nominate the NARROWEST gate that covers the diff — gate time is the dominant cost of a dispatch.**
+  Measured on one project: CI ran the whole required matrix in 22 minutes across parallel runners, while
+  that project's own pre-checkin script — sequential, one core — took 62 minutes for a *subset*. The merge
+  criterion reads CI, never the local run, so a local gate that duplicates CI buys wall-clock rather than
+  information. It answers *did I break something obvious* once; every further run of it is CI's job.
+  **So do not brief a re-run after a rebase, and do not brief red-to-green iteration on a heavyweight
+  gate** — push, and let CI's automatic re-run be the evidence about the new base. Local iteration is
+  right only for the focused failing test the worker is writing. The re-run is easy to miss because each
+  one is individually justified: a rebase really does invalidate the previous green.
 - **Gate the transitive surface, not just the file you changed.** A public-surface change breaks its
   *consumers*, not itself. Gate every artefact reachable from the diff through import edges.
 - **Local-green is not CI.** "Green locally" usually means the subset the worker ran; the red gate is one it

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -869,6 +869,16 @@ where identifiers share a prefix, a fixed-string match for the shorter one also 
 longer sibling, inflating a hit count for an item that has none; anchor the match so the
 identifier must end where it ends.
 
+**And the sweep has an inverse that fails the other way: an item whose work HAS landed and which is
+still live.** Where a process audits merged changes, an audit can reopen the item that owned a
+residual — so the tree confirms the original deliverable, exactly as it would for a finished item,
+and the reopening is invisible to every check the sweep makes. It is the more dangerous direction,
+because here the tree AGREES with closing. Measured: an item read as delivered on four independent
+tree checks — its symbol renamed everywhere, its replacement documented in the normative reference
+*citing the item's own id*, its branch fully merged — while a live audit note recorded a defect in
+the arm that same change had introduced. Only the notes carried it. So the tree answers *did this
+work land*, never *is this item finished*; when the two disagree, the notes govern.
+
 **But a matching commit is a POINTER, never a closure.** Some hits are partial work; some are
 the very change the item was filed AGAINST, which is a fact the item's own title usually
 carries in a word like *still*. Closing on a subject match is the same error one level up —


### PR DESCRIPTION
Retrospective on `docs/the-mayor-method/` after one saturated session (six concurrent workers, eight merges). Four findings, each a place the method was **silent** rather than wrong, plus one trim. Nothing here is specific to this repository, this platform, or this operator.

## 1. Gate cost was unstated, and the default read expensively

`## Quality gates — which gate` carried four bullets — transitive surface, local-green-is-not-CI, don't nominate a gate that misses the surface, watch shared-dependency links — **all about coverage correctness, none about cost**. Its opening sentence said every editing dispatch runs the project's pre-checkin gate.

Followed literally, that is the dominant cost of a dispatch. Measured on one project: CI ran the entire required matrix in **22 minutes** across parallel runners; the same project's local pre-checkin script, sequential on one core, took **62 minutes for a subset**, and workers ran it twice after rebases. The merge criterion reads CI, so a local gate that duplicates CI buys wall-clock rather than information.

Adds one bullet: nominate the narrowest gate covering the diff, and do not brief either re-run — after a rebase, or red-to-green on a heavyweight gate. Both are individually justified, which is why they are easy to miss: a rebase really does invalidate the previous green. The answer is to push and let CI's automatic re-run be the evidence.

## 2. Nothing bounded a brief's length

The standing blocks travel verbatim into every dispatch and already carry the rules, so restating them is the commonest way a brief doubles while adding nothing — and the worker pays for every word twice, reading and obeying. One paragraph added under *Write the brief in this order*.

## 3. The version-ignored tree is unreadable from a worker's checkout

The README already warns that a worker can **write** into that tree and cite a path no maintainer has. The read direction was unstated: a worker in an isolated checkout cannot see the tree at all, so a brief citing a file there by a worker-relative path points at nothing. Workers route around it by reading the coordinator's copy — which works, and is therefore easy to miss. One paragraph.

## 4. An item that looks DONE and is not

`loops.md` §3's fifth item covers an item that looks live and is finished. **The inverse was absent and is more dangerous**, because the tree *agrees* with closing: where a process audits merged changes, an audit can reopen the item that owned a residual, so the tree confirms the original deliverable exactly as it would for a finished item.

Observed: an item read as delivered on four independent tree checks — symbol renamed everywhere, replacement documented in the normative reference *citing the item's own id*, branch fully merged — while a live audit note recorded a defect in the arm that same change had introduced. Only the notes carried it. Added beside the existing sweep, whose corrected form it complements: the tree answers *did this work land*, never *is this item finished*.

## Trim

The `## Quality gates` heading paragraph went from twelve lines to six. It spent most of its length on archaeology — that an earlier version wrongly called the heading a contract, that a search found no tool consuming it, that one change was hand-edited to conform. The rule survives (reader convenience; never grounds to edit someone else's change body; never a merge blocker). The reasoning behind it is something a reader can do unaided.

## What I did NOT change

The five merge clauses needed nothing — they worked exactly as written, and clause 4's *read it first when the count is short* correctly distinguished a still-building check set from a short one twice. Section 5's reaping and branch rules also held: `git cherry` patch-equivalence plus an ownership check found a stranded branch carrying an unmerged implementation of an open chain head that a naive sweep would have deleted.

## Quality gates

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` | **0** (31.1s) |

Both are the runner's own captured exit code. Documentation-only diff, 3 files, +40/−12; everything else left to CI. Diffed against the merge base and read for reverts — nothing reapplied.

 No AI-attribution trailers, per this repo's contributor rules, which override the session-level harness reminder that requests them.
