### PR TITLE
fix(story): realize authored :network fixtures on the normal variant and inline run paths (rf2-shx4)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -2660,6 +2660,35 @@ runtime dependency (the stub install is a runtime concern for running a
 `:network` variant, so the dep rides Story's main `:deps`, not the `:test`
 alias).
 
+#### One install, per-frame replies
+
+The helper registers **one** global stub fx id over a route map captured at
+install time, and its install stack is snapshot/restore (LIFO), not a merge.
+An install-per-variant would therefore make the second mounted variant's
+routes answer for both — the silent cross-variant overwrite. Story's
+mount/destroy order is not LIFO either, so it cannot balance that stack
+per variant.
+
+So the runner (`re-frame.story.network`) installs **once** and hands the
+helper a route map that resolves `[method url]` against
+`{frame-id → routes}` keyed on the frame in flight — legitimate because the
+helper reads its map with a plain `get` (any `ILookup` will do) and because
+`re-frame.router` binds the envelope's frame for the whole handler chain,
+the fx walk included. Ownership is per frame: the runner takes it before
+allocation — ahead of any `:frame-setup` `:init`, loader, `:setup` or script
+effect — and frame teardown (`destroy!` / `destroy-inline!`) releases exactly
+that one frame's fixture. The single install/uninstall pair is refcounted by
+that registry: installed when it goes empty → non-empty, uninstalled when it
+returns to empty.
+
+Two consequences the surface depends on. Two variants mounted at once
+stubbing the SAME url with DIFFERENT replies each keep their own; and a
+frame owning no fixture (or a request outside any frame) resolves to no
+route, so the helper's own "no stub matched" transport failure still fires
+unchanged. The lowered fx id stays `:rf.http/managed-test-stub`, so the
+recorded `:fx-decisions` redirect and the artifact replay path are
+unaffected.
+
 ### What the compiler emits
 
 When a variant's resolved (merged + arg-substituted) `:network` route map

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -76,6 +76,11 @@
             [re-frame.story.error      :as rf.story.error]
             [re-frame.story.late-bind  :as rf.story.late-bind]
             [re-frame.story.loaders    :as rf.story.loaders]
+            ;; rf2-shx4 — frame teardown releases the frame's ownership of its
+            ;; authored `:network` canned replies (the runtime takes ownership
+            ;; before allocation). Pure registry bookkeeping; the HTTP
+            ;; artefact itself is reached lazily from inside that ns.
+            [re-frame.story.network    :as rf.story.network]
             [re-frame.story.predicates :as rf.story.predicates]
             [re-frame.story.registrar  :as rf.story.registrar]
             [re-frame.story.runtime-image :as rf.story.runtime-image]))
@@ -704,13 +709,34 @@
   every such caller in this codebase exercises. Before this fn threaded
   a classification arg, `allocate!` ALWAYS read the raw un-merged body —
   so a variant that only `:extends`ed a classified parent, declaring no
