### PR TITLE
test(ssr): parse the emitted HTML for real in the leading-LF witness (rf2-s7l5)

### DIFF
--- a/implementation/ssr/deps.edn
+++ b/implementation/ssr/deps.edn
@@ -60,7 +60,41 @@
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-machines   {:local/root "../machines"}
                        ;; Silent-on-success reporter.
-                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
+                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                       ;; rf2-s7l5 — TEST-ONLY HTML5 parser, and the only
+                       ;; non-re-frame dependency on this classpath.
+                       ;;
+                       ;; The leading-LF compensation this artefact emits
+                       ;; exists to survive an HTML PARSER: the tokenizer
+                       ;; discards one LF immediately after a `<pre>` /
+                       ;; `<listing>` / `<textarea>` start tag, so
+                       ;; `re-frame.ssr-hiccup-newline-test` can only witness
+                       ;; the repair by parsing the emitted markup and reading
+                       ;; the resulting node's `textContent`. A hand-written
+                       ;; MODEL of that rule cannot: it shares the belief it is
+                       ;; supposed to check, so a wrong rule agrees with itself
+                       ;; and the suite stays green (rf2-s7l5's own audit
+                       ;; residual, twice).
+                       ;;
+                       ;; WHY validator.nu AND NOT jsoup. jsoup is the obvious
+                       ;; reach and it is WRONG here — MEASURED on 1.22.1:
+                       ;; `HtmlTreeBuilderState` consumes the LF for `pre` /
+                       ;; `listing` but NOT for `textarea`, so
+                       ;; `<textarea>\n\nt</textarea>` parses to `"\n\nt"` and
+                       ;; a textarea witness written against it would pin the
+                       ;; parser's gap as the browser's behaviour.
+                       ;; `nu.validator/htmlparser` is a direct port of the
+                       ;; HTML5 tree-construction algorithm (it is the parser
+                       ;; behind the W3C/WHATWG validator), gets all three
+                       ;; right, and builds a real `org.w3c.dom` tree — so the
+                       ;; witness reads `Node.getTextContent()`, the literal
+                       ;; thing the browser contract is written in.
+                       ;;
+                       ;; One 417 KiB jar, no transitive dependencies, and
+                       ;; NOWHERE near a production build: `:paths ["src"]`
+                       ;; and `:deps` above are what ships, and nothing under
+                       ;; `src/` requires it.
+                       nu.validator/htmlparser  {:mvn/version "1.4.16"}}
          ;; The default PR/local gate excludes the heavy
          ;; `^:slow` / `^:stress` namespaces (here: the 2000-request
          ;; `ssr_teardown_load_test`). `re-frame.test-quiet.runner` passes
@@ -134,7 +168,13 @@
                  day8/re-frame2-flows      {:local/root "../flows"}
                  day8/re-frame2-routing    {:local/root "../routing"}
                  day8/re-frame2-machines   {:local/root "../machines"}
