### PR TITLE
ci(xray): schedule the manual-only epoch-delivery witness in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3269,6 +3269,38 @@ jobs:
       - name: Per-namespace test-isolation gate
         run: node scripts/check-per-ns-isolation.cjs
 
+      # THE MANUAL-ONLY EPOCH-DELIVERY WITNESS (rf2-zwgx, filed by
+      # rf2-kuky.82 AMEND 2(c)). Same family as the two isolation steps above
+      # — a claim about what a GRAPH loads, which the consolidated bundle
+      # cannot make. `:node-test-xray-manual-epoch` compiles ONE namespace
+      # whose require list reaches `re-frame.epoch` through
+      # `day8.re-frame2-xray.install` and nowhere else, then proves a manual
+      # `core/init!` alone receives a dispatched event's assembled epoch.
+      #
+      # Its ASSERTIONS already ride the consolidated bundle above (the
+      # namespace ends `-cljs-test`, so `:node-test`'s `cljs-test$` selects
+      # it). What runs ONLY here is the dependency-graph half: that bundle
+      # also loads `day8.re-frame2-xray.preload`, which carries the identical
+      # anchor, so the assertions pass whether or not `install.cljs` still
+      # spells its `[re-frame.epoch]` require. That is why the gate is not
+      # declared `covered-by: test:cljs` in scripts/check_gate_scheduling.py
+      # — a cover that reads true and grades nothing is the class that
+      # checker exists to refuse.
+      #
+      # A STEP IN THIS JOB RATHER THAN A JOB OF ITS OWN, for the reason the
+      # release build below gives at length. Every input that can change this
+      # build's output — tools/xray/{src,test}/**.{cljs,cljc} and
+      # implementation/shadow-cljs.edn — already arms `cljs_node_test`
+      # (measured against the classifier, not assumed), so it needs no
+      # classifier arm of its own and adds no condition to keep in sync. A
+      # dedicated job would pay a second JDK + Clojure CLI + `npm ci` +
+      # Maven-cache setup for one focused compile, and would add a required
+      # check to the rollup to buy nothing this step does not already buy.
+      # Cheap enough to sit here rather than last: one namespace and its
+      # closure, against the ~10-minute consolidated compile above.
+      - name: Xray manual-only epoch-delivery witness (graph isolation)
+        run: npm run test:xray-manual-epoch
+
       # Hicasso modules compile (rf2-2rtt6.73, rf2-okhdf, rf2-peorl; its own
       # script since rf2-6c12m.1). The ONE warnings-fatal compile of what no
       # other gate judges: the optional modules (motion / overlay / forms /

--- a/scripts/check_gate_scheduling.py
+++ b/scripts/check_gate_scheduling.py
@@ -236,29 +236,6 @@ DISPOSITIONS: dict[str, dict] = {
                "`^re-frame\\.testbed\\..+-cljs-test$` — again a strict subset "
                "of `cljs-test$`, so the scheduled consolidated lane runs them",
     },
