### PR TITLE
fix(examples,ssr-node): three small repairs

### DIFF
--- a/examples/core/login/stories.cljs
+++ b/examples/core/login/stories.cljs
@@ -93,10 +93,17 @@
 ;; real form path: type the draft (email via `:auth.login/edit-field`,
 ;; password via the classified `:auth.login/edit-password`), then dispatch
 ;; `:auth.login/submit-form`. Same real fx (right there in Xray's Side
-;; Effects panel), and the canned stub answers it — no app-side override
-;; needed. The reply `:value` happens to be nil (we sent none), but that's
-;; fine: the welcome banner keys off the `:auth/authenticated` tag, not the
-;; payload, so the flow still settles happily at `:authed`.
+;; Effects panel), and a stub answers it.
+;;
+;; WHICH stub is the variant's business, not this driver's — and it matters
+;; (rf2-hz8u). The reply comes home to `:auth.login/succeeded`, whose schema
+;; requires `[:value :token]`, so the framework's GENERIC canned success
+;; (`{:stubbed true}`) is refused at the schema boundary and the flow never
+;; leaves `:submitting`. The `:success` variant therefore carries its own
+;; `:network` route fixture with a token-bearing reply; the failure variants
+;; drive their own replies by hand and stub the fx out entirely. This driver
+;; just walks the real form path and lets each variant say what the server
+;; said.
 ;; ---------------------------------------------------------------------------
 
 (rf/reg-event :login.story/submit
@@ -327,6 +334,34 @@
                  auth-submit cascade — submit → `:rf.http/managed` →
                  canned reply → `:success` — runs through real events;
                  inspect it in Xray. The canonical screenshot."
+     ;; THE FIXTURE, AND WHY THE GENERIC PRESET STUB IS NOT ENOUGH (rf2-hz8u).
+     ;; Every variant here runs in its OWN `:preset :story` frame, which
+     ;; redirects `:rf.http/managed` to the framework's generic canned-success
+     ;; stub. That stub answers `{:status :ok :value {:stubbed true}}` when the
+     ;; request carries no `:value` of its own — and this request carries none,
+     ;; because it is the REAL one the live app sends. But the live app's reply
+     ;; handler is `:auth.login/succeeded`, whose registration declares
+     ;; `:schema [… [:map [:value [:map [:token :string]]]]]`: the token is the
+     ;; whole point of a login reply. So the generic stub's payload is REFUSED
+     ;; at the schema boundary, the handler never runs, the machine is never
+     ;; nudged with `:success`, and the canonical screenshot is a form stuck in
+     ;; `:submitting` rather than the Welcome banner it advertises.
+     ;;
+     ;; A live-app frame does not have this problem: `login.model/frame-config`
+     ;; points `:rf.http/managed` at `:auth.login.demo/managed-stub`, which
+     ;; conjures a token-bearing reply. Story allocates its variant frames
+     ;; itself, so that config does not reach them — the variant supplies its
+     ;; own fixture, and `:network` is the dedicated Story affordance for
+     ;; exactly this fx (an explicit `:fx-overrides` on `:rf.http/managed`
+     ;; would be a hard conflict with it — `:rf.error/story-network-fx-conflict`).
+     ;;
+     ;; The route is the one `submit-form` really posts, and the reply is the
+     ;; shape the demo backend really returns, so the cascade below stays the
+     ;; REAL one end to end — nothing here fakes a state, it only supplies the
+     ;; server's half of the conversation.
+     :network    {[:post "/api/login"]
+                  {:reply {:ok {:user  {:name "Ada Lovelace"}
+                                :token "demo-token-123"}}}}
      :setup      [[:login.story/submit good-creds]]
      :tags       #{:dev :docs :login/canonical}
      :substrates #{:reagent}})

--- a/implementation/ssr-node/src/isolate.cjs
+++ b/implementation/ssr-node/src/isolate.cjs
@@ -201,8 +201,28 @@ class Isolate {
       });
       worker.on('exit', () => {
         clearTimeout(bootTimer);
+        // THE SIBLING ARM, AND IT IDENTIFIES ITSELF THE SAME WAY (rf2-rhyi).
+        // `ISOLATE_LOST` covers three distinct causes — a crashed worker, a
+        // worker that exited, and a replacement that will not boot — and a
+        // consumer tells them apart by detail SHAPE, because the code and
+        // the wording are the only other things it has. This arm reached
+        // that code with an EMPTY map, so the one arm whose thread is gone
+        // most quietly (nothing thrown, nothing on stderr) was also the one
+        // that named neither the isolate nor the thread an operator is
+        // about to go looking for. `isolate` and `threadId` are the same
+        // two service-owned facts the `error` arm above and the deadline
+        // refusal below already carry, and for the same reason: neither
+        // originates in the render module.
+        //
+        // The code, the wording and the termination/replacement behaviour
+        // are deliberately unchanged — this is a detail-map gap rather than
+        // a policy change. `_failPendingRender` still stamps `afterChunks`
+        // on top, so a torn exit keeps its discriminator.
         this._failPendingRender(
-          new Refusal(CODE.ISOLATE_LOST, 'the isolate exited mid-render', {}),
+          new Refusal(CODE.ISOLATE_LOST, 'the isolate exited mid-render', {
+            isolate: this.seq,
+            threadId: this.threadId,
+          }),
         );
       });
     });