-                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                 ;; rf2-s7l5 — see the `:test` alias for why. This alias does
+                 ;; NOT compose onto `:test` (unlike `:prod-gate`), and the
+                 ;; runner LOADS every namespace under `test/` before it
+                 ;; filters vars, so a dependency missing here fails the slow
+                 ;; lane on namespace load rather than on a test.
+                 nu.validator/htmlparser   {:mvn/version "1.4.16"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 
   ;; Clojars deployment.

--- a/implementation/ssr/test/re_frame/ssr_hiccup_newline_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hiccup_newline_test.clj
@@ -25,14 +25,10 @@
   BYTES are where it becomes visible without a browser, and pinning those bytes
   against react-dom's is what this namespace does.
 
-  WHAT THIS WITNESS OBSERVES, AND WHAT IT DOES NOT (rf2-s7l5, merged-PR audit
-  #9377). It never invokes an HTML parser and never runs a client renderer.
-  There is no HTML parser on this artefact's classpath — `implementation/ssr`'s
-  `:test` alias resolves core plus schemas / flows / routing / machines /
-  test-quiet, and none of them carries one — and adding a dependency to a
-  shipping artefact to strengthen a test is an operator call, not a test
-  author's. So this namespace asserts exactly TWO things, and both are named
-  honestly at every assertion site:
+  WHAT THIS WITNESS OBSERVES (rf2-s7l5, merged-PR audits #9377 and #9391). It
+  PARSES the emitted markup with a conformant HTML5 parser and reads the
+  resulting DOM node's `textContent`. Two things are asserted, and both are
+  named honestly at every assertion site:
 
     1. EMITTED BYTES. `render-to-string` / `render-shell` / `emit-ui-tree`
        produce a specific string, pinned against react-dom/server 19.2's own
@@ -40,49 +36,57 @@
        independent pin: the expected bytes were measured from react-dom, not
        derived from this repository's rule.
 
-    2. A MODEL of the one HTML5 tokenizer rule — `modelled-text-content` below
-       applies \"a newline-eating element's start tag is followed by an ignored
-       LF\" (HTML Standard §13.2.6.4.x) to those bytes. It is NOT a parse, and
-       an assertion over it is NOT an observation of `textContent`. It is a
-       readability device: it re-expresses the byte pin in the units the
-       authored string is written in, so a reader can see WHY the extra LF
-       belongs there.
+    2. PARSED `textContent`. `parsed-text-content` below runs those bytes
+       through `nu.validator.htmlparser` — a direct port of the HTML5
+       tree-construction algorithm, the parser behind the W3C/WHATWG validator
+       — which yields an `org.w3c.dom` tree, and reads `Node.getTextContent()`
+       off the element. That is the browser contract's own vocabulary, not a
+       re-statement of this repository's rule, and it is what the acceptance
+       criterion asks for.
 
-  THE LIMIT, STATED PLAINLY. A model of a rule cannot independently establish
-  that rule. If the production compensation were wrong about WHICH elements eat
-  a newline, or about HOW MANY characters are eaten, a model that shares the
-  belief agrees with it and every assertion here stays green. The model's
-  roster is therefore written out as a LITERAL taken from the HTML Standard
-  rather than read from `rf.ssr.html-helpers/newline-eating-tags`, which removes
-  the circularity on the roster axis (and `one-roster-one-rule` below pins the
-  production roster against the same literal, from the other side). The
-  remaining shared belief — one LF, discarded, immediately after the start tag —
-  is not breakable without a real parser or a browser.
+  WHY THAT MATTERS, AND WHAT IT REPLACED. Until rf2-s7l5's second pass this
+  namespace carried a hand-written MODEL of the tokenizer rule instead of a
+  parse. A model cannot independently establish the rule it models: if the
+  production compensation were wrong about WHICH elements eat a newline, or
+  about HOW MANY characters are eaten, a model sharing that belief agrees with
+  it and every assertion stays green. The parser has no such coupling — it was
+  written from the HTML Standard by people who had never seen this repository.
 
-  WHAT WOULD CLOSE IT. Either an HTML5-conformant parser on the JVM side (jsoup
-  implements this tokenizer rule) added to this artefact's `:test` alias, or a
-  browser-level witness on an adapter testbed that reads the real node's
-  `textContent`. Both are outside a test author's remit here — the first adds a
-  dependency, the second adds a browser spec — and rf2-s7l5's audit residual is
-  closed on the rename rather than on either. Do not upgrade the wording below
-  to claim a parse without one of them actually being present.
+  WHY validator.nu AND NOT jsoup. jsoup is the obvious reach and it is wrong
+  for this witness — MEASURED on jsoup 1.22.1: its tree builder consumes the LF
+  for `pre` / `listing` but NOT for `textarea`, so a textarea assertion written
+  against it would pin jsoup's own conformance gap as the browser's behaviour.
+  See `implementation/ssr/deps.edn`.
+
+  THE CLIENT-RENDERING LEG. React's client path never parses HTML for a text
+  child: `createElement(:pre, nil, \"\\ncode\")` sets a DOM text node whose data
+  IS the authored string, so the client `textContent` and the authored string
+  are the same object of comparison. The server leg is therefore the whole
+  question, and `server-parse-matches-authored-and-client-text` below closes it
+  from both ends — our emitted bytes AND react-dom/server's own measured bytes
+  parse to the authored string.
+
+  WHAT IS STILL NOT OBSERVED HERE: a real browser. A conformant parser plus
+  byte parity with react-dom/server is the bound; a browser would add the
+  rendering engine's own text handling, which no gate in this artefact reaches.
 
   JVM-only, mirroring `re-frame.ssr-emit-test`: the emitters are
   platform-neutral `.cljc` and the shared rule's own unit-level proof runs on
   both platforms via `re-frame.ssr.emit-ui-tree-cljs-test`."
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.ssr.emit :as rf.ssr.emit]
             [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]
             [re-frame.ssr.streaming :as rf.ssr.streaming]
             [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
-            [re-frame.ssr.ui-tree :as rf.ssr.ui-tree]))
+            [re-frame.ssr.ui-tree :as rf.ssr.ui-tree])
+  (:import [java.io StringReader]
+           [nu.validator.htmlparser.dom HtmlDocumentBuilder]
+           [org.xml.sax InputSource]))
 
 (use-fixtures :each rf.ssr.test-fixture/reset-runtime)
 
 ;; ---------------------------------------------------------------------------
