### PR TITLE
docs(resources,http): stop attributing failure-trace redaction to the reflection-only resource :data-schema

### DIFF
--- a/implementation/http/src/re_frame/http/privacy_body.cljc
+++ b/implementation/http/src/re_frame/http/privacy_body.cljc
@@ -7,9 +7,11 @@
   payload**, classified per-slot via `:sensitive?` / `:large?` props on the
   request's `:decode` schema. This uses the shared schema-walker hooks
   (`:schemas/extract-sensitive-paths-from-schema` /
-  `:schemas/extract-large-paths-from-schema`) the resource `:data-schema`
-  surface (`re-frame.resources.classification`) and the app-schema elision
-  path consume — never a body-private walker.
+  `:schemas/extract-large-paths-from-schema`) the resource `:params-schema`
+  validation-failure-trace surface (`re-frame.resources.classification`, which
+  binds `(:params-schema spec)`) and the app-schema elision path consume —
+  never a body-private walker. The resource `:data-schema` is NOT among them:
+  it is a statically reflected shape fact with no runtime validation consumer.
 
   Three rules pin the contract:
 

--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -347,16 +347,22 @@
 ;; ---------------------------------------------------------------------------
 ;; Schemas validate; they do NOT classify durably.
 ;;
-;; A resource's `:data-schema` / `:params-schema` (and, for an infinite feed,
-;; the per-page validation supplied on the request's `:decode`)
+;; A resource's `:params-schema` (and, for an infinite feed, the per-page
+;; validation supplied on the request's `:decode`)
 ;; VALIDATES the value; it does NOT drive DURABLE egress classification. The
 ;; per-slot `:sensitive?` / `:large?` schema props survive ONLY for
 ;; VALIDATION-FAILURE-TRACE redaction (the validator's own transient egress
-;; product — `redact-invalid-params-error`, via the shared
-;; `:schemas/redact-validation-tags` seam) — NOT as a route into durable resource
+;; product — `redact-invalid-params-error`, which binds the spec's
+;; `:params-schema`, via the shared `:schemas/redact-validation-tags` seam) —
+;; NOT as a route into durable resource
 ;; data / params / scope classification (Spec 015 §Schemas describe shape, not
-;; durable egress policy). The SINGLE durable classification surface is the
-;; projection-relative `:sensitive` / `:large` path declarations on the spec
+;; durable egress policy). A resource's `:data-schema` drives NEITHER axis: it
+;; is a statically reflected shape fact with NO runtime validation consumer
+;; (surfaced as the process-node `:schema` by `re-frame.resources.tooling`), so
+;; it reaches no validator and therefore no failure trace — runtime shape-
+;; validation of a response rides the request's `:decode` instead
+;; (Spec 016 §Optional v1 keys). The SINGLE durable classification surface is
+;; the projection-relative `:sensitive` / `:large` path declarations on the spec
 ;; (`spec-declaration-marks`), LOWERED per instance into the per-frame elision
 ;; registry (`reconcile-registry`, the lowering section below) — one name per
 ;; fact, read back at egress through the SAME registry the routing / machines

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -140,10 +140,12 @@
 ;;     `project-entry-data` for `:data`, and `project-entry-scope` /
 ;;     `project-entry-params` for the scoped key's two classification-bearing
 ;;     components (indices 0 and 2 of `:resource/key`). The per-slot
-;;     `:sensitive?` / `:large?` props on a co-present `:data-schema` /
-;;     `:params-schema` do NOT drive durable egress classification — the schema
-;;     VALIDATES, it does not classify (rf2-fuqcob); a schema mark serves only
-;;     validation-failure-trace redaction (EP-0025).
+;;     `:sensitive?` / `:large?` props on a co-present `:params-schema` do NOT
+;;     drive durable egress classification — the schema VALIDATES, it does not
+;;     classify (rf2-fuqcob); a schema mark serves only validation-failure-trace
+;;     redaction (EP-0025). A co-present `:data-schema` drives NEITHER axis: it
+;;     is a statically reflected shape fact with NO runtime validation consumer,
+;;     so it reaches no validator and therefore no failure trace.
 ;;
 ;; A `:sensitive?` (or `:large?`) resource must NOT ship its data verbatim
 ;; onto the wire — every visitor of every SSR page would otherwise receive


### PR DESCRIPTION
Closes the last three prose sites that attribute validation-failure-trace redaction to the resource `:data-schema`. Bead `rf2-bsbs` (left OPEN for the merge audit).

