### PR TITLE
docs(resources): drop deleted rf/resources from the TanStack introspection-accessor list

### DIFF
--- a/docs/resources/coming-from-tanstack-query.md
+++ b/docs/resources/coming-from-tanstack-query.md
@@ -225,7 +225,7 @@ The two whole-view-model reads are `@(rf/subscribe [:rf/resource query])` and `@
 
 !!! note "The whole `rf/` resource API is the optional Resources artefact"
 
-    — late-bound by `day8/re-frame2-resources`, absent from an app that never requires it. The introspection accessors (`rf/resource-meta`, `rf/resource-state`, `rf/resources`) are the tool/test projection lane, not an app-read API; a view that reaches for them instead of a subscription is a category error (they take a one-shot snapshot and never re-render).
+    — late-bound by `day8/re-frame2-resources`, absent from an app that never requires it. The introspection accessors (`rf/resource-meta`, `rf/resource-state`) are the tool/test projection lane, not an app-read API; a view that reaches for them instead of a subscription is a category error (they take a one-shot snapshot and never re-render).
 
 Three command names earn a sentence each, because a query-library reader reaches for them and the mapping isn't obvious:
 


### PR DESCRIPTION
Fixes the one live-prose site that still named `rf/resources`, deleted by PR #9425.

`docs/resources/coming-from-tanstack-query.md:228` listed three introspection
accessors; two survive and one no longer exists. This is a user-facing migration
page aimed at readers arriving from TanStack Query, so it was pointing them at a
symbol they cannot call. One name dropped from the list — the sentence's
projection-lane point is unchanged and still correct.

Both surviving names verified live at source in
`implementation/resources/src/re_frame/resources.cljc`: `resource-meta` (line 95)
and `resource-state` (line 146). `resources` has no definition there.

`docs/EP/EP-0003-resource-queries.md:1259` carries `(rf/resources …)` inside a
clojure fence and is **deliberately untouched** — it is a dated design record, and
rf2-kuky.85's acceptance exempts dated retirement rows.

rf2-bn5a

## Quality gates

| gate | exit | notes |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | the link/anchor gate whose roots include `docs/` |
| `python -m mkdocs build --strict` | **0** | 38.09s; printed its build root, confirming it read this worktree |

Exit codes captured on the runner's own command line (redirect + `echo $?` in one
shell), never through a pipe.

**Gate teeth proven, not assumed.** `check_doc_slugs.py` prints nothing on success,
so its green was discriminated by a planted fault at the very line edited: a broken
relative link on line 228 took the gate to **exit 1**, naming
`docs\resources\coming-from-tanstack-query.md:228` and the missing target. Plant
match count read 1 before the run; restore verified by blob hash against the
committed object (`cc080330a8be5c7874ca6bc3b31803dcbd5f4084`, identical), residue
grep 0, tree clean. The fault existed only in this worktree, so the red is what
rules out a cross-worktree read.

**Prose correctness is not gated by anything, and was checked by hand.** No CI check
grades this claim:

- the guide-samples digest gate (`check_guide_samples.py`) covers `docs/core/hicasso/`
  only and never reads this page;
- `check_doc_slugs.py` and `mkdocs build --strict` grade link targets, anchors and
  link resolution — never prose claims;
- neither doc gate looks inside fenced code blocks at all;
- no ratchet covers this path: nothing under `scripts/` or `.github/` mentions
  `coming-from-tanstack` or `rf/resources`, and `check_retired_spellings.py` scans a
  different retired spelling and excludes `docs/` besides.

Hand-checked: "accessors" still reads correctly with two names; backticks and
parentheses balanced; the projection-lane sentence retained verbatim; a repo-wide
census (line-oriented, whitespace-flattened, and comment-marker-stripped, each with
a matching control) leaves exactly two `rf/resources` sites — the excluded EP-0003
fence and one test-file prose line describing the retirement itself, which is under
a fenced surface owned by another live worker.
