### PR TITLE
docs(005): a boot-time singleton is registered, not hand-spawned; record the Target 4 occupied-address result (rf2-kuky.70 items 2-3)

### DIFF
--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -2732,8 +2732,12 @@ entry and destroys on exit, recording the child's id in the parent's own
 
 The `[:rf.machine/spawn …]` fx is what declarative `:spawn` desugars INTO
 (per [§Desugaring rules](#desugaring-rules)), and it is also the only way to
-spawn a child whose lifetime is **not** bound to a state — a worker that must
-outlive the state that started it, or a boot-time singleton.
+spawn a child whose lifetime is **not** bound to a state — a dynamically
+created worker that must outlive the state that started it.
+
+A boot-time singleton is **not** spawned. It is registered, its registered id
+IS its address, and the frame's `:initial-events` supply the eager
+`[:rf.machine/start]` kick — see [Pattern-Boot §1. A singleton — addressed by its registered id, NOT `:spawn`](Pattern-Boot.md#1-a-singleton--addressed-by-its-registered-id-not-spawn).
 
 ```clojure
 :action (fn [{[_ url] :event}]


### PR DESCRIPTION
Delivers items **2 and 3** of the merged-PR audit of #9457, recorded on `rf2-kuky.70`.
Item 1 (manifest regeneration) is **not** touched: it was repaired by #9467 before the audit
note was written, and trunk now reads declared == counted == 481. The bead carries a mayor note
saying so. **The `:system-id` / `:child-machine` retirement itself is not revisited by this PR.**

`rf2-kuky.70` is deliberately left **OPEN** for the mayor to dispose.

## Item 2 — a doc contradiction inside one landed tree

`spec/005-StateMachines.md` §*Hand-emitting `[:rf.machine/spawn …]` — the desugar target*
listed **"or a boot-time singleton"** among the cases for a hand-emitted spawn. That contradicts
three sources in the same tree:

- `spec/Pattern-Boot.md` §*1. A singleton — addressed by its registered id, NOT `:spawn`*:
  *"This is **not** `spawn` … there is one, it is known at registration time, and its name is
  the address."*
- `spec/Pattern-Boot.md` §*2. The eager kick from `:initial-events`* — the frame's
  `:initial-events` dispatch the reserved `[:rf.machine/start]` marker.
- `skills/re-frame-migration/SKILL.md:124` — *"A singleton is not `:spawn`ed: there is one, it is
  known at registration time, and the id IS the address."*

**The fix is prose only.** The hand-emitted-spawn recipe is kept for its correct case — a
dynamically created worker whose lifetime outlives the state that started it — and the boot case
is pointed at the existing registered-id/`:initial-events` recipe rather than deleted, so the
reader who arrived looking for it is not left without an answer. **No second boot mechanism, and
no runtime-policy change.** Six lines added, two removed, one file.

## Item 3 — the Target 4 handoff

**The occupied-address probe DID find silent replacement.** This is the result Target 4 and the
bead's Acceptance asked the PR body to state.

`implementation/machines/test/re_frame/fixed_actor_id_addressing_test.clj`,
`spawning-onto-an-occupied-fixed-address-replaces-the-occupant`: a second ordinary
`[:rf.machine/spawn {… :fixed-actor-id :fai/slot}]` at an address a **live** actor already
occupies **replaces that actor's snapshot in place**. No error, no warning, no distinguishing
trace, and no sidelined copy of the first incarnation survives under an allocated id. The
`spawn-all-address-collisions` guard (`:rf.error/machine-spawn-all-duplicate-id`) is a
**within-batch** check and does not reach this path.

**Follow-up bead: `rf2-dokz`** — *"machines: spawning onto an OCCUPIED `:fixed-actor-id` silently
replaces the live occupant"*, P3, bug, `discovered-from: rf2-kuky.70`.

It was **filed rather than linked**: the tracker was searched first over four independent term
axes (`occupied`, `fixed-actor-id`, `occupied-address`, `fai/slot`, plus `silently replaces` /
`replaces a live` / `second spawn`) across title, description, notes, acceptance and design of all
1098 beads open and closed, with controls (`system-id` 18 hits, `child-machine` 5) firing on the
same instrument. The only pre-existing hits were `rf2-kuky.70` and `rf2-kuky.15` themselves.
`rf2-1vlyg` is a different and closed finding (reverse-creation teardown ordering for restored
mixed-prefix actors).

`rf2-dokz` explicitly does **not** reopen the `rf2-kuky.15` ruling and forbids a second name
registry; it asks only whether the live-occupant case should stay last-write-wins, warn, or
reject. The result and the link are also recorded as a note on `rf2-kuky.70`.

## Quality gates

Captured exit codes, read off each runner's own command line (never through a pipe).

| Gate | Result |
|---|---|
| `python scripts/check_doc_slugs.py` | **exit 0** — pass |
| `python -m mkdocs build --strict` | **exit 0** — pass; log confirms `spec/005-StateMachines.md` and `spec/Pattern-Boot.md` were staged and built |
| `implementation/machines` `clojure -M:test` | **exit 0** — 1199 tests, 4348 assertions, 0 failures, 0 errors |
| `scripts/check_retired_spellings.py` | **exit 0** — pass |
| `scripts/check_keyword_catalogue_drift.py` | **exit 0** — pass |
| `scripts/check_retired_composition_vocab.py` | **exit 0** — pass |
| `scripts/check_runtime_subsystem_grading.py` | **exit 0** — pass |
| `scripts/check_skill_re_frame2_drift.py` | **exit 0** — pass |
| `scripts/check_skill_implementor_partition_drift.py` | **exit 0** — pass |

**Totals: 9 gates run, 9 pass, 0 fail.**

The machines suite is nominated because two of its tests read `spec/005-StateMachines.md`
directly (`transition_geometry_terminology_jvm_test.clj:71` slurps it;
`destroyed_reason_channel_conformance_test.clj:106` resolves it), so this diff is genuinely its
subject rather than an unrelated surface. 1199/4348 matches the figure CI recorded for #9457.

**Not run, with reasons.** `scripts/check_readme_links.py --ci` — its three rosters are
repo-root markdown, `README.md` beside source, and tracked non-`README` markdown beside source;
`spec/` is outside all three and belongs to `check_doc_slugs.py`, which ran. The fast-PR spine —
this diff is one markdown file already covered by the two doc gates above, and re-running the
spine buys wall-clock rather than information.

### Sabotage proof

`check_doc_slugs.py` prints nothing on success, so its teeth were proved by a planted fault
rather than by a printed root.

1. Pre-plant blob hash recorded; plant's **match count read as 1 before the run**, so it was not
   a no-op.
2. The new anchor was rewritten to `#zzz-planted-bogus-anchor-mach70b-a` — a string that exists
   only in this worktree, so a run that had wandered into a sibling checkout would have come back
   green.
3. Gate went **red, captured exit 1**, naming `spec\005-StateMachines.md:2740 ->
   Pattern-Boot.md#zzz-planted-bogus-anchor-mach70b-a`.
4. Restored with `git checkout HEAD --`, and the restore verified by **git blob hash** against the
   committed object (`d69c98701686be79637475edb19ea42b815bac01`), not by the command's exit code.

### Hand verification — what no gate covers

**Nothing grades prose for truth**, so item 2's correctness rests on a direct source read of
`spec/Pattern-Boot.md` (lines 203–247) and `skills/re-frame-migration/SKILL.md:124`, quoted above.
A green from either link gate says nothing about whether the sentence is true.

**Neither link gate looks inside a fenced code block**, so the fence position was checked by hand:
the edited prose sits at lines 2733–2740, between the fences closing at 2729 and opening at 2742 —
it is prose, not fenced sample, so `check_doc_slugs.py` does grade the new link (and the plant
above confirms it).

**Table column counts**: the diff changes no table — 0 pipe-bearing lines added or removed.

**Anchor**: the one new link, `Pattern-Boot.md#1-a-singleton--addressed-by-its-registered-id-not-spawn`,
is validated by `check_doc_slugs.py` and follows the em-dash-to-`--` convention already proven by
the live `Pattern-Boot.md#worked-example--auth-machine-and-the-retry-ownership-boundary` links in
`spec/014-HTTPRequests.md` and `spec/005-StateMachines.md`.

### Tracker boundary

No `.beads/issues.jsonl` or any other database-derived `.beads` path is in this diff — verified 0,
with a control confirming the check was live (the same filter over a synthetically prefixed path
list returns 1). `spec/api-manifest.edn` is untouched; the diff is one file.
