### PR TITLE
fix(test-quiet): grade fixtures by lookup semantics, not by class (rf2-4yw1)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -113,14 +113,15 @@
   ## What the lane's FIXTURES will do
 
   A namespace that WAS discovered, WAS loaded and DOES hold tests still
-  runs none of them if its fixtures are not CALLABLE — `clojure.test`
-  calls a fixture with the test thunk, and a data structure called with one
-  argument is a key lookup that returns nil.  Callable is the whole
-  requirement, and it is wider than `fn?`: a var referring to a fixture
-  function is idiomatic and works.  `uncallable-fixtures` is the fourth
-  rule; it fires from `:summary`, the first hook that holds control after
-  every namespace this lane runs has loaded.  See its own docstring, and
-  rf2-4yw1."
+  runs none of them if its fixtures are DATA — `clojure.test` applies a
+  fixture to the test thunk, and a map, set, vector, keyword or symbol
+  invoked with one argument is a key lookup, so the thunk never runs.  Those
+  five are what `uncallable-fixtures` reports, and reporting them is all it
+  claims: applying the thunk is the requirement, it is much wider than `fn?`,
+  and the rule refuses a closed set rather than admitting a list.
+  `uncallable-fixtures` is the fourth rule; it fires from `:summary`, the
+  first hook that holds control after every namespace this lane runs has
+  loaded.  See its own docstring, and rf2-4yw1."
   (:require
     [re-frame.test-quiet]
     [clojure.java.io :as io]
@@ -891,12 +892,15 @@
 ;; runs.  Maps are `IFn`, so nothing throws.  cljs.test asserts on this
 ;; ("Fixtures may not be of mixed types"); the JVM half is the unguarded one.
 ;;
-;; WHAT THE RULE MAY NOT DO IS REFUSE HONEST CODE.  The requirement is that
-;; the entry be CALLED, not that it be `fn?`, and the two differ: a var
-;; referring to a fixture function, and a multimethod, both invoke the thunk
-;; while failing `fn?`.  `callable-fixture?` owns that distinction; the
-;; opposite over-correction — `ifn?` — would accept the map and disarm the
-;; rule entirely.
+;; WHAT THE RULE MAY NOT DO IS REFUSE HONEST CODE, and this is where two
+;; earlier rounds of it went wrong (rf2-4yw1).  The requirement is that the
+;; entry APPLY the thunk, not that it be `fn?`: a var referring to a fixture
+;; function, a multimethod and a `reify`d `IFn` all invoke the thunk while
+;; failing `fn?`, and each was refused in turn by a rule that listed the
+;; types it would accept.  That list can never be finished, because anyone
+;; may write a new `IFn`.  The set of values Clojure invokes as a LOOKUP
+;; can be, so `callable-fixture?` subtracts that closed set from `ifn?`
+;; instead — see its docstring for the direction the residual error runs in.
 ;;
 ;; MEASURED: a two-line namespace whose single `deftest` asserts `(= 1 2)`
 ;; reports `Ran 0 tests containing 0 assertions. / 0 failures, 0 errors.`
@@ -919,42 +923,70 @@
   to a map land here indistinguishably — which is the point."
   [:clojure.test/once-fixtures :clojure.test/each-fixtures])
 
