### PR TITLE
docs(views): record why `apply` at the render site is load-bearing (rf2-xccd)

### DIFF
--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -591,6 +591,35 @@
                       ;; `re-frame.performance/enabled?=false` the bracket DCEs
                       ;; and the form collapses to the bare `(apply render-fn
                       ;; args)` call.
+                      ;;
+                      ;; `apply` HERE IS LOAD-BEARING — do not rewrite it as a
+                      ;; direct call, and do not reach for `(.apply render-fn
+                      ;; nil …)` (rf2-xccd). The DIRECT Form-3 shape that
+                      ;; `re-frame.core/reg-view*` advertises — a `create-class`
+                      ;; result handed straight in, with no outer callable —
+                      ;; arrives here AS `render-fn`, because a class is `fn?`
+                      ;; and nothing upstream discriminates the registered
+                      ;; INPUT. It mounts correctly regardless, and only
+                      ;; because of how `cljs.core/apply` binds `this`:
+                      ;; a Reagent-family constructor carries no
+                      ;; `cljs$lang$applyTo`, so `apply` bottoms out in
+                      ;; `(.apply f f …)` — `this` is the CONSTRUCTOR OBJECT.
+                      ;; Both supported constructors are `(React.Component.call
+                      ;; this props …) … this`, so calling one as a plain
+                      ;; function stamps a few fields onto the class object and
+                      ;; RETURNS THE CLASS. `out` is therefore a `reagent-class?`
+                      ;; value, which the annotation walk below passes through
+                      ;; untouched and the substrate's own render-result branch
+                      ;; then mounts as `[klass & args]` (stock Reagent:
+                      ;; `reagent.impl.component/wrap-render`; reagent-slim:
+                      ;; `reagent2.impl.component/form-2-inner-fn` →
+                      ;; `class-mounting-render-fn`). Bind `this` to anything
+                      ;; else and the constructor either throws or mutates the
+                      ;; global object and returns it, and the shape breaks on
+                      ;; every substrate at once. The output-side discrimination
+                      ;; in `views/source-coord-annotation` is thus SUFFICIENT
+                      ;; rather than "too late"; no input-side special case is
+                      ;; wanted here.
                       (let [out        (rf.performance/mark-and-measure :render id
                                          (apply render-fn args))
                             elapsed-ms (when rf.interop/debug-enabled?


### PR DESCRIPTION
## rf2-xccd — verified refutation, plus the invariant that makes it true

`rf2-xccd` reported that the advertised direct Form-3 shape — a `create-class`
result handed straight to `reg-view*`, with no outer callable — is **invoked as
a render function instead of mounted**.

**The premise does not hold, on either supported Reagent-family substrate.** The
source reading behind the report is correct as far as it goes: `views.cljs` ends
in an unconditional `(apply render-fn args)`, a `create-class` result satisfies
`fn?`, and `views/source_coord_annotation.cljs`'s `reagent-class?` inspects the
render's OUTPUT rather than the registered INPUT. The shape mounts correctly
anyway. Worker `corev-a` measured that on stock Reagent on the browser lane
(PR #9387, three runs: candidate repair in place, repair disabled and verified
in the compiled bundle, and a planted fixture fault taking the lane red) and
withdrew its repair on the green sabotage run. What that measurement did not
carry was the *reason*, which left `reagent-slim` standing as an unrefuted arm.

This PR supplies the reason and closes the slim arm at source. No behaviour
change — the diff is 29 lines of comment.

### Why it works

`cljs.core/apply`, given a JS function with no `cljs$lang$applyTo`, bottoms out
in `(.apply f f …)` — so **`this` is the constructor object itself**. Both
supported constructors end `(React.Component.call this props …) … this`:

- stock Reagent 2.0.1 `reagent.impl.component/create-class`, the `cmp` fn
- `reagent2.impl.component/create-class*` in `adapters/reagent-slim`

So calling one as a plain function stamps `props` / `context` / `refs` /
`updater` (and `state` / `cljsArgv` on slim) onto the class object and
**returns the class**. `out` is therefore a `reagent-class?` value, which:

1. `inject-source-coord-attr`'s Form-3 branch passes through untouched, and
2. each substrate's own render-result branch mounts as `[klass & args]` —
   stock: `reagent.impl.component/wrap-render` lines 94–99; slim:
   `wrap-render` → `form-2-inner-fn` → `class-mounting-render-fn` (rf2-oyrj).

That is the same path the already-covered "outer fn returning a class" shape
takes; the direct shape reduces to it in one step. The output-side
discrimination is therefore **sufficient**, not "too late", and no input-side
special case is wanted.

### Why a comment is the right deliverable

The invariant is accidental, undocumented and one refactor away from being
lost. Rewriting the call as `(render-fn …)` or `(.apply render-fn nil …)` binds
`this` to `undefined`/global, at which point the constructor either throws or
mutates the global object and returns it — and the advertised direct Form-3
shape breaks on **every substrate at once**, with nothing in the tree naming the
cause. The comment pins it at the line a future editor would touch.

### Scope

- `implementation/core/src/re_frame/views.cljs` — comment only.
- No change to `views/source_coord_annotation.cljs`.
- Form-1 / Form-2 paths untouched; the defect does not reach them (they never
  hand a constructor to the render call).
- Regression coverage for the shape is PR #9387's
  `implementation/adapters/reagent/test/re_frame/form_3_direct_class_dom_cljs_test.cljs`;
  this PR deliberately does not duplicate it.

### Gates

Comment-only diff in a CLJS file. The changed-surface classifier was run
against `origin/main...HEAD` and against the touched path as a control — both
arm the same conservative core set (`implementation_jvm`, `cljs_node_test`,
`cljs_browser`, `cljs_prod`, …), confirming the instrument discriminates rather
than reporting a vacuous all-false. The core JVM artefact suite was started
locally and had not reached a verdict inside this dispatch's time box; per the
project's gate policy that lane is left to CI, which runs the whole matrix in
parallel. The browser lane was deliberately not run locally.
