### PR TITLE
api(manifest): drop the derivable :var-count from the generated manifest

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -261,7 +261,7 @@
 ;; judged most likely to hide a public authoring surface an application
 ;; requires directly. Fifty-one namespaces were unaccounted (routing 28,
 ;; resources 23) and ALL FIFTY-ONE classified internal: no new manifest row, no
-;; new documentation page, `:var-count` unchanged. The reason the two trees
+;; new documentation page, the row count unchanged. The reason the two trees
 ;; differ from hicasso is structural rather than lucky. Both are FAÇADE
 ;; artefacts — one enrolled door re-exporting what an app may call (27 rows for
 ;; routing, 21 for resources), with the siblings holding handler bodies,
@@ -942,7 +942,7 @@
    a duplicated `:cljs-only` entry, or a `:cljs-only` row colliding with a
    JVM-derived row, produced a manifest with two rows for one var (possibly
    with conflicting tier/kind/status/runtime metadata) and an inflated
-   `:var-count`. Downstream projections then either collapse the two rows to
+   row count. Downstream projections then either collapse the two rows to
    one (`xray-spec-check`'s strict `[namespace var]` SET, which cannot
    represent a duplicate at all) or tolerate multiple tiers — masking the
    contradiction. Detecting duplicates HERE, before write / `--check`, keeps
@@ -1055,7 +1055,7 @@
     ;; One-row-per-public-var invariant (rf2-nlnd9y.2). A duplicate
     ;; `[namespace var]` — within `:cljs-only`, or between a `:cljs-only`
     ;; row and a JVM-derived row — must FAIL generation / `--check`, never
-    ;; ship two rows for one var (which inflates :var-count and lets
+    ;; ship two rows for one var (which inflates the row count and lets
     ;; downstream projections silently overwrite or mask conflicting tiers).
     (when (seq dups)
       (throw (ex-info
@@ -1129,7 +1129,6 @@
                                "why most rows carry neither. "
                                "See that generator ns for the design.")
             :keystone     "rf2-3nbl5.2"
-            :var-count    (count rows)
             :tier-vocab   [:front-porch :advanced :tooling :adapter
                            :testing :internal-public :implementation
                            :deprecated]
@@ -1207,7 +1206,7 @@
     (spit @manifest-file (render-edn manifest))
     (println (format "Wrote %s (%d public vars)."
                      (.getPath ^java.io.File @manifest-file)
-                     (:var-count (:meta manifest))))
+                     (count (:vars manifest))))
     manifest))
 
 (defn check!
@@ -1228,7 +1227,7 @@
       ;; does not trip a spurious drift (the canonical committed file is LF).
       (= (render-edn generated) (str/replace (slurp @manifest-file) "\r\n" "\n"))
       (do (println (format "OK: spec/api-manifest.edn in sync (%d public vars)."
-                           (:var-count (:meta generated))))
+                           (count (:vars generated))))
           true)
 
       :else

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
@@ -11,7 +11,7 @@
   duplicated `:cljs-only` entry — or a `:cljs-only` row colliding with a
   JVM-derived row — produced two manifest rows for one var (possibly with
   conflicting tier/kind/status/runtime metadata) and an inflated
