### PR TITLE
test(resources): fix two map-form :each fixtures that ran zero tests on the JVM lane (rf2-4yw1)

### DIFF
--- a/implementation/resources/test/re_frame/resources_infinite_registration_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_infinite_registration_cljs_test.cljc
@@ -38,9 +38,19 @@
     {:request {:method :get :url "/api/feed"
                :params (cond-> {} page-param (assoc :cursor page-param))}}))
 
+;; FN form, not the `{:before … :after …}` map form (rf2-4yw1). `cljs.test`
+;; accepts both shapes; `clojure.test` accepts only a function, and given a map
+;; it invokes it as one — a map called with the test thunk is a KEY LOOKUP that
+;; returns nil and never runs the test. The JVM lane then reports zero tests for
+;; this namespace, silently and with exit 0. This file is `.cljc`, so it runs on
+;; both lanes and must use the shape both accept.
 (use-fixtures :each
-  {:before (fn [] (rf.registrar/clear-kind! :resource))
-   :after  (fn [] (rf.registrar/clear-kind! :resource))})
+  (fn [test-fn]
+    (rf.registrar/clear-kind! :resource)
+    (try
+      (test-fn)
+      (finally
+        (rf.registrar/clear-kind! :resource)))))
 
 (deftest valid-infinite-spec-registers
   (testing "a well-formed :infinite spec registers + reads back"

--- a/implementation/resources/test/re_frame/resources_scope_registry_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_scope_registry_cljs_test.cljc
@@ -33,9 +33,19 @@
 
 ;; ---- fixtures -------------------------------------------------------------
 
+;; FN form, not the `{:before … :after …}` map form (rf2-4yw1). `cljs.test`
+;; accepts both shapes; `clojure.test` accepts only a function, and given a map
+;; it invokes it as one — a map called with the test thunk is a KEY LOOKUP that
+;; returns nil and never runs the test. The JVM lane then reports zero tests for
+;; this namespace, silently and with exit 0. This file is `.cljc`, so it runs on
+;; both lanes and must use the shape both accept.
 (use-fixtures :each
-  {:before (fn [] (rf.registrar/clear-kind! :resource-scope))
-   :after  (fn [] (rf.registrar/clear-kind! :resource-scope))})
+  (fn [test-fn]
+    (rf.registrar/clear-kind! :resource-scope)
+    (try
+      (test-fn)
+      (finally
+        (rf.registrar/clear-kind! :resource-scope)))))
 
 ;; rf2-bqstzr — the canonical declared-inputs resolver split into the 3-slot
 ;; grammar's metadata middle slot (`session-meta`: `:doc` + `:inputs`) and the


### PR DESCRIPTION
Census-first dispatch for rf2-4yw1. The census is the deliverable; this diff is the
part of the remedy small enough to land with it.

## The defect, confirmed at source

`clojure.test/use-fixtures :each` takes a **function**. `cljs.test` also accepts the
`{:before f :after g}` **map**. Given a map, `clojure.test`'s `join-fixtures` composes it
into the chain and then invokes it with the test thunk — and a map invoked as a function is
a **key lookup**. It returns `nil`, the thunk never runs, and the namespace reports zero
tests. No error, no warning, exit 0, because maps are `IFn` at arity 1.

Reproduced standalone on Clojure 1.12.4 with a live control in the same run: the map-form
namespace reported `{:test 0, :pass 0, :fail 0, :error 0}` while an otherwise identical
fn-form namespace reported `{:test 2, :pass 1, :fail 1}` and surfaced its deliberate
failure. `:once` with a map zeroes a namespace the same way.

`cljs.test` is the half that validates: its `execution-strategy` classifies fixtures as
`:map` or `:fn` and asserts `"Fixtures may not be of mixed types"`. `clojure.test`
validates nothing.

## The census

Every `use-fixtures` **form** under the whole tracked tree was extracted with a
paren-balancing reader (string/char/comment aware) and its arguments classified — 1209
forms across 1201 files. 92 pass a map literal, but **90 of those are `.cljs`**, which no
JVM lane loads; the map form is correct there. The JVM-relevant set is `.clj`/`.cljc`:

| arg shape | forms in `.clj`/`.cljc` | verdict |
|---|---|---|
| `CALL-EXPR` | 347 | safe — resolved, all return `(fn [test-fn] …)` |
| `SYMBOL` | 311 | safe — all 50 distinct symbols resolve to a `defn` |
| `FN` | 48 | safe |
| **`MAP-LITERAL`** | **2** | **broken — both fixed here** |

The two are `implementation/resources/test/re_frame/resources_scope_registry_cljs_test.cljc`
and `…/resources_infinite_registration_cljs_test.cljc`. Both are `.cljc`, so they run on the
CLJS lane (where the map worked) and the JVM lane (where it did not).

The 227+116 `make-reset-runtime-fixture` call sites were the main risk and are clear: it
returns `(fn [test-fn] …)`. Four residuals were read by hand — a `#?@(:cljs […])` splice, a
machines re-export `def`, four `reset-runtime-fixture` `def`s binding the factory's return,
and Story's own `use-fixtures` wrapper, whose docstring already says *"Declare it with the FN
form — never the map form"*.

**Method and controls.** Four passes (line-oriented, whitespace-flattened,
comment-stripped-then-flattened, and hyphen-rejoined for the break-inside-a-token case) read
87/87/88/88 files — the passes genuinely differ, so the agreement is informative rather than
a shared blind spot. The form extractor was then controlled against a raw token count: 667
paren-headed `use-fixtures` occurrences against 639 extracted forms, and every one of the 28
was accounted for — 27 are docstring/comment mentions (zero live occurrences after masking)
and 1 is a nested wrapper call inside an outer form that *was* captured.

## The proof, on the ordinary JVM lane

A census that is only a grep is a hypothesis, so the blind spot was measured end to end with
a deliberately failing test in one of the two namespaces:

| `implementation/resources` `clojure -M:test` | tally | exit |
|---|---|---|
| baseline, unmodified | 839 tests / 7584 assertions, 0 failures | 0 |
| **map form + a deliberately failing test** | **839 tests / 7584 assertions, 0 failures** | **0** |
| **fn form + the same failing test** | **862 tests / 7668 assertions, 1 failure** | **1** |
| fn form, plant removed (this PR) | 861 tests / 7667 assertions, 0 failures | 0 |

Under the map form the planted fault is not merely unreported — it is **absent from the log
entirely**, and the tally is byte-identical to the clean baseline. Under the fn form the lane
names it at `resources_scope_registry_cljs_test.cljc:308` and goes red.

**22 tests and 83 assertions had never executed on the JVM lane.** All 22 pass now that they
run, so this recovers coverage without changing behaviour. The plant was removed and the
restore verified against the pre-plant blob hash `1433ddf7fb3ca06fd92cf3fb779462cc9a11c830`,
which is the base object the final diff is computed from.

Why no existing gate caught it: `check_test_lane_bijection.py` passes on both files, reporting
"1593 test-defining files, 44 lanes, every file selected". It proves a file is *selected*,
never that its tests *execute*. `RF2_MIN_TESTS` only fires when a whole lane runs zero, so a
zeroed namespace beside healthy siblings is invisible.

## Quality gates

- `implementation/resources` `clojure -M:test` — **PASS**, exit 0, 861 tests / 7667
  assertions, 0 failures (up from 839 / 7584; the increase is the evidence).
- Sabotage proof — planted fault **RED** under the fn form (exit 1, fault named) and
  **GREEN** under the map form (exit 0). Both exit codes captured on the runner's own command
  line, not read from the harness.
- Ratchets over the changed paths, all **PASS** exit 0: `check_test_lane_bijection.py`,
  `check_jvm_lane_rosters.py`, `check_retired_spellings.py`,
  `check_require_alias_dialect.py`, `check_architecture_census.py`.
- Not run: the CLJS lane. The fn form is supported by `cljs.test` (`execution-strategy`'s
  `:fn` branch), and 227 `.cljc` sites in this repo already use fn-form fixtures on both
  lanes; CI owns the CLJS lane.

## What is NOT in this PR

The bead offers three remedies: (a) convert, (b) make the map form fail loudly, (c) both.
This is (a) only. The recommendation for (b) goes back to the mayor with the census — the
short version is that a ~10-line runtime check in `re-frame.test-quiet.runner` (which already
owns the "a suite lane must prove it ran" floor) reading `:clojure.test/each-fixtures` and
`:clojure.test/once-fixtures` off each namespace's metadata and rejecting any non-`fn?` entry
covers 24 of 25 artefacts, needs no new script and no new CI job, and catches the indirect
case — a symbol bound to a map — that no static scan can see. That was prototyped and does
fire on both the literal and the indirect shape, but building it is not this dispatch's call.
