### PR TITLE
fix(bench): migrate five hicasso bench arms off the deleted mount! door

### DIFF
--- a/bench/hicasso/src/re_frame/bench/hicasso/amp_merge_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/amp_merge_clock_app.cljs
@@ -687,7 +687,19 @@
 
 (defn- mount-page
   [view]
-  (fn [container _props _n] (rf.hicasso/mount! container {:frame frame-id} (page view))))
+  ;; The root door is `client-root` + `render!`, and the FRAME is spelled in
+  ;; the TREE. `-main` has already made `frame-id` with `rf/make-frame`, so
+  ;; every arm root SCOPEs it (`frame-provider`) rather than ENSUREing it —
+  ;; the k roots of one batch are k roots sharing the one frame. The handle
+  ;; is allocated here rather than answered by the door, because `render!`
+  ;; answers nil; `client-root` is an inert atom, so what sits inside the
+  ;; timed window is what `mount!` used to allocate inside it too.
+  (fn [container _props _n]
+    (let [handle (rf.hicasso/client-root)]
+      (rf.hicasso/render! handle
+                          [rf.hicasso/frame-provider {:frame frame-id} (page view)]
+                          container)
+      handle)))
 
 (defn- unmount-page [handle] (rf.hicasso/unmount! handle))
 

--- a/bench/hicasso/src/re_frame/bench/hicasso/direct_return_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/direct_return_clock_app.cljs
@@ -216,7 +216,19 @@
 
 (defn- mount-page
   [view]
-  (fn [container _props _n] (rf.hicasso/mount! container {:frame frame-id} (page view))))
+  ;; The root door is `client-root` + `render!`, and the FRAME is spelled in
+  ;; the TREE. `-main` has already made `frame-id` with `rf/make-frame`, so
+  ;; every arm root SCOPEs it (`frame-provider`) rather than ENSUREing it —
+  ;; the k roots of one batch are k roots sharing the one frame. The handle
+  ;; is allocated here rather than answered by the door, because `render!`
+  ;; answers nil; `client-root` is an inert atom, so what sits inside the
+  ;; timed window is what `mount!` used to allocate inside it too.
+  (fn [container _props _n]
+    (let [handle (rf.hicasso/client-root)]
+      (rf.hicasso/render! handle
+                          [rf.hicasso/frame-provider {:frame frame-id} (page view)]
+                          container)
+      handle)))
 
 (defn- unmount-page [handle] (rf.hicasso/unmount! handle))
 

--- a/bench/hicasso/src/re_frame/bench/hicasso/ledger_frame_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/ledger_frame_clock_app.cljs
@@ -930,9 +930,12 @@
   "Mount the ledger into `container` on `frame-id`, and answer a promise
   of the mounted handle.
 
-  It goes through `rf.hicasso/mount!` — the application's own root door — with the
-  application's own view and the `initial-events` `ledger.app` publishes,
-  parameterised by the size the application itself defaults to. Nothing
+  It goes through `rf.hicasso/client-root` + `rf.hicasso/render!` — the
+  application's own root door — with the application's own view and the
+  `initial-events` `ledger.app` publishes, parameterised by the size the
+  application itself defaults to. The FRAME is spelled in the TREE, on
+  `rf.hicasso/frame-root`, which ENSUREs it: nothing made it beforehand,
+  so this head is what creates it and runs those `initial-events`. Nothing
   here reaches under `re-frame.hicasso.impl.*`, nothing rebuilds a view,
   and no scroll is simulated by dispatching an application event: every
   reading starts at a real `scroll` on a node the vendor rendered.
@@ -952,10 +955,13 @@
   DONE HERE. Both are process-wide and belong to whoever owns the
   process; [[-main]] owns the bench page and does both."
   [container frame-id]
