### PR TITLE
chore(derivation): demote the nine *-algebra-view fns off the public tooling tier

### DIFF
--- a/docs/api/re-frame.flows.md
+++ b/docs/api/re-frame.flows.md
@@ -222,29 +222,7 @@ Read-only views over the per-frame flow registry. They never touch the registrat
   (flows/flow-meta {:frame :app :id :cart/subtotal})
   ```
 
-### `flow-algebra-view`
-
-- **Kind**: function (JVM)
-- **Signature**:
-  ```clojure
-  (flow-algebra-view)
-  (flow-algebra-view frame-id)
-  ```
-- **Description**: Return the static derivation-algebra view of every registered flow. Each flow is lowered into the normalized derivation-node shape, so a tool can show subscriptions, flows, resources, route facts, and machine selectors as one family.
-
-  Each node carries:
-
-  - the flow's `:id`
-  - `:kind` `:derivation`
-  - `:source-form` `{:kind :reg-flow :id flow-id}`
-  - the declared `:inputs`, each lowered to `[:db path]` or `[:runtime …rest]`
-  - `:output` `[:db <output-path>]`
-  - the fixed classifications: `:storage` `:app-db`, `:evaluation` `:after-event`, `:lifecycle` `:frame`, `:materialized?` `true`
-  - `:owner` `[:frame frame-id]`
-  - the opaque `:derive` token
-  - `:source` / `:schema` / `:doc` when present
-
-  The zero-arity form returns `{frame-id {flow-id node}}`. The one-arity form returns `{flow-id node}` for a single frame. This is a JVM convenience alias; CLJS consumers call `re-frame.flows.tooling/flow-algebra-view` directly.
+The static derivation-algebra view of every registered flow — which lowers each flow into the normalized derivation-node shape, so a tool can show subscriptions, flows, resources, route facts and machine selectors as one family — ships **no public accessor** (Derivations §Flows expose algebra views). It lives in `re-frame.flows.tooling` and every consumer names that namespace directly: Xray and the conformance fixtures statically, `re-frame.derivation.graph` through `requiring-resolve` on the JVM.
 
 ## Runtime and test-support internals
 

--- a/docs/api/re-frame.machines.md
+++ b/docs/api/re-frame.machines.md
@@ -324,41 +324,9 @@ When a child spawns declaratively under a parent, the framework binds the child'
 
 ## Machine-tooling exports (JVM)
 
-The shipped machine-tooling exports are `re-frame.machines` aliases over `re-frame.machines.tooling`. The aliases are JVM-only; there is no `re-frame.core` facade export. CLJS tool consumers call `re-frame.machines.tooling/<name>` directly. The CLJS facade deliberately omits the tooling require, so an app that attaches no tool DCEs the tooling body. These exports render the machine *algebra view* that Xray and re-frame-pair navigate. There is **no** framework-level `machine->xstate-json`, `machine->mermaid`, or Stately bridge. Those exporters are owned by the separate post-v1 `day8/re-frame2-machines-viz` library, not the framework.
+The shipped machine-tooling exports are `re-frame.machines` aliases over `re-frame.machines.tooling`. The aliases are JVM-only; there is no `re-frame.core` facade export. CLJS tool consumers call `re-frame.machines.tooling/<name>` directly. The CLJS facade deliberately omits the tooling require, so an app that attaches no tool DCEs the tooling body. There is **no** framework-level `machine->xstate-json`, `machine->mermaid`, or Stately bridge. Those exporters are owned by the separate post-v1 `day8/re-frame2-machines-viz` library, not the framework.
 
-### `re-frame.machines/machine-algebra-view`
-
-- **Kind**: function (owned by `re-frame.machines`, JVM-only — not a `re-frame.core` facade export)
-- **Signature**:
-  ```clojure
-  (re-frame.machines/machine-algebra-view) → {machine-id node}
-  (re-frame.machines/machine-algebra-view machine-id) → node (or nil)
-  ```
-- **Description**: The static algebra view over a machine *definition*. This is the structure Xray's machine inspector and the docs/visualisation lane read. JVM-only. The zero-arity form returns `{machine-id node}` for every registered machine, or `{}` when none are registered. The one-arity form returns the single node for `machine-id`, or `nil` if it is not registered.
-- **Example**:
-  ```clojure
-  ;; The whole registry, keyed by machine-id — or one node (nil if unregistered).
-  (rf.machines/machine-algebra-view)
-  (rf.machines/machine-algebra-view :upload/main)
-  ```
-
-### `re-frame.machines/machine-instance-algebra-view`
-
-- **Kind**: function (owned by `re-frame.machines`, JVM-only — not a `re-frame.core` facade export)
-- **Signature**:
-  ```clojure
-  (re-frame.machines/machine-instance-algebra-view) → {actor-id node}
-  (re-frame.machines/machine-instance-algebra-view frame-id) → {actor-id node}
-  ```
-- **Description**: The algebra view for a live machine *instance*: definition plus current snapshot, so the view can highlight the active state. JVM-only. The zero-arity form reads the ambient current frame; the one-arity form names a `frame-id`. Returns:
-    - `{actor-id node}` — one node per live snapshot, covering singletons and spawned actors.
-    - `{}` — the frame has no live machines.
-    - `nil` — the frame is missing or destroyed, or this is a production build.
-- **Example**:
-  ```clojure
-  ;; Live nodes — one per machine snapshot in the frame (singletons + spawned actors).
-  (rf.machines/machine-instance-algebra-view :rf/default)
-  ```
+The machine *algebra views* Xray and re-frame-pair navigate are **not** among them. The static view over a machine definition and the live view over a machine instance ship **no public accessor** (Derivations §Machines expose algebra views): they live in `re-frame.machines.tooling` and every consumer names that namespace directly — Xray statically, `re-frame.derivation.graph` through `requiring-resolve` on the JVM.
 
 ### `re-frame.machines/machine-selector?`
 

--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -163,7 +163,9 @@ The URL ↔ route mapping is a prism. `match-url` reads a URL into route data. `
 
 ## Introspection and slice access
 
-This is the read-side surface over the route registry and the live route slice. The live readers expose the per-frame slice. The `*-algebra-view` helpers lower routes into the shared derivation/process-algebra node shape, so a tool can show subscriptions, flows, resources, route facts, and machine selectors as one family.
+This is the read-side surface over the route registry and the live route slice. The live readers expose the per-frame slice.
+
+Lowering routes into the shared derivation/process-algebra node shape — so a tool can show subscriptions, flows, resources, route facts and machine selectors as one family — is **not** part of it. The static route view and the live route-slice view ship **no public accessor** (Derivations §Routes expose algebra views): they live in `re-frame.routing.tooling` and every consumer names that namespace directly — Xray and the conformance fixtures statically, `re-frame.derivation.graph` through `requiring-resolve` on the JVM.
 
 "Which routes are registered, and what is route X's spec?" has **no routing-specific accessor** (rf2-kuky.31 retired `route-ids` / `route-meta`). It is the generic registrar query API, which every tool already speaks:
 
