### PR TITLE
test(epoch): restore the retained redacted-modified-paths coverage; retarget the trace.tooling docstring

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -45,7 +45,7 @@
 
 (defn non-neg-int?
   "True for non-negative integer values; nil and non-numeric values
-  fail. Mirrors the validation `re-frame.trace/configure-trace-buffer!`
+  fail. Mirrors the validation `re-frame.trace.tooling/configure-trace-buffer!`
   applies at its own config boundary."
   [x]
   (and (integer? x) (not (neg? x))))

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -1,5 +1,5 @@
 (ns re-frame.epoch-privacy-test
-  "Coverage for three epoch privacy surfaces:
+  "Coverage for four epoch privacy surfaces:
 
     1. The record-level :rf.epoch/sensitive? rollup — true when any
        captured trace event carries the :sensitive? stamp OR any
@@ -18,11 +18,18 @@
        egress off-box opt INTO projection at the wire boundary via
        projected-record.
 
+    4. The record-level :rf.epoch/redacted-modified-paths-count
+       integer — how many frame-declared sensitive app-db paths
+       changed value across the cascade. Computed in build-record from
+       the RAW dbs, so it survives the projection that replaces both
+       sides with the same :rf/redacted sentinel.
+
   Also covers retention caps and the JVM debug-disabled path."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.elision :as rf.elision]
             [re-frame.epoch :as rf.epoch]
+            [re-frame.epoch.assembly :as rf.epoch.assembly]
             [re-frame.frame :as rf.frame]
             [re-frame.interop :as rf.interop]
             [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
@@ -75,6 +82,19 @@
   [frame-id]
   (rf.frame/swap-runtime-db! frame-id
     (fn [rt] (rf.elision/apply-classification-effects rt {:sensitive [[:auth :password]]})))
+  nil)
+
+(defn- install-two-sensitive-paths-schema!
+  "Declare TWO sensitive paths against `frame-id` — `[:auth :password]`
+  and `[:auth :token]`. Same EP-0025 commit-plane write as
+  `install-sensitive-schema!`; the second path is what lets the
+  redacted-modified-paths counter be exercised with a discriminating
+  partial-modification control (one path changes, one does not).
+  Returns nil."
+  [frame-id]
+  (rf.frame/swap-runtime-db! frame-id
+    (fn [rt] (rf.elision/apply-classification-effects rt
+               {:sensitive [[:auth :password] [:auth :token]]})))
   nil)
 
 (defn- install-large-schema!
@@ -253,9 +273,13 @@
 ;; invariant has its authoritative pins in
 ;; `epoch_mcp_egress_conformance_test`
 ;; (`forwarder-projected-record-is-sensitive-idempotent` :255 +
-;; `forwarder-projected-record-is-large-idempotent` :305), with the
-;; redact×project composition cases in `epoch_redact_fn_projection_test`.
+;; `forwarder-projected-record-is-large-idempotent` :305).
 ;; Keep idempotency assertions there; do not duplicate them here (rf2-zymix).
+;; (The former `epoch_redact_fn_projection_test` carried the redact×project
+;; composition cases; the `:redact-fn` hook was retired outright on
+;; 2026-09-08 under rf2-kuky.7, so there is no such composition left to pin.
+;; Its RETAINED half — the redacted-modified-paths counter — moved here, to
+;; section 4 at the bottom of this file.)
 
 (deftest projected-record-redacts-sensitive-in-db-after
   (testing "frame-declared sensitive path in :db-after lands as
@@ -1099,3 +1123,221 @@
       (rf/dispatch-sync [:prod.priv/silent])
       (is (empty? (rf/epoch-history :rf/default))
           "ring stays empty — rollup never computed"))))
