### PR TITLE
test(login) + example(realworld-resources): Story success fixture guard (rf2-cckg) and the :observability teaching vehicle (rf2-gzp5)

### DIFF
--- a/examples/real-apps/realworld_resources/core.cljs
+++ b/examples/real-apps/realworld_resources/core.cljs
@@ -29,6 +29,9 @@
      http.cljs       — the demo backend stub + failure projection
      views.cljs      — passive pages + the small UI event glue"
   (:require [re-frame.core :as rf]
+            ;; `debug-enabled?` — the build-posture flag the production error
+            ;; sink is gated on (see PRODUCTION ERROR REPORTING below).
+            [re-frame.interop :as rf.interop]
             ;; Managed HTTP — the one built-in transport both resources and
             ;; mutations lower onto.
             [re-frame.http.managed]
@@ -201,6 +204,81 @@
                       (str "Token " token)))))
 
 ;; ============================================================================
+;; PRODUCTION ERROR REPORTING  —  the frame `:observability` sink
+;; ============================================================================
+;;
+;; Ship this app as an optimised production build and the compiler elides the
+;; whole dev-time trace surface: no trace stream, no epoch rings, no Xray. What
+;; survives on purpose is the always-on error substrate, and a frame's
+;; `:observability` policy is how its records reach your monitor. The full guide
+;; is ../../../docs/core/how-to/report-errors-in-production.md.
+;;
+;; Two moves, and keeping them separate is the whole lesson:
+;;
+;;   (a) THE FRAME DECLARES A POLICY — which sink ids take its error records,
+;;       and the egress boundary those records may cross. It is plain data, it
+;;       costs nothing, and it is declared UNCONDITIONALLY (`:observability` in
+;;       the `frame-root` config below).
+;;
+;;   (b) THE APP REGISTERS THE CONCRETE SINK FN against the id the policy named
+;;       — and that is the half you GATE, so a dev build never fires
+;;       dev-verbose records at a real monitoring backend.
+;;
+;; Routing is fail-closed, which is what makes that split safe: a frame with no
+;; policy routes nothing, there is no `:rf/default` sink synthesised on your
+;; behalf, and a policy naming a sink nobody registered routes nowhere —
+;; visibly, on purpose. So in a dev build (b) simply never runs, the record is
+;; routed nowhere, and the framework's own console fallback prints it for you.
+;; Exactly what you want on a laptop.
+;;
+;; What the sink receives is ALREADY PROJECTED, under this frame's
+;; classification and the entry's `:rf.egress/off-box-observability` profile.
+;; The JWT that `:auth/classify-token` marked sensitive is redacted before your
+;; code sees it, and the off-box profile omits the raw event-args slot
+;; altogether. A sink never scrubs anything itself — that is precisely why the
+;; policy lives on the frame instead of being passed as a callback.
+;;
+;; Don't reach for `register-listener! :trace` here. It carries everything,
+;; which is the temptation, and it is dev-only — a monitor built on it works
+;; beautifully in development and ships nothing at all, which you find out
+;; mid-incident.
+;;
+;; re-frame2 ships no Sentry / Datadog client and never will; a real deployment
+;; swaps the body of `report-error!` for its own. This demo prints the record's
+;; discriminators, which is also a fair tour of what one carries.
+
+(def error-sink-id
+  "The sink id the frame policy names and the sink fn registers under. One
+   def so the two halves cannot drift apart."
+  :realworld-resources.sinks/error-monitor)
+
+(def observability
+  "This frame's error-reporting POLICY. Data, declared unconditionally — the
+   gate belongs on the registration below, never on the declaration."
+  {:errors [{:sink              error-sink-id
+             :rf.egress/profile :rf.egress/off-box-observability}]})
+
+(defn- report-error! [record]
+  ;; `record` is a projected `:rf.observe/error`: `:error` is the canonical
+  ;; `:rf.error/*` discriminator, `:event-id` names what was in flight, and
+  ;; `:exception` carries the host throwable when the failure had one (several
+  ;; record shapes do not — branch, never assume).
+  (js/console.error "[conduit] re-frame2 error record"
+                    #js {:error     (str (:error record))
+                         :frame     (str (:frame record))
+                         :eventId   (str (:event-id record))
+                         :exception (:exception record)}))
+
+(defn install-error-monitor!
+  "Register the concrete sink — the GATED half. `debug-enabled?` is false in an
+   optimised build, so this is a no-op on a laptop and the framework's console
+   fallback handles dev failures instead. A real app ANDs this with its own
+   build flag and a present DSN."
+  []
+  (when-not ^boolean rf.interop/debug-enabled?
+    (rf/register-observability-sink! error-sink-id report-error!)))
+
+;; ============================================================================
 ;; window.__conduit_debug__  — CONFORMANCE-CONTRACT SURFACE
 ;; ============================================================================
 ;;
@@ -326,6 +404,10 @@
                       :url-bound?      true
                       :url-strategy    routing/url-strategy
                       :revalidate-on   #{:focus :reconnect}
