### PR TITLE
fix(test-quiet): accept callable fixtures, not only fn? (rf2-4yw1)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -113,9 +113,11 @@
   ## What the lane's FIXTURES will do
 
   A namespace that WAS discovered, WAS loaded and DOES hold tests still
-  runs none of them if its fixtures are not functions — `clojure.test`
-  calls a fixture with the test thunk, and a map called with one argument
-  is a key lookup that returns nil.  `uncallable-fixtures` is the fourth
+  runs none of them if its fixtures are not CALLABLE — `clojure.test`
+  calls a fixture with the test thunk, and a data structure called with one
+  argument is a key lookup that returns nil.  Callable is the whole
+  requirement, and it is wider than `fn?`: a var referring to a fixture
+  function is idiomatic and works.  `uncallable-fixtures` is the fourth
   rule; it fires from `:summary`, the first hook that holds control after
   every namespace this lane runs has loaded.  See its own docstring, and
   rf2-4yw1."
@@ -883,12 +885,18 @@
 ;;
 ;; `cljs.test` accepts a MAP fixture — `(use-fixtures :each {:before f
 ;; :after g})` — and this repo's `*_cljs_test.cljs` files use it throughout.
-;; `clojure.test` accepts functions ONLY, and validates nothing:
-;; `join-fixtures` folds whatever it is handed into the chain and calls it
-;; with the test thunk, and a map called with one argument is a KEY LOOKUP
-;; that returns nil, so the thunk never runs.  Maps are `IFn`, so nothing
-;; throws.  cljs.test asserts on this ("Fixtures may not be of mixed
-;; types"); the JVM half is the unguarded one.
+;; `clojure.test` validates nothing: `join-fixtures` folds whatever it is
+;; handed into the chain and calls it with the test thunk, and a map called
+;; with one argument is a KEY LOOKUP that returns nil, so the thunk never
+;; runs.  Maps are `IFn`, so nothing throws.  cljs.test asserts on this
+;; ("Fixtures may not be of mixed types"); the JVM half is the unguarded one.
+;;
+;; WHAT THE RULE MAY NOT DO IS REFUSE HONEST CODE.  The requirement is that
+;; the entry be CALLED, not that it be `fn?`, and the two differ: a var
+;; referring to a fixture function, and a multimethod, both invoke the thunk
+;; while failing `fn?`.  `callable-fixture?` owns that distinction; the
+;; opposite over-correction — `ifn?` — would accept the map and disarm the
+;; rule entirely.
 ;;
 ;; MEASURED: a two-line namespace whose single `deftest` asserts `(= 1 2)`
 ;; reports `Ran 0 tests containing 0 assertions. / 0 failures, 0 errors.`
@@ -911,19 +919,48 @@
   to a map land here indistinguishably — which is the point."
   [:clojure.test/once-fixtures :clojure.test/each-fixtures])
 
