### PR TITLE
test(views): witness the hook frame-resolution rule on the SCHEDULED path (rf2-kuky.62 audit)

### DIFF
--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_sub_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_sub_dom_cljs_test.cljs
@@ -548,6 +548,16 @@
 (deftest hook-no-provider-with-dynamic-scope-raises-no-frame-context
   (rf.adapter.react-shared-suite/assert-hook-no-provider-with-dynamic-scope-raises-no-frame-context cfg))
 
+;; The SCHEDULING half of the same rule (rf2-kuky.62, merged-PR audit of
+;; #9427). Every row above renders inside `act()`, which runs the body on
+;; the calling stack — the right harness for an adversarial precedence
+;; contest and the wrong one for "the same tree resolves the same frame
+;; under either scheduling mode". This row renders with the act
+;; environment OFF, so the body runs a host task later with the binding
+;; unwound.
+(deftest hook-scheduled-render-after-unwind-reads-context-only
+  (rf.adapter.react-shared-suite/assert-hook-scheduled-render-after-unwind-reads-context-only cfg))
+
 (deftest use-sub-cleanup-decrements-sub-cache-refcount
   (rf.adapter.react-shared-suite/assert-use-sub-cleanup-decrements-refcount cfg))
 

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -4211,6 +4211,17 @@
 ;; frame is deliberately bound live around the render, and in
 ;; `assert-hook-no-provider-with-dynamic-scope-raises-no-frame-context`,
 ;; where the binding IS the adversary.
+;;
+;; AND ONE ROW GOES THE OTHER WAY, because a `binding` cannot reach a
+;; SCHEDULED render at all.
+;; `assert-hook-scheduled-render-after-unwind-reads-context-only` renders
+;; outside `act` and so meets the body one host task later, with every
+;; `binding` unwound — which is the scheduling mode the ruling's design
+;; requirement is stated over and the one no row here could previously
+;; see. It therefore INSTALLS a persistent ambient frame (`set!` on the
+;; root var, the shape the async fixture itself uses) so there is still
+;; something for a dynamic tier to answer with; without one, that row
+;; would pass under either rule and witness nothing.
 ;; ===========================================================================
 
 (defn assert-use-sub-provider-tier-resolution-ambient-cleared
@@ -4446,15 +4457,22 @@
   RETURN is renderer-agnostic and covers both, but only a run under each
   says so.
 
-  Three parts:
+  Four parts, and the two SERVER legs are one hook each because the
+  refusal is raised per hook: `use-sub` and `use-frame` classify the same
+  `useContext` return through the same helper, but each raises under its
+  own `:op`, so a repair that reached only one of them would leave the
+  other answering the dynamically-bound frame on the server. (The
+  `use-frame` server leg was missing until the rf2-kuky.62 merged-PR
+  audit of #9427 noticed part 3 exercised the `use-sub` probe twice.)
 
     1. CLIENT — `use-sub`'s 1-arity, mounted with no provider inside a live
        `binding`. A `:rf.error/no-frame-context` trace fires and nothing is
        observed; in particular the dynamically-bound frame's value is not.
     2. CLIENT — the same for `use-frame`: the hook throws rather than
        handing back an ops bundle locked to the dynamic frame.
-    3. SERVER — `renderToString` with no provider inside the same live
-       binding throws `:rf.error/no-frame-context`.
+    3. SERVER — `renderToString` of the `use-sub` probe with no provider
+       inside the same live binding throws `:rf.error/no-frame-context`.
+    4. SERVER — the same for `use-frame`.
 
   The render throws out of the hook; React funnels that through `act()`, so
   each part tolerates the throw and asserts on the captured trace / the
@@ -4519,7 +4537,7 @@
                     "and handed back no ops bundle at all")
                 (finally
                   (try (.unmount root) (catch :default _ nil))))))
-          (testing "3. SERVER — the same refusal through react-dom/server"
+          (testing "3. SERVER — use-sub's refusal through react-dom/server"
             ;; The server renderer reads the SECONDARY context slot, so this
             ;; is a genuinely different read path, not a repeat of part 1.
             (reset! probe-frame-provider-observed [])
@@ -4529,12 +4547,263 @@
                                 nil
                                 (catch :default e e)))]
               (is (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))
-                  "with no boundary above it the ambient hook fails closed on the
-                   server too, live dynamic scope notwithstanding")
+                  (str "with no boundary above it the ambient hook fails closed on
+                        the server too, live dynamic scope notwithstanding. Saw "
+                       (pr-str (ex-data thrown))))
               (is (empty? @probe-frame-provider-observed)
                   "and nothing rendered")))
