### PR TITLE
docs(hicasso): reconcile the frame-boundary contract with what the shared ENSURE does

### DIFF
--- a/docs/api/re-frame.hicasso.md
+++ b/docs/api/re-frame.hicasso.md
@@ -191,11 +191,14 @@ as it likes, and no call here reaches a root the caller did not name.
 - **Description**: Adopts a container's existing server-rendered DOM rather than
   replacing it. Same root-options config as `mount!`. It returns *before* adoption
   finishes, and it must be handed the same `:identifier-prefix` the server render
-  used. **Its tree SCOPEs rather than ENSUREs**: state comes first and through a
-  different door — `re-frame.ssr/hydrate!` installs the server's app-db and must
-  run before this — so the frame already exists and
-  `[h/frame-provider {:frame …} …]` is the verb. An ENSURE there would seed
-  replacement state over the state the server rendered from.
+  used. **Its tree SCOPEs rather than ENSUREs, and the reason is SHAPE**:
+  `frame-root`'s ENSURE is commit-owned, so its first render emits no descendant
+  subtree, where an adopting root must render the server's element shape on its
+  first pass. `[h/frame-provider {:frame …} …]` renders its children immediately,
+  so the shapes agree. Neither hydration door creates the frame:
+  `re-frame.ssr/hydrate!` dispatches `:rf/hydrate` at a frame that must already
+  exist, so a boot makes the frame first, installs the payload second and adopts
+  the DOM third.
 
 ### `render!`
 