-  `:var-count`. Drift checks could still pass (committed + regenerated agree
+  row count. Drift checks could still pass (committed + regenerated agree
   on the duplicate), while downstream projections silently collapse the two
   rows to one (`xray-spec-check`'s strict `[namespace var]` SET, which cannot
   represent a duplicate at all) or tolerate multiple tiers — masking the

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -8,7 +8,6 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. The :action and :justification columns are the facade-audit axes (spec/Conventions.md §Facade policy fields 4 and 3) — also curated, and present on :facade? true rows ONLY, which is why most rows carry neither. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 472,
  :tier-vocab
  [:front-porch
   :advanced


### PR DESCRIPTION
Removes the derivable `:var-count` field from the generated `spec/api-manifest.edn`. Ruled under rf2-fa7c: code-only, no merge-policy change, no new gate.

## Why

The generated manifest stated the same fact twice — once as one row per public var, and once as an integer restating that row count. A generated file should not restate its own row count.

The redundancy was not merely untidy. Two independent PRs each deleting a *different* public var compute the **same** new value for the scalar, so they produce a textually identical edit that git merges without conflict while both row deletions survive — leaving the declared count disagreeing with the rows it describes. Three such mismatches reached trunk on 2026-09-08 across 22 manifest-touching commits (one of them off by two, from three interleaving branches), each repaired by a follow-up commit rather than by CI. Deleting the field makes that particular silent merge impossible.

## The change

- `build-manifest` no longer emits `:var-count` into `:meta`.
- `generate!` and `check!` take their console counts from `(count (:vars ...))`. The human-facing `(N public vars)` line is unchanged; the number simply stops being persisted.
- Three stale comments and one test docstring that named the field are updated.
- `spec/api-manifest.edn` regenerated — **not hand-edited**. The diff is `0 insertions, 1 deletion`: the removed header field and nothing else, with all 472 rows byte-identical.

`spec/api-manifest-metadata.edn` (curated input) and `spec/API.md` (curated prose) carry no count and are **not touched**.

## What still detects a row-count disagreement

`check!` compares the **complete LF-normalised rendering**, not a count. It therefore still reds on wrong rows, kinds, classifications or formatting — and it is strictly stronger than the removed scalar ever was, because equal counts could never establish correct var identities.

Proven in both directions, as the ruling asks:

- **Green:** against the regenerated file, `gen --check` exits 0 — `OK: spec/api-manifest.edn in sync (472 public vars).`
- **Red:** with one row's `:tier` altered from `:front-porch` to `:advanced` — leaving the row count at 472 and the line count at 493, so no count-based check could ever see it — `gen --check` exits **1** and names the row: `+ re-frame.core / capture-frame -> :front-porch :fn v1`.

What is knowingly given up: nothing detects a *declared-vs-counted* disagreement, because after this change there is no declared count to disagree. That is the point of the removal, and it is the accepted consequence of the ruling. The prevention hole for *other* derived scalars stays open by design; `tags-column-paired-floor` is the same class and is deliberately retained, since it records an independently reviewed expectation.

## Blast radius

No consumer read the field. A repo-wide census puts `var-count` in exactly three tracked files, whose only two executable readers are the console messages changed here. `check_thrown_error_messages.py` parses `:namespace`/`:var` rows by regex and never touches `:meta`; the CLJS probe reads the curated sidecar, not the generated manifest.

## Quality gates

All run locally from `implementation/scripts/api-manifest/`, exit codes captured on the runner's own command line (never through a pipe).

The full `api-manifest` job step set — 8 of 8 pass, 0 fail:

| step | exit |
|---|---|
| `gen --check` | 0 |
| `api-md-check` | 0 |
| `story-spec-check` | 0 |
| `xray-spec-check` | 0 |
| `skills-check` | 0 |
| `doc-guide-check` | 0 |
| `doc-api-check` | 0 |
| `clojure -M:test` (reconciler regressions) | 0 — 101 tests, 202 assertions, 0 failures, 0 errors |

Ratchets over the touched paths — 6 of 6 pass, 0 fail: `check_thrown_error_messages.py` (0; 333 files), `check_retired_spellings.py` (0; 901/205/1057 files), `check_require_alias_dialect.py` (0; 2820 files, 11061 require edges), `check_keyword_catalogue_drift.py` (0), `check-beads-pr-boundary.sh` (0), `check-commit-attribution.sh` (0). Each was confirmed to be a real graded pass rather than a silent zero, and the boundary and attribution guards were each exercised against an input they should reject (exit 1 both times).

`gen --check` was re-run after rebasing onto `origin/main` (a trunk commit touched `implementation/http/src/`, which could have staled the manifest) — still green at 472.

Gates that do **not** cover these paths, and so are not nominated: `check_doc_slugs.py` and `check_readme_links.py --ci` (no markdown changed), `mkdocs build --strict` (nothing under `docs_dir`, and `spec/api-manifest.edn` is data rather than a page). clj-kondo and Splint are left to CI, whose pinned versions grade the branch.

Bead: rf2-fa7c (left OPEN — the mayor disposes of beads).
