### PR TITLE
test(test-quiet): refuse a lane whose fixtures clojure.test cannot call (rf2-4yw1)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -108,7 +108,17 @@
   whichever the classpath resolves while the other never loads, running a
   suite twice under a tally that goes UP rather than down.
   `discovery-defects` is the third rule and it fires BEFORE any test does;
-  see its own docstring, and rf2-vruo9."
+  see its own docstring, and rf2-vruo9.
+
+  ## What the lane's FIXTURES will do
+
+  A namespace that WAS discovered, WAS loaded and DOES hold tests still
+  runs none of them if its fixtures are not functions — `clojure.test`
+  calls a fixture with the test thunk, and a map called with one argument
+  is a key lookup that returns nil.  `uncallable-fixtures` is the fourth
+  rule; it fires from `:summary`, the first hook that holds control after
+  every namespace this lane runs has loaded.  See its own docstring, and
+  rf2-4yw1."
   (:require
     [re-frame.test-quiet]
     [clojure.java.io :as io]
@@ -867,6 +877,72 @@
         (flush))
       (System/exit 1))))
 
+;; ----------------------------------------------------------------------
+;; What the lane's FIXTURES will do (rf2-4yw1) — a fixture the runner
+;; cannot CALL is a namespace that ran nothing.
+;;
+;; `cljs.test` accepts a MAP fixture — `(use-fixtures :each {:before f
+;; :after g})` — and this repo's `*_cljs_test.cljs` files use it throughout.
+;; `clojure.test` accepts functions ONLY, and validates nothing:
+;; `join-fixtures` folds whatever it is handed into the chain and calls it
+;; with the test thunk, and a map called with one argument is a KEY LOOKUP
+;; that returns nil, so the thunk never runs.  Maps are `IFn`, so nothing
+;; throws.  cljs.test asserts on this ("Fixtures may not be of mixed
+;; types"); the JVM half is the unguarded one.
+;;
+;; MEASURED: a two-line namespace whose single `deftest` asserts `(= 1 2)`
+;; reports `Ran 0 tests containing 0 assertions. / 0 failures, 0 errors.`
+;; and exits 0 under the map form.  Two `.cljc` namespaces under
+;; `implementation/resources` were zeroed exactly this way while the lane
+;; reported 839 tests / 7584 assertions, green (rf2-4yw1).
+;;
+;; WHY THIS IS A RUNTIME RULE AND NOT A SCAN.  A scan sees text, and
+;; `(use-fixtures :each fixture)` where `fixture` is a symbol bound to a map
+;; is spelled exactly like the legitimate fn form.  `use-fixtures` writes
+;; the args it was handed into the namespace's metadata, so reading that
+;; metadata back sees the VALUE either way.  The tree already holds a static
+;; half — `tools/story/test/re_frame/story/meta_fixtures_test.cljc` — and it
+;; is scoped to that one artefact's `test/` tree, which is how the two
+;; measured files escaped it.
+
+(def ^:private fixture-meta-keys
+  "The namespace-metadata keys `clojure.test/use-fixtures` writes.  Each
+  holds the ARGS the call was handed, so a map literal and a symbol bound
+  to a map land here indistinguishably — which is the point."
+  [:clojure.test/once-fixtures :clojure.test/each-fixtures])
+
+(defn uncallable-fixtures
+  "Every `[ns-sym fixture-key fixture]` registered on `namespaces` that
+  `clojure.test` cannot call, sorted by namespace name.
+
+  Empty is the only acceptable answer.  `fn?` is the whole test: it is
+  precisely what `join-fixtures` needs of each entry, so anything else is a
+  namespace whose tests will not run."
+  [namespaces]
+  (vec (sort-by (comp str first)
+                (for [ns-obj    namespaces
+                      meta-key  fixture-meta-keys
+                      fixture   (get (meta ns-obj) meta-key)
+                      :when     (not (fn? fixture))]
+                  [(ns-name ns-obj) meta-key fixture]))))
+
+(defn- uncallable-fixture-complaint
+  "The one-screen operator message for `offenders`.  ASCII only: it goes
+  through the platform-default stderr encoding, where an em dash renders as
+  a replacement character on a Windows console."
+  [offenders]
+  (str "this lane registered " (count offenders)
+       " fixture(s) clojure.test cannot call, so EVERY test in the"
+       " namespace(s) below silently did not run:\n"
+       (str/join "\n" (for [[ns-sym meta-key fixture] offenders]
+                        (str "  " ns-sym " " meta-key " -> "
+                             (.getName (class fixture)))))
+       "\nclojure.test hands each fixture the test thunk; a map called with"
+       " one argument is a key lookup returning nil, so the thunk never runs"
+       " and the tally stays green.\n"
+       "The {:before f :after g} map is cljs.test-only. Use the fn form:"
+       " (use-fixtures :each (fn [t] (before) (t) (after))) (rf2-4yw1).\n"))
+
 (defn- install-summary-method!
   "Install `f` as `clojure.test/report`'s `:summary` method, or — when `f`
   is nil — remove any installed method so the multimethod falls back to its
@@ -883,9 +959,9 @@
   invocation. On a RED run it replays `stderr-ring` to `original-err`, then
   delegates to `prior-summary-method` (the `:summary` method installed
   before this invocation) so the canonical summary line still prints, and
-  finally enforces this lane's claim — the `min-tests` floor for a suite
-  lane, or the zero-test expectation for a `--probe` lane (see the ns
-  docstring and `parse-min-tests`).
+  finally enforces this lane's claim — `uncallable-fixtures` first, then the
+  `min-tests` floor for a suite lane or the zero-test expectation for a
+  `--probe` lane (see the ns docstring and `parse-min-tests`).
 
   `:summary` is where both belong because it is the one place that
   holds BOTH the executed-test count and control before cognitect exits.
@@ -967,18 +1043,25 @@
     ;; through the platform-default stderr encoding, where an em dash renders
     ;; as a replacement char on a Windows console.
     (let [test-count (or (:test summary) 0)
-          exit-for-claim-mismatch!
+          fail-run!
           (fn [message]
             (.write original-err (str "\n[test-quiet] ERROR: " message))
             (.flush original-err)
-            (System/exit 1))]
+            (System/exit 1))
+          uncallable (uncallable-fixtures (all-ns))]
       (cond
+        ;; An uncallable fixture zeroes its whole namespace, so it is read
+        ;; BEFORE the coverage floor: a lane zeroed this way is otherwise
+        ;; reported as the discovery problem it does not have (rf2-4yw1).
+        (seq uncallable)
+        (fail-run! (uncallable-fixture-complaint uncallable))
+
         ;; A probe reaching this hook has already proved what it claims:
         ;; deps resolved and the discovery dirs were scanned. All that is
         ;; left is that it really is a probe.
         probe?
         (when (pos? test-count)
-          (exit-for-claim-mismatch!
+          (fail-run!
             (str "this lane is declared a classpath probe (" probe-flag
                       ") but executed " test-count " test(s).\n"
                       "A lane with tests claims COVERAGE, not resolution:"
@@ -987,7 +1070,7 @@
                       "so the test-count floor applies to it (rf2-qqzmf).\n")))
 
         (< test-count min-tests)
-        (exit-for-claim-mismatch!
+        (fail-run!
           (str "this run executed " test-count
                     " test(s), below the floor of " min-tests
                     " (" min-tests-env-var ").\n"

--- a/implementation/test-quiet/test/re_frame/test_quiet_fixture_integrity_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_fixture_integrity_test.clj
@@ -1,0 +1,126 @@
+(ns re-frame.test-quiet-fixture-integrity-test
+  "The rule `re-frame.test-quiet.runner/uncallable-fixtures` states, and the
+  defect it exists to make impossible (rf2-4yw1).
+
+  `cljs.test` accepts a MAP fixture — `(use-fixtures :each {:before f
+  :after g})` — and this repo's `*_cljs_test.cljs` files use it throughout.
+  `clojure.test` accepts functions only and validates nothing: it folds
+  whatever `use-fixtures` was handed into a chain and calls it with the test
+  thunk.  A map called with one argument is a KEY LOOKUP, returns nil, and
+  the thunk never runs.  Maps are `IFn`, so nothing throws; the namespace
+  contributes zero tests and the lane exits 0.
+
+  EVERY TEST HERE PINS THE DEFECT BEFORE IT PINS THE GUARD.  The defect is
+  pinned against `clojure.test/join-fixtures` itself — the function
+  `test-all-vars` builds its fixture chain with — so a guard that went on
+  agreeing with itself after clojure.test changed underneath would be
+  caught.  The end-to-end half (a real `deftest` that would FAIL, absent
+  from the tally, under the real `-main`, for both the map literal and a
+  symbol bound to a map) is pinned across a process boundary in
+  `re-frame.test-quiet-runner-contract-test`.
+
+  A NOTE ON THE PROBE NAMESPACES BELOW.  `uncallable-fixtures` reads
+  `(all-ns)` in the shipped call, so a probe namespace left behind with a
+  map fixture would red THIS artefact's own lane.  `with-probe-ns` removes
+  it in a `finally` for that reason, not for tidiness."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.test-quiet.runner :as rf.test-quiet.runner]))
+
+;; ----------------------------------------------------------------------
+;; Fixtures
+
+(def ^:private map-fixture
+  "The cljs.test form. Legitimate there; uncallable on the JVM."
+  {:before (fn [])
+   :after  (fn [])})
+
+(defn- with-probe-ns
+  "Create `ns-sym`, give it `fixtures` under `meta-key` exactly as
+  `clojure.test/use-fixtures` writes them (the ARGS seq, not the first of
+  them), hand the namespace to `f`, then remove it."
+  [ns-sym meta-key fixtures f]
+  (let [ns-obj (doto (create-ns ns-sym)
+                 (alter-meta! assoc meta-key fixtures))]
+    (try
+      (f ns-obj)
+      (finally
+        (remove-ns ns-sym)))))
+
+;; ----------------------------------------------------------------------
+;; The defect, pinned against clojure.test itself.
+
+(deftest a-map-fixture-swallows-the-test-thunk
+  (testing "THE DEFECT: `join-fixtures` — what `test-all-vars` builds its
+            chain with — calls each fixture with the test thunk, and a map
+            called at arity 1 is a key lookup that returns nil"
+    (let [ran? (atom false)
+          thunk #(reset! ran? true)]
+      (is (nil? ((clojure.test/join-fixtures [map-fixture]) thunk))
+          "the map returns nil rather than invoking the chain")
+      (is (false? @ran?)
+          (str "the whole bug: the test thunk is never called, nothing"
+               " throws (maps are IFn), and the namespace reports zero"
+               " tests. Measured on Clojure 1.12: a single `deftest`"
+               " asserting (= 1 2) under this fixture reports `Ran 0 tests"
+               " containing 0 assertions. / 0 failures, 0 errors.` and"
+               " exits 0."))))
+
+  (testing "the fn form runs the thunk, which is the only difference"
+    (let [ran? (atom false)
+          fn-fixture (fn [t] (t))]
+      ((clojure.test/join-fixtures [fn-fixture]) #(reset! ran? true))
+      (is (true? @ran?)))))
+
+;; ----------------------------------------------------------------------
+;; The rule.
+
+(deftest a-map-fixture-is-named-under-either-key
+  (doseq [meta-key [:clojure.test/each-fixtures :clojure.test/once-fixtures]]
+    (with-probe-ns 'probe.map-fixture-ns meta-key (list map-fixture)
+      (fn [ns-obj]
+        (let [offenders (rf.test-quiet.runner/uncallable-fixtures [ns-obj])]
+          (is (= [['probe.map-fixture-ns meta-key map-fixture]] offenders)
+              (str "both `use-fixtures` metadata keys are read; got "
+                   (pr-str offenders))))))))
+
+(deftest a-symbol-bound-to-a-map-is-named-too
+  (testing "the case a static scan cannot see: `use-fixtures` writes the
+            VALUE it was handed, so a map reaching the metadata through a
+            var is indistinguishable from a map literal here"
+    (let [lifecycle map-fixture]
+      (with-probe-ns 'probe.bound-fixture-ns :clojure.test/each-fixtures
+        (list lifecycle)
+        (fn [ns-obj]
+          (is (= 1 (count (rf.test-quiet.runner/uncallable-fixtures
+                            [ns-obj])))))))))
+
+(deftest function-fixtures-are-not-offenders
+  (testing "the guard must not red the honest form — a bare fn, several fns
+            from one call, and a namespace with no fixtures at all"
+    (with-probe-ns 'probe.fn-fixture-ns :clojure.test/each-fixtures
+      (list (fn [t] (t)) (fn [t] (t)))
+      (fn [ns-obj]
+        (is (= [] (rf.test-quiet.runner/uncallable-fixtures [ns-obj])))))
+    (is (= [] (rf.test-quiet.runner/uncallable-fixtures [(the-ns 'clojure.core)])))
+    (is (= [] (rf.test-quiet.runner/uncallable-fixtures [])))))
+
+(deftest this-lane-is-itself-clean
+  (testing "the shipped call — every namespace this JVM has loaded — and so
+            a live control that the rule holds on real code, not only on
+            probes"
+    (is (= [] (rf.test-quiet.runner/uncallable-fixtures (all-ns))))))
+
+;; ----------------------------------------------------------------------
+;; The complaint.
+
+(deftest the-complaint-names-the-namespace-and-the-repair
+  (with-probe-ns 'probe.complaint-ns :clojure.test/each-fixtures
+    (list map-fixture)
+    (fn [ns-obj]
+      (let [[[ns-sym meta-key fixture]]
+            (rf.test-quiet.runner/uncallable-fixtures [ns-obj])]
+        (is (= 'probe.complaint-ns ns-sym))
+        (is (= :clojure.test/each-fixtures meta-key))
+        (is (map? fixture)
+            "the offending value travels with the complaint, so the message
+             can name what it is rather than only that it is wrong")))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -34,6 +34,11 @@
      refuses the run (exit 1, named on stderr) instead of leaving it
      silently short a suite — and the same fixture is green the moment
      before that file arrives.
+   - FIXTURES: a namespace whose `use-fixtures` entry is not a function
+     — the cljs.test `{:before f :after g}` map, whether written at the
+     call site or reached through a var — refuses the run (exit 1, the
+     namespace named on stderr) instead of contributing zero tests to a
+     tally that reports itself green.
    - STDERR BUFFER: a green run that emits expected
      stderr warnings stays quiet (the warnings are buffered + dropped);
      a RED run REPLAYS the buffered stderr context so a failing run
@@ -366,6 +371,115 @@
           (is (str/includes? (str out err) "FIXTURE-THROW-MARKER")
               (str "the fixture exception message must surface; got"
                    "\n--- stdout ---\n" out "\n--- stderr ---\n" err)))))))
+
+;; ----------------------------------------------------------------------
+;; Fixture integrity (rf2-4yw1) — the wiring pin for
+;; `re-frame.test-quiet.runner/uncallable-fixtures`.
+;;
+;; The rule itself is pinned in-process against `clojure.test/join-fixtures`
+;; by `re-frame.test-quiet-fixture-integrity-test`.  What can only be seen
+;; across a process boundary is the end-to-end shape: a real `deftest` that
+;; would FAIL, absent from a tally that reports itself green, and the run
+;; then refused with the namespace named.  Both rows plant a failing
+;; assertion for exactly that reason — a passing one could not tell "the
+;; fixture swallowed it" from "it ran and passed".
+
+(def ^:private map-fixture-source
+  "The cljs.test map form, which `clojure.test` cannot call."
+  "(use-fixtures :each {:before (fn []) :after (fn [])})\n")
+
+(def ^:private bound-map-fixture-source
+  "The same map, reaching `use-fixtures` through a var.  Spelled exactly
+  like the legitimate fn form, which is why no text scan closes this."
+  (str "(def lifecycle {:before (fn []) :after (fn [])})\n"
+       "(use-fixtures :each lifecycle)\n"))
+
+(def ^:private min-tests-marker
+  "A fragment of the `RF2_MIN_TESTS` floor complaint, used to prove the
+  fixture rule is read FIRST."
+  "below the floor of")
+
+(defn- fixture-probe-source
+  "A one-`deftest` probe ns named `ns-name-str` whose single assertion FAILS,
+  under `fixture-source`."
+  [ns-name-str fixture-source]
+  (str "(ns " ns-name-str "\n"
+       "  (:require [clojure.test :refer [deftest is use-fixtures]]\n"
+       "            [re-frame.test-quiet]))\n"
+       fixture-source
+       "(deftest a-test-that-would-fail (is (= 1 2)))\n"))
+
+(defn- assert-uncallable-fixture-refused
+  "Run `source` as `probe/<file-stem>.clj` through the real `-main` and
+  assert BOTH halves: the failing assertion never ran, and the run was
+  refused with `ns-name-str` named."
+  [file-stem ns-name-str source]
+  (with-fixture-dir
+    (fn [dir]
+      (write-raw-fixture! dir file-stem source)
+      (let [{:keys [exit out err timed-out?]} (invoke-quiet-runner dir)]
+        (is (not timed-out?) "the run must terminate, not hang")
+
+        (testing "THE DEFECT: the deliberately failing assertion is absent
+                  from a tally that reports itself clean"
+          (is (str/includes? out "Ran 0 tests containing 0 assertions.")
+              (str "the map fixture must swallow the whole namespace; got"
+                   "\n--- stdout ---\n" out))
+          (is (not (str/includes? out "FAIL in"))
+              (str "and nothing may be reported failing; got\n" out)))
+
+        (testing "THE GUARD: the lane is refused and says which namespace,
+                  which fixture key, and what to write instead"
+          (is (= 1 exit)
+              (str "an uncallable fixture must red the lane; got exit " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? err ns-name-str)
+              (str "the offending namespace must be named; got\n" err))
+          (is (str/includes? err ":clojure.test/each-fixtures")
+              (str "and the metadata key it registered under; got\n" err))
+          (is (str/includes? err "(use-fixtures :each (fn [t] (before) (t) (after)))")
+              (str "and the repair; got\n" err))
+          (is (not (str/includes? err min-tests-marker))
+              (str "the coverage floor must NOT be the message: a lane"
+                   " zeroed by a fixture has no discovery problem, and the"
+                   " floor's advice would send the operator to the wrong"
+                   " file; got\n" err)))))))
+
+(deftest map-literal-fixture-refuses-the-run
+  (assert-uncallable-fixture-refused
+    "map_fixture_test" "probe.map-fixture-test"
+    (fixture-probe-source "probe.map-fixture-test" map-fixture-source)))
+
+(deftest symbol-bound-map-fixture-refuses-the-run
+  (let [source (fixture-probe-source "probe.bound-fixture-test"
+                                     bound-map-fixture-source)]
+    (testing "the indirect case is invisible to a text scan, which is why the
+              rule reads the metadata `use-fixtures` wrote rather than the
+              source that wrote it"
+      (is (not (str/includes? source "use-fixtures :each {"))
+          "the probe must NOT spell the map at the call site"))
+    (assert-uncallable-fixture-refused
+      "bound_fixture_test" "probe.bound-fixture-test" source)))
+
+(deftest function-fixtures-keep-the-run-green
+  (testing "the control: an ordinary lane with :once and :each FN fixtures is
+            untouched, so the guard cannot red honest code"
+    (with-fixture-dir
+      (fn [dir]
+        (write-raw-fixture! dir "fn_fixture_test"
+          (str "(ns probe.fn-fixture-test\n"
+               "  (:require [clojure.test :refer [deftest is use-fixtures]]\n"
+               "            [re-frame.test-quiet]))\n"
+               "(use-fixtures :once (fn [t] (t)))\n"
+               "(use-fixtures :each (fn [t] (t)))\n"
+               "(deftest a-passing-test (is (= 1 1)))\n"))
+        (let [{:keys [exit out err]} (invoke-quiet-runner dir)]
+          (is (zero? exit)
+              (str "got exit " exit "\n--- stdout ---\n" out
+                   "\n--- stderr ---\n" err))
+          (is (str/includes? out "Ran 1 tests containing 1 assertions.")
+              (str "and the fixture chain must still run the test; got\n"
+                   out)))))))
 
 ;; ----------------------------------------------------------------------
 ;; Nested-run banner correctness.


### PR DESCRIPTION
Deliverable **(b)** of rf2-4yw1 — the runtime half. Deliverable (a) (converting the two
offending files) landed as #9451; this branch is rebased on top of it and its diff is
disjoint. **rf2-4yw1 stays OPEN.**

## The defect

`clojure.test` accepts only functions as fixtures and validates nothing. `join-fixtures`
folds whatever `use-fixtures` was handed into the chain and calls it with the test thunk;
the `cljs.test` map form `{:before f :after g}` called at arity 1 is a **key lookup**,
returns nil, and the thunk never runs. Maps are `IFn`, so nothing throws: the namespace
contributes zero tests and the lane exits 0. `cljs.test` asserts on this ("Fixtures may not
be of mixed types"); the JVM half is the unguarded one.

Measured on Clojure 1.12 in this tree — a single `deftest` asserting `(= 1 2)` under a map
fixture reports `Ran 0 tests containing 0 assertions. / 0 failures, 0 errors.` and exits 0.

## The guard

`re-frame.test-quiet.runner/uncallable-fixtures` reads the two metadata keys `use-fixtures`
writes (`:clojure.test/once-fixtures`, `:clojure.test/each-fixtures`) off every loaded
namespace and refuses the run on any entry that is not `fn?`. It fires from `:summary` —
the first hook holding control after every namespace the lane runs has loaded — and is read
**before** the `RF2_MIN_TESTS` floor, so a lane zeroed this way is not misreported as the
discovery problem it does not have. One message, naming the namespace, the metadata key,
the offending type, and the fn form to write instead.

**Why runtime, not a scan.** `(use-fixtures :each fixture)`, where `fixture` is a symbol
bound to a map, is spelled exactly like the legitimate fn form. The tree already holds a
static half — `tools/story/test/re_frame/story/meta_fixtures_test.cljc` (rf2-k2g3i) — and
it walks one artefact's `test/` tree only, which is how the two files #9451 fixed escaped
it. No new script and no new CI job: this covers every artefact whose `:test` alias already
runs the quiet runner (31 rostered lanes).

## Quality gates

Every exit code below was captured on the runner's own command line (`echo $?`), never
through a pipe.

| gate | result |
|---|---|
| `implementation/test-quiet` `clojure -M:test` | **exit 0** — 62 tests / 307 assertions (8 new) |
| `implementation/core` `clojure -M:test` | **exit 0** — 2278 tests / 11786 assertions |
| `implementation/resources` `clojure -M:test` | **exit 0** — 862 tests / 7674 assertions |
| `implementation/epoch` `clojure -M:test` | **exit 0** — 568 tests / 7338 assertions |
| `implementation/flows` `clojure -M:test` | **exit 0** — 266 tests / 6211 assertions |
| `tools/story` `clojure -M:test` | **exit 0** — 1914 tests / 7047 assertions |
| `implementation/adapters/reagent` (`--probe` lane) | **exit 0** — 0 tests, floor correctly not applied |
| `python scripts/check_jvm_lane_rosters.py` | **exit 0** — 31 rostered artefacts |
| `python scripts/check_test_lane_bijection.py` | **exit 0** — 1595 test-defining files, new file selected |
| `python scripts/check_require_alias_dialect.py` | **exit 0** |
| `python scripts/check_retired_spellings.py` | **exit 0** |
| `clj-kondo --lint` (3 changed files) | **exit 0** — 0 errors, 0 warnings |

Six real lanes, 5950 tests / 40,363 assertions, no false positive.

`python scripts/check_fast_pr_gap.py --brief` was run to learn what CI still owns (99
required checks this spine does not run); those are left to CI per the gate-nomination
policy. Local clj-kondo here is v2025.10.23 against CI's pinned v2026.04.15, so its 0/0
is a sanity check rather than authority — CI's count grades this PR.

### Gate liveness — plant, red, restore

Three independent demonstrations that the guard bites, each with the exit code captured
directly and the restore verified by **git blob hash** against the committed object
(`git hash-object` vs `git rev-parse HEAD:<path>`), never by a diff.

1. **No plant at all.** Before the rebase onto #9451, `implementation/resources`
   `clojure -M:test -n re-frame.resources-scope-registry-cljs-test` exited **1** on the
   real in-tree defect, printing `Ran 0 tests containing 0 assertions. / 0 failures, 0
   errors.` above the guard's message naming
   `re-frame.resources-scope-registry-cljs-test :clojure.test/each-fixtures ->
   clojure.lang.PersistentArrayMap`. After the rebase that same lane is green at 862 tests
   / 7674 assertions.
2. **Map literal planted** in `test_quiet_pin_passing_test.clj` (plant read `2 0` on
   `--numstat` before the run, so it was not a no-op): lane exit **1**, namespace named.
   Restore hash `44510a42…` == committed blob.
3. **Symbol bound to a map planted** in the same file (`3 0` on `--numstat`): lane exit
   **1**, same message. The control matters here — `grep -c 'use-fixtures :each {'` reads
   **0** on this plant while reading **1** on plant 2's text, and the repo's own static
   guard regex also reads 0, so the case really is invisible to a text scan. Restore hash
   `44510a42…` == committed blob.

The map-fixture message won over the `RF2_MIN_TESTS` floor message in every red, which is
the ordering the `cond` pins and which `map-literal-fixture-refuses-the-run` asserts.

### Census behind "no false positives"

Reading every `.clj`/`.cljc` file under a `test/`/`testbeds/` directory with
`{:read-cond :allow :features #{:clj}}` — so reader conditionals are resolved to the JVM
branch rather than pattern-matched — 959 files carry 700 `use-fixtures` arguments:

| class | count |
|---|---|
| `CALL-EXPR` | 346 |
| `SYMBOL` | 308 |
| `FN` | 44 |
| `MAP-LITERAL` | 2 (both fixed by #9451) |
| `VECTOR` | 0 |

Each of the 308 `SYMBOL` arguments was then resolved to its definition: **306 are `defn`
vars**; the remaining 2 are one name, `reset-runtime-fixture`, `def`'d in
`implementation/epoch` and `implementation/flows` to
`(rf.test-support/make-reset-runtime-fixture …)` — a factory returning a fn, and both files
invoke it as one. Both lanes run green above. No symbol in the tree is bound to a map or a
vector.

`tools/re-frame2-pair-mcp` is the one artefact outside the quiet runner. Confirmed rather
than assumed: its 21 map-form fixture files are all `.cljs` and it has **zero** `.clj`/
`.cljc` files under `test/`, so it has no JVM exposure to this defect.

### What is NOT covered

The rule reads namespaces this JVM has **loaded**, so a `.cljs` file — where the map form is
legitimate and where 46 of them live — is outside it by construction, correctly. A `.cljc`
rename into a JVM lane brings the file into the rule's reach on the next run, which is the
case rf2-4yw1 was filed for.

## Verification by hand

Markdown table column counts in this body were checked by hand. The diff touches no
documentation tree, so no link/anchor gate applies to it.
