### PR TITLE
fix(gates): rule 3 of the attribution guard tests for a link, not a word

### DIFF
--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -370,7 +370,7 @@ Four shapes, case-insensitive, all anchored at **column 0**:
 |-------|---------|
 | the session trailer | a `Claude-Session:` line |
 | the co-author trailer, *when the address is the assistant's* | a `Co-Authored-By:` line whose value carries `@anthropic.com` |
-| the generated-with marker | a line that IS `… Generated with [Claude Code](…)` — decoration in front, its own link at the end |
+| the generated-with marker | a line that IS `… Generated with [Claude Code](…)` — decoration in front, its own **link** at the end |
 | the bare session URL | an `https://claude.ai/code/session_…` line, the URL and nothing else |
 
 That is the whole set. This is **not** a commit-message linter: it does not
@@ -407,6 +407,24 @@ and are unchanged: both key on a trailer **token** at column 0, which is already
 precisely git's own definition of a trailer, and widening what is already exact
 would only open a hole. Layer 10q pins both directions — prose permitted, a real
 trailer beside that same prose still refused.
+
+**Rule 3's second anchor tests for a link, not for the word "Claude".** That
+sentence is the repair the merged-PR audit of #9385 asked for, and it is worth
+stating because the first cut of the rule did not implement what this table row
+and the detector's own comment already promised: it asked whether the last
+blank-separated word *contained* `claude` or `anthropic`. So a column-0
+compliance sentence ending on a **filename** was still refused —
+
+     Generated with [Claude Code] was declined per CLAUDE.md.
+
+— while `No Generated with [Claude Code] trailer was added.` passed, on nothing
+but its final word. Same claim, no link and no attribution on either line, one
+rewording apart. The tail must now be a URL (`://`) whose host is the tool's,
+which is what "ends on its own link" means mechanically. **So a check of this
+guard must vary what the sentence *ends* on, not only whether it mentions a
+trailer** — a two-case check clears it and proves nothing. Layer 10q pairs that
+permitted sentence against `Generated with Claude Code https://claude.com/claude-code`,
+which shares its head and is still refused.
 
 **The co-author rule matches the address family, not the name.** All 31
 trailers in this repository's log carry `@anthropic.com` and the documented

--- a/scripts/git-hooks/lib/check-commit-attribution.sh
+++ b/scripts/git-hooks/lib/check-commit-attribution.sh
@@ -198,20 +198,46 @@ rf2_attribution_is_offending_line() {
   #      - NOTHING BUT DECORATION BEFORE IT. The harness writes the marker
   #        behind a robot emoji; a human writes it behind words. Words in
   #        front make the line a sentence, so the head must carry no letters.
-  #      - THE LINE ENDS ON THE TOOL'S NAME, i.e. the last blank-separated
+  #      - THE LINE ENDS ON THE TOOL'S OWN LINK, i.e. the last blank-separated
   #        word is the `[Claude Code](https://claude.com/claude-code)` link
   #        itself. Anything else after it is prose, and a marker with prose
   #        after it attributes nothing.
   #
   #    So `… Generated with [Claude Code](…)` is refused and `Generated with
   #    [Claude Code] was declined` is not — which is the whole of rf2-uo5f.
+  #
+  #    THE SECOND ANCHOR TESTS FOR A LINK, NOT FOR THE WORD "CLAUDE", and the
+  #    difference between those two is the residual this repair closes (the
+  #    merged-PR audit of #9385). The first cut of this rule asked only whether
+  #    the last word CONTAINED `claude` or `anthropic`, which the documentation
+  #    above, scripts/git-hooks/README.md and CLAUDE.md all described as "ends
+  #    on the tool's own link" — a promise the code did not keep. The gap is
+  #    not academic: it refuses an ordinary column-0 compliance sentence that
+  #    merely happens to END on such a word,
+  #
+  #      Generated with [Claude Code] was declined per CLAUDE.md.
+  #
+  #    whose final word `CLAUDE.md.` is a FILENAME. That line carries no link
+  #    and attributes nothing to anybody, and it is the same false-positive
+  #    class rf2-uo5f exists for, reached one rewording away from the case
+  #    already pinned: `No Generated with [Claude Code] trailer was added.`
+  #    passes only because it ends on `added.`. So the discriminator is
+  #    structural on BOTH halves — no letters in front, and a URL at the end
+  #    whose host is the tool's. A `://` is what makes the tail a link rather
+  #    than a word; deliberately NOT a list of negations ("No", "declined",
+  #    "not"), which was considered and rejected here as trivially defeatable.
   case "$_rf2a_low" in
     *'generated with'*)
       case "${_rf2a_low%%generated with*}" in
         *[a-z]*) ;;
         *)
