### PR TITLE
docs(registry): correct the :schema / :data-schema attribution in registrar's pure-documentation-keys

### DIFF
--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -500,12 +500,24 @@
   production and MUST be retained — `:sensitive?` / `:large?` drive
   redaction / egress projection (Spec 015 / EP-0015); `:tags` /
   `:interceptors` / the resource-mutation runtime keys drive runtime
-  behaviour; `:schema` / `:data-schema` are the SOURCE the `:sensitive?` /
-  `:large?` marks are PRECOMPUTED from at registration time (the marks are
-  stored as plain declarations, not derived from the schema VALUE at
-  egress — see `re-frame.classification` / `re-frame.elision` boot population), and
-  remain a dev introspection surface, so they are retained. `:rf/id` and
-  the handler fn ARE the registration.
+  behaviour; `:schema` drives PRODUCTION payload validation — the
+  `re-frame.spec/validate-at-boundary-interceptor` production arm and the
+  always-on `re-frame.cofx` recordable-value check that throws
+  `:rf.error/cofx-value-invalid` — and its per-slot `:sensitive?` /
+  `:large?` props survive ONLY to redact THAT validator's own failure trace
+  and thrown ex-data, NOT as a route into data classification (EP-0025
+  removed the schema→registry bridge, and the EP-0005 `:data-schema`→marks
+  bridge with it — see `re-frame.elision`). A resource `:data-schema`
+  drives NEITHER axis: it is a statically reflected shape fact with no
+  runtime validation consumer, surfaced as the process-node `:schema` by
+  `re-frame.resources.tooling`, and is retained as that reflection surface.
+  NOTHING is precomputed from either at registration time — durable app-db
+  classification rides the commit-plane classification effects into the
+  per-frame elision registry, and a registration's transient-payload
+  classification is the author's own `:sensitive` / `:large` / `:large?`
+  keys, DERIVED at read time off this registrar by
+  `re-frame.classification/registration-classification` (rf2-ehexnw).
+  `:rf/id` and the handler fn ARE the registration.
 
   Adding a key here is a Spec change (Spec 001 §Production elision
   contract — the elidable-vs-retained classification table)."


### PR DESCRIPTION
Closes the false attribution recorded on `rf2-ubai`.

## What was wrong

`implementation/core/src/re_frame/registrar.cljc`'s `pure-documentation-keys`
docstring claimed:

> `:schema` / `:data-schema` are the SOURCE the `:sensitive?` / `:large?` marks
> are PRECOMPUTED from at registration time

The first job of the dispatch was to establish whether that is actually false
here, since a sibling bead (`rf2-bsbs`) corrected the same class of claim in a
*different* artefact and its verdict does not automatically transfer. It is
false, and this was the **only site left in `implementation/core/src` still
asserting the bridge exists** — every other statement of the contract in the
same tree says the opposite:

| site | says |
|---|---|
| `elision.cljc` ns docstring | a schema slot prop "is **not** a route into this registry"; "the root `:data-schema` slot EP-0005 named is **retired** per EP-0029 A3" |
| `classification.cljc` L856 | `frame-snapshot-classification` is "the frame-owned replacement for the **removed** `:data-schema`→classification bridge" |
| `classification.cljc` L926 | "The prior machine `:data-schema`→classification bridge (EP-0005) is **removed**." |
| `late_bind/directory.cljc` L481 | "EP-0025 **reversed** the EP-0005 `:data-schema`→marks bridge; schema validates, it does not classify" |

Three separate things in the sentence were wrong:

1. **`:data-schema` is not a core registration-metadata key at all.**
   `re-frame.reg-meta/known-bare-keys` is built from
   `#{:doc :schema :tags :platforms :ns :line :column :file}` plus
   `#{:sensitive :large :large?}` and the per-kind extras — `:data-schema`
   appears nowhere. The *resource* `:data-schema` is a statically reflected
   shape fact with no runtime validation consumer.
