### PR TITLE
test(xray): manual-only epoch-delivery witness (rf2-kuky.82 AMEND 2(c))

### DIFF
--- a/implementation/package.json
+++ b/implementation/package.json
@@ -28,6 +28,7 @@
     "test:cljs-isolation": "node scripts/compile-node-test.cjs node-test out/node-test.js && node scripts/check-per-ns-isolation.cjs",
     "test:security": "node scripts/compile-node-test.cjs node-test-security out/node-test-security.js && node out/node-test-security.js",
     "test:testbed-support": "node scripts/compile-node-test.cjs node-test-testbed-support out/node-test-testbed-support.js && node out/node-test-testbed-support.js",
+    "test:xray-manual-epoch": "node scripts/compile-node-test.cjs node-test-xray-manual-epoch out/node-test-xray-manual-epoch.js && node out/node-test-xray-manual-epoch.js",
     "test:tools-machines-viz": "cd ../tools/machines-viz && clojure -M:cljs-test -m shadow.cljs.devtools.cli compile machines-viz-node-test && node ../../implementation/out/node-test-tools-machines-viz.js",
     "build:machines-viz-viewer": "shadow-cljs release machines-viz-viewer && node ../tools/machines-viz/scripts/stage-viewer-page.cjs",
     "build:hicasso-release": "shadow-cljs release hicasso-release && node hicasso/scripts/check_production_erasure.cjs --self-test && node hicasso/scripts/check_production_erasure.cjs && node hicasso/scripts/check_bundle_isolation.cjs --self-test && node hicasso/scripts/check_bundle_isolation.cjs",

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -867,6 +867,40 @@
    :main      re-frame.test-quiet.shadow-node/main
    :compiler-options {:infer-externs false}}
 
+  ;; rf2-kuky.82 AMEND 2(c) — the MANUAL-ONLY Xray epoch-delivery witness.
+  ;; Same shape as the three focused `:node-test` siblings above; here the
+  ;; narrow `:ns-regexp` is not an ergonomic convenience but the WHOLE
+  ;; TEETH of the gate.
+  ;;
+  ;; `install.cljs` carries a bare `[re-frame.epoch]` require that loads the
+  ;; epoch PRODUCER on the manual `core/init!` startup path (which requires
+  ;; `install`, never `preload`). Without it `(rf/register-listener! :epoch …)`
+  ;; degrades to the silent no-op it correctly performs for a host that
+  ;; tolerates the artefact's absence, and Xray's Time-Travel panel sits
+  ;; empty on every manual boot with nothing reporting why.
+  ;;
+  ;; That claim can only be tested in a graph that has no OTHER route to the
+  ;; producer, and the always-on `:node-test` bundle has several — starting
+  ;; with `day8.re-frame2-xray.preload`, which carries the identical anchor
+  ;; and is required by `preload_decoupling_cljs_test`. So a delivery
+  ;; assertion in the aggregate bundle passes whether or not `install.cljs`
+  ;; still spells its require: it cannot tell the two worlds apart. This
+  ;; build selects ONE namespace, whose require list reaches
+  ;; `re-frame.epoch` through `install.cljs` and nowhere else.
+  ;;
+  ;; The witness namespace also ends in `-cljs-test`, so it rides the
+  ;; always-on `:node-test` build too and its ASSERTIONS are graded on every
+  ;; PR; only the graph-isolation half needs this id.
+  ;;
+  ;; Run by `npm run test:xray-manual-epoch`.
+  :node-test-xray-manual-epoch
+  {:target    :node-test
+   :output-to "out/node-test-xray-manual-epoch.js"
+   :ns-regexp "^day8\\.re-frame2-xray\\.manual-epoch-delivery-cljs-test$"
+   :main      re-frame.test-quiet.shadow-node/main
+   :compiler-options {:warnings      {:redef false}
+                      :infer-externs false}}
+
   ;; rf2-hic-008 — the Hicasso artefact's RELEASE build: the substrate
   ;; compiled the way a consumer ships it.
   ;;