@@ -176,34 +178,6 @@ This is the read-side surface over the route registry and the live route slice. 
 ```
 
 The returned map carries the `:path` pattern plus whatever the registration declared, so every [reserved metadata key](#reserved-metadata-keys) reads back from it — `:params`, `:query`, `:query-defaults`, `:tags`, `:parent`, `:on-match`, **`:can-enter`**, `:can-leave`, `:scroll`, `:sensitive`, `:large`, and the cross-feature `:head` / `:resources`. (`:can-enter` and `:parent` are the two an auth guard and a branch-composition read back most.) It also carries the computed `:rf.route/rank` / `:rf.route/compiled` / coercion tables and the source coords. Unlike the resource / mutation / resource-scope kinds, a route registration carries its metadata at the **top level** — there is no inner-key projection step.
-
-### `route-algebra-view`
-
-- **Kind**: function (JVM convenience alias; CLJS callers use `re-frame.routing.tooling/route-algebra-view`)
-- **Signature**:
-  ```clojure
-  (route-algebra-view) → {route-id route-fact-node}
-  (route-algebra-view route-id) → route-fact-node or nil
-  ```
-- **Description**: The STATIC derivation/process-algebra view of every registered route. It is pure data over the `:route` registrar kind — no app-db, no runtime-db, no live slice. The zero-arity form returns the map for every route (`{}` when none). The one-arity form returns one node, or `nil`. JVM-runnable; consumed by Xray and the conformance fixtures. There is no `re-frame.core` facade export.
-
-  Each route lowers to a normalized node carrying:
-  - `:id` `:rf/route` — the route FACT identity (every route materializes the one route slice; the per-route registration id is under `:source-form`).
-  - `:kind` `:process`, `:refinement` `:route-fact`.
-  - `:source-form` `{:kind :reg-route :id <route-id>}`.
-  - `:inputs` — the route-transition inputs (`:rf.route/navigate` / `:rf.route/handle-url-change`).
-  - `:output` `[:runtime [:rf.runtime/routing :current]]`, `:storage` `:runtime-db`.
-  - `:evaluation` `:on-route`, `:lifecycle` `:frame`, `:materialized?` `true`.
-  - `:resource-edges` — only when the route declares `:resources`.
-
-### `route-slice-algebra-view`
-
-- **Kind**: function (JVM convenience alias; CLJS callers use `re-frame.routing.tooling/route-slice-algebra-view`)
-- **Signature**:
-  ```clojure
-  (route-slice-algebra-view frame-id) → route-fact-node or nil
-  ```
-- **Description**: The LIVE counterpart to `route-algebra-view`. It reads the route fact materialized in a frame's runtime-db at `[:rf.runtime/routing :current]` — the concrete matched route, with its params, query, transition state, and nav-token. Returns a single `:route-fact` node. Returns `nil` when the frame is missing or destroyed, or when no navigation has committed yet (so no route has been materialized). The node carries the same fixed classifications as the static node, plus `:route-id`, `:params`, `:query`, `:transition`, `:nav-token`, and `:owner` `[:route <route-id> <nav-token>]`. Runs on both CLJS and the JVM (a single runtime-db container deref).
 
 ### Reading the route and the pending-nav slot
 

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -2649,11 +2649,10 @@
 #?(:clj
    (do
      (def sub-topology       rf.subs.tooling/sub-topology)
-     (def sub-cache-snapshot rf.subs.tooling/sub-cache-snapshot)
-     ;; EP-0014 slice-2: the derivation/process algebra views. The static
-     ;; view is JVM-runnable (registrar-derived, partition-agnostic); the
-     ;; live cache view is CLJS-only (returns nil on the JVM, like
-     ;; `sub-cache-snapshot`). Both live in the tooling sibling so
-     ;; production CLJS bundles DCE the bodies.
-     (def sub-algebra-view       rf.subs.tooling/sub-algebra-view)
-     (def sub-cache-algebra-view rf.subs.tooling/sub-cache-algebra-view)))
+     (def sub-cache-snapshot rf.subs.tooling/sub-cache-snapshot)))
+;; rf2-kuky.86: no `sub-algebra-view` / `sub-cache-algebra-view` facade
+;; aliases. The EP-0014 slice-2 derivation/process algebra views ship NO
+;; public accessor (Derivations §Subscriptions expose algebra views) — both
+;; live in `re-frame.subs.tooling` so production CLJS bundles DCE the bodies,
+;; and every consumer names that sibling directly (Xray and the conformance
+;; fixtures statically; `re-frame.derivation.graph` requires it in-core).

--- a/implementation/core/test/re_frame/sub_algebra_view_test.clj
+++ b/implementation/core/test/re_frame/sub_algebra_view_test.clj
@@ -18,10 +18,10 @@
   edges) is the CLJS counterpart, pinned in the reagent runtime suite.
 
   Slice-2 ships NO public accessor (EP-0014 issue-1 disposition): the view
-  lives in the bundle-isolated `re-frame.subs.tooling` sibling, reached on
-  JVM through the `re-frame.subs/sub-algebra-view` convenience alias, and
-  consumed by Xray + the conformance fixtures. There is no
-  `re-frame.core/sub-algebra-view` public facade export.
+  lives in the bundle-isolated `re-frame.subs.tooling` sibling and is consumed
+  by Xray + the conformance fixtures, which name that sibling directly. There
+  is no `re-frame.core/sub-algebra-view` public facade export and — since
+  rf2-kuky.86 — no `re-frame.subs` JVM convenience alias either.
 
   ## Posture split (rf2-d2841)
 
@@ -87,12 +87,25 @@
     (is (= {} (rf.subs.tooling/sub-algebra-view)))
     (is (map? (rf.subs.tooling/sub-algebra-view)))))
 
-(deftest jvm-alias-mirrors-the-tooling-fn
-  (testing "the JVM `re-frame.subs/sub-algebra-view` alias is the tooling fn"
-    (rf/reg-sub :n (fn [db _] (:n db)))
-    (is (= (rf.subs.tooling/sub-algebra-view)
-           (rf.subs/sub-algebra-view))
-        "the JVM convenience alias projects identically to the tooling sibling")))
+(deftest facade-publishes-no-algebra-view-alias
+  ;; rf2-kuky.86 — the absence pin that replaced the JVM presence pin. The
+  ;; views ship NO public accessor (Derivations §Subscriptions expose algebra
+  ;; views): the `defn`s stay in `re-frame.subs.tooling` and `re-frame.subs`
+  ;; re-exports neither, so production CLJS bundles DCE the bodies and every
+  ;; consumer names the sibling directly.
+  (testing "`re-frame.subs` re-exports neither sub algebra view"
+    (is (nil? (ns-resolve 're-frame.subs 'sub-algebra-view))
+        "sub-algebra-view is not a public name on the subs facade")
+    (is (nil? (ns-resolve 're-frame.subs 'sub-cache-algebra-view))
+        "sub-cache-algebra-view is not a public name on the subs facade"))
+  (testing "the sibling's other JVM aliases are untouched"
+    (is (some? (ns-resolve 're-frame.subs 'sub-topology))
+        "sub-topology keeps its JVM alias")
+    (is (some? (ns-resolve 're-frame.subs 'sub-cache-snapshot))
+        "sub-cache-snapshot keeps its JVM alias"))
+  (testing "the tooling sibling still publishes both algebra views"
+    (is (some? (ns-resolve 're-frame.subs.tooling 'sub-algebra-view)))
+    (is (some? (ns-resolve 're-frame.subs.tooling 'sub-cache-algebra-view)))))
 
 ;; ---- reg-sub :db (layer-1) -----------------------------------------------
 

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -18,10 +18,12 @@
             [re-frame.flows.topo :as rf.flows.topo]
             [re-frame.interop :as rf.interop]
             [re-frame.late-bind :as rf.late-bind]
-            [re-frame.trace :as rf.trace]
-            ;; Keep tooling unreachable from the CLJS facade so Closure can
-            ;; remove it when no tool requires the sibling namespace.
-            #?@(:clj [[re-frame.flows.tooling :as rf.flows.tooling]])))
+            ;; No require of `re-frame.flows.tooling` on EITHER runtime
+            ;; (rf2-kuky.86). The JVM-only require existed solely to back the
+            ;; `flow-algebra-view` facade alias; that is retired, so tooling is
+            ;; now unreachable from this facade on both runtimes and Closure
+            ;; removes it whenever no tool requires the sibling directly.
+            [re-frame.trace :as rf.trace]))
 
 (def ^:no-doc stale-incarnation
   "Internal return marker: the exact frame owner vanished during a flow pass."
@@ -54,10 +56,11 @@
 (def reset-flows!       rf.flows.registry/reset-flows!)
 (def reset-last-inputs! rf.flows.registry/reset-last-inputs!)
 
-;; JVM tools get a convenience alias. CLJS tools require the bundle-isolated
-;; sibling directly.
-#?(:clj
-   (def flow-algebra-view rf.flows.tooling/flow-algebra-view))
+;; rf2-kuky.86: no `flow-algebra-view` facade alias. The flow algebra view
+;; ships NO public accessor (Derivations §Flows expose algebra views) — every
+;; tool requires the bundle-isolated `re-frame.flows.tooling` directly, and
+;; `re-frame.derivation.graph` reaches it through `requiring-resolve` on the
+;; JVM.
 
 ;; ---- partition-qualified input resolution -------------------------------
 ;;

--- a/implementation/flows/test/re_frame/flow_algebra_view_test.clj
+++ b/implementation/flows/test/re_frame/flow_algebra_view_test.clj
@@ -18,10 +18,11 @@
   and the source coordinates.
 
   Slice-3 ships NO public accessor (EP-0014 issue-1 disposition): the view
-  lives in the bundle-isolated `re-frame.flows.tooling` sibling, reached on
-  JVM through the `re-frame.flows/flow-algebra-view` convenience alias, and
-  consumed by Xray + the conformance fixtures. There is no
-  `re-frame.core/flow-algebra-view` public facade export."
+  lives in the bundle-isolated `re-frame.flows.tooling` sibling and is
+  consumed by Xray + the conformance fixtures, which name that sibling
+  directly. There is no `re-frame.core/flow-algebra-view` public facade export
+  and — since rf2-kuky.86 — no `re-frame.flows` JVM convenience alias either;
+  `re-frame.derivation.graph` reaches the view by `requiring-resolve`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.flows :as rf.flows]
@@ -62,12 +63,17 @@
   (testing "(flow-algebra-view frame-id) returns {} for a frame with no flows"
     (is (= {} (rf.flows.tooling/flow-algebra-view :rf/default)))))
 
-(deftest jvm-alias-mirrors-the-tooling-fn
-  (testing "the JVM `re-frame.flows/flow-algebra-view` alias is the tooling fn"
-    (rf/reg-flow :area {:inputs [[:w] [:h]] :output-path [:rect :area]} (fn [w h] (* (or w 0) (or h 0))))
-    (is (= (rf.flows.tooling/flow-algebra-view)
-           (rf.flows/flow-algebra-view))
-        "the JVM convenience alias projects identically to the tooling sibling")))
+(deftest facade-publishes-no-algebra-view-alias
+  ;; rf2-kuky.86 — the absence pin that replaced the JVM presence pin. The view
+  ;; ships NO public accessor (Derivations §Flows expose algebra views): the
+  ;; `defn` stays in `re-frame.flows.tooling` and the facade re-exports it on
+  ;; neither runtime, so `re-frame.derivation.graph` reaches it by
+  ;; `requiring-resolve` and CLJS tools by a direct `:require`.
+  (testing "`re-frame.flows` re-exports no flow algebra view"
+    (is (nil? (ns-resolve 're-frame.flows 'flow-algebra-view))
+        "flow-algebra-view is not a public name on the flows facade"))
+  (testing "the tooling sibling still publishes it"
+    (is (some? (ns-resolve 're-frame.flows.tooling 'flow-algebra-view)))))
 
 ;; ---- a registered flow exposes its algebra view --------------------------
 

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -182,25 +182,30 @@
 ;; Both inner-key projections are DOCUMENTED contracts (Spec 005 §Querying
 ;; machines, spec/API.md §Public registrar query API), not helpers.
 
-;; ---- derivation/process algebra views -------------------------------------
+;; ---- machine-selector recognizer + extractor ------------------------------
 ;;
-;; The derivation/process algebra view of registered machines
-;; (`machine-algebra-view`), their live instances / spawned actors
-;; (`machine-instance-algebra-view`), and the machine-selector recognizer
-;; (`machine-selector?`). A machine is the canonical `:process` member of the
-;; algebra (a derivation WITH state, lifecycle, and commands over time); its
-;; snapshot materializes into runtime-db, evaluated `:on-transition`.
+;; The machine-selector recognizer (`machine-selector?`) and the selector-target
+;; extractor (`machine-selector-targets`). A machine is the canonical `:process`
+;; member of the algebra (a derivation WITH state, lifecycle, and commands over
+;; time); its snapshot materializes into runtime-db, evaluated `:on-transition`.
+;; The algebra views over registered machines and over their live instances /
+;; spawned actors live in `re-frame.machines.tooling` and are reached there.
 ;;
-;; JVM convenience aliases: the bodies live in `re-frame.machines.tooling` so a
-;; CLJS app that loads the machines artefact but attaches no tool DCEs them (the
-;; CLJS facade never `:require`s the tooling sibling — the require above is
-;; `#?@(:clj ...)`-gated). CLJS consumers (Xray + conformance) call
-;; `re-frame.machines.tooling/<name>` directly. No `re-frame.core` facade
-;; export. Mirrors the `re-frame.flows/flow-algebra-view` JVM alias.
+;; rf2-kuky.86: no `machine-algebra-view` / `machine-instance-algebra-view`
+;; facade aliases. Both algebra views ship NO public accessor (Derivations
+;; §Machines expose algebra views) — every consumer names
+;; `re-frame.machines.tooling/<name>` directly (Xray and the conformance
+;; fixtures statically; `re-frame.derivation.graph` through
+;; `requiring-resolve` on the JVM).
+;;
+;; The selector recognizer and extractor KEEP their JVM convenience aliases:
+;; the bodies live in `re-frame.machines.tooling` so a CLJS app that loads the
+;; machines artefact but attaches no tool DCEs them (the CLJS facade never
+;; `:require`s the tooling sibling — the require above is `#?@(:clj ...)`-gated).
+;; CLJS consumers (Xray + conformance) call `re-frame.machines.tooling/<name>`
+;; directly. No `re-frame.core` facade export.
 #?(:clj
    (do
-     (def machine-algebra-view          rf.machines.tooling/machine-algebra-view)
-     (def machine-instance-algebra-view rf.machines.tooling/machine-instance-algebra-view)
      (def machine-selector?             rf.machines.tooling/machine-selector?)
      (def machine-selector-targets      rf.machines.tooling/machine-selector-targets)))
 

