### PR TITLE
docs(adapter): current-adapter answers the MAP; :kind is how you ask which substrate (rf2-kuky.74)

### DIFF
--- a/docs/api/re-frame.adapter.reagent.md
+++ b/docs/api/re-frame.adapter.reagent.md
@@ -28,7 +28,7 @@ The adapter ships in two artefacts: `day8/re-frame2-reagent` (full) and `day8/re
   ```
 - **Description**: The Reagent adapter map: the substrate spec you pass to `(rf/init! ...)` to install the browser-default Reagent substrate (stock `reagent.core` / `reagent.dom.client`).
   - There is no default-adapter registry and no keyword form. Require the adapter ns and pass its `adapter` Var explicitly at the call site.
-  - When this adapter is installed, `current-adapter` (in [`re-frame.core`](re-frame.core.md)) returns `:rf.adapter/reagent`.
+  - When this adapter is installed, `current-adapter` (in [`re-frame.core`](re-frame.core.md)) returns this map itself — that is the installed-adapter value, and its presence is how you ask whether an adapter is seated. The discriminator is a KEY on it: `(:kind (rf/current-adapter))` reads `:rf.adapter/reagent`.
   - The Reagent `frame-provider` is the substrate-agnostic provider from [`re-frame.core`](re-frame.core.md); children stay trailing-positional hiccup (`[rf/frame-provider {:frame …} & children]`).
 - **Example**:
   ```clojure

--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -786,16 +786,17 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
   (rf/current-adapter)          ;; => the adapter spec map passed to (rf/init! …), or nil
   (:kind (rf/current-adapter))  ;; => :rf.adapter/reagent
   ```
-- **On Hicasso**: this fn asks *which substrate*, and Hicasso is a view layer rather
-  than one — it owns Hiccup interpretation and the render boundary, while the reactive
-  container comes from an adapter the application installs. What Hicasso now ships is
-  one of the answers: `re-frame.hicasso.substrate` is an optional module of
-  `day8/re-frame2-hicasso` declaring `:kind :rf.adapter/hicasso`, and the install
-  chapter teaches `(rf/init! substrate/adapter)` as the default, so a Hicasso
-  application normally answers `:rf.adapter/hicasso`. Installing Reagent or UIx under
-  a Hicasso tree instead stays supported, and then the answer is that adapter's —
-  either way the value names the substrate the app booted on, never the layer its
-  views are authored in. See
+- **On Hicasso**: `(:kind (rf/current-adapter))` asks *which substrate*, and Hicasso is a
+  view layer rather than one — it owns Hiccup interpretation and the render boundary,
+  while the reactive container comes from an adapter the application installs. What
+  Hicasso now ships is one of the answers: `re-frame.hicasso.substrate` is an optional
+  module of `day8/re-frame2-hicasso` declaring `:kind :rf.adapter/hicasso`, and the
+  install chapter teaches `(rf/init! substrate/adapter)` as the default, so
+  `(:kind (rf/current-adapter))` normally reads `:rf.adapter/hicasso` in a Hicasso
+  application. Installing Reagent or UIx under a Hicasso tree instead stays supported,
+  and then the kind is that adapter's — either way `current-adapter` itself answers the
+  installed adapter map, and the `:kind` on it names the substrate the app booted on,
+  never the layer its views are authored in. See
   [Hicasso needs a substrate adapter](../core/hicasso/00-installation.md#hicasso-needs-a-substrate-adapter).
 
 ### `configure!`

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -532,8 +532,10 @@ imperative escape hatch (canvas refs, mount-lifecycle hooks for large
 list virtualisation, etc.) it resolves the active adapter via
 `re-frame.substrate.adapter/current-adapter` — which answers the installed
 adapter SPEC MAP — and dispatches on its `:kind` key (rf2-kuky.4:
-one read, map-shaped; the keyword-returning `current-adapter-spec` twin
-is struck). These escape-hatch sites are bounded — roughly five
+one read, map-shaped; the map-returning `current-adapter-spec` twin is
+struck, and with it `current-adapter`'s former keyword-returning
+spelling — the keyword was literally the `:kind` of that same map).
+These escape-hatch sites are bounded — roughly five
 of them across the codebase — and each lives next to the component
 that needs it, not in a central shim layer.
 


### PR DESCRIPTION
Closes nothing — rf2-kuky.74 stays OPEN for the coordinator to close.

## What this is

rf2-kuky.74 was reopened by the merged-PR audit of #9415. The runtime fold and the
live consumer migrations landed in #9415 and are **not touched here** — this is the
bounded prose sweep the audit named, and nothing else.

`rf/current-adapter` returns the installed adapter **MAP**. Three shipped prose sites
still described the pre-fold shape, so a reader copying a keyword comparison out of
them got `false` **with no error** — a silent wrong answer rather than a broken build.