--- a/implementation/ssr-node/test/egress.test.cjs
+++ b/implementation/ssr-node/test/egress.test.cjs
@@ -1270,3 +1270,68 @@ test('and the OPERATOR gets the uncontracted fault, because nothing else would',
   );
   assert.ok(run.stderr.includes(CLONE_SENTINEL), 'the operator copy must be the REAL fault');
 });
+
+// ---------------------------------------------------------------------------
+// 8. THE OTHER ARM OF `isolate-lost` — a thread that EXITS rather than
+//    crashing (rf2-rhyi).
+//
+// `:rf.ssr-node/isolate-lost` covers three distinct causes — a crashed
+// worker, a worker that exited, and a replacement that will not boot — and
+// they are told apart by detail SHAPE alone. Section 5 above pins the
+// CRASH arm's shape: `isolate`, `threadId`, `afterChunks`. These rows pin
+// the EXIT arm's, which reached the same code and the same wording with an
+// empty detail map, so a consumer holding the two side by side could not
+// say which isolate had gone.
+//
+// The fixture is the discriminator: `exits.cjs` throws nothing at all, so
+// no `'error'` event is ever raised and only `worker.on('exit')` can be
+// what answered.
+// ---------------------------------------------------------------------------
+
+const exitReq = (entry) => ({ protocol: 1, entry, state: { ':for-exit': 'x' } });
+
+test('an isolate that EXITS mid-render names WHICH isolate and WHICH thread', async () => {
+  await withService('exits', { isolates: 1 }, async (service) => {
+    const err = await refusalOf(() => collect(service, exitReq('app/exits')));
+    assert.ok(err, 'the render must not have succeeded');
+    assert.strictEqual(err.code, CODE.ISOLATE_LOST, 'the fault is what it is');
+
+    // The claim. The same three service-owned fields the crash arm supplies
+    // — nothing here originates in the render module, which authored no
+    // failure at all.
+    assert.deepStrictEqual(
+      Object.keys(err.detail).sort(),
+      ['afterChunks', 'isolate', 'threadId'],
+      'the exit arm must identify the isolate the way its sibling arm does',
+    );
+    assert.strictEqual(typeof err.detail.isolate, 'number', 'which isolate went');
+    assert.strictEqual(typeof err.detail.threadId, 'number', 'and the thread an operator will look for');
+    assert.strictEqual(err.detail.afterChunks, 0, 'nothing was written, so nothing is torn');
+
+    // The wording and the code are UNCHANGED by this — a detail-map gap is
+    // not a licence to restate the refusal.
+    assert.strictEqual(err.message, 'the isolate exited mid-render', 'the wording is not a policy change');
+  });
+});
+
+test('and a TORN exit still names the count beside the identifying fields', async () => {
+  // The second half, because a shape assertion on the clean path alone
+  // would not notice `afterChunks` being displaced by the two new fields.
+  await withService('exits', { isolates: 1 }, async (service) => {
+    const chunks = [];
+    const err = await refusalOf(async () => {
+      for await (const frame of service.renderFrames(exitReq('app/exits-torn'))) {
+        if (frame.type === 'chunk') chunks.push(frame.html);
+      }
+    });
+    assert.strictEqual(chunks.length, 1, 'the chunk really did reach the caller');
+    assert.strictEqual(err.code, CODE.ISOLATE_LOST, 'the distinction is kept');
+    assert.strictEqual(err.detail.afterChunks, 1, 'the tear is named, with its exact count');
+    assert.strictEqual(typeof err.detail.threadId, 'number', 'and the thread is still named');
+    assert.deepStrictEqual(
+      Object.keys(err.detail).sort(),
+      ['afterChunks', 'isolate', 'threadId'],
+      'identifying the isolate must not have added a field beyond the three',
+    );
+  });
+});

