### PR TITLE
fix(story): reach the :network fixture through a selected app image (rf2-shx4)

### DIFF
--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -453,7 +453,9 @@ redirects) is always live — authors never declare it. See
 A story body carries the SAME `:images` slot. A Story declares its
 **application image** ONCE on the story; every variant under it INHERITS that
 image and MAY layer its own `:images` on top. The resolved composition order is
-`[story-images… variant-images… runtime-image]` (later wins). This is the
+`[story-images… variant-images… runtime-image]` (later wins — a variant with a
+`:network` fixture layers one further library-owned image between the two, see
+[002-Runtime.md](002-Runtime.md)). This is the
 app-isolation mechanism for a MULTI-app testbed (several apps co-loaded into
 one process): each story scopes its variant frames to its own app namespace via
 `:select-ns`, rather than the whole co-loaded store.

--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -46,7 +46,7 @@ So `allocate!` ALWAYS composes the variant frame's `:images` vector
 ([EP-0026 §Layered Resolution](../../../spec/002-Frames.md)):
 
 ```
-[<story-images…> <variant-images…> runtime-image]
+[<story-images…> <variant-images…> network-fixture-image? runtime-image]
 ```
 
 - **story images** — the parent story's `:images` slot (see
@@ -57,6 +57,16 @@ So `allocate!` ALWAYS composes the variant frame's `:images` vector
   its own image — **behaviour variant -> image**: two variants reusing the SAME
   global event/sub id under DIFFERENT images resolve it to their own image's
   descriptor, with NO global-registrar clobber between runs).
+- **network-fixture image** — PRESENT ONLY when the frame owns an authored
+  `:network` fixture. The library-owned `:rf.story/network-fixture`
+  (`re-frame.story.network/fixture-image`) carries exactly ONE inline
+  `:reg-fx`: the frame-scoped managed-request stub the plan's `:fx-overrides`
+  redirect names. Without it a variant with an explicit app image resolves the
+  redirect to nothing and the request falls through to the real
+  `:rf.http/managed` transport. Layered after every app image (so nothing
+  authored shadows it) and before the runtime image, which the two do not
+  contest. See [017-Testing-Story.md §Reaching the fixture through a selected
+  app image](017-Testing-Story.md#reaching-the-fixture-through-a-selected-app-image).
 - **runtime image** — the canonical Story **runtime image**
   (`re-frame.story.runtime-image/runtime-image`), composed LAST. It selects
   Story's own runtime registrations (`:select-ns {:include

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -2689,6 +2689,35 @@ unchanged. The lowered fx id stays `:rf.http/managed-test-stub`, so the
 recorded `:fx-decisions` redirect and the artifact replay path are
 unaffected.
 
+#### Reaching the fixture through a selected app image
+
+Installing the stub is necessary but **not sufficient**, and the missing
+half is invisible on the default image. The helper registers into the
+process **source store**. A variant frame created with no `:images`
+projects that whole store (the EP-0026 DEFAULT image), so it resolves the
+stub; a variant that declares an app image — or inherits one from its
+parent story — resolves through a **selected, sealed generation** instead,
+and the stub is not in it. An image selects by `:rf.provenance/ns`, and a
+descriptor registered by a runtime `reg-fx` call carries no source
+provenance at all, so no namespace glob can select it. Such a frame still
+receives the `:fx-overrides` redirect and still fails **open**: the target
+is unresolvable, so the request falls through to the REAL
+`:rf.http/managed` transport.
+
+So a frame that owns a fixture is composed with one further library-owned
+image, `:rf.story/network-fixture` (`re-frame.story.network/fixture-image`),
+carrying **exactly one** inline `:reg-fx` — the handler the install just put
+in the source store, over the same frame-scoped route map. It is layered
+after every app image (so nothing authored shadows the fixture) and before
+the runtime image, which keeps its LAST position; the two select disjoint
+sets. Two properties are normative here. The fixture image MUST republish
+the installed handler rather than build its own, so there is one canned-reply
+implementation and two projections of it; and it MUST carry that one fx id
+and nothing else — **widening the app image to the whole store is not an
+acceptable repair**, because it trades this defect for the loss of the
+isolation the image exists to provide. It is a library contract, not an
+authored behaviour image: it never appears on a run result's `:images`.
+
 ### What the compiler emits
 
 When a variant's resolved (merged + arg-substituted) `:network` route map

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -560,7 +560,7 @@
   "Build the FULL `:images` vector a variant frame is created with (EP-0026
   §Layered Resolution — the later image WINS). The composition is:
 