+(defn- callable-fixture?
+  "Whether `clojure.test` will INVOKE `fixture` with the test thunk rather
+  than LOOK the thunk up inside it.
+
+  `join-fixtures` folds the entries with `compose-fixtures` into
+  `(fn [g] (f1 (fn [] (f2 g))))`, so the contract is behavioural — each entry
+  is applied to one argument and must CALL it — and behaviour is not
+  decidable from a value.  Both cheap approximations of it are wrong, in
+  opposite directions, and this predicate is the narrowest thing that is
+  wrong in neither (MEASURED on Clojure 1.12, rf2-4yw1):
+
+    - `ifn?` is too permissive.  Maps, sets, vectors, keywords and symbols
+      are all `IFn`, and every one of them reads its argument as a KEY.  That
+      is the defect this rule exists to catch, so `ifn?` would disarm it.
+    - `fn?` is too restrictive, which is the regression this predicate
+      replaces.  It tests for the `clojure.lang.Fn` marker, which
+      `clojure.lang.Var` and `clojure.lang.MultiFn` do not carry even though
+      both invoke the thunk correctly: `(use-fixtures :each #'lifecycle)` is
+      ordinary, idiomatic and WORKING, and the rule refused it while claiming
+      the namespace had run nothing.
+
+  So: a function, a multimethod, or an indirection resolving to one.  The Var
+  case RECURSES on the root rather than accepting every Var, because
+  `Var.invoke` forwards to whatever the root is — a Var whose root is a map
+  swallows the thunk exactly as the bare map does."
+  [fixture]
+  (or (fn? fixture)
+      (instance? clojure.lang.MultiFn fixture)
+      (and (var? fixture) (callable-fixture? (deref fixture)))))
+
 (defn uncallable-fixtures
   "Every `[ns-sym fixture-key fixture]` registered on `namespaces` that
   `clojure.test` cannot call, sorted by namespace name.
 
-  Empty is the only acceptable answer.  `fn?` is the whole test: it is
-  precisely what `join-fixtures` needs of each entry, so anything else is a
-  namespace whose tests will not run."
+  Empty is the only acceptable answer.  `callable-fixture?` is the test; see
+  its docstring for why neither `fn?` nor `ifn?` is."
   [namespaces]
   (vec (sort-by (comp str first)
                 (for [ns-obj    namespaces
                       meta-key  fixture-meta-keys
                       fixture   (get (meta ns-obj) meta-key)
-                      :when     (not (fn? fixture))]
+                      :when     (not (callable-fixture? fixture))]
                   [(ns-name ns-obj) meta-key fixture]))))
 
 (defn- uncallable-fixture-complaint
@@ -937,10 +974,11 @@
        (str/join "\n" (for [[ns-sym meta-key fixture] offenders]
                         (str "  " ns-sym " " meta-key " -> "
                              (.getName (class fixture)))))
-       "\nclojure.test hands each fixture the test thunk; a map called with"
-       " one argument is a key lookup returning nil, so the thunk never runs"
-       " and the tally stays green.\n"
-       "The {:before f :after g} map is cljs.test-only. Use the fn form:"
+       "\nclojure.test calls each fixture with the test thunk; a data"
+       " structure called with one argument is a key lookup returning nil,"
+       " so the thunk never runs and the tally stays green.\n"
+       "A fixture must be callable: a fn, a multimethod, or a var referring"
+       " to one. The {:before f :after g} map is cljs.test-only --"
        " (use-fixtures :each (fn [t] (before) (t) (after))) (rf2-4yw1).\n"))
 
 (defn- install-summary-method!

--- a/implementation/test-quiet/test/re_frame/test_quiet_fixture_integrity_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_fixture_integrity_test.clj
@@ -4,11 +4,22 @@
 
   `cljs.test` accepts a MAP fixture — `(use-fixtures :each {:before f
   :after g})` — and this repo's `*_cljs_test.cljs` files use it throughout.
-  `clojure.test` accepts functions only and validates nothing: it folds
-  whatever `use-fixtures` was handed into a chain and calls it with the test
-  thunk.  A map called with one argument is a KEY LOOKUP, returns nil, and
-  the thunk never runs.  Maps are `IFn`, so nothing throws; the namespace
-  contributes zero tests and the lane exits 0.
+  `clojure.test` validates nothing: it folds whatever `use-fixtures` was
+  handed into a chain and calls it with the test thunk.  A map called with
+  one argument is a KEY LOOKUP, returns nil, and the thunk never runs.  Maps
+  are `IFn`, so nothing throws; the namespace contributes zero tests and the
+  lane exits 0.
+
+  THE RULE IS ABOUT CALLING, NOT ABOUT `fn?` (rf2-4yw1).  `clojure.test`'s
+  requirement is behavioural — the entry is applied to the thunk and must
+  INVOKE it — and both cheap approximations of that are wrong in a different
+  direction.  `ifn?` is too permissive: maps, sets, keywords and symbols are
+  all `IFn` and every one of them treats the thunk as a KEY.  `fn?` is too
+  restrictive: a Var and a multimethod each invoke the thunk correctly while
+  carrying no `clojure.lang.Fn` marker, so `(use-fixtures :each #'lifecycle)`
+  — ordinary, idiomatic, and working — was refused with the false claim that
+  the namespace ran nothing.  Both directions are pinned below, and each is
+  pinned against `clojure.test/join-fixtures` FIRST.
 
   EVERY TEST HERE PINS THE DEFECT BEFORE IT PINS THE GUARD.  The defect is
   pinned against `clojure.test/join-fixtures` itself — the function
@@ -33,6 +44,29 @@
   "The cljs.test form. Legitimate there; uncallable on the JVM."
   {:before (fn [])
    :after  (fn [])})
