### PR TITLE
fix(gates): compare the attribution marker's URL host, not the whole word (rf2-uo5f)

### DIFF
--- a/scripts/git-hooks/lib/check-commit-attribution.sh
+++ b/scripts/git-hooks/lib/check-commit-attribution.sh
@@ -143,6 +143,64 @@
 # The detector.
 # ---------------------------------------------------------------------------
 
+# rf2_attribution_is_tool_link WORD
+#
+# Returns 0 when WORD carries a URL whose HOST is the tool's own, 1 otherwise.
+# WORD is the already-lower-cased final blank-separated word of a line, so it
+# arrives wearing whatever punctuation the surrounding text lent it — the
+# markdown marker's closing `)`, a sentence's full stop.
+#
+# THIS ISOLATES THE HOST, WHICH IS THE WHOLE POINT. Rule 3's tail anchor used
+# to ask whether the word CONTAINED `claude` or `anthropic` anywhere, which
+# every piece of documentation around it already described as "ends on the
+# tool's own link". A URL's PATH is not its host, so that test refused an
+# ordinary citation:
+#
+#      Generated with [Claude Code] was declined per https://github.com/day8/re-frame2/blob/main/CLAUDE.md.
+#
+#   — a link to the very rule the sentence is complying with, refused because
+# the FILENAME of that rule is `CLAUDE.md`. The same sentence citing
+# `README.md` passed. That is the rf2-uo5f false-positive class again, reached
+# through the tail rather than the head, and linking the rule rather than
+# naming its file is the natural thing to write.
+#
+# So: strip the scheme, take the authority, drop userinfo and port, and compare
+# the host itself. Subdomains of the tool's hosts count; a host that merely
+# ENDS on one of them does not, because the dot is the boundary — otherwise
+# `claude.com.example.invalid` would read as the tool's.
+rf2_attribution_is_tool_link() {
+  _rf2a_host="$1"
+
+  case "$_rf2a_host" in
+    *://*) ;;
+    *) return 1 ;;
+  esac
+
+  _rf2a_host=${_rf2a_host#*://}   # the authority onwards
+  _rf2a_host=${_rf2a_host%%/*}    # up to the path,
+  _rf2a_host=${_rf2a_host%%\?*}   # or the query, where there is no path,
+  _rf2a_host=${_rf2a_host%%#*}    # or the fragment.
+  _rf2a_host=${_rf2a_host#*@}     # userinfo goes BEFORE the port: it may hold a colon
+  _rf2a_host=${_rf2a_host%%:*}    # the port
+
+  # A host ends on a letter or a digit; anything after that belongs to the
+  # prose. This is what unwraps the markdown marker's `…claude-code)`.
+  while :; do
+    case "$_rf2a_host" in
+      ''|*[a-z0-9]) break ;;
+      *) _rf2a_host=${_rf2a_host%?} ;;
+    esac
+  done
+
+  case "$_rf2a_host" in
+    claude.com|*.claude.com) return 0 ;;
+    claude.ai|*.claude.ai) return 0 ;;
+    anthropic.com|*.anthropic.com) return 0 ;;
+  esac
+
+  return 1
+}
+
 # rf2_attribution_is_offending_line LINE
 #
 # Returns 0 when LINE is an AI-attribution line, 1 otherwise.
@@ -223,22 +281,34 @@ rf2_attribution_is_offending_line() {
   #    already pinned: `No Generated with [Claude Code] trailer was added.`
   #    passes only because it ends on `added.`. So the discriminator is
   #    structural on BOTH halves — no letters in front, and a URL at the end
-  #    whose host is the tool's. A `://` is what makes the tail a link rather
-  #    than a word; deliberately NOT a list of negations ("No", "declined",
-  #    "not"), which was considered and rejected here as trivially defeatable.
+  #    whose host is the tool's; deliberately NOT a list of negations ("No",
+  #    "declined", "not"), which was considered and rejected here as trivially
+  #    defeatable.
+  #
+  #    AND "WHOSE HOST IS THE TOOL'S" HAD TO BE IMPLEMENTED TOO, which is the
+  #    third round on the same sentence. That repair added a `://` test in
+  #    front of the substring test and kept the substring test behind it, so
+  #    the word still answered for the host and a citation URL whose PATH
+  #    carried `claude` was read as the tool's own link:
+  #
+  #      Generated with [Claude Code] was declined per https://github.com/day8/re-frame2/blob/main/CLAUDE.md.
+  #
+  #    was refused while the same sentence citing `README.md` passed, on
+  #    nothing but a word in the path. Linking the rule rather than naming its
+  #    file is the natural way to cite it — and this repository's rule file is
+  #    literally called CLAUDE.md — so the wording a brief invites most was the
+  #    one refused. `rf2_attribution_is_tool_link` above now parses the tail as
+  #    a URL and compares the HOST, which is what every piece of documentation
+  #    around this rule has promised since the first repair.
   case "$_rf2a_low" in
     *'generated with'*)
       case "${_rf2a_low%%generated with*}" in
         *[a-z]*) ;;
         *)
           _rf2a_tail=${_rf2a_low##* }
-          case "$_rf2a_tail" in
-            *://*)
-              case "$_rf2a_tail" in
-                *claude*|*anthropic*) return 0 ;;
-              esac
-              ;;
-          esac
+          if rf2_attribution_is_tool_link "$_rf2a_tail"; then
+            return 0
+          fi
           ;;
       esac
       ;;

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -2426,9 +2426,38 @@ MARKER_BARE_URL='Generated with Claude Code https://claude.com/claude-code'
 PROSE_POLICY_LINK='Trailers declined per https://claude.com/claude-code'
 PROSE_POLICY_LINK_CITED='No such trailer was added; the rule is at https://claude.com/claude-code'
 
+# AND THE THIRD ROUND: A CITATION URL IS NOT THE TOOL'S LINK (rf2-uo5f again).
+#
+# The two above end on the tool's own host and pass on their FIRST anchor —
+# each carries letters before `Generated with`, so neither reaches the tail
+# test at all. These two do reach it, and they are the shapes the repair before
+# this one still refused: the tail test asked whether the last word CONTAINED
+# `claude` or `anthropic` once it had seen a `://`, so it read a URL's PATH as
+# though it were the host.
+#
+# Both were measured at exit 1 against the landed detector, and the second is
+# the one that shows it is nothing to do with the wording: the SAME sentence
+# citing README.md instead passed. What separated them was a filename in a
+# path — and this repository's rule file is literally called CLAUDE.md, so
+# linking the rule rather than naming it, which is the natural way to cite it,
+# was the one form refused.
+#
+# THE PAIRED CONTROL IS `MARKER_URL_PATHED` BELOW: same structure, tool's own
+# HOST, so the host test has teeth rather than having merely stopped reading.
+PROSE_POLICY_URL='Generated with [Claude Code] was declined per https://github.com/day8/re-frame2/blob/main/CLAUDE.md.'
+PROSE_POLICY_URL_PATHED='Generated with [Claude Code] was declined per https://github.com/day8/day8/claude-notes.'
+
+# The mirror image of those two, and the reason the repair is a HOST test
+# rather than a removal: the tool's own host wearing a path that names
+# something else entirely. Nothing in the last word except the host says
+# "Claude Code", so a repair that reached for the path, or that dropped the
+# tail anchor to make the pair above pass, fails here.
+MARKER_URL_PATHED='Generated with Claude Code https://claude.com/day8/re-frame2/blob/main/README.md'
+
 for t in "$PROSE_COMPLIANCE" "$PROSE_MARKER_NAMED" "$PROSE_URL_NAMED" \
          "$PROSE_COMPLIANCE_TAIL" "$PROSE_POLICY_LINK" \
-         "$PROSE_POLICY_LINK_CITED"; do
+         "$PROSE_POLICY_LINK_CITED" "$PROSE_POLICY_URL" \
+         "$PROSE_POLICY_URL_PATHED"; do
   key=$(printf '%s' "$t" | cut -c1-40)
   out=$(printf 'Fixes the thing.\n\n%s\n' "$t" | run_attr_body)
   case "$out" in
@@ -2451,13 +2480,20 @@ done
 # shares a head with `PROSE_COMPLIANCE_TAIL` — a repair that widened the tail
 # hatch far enough to let the prose through would let this through with it. The
 # linked-policy pair sharpens that: they end on the same link the marker does,
-# so a body carrying both must still be refused for the marker alone.
+# so a body carrying both must still be refused for the marker alone. The
+# citation pair rides along for the same reason from the other side — they end
+# on a URL that is NOT the tool's, and the body still has to go red.
+#
+# `MARKER_URL_PATHED` joins the offending list because it is the one shape that
+# distinguishes a HOST test from a path test: refusing it while permitting
+# `PROSE_POLICY_URL_PATHED` is the whole of the third repair.
 for t in "$TRAILER_GENWITH" "$TRAILER_SESSION_URL" "$TRAILER_COAUTHOR" \
-         "$TRAILER_SESSION" "$MARKER_BARE_URL"; do
+         "$TRAILER_SESSION" "$MARKER_BARE_URL" "$MARKER_URL_PATHED"; do
   key=$(printf '%s' "$t" | cut -c1-32)
-  out=$(printf 'Fixes the thing.\n\n%s\n%s\n%s\n%s\n\n%s\n' \
+  out=$(printf 'Fixes the thing.\n\n%s\n%s\n%s\n%s\n%s\n%s\n\n%s\n' \
     "$PROSE_COMPLIANCE" "$PROSE_COMPLIANCE_TAIL" "$PROSE_POLICY_LINK" \
-    "$PROSE_POLICY_LINK_CITED" "$t" | run_attr_body)
+    "$PROSE_POLICY_LINK_CITED" "$PROSE_POLICY_URL" \
+    "$PROSE_POLICY_URL_PATHED" "$t" | run_attr_body)
   case "$out" in
     EXIT=0) fail "(10q) DISARMED: a body CARRYING a real trailer was allowed: $key..." ;;
     *)
@@ -2501,6 +2537,41 @@ case "$out" in
   *EXIT=0*) pass "(10q) a commit message ENDING on the tool's own link is permitted" ;;
   *) fail "(10q) FALSE POSITIVE: prose citing the policy by URL was refused ($out)"
      cat "$AERR" >&2 ;;
+esac
+
+# The citation pair at the detector: a commit message that ends on a URL whose
+# PATH carries the word and whose HOST does not. This is the shape the previous
+# repair still refused, and the reason it went unnoticed is that both anchors
+# have to be crossed to reach it — the line has to start at `Generated`, AND
+# end on a link.
+out=$(printf 'docs(gates): record the attribution rule\n\n%s\n%s\n' \
+  "$PROSE_POLICY_URL" "$PROSE_POLICY_URL_PATHED" | run_attr_lib 2>"$AERR") || true
+case "$out" in
+  *EXIT=0*) pass "(10q) a commit message ending on a CITATION url is permitted" ;;
+  *) fail "(10q) FALSE POSITIVE: rule 3's tail test reads a host, not a path ($out)"
+     cat "$AERR" >&2 ;;
+esac
+
+# BOTH DIRECTIONS IN ONE MESSAGE, which is the pairing that makes the host test
+# mean something: the citation sentences and a marker on the tool's own host
+# with a path that names neither the tool nor itself. Only the marker may be
+# quoted back — a listing that also names the citations is the false positive
+# returning, and the exit code alone would not show it.
+out=$(printf 'docs(gates): record the attribution rule\n\n%s\n%s\n\n%s\n' \
+  "$PROSE_POLICY_URL" "$PROSE_POLICY_URL_PATHED" "$MARKER_URL_PATHED" \
+  | run_attr_lib 2>"$AERR") || true
+case "$out" in
+  *EXIT=1*)
+    if grep -Fq "$MARKER_URL_PATHED" "$AERR" &&
+       ! grep -Fq "$PROSE_POLICY_URL" "$AERR" &&
+       ! grep -Fq "$PROSE_POLICY_URL_PATHED" "$AERR"; then
+      pass "(10q) the marker is quoted and the citations beside it are not"
+    else
+      fail "(10q) the refusal listing named the wrong lines"
+      cat "$AERR" >&2
+    fi
+    ;;
+  *) fail "(10q) DISARMED: a marker on the tool's host with an ordinary path was allowed ($out)" ;;
 esac
 
 out=$(printf 'docs(gates): record the attribution rule\n\n%s\n\n%s\n' \


### PR DESCRIPTION
## What

Rule 3 of the AI-attribution detector tested that the final blank-separated word of a line contained `://`, then asked whether that word contained `claude` or `anthropic` **anywhere**. It never isolated the host, so a citation URL whose **path** carried the word read as the tool's own marker link.

Measured against the landed detector on `origin/main` before any change:

| line | before | after |
|---|---|---|
| `Generated with [Claude Code] was declined per https://github.com/day8/re-frame2/blob/main/CLAUDE.md.` | **1** | **0** |
| the same line citing `README.md.` instead | 0 | 0 |
| `Generated with [Claude Code] was declined per https://github.com/day8/day8/claude-notes.` | **1** | **0** |
| `Generated with Claude Code https://claude.com/claude-code` | 1 | 1 |

Two false positives, and the discriminator between them and the passing case was the trailing word's *content* rather than the URL's host. Linking the rule rather than naming its file is the natural way to cite it, and this repository's rule file is literally called `CLAUDE.md` — so the wording a brief invites most was the one refused. A red from this arm cannot be cleared by editing the body: the workflow reads the frozen event payload, so only a new event clears it.

## How

`rf2_attribution_is_tool_link` parses the tail as a URL — scheme, authority, userinfo, port — and compares the **host** against `claude.com`, `claude.ai` and `anthropic.com`, subdomains included. The dot is the boundary, so a host that merely *ends* on one of them (`claude.com.example.invalid`) does not match.

This is the rule `scripts/git-hooks/README.md` (~line 422), the shape table and the detector's own comment have all promised since the first repair: *"the tail must now be a URL (`://`) whose host is the tool's"*. Nothing in the docs becomes false, so `README.md` is untouched. No negation wordlist, no message linter, nothing new is refused.

## Teeth

Every shape that must stay refused was measured after the change, and all five still are: a whole-line `Co-Authored-By:` on the assistant address, a whole-line `Claude-Session:`, the bare marker on the tool's own link, the markdown marker with its link, and a bare session URL alone on its line. Also refused after the change: the tool's host behind a port, behind a subdomain, behind userinfo, and upper-cased.

Then the host test was re-widened to the old substring behaviour in the worktree and the gate re-run: **116 passed, 4 failed**, and the four were exactly the new pins — the two citation shapes in the permitted loop, the new detector-level citation check, and the new pairing check. All 115 pre-existing assertions stayed green. Restored, and the restored file's git blob hash is identical to the committed one (`ad7273a4…`).

## Gate

`sh scripts/git-hooks/test-pre-commit.sh` — exit 0, **120 passed, 0 failed** (115 before; +5). Layer 10q gains the two citation shapes as permitted, `MARKER_URL_PATHED` as their mirror (the tool's own host wearing an ordinary path, still refused), and a check that the refusal listing names the marker and not the citations beside it.

Repo-wide residue ratchets over `scripts/` all exit 0, and `sh scripts/check-commit-attribution.sh origin/main` exits 0 on this branch's own commits.

## Sequencing

Based on `worker/attrib-c` (#9412), which adds regression pins to the same test file and deliberately did not touch the detector. Merge #9412 first, or merge this one and #9412 becomes a no-op. None of its pins are duplicated or reverted here.

rf2-uo5f