-      [<story-images…> <variant-images…> runtime-image]
+      [<story-images…> <variant-images…> fixture-image? runtime-image]
 
   - `story-images`   — the parent story's `:images` (the app image declared once
                        on the story; inherited by every variant). See
@@ -568,6 +568,19 @@
   - `variant-images` — the variant body's own `:images`, layered on top of the
                        story image (a BEHAVIOUR variant overriding specific
                        `[kind id]`s with its own image).
+  - `fixture-image`  — rf2-shx4: PRESENT ONLY when this frame owns an authored
+                       `:network` fixture (`rf.story.network/install-for-frame!`
+                       ran for it upstream in phase 0). It carries exactly ONE
+                       inline `:reg-fx` — the frame-scoped managed-request stub
+                       the plan's `:fx-overrides` redirect names — so a variant
+                       with an EXPLICIT app image can resolve that redirect's
+                       target. Without it the redirect names an id the sealed
+                       generation cannot resolve and the request falls through
+                       to the REAL `:rf.http/managed` transport, which is
+                       invisible to a default-image-only test. Composed after
+                       every app image (nothing authored can shadow the
+                       fixture) and before `runtime-image` (they are disjoint;
+                       the runtime image keeps its LAST position).
   - `runtime-image`  — the canonical Story RUNTIME IMAGE, composed LAST so the
                        Story machinery (lifecycle machine, `:rf.assert/*`
                        handlers, fx-stub redirects, runtime helpers, toolbar
@@ -589,7 +602,15 @@
   (let [story-imgs (story-images variant-id)
         app-imgs   (into (vec story-imgs) variant-images)]
     (when (seq app-imgs)
-      (conj app-imgs (rf.story.runtime-image/runtime-image)))))
+      ;; rf2-shx4 — the fixture image is layered ONLY when this frame owns a
+      ;; `:network` fixture AND the stub is genuinely installed
+      ;; (`fixture-image` reads the source store, so it returns nil rather
+      ;; than inlining a stale handler).
+      (let [fixture-img (when (rf.story.network/routes-for variant-id)
+                          (rf.story.network/fixture-image))]
+        (cond-> app-imgs
+          fixture-img (conj fixture-img)
+          :always     (conj (rf.story.runtime-image/runtime-image)))))))
 
 (defn- ->classification-effects
   "Convert a variant body's `:sensitive` / `:large` classification declaration

--- a/tools/story/src/re_frame/story/network.cljc
+++ b/tools/story/src/re_frame/story/network.cljc
@@ -45,8 +45,31 @@
   A frame with no fixture (or a request from no frame at all) resolves to
   `nil`, so `stub-handler` falls through to its own canned
   `\"no stub matched\"` transport failure — spec/017 §Network stubs, preserved
-  rather than reimplemented."
-  (:require [re-frame.frame :as rf.frame]
+  rather than reimplemented.
+
+  ## Why the install alone is not enough (the rf2-shx4 audit of PR #9398)
+
+  `install-managed-request-stubs!` registers into the process SOURCE STORE. A
+  variant frame created with NO `:images` projects the whole store (EP-0026's
+  DEFAULT image), so it sees that registration — which is why the
+  default-image acceptance tests passed. A variant that DECLARES an app image
+  (or inherits one from its parent story) resolves through a SELECTED, sealed
+  generation instead, and the stub is unreachable there: an image selects by
+  `:rf.provenance/ns`, and a descriptor registered by a runtime `reg-fx` call
+  carries no source provenance at all, so NO namespace glob can select it. The
+  frame still receives the `:fx-overrides` redirect, but its generation cannot
+  resolve the target — and the request falls through to the REAL
+  `:rf.http/managed` transport.
+
+  `fixture-image` closes that without widening the app image: it is a
+  library-owned image carrying EXACTLY ONE inline `:reg-fx` — the very handler
+  the install just registered, over the very same `FrameScopedRoutes` object.
+  `frames/compose-variant-images` layers it after the app images (so nothing
+  authored can shadow it) whenever the frame being allocated owns a fixture.
+  One implementation, one route map, two projections."
+  (:require [re-frame.core     :as rf]
+            [re-frame.frame    :as rf.frame]
+            [re-frame.registrar :as rf.registrar]
             ;; The raw HTTP stub pair lives in `re-frame.http.test-support`
             ;; (its home namespace, not the `re-frame.core` façade). CLJS
             ;; requires it directly; on the JVM it is resolved LAZILY at call
@@ -54,6 +77,22 @@
             ;; does not drag the http artefact's JVM-only transitive deps onto
             ;; the macro classpath. Same boundary `rf.story.artifact` uses.
             #?(:cljs [re-frame.http.test-support :as rf.http.test-support])))
+
+(def stub-fx-id
+  "The fx id `rf.story.plan/lower-network` points `:rf.http/managed` at, and
+  the one `re-frame.http.test-support/install-managed-request-stubs!`
+  registers. Named here so `fixture-image` can read the installed handler back
+  out of the source store; the id itself is unchanged (the recorded
+  `:fx-decisions` redirect, `spec/017` and `plan_network_test` all still pin
+  it)."
+  :rf.http/managed-test-stub)
+
+(def fixture-image-id
+  "The stable `:rf.image/id` of the library-owned fixture image — reported in
+  the generation's `:rf.gen/shadows` and by tooling. Library-owned under the
+  reserved `:rf.story/*` namespace (spec/Conventions.md), and deliberately NOT
+  an authored behaviour image (it never appears on a run result's `:images`)."
+  :rf.story/network-fixture)
 
 (defonce
   ^{:doc "frame-id → the frame's authored `{[method url] {:reply …}}` route
@@ -142,3 +181,31 @@
       (swap! frame-routes assoc frame-id routes)
       (when was-empty? (install!))
       frame-id)))
+
+(defn fixture-image
+  "The library-owned image that makes the installed stub fx reachable through a
+  frame's SELECTED generation — `nil` when no Story fixture is installed.
+
+  Read the ns docstring §Why the install alone is not enough for the why. The
+  what is one line of image: a single inline `:reg-fx` republishing the handler
+  `install-managed-request-stubs!` just put in the source store, so the SAME
+  closure over the SAME `FrameScopedRoutes` object answers on both projections.
+  Nothing else rides along — the app image keeps its isolation, and only the
+  one fx id the plan's redirect actually names becomes resolvable.
+
+  Taking the handler from the store (rather than rebuilding one) is what keeps
+  this a projection instead of a second network simulator: there is no canned
+  reply implementation here to drift from `re-frame.http.test-support`'s.
+  Read at composition time, which the runtime orders AFTER
+  `install-for-frame!`, so the top of the helper's install stack is Story's own.
+
+  PURE — `rf/image` builds inert data; this registers nothing."
+  []
+  (when-let [handler (:handler-fn (rf.registrar/store-lookup :fx stub-fx-id))]
+    (rf/image
+      {:id            fixture-image-id
+       :registrations {:reg-fx [[stub-fx-id
+                                 {:doc (str "Story :network fixture — the frame-scoped "
+                                            "managed-request stub, projected into a "
+                                            "selected image generation (rf2-shx4).")}
+                                 handler]]}})))

--- a/tools/story/test/re_frame/story/network_runtime_test.clj
+++ b/tools/story/test/re_frame/story/network_runtime_test.clj
@@ -134,6 +134,88 @@
           "SENTINEL: no managed request reached the production fx slot"))))
 
 ;; ===========================================================================
