### PR TITLE
docs(xray): spec/027 states the :snapshot :unknown exception (rf2-a0nt); rf2-7sx1 verified already at zero

### DIFF
--- a/tools/xray/spec/027-Hicasso-Evidence.md
+++ b/tools/xray/spec/027-Hicasso-Evidence.md
@@ -233,7 +233,11 @@ fields on the row and separate lines on the screen.
 - **Proven.** A cell's `epoch` is re-stamped by every commit that moved its
   value, so `:latest-reads` — the boundary's reads at its highest epoch — are
   the ones that moved most recently. `:snapshot` is the exact number React
-  compares in `checkIfSnapshotChanged`. Each entry names the READ
+  compares in `checkIfSnapshotChanged` — EXCEPT where an egress policy elided
+  a query whole and folded two boundaries reading DIFFERENT cells onto one
+  identity, which is reported as `:unknown` rather than as a sum no boundary
+  ever compared (rf2-h9lt); a fold of two READ ORDERS of the same cells keeps
+  its exact number. Each entry names the READ
   (`{:sub-id :query :frame-id}`, the query projected), not a bare sub-id:
   `[:row 1]` and `[:row 2]` are one registration and two different reads, and
   a Why view that answered ":row moved" to a developer looking at eight rows


### PR DESCRIPTION
Two items dispatched together. Only ONE produced a diff; the second is a verified
"the premise no longer holds".

## rf2-a0nt — spec/027 still called `:snapshot` the exact React number (CLOSES)

`tools/xray/spec/027-Hicasso-Evidence.md` §"Causality is never inferred from
adjacency" read `:snapshot` is the exact number React compares in
`checkIfSnapshotChanged` with no exception. PR #9393 (rf2-h9lt) made
`re-frame.hicasso.tool/explanation` report `:snapshot` as `evidence/unknown`
where the privacy fold merges DISTINCT raw read sets, and stated the exception
in the producer docstring and in `tools/re-frame2-pair-mcp/tool-descriptors.edn`.
`tools/xray/**` was fenced on that dispatch, so the third site was reported
rather than edited.

**Verified at source, not from the bead.** #9393 has not merged: on
`origin/main` the docstring still reads "`:snapshot` is the sum React itself
compares". The exception wording was read off `origin/worker/hic-a` — both the
`explanation` docstring and the `explain-render` descriptor — and the sentence
added here is the descriptor's own compact form, so the three sites carry one
phrasing rather than three.

One sentence added; nothing else on the page touched.

## rf2-7sx1 — require-alias dialect: PREMISE DOES NOT HOLD, no diff

The brief nominated seven surfaces still carrying baselined debt
(`spec-resource` 1, `test-quiet` 5, `reply-conformance` 13,
`derivation-conformance` 19, `security` 45, `schemas` 112, `epoch` 196) to sweep
and then lower in `scripts/require-alias-baseline.edn`. **Every one is already
at 0 with its floor already at 0**, and so is every other surface — the campaign
completed on trunk before this dispatch.

Whole-tree census on this base: `2807 file(s), 10924 re-frame require edge(s),
0 non-canonical`, all 27 surfaces `found 0 / floor 0`, exit **0**. Per-surface
`--scan-path` on each of the seven reads 0 non-canonical, 0 unparseable, exit 0.
The landing commits are on trunk: `161667b4f3` (four conformance surfaces),
`4f80afbfa8` (ssr/schemas/security/scripts/test-quiet), `8f2f07156f`
(epoch/flows/hicasso/adapters).

`scripts/require-alias-baseline.edn` is UNCHANGED by this PR — there is no floor
left to lower. rf2-7sx1 is NOT closed here; a note recording the verification is
appended to it for the mayor.

## Gates

Both zeros above are controlled, because a zero is not a check that passed.

**Alias ratchet — teeth proven at floor 0.** Committed first, then planted
`:as planted-misc-a` on `implementation/spec-resource/.../spec_resource_test.clj:38`
(match count 1 read before the run). Whole-tree gate exit **1**, naming
`implementation/spec-resource: 1 violation(s), floor 0` at that exact file and
line; the per-surface `--scan-path` arm — the instrument the seven zeros came
from — exit **1** on the same line. Restored; blob hash identical before and
after (`b9647d224d53661a4f25ad52d5ad308c37b9ef36`), tree clean, gate back to
exit **0**. The plant existed only in this worktree, so the red is the
discrimination.

**`python scripts/check_doc_slugs.py`** — exit **0**. `tools/*/spec` is inside
its roots. Teeth proven the same way: a broken anchor planted in the edited
paragraph took it to exit **1** naming
`tools/xray/spec/027-Hicasso-Evidence.md:239 -> #planted-fault-…`; restored,
blob hash identical (`4175017026aa922c68213095766b9c7002138abe`).

**Ratchets over the touched path** (a prose edit, so the retired-vocabulary
scans are the class that grades it), each exit **0**:
`check_retired_spellings`, `check_retired_composition_vocab`,
`check_retired_image_keys`, `check_view_lifetime_residue`,
`check_failure_corpus_residue`, `check_inject_cofx_residue`,
`check_ambient_durable_reads`, `check_allocation_non_claim`,
`check_keyword_catalogue_drift`, `check_skill_xray_tab_inventory_drift`,
`check_readme_links --ci`.

**Not run, deliberately.** No `clojure -M:test` — no artefact was swept, so
there is no swept artefact's suite to run, and the only diff is markdown. The
classifier arms `tools_jvm` and `cljs_node_test` on `tools/xray/**`; nothing
pins this file's content (the sole in-code reference is a docstring pointer in
`panels/hicasso.cljs`), so those lanes are CI's. `scripts/test-fast-pr.sh` was
not run, per the brief.

**Bound on the doc gates:** neither `check_doc_slugs.py` nor
`check_readme_links.py` looks inside a fenced block, and `mkdocs build --strict`
does not see `tools/` at all (outside `docs_dir`). The edit is prose outside any
fence, so `check_doc_slugs.py` is the gate that covers it; the paragraph's
wrapping and its one inline-code run were checked by eye.
