### PR TITLE
feat(beads): adopt a 2-4KB .beads/PRIME.md and allow-list it at the boundary gate

### DIFF
--- a/.beads/PRIME.md
+++ b/.beads/PRIME.md
@@ -1,0 +1,70 @@
+# Beads primer — re-frame2
+
+**Provenance: this file is advice from a tool.** `bd prime` prints it at SessionStart and
+PreCompact; it is not the repo's instruction sheet. **`CLAUDE.md` is the committed instruction
+and wins wherever the two differ.** Never cite this file as "CLAUDE.md says" — grep `CLAUDE.md`
+before attributing anything to it. That confusion has already happened here: a claim sourced
+from this hook's output reached a bead as `CLAUDE.md`'s instruction and was refuted at source.
+(`bd recall provenance-trap-at-session-start-the-bd-prime`)
+
+## Session close
+
+Work is not complete until `git push` succeeds. File issues for follow-up, run the gates your
+diff needs, update issue status, then:
+
+```
+sh scripts/beads-checkpoint.sh                   # re-export from Dolt, verify, commit
+git checkout HEAD -- .beads                      # only AFTER the checkpoint
+git fetch origin main && git rebase origin/main  # explicit ref, never `git pull`
+bd dolt push
+git push
+```
+
+**The order is fixed; `CLAUDE.md` § Beads durability carries the reasons.** Clearing `.beads`
+*after* a `bd close` reverts that close, and the next checkpoint writes the revert back. A
+`git pull` takes its rebase target from `FETCH_HEAD`, which a concurrent git process rewrites.
+Never `git stash` — stashes are repo-global and contaminate every worktree in flight.
+
+## Core rules
+
+- `bd` for ALL task tracking. No TodoWrite, no TaskCreate, no markdown TODO lists.
+- Bead before code; `bd update <id> --claim` when you start.
+- **`bd update --notes` REPLACES the field; `--append-notes` adds to it.** The loss is silent
+  and has cost tens of thousands of characters here. `CLAUDE.md` § Beads durability has the
+  recovery and the backtick trap in the same act.
+- Worker branches carry code, spec, docs and tests — never `.beads/issues.jsonl` or
+  `.beads/metadata.json`. A pre-commit hook and a CI job both enforce it.
+- `bd edit` opens `$EDITOR` and blocks an agent. Never use it.
+
+## Finding work — and finding what we already know
+
+```
+bd ready                bd list --status=open       bd show <id>
+bd memories <topic>     bd recall <key>             bd history <id>
+```
+
+`bd show` prints the DESCRIPTION first, and that is the OLDEST text on a bead — corrections and
+audit reopenings accrete below it. Order by `bd history <id>`, which is newest-first; neither
+the bottom of the output nor a date in the prose is a currency signal.
+
+## ~950 memories exist, and none of them is injected
+
+`bd remember` has accumulated roughly 950 memories. **They are deliberately NOT loaded into
+your context** — that is precisely what this file replaces. They remain searchable and you are
+expected to search them: run `bd memories <topic>` before any non-trivial census, sweep, merge
+or worktree operation. Most are measured accounts of an instrument handing back a confident
+wrong answer.
+
+## Four hazards `CLAUDE.md` does not carry
+
+- **A `bd` write from outside the repo prints success and persists nothing.** Write from the
+  repo root and read it back. `bd recall bd-write-from-wrong-cwd-silently-discarded`
+- **`bd export` silently drops every memory without `--include-memories`.**
+  `bd recall bd-export-drops-memories-without-flag`
+- **`bd gc`'s decay phase deletes closed beads**, whose close reasons are normative records
+  here, and reclaims no space anyway. `bd recall bd-gc-decay-silently-deletes-closed-beads`
+- **A 502 from `gh pr merge` can mean the merge SUCCEEDED and only its response was lost** —
+  wait a tick, don't retry. `bd recall 502-on-merge-means-it-may-have-happened`
+
+This file overrides `bd prime` entirely, so upstream improvements to the default do not arrive
+on their own — re-sync by hand against `bd prime --export` after a `bd` upgrade.