-          case "${_rf2a_low##* }" in
-            *claude*|*anthropic*) return 0 ;;
+          _rf2a_tail=${_rf2a_low##* }
+          case "$_rf2a_tail" in
+            *://*)
+              case "$_rf2a_tail" in
+                *claude*|*anthropic*) return 0 ;;
+              esac
+              ;;
           esac
           ;;
       esac

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -2363,6 +2363,17 @@ esac
 # AND the compliance sentence together, so a detector that had merely been
 # widened until the false positive went away fails it. That pairing is the
 # whole point: a guard that stops refusing real trailers is worse than the bug.
+#
+# THE FIRST REPAIR WAS PARTIAL, AND THE CASES BELOW ARE WHY IT WAS FOUND LATE.
+# Rule 3 has two anchors — no letters before `Generated with`, and the line
+# ending on the tool's own link — and every prose case pinned by the first
+# repair cleared it on the FIRST anchor, so the second was never exercised. It
+# had been written as a substring test for `claude`/`anthropic` in the last
+# blank-separated word, which is not the documented rule and refuses an
+# ordinary sentence that merely ENDS on such a word. The merged-PR audit of
+# #9385 found it. So the pairs below now vary what the sentence ENDS on, not
+# only whether it mentions a trailer: a two-case check of this guard clears it
+# and means nothing.
 
 # The sentence that reded #9330, and two more of the same class — one naming
 # the marker mid-sentence, one naming the session URL and then continuing.
@@ -2370,7 +2381,33 @@ PROSE_COMPLIANCE='No Co-Authored-By: Claude and no Generated with [Claude Code] 
 PROSE_MARKER_NAMED='The harness wanted a Generated with [Claude Code] marker here; it was declined per CLAUDE.md.'
 PROSE_URL_NAMED="$TRAILER_SESSION_URL is the bare URL the harness writes, and this body does not carry one."
 
-for t in "$PROSE_COMPLIANCE" "$PROSE_MARKER_NAMED" "$PROSE_URL_NAMED"; do
+# AND THE ONE THE FIRST REPAIR STILL REFUSED (the merged-PR audit of #9385).
+#
+# The three sentences above all clear rule 3 on its FIRST anchor — each carries
+# letters in front of `Generated with`, so the tail test never runs — and that
+# is exactly why they left the second anchor unexercised. This one starts at
+# `Generated`, so it reaches the tail; and its last blank-separated word is
+# `CLAUDE.md.`, a FILENAME carrying the substring `claude`.
+#
+# Under a tail test that asked whether the last word CONTAINED `claude` or
+# `anthropic`, this line was refused: no link on it, no attribution on it, one
+# rewording away from `No Generated with [Claude Code] trailer was added.`,
+# which passed only because it ends on `added.`. The documentation — this
+# file's own 10q preamble, the detector's rule-3 comment, README.md's shape
+# table and CLAUDE.md — all promised a rule that required the line to END ON
+# THE TOOL'S OWN LINK. The code did not implement that promise; now it does,
+# and this pair is what holds it to it. The permitted case below and the
+# `MARKER_BARE_URL` refusal further down are the two directions.
+PROSE_COMPLIANCE_TAIL='Generated with [Claude Code] was declined per CLAUDE.md.'
+
+# The marker written without markdown brackets — a real attribution whose tail
+# IS the tool's link. It is the control for the case above: same head (no
+# letters before `Generated with`), opposite tail, so a repair that had merely
+# stopped reading the tail at all fails here rather than passing silently.
+MARKER_BARE_URL='Generated with Claude Code https://claude.com/claude-code'
+
+for t in "$PROSE_COMPLIANCE" "$PROSE_MARKER_NAMED" "$PROSE_URL_NAMED" \
+         "$PROSE_COMPLIANCE_TAIL"; do
   key=$(printf '%s' "$t" | cut -c1-40)
   out=$(printf 'Fixes the thing.\n\n%s\n' "$t" | run_attr_body)
   case "$out" in