--- a/implementation/machines/test/re_frame/machine_algebra_view_test.clj
+++ b/implementation/machines/test/re_frame/machine_algebra_view_test.clj
@@ -24,10 +24,13 @@
   and the live spawned-actor projection.
 
   There is NO public accessor: the views live in the bundle-isolated
-  `re-frame.machines.tooling` sibling, reached on JVM through the
-  `re-frame.machines/machine-*` convenience aliases, and consumed by Xray +
-  the conformance fixtures. There is no `re-frame.core/machine-algebra-view`
-  public facade export."
+  `re-frame.machines.tooling` sibling and are consumed by Xray + the
+  conformance fixtures, which name that sibling directly. There is no
+  `re-frame.core/machine-algebra-view` public facade export and — since
+  rf2-kuky.86 — no `re-frame.machines` JVM convenience alias for the two
+  ALGEBRA VIEWS either; `re-frame.derivation.graph` reaches them by
+  `requiring-resolve`. The selector recognizer / extractor
+  (`machine-selector?`, `machine-selector-targets`) keep theirs."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines :as rf.machines]
@@ -91,15 +94,19 @@
         (rf.test-support/restore-registrar! snap)))))
 
 (deftest jvm-alias-mirrors-the-tooling-fn
-  (testing "the JVM `re-frame.machines/machine-*` aliases are the tooling fns"
-    (rf/reg-machine :upload/main upload-machine)
-    (is (= (rf.machines.tooling/machine-algebra-view)
-           (rf.machines/machine-algebra-view))
-        "machine-algebra-view alias projects identically to the tooling sibling")
+  ;; rf2-kuky.86 — the two ALGEBRA VIEW aliases are gone; the selector
+  ;; recognizer keeps its JVM alias, so this pin now carries both halves.
+  (testing "`re-frame.machines` re-exports neither machine algebra view"
+    (is (nil? (ns-resolve 're-frame.machines 'machine-algebra-view))
+        "machine-algebra-view is not a public name on the machines facade")
+    (is (nil? (ns-resolve 're-frame.machines 'machine-instance-algebra-view))
+        "machine-instance-algebra-view is not a public name on the machines facade"))
+  (testing "the tooling sibling still publishes both algebra views"
+    (is (some? (ns-resolve 're-frame.machines.tooling 'machine-algebra-view)))
+    (is (some? (ns-resolve 're-frame.machines.tooling 'machine-instance-algebra-view))))
+  (testing "the JVM `machine-selector?` alias is the tooling fn"
     (is (= rf.machines.tooling/machine-selector? rf.machines/machine-selector?)
-        "machine-selector? alias is the tooling fn")
-    (is (= rf.machines.tooling/machine-instance-algebra-view rf.machines/machine-instance-algebra-view)
-        "machine-instance-algebra-view alias is the tooling fn")))
+        "machine-selector? alias is the tooling fn")))
 
 ;; ---- a registered machine exposes its process node -----------------------
 

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -70,16 +70,14 @@
             ;; published on BOTH runtimes whenever resources is loaded — the
             ;; epoch tool-pair consults it on every off-box record projection.
             [re-frame.resources.trace-egress :as rf.resources.trace-egress]