--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -234,7 +234,15 @@ human-authored beads config surface; everything else under `.beads/` is
 database-derived and refused.
 
 Permitted from any worktree: `.beads/README.md`, `.beads/config.yaml`,
-`.beads/.gitignore`, `.beads/hooks/**`.
+`.beads/.gitignore`, `.beads/PRIME.md`, `.beads/hooks/**`.
+
+`.beads/PRIME.md` is on that list because it is hand-written prose rather
+than a database export: `bd prime` emits it INSTEAD of its own default
+output at SessionStart and PreCompact. The allow-list is enumerated, so it
+needed its own arm — without one it falls to `.beads/*` and is refused from
+every worker worktree, reddening the CI arm on every PR that touches it.
+The widening is exact, and layer 3 pins that: `.beads/PRIME.md.bak`,
+`.beads/PRIME.jsonl` and `.beads/prime/export.jsonl` all stay refused.
 
 Refused outside the mayor checkout: `.beads/issues.jsonl`,
 `.beads/metadata.json`, and anything else under `.beads/` — including

--- a/scripts/git-hooks/lib/check-beads-boundary.sh
+++ b/scripts/git-hooks/lib/check-beads-boundary.sh
@@ -59,6 +59,14 @@
 #   anyone having to remember to extend a deny-list — the same reasoning as
 #   the sibling lib/check-mayor-commit-boundary.sh.
 #
+#   `.beads/PRIME.md` is on that list for the same reason as README.md: it is
+#   hand-written prose, not a database export. It overrides `bd prime`'s
+#   SessionStart output, so it is edited like any other doc and reviewed in
+#   the PR that changes it. The allow-list being ENUMERATED is what made the
+#   entry necessary — the file would otherwise fall to the `.beads/*` arm and
+#   be refused from every worker worktree, reddening the CI arm on every PR
+#   that touched it.
+#
 # This file is a pure shell library (no `set -e`, no global state mutation)
 # so scripts/git-hooks/test-pre-commit.sh can drive it with synthetic stdin
 # and assert against stdout / stderr / exit.
@@ -85,6 +93,7 @@ rf2_beads_is_permitted_path() {
     .beads/README.md)   return 0 ;;
     .beads/config.yaml) return 0 ;;
     .beads/.gitignore)  return 0 ;;