--- a/docs/core/hicasso/00-installation.md
+++ b/docs/core/hicasso/00-installation.md
@@ -241,7 +241,13 @@ build calls:
 
 (defn ^:dev/after-load rerender! []
   (when-some [root @!root]
-    (h/render! root [counter])))
+    ;; The WHOLE tree `mount!` was handed, boundary head included — the frame
+    ;; is spelled in the tree, so a reload that drops the head renders a root
+    ;; with no frame under it. Re-rendering the head is free: it ENSUREs, finds
+    ;; the frame live and reuses it.
+    (h/render! root [h/frame-root {:id             :rf/default
+                                   :initial-events [[:counter/initialise]]}
+                     [counter]])))
 
 (defn ^:export init []
   (rf/init! substrate/adapter)
@@ -302,10 +308,12 @@ substrate spells, so a boot written here reads like a Reagent or UIx one. The
 `[counter]` and `[counter {}]` are equivalent. The body receives an empty props
 map in either case.
 
-Keep the returned handle for later renders and teardown:
+Keep the returned handle for later renders and teardown. `h/render!` takes the
+whole tree, boundary head and all — the frame lives in the tree now, so a
+re-render that drops the head renders a root with no frame under it:
 
 ```clojure
-(h/render! root [counter])
+(h/render! root [h/frame-root {:id :rf/default} [counter]])
 (h/unmount! root)
 ```
 

--- a/docs/core/hicasso/18-ssr-and-hydration.md
+++ b/docs/core/hicasso/18-ssr-and-hydration.md
@@ -154,10 +154,14 @@ The three calls have different jobs:
 - `rf/make-frame` creates the frame. Neither hydration step does it for you:
   `ssr/hydrate!` seeds a frame that already exists, and the tree
   `h/hydrate!` adopts SCOPEs that frame with `h/frame-provider` rather than
-  ensuring it. **`h/frame-root` is the wrong verb here** — its ENSURE runs at
-  commit, after the payload, and would seed replacement state over the state the
-  server rendered from. That is the whole reason the two verbs are two
-  components.
+  ensuring it. **`h/frame-root` is the wrong verb here, and the reason is
+  SHAPE** — its ENSURE is commit-owned, so its first render emits no descendant
+  subtree and the children arrive on a second pass. An adopting root must render
+  the server's element shape on its FIRST pass, `useId` positions included, so a
+  `frame-root` would hand React an empty tree where the server's markup is.
+  (It would not *overwrite* the payload: re-ensuring a live frame preserves
+  app-db and never replays `:initial-events`. The mismatch is the failure.)
+  That is the whole reason the two verbs are two components.
 - `ssr/hydrate!` applies the state payload through `:rf/hydrate`. It validates
   the wire frame id against the requested frame. A mismatch raises
   `:rf.error/hydration-frame-id-mismatch`; omitting `:frame` raises

--- a/docs/core/hicasso/api-reference.md
+++ b/docs/core/hicasso/api-reference.md
@@ -145,7 +145,7 @@ Two heads, one verb each — the pair every re-frame2 view substrate spells
 
 | Head | Verb | Contract |
 | --- | --- | --- |
-| `[h/frame-root {:id :f …} child …]` | **ENSURE** | Creates the frame if absent and REUSES the live one as it stands — no re-seed, no config refresh. Takes the **whole** `rf/make-frame` option map: `:initial-events`, `:images`, `:url-bound?`, `:fx-overrides`, `:preset`, every record-config key. `:id` is required and must be a keyword. Unmounting destroys nothing |
+| `[h/frame-root {:id :f …} child …]` | **ENSURE** | Creates the frame if absent and REUSES it if present: durable state (app-db, sub-cache, queue) survives and `:initial-events` are re-recorded but never replayed. A re-acquire is `rf/make-frame`'s idempotent replacement, so the record CONFIG does refresh — pass the creator's opts to join without changing anything. Takes the **whole** `rf/make-frame` option map: `:initial-events`, `:images`, `:url-bound?`, `:fx-overrides`, `:preset`, every record-config key. `:id` is required and must be a keyword. Unmounting destroys nothing |
 | `[h/frame-provider {:frame :f} child …]` | **SCOPE** | Provides an ALREADY-LIVE frame to the subtree, and creates, refreshes and destroys nothing. `:frame` takes a frame-id keyword or the live frame value `rf/make-frame` returns. An absent frame is `:rf.error/frame-provider-frame-absent` rather than a subtree scoped to nothing |
 
 Each refuses the other's key by name: `:frame` on a `frame-root` is
@@ -164,19 +164,29 @@ seeded markup on the page.
 
 ### Which verb an adopting root takes
 
-**A hydrating root SCOPEs.** Its frame already exists: `re-frame.ssr/hydrate!`
-installed the server's app-db one line earlier, and an ENSURE there would seed
-replacement state over the state the server rendered from. So state arrives
-first, through a different door, and the DOM is adopted second:
+**A hydrating root SCOPEs, and the reason is SHAPE rather than state.**
+`frame-root`'s ENSURE is commit-owned, so its first render emits no descendant
+subtree and the children arrive on a second pass. An adopting root has to render
+the server's element shape on its FIRST pass — that is what `hydrateRoot`
+matches against, `useId` positions included — so a `frame-root` here would hand
+React an empty tree where the server's markup is. `frame-provider` renders its
+children immediately, so the shapes agree.
+
+**Neither hydration door creates the frame.** `ssr/hydrate!` DISPATCHES
+`:rf/hydrate` at a frame that must already exist, so the frame is made first,
+the payload installed second, the DOM adopted third:
 
 ```clojure
-(ssr/hydrate! {:frame :app/main})                     ;; 1. state
-(h/hydrate! node {}                                   ;; 2. DOM
+(rf/make-frame {:id :app/main})                       ;; 1. frame
+(ssr/hydrate! {:frame :app/main})                     ;; 2. state
+(h/hydrate! node {}                                   ;; 3. DOM
   [h/frame-provider {:frame :app/main} [views/page {}]])
 ```
 
-Getting that order wrong is caught rather than silent: `frame-provider` fails
-loud on a frame that is not live.
+A boot that never made the frame is caught rather than silent: the `:rf/hydrate`
+dispatch into an absent frame is a no-op, and `frame-provider` then fails loud
+on it. What that does NOT catch is a frame that is live but never hydrated —
+liveness is the whole of the check, and an unhydrated frame passes it.
 
 **A hydrating root needs the same `:identifier-prefix` its server render used.**
 React numbers `useId` per root and prefixes it with this option, so a hydrating

--- a/docs/core/hicasso/cookbook.md
+++ b/docs/core/hicasso/cookbook.md
@@ -28,10 +28,12 @@ Everything below assumes a mounted root, so start here.
 (defonce !root (atom nil))
 
 (defn ^:dev/after-load reload!
-  "Re-render the mounted root after a hot reload."
+  "Re-render the mounted root after a hot reload — the WHOLE tree `mount!` was
+   handed, boundary head included."
   []
   (when-some [root @!root]
-    (h/render! root [views/app {}])))
+    (h/render! root
+      [h/frame-root {:id :app/main} [views/app {}]])))
 
 (defn ^:export -main []
   (rf/init! uix-adapter/adapter)
@@ -553,13 +555,15 @@ the DOM:
 
 ```clojure
 (ns my.app
-  (:require [re-frame.ssr :as ssr]
+  (:require [re-frame.core :as rf]
+            [re-frame.ssr :as ssr]
             [re-frame.hicasso :as h]
             [my.app.views :as views]))
 
 (defn ^:export -main []
-  (ssr/hydrate! {:frame :app/main})                    ;; 1. state
-  (h/hydrate! (js/document.getElementById "app")       ;; 2. DOM
+  (rf/make-frame {:id :app/main})                      ;; 1. frame
+  (ssr/hydrate! {:frame :app/main})                    ;; 2. state
+  (h/hydrate! (js/document.getElementById "app")       ;; 3. DOM
               {:identifier-prefix "main"}
               [h/frame-provider {:frame :app/main}
                [views/page {}]])
@@ -567,11 +571,12 @@ the DOM:
 ```
 
 **State comes first, and it is a different door.** `h/hydrate!` adopts DOM and
-nothing else, and its tree SCOPEs rather than ENSUREs: an adopting root takes its
-state from the server payload, and an `h/frame-root` here would seed replacement
-state over exactly what the server rendered from. `h/frame-provider` refuses a
-frame that is not live, so getting the two lines the wrong way round is caught
-rather than silent.
+nothing else, and its tree SCOPEs rather than ENSUREs — because `frame-root`'s
+ENSURE is commit-owned, so its first render emits no descendant subtree, where an
+adopting root must render the server's element shape on its first pass.
+`h/frame-provider` refuses a frame that is not live, so a boot that never called
+`rf/make-frame` is caught rather than silent; a frame that is live but never
+hydrated passes, because liveness is the whole of the check.
 
 **Hand both sides the same `:identifier-prefix`.** React numbers `useId` per root
 and prefixes it with this option, so a hydrating root given a different prefix —

--- a/docs/core/hicasso/glossary.md
+++ b/docs/core/hicasso/glossary.md
@@ -756,14 +756,17 @@ Related: [Installation](00-installation.md).
 <a id="hydrate"></a>
 ### `hydrate!`
 
-Two functions complete hydration:
+Two functions complete hydration, and neither creates the frame:
 
-- `re-frame.ssr/hydrate!` installs the server payload into the client frame;
+- `re-frame.ssr/hydrate!` installs the server payload into a client frame that
+  must already exist (`rf/make-frame` made it);
 - `h/hydrate!` adopts existing server DOM for one Hicasso root, under an
   `[h/frame-provider {:frame …}]` that SCOPEs the frame the payload landed in.
 
-State hydration must run before DOM adoption — and `frame-provider` fails loud
-when it has not, rather than scoping a subtree to a frame that is not there.
+State hydration must run before DOM adoption. `frame-provider` catches the boot
+that never made the frame at all — it refuses an ABSENT frame rather than scoping
+a subtree to nothing. It does not detect a frame that is live but never
+hydrated: liveness is the whole of the check.
 
 Related: [SSR and hydration](18-ssr-and-hydration.md).
 

--- a/examples/substrates/hicasso/login/README.md
+++ b/examples/substrates/hicasso/login/README.md
@@ -103,8 +103,9 @@ ignoring it.
 detour.** `rf.ssr/hydrate!` dispatches the server's payload INTO a frame; it
 does not make one. So an adopting boot makes the frame with its config, installs
 the payload, and then SCOPEs it with `[h/frame-provider {:frame …}]` — state
-first, DOM second. An `h/frame-root` there would ensure at commit, after the
-payload, and seed replacement state over exactly what the server rendered from.
+first, DOM second. An `h/frame-root` there would be the wrong shape: its ENSURE
+is commit-owned, so its first render emits no descendant subtree, where an
+adopting root must render the server's element shape on its first pass.
 
 Hot reload re-renders that one retained root (`h/render!`) rather than building
 a second one — calling `h/mount!` again would `createRoot` twice and discard

--- a/examples/substrates/hicasso/login/core.cljs
+++ b/examples/substrates/hicasso/login/core.cljs
@@ -308,9 +308,11 @@
         ;; one, and the frame it dispatches into needs `:fx-overrides` already
         ;; installed. So the frame is made, the payload replaces its app-db,
         ;; and the tree SCOPEs the result. An ENSURE in the tree here would
-        ;; run at COMMIT — after the payload, and seeding replacement state
-        ;; over the state the server rendered from, which is exactly the
-        ;; mistake the frame-root / frame-provider split exists to name.
+        ;; be the wrong SHAPE: its first render emits no descendant subtree,
+        ;; where an adopting root has to render the server's element shape on
+        ;; its first pass — which is exactly the mistake the frame-root /
+        ;; frame-provider split exists to name. (It would not overwrite the
+        ;; payload; re-ensuring a live frame preserves app-db.)
         (do (rf/make-frame (merge {:id  frame-id
                                    :doc "Login (Hicasso) demo frame."}
                                   model/frame-config))

--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -571,11 +571,18 @@
   three-key config used to be.
 
   **ENSURE, not create.** Absent, the frame is created and
-  `:initial-events` run once; live, it is REUSED exactly as it stands —
-  no re-seed, no config refresh — so a second root under the same `:id`
-  JOINs rather than resets. Unmounting destroys NOTHING: a frame outlives
-  the boundary that ensured it, and `rf/destroy-frame!` is the verb for
-  ending one.
+  `:initial-events` run once; live, it is REUSED — so a second root under
+  the same `:id` JOINs rather than resets. What survives is the DURABLE
+  state: app-db, runtime-db, sub-cache and queue, and `:initial-events`
+  are re-recorded but NEVER replayed (spec/002 §`frame-root`
+  reuse-without-reseed; EP-0027). What the re-acquire DOES refresh is the
+  record config, because the ENSURE is a second `rf/make-frame` under the
+  same id and that is `make-frame`'s ruled idempotent-replacement path —
+  the Clojure re-def model, where re-declaring an id refreshes its config
+  while its state survives. So a joining boundary that passes DIFFERENT
+  opts installs them; pass the creator's opts to join without changing
+  anything. Unmounting destroys NOTHING: a frame outlives the boundary
+  that ensured it, and `rf/destroy-frame!` is the verb for ending one.
 
   **The ENSURE is commit-owned.** The first render emits no subtree at
   all, and the frame is made in a `useLayoutEffect` — so a render React
@@ -603,11 +610,13 @@
       (h/hydrate! node {:identifier-prefix \"main\"}
         [h/frame-provider {:frame :app/main} [views/page {}]])
 
-  Three places want it. **After SSR**, where `rf.ssr/hydrate!` has
-  already installed the server's app-db and an ENSURE would seed
-  replacement state over it. **A second root on the page** sharing a
-  frame the first ensured. **A subtree on another frame** — a tenant
-  switcher, a preview pane — nested under the root's own boundary.
+  Three places want it. **After SSR**, where the frame was made before
+  the payload was installed and an adopting root must render the server's
+  element shape on its FIRST pass — which is the reason SCOPE is the verb
+  there, and it is a shape argument rather than a state one: see
+  `h/hydrate!`. **A second root on the page** sharing a frame the first
+  ensured. **A subtree on another frame** — a tenant switcher, a preview
+  pane — nested under the root's own boundary.
 
   `:frame` is required and takes the one frame-target grammar `dispatch`
   and `subscribe` teach: a frame-id keyword, or the live frame value
@@ -708,23 +717,35 @@
   refusals, and its roster). Returns the handle `render!` and `unmount!`
   take, unchanged.
 
-  **The tree SCOPEs rather than ENSUREs, and that is the SSR seam made
-  visible.** An adopting root's frame already exists: `rf.ssr/hydrate!`
-  made it from the server's payload one line earlier, so
-  `[h/frame-provider {:frame …} …]` is the verb, and an
-  `[h/frame-root {:id …} …]` there would be the mistake this split exists
-  to name — a boundary that seeds replacement state over the state just
-  adopted. `frame-provider` fails loud when the frame is absent, so
-  hydrating before installing the payload is caught rather than silently
-  scoping nothing.
+  **The tree SCOPEs rather than ENSUREs, and the reason is SHAPE, not
+  state.** `frame-root`'s ENSURE is commit-owned, so its FIRST render
+  emits no descendant subtree at all and the children arrive on a second
+  pass. An adopting root has to render the server's element shape on its
+  first pass — that is what `hydrateRoot` is matching against, `useId`
+  positions included — so an `[h/frame-root {:id …} …]` here hands React
+  an empty tree where the server's markup is, which is the mistake this
+  split exists to name. `[h/frame-provider {:frame …} …]` renders its
+  children immediately, so the shapes agree.
+
+  **The frame is NOT made by either hydration step.** `rf.ssr/hydrate!`
+  DISPATCHES `:rf/hydrate` at a frame that must already exist, so a boot
+  makes the frame first (`rf/make-frame`), installs the payload second,
+  adopts the DOM third. `frame-provider` refuses an ABSENT frame
+  (`:rf.error/frame-provider-frame-absent`), which catches a boot that
+  never made one — a dispatch into an absent frame is itself a silent
+  no-op, so this is the step that reports it. It does NOT detect a frame
+  that is live but never hydrated: liveness is the whole of the check,
+  and an unhydrated frame passes it.
 
   **State comes first, and it is a different door.** This adopts DOM;
   `re-frame.ssr/hydrate!` installs the server's app-db through
   `:rf/hydrate` and must run BEFORE this, so the first client render
-  sees the state the server rendered from:
+  sees the state the server rendered from. Three calls, three jobs, and
+  the frame step is its own — neither hydration door creates it:
 
-      (ssr/hydrate! {:frame :app/main})                      ;; 1. state
-      (h/hydrate! node {}                                    ;; 2. DOM
+      (rf/make-frame {:id :app/main})                        ;; 1. frame
+      (ssr/hydrate! {:frame :app/main})                      ;; 2. state
+      (h/hydrate! node {}                                    ;; 3. DOM
         [h/frame-provider {:frame :app/main} [views/page {}]])
 
   **Hand `:identifier-prefix` the same string the server render used.**
@@ -768,7 +789,16 @@
   answer its handle — **the hot-reload door**:
 
       (defn ^:dev/after-load reload! []
-        (h/render! @!root [app {}]))
+        (h/render! @!root
+          [h/frame-root {:id :app/main} [app {}]]))
+
+  **Re-render the WHOLE tree the root was mounted with, boundary head
+  included.** The frame is spelled in the tree, so a reload that drops
+  the head renders a root with no frame under it and every bare
+  `dispatch` / `subscribe` beneath it loses the frame it resolved
+  against. Hand `render!` what `mount!` was handed; only the view code
+  inside it has changed. Re-rendering the head is free — `frame-root`
+  ENSUREs, so it finds the frame live and reuses it.
 
   React reconciles the new tree against the one on the page, so the
   reloaded view code meets its own DOM. Calling `mount!` again would

--- a/implementation/hicasso/test/re_frame/hicasso/frame_boundary_heads_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/frame_boundary_heads_dom_cljs_test.cljs
@@ -203,23 +203,44 @@
           (rf.hicasso.impl.collector/reset-runtime!))))))
 
 ;; ---------------------------------------------------------------------------
