### PR TITLE
test(http): pin the reply-address roster — rf2-uc7d's fix is already live

### DIFF
--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -358,6 +358,25 @@
       (is (= {:note "plain"} (get-in r [:request :body])))
       (is (= :rf/redacted (get-in r [:request :headers "Cookie"]))))))
 
+;; The cases below are spelled out LITERALLY rather than read from
+;; `rf.http.encoding/reply-address-keys`, because that roster is the very
+;; thing under test: `project-managed-fx-args` reduces over it, so a test that
+;; also iterates it cannot see a key DROPPED from it. Measured — delete
+;; `:reply-to` from the roster and the projection stops classifying it while
+;; this namespace iterates the two survivors and reports 82 tests / 222
+;; assertions / 0 failures. That is exactly the rf2-uc7d defect returning
+;; through a door its own regression pin could not look at. The roster is
+;; pinned against this literal in its own assertion below, so the two cannot
+;; drift apart either.
+(def ^:private reply-address-keys-literal [:reply-to :on-success :on-failure])
+
+(deftest reply-address-roster-is-the-three-spelled-keys
+  (testing "rf2-uc7d — `reply-address-keys` is the unified `:reply-to` plus the
+            split `:on-success` / `:on-failure` sugar, in that order. Dropping
+            one silently un-classifies its payloads everywhere the roster is
+            reduced over, so the roster itself is pinned rather than trusted"
+    (is (= reply-address-keys-literal rf.http.encoding/reply-address-keys))))
+
 (deftest project-managed-fx-args-classifies-every-reply-address-key
   (testing "rf2-uc7d — the artefact-level fn applies the target registration's
             classification to ALL THREE reply-address keys. Core's
@@ -366,7 +385,7 @@
             `:http/project-managed-fx-args` hook actually resolves to, so the
             two doors cannot drift apart"
     (rf.registrar/register! :event ::reply-target {:sensitive [[:password]]})
-    (doseq [k rf.http.encoding/reply-address-keys]
+    (doseq [k reply-address-keys-literal]
       (let [r (rf.http.privacy/project-managed-fx-args
                 {:request {:method :post :url "https://api.example.test/save"}
                  k        [::reply-target {:password "hunter2" :user "ann"}]})]
@@ -380,7 +399,7 @@
 (deftest project-managed-fx-args-preserves-nil-reply-addresses
   (testing "rf2-uc7d — an explicit nil (fire-and-forget) survives as nil on
             every reply-address key, never a redaction sentinel"
-    (doseq [k rf.http.encoding/reply-address-keys]
+    (doseq [k reply-address-keys-literal]
       (let [r (rf.http.privacy/project-managed-fx-args
                 {:request {:method :get :url "/x"} k nil})]
         (is (contains? r k) (str k " stays present"))


### PR DESCRIPTION
Closes rf2-uc7d.

## Verdict: the bead's defect is ALREADY FIXED at tip — its regression pin was not

**The premise no longer holds.** rf2-uc7d was filed against source SHA `7ffdacf24d`, where
`project-managed-fx-args` (`implementation/http/src/re_frame/http/privacy.cljc`) applied
`redact-addr` to `:on-success` and `:on-failure` only, so a payload-carrying `:reply-to`
reached the generic HTTP fx traces unclassified. Verified at source at tip
(`origin/main` @ `9728970a70`), that branch is gone: the projection now reduces `redact-addr`
over `re-frame.http.encoding/reply-address-keys`, which is `[:reply-to :on-success :on-failure]`.
It landed in `4d950a180a` (PR #9370), which is exactly what the bead's own notes claim. The
ordering the bead asks for holds by construction — the redaction is applied inside the
`:http/project-managed-fx-args` late-bind hook that core's trace projector consults *before*
trace retention or egress, so nothing unclassified is ever retained. Both doors are pinned:
core's `fx_aggregate_classification_cljs_test.cljc` covers the `:rf.event/fx` aggregate and the
`[:rf.fx/id :rf.fx/args]` slot shape; this artefact pins the fn the hook resolves to.

**But the artefact-level pin could not see the defect it guards.** Proving the pin bites in this
worktree turned up a real hole. `project-managed-fx-args-classifies-every-reply-address-key`
and `project-managed-fx-args-preserves-nil-reply-addresses` both derived their cases from
`rf.http.encoding/reply-address-keys` — the same roster the production projection reduces over.
A key dropped from that roster therefore disappears from the assertions in the same motion that
it stops being classified. Measured: delete `:reply-to` from `reply-address-keys` and
`clojure -M:test -n re-frame.http-privacy-test` reports **82 tests / 222 assertions / 0 failures**
while the unified spelling leaks a declared-`:sensitive` field again. That is the rf2-uc7d defect
returning through a door its own pin could not look at.

## The change

Test-only, one file, additive.

- The two tests now iterate a literal `[:reply-to :on-success :on-failure]`.
- New `reply-address-roster-is-the-three-spelled-keys` pins the production roster against that
  literal, so the roster and the cases cannot drift apart.
- A comment records why the literal is deliberate, with the measured green-under-sabotage numbers.

No production behaviour changes. Refusal codes, sanitised wording and the `:reply-to` XOR
`:on-success`/`:on-failure` contract from PR #9370 are untouched.

## Quality gates

Runner's own captured exit codes, each echoed on the same command line as the run.

| Gate | Result |
|---|---|
| Sabotage control (`:reply-to` deleted from the roster), pre-change pin | `SABOTAGE_EXIT=0` — **green under the defect**, 82 tests / 222 assertions / 0 failures. This is the finding. |
| Failing-first, same fault, new pin | `RED_EXIT=1` — 83 tests / 228 assertions, **2 failures**: `(not (= :rf/redacted "hunter2"))` under `:reply-to`, and `(not (= [:reply-to :on-success :on-failure] [:on-success :on-failure]))`. |
| `cd implementation/http && clojure -M:test` (final, clean tree) | `HTTP_SUITE_EXIT=0` — 501 tests / 3969 assertions, 0 failures, 0 errors. |

The plant was restored by content hash, not by reading a diff: the blob hash of
`encoding.cljc` returned to the committed object (`08b1b8d07c…`) before the green run, and the
match count was read as `1` before each `sed` so neither plant could silently no-op. The red
discriminates the worktree — the fault existed only here, so a run that had wandered into a
sibling checkout would have come back green.

**Privacy/egress assertions (gate 3): in scope and green, but not because the diff needed them.**
The diff changes nothing that leaves the process in a trace or an egress payload — it is test-only
— so the obligation is vacuous. The assertions in question are this artefact's own
(`http_privacy_test.clj`, `http_privacy_integration_test.clj`) and both ran inside the 501-test
suite above.

**Left to CI:** the whole 87-check matrix. No spine, no `test:cljs`, no cross-artefact JVM sweep
was run locally — per the gate-nomination policy, one artefact suite once. Core's
`fx_aggregate_classification_cljs_test.cljc` is untouched by this diff and CI grades it on both
the JVM and CLJS lanes.

Attribution trailers are deliberately absent: `CLAUDE.md` forbids the
 `Co-Authored-By` / `Generated with` trailers and overrides the harness reminder that asks for them.