## The false claim, and why it is false

Three comment/docstring sites said the resource `:data-schema` drives validation-failure-trace redaction. It drives nothing. Verified three ways at source on this branch's base:

- The only resource failure projector is `resources/classification.cljc`'s `redact-invalid-params-error`, and it binds `(:params-schema spec)` — not `:data-schema`.
- `git grep -F '(:data-schema' -- implementation` returns exactly one site: `resources/tooling.cljc:239`'s `with-metadata`, which attaches it as the process-node `:schema` reflection fact (`(contains? spec :data-schema) (assoc :schema (:data-schema spec))`).
- `spec/016-Resources.md` §Optional v1 keys says it outright — optional, "does not drive runtime validation — it has no runtime validation consumer"; runtime shape-validation of a response rides the request's `:decode`.

## The three sites

1. `implementation/resources/src/re_frame/resources/classification.cljc` — the section comment above the lowering block.
2. `implementation/resources/src/re_frame/resources/ssr.cljc` — the EP-0025 reconciliation comment.
3. `implementation/http/src/re_frame/http/privacy_body.cljc` — the ns docstring, which attributed the shared schema-walker hooks to "the resource `:data-schema` surface (`re-frame.resources.classification`)", a namespace that in fact binds `:params-schema`.

Each now carries the three-way separation already landed in `spec/API.md` §Commit-plane declaration path and `spec/009-Instrumentation.md`: required `:params-schema` validation (machine `[:schemas :data]` alongside it), HTTP `:decode` response validation, and reflection-only resource `:data-schema` with no runtime validation consumer. No third phrasing was invented.

Legitimate `:data-schema` metadata/reflection references are retained; no machine-validation wording changed. **Comment and docstring text only — no code change**, and no runtime validation feature was added (the code is right; the prose was wrong).

## Quality gates

| gate | exit | result |
|---|---|---|
| `implementation/http` — `clojure -M:test` | **0** | 501 tests, 3969 assertions, 0 failures, 0 errors |
| `implementation/resources` — `clojure -M:test` | **0** | 839 tests, 7584 assertions, 0 failures, 0 errors |
| `python scripts/check_retired_spellings.py` | **0** | see caveat below |
| `python scripts/check_fast_pr_gap.py --brief` | 0 | report, not a suite — 99 required checks CI still owns |

Exit codes were captured with the redirect and `echo $?` on one command line and quoted from that file, never from a pipeline.

**Sabotage proof that the suite read this worktree.** A reader-breaking fault was planted at a line this PR edits (`privacy_body.cljc` line 13, unique anchor, match count 1 read before the run). The http suite went **red, exit 1**, naming `Syntax error reading source at (re_frame\http\privacy_body.cljc:17:0)`. Restored with `git checkout HEAD --` and verified by blob hash against the committed object (`38e438e0ac…`, identical), with zero planted residue.

### Gate nominations that did NOT hold, and why

- **`scripts/check_readme_links.py --ci` does not cover this diff.** The bead's gate note nominates it, correctly measured on `implementation/SECURITY.md` — but that gate walks **markdown only** (`README.md` via `_iter_readmes`, plus `git ls-files "*.md"`). This diff touches three `.cljc` files and zero markdown, so running it would buy a green that inspected nothing changed here. Nominated by path, and the path is not markdown.
- **`scripts/check_doc_slugs.py` likewise** — its roots are `docs/`, `spec/`, `skills/`, `migration/`, `tools/*/spec`; `implementation/**` is outside them.
- **`check_retired_spellings.py` is green but vacuous here.** It does scan `implementation/`, but `_mask_strings` blanks string-literal contents and `_LINE_COMMENT_RE` strips `;` comments before its token rules run — which is exactly and only the surface this diff edits. Reported as a real exit 0 rather than as coverage.

Changed-surface classifier on these three paths arms `implementation_jvm`, `cljs_node_test`, `cljs_browser`, `examples_compile`, `cljs_prod`, `bundle_isolation` (control on `implementation/shadow-cljs.edn` returned a different, richer set). The two JVM lanes are covered above; the CLJS lanes are CI's.

## Adjacent site found, NOT swept

`implementation/core/src/re_frame/registrar.cljc:503` says "`:schema` / `:data-schema` are the SOURCE the `:sensitive?` / `:large?` marks are PRECOMPUTED from at registration time". That is the same family of claim, but it sits outside this bead's three enumerated sites and in a different artefact. Reported rather than swept — widening scope is how the parent bead reached four audit rounds.