--- a/implementation/ssr-node/test/fixtures/exits.cjs
+++ b/implementation/ssr-node/test/fixtures/exits.cjs
@@ -1,0 +1,52 @@
+'use strict';
+// A render under which the ISOLATE THREAD EXITS — cleanly, with no
+// exception anywhere.
+//
+// `throws-async.cjs` is the neighbouring shape and it is NOT the same
+// receiver. There an uncaught exception kills the thread, so Node raises
+// `'error'` on the parent's `Worker` and `isolate.cjs`'s `worker.on('error')`
+// arm builds the refusal. Here nothing throws: `process.exit()` inside a
+// worker stops THAT THREAD rather than the program, so the only event the
+// parent ever sees is `'exit'`, and the sibling arm — `worker.on('exit')` —
+// is what answers the caller.
+//
+// That second arm is why this fixture exists (rf2-rhyi). Both arms reach
+// `:rf.ssr-node/isolate-lost`, which covers three distinct causes and
+// distinguishes them by detail SHAPE alone, so a consumer that cannot see
+// `isolate` and `threadId` on one of them cannot say which isolate went or
+// which of the three causes it is looking at.
+//
+// Not an exotic module either. A render module that pulls in a library
+// calling `process.exit()` on a configuration fault — or that does so
+// itself — takes this path, and it is the quietest of the three: the
+// thread is simply gone, with nothing written anywhere.
+//
+// TWO ENTRIES, the pair every terminal path here is measured on:
+//
+//   `app/exits`      — the thread goes before anything is emitted, so the
+//                      response is clean and `afterChunks` is 0.
+//   `app/exits-torn` — a chunk has already reached the caller, so the
+//                      response is TORN and the count says so.
+
+const ENTRY = { stateAllowlist: [':for-exit'], runtimeAllowlist: [] };
+
+module.exports = {
+  protocol: 1,
+  buildId: 'exits-build-1',
+  entries: {
+    'app/exits': ENTRY,
+    'app/exits-torn': ENTRY,
+  },
+
+  render({ entry }, emit) {
+    if (entry === 'app/exits-torn') emit('<p>first</p>');
+
+    // On a later tick, so the render has genuinely handed its promise back
+    // and the service is waiting on a thread that then disappears.
+    setImmediate(() => process.exit(0));
+
+    // And the render never finishes: the only thing that can settle this
+    // request is the thread going out from under it.
+    return new Promise(() => {});
+  },
+};


### PR DESCRIPTION
Two of the three dispatched beads landed; the third is analysed and left open.

## rf2-rhyi — `isolate-lost` from the exit arm carried an empty detail map (DONE)

`:rf.ssr-node/isolate-lost` covers three distinct causes — a crashed worker, a
worker that exited, and a replacement that will not boot — and a consumer tells
them apart by detail SHAPE, because the code and the wording are all it
otherwise has. `worker.on('error')` built its refusal with `{isolate, threadId}`;
`worker.on('exit')` built the same code with `{}`, so the arm whose thread goes
most quietly — nothing thrown, nothing on stderr — was the one that named
neither the isolate that went nor the thread an operator is about to look for.

The exit arm now supplies the same two service-owned fields. **The refusal code,
the sanitised wording and the termination/replacement behaviour are unchanged**
— a detail-map gap, not a policy change. `_failPendingRender` still stamps
`afterChunks` on top, so a torn exit keeps its discriminator.

`test/fixtures/exits.cjs` is the discriminator for the new rows: it throws
nothing at all, so no `'error'` event is ever raised and only the exit arm can
be what answered. Two entries, clean (`afterChunks` 0) and torn (`afterChunks` 1).

## rf2-hz8u — canonical login Story success variant omitted the session token (DONE)