## The three sites, each re-anchored by text at tip

1. **`docs/api/re-frame.adapter.reagent.md`** (was line 31) — said `current-adapter`
   "returns `:rf.adapter/reagent`". It now says the fn returns this adapter map itself
   (and that its *presence* is the seated-or-not question), with
   `(:kind (rf/current-adapter))` as the discriminator read.

2. **`docs/api/re-frame.core.md`** (was lines 789–798, the **On Hicasso** bullet) —
   described the fn as a substrate discriminator and said a Hicasso application
   "normally answers `:rf.adapter/hicasso`". Rewritten around
   `(:kind (rf/current-adapter))`, preserving the map/presence distinction: the fn
   answers the map, the `:kind` on it names the substrate.
   Worth noting: the section's own **Description** and **Example** blocks immediately
   above (lines 779–787) were already correct — only this trailing bullet lagged, which
   is why the defect survived #9415's sweep.

3. **`tools/xray/spec/008-Embedding-Contract.md`** (was line 535) — the dated rf2-kuky.4
   retirement record had the twins **backwards**: it called the deleted
   `current-adapter-spec` *keyword-returning*. Cross-checked against
   `spec/006-ReactiveSubstrate.md:2292` ("the keyword form was literally
   `(:kind (current-adapter-spec))`") and `spec/API.md:903`: `current-adapter-spec` was
   the **map**-returning twin, and the keyword-returning spelling was `current-adapter`'s
   own. The **dated retirement record is kept** — a dated retirement row is documentation
   under this project's convention, not residue — and only which name returned which
   shape is corrected.

Runtime shape verified at source before editing:
`implementation/core/src/re_frame/substrate/adapter.cljc:180-192` — "Return the installed
adapter SPEC MAP … plus a `:kind` discriminator keyword."

## Scope discipline

- **No runtime change, no shim, no alias, no API expansion**, per the audit.
- `spec/API.md` and `spec/api-manifest*.edn` are untouched (a sibling PR holds them).
- `docs/api/re-frame.core.md` line ~842 carries a *different* bead's residual (the
  optional-key-absence coupling claim). **Deliberately left alone** so the two fixes
  do not collide — this PR touches only the `current-adapter` prose in that file.
- The exempted `docs/design` citations and the four accepted dated retirement hits are
  not swept.

A census of `current-adapter` across `docs/` (excluding `docs/design/`) returns only the
two sites fixed here plus two bare "see also" name-listings, which carry no shape claim.

## Gates

Each run with the redirect and the runner's own `echo $?` on one command line; the number
quoted is the captured one, never a harness report. Nothing piped through a filter.

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_readme_links.py --ci` | **0** |
| `python -m mkdocs build --strict` | **0** |
| `python scripts/check_retired_spellings.py` | **0** |
| `python scripts/check_adapter_disposition.py` | **0** |
| `python scripts/check_keyword_catalogue_drift.py` | **0** |

Nominated by path, not job name: `check_doc_slugs.py`'s roots cover `docs/`, `spec/` and
`tools/*/spec`, and `check_readme_links.py --ci` covers the rest. The job that runs both
is named `verify-readme-links`. The last three are the ratchets whose subject this diff
touches — a retired spelling (`current-adapter-spec`) and the adapter `:kind` vocabulary.
`scripts/test-fast-pr.sh` was not run: no code changed.

## Proof the gate bites, on this worktree

A broken anchor was planted **on a line this PR edits** in
`docs/api/re-frame.adapter.reagent.md` (`re-frame.core.md#adocs-a-planted-broken-anchor`).
The plant's match count was read as **1 before the run**, so it was a real plant and not a
silent no-op. `check_doc_slugs.py` then returned **exit 1**, naming the file, the line and
the anchor. The plant existed only in this checkout, so the red is also the evidence the
gate read this tree and not a sibling's.

Restored with `git checkout HEAD --` and verified by **blob hash**, not by exit code:
restored `d23052c10a4301021d169c82b0c3712c4fe9f9f9`, committed blob
`d23052c10a4301021d169c82b0c3712c4fe9f9f9` — identical. Residual grep for the planted
token: 0. `check_doc_slugs.py` re-run green at **exit 0** afterwards. The plant was made
*after* committing this PR's own edits, so the restore could not discard them.

## Fenced code blocks

Neither link gate looks inside a fenced code block, so this was checked by hand: fence
parity was counted before each edited line — 4, 142 and 14 fences precede them
respectively, all **even**, so all three edits sit in prose and **outside** any fence.
Both gates therefore genuinely cover every link and anchor touched here; no
inside-a-fence link or anchor was edited. Table column counts in these files were not
altered (no table rows are in the diff).

Per the standing rule, this dispatch touches `tools/xray/` and updates that tool's spec
in the same PR.
