### PR TITLE
docs(ci): the canary's own record covers its whole lifetime, and names the token (rf2-amh0)

### DIFF
--- a/.github/workflows/post-merge-workflow-sanity.yml
+++ b/.github/workflows/post-merge-workflow-sanity.yml
@@ -225,6 +225,15 @@ jobs:
             # <sha>". This is not a trade-off between two workable targets: the
             # merge commit was never dispatchable.
             #
+            # THE TOKEN IS NOT THE OBSTACLE, so a correct ref is the whole fix.
+            # Events triggered by `GITHUB_TOKEN` do not normally create workflow
+            # runs — that is the recursion guard — but `workflow_dispatch` is one
+            # of the two documented exceptions that "always create workflow
+            # runs". So `actions: write` above plus a resolvable ref is the
+            # complete set of conditions, and a reader who finds this canary
+            # still silent should suspect the ref or the guards, never the token.
+            # See docs.github.com/en/actions/concepts/security/github_token.
+            #
             # MEASURED (rf2-amh0). This step passed the `github.sha` context
             # value as the ref from the file's first commit until this one — an
             # expression not written out here, because Actions substitutes
@@ -233,10 +242,19 @@ jobs:
             # 2026-09-05), 26 reached a dispatch and made 27 attempts; ALL 27
             # returned that same 422, and all 26 runs concluded `success`,
             # because a `|| { echo WARN; }` swallow that this commit removes took
-            # every one of them. Zero dispatches have ever succeeded. The
-            # 19 older runs (2026-05-28 to 2026-06-05) have expired logs (HTTP
-            # 410) so they are unmeasured, not clean — the argument was identical
-            # in their revisions, so any attempt they made failed the same way.
+            # every one of them. Zero dispatches have ever succeeded — and that
+            # last claim now rests on the whole lifetime rather than on the
+            # readable window, because a successful dispatch leaves a
+            # `workflow_dispatch` RUN behind and runs outlive their logs.
+            # Enumerated 2026-09-08 over every target this canary has named
+            # (expensive-tests.yml, freehand-conformance.yml, freehand-bench.yml)
+            # there are 7 `workflow_dispatch` runs all time, each triggered by
+            # the human maintainer on a branch ref and none by
+            # `github-actions[bot]`; freehand-conformance.yml, which the canary
+            # attempted 5 times, has ZERO. That covers the 19 runs whose logs
+            # have since expired (2026-05-28 to 2026-06-05, HTTP 410) with
+            # evidence, where this comment previously offered only a deduction
+            # from an unchanged argument.
             #
             # THE TIP, NOT THE MERGE COMMIT — deliberate. `github.ref_name` is
             # the branch this event is on (`main` for the push trigger; whatever


### PR DESCRIPTION
## The brief's premise did not hold, and I say so first

I was dispatched to fix (1) the dispatch ref being a commit sha and (2) the `|| { echo WARN; }` swallow in
`.github/workflows/post-merge-workflow-sanity.yml`. **Both were already repaired on `main`** by PR #9287
(`68b39d396a`, merged 2026-09-05T06:24:24Z), and PR #9394 (`ec489d7d3b`, merged 2026-09-07T13:52:21Z) added
the test pins that stop either half regressing silently. Verified at source at tip, not carried forward:

- `DISPATCH_REF` is the `github.ref_name` expression, arriving through `env:`, never interpolated into the run body.
- The dispatch is an `if` whose else-arm emits `::error::`, increments a counter, and `exit 1`s after the loop.
- `_post-merge-sanity-base.test.cjs` carries six dispatch arms (D1-D4 plus two structural pins), 15 tests total.

So there was no defect to fix. What follows is the part of the brief that was still owed.

## What this PR changes - comment only, no behaviour change

The brief asked me to establish the dispatch history before writing a claim into the file, and warned against
writing "always broken" unless I could show it. I can now show it *better than the file currently does*, so
the correction lands where the record lives.

**1. The lifetime claim no longer rests on a deduction.** The comment said the 19 runs whose logs have expired
(HTTP 410) were "unmeasured, not clean", and inferred their outcome from the argument being byte-identical.
That inference is now unnecessary: **a successful dispatch leaves a `workflow_dispatch` RUN behind, and runs
outlive their logs.** Enumerated over all three targets this canary has ever named:

| target | canary attempts (logged) | dispatch runs, all time | triggered by |
|---|---|---|---|
| `expensive-tests.yml` | 18 | 6 | the human maintainer, branch refs |
| `freehand-conformance.yml` | 5 | **0** | - |
| `freehand-bench.yml` | 4 | 1 | the human maintainer, `main` |

Seven lifetime dispatch runs, every one triggered by the human maintainer on a branch ref, **none by
`github-actions[bot]`**. `freehand-conformance.yml` has zero despite five canary attempts, which alone refutes
any success there. This reaches the expired window with evidence rather than inference.

**2. The one implicit link is now named.** Nothing in the file said whether `GITHUB_TOKEN` can create a
dispatch at all. It can: events triggered by `GITHUB_TOKEN` do not normally create workflow runs - the
recursion guard - but `workflow_dispatch` is one of the two documented exceptions that *always* create workflow
runs. So `actions: write` plus a resolvable ref is the complete set of conditions, and a future reader who
finds the canary silent should suspect the ref or the guards, never the token.