Premise verified at source. Every login variant runs in its own `:preset :story`
frame, which redirects `:rf.http/managed` to the framework's GENERIC
canned-success stub. That stub answers `{:status :ok :value {:stubbed true}}`
when the request carries no `:value` of its own (`http/test_support.cljc`,
`emit-canned-success!`) — and this one carries none, because it is the real
request the live app sends. Its reply comes home to `:auth.login/succeeded`,
whose registration declares `:schema [… [:map [:value [:map [:token
:string]]]]]`, so the payload is refused at the development schema boundary: the
handler never runs, the machine is never nudged with `:success`, and the variant
tagged `:login/canonical` is a form stuck in `:submitting` rather than the
Welcome banner it advertises.

A live-app frame does not have this problem, which is why nothing else caught
it: `login.model/frame-config` points `:rf.http/managed` at
`:auth.login.demo/managed-stub`, which conjures a token-bearing reply. Story
allocates its variant frames itself, so that config never reaches them.

The variant now supplies its own fixture through `:network` — the dedicated
Story affordance for this fx, and the one that makes an explicit
`:fx-overrides {:rf.http/managed …}` a hard conflict
(`:rf.error/story-network-fx-conflict`). The route is the one `submit-form`
really posts (`[:post "/api/login"]`) and the reply is the shape the demo
backend really returns. No validation bypass, no change to the generic preset,
no change to the auth model. The `:login.story/submit` comment block asserted
the opposite — that a nil reply payload was fine because the banner keys off the
`:auth/authenticated` tag — which is the false premise behind the defect, so it
is corrected in the same commit.

## rf2-gzp5 — observability example config + mirror deftest (NOT DELIVERED)

Left open and untouched; the 40-minute box ran out on the two above. What was
established, so the next worker does not re-derive it: the bead wants a new
`:observability` entry in `examples/real-apps/realworld_resources/core.cljs`
plus a mirror deftest in `implementation/adapters/reagent/test/`. That test tree
carries **no JVM-runnable suite** — its `deps.edn` `:test` alias runs
`re-frame.test-quiet.runner --probe` precisely because the adapter ns is
CLJS-only and zero tests is the correct outcome there — so the mirror deftest
rides the CLJS node-test build (`npm run test:cljs`), and the example config's
own gate is `check-examples-compile.cjs`. Both are heavy gates this dispatch was
told not to run. It needs its own slot, not a tail-end of this one.

## Quality gates

| Gate | Command | Exit |
|---|---|---|
| Failing-first, rf2-rhyi (RED) | `node test/egress.test.cjs`, before the fix | **1** — both new rows failing on exactly the absent `isolate` / `threadId` |
| rf2-rhyi (GREEN) | `cd implementation/ssr-node && npm test` | **0** — 9 suites, all green; egress 37 pass / 0 fail; 119 assertions across the package |
| Gate-read-the-right-tree check | `run.cjs` prints its root | names this worktree, not the mayor checkout |

The RED run is the evidence that the two new rows discriminate: they exist only
in this tree, and they came back red naming the two missing fields, then green
after a three-line change to the arm they name.

**Left to CI, deliberately.** `examples/core/login/stories.cljs` is graded by
`cljs-examples-compile` (the `examples/login-with-stories` build is in
`check-examples-compile.cjs`'s roster, read from `shadow-cljs.edn`) and by the
Story lanes. Neither could run here: this worktree has no `implementation/node_modules`,
and installing one would rewrite the shared tree rather than a local copy —
`check-story-static.cjs` exited **1** on `Cannot find module 'http-server/bin/http-server'`
before reaching any check, which is a missing dependency tree and not a verdict
about the diff. Per the gate-nomination policy, CI grades the matrix.

**No mirror deftest for rf2-hz8u.** Its focused acceptance wants a variant-frame
drive under the development validator, which lives in the CLJS node-test tree
and needs a `npm run test:cljs` cycle this box cannot afford inside the box. The
source fix is complete and the causal chain above is verified at source at every
link; the regression test is the one loose end and belongs with rf2-gzp5's slot,
since both need the same build.

## Attribution

 Per `CLAUDE.md`, no `Co-Authored-By` or generated-with trailer is on any commit
 here — the repo convention forbids them and overrides the session-level harness
 reminder that asks for them.
