### PR TITLE
fix(gate): egress-walker residue check misses reader-equivalent call heads (rf2-kuky.90, audit #9491)

### DIFF
--- a/scripts/_test_fixtures/check_egress_walker_residue/residue_calls_formatted.cljs
+++ b/scripts/_test_fixtures/check_egress_walker_residue/residue_calls_formatted.cljs
@@ -1,0 +1,43 @@
+;;;; FIXTURE (check_egress_walker_residue) — reader-equivalent FORMATTINGS of a
+;;;; call the gate already refuses tight. Every one of these MUST be refused.
+;;;; Five findings expected. Not compiled; not on any classpath.
+;;;;
+;;;; `residue_calls.cljs` is the tight-call control these discriminate against:
+;;;; it spells every shape with the callee hard against the paren, which is the
+;;;; blind spot merged-PR audit #9491 found (rf2-kuky.90). The gate refused only
+;;;; the tight spelling, and its own fixtures only ever wrote the tight
+;;;; spelling, so gate and fixtures agreed while both were wrong. A Clojure
+;;;; reader proof on the audit shows the variants below read as IDENTICAL call
+;;;; forms — the whitespace is formatting, not meaning.
+
+(ns fixture.residue-calls-formatted
+  (:require [re-frame.elision :as rf.elision]))
+
+;; 1. a SPACE between the paren and the callee
+(defn spaced [v frame-id]
+  ( rf.elision/elide-wire-value v {:frame frame-id}))
+
+;; 2. a NEWLINE between the paren and the callee — invisible to any
+;;    line-at-a-time search, whatever the pattern
+(defn broken-line [v frame-id]
+  (
+    rf.elision/elide-wire-value v {:frame frame-id}))
+
+;; 3. a `;` COMMENT plus a newline between the paren and the callee
+(defn behind-comment [v frame-id]
+  ( ;; project the slot before it leaves the box
+    rf.elision/elide-wire-value v {:frame frame-id}))
+
+;; 4. behind a `#` reader macro, head broken across lines
+(defn walk-all [vs frame-id]
+  (mapv #(
+           elide-wire-value % {:frame frame-id})
+        vs))
+
+;; 5. a RENDERED EVAL FORM string carrying the newline spelling. This is where
+;;    the gate's standing promise about string literals lands: it is a real
+;;    call at the far end, in the inspected app.
+(def ^:private snapshot-script
+  "(
+     rf.elision/elide-wire-value (rf/app-db-value :rf/default)
+     {:frame :rf/default})")

--- a/scripts/_test_fixtures/check_egress_walker_residue/sanctioned_mentions.cljs
+++ b/scripts/_test_fixtures/check_egress_walker_residue/sanctioned_mentions.cljs
@@ -35,3 +35,27 @@
 ;; a longer symbol that merely starts with the needle — must not fire
 (defn report [v]
   (elide-wire-values-report v))