2. **`:schema` is not a source the marks are derived from either.** Its
   per-slot `:sensitive?` / `:large?` props redact only the validator's OWN
   failure trace and thrown ex-data (EP-0015 §8, "Schemas Describe Shape, Not
   Public Egress Policy").
3. **"PRECOMPUTED at registration time" inverts the model.** Nothing is
   stashed at registration — `validate-classification!` runs
   `normalise-classification` purely for its throw side-effect and *discards*
   the result — and `registration-classification` **derives** the declaration
   at READ time off this registrar (`rf2-ehexnw`).

The parenthetical was already half-contradicting its own sentence ("the marks
are stored as plain declarations"), which is likely how it survived review.

## What the replacement says

It states the real reason `:schema` is retained under the production-elision
contract, which the old text never gave: `:schema` drives **production**
payload validation — `re-frame.spec/validate-at-boundary-interceptor`'s
production arm ("Production path", used precisely where dev-time validation is
elided) and the always-on `re-frame.cofx` recordable-value check that throws
`:rf.error/cofx-value-invalid` as a production hard error. Then it records that
schema props reach only the validator's own failure trace, that a resource
`:data-schema` drives neither axis, and where classification actually comes
from.

Phrasing is matched to the corrections already carried by `spec/API.md`
§Commit-plane declaration path, `spec/009-Instrumentation.md` §Privacy /
sensitive data in traces, and
`implementation/resources/src/re_frame/resources/classification.cljc` — no
third spelling invented. Legitimate `:data-schema` references are retained;
only the false attribution changed.

**Docstring text only. No runtime behaviour changes**, no validator added.

## Quality gates

Comment-only diff (one file, 18/6, entirely inside one docstring), so the gates
are scoped to "did I break the reader" plus the ratchets that grade the touched
path. Exit codes below were captured with the redirect and the `echo $?` on the
runner's own command line, never through a pipe.

| gate | exit | result |
|---|---|---|
| `implementation/core` `clojure -M:test` (full JVM artefact suite) | **0** | **2280 tests, 11790 assertions, 0 failures, 0 errors** |
| namespace-load reader gate (`require 're-frame.registrar`) | **0** | loads; `pure-documentation-keys` still `#{:doc}` (1 member) |
| `scripts/check_retired_spellings.py` (scans `implementation/`, incl. the arrow rule) | 0 | pass — self-test also 0 |
| `scripts/check_ambient_durable_reads.py` | 0 | pass — self-test also 0 |
| `scripts/check_keyword_catalogue_drift.py` | 0 | pass — self-test also 0 |
| `scripts/check_retired_composition_vocab.py` | 0 | pass |
| `scripts/check_require_alias_dialect.py` | 0 | pass |

**Sabotage proof the gate has teeth on this file.** A stray `"` planted in the
edited docstring (match count read as 1 *before* the run, so the plant was not a
no-op) turned the reader gate RED — exit **1**, `Syntax error reading source at
(re_frame/registrar.cljc:527:64). Unmatched delimiter: )`. The fault existed only
in this worktree, so a run that had wandered elsewhere would have come back
green. Restore was verified by **blob** hash against the committed object
(`08f19199a8e6c5f5b7999051c7c67221f459a886`, identical before and after), not by
the restore command's exit code, and the planted string greps to 0 residue.

**No test pins the prose.** `doc_metadata_prod_elision_test.clj`'s
`pure-documentation-keys-is-closed-to-doc` asserts on the *value* (`= #{:doc}`,
and `:schema` / `:data-schema` / `:tags` / `:interceptors` / `:sensitive?` not
members) — unchanged here. Nothing in the repo references the removed phrase.

**Skipped, with reasons.** No heavier local suite was run: the changed-surface
classifier arms 16 CI surfaces off `implementation/core/src/**`
(`implementation_jvm`, `cljs_node_test`, `cljs_browser`, `cljs_prod`,
`bundle_isolation`, `mcp_conformance`, …), all of which CI runs in parallel;
re-running them here would buy wall-clock, not information, since a docstring
edit can only fail as a reader/compile error and that is settled above and by
the artefact suite. `python scripts/check_fast_pr_gap.py --brief` reports 99
required checks this local set does not decide — CI is authoritative for those.

Refs: rf2-ubai