@@ -2386,11 +2423,16 @@ for t in "$PROSE_COMPLIANCE" "$PROSE_MARKER_NAMED" "$PROSE_URL_NAMED"; do
   esac
 done
 
-# The paired half, and the one that proves the guard was not disarmed: the SAME
-# compliance sentence, now beside a trailer the body really does carry.
-for t in "$TRAILER_GENWITH" "$TRAILER_SESSION_URL" "$TRAILER_COAUTHOR" "$TRAILER_SESSION"; do
+# The paired half, and the one that proves the guard was not disarmed: BOTH
+# compliance sentences, now beside a trailer the body really does carry.
+# `MARKER_BARE_URL` is in the offending list because it is the shape that
+# shares a head with `PROSE_COMPLIANCE_TAIL` — a repair that widened the tail
+# hatch far enough to let the prose through would let this through with it.
+for t in "$TRAILER_GENWITH" "$TRAILER_SESSION_URL" "$TRAILER_COAUTHOR" \
+         "$TRAILER_SESSION" "$MARKER_BARE_URL"; do
   key=$(printf '%s' "$t" | cut -c1-32)
-  out=$(printf 'Fixes the thing.\n\n%s\n\n%s\n' "$PROSE_COMPLIANCE" "$t" | run_attr_body)
+  out=$(printf 'Fixes the thing.\n\n%s\n%s\n\n%s\n' \
+    "$PROSE_COMPLIANCE" "$PROSE_COMPLIANCE_TAIL" "$t" | run_attr_body)
   case "$out" in
     EXIT=0) fail "(10q) DISARMED: a body CARRYING a real trailer was allowed: $key..." ;;
     *)
@@ -2415,11 +2457,37 @@ case "$out" in
      cat "$AERR" >&2 ;;
 esac
 
+out=$(printf 'docs(gates): record the attribution rule\n\n%s\n' "$PROSE_COMPLIANCE_TAIL" \
+  | run_attr_lib 2>"$AERR") || true
+case "$out" in
+  *EXIT=0*) pass "(10q) a commit message ENDING on a claude-ish word is permitted" ;;
+  *) fail "(10q) FALSE POSITIVE: rule 3's tail test reads a word, not a link ($out)"
+     cat "$AERR" >&2 ;;
+esac
+
 out=$(printf 'docs(gates): record the attribution rule\n\n%s\n\n%s\n' \
   "$PROSE_COMPLIANCE" "$TRAILER_GENWITH" | run_attr_lib 2>"$AERR") || true
 case "$out" in
   *EXIT=1*) pass "(10q) a commit message that CARRIES the marker is still refused" ;;
   *) fail "(10q) DISARMED: a commit message carrying the marker was allowed ($out)" ;;