## The semantic choice, stated deliberately

The brief asked me to pick between the branch tip and the merge commit and justify it. **The choice is already
made in the file and I endorse it rather than re-opening it: the tip.** It is not a trade-off between two
workable targets - the merge commit was never dispatchable at all, since the endpoint resolves `ref` in the ref
namespace and a commit id is not in it. Among the targets that *do* resolve, `github.ref_name` is right because
it is what the next cron tick will use, which is precisely the question this canary asks; and it beats a literal
`main` because the workflow also declares `workflow_dispatch`, where a literal would be wrong. Two
workflow-editing merges landing close together share one dispatch of the later tip, and
`concurrency: cancel-in-progress` already collapses that case.

On the `||`: also already resolved, correctly. A failed dispatch is not a non-fatal condition for a workflow
that exists to dispatch, and the shipped code fails the step *and* raises an annotation - failures counted
rather than aborting the loop, so one bad target cannot hide the fate of the others.

## Proof of the argument shape - live, against the real API, starting no run

Two probes that both return 422 (so neither creates anything), whose *different messages* isolate the ref as
the variable:

- dispatchable workflow + commit sha gives `HTTP 422: No ref found for: 66e1a69f8a...` - ref resolution
  **failed**; the API never reached the trigger check. This reproduces the logged production failure verbatim.
- non-dispatchable workflow (`test.yml`) + branch name `main` gives `HTTP 422: Workflow does not have
  'workflow_dispatch' trigger` - ref **resolved**; the API got past ref resolution and refused for an unrelated
  reason.

Ref-namespace control: `git/ref/heads/main` resolves to `66e1a69f8a...` (exit 0); `git/ref/heads/<that same
sha>` 404s. Confirmed after both probes that no new run appeared for either workflow.

## Live status the brief asked about - one context claim is now stale

The brief carried "`expensive-tests.yml` had not run since 2026-09-04, so PR #9276's `mcp-live-windows` job had
never executed". **That is no longer true.** Three scheduled runs have since completed successfully
(2026-09-05, -06, -07), and the job `MCP live hermetic suite on WINDOWS (two consecutive runs)` **ran and
passed in all three**. The repo's first Windows leg has now executed three times, green. (rf2-2qa7 owns
reading those.) All three are `schedule` events, so they say nothing about this dispatcher.

## What is still NOT established, and why this PR does not close the bead

The acceptance is a **live witness**, which no local work can supply: a dispatch runs the default-branch copy,
so nothing is provable from a PR branch. Re-measured at tip:

- `git log 68b39d396a..origin/main -- .github/workflows/expensive-tests.yml` gives **0 commits** (control: 5
  workflow edits and 586 commits in the same window).
- The four sanity runs since the fix (`34021127885`, `34031499789`, `34126485953`, `34157181571`) each print
  exactly one real line with the ANSI command-echo filtered: `skip (excluded): test.yml`. No dispatch attempted.
- `expensive-tests.yml` remains the only workflow that is both dispatchable and not excluded - re-verified at
  tip against the EXCLUDE array, not carried forward. (`test.yml` does **not** declare `workflow_dispatch` at
  tip, contrary to an older note on the bead.)

**This PR is not its own witness either**, for the reason already on record: this file is on its own EXCLUDE
list (`# self`), so its merge prints `skip (excluded)` and dispatches nothing. It therefore cannot manufacture
the trigger, which is what the bead asks. **Close condition unchanged**: the next `main` merge editing
`expensive-tests.yml` must print `dispatching:` *not* followed by `No ref found for`, then `dispatched:`, with
a matching dispatch run at the branch tip. Do not force it by dispatching the nightly by hand - it now carries
the Windows leg.

## Gates

Foreground, exit echoed on the same command line as the redirect, never piped; re-run on the final rebased
base `66e1a69f8a`:

- `python scripts/check_workflow_yaml.py` gives **0** (11 files)
- `python scripts/check_workflow_job_timeouts.py` gives **0** (117 jobs / 11 files)
- `node --test implementation/scripts/_post-merge-sanity-base.test.cjs` gives **0** (15 passed)

**Sabotage control.** After committing, I re-introduced this bead's own defect - `DISPATCH_REF` changed from
the `github.ref_name` expression to the `github.sha` one, plant match count read as **1** before running
anything. The pin went red: **exit 1**, `FAIL the dispatch ref is a BRANCH ref, through env:, and never a
commit id (rf2-amh0)`, and the stack named this worktree, confirming which tree the run read. The fault existed
only here, so a run that had wandered into a sibling checkout would have come back green. Restore verified by
git **blob** hash `58cc0cbefe109be901ca6991e233dd0a7e72319a` against the committed object, not by reading a
diff.

**Surfaces.** `report-changed-surfaces.sh` classifies this path as arming **no** tiered surface, every flag
false (instrument controls: `implementation/core/src/re_frame/core.cljs` arms 16; a nonsense path arms 0). So
this is graded by the unconditional jobs only. No job added, nothing renamed.

Manual check, since no gate reads prose: the one table above has 4 header columns, 4 separator cells and 4
cells in each of its 3 body rows.
