### PR TITLE
ci(lint): stop lint.yml cancelling its own trunk runs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -156,9 +156,31 @@ on:
     - cron: '30 3 * * *'
   workflow_dispatch:
 
+# Cancel older in-flight runs of THIS workflow on the same PR when a
+# force-push / rebase lands a new HEAD — but never on the trunk. Mirrors
+# the shape test.yml has carried since rf2-d4t7g.
+#
+# Keying: for PRs, group on the PR number so every push to the same PR
+# branch reuses one slot. On every other event — push to main, the nightly
+# schedule, a manual dispatch — fall back to `github.run_id`, which is
+# unique per run, so each trunk commit gets its own independent group and
+# successive main pushes cannot share one.
+#
+# BOTH HALVES ARE LOAD-BEARING (rf2-vktd); keying alone would half-fix it.
+# The previous shape grouped on `github.ref` and cancelled unconditionally,
+# and on main `github.ref` is the SAME VALUE for every push — so all trunk
+# runs shared one group and each push cancelled the one before it. A
+# cancelled run still REPORTS: the `Lint required` aggregator below is
+# `if: always()`, and a cancelled dependency is neither success nor
+# skipped, so the aggregate goes red with no lint finding behind it.
+# Measured over the last 200 main-branch runs before this change: 76
+# cancelled, 124 success, 0 failure — every red on trunk was a
+# cancellation — against 0 cancelled for test.yml over the same window,
+# branch and instrument. `Lint required` is a required status check in the
+# branch ruleset, so that noise sits on a signal that gates merges.
 concurrency:
-  group: lint-${{ github.ref }}
-  cancel-in-progress: true
+  group: lint-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Lightweight changed-surface gate (rf2-aemyt). On a pull_request this


### PR DESCRIPTION
## What

`.github/workflows/lint.yml` grouped its concurrency on `github.ref` and
cancelled in-progress runs unconditionally:

```yaml
concurrency:
  group: lint-${{ github.ref }}
  cancel-in-progress: true
```

On `main`, `github.ref` is the same value for every push, so every trunk run
shared one concurrency group and each push cancelled the one before it.

This adopts the shape `test.yml` has carried since rf2-d4t7g:

```yaml
concurrency:
  group: lint-${{ github.event.pull_request.number || github.run_id }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

**Both differences are load-bearing**; copying only the group key would
half-fix it:

1. the group key falls back to `github.run_id`, which is unique per run,
   rather than `github.ref`, which is identical for every trunk push;
2. cancellation is gated to `pull_request`, so a trunk run is never
   cancelled at all.

PR behaviour is unchanged: pushes to one PR still coalesce into one slot and
still cancel the previous in-flight run.

## Why it destroyed the signal

A cancelled run still reports. The `Lint required` aggregator is
`if: always()`, and its pass rule accepts `success` and `skipped` but refuses
`failure` and `cancelled` — so a concurrency cancellation makes the aggregate
go **red with no lint finding behind it**.

Verified on cancelled `main` run `34213407147`: all seven jobs read
`cancelled`, and `Lint required` read `failure`.

`Lint required` is one of three required status checks in the repository's
active branch ruleset (alongside `All required checks passed` and
`Docs required`), so this noise sits on a signal that gates merges rather
than on a trunk-readability nicety.

## Measured

Last 200 `main`-branch runs of each workflow (`gh run list --workflow=<wf>
--branch=main --limit 200 --json conclusion,createdAt`):

| workflow | window | cancelled | success | failure |
|---|---|---:|---:|---:|
| `lint.yml` | 2026-09-05T00:40:47Z → 2026-09-07T14:08:54Z | **76** | 124 | 0 |
| `test.yml` (control) | 2026-09-05T02:36:54Z → 2026-09-08T10:03:40Z | **0** | 196 | 3 |

38% of trunk lint runs were cancelled, and **every** non-success trunk outcome
was a cancellation rather than a lint finding. `test.yml` — already on the
shape adopted here, same branch, window and instrument, and demonstrably
non-zero-capable via its 3 real failures — cancelled nothing.

## Check-set impact: none

`.github/workflows/*` is a hot-zone path and a change here can move the set of
checks a PR is graded on (merge-criterion clause 5). Measured with the
two-space job-key discriminator, exercised in both directions first so a zero
could be trusted:

| measurement | result |
|---|---|
| control `366e4fca79` (added a job) | `1` |
| control `4cf4d711a2` (added none) | `0` |
| same diff, unindented form (broken) | `0` on the positive control |
| **this branch vs merge base, keys added** | **`0`** |
| **this branch vs merge base, keys removed** | **`0`** |

No job keys move, so the band should not move.

## Quality gates

Nominated by path. The surface is one YAML file under `.github/workflows/`.

| gate | exit | result |
|---|---:|---|
| `python scripts/check_workflow_yaml.py --verbose` | 0 | PASS — 11 files parse |
| `python scripts/check_workflow_job_timeouts.py` | 0 | PASS — 117 jobs across 11 files |
| `node implementation/scripts/_lint-workflow-policy.test.cjs` | 0 | PASS — 4/4 (the policy guard whose subject is this file) |
| `python scripts/check_gate_scheduling.py` | 0 | PASS — 34 gate commands, 30 scheduled |

**4 passed, 0 failed.**

Sabotage-proved. An unmatched-quote fault was planted on the `group:` line
(match count read as 1 before the run, so the plant was not a no-op).
`check_workflow_yaml.py` went **exit 1** naming `.github/workflows/lint.yml`
line 217; `check_workflow_job_timeouts.py` went **exit 2** naming the same
file. Restored and verified by git blob hash against the committed object
(`0bb393395c4d8dc8702067604c9a8ab40693d117`), not by the restore's exit code.

Not run, with reasons:
- `actionlint` — not installed on this box (`command -v` exit 1), and
  `check_workflow_yaml.py`'s own header records that it appears nowhere in the
  tracked tree.
- `check_doc_slugs.py`, `check_readme_links.py --ci` and
  `mkdocs build --strict` do **not** cover `.github/**`: the first two carry
  roots that exclude it, and MkDocs' `docs_dir` is `docs`, so nominating any
  of them would buy a green that inspected nothing changed here.

Verified by hand: table column counts in this body, and that the two
`${{ ... }}` expressions match `test.yml`'s working forms character for
character apart from the `lint-`/`tests-` prefix.

Refs rf2-vktd