-;; W3 — a SECOND boundary under the same :id JOINs: no re-seed, no refresh
+;; W3 — a SECOND boundary under the same :id JOINs: DURABLE STATE survives,
+;;      `:initial-events` are not replayed, and the record CONFIG refreshes
 ;; ---------------------------------------------------------------------------
+;;
+;; The two halves of this row point in opposite directions, and that is the
+;; contract rather than a wrinkle. `frame-root`'s ENSURE is a second
+;; `rf/make-frame` under the same id, which is spec/002 §`frame-root`'s
+;; reuse-without-reseed on the state side (app-db, sub-cache, queue survive;
+;; `:initial-events` are re-recorded, never replayed) and `make-frame`'s ruled
+;; IDEMPOTENT REPLACEMENT on the config side — the Clojure re-def model, where
+;; re-declaring an id refreshes its config while its state survives.
+;;
+;; The second `testing` block below is the one that had no witness: the facade
+;; docstring once promised "no config refresh", which the shared lifecycle does
+;; not do and this file could not see, because a state-only reading is green
+;; either way. `:fx-overrides` is the instrument, because a live effect handler
+;; is config that ANNOUNCES which incarnation is installed.
 
 (deftest a-second-frame-root-under-one-id-joins-without-re-seeding
   (if-not (rf.hicasso.impl.mount/browser?)
     (skip! ":node-test has no DOM")
     (let [_ (bare!)
+          _ (reset! !fx-seen nil)
           a (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!) {}
               [rf.hicasso/frame-root
-               {:id ensured :initial-events [[::seed "creator"]]}
+               {:id             ensured
+                :initial-events [[::seed "creator"]]
+                :fx-overrides   {::stamp-fx (fn [_ _] (reset! !fx-seen :creator))}}
                [panel {:tag "a"}]])
           ;; The joining boundary names its own `:initial-events`, and they must
           ;; be IGNORED. A head that replayed would leave "joiner" on both
           ;; screens, and this row is the only thing on the page to notice.
+          ;; Its `:fx-overrides` is the opposite case: config, which DOES take.
           b (rf.hicasso/mount! (rf.hicasso.impl.mount/fresh-container!) {}
               [rf.hicasso/frame-root
-               {:id ensured :initial-events [[::seed "joiner"]]}
+               {:id             ensured
+                :initial-events [[::seed "joiner"]]
+                :fx-overrides   {::stamp-fx (fn [_ _] (reset! !fx-seen :joiner))}}
                [panel {:tag "b"}]])]
       (try
         (testing "the joining boundary did not re-seed — the creator's state
@@ -231,6 +252,19 @@
           (rf.hicasso.impl.mount/dispatch! ensured [::relabel "shared"])
           (is (= ["shared" "shared"] [(text-at a ".label") (text-at b ".label")])
               "the two roots did not join one frame"))
+
+        (testing "but the record CONFIG did refresh — the joiner's
+                  `:fx-overrides` is the live one. This is `make-frame`'s
+                  idempotent replacement, not a defect: JOIN with the creator's
+                  opts to change nothing"
+          (reset! !fx-seen nil)
+          (rf.hicasso.impl.mount/dispatch! ensured [::stamp-via-fx])
+          (is (= :joiner @!fx-seen)
+              (str "the joining head's `:fx-overrides` did not install: the "
+                   "effect ran " (pr-str @!fx-seen) ". A `:creator` reading "
+                   "here would mean the shared ENSURE had stopped refreshing "
+                   "config, which is a CONTRACT CHANGE across every substrate "
+                   "riding `frame-root-fc` — not a Hicasso-local fix")))
         (finally
           (rf.hicasso/unmount! a) (rf.hicasso/unmount! b)
           (detach! a) (detach! b)

--- a/skills/reagent-migration/evals/evals.json
+++ b/skills/reagent-migration/evals/evals.json
@@ -136,11 +136,11 @@
     {"id": 25, "kind": "behavioural", "tier": "M", "name": "m-root-mount-ensures-frame",
      "prompt": "Migrate the boot for this app to Hicasso:\n(ns app.core (:require [reagent.dom :as rdom] [re-frame.core :as rf] [re-frame.adapter.reagent :as ra]))\n(defn init! []\n  (rf/init! ra/adapter)\n  (rf/dispatch-sync [:app/init])\n  (rdom/render [app] (js/document.getElementById \"root\")))",
      "expectations": [
-       "Collapses the boot into ONE mount: (h/mount! el {:frame ::frame :initial-events [[:app/init]]} [app {}]) — the dispatch-sync seed becomes :initial-events, because mounting ENSURES the frame and seeds it before the first paint.",
-       "States h/mount! takes a CONFIG MAP — (container config hiccup) — carrying :frame, optional :initial-events, and optional :identifier-prefix.",
+       "Collapses the boot into ONE mount with the frame spelled IN THE TREE: (h/mount! el {} [h/frame-root {:id ::frame :initial-events [[:app/init]]} [app {}]]) — the dispatch-sync seed becomes :initial-events on the frame-root head, because that head ENSURES the frame and the seed is on the page when the door returns.",
+       "States h/mount! takes a CONFIG MAP — (container config hiccup) — carrying ROOT options only, :identifier-prefix being the whole roster. Handing it :frame or :initial-events is :rf.error/hicasso-frame-config-misplaced and any other key is :rf.error/hicasso-unknown-root-option; it does not silently ignore them.",
        "KEEPS (rf/init! ra/adapter): frame construction raises :rf.error/no-adapter-installed until a reactive adapter is installed, nothing installs one for you (there is no default-adapter registry), and a Reagent adapter under a Hicasso tree keeps working exactly as it did. Does not delete it as Reagent scaffolding.",
-       "Adds the defonce root atom and a ^:dev/after-load hook calling (h/render! @!root [app {}]), and explains that calling h/mount! again would createRoot a second time and replace the tree, discarding every node and scrap of component state.",
-       "An explicit (rf/make-frame {:id ::frame :initial-events [[:app/init]]}) BEFORE the mount is also acceptable — the mount then joins the live frame without re-seeding — but it must not be presented as REQUIRED, and the mount must not be shown as positional."
+       "Adds the defonce root atom and a ^:dev/after-load hook that re-renders the WHOLE tree, boundary head included — (h/render! @!root [h/frame-root {:id ::frame} [app {}]]) — and explains that calling h/mount! again would createRoot a second time and replace the tree, discarding every node and scrap of component state. A reload that drops the head renders a root with no frame under it.",
+       "An explicit (rf/make-frame {:id ::frame :initial-events [[:app/init]]}) BEFORE the mount is also acceptable — the tree then SCOPEs it with [h/frame-provider {:frame ::frame} …] rather than ensuring it — but it must not be presented as REQUIRED, and the mount must not be shown as positional."
      ]},
 
     {"id": 26, "kind": "behavioural", "tier": "M", "name": "m-keystroke-handler-becomes-key-map",

--- a/skills/reagent-migration/references/catalog-mechanical.md
+++ b/skills/reagent-migration/references/catalog-mechanical.md
@@ -296,7 +296,8 @@ an author-written one. Pass children positionally.
                    [app {}]])))
 
 (defn ^:dev/after-load reload! []
-  (h/render! @!root [app {}]))
+  (h/render! @!root
+    [h/frame-root {:id ::frame} [app {}]]))
 ```
 
 Four things matter, and the first two are the ones a migration gets wrong:
@@ -326,8 +327,12 @@ Four things matter, and the first two are the ones a migration gets wrong:
   installs it nor displaces what the app has. *"Stays" is about a migration in
   progress. If the app ends with no Reagent view at all, the choice reopens and
   the author gets told — MIG-24 §When no Reagent view remains.*
-- **`h/render!` is the hot-reload door.** It re-renders the root React already
-  has, so the reloaded view code meets its own DOM. Calling `h/mount!` again
+- **`h/render!` is the hot-reload door, and it takes the WHOLE tree — boundary
+  head included.** It re-renders the root React already has, so the reloaded
+  view code meets its own DOM. The frame lives in the tree now, so a reload that
+  drops the head renders a root with no frame under it and every bare `h/sub` /
+  `h/dispatch` beneath loses what it resolved against; re-rendering the head is
+  free, because it ENSUREs and finds the frame live. Calling `h/mount!` again
   would `createRoot` a second time and replace the tree, discarding every node
   and scrap of component state.
 - **`h/unmount!` is `mount!`'s inverse** and is idempotent. It leaves sibling

--- a/skills/reagent-migration/references/catalog-reject.md
+++ b/skills/reagent-migration/references/catalog-reject.md
@@ -55,9 +55,13 @@ rather than an ergonomics gap. Two honest routes before you hold:
 - The read is **non-reactive** (a one-shot in a callback) → that is a
   `re-frame.core` verb taking a frame option, not a view one. Check the core
   facade for what the project's version exports rather than assuming a spelling.
-- The subtree genuinely belongs to another frame → it is another **root**. Make
-  that frame and mount it with `h/mount!` in its own container, under an
-  `[h/frame-provider {:frame …}]` naming it.
+- The subtree genuinely belongs to another frame → **nest a boundary on it**.
+  Make that frame, then wrap the subtree in an `[h/frame-provider {:frame …}]`
+  naming it, in place, inside the tree you already have — every bare `h/sub` and
+  `h/dispatch` beneath it resolves against that frame instead. A second root in
+  its own container is still available and is the right answer when the subtree
+  is genuinely a separate mount (a portal into foreign DOM, a detached preview),
+  but it is no longer required merely to read another frame.
 
 If neither fits — a cell inside one tree that must reactively read a sibling
 frame — hold the view.


### PR DESCRIPTION
Closes the prose/contract residuals the merged-PR audit of #9375 reopened `rf2-kuky.58` for. **No public name is added and no manifest row moves** — this touches neither `spec/API.md` nor either `api-manifest*.edn` sidecar, so it does not contend for the manifest lane.

## What the bead's three title clauses already held

Measured at source on `main` before editing anything; all three were delivered by #9375 and none needed work:

1. **`h/frame-root` takes the full `make-frame` opts** — `hicasso.cljc` aliases `rf.hicasso.impl.frame-boundary/frame-root`; core's `frame-root-opts` `dissoc`s only the two substrate carriers (`:children`, `:fallback`) and passes every other key through to `make-frame`.
2. **`h/frame-provider` exists as specified** — a NEW public authoring head, distinct from the private `substrate/frame-provider` contract slot, which correctly stays private.
3. **Mount config fails loud** — `require-root-options!` refuses `:frame` / `:initial-events` with `:rf.error/hicasso-frame-config-misplaced` and any other key with `:rf.error/hicasso-unknown-root-option`.

## The four residuals, and what landed for each

**1. "Reuse without config refresh" was not what the shared ENSURE does.** `h/frame-root`'s docstring promised *no re-seed, no config refresh*, but its path is `frame-root-fc`'s layout effect (`#js []` deps) → `acquire-frame-root!` → `make-frame` **unconditionally** → `upsert-frame!`, which takes the idempotent-replacement branch and refreshes record config. `spec/002-Frames.md` rules the contract as **reuse-without-reseed** — durable state survives, `:initial-events` re-recorded but never replayed — and says nothing about config; `frame.cljc` states the refresh in terms ("re-declaring the same id refreshes config while durable state survives").