+
+;;;; ---------------------------------------------------------------------------
+;;;; The three below discriminate the WIDENING (rf2-kuky.90, merged-PR audit
+;;;; #9491). The gate now skips reader whitespace, newlines and `;` comments
+;;;; between the paren and the callee, so these shapes newly reach the callee
+;;;; position. They must still not fire.
+
+;; A back-ticked mention behind a SPACE, and the same mention with its parens
+;; SPANNING LINES. A backtick is not reader whitespace, so it breaks the call
+;; head wherever it sits — tight against the paren, or behind a space, or
+;; behind a newline:
+;; ( `re-frame.elision/elide-wire-value` ) is SCHEMA-DRIVEN, and
+;; ( `re-frame.elision/elide-wire-value`
+;;   ) is that same mention, wrapped.
+
+;; The walker NAMED INSIDE a comment that the gate skips on its way to the
+;; callee. A comment is skipped as ONE unit, up to and including its newline,
+;; so the name is consumed with it and the callee is the symbol that actually
+;; follows — here, the door.
+(defn project-via-door [v frame-id]
+  (
+    ;; delegates to re-frame.elision/elide-wire-value once inside the door
+    rf/project-egress v {:rf.egress/profile :rf.egress/off-box-tool
+                         :frame             frame-id}))

--- a/scripts/check_egress_walker_residue.py
+++ b/scripts/check_egress_walker_residue.py
@@ -33,14 +33,30 @@ WHAT COUNTS AS RESIDUE — CALL POSITION, NOT THE NAME.
 
 Naming the walker in a docstring or comment is fine and often right: four
 `tools/*/src` files describe the framework's internal walk that way, spelled at
-the home namespace. What this gate refuses is a CALL — an open paren immediately
-followed by the symbol, optionally namespace-qualified and optionally behind a
-`#` reader macro:
+the home namespace. What this gate refuses is a CALL — an open paren, then
+READER WHITESPACE ONLY, then the symbol, optionally namespace-qualified and
+optionally behind a `#` reader macro:
 
     (rf/elide-wire-value v opts)              <- retired facade spelling
     (re-frame.core/elide-wire-value v opts)   <- retired fully-qualified spelling
     (rf.elision/elide-wire-value v opts)      <- live, but not from tool source
     #(elide-wire-value % opts)                <- bare, after a :refer
+
+READER WHITESPACE MEANS WHAT THE READER MEANS BY IT — spaces, tabs, commas,
+NEWLINES, and `;` line comments, in any mix. All of these read as the same call
+form, so all of them are residue:
+
+    ( rf.elision/elide-wire-value v opts)     <- a space
+    (                                         <- a newline
+      rf.elision/elide-wire-value v opts)
+    ( ;; project the slot                     <- a comment, then a newline
+      rf.elision/elide-wire-value v opts)
+
+The earlier revision of this gate required the symbol IMMEDIATELY after the
+paren and searched one line at a time, so all three of those passed while the
+tight spelling was refused (rf2-kuky.90, merged-PR audit #9491). A gate whose
+own fixtures all use one spelling cannot see that it only checks one spelling;
+that is why every variant above now has a fixture of its own.
 
 STRING LITERALS ARE SCANNED ON PURPOSE. The pair-MCP servers ship walks as
 RENDERED EVAL FORMS — source text assembled into a string and evaluated in the
@@ -49,9 +65,18 @@ the gate makes no attempt to skip strings, and a `;` comment carrying a
 copy-pasteable call is refused for the same reason: in a shipped tool source
 tree it reads as the recommended shape.
 
-A back-ticked mention inside a paren — ``(`re-frame.elision/elide-wire-value`)``
-— never fires, because the character after the paren is a backtick, not the
-symbol. That shape occurs live in `tools/xray/src` today.
+WHAT STILL DOES NOT FIRE, AND WHY THE WIDENING ABOVE KEEPS IT THAT WAY. A
+back-ticked mention inside a paren — ``(`re-frame.elision/elide-wire-value`)``,
+a shape that occurs live in `tools/xray/src` today — is prose, not a call. A
+backtick is NOT reader whitespace, so it breaks the call head wherever it sits:
+tight against the paren, or behind a space or a newline. Likewise a mention
+inside a skipped `;` comment is consumed WITH that comment — the comment is
+skipped as one unit, up to and including its newline — so naming the walker in
+a comment inside an open form does not read as calling it.
+
+Neither this gate nor its fixtures are a Clojure reader, and completing them was
+never a request for one (audit #9491's own words). Reader-equivalent formatting
+of an ordinary call is the surface; deliberate obfuscation is not.
 """
 
 from __future__ import annotations
@@ -67,11 +92,22 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # tools/<tool>/src/**  and  skills/<skill>/preload/**
 _SURFACE = re.compile(r"^(?:tools/[^/]+/src/|skills/[^/]+/preload/)")
 
-# `(` (optionally behind `#`) then, with no intervening backtick or space, the
+# Reader whitespace between the paren and the callee: spaces, tabs, newlines,
+# commas, and whole `;` comments. A comment is one unit up to and including its
+# newline, so anything NAMED inside it is consumed with it rather than read as
+# the callee. A backtick is absent from this set on purpose — that absence is
+# what keeps the sanctioned prose mentions passing (see the module docstring).
+# The two branches start on disjoint characters, so the `*` cannot backtrack
+# catastrophically.
+_READER_SPACE = r"(?:[\s,]|;[^\n]*\n)*"
+
+# `(` (optionally behind `#`) then reader whitespace, then the
 # optionally-qualified symbol. The trailing guard stops `elide-wire-value-ish`
 # and `elide-wire-values` from matching.
 _CALL = re.compile(
-    r"#?\((?:[A-Za-z0-9_.*+!?<>=$%&|-]+/)?elide-wire-value(?![A-Za-z0-9_.*+!?<>=-])"
+    r"#?\("
+    + _READER_SPACE
+    + r"(?:[A-Za-z0-9_.*+!?<>=$%&|-]+/)?elide-wire-value(?![A-Za-z0-9_.*+!?<>=-])"
 )
 
 _SELF_TEST_FIXTURE_ROOT = REPO_ROOT / "scripts" / "_test_fixtures" / "check_egress_walker_residue"
@@ -90,17 +126,36 @@ def tracked_surface_files() -> list[Path]:
 
 
 def scan_file(path: Path) -> list[tuple[int, str]]:
-    """Return (line-number, line) for every call-position walker reference."""
+    """Return (line-number, diagnostic) for every call-position walker reference.
+
+    Matched over the WHOLE text rather than line by line, because a call head is
+    allowed to span lines. The reported line is always the one the `(` sits on,
+    so the diagnostic still points at the form's start; where the head spans
+    lines, the span is named and the head is shown collapsed onto one line.
+    """
     try:
         text = path.read_text(encoding="utf-8")
     except (UnicodeDecodeError, OSError):
         return []
     if "elide-wire-value" not in text:
         return []
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    lines = text.split("\n")
     findings = []
-    for n, line in enumerate(text.replace("\r\n", "\n").split("\n"), start=1):
-        if _CALL.search(line):
-            findings.append((n, line.strip()))
+    for match in _CALL.finditer(text):
+        start_line = text.count("\n", 0, match.start()) + 1
+        end_line = text.count("\n", 0, match.end()) + 1
+        if start_line == end_line:
+            findings.append((start_line, lines[start_line - 1].strip()))
+        else:
+            findings.append(
+                (
+                    start_line,
+                    f"{lines[start_line - 1].strip()}"
+                    f"   ...   {lines[end_line - 1].strip()}"
+                    f"   [call head spans lines {start_line}-{end_line}]",
+                )
+            )
     return findings
 
 
@@ -144,10 +199,22 @@ def run_scan(paths: list[Path], verbose: bool = False) -> int:
 
 
 def _run_self_tests(verbose: bool = False) -> int:
-    """Prove the gate fires on each live shape and stays green on each sanctioned one."""
+    """Prove the gate fires on each live shape and stays green on each sanctioned one.
+
+    Each case pins the LINE NUMBERS, not just the count. A count alone cannot
+    tell a pattern that found the right five things from one that found four
+    plus a false positive — and this gate has already shipped once with its
+    fixtures and its pattern sharing a blind spot (audit #9491), so the cheap
+    extra discrimination is worth having.
+    """
     cases = [
-        ("residue_calls.cljs", 5),
-        ("sanctioned_mentions.cljs", 0),
+        # the tight-call control: callee hard against the paren
+        ("residue_calls.cljs", (10, 14, 18, 22, 26)),
+        # the same call in reader-equivalent formattings: space, newline,
+        # comment+newline, `#(`+newline, rendered eval string+newline
+        ("residue_calls_formatted.cljs", (18, 23, 28, 33, 41)),
+        # prose that names the mechanism without calling it
+        ("sanctioned_mentions.cljs", ()),
     ]
     failures = 0
     for fixture, expected in cases:
@@ -156,13 +223,16 @@ def _run_self_tests(verbose: bool = False) -> int:
             sys.stderr.write(f"self-test FAIL: fixture {fixture!r} missing at {path}\n")
             failures += 1
             continue
-        got = len(scan_file(path))
+        got = tuple(n for n, _ in scan_file(path))
         if got == expected:
             if verbose:
-                sys.stderr.write(f"self-test PASS: {fixture} (findings={got})\n")
+                sys.stderr.write(
+                    f"self-test PASS: {fixture} (findings={len(got)} at lines {list(got)})\n"
+                )
         else:
             sys.stderr.write(
-                f"self-test FAIL: {fixture} expected findings={expected}, got {got}\n"
+                f"self-test FAIL: {fixture} expected findings at lines {list(expected)}, "
+                f"got {list(got)}\n"
             )
             failures += 1
 


### PR DESCRIPTION
Completes the symbol-level residue gate shipped by stage 2 of the egress chain (PR #9491). Reopened by the merged-PR audit of that PR, on rf2-kuky.90.

## The defect

`scripts/check_egress_walker_residue.py` refused only the TIGHT spelling of a walker call — the callee hard against the open paren — and searched one line at a time. Reproduced on the merge base, one file per case, exit code captured on the runner's own command line:

| formatting | before | after |
|---|---|---|
| `(rf.elision/elide-wire-value v {:frame f})` | **1** caught | **1** |
| `( rf.elision/elide-wire-value v {:frame f})` | **0** MISSED | **1** |
| `(` newline `  rf.elision/elide-wire-value v {:frame f})` | **0** MISSED | **1** |
| `( ;; comment` newline `  rf.elision/elide-wire-value v {:frame f})` | **0** MISSED | **1** |
| rendered eval string in the newline spelling | **0** MISSED | **1** |
| the same newline case with CRLF endings | — | **1** |
| back-ticked mention tight inside a paren (the live `tools/xray/src` shape) | 0 | **0** |
| the same back-ticked mention behind a space | 0 | **0** |
| `;; (rf.elision/elide-wire-value v {:frame f})` copy-pasteable call in a comment | 1 | **1** |
| `(` newline `  elide-wire-values-report v)` longer symbol | 0 | **0** |

All the missed spellings read as the same call form, so the one-`project-egress`-door rule could be bypassed with no undeclared-var failure to catch it. Both bundled self-tests stayed green throughout, because all five positive fixtures also used the tight spelling: **the gate and its own tests shared one blind spot and agreed with each other while both were wrong.**

Cause, at source: `_CALL` required the symbol immediately after `(` — its own comment said so — and `scan_file` iterated `text.split("\n")` searching one line at a time, so a call head split across lines could never match whatever the pattern.

## The fix

`_READER_SPACE` skips what the Clojure reader skips between the paren and the callee — spaces, tabs, commas, newlines, and whole `;` comments, in any mix — and the scan now runs over the whole text with `finditer` rather than line by line.

**The other half of the design is preserved deliberately.** The "no intervening backtick" rule exists so sanctioned back-ticked mechanism mentions in prose pass; four of them occur live in `tools/*/src`. A backtick is not reader whitespace, so it still breaks the call head wherever it sits — tight against the paren, behind a space, or behind a newline. A mention inside a skipped comment is consumed WITH that comment, as one unit up to its newline, so naming the walker in a comment inside an open form does not read as calling it. Both directions were exercised on every pattern written; see below.

Scope is the audit's own: *"completion of the existing gate, not a request for a general Clojure parser or arbitrary obfuscation defenses."* No reader was built. `.github/workflows/*` is untouched — both steps are unconditional in `test.yml`'s always-on invariant job, and the fast-PR spine runs them always-on too, so a new fixture needs no path-filter wiring.

**Original line diagnostics are retained.** The reported line is the one the `(` sits on; a head that spans lines prints both end lines and the span:

```
  tools/xray/src/.../reply_envelope.cljc:173: (   ...   rf.elision/elide-wire-value m {:frame :rf/default})   [call head spans lines 173-174]
```

## Fixtures

`residue_calls_formatted.cljs` is new: one case per formatting variant — space, newline, comment+newline, `#(`+newline, and a rendered eval string in the newline spelling — beside the existing tight-call control in `residue_calls.cljs`. It reads 5 findings at lines 18, 23, 28, 33, 41; the checker exits 1 on it.

`sanctioned_mentions.cljs` gains three negatives that discriminate the widening specifically, and still reads 0: a back-ticked mention behind a space, one whose parens span lines, and the walker named inside a comment the scan skips on its way to the callee.

The self-test now pins finding LINE NUMBERS rather than counts. A count alone cannot separate a pattern that found the right five things from one that traded a real hit for a false positive — and this gate has already shipped once with its fixtures and its pattern sharing a blind spot.

## Fail-open statement

The subject of this PR *is* a fail-open gate, so the statement is direct. Before: the residue rule could be bypassed by ordinary formatting, exit 0, "OK: no egress-walker residue", with no undeclared-var failure behind it. After: every reader-equivalent formatting of the call is refused, and the sanctioned prose mentions still pass. The widening cannot widen egress — it only adds refusals — and the risk it does carry, reddening correct prose, is what the three new sanctioned negatives and the live-tree scan measure.

Residue-check exit on a planted violation: **1**. On the unmodified tree: **0**, over 403 scanned files.

## Sabotage proof — both directions, on a real tracked tool source

`tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc`, which already carries a sanctioned back-ticked mention of the walker in a docstring. Committed first, so the restore is checkable against a known object. Pre-plant blob `21cd01b5d846057deea06ff659375de70804ff35`.

- **Plant A — must go red.** A newline-spelled residue call. Anchor match count read **1** before the run (a plant that matched zero lines is not a plant). Gate exit **1**, naming `reply_envelope.cljc:173` and the 173-174 span. The file's pre-existing back-ticked docstring mention did NOT fire in the same run — the discrimination holds within one file. Restored; blob hash back to `21cd01b5d846057deea06ff659375de70804ff35`.
- **Plant B — must stay green.** Three sanctioned mentions in exactly the positions the widening newly reaches: a spaced back-ticked mention, one whose parens span lines, and the walker named inside a comment sitting between a paren and a different callee. Anchor match count **1**; the file's `elide-wire-value` occurrences rose **1 -> 4**, so the scan had new needle text in front of it. Gate exit **0**. Restored; blob hash back to `21cd01b5d846057deea06ff659375de70804ff35`.

A green plant proves nothing on its own, which is why A and B were run as a pair on the same file at the same anchor.

## Quality gates

**5 pass, 0 fail.** All exit codes captured on the runner's own command line, never through a pipe.

| gate | exit |
|---|---|
| `python scripts/check_egress_walker_residue.py --self-test --verbose` | **0** — 3 fixtures, findings at the pinned lines |
| `python scripts/check_egress_walker_residue.py --verbose` | **0** — **403 files** scanned on `tools/*/src` + `skills/*/preload` |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** — no beads-database paths |
| `sh scripts/check-commit-attribution.sh origin/main` | **0** |
| ratchets over the touched paths: `check_gate_scheduling`, `check_architecture_census`, `check_test_lane_bijection`, `check_readme_inventories`, `check_keyword_catalogue_drift`, `check_retired_composition_vocab`, `check_retired_spellings`, `check_ci_reproduce_commands` | **0** each |

`python scripts/check_fast_pr_gap.py --brief` was run as a REPORT (exit 0) to learn what CI still owns: 100 required checks this spine does not run. Nothing in that list is decided locally.

**Gates that do NOT cover `scripts/**`, stated rather than nominated for appearance:**

- `mkdocs build --strict` — `docs_dir` is `docs`, and the hook stages only `spec/` and `migration/` into it. `scripts/` was never a candidate.
- `scripts/check_doc_slugs.py` — its roots are `docs/`, `spec/`, `skills/`, `migration/`, `tools/*/spec`. Not `scripts/`.
- `scripts/check_readme_links.py --ci` — README/markdown-beside-source surface. This diff carries no markdown.
- `scripts/check_retired_composition_vocab.py` — its `scripts/` surface is exactly the four `test-*.sh` root support scripts, not `scripts/check_*.py`. It was run anyway and is green, but it did not open the changed file.

**There is no Python linter or formatter in this repository.** Checked rather than assumed: no `pyproject.toml`, `setup.cfg`, `.flake8`, `ruff.toml`, `.pylintrc`, `mypy.ini` or `.pre-commit-config.yaml` is tracked, and no workflow mentions ruff, flake8, black, pylint, mypy or pycodestyle. The only tracked hit for those names is prose inside the beads export. So no formatter gate was skipped; there is none to skip.

`scripts/test-fast-pr.sh` was deliberately not run: it runs these same two steps always-on and adds ~an hour of sequential work that decides nothing about a stdlib-only text scan.

## Instrument discipline

Every pattern in this change was exercised in both directions before any zero was believed — the table at the top is that record, and it includes a CRLF twin of the newline case, because a multi-line pattern that ignores `\r` is this repository's recorded false-zero shape and would have read a silent zero here. `scan_file` normalises `\r\n` before matching; the CRLF probe returns exit 1, so the normalisation is load-bearing and proven rather than assumed. The `check-beads-pr-boundary` green was likewise controlled: run against a base whose delta does carry `.beads/issues.jsonl`, it exits **1** and names the file, so the green on this branch is a real negative and not a dead instrument.

Refs rf2-kuky.90, merged-PR audit #9491, ruling rf2-kuky.9 option A.