+
+;; ---- 4. :rf.epoch/redacted-modified-paths-count ----------------------------
+;;
+;; Per Spec-Schemas §`:rf/epoch-record` and Privacy.md §Epoch privacy posture:
+;; each assembled record carries an integer count of frame-declared sensitive
+;; app-db paths whose value differs between `:db-before` and `:db-after`.
+;; Computed inside `build-record` from the RAW dbs (the stored record is always
+;; raw), so it survives the projection that replaces BOTH sides with the same
+;; `:rf/redacted` sentinel — which is the whole point: a post-projection
+;; structural diff sees `:rf/redacted` = `:rf/redacted` and emits no row, and
+;; this counter is the only surviving signal that something classified moved.
+;;
+;; PROVENANCE (rf2-kuky.7): these six tests were written under rf2-dl3gx and
+;; lived in `epoch_redact_fn_projection_test`, whose OTHER half pinned the
+;; `:redact-fn` hook. That hook was retired outright on 2026-09-08 and the file
+;; went with it — but none of the six installs the hook, and the counter is
+;; explicitly RETAINED, so they move here rather than disappearing. Names are
+;; preserved (G1..G7) so the rf2-dl3gx coverage matrix still reads across.
+;;
+;;   G1. No sensitive paths declared                       -> 0.
+;;   G2. Sensitive path declared but value unchanged       -> 0.
+;;   G3. Sensitive path declared and value changed         -> 1; rollup true.
+;;   G4. Multiple sensitive paths, partial modification    -> the count.
+;;   G6. Projection passes the counter through unchanged.
+;;   G7. Halted record (nil :db-before / :db-after) edge.
+;;
+;; The G1/G2 zero cases are the DISCRIMINATING CONTROLS for G3/G4: without
+;; them a producer hard-wired to return a positive integer would pass.
+
+(deftest G1-no-sensitive-paths-yields-zero-count
+  (testing "with no frame-declared sensitive paths registered, the
+            counter is 0 (the empty-paths short-circuit)."
+    (rf/make-frame {:id :test/main})
+    (rf/reg-event :seed (fn [_ _] {:db {:n 0}}))
+    (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})
+
+    (let [raw (last-record :test/main)]
+      (is (= {:n 1} (:db-after raw))
+          "CONTROL — the cascade really ran and really changed the db")
+      (is (= 0 (:rf.epoch/redacted-modified-paths-count raw))
+          "no declarations -> 0, regardless of how much the db changed"))))
+
+(deftest G2-sensitive-path-unchanged-yields-zero-count
+  (testing "a sensitive path is declared but its value did NOT change
+            across the cascade — the counter is 0. This is the control
+            that keeps G3 honest: a declaration alone is not enough."
+    (rf/make-frame {:id :test/main})
+    (install-sensitive-schema! :test/main)
+    (rf/reg-event :seed (fn [_ _]
+                          {:db {:auth   {:password "topsecret"}
+                                :public {:counter 0}}}))
+    (rf/reg-event :touch-public
+                  (fn [{:keys [db]} _] {:db (update-in db [:public :counter] inc)}))
+    (rf/dispatch-sync [:seed]         {:frame :test/main})
+    (rf/dispatch-sync [:touch-public] {:frame :test/main})
+
+    (let [raw (last-record :test/main)]
+      (is (= "topsecret" (get-in raw [:db-before :auth :password]))
+          "CONTROL — the declared path is populated on BOTH sides")
+      (is (= "topsecret" (get-in raw [:db-after :auth :password])))
+      (is (= 1 (get-in raw [:db-after :public :counter]))
+          "CONTROL — a NON-declared path did change, so the zero below is
+           about the declaration and not about an inert cascade")
+      (is (= 0 (:rf.epoch/redacted-modified-paths-count raw))
+          ":auth :password value identical pre/post — counter = 0"))))
+
+(deftest G3-sensitive-path-modified-yields-positive-count
+  (testing "a sensitive path's value changed across the cascade — the
+            counter is 1. The :rf.epoch/sensitive? rollup also reads true."
+    (rf/make-frame {:id :test/main})
+    (install-sensitive-schema! :test/main)
+    (rf/reg-event :login
+                  (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
+    (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
+
+    (let [raw (last-record :test/main)]
+      (is (= 1 (:rf.epoch/redacted-modified-paths-count raw))
+          ":auth :password mutated nil -> \"topsecret\" — count = 1")
+      (is (true? (:rf.epoch/sensitive? raw))
+          "rollup also true — both signals key on the same registry"))))
+
+(deftest G4-multiple-sensitive-paths-partial-modification
+  (testing "two sensitive paths declared; one changes, the other does
+            not — the counter is 1, not 2. This is the assertion that a
+            producer returning `(count declarations)` would fail."
+    (rf/make-frame {:id :test/main})
+    (install-two-sensitive-paths-schema! :test/main)
+    (rf/reg-event :seed
+                  (fn [_ _] {:db {:auth {:password "pw-1" :token "tk-1"}}}))
+    (rf/reg-event :rotate-token
+                  (fn [{:keys [db]} [_ tk]] {:db (assoc-in db [:auth :token] tk)}))
+    (rf/dispatch-sync [:seed]                    {:frame :test/main})
+    (rf/dispatch-sync [:rotate-token "tk-fresh"] {:frame :test/main})
+
+    (let [raw (last-record :test/main)]
+      (is (= "pw-1" (get-in raw [:db-after :auth :password]))
+          "CONTROL — the second declared path is present and UNCHANGED")
+      (is (= 1 (:rf.epoch/redacted-modified-paths-count raw))
+          ":token changed (count += 1); :password unchanged (filtered)")))
+
+  (testing "both declared paths change in the same cascade — counter is 2"
+    (rf/make-frame {:id :test/main})
+    (install-two-sensitive-paths-schema! :test/main)
+    (rf/reg-event :login-both
+                  (fn [{:keys [db]} [_ pw tk]]
+                    {:db (-> db
+                             (assoc-in [:auth :password] pw)
+                             (assoc-in [:auth :token]    tk))}))
+    (rf/dispatch-sync [:login-both "topsecret" "tok-xyz"] {:frame :test/main})
+
+    (let [raw (last-record :test/main)]
+      (is (= 2 (:rf.epoch/redacted-modified-paths-count raw))
+          "both :password and :token changed — count = 2"))))
+
+(deftest G6-projection-preserves-counter
+  (testing "projected-record passes :rf.epoch/redacted-modified-paths-count
+            through unchanged — the integer is structurally non-sensitive
+            bookkeeping, parallel to :rf.epoch/sensitive?. Without this the
+            counter would be computed and then thrown away at the one
+            boundary it exists to serve."
+    (rf/make-frame {:id :test/main})
+    (install-sensitive-schema! :test/main)
+    (rf/reg-event :login
+                  (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
+    (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
+
+    (let [raw       (last-record :test/main)
+          projected (rf.epoch/projected-record raw)]
+      (is (= 1 (:rf.epoch/redacted-modified-paths-count raw)))
+      (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
+          "CONTROL — the projection really redacted the declared path, so
+           the counter below is the ONLY surviving signal that it moved")
+      (is (= 1 (:rf.epoch/redacted-modified-paths-count projected))
+          "projection preserves the counter verbatim")
+      (is (= (:rf.epoch/redacted-modified-paths-count raw)
+             (:rf.epoch/redacted-modified-paths-count
+               (rf.epoch/projected-record projected)))
+          "idempotent under a second projection pass"))))
+
+(deftest G7-counter-handles-nil-db-edge
+  (testing "halted-destroy records may carry nil :db-before or nil
+            :db-after (rf2-v0jwt). The producer handles the nil edge:
+            nil/non-nil at a declared path IS a change, nil/nil is not."
+    (rf/make-frame {:id :test/main})
+    (install-sensitive-schema! :test/main)
+    (is (= 0 (rf.epoch.assembly/redacted-modified-paths-count :test/main nil nil))
+        "nil -> nil at every path: 0 changes")
+    (is (= 1 (rf.epoch.assembly/redacted-modified-paths-count
+               :test/main nil {:auth {:password "x"}}))
+        "nil -> {:auth {:password \"x\"}}: 1 change at the sensitive path")
+    (is (= 1 (rf.epoch.assembly/redacted-modified-paths-count
+               :test/main {:auth {:password "x"}} nil))
+        "{:auth {:password \"x\"}} -> nil: 1 change at the sensitive path")
+    (is (= 0 (rf.epoch.assembly/redacted-modified-paths-count
+               :test/main
+               {:auth {:password "x"}}
+               {:auth {:password "x"}}))
+        "value-equal across the cascade: 0 changes")))
+
+;; ---- the retired :redact-fn sub-key is inert -------------------------------
+;;
+;; rf2-kuky.7 deleted the `(rf/configure! {:epoch-history {:redact-fn f}})`
+;; hook outright — no shim, no deprecation warning. `:redact-fn` is now an
+;; UNKNOWN sub-key of `:epoch-history`, and `configure!`'s dev-gated
+;; `:rf.warning/unknown-configure-key` diagnostic fires on TOP-LEVEL keys
+;; only, so an unknown sub-key is silently dropped like any other. This pins
+;; that posture from the caller's side: submitting it neither throws nor
+;; installs nor invokes.
+
+(deftest retired-redact-fn-sub-key-installs-and-invokes-nothing
+  (testing "submitting the retired :redact-fn sub-key is a silent drop:
+            configure! does not throw, no :redact-fn slot appears in the
+            live config, and the submitted fn is never called at any point
+            in record assembly or projection."
+    (rf/make-frame {:id :test/main})
+    (install-sensitive-schema! :test/main)
+
+    (is (= #{:depth :trace-events-keep}
+           (set (keys (:epoch-history (rf/current-config)))))
+        "RESET BASELINE — the fixture-reset config carries exactly the two
+         retained knobs; no :redact-fn slot survives the retirement")
+
+    (let [calls (atom 0)
+          scrub (fn [record] (swap! calls inc) (assoc record :db-after :rf/redacted))]
+      (rf/configure! {:epoch-history {:redact-fn         scrub
+                                      :trace-events-keep 3}})
+
+      (is (= 3 (:trace-events-keep (:epoch-history (rf/current-config))))
+          "DISCRIMINATING CONTROL — the SAME configure! call was processed and
+           its recognised sibling key landed, so the absence below is a DROP
+           of :redact-fn and not a no-op over the whole map")
+      (is (= #{:depth :trace-events-keep}
+             (set (keys (:epoch-history (rf/current-config)))))
+          "the retired key installed nothing — no :redact-fn slot appears")
+
+      (rf/reg-event :login
+                    (fn [{:keys [db]} [_ pw]] {:db (assoc-in db [:auth :password] pw)}))
+      (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
+
+      (let [raw       (last-record :test/main)
+            projected (rf.epoch/projected-record raw)]
+        (is (some? raw)
+            "CONTROL — a record was actually assembled")
+        (is (= {:auth {:password "topsecret"}} (:db-after raw))
+            "CONTROL — storage stayed RAW; the retirement is projection-side")
+        (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
+            "CONTROL — the projection really ran over a NONEMPTY record, so
+             the zero call-count below cannot be satisfied vacuously by an
+             unexercised projection")
+        (is (map? (:db-after projected))
+            "the fn's own whole-slot collapse never happened — :db-after is
+             still a walked map, not the scalar sentinel it would have
+             returned")
+        (is (zero? @calls)
+            "the submitted fn was never invoked — there is no hook left to
+             call it from")))))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -3604,8 +3604,7 @@
     ;; :rf.warning/* OPERATION through three syntactic seams, all scanned here:
     ;;   (trace/emit! <op-type> :rf.epoch/OP ...)   — the success emits
     ;;                                                 (snapshotted / outcome
-    ;;                                                 / restored / db-replaced
-    ;;                                                 / the redact-fn warning)
+    ;;                                                 / restored / db-replaced)
     ;;   {:outcome :fail :op :rf.epoch/OP ...}       — the precondition-failure
     ;;                                                 results, emitted by
     ;;                                                 `emit-precondition-failure!`


### PR DESCRIPTION
Two clustered audit residuals on one surface (`implementation/epoch/**`), one commit each. Both beads stay OPEN for the coordinator to dispose.

## Commit 1 — rf2-kuky.7 (merged-PR audit of #9452)

A bounded **coverage** regression, not an API mistake. **The API deletion stands: no hook, no convenience export, no warning category comes back.**

Deleting `epoch_redact_fn_projection_test.clj` also deleted six tests that never installed the retired hook. They exercise `:rf.epoch/redacted-modified-paths-count`, which the bead explicitly RETAINS.

**Premise verified at source before acting.** A four-pass census over `implementation/epoch/test` (line-oriented, whitespace-flattened, comment-markers-stripped-then-flattened, and hyphen-rejoined for the line-broken-token case — the needle carries hyphens) found the counter named **once** in the whole tree, at `epoch_test.clj:3616`, which is a comment. Control (`projected-record`) read **346** on every pass, so the 1 is a measurement and not a dead instrument. Pair's `sensitive_filter_test.cljs` only feeds synthetic integers to a forwarder. The headline green had indeed stopped witnessing the retained producer.

G1, G2, G3, G4, G6 and G7 are **recovered from `bf077b4245^`** (the deletion commit's parent) rather than reconstructed from their names, and moved into `epoch_privacy_test.clj` as **section 4**. Names are preserved so the rf2-dl3gx coverage matrix still reads across. Their discriminating changed/unchanged controls are kept and, in a few places, strengthened:

- **G1/G2 are the zero cases that keep G3/G4 honest.** G1 asserts the cascade really changed the db before asserting the counter is 0; G2 asserts the declared path is populated on both sides AND that a non-declared path did change, so its zero is about the declaration and not an inert cascade.
- **G4's partial-modification leg** is the assertion a producer returning `(count declarations)` would fail; it now names the unchanged second path explicitly.
- **G6** asserts the projection really redacted the declared path *before* asserting the counter survived it — which is the whole point of the signal (a post-projection structural diff sees `:rf/redacted` = `:rf/redacted` and emits no row).
- **G7** calls `assembly/redacted-modified-paths-count` through a normal ns alias instead of the old inline `require` + `resolve`.

**The bead's still-unfulfilled "Tests to add" paragraph** is also delivered: `retired-redact-fn-sub-key-installs-and-invokes-nothing` pins that `(rf/configure! {:epoch-history {:redact-fn f}})` neither throws nor installs nor invokes `f`, and that the reset baseline's key set is exactly `#{:depth :trace-events-keep}`. **Two controls stop it passing vacuously:**

1. A recognised sibling key (`:trace-events-keep 3`) in the **same** `configure!` call is shown to land — so the `:redact-fn` absence is a *drop*, not a no-op over the whole map.
2. A **nonempty** record is assembled and projected (the declared path is asserted `:rf/redacted` in the projection and verbatim in raw storage) — so the zero call-count cannot be satisfied by an unexercised projection.

This is the existing unknown-sub-key posture, verified at source: `core.cljc`'s `:rf.warning/unknown-configure-key` diagnostic fires on **top-level** keys only, and `state/merge-config!` `select-keys`es `[:depth :trace-events-keep]`, so an unknown sub-key is silently dropped.

Two comments left dangling by the retirement are corrected: `epoch_privacy_test.clj`'s pointer at the deleted file, and the `redact-fn` warning in `epoch_test.clj`'s emit-seam catalogue.

**Note on the bead's zero-residue acceptance criterion.** The `:redact-fn` census now also names the new pin test, by design — the audit note (newer text than that criterion) explicitly asks for a test that submits the retired sub-key. Every other `:redact-fn` hit repo-wide remains prose/retirement bookkeeping.

## Commit 2 — rf2-kuky.52 (merged-PR audit of #9435)

`implementation/epoch/src/re_frame/epoch/state.cljc:48` still named the deleted `re-frame.trace/configure-trace-buffer!` in `non-neg-int?`'s docstring. #9435 left it deliberately because a sibling held the epoch fence. Retargeted to the live `re-frame.trace.tooling/configure-trace-buffer!`.

**Docstring only — no runtime change, no shim, no new API, no acceptance rewrite.**

**Zero-residue census re-run** over all six retired spellings (`register-listener!`, `unregister-listener!`, `clear-listeners!`, `trace-buffer`, `clear-trace-buffer!`, `configure-trace-buffer!` reached through `rf.trace/` or `re-frame.trace/`), across the whole tracked tree excluding `ai/` and `.beads/`:

| pass | residue | control (same shape, `.tooling` spelling admitted) |
|---|---|---|
| line-oriented | 0 | 749 |
| whitespace-flattened | 0 | 749 |
| comment-markers stripped, then flattened | 0 | 749 |
| hyphen-rejoined across line breaks | 0 | 749 |

The target regex was additionally exercised against the pre-fix line and matched it, so the zero is a measurement rather than a dead instrument.

## Quality gates

Nominated by path; the diff is confined to `implementation/epoch/**`.

| gate | result |
|---|---|
| `implementation/epoch` `clojure -M:test` | **exit 0** — 526 tests, 7221 assertions, **0 failures, 0 errors** |
| `implementation/core` `clojure -M:test` | **exit 0** — 2288 tests, 11795 assertions, **0 failures, 0 errors** |
| `implementation/epoch` `clojure -M:test` under a planted fault | **exit 1** — 11 failures (see below) |
| `check_retired_spellings.py` (+ `--self-test`) | exit 0 / exit 0 |
| `check_require_alias_dialect.py` (+ `--self-test`) | exit 0 / **79 passed, 0 failed** |
| `check_keyword_catalogue_drift.py` (+ `--self-test`) | exit 0 / exit 0 |
| `check_retired_composition_vocab.py`, `check_test_lane_bijection.py`, `check_jvm_lane_rosters.py`, `check_architecture_census.py`, `check_ambient_durable_reads.py`, `check_failure_corpus_residue.py`, `check_thrown_error_messages.py`, `check_runtime_subsystem_grading.py`, `check_view_lifetime_residue.py`, `check_inject_cofx_residue.py`, `check_retired_image_keys.py` | all exit 0 |
| `check-ai-tracking-ratchet.sh`, `check-beads-pr-boundary.sh`, `check-no-hardcoded-paths.sh`, `check-commit-attribution.sh` | all exit 0 |
| `python scripts/check_fast_pr_gap.py --brief` | run as a REPORT — 99 required checks this spine does not decide; CI owns them |

Every exit code above was captured on the runner's own command line and echoed there; none was read through a pipe or taken from a harness report.

**Epoch suite delta is exactly the new tests:** 519 → **526** tests (+7: G1, G2, G3, G4, G6, G7, and the retired-sub-key pin) and 7194 → **7221** assertions (+27), against the counts the #9452 audit recorded at that merge.

**Skipped, with reasons.** `scripts/check_doc_slugs.py` and `check_readme_links.py --ci` — the diff touches no markdown path (three `.clj`/`.cljc` files). `mkdocs build --strict` — same. `spec/api-manifest` `gen --check` — the diff adds, removes and renames **no public var** (`assembly.cljc` is byte-identical to trunk; `state.cljc` is a docstring line inside the already-public `non-neg-int?`), so the var set does not move; trunk's known declared-vs-counted manifest drift is PR #9464's, not this PR's. `scripts/test-fast-pr.sh` — it tiers on the changed-surface classifier and would double-run the per-artefact suites already listed.

## The restored tests are shown to BITE

The audit's exact finding was tests that pass without exercising anything, so the move is proved by sabotage rather than asserted.

**Plant.** Two lines in the counter producer, `implementation/epoch/src/re_frame/epoch/assembly.cljc` — the `(if (empty? sensitive-paths) 0 …)` short-circuit and the `reduce`'s `0` seed, both changed to `7`. No constant can satisfy the suite: a zero constant fails G3/G4/G6, a positive one fails G1/G2/G7, and `7` fails all of them at once.

**Plant verified applied before the run was spent:** `git diff --numstat` read `2 2`, and the working-tree content hash moved from the committed blob `07f04fc96db07a19f05946fb4a9a182a0b39f5fb` to `4a19b989b27b527bc75756cb6d2dd7fd8ac321c7`.

**Red, exit 1, 11 failures — and all six restored tests are among them:**

```
FAIL in (G1-no-sensitive-paths-yields-zero-count)            (epoch_privacy_test.clj:1167)
FAIL in (G2-sensitive-path-unchanged-yields-zero-count)      (epoch_privacy_test.clj:1191)
FAIL in (G3-sensitive-path-modified-yields-positive-count)   (epoch_privacy_test.clj:1204)
FAIL in (G4-multiple-sensitive-paths-partial-modification)   (epoch_privacy_test.clj:1225)
FAIL in (G4-multiple-sensitive-paths-partial-modification)   (epoch_privacy_test.clj:1239)
FAIL in (G6-projection-preserves-counter)                    (epoch_privacy_test.clj:1256)
FAIL in (G6-projection-preserves-counter)                    (epoch_privacy_test.clj:1260)
FAIL in (G7-counter-handles-nil-db-edge)                     (epoch_privacy_test.clj:1273)
FAIL in (G7-counter-handles-nil-db-edge)                     (epoch_privacy_test.clj:1275)
FAIL in (G7-counter-handles-nil-db-edge)                     (epoch_privacy_test.clj:1278)
FAIL in (G7-counter-handles-nil-db-edge)                     (epoch_privacy_test.clj:1281)
```

The sabotage run reported the **same** 526 tests / 7221 assertions as the control run, so no namespace aborted early and every failure is assertion-level.

**Restore verified by BLOB HASH, not by the restore command's exit code:** after `git checkout HEAD -- …`, `git hash-object --path` on the working file reads `07f04fc96db07a19f05946fb4a9a182a0b39f5fb`, identical to `HEAD:implementation/epoch/src/re_frame/epoch/assembly.cljc`, and `git status` is clean. `--path` is used so git's own clean filter runs; a raw byte digest would disagree on a CRLF checkout.

## Hand checks

No automated gate reads markdown prose here, and nothing in this diff is markdown — the three changed files are Clojure source. Paren balance on the two edited test files was verified mechanically (string-aware, comment-aware depth counter, final depth 0) before a suite run was spent. No table columns or heading anchors are involved.

## Boundaries

- Worker worktree guard run before editing; exit 0.
- No `.beads/issues.jsonl` or any other database-derived `.beads` path in the diff — `git diff --name-only <merge-base>...HEAD | grep -c '^\.beads/'` reads **0**, with the control (`^implementation/`) reading **3**, so the check is live.
- Nothing was stashed.
- Diffed against the **merge base** (not the trunk tip) for silent reverts: every deleted line is one of the six this PR intends — the retargeted docstring line, the "three surfaces" ns-docstring line, the two-line pointer at the deleted test file, and the two-line stale `redact-fn` warning entry. No sibling's work is undone.


## Rebased onto `0db59223b6`

The first push inherited trunk's `Public-API manifest drift-check` red (and the dependent `Lint required`) — `spec/api-manifest.edn` declared one more public var than it held. That was **never this diff**: trunk's own `b0ecc34a71` fixed it by regeneration, and on the new base declared == **independently counted rows** == **491** (counted by parsing the `:vars` vector rather than reading the `:var-count` field, with a wrong-shape control reading 0 and a distinct-namespace control reading 48).

`git merge-tree --write-tree` against the pinned base reported **zero conflicts**. That instrument was controlled before being believed: a synthetic commit editing the same docstring line was built with plumbing and merge-tree returned **exit 1** on it, naming the file and printing all three stages. (Its first draft was a silent no-op — the `sed` pattern used the post-fix spelling, so the "control" blob came back byte-identical to trunk's. Caught by hashing it.)

The rebase was structurally trivial: **7 trunk commits, none touching `implementation/epoch/**`** — six `.beads/issues.jsonl` checkpoints and the one manifest regeneration. All four relevant blobs are byte-identical across the rebase, `assembly.cljc` included (`07f04fc96db07a19f05946fb4a9a182a0b39f5fb`).

**The plant was re-run on the new base anyway**, because the restored coverage is this PR's entire point: exit **1**, 11 failures, **all six restored G-tests among them**, at the same 526 / 7221 as the control run. Restore re-verified by blob hash back to `07f04fc96db07a19f05946fb4a9a182a0b39f5fb`, tree clean.