Taken the audit's **contract-reconciliation** branch rather than its no-refresh branch, deliberately: suppressing the refresh for Hicasso alone would fork the two-pass this bead forbids forking, and changing it in core would silently move `rf/frame-root` and the UIx head too. That is a cross-substrate ruling, not a Hicasso docstring fix.

`impl.mount/ensure-frame!` keeps its own "no config refresh" wording and is **correct** — it guards on `frame-incarnation-token` and skips `make-frame` when live. That is the private positional path, not the facade's. The two are no longer described in the same words.

**2. The hydration guidance made two false causal claims.**
- *"`rf.ssr/hydrate!` made the frame from the payload one line earlier"* — it does not. It `dispatch-sync`s `[:rf/hydrate payload]` **at a frame that must already exist**. Samples that showed two steps now show three, with `rf/make-frame` first.
- *"An ENSURE after a payload would seed replacement state over it"* — it would not; re-ensuring a live frame preserves app-db and does not replay `:initial-events`.

The real reason a hydrating root SCOPEs is **shape**: `frame-root`'s first render emits no descendant subtree, where an adopting root must render the server's element shape on its first pass (`useId` positions included). `frame-provider`'s guardrail is now stated to its actual reach — it refuses an **absent** frame, and does **not** detect a frame that is live but never hydrated.

