### PR TITLE
fix(flows): name the resolvable surface symbol in the flow-eval-exception :where (rf2-0v23)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -257,7 +257,7 @@
         stale-incarnation
         (rf.error/throw-error!
           :rf.error/flow-eval-exception
-          'rf/run-flows-on-db
+          're-frame.flows/run-flows-on-db
           (if (= :derive phase)
             (str "a flow's :derive fn threw while recomputing flow "
                  (pr-str flow-id)

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -592,8 +592,11 @@
         (is (some? thrown) "the rethrown ex-info reached the substrate record")
         (is (= :rf.error/flow-eval-exception (:rf.error/id data))
             ":rf.error/id is the canonical machine discriminator (was nil pre-fix)")
-        (is (= 'rf/run-flows-on-db (:where data))
-            ":where names the user-facing surface symbol (bare canonical slot)")
+        (is (= 're-frame.flows/run-flows-on-db (:where data))
+            ":where names the user-facing surface symbol (bare canonical slot),
+             qualified by its OWNING namespace because `run-flows-on-db` is not
+             exported by the `re-frame.core` facade — an `rf/`-prefixed spelling
+             would be a symbol the reader cannot resolve (rf2-0v23)")
         (is (= :no-recovery (:recovery data))
             ":recovery names the disposition (matches the catalogue row)")
         (is (string? (:reason data)) ":reason is a human sentence")


### PR DESCRIPTION
## What and why

`re-frame.flows/flow-eval-failure!` passed `'rf/run-flows-on-db` as the `where-sym`
of the `:rf.error/flow-eval-exception` it throws, so the diagnostic named a symbol
that does not exist. An author who read the message and typed the name got
"no such var" — the sequential failure rf2-z67m removed at seven sibling sites.

Verified at source rather than inferred from the pattern:

- `spec/api-manifest.edn` carries exactly one row for the name, and it is
  `{:namespace "re-frame.flows", :var "run-flows-on-db", … :facade? false}`.
- `implementation/core/src/re_frame/core.cljc` does not contain the name at all
  (0 occurrences).
- The live public set settles it: `(ns-publics 're-frame.core)` is 82 vars on the
  JVM and `run-flows-on-db` is not among them, while the control `reg-flow` is.

## The rule applied

`core.cljc`'s own name-the-real-door error map (`not-queryable-kinds`) spells a
symbol with `rf/` if and only if the facade exports it, and with its owning
namespace otherwise — it writes `re-frame.flows/flows` beside `rf/frame-ids` in
one map, and the manifest confirms the discriminator (`frame-ids` is a
`re-frame.core` row, `flows` is a `re-frame.flows` row with `:facade? false`).
So this becomes `'re-frame.flows/run-flows-on-db`.

## The test pin moves in the same commit

`flows_trace_test.clj`'s `flow-eval-boundary-rethrow-carries-canonical-thrown-error-shape`
pins this spelling. That test is about the canonical thrown-error SHAPE (rf2-cjr635):
a `:where` symbol present in the bare top-level ex-data slot, surviving an
`:exception`-dropping egress profile, alongside `:rf.error/id`, `:recovery`,
`:reason` and the `[:rf.error/<id>]` greppability token. Its intent is unchanged —
`:where` still names the user-facing surface symbol — and the assertion message now
states why the owning-namespace form is the correct one. A message and the test
that pins it are one holding, so both halves are in one commit.

## Behavioural proof

The error was triggered for real (a throwing `:derive` under a `reg-flow`, driven
through `dispatch-sync`) and the `:where` symbol resolved from inside a namespace
that does `(:require [re-frame.core :as rf])` — exactly what a reader would type:

| | `:where` symbol | resolves? |
|---|---|---|
| before | `rf/run-flows-on-db` | **nil** |
| after | `re-frame.flows/run-flows-on-db` | `#'re-frame.flows/run-flows-on-db` |

Controls in the same run: `rf/reg-flow` and `rf/dispatch` both resolve, so the
`nil` is a real absence and not a dead alias. The human `:reason` sentence and the
greppability token are byte-identical before and after; only the surface symbol moved.

## Scope

No public name moves. `spec/api-manifest.edn` (`:var-count 472`), its metadata
sidecar and `spec/API.md` are untouched, as is every `.beads` path.

## Quality gates

Passes 6, fails 0. Every exit code below was captured on the runner's own command
line (`cmd > log 2>&1; echo $? > exitfile`), never through a pipe.

| gate | exit | result |
|---|---|---|
| `implementation/flows` `clojure -M:test` | 0 | 266 tests, 6212 assertions, 0 failures, 0 errors |
| `implementation/core` `clojure -M:test` | 0 | 2301 tests, 11878 assertions, 0 failures, 0 errors |
| `implementation/core` `clojure -M:test -n re-frame.thrown-error-message-conformance-cljs-test` | 0 | 11 tests, 53 assertions — the conformance ns specifically, proving it was not disturbed |
| `python scripts/check_thrown_error_messages.py` | 0 | 333 framework source files scanned under `implementation` (`--verbose`); `--self-test` also exit 0, so the empty log is an honest pass rather than a dead instrument |
| `python scripts/check_retired_spellings.py`, `check_retired_composition_vocab.py`, `check_keyword_catalogue_drift.py`, `check_require_alias_dialect.py`, `check_architecture_census.py` | 0 each | ratchet-shaped scans that grade `implementation/**` |
| `python scripts/check_fast_pr_gap.py --brief` | 0 | run to learn what CI still owns (100 required checks with no lane locally); not itself a suite |

**Sabotage proof.** The pre-fix spelling was re-planted at the one line this PR
changes in `flows.cljc`. Pre-run match count for the anchor was **1** (not a
no-op plant), and the planted blob `10514dff17…` is byte-identical to the pre-fix
object named in the commit's own `index 10514dff17..b78b62bfe5` line. The flows
suite then exited **1**, naming the plant precisely:

```
FAIL in (flow-eval-boundary-rethrow-carries-canonical-thrown-error-shape) (flows_trace_test.clj:595)
expected: (= (quote re-frame.flows/run-flows-on-db) (:where data))
  actual: (not (= re-frame.flows/run-flows-on-db rf/run-flows-on-db))
Ran 266 tests containing 6212 assertions.
1 failures, 0 errors.
```

Same 266/6212 as the clean run, so the plant did not truncate the lane. The
restore was verified **by git blob hash** (`b78b62bfe5f16723df9cdc6aaf58117df81e9cb7`
== `HEAD:implementation/flows/src/re_frame/flows.cljc`), not by an exit code.

**Document gates deliberately not nominated**, because they do not cover
`implementation/**`: `mkdocs build --strict` (`docs_dir: docs`, plus `spec/` and
`migration/` staged in by `mkdocs_hooks.py` — `implementation/` was never a
candidate and `mkdocs_hooks.py` classes it as "CLJS source; not docs"), and
`scripts/check_doc_slugs.py` (`DEFAULT_ROOTS` is `docs`, `spec`, `skills`,
`migration`, plus `tools/*/spec`). `scripts/check_readme_links.py --ci` does reach
markdown beside source, but this diff contains no markdown at all.

## Same class, found and left (not fixed here)

A controlled sweep of `'rf/…` symbols in `where-sym` argument position across
`implementation/**/src` found 138 candidates: 115 resolve on the facade, **21 do
not** — the largest clusters being `interceptor_registry.cljc` (4),
`adapters/test-react` (4, local-test-only), and three `rf/render` sites in
`substrate/plain_atom.cljc`, `substrate/spine.cljs` and `ssr/substrate.cljc`.
These are left for the durable fix rf2-z67m recommends.

One finding matters for that fix's design: **`spec/api-manifest.edn` alone is not
a sufficient oracle.** It carries public *documented* vars, so `^:no-doc` facade
publics have no row — a manifest-only test produced 23 hits where the live public
set produced 21, falsely flagging `rf/reset-frame!` and `rf/reload-images!`, both
of which do resolve. The oracle should be `ns-publics` of the facade (or the
manifest unioned with the no-doc publics).

Refs: rf2-0v23