-            [re-frame.resources.work-ledger :as rf.resources.work-ledger]
-            ;; JVM-only require of the resources tooling sibling that backs the
-            ;; `resource-algebra-view`
-            ;; / `resource-cache-algebra-view` aliases at the foot of this ns.
-            ;; CLJS deliberately OMITS this require so a CLJS app that loads the
-            ;; resources artefact but never attaches a tool DCEs the tooling
-            ;; body wholesale — the facade never reaches it. JVM has no bundle
-            ;; to protect; the alias gives JVM tools / conformance fixtures the
-            ;; ergonomic `re-frame.resources/<name>` shape.
-            #?@(:clj [[re-frame.resources.tooling :as rf.resources.tooling]])))
+            ;; No require of `re-frame.resources.tooling` on EITHER runtime
+            ;; (rf2-kuky.86). The JVM-only require existed solely to back the
+            ;; `resource-algebra-view` / `resource-cache-algebra-view` facade
+            ;; aliases; those are retired, so the facade now reaches the
+            ;; bundle-isolated tooling sibling on neither runtime. JVM tools
+            ;; and conformance fixtures name `re-frame.resources.tooling/<name>`
+            ;; directly, as CLJS consumers already did.
+            [re-frame.resources.work-ledger :as rf.resources.work-ledger]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -99,22 +97,15 @@
 ;; `rf.resources.registry/resource-meta` survives as the artefact's own
 ;; shorthand for that projection; it is not a public name.
 
