### PR TITLE
fix(errors): name a resolvable symbol in seven schemas/flows diagnostics

### DIFF
--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -92,7 +92,7 @@
   a frame value (`rf/make-frame`'s return token). The whole-registry read is
   `flows-snapshot`."
   [opts]
-  (get @flows-by-frame (read-frame-id opts 'rf/flows) {}))
+  (get @flows-by-frame (read-frame-id opts 're-frame.flows/flows) {}))
 
 (defn flow-meta
   "Return one flow's registration map in the named frame, or nil.
@@ -100,7 +100,7 @@
   `(flow-meta {:frame f :id flow-id})`. Both keys are required; `:frame`
   accepts a frame-id keyword or a frame value."
   [{:keys [id] :as opts}]
-  (get-in @flows-by-frame [(read-frame-id opts 'rf/flow-meta) id]))
+  (get-in @flows-by-frame [(read-frame-id opts 're-frame.flows/flow-meta) id]))
 
 (defn ^:no-doc last-inputs-snapshot
   "Return raw cached inputs as `{flow-id {frame-id inputs}}`.

--- a/implementation/schemas/src/re_frame/schemas/digest.cljc
+++ b/implementation/schemas/src/re_frame/schemas/digest.cljc
@@ -159,7 +159,7 @@
   event), the epoch-restore schema-mismatch trace (Tool-Pair §Time-
   travel), and pair-tool drift detection."
   [opts]
-  (-> (rf.schemas.storage/read-frame-id opts 'rf/app-schemas-digest)
+  (-> (rf.schemas.storage/read-frame-id opts 're-frame.schemas/app-schemas-digest)
       (rf.schemas.storage/frame-schema-entries)
       (update-vals :schema)
       (compute-digest)))

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -50,7 +50,7 @@
      (when-not (keyword? frame-id)
        (rf.error/throw-error!
          :rf.error/app-schemas-bad-arg
-         'rf/app-schemas
+         're-frame.schemas/app-schemas
           (str "the :frame opt must be a frame-id keyword or a frame value "
               "(from rf/make-frame); got " (pr-str frame-target)
               ", which resolved to the non-keyword frame target "
@@ -77,7 +77,7 @@
     :else
     (rf.error/throw-error!
       :rf.error/app-schemas-bad-arg
-      'rf/app-schemas
+      're-frame.schemas/app-schemas
       (str "app-schemas expects a keyword frame-id, a frame value, or an "
            "opts map; got " (pr-str opts-or-frame-id) ". Pass a frame-id "
            "keyword, a frame value (from rf/make-frame), or a "
@@ -699,7 +699,7 @@
   against the NAMED frame; schemas registered against a different frame do
   not appear."
   [opts]
-  (frame-schema-entries (read-frame-id opts 'rf/app-schemas)))
+  (frame-schema-entries (read-frame-id opts 're-frame.schemas/app-schemas)))
 
 (defn app-schema-meta
   "Return one path's registration metadata map in a frame, or nil.
@@ -717,7 +717,7 @@
   as a tooling and agent surface."
   [{:keys [path] :as opts}]
   ;; Lookup uses the same canonical concrete path identity as registration.
-  (get-in @schemas-by-frame [(read-frame-id opts 'rf/app-schema-meta)
+  (get-in @schemas-by-frame [(read-frame-id opts 're-frame.schemas/app-schema-meta)
                              (rf.path/normalize-concrete path)]))
 
 ;; ---- hot-reload semantics ------------------------------------------------


### PR DESCRIPTION
Closes the diagnostic half of rf2-z67m. `read-frame-id`'s second argument is the
symbol its error message reports when a frame cannot be resolved. At five call
sites that symbol was an `rf/…` spelling `re-frame.core` does not export, so the
message named a door that is not there — and the failure is *sequential*, which
is what makes it worth fixing: call one of these readers without `:frame`, get an
error naming `rf/app-schemas`, type that, and get "no such var".

## The change

Seven `where-sym` arguments, one token each. No behaviour changes.

| site | was | now |
|---|---|---|
| `schemas/storage.cljc` `app-schemas` | `'rf/app-schemas` | `'re-frame.schemas/app-schemas` |
| `schemas/storage.cljc` `app-schema-meta` | `'rf/app-schema-meta` | `'re-frame.schemas/app-schema-meta` |
| `schemas/digest.cljc` `app-schemas-digest` | `'rf/app-schemas-digest` | `'re-frame.schemas/app-schemas-digest` |
| `flows/registry.cljc` `flows` | `'rf/flows` | `'re-frame.flows/flows` |
| `flows/registry.cljc` `flow-meta` | `'rf/flow-meta` | `'re-frame.flows/flow-meta` |
| `schemas/storage.cljc` `resolve-frame` bad-target throw | `'rf/app-schemas` | `'re-frame.schemas/app-schemas` |
| `schemas/storage.cljc` `coerce-opts` bad-arg throw | `'rf/app-schemas` | `'re-frame.schemas/app-schemas` |

The last two are not `read-frame-id` sites, but they are the same defect on the
same reader. Leaving them would have made `app-schemas` name itself two
different ways depending on which of its validations fired.

## Which spelling, and why

**Fully qualified, not a require-alias.** The deciding evidence is that this tree
already answers this exact question, in the one place that is genuinely
comparable — an error message whose stated job is to name a door.
`re-frame.core`'s `:rf.error/registrar-kind-not-queryable` (its
`not-queryable-kinds` table) spells the flows readers
`re-frame.flows/flows` / `flow-meta` / `flows-snapshot` **fully qualified**,
while spelling `rf/frame-ids` / `rf/frame-meta` with `rf/` in the very same map.
The discriminator is visible there: `rf/` iff the facade exports it, owning
namespace otherwise. `frame-ids` and `frame-meta` are facade exports; the five
readers here are deliberately not (per the flows/schemas façade-boundary note,
rf2-wad2fl — only the `reg-*` registration macros stay central).

Two supporting reasons: an alias is a per-file choice an error message cannot
know (the docs' `flows/flows` reads correctly only because the page has just
declared `(:require [re-frame.flows :as flows])`), and the alias dialect is
itself unruled — rf2-xs2i is open on exactly that. A qualified symbol also tells
the reader *what to require* as well as what to call.

## Verification

Checked at runtime rather than by pattern (`ns-resolve` against `re-frame.core`,
`resolve` for the targets):

- all five old spellings — `rf/app-schemas`, `rf/app-schema-meta`,
  `rf/app-schemas-digest`, `rf/flows`, `rf/flow-meta` — **NOT EXPORTED**;
- all five new spellings — **RESOLVE**;
- `rf/reg-flow`, `rf/reg-app-schema`, `rf/reg-app-schemas`, `rf/clear` are
  genuinely exported and are **left alone**.

Message text, before and after, from the real entry point:

```
BEFORE: rf/flows requires an explicit frame: pass {:frame <frame-id-or-frame-value>}. …
AFTER : re-frame.flows/flows requires an explicit frame: pass {:frame <frame-id-or-frame-value>}. …
```

And the point of the bead, as a resolution check:

```
rf/flows              -> *** NO SUCH VAR ***
re-frame.flows/flows  -> RESOLVES
```

No public name moves: `spec/API.md`, `spec/api-manifest.edn` and its metadata
sidecar are untouched, and no `:var-count` changes. No test pinned any of the
seven changed symbols (verified with a control that fires: the `:where` pins
that do exist are for `'rf/reg-flow` / `'rf/reg-app-schema`, both exported and
both untouched).

## Not done here

`implementation/flows/src/re_frame/flows.cljc` throws
`:rf.error/flow-eval-exception` with `where` = `'rf/run-flows-on-db`, which is
**also** not a facade export — the same defect class, found while sweeping. It is
deliberately left out of scope: unlike the seven above, it **is** pinned by a
test (`flows/test/re_frame/flows_trace_test.clj` asserts `(= 'rf/run-flows-on-db
(:where data))`), so changing it means editing an asserted contract rather than
correcting an unpinned string. Worth its own bead.

## Quality gates

| gate | captured exit | result |
|---|---|---|
| `implementation/schemas` — `clojure -M:test` | **0** | 390 tests, 19312 assertions, 0 failures, 0 errors |
| `implementation/flows` — `clojure -M:test` | **0** | 266 tests, 6211 assertions, 0 failures, 0 errors |
| `implementation/core` — `clojure -M:test` | **0** | 2301 tests, 11873 assertions, 0 failures, 0 errors |
| `implementation/core` — `clojure -M:test -n re-frame.thrown-error-message-conformance-cljs-test` | **0** | 11 tests, 53 assertions, 0 failures — the conformance gate is undisturbed |
| `scripts/check_thrown_error_messages.py` (subject ratchet) | **0** | 333 framework source files scanned, none bare-keyword |
| `scripts/check_retired_spellings.py` | **0** | clean |
| `scripts/check_require_alias_dialect.py` | **0** | clean |

Exit codes captured on the runner's own command line, never through a pipe.

**Sabotage proof** (schemas suite). Baseline blob of `schemas/storage.cljc`
`f1c4bc4e9b3b7d3344674f9c29f1db5e5b55a5bb`. Planted a fault at line 702 — a line
this PR edits — replacing the resolved frame id with a bogus keyword; the plant's
anchor matched exactly **1** line before the run, and the blob moved to
`3fd844d7e9c0342ca58d1134d7e0d514f56f7b47`, so it was not a no-op. The gate went
**red, captured exit 1**, with **22 failures** against the control's 0, landing on
`app-schemas-returns-path-to-meta-map` / `app-schemas-per-frame-isolation` —
exactly the surface broken. Test and assertion counts were unchanged at
390/19312, so the plant was scoped and crashed no namespace. Restored and
verified **by git blob hash** back to `f1c4bc4e9b…`, not by the restore command's
exit code.

**Document gates do not cover this diff, and are not nominated.**
`check_doc_slugs.py`'s `DEFAULT_ROOTS` are `docs`, `spec`, `skills`, `migration`
(plus `tools/*/spec`) — `implementation/` is not among them. `mkdocs`' `docs_dir`
is `docs`, so `implementation/**` was never a candidate for `exclude_docs` at all.
`check_readme_links.py` grades README/root/beside-source *markdown*; this diff
touches no markdown. Nominating any of them would have bought a green that
inspected nothing changed here.
