### PR TITLE
docs(story): spell the theme injectors with the aliases 016-Design-Tokens binds

### DIFF
--- a/tools/story/spec/016-Design-Tokens.md
+++ b/tools/story/spec/016-Design-Tokens.md
@@ -101,7 +101,7 @@ as the visual sibling for systems missing the webfont, then
 ### Webfont delivery
 
 The chrome injects `@font-face` rules via
-`(theme.typography/inject-font-faces!)` at shell mount. Per
+`(typography/inject-font-faces!)` at shell mount. Per
 rf2-2rwdc + the rf2-s1r9a Phase 1 browser-gate trace, the
 auto-injected declarations are **`local()`-only** — no HTTP fetch is
 ever attempted. An OS-installed Plex picks up automatically (Mike's
@@ -723,11 +723,11 @@ The shell composes the six token domains in one pass at
 
 ```clojure
 ;; theme/typography.cljc
-(theme.typography/inject-font-faces!)   ; @font-face → document.head
+(typography/inject-font-faces!)   ; @font-face → document.head
 ;; theme/motion.cljc
-(theme.motion/inject-motion-css!)       ; @keyframes + reduced-motion → document.head
+(motion/inject-motion-css!)       ; @keyframes + reduced-motion → document.head
 ;; theme/depth.cljc
-(theme.depth/inject-grain-css!)         ; ::before grain overlay → document.head
+(depth/inject-grain-css!)         ; ::before grain overlay → document.head
 ```
 
 Three idempotent one-shot injections, each gated on


### PR DESCRIPTION
Closes nothing — **rf2-gbuh stays open** on its ruling. This is the eighth and last of the
option-(b) contradictions that bead's census identified; what remains on it is Mike's
(a)-versus-(c) call, which this PR deliberately does not prejudge.

## What was wrong

`tools/story/spec/016-Design-Tokens.md` teaches a require form at `:53-57`:

```clojure
(:require [re-frame.story.theme.colors      :refer [tokens]]
          [re-frame.story.theme.typography  :as typography :refer [sans-stack mono-stack]]
          [re-frame.story.theme.motion      :as motion]
          [re-frame.story.theme.depth       :as depth]
          [re-frame.story.theme.glyphs      :as glyphs])
```

…and then four use-sites spell dotted prefixes the page binds nowhere:

| line | was | now |
|---|---|---|
| 104 | `theme.typography/inject-font-faces!` | `typography/inject-font-faces!` |
| 726 | `theme.typography/inject-font-faces!` | `typography/inject-font-faces!` |
| 728 | `theme.motion/inject-motion-css!` | `motion/inject-motion-css!` |
| 730 | `theme.depth/inject-grain-css!` | `depth/inject-grain-css!` |

## Why the require form is the authority, and why these four are the outliers

The page's own idiom already agrees with its require form. The **same two functions** are
written with the bound alias elsewhere on the same page — `motion/inject-motion-css!` at
`:411` and `depth/inject-grain-css!` at `:514` — alongside `typography/type-scale`,
`motion/transitions`, `motion/stagger-animation`, `depth/shadows`, `depth/backdrops` and
`depth/grain-css`. That is ten alias-form use-sites against four dotted ones.

The namespaces were right; only the spelling was wrong. Verified at source:
`inject-font-faces!` is defined in `tools/story/src/re_frame/story/theme/typography.cljc`,
`inject-motion-css!` in `.../theme/motion.cljc`, `inject-grain-css!` in `.../theme/depth.cljc`.

Each fenced line loses exactly six characters, so the comment column is preserved and the
block stays aligned.

## Deliberately left, and recorded rather than fixed

Two further `theme.*/` spellings on the page are **not** touched, because neither
contradicts a binding the page itself makes:

- `:256` `theme.status/descriptor` — `theme.status` is bound nowhere on this page.
  (`re-frame.story.theme.status` is a real namespace, but the page never requires it.)
- `:273` `theme.colors/tokens` — the page binds colors by `:refer [tokens]` with **no**
  `:as` alias, so there is no alias for the dotted form to disagree with.

Choosing a spelling for either would answer the wider canonicalisation question that
rf2-gbuh still holds open. Left for that ruling.

## Census

Relation-shaped, per file: prose bindings against prose use-sites, reporting only where the
two disagree. Four passes (line-oriented / whitespace-flattened / comment-markers-stripped-
then-flattened / hyphen-at-line-break rejoined), because the needles contain hyphens.

| | before | after |
|---|---|---|
| dotted `theme.X/` use-sites contradicting a binding | 4 | **0** |
| dotted `theme.X/` use-sites with no binding to contradict (left) | 2 | 2 |
| bare bound-alias use-sites (the page's own idiom) | 10 | 14 |
| total `inject-*!)` call sites on the page | 6 | 6 |

All four passes agreed on every count, before and after — no line-broken or hyphen-broken
site was hiding from the line-oriented pass.

**The final zero is not a dead-instrument zero.** The same dotted pattern still returns
**2** hits on the after-tree (the two sites left above), and the total `inject-*!)` count is
invariant at 6, so the tokens were renamed rather than deleted.

**Control that exercises the defect, not merely present.** The ERE bracket-expression trap
was run against this page's real data: a class written `[ )\]]` closes at the `]` and makes
the trailing one a required literal, so it reads **0** where the correct `[])[:space:]]`
reads **3** and no class at all reads **6**. The targets here end in `!)`, which is exactly
where that trap bites, so it was checked rather than assumed.

## Quality gates

Nominated by path. The surface is `tools/*/spec`.

**Covering this path — 4 pass, 0 fail:**

| gate | exit | note |
|---|---|---|
| `scripts/check_doc_slugs.py` | 0 | roots include `tools/*/spec`; `--verbose` prints `tools/story/spec  31` |
| `scripts/check_doc_slugs.py --self-test` | 0 | fixture self-tests |
| `scripts/check-commit-attribution.sh origin/main` | 0 | |
| `scripts/check-beads-pr-boundary.sh origin/main` | 0 | no beads-database path in the diff |

**Ratchets over the paths touched — all read `.md`, all exit 0:**
`check_require_alias_dialect` (the ratchet this epic is about), `check_retired_spellings`,
`check_retired_composition_vocab`, `check_retired_image_keys`, `check_inject_cofx_residue`,
`check_keyword_catalogue_drift`, `check_architecture_census`, `check-ai-tracking-ratchet.sh`.

**Ran but does NOT cover this path, recorded so the green is not miscounted as evidence:**

- `scripts/check_readme_links.py --ci` — exit 0, but its `_is_excluded` explicitly refuses
  `tools/*/spec/` (no double-coverage with the docs gate), and this file is neither a
  `README.md` nor repo-root markdown. **It inspected nothing changed here.**
- `python -m mkdocs build --strict` — exit 0 in 21.8s, but `mkdocs_hooks.py`'s `_STAGE`
  table stages only `spec` and `migration` into `docs_dir: docs`. `tools/*/spec` is not
  staged. Positive evidence rather than an argument from config: `016-Design-Tokens`
  appears **0 times** in the build log. **It inspected nothing changed here.**

No `tools/story` suite grades this page: `story-spec-check` reads `tools/story/spec/API.md`
only, and nothing under any test tree opens `016-Design-Tokens.md`. The changed-surface
classifier arms **no** code surface for this diff (all 29 surfaces read `false`).

### Gate provenance — sabotage proof

`check_doc_slugs.py` was proved to read this branch's tree, planted after the real edit was
committed so the restore had a known object to return to.

1. **Planted in prose, not in a fence** — deliberately, because both link gates share one
   extractor that strips fences before reading a line. A plant inside the fenced block at
   `:724-731` would have been invisible and returned a false green.
2. **Match count read before the run**: 1 for the broken file target, 1 for the broken
   anchor. The git blob hash moved `982beaa11d…` → `bc61bc471d…`, so the plant applied
   rather than silently no-opping.
3. **Gate went red, exit 1**, naming both faults with file and line —
   `BROKEN TARGET: tools\story\spec\016-Design-Tokens.md:105 -> ./RF2-GBUH-PLANT-NO-SUCH-FILE.md`
   and `BROKEN ANCHOR: ...:106 -> #rf2-gbuh-plant-no-such-anchor`. The fault existed only in
   this worktree, so a run that had wandered into a sibling checkout would have come back green.
4. **Restore verified by git blob hash**, not by exit code: back to
   `982beaa11d17cab5c7b4aa4c58fd2463638aa988`, plant residue 0, tree clean.

### Two limits, stated rather than papered over

1. **Neither link gate looks inside a fenced code block**, and **three of the four sites
   fixed here are inside the fence at `:724-731`**. Those three were checked by hand against
   the page's own require form at `:53-57`; no link target, anchor, heading or table row was
   touched anywhere in the diff, so nothing the gates do grade was moved.
2. **Nothing grades prose for truth.** The correctness of the new spelling rests on a read of
   the require form plus the source check above (each function found by its `defn` in the
   namespace its libspec names), not on any automated check.