**3. `render!` dropped the boundary head in every public example.** #9375 measured that omission breaking HMR and repaired nine callers, but the teaching surface still showed the head-less form: the facade docstring, `00-installation.md` (×2), `cookbook.md`, `catalog-mechanical.md`, and eval 25. Eval 25 was worse than stale — it asserted the **retired root-door config**, which now throws. `catalog-reject.md`'s "another frame means another root" is likewise overtaken by the nested `frame-provider` affordance `spec/006-ReactiveSubstrate.md` records.

**4. The arm1 cold-mount before/after figure is NOT in this PR, and is not a gate.** It is the governed K1 evidence programme (`docs/design/hicasso/product/lanes/evidence-baseline.md`), whose rows are operator-adjudicated against a ratified ceiling — filing one is a governance act, not a worker gate run. This change moves **no runtime path**, so it has no before/after of its own; the comparison is owed against #9375's runtime change. Flagged rather than silently skipped.

## The witness that was missing

W3 (`a-second-frame-root-under-one-id-joins-without-re-seeding`) checked only non-reseeding and shared label updates, so it was green either way and could not see the config question at all. It now **observes the refresh** through a live `:fx-overrides` handler: creator installs one, joiner installs another, and the joiner's is the one that runs. Its failure message names what a `:creator` reading would mean — a contract change across every substrate riding `frame-root-fc`, not a Hicasso-local fix.