-;; Derivation/process algebra views of
-;; registered resources (`resource-algebra-view`, static) and of a frame's
-;; live cache entries (`resource-cache-algebra-view`, live). A resource is the
-;; canonical PROCESS member of the algebra (Derivations §Process). The static
-;; view is JVM-runnable (the resource registry is partition-agnostic metadata),
-;; so JVM convenience aliases let tools / conformance fixtures reach it as
-;; `re-frame.resources/<name>` without naming the sibling. The bodies live in
-;; `re-frame.resources.tooling` so a CLJS app that loads the resources artefact
-;; but attaches no tool DCEs them (the CLJS facade never `:require`s the tooling
-;; sibling — the require above is `#?@(:clj ...)`-gated). CLJS consumers (Xray +
-;; conformance) call `re-frame.resources.tooling/<name>` directly. No
-;; `re-frame.core` facade export.
-#?(:clj
-   (do
-     (def resource-algebra-view       rf.resources.tooling/resource-algebra-view)
-     (def resource-cache-algebra-view rf.resources.tooling/resource-cache-algebra-view)))
+;; rf2-kuky.86: no `resource-algebra-view` / `resource-cache-algebra-view`
+;; facade aliases. The derivation/process algebra views of registered
+;; resources (static) and of a frame's live cache entries (live) — a resource
+;; being the canonical PROCESS member of the algebra (Derivations §Process) —
+;; ship NO public accessor (Derivations §Resources expose process nodes). The
+;; bodies stay in the bundle-isolated `re-frame.resources.tooling`, which every
+;; consumer requires directly: Xray and the conformance fixtures statically,
+;; `re-frame.derivation.graph` through `requiring-resolve` on the JVM. No
+;; `re-frame.core` facade export either.
 
 ;; Mutations (Spec 016 §Mutations). `reg-mutation` registers a causal-write
 ;; mutation; `:rf.mutation/execute` runs it over the SAME managed-HTTP

--- a/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
@@ -23,10 +23,12 @@
   opaque `:derive` request token, source coords, and the live entry view.
 
   Slice-4 ships NO public accessor (EP-0014 issue-1 disposition): the views
-  live in the bundle-isolated `re-frame.resources.tooling` sibling, reached
-  on JVM through the `re-frame.resources/resource-algebra-view` convenience
-  alias, and consumed by Xray + the conformance fixtures. There is no
-  `re-frame.core/resource-algebra-view` public facade export."
+  live in the bundle-isolated `re-frame.resources.tooling` sibling and are
+  consumed by Xray + the conformance fixtures, which name that sibling
+  directly. There is no `re-frame.core/resource-algebra-view` public facade
+  export and — since rf2-kuky.86 — no `re-frame.resources` JVM convenience
+  alias either; `re-frame.derivation.graph` reaches the views by
+  `requiring-resolve`."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
@@ -432,9 +434,17 @@
       (is (contains? view :b/y)))))
 
 #?(:clj
-   (deftest jvm-alias-mirrors-the-tooling-fn
-     (testing "the JVM re-frame.resources/resource-algebra-view alias is the tooling fn"
-       (rf/reg-resource :article/by-slug (article-spec) article-spec-request)
-       (is (= (rf.resources.tooling/resource-algebra-view)
-              (re-frame.resources/resource-algebra-view))
-           "the JVM convenience alias projects identically to the tooling sibling"))))
+   (deftest facade-publishes-no-algebra-view-alias
+     ;; rf2-kuky.86 — the absence pin that replaced the JVM presence pin. Both
+     ;; views ship NO public accessor (Derivations §Resources expose process
+     ;; nodes): the `defn`s stay in `re-frame.resources.tooling` and the facade
+     ;; re-exports neither, so `re-frame.derivation.graph` reaches them by
+     ;; `requiring-resolve` and CLJS tools by a direct `:require`.
+     (testing "`re-frame.resources` re-exports neither resource algebra view"
+       (is (nil? (ns-resolve 're-frame.resources 'resource-algebra-view))
+           "resource-algebra-view is not a public name on the resources facade")
+       (is (nil? (ns-resolve 're-frame.resources 'resource-cache-algebra-view))
+           "resource-cache-algebra-view is not a public name on the resources facade"))
+     (testing "the tooling sibling still publishes both"
+       (is (some? (ns-resolve 're-frame.resources.tooling 'resource-algebra-view)))
+       (is (some? (ns-resolve 're-frame.resources.tooling 'resource-cache-algebra-view))))))

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -63,10 +63,12 @@
             [re-frame.routing.subs :as rf.routing.subs]
             [re-frame.routing.url-bound :as rf.routing.url-bound]
             [re-frame.routing.url-change :as rf.routing.url-change]
-            ;; The JVM facade provides convenience aliases for tooling. CLJS
-            ;; consumers require the tooling namespace directly, keeping it
-            ;; out of applications that load routing but attach no tool.
-            #?@(:clj  [[re-frame.routing.tooling :as rf.routing.tooling]])
+            ;; No require of `re-frame.routing.tooling` on EITHER runtime
+            ;; (rf2-kuky.86). The facade published JVM convenience aliases for
+            ;; the algebra views; those are retired, so every consumer — JVM
+            ;; and CLJS alike — requires the bundle-isolated tooling sibling
+            ;; directly, and `re-frame.derivation.graph` reaches it through
+            ;; `requiring-resolve` rather than through this facade.
             #?@(:cljs [[re-frame.views :as rf.views]])))
 
 ;; ---- public API re-exports ----------------------------------------------
@@ -120,13 +122,12 @@
 ;; slice path is `[:rf.runtime/routing :current]` (Conventions §Reserved
 ;; runtime-db keys).
 
-;; JVM tools get facade aliases for the static route algebra and a frame's
-;; live route-slice algebra. CLJS tools require `re-frame.routing.tooling`
-;; directly so production routing does not reach the tooling namespace.
-#?(:clj
-   (do
-     (def route-algebra-view       rf.routing.tooling/route-algebra-view)
-     (def route-slice-algebra-view rf.routing.tooling/route-slice-algebra-view)))
+;; rf2-kuky.86: no `route-algebra-view` / `route-slice-algebra-view` facade
+;; aliases. The static route algebra and a frame's live route-slice algebra
+;; ship NO public accessor (Derivations §Routes expose algebra views) — the
+;; bodies stay in the bundle-isolated `re-frame.routing.tooling`, which every
+;; consumer requires directly: Xray statically, `re-frame.derivation.graph`
+;; through `requiring-resolve` on the JVM.
 
 ;; URL-owner resolution
 (def url-owner-frame-id         rf.routing.nav-fx/url-owner-frame-id)

--- a/implementation/routing/test/re_frame/route_algebra_view_test.clj
+++ b/implementation/routing/test/re_frame/route_algebra_view_test.clj
@@ -22,10 +22,11 @@
       transition / nav-token / owner).
 
   Slice-5 ships NO public accessor (EP-0014 issue-1 disposition): the views
-  live in the bundle-isolated `re-frame.routing.tooling` sibling, reached on
-  JVM through the `re-frame.routing/route-algebra-view` convenience alias, and
-  consumed by Xray + the conformance fixtures. There is no
-  `re-frame.core/route-algebra-view` public facade export.
+  live in the bundle-isolated `re-frame.routing.tooling` sibling and are
+  consumed by Xray + the conformance fixtures, which name that sibling
+  directly. There is no `re-frame.core/route-algebra-view` public facade
+  export and — since rf2-kuky.86 — no `re-frame.routing` JVM convenience alias
+  either; `re-frame.derivation.graph` reaches the views by `requiring-resolve`.
 
   ## Posture split (rf2-o5dbf)
 