+;; The EXPLICIT-APPLICATION-IMAGE path (rf2-shx4, merged-PR audit of #9398)
+;;
+;; The two registered tests above run on the DEFAULT image — `:images` absent,
+;; so the frame projects the WHOLE source store and the helper-installed
+;; `:rf.http/managed-test-stub` is visible through it. That is why they passed
+;; while the audit's case did not: a variant that declares (or inherits) an app
+;; image resolves through a SELECTED, sealed generation, and the stub the HTTP
+;; helper registers carries no selectable provenance at all, so the
+;; `:fx-overrides` redirect the frame DOES receive names a target its image
+;; cannot resolve — and the request falls through to the real
+;; `:rf.http/managed` slot (here, the capture sentinel).
+;;
+;; The fix makes the fixture reachable through the selected generation as well,
+;; WITHOUT widening the app image: `frames/compose-variant-images` layers the
+;; library-owned `:rf.story/network-fixture` image, which carries exactly ONE
+;; inline `:reg-fx` — the very handler `install-managed-request-stubs!`
+;; registered over the frame-scoped route map. One implementation, one route
+;; map, two projections.
+;; ===========================================================================
+
+(deftest registered-variant-with-inherited-app-image-realizes-its-fixture
+  (testing "a variant whose app image is INHERITED from its parent story still
+            gets its authored :network fixture — the selected generation
+            resolves the stub target rather than falling through to the
+            production :rf.http/managed slot (rf2-shx4 audit of PR #9398)"
+    (rf.story/reg-story :story.netimg
+                        {:doc    "Parent story declaring the app image once."
+                         :images [(rf/image {:id        :net/app-image
+                                             :select-ns {:include ["re-frame.story.network-runtime-test"]}})]})
+    (rf.story/reg-variant :story.netimg/cart
+                          {:network cart-fixture
+                           :setup   [[:dispatch [:net/load]]]})
+    (let [result (run-target :story.netimg/cart)]
+      (is (= [:net/app-image] (:images result))
+          "precondition: the variant really did inherit an EXPLICIT app image
+           (so the frame resolves a SELECTED generation, not the default
+           whole-store projection)")
+      (is (= {:items [1]} (:cart (:app-db result)))
+          "the authored fixture answered the managed request through the
+           selected image")
+      (is (= [] @live-requests)
+          "SENTINEL: no managed request reached the production fx slot"))))
+
+(deftest registered-variant-with-own-app-image-realizes-its-fixture
+  (testing "the same holds for an app image declared on the VARIANT body"
+    (rf.story/reg-variant :story.netimg2/cart
+                          {:images  [(rf/image {:id        :net/app-image
+                                                :select-ns {:include ["re-frame.story.network-runtime-test"]}})]
+                           :network cart-fixture
+                           :setup   [[:dispatch [:net/load]]]})
+    (let [result (run-target :story.netimg2/cart)]
+      (is (= [:net/app-image] (:images result))
+          "precondition: an explicit app image is in force")
+      (is (= {:items [1]} (:cart (:app-db result)))
+          "the authored fixture answered the managed request")
+      (is (= [] @live-requests)
+          "SENTINEL: no managed request reached the production fx slot"))))
+
+(deftest app-image-frame-keeps-application-isolation
+  (testing "the fixture image adds EXACTLY the one stub fx the redirect names —
+            it does not widen the app image to the whole store. A registration
+            the app image does not select stays UNRESOLVABLE in the frame."
+    ;; A registration authored OUTSIDE the app image's selected namespace.
+    (require 'story.test-helpers.image-behaviour-v1 :reload)
+    (rf.story/reg-variant :story.netimg3/cart
+                          {:images  [(rf/image {:id        :net/app-image
+                                                :select-ns {:include ["re-frame.story.network-runtime-test"]}})]
+                           :network cart-fixture
+                           :setup   [[:dispatch [:net/load]]]})
+    (let [result   (run-target :story.netimg3/cart)
+          resolver (:rf.gen/resolver (rf/frame-generation :story.netimg3/cart))]
+      (is (= {:items [1]} (:cart (:app-db result)))
+          "the fixture answered")
+      (is (contains? resolver [:fx :rf.http/managed-test-stub])
+          "the stub fx the :fx-overrides redirect names IS in the frame's
+           generation — that is the whole repair")
+      (is (not (contains? resolver [:event :img.counter/step]))
+          "and nothing else came with it: a registration authored outside the
+           app image's selected namespace is still invisible to the frame")
+      (is (= [] @live-requests) "SENTINEL: still no live request"))))
+
+;; ===========================================================================
 ;; Isolation + ownership
 ;; ===========================================================================
 


### PR DESCRIPTION
Closes the merged-PR audit of #9398 on **rf2-shx4**. The original deliverable stands; this is the residual it named.

## The defect

`install-managed-request-stubs!` registers `:rf.http/managed-test-stub` into the process **source store**. A variant frame created with no `:images` projects that whole store (EP-0026's DEFAULT image) and resolves the stub — which is why the acceptance suite went green. A variant that declares an app image, or inherits one from its parent story, resolves through a **selected, sealed generation** instead, and the stub is not in it: an image selects by `:rf.provenance/ns`, and a descriptor registered by a runtime `reg-fx` call carries no source provenance at all, so no namespace glob can select it.

Such a frame still receives the `:fx-overrides` redirect and still fails **open** — the target is unresolvable, so the managed request falls through to the REAL `:rf.http/managed` transport. Default-image-only tests cannot see it.

## The repair

`re-frame.story.network/fixture-image` — a library-owned `:rf.story/network-fixture` image carrying **exactly one** inline `:reg-fx`: the handler the install just put in the source store, over the same `FrameScopedRoutes` object. `frames/compose-variant-images` layers it when the frame owns a fixture, after every app image (so nothing authored can shadow it) and before the runtime image, which keeps its LAST position; the two select disjoint sets.

Two properties are deliberate. Republishing the *installed* handler rather than rebuilding one keeps this a projection of the existing canned-reply machinery instead of a second HTTP simulator. And carrying that one fx id and nothing else keeps the app image's isolation — **widening the app image to the whole store was explicitly rejected**: it would trade the defect for the loss of the isolation the image exists to provide. A regression test pins that direction too.

Unchanged by construction, as the audit required: the install stays refcounted **by the registry** (not per variant), the registry key stays normalised through `rf.frame/frame-value->id`, and the lowered fx id is untouched — so `:fx-decisions`, spec/017's lowering contract and `plan_network_test.cljc` all stand.

## Evidence

Three new registered-run regressions in `re-frame.story.network-runtime-test`: app image **inherited from the parent story**, app image on the **variant body**, and an **isolation control** proving a registration authored outside the image's selected namespace stays invisible to the frame. Each asserts the authored reply and **zero capture-sentinel calls**; every test in the suite registers `:rf.http/managed` as a capture-only sentinel, so no request is ever issued.

- **Pre-fix** (new tests against the landed tree), `clojure -M:test -n re-frame.story.network-runtime-test`: **exit 1** — 9 tests / 30 assertions, **7 failures**. The sentinel held the escaped managed payload (`[{:request {:method :get :url "/api/cart"} ...}]`) and the frame's generation resolver did **not** contain `[:fx :rf.http/managed-test-stub]` — the audit's finding reproduced exactly. The `:images` preconditions passed, so an explicit app image really was in force.
- **DEFAULT-image control**: the four pre-existing default-image tests were green in that same red run and stayed green after — the case that already worked did not move.
- **Post-fix**, same focused command: **exit 0** — 9 tests / 30 assertions, 0 failures (same counts as the red run, so no namespace was skipped).
- **Gate — `tools/story` artefact suite** (`clojure -M:test`): **exit 0** — 1912 tests / 7040 assertions, 0 failures, 0 errors (#9398 measured 1909 / 7030; the delta is exactly these three tests).
- `python scripts/check_doc_slugs.py`: **exit 0**.
- Ratchets over the touched paths — `check_require_alias_dialect`, `check_retired_image_keys`, `check_retired_composition_vocab`, `check_retired_spellings`, `check_keyword_catalogue_drift`, `check_architecture_census`, `check_readme_inventories`, `check_thrown_error_messages`: **exit 0** each.

The changed-surface classifier arms `tools_jvm` (run above), plus `cljs_node_test`, `cljs_browser`, `examples_compile`, `mcp_conformance` and `story_xray_browser` — left to CI.

## Spec

`tools/story/spec/017-Testing-Story.md` gains the normative subsection *Reaching the fixture through a selected app image*, including the explicit refusal of the widen-the-image repair. `002-Runtime.md` records the composition change (`[story-images… variant-images… network-fixture-image? runtime-image]`) and `001-Authoring.md` carries a one-clause pointer. Markdown anchors and table shapes checked by hand; no table column counts changed.