+          (testing "4. SERVER — use-frame's refusal through react-dom/server"
+            ;; The leg the merged-PR audit of #9427 found missing: part 3
+            ;; rendered the use-sub probe on both of its runs, so the server's
+            ;; SECONDARY slot had never been exercised through `use-frame` at
+            ;; all. The dynamic scope is live and names a REAL, SEEDED frame,
+            ;; so the only reason the hook can refuse is that it declined to
+            ;; consult the dynamic tier.
+            (reset! use-frame-observed [])
+            (let [thrown (binding [rf.frame/*current-frame* dyn-frame]
+                           (try (.renderToString react-dom-server
+                                  (probe-use-frame-element))
+                                nil
+                                (catch :default e e)))]
+              (is (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))
+                  (str "use-frame fails closed on the server renderer too, rather
+                        than handing back a bundle locked to the frame the live
+                        with-frame named. Saw " (pr-str (ex-data thrown))))
+              (is (empty? @use-frame-observed)
+                  "and handed back no ops bundle at all")))
           (finally
             (rf.trace.tooling/unregister-listener! lk))))))))
+
+(defn- root-swallowing-uncaught!
+  "A concurrent root whose UNCAUGHT render errors land in `sink` rather
+  than in the host's error reporter.
+
+  Every other refusal row here renders inside `act()`, which rethrows on
+  the calling stack — so a `try` around the render is enough and no root
+  option is needed. A SCHEDULED render has no such stack: the throw
+  surfaces on React's own task, where the page (and therefore the browser
+  runner) would see it as an unhandled error. React 19's `createRoot`
+  option is the supported interception point, and it is used for
+  containment only — the load-bearing signal stays the emitted
+  `:rf.error/no-frame-context` trace, exactly as in the act-driven rows."
+  [sink]
+  (react-dom-client/createRoot
+    (make-mount-node!)
+    #js {:onUncaughtError (fn [e _info] (when (nil? @sink) (reset! sink e)))}))
+
+(defn assert-hook-scheduled-render-after-unwind-reads-context-only
+  "rf2-kuky.62, merged-PR audit of #9427 — THE SCHEDULING WITNESS, and the
+  one shape the rest of this cluster cannot reach.
+
+  Every other row in this section renders inside `act()` — and Hicasso's
+  own rows inside `flushSync` — so the component body runs on the very
+  stack that scheduled it and a `with-frame` around the render really is
+  live while the body runs. That is the right harness for an ADVERSARIAL
+  row, because a dynamic tier can only ever win there. It is the wrong
+  harness for the other half of what rf2-kuky.61 ruled: *the same
+  component tree resolves the same frame under either scheduling mode — a
+  scheduled concurrent render and a synchronous act/flushSync/server
+  render must not disagree*. Until this row, the scheduled half had no
+  witness at all, and the audit said so.
+
+  THE SHAPE. `root.render` is called on a concurrent root with the act
+  environment OFF, so React schedules the work and returns; the body runs
+  on a later host task, by which time the `binding` around the render call
+  has unwound. Four legs, and the first is what makes the other three mean
+  anything:
+
+    1. THAT THE RENDER REALLY DID RUN LATE. Immediately after
+       `root.render` returns — still INSIDE the binding — the probe's
+       observation atom is EMPTY. The body had not run, so everything
+       observed afterwards was observed outside the bound extent. Without
+       this leg the row would be indistinguishable from a synchronous one
+       that happened to pass.
+    2. THE PROVIDER RESULT, on that schedule: `use-sub`'s 1-arity reads
+       the provider's frame, and `use-frame`'s bundle is locked to it.
+    3. THE NO-PROVIDER REFUSAL, on that schedule: the same render with no
+       provider above it raises `:rf.error/no-frame-context`, on both
+       hooks.
+
+  WHY THERE IS A PERSISTENT AMBIENT FRAME, and why it is `set!` and not
+  `binding`. A `binding` cannot survive the hop to a scheduled render —
+  that is the whole point of the row — so a row that used only one would
+  reach the body with NO dynamic frame at all, and legs 2 and 3 would pass
+  under a dynamic-var-FIRST implementation just as readily, saying
+  nothing. A real ambient scope on this schedule is the persistent kind,
+  which is exactly the shape `make-reset-runtime-fixture`'s own async form
+  uses (`set!` on the root var, because its `:before` returns long before
+  an async body resumes). So this row installs one, and it is the
+  adversary: a hook that consulted the dynamic tier would answer
+  `:from-ambient` in leg 2 and would not refuse at all in leg 3.
+
+  THREE FRAMES, so a failure says WHICH tier answered — the provider's
+  (`:from-provider`), the persistent ambient's (`:from-ambient`), and the
+  one the unwound `binding` named (`:from-dynamic`).
+
+  cfg keys:
+    :substrate-kw                   keyword fragment for minted ids
+    :frame-provider-mount-element   thunk (fn [frame-kw child-el])
+    :probe-frame-provider-element   thunk → 1-arg ProbeFrameProvider
+    :probe-frame-provider-observed  atom the probe pushes observed values into
+    :probe-use-frame-element        thunk → the ProbeUseFrame element
+    :use-frame-observed             atom the use-frame probe pushes into
+    :frame-provider-query           query-v keyword the probe subscribes to"
+  [{:keys [name substrate-kw frame-provider-mount-element probe-frame-provider-element
+           probe-frame-provider-observed probe-use-frame-element use-frame-observed
+           frame-provider-query]}]
+  (testing (str name " — a SCHEDULED render reads React context after the scope unwinds (rf2-kuky.62 audit)")
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises the assertion")
+      (async done
+        (let [provider-frame (mint-kw substrate-kw "scheduled-provider-frame")
+              ambient-frame  (mint-kw substrate-kw "scheduled-ambient-frame")
+              scope-frame    (mint-kw substrate-kw "scheduled-scope-frame")
+              bumped         (mint-kw substrate-kw "scheduled-bump")
+              lk             (keyword "re-frame.adapter.react-shared-suite"
+                                      (str "kuky62-scheduled-" (clojure.core/name substrate-kw)))
+              traces         (atom [])
+              no-frame?      (fn [] (some #(= :rf.error/no-frame-context (:operation %)) @traces))
+              act-env-was    (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)
+              ambient-was    rf.frame/*current-frame*
+              roots          (atom [])
+              new-root!      (fn [sink]
+                               (let [r (root-swallowing-uncaught! sink)]
+                                 (swap! roots conj r)
+                                 r))
+              ;; Budget in host macrotask turns. Generous, because the
+              ;; expiry is not silence — `await-settlement!` runs the
+              ;; continuation anyway, so a render that never arrived
+              ;; surfaces as a named failed assertion carrying what the
+              ;; probe did see, rather than as a runner timeout.
+              turns          360
+              finish!        (fn []
+                               (rf.trace.tooling/unregister-listener! lk)
+                               (run! (fn [r] (try (.unmount r) (catch :default _ nil))) @roots)
+                               (set! rf.frame/*current-frame* ambient-was)
+                               (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) act-env-was)
+                               (done))]
+          (rf.trace.tooling/register-listener! lk (fn [ev] (swap! traces conj ev)))
+          ;; No act, and no flushSync anywhere below: `root.render` must be
+          ;; free to SCHEDULE rather than to commit on this stack.
+          (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+          (rf/make-frame {:id provider-frame :doc "rf2-kuky.62 scheduled-render provider frame"})
+          (rf/make-frame {:id ambient-frame  :doc "rf2-kuky.62 scheduled-render persistent ambient frame"})
+          (rf/make-frame {:id scope-frame    :doc "rf2-kuky.62 scheduled-render with-frame scope frame"})
+          (rf/reg-event ::scheduled-seed (fn [_ [_ v]] {:db {:k v}}))
+          (rf/reg-event bumped (fn [{:keys [db]} _] {:db (assoc db :bumped true)}))
+          (rf/dispatch-sync [::scheduled-seed :from-provider] {:frame provider-frame})
+          (rf/dispatch-sync [::scheduled-seed :from-ambient]  {:frame ambient-frame})
+          (rf/dispatch-sync [::scheduled-seed :from-dynamic]  {:frame scope-frame})
+          (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
+          ;; THE ADVERSARY, installed only now — every `make-frame` above ran
+          ;; before it, so none of them saw a synthetic ambient scope.
+          (set! rf.frame/*current-frame* ambient-frame)
+          (letfn [(leg-4-use-frame-no-provider []
+                    (testing "4. NO PROVIDER, scheduled — use-frame refuses too"
+                      (reset! traces [])
+                      (reset! use-frame-observed [])
+                      (let [sink (atom nil)
+                            root (new-root! sink)]
+                        (binding [rf.frame/*current-frame* scope-frame]
+                          (.render root (probe-use-frame-element))
+                          (is (empty? @use-frame-observed)
+                              "scheduled, not committed: nothing ran inside the bound extent"))
+                        (await-settlement!
+                          (fn [] (or (some? @sink) (no-frame?)))
+                          (fn []
+                            (is (no-frame?)
+                                (str "use-frame refused on the scheduled render as well — "
+                                     "the ops bundle is not a second door onto the dynamic "
+                                     "tier. React surfaced " (pr-str (some-> @sink ex-data))))
+                            (is (empty? @use-frame-observed)
+                                "and handed back no ops bundle at all")
+                            (finish!))
+                          turns))))
+
+                  (leg-3-use-sub-no-provider []
+                    (testing "3. NO PROVIDER, scheduled — use-sub refuses although a real ambient frame is live"
+                      (reset! traces [])
+                      (reset! probe-frame-provider-observed [])
+                      (let [sink (atom nil)
+                            root (new-root! sink)]
+                        (binding [rf.frame/*current-frame* scope-frame]
+                          (.render root (probe-frame-provider-element))
+                          (is (empty? @probe-frame-provider-observed)
+                              "scheduled, not committed: nothing ran inside the bound extent"))
+                        (await-settlement!
+                          (fn [] (or (some? @sink) (no-frame?)))
+                          (fn []
+                            (is (no-frame?)
+                                (str "a :rf.error/no-frame-context trace fired on the SCHEDULED "
+                                     "render — absence of a provider is refused whatever the "
+                                     "dynamic tier says, and here it says " (pr-str ambient-frame)
+                                     ". React surfaced " (pr-str (some-> @sink ex-data))))
+                            (is (not (some #{:from-ambient} @probe-frame-provider-observed))
+                                "and the persistent ambient frame's value was NEVER read — this
+                                 is the leg a dynamic-var tier would pass by answering it")
+                            (is (empty? @probe-frame-provider-observed)
+                                "nothing was observed at all")
+                            (leg-4-use-frame-no-provider))
+                          turns))))
+
+                  (leg-2-use-frame-provider []
+                    (testing "2. PROVIDER present, scheduled — use-frame's bundle is the provider's"
+                      (reset! use-frame-observed [])
+                      (let [root (new-root! (atom nil))]
+                        (binding [rf.frame/*current-frame* scope-frame]
+                          (.render root (frame-provider-mount-element
+                                          provider-frame (probe-use-frame-element)))
+                          (is (empty? @use-frame-observed)
+                              "the body had NOT run when `render` returned inside the binding"))
+                        (await-settlement!
+                          (fn [] (seq @use-frame-observed))
+                          (fn []
+                            (let [ops (peek @use-frame-observed)]
+                              (is (= provider-frame (:frame ops))
+                                  (str "use-frame captured the PROVIDER's frame on a render that "
+                                       "ran after the scope unwound. Observed " (pr-str (:frame ops))))
+                              (when (some? ops)
+                                ((:dispatch-sync ops) [bumped])
+                                (is (true? (:bumped (rf/app-db-value provider-frame)))
+                                    "the dispatch obtained FROM use-frame moved the provider frame")
+                                (is (nil? (:bumped (rf/app-db-value ambient-frame)))
+                                    "and left the persistent ambient frame untouched")
+                                (is (nil? (:bumped (rf/app-db-value scope-frame)))
+                                    "and the frame the unwound with-frame named untouched")))
+                            (leg-3-use-sub-no-provider))
+                          turns))))
+
+                  (leg-1-use-sub-provider []
+                    (testing "1. PROVIDER present, scheduled — use-sub reads it after the scope unwinds"
+                      (reset! probe-frame-provider-observed [])
+                      (let [root (new-root! (atom nil))]
+                        (binding [rf.frame/*current-frame* scope-frame]
+                          (.render root (frame-provider-mount-element
+                                          provider-frame (probe-frame-provider-element)))
+                          ;; THE RECORDING. Nothing has been observed yet, so
+                          ;; every reading below was taken outside the extent
+                          ;; of the binding this line sits inside.
+                          (is (empty? @probe-frame-provider-observed)
+                              "the body had NOT run when `render` returned inside the binding —
+                               React scheduled it, so everything read below was read after the
+                               bound extent"))
+                        (is (= ambient-frame rf.frame/*current-frame*)
+                            "and the bound extent really has unwound: the dynamic tier now names
+                             the persistent ambient frame, not the one the binding named")
+                        (await-settlement!
+                          (fn [] (seq @probe-frame-provider-observed))
+                          (fn []
+                            (is (some #{:from-provider} @probe-frame-provider-observed)
+                                (str "the scheduled render resolved the PROVIDER's frame. Observed "
+                                     (pr-str @probe-frame-provider-observed)))
+                            (is (not (some #{:from-ambient} @probe-frame-provider-observed))
+                                "not the persistent ambient frame — which IS live while the body
+                                 runs, and is what a dynamic-var tier would have answered here")
+                            (is (not (some #{:from-dynamic} @probe-frame-provider-observed))
+                                "and not the frame the unwound binding named")
+                            (leg-2-use-frame-provider))
+                          turns))))]
+            (leg-1-use-sub-provider)))))))
 
 (defn assert-use-sub-cleanup-decrements-refcount
   "rf2-7g959: use-sub pairs subscribe with rf.subs/unsubscribe on

--- a/implementation/hicasso/test/re_frame/hicasso/hooks_island_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hooks_island_dom_cljs_test.cljs
@@ -838,7 +838,13 @@
                         own concurrent root actually uses"
                 (is (= #{kb} (rf.hicasso.roots-frames-support/cell-keys)))
                 (is (= 1 (count (readers-of kb))))
-                (is (empty? (readers-of ka))
+                ;; Counted rather than `empty?`, unlike W5c's identical
+                ;; claim: a reader is a React registration object, and on
+                ;; FAILURE `cljs.test` prints the actual value — which blows
+                ;; the stack on that object's cycles and turns a legible
+                ;; failure into a RangeError. (Measured on the sabotage run
+                ;; that proved this row bites.)
+                (is (zero? (count (readers-of ka)))
                     "alpha has no reader at all, although it is the frame the
                      persistent ambient scope names")
                 (is (= "beta-price"

--- a/implementation/hicasso/test/re_frame/hicasso/hooks_island_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hooks_island_dom_cljs_test.cljs
@@ -72,7 +72,11 @@
             [re-frame.hicasso.tool :as rf.hicasso.tool]
             [re-frame.test-support :as rf.test-support]
             [uix.core :as uix :refer-macros [defui]]
-            ["react" :as react]))
+            ["react" :as react]
+            ;; W5d mounts a root of its own, because every published door
+            ;; here commits inside `flushSync` and the row's whole subject
+            ;; is the SCHEDULED commit those doors deliberately do not take.
+            ["react-dom/client" :as react-dom-client]))
 
 (def ^:private alpha ::alpha)
 (def ^:private beta  ::beta)
@@ -106,6 +110,7 @@
     :hooks/frame-isolation
     :hooks/frame-isolation-uix
     :hooks/context-only-resolution
+    :hooks/scheduled-resolution
     :hooks/two-cells
     :hooks/incarnation
     :hooks/transition})
@@ -734,6 +739,179 @@
       (-> (dynamic-scope-row! host :hooks/context-only-resolution)
           (.catch (report-failure! "W5c hook frame resolution is context-only"))
           (.then (fn [_] (release-minted!) (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; W5d. The same rule on the SCHEDULED path — the mode no other row can see
+;; ---------------------------------------------------------------------------
+;;
+;; W5c above and the node lane's `with-frame` row both render the island on
+;; the calling stack — `flushSync` there, `renderToStaticMarkup` here — which
+;; is the only shape in which a dynamic-var tier could ever WIN, and so the
+;; right harness for an adversarial precedence contest. It is the wrong
+;; harness for the other half of what rf2-kuky.61 ruled: *the same component
+;; tree resolves the same frame under either scheduling mode*. The merged-PR
+;; audit of #9427 found that half unwitnessed on both hook families.
+;;
+;; This row is it, for the NATIVE pair. The island is mounted on a plain
+;; concurrent root with the act environment off, so `render` SCHEDULES and
+;; returns; the body runs a host task later, by which time the `with-frame`
+;; around the mount has unwound. `!island-runs` is the recording: it is still
+;; zero on the line after `render` returns, inside the scope, and positive
+;; once the row has waited — so everything read afterwards was read outside
+;; the bound extent.
+;;
+;; WHY THE ROW INSTALLS A PERSISTENT AMBIENT FRAME. A `with-frame` cannot
+;; reach a scheduled body at all — that is the point — so on its own it
+;; leaves the body with NO dynamic frame, and both legs below would pass
+;; under a dynamic-var-first rule just as readily. A real ambient scope on
+;; this schedule is the persistent kind (`set!` on the root var, which is
+;; precisely what `make-reset-runtime-fixture`'s async form does, for the
+;; same reason: its `:before` returns long before an async body resumes).
+;; So the row installs one naming `alpha`, and it is the adversary — a hook
+;; that consulted the dynamic tier would key its cell to alpha in leg 1 and
+;; would not refuse at all in leg 2.
+
+(defn- scheduled-root!
+  "A concurrent root whose UNCAUGHT render errors land in `sink`.
+
+  Leg 2's island throws out of its own hook, and a SCHEDULED render has no
+  caller's stack to throw on: React surfaces it on its own task, where the
+  page — and so the browser runner — would see an unhandled error. React
+  19's `createRoot` option is the supported interception point, and here it
+  is also the READING, because `impl/error/fail!` throws rather than
+  emitting, so there is no listener axis to read the refusal off."
+  [container sink]
+  (react-dom-client/createRoot
+    container
+    #js {:onUncaughtError (fn [e _info] (when (nil? @sink) (reset! sink e)))}))
+
+(defn- scheduled-resolution-row!
+  "Both legs, on one persistent ambient scope. `roots` and `containers`
+  collect what the row mints so the single trailing step can tear it down
+  on either arm — this row mints its own roots, so `release-minted!` (which
+  knows only about `mount-live!`'s handles) cannot see them."
+  [roots containers]
+  (let [ka  (price-key alpha "AAPL")
+        kb  (price-key beta  "AAPL")
+        new-root! (fn [sink]
+                    (let [c (rf.hicasso.impl.mount/fresh-container!)
+                          r (scheduled-root! c sink)]
+                      (swap! containers conj c)
+                      (swap! roots conj r)
+                      [c r]))]
+    (seat! alpha {"AAPL" "alpha-price"})
+    (seat! beta  {"AAPL" "beta-price"})
+    ;; THE ADVERSARY, installed after both frames exist so neither
+    ;; `make-frame` ran under a synthetic ambient scope.
+    (set! rf.frame/*current-frame* alpha)
+    (let [[container root] (new-root! (atom nil))
+          runs-in-extent   (atom nil)]
+      (reset! !island-runs 0)
+      (reset! !last-ops nil)
+      (rf/with-frame alpha
+        (.render ^js root
+          (rf.hicasso.impl.mount/provider beta (react/createElement ticker #js {:sym "AAPL"})))
+        (reset! runs-in-extent @!island-runs))
+      (-> (rf.hicasso.roots-frames-support/wait-until! #(= 1 (count (readers-of kb))))
+          (.then
+            (fn [subscribed?]
+              (testing "the render really did run LATE: the island body had not
+                        run when `render` returned inside the `with-frame`, and
+                        it had by the time the row read anything. Without this
+                        leg the row is indistinguishable from W5c"
+                (is (zero? @runs-in-extent)
+                    (str "React SCHEDULED the mount rather than committing it on "
+                         "the calling stack; body runs inside the scope: "
+                         @runs-in-extent))
+                (is (pos? @!island-runs))
+                (is (= alpha rf.frame/*current-frame*)
+                    "and the dynamic tier is not empty while it runs — it names
+                     alpha, so a hook that consulted it had an answer available"))
+
+              (is (true? subscribed?)
+                  (str "the island subscribed under the BOUNDARY's frame. Cell keys "
+                       (pr-str (rf.hicasso.roots-frames-support/cell-keys))
+                       ", residue " (pr-str (rf.hicasso.test.runtime/residue))))
+
+              (testing "one cell, keyed to the frame the boundary named — the
+                        same reading W5c takes, now on the schedule a consumer's
+                        own concurrent root actually uses"
+                (is (= #{kb} (rf.hicasso.roots-frames-support/cell-keys)))
+                (is (= 1 (count (readers-of kb))))
+                (is (empty? (readers-of ka))
+                    "alpha has no reader at all, although it is the frame the
+                     persistent ambient scope names")
+                (is (= "beta-price"
+                       (some-> (.querySelector ^js container ".price") .-textContent))))
+
+              (testing "`use-frame` is locked to the same frame on this schedule,
+                        and a dispatch through its bundle moves that frame only"
+                (is (= beta (:frame @!last-ops)))
+                ((:dispatch-sync @!last-ops) [::set-price "AAPL" "beta-moved"])
+                (rf.hicasso.impl.mount/settle!)
+                (is (= "beta-moved" (get-in (rf/app-db-value beta) [:prices "AAPL"])))
+                (is (= "alpha-price" (get-in (rf/app-db-value alpha) [:prices "AAPL"]))))
+
+              ;; Leg 1's tree goes away before leg 2 mints its own, so the
+              ;; cell census leg 2 reads is about leg 2.
+              (.unmount ^js root)
+              nil))))))
+
+(defn- scheduled-refusal-leg!
+  "Leg 2: the same schedule with NO boundary above the island. The
+  persistent ambient scope still names `alpha`, and the hook still
+  refuses — which is what separates *context ONLY* from *context FIRST*
+  on the scheduled path, exactly as the node lane's frameless row does on
+  the synchronous one."
+  [roots containers]
+  (let [ka   (price-key alpha "AAPL")
+        sink (atom nil)
+        c    (rf.hicasso.impl.mount/fresh-container!)
+        r    (scheduled-root! c sink)
+        runs-in-extent (atom nil)]
+    (swap! containers conj c)
+    (swap! roots conj r)
+    (reset! !island-runs 0)
+    (rf/with-frame alpha
+      (.render ^js r (react/createElement ticker #js {:sym "AAPL"}))
+      (reset! runs-in-extent @!island-runs))
+    (-> (rf.hicasso.roots-frames-support/wait-until! #(some? @sink))
+        (.then
+          (fn [refused?]
+            (is (zero? @runs-in-extent)
+                "scheduled, not committed: nothing ran inside the bound extent")
+            (is (true? refused?)
+                (str "the scheduled render refused. Cell keys "
+                     (pr-str (rf.hicasso.roots-frames-support/cell-keys))
+                     ", island body runs " @!island-runs))
+            (let [data (ex-data @sink)]
+              (testing "and it refused with the ruled error, named by the NATIVE
+                        hook — a dynamic-var tier would have answered alpha here
+                        instead, on a schedule where nobody would see it"
+                (is (= :rf.error/no-frame-context (:rf.error/id data))
+                    (str "saw " (pr-str data)))
+                (is (= 're-frame.hicasso.native/use-sub (:where data)))))
+            (is (not (contains? (rf.hicasso.roots-frames-support/cell-keys) ka))
+                "and nothing was built under the frame the ambient scope named")
+            (exercised! :hooks/scheduled-resolution)
+            nil)))))
+
+(deftest a-scheduled-render-that-outlives-the-scope-still-reads-the-boundarys-frame
+  (async done
+    (if-not (rf.hicasso.impl.mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [ambient-was rf.frame/*current-frame*
+            roots       (atom [])
+            containers  (atom [])]
+        (-> (scheduled-resolution-row! roots containers)
+            (.then (fn [_] (scheduled-refusal-leg! roots containers)))
+            (.catch (report-failure! "W5d scheduled render is context-only"))
+            (.then (fn [_]
+                     (run! (fn [r] (try (.unmount ^js r) (catch :default _ nil))) @roots)
+                     (run! (fn [c] (try (.remove ^js c) (catch :default _ nil))) @containers)
+                     (set! rf.frame/*current-frame* ambient-was)
+                     (release-minted!)
+                     (done))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W5b. Two calls are two cells


### PR DESCRIPTION
Closes the repair the merged-PR audit of #9427 reopened `rf2-kuky.62` for. Test-only —
no production source is touched, no new API, flag or compatibility tier, and the original
acceptance criteria are not rewritten.

## What was owed

The audit accepted the context-only implementation, the preserved imperative chain, the
shared classifier, the incarnation memo and native collector ownership. What it found
undelivered was the ORIGINAL Tests witness matrix item 2: *"cover an ordinary scheduled
update (non-act, so `*current-frame*` is unbound when the body runs)"*.

Confirmed at source before acting on it, at `0e53f2e218`:

- `react_shared_suite.cljs` `assert-hook-no-provider-with-dynamic-scope-raises-no-frame-context`
  had client legs only, both inside `act-fn` (a live binding), and its SERVER leg rendered
  `probe-frame-provider-element` — the `use-sub` probe — never `probe-use-frame-element`.
- `assert-use-sub-no-provider-no-dynamic-raises-no-frame-context` also renders inside `act-fn`.
- `hooks_island_cljs_test.cljs` covers both native hooks via synchronous
  `renderToStaticMarkup`; `hooks_island_dom_cljs_test.cljs`'s W5c covers a synchronous
  `flushSync` mount.

So no witness exercised the ordinary SCHEDULED update outside `act`/`flushSync`, after the
dynamic binding had unwound — which is the half of the ruling's own design requirement
("the same component tree resolves the same frame under either scheduling mode") that had
never been asserted. The transition and tear rows exercise a present frame and a different
invariant, so they do not substitute.

## What landed

**1. `react_shared_suite.cljs` — `assert-hook-scheduled-render-after-unwind-reads-context-only`,
wired into the UIx entry as `hook-scheduled-render-after-unwind-reads-context-only`.**
Renders on a concurrent root with `IS_REACT_ACT_ENVIRONMENT` OFF, so `root.render` schedules
and returns and the body runs a host task later. Four legs: `use-sub`'s 1-arity and
`use-frame` under a provider, and both refusing with no provider.

*The recording that the render ran after the bound extent* is the probe's own observation
atom being EMPTY on the line after `render` returns, still inside the `binding` — plus a
read of `rf.frame/*current-frame*` immediately after the binding unwinds. Without that leg
the row would be indistinguishable from a synchronous one that happened to pass.

*Why the row installs a persistent ambient frame.* A `binding` cannot survive the hop to a
scheduled render — that is the point — so on its own it would reach the body with no dynamic
frame at all and every leg would pass under a dynamic-var-FIRST rule too, witnessing nothing.
A real ambient scope on this schedule is the persistent kind, which is exactly what
`make-reset-runtime-fixture`'s own async form uses (`set!` on the root var, because its
`:before` returns long before an async body resumes). So the row installs one, restores the
previous value in its teardown, and that frame is the adversary. Three frames — provider,
persistent ambient, and the one the unwound binding named — so a failure says WHICH tier
answered.

**2. `react_shared_suite.cljs` — the missing SERVER no-provider leg for `use-frame`** (new
part 4 of the existing row, with the dynamic scope live and naming a real seeded frame).
Fizz's secondary `_currentValue2` slot had never been read through `use-frame`.

**3. `hooks_island_dom_cljs_test.cljs` — W5d, the same two legs against the NATIVE hook
pair.** Its own concurrent root (every published Hicasso door commits inside `flushSync`,
which is the mode the row exists to avoid), `!island-runs` as the after-the-extent recording,
and the refusal read off React 19's `createRoot` `onUncaughtError` — `impl/error/fail!`
throws rather than emitting, so there is no listener axis to read it from, and a scheduled
render has no caller's stack for the throw to reach. Rostered as `:hooks/scheduled-resolution`
in `declared-population`.

Every existing synchronous/provider-precedence, held-ops-after-unwind and native
ownership/teardown assertion is retained unchanged.

## Failing-first evidence

The deliverable here is tests, so the proof is a sabotage run: the pre-ruling
dynamic-var-first behaviour was planted at all three resolution sites — `spine.cljs`'s
1-arity hook, `use_frame.cljs`, and `collector/resolve-frame!` — the browser lane run, then
the plant restored and verified by `git hash-object` against the committed blobs (all three
matched byte-for-byte; the restore is checked by hash, not by the restore command's exit code).

Planted run: **exit 1**, 834 tests / 4566 assertions, 36 failures, 1 error. The new rows
failed on exactly the tier they are written to discriminate:

- `hook-scheduled-render-after-unwind-reads-context-only` — *"the scheduled render resolved
  the PROVIDER's frame. Observed `[:from-ambient]`"*, and both no-provider legs reported no
  `:rf.error/no-frame-context` trace at all.
- `a-scheduled-render-that-outlives-the-scope-still-reads-the-boundarys-frame` — cell keys
  `#{[…/alpha […/price "AAPL"]]}` where `#{[…/beta …]}` was expected, DOM read `alpha-price`,
  `use-frame`'s bundle came back locked to `alpha`, and the no-provider leg did not refuse.

Notably the `runs-in-extent` / observation-atom-empty legs PASSED under the plant, which is
the positive evidence that React really did schedule rather than commit on the calling stack.

The sabotage run also surfaced a reporting hazard that only appears on failure: a cell's
reader list holds React registration objects whose cycles blow the stack when `cljs.test`
`pr-str`s them, turning a legible failure into a `RangeError`. W5d's alpha-reader claim is
therefore counted rather than `empty?`-tested (second commit); W5c's identical claim is left
alone, since it passes.

## Quality gates

| gate | result |
|---|---|
| `npm run test:browser` (planted, attempt 1) | **exit 1** — 834 tests / 4566 assertions, 36 failures, 1 error (the intended sabotage red) |
| `npm run test:browser` (clean, attempt 2) | **exit 0** — 834 tests / 4572 assertions, **0 failures, 0 errors** |
| `python scripts/check_fast_pr_gap.py --brief` | exit 0 (report, not a suite) |
| ratchets over the touched paths: `check_require_alias_dialect`, `check_retired_spellings`, `check_retired_composition_vocab`, `check_ambient_durable_reads`, `check_architecture_census`, `check_runtime_subsystem_grading`, `check_gate_scheduling`, `check_test_lane_bijection`, `check_thrown_error_messages`, `check_view_lifetime_residue`, `check_failure_corpus_residue`, `check_jvm_lane_rosters`, `check_keyword_catalogue_drift` | all exit 0 |
| `check-ai-tracking-ratchet.sh`, `check-no-hardcoded-paths.sh`, `check-beads-pr-boundary.sh` | all exit 0 |

Exit codes are the runner's own, captured on the same command line as the redirect and read
from a per-worktree, per-attempt `.exit` file — never through a pipe.

The browser lane is the only lane that executes these assertions: both rows self-gate on
`(browser?)` and degrade to a stated skip under `:node-test`. It maps to CI's `cljs-browser`
job. Baseline for comparison is the audit's own reading of the merged #9427 run — browser
832 tests / 4537 assertions — so this PR adds 2 tests and 35 assertions and removes none.

Not run locally, left to CI, per the gate policy: `test:cljs` (the node lane, 11k+ tests —
it compiles these namespaces but runs both new rows as stated skips), the JVM lanes, lint
(clj-kondo is pinned to 2026.04.15 in CI and a differently-versioned local binary proves
nothing in either direction), and docs. No documentation, spec or manifest path is touched,
so no doc gate is nominated: nominating one would buy a green that inspected nothing.

## Scope

Nothing outside `implementation/core/test/`, `implementation/adapters/uix/test/` and
`implementation/hicasso/test/` is modified. No `.beads` path is committed. `implementation/ssr/**`,
`implementation/resources/**`, `implementation/http/**` and `implementation/epoch/**` are
untouched.
