### PR TITLE
docs(resources): the whole-table nil does not distinguish unallocated from no-such-frame

### DIFF
--- a/docs/api/re-frame.resources.md
+++ b/docs/api/re-frame.resources.md
@@ -540,8 +540,11 @@ never by mutation id, so concurrent submissions of the same mutation stay distin
 
 Both subtrees are allocated **lazily**: `:rf.runtime/resources` is absent until the first resource write,
 and `:rf.runtime/mutations` is absent in an app that registers no mutation, so either read can return
-`nil`. `nil` here means *the subtree has not been allocated*, not *no such frame* — an unknown or
-destroyed frame makes `rf/frame-state-value` itself return `nil`.
+`nil` at a live frame. **That `nil` does not by itself say which case you are in** —
+`rf/frame-state-value` returns `nil` for an unknown or destroyed frame, and `get-in` of that `nil` is
+indistinguishable from `get-in` of a live frame whose subtree is unallocated. At a frame you already know
+is live, read it as *the subtree has not been allocated*; where you do not,
+`(rf/frame-state-value :app/main)` is itself the frame-liveness read.
 
 Xray exposes the same shapes, plus:
 


### PR DESCRIPTION
Bead: rf2-kuky.85 (third merged-PR audit, #9439). One-claim prose correction; the bead stays OPEN.

## What was wrong

`docs/api/re-frame.resources.md` §Enumerating the whole live table claimed that a `nil` from the
documented `get-in` recipes means the runtime-db subtree has not been allocated, "not *no such frame*".

The recipes cannot draw that distinction. They compose `get-in` with `rf/frame-state-value`, and
`frame-state-value` returns `nil` for an unknown or destroyed frame:

- `re-frame.core/frame-state-value` delegates to `rf.frame/frame-state-value` (core.cljc), whose own
  docstring says "or `nil` for an unknown / destroyed frame";
- that delegates to `frame-slot-value` (frame.cljc), a `when-let` over `frame-slot` — so an unknown or
  destroyed frame yields `nil` rather than an empty projection.

`get-in` of that `nil` returns the same `nil` as `get-in` of a live frame whose subtree is simply
unallocated, so the composed read's `nil` is ambiguous between exactly the two cases the sentence set
against each other.

Composition probe over the two documented `frame-state-value` results, plus a control:

```
{:missing-frame [nil nil], :live-empty-frame [nil nil]}
{:results-identical? true, :both-all-nil? true}
{:CONTROL-allocated [{:k1 #:resource{:id :a}} {:i1 #:mutation{:id :m}}], :CONTROL-differs? true}
```

The control fires (an allocated subtree gives a different, non-`nil` result), so the probe is not an
instrument that returns `nil` for everything.

## What changed

The sentence, and only the sentence. It now states plainly that the `nil` alone does not distinguish the
two cases, and qualifies the unallocated-subtree reading with a frame the caller already knows is live.

**The recipes are unchanged** — no guard, no wrapper, no new error, no extra lifecycle policy, no new
API. The fix is to make the sentence true, not to make the runtime disambiguate. `rf/frame-state-value`'s
own `nil`, already the outer call in each recipe, is the frame-liveness read for a caller who needs to
tell the two apart.

`docs/api/re-frame.core.md` needs no matching change: its shorter note (line ~1570) says only that either
read can return `nil` before first use, which is true, and it defers to this page for the full contract.
A repo-wide search for the claim found it in this one place only.

Out of scope and untouched, per the bead: the stale accessor lists (rf2-tc7y, merged and closed) and
`docs/EP/EP-0003-resource-queries.md` (a `Status: final` dated design record).

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `python scripts/check_doc_slugs.py` | 0 | pass, no output |
| `clojure -M -m re-frame.api-manifest.doc-api-check` | 0 | 348 public-var references in sync; 147 eligible manifest vars have page + member entry |
| `python -m mkdocs build --strict` | 0 | built in 37.35s (bare `mkdocs` exits 127 on this box) |

Exit codes captured with the redirect and the echo on one command line, read from the runner's own
status, never through a pipe.

**Both doc gates were proven to bite on this worktree by planted faults, each restored and the restore
verified by git blob hash** (`74f9688fd1966a853fd56af21f13275443c22cf0`, identical before and after both
plants; zero plant residue):

- a broken in-page anchor planted on the edited line: `check_doc_slugs.py` exit **1**, naming
  `docs/api/re-frame.resources.md:547 -> #<planted-anchor>`;
- a call-position reference to a non-existent var planted on the same line (1 substitution, counted
  before the run): `doc-api-check` exit **1**, naming `docs/api/re-frame.resources.md:547` and the
  planted var with "no manifest row".

The second plant also establishes that `doc-api-check` grades **prose inline code spans**, not only
fenced blocks — so the new `(rf/frame-state-value :app/main)` reference this PR adds was genuinely
reconciled against the manifest, where `re-frame.core/frame-state-value` is a row with `:facade? true`.

**Verified by hand, because no gate covers it**: neither doc gate grades a prose claim, and both strip
fenced blocks before reading links. The correctness of the replacement sentence rests on the source read
of `core.cljc` / `frame.cljc` and the composition probe above, not on any green here. Markdown emphasis
and inline-code spans in the new text were checked by eye; the paragraph re-wraps within the section's
existing ~105-column width; no link or heading was added or moved.