+(defn- lookup-invocation?
+  "Whether invoking `x` with one argument LOOKS THAT ARGUMENT UP rather than
+  APPLYING `x` to it.
+
+  `clojure.lang` gives exactly these five values that meaning — a map, a set
+  or a vector reads the argument as a key or an index into itself; a keyword
+  or a symbol reads ITSELF as a key in the argument — and the list is CLOSED,
+  because `clojure.lang` fixes it.  Nothing anyone writes joins it: a
+  user-defined `IFn` invokes whatever its own body invokes, which makes it a
+  function, not a lookup."
+  [x]
+  (or (map? x) (set? x) (vector? x) (keyword? x) (symbol? x)))
+
 (defn- callable-fixture?
   "Whether `clojure.test` will INVOKE `fixture` with the test thunk rather
   than LOOK the thunk up inside it.
 
   `join-fixtures` folds the entries with `compose-fixtures` into
   `(fn [g] (f1 (fn [] (f2 g))))`, so the contract is behavioural — each entry
-  is applied to one argument and must CALL it — and behaviour is not
-  decidable from a value.  Both cheap approximations of it are wrong, in
-  opposite directions, and this predicate is the narrowest thing that is
-  wrong in neither (MEASURED on Clojure 1.12, rf2-4yw1):
+  is applied to one argument and must CALL it — and behaviour is NOT decidable
+  from a value.  This predicate does not pretend to decide it.  It decides the
+  one thing that is decidable, and it is written as a SUBTRACTION from `ifn?`
+  rather than as a list of accepted types, because the two populations of
+  `IFn` are not symmetrical (MEASURED on Clojure 1.12, rf2-4yw1):
 
-    - `ifn?` is too permissive.  Maps, sets, vectors, keywords and symbols
-      are all `IFn`, and every one of them reads its argument as a KEY.  That
-      is the defect this rule exists to catch, so `ifn?` would disarm it.
-    - `fn?` is too restrictive, which is the regression this predicate
-      replaces.  It tests for the `clojure.lang.Fn` marker, which
-      `clojure.lang.Var` and `clojure.lang.MultiFn` do not carry even though
-      both invoke the thunk correctly: `(use-fixtures :each #'lifecycle)` is
-      ordinary, idiomatic and WORKING, and the rule refused it while claiming
-      the namespace had run nothing.
+    - The APPLYING population is OPEN.  A fn, a multimethod, a `reify` or
+      `deftype` implementing `IFn`, a proxy, a Var forwarding to any of them:
+      all apply their argument, and no enumeration of them stays complete,
+      because the next one has not been written yet.  Two earlier rounds of
+      this rule enumerated anyway — first `fn?`, then `fn?` or `MultiFn` or a
+      Var resolving to one — and each list refused honest, working code while
+      announcing that the namespace had run nothing.  `fn?` alone rejects
+      `(use-fixtures :each #'lifecycle)`; the widened list still rejected
+      `(reify clojure.lang.IFn (invoke [_ t] (t)))`.
+    - The LOOKUP population is CLOSED — see `lookup-invocation?`.
 
-  So: a function, a multimethod, or an indirection resolving to one.  The Var
-  case RECURSES on the root rather than accepting every Var, because
-  `Var.invoke` forwards to whatever the root is — a Var whose root is a map
-  swallows the thunk exactly as the bare map does."
+  So the rule is `ifn?` MINUS the closed set, and everything else is accepted.
+  Read the direction of the residual error deliberately: an exotic `IFn` that
+  ignores its argument is accepted and its namespace stays silently zeroed,
+  which is the original defect surviving in a corner.  That is the right trade
+  against a guard that reds idiomatic code, and it is the whole reason this is
+  a subtraction — a guard that refuses valid code is worse than the defect it
+  catches.
+
+  A Var is in neither population: it is an INDIRECTION, and `Var.invoke`
+  forwards to its root, so the question about a Var is the question about its
+  root.  Hence the recursion rather than a blanket `var?` — a Var whose root
+  is a map swallows the thunk exactly as the bare map does."
   [fixture]
-  (or (fn? fixture)
-      (instance? clojure.lang.MultiFn fixture)
-      (and (var? fixture) (callable-fixture? (deref fixture)))))
+  (if (var? fixture)
+    (recur (deref fixture))
+    (and (ifn? fixture)
+         (not (lookup-invocation? fixture)))))
 
 (defn uncallable-fixtures
   "Every `[ns-sym fixture-key fixture]` registered on `namespaces` that
-  `clojure.test` cannot call, sorted by namespace name.
+  `clojure.test` will LOOK THE TEST THUNK UP IN rather than call, sorted by
+  namespace name.
 
-  Empty is the only acceptable answer.  `callable-fixture?` is the test; see
-  its docstring for why neither `fn?` nor `ifn?` is."
+  Empty is the only acceptable answer, and it is the WEAKER of the two
+  answers: emptiness says no fixture is one of the values Clojure invokes as
+  a lookup, not that every fixture applies its thunk.  `callable-fixture?` is
+  the test; see its docstring for why the rule subtracts a closed set from
+  `ifn?` instead of listing the function types it accepts."
   [namespaces]
   (vec (sort-by (comp str first)
                 (for [ns-obj    namespaces
@@ -969,16 +1001,21 @@
   a replacement character on a Windows console."
   [offenders]
   (str "this lane registered " (count offenders)
-       " fixture(s) clojure.test cannot call, so EVERY test in the"
-       " namespace(s) below silently did not run:\n"
+       " fixture(s) that are DATA rather than functions, so the tests in the"
+       " namespace(s) below did not run:\n"
        (str/join "\n" (for [[ns-sym meta-key fixture] offenders]
                         (str "  " ns-sym " " meta-key " -> "
                              (.getName (class fixture)))))
-       "\nclojure.test calls each fixture with the test thunk; a data"
-       " structure called with one argument is a key lookup returning nil,"
-       " so the thunk never runs and the tally stays green.\n"
-       "A fixture must be callable: a fn, a multimethod, or a var referring"
-       " to one. The {:before f :after g} map is cljs.test-only --"
+       "\nclojure.test applies each fixture to the test thunk. Invoking a"
+       " map, set, vector, keyword or symbol with one argument LOOKS THAT"
+       " ARGUMENT UP as a key or an index instead of calling it, so the thunk"
+       " never runs and the tally stays green.\n"
+       "Those five values are all this rule reports: it does not certify any"
+       " other fixture, only that none here is one Clojure invokes as a"
+       " lookup.\n"
+       "A fixture must APPLY its argument -- a fn, a multimethod, a var"
+       " referring to one, or any IFn that calls the thunk. The"
+       " {:before f :after g} map is cljs.test-only --"
        " (use-fixtures :each (fn [t] (before) (t) (after))) (rf2-4yw1).\n"))
 
 (defn- install-summary-method!

--- a/implementation/test-quiet/test/re_frame/test_quiet_fixture_integrity_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_fixture_integrity_test.clj
@@ -15,11 +15,21 @@
   INVOKE it — and both cheap approximations of that are wrong in a different
   direction.  `ifn?` is too permissive: maps, sets, keywords and symbols are
   all `IFn` and every one of them treats the thunk as a KEY.  `fn?` is too
-  restrictive: a Var and a multimethod each invoke the thunk correctly while
-  carrying no `clojure.lang.Fn` marker, so `(use-fixtures :each #'lifecycle)`
-  — ordinary, idiomatic, and working — was refused with the false claim that
-  the namespace ran nothing.  Both directions are pinned below, and each is
-  pinned against `clojure.test/join-fixtures` FIRST.
+  restrictive: a Var, a multimethod and a `reify`d `IFn` each invoke the
+  thunk correctly while carrying no `clojure.lang.Fn` marker, so
+  `(use-fixtures :each #'lifecycle)` — ordinary, idiomatic, and working —
+  was refused with the false claim that the namespace ran nothing.  Both
+  directions are pinned below, and each is pinned against
+  `clojure.test/join-fixtures` FIRST.
+
+  WHY THE CALLABLE ROWS ARE NOT A LIST, AND MUST NOT BECOME ONE.  Two
+  earlier rounds repaired this rule by ADDING an accepted type — `fn?`, then
+  `fn?` or `MultiFn` or a Var resolving to one — and each list was refuted
+  by the next valid callable somebody wrote.  The population of things that
+  apply their argument is open; the population Clojure invokes as a LOOKUP
+  is closed, so the rule now subtracts the second from `ifn?`.  The
+  `reify` row below is therefore not a fourth entry on a list: it is the
+  witness that no list is being kept.
 
   EVERY TEST HERE PINS THE DEFECT BEFORE IT PINS THE GUARD.  The defect is
   pinned against `clojure.test/join-fixtures` itself — the function
@@ -57,6 +67,14 @@
   (fn [_t] :only))
 
 (defmethod multi-lifecycle :only [t] (t))
+
+(def ^:private reified-lifecycle
+  "A fixture that is nothing but the `IFn` contract — no `clojure.lang.Fn`
+  marker, no `MultiFn`, no Var.  It is the shape that refuted the round-two
+  repair (rf2-4yw1): a positive list of implementation classes cannot name
+  it, because any `reify`, `deftype` or `proxy` produces a fresh class."
+  (reify clojure.lang.IFn
+    (invoke [_ t] (t))))
 
 (defn- calls-thunk?
   "Whether `clojure.test/join-fixtures` — the chain `test-all-vars` builds —
@@ -142,13 +160,17 @@
 ;; The other direction: callable entries `fn?` does not recognise (rf2-4yw1).
 
 (deftest callable-fixtures-that-are-not-fn-are-not-offenders
-  (testing "THE DEFECT THIS TIME IS THE GUARD'S: `#'lifecycle` and a
-            `defmulti` fixture both RUN the test, and `fn?` says false of
-            both, so `fn?` cannot be the contract"
+  (testing "THE DEFECT THIS TIME IS THE GUARD'S: a Var, a `defmulti` and a
+            bare `reify`d `IFn` all RUN the test, and `fn?` says false of
+            every one of them, so `fn?` cannot be the contract — nor can any
+            longer list of classes, which is what the last row proves"
     (doseq [[label fixture] [["a Var referring to a function" #'lifecycle]
                              ["a multimethod"                 multi-lifecycle]
                              ["a Var referring to a multimethod"
-                              #'multi-lifecycle]]]
+                              #'multi-lifecycle]
+                             ["a custom IFn implementation"   reified-lifecycle]
+                             ["a Var referring to a custom IFn"
+                              #'reified-lifecycle]]]
       (is (false? (fn? fixture))
           (str label " is not `fn?` — which is why the guard refused it"))
       (is (true? (calls-thunk? fixture))
@@ -177,6 +199,36 @@
                 "accepting every Var would reopen the defect one level down")))
         (finally
           (remove-ns 'probe.var-to-map-holder))))))
+
+(defn- never-calls-thunk?
+  "Whether `join-fixtures` fails to run the thunk for `fixture` — either by
+  looking it up and discarding it (a map, set, keyword or symbol returns
+  nil) or by throwing on the lookup (a vector needs a numeric index).  The
+  two paths differ; the property the rule is about is the one they share."
+  [fixture]
+  (try
+    (not (calls-thunk? fixture))
+    (catch Throwable _ true)))
+
+(deftest every-lookup-value-is-refused-though-ifn?-is-true-of-each
+  (testing "THE TRAP that makes bare `ifn?` the wrong repair, and the reason
+            the rule subtracts a CLOSED set from it rather than widening to
+            it: each of these five is `IFn`, each is invoked as a LOOKUP, and
+            each must stay refused (rf2-4yw1)"
+    (doseq [[label fixture] [["a map"     {:before (fn []) :after (fn [])}]
+                             ["a set"     #{:before :after}]
+                             ["a vector"  [(fn [t] (t))]]
+                             ["a keyword" :before]
+                             ["a symbol"  'lifecycle]]]
+      (is (true? (ifn? fixture))
+          (str label " is `IFn`, so `ifn?` would admit it"))
+      (is (true? (never-calls-thunk? fixture))
+          (str label " nevertheless never runs the test thunk"))
+      (with-probe-ns 'probe.lookup-fixture-ns :clojure.test/each-fixtures
+        (list fixture)
+        (fn [ns-obj]
+          (is (= 1 (count (rf.test-quiet.runner/uncallable-fixtures [ns-obj])))
+              (str "and so the guard must keep refusing " label)))))))
 
 (deftest this-lane-is-itself-clean
   (testing "the shipped call — every namespace this JVM has loaded — and so

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -34,13 +34,14 @@
      refuses the run (exit 1, named on stderr) instead of leaving it
      silently short a suite — and the same fixture is green the moment
      before that file arrives.
-   - FIXTURES: a namespace whose `use-fixtures` entry cannot be CALLED
-     — the cljs.test `{:before f :after g}` map, whether written at the
-     call site or reached through a var — refuses the run (exit 1, the
-     namespace named on stderr) instead of contributing zero tests to a
-     tally that reports itself green; and, in the other direction, an
-     entry that IS callable without being `fn?` — a var referring to a
-     fixture function — keeps its lane green (rf2-4yw1).
+   - FIXTURES: a namespace whose `use-fixtures` entry is DATA rather
+     than a function — the cljs.test `{:before f :after g}` map, whether
+     written at the call site or reached through a var — refuses the run
+     (exit 1, the namespace named on stderr) instead of contributing
+     zero tests to a tally that reports itself green; and, in the other
+     direction, entries that APPLY the thunk without being `fn?` — a var
+     referring to a fixture function, and a bare `reify` of
+     `clojure.lang.IFn` — keep their lane green (rf2-4yw1).
    - STDERR BUFFER: a green run that emits expected
      stderr warnings stays quiet (the warnings are buffered + dropped);
      a RED run REPLAYS the buffered stderr context so a failing run
@@ -507,6 +508,20 @@
       (str "(defn lifecycle [t] (t))\n"
            "(use-fixtures :once #'lifecycle)\n"
            "(use-fixtures :each #'lifecycle)\n"))))
+
+(deftest custom-ifn-fixtures-keep-the-run-green
+  (testing "THE ROW THAT ENDS THE LIST (rf2-4yw1): a bare `reify` of
+            `clojure.lang.IFn` invokes the thunk and the test runs, yet it
+            carries no `Fn` marker, is no `MultiFn` and is no Var — so no
+            enumeration of accepted implementation classes can name it, and
+            two rounds of this guard refused it while the test it guards was
+            passing.  The rule is now `ifn?` minus the closed set of values
+            Clojure invokes as a lookup, which admits this without admitting
+            a map; the two red rows above are the other half of that claim."
+    (assert-callable-fixture-runs-green
+      "ifn_fixture_test" "probe.ifn-fixture-test"
+      (str "(use-fixtures :each"
+           " (reify clojure.lang.IFn (invoke [_ t] (t))))\n"))))
 
 ;; ----------------------------------------------------------------------
 ;; Nested-run banner correctness.


### PR DESCRIPTION
Round three of rf2-4yw1. Reopened by the merged-PR audit of #9462, which found the round-two repair still a **positive allowlist of implementation classes** — `Fn`, `MultiFn`, or a Var resolving to one — rather than the callable behaviour `join-fixtures` accepts. A valid custom `IFn` fixture ran its test and was refused anyway.

## What the new predicate tests, and why a lookup type cannot fool it

`clojure.test/join-fixtures` folds each entry with `compose-fixtures` into `(fn [g] (f1 (fn [] (f2 g))))`. The contract is behavioural — each entry is applied to one argument and must **call** it — and behaviour is not decidable from a value. The previous two rounds tried to decide it by listing the types that satisfy it. That list can never be finished:

| population of `IFn` | membership | can it be enumerated? |
|---|---|---|
| values that **apply** their argument | `fn`, `defmulti`, `reify`, `deftype`, `proxy`, a Var forwarding to any of them, and whatever is written next | **No** — open-ended by construction; anyone may write a new `IFn` |
| values Clojure invokes as a **lookup** | map, set, vector, keyword, symbol | **Yes** — closed, fixed by `clojure.lang` |

Only one side is enumerable, so the rule is now the **subtraction** rather than the list:

```clojure
(defn- lookup-invocation? [x]
  (or (map? x) (set? x) (vector? x) (keyword? x) (symbol? x)))

(defn- callable-fixture? [fixture]
  (if (var? fixture)
    (recur (deref fixture))
    (and (ifn? fixture)
         (not (lookup-invocation? fixture)))))
```

**Why a lookup type cannot fool it.** The obvious repair — widen to bare `ifn?` — disarms the rule entirely, because `ifn?` is true of all five lookup values; that is exactly what those five are subtracted for, and the new `every-lookup-value-is-refused-though-ifn?-is-true-of-each` test asserts `ifn?` **true** and refusal **both** for each of the five, so a future widening to bare `ifn?` reds five rows. Nothing a user writes joins the closed set: a user-defined `IFn` invokes whatever its own body invokes, which makes it a function, not a lookup.

The **Var recursion from round two survives and is load-bearing**: a Var is an indirection, `Var.invoke` forwards to its root, so the question about a Var is the question about its root. A blanket `var?` would reopen the original defect one level down.

**The residual error now runs the safe way, deliberately.** An exotic `IFn` that ignores its argument is accepted and its namespace stays silently zeroed — the original defect surviving in a corner — rather than honest code being refused. That trade is stated in the predicate's docstring, because a guard that refuses valid, idiomatic code is worse than the defect it catches.

**Strictly wider than the old allowlist.** Every value the old predicate accepted, the new one accepts: `fn?` implies `ifn?` and no fn is a lookup value; `MultiFn` likewise; the Var branch is unchanged in shape. No lane green before is red now — see rows 1–3 below, measured both before and after.

## The prose

The false claim the audit named is gone from all four sites that carried it.

- `callable-fixture?`'s docstring no longer says `fn?` is the contract; it states which population is open, which is closed, and which direction the residual error runs in.
- `uncallable-fixtures`' docstring now says empty is the **weaker** of the two answers: no fixture is a lookup value, *not* that every fixture applies its thunk.
- The operator complaint no longer deduces "EVERY test in the namespace silently did not run" from a class test. It names the mechanism that is actually established, and says outright that those five values are all it reports:

```
[test-quiet] ERROR: this lane registered 1 fixture(s) that are DATA rather than functions, so the tests in the namespace(s) below did not run:
  probe.maplit-fixture-test :clojure.test/each-fixtures -> clojure.lang.PersistentArrayMap
clojure.test applies each fixture to the test thunk. Invoking a map, set, vector, keyword or symbol with one argument LOOKS THAT ARGUMENT UP as a key or an index instead of calling it, so the thunk never runs and the tally stays green.
Those five values are all this rule reports: it does not certify any other fixture, only that none here is one Clojure invokes as a lookup.
A fixture must APPLY its argument -- a fn, a multimethod, a var referring to one, or any IFn that calls the thunk. The {:before f :after g} map is cljs.test-only -- (use-fixtures :each (fn [t] (before) (t) (after))) (rf2-4yw1).
```

- The ns docstring and the section comment above the rule were moved with it.

## Seven-state evidence — measured through the real quiet runner

Every row is a fresh JVM running `re-frame.test-quiet.runner/-main` over an isolated one-`deftest` probe directory. Exit codes are the runner's own, captured on the invoking command line into a per-case `.exit` file — never read through a pipe. Green rows carry a **passing** assertion so the tally discriminates *it ran* from *it was skipped*; red rows carry a **failing** one, so a clean tally proves the thunk was swallowed rather than that it passed.

| # | fixture form | expected | exit BEFORE | exit AFTER | tally AFTER | class named |
|---|---|---|---|---|---|---|
| 1 | `(fn [t] (t))` | green | 0 | **0** | 1 test / 1 assertion | — |
| 2 | `#'lifecycle` (root is a fn) | green | 0 | **0** | 1 test / 1 assertion | — |
| 3 | `defmulti` fixture | green | 0 | **0** | 1 test / 1 assertion | — |
| 4 | `(reify clojure.lang.IFn (invoke [_ t] (t)))` | green | **1** ← the regression | **0** | 1 test / 1 assertion | — |
| 5 | `{:before f :after g}` literal | red | 1 | **1** | 0 tests / 0 assertions | `clojure.lang.PersistentArrayMap` |
| 6 | symbol bound to that map | red | 1 | **1** | 0 tests / 0 assertions | `clojure.lang.PersistentArrayMap` |
| 7 | `#'lifecycle` whose root is that map | red | 1 | **1** | 0 tests / 0 assertions | `clojure.lang.Var` |

Row 4 is the audit's repro verbatim. **Before**: 1 test / 1 assertion, zero failures, then exit 1 with the reified class named — the tests ran and the runner said they had not. **After**: exit 0. Rows 5–7 are unmoved, which is the round-two recursion proving it did not regress.

## Tests added

- **`reify`d custom `IFn`**, the control the audit says is missing — in-process beside the existing fn / Var / MultiFn rows (and as a Var referring to one), and end-to-end through the real `-main` as `custom-ifn-fixtures-keep-the-run-green`.
- **`every-lookup-value-is-refused-though-ifn?-is-true-of-each`** — all five lookup values, each asserted `ifn?`-true, each asserted never to run the thunk, each asserted still refused. This is the row that makes a future widening to bare `ifn?` impossible to land quietly.

Both test namespaces grade the guard against `clojure.test/join-fixtures` itself before grading it against the guard's own opinion, as the existing rows already did.

## Quality gates

**Nominated by path.** `implementation/test-quiet` is the diff; the sweep exists because the whole risk of this guard is redding honest code — `uncallable-fixtures` reads `(all-ns)`, so every lane below exercises the predicate against every fixture value that lane loads. A false positive anywhere reds the lane it appears in.

| lane | tests | assertions | exit |
|---|---|---|---|
| `implementation/test-quiet` | 67 | 343 | **0** |
| `implementation/core` | 2288 | 11789 | **0** |
| `implementation/machines` | 1199 | 4348 | **0** |
| `tools/story` | 1914 | 7047 | **0** |
| `implementation/resources` | 862 | 7674 | **0** |
| `implementation/ssr` | 658 | 4294 | **0** |
| `implementation/routing` | 559 | 3554 | **0** |
| `implementation/flows` | 266 | 6211 | **0** |
| `implementation/epoch` | 519 | 7194 | **0** |
| `implementation/ssr-ring` | 240 | 1211 | **0** |
| `implementation/schemas` | 390 | 19302 | **0** |
| `implementation/http` | 493 | 3959 | **0** |
| `implementation/security` | 92 | 725 | **0** |
| **total** | **9547** | **77651** | **0 failures, 0 errors** |

**Fixture-form coverage.** `git grep -cE 'use-fixtures[[:space:]]+:(each|once)'` over `*.clj` / `*.cljc` reads **681** forms tree-wide; the thirteen lanes above hold **657** of them, 96.5%. Round two ran 5409 tests / 26670 assertions over 336 of 676 forms; this is 1.8x the tests, 2.9x the assertions and 2.0x the fixture forms.

**Gate liveness, proved by a planted fault rather than asserted.** Committed first, then planted: `(not (lookup-invocation? fixture))` → `(ifn? fixture)`, i.e. the widening to bare `ifn?` the audit explicitly forbids. Match count read **before** the run: 1 (not a no-op plant). `implementation/test-quiet` then exited **1** with **20 failures** naming exactly what was planted — all five lookup rows, both map end-to-end rows, the Var-to-map row and the complaint row. That red exists only in this worktree, which is the discrimination: a run that had wandered into a sibling checkout would have come back green. Restore verified by **git blob hash** against the committed object (`7de3d075ef03c2bf31e4311d989cd1a5c361b75e` before and after), not by the restore command's exit code.

**Ratchets over the touched paths**, all exit 0: `check-ai-tracking-ratchet.sh`, `check-beads-pr-boundary.sh`, `check-no-hardcoded-paths.sh`.

**No tracker database in the diff**, verified with a live control rather than a bare zero: the diff is three files, all under `implementation/test-quiet`, and `grep -c '^\.beads/'` reads **0**. Feeding that same path list through the gate's own classifier (`check_beads_boundary ci`) exits 0; appending one `.beads/issues.jsonl` line to the same list through the same pipeline exits **1** and names it — so the zero is a check that passed, not an instrument that was dead.

**Manifest untouched.** `spec/api-manifest.edn` carries no `test-quiet` entry at all (`grep -c` reads 0), no public name moved, and the diff touches none of the trio. Trunk's declared-493-vs-491 drift is PR #9467's, not this branch's.

**Local clj-kondo over the three changed files: 0 errors, 0 warnings** — but the local binary is v2025.10.23 where `lint.yml` pins **v2026.04.15**, so per the standing rule that green proves nothing on its own. CI's count is the one that grades this PR.

**Left to CI**, derived rather than listed by hand: `python scripts/check_fast_pr_gap.py --brief` names 99 required checks no local lane decides. The three required contexts are `All required checks passed`, `Lint required` and `Docs required`. `scripts/test-fast-pr.sh` was deliberately not run — it tiers on the changed-surface classifier and would double-run the per-artefact suites above, and this diff touches neither the spine nor its fixture tree.

## Scope

Three files, all under `implementation/test-quiet`. One predicate, one helper, and prose. No new public API, no compatibility shim, no CI job, no script, no workflow change — the required-check band does not move. `spec/`, the manifest trio and the peer-owned artefacts are untouched.

## Bead

rf2-4yw1 stays **OPEN** for the audit of this merge.
