### PR TITLE
docs(method): a retired alert-channel read is spelled as absent values, not a note

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -471,6 +471,19 @@ has returned since the close, and never by reopening the closed item, whose clos
 normative record. The query, the label and the field that carries the URL are repository values,
 and they live in the agent-instructions file, per the rule at the head of this page.
 
+**When that file carries no such values, the read is not owed — do not reconstruct one.** A
+repository whose alert channel has gone quiet may retire this read deliberately, and the
+retirement is spelled as the ABSENCE of those values rather than as a note saying so. That
+absence reads exactly like an oversight, and a standing loop prompt can go on naming the sweep
+long after the values it pointed at are gone — so the coordinator looks where they should be,
+finds nothing, and invents a query. **An invented query is worse than no read at all.** Measured:
+the one invented was the label-filtered issue index, which that repository's own alerter refuses
+in a source comment — the index is eventually consistent, and had already made the alerter open a
+duplicate alert when it lagged. It then returned a reassuring empty result on every tick of a long
+session. THE EMPTY RESULT WAS CORRECT, which is why nothing on screen betrayed it: the channel
+genuinely held no open alerts, so the wrong instrument and the right one agreed, and their
+agreement is not evidence. Values present, do the read; values absent, skip it and report nothing.
+
 **Read the newest note first, and order the item by the tracker's own timestamps** — not by
 position, and not by dates written in the prose. The mechanics are set out for the worker under
 [*Common preamble*](dispatch-prompt-template.md#common-preamble) in


### PR DESCRIPTION
## What

`loops.md`'s *Read the host's alert channel* paragraph ends by saying the query, the label and the URL field are repository values living in the agent-instructions file. It never says what the read means when that file carries **none** — and "none" is precisely what a deliberate retirement looks like, because the obligation is removed entire with no stub, so the absence *is* the record of the decision.

## Why

That absence is indistinguishable from an oversight, and a standing loop prompt outlives it: the prompt goes on naming the sweep and citing the agent-instructions file for values that were deleted. The coordinator looks where they should be, finds nothing, and reconstructs a query.

Measured here: the reconstructed query was the label-filtered issue index — the one this repository's own alerter refuses in a source comment on `fetch_open_issues`, because the index is eventually consistent and had already made the alerter open a duplicate alert when it lagged. It ran on every tick of a long session and returned empty every time.

**The empty result was correct.** The channel held no open alerts at all, so a wrong instrument and a right one agreed, and nothing on screen betrayed the difference. That is why this needed a documented branch rather than a one-off correction.

## The change

One paragraph, adding the missing branch: values present, do the read; values absent, skip it and report nothing. Generic, as this page is — no repository values are named.

Nothing else moves. The alerter, the workflow and the signature logic are untouched, and the generic paragraph itself still stands.

## Quality gates

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `python -m mkdocs build --strict` | 0 (29.0s) |

`docs/the-mayor-method/` is not in `mkdocs.yml`'s `exclude_docs`, so the strict build covers this page.

**Plant proof:** a broken anchor inserted into the new paragraph took `check_doc_slugs.py` to **exit 1**, naming `loops.md:479` and the anchor. Restore verified by `git hash-object` against the pre-plant blob (`676d5ad351`), not by the restore command's exit code.