### PR TITLE
gate(errors): assert a thrown error's where-sym names a reachable var (rf2-z5lv)

### DIFF
--- a/scripts/_test_fixtures/check_thrown_error_messages/wheresym/negative_where_syms.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/wheresym/negative_where_syms.cljc
@@ -1,0 +1,124 @@
+(ns wheresym.negative-where-syms
+  "NEGATIVE where-sym fixtures (rf2-z5lv): every one of these must stay GREEN.
+
+  A gate that only proves it FIRES is half a gate. These pin the other half —
+  and specifically the three ways this rule could go wrong in the expensive
+  direction, by reporting correct code:
+
+    * demanding a SPELLING rather than resolvability. `rf.fixture/known-public`
+      and `re-frame.fixture/known-public` are the same var written two ways and
+      both are right, exactly as `re-frame.core`'s own `not-queryable-kinds`
+      map writes `re-frame.flows/flows` beside `rf/frame-ids`;
+    * grading against DOCUMENTED publics rather than public vars — the
+      `^:no-doc` case, which is the whole reason the manifest is not the
+      oracle;
+    * grading against ONE runtime — the `#?(:cljs …)` / `#?(:clj …)` case,
+      which is how `rf/frame-provider` and `rf/frame-root` ship."
+  (:require [re-frame.error :as rf.error]))
+
+;; ---- resolvable, both spellings ------------------------------------------
+
+(defn alias-spelling []
+  (rf.error/throw-error!
+    :rf.error/ok-one
+    'rf.fixture/known-public
+    "the canonical alias dialect"))
+
+(defn fully-qualified-spelling []
+  (rf.error/throw-error!
+    :rf.error/ok-two
+    're-frame.fixture/known-public
+    "THE SAME VAR, fully qualified. Both are correct."))
+
+;; ---- resolvable across every public definition shape ---------------------
+
+(defn plain-var []
+  (rf.error/throw-error! :rf.error/ok-three 'rf.fixture/known-var "a `def`"))
+
+(defn macro []
+  (rf.error/throw-error! :rf.error/ok-four 'rf.fixture/known-macro "a `defmacro`"))
+
+(defn multi []
+  (rf.error/throw-error! :rf.error/ok-five 'rf.fixture/known-multi "a `defmulti`"))
+
+(defn no-doc []
+  (rf.error/throw-error!
+    :rf.error/ok-six
+    'rf.fixture/no-doc-public
+    "`^:no-doc` is a DOCUMENTATION flag, not a privacy one. It resolves, and it
+     carries no manifest row — which is why a manifest-only oracle reported
+     `reset-frame!` and `reload-images!` as dead doors."))
+
+(defn cljs-only []
+  (rf.error/throw-error!
+    :rf.error/ok-seven
+    'rf.fixture/cljs-only-public
+    "public under `:cljs` only. A JVM-only oracle reports this as a dead door."))
+
+(defn clj-only []
+  (rf.error/throw-error!
+    :rf.error/ok-eight
+    'rf.fixture/clj-only-public
+    "public under `:clj` only."))
+
+(defn var-defining-macros []
+  (rf.error/throw-error! :rf.error/ok-nine 'rf.fixture/Panel "defined by `reg-view`")
+  (rf.error/throw-error! :rf.error/ok-ten 'rf.fixture/imported-fn "interned by `import-fn`"))
+
+;; ---- not checkable, and saying so is honest ------------------------------
+
+(defn third-party []
+  (rf.error/throw-error!
+    :rf.error/ok-eleven
+    'thirdparty.lib/whatever
+    "a namespace this tree does not define and does not own. Nothing here can
+     say whether it resolves, so it is counted and skipped rather than guessed
+     at in either direction."))
+
+(defn unqualified []
+  (rf.error/throw-error!
+    :rf.error/ok-twelve
+    'some-local-macro
+    "no namespace to check it against. Two of these live on trunk."))
+
+;; ---- text that LOOKS like a site but is not ------------------------------
+
+(defn quoted-in-a-docstring
+  "A docstring may quote the shape it documents:
+     (rf.error/throw-error! :rf.error/x 'rf.fixture/ghost-in-a-docstring reason)
+   `re-frame.error`'s own docstrings do exactly this, so a scan that left
+   strings visible would report the documentation of this contract as a
+   violation of it."
+  []
+  :ok)
+
+;; A comment may quote it too:
+;;   (rf.error/throw-error! :rf.error/x 'rf.fixture/ghost-in-a-comment reason)
+
+(defn char-literal-then-a-real-call [c]
+  ;; REGRESSION PIN. `\"` outside a string is the character `"`, not a
+  ;; delimiter. Read as a delimiter it swallows the rest of the file — measured
+  ;; on `re-frame.ssr.html-helpers`, where it took both real where-syms with it
+  ;; and the scan reported zero. The call below must still be SEEN (and must
+  ;; resolve, so this fixture stays green): if the mask desynchronises here, the
+  ;; positive fixture's later sites are the ones that go quiet.
+  (when (= c \")
+    (rf.error/throw-error!
+      :rf.error/ok-thirteen
+      'rf.fixture/known-public
+      "reached past a character literal")))
+
+(defn no-error-id-is-not-a-framework-error []
+  ;; `:where` in a map WITHOUT `:rf.error/id` is not a framework thrown error,
+  ;; so the slot is not read. rf2:builder-bypass-ok
+  (throw (ex-info "an application's own error"
+                  {:where 'rf.fixture/ghost-not-a-framework-error})))
+
+(defn nested-quoted-symbol-is-not-a-where-sym []
+  ;; Only a TOP-LEVEL argument that is EXACTLY a quoted symbol is a where-sym.
+  ;; A quoted symbol riding inside `:extra` is data the site chose to carry.
+  (rf.error/throw-error!
+    :rf.error/ok-fourteen
+    'rf.fixture/known-public
+    "the where-sym is the top-level one"
+    {:extra {:sym 'rf.fixture/ghost-nested}}))

--- a/scripts/_test_fixtures/check_thrown_error_messages/wheresym/positive_where_syms.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/wheresym/positive_where_syms.cljc
@@ -1,0 +1,126 @@
+(ns wheresym.positive-where-syms
+  "POSITIVE where-sym fixtures (rf2-z5lv): every one of these must FIRE.
+
+  Two families are planted here, and they are separate on purpose.
+
+  (1) FORMATTING VARIANTS OF THE CALL HEAD. A sibling gate in this directory
+      shipped matching only calls whose callee sat tight against the paren —
+      and its self-test stayed green, because all five of its positive
+      fixtures wrote it that way. The gate and its own tests shared one blind
+      spot and agreed with each other (audit #9491). So the head is written
+      here tight, behind a space, behind a newline, behind a comment, and
+      unqualified, and the self-test pins LINE NUMBERS rather than a count:
+      a count cannot separate `found the right ones` from `traded a real hit
+      for a false positive`.
+
+  (2) REASONS A SYMBOL DOES NOT RESOLVE. Not-public is not one thing: the
+      namespace may not exist, the var may be private by three different
+      spellings, or the name may belong to a `defmethod` that extends a
+      multimethod without defining anything.
+
+  `re-frame.fixture` is the oracle fixture beside this file. `rf.fixture/…`
+  and `re-frame.fixture/…` are the SAME namespace under the canonical alias
+  dialect, which is why a private var fires under BOTH spellings — the rule is
+  resolvability, never a spelling."
+  (:require [re-frame.error :as rf.error]
+            [re-frame.error :refer [throw-error!]]))
+
+;; ---- (1) the call head, five reader-equivalent formattings ---------------
+
+(defn ghost-tight []
+  (rf.error/throw-error!
+    :rf.error/ghost-one
+    'rf.fixture/ghost-one
+    "the callee sits tight against the paren"))
+
+(defn ghost-space []
+  ( rf.error/throw-error!
+    :rf.error/ghost-two
+    'rf.fixture/ghost-two
+    "a space between the paren and the callee"))
+
+(defn ghost-newline []
+  (
+    rf.error/throw-error!
+    :rf.error/ghost-three
+    'rf.fixture/ghost-three
+    "a newline between the paren and the callee"))
+
+(defn ghost-comment []
+  ( ;; a comment, then a newline, then the callee
+    rf.error/throw-error!
+    :rf.error/ghost-four
+    'rf.fixture/ghost-four
+    "a comment between the paren and the callee"))
+
+(defn ghost-unqualified-head []
+  (throw-error! :rf.error/ghost-five 'rf.fixture/ghost-five
+                "an unqualified callee, and the where-sym INLINE on the head line"))
+
+;; ---- (1b) the other two rostered builders --------------------------------
+;;
+;; `_WHERE_SYM_FORMS` is a roster, and the self-test holds every entry to
+;; owning a case here. `throw-inline-interceptor-removed!` is why the where-sym
+;; is taken as THE QUOTED-SYMBOL ARGUMENT rather than by index: its where-sym
+;; is the FIRST argument, not the second.
+
+(defn ghost-thrown-ex-info []
+  (throw (rf.error/thrown-ex-info
+           :rf.error/ghost-six
+           'rf.fixture/ghost-six
+           "thrown-ex-info builds without throwing; same where-sym position")))
+
+(defn ghost-inline-interceptor []
+  (rf.error/throw-inline-interceptor-removed!
+    'rf.fixture/ghost-seven
+    "this builder takes its where-sym FIRST"
+    {:entry :x}))
+
+;; ---- (1c) the `:where` SLOT of a hand-built framework ex-data map ---------
+;;
+;; Invisible to the builder scan, and not a corner: six of the façade-family
+;; findings on trunk are slot sites in `re-frame.conformance`. The message here
+;; is deliberately CONFORMANT (it carries the token), so the only thing that
+;; can fire is the where-sym rule.
+
+(defn ghost-where-slot []
+  (throw (ex-info "hand-built payload [:rf.error/ghost-eight]"
+                  {:rf.error/id :rf.error/ghost-eight
+                   :where       'rf.fixture/ghost-eight
+                   :reason      "hand-built payload"})))
+
+;; ---- (2) the reasons a symbol does not resolve ---------------------------
+
+(defn unknown-namespace []
+  (rf.error/throw-error!
+    :rf.error/no-such-ns
+    'rf.nosuch/thing
+    "no namespace `re-frame.nosuch` exists in this tree"))
+
+(defn private-defn- []
+  (rf.error/throw-error!
+    :rf.error/private-defn
+    're-frame.fixture/private-fn
+    "FULLY QUALIFIED and still a dead door — the var is `defn-`. This is the
+     live `'re-frame.router/build-envelope` shape, and it is why the rule
+     cannot be `always fully qualify`."))
+
+(defn private-meta-keyword []
+  (rf.error/throw-error!
+    :rf.error/private-var
+    'rf.fixture/private-var
+    "`^:private`"))
+
+(defn private-meta-map []
+  (rf.error/throw-error!
+    :rf.error/private-meta-var
+    'rf.fixture/private-meta-var
+    "`^{:private true}`"))
+
+(defn defmethod-defines-nothing []
+  (rf.error/throw-error!
+    :rf.error/foreign-multi
+    'rf.fixture/foreign-multi
+    "`defmethod` EXTENDS a multimethod; it defines no var, so this name is not
+     public in the fixture namespace. Drop the `defmethod` carve-out from
+     `_public_names_defined_by` and this site goes green."))

--- a/scripts/_test_fixtures/check_thrown_error_messages/wheresym/re_frame/fixture.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/wheresym/re_frame/fixture.cljc
@@ -1,0 +1,83 @@
+(ns re-frame.fixture
+  "THE ORACLE FIXTURE for the where-sym rule (rf2-z5lv).
+
+  Not a live namespace. It exists so the self-test can grade where-syms
+  against a public-var set it CONTROLS, rather than against the real tree
+  — where a legitimate rename would move the fixtures' answers.
+
+  Its file path is the MUNGED namespace (`re_frame/fixture.cljc`), because
+  `PublicVarIndex` resolves a namespace by that munge and by nothing else.
+  It sits under the canonical alias dialect too, so `'rf.fixture/x` and
+  `'re-frame.fixture/x` are the SAME symbol spelled two ways — which is what
+  the negative fixture uses to pin that the rule is resolvability, never a
+  spelling.
+
+  Every definition shape below is load-bearing: the public ones must be
+  reachable and the private ones must NOT be, or the rule reports the wrong
+  answer in one of its two directions."
+  (:require [re-frame.core :as rf]))
+
+;; ---- PUBLIC: the ordinary shapes -----------------------------------------
+
+(def known-var 1)
+
+(defn known-public [x] x)
+
+(defmacro known-macro [x] x)
+
+(defmulti known-multi :kind)
+
+;; ---- PUBLIC: `^:no-doc`, WHICH IS THE WHOLE MANIFEST-ORACLE REFUTATION ----
+;;
+;; `spec/api-manifest.edn` rows DOCUMENTED publics, so a `^:no-doc` var is
+;; fully resolvable and carries no row. On trunk `re-frame.core` ships eleven
+;; of them (`reset-frame!` and `reload-images!` among them), and a
+;; manifest-only oracle reported both as dead doors. Pinned here so the
+;; refutation cannot be quietly undone.
+(def ^:no-doc no-doc-public 2)
+
+;; ---- PUBLIC on ONE PLATFORM ONLY -----------------------------------------
+;;
+;; The façade ships `rf/frame-provider` and `rf/frame-root` exactly like this.
+;; They are absent from the JVM's `ns-publics` and present in every CLJS build,
+;; so the rule asserts about the UNION of the arms; a JVM-only oracle reports
+;; both as dead doors.
+#?(:cljs (def cljs-only-public 3))
+#?(:clj  (def clj-only-public 4))
+
+;; ---- PUBLIC through a var-defining macro that does not begin `def` --------
+;;
+;; `_EXTRA_DEF_HEADS`. Both of these are real shapes: `reg-view` defines the
+;; component var (eleven Xray namespaces row one), and `import-fn` interns a
+;; re-export (`re-frame.ssr.ring` ships five). The manifest control caught the
+;; parser missing both.
+(rf/reg-view Panel
+  [:div "panel"])
+
+(import-fn re-frame.other/imported-fn)
+
+;; ---- PRIVATE: must NOT be reachable --------------------------------------
+;;
+;; A private var does not resolve for a reader either, so a where-sym naming
+;; one is a dead door even when fully qualified — which is the live
+;; `'re-frame.router/build-envelope` shape, a `defn-`.
+
+(defn- private-fn [x] x)
+
+(def ^:private private-var 5)
+
+(def ^{:private true} private-meta-var 6)
+
+;; ---- DEFINES NOTHING: `defmethod` extends, it does not define -------------
+;;
+;; `foreign-multi` is deliberately NOT defined here — it stands for a
+;; multimethod owned elsewhere and extended from this namespace. That is what
+;; makes it a DISCRIMINATOR: drop the `defmethod` carve-out from
+;; `_public_names_defined_by` and this name becomes "public", which greens the
+;; positive fixture's `'rf.fixture/foreign-multi` site. Extending
+;; `known-multi` instead would prove nothing, because `defmulti` already
+;; defines that name.
+
+(defmethod known-multi :a [_] :a)
+
+(defmethod foreign-multi :b [_] :b)

--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -119,12 +119,51 @@ names it). The one framework artefact that CANNOT `:require` `re-frame.error`
 (the bundle-isolated `reagent-slim` adapter) hand-rolls a human sentence
 inline — so it too must clear the gate, and it is under `implementation/`.
 
-Exit code:
-    0  no bare-keyword thrown-error message in framework source
-    1  at least one (results printed file:line)
-    2  invocation / setup error
+THE WHERE-SYM RULE (rf2-z5lv) — the door the message names must EXIST
 
-Dependency-light — Python stdlib only.
+The rules above grade the MESSAGE. This one grades the other half of the same
+promise. `thrown-ex-info` / `throw-error!` take a `where-sym` as their SECOND
+positional argument and land it in `:where`, and its whole job — in
+`re-frame.error`'s own words — is that "a grep-for-symbol lands on the call
+site". A where-sym that names nothing reachable sends the author who reads the
+message to a door that is not there.
+
+Three beads paid for that one site at a time (rf2-z67m fixed seven, rf2-0v23 an
+eighth, and a sweep measured twenty-one more), which is what makes it a gate's
+job rather than a fix's.
+
+  * THE RULE IS RESOLVABILITY, NOT A SPELLING. `re-frame.core`'s own
+    `not-queryable-kinds` map writes `re-frame.flows/flows` fully qualified
+    beside `rf/frame-ids` under the façade alias, in the same map, and both are
+    right — the discriminator is whether the namespace exports the name. A
+    fully-qualified symbol still fails when the var is private, which is the
+    live `'re-frame.router/build-envelope` (a `defn-`) shape.
+  * THE ORACLE IS THE PUBLIC VAR SET, NOT `spec/api-manifest.edn`, which rows
+    DOCUMENTED publics only — measured on trunk, `re-frame.core` has 71 rows
+    against 82 JVM publics, and the `^:no-doc` façade stubs `reset-frame!` /
+    `reload-images!` carry none. The manifest is used instead as the
+    INDEPENDENT CONTROL on the derived oracle (`oracle_problems`).
+  * IT ASSERTS ABOUT BOTH RUNTIMES. The public set is read from source across
+    both reader-conditional arms, because `rf/frame-provider` and
+    `rf/frame-root` are `#?(:cljs (def …))` façade exports that a JVM-only
+    oracle reports as dead doors.
+  * IT DOES NOT RED THE TREE. `scripts/where-sym-baseline.edn` records what
+    trunk already carries; an unlisted symbol has a floor of zero, so a NEW
+    dead door fails, and a recorded floor ratchets DOWN only.
+
+Both halves of the where-sym rule are defined over the ROSTERED scan surface,
+so `--scan-dir` skips it rather than misgrading an ad-hoc corpus.
+
+Exit code:
+    0  no bare-keyword thrown-error message in framework source, and no
+       where-sym over its recorded floor
+    1  at least one (results printed file:line)
+    2  invocation / setup error, or an instrument that cannot be trusted —
+       the derived public-var oracle contradicting the generated manifest, or
+       a where-sym population collapsed below `:min-where-syms`
+
+Dependency-light — Python stdlib only (plus `git ls-files`, for the tracked
+Clojure roster the where-sym oracle resolves against).
 """
 
 from __future__ import annotations
@@ -852,6 +891,827 @@ class Finding(NamedTuple):
     line: int
     kind: str
     snippet: str
+    # The WHERE-SYM findings below carry the offending symbol here. The bare
+    # keyword / builder-bypass kinds have no such datum and leave it empty.
+    # A default keeps every existing construction site a 4-tuple.
+    detail: str = ""
+
+
+# --------------------------------------------------------------------------
+# THE WHERE-SYM RULE (rf2-z5lv) — the door the message sends the author to
+# must EXIST
+# --------------------------------------------------------------------------
+#
+# `thrown-ex-info` / `throw-error!` take a `where-sym` as their SECOND
+# positional argument and land it in the ex-data `:where` slot. Its whole job,
+# in `re-frame.error`'s own words, is that "a grep-for-symbol lands on the call
+# site" — so an author reads the thrown message, types the symbol, and expects
+# to find something. When the symbol names nothing that resolves, the message
+# sends them to a door that is not there.
+#
+# Three beads have now paid for that one site at a time: rf2-z67m fixed seven,
+# rf2-0v23 an eighth, and a sweep for rf2-z5lv measured twenty-one more. This
+# section is what stops the twenty-second being written.
+#
+# THE RULE IS RESOLVABILITY, NOT A SPELLING. `re-frame.core`'s own
+# `not-queryable-kinds` map writes `re-frame.flows/flows` fully qualified
+# BESIDE `rf/frame-ids` under the façade alias, in the same map, and both are
+# right — the discriminator is whether the façade exports the name, not how the
+# symbol is spelled. So a check that demanded fully-qualified symbols would be
+# wrong about live, correct code. What is asserted here is only that the symbol
+# NAMES SOMETHING REACHABLE.
+#
+# THE ORACLE IS THE PUBLIC VAR SET, NOT `spec/api-manifest.edn`. The manifest
+# rows DOCUMENTED publics, so a `^:no-doc` façade export resolves perfectly and
+# carries no row: measured on trunk, `re-frame.core` has 71 manifest rows
+# against 82 JVM `ns-publics` (84 counting the two `#?(:cljs …)` arms), and
+# `reset-frame!` / `reload-images!` — live `^:no-doc` façade stubs — carry zero
+# rows apiece. A manifest-only oracle therefore reports non-resolving sites that
+# resolve. The manifest is used here for something it IS authoritative about:
+# see `_manifest_rows` and `oracle_problems` below, where it is the independent
+# second instrument that catches this one going blind.
+#
+# WHICH RUNTIME. The public set is read from SOURCE, across BOTH reader-
+# conditional arms, so a name public under `:clj` OR `:cljs` resolves. That is a
+# deliberate union and it is measured, not assumed: `rf/frame-provider` and
+# `rf/frame-root` are `#?(:cljs (def …))` façade exports, absent from the JVM's
+# `ns-publics` and present in every CLJS build, and a JVM-only oracle would
+# report both as dead doors. The union is also the only direction that cannot
+# manufacture a false red on a legitimately platform-specific name. It does
+# leave one honest gap — a where-sym naming a CLJS-only var thrown from a
+# JVM-only path is a dead door for a JVM reader and passes here — which is a
+# bound worth stating rather than a defect worth machinery: the name still
+# exists in the tree, so the grep the where-sym exists to serve still lands.
+
+# The forms that take a where-sym. A ROSTER, because there is no textual
+# property that separates "an argument that is a where-sym" from "an argument
+# that is a quoted symbol"; the self-test holds every entry to owning a fixture,
+# the way `_STR_ERR_VAR_NAMES` and `_VECTOR_BINDER_HEADS` already are. A missing
+# entry costs a MISSED site, so `:min-where-syms` in the baseline is what keeps
+# that from being silent.
+#
+# The where-sym is taken as THE QUOTED-SYMBOL ARGUMENT rather than by index,
+# which is why one roster serves forms whose where-sym sits in different
+# positions (`throw-error!` second, `throw-inline-interceptor-removed!` first).
+# Measured over the whole scan surface: 267 rostered calls, 180 with exactly one
+# quoted-symbol argument and 87 with none — never two. A nested quoted symbol
+# (inside an `:extra` map, say) is invisible to this, because only a TOP-LEVEL
+# argument that is EXACTLY a quoted symbol is read.
+_WHERE_SYM_FORMS: tuple[str, ...] = (
+    "throw-error!",
+    "thrown-ex-info",
+    "throw-inline-interceptor-removed!",
+)
+
+# `\b` IS THE WRONG GUARD HERE AND FAILS SILENTLY. Every builder but one ends
+# in `!`, and `!` is not a word character — so `throw-error!\b` requires a word
+# character immediately after the `!`, which never occurs, and the pattern
+# matches NOTHING while looking exactly like a pattern that works. Measured on a
+# two-call sample: the `\b` form read 0, this one read 2. A trailing negative
+# lookahead over the symbol-constituent class is the correct guard.
+_SYM_TAIL = r"(?![\w*+!?<>=-])"
+_WHERE_CALL_RE = re.compile(
+    r"\(\s*(?:[\w.*+!?<>=-]+/)?("
+    + "|".join(re.escape(f) for f in _WHERE_SYM_FORMS)
+    + r")" + _SYM_TAIL
+)
+
+# A Clojure symbol, and the quoted symbol that is a where-sym. The `/` is a
+# SEPARATE alternation rather than a member of the character class: putting it
+# in the class would let `a/b/c` through, and leaving it out of the pattern
+# altogether — which is the mistake that made a first pass of this scan report
+# two where-syms where there are 193 — matches only the unqualified ones.
+_CLJ_SYM = r"[A-Za-z0-9_.*+!?<>=&$%|-]+"
+_QUOTED_SYM_RE = re.compile(r"^'(" + _CLJ_SYM + r"(?:/" + _CLJ_SYM + r")?)$")
+
+# `:where <form>` inside an ex-data map. The canonical builders write this slot
+# themselves, so it is only READ here for the raw `(ex-info … {… :rf.error/id …
+# :where '<sym> …})` sites that build their payload by hand. Those are invisible
+# to the builder scan above and are not a corner: six of the façade-family
+# findings on trunk are `:where`-slot sites in `re-frame.conformance`.
+_WHERE_KEY_RE = re.compile(r":where" + _SYM_TAIL)
+
+# THE CANONICAL ALIAS DIALECT, from `spec/Conventions.md` §Require-alias dialect
+# (the same mapping `scripts/check_require_alias_dialect.py` ratchets the tree
+# onto): `re-frame.core` takes the bare root alias `rf`, every other framework
+# namespace takes `rf.<full dotted tail>`. A where-sym is USER-FACING text — it
+# tells an author what to type — so it is resolved against that one public
+# dialect, never against the aliases of the file it happens to be written in.
+_ROOT_ALIAS = "rf"
+_ROOT_NS = "re-frame.core"
+_FRAMEWORK_NS_PREFIX = "re-frame"
+
+
+def _namespace_of_where_sym(qualifier: str) -> str:
+    """The namespace a where-sym's QUALIFIER names, under the canonical dialect."""
+    if qualifier == _ROOT_ALIAS:
+        return _ROOT_NS
+    if qualifier.startswith(_ROOT_ALIAS + "."):
+        return _FRAMEWORK_NS_PREFIX + "." + qualifier[len(_ROOT_ALIAS) + 1:]
+    return qualifier
+
+
+def _is_framework_family(qualifier: str, namespace: str) -> bool:
+    """Is this where-sym one the FRAMEWORK owns — so a namespace that does not
+    exist is a finding rather than an unknowable third-party reference?"""
+    return (
+        qualifier == _ROOT_ALIAS
+        or qualifier.startswith(_ROOT_ALIAS + ".")
+        or qualifier.startswith(_ROOT_ALIAS + "-")
+        or namespace == _FRAMEWORK_NS_PREFIX
+        or namespace.startswith(_FRAMEWORK_NS_PREFIX + ".")
+    )
+
+
+# --------------------------------------------------------------------------
+# The oracle: a namespace's PUBLIC VAR set, read statically from source
+# --------------------------------------------------------------------------
+#
+# WHY STATIC. The truth is `ns-publics`, and this gate cannot call it: it runs
+# as a bare `python scripts/…` step in the PR spine, in ~1s, with no JVM and no
+# shadow-cljs compile (CLJS has no runtime `ns-publics` at all — the manifest
+# generator's own CLJS probe has to read the ANALYZER's compilation env at
+# compile time). So the public set is derived from source text, and the design
+# question is not "is a static parse exact?" — it is "what catches it when it
+# stops being?". Two things do, and they fail in opposite directions:
+#
+#   * the parse going BLIND fails CLOSED and loudly: publics vanish, so
+#     where-syms that used to resolve stop resolving and the gate reds naming
+#     each one. There is no silent-zero direction here.
+#   * the parse going TOO GENEROUS is the dangerous direction, and
+#     `oracle_problems` below is the guard: `spec/api-manifest.edn` is generated
+#     from live `ns-publics` by a different tool on a different runtime, so
+#     every rowed var MUST appear in the derived set. It is a strict subset
+#     (the manifest drops `^:no-doc`), which is exactly what makes it usable as
+#     a floor. Measured on trunk: 472 rows across 48 namespaces, all present.
+#     That control has already earned its place — it caught this parser missing
+#     `(import-fn …)` re-exports in `re-frame.ssr.ring` and `(rf/reg-view Panel
+#     …)` component vars across eleven Xray namespaces, both of which would
+#     otherwise have produced confident, well-formed FALSE findings.
+#
+# THE RULE, NOT A ROSTER: a top-level form whose head — after any namespace
+# qualifier — begins `def` defines its first non-metadata symbol argument.
+# `defn-` and any other `def…-` spelling is private by convention, `^:private`
+# / `^{:private true}` is private by declaration, and `defmethod` extends a
+# multimethod rather than defining a var. That rule covers `def`, `defn`,
+# `defmacro`, `defmulti`, `defrecord`, `defprotocol` and — the reason it is a
+# rule and not a list — this tree's own var-defining macros
+# (`defreg-macro reg-sub`, `defreg-event-macro reg-event`, `defwrapper`), which
+# a list would have missed and which supply 27 of the façade's 84 publics.
+# `_EXTRA_DEF_HEADS` carries the two var-defining macros that do NOT begin
+# `def`; the manifest control above is what says when a third one appears.
+_EXTRA_DEF_HEADS = frozenset({"reg-view", "import-fn"})
+
+_FORM_HEAD_TOKEN_RE = re.compile(r"\(\s*(:?[A-Za-z0-9_.*+!?<>=&$%|'/-]+)")
+_PRIVATE_META_RE = re.compile(r"\^\s*(?::private\b|\{[^{}]*:private\s+true)")
+# A reader-conditional arm head (`#?(:clj …)`) and the two transparent wrappers
+# a top-level def hides behind. `#?(:cljs (def frame-root …))` is how the façade
+# ships its two CLJS-only exports, so a scan that does not descend here reports
+# them as dead doors — the exact false red this section exists to avoid.
+_PLATFORM_KEYWORD_RE = re.compile(r"^:(clj|cljs|cljr|default)$")
+_TRANSPARENT_DEF_WRAPPERS = frozenset({"do", "comment"})
+_NS_FORM_RE = re.compile(
+    r"\(\s*ns\s+(?:\^\{[^{}]*\}\s+|\^[\w:.-]+\s+)*(" + _CLJ_SYM + r")"
+)
+
+
+def _top_level_forms(masked: str) -> Iterable[str]:
+    """Every balanced top-level `( … )` form in comment-masked text."""
+    i = 0
+    n = len(masked)
+    while i < n:
+        if masked[i] == "(":
+            end = _balanced_extent(masked, i)
+            if end is None:
+                return
+            yield masked[i:end]
+            i = end
+        else:
+            i += 1
+
+
+def _public_names_defined_by(form: str) -> list[str]:
+    """The PUBLIC var names a top-level form defines (see the rule above)."""
+    m = _FORM_HEAD_TOKEN_RE.match(form)
+    if not m:
+        return []
+    raw_head = m.group(1)
+    head = raw_head.rsplit("/", 1)[-1]
+    # The form's closing paren must come off, or a single-argument form's
+    # only argument is returned WITH it and matches no symbol pattern. That
+    # is not hypothetical: it is what hid every `(import-fn …)` re-export.
+    body = form[m.end():-1]
+    if _PLATFORM_KEYWORD_RE.match(raw_head):
+        return [n for f in _top_level_forms(form[1:-1])
+                for n in _public_names_defined_by(f)]
+    if head in _TRANSPARENT_DEF_WRAPPERS:
+        return [n for f in _top_level_forms(body)
+                for n in _public_names_defined_by(f)]
+    if head == "import-fn":
+        # `(import-fn <ns>/<name>)` interns `<name>` in THIS namespace.
+        forms = _split_forms(body)
+        if forms and re.fullmatch(_CLJ_SYM + r"(?:/" + _CLJ_SYM + r")?", forms[0]):
+            return [forms[0].rsplit("/", 1)[-1]]
+        return []
+    defines = (
+        head.startswith("def") and not head.endswith("-") and head != "defmethod"
+    ) or head in _EXTRA_DEF_HEADS
+    if not defines:
+        return []
+    for arg in _split_forms(body):
+        if arg.startswith("^"):
+            if _PRIVATE_META_RE.search(arg):
+                return []
+            continue
+        return [arg] if re.fullmatch(_CLJ_SYM, arg) else []
+    return []
+
+
+def _namespace_and_publics(path: Path) -> tuple[str | None, set[str]]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None, set()
+    masked = "\n".join(_mask_comments(text))
+    ns_match = _NS_FORM_RE.search(masked)
+    names: set[str] = set()
+    for form in _top_level_forms(masked):
+        names.update(_public_names_defined_by(form))
+    return (ns_match.group(1) if ns_match else None), names
+
+
+class PublicVarIndex:
+    """`namespace -> public var names`, resolved lazily by the standard
+    `re-frame.core -> re_frame/core.clj[cs]` munge.
+
+    LAZY BY MUNGED PATH, not an eager index of the tree. Eagerly reading all
+    2820 tracked Clojure sources to learn their `ns` forms took 21s; resolving
+    only the dozen-odd namespaces the where-syms actually name takes 0.03s to
+    prepare and reads one file per namespace. The whole point of a gate hosted
+    in the always-on PR spine is that it costs nothing to run.
+    """
+
+    def __init__(self, source_paths: Iterable[Path]):
+        self._by_stem: dict[str, list[Path]] = {}
+        for path in source_paths:
+            posix = path.as_posix()
+            for suffix in _SOURCE_SUFFIXES:
+                if posix.endswith(suffix):
+                    self._by_stem.setdefault(
+                        posix[:-len(suffix)], []
+                    ).append(path)
+                    break
+        self._cache: dict[str, set[str] | None] = {}
+
+    def files_for(self, namespace: str) -> list[Path]:
+        stem = namespace.replace("-", "_").replace(".", "/")
+        return [
+            path
+            for key, paths in self._by_stem.items()
+            if key == stem or key.endswith("/" + stem)
+            for path in paths
+        ]
+
+    def publics_of(self, namespace: str) -> set[str] | None:
+        """The namespace's public var names, or None when this tree defines no
+        such namespace. None is a DIFFERENT ANSWER from the empty set, and
+        conflating them is how a scan reports a confident clean sweep over a
+        namespace it never opened."""
+        if namespace in self._cache:
+            return self._cache[namespace]
+        paths = self.files_for(namespace)
+        names: set[str] | None = None
+        for path in paths:
+            found_ns, publics = _namespace_and_publics(path)
+            if found_ns != namespace:
+                continue
+            names = (names or set()) | publics
+        self._cache[namespace] = names
+        return names
+
+
+class OracleUnavailable(Exception):
+    """The tree the public-var oracle needs could not be enumerated."""
+
+
+def _tracked_clojure_sources(repo_root: Path) -> list[Path]:
+    """Every git-tracked Clojure source in the repository.
+
+    GIT-TRACKED, not walked. An untracked scratch namespace must not be able to
+    make a where-sym resolve, and a built checkout carries tens of thousands of
+    compiler-output files a walk would have to prune. `scripts/_test_fixtures/`
+    is excluded for the reason its siblings state: it is where every checker in
+    this directory plants the defect it exists to catch, so a fixture's
+    deliberately-broken namespace is not a public surface.
+
+    An empty result is an ERROR, never an empty oracle. Recognising nothing and
+    finding nothing are different outcomes, and only one of them is a clean
+    tree — with an empty oracle EVERY where-sym would be reported as a dead
+    door, which is loud, but the diagnosis would name the wrong thing.
+    """
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["git", "ls-files", "--", "*.clj", "*.cljc", "*.cljs"],
+            cwd=repo_root, capture_output=True, text=True, check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise OracleUnavailable(
+            f"cannot enumerate git-tracked Clojure sources under {repo_root}: "
+            f"{exc}. The where-sym rule resolves a symbol against the public "
+            "vars of the namespace it names, which needs the tracked tree."
+        ) from exc
+    paths = [
+        repo_root / rel
+        for rel in out.split("\n")
+        if rel and not rel.startswith("scripts/_test_fixtures/")
+    ]
+    if not paths:
+        raise OracleUnavailable(
+            f"no git-tracked Clojure sources under {repo_root}. The where-sym "
+            "oracle would be empty, which is not the same as a clean tree."
+        )
+    return paths
+
+
+_MANIFEST_REL = "spec/api-manifest.edn"
+_MANIFEST_ROW_RE = re.compile(r':namespace "([^"]+)", :var "([^"]+)"')
+
+
+def _manifest_rows(repo_root: Path) -> dict[str, set[str]]:
+    """`namespace -> rowed var names` from the GENERATED public-API manifest."""
+    text = (repo_root / _MANIFEST_REL).read_text(encoding="utf-8", errors="replace")
+    rows: dict[str, set[str]] = {}
+    for namespace, var in _MANIFEST_ROW_RE.findall(text):
+        rows.setdefault(namespace, set()).add(var)
+    return rows
+
+
+def oracle_problems(index: PublicVarIndex, rows: dict[str, set[str]]) -> list[str]:
+    """Every way the derived public-var oracle contradicts the manifest.
+
+    The manifest is generated from LIVE `ns-publics` by a different tool on a
+    different runtime, minus the `^:no-doc` carve-out — so it is a strict SUBSET
+    of the truth this parser derives, and any rowed var missing from the derived
+    set means the parser has stopped seeing a whole shape of definition. That is
+    the failure that would otherwise arrive as confident FALSE findings, so it
+    is an rc=2 'this instrument is not usable', never a finding.
+    """
+    problems: list[str] = []
+    for namespace in sorted(rows):
+        publics = index.publics_of(namespace)
+        if publics is None:
+            problems.append(
+                f"{namespace}: the manifest rows this namespace but no source "
+                "file defines it — the oracle cannot see the tree it is "
+                "grading."
+            )
+            continue
+        missing = sorted(rows[namespace] - publics)
+        if missing:
+            problems.append(
+                f"{namespace}: manifest-rowed public var(s) the derived oracle "
+                f"does not see: {', '.join(missing)}. A var-defining form this "
+                "parser does not recognise has appeared (see "
+                "`_public_names_defined_by`); until it does, every where-sym "
+                "naming one of these would be reported as a dead door."
+            )
+    return problems
+
+
+def _mask_reader_noise(text: str) -> str:
+    """Blank `;` comments AND string CONTENTS in one reader-faithful pass,
+    length-preserving, keeping the quote characters so forms still balance.
+
+    THE WHERE-SYM RULE NEEDS ITS OWN MASK, and cannot layer on `_mask_comments`
+    — that function deliberately leaves string contents visible (pattern (a)
+    MUST see a literal `":rf.error/…"` message), and it treats a CHARACTER
+    LITERAL's payload as ordinary text. Both matter here:
+
+      * a where-sym is CODE and can never live inside a string, while this
+        repo's docstrings quote builder calls constantly — `re-frame.error`'s
+        own docstring writes ``:where 'rf/reg-event`` — so leaving strings
+        visible reports the DOCUMENTATION of this contract as violations of it;
+      * `\\"` outside a string is the character `"`, not a delimiter. Missing
+        that does not fail locally: it desynchronises from the reader and
+        swallows THE REST OF THE FILE. Measured on
+        `re-frame.ssr.html-helpers`, which writes `(= c \\")` at :310 — read as
+        a quote, every `throw-error!` after it vanished, and the file's two
+        real where-syms reported as zero. It fails in the REASSURING direction,
+        because a scan that has gone blind reports FEWER findings, which reads
+        as progress.
+
+    `#"…"` regex literals are strings for this purpose and need no special
+    case; a `;` inside a string is not a comment, which is why one pass has to
+    do both jobs rather than two passes doing one each.
+    """
+    out = list(text)
+    i = 0
+    n = len(text)
+    in_string = False
+    while i < n:
+        c = text[i]
+        if in_string:
+            if c == "\\" and i + 1 < n:
+                # An escape pair inside a string is content: blank it as a
+                # unit so `\"` cannot be read as the closing delimiter.
+                out[i] = " "
+                out[i + 1] = " "
+                i += 2
+                continue
+            if c == '"':
+                in_string = False
+            elif c != "\n":
+                out[i] = " "
+            i += 1
+            continue
+        if c == "\\":
+            i += 2          # a character literal: `\"`, `\;`, `\newline`, …
+            continue
+        if c == ";":
+            j = text.find("\n", i)
+            end = n if j == -1 else j
+            for k in range(i, end):
+                out[k] = " "
+            i = end
+            continue
+        if c == '"':
+            in_string = True
+        i += 1
+    return "".join(out)
+
+
+class WhereSym(NamedTuple):
+    path: Path
+    line: int
+    symbol: str
+    source: str  # "builder" | "where-slot"
+    snippet: str = ""
+
+
+def _extract_call_body(text: str, open_paren_idx: int, head: str) -> str | None:
+    """The BODY of the `(<head> …)` form opening at `open_paren_idx` — the text
+    between the head token and the matching close paren. String-aware; the
+    caller passes comment-masked text."""
+    n = len(text)
+    i = open_paren_idx
+    depth = 0
+    in_string = False
+    start_body = None
+    head_re = re.compile(r"\(\s*(?:[\w.*+!?<>=-]+/)?" + re.escape(head) + _SYM_TAIL)
+    while i < n:
+        c = text[i]
+        if in_string:
+            if c == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if c == '"':
+                in_string = False
+            i += 1
+            continue
+        if c == '"':
+            in_string = True
+            i += 1
+            continue
+        if c == "(":
+            depth += 1
+            if depth == 1:
+                m = head_re.match(text, i)
+                if not m:
+                    return None
+                start_body = m.end()
+            i += 1
+            continue
+        if c == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start_body:i] if start_body is not None else None
+            i += 1
+            continue
+        i += 1
+    return None
+
+
+def _scan_where_syms(path: Path, text: str, raw_lines: list[str]) -> list[WhereSym]:
+    """Every QUOTED where-sym in the file, from both places one can be written:
+    a rostered builder call's quoted-symbol argument, and the `:where` slot of a
+    hand-built framework ex-data map.
+
+    A where-sym that is NOT a quoted symbol — a bare local (`where`,
+    `where-sym`) threaded through a helper, a keyword, a computed form — is not
+    returned at all. Nothing static can say what it will be at runtime, and
+    guessing would trade this gate's false reds for false greens. `--verbose`
+    reports how many were skipped so the silence is visible.
+    """
+    # This rule masks the RAW text itself rather than reusing the shared
+    # comment mask — see `_mask_reader_noise` for the two reasons, both of
+    # which produced measured wrong answers on live source.
+    masked = _mask_reader_noise(text)
+
+    def snippet(line_no: int) -> str:
+        return raw_lines[line_no - 1].strip() if 0 <= line_no - 1 < len(raw_lines) else ""
+
+    found: list[WhereSym] = []
+    for m in _WHERE_CALL_RE.finditer(masked):
+        body = _extract_call_body(masked, m.start(), m.group(1))
+        if body is None:
+            continue
+        line_no = _line_of_offset(masked, m.start())
+        for arg in _split_forms(body):
+            q = _QUOTED_SYM_RE.match(arg)
+            if q:
+                found.append(
+                    WhereSym(path, line_no, q.group(1), "builder", snippet(line_no))
+                )
+    for m in _EX_INFO_OPEN_RE.finditer(masked):
+        body = _extract_ex_info_form(masked, m.start())
+        if body is None:
+            continue
+        _, rest = _split_first_arg(body)
+        if not _HAS_ERROR_ID_RE.search(rest):
+            continue
+        key = _WHERE_KEY_RE.search(rest)
+        if not key:
+            continue
+        value, _ = _split_first_arg(rest[key.end():])
+        q = _QUOTED_SYM_RE.match(value)
+        if q:
+            line_no = _line_of_offset(masked, m.start())
+            found.append(
+                WhereSym(path, line_no, q.group(1), "where-slot", snippet(line_no))
+            )
+    return found
+
+
+def where_sym_findings(
+    observed: list[WhereSym], index: PublicVarIndex
+) -> list[Finding]:
+    """The where-syms that name no reachable var."""
+    findings: list[Finding] = []
+    for site in observed:
+        if "/" not in site.symbol:
+            # An UNQUALIFIED where-sym names no namespace to check it against,
+            # and inventing one would be guessing. Two exist on trunk
+            # (`'defwrapper`, `'defreg-macro`); both name a macro a reader can
+            # still grep for. Counted, never a finding.
+            continue
+        qualifier, name = site.symbol.rsplit("/", 1)
+        namespace = _namespace_of_where_sym(qualifier)
+        publics = index.publics_of(namespace)
+        if publics is None:
+            if _is_framework_family(qualifier, namespace):
+                findings.append(Finding(
+                    site.path, site.line, "where-sym-unknown-namespace",
+                    site.snippet, site.symbol,
+                ))
+            # A genuinely third-party namespace cannot be checked from this
+            # tree; saying so is honest where a green would not be.
+            continue
+        if name not in publics:
+            findings.append(Finding(
+                site.path, site.line, "where-sym-unresolvable",
+                site.snippet, site.symbol,
+            ))
+    return sorted(findings, key=lambda f: (str(f.path), f.line, f.detail))
+
+
+_WHERE_SYM_KINDS = ("where-sym-unresolvable", "where-sym-unknown-namespace")
+
+
+# --------------------------------------------------------------------------
+# The where-sym BASELINE — a per-symbol floor, not a zero gate
+# --------------------------------------------------------------------------
+#
+# Eighty-two where-syms on trunk name nothing that resolves. A check that
+# failed them all on the day it landed would red every open PR, so this is a
+# RATCHET on the shape `scripts/require-alias-baseline.edn` already established
+# here: `:sites` records what each offending symbol is allowed to carry, a
+# symbol absent from the file has a floor of ZERO (so a NEW dead door reds
+# immediately, which is the whole point), and a recorded floor may only fall.
+#
+# Recording a symbol is NOT a ruling that it should be fixed, and disposing of
+# one is another item's work — the sweep that measured them says outright that
+# every site needs reading before acting. What the file guarantees is only that
+# the number cannot grow.
+#
+# THE TWO KEYS RATCHET IN OPPOSITE DIRECTIONS, and reading it as one rule gets
+# half the file exactly wrong — the trap `check_require_alias_dialect.py` paid
+# for twice and wrote down:
+#
+#   * a `:sites` floor is an ALLOWANCE, checked `found > floor -> fail`. Raising
+#     it loosens the gate. It may only FALL.
+#   * `:min-where-syms` is the ANTI-BLINDNESS guard, checked
+#     `observed < min -> unusable`. LOWERING it loosens the gate — the inverse.
+#     It may only RISE.
+#
+# `:min-where-syms` is the answer to this gate's own worst failure mode. Every
+# finding here is the output of a search, and a search that has quietly stopped
+# matching reports a clean sweep in the same words as a clean tree. If the
+# extraction goes blind — a builder renamed out of `_WHERE_SYM_FORMS`, a
+# character class that stops covering a spelling — the observed population
+# collapses, and this floor turns that from a green into an rc=2 that says so.
+# A proposed INCREASE to any site floor refuses the whole write rather than
+# being dropped from it: a partial file matches neither the tree nor the
+# previous baseline, and nothing in it records which happened. Deliberately
+# raising a floor stays possible and stays a HAND EDIT, which is visible in
+# review.
+
+WHERE_SYM_BASELINE_REL = "scripts/where-sym-baseline.edn"
+
+
+class WhereSymBaseline(NamedTuple):
+    min_where_syms: int
+    sites: dict[str, int]
+
+
+class BaselineError(Exception):
+    pass
+
+
+def parse_where_sym_baseline(text: str) -> WhereSymBaseline:
+    """Read the baseline EDN. Deliberately strict: anything this reader does
+    not consume is an ERROR, not an ignored key. A baseline half-read is a floor
+    half-applied, and that fails in the direction that admits a regression."""
+    masked = "\n".join(_mask_comments(text))
+    start = masked.find("{")
+    if start == -1:
+        raise BaselineError("no map in the baseline file")
+    end = _balanced_extent(masked, start)
+    if end is None:
+        raise BaselineError("the baseline map does not balance")
+    tokens = _split_forms(masked[start + 1:end - 1])
+    if len(tokens) % 2 != 0:
+        raise BaselineError("the baseline map is not a sequence of key/value pairs")
+    min_where_syms: int | None = None
+    sites: dict[str, int] | None = None
+    for key, value in zip(tokens[0::2], tokens[1::2]):
+        if key == ":min-where-syms":
+            if not value.isdigit():
+                raise BaselineError(
+                    f":min-where-syms must be a non-negative integer, got {value!r}"
+                )
+            min_where_syms = int(value)
+        elif key == ":sites":
+            if not value.startswith("{"):
+                raise BaselineError(":sites must be a map")
+            inner = _split_forms(value[1:-1])
+            if len(inner) % 2 != 0:
+                raise BaselineError(":sites is not a sequence of key/value pairs")
+            sites = {}
+            for sym, floor in zip(inner[0::2], inner[1::2]):
+                if not (sym.startswith('"') and sym.endswith('"') and len(sym) >= 2):
+                    raise BaselineError(f"site keys must be strings, got {sym!r}")
+                if not floor.isdigit():
+                    raise BaselineError(
+                        f"site {sym} floor must be a non-negative integer, got {floor!r}"
+                    )
+                sites[sym[1:-1]] = int(floor)
+        else:
+            raise BaselineError(f"unrecognised baseline key {key!r}")
+    if min_where_syms is None:
+        raise BaselineError("the baseline names no :min-where-syms floor")
+    if sites is None:
+        raise BaselineError("the baseline names no :sites map")
+    return WhereSymBaseline(min_where_syms, sites)
+
+
+class WhereSymBaselinePlan(NamedTuple):
+    baseline: WhereSymBaseline
+    notes: list[str]
+    refusals: list[str]   # non-empty: write NOTHING
+
+
+def plan_where_sym_baseline(
+    counts: dict[str, int], total_observed: int,
+    previous: WhereSymBaseline | None,
+) -> WhereSymBaselinePlan:
+    """The baseline `--write-where-sym-baseline` may write, given the one on
+    disk. Monotonic in both keys, in opposite directions (see the block above)."""
+    notes: list[str] = []
+    refusals: list[str] = []
+    if previous is None:
+        return WhereSymBaselinePlan(
+            WhereSymBaseline(int(total_observed * 0.9), dict(sorted(counts.items()))),
+            [f"no readable baseline on disk: writing a fresh one "
+             f"({len(counts)} symbol(s), {sum(counts.values())} site(s))."],
+            [],
+        )
+    floors: dict[str, int] = {}
+    for symbol in sorted(counts):
+        found = counts[symbol]
+        old = previous.sites.get(symbol)
+        if old is None:
+            floors[symbol] = found
+            notes.append(
+                f"NEW dead door {symbol}: floor set to its observed {found}. "
+                "This is the one path by which debt enters the file."
+            )
+        elif found > old:
+            floors[symbol] = old
+            refusals.append(
+                f"{symbol}: {found} site(s) against a floor of {old} — writing "
+                f"it would RAISE the floor by {found - old} and bless the "
+                "regression."
+            )
+        else:
+            if found < old:
+                notes.append(f"{symbol}: floor {old} -> {found}.")
+            floors[symbol] = found
+    for symbol in sorted(set(previous.sites) - set(counts)):
+        notes.append(
+            f"{symbol} resolves everywhere now: its floor of "
+            f"{previous.sites[symbol]} is dropped."
+        )
+    recomputed = int(total_observed * 0.9)
+    if recomputed >= previous.min_where_syms:
+        min_where_syms = recomputed
+    else:
+        min_where_syms = previous.min_where_syms
+        notes.append(
+            f":min-where-syms HELD at {previous.min_where_syms} (the recompute "
+            f"proposed {recomputed}). It is the anti-blindness guard, not an "
+            "allowance: lowering it LOOSENS the gate, so a shrinking population "
+            "is a thing to investigate by hand, never to write down."
+        )
+    return WhereSymBaselinePlan(
+        WhereSymBaseline(min_where_syms, floors), notes, refusals
+    )
+
+
+def render_where_sym_baseline(baseline: WhereSymBaseline) -> str:
+    width = max((len(s) for s in baseline.sites), default=0) + 4
+    lines = [
+        ";; Thrown-error where-sym baseline (rf2-z5lv) — regenerate with",
+        ";;     python scripts/check_thrown_error_messages.py "
+        "--write-where-sym-baseline",
+        ";;",
+        ";; A thrown error's `where-sym` names WHERE the failure happened so an",
+        ";; author who reads the message can grep for it. `:sites` records the",
+        ";; symbols that currently name nothing reachable, and how many sites",
+        ";; each is allowed. A symbol NOT listed has a floor of zero, so a new",
+        ";; dead door fails the gate. A listed floor ratchets DOWN only; the",
+        ";; gate reports any symbol now below its floor so the number can be",
+        ";; lowered, and reports one that has cleared entirely so the entry can",
+        ";; be dropped. Recording a symbol is not a ruling that it must be",
+        ";; fixed — each site needs reading before acting.",
+        ";;",
+        ";; `:min-where-syms` is a floor on the TOTAL quoted where-syms the scan",
+        ";; observes. It is not an allowance: it is what stops this gate",
+        ";; reporting a confident clean sweep after its extraction has gone",
+        ";; blind. It ratchets the OTHER way — up only.",
+        "{:min-where-syms " + str(baseline.min_where_syms),
+        "",
+        " :sites",
+        " {",
+    ]
+    for symbol in sorted(baseline.sites):
+        lines.append(f'  {("%s" % (chr(34) + symbol + chr(34))).ljust(width)}'
+                     f'{baseline.sites[symbol]}')
+    lines.append(" }}")
+    return "\n".join(lines) + "\n"
+
+
+class WhereSymVerdict(NamedTuple):
+    violations: list[str]   # non-empty: the gate is RED
+    notes: list[str]        # ratchet-down opportunities; never fatal
+    unusable: list[str]     # non-empty: rc=2, the instrument cannot be trusted
+
+
+def grade_where_syms(
+    findings: list[Finding], total_observed: int, baseline: WhereSymBaseline,
+) -> WhereSymVerdict:
+    counts: dict[str, int] = {}
+    for f in findings:
+        counts[f.detail] = counts.get(f.detail, 0) + 1
+    violations: list[str] = []
+    notes: list[str] = []
+    unusable: list[str] = []
+    if total_observed < baseline.min_where_syms:
+        unusable.append(
+            f"only {total_observed} quoted where-sym(s) observed, against a "
+            f"`:min-where-syms` floor of {baseline.min_where_syms}. This gate "
+            "does not report a clean sweep over a corpus it has stopped being "
+            "able to read: either the extraction has gone blind (a builder "
+            "missing from `_WHERE_SYM_FORMS`, a pattern that no longer matches "
+            "a live spelling) or the scan surface shrank. Investigate before "
+            "touching the baseline — lowering the floor is how this guard gets "
+            "given away."
+        )
+    for symbol in sorted(counts):
+        floor = baseline.sites.get(symbol, 0)
+        if counts[symbol] > floor:
+            violations.append(
+                f"{symbol}: {counts[symbol]} site(s) against a floor of {floor}"
+            )
+    for symbol in sorted(baseline.sites):
+        found = counts.get(symbol, 0)
+        if found < baseline.sites[symbol]:
+            notes.append(
+                f"{symbol}: {found} site(s) now, floor {baseline.sites[symbol]} — "
+                + ("drop the entry" if found == 0 else "lower the floor")
+                + f" in {WHERE_SYM_BASELINE_REL}."
+            )
+    return WhereSymVerdict(violations, notes, unusable)
 
 
 # --------------------------------------------------------------------------
@@ -984,9 +1844,17 @@ def _line_of_offset(text: str, offset: int) -> int:
     return text.count("\n", 0, offset) + 1
 
 
-def _scan_text(path: Path, text: str) -> list[Finding]:
+def _scan_text(
+    path: Path, text: str, where_syms: list[WhereSym] | None = None,
+) -> list[Finding]:
     masked = "\n".join(_mask_comments(text))
     raw_lines = text.splitlines()
+    # The where-sym extraction rides the SAME masked text as everything else,
+    # so it costs one pass rather than a second read of the tree. Collected
+    # rather than graded here: a where-sym is judged against the public-var
+    # oracle and the baseline, which are whole-run facts, not per-file ones.
+    if where_syms is not None:
+        where_syms.extend(_scan_where_syms(path, text, raw_lines))
 
     def raw_snippet(line_no: int) -> str:
         return raw_lines[line_no - 1].strip() if 0 <= line_no - 1 < len(raw_lines) else ""
@@ -1015,11 +1883,19 @@ def _scan_text(path: Path, text: str) -> list[Finding]:
     return sorted(unique, key=lambda f: (str(f.path), f.line))
 
 
-def scan(scan_root: Path, include_tests: bool = False) -> list[Finding]:
+def scan(
+    scan_root: Path, include_tests: bool = False,
+    where_syms: list[WhereSym] | None = None,
+) -> list[Finding]:
+    """Every message-shape finding under `scan_root`.
+
+    `where_syms`, when supplied, also collects every quoted where-sym observed.
+    It is an out-parameter rather than a second return value so the ~30 existing
+    fixture cases keep calling `scan(path)` and reading a plain list."""
     findings: list[Finding] = []
     for path in _iter_source_files(scan_root, include_tests):
         text = path.read_text(encoding="utf-8", errors="replace")
-        findings.extend(_scan_text(path, text))
+        findings.extend(_scan_text(path, text, where_syms))
     return findings
 
 
@@ -1051,6 +1927,95 @@ _FIX_HINT = (
 )
 
 
+_WHERE_SYM_FIX_HINT = (
+    "A thrown error's where-sym is the second positional argument of "
+    "`error/throw-error!` / `error/thrown-ex-info` (and the `:where` slot it "
+    "lands in). Its ONE job is that an author who reads the message can grep "
+    "for the symbol and land on something — so it must NAME A REACHABLE VAR.\n"
+    "  * The rule is RESOLVABILITY, not a spelling. `rf/reg-flow` and\n"
+    "    `re-frame.flows/flows` are BOTH right — `re-frame.core`'s own\n"
+    "    `not-queryable-kinds` map writes one of each, side by side — because\n"
+    "    the discriminator is whether the namespace exports the name.\n"
+    "  * So the fix is whichever of these is true of the site:\n"
+    "      - the façade DOES export it: keep `'rf/<name>`;\n"
+    "      - the owning namespace exports it but the façade does not: spell it\n"
+    "        fully, `'re-frame.<ns>/<name>` (or `'rf.<tail>/<name>` under the\n"
+    "        Conventions §Require-alias dialect);\n"
+    "      - nothing exports it (it is private, or it is a MODULE name rather\n"
+    "        than a fn): name the nearest PUBLIC entry point the author would\n"
+    "        actually call.\n"
+    "  * A private var does not resolve for a reader either — a fully-qualified\n"
+    "    `'re-frame.router/build-envelope` still fails, because that var is\n"
+    "    `defn-`.\n"
+    "  Recorded, already-known dead doors live in " + WHERE_SYM_BASELINE_REL +
+    "; that file\n"
+    "  ratchets DOWN only, so clearing one is welcome and raising a floor is a\n"
+    "  hand edit that shows up in review."
+)
+
+
+def _report_where_syms(
+    findings: list[Finding], baseline: WhereSymBaseline,
+    verdict: WhereSymVerdict, repo_root: Path,
+) -> None:
+    over = {v.split(":")[0] for v in verdict.violations}
+    sys.stderr.write(
+        f"\n{len(verdict.violations)} thrown-error where-sym(s) name nothing "
+        "reachable, above the recorded floor (rf2-z5lv / Spec 009 §The "
+        "thrown-error shape):\n\n"
+    )
+    for line in verdict.violations:
+        sys.stderr.write(f"  {line}\n")
+    sys.stderr.write("\n")
+    for f in findings:
+        if f.detail not in over:
+            continue
+        try:
+            rel = f.path.relative_to(repo_root)
+        except ValueError:
+            rel = f.path
+        rel_str = str(rel).replace("\\", "/")
+        sys.stderr.write(f"  {f.kind}: {rel_str}:{f.line}  '{f.detail}\n")
+        sys.stderr.write(f"      {f.snippet}\n")
+    sys.stderr.write(f"\nFix:\n  {_WHERE_SYM_FIX_HINT}\n")
+
+
+def _write_where_sym_baseline(
+    repo_root: Path, findings: list[Finding], total_observed: int,
+    previous: WhereSymBaseline | None,
+) -> int:
+    counts: dict[str, int] = {}
+    for f in findings:
+        counts[f.detail] = counts.get(f.detail, 0) + 1
+    plan = plan_where_sym_baseline(counts, total_observed, previous)
+    if plan.refusals:
+        sys.stderr.write(
+            "\nrefusing to write the where-sym baseline — every one of these "
+            "would RAISE a floor:\n\n"
+        )
+        for refusal in plan.refusals:
+            sys.stderr.write(f"  {refusal}\n")
+        sys.stderr.write(
+            "\nA symbol above its floor means the gate is ALREADY RED, so "
+            "there is no state in which recording another symbol's win is the "
+            "next thing to do. Fix the new site, or hand-edit the EDN if the "
+            "raise is deliberate.\n"
+        )
+        return 1
+    (repo_root / WHERE_SYM_BASELINE_REL).write_text(
+        render_where_sym_baseline(plan.baseline), encoding="utf-8"
+    )
+    sys.stderr.write(f"wrote {WHERE_SYM_BASELINE_REL}\n")
+    for note in plan.notes:
+        sys.stderr.write(f"  {note}\n")
+    sys.stderr.write(
+        f"  :min-where-syms {plan.baseline.min_where_syms}, "
+        f"{len(plan.baseline.sites)} symbol(s), "
+        f"{sum(plan.baseline.sites.values())} site(s).\n"
+    )
+    return 0
+
+
 def _report(findings: list[Finding], repo_root: Path) -> None:
     sys.stderr.write(
         f"\n{len(findings)} bare-keyword thrown-error message(s) found in "
@@ -1078,7 +2043,9 @@ def main(argv: list[str]) -> int:
             "message is a bare `:rf.*` discriminator keyword (the retired "
             "keyword-only shape) OR a builder bypass — a raw ex-info carrying "
             "`:rf.error/id` whose message skips the builder + the "
-            "`[:rf.<ns>/<id>]` token."
+            "`[:rf.<ns>/<id>]` token. rf2-z5lv: also fail on a thrown error "
+            "whose WHERE-SYM names no reachable var, above the floor recorded "
+            "in " + WHERE_SYM_BASELINE_REL + "."
         ),
     )
     parser.add_argument(
@@ -1116,6 +2083,17 @@ def main(argv: list[str]) -> int:
         help=(
             "Run the bundled fixture-based self-tests in "
             "scripts/_test_fixtures/check_thrown_error_messages/ and exit."
+        ),
+    )
+    parser.add_argument(
+        "--write-where-sym-baseline",
+        action="store_true",
+        help=(
+            "Rewrite " + WHERE_SYM_BASELINE_REL + " from the current tree. "
+            "MONOTONIC, and the two keys ratchet OPPOSITE ways: a site floor "
+            "may only fall and :min-where-syms may only rise, so a proposed "
+            "increase to any site floor refuses the whole write rather than "
+            "blessing the regression."
         ),
     )
     args = parser.parse_args(argv)
@@ -1177,15 +2155,118 @@ def main(argv: list[str]) -> int:
             f"(tests {'included' if args.include_tests else 'excluded'})...\n"
         )
 
+    observed: list[WhereSym] = []
     findings: list[Finding] = []
     for root in scan_roots:
-        findings.extend(scan(root, include_tests=args.include_tests))
+        findings.extend(
+            scan(root, include_tests=args.include_tests, where_syms=observed)
+        )
+
+    # ---- the where-sym rule (rf2-z5lv) ------------------------------------
+    #
+    # Its oracle is the PUBLIC VAR SET of the namespace a where-sym names, so
+    # it needs the whole tree rather than the scan surface: a where-sym written
+    # under `implementation/` can name a namespace living anywhere.
+    #
+    # SKIPPED WHOLESALE UNDER `--scan-dir`, and that is the only honest option.
+    # Both halves of the rule are defined over the ROSTERED surface: the site
+    # floors record what that surface carries, and `:min-where-syms` is a floor
+    # on what that surface yields. Point the scan somewhere else and the floor
+    # fires on a corpus that is smaller for a legitimate reason, while grading
+    # findings WITHOUT the floor would drop the one guard that separates "no
+    # dead doors here" from "this scan stopped seeing them" — the confident
+    # zero this whole gate is built to refuse. So an ad-hoc surface gets the
+    # message rules and says plainly that it got nothing else.
+    if args.scan_dirs:
+        if findings:
+            _report(findings, repo_root)
+            return 1
+        if args.verbose:
+            sys.stderr.write(
+                "no bare-keyword thrown-error messages under the requested "
+                "scan dir(s). The where-sym rule was SKIPPED: its baseline and "
+                f"its `:min-where-syms` floor both describe the rostered "
+                f"surface ({', '.join(DEFAULT_SCAN_DIRS)}), so neither is "
+                "meaningful here.\n"
+            )
+        return 0
+
+    try:
+        index = PublicVarIndex(_tracked_clojure_sources(repo_root))
+    except OracleUnavailable as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+    try:
+        rows = _manifest_rows(repo_root)
+    except OSError as exc:
+        sys.stderr.write(
+            f"error: cannot read {_MANIFEST_REL}: {exc}. It is this gate's "
+            "independent control on its own public-var oracle; without it the "
+            "where-sym rule cannot be trusted.\n"
+        )
+        return 2
+    unusable = oracle_problems(index, rows)
+    if unusable:
+        sys.stderr.write(
+            "\nerror: the where-sym public-var oracle disagrees with the "
+            f"GENERATED {_MANIFEST_REL}, so it is not usable:\n\n"
+        )
+        for problem in unusable:
+            sys.stderr.write(f"  {problem}\n")
+        return 2
+
+    ws_findings = where_sym_findings(observed, index)
+    baseline: WhereSymBaseline | None = None
+    try:
+        baseline = parse_where_sym_baseline(
+            (repo_root / WHERE_SYM_BASELINE_REL).read_text(encoding="utf-8")
+        )
+    except (OSError, BaselineError) as exc:
+        # A MALFORMED baseline is fatal in both modes — half-read is a floor
+        # half-applied. A MISSING one is fatal only when gating: the write mode
+        # has to be able to create the file the first time.
+        if not (args.write_where_sym_baseline and isinstance(exc, OSError)):
+            sys.stderr.write(
+                f"error: cannot read {WHERE_SYM_BASELINE_REL}: {exc}\n"
+            )
+            return 2
+
+    if args.write_where_sym_baseline:
+        return _write_where_sym_baseline(
+            repo_root, ws_findings, len(observed), baseline
+        )
+
+    verdict = grade_where_syms(ws_findings, len(observed), baseline)
+    if verdict.unusable:
+        sys.stderr.write("\nerror: the where-sym scan is not usable:\n\n")
+        for problem in verdict.unusable:
+            sys.stderr.write(f"  {problem}\n")
+        return 2
+
+    if args.verbose:
+        qualified = sum(1 for w in observed if "/" in w.symbol)
+        sys.stderr.write(
+            f"where-sym: {len(observed)} quoted where-sym(s) observed "
+            f"({qualified} qualified, {len(observed) - qualified} unqualified "
+            f"and therefore uncheckable), floor {baseline.min_where_syms}; "
+            f"{len(ws_findings)} name nothing reachable, "
+            f"{len(baseline.sites)} symbol(s) baselined.\n"
+        )
+        for note in verdict.notes:
+            sys.stderr.write(f"  RATCHET DOWN: {note}\n")
+
+    # A where-sym over its floor is reported with the same weight as a bad
+    # message: both are the thrown-error shape failing its reader.
+    if verdict.violations:
+        _report_where_syms(ws_findings, baseline, verdict, repo_root)
     if findings:
         _report(findings, repo_root)
+    if findings or verdict.violations:
         return 1
     if args.verbose:
         sys.stderr.write(
-            "no bare-keyword thrown-error messages in framework source.\n"
+            "no bare-keyword thrown-error messages in framework source, and "
+            "every where-sym over its baseline floor names a reachable var.\n"
         )
     return 0
 
@@ -1388,6 +2469,7 @@ def _run_self_tests(verbose: bool = False) -> int:
             )
 
     failures += _run_roster_self_tests(verbose=verbose)
+    failures += _run_where_sym_self_tests(verbose=verbose)
     failures += _run_cli_self_tests(verbose=verbose)
 
     if failures:
@@ -1461,6 +2543,352 @@ def _run_roster_self_tests(verbose: bool = False) -> int:
 
 
 # --------------------------------------------------------------------------
+# WHERE-SYM self-tests (rf2-z5lv)
+# --------------------------------------------------------------------------
+#
+# EVERY CASE PINS LINE NUMBERS, NOT COUNTS. A count cannot separate "found the
+# right sites" from "traded a real hit for a false positive", and the sibling
+# gate in this directory shipped for a week matching only one of five
+# reader-equivalent call spellings with its own self-test green throughout —
+# because every fixture it had used that one spelling (audit #9491, repaired by
+# #9496 with exactly this change). The fixtures here therefore vary the call
+# head five ways, and the assertions read `(line, kind, symbol)`.
+
+_WHERE_SYM_FIXTURE_ROOT = _SELF_TEST_FIXTURE_ROOT / "wheresym"
+_WHERE_SYM_POSITIVE = "positive_where_syms.cljc"
+_WHERE_SYM_NEGATIVE = "negative_where_syms.cljc"
+_WHERE_SYM_ORACLE = "re_frame/fixture.cljc"
+
+
+def _fixture_where_sym_index() -> PublicVarIndex:
+    """An oracle built from the FIXTURE tree, never the live one. Grading the
+    fixtures against the real `re-frame.core` would make a legitimate rename
+    somewhere else change this suite's answers."""
+    return PublicVarIndex(sorted(_WHERE_SYM_FIXTURE_ROOT.rglob("*.cljc")))
+
+
+def _crosses_call_head(text: str, head: str) -> bool:
+    """Does `text` contain a `(<head> …)` call, optionally namespace-qualified?"""
+    return bool(re.search(
+        r"\(\s*(?:[\w.*+!?<>=-]+/)?" + re.escape(head) + _SYM_TAIL, text
+    ))
+
+
+def _run_where_sym_self_tests(verbose: bool = False) -> int:
+    failures = 0
+
+    def fail(msg: str) -> None:
+        nonlocal failures
+        failures += 1
+        sys.stderr.write(f"where-sym self-test FAIL: {msg}\n")
+
+    for name in (_WHERE_SYM_POSITIVE, _WHERE_SYM_NEGATIVE, _WHERE_SYM_ORACLE):
+        if not (_WHERE_SYM_FIXTURE_ROOT / name).is_file():
+            fail(f"fixture {name!r} missing at {_WHERE_SYM_FIXTURE_ROOT / name}")
+    if failures:
+        return failures
+
+    index = _fixture_where_sym_index()
+
+    # ---- the ORACLE itself: which definition shapes are public --------------
+    #
+    # Asserted as an EXACT set. Each entry is a shape that has been got wrong:
+    # `^:no-doc` is the manifest-oracle refutation, the two platform arms are
+    # the runtime question, and `Panel` / `imported-fn` are the two
+    # var-defining macros that do not begin `def` — both of which this parser
+    # missed until the manifest control caught them. The absences matter as
+    # much: three privacy spellings and a `defmethod`.
+    expected_publics = {
+        "known-var", "known-public", "known-macro", "known-multi",
+        "no-doc-public", "cljs-only-public", "clj-only-public",
+        "Panel", "imported-fn",
+    }
+    got_publics = index.publics_of("re-frame.fixture")
+    if got_publics != expected_publics:
+        missing = sorted(expected_publics - (got_publics or set()))
+        extra = sorted((got_publics or set()) - expected_publics)
+        fail(
+            "the derived public-var oracle disagrees with the fixture namespace"
+            + (f"\n      NOT SEEN as public: {', '.join(missing)}" if missing else "")
+            + (f"\n      WRONGLY public: {', '.join(extra)} — a private var or a "
+               "`defmethod` leaking into the public set turns a real dead door "
+               "GREEN" if extra else "")
+        )
+    elif verbose:
+        sys.stderr.write(
+            f"where-sym self-test PASS: oracle sees {len(expected_publics)} "
+            "public(s) in the fixture namespace, and neither private var nor "
+            "`defmethod` name among them\n"
+        )
+
+    # A namespace this tree does not define is None, NOT the empty set.
+    # Conflating them is how a scan reports a clean sweep over a namespace it
+    # never opened — here it would silently green every where-sym naming it.
+    if index.publics_of("re-frame.nosuch") is not None:
+        fail("an undefined namespace must answer None, not an empty public set")
+
+    # ---- the two fixture files, pinned by (line, kind, symbol) --------------
+    cases: list[tuple[str, tuple[tuple[int, str, str], ...]]] = [
+        (_WHERE_SYM_POSITIVE, (
+            # the five reader-equivalent formattings of the call head
+            (31, "where-sym-unresolvable", "rf.fixture/ghost-one"),
+            (37, "where-sym-unresolvable", "rf.fixture/ghost-two"),
+            (43, "where-sym-unresolvable", "rf.fixture/ghost-three"),
+            (50, "where-sym-unresolvable", "rf.fixture/ghost-four"),
+            (57, "where-sym-unresolvable", "rf.fixture/ghost-five"),
+            # the other two rostered builders
+            (68, "where-sym-unresolvable", "rf.fixture/ghost-six"),
+            (74, "where-sym-unresolvable", "rf.fixture/ghost-seven"),
+            # the `:where` slot of a hand-built framework ex-data map
+            (87, "where-sym-unresolvable", "rf.fixture/ghost-eight"),
+            # the reasons a symbol does not resolve
+            (95, "where-sym-unknown-namespace", "rf.nosuch/thing"),
+            (101, "where-sym-unresolvable", "re-frame.fixture/private-fn"),
+            (109, "where-sym-unresolvable", "rf.fixture/private-var"),
+            (115, "where-sym-unresolvable", "rf.fixture/private-meta-var"),
+            (121, "where-sym-unresolvable", "rf.fixture/foreign-multi"),
+        )),
+        (_WHERE_SYM_NEGATIVE, ()),
+    ]
+    for fixture, expected in cases:
+        path = _WHERE_SYM_FIXTURE_ROOT / fixture
+        text = path.read_text(encoding="utf-8", errors="replace")
+        observed = _scan_where_syms(path, text, text.splitlines())
+        got = tuple(
+            (f.line, f.kind, f.detail)
+            for f in where_sym_findings(observed, index)
+        )
+        if got != expected:
+            fail(
+                f"{fixture}\n"
+                f"      expected {list(expected)}\n"
+                f"      got      {list(got)}"
+            )
+        elif verbose:
+            sys.stderr.write(
+                f"where-sym self-test PASS: {fixture} "
+                f"({len(observed)} where-sym(s) observed, "
+                f"{len(got)} finding(s) at lines {[l for l, _, _ in got]})\n"
+            )
+
+    # The NEGATIVE fixture must still be OBSERVING sites, or it proves nothing:
+    # a mask that blanked the whole file would also report zero findings.
+    neg_path = _WHERE_SYM_FIXTURE_ROOT / _WHERE_SYM_NEGATIVE
+    neg_text = neg_path.read_text(encoding="utf-8", errors="replace")
+    neg_observed = _scan_where_syms(neg_path, neg_text, neg_text.splitlines())
+    if len(neg_observed) < 14:
+        fail(
+            f"the negative fixture observed only {len(neg_observed)} where-sym(s). "
+            "A green there is only evidence while the sites are still being SEEN "
+            "— zero findings over zero observations is what a dead scan looks like."
+        )
+    neg_symbols = {w.symbol for w in neg_observed}
+    for ghost in ("rf.fixture/ghost-in-a-docstring", "rf.fixture/ghost-in-a-comment",
+                  "rf.fixture/ghost-nested", "rf.fixture/ghost-not-a-framework-error"):
+        if ghost in neg_symbols:
+            fail(
+                f"{ghost} was read as a where-sym. It is planted in prose, in a "
+                "nested `:extra` map, or in an ex-data map with no "
+                "`:rf.error/id` — none of which is a where-sym."
+            )
+
+    # ---- rosters: every entry owns a case ----------------------------------
+    pos_text = (_WHERE_SYM_FIXTURE_ROOT / _WHERE_SYM_POSITIVE).read_text(
+        encoding="utf-8", errors="replace"
+    )
+    uncrossed = [h for h in _WHERE_SYM_FORMS if not _crosses_call_head(pos_text, h)]
+    if uncrossed:
+        fail(
+            f"_WHERE_SYM_FORMS entr(y/ies) no fixture calls: {', '.join(uncrossed)}. "
+            f"Plant a `({uncrossed[0]} … '<unresolvable sym> …)` site in "
+            f"{_WHERE_SYM_POSITIVE}; deleting the entry must make it go quiet."
+        )
+    elif verbose:
+        sys.stderr.write(
+            f"where-sym self-test PASS: all {len(_WHERE_SYM_FORMS)} "
+            "_WHERE_SYM_FORMS entries have a case\n"
+        )
+    oracle_text = (_WHERE_SYM_FIXTURE_ROOT / _WHERE_SYM_ORACLE).read_text(
+        encoding="utf-8", errors="replace"
+    )
+    unexercised = [h for h in sorted(_EXTRA_DEF_HEADS)
+                   if not _crosses_call_head(oracle_text, h)]
+    if unexercised:
+        fail(
+            f"_EXTRA_DEF_HEADS entr(y/ies) the oracle fixture does not define a "
+            f"var with: {', '.join(unexercised)}. Each entry is a promise that a "
+            "macro NOT beginning `def` defines a public var; an unexercised one "
+            "can be deleted, after which every where-sym naming its output "
+            "becomes a false finding."
+        )
+    elif verbose:
+        sys.stderr.write(
+            f"where-sym self-test PASS: all {len(_EXTRA_DEF_HEADS)} "
+            "_EXTRA_DEF_HEADS entries have a case\n"
+        )
+
+    # ---- the reader mask, in BOTH directions -------------------------------
+    #
+    # A search whose failure mode is a silent false zero needs a control that
+    # BITES, not only one that comes back clean. Each pair below is one probe
+    # that must find something and one that must not, sharing the shape.
+    mask_cases: list[tuple[str, str, list[str]]] = [
+        ("a character literal is not a string delimiter",
+         '(= c \\")\n(throw-error! :rf.error/x \'rf/after-char-literal "r")',
+         ["rf/after-char-literal"]),
+        ("a docstring quoting a builder call is not a call",
+         '(defn f "see (throw-error! :rf.error/x \'rf/ghost r)" [] 1)',
+         []),
+        ("a `;` comment quoting a builder call is not a call",
+         ";; (throw-error! :rf.error/x 'rf/ghost r)\n"
+         "(throw-error! :rf.error/y 'rf/live r)",
+         ["rf/live"]),
+        ("a `;` INSIDE a string does not start a comment",
+         '(throw-error! :rf.error/x \'rf/after-semicolon-string "a; b")',
+         ["rf/after-semicolon-string"]),
+    ]
+    for name, src, expected_syms in mask_cases:
+        got_syms = [w.symbol for w in
+                    _scan_where_syms(Path("<probe>"), src, src.splitlines())]
+        if got_syms != expected_syms:
+            fail(f"reader mask — {name}: expected {expected_syms}, got {got_syms}")
+        elif verbose:
+            sys.stderr.write(f"where-sym self-test PASS: reader mask — {name}\n")
+
+    failures += _run_where_sym_baseline_self_tests(verbose=verbose)
+    return failures
+
+
+def _run_where_sym_baseline_self_tests(verbose: bool = False) -> int:
+    """The RATCHET, whose two keys move in opposite directions.
+
+    Exercised directly rather than through the CLI so both directions can be
+    asserted without writing a file. The sibling ratchet's `--write-baseline`
+    shipped rewriting every floor to the current count, so the repair command
+    its own header advertised silently BLESSED regressions; these cases are
+    what stop that being rediscovered here.
+    """
+    failures = 0
+
+    def fail(msg: str) -> None:
+        nonlocal failures
+        failures += 1
+        sys.stderr.write(f"where-sym baseline self-test FAIL: {msg}\n")
+
+    good = '{:min-where-syms 10\n :sites {"rf/a" 3 "rf.b/c" 0}}'
+    try:
+        parsed = parse_where_sym_baseline(good)
+    except BaselineError as exc:
+        parsed = None
+        fail(f"a well-formed baseline was rejected: {exc}")
+    if parsed is not None and (parsed.min_where_syms != 10
+                               or parsed.sites != {"rf/a": 3, "rf.b/c": 0}):
+        fail(f"a well-formed baseline parsed wrong: {parsed}")
+
+    # Strict: anything the reader does not consume is an ERROR. A baseline
+    # half-read is a floor half-applied, which fails toward admitting a
+    # regression.
+    for text, why in (
+        ('{:sites {"rf/a" 1}}', "no :min-where-syms"),
+        ('{:min-where-syms 1}', "no :sites"),
+        ('{:min-where-syms 1 :sites {"rf/a" 1} :extra 2}', "unrecognised key"),
+        ('{:min-where-syms 1 :sites {rf/a 1}}', "non-string site key"),
+        ('{:min-where-syms 1 :sites {"rf/a" "one"}}', "non-integer floor"),
+        ('{:min-where-syms "ten" :sites {"rf/a" 1}}', "non-integer :min-where-syms"),
+        ('{:min-where-syms 1 :sites ["rf/a" 1]}', ":sites is not a map"),
+    ):
+        try:
+            parse_where_sym_baseline(text)
+        except BaselineError:
+            continue
+        fail(f"a malformed baseline was ACCEPTED ({why}): {text}")
+
+    previous = WhereSymBaseline(100, {"rf/a": 3, "rf/b": 2, "rf/gone": 1})
+
+    # A site floor is an ALLOWANCE: it may only FALL.
+    plan = plan_where_sym_baseline({"rf/a": 1, "rf/b": 2}, 200, previous)
+    if plan.refusals:
+        fail(f"a downward move was refused: {plan.refusals}")
+    if plan.baseline.sites != {"rf/a": 1, "rf/b": 2}:
+        fail(f"a downward move wrote {plan.baseline.sites}")
+    if not any("rf/gone" in n for n in plan.notes):
+        fail("a symbol that has cleared entirely was not reported as droppable")
+
+    # A proposed INCREASE refuses the WHOLE write — never a partial file that
+    # matches neither the tree nor the previous baseline.
+    plan = plan_where_sym_baseline({"rf/a": 9, "rf/b": 1}, 200, previous)
+    if not plan.refusals:
+        fail("raising a site floor was allowed — the gate would go green by "
+             "moving the goalposts")
+    elif "rf/a" not in plan.refusals[0]:
+        fail(f"the refusal does not name the offending symbol: {plan.refusals}")
+
+    # A genuinely NEW symbol has to start somewhere, and that is the one path
+    # by which debt enters the file — so it is called out rather than silent.
+    plan = plan_where_sym_baseline({"rf/a": 3, "rf/b": 2, "rf/new": 1}, 200, previous)
+    if plan.refusals or plan.baseline.sites.get("rf/new") != 1:
+        fail(f"a new symbol was not recorded at its observed count: {plan}")
+    if not any("NEW" in n and "rf/new" in n for n in plan.notes):
+        fail("a new symbol entered the baseline silently")
+
+    # `:min-where-syms` IS THE INVERSE. Lowering it loosens the gate, so a
+    # shrinking population is held rather than written down.
+    plan = plan_where_sym_baseline({}, 50, previous)
+    if plan.baseline.min_where_syms != 100:
+        fail(
+            f":min-where-syms fell to {plan.baseline.min_where_syms}. It is the "
+            "anti-blindness guard, not an allowance — applying the site rule to "
+            "it gives away the protection that stops a blind scan reporting a "
+            "clean sweep."
+        )
+    plan = plan_where_sym_baseline({}, 1000, previous)
+    if plan.baseline.min_where_syms != 900:
+        fail(f":min-where-syms did not rise with the corpus: {plan.baseline}")
+
+    # ---- grading -----------------------------------------------------------
+    here = Path("<probe>")
+
+    def finding(symbol: str, line: int = 1) -> Finding:
+        return Finding(here, line, "where-sym-unresolvable", "", symbol)
+
+    baseline = WhereSymBaseline(10, {"rf/known": 2})
+
+    # A NEW dead door has an implicit floor of ZERO and reds immediately.
+    verdict = grade_where_syms([finding("rf/brand-new")], 50, baseline)
+    if not verdict.violations or "rf/brand-new" not in verdict.violations[0]:
+        fail(f"a new dead door did not red: {verdict.violations}")
+
+    # A baselined symbol AT its floor is clean; BELOW it is a ratchet-down note.
+    verdict = grade_where_syms(
+        [finding("rf/known", 1), finding("rf/known", 2)], 50, baseline
+    )
+    if verdict.violations:
+        fail(f"a symbol at its floor red: {verdict.violations}")
+    verdict = grade_where_syms([finding("rf/known")], 50, baseline)
+    if verdict.violations or not verdict.notes:
+        fail(f"a symbol below its floor was not reported as lowerable: {verdict}")
+    verdict = grade_where_syms([], 50, baseline)
+    if not any("drop the entry" in n for n in verdict.notes):
+        fail("a cleared symbol was not reported as droppable")
+
+    # ANTI-BLINDNESS: a population below the floor is UNUSABLE, not clean.
+    verdict = grade_where_syms([], 3, baseline)
+    if not verdict.unusable:
+        fail(
+            "a where-sym population far below `:min-where-syms` reported CLEAN. "
+            "That is this gate's own worst failure: a search that has stopped "
+            "matching answers `nothing here` in the same words as a clean tree."
+        )
+    if verbose and not failures:
+        sys.stderr.write(
+            "where-sym self-test PASS: baseline parses strictly, site floors "
+            "fall only, :min-where-syms rises only, a new dead door reds, and a "
+            "collapsed population is unusable rather than green\n"
+        )
+    return failures
+
+
+# --------------------------------------------------------------------------
 # CLI-level self-tests (rf2-un9fk) — the scan-ROOT validation, which the
 # fixture cases above cannot reach (they call `scan()` directly, bypassing
 # argument handling entirely).
@@ -1474,6 +2902,7 @@ def _run_roster_self_tests(verbose: bool = False) -> int:
 # this script.
 
 _CLI_NEGATIVE_FIXTURE_DIR = "scripts/_test_fixtures/check_thrown_error_messages/negative"
+_CLI_WHERE_SYM_NEGATIVE_DIR = "scripts/_test_fixtures/check_thrown_error_messages/wheresym"
 
 
 def _run_cli_self_tests(verbose: bool = False) -> int:
@@ -1491,6 +2920,14 @@ def _run_cli_self_tests(verbose: bool = False) -> int:
          ["--scan-dir", "README.md"], 2),
         ("mixed valid dir + file fails the WHOLE invocation",
          ["--scan-dir", _CLI_NEGATIVE_FIXTURE_DIR, "--scan-dir", "README.md"], 2),
+        # An AD-HOC surface must not be graded against the where-sym baseline.
+        # Both halves of that rule — the site floors and `:min-where-syms` —
+        # describe the ROSTERED surface, so a narrow `--scan-dir` would trip the
+        # anti-blindness floor on a corpus that is small for a legitimate
+        # reason. This case pins the skip; without it, `--scan-dir` exits 2 on
+        # every fixture directory in this tree.
+        ("an ad-hoc --scan-dir skips the where-sym rule rather than misgrading it",
+         ["--scan-dir", _CLI_WHERE_SYM_NEGATIVE_DIR], 0),
     ]
 
     failures = 0

--- a/scripts/where-sym-baseline.edn
+++ b/scripts/where-sym-baseline.edn
@@ -1,0 +1,59 @@
+;; Thrown-error where-sym baseline (rf2-z5lv) — regenerate with
+;;     python scripts/check_thrown_error_messages.py --write-where-sym-baseline
+;;
+;; A thrown error's `where-sym` names WHERE the failure happened so an
+;; author who reads the message can grep for it. `:sites` records the
+;; symbols that currently name nothing reachable, and how many sites
+;; each is allowed. A symbol NOT listed has a floor of zero, so a new
+;; dead door fails the gate. A listed floor ratchets DOWN only; the
+;; gate reports any symbol now below its floor so the number can be
+;; lowered, and reports one that has cleared entirely so the entry can
+;; be dropped. Recording a symbol is not a ruling that it must be
+;; fixed — each site needs reading before acting.
+;;
+;; `:min-where-syms` is a floor on the TOTAL quoted where-syms the scan
+;; observes. It is not an allowance: it is what stops this gate
+;; reporting a confident clean sweep after its extraction has gone
+;; blind. It ratchets the OTHER way — up only.
+{:min-where-syms 173
+
+ :sites
+ {
+  "re-frame.router/build-envelope"           2
+  "reagent2.impl.component/->react-element"  1
+  "rf-machines/make-machine-handler"         1
+  "rf-machines/reg-machine"                  1
+  "rf-machines/reg-machine*"                 2
+  "rf.http/classify-response-body"           1
+  "rf.http/decode-response-body"             2
+  "rf.http/json-parse"                       1
+  "rf.mutation/execute"                      1
+  "rf.resource/invalidate-tags"              4
+  "rf.ssr.head/emit"                         2
+  "rf.ssr.ring/import-fn"                    1
+  "rf.ssr/cookie->set-cookie-header"         5
+  "rf.ssr/emit"                              6
+  "rf.ssr/html-helpers"                      2
+  "rf.ssr/manifest-script"                   2
+  "rf.ssr/payload-policy"                    3
+  "rf.ssr/response"                          9
+  "rf.ssr/ssr-handler"                       7
+  "rf.ssr/stream-handler"                    2
+  "rf.ssr/streaming"                         1
+  "rf.ssr/trusted-shell"                     1
+  "rf/conformance-eval"                      6
+  "rf/invoke-handler"                        2
+  "rf/poll-until"                            1
+  "rf/reg-classification"                    1
+  "rf/register-handler"                      1
+  "rf/render"                                3
+  "rf/replace-container!"                    1
+  "rf/resolve-chain"                         1
+  "rf/resolve-interceptor-ref"               3
+  "rf/route-resource-plan"                   1
+  "rf/set-db"                                1
+  "rf/test-react-mount!"                     1
+  "rf/test-react-mount-child!"               1
+  "rf/test-react-trigger-update!"            1
+  "rf/test-react-unmount"                    1
+ }}


### PR DESCRIPTION
Closes the defect class behind rf2-z67m (seven sites) and rf2-0v23 (an eighth): a thrown error's `where-sym` can name a symbol that does not resolve, so an author who reads the message and types the name gets "no such var".

`scripts/check_thrown_error_messages.py` already sweeps the framework's `ex-info` / `throw-error!` calls and had **no notion of `where-sym` at all**. It does now, on the same masked pass, so the gate still costs 1.9s over 333 files. It was already wired into `test.yml` as two steps, so no workflow change was needed.

## What the rule is

**Resolvability, never a spelling.** `rf/reg-flow` and `re-frame.flows/flows` are both correct — `core.cljc`'s own `not-queryable-kinds` map writes one of each side by side, because the discriminator is whether the namespace exports the name. A fully-qualified symbol still fails when the var is private, which is the live `'re-frame.router/build-envelope` (a `defn-`) shape.

**The oracle is the public var set, not `spec/api-manifest.edn`.** Re-verified at source: the manifest rows *documented* publics, so `re-frame.core` reads **71 manifest rows against 82 JVM `ns-publics`**, and the `^:no-doc` façade stubs `reset-frame!` / `reload-images!` carry **zero rows apiece** while resolving perfectly (control: `reg-flow` reads 2). A manifest-only oracle reports resolvable names as dead doors.

The manifest is used instead as the **independent control on the derived oracle**: all **472 rows across 48 namespaces** must appear in the statically-derived public set, or the gate exits 2 rather than emitting false findings. That control earned its place immediately — it caught the parser missing `(import-fn …)` re-exports in `re-frame.ssr.ring` and `(rf/reg-view Panel …)` component vars across eleven Xray namespaces, both of which would otherwise have produced confident, well-formed **false** findings.

**Both runtimes.** The public set is read from source across both reader-conditional arms. `rf/frame-provider` and `rf/frame-root` are `#?(:cljs (def …))` façade exports absent from the JVM's `ns-publics` (82 JVM vs 84 union), so a JVM-only oracle reports both as dead doors. The union is the only direction that cannot manufacture a false red on a legitimately platform-specific name. Stated bound: a where-sym naming a CLJS-only var thrown from a JVM-only path passes.

## The baseline

`scripts/where-sym-baseline.edn` — **37 symbols, 82 sites**, modelled on `scripts/require-alias-baseline.edn`. An unlisted symbol has an implicit floor of **zero**, so a new dead door reds. The two keys ratchet **opposite ways**: a site floor is an allowance and may only fall; `:min-where-syms` is the anti-blindness guard and may only rise. `--write-where-sym-baseline` is monotonic and refuses the whole write on any proposed increase.

Recording a symbol is **not** a ruling that it must be fixed — disposing of the 82 is separate work, and this PR fixes none of them.

## Scope note for the reviewer

The bead's sweep named **21** façade-family sites. This extractor finds those same 21 plus **4 more** it could not see (`:where` slots in hand-built `ex-info` maps in `re-frame.conformance`), giving 25 in the `rf/` family; the remaining 57 are `rf.ssr/*`, `rf.http/*`, `rf-machines/*`, `rf.resource/*` and friends, which name an internal *module* rather than a callable var. They are the same defect class and are baselined, not fixed. One of the bead's 21 (`'rf/run-flows-on-db`) was fixed by PR #9499 while this was in flight.

## Quality gates

Exit codes captured on the runner's own command line, never through a pipe.

| gate | exit |
|---|---|
| `python scripts/check_thrown_error_messages.py --self-test --verbose` | **0** — 27 fixture cases + 3 roster + where-sym + 5 CLI |
| `python scripts/check_thrown_error_messages.py --verbose` | **0** — 333 files, 193 where-syms observed, floor 173 |
| 14 repo-wide ratchets that could grade the new `.cljc` fixtures | **0** each |

Repo-wide ratchets run (all exit 0): `check_allocation_non_claim`, `check_architecture_census`, `check_conformance_fixture_edn`, `check_keyword_catalogue_drift`, `check_test_lane_bijection`, `check_view_lifetime_residue`, `check_require_alias_dialect`, `check_retired_spellings`, `check_retired_composition_vocab`, `check_retired_image_keys`, `check_ambient_durable_reads`, `check_egress_walker_residue`, `check_failure_corpus_residue`, `check_inject_cofx_residue`.

**Gates deliberately not run, with reasons.** No Python linter or formatter exists in this repo — verified by config file (none tracked) and by workflow mention (none), not assumed. No document gate covers `scripts/**`: `check_doc_slugs.py`'s roots are `docs/`, `spec/`, `skills/`, `migration/`, `tools/*/spec`; `check_readme_links.py --ci` excludes `scripts/_test_fixtures/`; `mkdocs build --strict` has `docs_dir: docs` plus the staged `spec/` and `migration/` trees. clj-kondo and Splint `--lint` only `implementation`, `examples`, `testbeds` and four `tools/` trees, so the new fixtures are outside the lint surface. No Clojure artefact suite is nominated: no `.clj`/`.cljc` outside `scripts/_test_fixtures/` changed.

## Sabotage proof, both directions

Each plant's match count was read **before** the run, and each restore verified **by git blob hash** against the committed object.

| plant (real tracked source, `implementation/core/src/re_frame/cofx.cljc`) | exit |
|---|---|
| `'rf/reg-cofx` → `'rf/reg-cofx-typo` (non-resolving) | **1**, naming `cofx.cljc:101` and the symbol |
| `'rf/reg-cofx` → `'rf/reg-event` (façade alias, resolvable) | **0** |
| `'rf/reg-cofx` → `'re-frame.cofx/reg-cofx` (fully qualified, resolvable) | **0** |

The last two together are the empirical form of "resolvability, not a spelling".

Two further plants, in the gate itself, prove the guards against this gate's own worst failure mode — a search that has quietly stopped matching:

| plant | exit |
|---|---|
| rename one builder out of `_WHERE_SYM_FORMS` (population collapses 193 → 31) | **2**, not a green |
| empty `_EXTRA_DEF_HEADS` (oracle goes blind to two var-defining macros) | **2**, naming the missing manifest-rowed vars |

One plant matched **zero** lines on the first attempt — the anchor carried a `\n` and the file is CRLF. The pre-run match count caught it before a run was spent, which is exactly what that rule is for.

## A silent false zero found in this scan while building it

The fixtures caught a real defect in the extraction. `\"` outside a string is the character `"`, not a delimiter; read as a delimiter it desynchronises from the reader and swallows **the rest of the file**. Measured on `re-frame.ssr.html-helpers`, which writes `(= c \")` at :310 — both of that file's real `throw-error!` where-syms reported as zero. It fails in the *reassuring* direction, because a blinded scan reports fewer findings, which reads as progress. Fixed, and pinned by a regression fixture plus a four-case reader-mask control.

Fixtures vary the call head five reader-equivalent ways (tight, space, newline, comment, unqualified) and pin **line numbers rather than counts**, per the #9491 audit on the sibling egress gate: a count cannot separate "found the right ones" from "traded a real hit for a false positive".

No public name moves, so `spec/API.md` and both `api-manifest` sidecars are untouched.