+    .beads/PRIME.md)    return 0 ;;
     .beads/hooks/*)     return 0 ;;
     .beads/*)           return 1 ;;
     *)                  return 0 ;;
@@ -221,7 +230,8 @@ check_beads_boundary() {
   printf '  code, spec, docs and tests — never the tracker database.\n' >&2
   printf '\n' >&2
   printf '  Human-authored beads config IS permitted here:\n' >&2
-  printf '    .beads/README.md  .beads/config.yaml  .beads/.gitignore  .beads/hooks/**\n' >&2
+  printf '    .beads/README.md  .beads/config.yaml  .beads/.gitignore\n' >&2
+  printf '    .beads/PRIME.md   .beads/hooks/**\n' >&2
   printf '\n' >&2
   printf '  Merge-side rule: never resolve a .beads conflict with --theirs/--ours.\n' >&2
   printf '  See CLAUDE.md > Beads durability.\n' >&2

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -448,12 +448,45 @@ for p in .beads/metadata.json .beads/events.jsonl .beads/beads.db .beads/dolt/no
 done
 
 # 3e: the human-authored beads config surface stays committable from anywhere.
-out=$(printf '.beads/README.md\n.beads/config.yaml\n.beads/.gitignore\n.beads/hooks/pre-commit\n' \
+out=$(printf '.beads/README.md\n.beads/config.yaml\n.beads/.gitignore\n.beads/PRIME.md\n.beads/hooks/pre-commit\n' \
       | run_beads_lib commit 2>"$BERR") || true
 case "$out" in
   *EXIT=0*) pass "human-authored beads config -> exit 0" ;;
   *) fail "human-authored beads config -> wrongly refused: $out"; cat "$BERR" >&2 ;;
 esac
+
+# 3e-bis: `.beads/PRIME.md` specifically.
+#
+# It is hand-written prose overriding `bd prime`'s SessionStart output, not a
+# database export, so a worker branch may carry it. The allow-list is
+# ENUMERATED, so this needs its own arm — without one the file falls through to
+# `.beads/*` and is refused from every worker worktree, reddening the CI arm on
+# every PR that touches it. Pinned alone rather than only inside 3e's batch: a
+# batch that exits 0 says nothing about WHICH member earned it.
+out=$(printf '.beads/PRIME.md\n' | run_beads_lib commit 2>"$BERR") || true
+case "$out" in
+  *EXIT=0*) pass ".beads/PRIME.md alone -> exit 0 (allow-listed)" ;;
+  *) fail ".beads/PRIME.md alone -> wrongly refused: $out"; cat "$BERR" >&2 ;;
+esac
+
+# ...and the widening is EXACT: neighbours that merely look like it stay
+# refused, so the new arm cannot be a `.beads/PRIME*` or `.beads/*.md` hole.
+for p in .beads/PRIME.md.bak .beads/PRIME.jsonl .beads/prime/export.jsonl .beads/NOTES.md; do
+  out=$(printf '%s\n' "$p" | run_beads_lib commit 2>"$BERR") || true
+  case "$out" in
+    *EXIT=1*) pass "PRIME lookalike still refused: $p" ;;
+    *) fail "PRIME lookalike WRONGLY permitted: $p (exit: $out)" ;;
+  esac
+done
+
+# ...and the refusal diagnostic advertises the permitted surface accurately,
+# so someone who hits it is not told PRIME.md is forbidden when it is not.
+out=$(printf '.beads/issues.jsonl\n' | run_beads_lib commit 2>"$BERR") || true
+if grep -q '\.beads/PRIME\.md' "$BERR"; then
+  pass "refusal diagnostic lists .beads/PRIME.md as permitted"
+else
+  fail "refusal diagnostic omits .beads/PRIME.md from the permitted surface"; cat "$BERR" >&2
+fi
 
 # 3f: mixed -> refused, and the listing names ONLY the beads path.
 out=$(printf 'implementation/core/src/ok.cljc\n.beads/issues.jsonl\n' \


### PR DESCRIPTION
Adopts a short `.beads/PRIME.md` overriding `bd prime`'s output, and adds the boundary-gate allow-list entry that lets the file exist on a worker branch at all.

## Why

`bd prime` runs on every SessionStart and PreCompact and emits ~1.8 MB, 99.7% of it memory bodies. The host's preview keeps head and tail, so the workflow context already arrives — what is serialised and then discarded is the ~900 memory bodies in between. `bd prime` reads `.beads/PRIME.md` and emits it *instead* of that default, so this replaces the discarded bulk with a deliberate choice about what rides in every session's opening context.

**This is not sold on latency.** The severe stalls correlate with *missing* memory output — all 40 intact memory-free runs took over 10 s, while only 4 of 421 large-output runs did — so reduced work is a reasonable expectation, not a promise.

## The file

3,774 bytes committed (canonical LF; 3,844 on a Windows CRLF checkout — the 70-byte delta is exactly the newline count). The 2-4 KB target was treated as an editorial target rather than a ceiling to build up to: every line here is a line in every future session's context window.

Ordered workflow-context-first, which is the ordering `bd prime` gets backwards:

1. **A provenance line, at the top.** It is advice from a tool; `CLAUDE.md` is the committed instruction and wins where they differ; it must not be cited as "CLAUDE.md says". A short confident file is *more* mistakable for `CLAUDE.md` than 1.8 MB of noise ever was, and that confusion has already happened here once.
2. Session-close sequence and the core bd rules (bd for all tracking, no TodoWrite/markdown TODOs, bead before code, `--append-notes` never `--notes`).
3. Finding-work commands, with `bd memories <topic>` and `bd recall <key>` prominent.
4. A paragraph stating that ~950 memories exist, are deliberately not injected, and are expected to be searched.
5. Four one-line pointers — substance plus a `bd recall` key — for silent-failure hazards `CLAUDE.md` does not already carry. Each was checked against `CLAUDE.md` before inclusion (0 hits each, against controls that fire).

Anything `CLAUDE.md` already says is left to `CLAUDE.md`, which is what keeps the file small.

## The allow-list

The classifier is an *enumerated* allow-list, so `.beads/PRIME.md` fell to the `.beads/*` refuse arm. Both arms — the `pre-commit` hook and the CI gate — source one classifier, `rf2_beads_is_permitted_path`, so the entry lands in a single place and both pick it up. No second arm needed changing; that was verified rather than assumed.

## Quality gates

All exit codes captured on the runner's own command line, never through a pipe.

| Gate | Exit |
|---|---|
| `scripts/check-beads-pr-boundary.sh origin/main` (post-rebase) | 0 |
| `scripts/git-hooks/test-pre-commit.sh` | 0 — 126 passed, 0 failed |
| `scripts/check_readme_links.py --ci` | 0 |
| `scripts/check-ai-tracking-ratchet.sh` | 0 |
| `scripts/check_skill_re_frame2_drift.py` | 0 |
| `scripts/check-commit-attribution.sh origin/main` | 0 |
| `scripts/install-git-hooks.sh --check` (bare, exit code only) | 0 |

**Two-direction proof of the widening**, on both arms:

- `.beads/PRIME.md` in the branch delta -> boundary gate exit **0**.
- A genuine `.beads/issues.jsonl` change planted (2061 -> 2062 rows, blob hash moved, so the plant is provably not a no-op): the `pre-commit` hook refused it at commit time (exit **1**), and with it forced into a commit the CI arm refused it too (exit **1**), naming only `.beads/issues.jsonl` and not `PRIME.md`. Restored and verified by git blob hash.
- **The pass is earned, not vacuous**: removing the new allow-list arm turns the gate **red on `.beads/PRIME.md`**. Restored and verified by blob hash.
- `check_readme_links.py` was likewise shown to have teeth on `scripts/git-hooks/README.md` via a planted broken target (exit 1, naming file, line and target), then restored by blob hash.

Six new assertions in layer 3 pin the permission on its own, pin that the widening is *exact* (`.beads/PRIME.md.bak`, `.beads/PRIME.jsonl`, `.beads/prime/export.jsonl`, `.beads/NOTES.md` all stay refused), and pin that the refusal diagnostic advertises the permitted surface accurately.

**Override verified to actually fire before anything relies on it**, in an isolated fixture: with the file present `bd prime` emits it exactly (76 B); renamed away in the same fixture it emits the 1,313,574 B default; `--hook-json` carries the override in the SessionStart envelope; `--export` ignores it and remains the re-sync source.

**Gates that do NOT cover `.beads/PRIME.md`, stated rather than nominated:** `.beads` is in `check_readme_links.py`'s `EXCLUDE_DIR_NAMES` and is not among `check_doc_slugs.py`'s roots (`docs`, `spec`, `skills`, `migration`, `tools/*/spec`). So **nothing validates links or anchors in `.beads/PRIME.md`** — moot here, since the file contains zero markdown links by construction, but worth knowing before someone adds one. The changed-surface classifier arms no CI surface for this diff (verified against a control that fires on a core path). Nothing grades prose for truth, so the accuracy of the file's content rests on the bead's contents list and on review. The file contains no tables.

## Follow-up deliberately not in this PR

The matching `CLAUDE.md` amendment — adding `.beads/PRIME.md` to the Beads-durability enumeration of human-authored config — is held back because that file is owned by another worker this tick. The wording has been handed over separately so the two changes cannot conflict.