+
+(defn- lifecycle
+  "An ordinary fixture function, referred to below as `#'lifecycle` — the
+  idiomatic Var form the guard used to refuse (rf2-4yw1)."
+  [t]
+  (t))
+
+(defmulti ^:private multi-lifecycle
+  "A `defmulti` fixture: `clojure.lang.MultiFn` is not `fn?` either, and it
+  invokes the thunk just as a plain fn does."
+  (fn [_t] :only))
+
+(defmethod multi-lifecycle :only [t] (t))
+
+(defn- calls-thunk?
+  "Whether `clojure.test/join-fixtures` — the chain `test-all-vars` builds —
+  actually INVOKES the test thunk when handed `fixture`.  This is the real
+  contract, and every assertion below is graded against it rather than
+  against the guard's opinion of it."
+  [fixture]
+  (let [ran? (atom false)]
+    ((clojure.test/join-fixtures [fixture]) #(reset! ran? true))
+    @ran?))
 
 (defn- with-probe-ns
   "Create `ns-sym`, give it `fixtures` under `meta-key` exactly as
@@ -103,6 +137,46 @@
         (is (= [] (rf.test-quiet.runner/uncallable-fixtures [ns-obj])))))
     (is (= [] (rf.test-quiet.runner/uncallable-fixtures [(the-ns 'clojure.core)])))
     (is (= [] (rf.test-quiet.runner/uncallable-fixtures [])))))
+
+;; ----------------------------------------------------------------------
+;; The other direction: callable entries `fn?` does not recognise (rf2-4yw1).
+
+(deftest callable-fixtures-that-are-not-fn-are-not-offenders
+  (testing "THE DEFECT THIS TIME IS THE GUARD'S: `#'lifecycle` and a
+            `defmulti` fixture both RUN the test, and `fn?` says false of
+            both, so `fn?` cannot be the contract"
+    (doseq [[label fixture] [["a Var referring to a function" #'lifecycle]
+                             ["a multimethod"                 multi-lifecycle]
+                             ["a Var referring to a multimethod"
+                              #'multi-lifecycle]]]
+      (is (false? (fn? fixture))
+          (str label " is not `fn?` — which is why the guard refused it"))
+      (is (true? (calls-thunk? fixture))
+          (str label " nevertheless invokes the test thunk, so"
+               " `clojure.test` runs the namespace's tests normally"))
+      (with-probe-ns 'probe.callable-fixture-ns :clojure.test/each-fixtures
+        (list fixture)
+        (fn [ns-obj]
+          (is (= [] (rf.test-quiet.runner/uncallable-fixtures [ns-obj]))
+              (str "and so the guard must accept " label)))))))
+
+(deftest a-var-referring-to-a-map-is-still-an-offender
+  (testing "a Var is an INDIRECTION, not a licence: `Var.invoke` forwards to
+            its root, so a Var whose root is a map swallows the thunk exactly
+            as the bare map does and must stay refused"
+    (let [holder    (create-ns 'probe.var-to-map-holder)
+          var-to-map (intern holder 'lifecycle map-fixture)]
+      (try
+        (is (false? (calls-thunk? var-to-map))
+            "the thunk is swallowed through the Var just as it is directly")
+        (with-probe-ns 'probe.var-to-map-ns :clojure.test/each-fixtures
+          (list var-to-map)
+          (fn [ns-obj]
+            (is (= 1 (count (rf.test-quiet.runner/uncallable-fixtures
+                              [ns-obj])))
+                "accepting every Var would reopen the defect one level down")))
+        (finally
+          (remove-ns 'probe.var-to-map-holder))))))
 
 (deftest this-lane-is-itself-clean
   (testing "the shipped call — every namespace this JVM has loaded — and so

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -34,11 +34,13 @@
      refuses the run (exit 1, named on stderr) instead of leaving it
      silently short a suite — and the same fixture is green the moment
      before that file arrives.
-   - FIXTURES: a namespace whose `use-fixtures` entry is not a function
+   - FIXTURES: a namespace whose `use-fixtures` entry cannot be CALLED
      — the cljs.test `{:before f :after g}` map, whether written at the
      call site or reached through a var — refuses the run (exit 1, the
      namespace named on stderr) instead of contributing zero tests to a
-     tally that reports itself green.
+     tally that reports itself green; and, in the other direction, an
+     entry that IS callable without being `fn?` — a var referring to a
+     fixture function — keeps its lane green (rf2-4yw1).
    - STDERR BUFFER: a green run that emits expected
      stderr warnings stays quiet (the warnings are buffered + dropped);
      a RED run REPLAYS the buffered stderr context so a failing run
@@ -461,25 +463,50 @@
     (assert-uncallable-fixture-refused
       "bound_fixture_test" "probe.bound-fixture-test" source)))
 
+(defn- assert-callable-fixture-runs-green
+  "Run a one-`deftest` probe under `fixture-source` through the real `-main`
+  and assert the honest lane is untouched: the test RAN and the process
+  exited 0.  The passing assertion is the point — under a swallowed fixture
+  the tally would read `Ran 0 tests`, so the count discriminates `it ran` from
+  `it was skipped` exactly as the red rows' failing assertion does."
+  [file-stem ns-name-str fixture-source]
+  (with-fixture-dir
+    (fn [dir]
+      (write-raw-fixture! dir file-stem
+        (str "(ns " ns-name-str "\n"
+             "  (:require [clojure.test :refer [deftest is use-fixtures]]\n"
+             "            [re-frame.test-quiet]))\n"
+             fixture-source
+             "(deftest a-passing-test (is (= 1 1)))\n"))
+      (let [{:keys [exit out err]} (invoke-quiet-runner dir)]
+        (is (zero? exit)
+            (str "got exit " exit "\n--- stdout ---\n" out
+                 "\n--- stderr ---\n" err))
+        (is (str/includes? out "Ran 1 tests containing 1 assertions.")
+            (str "and the fixture chain must still run the test; got\n"
+                 out))))))
+
 (deftest function-fixtures-keep-the-run-green
   (testing "the control: an ordinary lane with :once and :each FN fixtures is
             untouched, so the guard cannot red honest code"
-    (with-fixture-dir
-      (fn [dir]
-        (write-raw-fixture! dir "fn_fixture_test"
-          (str "(ns probe.fn-fixture-test\n"
-               "  (:require [clojure.test :refer [deftest is use-fixtures]]\n"
-               "            [re-frame.test-quiet]))\n"
-               "(use-fixtures :once (fn [t] (t)))\n"
-               "(use-fixtures :each (fn [t] (t)))\n"
-               "(deftest a-passing-test (is (= 1 1)))\n"))
-        (let [{:keys [exit out err]} (invoke-quiet-runner dir)]
-          (is (zero? exit)
-              (str "got exit " exit "\n--- stdout ---\n" out
-                   "\n--- stderr ---\n" err))
-          (is (str/includes? out "Ran 1 tests containing 1 assertions.")
-              (str "and the fixture chain must still run the test; got\n"
-                   out)))))))
+    (assert-callable-fixture-runs-green
+      "fn_fixture_test" "probe.fn-fixture-test"
+      (str "(use-fixtures :once (fn [t] (t)))\n"
+           "(use-fixtures :each (fn [t] (t)))\n"))))
+
+(deftest var-fixtures-keep-the-run-green
+  (testing "THE REGRESSION CONTROL (rf2-4yw1): `(use-fixtures :each
+            #'lifecycle)` is ordinary, idiomatic and WORKING — `Var.invoke`
+            forwards to the root function, so the test runs — yet `fn?` is
+            false of a Var, and the guard refused the lane with the false
+            claim that every test in it silently did not run.  A census of
+            today's corpus cannot stand in for this row: it says only that
+            nobody happens to write the form, not that the form is broken."
+    (assert-callable-fixture-runs-green
+      "var_fixture_test" "probe.var-fixture-test"
+      (str "(defn lifecycle [t] (t))\n"
+           "(use-fixtures :once #'lifecycle)\n"
+           "(use-fixtures :each #'lifecycle)\n"))))
 
 ;; ----------------------------------------------------------------------
 ;; Nested-run banner correctness.


### PR DESCRIPTION
Fixes the demonstrated false positive in `re-frame.test-quiet.runner/uncallable-fixtures`,
added by #9453 and reopened on rf2-4yw1 by that PR's merged-PR audit. The map-as-lookup defect
the rule exists to catch is preserved in all four of its shapes.

## What was wrong

The rule refused any `use-fixtures` entry failing `fn?`, then announced that **every test in the
namespace silently did not run**. That claim is false for a Var. `(defn lifecycle [t] (t))`
followed by `(use-fixtures :each #'lifecycle)` runs the test correctly, because `Var.invoke`
forwards to its root — measured through the real lane at the pre-fix source, the run reports
`Ran 1 tests containing 1 assertions. / 0 failures, 0 errors.` **and exits 1** naming
`clojure.lang.Var`.

The docstring at `uncallable-fixtures` asserted the reason: *"`fn?` is the whole test: it is
precisely what `join-fixtures` needs of each entry"*. That is the false claim, so the prose moves
with the code — otherwise the defect stays documented as intended behaviour.

## What `join-fixtures` actually does with each candidate

`join-fixtures` reduces the entries with `compose-fixtures`, which builds
`(fn [g] (f1 (fn [] (f2 g))))`. So each entry is **applied to one argument and must CALL it**.
That is a behavioural requirement, and no predicate over a value decides it. Both cheap
approximations are wrong, in opposite directions — measured on Clojure 1.12, each row asserting
whether `join-fixtures` invokes the thunk:

| candidate | `fn?` | `ifn?` | calls the thunk? |
|---|---|---|---|
| `(fn [t] (t))` | true | true | **yes** |
| `#'lifecycle` (root is a fn) | false | true | **yes** |
| a `defmulti` fixture | false | true | **yes** |
| `{:before f :after g}` | false | true | no — key lookup, returns nil |
| `#'lifecycle` where the root is a **map** | false | true | no — forwards to the map |
| keyword / set / symbol | false | true | no — key lookup |
| vector | false | true | no — throws `Key must be integer` |

`ifn?` is true in every row, so it would disarm the rule entirely. `fn?` is false for `Var` and
`MultiFn`, which is the regression: neither carries the `clojure.lang.Fn` marker `fn?` tests for,
yet both invoke the thunk.

## The predicate

`callable-fixture?` is the narrowest thing wrong in neither direction — **a function, a
multimethod, or an indirection resolving to one**:

```clojure
(or (fn? fixture)
    (instance? clojure.lang.MultiFn fixture)
    (and (var? fixture) (callable-fixture? (deref fixture))))
```

The Var case **recurses on the root** rather than accepting every Var. That is not incidental: a
Var whose root is a map swallows the thunk exactly as the bare map does (row 5 above), so
`(and (var? f) …)` alone would reopen the defect one level down. The recursion mirrors
`Var.invoke`, which forwards to whatever the root is.

It is also strictly wider than `fn?` — `(fn? x)` implies `(callable-fixture? x)` — so **no lane
that was green can become red** by this change. The lane sweep below is the empirical half of that.

No API validation and no compatibility shim: this is a test-runner regression, and the repair is
programmer-trusting callable semantics.

## Four-state evidence — the real lane, exit codes read from the runner's own command line

Four one-`deftest` probe namespaces, each in its own isolated discovery root, each run through
`clojure.main -m re-frame.test-quiet.runner -d <root>` in a fresh JVM. The green rows assert a
passing test so the tally discriminates *it ran* from *it was skipped*; the red rows assert a
**failing** one, so a green tally could only mean the thunk was swallowed.

| fixture | before (source at `HEAD~`) | after | tally | complaint |
|---|---|---|---|---|
| `(use-fixtures :once/:each lifecycle)` — plain fn | exit **0** | exit **0** | `Ran 1 tests containing 1 assertions. / 0 failures, 0 errors.` | none |
| `(use-fixtures :once/:each #'lifecycle)` — **the regression** | exit **1** | exit **0** | `Ran 1 tests containing 1 assertions. / 0 failures, 0 errors.` | before: names `clojure.lang.Var` and claims every test did not run. after: none |
| `(use-fixtures :each {:before … :after …})` — map literal | exit **1** | exit **1** | `Ran 0 tests containing 0 assertions.` | names `probe.map-literal-fixture-test :clojure.test/each-fixtures -> clojure.lang.PersistentArrayMap` |
| `(def lifecycle {…})` + `(use-fixtures :once lifecycle)` — symbol-bound map, `:once` | exit **1** | exit **1** | `Ran 0 tests containing 0 assertions.` | names `probe.map-symbol-fixture-test :clojure.test/once-fixtures -> clojure.lang.PersistentArrayMap` |

The before column is the pre-fix `runner.clj` extracted from the parent commit and placed ahead of
`src` on the classpath, so the four rows differ only in that one file. Row 2 before/after is the
whole finding: identical tally, opposite exit code.

## Tests added

- `re-frame.test-quiet-fixture-integrity-test` (in-process, pinned against
  `clojure.test/join-fixtures` itself before it is pinned against the guard):
  `callable-fixtures-that-are-not-fn-are-not-offenders` — `#'lifecycle`, a multimethod, and a Var
  referring to one: each asserted `(false? (fn? …))` **and** `(true? (calls-thunk? …))` **and**
  accepted by the rule. `a-var-referring-to-a-map-is-still-an-offender` pins the recursion.
- `re-frame.test-quiet-runner-contract-test/var-fixtures-keep-the-run-green` — the real-run
  callable-Var control, beside the existing function and map controls, through the real `-main`
  across a process boundary. The green rows now share one helper with the same shape as the red
  rows' helper.

A census of today's corpus is deliberately **not** treated as evidence here: repo-wide,
`use-fixtures :each|:once #'…` reads **0** across `*.clj`/`*.cljc` against a live control of
**676** for all `use-fixtures :each|:once` forms in the same file set (shape control: 26 for the
fn-literal form). Nothing on main was red from this — it was a latent false positive. That count
says only that nobody happens to write the form today, not that the form is broken.

## Quality gates

Run in the foreground to completion; every number below was captured with the redirect and the
`echo $?` on one command line and quoted from that file, not from a harness report.

| gate | result |
|---|---|
| `implementation/test-quiet` `clojure -M:test` — **before** the fix, with the new tests | exit **1**, 65 tests / 320 assertions, **4 failures** (the false positive, reproduced) |
| `implementation/test-quiet` `clojure -M:test` — after | exit **0**, 65 tests / 320 assertions, 0 failures |
| `implementation/core` `clojure -M:test` | exit **0**, 2288 tests / 11798 assertions, 0 failures |
| `tools/story` `clojure -M:test` | exit **0**, 1914 tests / 7047 assertions, 0 failures |
| `implementation/routing` `clojure -M:test` | exit **0**, 559 tests / 3554 assertions, 0 failures |
| `implementation/ssr` `clojure -M:test` | exit **0**, 648 tests / 4271 assertions, 0 failures |
| `scripts/check_test_lane_bijection.py` | exit 0 |
| `scripts/check_readme_inventories.py` | exit 0 |
| `scripts/check_jvm_lane_rosters.py` | exit 0 |
| `scripts/check_require_alias_dialect.py` | exit 0 |
| `scripts/check_retired_spellings.py` | exit 0 |
| `scripts/check-commit-attribution.sh origin/main` | exit 0 |

**Why that lane set.** The guard fires from `:summary` over `(all-ns)`, so every JVM artefact lane
exercises it, and the risk this PR carries is redding honest code. Those four lanes are the
non-fenced artefacts with the densest fixture use — 336 of the tree's 676 `use-fixtures
:each|:once` forms — and they consume this branch's `test-quiet` through `:local/root`, so the
edited runner is the one that graded 5409 tests / 26670 assertions. `implementation/machines`,
`implementation/resources`, `implementation/epoch`, `implementation/hicasso` and `tools/xray` are
held by concurrent work and were left alone; CI grades them.

**Sabotage proof the gate is live and read this branch.** `(or (fn? fixture)` was replaced by
`(or (ifn? fixture)` — the over-permissive predicate the docstring warns about. Anchor match count
read **1** before the run, so the plant was not a no-op. The suite went **exit 1 with 15
failures**, naming every map-rejection row including the Var-to-map recursion row and both
subprocess red rows. Restored with `git checkout HEAD --` and verified by git **blob** hash:
`52c5d85f89ac8c8376b7bfeddb38ed8dcc38df29` before the plant, `801ebd2dbd927f91ca777bbea0eedbcab61810cc`
under it, back to `52c5d85f89ac8c8376b7bfeddb38ed8dcc38df29` after.

**What CI still owns.** `python scripts/check_fast_pr_gap.py --brief` reports 99 required checks
this local gating does not decide. The changed-surface classifier, run over this diff's paths,
arms `implementation_jvm` and `cljs_node_test` (control: a `core.cljc` path arms 16 surfaces, so
the classifier was live). `clj-kondo`/Splint were left to CI, whose pinned version is the one that
grades the PR. No `.github/workflows/**` change, no new job, no new script — the required-check
band does not move.

**Verified by hand:** no `.beads` path in the diff — `git diff --name-only origin/main...HEAD |
grep -c '^\.beads/'` reads 0, with a control on a synthetic `.beads/issues.jsonl` line reading 1,
so the filter is live. The diff is confined to `implementation/test-quiet/**`; no fixture in any
other artefact was repaired or converted.

rf2-4yw1