+esac
+
+# And the tail control at the detector too: the marker with no markdown
+# brackets, whose last word IS the tool's link. Same head as the permitted
+# sentence above, opposite tail — so this pair, not either half alone, is what
+# pins rule 3's second anchor to a LINK rather than to a word.
+out=$(printf 'docs(gates): record the attribution rule\n\n%s\n\n%s\n' \
+  "$PROSE_COMPLIANCE_TAIL" "$MARKER_BARE_URL" | run_attr_lib 2>"$AERR") || true
+case "$out" in
+  *EXIT=1*)
+    if grep -Fq "$MARKER_BARE_URL" "$AERR"; then
+      pass "(10q) a bare-URL generated-with marker is still refused, and quoted"
+    else
+      fail "(10q) refused, but the diagnostic never quoted the bare-URL marker"
+      cat "$AERR" >&2
+    fi
+    ;;
+  *) fail "(10q) DISARMED: a marker ending on the tool's own link was allowed ($out)" ;;
 esac
 
 git -C "$AREPO" checkout -q main >/dev/null 2>&1 || true


### PR DESCRIPTION
Closes the residual on rf2-uo5f found by the merged-PR audit of #9385.

## The defect

The detector's rule 3 (the generated-with marker) has two anchors: nothing but
decoration in front of `Generated with`, and the line ending on the tool's own
link. The detector's own comment, `scripts/git-hooks/README.md` and `CLAUDE.md`
all describe the second anchor that way. The code did not implement it — it
asked only whether the LAST blank-separated word contained the substring
`claude` or `anthropic` (`case "${_rf2a_low##* }"`).

So an ordinary column-0 sentence was still refused when it happened to end on a
word carrying that substring. Reproduced against the landed shared detector
before any change, via `scripts/check-commit-attribution.sh --pr-body`:

| line | before | after |
|---|---|---|
| `Generated with [Claude Code] was declined per CLAUDE.md.` | exit 1 (false positive) | exit 0 |
| `No Generated with [Claude Code] trailer was added.` | exit 0 | exit 0 |
| `Generated with Claude Code https://claude.com/claude-code` | exit 1 | exit 1 |

Both of the first two make the same claim, carry no link and attribute nothing;
they differ only in their final word. The second passed only because it ends on
`added.`, so the false-positive class was one rewording away from live.

## The change

Rule 3's tail test now requires the last blank-separated word to be a URL
(`://`) whose host is the tool's — which is what "ends on its own link" means
mechanically. It is not a negation wordlist (`No`, `not`, `declined`…): that
was considered and rejected here as trivially defeatable, and this is not
widened into a general commit-message linter. Rules 1, 2 and 4 are untouched.

## Tests

Layer 10q in `scripts/git-hooks/test-pre-commit.sh` gains the audit's sentence
in the permitted loop, and a control that SHARES ITS HEAD and must still offend
— the same marker written with a bare URL instead of markdown brackets — in the
offending loop, in the paired body, and at the detector. That pairing is the
point: every prose case pinned by the earlier repair cleared rule 3 on its
FIRST anchor and left the tail unexercised, which is why the gap survived.

## Gates

- `sh scripts/git-hooks/test-pre-commit.sh` — **exit 0**, 112 passed / 0 failed.
- Sabotage control: reverting rule 3's tail to the old substring form makes the
  same run **exit 1** with exactly 2 failures, both of them the new cases
  (110/2). The change exists only on this branch, so the red also proves the
  run read this worktree.
- Restore verified by git blob hash, identical to the pre-plant object.
- Direct `--pr-body` probes for the three lines above, plus proof the guard is
  not disarmed: `Co-Authored-By:` with the assistant's address → exit 1, a
  `Claude-Session:` line → exit 1, a bare `https://claude.ai/code/session_…`
  alone on its line → exit 1.
- `python scripts/check_view_lifetime_residue.py` → exit 0;
  `python scripts/check_readme_links.py --ci` → exit 0.

Option (d) of rf2-uo5f — the misleading `beads-pr-boundary` job name — is NOT
touched here. It was carved out to rf2-mfzw and remains fenced to fleet-zero;
`.github/workflows/**` is untouched by this PR.