-;; The MODEL — not a parser. See the ns docstring for what it does and does not
-;; establish.
+;; The PARSER — a real HTML5 tree construction, not a model of one.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private html5-newline-eating-elements
@@ -90,54 +94,58 @@
   (§13.2.6.4.x — the `in body` insertion mode drops one LF immediately after a
   `pre` / `listing` / `textarea` start tag).
 
-  DELIBERATELY A LITERAL, not `rf.ssr.html-helpers/newline-eating-tags`: the
-  model must not read the production roster it is used to check, or a wrong
+  DELIBERATELY A LITERAL, not `rf.ssr.html-helpers/newline-eating-tags`: this
+  namespace must not read the production roster it is used to check, or a wrong
   roster would agree with itself. `one-roster-one-rule` pins the production
-  roster against the same literal from the other side."
+  roster against this literal from the other side. The PARSER below shares no
+  roster with either — it derives the behaviour from the standard itself, which
+  is the whole reason it is here."
   #{"pre" "listing" "textarea"})
 
-(defn- modelled-text-content
-  "MODELS — does not parse — the DOM `textContent` a browser would yield for
-  `html`, a single element whose body is text. Strips the start and end tag,
-  then applies the one HTML5 rule under test: one LF immediately after a
-  `<pre>` / `<listing>` / `<textarea>` start tag is DISCARDED by the tokenizer.
+(defn- parsed-text-content
+  "PARSES `html` with `nu.validator.htmlparser` — a port of the HTML5
+  tree-construction algorithm — and returns the `textContent` of the first
+  element in the resulting `org.w3c.dom` document whose tag name is `tag`.
 
-  An assertion over this function is an assertion about the emitted BYTES,
-  re-expressed in the units the authored string is written in. It is NOT an
-  observation of a real DOM node's `textContent`, and it cannot independently
-  establish the tokenizer rule it applies — see the ns docstring."
-  [html]
-  (let [[_ tag body] (re-matches #"(?s)<([A-Za-z][A-Za-z0-9-]*)[^>]*>(.*)</[A-Za-z][A-Za-z0-9-]*>"
-                                 html)
-        _            (assert (some? tag) (str "the model saw no element: " (pr-str html)))
-        newline-eater? (contains? html5-newline-eating-elements
-                                  (str/lower-case tag))
-        parsed       (if (and newline-eater? (str/starts-with? body "\n"))
-                       (subs body 1)
-                       body)]
-    ;; Un-escape the entity forms this emitter produces, so the model reports
-    ;; the authored text rather than the wire text.
-    (-> parsed
-        (str/replace "&lt;" "<")
-        (str/replace "&gt;" ">")
-        (str/replace "&quot;" "\"")
-        (str/replace "&#39;" "'")
-        (str/replace "&amp;" "&"))))
+  This is the browser contract's own vocabulary: `Node.getTextContent()` on a
+  real parsed node, not a re-statement of this repository's compensation rule.
+  Entity references, the newline-eating rule and raw-text element handling are
+  all the parser's, not ours."
+  [tag html]
+  (let [doc      (.parse (HtmlDocumentBuilder.)
+                         (InputSource. (StringReader. html)))
+        elements (.getElementsByTagName doc tag)]
+    (assert (pos? (.getLength elements))
+            (str "the parse produced no <" tag "> element: " (pr-str html)))
+    (.getTextContent (.item elements 0))))
 
