### PR TITLE
fix(api-manifest): regenerate to correct :var-count 493 -> 491 (rf2-cveo, 2nd instance)

### DIFF
--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -8,7 +8,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. The :action and :justification columns are the facade-audit axes (spec/Conventions.md §Facade policy fields 4 and 3) — also curated, and present on :facade? true rows ONLY, which is why most rows carry neither. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 493,
+ :var-count 491,
  :tier-vocab
  [:front-porch
   :advanced


### PR DESCRIPTION
Clears a **RED ON MAIN**. `spec/api-manifest.edn` on trunk declares two more public vars than it carries, and the required `api-manifest` gate fails.

**Bead:** this is the *second* instance of the defect recorded on **rf2-cveo**, arriving from a different PR. rf2-cveo itself is already CLOSED (its first instance was corrected on trunk by a sibling's rebase regeneration before the dispatched fix could land, and my earlier PR #9464 was closed as superseded — not rejected). A successor bead was being filed as this work started; the coordinator will re-point this PR to it. The **systemic** cause is deliberately not addressed here — it is owned by **rf2-fa7c**, which awaits a ruling.

## What is wrong

At trunk `8808ad22a0`, reproduced in this worktree from a fresh `origin/main` before changing anything:

```
cd implementation/scripts/api-manifest
clojure -M -m re-frame.api-manifest.gen --check
```
→ **exit 1**
```
DRIFT: generated manifest differs from spec/api-manifest.edn.
Regenerate with: clojure -M -m re-frame.api-manifest.gen
  (var set identical; :meta or formatting differs — regenerate)
```

PR #9457 removed two rows and regenerated to 493 against a main that still carried 495 rows; by the time its rebase-merge replayed, main was already at 493 rows, so the product is **491 rows under a 493 header**. The header lags by two.

## Before / after counts

Three independent row instruments, plus the declared `:meta :var-count` field:

| instrument | before | after |
|---|---|---|
| `` `{:namespace "` `` rows | 491 | 491 |
| `` `, :tier ` `` rows | 491 | 491 |
| `` `:runtime-verified?` `` rows | 491 | 491 |
| declared `:var-count` | **493** | **491** |

The expected post-fix count was derived from these independently counted rows (**491**), not taken on trust from the brief; **actual landed at 491**, and the generator printed the same figure itself — `Wrote … (491 public vars).` Expected, actual and the generator's own count all agree.

**No manifest row was added or removed.** The whole diff is one line — the `:var-count` scalar in the `:meta` map, `493` → `491`. `git diff --numstat` against the merge base reads `1 1 spec/api-manifest.edn`. The `:vars` list is byte-identical to trunk, so no public name moved. The generator's own pre-fix verdict independently corroborates this: it said `var set identical` before anything was changed.

## How it was fixed

Regenerated only:

```
cd implementation/scripts/api-manifest
clojure -M -m re-frame.api-manifest.gen
```

The file carries a `GENERATED … do NOT hand-edit` header; it was not hand-edited. The regeneration touched no other file.

## Quality gates

Run in the foreground to completion, each exit code read off the runner's own command line, never through a pipe.

| gate | exit | output |
|---|---|---|
| `re-frame.api-manifest.gen --check` (before) | **1** | `DRIFT … (var set identical; :meta or formatting differs — regenerate)` |
| `re-frame.api-manifest.gen --check` (after) | **0** | `OK: spec/api-manifest.edn in sync (491 public vars).` |
| `re-frame.api-manifest.api-md-check` | **0** | `OK: spec/API.md projection in sync (151 var-rows checked against the manifest).` |
| `re-frame.api-manifest.doc-api-check` | **0** | `OK: spec/Privacy.md + docs/api/ + docs/story/api/ projection in sync (350 public-var references checked)` / `OK: docs/api page+member coverage in sync (141 eligible manifest vars each have a page + member entry).` |

Pass 3, fail 0 (plus the deliberate pre-fix red that is the defect being cleared).

**No plant-and-restore was staged, by design.** The gate was *already red on trunk* and this change turning it green is stronger liveness evidence than any planted fault — the red came from the real defect, in this worktree, and cleared only after the regeneration.

The remaining check-mains in the `api-manifest` job (`story-spec-check`, `xray-spec-check`, `skills-check`, `doc-guide-check`) all reconcile against the manifest's `:vars` list, which this diff leaves byte-identical, so they cannot observe this change; CI runs them regardless.

## Scope

One regenerated file, one commit, branched fresh from current `origin/main`. No root-cause investigation, no new guard or gate, no merge-tooling change — that work belongs to rf2-fa7c.
