### PR TITLE
docs(resources): restore the three-read migration guidance beside the retained introspection APIs

### DIFF
--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -1549,6 +1549,36 @@ Resources are an optional capability (cached server-state reads plus mutations) 
 - **Signature**: `(mutation-state {:instance … :frame …}) → row or nil`
 - Tool/test lane: a mutation **instance**'s durable runtime row (`{:status :result :error …}`) at an explicit frame. Full contract in [re-frame.resources.md](re-frame.resources.md).
 
+#### Enumerating resources and mutations — the three reads
+
+There is no bundled `resources` / `mutations` read (both were deleted by rf2-kuky.85: each packed a
+registry enumeration and a runtime-db table read into one call, and the two halves already have their
+own door). Three distinct reads answer three different questions:
+
+```clojure
+;; 1. REGISTRY — what is registered? Process-global registrar; no frame.
+(keys (rf/registrations {:source :store :kind :resource}))  ;; => (:article/by-slug :feed/timeline)
+(keys (rf/registrations {:source :store :kind :mutation}))  ;; => (:article/save)
+
+;; 2. WHOLE LIVE TABLE — the reserved runtime-db path, off the frame-state projection.
+(get-in (rf/frame-state-value :app/main) [:rf.db/runtime :rf.runtime/resources :entries])
+;; => {<key-id> <entry> …}
+(get-in (rf/frame-state-value :app/main) [:rf.db/runtime :rf.runtime/mutations])
+;; => {<instance-id> {:mutation/id … :instance/id … :status … :result … :error …} …}
+
+;; 3. ONE ENTRY / ONE INSTANCE — the per-target live-state reads above.
+(rf/resource-state {:resource :article/by-slug :scope :rf.scope/global
+                    :params {:slug "welcome"} :frame :app/main})
+(rf/mutation-state {:instance :form/save-1 :frame :app/main})
+```
+
+Read the tables **as they are keyed**. `:entries` is keyed by each entry's CEDN-1 byte `key-id`, and the
+entry carries its own `:resource/key` tuple; `:rf.runtime/mutations` is keyed by mutation **instance** id
+(`:instance/id`), never by mutation id. Re-keying either table onto its human-readable field can collapse
+distinct rows. Both subtrees are allocated lazily, so either read can return `nil` before the capability
+is first used. Full contract in
+[re-frame.resources.md](re-frame.resources.md#enumerating-the-whole-live-table).
+
 ## See also
 
 - [Subscriptions](../core/subscriptions.md), [Frames](../core/frames.md), [Effects](../core/effects.md), [Coeffects](../core/coeffects.md), [Observability](../core/observability.md) — the concept guides behind these surfaces.

--- a/docs/api/re-frame.resources.md
+++ b/docs/api/re-frame.resources.md
@@ -397,8 +397,10 @@ A view reads the merged list and dispatches the causal `[:rf.resource/load-more 
 
 These direct functions are the tool/test projection lane, not an app-read API:
 
-- `resource-meta` / `mutation-meta` project the **registration** (the registered spec).
-- `resource-state` / `resources` / `mutation-state` / `mutations` project **runtime state** (the live entries) as a one-shot, non-reactive snapshot at an explicit frame.
+- `resource-meta` / `mutation-meta` project the **registration** (the registered spec), and `rf/registrations` enumerates the registry.
+- `resource-state` / `mutation-state` project **runtime state** (one live entry, one live instance) as a one-shot, non-reactive snapshot at an explicit frame; the **whole** live table is the reserved runtime-db path read off `rf/frame-state-value` ([§Enumerating the whole live table](#enumerating-the-whole-live-table)).
+
+There is no bundled read returning both the registry and the live table: `resources` and `mutations` were deleted by rf2-kuky.85, and the three reads below are the replacement.
 
 They serve Xray, unit tests, and SSR serialization — contexts with no reactive subscription. App views read runtime state through the passive [`:rf.resource/*` / `:rf.mutation/*` subscriptions](#resource-subscriptions-passive), never through these functions — they do not re-render on change. Registering a handler, dispatching a cause, projecting a snapshot, and subscribing are four distinct jobs; see [The model — three lanes](../resources/concepts.md#three-lanes--registering-causing-projecting).
 
@@ -499,6 +501,47 @@ They serve Xray, unit tests, and SSR serialization — contexts with no reactive
 (re-frame.resources/mutation-ids)
 ;; => [:article/save]
 ```
+
+### Enumerating the whole live table
+
+The registry, the whole live table, and one entry are **three different reads**. The registry answers
+*what is registered* and takes no frame; the live tables are runtime-db state and are read at an explicit
+frame through the reserved paths ([§Cache home](#cache-home)); `resource-state` / `mutation-state` narrow
+to one target.
+
+```clojure
+;; 1. REGISTRY — every registered id, no frame.
+(keys (rf/registrations {:source :store :kind :resource}))  ;; => (:article/by-slug :feed/timeline)
+(keys (rf/registrations {:source :store :kind :mutation}))  ;; => (:article/save)
+
+;; 2. WHOLE LIVE TABLE — the reserved runtime-db path off the frame-state projection.
+(get-in (rf/frame-state-value :app/main) [:rf.db/runtime :rf.runtime/resources :entries])
+;; => {<key-id> {:resource/id :article/by-slug
+;;               :resource/key [:rf.scope/global :article/by-slug {:slug "welcome"}]
+;;               :data … :error … :generation … :current-work …}
+;;     …}
+(get-in (rf/frame-state-value :app/main) [:rf.db/runtime :rf.runtime/mutations])
+;; => {<instance-id> {:mutation/id :article/save :instance/id :form/save-1
+;;                    :status … :result … :error … :generation …}
+;;     …}
+
+;; 3. ONE ENTRY / ONE INSTANCE — the narrowed reads documented above.
+(rf/resource-state {:resource :article/by-slug :scope :rf.scope/global
+                    :params {:slug "welcome"} :frame :app/main})
+(rf/mutation-state {:instance :form/save-1 :frame :app/main})
+```
+
+**Read each table as it is keyed.** `:entries` is keyed by the entry's CEDN-1 byte `key-id`
+([§Resource identity](../../spec/016-Resources.md#resource-identity)) — the entry's human-readable
+`[scope resource-id params]` tuple rides the row as `:resource/key`, and re-keying the table onto it can
+collapse distinct entries. `:rf.runtime/mutations` is keyed by mutation **instance** id (`:instance/id`),
+never by mutation id, so concurrent submissions of the same mutation stay distinct; re-keying onto
+`:mutation/id` collapses them.
+
+Both subtrees are allocated **lazily**: `:rf.runtime/resources` is absent until the first resource write,
+and `:rf.runtime/mutations` is absent in an app that registers no mutation, so either read can return
+`nil`. `nil` here means *the subtree has not been allocated*, not *no such frame* — an unknown or
+destroyed frame makes `rf/frame-state-value` itself return `nil`.
 
 Xray exposes the same shapes, plus:
 


### PR DESCRIPTION
Closes the documentation half of **rf2-kuky.85**, reopened by the merged-PR audit of #9425.

The audit accepted the implementation deletion of `rf/resources` / `rf/mutations` and the retained
runtime assertions. What it found incomplete was original **ruling refinement (i)**: both API
references deleted the two bundled sections without leaving either a replacement enumeration or a
whole-table recipe, so each page documented the per-entry live-state read with no way to enumerate.

## What changed

Both pages now present **three distinct reads** for three different questions:

| question | read |
|---|---|
| what is registered? | `(keys (rf/registrations {:source :store :kind :resource}))` / `{:kind :mutation}` |
| the whole live table | `(get-in (rf/frame-state-value f) [:rf.db/runtime :rf.runtime/resources :entries])` / `[:rf.db/runtime :rf.runtime/mutations]` |
| one entry / one instance | `rf/resource-state` / `rf/mutation-state` |

- `docs/api/re-frame.core.md` — a new subsection closing the Resources re-export group, stating the
  three reads and why the bundle is gone.
- `docs/api/re-frame.resources.md` — a new `### Enumerating the whole live table` section carrying the
  same three reads with the entry and instance row shapes.

Per refinement (ii) the tables are documented **as they are keyed**: `:entries` by the entry's CEDN-1
byte `key-id`, with the `[scope resource-id params]` tuple riding the row as `:resource/key`; and
`:rf.runtime/mutations` by mutation **instance** id (`:instance/id`), never by mutation id. Both pages
say that re-keying either table onto its human-readable field can collapse distinct rows.

**No replacement wrappers are introduced.** The spec (016 §Introspection) and the api-cheatsheet already
establish this direction; these pages now match them rather than adding sugar.

### Incidental correction

`docs/api/re-frame.resources.md` still named the deleted `resources` / `mutations` as the runtime-state
projectors. That line is not in call position, so `doc-api-check` could not see it.

## Quality gates

Docs-only diff (two files under `docs/api/`). Narrowest covering gates, each run once in the
foreground, exit code captured on the runner's own command line — never through a pipe:

| gate | exit | notes |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | anchors + repo-relative link targets |
| `doc-api-check` (`clojure -M -m re-frame.api-manifest.doc-api-check`) | **0** | 347 public-var references checked; 148 eligible manifest vars each have a page + member entry |
| `python -m mkdocs build --strict` | **0** | built in 28.9s; link resolution inside the built site (bare `mkdocs` exits 127 here) |

Both silent/ambiguous gates were proved to have teeth **on this branch's tree**, then restored and the
restore verified by `git hash-object` against the committed blob (not by the restore's exit code):

- `check_doc_slugs.py` — a broken anchor planted **in prose** (the extractor strips fenced blocks, so a
  fence plant would have returned a false green) → exit **1**, naming `docs/api/re-frame.resources.md:509`
  and the planted anchor.
- `doc-api-check` — the deleted name `rf/mutations` reintroduced in a fence, the exact drift class this
  gate exists to catch → exit **1**, naming `docs/api/re-frame.core.md:1572` and `rf/mutations`. Its
  extractor does not strip fences, so a fence plant is the right column here.

Both reds name a fault that existed only in this worktree, which is what discriminates this tree from a
sibling's. Restores verified: blobs `bc65fddd9d…` and `308d40960d…` both matched.

### Hand-checked, because no gate grades it

Neither doc gate grades prose correctness, and **both strip fenced code blocks before extracting links**
— every recipe added here lives in a fence, so no gate inspected the code samples at all. Verified by
hand against source:

- both recipes match `spec/016-Resources.md` §Introspection (the `get-in … :entries` line is verbatim
  from it) and `api-cheatsheet.md` line 96;
- entry fields `:resource/id` `:resource/key` `:data` `:error` `:generation` `:current-work` against the
  entry shape in `spec/016-Resources.md`; instance fields `:mutation/id` `:instance/id` `:status`
  `:result` `:error` `:generation` against its `:rf.runtime/mutations` clause-1 row;
- `key-id` as the `:entries` map key, and the lazy-allocation claim for both subtrees, against the same
  spec;
- `rf/frame-state-value` returning `nil` for an unknown / destroyed frame against its own entry in
  `re-frame.core.md`.

No tables were added or altered, so there are no column counts to check.

## Out of scope — reported, not fixed

A residual census found the deleted names still referenced **outside** the two pages this bead owns.
Left alone deliberately: the audit's repair names only the two API references, two of these sites sit in
files fenced to other open PRs, and no gate catches any of them (only `docs/api/**` is scanned in call
position).

- `docs/EP/EP-0003-resource-queries.md:1259` — `(rf/resources {:frame :app/main})`, a live call-position
  reference to a deleted fn, in a tree `doc-api-check` does not scan.
- `spec/016-Resources.md:481` and `:574`, `spec/Runtime-Subsystems.md:161` — `resources` / `mutations`
  still listed among the tool accessors.
- `spec/009-Instrumentation.md:2272` and `spec/api-manifest-metadata.edn:976` — same, and both are
  **fenced to other open PRs**.

Worth a follow-up bead; not widened into here.