-(deftest text-content-model-is-itself-exercised
-  ;; The model underwrites every modelled-text-content assertion below, so
-  ;; prove it BITES in the direction it is used: it must report the loss on the
-  ;; uncompensated markup, and no loss on a non-newline-eating element. This is
-  ;; a check on the MODEL, not on a browser — see the ns docstring.
-  (testing "an UNCOMPENSATED newline-eating element loses its leading LF"
-    (is (= "code" (modelled-text-content "<pre>\ncode</pre>"))
-        "this is the defect rf2-s7l5 repairs, seen through the model"))
-  (testing "a COMPENSATED one round-trips"
-    (is (= "\ncode" (modelled-text-content "<pre>\n\ncode</pre>"))))
-  (testing "a non-newline-eating element eats nothing"
-    (is (= "\ncode" (modelled-text-content "<div>\ncode</div>"))))
-  (testing "entity forms are un-escaped by the model"
-    (is (= "\n<a> & b" (modelled-text-content "<pre>\n\n&lt;a&gt; &amp; b</pre>")))))
+(deftest the-parser-is-itself-exercised
+  ;; NEGATIVE CONTROL, and the acceptance criterion names it: the parser must
+  ;; report the LOSS on UNCOMPENSATED markup — the exact pre-repair emitter
+  ;; output — or every green below would be vacuous. A witness that has never
+  ;; been red about the defect is not a witness.
+  (testing "UNCOMPENSATED markup — the pre-repair bytes — loses its leading LF"
+    (is (= "code" (parsed-text-content "pre" "<pre>\ncode</pre>"))
+        "this is rf2-s7l5's defect, observed rather than modelled")
+    (is (= "listed" (parsed-text-content "listing" "<listing>\nlisted</listing>")))
+    (is (= "text" (parsed-text-content "textarea" "<textarea>\ntext</textarea>"))))
+  (testing "COMPENSATED markup round-trips"
+    (is (= "\ncode" (parsed-text-content "pre" "<pre>\n\ncode</pre>"))))
+  (testing "a non-newline-eating element eats nothing, compensated or not"
+    (is (= "\ncode" (parsed-text-content "div" "<div>\ncode</div>"))))
+  (testing "the parser owns entity decoding"
+    (is (= "\n<a> & b" (parsed-text-content "pre" "<pre>\n\n&lt;a&gt; &amp; b</pre>"))))
+  (testing "the roster the parser exhibits IS the HTML Standard literal"
+    ;; Read off the parser rather than asserted at it: for each element, the
+    ;; compensated and uncompensated parses differ exactly where the standard
+    ;; says one LF is eaten.
+    (is (= html5-newline-eating-elements
+           (set (for [tag   ["pre" "listing" "textarea" "div" "span" "p"]
+                      :when (not= (parsed-text-content
+                                   tag (str "<" tag ">\nx</" tag ">"))
+                                  "\nx")]
+                  tag)))
+        "pre / listing / textarea eat a leading LF; nothing else does")))
 
 ;; ---------------------------------------------------------------------------
 ;; The shared rule — one roster, one implementation (acceptance: "share the
@@ -173,26 +181,25 @@
     (let [html (rf.ssr.emit/render-to-string [:pre "\ncode"])]
       (is (= "<pre>\n\ncode</pre>" html)
           "byte parity with react-dom/server 19.2 renderToStaticMarkup")
-      (is (= "\ncode" (modelled-text-content html))
-          "the MODELLED text content is the authored string — a model of the
-           tokenizer rule over the emitted bytes, not a parse (ns docstring)")))
+      (is (= "\ncode" (parsed-text-content "pre" html))
+          "the PARSED textContent is the authored string")))
   (testing "[:textarea \"\\ntext\"] — the same content loss"
     (let [html (rf.ssr.emit/render-to-string [:textarea "\ntext"])]
       (is (= "<textarea>\n\ntext</textarea>" html))
-      (is (= "\ntext" (modelled-text-content html)))))
+      (is (= "\ntext" (parsed-text-content "textarea" html)))))
   (testing "<listing> is a newline-eating element too"
     (let [html (rf.ssr.emit/render-to-string [:listing "\nlisted"])]
       (is (= "<listing>\n\nlisted</listing>" html))
-      (is (= "\nlisted" (modelled-text-content html)))))
+      (is (= "\nlisted" (parsed-text-content "listing" html)))))
   (testing "every EXTRA authored LF survives (one is eaten, the rest remain)"
     (let [html (rf.ssr.emit/render-to-string [:pre "\n\ncode"])]
       (is (= "<pre>\n\n\ncode</pre>" html))
-      (is (= "\n\ncode" (modelled-text-content html)))))
+      (is (= "\n\ncode" (parsed-text-content "pre" html)))))
   (testing "text is still escaped alongside the compensation"
     (let [html (rf.ssr.emit/render-to-string [:pre "\n<a> & b"])]
       (is (= "<pre>\n\n&lt;a&gt; &amp; b</pre>" html))
-      (is (= "\n<a> & b" (modelled-text-content html))
-          "the authored string, escaped on the wire and un-escaped by the model")))
+      (is (= "\n<a> & b" (parsed-text-content "pre" html))
+          "the authored string, escaped on the wire and decoded by the parser")))
   (testing "an attrs map does not disturb the rule"
     (is (= "<pre class=\"c\">\n\ncode</pre>"
            (rf.ssr.emit/render-to-string [:pre {:class "c"} "\ncode"]))))
