### PR TITLE
fix(subs): release the input reaction acquired, not the address (rf2-1frc residual)

### DIFF
--- a/implementation/adapters/uix/test/re_frame/adapter/uix_evicted_shared_child_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_evicted_shared_child_dom_cljs_test.cljs
@@ -1,0 +1,157 @@
+(ns re-frame.adapter.uix-evicted-shared-child-dom-cljs-test
+  "rf2-1frc (residual) — TWO MOUNTED UIx parents over ONE shared child survive a
+  framework-owned cache eviction still sharing that child.
+
+  ## What this pins that the unit lane cannot
+
+  `re-frame.subs-evicted-input-release-cljs-test` (core, `.cljc`) drives the
+  same seam with a hand-rolled eager-reacquisition holder and asserts the
+  sub-cache ref-count directly. This is the MOUNTED counterpart the acceptance
+  asks for: two real `use-sub` consumers under the real React-hook spine, so
+  the reacquisition under test is the spine's own `on-committed-disposed`
+  callback rather than a stand-in, and the consequence is read off COMMITTED
+  DOM rather than off a ref-count alone.
+
+  ## The defect
+
+  Both eviction primitives (`rf.subs.cache/invalidate-frame-subs!` and
+  `clear-sub-cache!`) remove the whole condemned batch from the cache atom
+  BEFORE disposing any member of it, and since PR #9373 a mounted hook whose
+  reaction is disposed REACQUIRES from inside that walk. So a later member's
+  teardown ran against a cache an earlier member had already repopulated — and
+  `re-frame.subs`' input release was address-only where the cache-dissoc
+  beside it was `identical?`-guarded. Two parents P1/P2 over one child C went
+  `{C 2, P1 1, P2 1}` → `{C 1, P1 1, P2 1}`, with P1 left holding the
+  intermediate child that P2's release had disposed, and a third C built for
+  P2.
+
+  The repair routes the release through `re-frame.subs/unsubscribe-if-reaction`
+  carrying the reaction the build actually acquired.
+
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` (ns-regexp
+  `-dom-cljs-test$`) discovers it for the real DOM assertions; `:node-test`'s
+  `cljs-test$` regex also matches, where the test self-gates on `(browser?)`
+  and no-ops cleanly."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            ["react" :as React]
+            ["react-dom/client" :as react-dom-client]
+            [uix.core :as uix :refer-macros [defui $]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.subs.cache :as rf.subs.cache]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.test-support :as rf.test-support]))
+
+;; MAP-FORM fixture with `:async? true`: the assertions below cross the spine's
+;; provisional-acquisition horizon (`settle-past-the-horizon!`), so they are
+;; `(async done …)` tests and cljs.test refuses those under a plain-fn `:each`
+;; fixture.
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.adapter.uix/adapter :async? true}))
+
+(def ^:private ec-frame :rf.uix-evicted-shared-child/frame)
+
+(def ^:private observed-a (atom []))
+(def ^:private observed-b (atom []))
+
+(defui ParentA []
+  (let [v (rf.adapter.uix/use-sub [::p1] {:frame ec-frame})]
+    (swap! observed-a conj v)
+    ($ :div {:id "ec-a"} (str "a=" v))))
+
+(defui ParentB []
+  (let [v (rf.adapter.uix/use-sub [::p2] {:frame ec-frame})]
+    (swap! observed-b conj v)
+    ($ :div {:id "ec-b"} (str "b=" v))))
+
+(defui BothParents []
+  ($ :div
+     ($ ParentA)
+     ($ ParentB)))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (when (exists? (.-act React)) (.-act React)))
+
+(def ^:private horizon-settle-ms
+  "Comfortably past the spine's provisional reap horizon
+  (`rf.substrate.spine/provisional-horizon-ms`, ruled 4 by rf2-2rtt6.71): these
+  assertions read the state the reaper LEFT, so a settle that races it proves
+  nothing."
+  24)
+
+(defn- settle! [k] (js/setTimeout k horizon-settle-ms))
+
+(defn- ref-count-of
+  [query-v]
+  (or (get-in @(:sub-cache (rf.frame/frame ec-frame)) [query-v :ref-count]) 0))
+
+(deftest two-mounted-parents-keep-sharing-one-child-across-a-cache-clear
+  (testing "UIx — two mounted use-sub consumers over ONE shared declared input
+            survive clear-sub-cache! still sharing that input (rf2-1frc)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (async done
+            (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+            (reset! observed-a [])
+            (reset! observed-b [])
+            (rf/make-frame {:id  ec-frame
+                            :doc "rf2-1frc two-parent / shared-child probe frame"})
+            (rf/reg-event ::seed (fn [_ctx _e] {:db {:n 1}}))
+            (rf/reg-event ::inc  (fn [{:keys [db]} _e] {:db (update db :n inc)}))
+            (rf/dispatch-sync [::seed] {:frame ec-frame})
+            (rf/reg-sub ::child (fn [db _q] (:n db)))
+            (rf/reg-sub ::p1 {:inputs [[::child]]} (fn [[c] _q] (* 10 c)))
+            (rf/reg-sub ::p2 {:inputs [[::child]]} (fn [[c] _q] (* 100 c)))
+
+            (let [mount-node (.createElement js/document "div")
+                  root       (react-dom-client/createRoot mount-node)]
+              (act-fn (fn [] (.render root ($ BothParents))))
+              (settle!
+                (fn []
+                  (is (= 2 (ref-count-of [::child]))
+                      "baseline: the shared child carries one ref per mounted parent")
+                  (is (= "a=10b=100" (.-textContent mount-node))
+                      "baseline: both parents committed their derived values")
+
+                  ;; THE FRAMEWORK-OWNED EVICTION. Every slot leaves the cache
+                  ;; before any of them is disposed, so the second parent's
+                  ;; teardown runs against a cache the first parent's eager
+                  ;; reacquisition has already repopulated.
+                  (act-fn (fn [] (rf.subs.cache/clear-sub-cache! ec-frame)))
+
+                  (settle!
+                    (fn []
+                      (is (= 2 (ref-count-of [::child]))
+                          "THE BUG (rf2-1frc residual): pre-fix this read 1 — the
+                           second parent's address-only input release decremented
+                           and disposed the SUCCESSOR child the first parent had
+                           just built, and its own reacquisition built a third")
+                      (is (= 1 (ref-count-of [::p1]))
+                          "P1 holds exactly one reference to its rebuilt reaction")
+                      (is (= 1 (ref-count-of [::p2]))
+                          "P2 holds exactly one reference to its rebuilt reaction")
+
+                      ;; The point of the ref-count: a parent left holding the
+                      ;; disposed intermediate child stops re-committing.
+                      (act-fn (fn [] (rf/dispatch-sync [::inc] {:frame ec-frame})))
+                      (settle!
+                        (fn []
+                          (is (= "a=20b=200" (.-textContent mount-node))
+                              "BOTH mounted parents re-committed after the
+                               eviction — neither is watching a child that was
+                               disposed out from under it")
+                          (act-fn (fn [] (.unmount root)))
+                          (settle!
+                            (fn []
+                              (is (zero? (ref-count-of [::child]))
+                                  "unmounting both parents releases the shared
+                                   child exactly — no leak, no double-release")
+                              (done))))))))))))))))

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -766,7 +766,8 @@
 ;; (`clear-sub-cache!`) is reached through `re-frame.core`'s defalias
 ;; pointing at `re-frame.subs.cache/*` directly (no facade re-export).
 
-(declare subscribe subscribe-in-frame unsubscribe compute-and-cache!)
+(declare subscribe subscribe-in-frame unsubscribe unsubscribe-if-reaction
+         compute-and-cache!)
 
 ;; ---- acquire recovery channel (rf2-vxgfnd.27) ----------------------------
 ;;
@@ -925,12 +926,33 @@
         [recovery-qs true]))))
 
 (defn- release-input-ref!
-  "Release ONE declared input ref by calling `unsubscribe`, surfacing a
-  throw as a dev breadcrumb instead of discarding it silently.
+  "Release ONE declared input ref — the CONCRETE `input-reaction` this build
+  acquired — surfacing a throw as a dev breadcrumb instead of discarding it
+  silently.
 
-  A layer-2+ reaction's disposal walks `input-signals` and `unsubscribe`s
+  RELEASE WHAT YOU ACQUIRED (rf2-1frc). This was an address-only
+  `unsubscribe`, on the reading that the slot at `input-q` could not be
+  replaced between a parent's build and its disposal. It can, and the two
+  eviction primitives make it ORDINARY rather than exotic: both
+  `rf.subs.cache/invalidate-frame-subs!` and `clear-sub-cache!` remove the
+  whole condemned batch from the cache atom BEFORE they dispose any member of
+  it, and since PR #9373 a mounted React hook whose reaction is disposed
+  REACQUIRES eagerly from inside that walk. So a later member's teardown runs
+  against a cache an earlier member has already repopulated: two mounted
+  parents over one shared child ended with the second parent's release
+  decrementing — and disposing — the SUCCESSOR child the first parent was
+  holding, leaving one counted ref where two were owed.
+
+  So the release is identity-guarded through `unsubscribe-if-reaction`,
+  matching the cache-dissoc step of the very same on-dispose callback (which
+  was `identical?`-guarded all along — the asymmetry WAS the defect). A
+  release whose reaction is no longer the cache's no-ops, its reference having
+  died with the eviction; a release whose reaction IS the cache's takes the
+  ordinary 1 → 0 in-tick disposal, exactly as `unsubscribe` did.
+
+  A layer-2+ reaction's disposal walks `input-signals` and releases
   each — symmetric with the per-input `subscribe` bumps taken at build
-  time. The walk is BEST-EFFORT: one input's `unsubscribe` throwing must
+  time. The walk is BEST-EFFORT: one input's release throwing must
   NOT skip the remaining inputs (a leaked sibling ref-count would compound),
   so the caller keeps looping. Before rf2-is8ov5 the throw was caught and
   dropped (`(catch … _ nil)`), leaving no trace — a ref-count leak from a
@@ -952,9 +974,9 @@
   release on the escaped-caching path, `:sub-cycle-unwind` for the earlier
   inputs released when a declared-input cycle in a non-first input abandons the build —
   rf2-t3cpn3). Returns nil."
-  [frame-id input-q where]
+  [frame-id input-q input-reaction where]
   (try
-    (unsubscribe frame-id input-q)
+    (unsubscribe-if-reaction frame-id input-q input-reaction)
     (catch #?(:clj Throwable :cljs :default) ex
       (rf.trace/emit-error! :rf.warning/sub-input-dispose-exception
                          {:category         :rf.warning/sub-input-dispose-exception
@@ -1303,6 +1325,10 @@
                                        ;; the minimal precise fix; any other
                                        ;; (theoretical) throw re-propagates
                                        ;; unchanged.
+                                       ;; `acquired` holds `[input-q reaction]`
+                                       ;; pairs, not bare addresses: the unwind
+                                       ;; releases the CONCRETE reaction it
+                                       ;; took (rf2-1frc).
                                        (let [acquired (volatile! [])]
                                          (try
                                            ;; rf2-7w1im: fence the recursive input
@@ -1316,13 +1342,13 @@
                                                    (let [r (subscribe-in-frame
                                                              frame-id input-q
                                                              expected-incarnation)]
-                                                     (vswap! acquired conj input-q)
+                                                     (vswap! acquired conj [input-q r])
                                                      r))
                                                  input-qs)
                                            (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
                                              (when (= :rf.error/sub-cycle (:rf.error/id (ex-data e)))
-                                               (doseq [input-q @acquired]
-                                                 (release-input-ref! frame-id input-q :sub-cycle-unwind)))
+                                               (doseq [[input-q input-r] @acquired]
+                                                 (release-input-ref! frame-id input-q input-r :sub-cycle-unwind)))
                                              (throw e))))))
         memoised-body (cond
                         input-error?
@@ -1440,10 +1466,18 @@
             ;; parent slot so the cache invariant ("ref-count reflects
             ;; live refs") holds at every observable moment.
             ;; Best-effort per-input release: a throw from one input's
-            ;; `unsubscribe` surfaces a dev breadcrumb (rf2-is8ov5) and the
+            ;; release surfaces a dev breadcrumb (rf2-is8ov5) and the
             ;; loop continues so the remaining inputs still release.
-            (doseq [input-q input-signals]
-              (release-input-ref! frame-id input-q :on-dispose))
+            ;; rf2-1frc — hand each release the CONCRETE input reaction this
+            ;; build acquired (`inputs` is `mapv`'d from `input-signals`, so
+            ;; the two are positionally parallel by construction). An
+            ;; address-only release stole a successor entry's ref whenever an
+            ;; eviction batch was repopulated mid-walk by an eagerly
+            ;; reacquiring holder; the identity guard makes it a no-op
+            ;; instead, symmetric with the `identical?`-guarded cache-dissoc
+            ;; immediately below.
+            (doseq [[input-q input-r] (map vector input-signals inputs)]
+              (release-input-ref! frame-id input-q input-r :on-dispose))
             (swap! cache (fn [m]
                            (if (identical? reaction (:reaction (get m k)))
                              (dissoc m k)
@@ -1491,8 +1525,11 @@
       (do
         (when (and (not layer-1?)
                    (seq input-signals))
-          (doseq [input-q input-signals]
-            (release-input-ref! frame-id input-q :not-cached-release)))
+          ;; rf2-1frc — same identity-guarded release as the on-dispose walk:
+          ;; a frame torn down mid-build can have a SAME-ID successor whose
+          ;; cache an address-only release would decrement.
+          (doseq [[input-q input-r] (map vector input-signals inputs)]
+            (release-input-ref! frame-id input-q input-r :not-cached-release)))
         reaction))))))
 
 (defn- compute-and-cache!
@@ -2478,8 +2515,12 @@
   still holds `reaction`**, then take the ordinary 1 → 0 in-tick disposal.
 
   Not public API and not an alternative teardown: it exists for holders
-  whose reference can outlive its slot, and both of them are the React-hook
-  spine's.
+  whose reference can outlive its slot. Two of the three are the React-hook
+  spine's; the third is this namespace's own layer-2+ input release
+  (`release-input-ref!`, rf2-1frc), which outlives its slot for the same
+  reason case 2 does — an eviction batch is removed from the cache before it
+  is disposed, so an eagerly reacquiring holder can repopulate a slot mid-walk
+  and a later member's address-only release would decrement the successor.
 
     1. The RENDER-PHASE PROVISIONAL acquisition, released either by the
        commit that adopts it or by a host-macrotask reaper, across a window

--- a/implementation/core/test/re_frame/sub_dispose_trace_test.clj
+++ b/implementation/core/test/re_frame/sub_dispose_trace_test.clj
@@ -457,6 +457,16 @@
           ;; so the parent itself releases normally; the parent's dispose
           ;; callback then hits the redefed per-input releases.
           real-unsub @#'rf.subs/unsubscribe
+          ;; rf2-1frc — the per-input release is no longer the address-only
+          ;; `unsubscribe`: it is the IDENTITY-GUARDED
+          ;; `unsubscribe-if-reaction`, carrying the concrete input reaction
+          ;; the parent's build acquired. The mechanism this test pins (a
+          ;; throwing input release is surfaced as a dev breadcrumb and does
+          ;; NOT abort the walk) is unchanged; only which var the walk calls
+          ;; moved, so the redef below moves with it. Redefing `unsubscribe`
+          ;; alone would leave the walk untouched and every assertion here
+          ;; would read a trace that was never emitted.
+          real-unsub-if @#'rf.subs/unsubscribe-if-reaction
           cache      (:sub-cache (rf.frame/frame :rf/default))]
       (try
         ;; Hold the layer-2 sub (which subscribes both inputs, bumping their
@@ -468,12 +478,12 @@
           ;; Make the FIRST input's (`[:sub/a]`) release throw; every other
           ;; query-v (the parent's own trigger goes through `real-unsub`
           ;; directly, and `[:sub/b]` here) delegates to the real fn.
-          (with-redefs [rf.subs/unsubscribe
-                        (fn [frame-id query-v]
+          (with-redefs [rf.subs/unsubscribe-if-reaction
+                        (fn [frame-id query-v reaction]
                           (if (= query-v [:sub/a])
                             (throw (ex-info "boom: custom adapter -dispose threw"
                                             {:query-v query-v}))
-                            (real-unsub frame-id query-v)))]
+                            (real-unsub-if frame-id query-v reaction)))]
             ;; Trigger the parent's 1 → 0 dispose via the captured original,
             ;; so the PARENT disposes (its on-dispose callback runs the
             ;; per-input release walk against the redefed `rf.subs/unsubscribe`).

--- a/implementation/core/test/re_frame/subs_evicted_input_release_cljs_test.cljc
+++ b/implementation/core/test/re_frame/subs_evicted_input_release_cljs_test.cljc
@@ -1,0 +1,225 @@
+(ns re-frame.subs-evicted-input-release-cljs-test
+  "rf2-1frc (residual) — a layer-2+ sub's disposal must release the input
+  reactions it ACTUALLY ACQUIRED, never whatever now sits at those addresses.
+
+  ## The defect
+
+  PR #9373 gave the React-hook spine EAGER REACQUISITION: when a mounted
+  hook's committed reaction is disposed by a framework-owned eviction (hot
+  reload, an explicit `clear-sub-cache!`, a frame generation change), the
+  `rf.interop/add-on-dispose!` callback re-subscribes IMMEDIATELY and rewires
+  onto the successor, so the mount is never left holding a dead node.
+
+  Both eviction primitives remove the whole condemned batch from the cache
+  atom BEFORE they dispose any member of it — `invalidate-frame-subs!`
+  `swap-vals!`-dissocs the transitive closure and then walks `evicted-keys`,
+  and `clear-sub-cache!` `(reset! cache {})` and then walks the pre-clear
+  snapshot. Combined with eager reacquisition, that means a LATER member of
+  the batch is disposed AFTER an earlier member has already rebuilt its
+  subtree into the (now live again) cache.
+
+  `re-frame.subs`' built-in on-dispose callback was asymmetric across exactly
+  that window: its cache-dissoc step is IDENTITY-GUARDED (`identical?
+  reaction (:reaction (get m k))`), but its declared-input release was an
+  address-only `unsubscribe`. So the second parent's teardown decremented —
+  and disposed — the SUCCESSOR child the first parent had just built and was
+  holding.
+
+  Ordinary topology, no exotica: two mounted parents P1 and P2 declaring the
+  same child C. Before: `{C 2, P1 1, P2 1}`. Evict all three. Disposing old P1
+  reacquires new P1 and builds new C (count 1). Disposing old P2 then
+  unsubscribes C BY ADDRESS, driving new C 1 → 0 and disposing it under the
+  live P1; P2's own reacquisition builds a third C. After: `{C 1, P1 1, P2 1}`
+  with P1 watching a disposed node — it stops seeing app-db movement, and a
+  later release of either parent retires the remaining child's only counted
+  ref under its sibling.
+
+  ## The repair under test
+
+  The release is routed through the identity guard that already existed for
+  the spine's own holders — `re-frame.subs/unsubscribe-if-reaction` — carrying
+  the concrete input reaction the build acquired. A release whose reaction is
+  no longer the cache's no-ops (its reference died with the eviction) instead
+  of stealing a successor's; a release whose reaction IS the cache's takes the
+  ordinary 1 → 0 in-tick disposal exactly as before.
+
+  ## What this namespace does NOT assume
+
+  It does not require a MANUALLY disposed reaction to be reusable. Every
+  eviction here is framework-owned (`clear-sub-cache!`, a `reg-sub`
+  replacement); the claim is only that a hook which reacquires across such an
+  eviction ends up sharing ONE child with its sibling.
+
+  ## Posture split (rf2-d2841)
+
+  Every assertion is posture-independent: ref-counts and reactivity, no
+  `:trace` observation, and the seam itself carries no `rf.interop/debug-
+  enabled?` gate.
+
+  `.cljc` — runs under both `clojure -M:test` (JVM) and `npm run test:cljs`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.flows :as rf.flows]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.subs :as rf.subs]
+            [re-frame.subs.cache :as rf.subs.cache]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf.flows/reset-flows!)
+  (rf.schemas/clear-schemas-by-frame!)
+  ;; rf2-qj4g — COLD-START the adapter slot: this ns shares the node bundle
+  ;; with suites that seat Reagent / UIx / SSR, so a bare `init!` would be a
+  ;; no-op whenever one of them ran first.
+  (rf/destroy-adapter!)
+  (rf/init! rf.substrate.plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- entry
+  [frame-id query-v]
+  (get @(:sub-cache (rf.frame/frame frame-id)) query-v))
+
+(defn- ref-count
+  [frame-id query-v]
+  (:ref-count (entry frame-id query-v)))
+
+(defn- cached-reaction
+  [frame-id query-v]
+  (:reaction (entry frame-id query-v)))
+
+(defn- eager-holder!
+  "A minimal stand-in for the React-hook spine's COMMITTED acquisition
+  (`re-frame.substrate.spine`'s `on-committed-disposed`): hold one durable
+  reference to `query-v` in `frame-id` and, when the held reaction is disposed
+  by a framework-owned eviction, re-subscribe immediately and rewire.
+
+  Deliberately mirrors the spine's guards — it re-acquires only while it is
+  still the holder of THAT reaction and only while the frame is alive — so the
+  reading here is about `re-frame.subs`' input-release symmetry and not about
+  the hook. Returns an atom holding the current reaction."
+  [frame-id query-v]
+  (let [held (atom nil)]
+    (letfn [(wire! [r]
+              (reset! held r)
+              (rf.interop/add-on-dispose! r
+                (fn []
+                  (when (and (identical? r @held)
+                             (some? (rf.frame/frame frame-id)))
+                    (wire! (rf.subs/subscribe query-v {:frame frame-id}))))))]
+      (wire! (rf.subs/subscribe query-v {:frame frame-id})))
+    held))
+
+(defn- register-two-parents-one-child!
+  []
+  (rf/reg-event :ev/seed (fn [_ctx [_ v]] {:db {:n v}}))
+  (rf/reg-sub :ev/child (fn [db _q] (:n db)))
+  (rf/reg-sub :ev/p1 {:inputs [[:ev/child]]} (fn [[c] _q] [:p1 c]))
+  (rf/reg-sub :ev/p2 {:inputs [[:ev/child]]} (fn [[c] _q] [:p2 c])))
+
+;; ---- 1. explicit clear-sub-cache! ----------------------------------------
+
+(deftest evicted-parent-release-does-not-steal-the-successor-childs-ref
+  (testing "two eagerly-reacquiring parents over ONE shared child survive an
+            explicit clear-sub-cache! sharing the SAME rebuilt child"
+    (register-two-parents-one-child!)
+    (rf/make-frame {:id :ev/frame})
+    (rf/dispatch-sync [:ev/seed 1] {:frame :ev/frame})
+
+    (let [h1 (eager-holder! :ev/frame [:ev/p1])
+          h2 (eager-holder! :ev/frame [:ev/p2])]
+      (is (= [:p1 1] @@h1) "P1 derives from the child")
+      (is (= [:p2 1] @@h2) "P2 derives from the same child")
+      (is (= 2 (ref-count :ev/frame [:ev/child]))
+          "baseline: the shared child carries one ref per parent")
+
+      ;; THE FRAMEWORK-OWNED EVICTION. The whole batch leaves the cache before
+      ;; any member of it is disposed, so the second parent's teardown runs
+      ;; against a cache the first parent has already repopulated.
+      (rf.subs.cache/clear-sub-cache! :ev/frame)
+
+      (is (= 2 (ref-count :ev/frame [:ev/child]))
+          "THE BUG (rf2-1frc residual): pre-fix this read 1 — the second
+           parent's address-only input release decremented the SUCCESSOR child
+           the first parent had just built, disposing it, and the second
+           parent's own reacquisition then built a third one")
+      (is (some? (cached-reaction :ev/frame [:ev/child]))
+          "one child reaction is cached for both parents")
+
+      ;; Reactivity pins. NOT the discriminator — measured, these two PASS
+      ;; pre-fix on the plain-atom substrate, whose watch survives the
+      ;; premature dispose; the ref-count above is what the defect moves. They
+      ;; stay as the regression floor the acceptance asks for, and the
+      ;; substrate-visible consequence is pinned in the UIx browser lane.
+      (rf/dispatch-sync [:ev/seed 2] {:frame :ev/frame})
+      (is (= [:p1 2] @@h1) "P1 remains reactive after the eviction")
+      (is (= [:p2 2] @@h2) "P2 remains reactive after the eviction"))))
+
+(deftest surviving-parent-keeps-its-child-when-its-sibling-releases
+  (testing "after the eviction storm, unmounting ONE parent leaves the other
+            parent's child ref intact"
+    (register-two-parents-one-child!)
+    (rf/make-frame {:id :ev/frame})
+    (rf/dispatch-sync [:ev/seed 1] {:frame :ev/frame})
+
+    (let [h1 (eager-holder! :ev/frame [:ev/p1])
+          h2 (eager-holder! :ev/frame [:ev/p2])]
+      @@h1
+      @@h2
+      (rf.subs.cache/clear-sub-cache! :ev/frame)
+
+      ;; "Unmount" P2: release the reaction it actually holds, exactly as the
+      ;; spine's cleanup does.
+      (let [held2 @h2]
+        (reset! h2 nil)                                    ; stop reacquiring
+        (rf.subs/unsubscribe-if-reaction :ev/frame [:ev/p2] held2))
+
+      (is (= 1 (ref-count :ev/frame [:ev/child]))
+          "the child keeps P1's ref — pre-fix the count was already 1 before
+           this release, so P2's unmount retired P1's only child outright")
+      (is (some? (cached-reaction :ev/frame [:ev/child]))
+          "the child slot survives P2's unmount")
+
+      (rf/dispatch-sync [:ev/seed 3] {:frame :ev/frame})
+      (is (= [:p1 3] @@h1)
+          "the surviving parent is still reactive after its sibling unmounts"))))
+
+;; ---- 2. reg-sub replacement (hot reload) ---------------------------------
+
+(deftest reg-sub-replacement-of-the-shared-child-keeps-both-parents-sharing-it
+  (testing "replacing the shared child's registration evicts child + both
+            parents in ONE batch; the eagerly-reacquiring parents must end up
+            sharing one successor child"
+    (register-two-parents-one-child!)
+    (rf/make-frame {:id :ev/frame})
+    (rf/dispatch-sync [:ev/seed 1] {:frame :ev/frame})
+
+    (let [h1 (eager-holder! :ev/frame [:ev/p1])
+          h2 (eager-holder! :ev/frame [:ev/p2])]
+      (is (= [:p1 1] @@h1))
+      (is (= [:p2 1] @@h2))
+
+      ;; Spec 001 §Hot-reload semantics: re-registering the child fires the
+      ;; replacement hook, which evicts the child's transitive dependent
+      ;; closure — child, P1 and P2 — as one batch.
+      (rf/reg-sub :ev/child (fn [db _q] (* 100 (:n db))))
+
+      (is (= 2 (ref-count :ev/frame [:ev/child]))
+          "THE BUG (rf2-1frc residual): both parents share ONE rebuilt child")
+      (is (= [:p1 100] @@h1)
+          "P1 runs the replacement child body")
+      (is (= [:p2 100] @@h2)
+          "P2 runs the replacement child body")
+
+      (rf/dispatch-sync [:ev/seed 2] {:frame :ev/frame})
+      (is (= [:p1 200] @@h1) "P1 stays reactive across the replacement")
+      (is (= [:p2 200] @@h2) "P2 stays reactive across the replacement"))))


### PR DESCRIPTION
## The defect

A layer-2+ sub's on-dispose callback released its declared inputs with an **address-only** `unsubscribe`, while the cache-dissoc step immediately beside it in the same callback was identity-guarded with `identical?`. **That asymmetry was the defect.**

Both eviction primitives remove the whole condemned batch from the cache atom **before** disposing any member of it — `rf.subs.cache/invalidate-frame-subs!` `swap-vals!`-dissocs the transitive dependent closure and then walks `evicted-keys`, and `clear-sub-cache!` does `(reset! cache {})` and then walks the pre-clear snapshot. Since PR #9373 a mounted React hook whose committed reaction is disposed **reacquires eagerly** from inside that walk (`spine.cljs`'s `on-committed-disposed`). So a later member's teardown runs against a cache an earlier member has already repopulated.

Ordinary topology, no exotica — two mounted parents `P1`/`P2` declaring the same child `C`:

- before: `{C 2, P1 1, P2 1}`; evict all three
- disposing old `P1` reacquires new `P1`, which builds new `C` (count 1)
- disposing old `P2` then unsubscribes `C` **by address**, driving new `C` 1 → 0 and disposing it under the live `P1`; `P2`'s own reacquisition builds a third `C`
- after: `{C 1, P1 1, P2 1}`, with `P1` watching a disposed node and a later release of either parent able to retire the remaining child's only counted ref under its sibling

## The repair

The release routes through the existing `re-frame.subs/unsubscribe-if-reaction`, carrying the concrete input reaction the build acquired. `inputs` is `mapv`'d from `input-signals`, so the two are positionally parallel by construction — no new bookkeeping. A release whose reaction is no longer the cache's no-ops (its reference died with the eviction); a release whose reaction **is** the cache's takes the ordinary 1 → 0 in-tick disposal exactly as `unsubscribe` did.

All three release sites move together so no address-only release survives:

- `:on-dispose` — the defect
- `:not-cached-release` — same hazard through a same-id successor frame when the frame is torn down mid-build
- `:sub-cycle-unwind` — the `acquired` volatile now holds `[query-v reaction]` pairs

`unsubscribe-if-reaction`'s docstring counted its holders ("both of them are the React-hook spine's"); it now names the third.

No new public API, no programmer-facing ceremony. **No requirement that a manually disposed reaction be reusable** — every eviction here is framework-owned.

## Tests, failing first

`implementation/core/test/re_frame/subs_evicted_input_release_cljs_test.cljc` (new, runs on the JVM suite and the node CLJS lane) drives the seam with a stand-in for the spine's eager holder across **both** framework-owned triggers — explicit `clear-sub-cache!` and a `reg-sub` replacement of the shared child — and asserts the shared child keeps two refs, plus the sibling-unmount case (one parent releasing must not retire the other's child).

Measured on `cd implementation/core && clojure -M:test -n re-frame.subs-evicted-input-release-cljs-test`:

- **pre-fix: exit 1** — `Ran 3 tests containing 17 assertions. 4 failures, 0 errors.` The discriminating reads were `(not (= 2 1))` on the child ref-count under both triggers, and `(not (= 1 nil))` / `(not (some? nil))` on the sibling-unmount case (the child slot was gone outright).
- **post-fix: exit 0** — `0 failures, 0 errors.`

Both of those runs are on this worktree only, which is what makes the red the discrimination.

Honest note on what does **not** discriminate: the two reactivity assertions in the first test **pass pre-fix** on the plain-atom substrate, whose watch survives the premature dispose. They are kept as a regression floor and labelled as such in the file; the ref-count is what the defect moves.

`implementation/adapters/uix/test/re_frame/adapter/uix_evicted_shared_child_dom_cljs_test.cljs` (new) is the mounted browser-lane witness the acceptance asks for: two real `use-sub` parents over one shared declared input, under the real hook spine, with the consequence read off **committed DOM** (`a=10b=100` → `a=20b=200`) as well as ref-counts, and a post-unmount release check. It ends in `-dom-cljs-test` so `:browser-test` discovers it and `:node-test` runs it through its `(browser?)` self-gate. **It was written but deliberately not run locally — that lane is CI's, per the gate policy.** `implementation/adapters/uix/test` is already a `shadow-cljs.edn` source path, so no build config moved.

## Gates run

- `clojure -M:test -n re-frame.subs-evicted-input-release-cljs-test` — exit 1 (pre-fix) → exit 0 (post-fix), quoted above.
- Full `implementation/core` artefact suite, `clojure -M:test` — **exit 1**, `Ran 2268 tests containing 11732 assertions. 8 failures, 0 errors.` All eight were the single namespace `sub_dispose_trace_test`, whose `input-dispose-throw-is-surfaced-and-isolated` redefs `rf.subs/unsubscribe` to make one input's release throw; the walk no longer calls that var. The redef moves to `rf.subs/unsubscribe-if-reaction` with the same discrimination and delegation — the mechanism the test pins (a throwing input release is surfaced as a `:rf.warning/sub-input-dispose-exception` breadcrumb and does **not** abort the walk) is untouched.
- Re-run of the four affected namespaces (`sub-dispose-trace-test`, `subs-evicted-input-release-cljs-test`, `sub-cache-test`, `subs-generation-refresh-cljs-test`) — **exit 0**, `Ran 57 tests containing 279 assertions. 0 failures, 0 errors.`

Every exit code above is the runner's own, captured with the redirect and the `echo` on one command line. The full artefact suite was **not** re-run after the test-side repair — that re-run is CI's, per the gate policy; the four namespaces the change can reach were re-run instead.

Left to CI: the node CLJS lane, the browser lane (including the new UIx DOM witness), and every other artefact. `implementation/adapters/uix/src` is untouched — the UIx adapter's `use-sub` is a thin re-export and this was never an adapter change.