-    # rf2-kuky.82 AMEND 2(c).  The one DECLARED HOLE in this file, and it is
-    # NOT `covered-by: test:cljs` even though its namespace does ride that
-    # lane.  `:node-test-xray-manual-epoch` selects the same single
-    # `-cljs-test$` namespace the consolidated build already runs, so on the
-    # rule the two siblings above use this would read as a strict subset —
-    # and that reading would be exactly wrong.  The teeth of this gate are
-    # the DEPENDENCY GRAPH, not the assertions: it proves `install.cljs`'s
-    # bare `[re-frame.epoch]` require is what loads the epoch producer on the
-    # manual `core/init!` startup path, and the consolidated bundle also
-    # loads `day8.re-frame2-xray.preload`, which carries the identical
-    # anchor.  So `test:cljs` runs the assertions and cannot fail them in
-    # either world.  Claiming cover here would be a premise that reads true
-    # and grades nothing — the class this checker exists to refuse.
-    "test:xray-manual-epoch": {
-        "kind": "unscheduled",
-        "bead": "rf2-zwgx",
-        "why": "the focused build landed with no CI home because "
-               "`.github/workflows/**` was fenced to a peer worker on the "
-               "tick that built it — the same fence that made "
-               "`test:hicasso-controlled` and `test:hicasso-hmr` declare "
-               "themselves here before rf2-ga8m / rf2-hic-015 gave them "
-               "jobs. rf2-zwgx owes the step and the deletion of this entry",
-    },
     "test:cljs-isolation": {
         "kind": "ci-runs-it-directly",
         "probe": "node scripts/check-per-ns-isolation.cjs",
@@ -302,20 +279,47 @@ DISPOSITIONS: dict[str, dict] = {
     # green — and a declared hole that outlives its gate's schedule is the
     # same class of lie as an undeclared one, told the other way round.
     #
-    # ONE DECLARED HOLE REMAINS — `test:xray-manual-epoch` (rf2-zwgx), the
-    # entry above.  This sentence has twice said the opposite while a hole sat
-    # beneath it, so read the SUMMARY LINE this script prints (`N of them
-    # known holes with beads`) rather than this comment: a checker asserting
-    # its own completeness in prose is the failure mode, not the check.
+    # `test:xray-manual-epoch` (rf2-zwgx, filed by rf2-kuky.82 AMEND 2(c)) was
+    # the last declared hole, and it is DELETED.  The manual-only
+    # epoch-delivery witness landed with no CI home because
+    # `.github/workflows/**` was fenced to a peer worker on the tick that
+    # built it — the same fence the two hicasso entries below hit — and
+    # rf2-zwgx landed the missing half: a step of test.yml's `cljs` job.
+    # No classifier arm and no job of its own, because every input that can
+    # change `:node-test-xray-manual-epoch`'s output
+    # (tools/xray/{src,test}/**.{cljs,cljc}, implementation/shadow-cljs.edn)
+    # already arms `cljs_node_test`, which is what lights that job.
     #
-    # `test:hicasso-hmr` (rf2-hic-015) was that entry, and it is DELETED.  The
-    # Hicasso HMR gate — the only surface in the repo that drives a REAL hot
-    # reload, 36 reloads and 105 checks per engine through `shadow-cljs watch`
-    # in Chromium, Firefox and WebKit — landed green under rf2-vsgq and ran
-    # nowhere, because rf2-vsgq's fence stopped at the browser test tree.  It
-    # declared itself here rather than go silently unrun.  rf2-hic-015 landed
-    # the missing half: the required `cljs-hicasso-hmr` job, its `hicasso_hmr`
-    # classifier arm, and the matching _changed-surfaces.test.cjs rows.
+    # WHAT THE rf2-zwgx ENTRY KNEW, kept because the choice of home rests on
+    # it: this gate is NOT `covered-by: test:cljs`, even though it does ride
+    # that lane.  `:node-test-xray-manual-epoch` selects the same single
+    # `-cljs-test$` namespace the consolidated build already runs, so on the
+    # rule the `test:security` / `test:testbed-support` siblings above use it
+    # would read as a strict subset — and that reading would be exactly wrong.
+    # The teeth are the DEPENDENCY GRAPH, not the assertions: the gate proves
+    # `install.cljs`'s bare `[re-frame.epoch]` require is what loads the epoch
+    # producer on the manual `core/init!` startup path, and the consolidated
+    # bundle also loads `day8.re-frame2-xray.preload`, which carries the
+    # identical anchor.  So `test:cljs` runs the assertions and cannot fail
+    # them in either world.  Claiming cover would have been a premise that
+    # reads true and grades nothing — the class this checker exists to refuse.
+    #
+    # DO NOT WRITE A COUNT HERE.  The sentence that stood at this spot twice
+    # said no holes remained while one sat beneath it, and then said ONE
+    # REMAINS until this deletion.  Read the SUMMARY LINE this script prints
+    # (`N of them known holes with beads`) rather than any prose here: a
+    # checker asserting its own completeness in prose is the failure mode, not
+    # the check.
+    #
+    # `test:hicasso-hmr` (rf2-hic-015) was the entry before that, and it is
+    # DELETED too.  The Hicasso HMR gate — the only surface in the repo that
+    # drives a REAL hot reload, 36 reloads and 105 checks per engine through
+    # `shadow-cljs watch` in Chromium, Firefox and WebKit — landed green under
+    # rf2-vsgq and ran nowhere, because rf2-vsgq's fence stopped at the browser
+    # test tree.  It declared itself here rather than go silently unrun.
+    # rf2-hic-015 landed the missing half: the required `cljs-hicasso-hmr` job,
+    # its `hicasso_hmr` classifier arm, and the matching
+    # _changed-surfaces.test.cjs rows.
     #
     # TWO THINGS THE DELETED ENTRY KNEW, kept because the job now depends on
     # both.  It needs a `shadow-cljs watch` and shadow's own `:dev-http` on


### PR DESCRIPTION
Closes the one declared hole in `scripts/check_gate_scheduling.py`: `npm run test:xray-manual-epoch` gets a CI home, and the `unscheduled` DISPOSITIONS entry naming rf2-zwgx is deleted in the same change. A declared hole that outlives its gate's schedule is the same class of lie as an undeclared one, told the other way round — so the two move together.

Refs rf2-zwgx (filed by rf2-kuky.82 AMEND 2(c)). Two files, +72/−36.

## NO REQUIRED CHECK IS ADDED — the band does not move

Stated prominently because it is the number every merge decision in this repo is measured against.

**79 required jobs on main, 79 on this branch, no required check added.**

Measured, not asserted, on both sides:

| measurement | `origin/main` (`c5adf395a3`) | this branch |
|---|---|---|
| `check_fast_pr_gap.py` — required jobs across 3 workflows | 79 | 79 |
| `check_workflow_job_timeouts.py` — jobs in `test.yml` | 71/71 capped | 71/71 capped |
| `check_fast_pr_gap.py` — required checks unrun locally | 99 | 100 |

The one number that moves is the last, and it is a *step* count inside the spine's gap map, not a rollup check: `check_fast_pr_gap.py`'s own header says a new step inside an existing job is reported as unrun until somebody teaches it otherwise, and that the failure mode of being wrong is a worker running one check too many. Its `--check` ratchet stays clean (`fast-PR gap map clean`).

To be explicit about which number is which: 79 is the **required-jobs** count this workflow trio schedules; it is a different and narrower number than the per-PR **rollup band** (the total CheckRuns a PR is graded on). Neither moves here, because this change adds a step to an existing job and no job at all.

## Why a STEP of the `cljs` job, and not a job, and not another tier

The gate compiles `:node-test-xray-manual-epoch` — a build selecting ONE namespace whose require list reaches `re-frame.epoch` through `day8.re-frame2-xray.install` and nowhere else — then proves a manual `core/init!` alone receives a dispatched event's assembled epoch.

**Surface: `cljs_node_test`.** Every input that can change that build's output already arms it, measured against the classifier rather than assumed:

```
.github/scripts/report-changed-surfaces.sh tools/xray/src/day8/re_frame2_xray/install.cljs  -> cljs_node_test=true
.github/scripts/report-changed-surfaces.sh implementation/shadow-cljs.edn                   -> cljs_node_test=true
.github/scripts/report-changed-surfaces.sh docs/index.md                                    -> cljs_node_test=false   (control)
.github/scripts/report-changed-surfaces.sh tools/xray/src/foo.clj                           -> cljs_node_test=false   (control)
```

Both controls fire, so the `true`s are discrimination rather than a stuck output. `cljs_node_test` is exactly what lights the `cljs` job, so the step needs **no classifier arm of its own** and adds no condition to keep in sync — the rf2-hic-021 lesson the `build:hicasso-release` step in the same job already records at length: a job gated on a surface condition is correct exactly until the thing it guards grows one more input, and nothing makes anyone revisit the condition then.

**Tier: per-PR, in the always-scheduled `cljs` job — not the nightly, and not a job of its own.**

* *Not nightly.* The claim being defended is a single `:require` in `install.cljs`. It is deleted or reordered by an ordinary refactor of a file that arms this job on every PR; catching that twenty-four hours later means catching it after the PR merged. The whole argument in `check_gate_scheduling.py`'s own "WHY IT LIVES IN `scripts/` AND RUNS PER-PR" note applies unchanged.
* *Not its own job.* A dedicated job pays a second JDK + Clojure CLI + `npm ci` + Maven-cache setup for one focused compile, needs its own classifier condition, and adds a required check to the rollup — to buy nothing this step does not already buy from a runner that has paid for all of it.
* *Not `test:cljs` (the consolidated lane).* See below; this is the load-bearing one.
* *Placement within the job:* directly after the two per-namespace test-isolation steps, whose family it belongs to — all three are claims about what a **graph** loads, which the consolidated bundle cannot make. Before the two Hicasso compiles, which are more expensive.

## NOT `covered-by: test:cljs`, deliberately

The witness namespace ends `-cljs-test`, so `:node-test`'s `cljs-test$` selects it and its **assertions** already ride the consolidated bundle on every PR. On the rule the `test:security` / `test:testbed-support` siblings use, that would read as a strict subset and `covered-by: test:cljs` would look right.

It would be exactly wrong. The consolidated bundle **also loads `day8.re-frame2-xray.preload`**, which carries the identical anchor — so the assertions pass whether or not `install.cljs` still spells its `[re-frame.epoch]` require. The bundle cannot tell the two worlds apart. The dependency-graph half is the entire teeth of the gate, it runs only under the focused build id, and claiming cover would have been a premise that reads true and grades nothing — the class this checker exists to refuse.

That reasoning came from the witness's own author and is preserved in the file, moved from the deleted entry into the closure record above the hicasso entries.

## What the checker now reports

```
main:        gate-scheduling: 34 gate commands, 29 scheduled, 5 declared (1 of them known holes with beads).
this branch: gate-scheduling: 34 gate commands, 30 scheduled, 4 declared (0 of them known holes with beads).
```

`--verbose` on this branch lists `scheduled  test:xray-manual-epoch`.

The prose that stood where the entry's obituary now sits used to assert its own completeness ("no declared holes remain", twice, while a hole sat beneath it; then "ONE REMAINS"). It is replaced with a `DO NOT WRITE A COUNT HERE` note pointing the reader at the summary line the script prints, rather than with a fresh count that will rot the same way.

## Coverage note

`implementation/scripts/check-examples-compile.cjs --list` enumerates **58** builds and names none of `:node-test-xray-manual-epoch` (asked of the tool rather than grepped for the id, per the standing trap). So that derived sweep does not reach this build, and the step added here is its only scheduled home.

## Quality gates

All run in the foreground to completion, exit codes read off the runner's own command line, never through a pipe.

| gate | mode | exit |
|---|---|---|
| `python scripts/check_gate_scheduling.py --self-test --verbose` | self-test | **0** — all checks passed |
| `python scripts/check_gate_scheduling.py --verbose` | live | **0** — 34/30/4, 0 known holes |
| `python scripts/check_workflow_yaml.py` | live | **0** — 11 files well-formed |
| `python scripts/check_workflow_job_timeouts.py --self-test` | self-test | **0** |
| `python scripts/check_workflow_job_timeouts.py --verbose` | live | **0** — 117 jobs across 11 files, 71/71 in `test.yml` |
| `python scripts/check_ci_reproduce_commands.py --self-test` | self-test | **0** |
| `python scripts/check_ci_reproduce_commands.py --check --verbose` | live | **0** |
| `python scripts/check_fast_pr_gap.py` | ratchet | **0** — gap map clean |
| `node implementation/scripts/_changed-surfaces.test.cjs` | mirror | **0** — 366 passed |

**9 passed, 0 failed.**

Nominated by path, after reading what each reads: `check_gate_scheduling.py` is the diff's own subject; `check_workflow_yaml.py` and `check_workflow_job_timeouts.py` are the two workflow-shape gates over `.github/workflows/**`; `check_ci_reproduce_commands.py` is the structural guard over checker steps in `test.yml`; `check_fast_pr_gap.py` is the ratchet that grades required gate steps in the three workflows; `_changed-surfaces.test.cjs` is the classifier mirror carrying `test.yml`-shape assertions.

Deliberately **not** run, with reasons: `scripts/test-fast-pr.sh` (the diff touches neither the spine nor its fixture tree, and it tiers itself on the same classifier); `npm run test:xray-manual-epoch` itself (it needs a shadow-cljs JVM compile that CI's `cljs` job now performs on the runner that has already paid for the toolchain — this PR is where that first green run happens); `implementation/scripts/_rigorous-local-inventory.test.cjs` (scoped by its own header to `expensive-tests.yml`'s `browser-bundle-and-story-gates` job, which this diff does not touch); `mkdocs build --strict` and the two link gates (no path under their roots is touched).

### Sabotage proof — the gate can go red on this tree

Per the plant-then-restore discipline, and run **after** committing so the restore is checkable against a known object:

1. Match count read **before** the plant: `grep -c -F 'npm run test:xray-manual-epoch' .github/workflows/test.yml` → **1**. A plant that matched zero lines is not a plant.
2. Planted: the step's `run:` value rewritten to `npm run test:xray-manual-epoch-PLANTED` (1 replacement, reported by the patcher itself). Working-file blob hash moved `0411dd338c…` → `182a6324fb…`, so the source really changed.
3. Gate run: `python scripts/check_gate_scheduling.py` → exit **1**, `gate-scheduling: FAIL`, naming `test:xray-manual-epoch: defined in implementation/package.json, invoked by no workflow, and carrying no DISPOSITIONS entry.`
4. **The red is the discrimination.** That failure is reachable only on a tree where the DISPOSITIONS entry has been deleted — on `main` the entry is still there and the same plant would be green — so the run read this worktree and not a sibling's.
5. Restored with `git checkout HEAD -- .github/workflows/test.yml`, verified by **git blob hash** and not by the restore's exit code: `git hash-object` → `0411dd338ccdd86ba325e4b6e070e99a7e870dd7`, byte-identical to `git rev-parse HEAD:.github/workflows/test.yml`. `PLANTED` residue count 0; anchor count back to 1; `git status` clean.
6. Gate re-run after restore → exit **0**, 34/30/4.

### Hand-checked, because no gate covers it

Nothing validates a workflow comment's prose or a markdown table's column counts. The two comment blocks added here were read back in place; the three tables in this body were checked for column-count consistency by hand.

## Fences

* Two files only: `.github/workflows/test.yml` (+32/−0) and `scripts/check_gate_scheduling.py` (+40/−36).
* `git diff --name-only <merge-base>...HEAD | grep -c '^\.beads/'` → **0**, with a live control (the same filter reads 1 against a synthetic `.beads/issues.jsonl` line), so the check is not a dead instrument.
* No `api-manifest` path in the diff — **0** matches. The generated manifest is untouched.
* Diffed against the **merge base** (`c5adf395a3`), not the trunk tip, and read for what it would revert: the only hunks are the two above; no sibling's landed work is undone.