@@ -114,12 +115,20 @@
     (is (nil? (rf.routing.tooling/route-algebra-view :route/ghost))
         "an unregistered route id projects to nil")))
 
-(deftest jvm-alias-mirrors-the-tooling-fn
-  (testing "the JVM `re-frame.routing/route-algebra-view` alias is the tooling fn"
-    (rf/reg-route :route/home {} "/")
-    (is (= (rf.routing.tooling/route-algebra-view)
-           (rf.routing/route-algebra-view))
-        "the JVM convenience alias projects identically to the tooling sibling")))
+(deftest facade-publishes-no-algebra-view-alias
+  ;; rf2-kuky.86 — the absence pin that replaced the JVM presence pin. The
+  ;; views ship NO public accessor (Derivations §Routes expose algebra views):
+  ;; the `defn`s stay in `re-frame.routing.tooling` and the facade re-exports
+  ;; neither, so `re-frame.derivation.graph` reaches them by `requiring-resolve`
+  ;; and CLJS tools by a direct `:require`.
+  (testing "`re-frame.routing` re-exports neither route algebra view"
+    (is (nil? (ns-resolve 're-frame.routing 'route-algebra-view))
+        "route-algebra-view is not a public name on the routing facade")
+    (is (nil? (ns-resolve 're-frame.routing 'route-slice-algebra-view))
+        "route-slice-algebra-view is not a public name on the routing facade"))
+  (testing "the tooling sibling still publishes both"
+    (is (some? (ns-resolve 're-frame.routing.tooling 'route-algebra-view)))
+    (is (some? (ns-resolve 're-frame.routing.tooling 'route-slice-algebra-view)))))
 
 ;; ---- a registered route exposes its fact-node view -----------------------
 

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -1672,17 +1672,19 @@
   ;; rf2-ma0wvq — spawned-actor ownership resolver, published as the
   ;; `:machines/owning-actor-id` late-bind hook the http artefact consults.
   ["re-frame.machines" "owning-actor-id"]       {:tier :implementation :owner "005" :status "v1"}
-  ;; EP-0014 slice-6 (rf2-2axssk): the derivation/process algebra views of
-  ;; registered machines, their live instances / spawned actors, and the
-  ;; machine-selector recognizer. JVM convenience aliases; the bodies live in
-  ;; the bundle-isolated `re-frame.machines.tooling` sibling (the CLJS facade
-  ;; never `:require`s it — the require is `#?@(:clj ...)`-gated — so prod CLJS
-  ;; bundles DCE them). `:tooling`, no `re-frame.core` facade export (EP-0014
-  ;; issue-1 disposition). Owner 005 = machines host spec (the flow=013 /
-  ;; routing=012 host-namespace precedent). Mirror of `flow-algebra-view`
-  ;; (slice-3) / `sub-algebra-view` (slice-2).
-  ["re-frame.machines" "machine-algebra-view"]          {:tier :tooling :owner "005" :status "v1"}
-  ["re-frame.machines" "machine-instance-algebra-view"] {:tier :tooling :owner "005" :status "v1"}
+  ;; EP-0014 slice-6 (rf2-2axssk): the machine-selector recognizer. JVM
+  ;; convenience alias; the body lives in the bundle-isolated
+  ;; `re-frame.machines.tooling` sibling (the CLJS facade never `:require`s it
+  ;; — the require is `#?@(:clj ...)`-gated — so prod CLJS bundles DCE it).
+  ;; `:tooling`, no `re-frame.core` facade export (EP-0014 issue-1
+  ;; disposition). Owner 005 = machines host spec (the flow=013 / routing=012
+  ;; host-namespace precedent).
+  ;;
+  ;; rf2-kuky.86: the two algebra views (`machine-algebra-view`,
+  ;; `machine-instance-algebra-view`) carried rows here until their JVM facade
+  ;; aliases were deleted. They are NOT retired — the `defn`s stay public in
+  ;; `re-frame.machines.tooling`, which the generator does not introspect, so
+  ;; they now carry no row for the same reason `sub-algebra-view` never did.
   ["re-frame.machines" "machine-selector?"]             {:tier :tooling :owner "005" :status "v1"}
   ;; rf2-4qmiij — machine-selector edge extractor: the SET of machine ids a
   ;; selector sub reads, so a graph tool draws the `:selector` edge to the
@@ -1762,22 +1764,15 @@
   ["re-frame.routing" "routing-state-classification"] {:tier :implementation :owner "012" :status "v1"}
   ["re-frame.routing" "reset-nav-counters!"]    {:tier :implementation :owner "012" :status "v1"}
   ["re-frame.routing" "reset-url-claims!"]      {:tier :implementation :owner "012" :status "v1"}
-  ;; EP-0014 slice-5 (rf2-eiiifu): the derivation/process algebra view of
-  ;; registered routes (`route-algebra-view`, static) and a frame's live
-  ;; route slice (`route-slice-algebra-view`, live). JVM-only convenience
-  ;; aliases of `re-frame.routing.tooling/route-algebra-view` /
-  ;; `route-slice-algebra-view` (the bodies live in the bundle-isolated
-  ;; tooling sibling; the CLJS facade never `:require`s it — the require is
-  ;; `#?@(:clj ...)`-gated — so prod CLJS bundles DCE it). `:tooling`, no
-  ;; `re-frame.core` facade export (EP-0014 issue-1 disposition). Owner
-  ;; "012" to match the host `re-frame.routing` spec section (the sibling
-  ;; routing rows above), mirroring how `re-frame.flows/flow-algebra-view`
-  ;; (slice-3) carries owner "013" for its host `re-frame.flows`. Mirror of
-  ;; `sub-algebra-view` (slice-2) — which carries no manifest row only
-  ;; because its host `re-frame.subs` is not a generator-introspected
-  ;; namespace, whereas `re-frame.routing` is.
-  ["re-frame.routing" "route-algebra-view"]       {:tier :tooling :owner "012" :status "v1"}
-  ["re-frame.routing" "route-slice-algebra-view"] {:tier :tooling :owner "012" :status "v1"}
+  ;; EP-0014 slice-5 (rf2-eiiifu) / rf2-kuky.86: the derivation/process algebra
+  ;; view of registered routes (`route-algebra-view`, static) and a frame's
+  ;; live route slice (`route-slice-algebra-view`, live) carried `:tooling`
+  ;; rows here while `re-frame.routing` published JVM-only convenience aliases
+  ;; of them. Those aliases are deleted, so the rows are gone. The views are
+  ;; NOT retired — the `defn`s stay public in the bundle-isolated
+  ;; `re-frame.routing.tooling`, which the generator does not introspect, so
+  ;; they now carry no row for exactly the reason `sub-algebra-view` never did:
+  ;; the host namespace is not generator-introspected.
 
   ;; =========================================================================
   ;; re-frame.resources — optional artefact (day8/re-frame2-resources), §016.