## A note on the bead's own acceptance criterion

`git grep -n 'ignored without complaint' docs spec returns nothing` still has one hit: `spec/009-Instrumentation.md`'s error-catalogue row for `:rf.error/hicasso-unknown-root-option`, which describes the retired contract **in past tense as the justification for the error id**. That is retirement bookkeeping and must stay. Ran the two-axis union `views-b` prescribed (`ignored without complaint` + `is closed at` / `every other key`): no *live* statement of the retired contract survives.

## Quality gates

Run from the worker worktree; each exit code read from the runner's own command line, never through a pipe.

| gate | exit | covers |
| --- | --- | --- |
| `npm run test:hicasso-invariants` | **0** | guide-sample verb check — 76 verbs at 419 sites across 29 pages resolve; covers every fenced block I edited under `docs/core/hicasso/` |
| `python scripts/check_doc_slugs.py` | **0** | link targets + heading anchors under `docs/`, `spec/`, `skills/` |
| `python -m mkdocs build --strict` | **0** | link resolution inside the built site (`mkdocs` is not on PATH here — exit 127; `python -m mkdocs` is the entry point) |
| `python scripts/check_readme_links.py --ci` | **0** | `examples/substrates/hicasso/login/README.md` — outside the docs gate's roots |
| paren-balance scan, 3 edited Clojure files | **0** | mechanical depth count |