--- a/scripts/check_gate_scheduling.py
+++ b/scripts/check_gate_scheduling.py
@@ -236,6 +236,29 @@ DISPOSITIONS: dict[str, dict] = {
                "`^re-frame\\.testbed\\..+-cljs-test$` — again a strict subset "
                "of `cljs-test$`, so the scheduled consolidated lane runs them",
     },
+    # rf2-kuky.82 AMEND 2(c).  The one DECLARED HOLE in this file, and it is
+    # NOT `covered-by: test:cljs` even though its namespace does ride that
+    # lane.  `:node-test-xray-manual-epoch` selects the same single
+    # `-cljs-test$` namespace the consolidated build already runs, so on the
+    # rule the two siblings above use this would read as a strict subset —
+    # and that reading would be exactly wrong.  The teeth of this gate are
+    # the DEPENDENCY GRAPH, not the assertions: it proves `install.cljs`'s
+    # bare `[re-frame.epoch]` require is what loads the epoch producer on the
+    # manual `core/init!` startup path, and the consolidated bundle also
+    # loads `day8.re-frame2-xray.preload`, which carries the identical
+    # anchor.  So `test:cljs` runs the assertions and cannot fail them in
+    # either world.  Claiming cover here would be a premise that reads true
+    # and grades nothing — the class this checker exists to refuse.
+    "test:xray-manual-epoch": {
+        "kind": "unscheduled",
+        "bead": "rf2-zwgx",
+        "why": "the focused build landed with no CI home because "
+               "`.github/workflows/**` was fenced to a peer worker on the "
+               "tick that built it — the same fence that made "
+               "`test:hicasso-controlled` and `test:hicasso-hmr` declare "
+               "themselves here before rf2-ga8m / rf2-hic-015 gave them "
+               "jobs. rf2-zwgx owes the step and the deletion of this entry",
+    },
     "test:cljs-isolation": {
         "kind": "ci-runs-it-directly",
         "probe": "node scripts/check-per-ns-isolation.cjs",
@@ -279,10 +302,11 @@ DISPOSITIONS: dict[str, dict] = {
     # green — and a declared hole that outlives its gate's schedule is the
     # same class of lie as an undeclared one, told the other way round.
     #
-    # NO DECLARED HOLE REMAINS, and this time the sentence is true.  It was
-    # written once before, above the `test:hicasso-hmr` entry that then sat
-    # directly beneath it — a checker asserting its own completeness while the
-    # counter under it read `1 of them known holes`.
+    # ONE DECLARED HOLE REMAINS — `test:xray-manual-epoch` (rf2-zwgx), the
+    # entry above.  This sentence has twice said the opposite while a hole sat
+    # beneath it, so read the SUMMARY LINE this script prints (`N of them
+    # known holes with beads`) rather than this comment: a checker asserting
+    # its own completeness in prose is the failure mode, not the check.
     #
     # `test:hicasso-hmr` (rf2-hic-015) was that entry, and it is DELETED.  The
     # Hicasso HMR gate — the only surface in the repo that drives a REAL hot

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -935,6 +935,24 @@ Xray's time-travel panel still renders an empty state when
 `(empty? (rf/epoch-history ...))` — but that reflects a target frame
 with **no epochs recorded yet**, not an absent artefact.
 
+**Where that guarantee is witnessed.** The claim above is about a
+DEPENDENCY GRAPH, so no test sharing a bundle with `preload.cljs` can
+grade it: the preload carries the identical bare require, and a delivery
+assertion beside it passes whether or not `install.cljs` still spells its
+own. The witness is therefore a namespace plus a build that selects only
+that namespace —
+`tools/xray/test/day8/re_frame2_xray/manual_epoch_delivery_cljs_test.cljs`
+under the `:node-test-xray-manual-epoch` build in
+`implementation/shadow-cljs.edn` (`npm run test:xray-manual-epoch`). Its
+require list reaches `re-frame.epoch` through `install.cljs` and nowhere
+else, and it asserts both halves of the paragraph above: that the
+producer reads as loaded through `(rf/features)` after requiring the
+manual facade alone, and that an `:epoch` listener registered through the
+facade after `core/init!` receives a dispatched event's assembled
+`:rf/epoch-record`. Delete the require and that build goes red; the
+always-on `:node-test` bundle, which runs the same namespace, stays
+green — which is precisely why the focused build exists.
+
 **Frame-destroy handling.** When the host frame whose drain
 produced an epoch is later destroyed (per
 [Spec 002 §Destroy](../../../spec/002-Frames.md)), the framework

--- a/tools/xray/test/day8/re_frame2_xray/manual_epoch_delivery_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/manual_epoch_delivery_cljs_test.cljs
@@ -1,0 +1,123 @@
+(ns day8.re-frame2-xray.manual-epoch-delivery-cljs-test
+  "rf2-kuky.82 AMEND 2(c) — the MANUAL-ONLY Xray epoch-delivery witness.
+
+  ## What this pins
+
+  `install.cljs` carries a bare `[re-frame.epoch]` require whose only job
+  is to LOAD the epoch PRODUCER namespace on the manual startup path.
+  `day8.re-frame2-xray.core` requires `install`, never `preload`, so a
+  host that boots Xray by calling `core/init!` gets the producer through
+  that require and through nothing else. The facade reaches the producer
+  through a late-bind hook an unloaded namespace never populates, so
+  without the require `(rf/register-listener! :epoch …)` degrades to the
+  silent no-op it correctly performs for a host that must tolerate the
+  artefact's absence — and Xray's Time-Travel panel would sit empty on
+  every manual boot with nothing anywhere reporting why.
+  `tools/xray/spec/011-Launch-Modes.md` §Epoch artefact is a hard Xray
+  dependency states that contract; this namespace is its witness.
+
+  ## Why it needs its OWN build
+
+  `preload_decoupling_cljs_test` already covers the manual facade's
+  inertness, but it `:require`s `day8.re-frame2-xray.preload`, and
+  `preload.cljs` carries the SAME bare `[re-frame.epoch]` anchor. So does
+  most of the always-on `:node-test` bundle. In any graph that loads the
+  preload, the producer is present however `install.cljs` is spelled, and
+  a delivery assertion there passes in both worlds — which is exactly the
+  gap this file closes.
+
+  The discriminating surface is therefore the DEPENDENCY GRAPH, not the
+  assertions. `:node-test-xray-manual-epoch` (implementation/shadow-cljs.edn)
+  selects THIS namespace and nothing else, so the compiled bundle contains
+  only what the manual host's own graph contains: `re-frame.core`, a
+  substrate adapter, the test-support fixture, and `day8.re-frame2-xray.core`.
+  Nothing in that set reaches `re-frame.epoch` except `install.cljs`'s
+  anchor — verified by removing the anchor and watching this namespace go
+  red under `npm run test:xray-manual-epoch`.
+
+  This namespace also ends in `-cljs-test`, so it rides the always-on
+  `:node-test` build's `cljs-test$` regexp and its ASSERTIONS are graded on
+  every PR. Only the graph-isolation half needs the focused build; in the
+  aggregate bundle these tests pass whether or not the anchor is there.
+
+  ## Deliberately NOT required here
+
+  `re-frame.epoch`, `re-frame.epoch.state` and `day8.re-frame2-xray.preload`
+  are all absent from the require list ON PURPOSE — each would load the
+  producer itself and rescue a removed anchor. The producer-loading claim
+  is read through `rf/features`, which is a pure keyword lookup in the
+  always-loaded late-bind hooks atom and requires nothing optional; the
+  delivery claim is read through `rf/register-listener!` and
+  `rf/epoch-history`, the same public doors a host uses."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.core :as xray]))
+
+;; No DOM under `:node-test`; the plain-atom adapter is the right substrate
+;; (same choice as `re-frame.epoch-cljs-test`). The fixture snapshot/restores
+;; the registrar and drives the epoch reset hooks (`:epoch/clear-history!`,
+;; `:epoch/clear-epoch-listeners!`, `:epoch/reset-config!`) so each test starts
+;; from a shipped-default ring.
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter}))
+
+;; ---- (1) the graph claim -------------------------------------------------
+
+(deftest manual-graph-alone-loads-the-epoch-producer
+  (testing "requiring the manual `core` facade — and nothing else optional —
+            LOADS the epoch producer, so the artefact reads as present
+            through the public feature-inspection door"
+    (is (true? (get-in (rf/features) [:epoch :loaded?]))
+        "re-frame.epoch is loaded by install.cljs's bare require, reached
+         through `day8.re-frame2-xray.core` alone — no preload, no direct
+         require from this namespace")))
+
+;; ---- (2) the delivery claim ----------------------------------------------
+
+(deftest manual-init!-receives-a-dispatched-events-assembled-epoch
+  (testing "after the manual public `core/init!`, an `:epoch` listener
+            registered through the facade RECEIVES the assembled
+            `:rf/epoch-record` for a dispatched event — the fan-out
+            `install/register-epoch-collector!` itself rides, proving that
+            registration is not the silent no-op an unloaded producer
+            would make of it"
+    (let [seen (atom [])]
+      (rf/reg-event ::bump (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+
+      ;; The manual startup path under test. `init!` wires the registry
+      ;; handlers, the trace + epoch collectors, the browser exports and the
+      ;; keybinding; it is the documented alternative to `:devtools/preloads`.
+      (xray/init!)
+
+      ;; A probe on the same public stream Xray's own collector attaches to,
+      ;; registered AFTER init! so nothing init! dispatches is counted.
+      ;; Filtered to the host frame: `init!` seats Xray's own `:rf/xray`
+      ;; frame, whose epochs are not this assertion's subject.
+      (rf/register-listener! :epoch ::witness
+                             (fn [record] (swap! seen conj record)))
+
+      (rf/dispatch-sync [::bump])
+
+      (let [records (filterv #(= :rf/default (:frame %)) @seen)
+            record  (first records)]
+        (is (= 1 (count records))
+            "exactly one fan-out for one dequeued event on the host frame")
+        (is (= ::bump (:event-id record))
+            ":event-id names the dispatched event")
+        (is (= [::bump] (:trigger-event record))
+            ":trigger-event is the full event vector")
+        (is (= {:n 1} (:db-after record))
+            ":db-after is the post-settle snapshot — an ASSEMBLED record,
+             not a bare notification")
+        (is (= :ok (:outcome record))
+            ":outcome :ok pins the event-settle outcome"))
+
+      (let [history (rf/epoch-history :rf/default)]
+        (is (= 1 (count history))
+            "the same epoch is retained in the frame's ring — the vector
+             Xray's Time-Travel panel re-reads")
+        (is (= ::bump (:event-id (last history)))
+            "and it is the dispatched event's record")))))


### PR DESCRIPTION
Delivers **rf2-kuky.82 AMEND 2(c)** — the acceptance clause the merged-PR audit of #9437 reopened the bead for. The demotion work that landed in #9437 (the five epoch doors as implementation-tier hook targets, the duplicate manifest rows) is untouched.

## What was missing

`install.cljs` carries a bare `[re-frame.epoch]` require whose only job is to LOAD the epoch **producer** on the manual startup path — `day8.re-frame2-xray.core` requires `install`, never `preload`. Without it, `(rf/register-listener! :epoch …)` degrades to the silent no-op it correctly performs for a host that tolerates the artefact's absence, and Xray's Time-Travel panel sits empty on every manual boot with nothing anywhere reporting why. `tools/xray/spec/011-Launch-Modes.md` §Epoch artefact is a hard Xray dependency states that contract. Nothing witnessed it.

## What the witness proves that `preload_decoupling_cljs_test.cljs` cannot

That test requires `day8.re-frame2-xray.preload`, and `preload.cljs` carries the **identical** bare `[re-frame.epoch]` anchor. So its `init!-performs-the-manual-install` test observes the registry in a bundle where the producer is loaded regardless of how `install.cljs` is spelled — it passes in both worlds, which is exactly the defect. So does every other assertion in the always-on `:node-test` bundle: measured, `out/node-test.js` carries 3 references to `re_frame2_xray.preload`.

The claim is about a **dependency graph**, not about assertions, so the witness needs a graph of its own:

* `tools/xray/test/day8/re_frame2_xray/manual_epoch_delivery_cljs_test.cljs` requires only `re-frame.core`, `re-frame.substrate.plain-atom`, `re-frame.test-support` and `day8.re-frame2-xray.core`. `re-frame.epoch`, `re-frame.epoch.state` and the preload are absent **on purpose** — each would load the producer itself and rescue a removed anchor. The producer-loading claim is read through `rf/features` (a pure keyword lookup in the always-loaded late-bind hooks atom, no optional require); the delivery claim through `rf/register-listener!` and `rf/epoch-history`, the public doors a host uses.
* `:node-test-xray-manual-epoch` (`implementation/shadow-cljs.edn`) selects that one namespace. Same shape as the three focused `:node-test` siblings beside it (`-security`, `-testbed-support`, `-hicasso`); here the narrow `:ns-regexp` is the whole teeth rather than an ergonomic convenience.

It asserts (a) the producer reads as loaded through `(rf/features)` after requiring the manual facade **alone**, and (b) after the public `core/init!`, an `:epoch` listener registered through the facade receives a dispatched event's **assembled** `:rf/epoch-record` — `:event-id`, `:trigger-event`, `:db-after`, `:outcome` — and the same record is retained in the frame's ring.

## Plant-and-restore (the gate-liveness proof for the witness itself)

`install.cljs`'s `[re-frame.epoch]` line removed, gate re-run, restored, re-run. Exit codes read from the runner's own command line, never through a pipe.

| run | `install.cljs` | modules in bundle | `re_frame.epoch.*` in graph | result |
|---|---|---|---|---|
| 1 | anchor present | 531 | 6 | **exit 0** — 2 tests, 8 assertions, 0 failures |
| 2 | **anchor removed** | 525 | **0** | **exit 1** — 8 failures / 8 assertions |
| 3 | restored | 531 | 6 | **exit 0** — 2 tests, 8 assertions, 0 failures |

* Plant match count read **before** the run: 1 line (`^            \[re-frame\.epoch\]\r?$`). Without the `\r?` the same pattern reads **0** — these files are CRLF, so the control was needed to trust the count at all.
* Restore verified by **blob hash**, not by a diff or an exit code: `git hash-object` read `50b26b31f3c8257d086ed2863005ed31139c053c` before the plant and the identical value after the restore, matching `git rev-parse HEAD:tools/xray/src/day8/re_frame2_xray/install.cljs`.
* **No incidental producer load rescued the plant**, checked on the actual compiled graph rather than reasoned about: under the plant the bundle carried **zero** `re_frame.epoch.*` modules while `re_frame2_xray.install` was still present (control), and the first failure was `(get-in (rf/features) [:epoch :loaded?])` reading `false` — the silent-no-op path itself.
* Each run's `shadow-cljs - config:` line named this worktree's `implementation/shadow-cljs.edn`, so the gate is confirmed to have read this tree.

The witness also passes **inside** the aggregate bundle (`node out/node-test.js --test=day8.re-frame2-xray.manual-epoch-delivery-cljs-test`, exit 0) — it ends in `-cljs-test`, so its assertions ride the always-on lane on every PR. Only the graph-isolation half needs the focused build.

## Quality gates

**8 gates run, 8 pass, 0 fail.** Plus 2 deliberate reds from planted faults (counted separately — both restored and re-verified).

| gate | how run | result |
|---|---|---|
| `npm run test:xray-manual-epoch` (the new witness) | foreground, ×3 | **0 / 1 / 0** — plant-and-restore table above |
| `node out/node-test.js --test=<witness ns>` (aggregate bundle) | foreground | **exit 0**, 2 tests / 8 assertions |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | foreground | **exit 0**, 1921 files, 0 warnings |
| `npm run test:scripts` | foreground | **exit 0**, 123 pass / 0 fail — the policy suite grading `shadow-cljs.edn` + `package.json` |
| `python scripts/check_gate_scheduling.py` (+ `--self-test`) | foreground | **exit 0** both; summary now reads `34 gate commands, 29 scheduled, 5 declared (1 of them known holes with beads)` |
| `python scripts/check_doc_slugs.py` | foreground | **exit 0** — and proved red on a planted anchor in the edited file (below) |
| `node implementation/scripts/check-examples-compile.cjs --list` | foreground | **exit 0**, 58 builds, unchanged — the new build id is a `:node-test-*`, not in that roster |
| `check_readme_links.py --ci`, `check-no-hardcoded-paths.sh`, `check_retired_spellings.py`, `check-ai-tracking-ratchet.sh`, `check_fast_pr_gap.py --brief` | foreground | **exit 0** each |

**Second planted fault, for the doc gate.** A `[plant](#rf2-kuky-82-no-such-heading)` anchor inserted into the edited paragraph of `tools/xray/spec/011-Launch-Modes.md`: `check_doc_slugs.py` went **exit 1**, naming `tools\xray\spec\011-Launch-Modes.md:938 -> #rf2-kuky-82-no-such-heading`. Restored and verified by blob hash (`e44d53dae830de5af7b18b75657f59f3f4083ab4` before and after); gate back to exit 0.

**Gates deliberately NOT nominated, with reasons:**

* `xray-spec-check` — reads `tools/xray/spec/API.md` **only** (`xray_spec_check.clj:186`). It does not cover `011-Launch-Modes.md`, and running it would have bought a green that inspected nothing changed here. `check_doc_slugs.py` is the gate that reaches `tools/*/spec`, and it is proved live above.
* `mkdocs build --strict` — `docs_dir` is `docs`, and only `spec/` and `migration/` are staged into it by `mkdocs_hooks.py`. `tools/xray/spec/` is outside the build's reach entirely.
* `gen --check` / the api-manifest reconciler — **no public name moves in this PR.** The diff touches no `spec/api-manifest*.edn` path and defines no new public var; the witness reads existing facade doors only. Expected manifest delta: none. Actual: `git diff --stat origin/main...HEAD` lists 5 files, none of them a manifest path.
* `npm run test:bundle-isolation` — AMEND 2(c) names it for a *changed shipped build*. No shipped build changed: the added id is a `:node-test` target that compiles test namespaces and ships in nothing. The epoch sentinels' absence from the counter bundle is untouched.
* The full `npm run test:cljs` run — the witness namespace was executed inside that exact compiled bundle by name (exit 0, row 2 above); running the remaining ~11k tests locally duplicates the `cljs` job for no information.

**Anchors and table column counts in this body and in the edited spec page were verified by hand.** The `011-Launch-Modes.md` addition introduces no links and no headings; the tables above are 5-column and 3-column throughout.

## The declared hole, and what it is not

`npm run test:xray-manual-epoch` has **no CI home**, because `.github/workflows/**` was fenced to a peer worker on this tick. It is declared `unscheduled` in `scripts/check_gate_scheduling.py` under **rf2-zwgx**, which owes the `test.yml` step and the deletion of that entry.

It is deliberately **not** `covered-by: test:cljs`, even though the namespace does ride that lane and on the rule its two siblings use it would read as a strict `cljs-test$` subset. That reading would be exactly wrong: the consolidated bundle also loads the preload, so it runs the assertions and cannot fail them in either world. A premise that reads true and grades nothing is the class that checker exists to refuse.

Same fence, same shape as `test:hicasso-controlled` (rf2-hic-016 → rf2-ga8m) and `test:hicasso-hmr` (rf2-hic-015), both of which declared themselves there for exactly this reason and were later given jobs.

## Scope

One missing regression witness. No new API, no listener-behaviour change, no validation apparatus, no rewritten acceptance criteria. `install.cljs`, `preload.cljs`, `core.cljs`, the late-bind directory and `preload_decoupling_cljs_test.cljs` are all unmodified — the preload-path coverage is retained as-is. rf2-kuky.53's scoped deletion and rf2-kuky.73's state-reader migration are not touched.

The `implementation/shadow-cljs.edn` edit is hot-zone and kept minimal: one build map appended after its three focused `:node-test` siblings, plus its comment. No existing build is altered.


---

## Rebased onto `c4686fa726` — witness re-verified, not merely re-confirmed

The two reds on the previous head (`Public-API manifest drift-check` and the dependent `Lint required`) were inherited from trunk, not from this diff: `spec/api-manifest.edn` was declaring one more public var than it carried. PR #9467 landed the regeneration. Checked on this branch's new base by **independently counted rows**, never the declared field: `grep -c ':namespace "'` reads **491** and `:var-count` reads **491** — equal, with the instrument controlled (74 `re-frame.core` rows). This diff touches no manifest path, so there was nothing here to regenerate.

**Conflicts: none.** `git merge-tree --write-tree c4686fa726 worker/xraywit-a` exited 0 with a bare tree oid. Measured rather than assumed: across the 38 trunk commits since the old base, **none** touched any of this PR's five files, and none touched `install.cljs`, `preload.cljs` or `core.cljs`. Positive control for that instrument: the same query over `spec/api-manifest.edn` reports 24 changed lines, so the zeros are honest. The rebase applied clean and the diff against the new merge base is byte-for-byte the same shape — 5 files, 204 insertions, 4 deletions.

**The plant-and-restore was re-run anyway, and this is the reason.** Nothing of mine moved, but trunk moved the witness's *own dependency graph* underneath it — `re-frame.core`, `re-frame.epoch`, `epoch/assembly`, `epoch/capture`, `epoch/state` and `epoch/tool_pair`, 231 deletions. A pre-rebase green is evidence about a tree that no longer exists, and this build has **no CI lane** to re-grade it, so a local re-run is the only thing that can. 196 files recompiled on the first run, confirming those changes really did reach this graph.

| run (new base) | `install.cljs` | modules | `re_frame.epoch.*` in graph | result |
|---|---|---|---|---|
| 4 | anchor present | 531 | 6 | **exit 0** — 2 tests, 8 assertions, 0 failures |
| 5 | **anchor removed** | 525 | **0** | **exit 1** — 8 failures / 8 assertions |
| 6 | restored | 531 | 6 | **exit 0** — 2 tests, 8 assertions, 0 failures |

Match count read before the plant: **1**. Restore verified by blob hash — `50b26b31f3c8257d086ed2863005ed31139c053c` before the plant and after the restore, equal to `git rev-parse HEAD:tools/xray/src/day8/re_frame2_xray/install.cljs`. Under the plant the compiled graph again carried **zero** `re_frame.epoch.*` modules while `re_frame2_xray.install` remained present as the control, and `re_frame2_xray.preload` read **0** in every run — the isolation the build exists for is intact on the new base.
