### PR TITLE
test(resources): pin two simultaneous explicit-scope subs on distinct cache entries (rf2-kuky.81)

### DIFF
--- a/implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc
@@ -246,6 +246,73 @@
     (is (some? (entry (rf.resources.state/scoped-resource-key
                         [:rf.scope/tenant {:tenant-id "acme"}] :t/notes {}))))))
 
+(deftest two-explicit-scope-subs-keep-distinct-cache-entries
+  ;; rf2-kuky.81 — THE CACHE-WITNESS PATTERN at the suite level. Two live
+  ;; subscriptions over ONE resource with IDENTICAL params, separated only by
+  ;; an explicit `:scope` override on each query, each read their OWN loaded
+  ;; value at the same time.
+  ;;
+  ;; This is the POSITIVE counterpart of `wrong-scope-override-reads-its-own-
+  ;; empty-entry` above. That test pins the fail-closed half — an override
+  ;; addressing an EMPTY key — and is satisfied by a runtime that resolves the
+  ;; override to nothing at all. This one pins the half a collapse would
+  ;; break: two overrides addressing two POPULATED keys, neither borrowing the
+  ;; other's data. Reading two entries DIRECTLY (as
+  ;; `resources_scoped_owner_lifecycle_cljs_test.cljc`'s
+  ;; `acquire-two-scopes-are-independent-owners` does) does not reach this
+  ;; property either — the seam is the sub's own key resolution.
+  ;;
+  ;; The BROWSER witness for the same property already exists and stays:
+  ;; `testbeds/tenant_switcher/core.cljs` (the cache-witness panel) with step 3
+  ;; of its `spec.cjs`, where two explicit queries render two tenants' mottos
+  ;; side by side. This is the focused suite-level regression BESIDE it — it
+  ;; runs in the resources JVM lane and the CLJS node-test lane on every PR,
+  ;; where the testbed's dedicated browser job is path-gated and can be skipped.
+  (ensure-feed! "acme"   1 [:app :acme 1]   {:motto "acme-only"})
+  (ensure-feed! "globex" 1 [:app :globex 1] {:motto "globex-only"})
+  ;; A THIRD tenant is the ambient identity, so NEITHER override coincides with
+  ;; what the `{:from-db :t/tenant}` spec policy resolves to: a read that fell
+  ;; back to the policy would address initech's un-ensured key and go idle, and
+  ;; a read that collapsed both queries onto one key would hand back the same
+  ;; motto twice. Both faults are visible in the assertions below.
+  (rf/dispatch-sync [:t/login "initech"])
+  (let [q-acme    {:resource :t/feed :params {:page 1}
+                   :scope [:rf.scope/tenant {:tenant-id "acme"}]}
+        q-globex  {:resource :t/feed :params {:page 1}
+                   :scope [:rf.scope/tenant {:tenant-id "globex"}]}
+        st-acme   (rf/subscribe [:rf/resource q-acme])
+        st-globex (rf/subscribe [:rf/resource q-globex])
+        d-acme    (rf/subscribe [:rf.resource/data q-acme])
+        d-globex  (rf/subscribe [:rf.resource/data q-globex])
+        db        (rf/app-db-value :rf/default)]
+    (testing "the two overrides resolve DIFFERENT scoped keys — one resource,
+              one params map, so the explicit scope is the only thing that
+              separates them"
+      (is (not= (rf.resources.subs/resolve-scoped-key q-acme   db)
+                (rf.resources.subs/resolve-scoped-key q-globex db))
+          "identical resource + params, two distinct keys")
+      (is (= #{(tenant-key "acme" 1) (tenant-key "globex" 1)} (set (keys (entries))))
+          "both entries are live in the cache at once"))
+    (testing "both subs are live SIMULTANEOUSLY and each reads its own loaded
+              value — the explicit `:scope` override partitions the cache at
+              the READ, so neither sub can ever observe the other's data"
+      (is (= :loaded (:status @st-acme)))
+      (is (= :loaded (:status @st-globex)))
+      (is (= {:motto "acme-only"}   @d-acme))
+      (is (= {:motto "globex-only"} @d-globex))
+      ;; re-deref both, interleaved: neither read displaces the other's value
+      (is (= {:motto "acme-only"}   (:data @st-acme)))
+      (is (= {:motto "globex-only"} (:data @st-globex)))
+      (is (not= @d-acme @d-globex)
+          "two distinct values — not one entry answering both queries"))
+    (testing "the control: the SAME resource + params with NO override falls
+              back to the `{:from-db :t/tenant}` spec policy and reads
+              initech's un-ensured key — proof the two loaded reads above came
+              from the OVERRIDES and not from the ambient policy scope"
+      (let [st-policy (rf/subscribe [:rf/resource {:resource :t/feed :params {:page 1}}])]
+        (is (= :idle (:status @st-policy)))
+        (is (nil? (:data @st-policy)))))))
+
 (deftest nil-resolving-sub-scope-fails-closed-loudly
   ;; A {:from-db} sub whose resolver yields nil (no logged-in viewer) raises
   ;; the sub-side fail-closed diagnostic — never a silent :idle / global /


### PR DESCRIPTION
Delivers the reopened audit residual of **rf2-kuky.81**: the one test its original Tests paragraph asked for and PR #9458 did not land — *"one test that two explicit-`:scope` subs over the same resource+params keep distinct cache entries (the cache-witness pattern) — cite the testbed."*

Test-only. No runtime, spec, doc, skill or manifest change; the two-policy implementation that landed in #9458 stands untouched.

## What lands

One `deftest`, `two-explicit-scope-subs-keep-distinct-cache-entries`, in `implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc` — the suite whose namespace docstring already frames the scope boundary as the READ-PATH guarantee asserted at the live `rf/subscribe` seam.

One resource (`:t/feed`), identical params (`{:page 1}`), two tenant scopes loaded with distinguishable data, then two live subscriptions separated only by a concrete `:scope` override on each query. A **third** tenant is made the ambient identity, so neither override coincides with what the `{:from-db :t/tenant}` spec policy resolves to. That makes both failure directions visible: a read that fell back to the policy addresses the third tenant's un-ensured key and goes idle, and a read that collapsed both queries onto one key hands back the same value twice. A no-override control subscription asserts the idle policy read, which is what makes the two loaded reads attributable to the overrides rather than to the ambient scope.

## The browser witness is preserved and cited, not duplicated

`testbeds/tenant_switcher/core.cljs` (the cache-witness panel) with step 3 of its `spec.cjs` already asserts that two explicit queries render two tenants' own distinct loaded mottos. **That testbed is untouched by this PR** and is cited by name in the new test's comment. This is the focused suite-level regression *beside* it: the testbed's dedicated browser job is path-gated and was SKIPPED on #9458, whereas this test runs in the resources JVM lane and the CLJS node-test lane on every PR.

## Why the three existing candidates did not already cover it

Re-verified at source rather than taken from the audit note:

- `wrong-scope-override-reads-its-own-empty-entry` (same file) pins the **fail-closed** half — one explicit override addressing an **empty** key, asserting the other entry still exists via a direct entry read. A runtime that resolved the override to nothing at all would still satisfy it.
- `sub-re-keys-on-mid-session-account-switch` (`resources_from_db_scope_cljs_test.cljc`) exercises **one** subscription, and its query carries no `:scope` — it is the inherited-policy path.
- `acquire-two-scopes-are-independent-owners` (`resources_scoped_owner_lifecycle_cljs_test.cljc`) reads `(entry ka)` / `(entry kb)` **directly**; no subscription is involved, so the sub's own key resolution — the seam a collapse would break — is never exercised.

## Quality gates

| gate | result |
|---|---|
| `implementation/resources` `clojure -M:test` (full artefact suite, foreground) | **exit 0** — 860 tests / 7671 assertions, 0 failures, 0 errors |
| focused namespace `clojure -M:test -n re-frame.resources-scope-leak-boundary-cljs-test` | **exit 0** — 9 tests / 38 assertions |
| **sabotage run** (see below) | **exit 1** — 11 failures, 8 of them naming the new test |
| `scripts/check_retired_spellings.py` | exit 0 |
| `scripts/check_test_lane_bijection.py` | exit 0 |
| `scripts/check_jvm_lane_rosters.py` | exit 0 |
| `scripts/check_thrown_error_messages.py` | exit 0 |
| `scripts/check_require_alias_dialect.py` | exit 0 |
| `scripts/check_retired_composition_vocab.py` | exit 0 |
| `scripts/check-no-hardcoded-paths.sh` | exit 0 |

Every exit code above was captured on the runner's own command line and read from an exit file, never through a pipe.

The full suite's 860/7671 is exactly +1 test / +11 assertions over the 859/7660 the #9458 audit recorded for this artefact, which corroborates that the new test ran and that nothing else moved.

**Skipped, with reason:** `npm run test:cljs`. The JVM lane was checked rather than assumed and **does** execute this `_cljs_test.cljc` (its namespace ends `-test`, and the focused JVM run above collected it), so the brief's conditional for adding the CLJS lane does not apply. The diff introduces no CLJS-specific API — `rf/subscribe`, deref of a `:rf.resource/data` sub and `rf/app-db-value` are all already exercised cross-host in this same file — and `test.yml`'s CLJS node-test lane grades the file in CI on every PR (`scripts/check_fast_pr_gap.py --brief` confirms it is one of the 99 required checks the local spine does not decide).

### The test is shown to discriminate

A green test that would also have been green before the behaviour it pins is worthless, so the guard was proved by planting the exact fault the audit named — the query `:scope` override being ignored and collapsed to the policy scope.

- **Plant:** `implementation/resources/src/re_frame/resources/subs.cljc:108`, `resolve-scoped-key`'s call to `resolve-scope-for-sub`, with `(:scope payload)` replaced by `nil`.
- **Match count read before the run: 1** — so the plant was not a no-op. Blob hash moved `7213713796…` → `43436cbcc6…`.
- **Sabotage run: exit 1**, 9 tests / 38 assertions — identical test and assertion counts to the control run, so no namespace was crashed and the reds are the property under test. 11 failures, **8 naming `two-explicit-scope-subs-keep-distinct-cache-entries`**. The first failure prints the collapse literally: both queries resolved the same key `[[:rf.scope/tenant {:tenant-id "initech"}] :t/feed {:page 1}]`, and both status subs read `:idle` instead of `:loaded`.
- **Restore verified by git blob hash**, not by the restore command's exit code: the working file hashes `721371379651b1199efcf404e5dafd728ef46b78`, equal to the committed blob, and the original spelling's match count is back to 1. `git status` clean.

The plant was transient, was never committed, and `subs.cljc` does not appear in this PR's diff.

### Verified by hand

- Table column counts in this body checked by hand (11-row gate table, 2 columns; every row 2 cells).
- Paren depth of the edited file counted mechanically before any suite was started (final depth 0).
- `git diff --numstat <merge-base>...HEAD` reads `67 0` on one file — additions only, so nothing a sibling landed is reverted by this push.
- No `.beads` path in the diff (0), with a live control on a path that is in the diff returning 1.
- No fenced file touched: `implementation/resources/src/re_frame/resources/route.cljc`, `spec/016-Resources.md`, `spec/Derivations.md` and `subs.cljc` are all absent from the diff (rf2-kuky.83 holds them). `spec/api-manifest.edn`, its metadata sidecar and `spec/API.md` are untouched.

Bead rf2-kuky.81 is left **OPEN** for the mayor to dispose.