**Gate-read-my-worktree proof.** `test:hicasso-invariants` prints no root, so it was proved by a planted fault: `h/frame-root` → `h/frame-rooot` in a `cookbook.md` fenced block returned **exit 1** naming `re-frame.hicasso/frame-rooot: named at cookbook.md block 1`. The fault existed only in this worktree, so a run that had wandered elsewhere would have come back green. Restore verified by **blob hash** against the committed object, not by the restore command's exit code: `c42ad5f5d613a9aa02260a39e5c59c3d669720df` before and after.

**Paren-scan control.** Its first control did **not** bite (exit 0 on a file I had deliberately broken) — the target line was a comment and the `)$` anchor could not match across the `\r` on these CRLF files. Rebuilt to strip a real closing paren: **exit 1**, naming the unclosed form at line 179. Only then were the three BALANCED readings trustworthy.

**`:node-test-hicasso` did not run, and is reported as no verdict rather than a pass.** The fresh worktree has no `node_modules`, so `compile-node-test.cjs` died with `Cannot find module 'shadow-cljs/cli/runner.js'`. My captured exit file read `EXIT=1` while the harness reported the same run as **exit code 0** — quoting the captured number. I did not junction the coordinator's `node_modules` to get past it (a recorded, twice-observed hazard) and did not iterate on a heavyweight lane locally.

**Left to CI**, per the narrowest-gate policy: `:node-test-hicasso`, `npm run test:browser` (which is what actually grades the new W3 assertion — it is a `-dom-cljs-test` and degrades to a stated skip without a DOM), `test:examples-compile`, and the lint matrix.

## Hand verification (no gate covers these)

- **Table column counts** — `api-reference.md`'s two-head table: 4 pipes / 3 columns across header, separator and both rows.
- **`evals.json` parses** — `json.load` OK.
- **Merge-base diff read for silent reverts** — `origin/main...HEAD` is additions to files I edited only. `main` moved during the session (`2b786f15c7` → `b5bf13726e`) with **zero overlap** on my paths: beads checkpoints plus `resources`/`http`, both fenced surfaces I stayed out of.