@@ -201,23 +208,48 @@
 
 (deftest non-streaming-hiccup-vacuity-controls
   (testing "CONTROL: no leading LF ⇒ no compensation"
-    (is (= "<pre>code</pre>" (rf.ssr.emit/render-to-string [:pre "code"])))
-    (is (= "<textarea>text</textarea>" (rf.ssr.emit/render-to-string [:textarea "text"]))))
-  (testing "CONTROL: a leading CR is not a newline-eating trigger"
-    (is (= "<pre>\r\ncode</pre>" (rf.ssr.emit/render-to-string [:pre "\r\ncode"]))))
+    (let [html (rf.ssr.emit/render-to-string [:pre "code"])]
+      (is (= "<pre>code</pre>" html))
+      (is (= "code" (parsed-text-content "pre" html))
+          "the acceptance's no-leading-LF control, observed through the parser"))
+    (let [html (rf.ssr.emit/render-to-string [:textarea "text"])]
+      (is (= "<textarea>text</textarea>" html))
+      (is (= "text" (parsed-text-content "textarea" html)))))
   (testing "CONTROL: a non-newline-eating element is never compensated"
-    (is (= "<div>\ncode</div>" (rf.ssr.emit/render-to-string [:div "\ncode"]))))
-  (testing "CONTROL: the existing MULTI-CHILD rule is preserved"
-    (is (= "<pre>\nab</pre>" (rf.ssr.emit/render-to-string [:pre "\na" "b"]))
-        "React leaves a multi-child body untouched; so do we")
-    (is (= "<pre>\n<b>x</b></pre>" (rf.ssr.emit/render-to-string [:pre "\n" [:b "x"]]))
-        "an element sibling is a multi-child body"))
+    (let [html (rf.ssr.emit/render-to-string [:div "\ncode"])]
+      (is (= "<div>\ncode</div>" html))
+      (is (= "\ncode" (parsed-text-content "div" html))
+          "no compensation is owed, and none is lost")))
   (testing "CONTROL: RAW-TEXT handling is untouched"
-    (is (= "<script>\nvar a = 1 < 2;</script>"
-           (rf.ssr.emit/render-to-string [:script "\nvar a = 1 < 2;"]))
-        "script/style are raw text, never newline-eating, never escaped")
+    (let [html (rf.ssr.emit/render-to-string [:script "\nvar a = 1 < 2;"])]
+      (is (= "<script>\nvar a = 1 < 2;</script>" html)
+          "script/style are raw text, never newline-eating, never escaped")
+      (is (= "\nvar a = 1 < 2;" (parsed-text-content "script" html))
+          "the parser confirms it: raw text, LF intact, `<` not an entity"))
     (is (= "<style>\n.a { color: red }</style>"
-           (rf.ssr.emit/render-to-string [:style "\n.a { color: red }"])))))
+           (rf.ssr.emit/render-to-string [:style "\n.a { color: red }"]))))
+  ;; The two controls below record REACT-PARITY DIVERGENCES rather than
+  ;; round-trips. In each the parser DOES eat a character that no compensation
+  ;; replaces — because react-dom/server does not compensate either, and byte
+  ;; parity with react-dom is this emitter's contract. Pinning what the parser
+  ;; actually reports keeps the witness from overstating the repair's reach.
+  (testing "CONTROL: a leading CR is not a newline-eating trigger (React parity)"
+    (let [html (rf.ssr.emit/render-to-string [:pre "\r\ncode"])]
+      (is (= "<pre>\r\ncode</pre>" html)
+          "React's test is `charAt(0) === '\\n'`, so CRLF is not compensated")
+      (is (= "code" (parsed-text-content "pre" html))
+          "and the parser normalises CRLF→LF before eating it, so BOTH
+           characters go — a divergence shared with react-dom/server, not a
+           regression this bead introduces")))
+  (testing "CONTROL: the existing MULTI-CHILD rule is preserved (React parity)"
+    (let [html (rf.ssr.emit/render-to-string [:pre "\na" "b"])]
+      (is (= "<pre>\nab</pre>" html)
+          "React leaves a multi-child body untouched; so do we")
+      (is (= "ab" (parsed-text-content "pre" html))
+          "so the parser still eats that LF — React's own documented behaviour
+           for `typeof children !== 'string'`"))
+    (is (= "<pre>\n<b>x</b></pre>" (rf.ssr.emit/render-to-string [:pre "\n" [:b "x"]]))
+        "an element sibling is a multi-child body")))
 
 ;; ---------------------------------------------------------------------------
 ;; The streaming hiccup emitter — render-shell's walk-dom-tag
@@ -231,10 +263,14 @@
     ;; RED-BEFORE lever: walk-dom-tag emitted "<pre>\ncode</pre>".
     (let [html (shell [:pre "\ncode"])]
       (is (= "<pre>\n\ncode</pre>" html))
-      (is (= "\ncode" (modelled-text-content html)))))
+      (is (= "\ncode" (parsed-text-content "pre" html)))))
   (testing "textarea and listing through the shell walk"
-    (is (= "<textarea>\n\ntext</textarea>" (shell [:textarea "\ntext"])))
-    (is (= "<listing>\n\nlisted</listing>" (shell [:listing "\nlisted"]))))
+    (let [html (shell [:textarea "\ntext"])]
+      (is (= "<textarea>\n\ntext</textarea>" html))
+      (is (= "\ntext" (parsed-text-content "textarea" html))))
+    (let [html (shell [:listing "\nlisted"])]
+      (is (= "<listing>\n\nlisted</listing>" html))
+      (is (= "\nlisted" (parsed-text-content "listing" html)))))
   (testing "BYTE PARITY between the two hiccup emitters"
     (doseq [tree [[:pre "\ncode"] [:textarea "\ntext"] [:listing "\nl"]
                   [:pre "code"] [:pre "\r\ncode"] [:div "\ncode"]
@@ -249,13 +285,19 @@
 
 (deftest streaming-hiccup-vacuity-controls
   (testing "CONTROL: no leading LF ⇒ no compensation"
-    (is (= "<pre>code</pre>" (shell [:pre "code"]))))
+    (let [html (shell [:pre "code"])]
+      (is (= "<pre>code</pre>" html))
+      (is (= "code" (parsed-text-content "pre" html)))))
   (testing "CONTROL: a non-newline-eating element is never compensated"
-    (is (= "<div>\ncode</div>" (shell [:div "\ncode"]))))
+    (let [html (shell [:div "\ncode"])]
+      (is (= "<div>\ncode</div>" html))
+      (is (= "\ncode" (parsed-text-content "div" html)))))
   (testing "CONTROL: the multi-child rule is preserved in the shell walk too"
     (is (= "<pre>\nab</pre>" (shell [:pre "\na" "b"]))))
   (testing "CONTROL: raw-text handling is untouched in the shell walk"
-    (is (= "<script>\nvar a = 1 < 2;</script>" (shell [:script "\nvar a = 1 < 2;"])))))
+    (let [html (shell [:script "\nvar a = 1 < 2;"])]
+      (is (= "<script>\nvar a = 1 < 2;</script>" html))
+      (is (= "\nvar a = 1 < 2;" (parsed-text-content "script" html))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Three-path agreement — the S5 serialiser already had the rule; the point of
@@ -274,3 +316,46 @@
           (str "S5 serialiser vs sync hiccup emitter on <" tag ">"))
       (is (= from-s5 (shell hiccup))
           (str "S5 serialiser vs streaming hiccup emitter on <" tag ">")))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-s7l5's acceptance criterion, stated once and closed in one place.
+;; ---------------------------------------------------------------------------
+
+(def ^:private react-dom-static-markup
+  "react-dom/server 19.2 `renderToStaticMarkup` output, MEASURED, for the same
+  content. The independent reference: these bytes were read off react-dom, not
+  derived from this repository's rule, so parsing them is a check on the
+  BROWSER-side claim rather than on our own emitter."
+  {"pre"      ["\ncode"   "<pre>\n\ncode</pre>"]
+   "listing"  ["\nlisted" "<listing>\n\nlisted</listing>"]
+   "textarea" ["\ntext"   "<textarea>\n\ntext</textarea>"]})
+
+(deftest server-parse-matches-authored-and-client-text
+  ;; THE ACCEPTANCE: for one LF-leading string under pre / listing / textarea,
+  ;; PARSE the emitted non-streaming AND streaming HTML and assert the parsed
+  ;; textContent is the authored string — which is also the client rendering,
+  ;; because React's client path sets a lone string child as a DOM text node
+  ;; whose `data` IS that string (no HTML parse is involved on the client, so
+  ;; nothing can eat a newline there). Server-vs-client text agreement is
+  ;; therefore exactly "the parsed server text equals the authored string".
+  (doseq [[tag [authored expected-bytes]] react-dom-static-markup]
+    (let [hiccup      [(keyword tag) authored]
+          sync-html   (rf.ssr.emit/render-to-string hiccup)
+          stream-html (shell hiccup)]
+      (testing (str "<" tag "> — non-streaming")
+        (is (= expected-bytes sync-html)
+            "byte parity with the measured react-dom/server output")
+        (is (= authored (parsed-text-content tag sync-html))
+            "parsed textContent == the authored string == the client rendering"))
+      (testing (str "<" tag "> — streaming")
+        (is (= expected-bytes stream-html))
+        (is (= authored (parsed-text-content tag stream-html))
+            "parsed textContent == the authored string == the client rendering"))
+      (testing (str "<" tag "> — react-dom's own bytes parse the same way")
+        (is (= authored (parsed-text-content tag expected-bytes))
+            "the browser-side claim, checked against react-dom rather than us"))
+      (testing (str "<" tag "> — NEGATIVE CONTROL: the pre-repair bytes")
+        (is (not= authored
+                  (parsed-text-content tag (str "<" tag ">" authored "</" tag ">")))
+            "uncompensated markup — what both hiccup emitters produced before
+             rf2-s7l5 — parses to one character SHORT of the authored string")))))


### PR DESCRIPTION
## rf2-s7l5 — the reopened residual, closed by parsing rather than by relabelling

The production repair landed in #9377. The audits reopened this bead twice for the
same gap: the acceptance asks for the emitted **non-streaming and streaming** markup
to be **parsed** and the resulting node's `textContent` compared with the authored
string and the client rendering, and the witness carried a hand-written **model** of
the tokenizer rule instead. #9391 relabelled the model honestly, which the audit
accepted as an improvement but not as the observation — correctly labelling a model
does not execute the acceptance.

This parses.

### What changed

**`implementation/ssr/deps.edn`** — `nu.validator/htmlparser 1.4.16` added to this
artefact's own `:test` and `:slow-test` aliases. Test-only: one 417 KiB jar, no
transitive dependencies, `:paths ["src"]` and the top-level `:deps` are untouched,
and nothing under `src/` requires it. It goes in **both** aliases because
`:slow-test` does not compose onto `:test` and the runner loads every namespace under
`test/` before it filters vars.

**Not jsoup**, which is the obvious reach and is wrong for this witness — measured on
jsoup 1.22.1, its tree builder consumes the leading LF for `pre` and `listing` but
**not** for `textarea`, so `<textarea>\n\nt</textarea>` parses to `"\n\nt"` and a
textarea assertion written against it would pin jsoup's own conformance gap as the
browser's behaviour. `nu.validator/htmlparser` is a port of the HTML5
tree-construction algorithm (the parser behind the W3C/WHATWG validator), gets all
three right, and builds an `org.w3c.dom` tree — so the witness reads
`Node.getTextContent()`, literally the vocabulary the browser contract is written in.

**`ssr_hiccup_newline_test.clj`** — `modelled-text-content` is replaced by
`parsed-text-content`, and every assertion that used the model now reads a real parsed
node. Added `server-parse-matches-authored-and-client-text`, which states the
acceptance once and closes it: for `pre` / `listing` / `textarea`, the non-streaming
emitter, the streaming shell walk **and** react-dom/server's own measured bytes all
parse to the authored string, with the uncompensated (pre-repair) markup as the
negative control.

### The client-rendering leg

React's client path never parses HTML for a lone string child: `createElement(:pre,
nil, "\ncode")` sets a DOM text node whose `data` **is** the authored string, so client
`textContent` and the authored string are the same object of comparison. Server-vs-client
text agreement therefore reduces to "the parsed server text equals the authored string",
which is what the new test asserts — from both ends, ours and react-dom's.

### Held properties

- The roster literal stays a **literal**: the namespace still does not read
  `rf.ssr.html-helpers/newline-eating-tags`, and `one-roster-one-rule` still pins
  production against it from the other side. The parser shares no roster with either.
- Raw-text handling and the existing multi-child rule are preserved, and now
  **observed** through the parser rather than only pinned as bytes.
- The compensation is still shared — one roster, one rule, read by all three SSR
  paths. No second roster was created.

### Two React-parity divergences the parser exposed, now pinned as such

Both are pre-existing and deliberate; neither is changed here, and pinning them keeps
the witness from overstating the repair's reach.

- **A leading CRLF still loses both characters.** React's test is `charAt(0) === '\n'`,
  so `[:pre "\r\ncode"]` is not compensated; the parser normalises CRLF→LF in input
  preprocessing and then eats it, so it parses to `"code"`.
- **A multi-child body still loses its LF.** React leaves `typeof children !== 'string'`
  untouched, so `[:pre "\na" "b"]` parses to `"ab"`.

Byte parity with react-dom/server is this emitter's contract, so matching react-dom in
both cases is the correct behaviour, not a regression.

### Red-before evidence

Reverting the shared compensation locally (`(contains? newline-eating-tags tag-lc)` →
`(contains? #{} tag-lc)` in `html_helpers.cljc`, a one-line plant matching exactly one
line) put the witness **red at exit 1, 33 failures of 95 assertions**, with the parse
assertions naming the defect directly:

```
FAIL in (server-parse-matches-authored-and-client-text)
<pre> - non-streaming
parsed textContent == the authored string == the client rendering
expected: (= authored (parsed-text-content tag sync-html))
  actual: (not (= "\ncode" "code"))
```

and the same on the streaming emitter. Restored, and the restored file's git blob hash
is identical to the pre-plant one (`1e2517124eefe5ec59deed809e5749905829bdb9`).

### Gate

`cd implementation/ssr && clojure -M:test` — **exit 0**, 652 tests / 4289 assertions,
0 failures, 0 errors. (Captured with the redirect and the echo on one command line; the
number quoted is the runner's own.) `scripts/test-fast-pr.sh` was deliberately not run
per the gate-nomination policy; CI owns the matrix.

No production behaviour change, no shipping dependency, no new API.