@@ -1812,12 +1807,14 @@
   ;;       ARTEFACT-INTERNALLY in `re-frame.resources.registry` /
   ;;       `re-frame.resources.mutation-registry`, which the generator does
   ;;       not introspect, so they carry no row.
-  ;;   (c) The two algebra views are `:tooling` with no facade export —
-  ;;       `#?(:clj ...)`-gated JVM aliases of the bundle-isolated
-  ;;       `re-frame.resources.tooling` sibling, so a CLJS app that loads
-  ;;       resources but attaches no tool DCEs the bodies. Exact mirror of
-  ;;       `flow-algebra-view` / `route-algebra-view` / `machine-algebra-view`
-  ;;       (EP-0014 issue-1 disposition).
+  ;;   (c) The two algebra views carry NO row (rf2-kuky.86). They were
+  ;;       `:tooling` while `re-frame.resources` published `#?(:clj ...)`-gated
+  ;;       JVM aliases of the bundle-isolated `re-frame.resources.tooling`
+  ;;       sibling; those aliases are deleted, so the only public names are
+  ;;       the sibling's own `defn`s and the generator does not introspect
+  ;;       that namespace. Exact mirror of `flow-algebra-view` /
+  ;;       `route-algebra-view` / `machine-algebra-view`, all demoted the
+  ;;       same way by the same bead (EP-0014 issue-1 disposition).
   ;; =========================================================================
   ;; (a) Facade-mirrored — resources.
   ["re-frame.resources" "reg-resource"]         {:tier :advanced :owner "016" :status "v1 (optional capability)"}
@@ -1833,10 +1830,12 @@
   ["re-frame.resources" "reg-resource-scope"]   {:tier :advanced :owner "016" :status "v1 (optional capability)"}
   ["re-frame.resources" "resolve-resource-scope"] {:tier :advanced :owner "016" :status "v1 (optional capability)"}
   ;; (c) Algebra views — a resource is the canonical PROCESS member of the
-  ;; algebra (Derivations §Process). Static registry view + live per-frame
-  ;; cache-entry view.
-  ["re-frame.resources" "resource-algebra-view"]       {:tier :tooling :owner "016" :status "v1 (optional capability)"}
-  ["re-frame.resources" "resource-cache-algebra-view"] {:tier :tooling :owner "016" :status "v1 (optional capability)"}
+  ;; algebra (Derivations §Process). rf2-kuky.86: the static registry view and
+  ;; the live per-frame cache-entry view carried `:tooling` rows here while
+  ;; `re-frame.resources` published JVM aliases of them. Those aliases are
+  ;; deleted, so the rows are gone; the `defn`s stay public in the
+  ;; bundle-isolated `re-frame.resources.tooling`, which the generator does not
+  ;; introspect.
 
   ;; =========================================================================
   ;; re-frame.flows — optional artefact (day8/re-frame2-flows), §013.
@@ -1856,16 +1855,14 @@
   ;; rollback seam, NOT an egress boundary), so it stays off the public
   ;; manifest. Off-box reads ride the elided trace path, not a dedicated
   ;; accessor.
