### PR TITLE
docs(core): stop describing :events/:errors as live register-listener! streams

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -2391,9 +2391,15 @@
   clear-trace-buffer!    rf.trace.tooling/clear-trace-buffer!)
 
 ;; The always-on event-emit / error-emit listener registries are NO LONGER
-;; facade exports. They are reached through the stream-parameterized
-;; `register-listener!` / `unregister-listener!` verb above with the
-;; `:events` / `:errors` stream (rf2-ikjmkm, decision rf2-dbo0c9 Option C).
+;; facade exports. The per-registry verbs were folded into the
+;; stream-parameterized `register-listener!` / `unregister-listener!` pair
+;; above (rf2-ikjmkm, decision rf2-dbo0c9 Option C), and rf2-kuky.69 then
+;; retired the `:events` / `:errors` streams from that pair's vocabulary —
+;; which is now `#{:trace :epoch}`, two raw dev streams. So NO facade
+;; spelling reaches these registries at all: they are IMPLEMENTATION-tier,
+;; and production observation is a different verb —
+;; `register-observability-sink!` against a frame's `:observability` policy,
+;; or the `(rf/configure! {:observability …})` process default.
 ;; Between-scenario test isolation clears the registries via the lower-level
 ;; `re-frame.event-emit/clear-event-listeners!` /
 ;; `re-frame.error-emit/clear-error-listeners!` sinks directly (the former
@@ -2526,10 +2532,12 @@
 
 ;; There are deliberately NO façade `register-epoch-listener!` /
 ;; `unregister-epoch-listener!` exports (retired rf2-9flalp — API-shrink #4).
-;; The epoch stream is one of the four pure observation streams,
-;; so it is registered through the single stream-parameterized verb —
+;; The epoch stream is one of the TWO raw dev observation streams —
+;; `register-listener!`'s vocabulary is `#{:trace :epoch}` since rf2-kuky.69
+;; retired the `:events` / `:errors` members — so it is registered through
+;; the single stream-parameterized verb —
 ;; `(rf/register-listener! :epoch id f)` / `(rf/unregister-listener! :epoch
-;; id)` — exactly like `:trace` / `:events` / `:errors`. Those verbs delegate
+;; id)` — exactly like `:trace`, the other member. Those verbs delegate
 ;; to the same optional-artefact wrappers (`re-frame.core-epoch/register-
 ;; epoch-listener!`, late-bound via `:epoch/register-epoch-listener!`), which
 ;; remain the implementation and degrade to nil when the `day8/re-frame2-epoch`


### PR DESCRIPTION
Last residual of rf2-kuky.69: two comments in the `re-frame.core` facade still described the vocabulary this bead retired as the live route. Comment-only — no code, export, require or behaviour changes.

## What was false, and why it survived

`rf2-kuky.69` shrank `register-listener!` / `unregister-listener!` to `#{:trace :epoch}`. The censuses that cleared the bead were a **literal-call** census and a **prose** census over `spec/`, `docs/` and `skills/`. Neither reads source comments, which is the axis these two sat on.

**`:2393-2396`** said the always-on event-emit / error-emit registries "are reached through the stream-parameterized `register-listener!` / `unregister-listener!` verb above with the `:events` / `:errors` stream". They are not reachable that way at all any more. Rewritten to say the registries are implementation-tier and that the pair's vocabulary is now `#{:trace :epoch}`.

**`:2529-2532`** said "the epoch stream is one of the four pure observation streams ... exactly like `:trace` / `:events` / `:errors`". Both halves false — two streams, and two of the three names retired. Rewritten to "one of the TWO raw dev observation streams ... exactly like `:trace`, the other member".

The `rf2-ikjmkm` / `rf2-dbo0c9 Option C` provenance and the "a dedicated per-channel pair was the exact shape Option C abolished" reasoning are both preserved; only the vocabulary claims changed.

## The source read establishing the live vocabulary

Nothing grades a comment for truth, so the correction rests on reading the facade at source:

- `core.cljc:2283-2285` — `(def ^:private listener-streams "Closed vocabulary for register-listener! / unregister-listener!." #{:trace :epoch})`
- `core.cljc:2340-2343` — `register-listener!`'s `case` has exactly two arms, `:trace` and `:epoch`; anything else calls `unknown-listener-stream!`
- `core.cljc:2352-2355` — `unregister-listener!`, same two arms
- `unknown-listener-stream!`'s own message: "pass one of the two raw dev observation streams"

So `:events` / `:errors` passed to either verb now throw `:rf.error/unknown-listener-stream`.

The **other** claims in the `:2393` block were checked and are TRUE, so they were left alone: `re-frame.event-emit/clear-event-listeners!` (`event_emit.cljc:105`) and `re-frame.error-emit/clear-error-listeners!` (`error_emit.cljc:85`) both exist and are driven by `test_support.cljc:568`; the `:error-emit/register-error-listener!` late-bind hooks are live (`frame.cljc:2837,3975`); the SSR error projector registers at `ssr.cljc:396`; and routing genuinely registers no error listener (`routing.cljc:215-220`).

## Ten sites deliberately NOT swept

Twelve lines in this file mention `:events` or `:errors`; ten are correct and were left untouched.

- `:67`, `:2262` — retirement bookkeeping in the past tense.
- `:2706`, `:2728`, `:2828`, `:2893` — `:events-retained`, a **trace-buffer config key**.
- `:2719`, `:2730`, `:2736`, `:2742` — `:observability {:errors [<sink-entry>]}`, the **production sink config**.

Those are different keys that merely share a spelling with the retired stream names; editing them would break live configuration documentation. A blind sweep of this file would be wrong.

## Census for the same defect elsewhere in source comments

Four token axes over 1474 tracked `implementation/**` Clojure files, each in four passes (line-oriented, whitespace-flattened, comment-markers-stripped-then-flattened, and hyphen-at-line-break rejoined), each with a live control on the identical command shape:

| axis | control | target before | target after |
|---|---|---|---|
| `register-listener!` with `:events`/`:errors` as its stream arg | fired in 147 files | **0** | 0 |
| "four ... observation/listener streams" | fired in 5 files | 2 (both this file) | **0** |
| retired four-member enum `:trace ... :events/:errors` | fired in 5 files | 3 (all this file) | **0** |

No other source-comment site in `implementation/**` carries the defect. The remaining proximity matches were read individually and are all true: `observability.cljc` and `test_support.cljc` describe the retirement in the **past tense**; `always_on_axis_conformance_cljs_test.cljc` **asserts** the docstring no longer offers the retired streams; and the `:errors`-stream nouns in `cofx_cljs_test`, `router_carried_frame_test` and `resources_mutation_cljs_test` name the always-on error-emit substrate and the `:observability :errors` sink, never the facade verb.

## Quality gates

**5 run, 5 passed, 0 failed.** Exit codes captured on the runner's own command line (redirect + `echo $?` in one shell), never through a pipe.

| gate | exit |
|---|---|
| `implementation/core` `clojure -M:test` — 2301 tests, 11879 assertions, 0 failures, 0 errors | **0** |
| `python scripts/check_retired_spellings.py --verbose` | **0** |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** |
| `python scripts/check_keyword_catalogue_drift.py` | **0** |
| `python scripts/check_thrown_error_messages.py` | **0** |
| `clj-kondo --lint implementation/core/src/re_frame/core.cljc --fail-level error` — **errors: 0**, 19 warnings | **0** |

The 19 clj-kondo warnings are pre-existing (lines 667-696, unrelated to this diff) and the job's own rule is `--fail-level error`. **The local clj-kondo is v2025.10.23 where CI pins v2026.04.15**, so this local pass is not authoritative for the linter's opinion generally — it is evidence only that the file still parses and balances, which is version-robust.

**Gates deliberately NOT nominated**, because none of them reads `implementation/**` source comments and each would have returned a green that inspected nothing in this diff: `doc-api-check`, `scripts/check_doc_slugs.py`, and `mkdocs build --strict`.

**Sabotage proof (clj-kondo).** Committed first, then planted an unbalanced open form at line 2398 — a line authored by this change. Plant match count read **1 before the run** (a zero would have made the plant a no-op), and the blob moved `4522576e04` -> `282c4faa90`. The gate went **red, exit 3**, `errors: 2`, naming `core.cljc:2398:1: error: Found an opening ( with no matching )` — my exact plant. Since the fault existed only in this worktree, the red is also the proof the gate read the right tree. Restored and verified **by git blob hash**, not by exit code: restored blob `4522576e04c01c97ff1d97107d4ea6653f900b79`, identical to the committed object. Post-restore re-run exit **0**.

**Stated limit: nothing grades a comment for truth.** No gate in this repo can tell a true comment from a false one, which is exactly how these two survived a merged PR and two audit passes. The correction rests on the source read shown above, not on any green below it.

## Hand verification

Both edits are `;;` line comments, so they cannot unbalance a form — mechanically confirmed: every added and removed line in the diff starts with `;;` (0 non-comment changed lines across 14 insertions / 6 deletions, 2 hunks). CRLF line endings preserved.