-  (let [handle (rf.hicasso/mount! container
-                         {:frame          frame-id
-                          :initial-events (rf.hicasso.examples.ledger.app/initial-events total)}
-                         [rf.hicasso.examples.ledger.views/ledger {}])
+  (let [handle (rf.hicasso/client-root)
+        _      (rf.hicasso/render! handle
+                                   [rf.hicasso/frame-root
+                                    {:id             frame-id
+                                     :initial-events (rf.hicasso.examples.ledger.app/initial-events total)}
+                                    [rf.hicasso.examples.ledger.views/ledger {}]]
+                                   container)
         geom   {:row-height      rf.hicasso.examples.ledger.views/row-height
                 :viewport-height rf.hicasso.examples.ledger.views/viewport-height
                 :overscan        rf.hicasso.examples.ledger.views/overscan

--- a/bench/hicasso/src/re_frame/bench/hicasso/slice_broad_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/slice_broad_clock_app.cljs
@@ -936,11 +936,14 @@
   "Mount both arms into their own containers on their own frames, and
   answer a promise that resolves once both pages are on the screen.
 
-  The Hicasso arm goes through `rf.hicasso/mount!`, the application's own root
-  door, with the application's own views and `initial-events`. The donor
-  arm makes its frame with `rf/make-frame` — core's own door, carrying
-  the SAME `:initial-events` — and renders through `uix.dom`, which is
-  how a UIx application mounts.
+  The Hicasso arm goes through `rf.hicasso/client-root` +
+  `rf.hicasso/render!`, the application's own root door, with the
+  application's own views and `initial-events`. Its frame is spelled in
+  the TREE, on `rf.hicasso/frame-root`, which ENSUREs it — so the Hicasso
+  arm still makes its own frame, exactly as it did when the root door
+  carried `:frame`. The donor arm makes its frame with `rf/make-frame` —
+  core's own door, carrying the SAME `:initial-events` — and renders
+  through `uix.dom`, which is how a UIx application mounts.
 
   `:identifier-prefix` on both, distinct: `useId` numbers every root from
   the same start, and a page with two roots either names them apart or
@@ -988,11 +991,17 @@
   ([{hic-frame :hicasso don-frame :donor}]
    (let [hic-container (rf.bench.hicasso.lane/fresh-container!)
          don-container (rf.bench.hicasso.lane/fresh-container!)
-         handle        (rf.hicasso/mount! hic-container
-                                 {:frame             hic-frame
-                                  :identifier-prefix "hic"
-                                  :initial-events    initial-events}
-                                 [rf.hicasso.examples.slice.views/app {}])
+         handle        (rf.hicasso/client-root)
+         ;; `:identifier-prefix` is a ROOT option and stays on the door;
+         ;; `:frame` and `:initial-events` are FRAME configuration and are
+         ;; spelled in the TREE, on the ENSUREing `frame-root` head.
+         _             (rf.hicasso/render! handle
+                                           [rf.hicasso/frame-root
+                                            {:id             hic-frame
+                                             :initial-events initial-events}
+                                            [rf.hicasso.examples.slice.views/app {}]]
+                                           hic-container
+                                           {:identifier-prefix "hic"})
          _             (rf/make-frame {:id             don-frame
                                        :initial-events initial-events})
          don-root      (uix-dom/create-root don-container {:identifier-prefix "don"})]

--- a/bench/hicasso/src/re_frame/bench/hicasso/slice_echo_clock_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/slice_echo_clock_app.cljs
@@ -171,9 +171,10 @@
 
   ## THE POPULATION IS THE SLICE APPLICATION, MOUNTED THROUGH ITS OWN DOOR
 
-  [[boot!]] calls `rf.hicasso/mount!` with the slice's own `[views/app {}]` and the
-  same two `:initial-events` its `-main` passes, differing only in which
-  route it opens on — which is data the application already takes. Nothing
+  [[boot!]] calls `rf.hicasso/render!` with the slice's own `[views/app {}]`
+  under an ENSUREing `rf.hicasso/frame-root` head carrying the same two
+  `:initial-events` its `-main` passes, differing only in which route it
+  opens on — which is data the application already takes. Nothing
   here reaches under `re-frame.hicasso.impl.*`, nothing rebuilds a view,
   and no interaction is simulated by dispatching an event: every reading
   starts at a DOM event on a node the application rendered.
@@ -831,13 +832,16 @@
   `act` flag have to survive it, so it installs its own through
   `re-frame.test-support`'s reset fixture and restores the flag itself."
   [container frame-id]
-  (let [handle (rf.hicasso/mount! container
-                         {:frame          frame-id
-                          :initial-events [[::rf.hicasso.examples.slice.events/seed]
-                                           [:rf.route/navigate
-                                            {:to     rf.hicasso.examples.slice.routes/article
-                                             :params {:slug article-slug}}]]}
-                         [rf.hicasso.examples.slice.views/app {}])]
+  (let [handle (rf.hicasso/client-root)
+        _      (rf.hicasso/render! handle
+                                   [rf.hicasso/frame-root
+                                    {:id             frame-id
+                                     :initial-events [[::rf.hicasso.examples.slice.events/seed]
+                                                      [:rf.route/navigate
+                                                       {:to     rf.hicasso.examples.slice.routes/article
+                                                        :params {:slug article-slug}}]]}
+                                    [rf.hicasso.examples.slice.views/app {}]]
+                                   container)]
     (swap! !state assoc
            :container container
            :handle handle


### PR DESCRIPTION
Closes nothing — rf2-a7ds stays open for the operator to dispose.

## What was broken

Five bench arm apps called `rf.hicasso/mount!`, a public name that no longer
exists. They were broken twice over: the door was deleted (rf2-kuky.59), and
the opts map they hand it carries `:frame` / `:initial-events`, which the root
door had already stopped accepting one commit earlier (rf2-kuky.58) — the
roster is `#{:hydrate? :identifier-prefix}` and anything else raises
`:rf.error/hicasso-frame-config-misplaced`.

Eight sites in five files: five executable calls and three prose blocks that
taught the deleted door.

| file | call | prose |
|---|---|---|
| `amp_merge_clock_app.cljs` | 690 | — |
| `direct_return_clock_app.cljs` | 219 | — |
| `ledger_frame_clock_app.cljs` | 955 | 933 |
| `slice_broad_clock_app.cljs` | 991 | 939 |
| `slice_echo_clock_app.cljs` | 834 | 174 |

## The replacement, and why the two heads differ

Read from `h/render!`'s own docstring (`implementation/hicasso/src/re_frame/hicasso.cljc:674`)
and the impl (`impl/mount.cljs:510-570`): `client-root` allocates an inert
handle, `render! (handle tree node [opts])` creates on its first call and
updates thereafter, `unmount!` takes the same handle. `render!` answers nil, so
the handle now comes from `client-root` rather than from the door.

Which boundary head an arm takes is decided by whether its frame already
exists, and that is what keeps the numbers comparable:

- **`amp_merge`, `direct_return` — `frame-provider` (SCOPE).** These are
  mount-timed: `lane/mount-batch!` brackets `(:mount arm)` inside `flushSync`.
  Their `-main` has already made the frame with `rf/make-frame`, so the k roots
  of a batch are k roots sharing one live frame — the second case
  `frame-provider`'s docstring names. `frame-root` would also work, but its
  ENSURE is commit-owned and emits no subtree on its first pass, which would
  put a second render pass inside the timed window.
- **`ledger_frame`, `slice_echo`, `slice_broad` — `frame-root` (ENSURE).**
  Nothing makes their frame beforehand; the old opts map did it. They carry the
  same `:initial-events` across, and `boot!` is called once from `-main` and
  sits in no measured window. `slice_broad` keeps `:identifier-prefix "hic"` on
  the door, where it is a root option.

No measurement semantics changed: the same trees render into the same
containers on the same frames, `unmount!` is untouched, and the handle
allocation that now sits in the timed window is the one `mount!` used to
perform inside it.

## Quality gates

**No CI gate reaches `bench/**`, so CI green is not evidence here.** `bench/*`
is classified to no PR gate (rf2-6c12m.1), `implementation/shadow-cljs.edn`
carries zero `:bench` build ids so `check-examples-compile.cjs` does not see
the tree, and CI's clj-kondo lints `implementation/`, `tools/`, `examples/`,
`testbeds/` — not `bench/`. That is precisely why five broken call sites sat
here. The evidence below is a local before/after, not a check run.

| gate | exit | covers `bench/**`? |
|---|---|---|
| `bench/hicasso` `compile_gate.cjs`, this tree | **0** — 155 namespaces, 0 warnings | **yes — this is the gate** |
| `bench/hicasso` `compile_gate.cjs`, pre-fix tree | **1** — 5 × `:undeclared-var` | yes |
| `scripts/check_retired_spellings.py` | 0 (self-test: 72 passed) | yes, rules (d) and (f) |
| `scripts/check_require_alias_dialect.py` | 0 (self-test: 79 passed) | yes |
| `clj-kondo` over the five files | 0 — errors 0, warnings 0 | not in CI's lint paths; local v2025.10.23 vs CI pin v2026.04.15, so this proves parsing only |
| `scripts/check_doc_slugs.py` | not run | **no** — `DEFAULT_ROOTS` is docs/spec/skills/migration |
| `scripts/check_readme_links.py --ci` | not run | **no** — this diff contains no markdown |

**The before/after is the whole evidence.** The lane's own hand-run
`compile_gate.cjs` compiles every namespace under `bench/hicasso/src/`
warnings-fatal, and it closes exactly this class ("a deleted def … an
undeclared var"). Reverting the five files to the merge base and re-running it
produced exit 1 with five `:undeclared-var` warnings, each reading
`Use of undeclared Var re-frame.hicasso/mount!` and naming lines 690, 219, 834,
955 and 991 — exactly the five executable sites, and exactly five, which
independently confirms the other three occurrences are prose. Restoring gave
exit 0 across 155 namespaces, and the restore was verified by `git hash-object`
against the committed blobs rather than by the checkout's exit code.

`clj-kondo` was measured to have **no teeth on this defect**: run over the
pre-fix file it names `mount!` zero times, because without a classpath it
cannot resolve `re-frame.hicasso`'s vars. Nominating it here would have bought
a green that inspected nothing.

## Found and deliberately left

Five prose mentions of `h/mount!` survive in bench suites this PR does not
touch — `ledger_frame_dom_cljs_test.cljs:146,263`,
`slice_broad_window_dom_cljs_test.cljs:424`,
`slice_echo_window_dom_cljs_test.cljs:122,183`. All five are docstring or
`testing`-string text, not calls; the compile gate is silent on them and they
are outside this bead's stated scope. The surviving `h/mount!` references under
`docs/design/hicasso/**` are deliberate retirement bookkeeping.

`rf.hicasso/value` reads as a var reference to a name absent from the manifest,
but every one of its 11 occurrences is the auto-resolved keyword
`::rf.hicasso/value`. Not a defect. The only var names `bench/` takes from
`re-frame.hicasso` are `sub`, `defview`, `unmount!` and `mount!`, and the first
three are all rostered.

## Not actioned — an operator call

The bead's acceptance criteria include "a recorded decision on whether `bench/*`
gets a nightly compile sweep or documented drift", and the bead's own text says
that half "is an operator call and should not be actioned without it". It is
left for the operator. The finding that argues for it: `compile_gate.cjs`
already exists, already covers the whole lane by construction, and took 30
seconds — nothing about the no-PR-gate ruling is threatened by running it
nightly.
