### PR TITLE
fix(api-manifest): regenerate to correct :var-count 496 -> 495 (rf2-cveo)

### DIFF
--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -8,7 +8,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. The :action and :justification columns are the facade-audit axes (spec/Conventions.md §Facade policy fields 4 and 3) — also curated, and present on :facade? true rows ONLY, which is why most rows carry neither. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 496,
+ :var-count 495,
  :tier-vocab
  [:front-porch
   :advanced


### PR DESCRIPTION
Clears a **RED ON MAIN**. `spec/api-manifest.edn` on trunk declared one more public var than it carried, and the required `api-manifest` gate failed.

Fixes rf2-cveo.

## What was wrong

At trunk `27472063a1`, reproduced independently in this worktree before changing anything:

```
cd implementation/scripts/api-manifest
clojure -M -m re-frame.api-manifest.gen --check
```
→ **exit 1**
```
DRIFT: generated manifest differs from spec/api-manifest.edn.
Regenerate with: clojure -M -m re-frame.api-manifest.gen
  (var set identical; :meta or formatting differs — regenerate)
```

## Before / after counts

Three independent row instruments, plus the declared `:meta :var-count` field:

| instrument | before | after |
|---|---|---|
| `` `{:namespace "` `` rows | 495 | 495 |
| `` `, :tier ` `` rows | 495 | 495 |
| `` `:runtime-verified?` `` rows | 495 | 495 |
| declared `:var-count` | **496** | **495** |

The expected post-fix count was derived from the independently counted rows (495), not taken on trust; actual landed at 495. Expected and actual agree.

**No manifest row was added or removed.** The whole diff is one line — the `:var-count` scalar in the `:meta` map, `496` → `495`. `git diff --numstat` reads `1 1 spec/api-manifest.edn`. The `:vars` list is byte-identical to trunk, so no public name moved and the manifest's var set is unchanged.

## How it was fixed

Regenerated only:

```
cd implementation/scripts/api-manifest
clojure -M -m re-frame.api-manifest.gen        # "Wrote ... (495 public vars)."
```

The file carries a `GENERATED … do NOT hand-edit` header; it was not hand-edited. The regeneration touched no other file.

## Quality gates

Run in the foreground to completion, each exit code read off the runner's own command line (never through a pipe).

| gate | exit | output |
|---|---|---|
| `re-frame.api-manifest.gen --check` (before) | **1** | `DRIFT … (var set identical; :meta or formatting differs — regenerate)` |
| `re-frame.api-manifest.gen --check` (after) | **0** | `OK: spec/api-manifest.edn in sync (495 public vars).` |
| `re-frame.api-manifest.api-md-check` | **0** | `OK: spec/API.md projection in sync (154 var-rows checked against the manifest).` |
| `re-frame.api-manifest.doc-api-check` | **0** | `OK: spec/Privacy.md + docs/api/ + docs/story/api/ projection in sync (354 public-var references checked)` / `OK: docs/api page+member coverage in sync (145 eligible manifest vars each have a page + member entry).` |

Pass 3, fail 0 (plus the deliberate pre-fix red that is the defect being cleared).

**No plant-and-restore was staged, by design.** The gate was *already red on trunk* and this change turning it green is stronger liveness evidence than any planted fault — the red came from the real defect, in this worktree, and cleared only after the regeneration.

The remaining check-mains in the `api-manifest` job (`story-spec-check`, `xray-spec-check`, `skills-check`, `doc-guide-check`) all reconcile against the manifest's `:vars` list, which this diff leaves byte-identical, so they cannot observe this change; CI runs them regardless.

## Scope

One regenerated file. No root-cause investigation, no new guard or gate, no merge-tooling change — the causal analysis is recorded on rf2-cveo and any preventive work is a separate decision.