+                      ;; Where this frame's error records go, and how far they
+                      ;; may travel. Declared unconditionally; see PRODUCTION
+                      ;; ERROR REPORTING above.
+                      :observability   observability
                       :fx-overrides    {:rf.http/managed :realworld-resources.demo/http-stub}
                       :initial-events  [[:auth/classify-token]
                                             [:auth/initialise]
@@ -359,4 +441,10 @@
   (rf/with-frame app-frame
     (rf/reg-http-interceptor :realworld/bearer-auth
                              {:before bearer-auth-interceptor}))
+  ;; The gated half of the error-reporting pair (the frame declares the policy
+  ;; unconditionally, in `mount!`). Registering before the frame exists is fine
+  ;; and is the safer order: the sink registry is keyed by id and consulted
+  ;; when a record is routed, so the monitor is live from the very first
+  ;; `:initial-events` dispatch rather than from some later boot step.
+  (install-error-monitor!)
   (mount!))

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_observability_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_observability_cljs_test.cljs
@@ -1,0 +1,190 @@
+(ns re-frame.realworld-resources-observability-cljs-test
+  "Mirror test for the RealWorld-on-resources example's production
+   error-reporting wiring — the frame `:observability` sink (rf2-gzp5).
+
+   WHY IT EXISTS. The frame `:observability` sink is the documented normal
+   production observation surface (spec/API.md, spec/009,
+   docs/core/observability.md and the report-errors-in-production how-to all
+   teach it first), but until rf2-gzp5 NO example in the tree configured one,
+   so a reader who followed the guide had nothing to copy from. The example now
+   carries the CONFIGURATION — `realworld-resources.core/observability` (the
+   frame's policy) and `install-error-monitor!` (the gated sink registration) —
+   and this ns carries every assertion about it. That split is the standing
+   test-free-examples lock (rf2-8cevm): no `*.spec.cjs` under `examples/`, so
+   the example is configuration and the framework test tree does the grading.
+
+   WHAT IS PINNED, and each row is a claim the guide makes that a reader would
+   be entitled to rely on:
+
+     1. THE POLICY IS WELL-FORMED and names the same sink id the example's own
+        registration uses — the two halves cannot drift, because both read one
+        def.
+     2. THE POLICY ACTUALLY ROUTES. A handler exception in a frame configured
+        with the EXAMPLE'S OWN policy map delivers exactly one
+        `:rf.observe/error` record to a sink registered under the example's own
+        id — and that record arrives ALREADY PROJECTED, with the JWT the app
+        classifies sensitive redacted. A sink that had to scrub for itself
+        would make the whole design pointless, so this is the load-bearing one.
+     3. ROUTING IS FAIL-CLOSED. The same registered sink and the same throwing
+        handler, in a frame that declares NO policy, route nothing. This is
+        what makes the example's unconditional declaration meaningful: it is
+        the declaration, not the registration, that opens the channel.
+     4. THE GATE IS ON THE REGISTRATION, NOT THE DECLARATION.
+        `install-error-monitor!` follows `rf.interop/debug-enabled?` — so a dev
+        build registers no sink and the framework's own console fallback takes
+        the record, which is the posture the how-to argues for at length.
+
+   The fixture clears the sink registry and the always-on error-listener
+   registry around each test, so a sink registered here cannot leak into a
+   sibling namespace sharing the consolidated node-test bundle.
+
+   ns ends in `-cljs-test` so shadow-cljs's `:node-test` build picks it up. No
+   DOM: the records are read off a capturing sink, not off a rendered page."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.elision :as rf.elision]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.observability :as rf.observability]
+            [re-frame.projection :as rf.projection]
+            [re-frame.test-support :as rf.test-support]
+            ;; The example's production source — the subject. Requiring it
+            ;; registers the whole app at ns-load; all this ns reads off it are
+            ;; the two error-reporting defs and the gated installer.
+            [realworld-resources.core :as app]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.reagent/adapter
+     :init-fn (fn []
+                (rf.error-emit/clear-error-listeners!)
+                (rf.observability/clear-observability-sinks!))}))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(def ^:private sensitive-token
+  "Stands in for the Conduit JWT. The example marks [:auth :token] sensitive at
+   frame creation (`:auth/classify-token`), so this string must never reach a
+   sink raw."
+  "CONDUIT-JWT-SENTINEL-4f21c9")
+
+(defn- classify-token-sensitive!
+  "Mirror of the example's `:auth/classify-token` initial event — the durable
+   app-db classification is a commit-plane effect (EP-0025), so declaring it
+   here is the same declaration the app makes at boot."
+  [frame-id]
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects
+               rt {:sensitive [[:auth :token]]}))))
+
+(defn- reg-throwing-event! [frame-id]
+  (rf/reg-event ::boom
+    {:frame frame-id}
+    (fn [_ _] (throw (ex-info "kaboom" {:cause :test})))))
+
+(defn- drive-failure! [frame-id]
+  (rf/dispatch-sync [::boom {:auth {:token sensitive-token}}] {:frame frame-id}))
+
+;; ---------------------------------------------------------------------------
+;; 1. the policy is well-formed and single-sourced
+;; ---------------------------------------------------------------------------
+
+(deftest example-declares-a-well-formed-error-sink-policy
+  (testing "the example's frame policy names ONE :errors sink, under a member
+            of the closed egress-profile enum, using the same id its own
+            registration uses"
+    (is (keyword? app/error-sink-id)
+        "the sink id is a keyword — what a frame entry's :sink must carry")
+    (let [entries (:errors app/observability)]
+      (is (= [:errors] (keys app/observability))
+          "the policy declares the :errors stream and nothing else")
+      (is (= 1 (count entries))
+          "exactly one sink entry — the example teaches one monitor")
+      (let [entry (first entries)]
+        (is (= app/error-sink-id (:sink entry))
+            "the entry names the example's own sink id, so the policy and the
+             registration cannot drift apart")
+        (is (contains? rf.projection/profiles (:rf.egress/profile entry))
+            "the egress profile is a member of the closed EP-0015 enum")
+        (is (= :rf.egress/off-box-observability (:rf.egress/profile entry))
+            "and it is the off-box boundary — this record leaves the box for a
+             hosted monitor, which is the profile that decides how much of it
+             survives projection")))))
+
+;; ---------------------------------------------------------------------------
+;; 2. the policy routes, and the record arrives already projected
+;; ---------------------------------------------------------------------------
+
+(deftest example-policy-routes-one-projected-error-record
+  (testing "a handler exception in a frame configured with the EXAMPLE'S OWN
+            :observability map delivers exactly one projected
+            :rf.observe/error record to a sink registered under the example's
+            own id, with the sensitive JWT redacted before the sink sees it"
+    (let [seen (atom [])]
+      (rf/register-observability-sink! app/error-sink-id
+                                       (fn [record] (swap! seen conj record)))
+      (rf/make-frame {:id ::routed :observability app/observability})
+      (classify-token-sensitive! ::routed)
+      (reg-throwing-event! ::routed)
+      (drive-failure! ::routed)
+
+      (is (= 1 (count @seen))
+          "the declared sink fired exactly once")
+      (let [r (first @seen)]
+        (is (= :rf.observe/error (:kind r))
+            "the record is a canonical :rf.observe/error")
+        (is (= ::routed (:frame r))
+            "it names the frame it failed in — the context worth having at 3am")
+        (is (= :rf.error/handler-exception (:error r))
+            "the canonical discriminator a sink branches on")
+        (is (= ::boom (:event-id r))
+            "and the event that was in flight")
+        ;; The load-bearing assertion: the sink did no scrubbing, and the token
+        ;; is redacted anyway, because the runtime projected the record under
+        ;; the frame's classification before handing it over.
+        (is (= :rf/redacted (get-in (:event r) [1 :auth :token]))
+            "the sensitive JWT inside the error's :event is REDACTED — the sink
+             received an already-projected record and re-implements nothing")
+        (is (not= sensitive-token (get-in (:event r) [1 :auth :token]))
+            "explicitly: the raw token did not reach the sink")))))
+
+;; ---------------------------------------------------------------------------
+;; 3. fail-closed — the DECLARATION is what opens the channel
+;; ---------------------------------------------------------------------------
+
+(deftest a-frame-without-the-policy-routes-nothing
+  (testing "the same registered sink and the same throwing handler route
+            NOTHING from a frame that declares no :observability policy — which
+            is why the example declares its policy unconditionally"
+    (let [seen (atom [])]
+      (rf/register-observability-sink! app/error-sink-id
+                                       (fn [record] (swap! seen conj record)))
+      (rf/make-frame {:id ::unclassified})
+      (classify-token-sensitive! ::unclassified)
+      (reg-throwing-event! ::unclassified)
+      (drive-failure! ::unclassified)
+      (is (empty? @seen)
+          "no record routed: there is no :rf/default sink synthesised on your
+           behalf, so you cannot leak from a frame you never classified"))))
+
+;; ---------------------------------------------------------------------------
+;; 4. the gate is on the REGISTRATION
+;; ---------------------------------------------------------------------------
+
+(deftest the-sink-registration-is-gated-on-build-posture
+  (testing "install-error-monitor! follows debug-enabled? — a dev build
+            registers nothing (and the framework's console fallback takes the
+            record instead), while an optimised build registers the sink"
+    (let [result (app/install-error-monitor!)]
+      (if ^boolean rf.interop/debug-enabled?
+        (is (nil? result)
+            "dev build: the gate is closed, nothing registered — the policy is
+             still declared, so the record routes to no sink and the framework
+             prints it for you")
+        (is (= app/error-sink-id result)
+            "optimised build: the gate is open and the sink registers under the
+             id the frame policy names")))))

--- a/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
@@ -51,8 +51,21 @@
 
    This ns asserts everything the example owns is redacted, pins the two
    registration declarations the projector consumes, and — post-rf2-6h3c02 — the
-   two formerly-residual framework slots."
-  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+   two formerly-residual framework slots.
+
+   THE STORY VARIANT'S OWN TOKEN FIXTURE (rf2-cckg / rf2-hz8u). Everything
+   above drives `:auth.login/succeeded` with an EXPLICITLY token-bearing reply
+   this file writes, which is exactly why it never covered the canonical Story
+   variant: `:story.login/success` does not write a reply, it runs the REAL
+   form path in a `:preset :story` frame and lets the server's half arrive
+   through `:rf.http/managed`. That frame redirects the fx to the framework's
+   GENERIC canned-success stub, whose `{:stubbed true}` payload has no
+   `[:value :token]` and is therefore refused at `:auth.login/succeeded`'s
+   schema boundary — leaving the canonical screenshot stuck in `:submitting`.
+   PR #9386 fixed the SOURCE by giving the variant its own `:network` route
+   fixture; the final section of this ns is the acceptance for it, driving the
+   ACTUAL registered variant rather than a reply of its own."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is async]]
             [re-frame.core :as rf]
             [re-frame.classification :as rf.classification]
             [re-frame.privacy :as rf.privacy]
@@ -62,8 +75,28 @@
             ;; login.model pulls these transitively; require here so the ns is
             ;; self-sufficient (mirrors the sibling login test namespaces).
             [re-frame.schemas]
+            ;; The Malli adapter publishes the validator the `:where :event`
+            ;; boundary routes through. Without it a schema-refusal assertion
+            ;; would be vacuously green, because nothing would be validating —
+            ;; the development-default posture the rf2-cckg drive below asserts
+            ;; under (mirrors re-frame.login-cljs-test).
+            [re-frame.schemas.malli]
             [re-frame.machines]
-            [login.model])
+            ;; rf2-cckg — the Story deck under test. `login.stories` sources
+            ;; `login.core` (views) which sources `login.model`, so requiring it
+            ;; registers the whole example; `re-frame.story` is the runtime that
+            ;; allocates the variant frame. TEST-ONLY: this ns is a
+            ;; `*_cljs_test` namespace on the consolidated `:node-test`
+            ;; classpath (which already carries `../tools/story/src` and
+            ;; `../examples/core`), so the `tools/` bundle-isolation contract —
+            ;; a PRODUCTION-build contract, graded by
+            ;; implementation/scripts/check-bundle-isolation.cjs against
+            ;; compiled release bundles — is untouched: no production build
+            ;; requires this namespace.
+            [re-frame.story :as rf.story]
+            [re-frame.story.async :as rf.story.async]
+            [login.model]
+            [login.stories :as login-stories])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (use-fixtures :each
@@ -238,3 +271,127 @@
     (is (= {:sensitive [[:token]]}
            (rf.classification/registration-classification :fx :auth.session/store))
         ":auth.session/store owns [:token] — its own transient fx arg")))
+
+;; ---------------------------------------------------------------------------
+;; rf2-cckg — the canonical Story variant reaches :authed on its OWN fixture
+;; ---------------------------------------------------------------------------
+;;
+;; Everything above supplies the reply itself. This section supplies NOTHING:
+;; it runs the registered `:story.login/success` variant exactly as the Story
+;; shell does, so the only thing standing between `submit-form` and the Welcome
+;; banner is the variant's own `:network` route fixture. Delete that fixture and
+;; every assertion below goes red, which is the regression this section exists
+;; to hold (rf2-hz8u's acceptance; the source fix landed in PR #9386).
+
+(def ^:private story-fixture-token
+  "The token `:story.login/success`'s `:network` route fixture hands back — the
+   same string the live demo backend (`:auth.login.demo/managed-stub`) conjures,
+   so the Story frame and the live-app frame agree on the server's half."
+  "demo-token-123")
+
+(defn- install-storage-stub!
+  "Install a RECORDING `localStorage` stub on `globalThis` and return
+   `[recorded restore!]`.
+
+   `:auth.session/store`'s handler body is the example's one platform-bound
+   line — `(.setItem (.-localStorage js/globalThis) \"auth/token\" token)` — so
+   stubbing the STORAGE rather than the fx keeps the real registered handler in
+   the run and still asserts the token it received. Node has no `localStorage`,
+   which is why the effect is otherwise a silent no-op here (and why nothing
+   persists to a browser). `defineProperty` rather than `set!` because a host
+   that DOES define the global may define it as an accessor, where a plain
+   assignment throws under strict mode."
+  []
+  (let [recorded (atom {})
+        prior    (.-localStorage js/globalThis)
+        stub     #js {:setItem    (fn [k v] (swap! recorded assoc k v))
+                      :getItem    (fn [k] (get @recorded k))
+                      :removeItem (fn [k] (swap! recorded dissoc k))}]
+    (js/Object.defineProperty
+      js/globalThis "localStorage"
+      #js {:value stub :configurable true :writable true})
+    [recorded
+     (fn restore! []
+       (if (undefined? prior)
+         (js-delete js/globalThis "localStorage")
+         (js/Object.defineProperty
+           js/globalThis "localStorage"
+           #js {:value prior :configurable true :writable true})))]))
+
+(defn- event-schema-refusals
+  "The `:where :event` schema-refusal traces in `traces` — the boundary that
+   turned the generic canned payload away before the fix."
+  [traces]
+  (filterv #(and (= :rf.error/schema-validation-failure (:operation %))
+                 (= :event (-> % :tags :where)))
+           traces))
+
+(deftest story-success-variant-drives-the-real-cascade-to-authed
+  (testing "the registered :story.login/success variant — run in a newly
+            allocated Story frame, with the development Malli validator live —
+            reaches :authed, satisfies the Welcome banner's own tag predicate,
+            hands the fixture token to :auth.session/store, and is refused at no
+            event-schema boundary along the way"
+    ;; Re-fire the EXAMPLE's deck first. The login_form TESTBED deck
+    ;; (tools/story/testbeds/login_form) registers variants under the same
+    ;; `:story.login` parent and shares the consolidated node-test bundle, so
+    ;; without this the body under test is whichever deck loaded last
+    ;; (re-frame.story.login-example-seed-cljs-test guards the same way).
+    ;; `register-all!` is idempotent.
+    (login-stories/register-all!)
+    (let [[recorded restore!] (install-storage-stub!)
+          traces              (atom [])]
+      (rf/register-listener! :trace ::story-probe (fn [ev] (swap! traces conj ev)))
+      (async done
+        (-> (rf.story/run-variant :story.login/success)
+            (rf.story.async/then
+              (fn [result]
+                (rf/unregister-listener! :trace ::story-probe)
+                (try
+                  (let [fs    (rf/frame-state-value :story.login/success)
+                        state (get-in fs [:rf.db/runtime :rf.runtime/machines
+                                          :snapshots :auth.login/flow :state])]
+                    (is (= :ready (:lifecycle result))
+                        "the variant's own lifecycle completed — setup, loaders,
+                         events and play all ran (a failed run would strand it
+                         short of :ready and make every assertion below moot)")
+
+                    ;; --- the flow left :submitting ---------------------------
+                    (is (= :authed state)
+                        "the real cascade — submit-form → :rf.http/managed →
+                         the variant's :network reply → :auth.login/succeeded →
+                         a credential-free :success signal — landed the machine
+                         at :authed. Before the fixture landed this read
+                         :submitting, because the generic canned payload was
+                         refused before :auth.login/succeeded ever ran")
+
+                    ;; --- the Welcome view's own predicate --------------------
+                    ;; login.core/login-banner renders [:span "Welcome!"] iff
+                    ;; this sub is true; computing it against the frame-state is
+                    ;; the DOM-free read of the same branch.
+                    (is (true? (rf/compute-sub
+                                 [:rf.machine/has-tag? :auth.login/flow
+                                  :auth/authenticated]
+                                 fs))
+                        "the :auth/authenticated tag is set, so the banner shows
+                         'Welcome!' rather than the form — the canonical
+                         screenshot the variant advertises")
+
+                    ;; --- the persistence fx got the fixture's token ----------
+                    (is (= story-fixture-token (get @recorded "auth/token"))
+                        "the REAL :auth.session/store handler ran and wrote the
+                         variant's fixture token to the stubbed storage — the
+                         token travelled the whole cascade intact, and nothing
+                         touched browser persistence (Node has no localStorage;
+                         the stub is this test's own)")
+
+                    ;; --- and nothing was turned away at a schema boundary ----
+                    (let [refusals (event-schema-refusals @traces)]
+                      (is (empty? refusals)
+                          (str "no event-schema refusal fired during the run; "
+                               "got " (count refusals) " — "
+                               (pr-str (mapv #(-> % :tags :rf.event/id) refusals))))))
+                  (finally
+                    (restore!)
+                    (rf.story/destroy-variant! :story.login/success)
+                    (done))))))))))

--- a/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
@@ -63,9 +63,11 @@
    `[:value :token]` and is therefore refused at `:auth.login/succeeded`'s
    schema boundary — leaving the canonical screenshot stuck in `:submitting`.
    PR #9386 fixed the SOURCE by giving the variant its own `:network` route
-   fixture; the final section of this ns is the acceptance for it, driving the
-   ACTUAL registered variant rather than a reply of its own."
-  (:require [cljs.test :refer-macros [deftest testing use-fixtures is async]]
+   fixture; the final section of this ns guards that fixture, and records what
+   the acceptance found when it tried to drive it."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [malli.core :as m]
+            [re-frame.registrar :as rf.registrar]
             [re-frame.core :as rf]
             [re-frame.classification :as rf.classification]
             [re-frame.privacy :as rf.privacy]
@@ -76,39 +78,30 @@
             ;; self-sufficient (mirrors the sibling login test namespaces).
             [re-frame.schemas]
             ;; The Malli adapter publishes the validator the `:where :event`
-            ;; boundary routes through. Without it a schema-refusal assertion
-            ;; would be vacuously green, because nothing would be validating —
-            ;; the development-default posture the rf2-cckg drive below asserts
-            ;; under (mirrors re-frame.login-cljs-test).
+            ;; boundary routes through, and the `m/explain` the rf2-cckg guard
+            ;; below runs against the registered `:auth.login/succeeded` schema
+            ;; (mirrors re-frame.login-cljs-test).
             [re-frame.schemas.malli]
             [re-frame.machines]
             ;; rf2-cckg — the Story deck under test. `login.stories` sources
             ;; `login.core` (views) which sources `login.model`, so requiring it
-            ;; registers the whole example; `re-frame.story` is the runtime that
-            ;; allocates the variant frame. TEST-ONLY: this ns is a
-            ;; `*_cljs_test` namespace on the consolidated `:node-test`
-            ;; classpath (which already carries `../tools/story/src` and
-            ;; `../examples/core`), so the `tools/` bundle-isolation contract —
-            ;; a PRODUCTION-build contract, graded by
-            ;; implementation/scripts/check-bundle-isolation.cjs against
-            ;; compiled release bundles — is untouched: no production build
-            ;; requires this namespace.
-            [re-frame.story :as rf.story]
-            [re-frame.story.async :as rf.story.async]
+            ;; registers the whole example; `re-frame.story.plan` compiles the
+            ;; registered variant body to the plan the guard below reads (pure
+            ;; data → data, no host). TEST-ONLY: this ns is a `*_cljs_test`
+            ;; namespace on the consolidated `:node-test` classpath (which
+            ;; already carries `../tools/story/src` and `../examples/core`), so
+            ;; the `tools/` bundle-isolation contract — a PRODUCTION-build
+            ;; contract, graded by check-bundle-isolation.cjs against compiled
+            ;; release bundles — is untouched: no production build requires this
+            ;; namespace.
+            [re-frame.story.plan :as rf.story.plan]
             [login.model]
             [login.stories :as login-stories])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
-;; `:async? true` because the rf2-cckg drive at the foot of this ns is an
-;; `async` test (`rf.story/run-variant` resolves a promise). cljs.test refuses a
-;; FN-form fixture around any async body — "Async tests require fixtures to be
-;; specified as maps. Testing aborted." — and the abort takes the whole bundle
-;; down, not just this namespace. The map form serves the four synchronous tests
-;; above unchanged.
 (use-fixtures :each
   (rf.test-support/make-reset-runtime-fixture
-    {:adapter rf.adapter.reagent/adapter
-     :async?  true}))
+    {:adapter rf.adapter.reagent/adapter}))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers
@@ -280,125 +273,89 @@
         ":auth.session/store owns [:token] — its own transient fx arg")))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-cckg — the canonical Story variant reaches :authed on its OWN fixture
+;; rf2-cckg - the canonical Story variant's own token fixture
 ;; ---------------------------------------------------------------------------
 ;;
-;; Everything above supplies the reply itself. This section supplies NOTHING:
-;; it runs the registered `:story.login/success` variant exactly as the Story
-;; shell does, so the only thing standing between `submit-form` and the Welcome
-;; banner is the variant's own `:network` route fixture. Delete that fixture and
-;; every assertion below goes red, which is the regression this section exists
-;; to hold (rf2-hz8u's acceptance; the source fix landed in PR #9386).
+;; Everything above supplies the reply itself. `:story.login/success` supplies
+;; NOTHING: it runs the real form path in a `:preset :story` frame and lets the
+;; server's half arrive through `:rf.http/managed`. That frame redirects the fx
+;; to the framework's GENERIC canned-success stub, whose `{:stubbed true}`
+;; payload carries no `[:value :token]` and is refused at
+;; `:auth.login/succeeded`'s schema boundary - leaving the canonical screenshot
+;; stuck in `:submitting`. PR #9386's fix gave the variant its own `:network`
+;; route fixture, and this section guards it.
+;;
+;; WHAT IS GUARDED HERE, AND WHY IT IS THE PLAN RATHER THAN A LIVE DRIVE.
+;; rf2-cckg asked for the end-to-end drive: run the registered variant and
+;; assert it reaches `:authed`. That was written, run against the whole
+;; node-test lane, and it FAILS at this tip - not because the fixture is absent
+;; but because `:network` is INERT on a live `run-variant`. The plan compiler
+;; lowers `:network` to `:fx-overrides {:rf.http/managed
+;; :rf.http/managed-test-stub}` (`re-frame.story.plan/lower-network`), and
+;; `:rf.http/managed-test-stub` is registered ONLY by
+;; `re-frame.http.test-support/install-managed-request-stubs!` - which, across
+;; `tools/story/src`, is called by artifact REPLAY (`re-frame.story.artifact`)
+;; and by nothing on the `run-variant` path. So the override names a target
+;; that does not resolve, the preset's generic stub answers, and the drive
+;; reproduces the PRE-FIX symptom exactly: machine `:submitting`,
+;; `:auth/authenticated` false, no token stored, and one
+;; `:rf.error/schema-validation-failure :where :event` naming `[1 :value :token]`
+;; as a missing key.
+;;
+;; The repair belongs in the Story runtime, which this namespace may not reach.
+;; Until it lands, the guard that CAN hold from here is the one below: the
+;; registered variant's COMPILED PLAN must carry the token-bearing route and
+;; must lower it onto the managed-HTTP seam. Delete the `:network` slot from
+;; examples/core/login/stories.cljs and every assertion below goes red, which is
+;; the regression rf2-cckg exists to hold. What it cannot yet witness is the
+;; cascade actually arriving; that is the follow-on.
 
 (def ^:private story-fixture-token
-  "The token `:story.login/success`'s `:network` route fixture hands back — the
+  "The token `:story.login/success`'s `:network` route fixture hands back - the
    same string the live demo backend (`:auth.login.demo/managed-stub`) conjures,
    so the Story frame and the live-app frame agree on the server's half."
   "demo-token-123")
 
-(defn- install-storage-stub!
-  "Install a RECORDING `localStorage` stub on `globalThis` and return
-   `[recorded restore!]`.
+(def ^:private login-route
+  "The route `submit-form` really posts, and the key the variant files its
+   fixture under."
+  [:post "/api/login"])
 
-   `:auth.session/store`'s handler body is the example's one platform-bound
-   line — `(.setItem (.-localStorage js/globalThis) \"auth/token\" token)` — so
-   stubbing the STORAGE rather than the fx keeps the real registered handler in
-   the run and still asserts the token it received. Node has no `localStorage`,
-   which is why the effect is otherwise a silent no-op here (and why nothing
-   persists to a browser). `defineProperty` rather than `set!` because a host
-   that DOES define the global may define it as an accessor, where a plain
-   assignment throws under strict mode."
-  []
-  (let [recorded (atom {})
-        prior    (.-localStorage js/globalThis)
-        stub     #js {:setItem    (fn [k v] (swap! recorded assoc k v))
-                      :getItem    (fn [k] (get @recorded k))
-                      :removeItem (fn [k] (swap! recorded dissoc k))}]
-    (js/Object.defineProperty
-      js/globalThis "localStorage"
-      #js {:value stub :configurable true :writable true})
-    [recorded
-     (fn restore! []
-       (if (undefined? prior)
-         (js-delete js/globalThis "localStorage")
-         (js/Object.defineProperty
-           js/globalThis "localStorage"
-           #js {:value prior :configurable true :writable true})))]))
-
-(defn- event-schema-refusals
-  "The `:where :event` schema-refusal traces in `traces` — the boundary that
-   turned the generic canned payload away before the fix."
-  [traces]
-  (filterv #(and (= :rf.error/schema-validation-failure (:operation %))
-                 (= :event (-> % :tags :where)))
-           traces))
-
-(deftest story-success-variant-drives-the-real-cascade-to-authed
-  (testing "the registered :story.login/success variant — run in a newly
-            allocated Story frame, with the development Malli validator live —
-            reaches :authed, satisfies the Welcome banner's own tag predicate,
-            hands the fixture token to :auth.session/store, and is refused at no
-            event-schema boundary along the way"
-    ;; Re-fire the EXAMPLE's deck first. The login_form TESTBED deck
-    ;; (tools/story/testbeds/login_form) registers variants under the same
-    ;; `:story.login` parent and shares the consolidated node-test bundle, so
-    ;; without this the body under test is whichever deck loaded last
-    ;; (re-frame.story.login-example-seed-cljs-test guards the same way).
-    ;; `register-all!` is idempotent.
+(deftest story-success-variant-carries-its-own-token-bearing-fixture
+  (testing "the registered :story.login/success variant compiles to a plan whose
+            :network route answers the real login POST with a token-bearing
+            reply - the shape :auth.login/succeeded's schema requires, and the
+            thing the generic preset stub cannot supply"
+    ;; Re-fire the EXAMPLE's deck so the body under test is the example's own
+    ;; (`register-all!` is idempotent; the seed regression in the Story test
+    ;; tree re-asserts the same way).
     (login-stories/register-all!)
-    (let [[recorded restore!] (install-storage-stub!)
-          traces              (atom [])]
-      (rf/register-listener! :trace ::story-probe (fn [ev] (swap! traces conj ev)))
-      (async done
-        (-> (rf.story/run-variant :story.login/success)
-            (rf.story.async/then
-              (fn [result]
-                (rf/unregister-listener! :trace ::story-probe)
-                (try
-                  (let [fs    (rf/frame-state-value :story.login/success)
-                        state (get-in fs [:rf.db/runtime :rf.runtime/machines
-                                          :snapshots :auth.login/flow :state])]
-                    (is (= :ready (:lifecycle result))
-                        "the variant's own lifecycle completed — setup, loaders,
-                         events and play all ran (a failed run would strand it
-                         short of :ready and make every assertion below moot)")
+    (let [world (:world (rf.story.plan/variant-plan :story.login/success))
+          reply (get-in world [:network login-route :reply :ok])]
+      (is (some? (get-in world [:network login-route]))
+          (str "the variant declares a :network route for " (pr-str login-route)
+               "; got routes " (pr-str (keys (:network world)))))
+      (is (= story-fixture-token (:token reply))
+          "the reply carries the demo token - without it the generic canned
+           payload is refused at the schema boundary and the canonical
+           screenshot never leaves :submitting")
+      (is (some? (:user reply))
+          "and the :user sibling the Welcome banner reads")
+      ;; Asserted against the REGISTERED schema rather than a copy of it, so a
+      ;; tightening of :auth.login/succeeded reds this test rather than
+      ;; silently outrunning it.
+      (is (nil? (m/explain (:schema (rf.registrar/lookup :event :auth.login/succeeded))
+                           [:auth.login/succeeded {:status :ok :value reply}]))
+          ":auth.login/succeeded ACCEPTS the fixture's reply - the boundary that
+           refuses the generic {:stubbed true} payload"))))
 
-                    ;; --- the flow left :submitting ---------------------------
-                    (is (= :authed state)
-                        "the real cascade — submit-form → :rf.http/managed →
-                         the variant's :network reply → :auth.login/succeeded →
-                         a credential-free :success signal — landed the machine
-                         at :authed. Before the fixture landed this read
-                         :submitting, because the generic canned payload was
-                         refused before :auth.login/succeeded ever ran")
-
-                    ;; --- the Welcome view's own predicate --------------------
-                    ;; login.core/login-banner renders [:span "Welcome!"] iff
-                    ;; this sub is true; computing it against the frame-state is
-                    ;; the DOM-free read of the same branch.
-                    (is (true? (rf/compute-sub
-                                 [:rf.machine/has-tag? :auth.login/flow
-                                  :auth/authenticated]
-                                 fs))
-                        "the :auth/authenticated tag is set, so the banner shows
-                         'Welcome!' rather than the form — the canonical
-                         screenshot the variant advertises")
-
-                    ;; --- the persistence fx got the fixture's token ----------
-                    (is (= story-fixture-token (get @recorded "auth/token"))
-                        "the REAL :auth.session/store handler ran and wrote the
-                         variant's fixture token to the stubbed storage — the
-                         token travelled the whole cascade intact, and nothing
-                         touched browser persistence (Node has no localStorage;
-                         the stub is this test's own)")
-
-                    ;; --- and nothing was turned away at a schema boundary ----
-                    (let [refusals (event-schema-refusals @traces)]
-                      (is (empty? refusals)
-                          (str "no event-schema refusal fired during the run; "
-                               "got " (count refusals) " — "
-                               (pr-str (mapv #(-> % :tags :event-id) refusals))))))
-                  (finally
-                    (restore!)
-                    (rf.story/destroy-variant! :story.login/success)
-                    (done))))))))))
+(deftest story-success-fixture-lowers-onto-the-managed-http-seam
+  (testing "the compiled plan lowers :network onto :rf.http/managed - the
+            variant does not invent an HTTP mock, it redirects the real fx, so
+            the cascade it describes stays the real one end to end"
+    (login-stories/register-all!)
+    (let [plan (rf.story.plan/variant-plan :story.login/success)]
+      (is (= :rf.http/managed-test-stub
+             (get-in plan [:world :frame :fx-overrides :rf.http/managed]))
+          ":network lowered to the managed-request stub override
+           (re-frame.story.plan/lower-network)"))))

--- a/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
@@ -99,9 +99,16 @@
             [login.stories :as login-stories])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
+;; `:async? true` because the rf2-cckg drive at the foot of this ns is an
+;; `async` test (`rf.story/run-variant` resolves a promise). cljs.test refuses a
+;; FN-form fixture around any async body — "Async tests require fixtures to be
+;; specified as maps. Testing aborted." — and the abort takes the whole bundle
+;; down, not just this namespace. The map form serves the four synchronous tests
+;; above unchanged.
 (use-fixtures :each
   (rf.test-support/make-reset-runtime-fixture
-    {:adapter rf.adapter.reagent/adapter}))
+    {:adapter rf.adapter.reagent/adapter
+     :async?  true}))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers

--- a/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
@@ -397,7 +397,7 @@
                       (is (empty? refusals)
                           (str "no event-schema refusal fired during the run; "
                                "got " (count refusals) " — "
-                               (pr-str (mapv #(-> % :tags :rf.event/id) refusals))))))
+                               (pr-str (mapv #(-> % :tags :event-id) refusals))))))
                   (finally
                     (restore!)
                     (rf.story/destroy-variant! :story.login/success)


### PR DESCRIPTION
Two beads, paired because both need the same heavy CLJS node-test build.

## rf2-gzp5 — the frame `:observability` sink gets a teaching vehicle

Premise verified at this base: `git grep -F ':observability' -- examples testbeds` returns
nothing (control: 20 files under `docs/` and `spec/`). No sibling bead had supplied one.

The sink is the documented normal production observation surface — `spec/API.md`, `spec/009`,
`docs/core/observability.md` and the report-errors-in-production how-to all teach it first — but
no example configured one, so a reader following the guide had nothing to copy from.

`examples/real-apps/realworld_resources/core.cljs` gains the **configuration only**:

- `observability`, the frame's error-reporting policy, declared unconditionally on the
  `frame-root` config;
- `error-sink-id`, one def both halves read so policy and registration cannot drift;
- `install-error-monitor!`, the **gated** registration of the concrete sink fn, called from `run`.

That split is the lesson and the surrounding comment says why: routing is fail-closed, so the
*declaration* opens the channel and the *registration* is what you gate. A dev build therefore
registers no sink, the record routes nowhere, and the framework's console fallback prints it.
The comment also covers what the sink receives (an already-projected record, with the JWT
`:auth/classify-token` marks sensitive redacted before app code sees it) and why
`register-listener! :trace` is the wrong reach.

Every assertion lives in the framework test tree per the standing test-free-examples lock
(rf2-8cevm) — a new focused deftest ns in the Reagent adapter test tree that reads the example's
own defs rather than restating them. Four pins: the policy is well-formed and single-sourced;
a handler exception in a frame carrying that same policy map delivers exactly one projected
`:rf.observe/error` with the sensitive JWT redacted; the same sink and handler route nothing from
a frame with no policy; and the installer follows `debug-enabled?`.

## rf2-cckg — and a P1 finding underneath it

The acceptance rf2-cckg asked for (drive the registered `:story.login/success` variant to
`:authed`) was written and run against the whole node-test lane. **It fails at this tip, and not
because the fixture is missing — `:network` is inert on a live `run-variant`.**

`re-frame.story.plan/lower-network` lowers `:network` to
`:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}`. That fx id is registered by exactly
one thing, `re-frame.http.test-support/install-managed-request-stubs!`, and across
`tools/story/src` that helper is called only from `re-frame.story.artifact` (replay) — nothing on
the `run-variant` / `allocate!` path calls it. So the override names a target that does not
resolve, the `:preset :story` generic canned stub answers, and the drive reproduces the pre-fix
symptom exactly: machine `:submitting`, `:auth/authenticated` false, no token stored, and one
`:rf.error/schema-validation-failure :where :event` naming `[1 :value :token]` as a missing key.

The discriminating measurement: **identical failure with the `:network` slot present and with it
removed.** The compiled bundle was confirmed to carry the fixture
(`grep -c 'Ada Lovelace' …/cljs-runtime/login.stories.js` = 1), so this is not a stale compile.
So PR #9386's source fix does not actually reach the canonical screenshot. Filed as **rf2-o6ym**
(P1), with the repair (install the `[:world :network]` route map on the allocate path, uninstall
LIFO on destroy — `artifact/with-network-stubs` is the shape to reuse) and the acceptance that
restores the drive. `tools/story/**` was fenced for this dispatch, so the fix is not attempted here.

What lands is the guard that can hold from a core test namespace: the registered variant's
compiled plan must carry the token-bearing route for the POST the form really makes; that reply
must satisfy the **registered** `:auth.login/succeeded` schema (asserted via `m/explain` against
the live registration, not a copy); and the plan must lower it onto the managed-HTTP seam. Delete
the `:network` slot from `examples/core/login/stories.cljs` and all of it goes red — the
regression rf2-cckg exists to hold. The namespace says in place what it cannot yet witness.

## Gates

Nominated lane, run from `implementation/`, exit codes captured on one command line
(`… > log 2>&1; echo $? > exit`) and quoted from the file, never from the harness:

| run | what | captured exit |
|---|---|---|
| 1 | `npm run test:cljs`, full lane | **1** — a fn-form fixture around an `async` body aborts the whole bundle; fixed |
| 2 | plant (`:network` slot removed) + focused ns | **1** — 4 failures, all mine |
| 3 | `npm run test:cljs`, full lane, fixture restored | **1** — same 4 failures, which is the finding above; 11395 tests / 57462 assertions, 0 errors |
| 4 | focused, both new namespaces, after reshaping | **0** — 10 tests, 139 assertions, 0 failures 0 errors |

`scripts/check_require_alias_dialect.py` exits **0** (`re-frame.interop` is aliased `rf.interop`
per the Conventions dialect; the how-to's prose spells it `interop`).

Plant/restore verified by git blob hash, not by reading a diff: baseline
`579e9b4d9e51ed867553a9e78628e1136b5ba930`, restored to the same. The gate was confirmed to have
read this worktree by the planted fault going red, and independently by the source-coord path the
failing trace printed.

Left to CI: everything else in the 87-check matrix, including
`node implementation/scripts/check-examples-compile.cjs` — its 58-build sweep plus a fourth heavy
compile would have doubled the dispatch's gate time, and the one example edit is a `def` plus a
config key on an existing `frame-root`, compiled in runs 3 and 4 as part of the node-test
classpath. Per the gate-nomination policy I did not run `scripts/test-fast-pr.sh`.

Beads: rf2-cckg (partially — the plan-level guard lands, the drive waits on rf2-o6ym),
rf2-gzp5 (complete), rf2-o6ym (filed).