-  ;; EP-0014 slice-3 (rf2-s8w3nw): the derivation/process algebra view of
-  ;; registered flows. JVM-only convenience alias of
-  ;; `re-frame.flows.tooling/flow-algebra-view` (the body lives in the
-  ;; bundle-isolated tooling sibling; the CLJS facade never `:require`s it,
-  ;; so prod CLJS bundles DCE it). `:tooling`, no `re-frame.core` facade
-  ;; export (EP-0014 issue-1 disposition). Mirror of `sub-algebra-view`
-  ;; (slice-2) — which carries no manifest row only because its host
-  ;; `re-frame.subs` is not a generator-introspected namespace, whereas
-  ;; `re-frame.flows` is.
-  ["re-frame.flows" "flow-algebra-view"]     {:tier :tooling :owner "013" :status "v1"}
+  ;; EP-0014 slice-3 (rf2-s8w3nw) / rf2-kuky.86: the derivation/process algebra
+  ;; view of registered flows carried a `:tooling` row here while
+  ;; `re-frame.flows` published a JVM-only convenience alias of
+  ;; `re-frame.flows.tooling/flow-algebra-view`. That alias is deleted, so the
+  ;; row is gone. The view is NOT retired — the `defn` stays public in the
+  ;; bundle-isolated tooling sibling, which the generator does not introspect,
+  ;; so it now carries no row for exactly the reason `sub-algebra-view` never
+  ;; did.
   ["re-frame.flows" "run-flows-on-db"]       {:tier :implementation :owner "013" :status "v1"}
   ["re-frame.flows" "reset-flows!"]          {:tier :implementation :owner "013" :status "v1"}
   ["re-frame.flows" "reset-last-inputs!"]    {:tier :implementation :owner "013" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -8,7 +8,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. The :action and :justification columns are the facade-audit axes (spec/Conventions.md §Facade policy fields 4 and 3) — also curated, and present on :facade? true rows ONLY, which is why most rows carry neither. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 479,
+ :var-count 472,
  :tier-vocab
  [:front-porch
   :advanced
@@ -162,7 +162,6 @@
   {:namespace "re-frame.epoch", :var "register-epoch-listener!", :tier :implementation, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only; hook target for :epoch/register-epoch-listener!; the public door is rf/register-listener! :epoch)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.epoch", :var "settle!", :tier :implementation, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.epoch", :var "unregister-epoch-listener!", :tier :implementation, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only; hook target for :epoch/unregister-epoch-listener!; the public door is rf/unregister-listener! :epoch)", :facade? false, :runtime-verified? true}
-  {:namespace "re-frame.flows", :var "flow-algebra-view", :tier :tooling, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "flow-meta", :tier :tooling, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "flows", :tier :tooling, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "flows-snapshot", :tier :tooling, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
@@ -212,8 +211,6 @@
   {:namespace "re-frame.machines", :var "after-schedule-fx", :tier :implementation, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.machines", :var "destroy-machine-fx", :tier :implementation, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.machines", :var "install-machine-runtime!", :tier :implementation, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
-  {:namespace "re-frame.machines", :var "machine-algebra-view", :tier :tooling, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
-  {:namespace "re-frame.machines", :var "machine-instance-algebra-view", :tier :tooling, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.machines", :var "machine-selector-targets", :tier :tooling, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.machines", :var "machine-selector?", :tier :tooling, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.machines", :var "machine-transition", :tier :advanced, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
@@ -240,8 +237,6 @@
   {:namespace "re-frame.resources", :var "reg-resource", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.resources", :var "reg-resource-scope", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.resources", :var "resolve-resource-scope", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
-  {:namespace "re-frame.resources", :var "resource-algebra-view", :tier :tooling, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
-  {:namespace "re-frame.resources", :var "resource-cache-algebra-view", :tier :tooling, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.resources", :var "resource-state", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "counter-snapshot", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "frame-scroll-cache", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
@@ -255,9 +250,7 @@
   {:namespace "re-frame.routing", :var "reset-nav-counters!", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "reset-scroll-cache!", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "reset-url-claims!", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
-  {:namespace "re-frame.routing", :var "route-algebra-view", :tier :tooling, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "route-link-render-ssr", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
-  {:namespace "re-frame.routing", :var "route-slice-algebra-view", :tier :tooling, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "route-url", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "routing-state-classification", :tier :implementation, :kind :var, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "save-scroll-position", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Demotes the nine `*-algebra-view` fns off the public tooling tier (rf2-kuky.86). **Demote, do not delete**: all nine `defn`s stay exactly where they are, unchanged in name and namespace.

## What moved

Nine `#?(:clj (def ...))` facade aliases across **five** files — `subs.cljc` (2), `flows.cljc` (1), `machines.cljc` (2), `resources.cljc` (2), `routing.cljc` (2) — plus the three JVM-only tooling `:require`s that existed solely to back them. `machines` keeps `machine-selector?` / `machine-selector-targets`; `subs` keeps `sub-topology` / `sub-cache-snapshot`.

The bead's edit list names FOUR alias blocks. There are five — it omits `flows.cljc` entirely. Found by construct (`(def [a-z-]*algebra-view`), not from the bead's list.

## Two corrections to the bead's target state, both measured at source

**Seven manifest rows, not nine.** `sub-algebra-view` / `sub-cache-algebra-view` were never rowed: `re-frame.subs` is not a generator-introspected namespace.

**The seven rows are DROPPED, not re-tiered, and `:var-count` necessarily moves 479 -> 472.** `gen.clj`'s `public-vars-of` builds rows from `ns-publics`, so a row exists iff the var is public in a rostered namespace. Deleting an alias deletes the var, hence its row — there is no "keep the row, change its tier" for a name that no longer exists. Re-tiering and deleting are mutually exclusive for the same var, which is why acceptance criterion 1 ("the nine rows at tier `:implementation`; the alias blocks are gone") cannot be satisfied as written. The generator confirmed this independently by naming exactly those seven as stale sidecar entries.

`:var-count` reconciled three ways: declared **472** = independent `{:namespace ` row count **472** = tier histogram sum **472**. `:tier :tooling` 202 -> 195 (-7); `:tier :implementation` unchanged at 125.

## What is unaffected, and why

`re-frame.derivation.graph` resolves the **`.tooling`** namespaces, never the facades, and reaches them by `requiring-resolve`, which self-loads — so removing the dead facade requires cannot break it. Verified directly on the JVM: all five families resolve, 10/10 static+live fn slots non-nil, `:machines` still carries `selector-targets`, and all nine facade aliases now resolve to `nil`.

Xray statically requires the five `.tooling` siblings itself, so it is untouched.

**No Xray spec rewrite was warranted.** The bead asks for `tools/xray/spec/024`/`025` references to be rewritten "to name the composed derivation graph rather than the per-artefact algebra views". Every one of those references names the `.tooling` siblings or the algebra-view *families* — both factually correct descriptions of Xray's CLJS wiring, which this PR does not change. Rewriting them would have made the Xray spec false. `xray-spec-check` passes untouched.

**`spec/Derivations.md` needed no edit** — it already says these views ship "no public accessor" in six places. The facade aliases contradicted that; deleting them makes the spec true.

## Tests

Five JVM presence pins become **absence pins**, which pin the demotion itself rather than merely tolerating it.

## Quality gates

All exit codes captured on the runner's own command line, never through a pipe.

| Gate | Exit |
|---|---|
| `api-manifest.gen --check` | 0 |
| `api-manifest.api-md-check` | 0 |
| `api-manifest.doc-api-check` | 0 |
| `api-manifest.xray-spec-check` | 0 |
| `api-manifest.story-spec-check` | 0 |
| `api-manifest.skills-check` | 0 |
| `api-manifest.doc-guide-check` | 0 |
| api-manifest reconciler `clojure -M:test` | 0 (101 tests / 202 assertions) |
| `implementation/core` `clojure -M:test` | 0 (2301 tests / 11878 assertions) |
| `implementation/routing` `clojure -M:test` | 0 (559 / 3557) |
| `implementation/flows` `clojure -M:test` | 0 (266 / 6212) |
| `implementation/machines` `clojure -M:test` | 0 (1207 / 4367) |
| `implementation/resources` `clojure -M:test` | 0 (863 / 7686) |
| JVM late-bound resolve probe | 0 (5/5 families, 10/10 fn slots) |
| `scripts/check_doc_slugs.py` | 0 |
| `scripts/check_readme_links.py --ci` | 0 |
| `python -m mkdocs build --strict` | 0 |

**Sabotage proof (`doc-api-check`).** Planted a call-position `(rf/machine-algebra-view)` — a name this PR demotes — into `docs/api/re-frame.machines.md`, a file this PR changes. Match count read **1** before the run. Gate went **red, exit 1**, naming `docs/api/re-frame.machines.md:333  \`rf/machine-algebra-view\`  no manifest row`. Restored, verified **by git blob hash** against the committed object (`bbd09184…`, equal), re-ran green (exit 0). The plant existed only in this worktree, so the red is also the proof the gate read this tree.

A first plant attempt silently **no-opped** — the anchor was matched with `\n` against a CRLF file, and the tool still reported success. The pre-run match count caught it (read 0), and the blob hash confirmed the file was byte-identical. Recorded because that is the exact failure mode the match-count rule exists for.

**Gates left to CI, with reasons.** The CLJS lanes (`test:cljs`, `cljs-examples-compile`, adapter smokes, `test:xray-feature-gate`) were not run locally: this worktree has no `node_modules`, and the boundary rule forbids linking the shared tree for a gate that may reinstall it. Installing a private tree plus compiling would have pushed total gate time past the time box for evidence CI produces automatically. The CLJS risk is bounded by construction: **every deleted line sits inside a `#?(:clj …)` or `#?@(:clj …)` arm**, so the CLJS reader sees an identical namespace surface, and no CLJS-reachable reference to any algebra-view name changed (four-pass census — line-oriented, flattened, comment-stripped, hyphen-rejoined — reads 0 facade-qualified references against a live control of 176 tooling-qualified ones).

**Two gate limits, stated rather than papered over.** Neither link gate looks inside a fenced code block, so the `clojure` samples in the trimmed `docs/api` sections were checked by hand. And nothing grades prose for truth — the rewritten descriptions in `docs/api/*.md`, the five facade comments and the sidecar commentary are unverified by any gate.