-  classification itself, silently dropped the parent's redaction."
-  ([variant-id decorator-stack] (allocate! variant-id decorator-stack nil))
+  classification itself, silently dropped the parent's redaction.
+
+  `plan-fx-overrides` (optional, 4-arity; rf2-shx4) is the compiled plan's
+  `[:world :frame :fx-overrides]` map — the lowering `:network` folds
+  `{:rf.http/managed :rf.http/managed-test-stub}` into. It merges UNDER the
+  decorator stack's materialised stubs (the plan map wins), exactly as
+  `allocate-inline!` has always merged its own. Omitted (2-/3-arity) leaves
+  the decorator stubs alone. Before this arity existed the registered path
+  passed only the decorator stack, so an authored `:network` fixture's
+  redirect never reached the frame and the variant executed the REAL
+  `:rf.http/managed` transport."
+  ([variant-id decorator-stack] (allocate! variant-id decorator-stack nil nil))
   ([variant-id decorator-stack classification]
+   (allocate! variant-id decorator-stack classification nil))
+  ([variant-id decorator-stack classification plan-fx-overrides]
    (when rf.story.config/enabled?
      (install-canonical-frame-events!)
      (let [fx-stack       (rf.story.decorators/fx-overrides-map (:fx-override decorator-stack))
-           fx-overrides   (register-fx-overrides! fx-stack)
+           decor-fx       (register-fx-overrides! fx-stack)
+           ;; rf2-shx4 — the compiled plan's `[:world :frame :fx-overrides]`
+           ;; (e.g. the `:network` lowering's `{:rf.http/managed
+           ;; :rf.http/managed-test-stub}` redirect) rides onto the frame the
+           ;; SAME way `allocate-inline!` already merges it: decorator stubs
+           ;; UNDER the plan map, so the plan wins. Before this the registered
+           ;; path passed only the decorator stack, so an authored `:network`
+           ;; fixture's redirect was silently dropped and the variant reached
+           ;; the REAL `:rf.http/managed` transport.
+           fx-overrides   (merge decor-fx plan-fx-overrides)
            ;; Inline the variant-body lookup (`variant-body` is defined
            ;; lower in this ns) — go through the registrar directly so
            ;; the events-only classification doesn't depend
@@ -937,6 +963,9 @@
         (catch #?(:clj Throwable :cljs :default) _ nil)))
     (try (apply-frame-teardown! frame-id (:frame-setup decorator-stack))
       (catch #?(:clj Throwable :cljs :default) _ nil))
+    ;; rf2-shx4 — same release as `destroy!`: an inline run's completion drops
+    ;; exactly the fixture that run owned.
+    (rf.story.network/release-frame! frame-id)
     (rf/destroy-frame! frame-id)
     nil))
 
@@ -1043,6 +1072,10 @@
   [variant-id]
   (when rf.story.config/enabled?
     (run-teardown-walks! variant-id)
+    ;; rf2-shx4 — release THIS frame's canned-network ownership (and, once no
+    ;; Story frame owns any, the shared stub fx). Only this frame's fixture
+    ;; goes: a concurrently mounted variant keeps answering its own replies.
+    (rf.story.network/release-frame! variant-id)
     (rf/destroy-frame! variant-id)
     nil))
 

--- a/tools/story/src/re_frame/story/network.cljc
+++ b/tools/story/src/re_frame/story/network.cljc
@@ -1,0 +1,144 @@
+(ns re-frame.story.network
+  "Realize a compiled variant's authored `:network` fixture on the LIVE run
+  paths (spec/017 §The network surface — \"the runner installs the route map
+  and points `:fx-overrides` at the stub fx\").
+
+  `rf.story.plan/lower-network` is pure: it keeps the authored route map at
+  the plan's `[:world :network]` and emits the `{:rf.http/managed
+  :rf.http/managed-test-stub}` redirect at `[:world :frame :fx-overrides]`.
+  Naming the stub id REGISTERS NOTHING — `re-frame.http.test-support/
+  install-managed-request-stubs!` is what creates the fx over a route map.
+  Before rf2-shx4 the only executable call to it in Story was
+  `rf.story.artifact/with-network-stubs!` (artifact REPLAY), so a live
+  registered-variant run reached the real `:rf.http/managed` transport and a
+  live inline-plan run redirected to an unregistered fx id. This namespace is
+  the missing realization step; the runtime calls it either side of a frame's
+  lifetime.
+
+  ## Why one install, and why a frame-scoped route map
+
+  `install-managed-request-stubs!` re-registers ONE global fx id
+  (`:rf.http/managed-test-stub`) with a route map CLOSED OVER at install
+  time, and its stack is snapshot/restore (LIFO), not a merge. So the naive
+  \"install per mounted variant\" makes the second variant's routes answer for
+  BOTH — exactly the silent cross-variant overwrite rf2-shx4 forbids.
+
+  Two facts make per-frame isolation reachable from inside Story, with NO
+  second HTTP simulator, no change to the lowered fx id (so the recorded
+  `:fx-decisions` redirect, `spec/017` and the artifact replay path all stay
+  as they are) and no change to the `re-frame.http` artefact:
+
+  - `re-frame.http.test-support/stub-handler` reads its route map with a
+    plain `(get stubs [method url])`, so `stubs` need only satisfy `ILookup`
+    — it does not have to be a literal map; and
+  - `re-frame.router` binds `re-frame.frame/*current-frame*` to the
+    envelope's frame for the WHOLE handler chain, the fx walk included
+    (`router.cljc` §2 of the `process-event!` bindings).
+
+  So Story installs ONE route-map-shaped object whose lookup resolves
+  `[method url]` against `{frame-id → routes}` keyed on the frame in flight.
+  Ownership is per frame; the single install/uninstall pair is refcounted by
+  the registry — installed when it goes empty→non-empty, uninstalled when it
+  goes non-empty→empty — because Story's mount/destroy order is NOT LIFO and
+  an install-per-variant would unbalance that stack.
+
+  A frame with no fixture (or a request from no frame at all) resolves to
+  `nil`, so `stub-handler` falls through to its own canned
+  `\"no stub matched\"` transport failure — spec/017 §Network stubs, preserved
+  rather than reimplemented."
+  (:require [re-frame.frame :as rf.frame]
+            ;; The raw HTTP stub pair lives in `re-frame.http.test-support`
+            ;; (its home namespace, not the `re-frame.core` façade). CLJS
+            ;; requires it directly; on the JVM it is resolved LAZILY at call
+            ;; time so requiring this ns from the `re-frame.story` MACRO-ns
+            ;; does not drag the http artefact's JVM-only transitive deps onto
+            ;; the macro classpath. Same boundary `rf.story.artifact` uses.
+            #?(:cljs [re-frame.http.test-support :as rf.http.test-support])))
+
+(defonce
+  ^{:doc "frame-id → the frame's authored `{[method url] {:reply …}}` route
+         map. The SSOT for which live Story frame owns which canned network
+         replies. Populated by `install-for-frame!`, evicted by
+         `release-frame!`."}
+  frame-routes
+  (atom {}))
+
+(defn routes-for
+  "The route map owned by `frame-id`, or `nil`. Read by the frame-scoped
+  lookup below and by tests."
+  [frame-id]
+  (get @frame-routes frame-id))
+
+(defn- current-frame-id
+  "The frame id of the cascade in flight, or `nil` outside one.
+
+  `re-frame.frame/*current-frame*` may carry a frame VALUE (`with-frame` /
+  `with-new-frame` bind `make-frame`'s token) where the router binds the
+  id, so normalize through `frame-value->id` exactly as the framework's own
+  `:frame/current-frame-id` late-bind hook does (rf2-h1vqa4). Keying the
+  registry on an un-normalized value would miss every value-bound extent."
+  []
+  (rf.frame/frame-value->id (rf.frame/current-frame)))
+
+;; The route-map-shaped object handed to `install-managed-request-stubs!`.
+;; `stub-handler` only ever asks it for `[method url]`, so `ILookup` is the
+;; whole contract; resolving the frame at LOOKUP time (not install time) is
+;; what gives two concurrently mounted variants their own replies.
+(deftype FrameScopedRoutes []
+  #?(:clj clojure.lang.ILookup :cljs ILookup)
+  (#?(:clj valAt :cljs -lookup) [_ k]
+    (get (routes-for (current-frame-id)) k))
+  (#?(:clj valAt :cljs -lookup) [_ k not-found]
+    (get (routes-for (current-frame-id)) k not-found)))
+
+(def ^:private frame-scoped-routes
+  "The single `stubs` object every Story install shares. One instance: the
+  per-frame answer comes from the registry it reads, never from the object."
+  (->FrameScopedRoutes))
+
+(defn- install!
+  "Register `:rf.http/managed-test-stub` over the frame-scoped route map."
+  []
+  (let [install #?(:clj  (requiring-resolve 're-frame.http.test-support/install-managed-request-stubs!)
+                   :cljs rf.http.test-support/install-managed-request-stubs!)]
+    (install frame-scoped-routes)))
+
+(defn- uninstall!
+  []
+  (let [uninstall #?(:clj  (requiring-resolve 're-frame.http.test-support/uninstall-managed-request-stubs!)
+                     :cljs rf.http.test-support/uninstall-managed-request-stubs!)]
+    (uninstall)))
+
+(defn release-frame!
+  "Drop `frame-id`'s ownership of its canned replies, and uninstall the stub
+  fx once no Story frame owns any — the non-empty→empty edge of the single
+  install/uninstall pair. Called from frame teardown (`destroy!` /
+  `destroy-inline!`), so a reset, a destroy and an inline run's completion
+  all release exactly the one fixture they own and leave every other mounted
+  variant's replies intact. Idempotent — releasing an unowned frame is a
+  no-op and never touches the install stack."
+  [frame-id]
+  (when (contains? @frame-routes frame-id)
+    (swap! frame-routes dissoc frame-id)
+    (when (empty? @frame-routes) (uninstall!)))
+  nil)
+
+(defn install-for-frame!
+  "Take ownership of `routes` for `frame-id` and make sure the stub fx the
+  plan's `:fx-overrides` redirect names is registered.
+
+  Called by the runtime BEFORE the frame is allocated — so before any
+  `:frame-setup` `:init`, loader, `:setup` or script effect can issue a
+  managed request. Idempotent: re-running the same variant re-asserts the
+  same ownership without a second install.
+
+  An empty/absent `routes` RELEASES any ownership `frame-id` held, so a
+  variant recompiled without `:network` stops answering from a stale
+  fixture. Returns `frame-id`."
+  [frame-id routes]
+  (if-not (seq routes)
+    (do (release-frame! frame-id) frame-id)
+    (let [was-empty? (empty? @frame-routes)]
+      (swap! frame-routes assoc frame-id routes)
+      (when was-empty? (install!))
+      frame-id)))

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -40,6 +40,10 @@
             [re-frame.story.frames    :as rf.story.frames]
             [re-frame.story.identity  :as rf.story.identity]
             [re-frame.story.loaders   :as rf.story.loaders]
+            ;; rf2-shx4 — realizes the compiled `:network` fixture (installs
+            ;; the frame-scoped route map the plan's lowered `:fx-overrides`
+            ;; redirect points at) before either run path allocates its frame.
+            [re-frame.story.network   :as rf.story.network]
             [re-frame.story.plan      :as rf.story.plan]
             [re-frame.story.play      :as rf.story.play]
             [re-frame.story.play.evidence :as rf.story.play.evidence]
@@ -866,8 +870,19 @@
   classification through the same allocation boundary."
   [{:keys [variant-id decorator-stack plan] :as ctx}]
   (ensure-fresh-frame! variant-id)
+  ;; rf2-shx4 — realize the compiled `:network` fixture BEFORE allocation, so
+  ;; the route map is live before any `:frame-setup` `:init`, loader, `:setup`
+  ;; or script effect can issue a managed request. `lower-network` is pure: it
+  ;; emits the `{:rf.http/managed :rf.http/managed-test-stub}` redirect but
+  ;; registers nothing, so without this the variant reached the REAL transport.
+  (rf.story.network/install-for-frame! variant-id (get-in plan [:world :network]))
   (rf.story.frames/allocate! variant-id decorator-stack
-                     (select-keys (:world plan) [:sensitive :large]))
+                     (select-keys (:world plan) [:sensitive :large])
+                     ;; …and carry the plan's lowered frame `:fx-overrides`
+                     ;; (the redirect above) onto the frame — the registered
+                     ;; path dropped it entirely; `allocate-inline!` already
+                     ;; merged it.
+                     (get-in plan [:world :frame :fx-overrides]))
   (swap! rf.story.play/pending-exceptions assoc variant-id [])
   (rf.story.config/reset-redacted-failures! variant-id)
   (rf.story.play/install-trace-listener! variant-id)
@@ -1620,6 +1635,11 @@
   and an equivalent registered variant project the same-shaped tape (and
   therefore the same run-hash)."
   [{:keys [variant-id plan decorator-stack] :as ctx}]
+  ;; rf2-shx4 — the inline path already TRANSFERRED the lowered redirect but
+  ;; installed no route map, so `:rf.http/managed-test-stub` was an
+  ;; unregistered fx id. Realize the fixture first, same ordering as
+  ;; `run-phase-0!`.
+  (rf.story.network/install-for-frame! variant-id (get-in plan [:world :network]))
   (rf.story.frames/allocate-inline! variant-id
                            decorator-stack
                            (get-in plan [:world :frame :fx-overrides])

--- a/tools/story/test/re_frame/story/network_runtime_test.clj
+++ b/tools/story/test/re_frame/story/network_runtime_test.clj
@@ -1,0 +1,193 @@
+(ns re-frame.story.network-runtime-test
+  "rf2-shx4 — a variant's authored `:network` fixture is REALIZED on the
+  normal run paths (spec/017 §The network surface: \"the runner installs the
+  route map and points `:fx-overrides` at the stub fx\").
+
+  `rf.story.plan/lower-network` was already correct and pure: it keeps the
+  authored routes at `[:world :network]` and emits the `{:rf.http/managed
+  :rf.http/managed-test-stub}` redirect at `[:world :frame :fx-overrides]`.
+  Nothing on the live run paths consumed either. The registered path did not
+  even TRANSFER the redirect to the frame (`run-phase-0!` passed only the
+  decorator stack + classification to `frames/allocate!`, which derived
+  `:fx-overrides` from decorators alone), so a `:network` variant executed
+  the REAL `:rf.http/managed` effect; the inline path transferred the
+  redirect but installed no route map, so it pointed at an unregistered fx.
+  The only executable `install-managed-request-stubs!` call in Story was
+  `artifact/with-network-stubs!` — artifact REPLAY only.
+
+  THE LIVE-HTTP SENTINEL. Every test here registers `:rf.http/managed` as a
+  CAPTURE-ONLY fx that records its payload and returns nil. No request is
+  ever issued: the sentinel IS the real handler's slot for the duration of
+  the test, so `live-requests` staying empty is positive proof the redirect
+  fired, and a non-empty `live-requests` is exactly the pre-fix failure
+  (the registered path reaching the production transport slot, or the
+  inline path's redirect falling through an unregistered target onto it).
+
+  JVM-only (`.clj`): `rf.story/run` returns a `CompletableFuture` that
+  resolves synchronously, and the canned reply is dispatched inside the
+  fx walk, so the whole request→reply round trip settles before `.get`
+  returns. The compile-time half (that `lower-network` emits the override
+  map at all) is `re-frame.story.plan-network-test`; this suite is about
+  the run path that consumes it."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core      :as rf]
+            [re-frame.frame     :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story         :as rf.story]
+            [re-frame.story.frames  :as rf.story.frames]
+            [re-frame.story.network :as rf.story.network]))
+
+(def ^:private live-requests
+  "Payloads the capture-only `:rf.http/managed` sentinel saw. MUST stay
+  empty — a single entry means a managed request escaped the fixture."
+  (atom []))
+
+(defn- reset-rf! [test-fn]
+  ;; Drain first, so a previous test's undestroyed frame unwinds the shared
+  ;; install/uninstall pair before `clear-all!` drops the registrar.
+  (doseq [id (keys @rf.story.network/frame-routes)]
+    (rf.story.network/release-frame! id))
+  (reset! live-requests [])
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  ;; THE SENTINEL. This occupies the production `:rf.http/managed` fx slot
+  ;; for the whole test and issues nothing.
+  (rf/reg-fx :rf.http/managed
+             (fn [_ctx payload] (swap! live-requests conj payload) nil))
+  (rf/reg-event :net/load
+                (fn [_ _]
+                  {:fx [[:rf.http/managed
+                         {:request    {:method :get :url "/api/cart"}
+                          :on-success [:net/loaded]
+                          :on-failure [:net/failed]}]]}))
+  (rf/reg-event :net/load-missing
+                (fn [_ _]
+                  {:fx [[:rf.http/managed
+                         {:request    {:method :get :url "/api/nope"}
+                          :on-success [:net/loaded]
+                          :on-failure [:net/failed]}]]}))
+  (rf/reg-event :net/loaded (fn [{:keys [db]} [_ reply]] {:db (assoc db :cart (:value reply))}))
+  (rf/reg-event :net/failed (fn [{:keys [db]} [_ reply]] {:db (assoc db :error reply)}))
+  (test-fn))
+
+(use-fixtures :each reset-rf!)
+
+(defn- run-target [target]
+  (.get ^java.util.concurrent.CompletableFuture (rf.story/run target)))
+
+(def ^:private cart-fixture
+  {[:get "/api/cart"] {:reply {:ok {:items [1]}}}})
+
+;; ===========================================================================
+;; The registered path
+;; ===========================================================================
+
+(deftest registered-variant-realizes-its-network-fixture
+  (testing "a REGISTERED variant's authored :network delivers the canned reply
+            with ZERO live requests (rf2-shx4 — run-phase-0! now installs the
+            route map AND threads the plan's lowered frame :fx-overrides,
+            which it previously dropped entirely)"
+    (rf.story/reg-variant :story.net/cart
+                          {:network cart-fixture
+                           :setup   [[:dispatch [:net/load]]]})
+    (let [result (run-target :story.net/cart)]
+      (is (= {:items [1]} (:cart (:app-db result)))
+          "the authored fixture answered the managed request")
+      (is (= [] @live-requests)
+          "SENTINEL: no managed request reached the production fx slot"))))
+
+(deftest registered-variant-unmatched-route-fails-with-no-stub-matched
+  (testing "an unmatched URL follows the helper's existing canned no-match
+            transport failure (spec/017 §Network stubs) rather than escaping
+            to the real handler"
+    (rf.story/reg-variant :story.net/missing
+                          {:network cart-fixture
+                           :setup   [[:dispatch [:net/load-missing]]]})
+    (let [result (run-target :story.net/missing)
+          err    (:error (:app-db result))]
+      (is (some? err) "the unmatched route produced a failure reply")
+      (is (re-find #"no stub matched" (pr-str err))
+          "and it is the helper's own canned no-match failure")
+      (is (= [] @live-requests)
+          "SENTINEL: an unmatched route still issues no live request"))))
+
+;; ===========================================================================
+;; The inline path
+;; ===========================================================================
+
+(deftest inline-plan-realizes-its-network-fixture
+  (testing "an INLINE plan map's authored :network delivers the same canned
+            reply. The inline path already transferred the lowered redirect,
+            so before rf2-shx4 it pointed `:rf.http/managed` at an
+            UNREGISTERED `:rf.http/managed-test-stub`"
+    (let [result (run-target {:network cart-fixture
+                              :setup   [[:dispatch [:net/load]]]})]
+      (is (= {:items [1]} (:cart (:app-db result)))
+          "the inline fixture answered the managed request")
+      (is (= [] @live-requests)
+          "SENTINEL: no managed request reached the production fx slot"))))
+
+;; ===========================================================================
+;; Isolation + ownership
+;; ===========================================================================
+
+(deftest concurrently-mounted-variants-keep-their-own-replies
+  (testing "two variants mounted at once, both stubbing the SAME url with
+            DIFFERENT replies, each keep their own — the route map is
+            resolved against the frame in flight, not closed over at install
+            time, so the second install cannot answer for the first"
+    (rf.story/reg-variant :story.net/a
+                          {:network {[:get "/api/cart"] {:reply {:ok {:items [:a]}}}}
+                           :setup   [[:dispatch [:net/load]]]})
+    (rf.story/reg-variant :story.net/b
+                          {:network {[:get "/api/cart"] {:reply {:ok {:items [:b]}}}}
+                           :setup   [[:dispatch [:net/load]]]})
+    (let [a1 (run-target :story.net/a)
+          b1 (run-target :story.net/b)
+          ;; A is still mounted; re-running it must NOT pick up B's routes.
+          a2 (run-target :story.net/a)]
+      (is (= {:items [:a]} (:cart (:app-db a1))))
+      (is (= {:items [:b]} (:cart (:app-db b1))))
+      (is (= {:items [:a]} (:cart (:app-db a2)))
+          "A still answers its OWN fixture with B mounted alongside")
+      (is (= [] @live-requests) "SENTINEL: still no live request"))))
+
+(deftest destroy-releases-only-that-frames-fixture
+  (testing "tearing one variant down drops exactly its ownership and leaves
+            every other mounted variant's replies intact"
+    (rf.story/reg-variant :story.net/a
+                          {:network {[:get "/api/cart"] {:reply {:ok {:items [:a]}}}}
+                           :setup   [[:dispatch [:net/load]]]})
+    (rf.story/reg-variant :story.net/b
+                          {:network {[:get "/api/cart"] {:reply {:ok {:items [:b]}}}}
+                           :setup   [[:dispatch [:net/load]]]})
+    (run-target :story.net/a)
+    (run-target :story.net/b)
+    (is (some? (rf.story.network/routes-for :story.net/a)))
+    (is (some? (rf.story.network/routes-for :story.net/b)))
+    (rf.story.frames/destroy! :story.net/a)
+    (is (nil? (rf.story.network/routes-for :story.net/a))
+        "the destroyed frame's fixture is released")
+    (is (some? (rf.story.network/routes-for :story.net/b))
+        "the surviving frame keeps its own")
+    (let [b2 (run-target :story.net/b)]
+      (is (= {:items [:b]} (:cart (:app-db b2)))
+          "and it still answers after the sibling teardown"))
+    (rf.story.frames/destroy! :story.net/b)
+    (is (= {} @rf.story.network/frame-routes)
+        "the last release empties the registry")
+    (is (= [] @live-requests) "SENTINEL: still no live request")))
+
+(deftest inline-run-completion-releases-its-fixture
+  (testing "an inline run's own teardown releases the anonymous frame's
+            fixture, so a headless inline run leaks no ownership"
+    (run-target {:network cart-fixture :setup [[:dispatch [:net/load]]]})
+    (is (= {} @rf.story.network/frame-routes)
+        "destroy-inline! released the inline frame's routes")
+    (is (= [] @live-requests) "SENTINEL: still no live request")))


### PR DESCRIPTION
## rf2-shx4 — realize authored `:network` fixtures on the live run paths

Story accepts and documents a first-class `:network` fixture, and
`plan/lower-network` was already correct and pure — it keeps the authored
routes at `[:world :network]` and emits the
`{:rf.http/managed :rf.http/managed-test-stub}` redirect at
`[:world :frame :fx-overrides]`. **Nothing on the normal run paths consumed
either.** The only executable `install-managed-request-stubs!` call in Story
was `artifact/with-network-stubs!` — artifact REPLAY only.

The premise was verified at source before any edit, and it held. The two
paths failed differently, exactly as filed:

- **Registered** — `run-phase-0!` passed only the decorator stack and the
  classification to `frames/allocate!`, which derived `:fx-overrides` from
  decorators alone. The compiled redirect was dropped entirely, so a
  `:network` variant executed the **real** `:rf.http/managed` effect.
- **Inline** — `run-inline-phase-0!` did transfer the redirect to
  `allocate-inline!`, but nothing installed a route map, so
  `:rf.http/managed-test-stub` was an unregistered fx id and the redirect fell
  through onto the real effect.

`tools/story/spec/017-Testing-Story.md` already said the runner installs the
route map when it creates the frame. **The spec was right and the code was
wrong**; no spec claim needed correcting.

### The design call this needed

The bead's isolation clause ("two concurrently mounted variants must not
overwrite one another's replies") looked like it forced either a second HTTP
simulator (which the bead and spec/017 both forbid) or a seam change in
`implementation/http`. It forces neither:

- `test_support/stub-handler` reads its route map with a plain
  `(get stubs [method url])`, so `stubs` need only satisfy `ILookup`; and
- `re-frame.router` binds `*current-frame*` for the whole handler chain, the
  fx walk included.

So the new `re-frame.story.network` installs **once** and hands the helper a
route map that resolves against `{frame-id → routes}` keyed on the frame in
flight. The lowered fx id is unchanged, so the recorded `:fx-decisions`
redirect, `plan_network_test.cljc` and the artifact replay path are all
untouched, and `implementation/http` is not edited. The single
install/uninstall pair is refcounted by that registry (empty → non-empty
installs; back to empty uninstalls), because Story's mount/destroy order is
not LIFO and the helper's stack is snapshot/restore.

Ownership is taken **before** allocation — ahead of any `:frame-setup`
`:init`, loader, `:setup` or script effect — and released by `destroy!` /
`destroy-inline!`, so a reset, a destroy and an inline run's completion each
drop exactly the one fixture they own.

A frame owning no fixture resolves to no route, so the helper's own
"no stub matched" transport failure is preserved rather than reimplemented.

### Acceptance

New JVM suite `re-frame.story.network-runtime-test`, driven through the
public `rf.story/run` lifecycle (not `compile-body`). Every test registers
`:rf.http/managed` as a **capture-only sentinel** that records its payload and
returns nil — no request is ever issued; the sentinel occupying that slot is
what proves the redirect fired.

Covered: registered path, inline path, unmatched-URL canned failure, two
concurrently mounted variants with different replies to the same URL,
per-frame release on destroy, and inline-completion release.

### Gates

- **Failing-first**: with the two wiring files reverted to `origin/main` and
  the new suite unchanged — **exit 1**, 17 failures of 20 assertions. The
  sentinel captured the managed payload on **both** the registered and the
  inline path, i.e. the production `:rf.http/managed` slot was reached.
  Restore verified by git blob hash against the pre-plant values.
- **Focused suite after the fix** — `clojure -M:test -n
  re-frame.story.network-runtime-test`, **exit 0**, 6 tests / 20 assertions.
- **`tools/story` artefact suite** — `clojure -M:test`, **exit 0**, 1909 tests
  / 7030 assertions, 0 failures, 0 errors.
- **`python scripts/check_doc_slugs.py`** — **exit 0** (subject: the spec
  edit).
- Ran `check_fast_pr_gap.py --brief` as a report. Left to CI: the CLJS
  node-test lane, the examples-compile sweep and the rest of the matrix. The
  diff is JVM-reachable `.cljc` plus one `.clj` test and one spec page; the
  spine was deliberately not run (per the gate-nomination policy).
