### PR TITLE
fix(machines): spawning onto an occupied :fixed-actor-id destroys the occupant cleanly first (rf2-dokz)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -758,3 +758,48 @@
 
       :else
       (rf.machines.lifecycle-fx.traces/emit-destroy-bad-arg! frame-id :unknown-shape args))))
+
+;; ---- occupied-address replacement (rf2-dokz) -------------------------------
+
+(defn destroy-occupant-for-replacement!
+  "Tear a LIVE occupant of `actor-id` down through the ORDINARY destroy path so
+  a `:rf.machine/spawn` arriving at an OCCUPIED `:fixed-actor-id` REPLACES it
+  cleanly instead of overwriting its snapshot. Called by
+  `lifecycle-fx.spawn/spawn-fx*` immediately before its install; see Spec 005
+  §Spec-spec keys §Spawning onto an OCCUPIED fixed address.
+
+  WHY IT DELEGATES rather than reaching for the pipeline directly. Spawn's old
+  behaviour was ONE unguarded `assoc-in` at the snapshot path, and because a
+  spawned actor's liveness IS that snapshot's presence (Spec 005 §Liveness is
+  derived from runtime-db) that single write was simultaneously the new actor's
+  BIRTH and the occupant's unannounced DEATH — so none of the nine ordered
+  teardown steps ran and all three of Spec 005 §What auto-cancels on destroy's
+  named guarantees were silently void (the occupant's authored `:exit` never
+  fired, its armed `:after` timers stayed armed on the host clock, its in-flight
+  `:rf.http/managed` requests kept flying, its `[:machine <actor-id>]` resource
+  owners kept polling). Routing through `destroy-machine-fx`'s KEYWORD branch —
+  rather than calling the private `teardown-live-actor!` — is deliberate: the
+  keyword form is what `[:rf.machine/destroy <actor-id>]` itself takes, so the
+  replacement gets `prepare-join-child-teardown!`'s join preparation, the fresh
+  `effect-fence`, and the `:rf.machine/destroyed` emit for free, and it cannot
+  drift from the ordinary path because it IS the ordinary path.
+
+  `:reason` is the EXISTING `:explicit`, never a new enum member: both
+  `prepare-join-child-teardown!`'s live-join-child cancellation (its
+  `cancel-current?` gate) and `traces/emit-destroyed!`'s cancelled-reply facts
+  (its `cancelled?` gate) test for exactly `:explicit`, so a bespoke reason
+  would SKIP both and leave a replaced join child's attempt uncancelled with its
+  reply facts unemitted.
+
+  Returns `true` when the address was occupied and the teardown ran, `false`
+  when it was EMPTY. False is the overwhelmingly common answer — ordinary
+  re-entry at a `:fixed-actor-id` arrives after the exit cascade has already
+  destroyed the previous incarnation — and one `actor-live?` read is its whole
+  cost. A `true` tells the caller its pre-teardown `runtime-db` snapshot is
+  STALE and the install must be rebuilt from the post-teardown value."
+  [frame-id actor-id]
+  (boolean
+    (when (and actor-id
+               (actor-live? frame-id actor-id (rf.frame/frame-runtime-db-value frame-id)))
+      (destroy-machine-fx {:frame frame-id} actor-id)
+      true)))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -27,6 +27,12 @@
             [re-frame.late-bind :as rf.late-bind]
             [re-frame.machines.classification :as rf.machines.classification]
             [re-frame.machines.data-validation :as rf.machines.data-validation]
+            ;; rf2-dokz — the occupied-`:fixed-actor-id` replacement runs the
+            ;; occupant through the ORDINARY destroy path. Nothing under
+            ;; `lifecycle-fx.destroy`'s require graph reaches this ns (only the
+            ;; `re-frame.machines` aggregator requires it), so the edge is
+            ;; acyclic.
+            [re-frame.machines.lifecycle-fx.destroy :as rf.machines.lifecycle-fx.destroy]
             [re-frame.machines.lifecycle-fx.resolver :as rf.machines.lifecycle-fx.resolver]
             [re-frame.machines.parallel :as rf.machines.parallel]
             [re-frame.machines.paths :as rf.machines.paths]
@@ -441,12 +447,21 @@
   `initial-snap` (built once by the caller) is threaded in rather than
   re-built here.
 
-  `rt-after-alloc` is the post-id-allocation runtime-db computed by the
-  caller (see `spawn-fx`); `swap-runtime-db!`'s fn arg is discarded — the
-  merge is applied on top of `rt-after-alloc` so the caller's counter bump
-  survives. Under Spec 002's single-drainer invariant the discarded
-  re-read is value-equal to the snapshot the caller already had. Machine
-  snapshots are durable runtime-db state (EP-0001).
+  `rt-after-alloc` is the install base the caller computed (see `spawn-fx*`);
+  `swap-runtime-db!`'s fn arg is discarded — the merge is applied on top of
+  that base so the caller's counter bump survives. Under Spec 002's
+  single-drainer invariant the discarded re-read is value-equal to the snapshot
+  the caller already had. Machine snapshots are durable runtime-db state
+  (EP-0001).
+
+  rf2-dokz — DISCARDING `_rt` MAKES THE BASE'S CURRENCY THE CALLER'S PROBLEM,
+  and there is exactly one path on which the caller's first read is NOT current:
+  an occupied-`:fixed-actor-id` replacement writes to runtime-db (the occupant's
+  teardown) between that read and this swap. Handing the pre-teardown value in
+  would silently RESTORE the occupant's snapshot and undo the destroy. So
+  `spawn-fx*` rebuilds the base from the post-teardown runtime-db before calling
+  here (`install-base-after-replacing-occupant!`); this fn is unchanged and
+  simply installs whatever base it is given.
 
   `type-ref-fn` is a THUNK, not a value (rf2-zo5n9). The revertible TYPE
   reference a PREPARED `:spawn-all` child stamps is registrar-DERIVED —
@@ -757,7 +772,15 @@
       from runtime-db alone. The runtime stamps `:rf/self-id`
       (the spawned actor's own address) and, when applicable,
       `:rf/parent-id` + `:rf/invoke-id` into the actor's initial `:data`.
-      Re-spawn under the same id replaces — last-write-wins.
+      Re-spawn at an address a LIVE actor still occupies REPLACES that
+      actor, and replacement is a CLEAN destroy-then-install: rf2-dokz
+      runs the occupant through the ordinary `[:rf.machine/destroy
+      <actor-id>]` path first (`:reason :explicit`, join preparation
+      included), so its `:exit` runs and its timers / managed HTTP /
+      resource owners release, and only then installs the newcomer from
+      the post-teardown runtime-db. It is NOT last-write-wins over a live
+      snapshot. Independent CHILD lifetimes are not reaped — see Spec 005
+      §Spec-spec keys.
    3. If `:rf/parent-id` + `:rf/invoke-id` present (declarative `:spawn`
       desugar), bind the spawned id at
       `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]`.
@@ -829,6 +852,66 @@
 
       :else
       (spawn-fx* frame-id args))))
+
+(defn- install-base-after-replacing-occupant!
+  "rf2-dokz — the occupied-`:fixed-actor-id` step. Returns the `runtime-db`
+  value `install-spawn!` must build its install on, or nil when the install must
+  NOT proceed.
+
+  Three things happen here, in this order, and the order is the contract.
+
+  (1) NOTHING IS DISTURBED UNTIL THE INCOMING SPAWN IS KNOWN GOOD. The caller
+  has already resolved the spec, built `initial-snap` and run the
+  `[:schemas :data]` validator (`rejected?`), and gates this whole cascade on
+  that verdict — so a spawn that will be REJECTED never reaches here and leaves
+  the occupant intact. Replacement is not a licence to destroy on the way to
+  failing.
+
+  (2) THE OCCUPANT IS TORN DOWN THROUGH THE ORDINARY DESTROY PATH, under the
+  EXISTING `:reason :explicit` (see
+  `lifecycle-fx.destroy/destroy-occupant-for-replacement!` for why it delegates
+  and why the reason may not be a new enum member). Scoped to a SUPPLIED
+  `:fixed-actor-id`: a generated `<type>#<n>` address that collides with a live
+  actor is the separate reseeded-`:rf/spawn-counter` defect (rf2-1sip), not this
+  one, and is deliberately left alone.
+
+  (3) THE INSTALL BASE IS REBUILT FROM THE POST-TEARDOWN VALUE. This is the trap
+  the fix exists to avoid: `install-spawn!`'s `install-fn` DISCARDS the swap's
+  `_rt` argument and returns a value captured before it, so passing the caller's
+  pre-teardown `rt-after-alloc` would RESTORE every slot the teardown just
+  removed — the occupant's snapshot among them — and the destroy would be undone
+  by the very write it was meant to precede. Re-reading the frame's live
+  `runtime-db` here is the whole repair. The one delta `rt-after-alloc` carries
+  over `old-rt` that must survive the rebase is `drop-prepared-entry`, so it is
+  re-applied (it is a belt-and-braces no-op against a slot that is not a live
+  join). The spawn-counter bump is NOT re-applied and does not need to be: it is
+  taken only when `pre-allocated-actor-id` returned nil, and a `:fixed-actor-id`
+  spawn always has one.
+
+  Between this read and the swap sit only the `type-ref-fn` force, the
+  `(continue?)` rechecks and the two spawned traces — no `runtime-db` writer —
+  so the rebased base is as current at commit as the caller's own read is on the
+  untouched path (Spec 002 §Single drainer per frame).
+
+  RETURNS NIL WHEN THE TEARDOWN COST US THE FRAME. The occupant's authored
+  `:exit` is APPLICATION code running synchronously inside the teardown: it can
+  destroy this frame outright (the live `runtime-db` then reads nil) or destroy
+  incarnation A and publish a same-id B (`continue?` goes false — and note that
+  fence is a FRAME fence, so it is checked here explicitly rather than assumed
+  to cover same-address actor churn). Either way the replacement must not
+  install, and returning nil suppresses the spawned traces as well as the write.
+  On the untouched path `rt-after-alloc` is handed straight back, so a spawn at
+  an EMPTY address pays one `actor-live?` read and nothing else."
+  [frame-id args spawned-id prepared rt-after-alloc continue?]
+  (if-not (and (contains? args :fixed-actor-id)
+               (rf.machines.lifecycle-fx.destroy/destroy-occupant-for-replacement!
+                 frame-id spawned-id))
+    rt-after-alloc
+    (when (or (nil? continue?) (continue?))
+      (when-let [rt (rf.frame/frame-runtime-db-value frame-id)]
+        (if prepared
+          (drop-prepared-entry rt args spawned-id)
+          rt)))))
 
 (defn- spawn-fx*
   "The accepted-spawn body of `spawn-fx` — runs only after the
@@ -994,7 +1077,25 @@
     ;;       trace / dispatch tail may land on B.
     ;; A destroyed-frame or owner-lost spawn is a clean no-op — no trace, no
     ;; install, no dispatch — symmetric with the schema-reject path's atomicity.
-    (when (and (not rejected?) old-rt (continue?))
+    ;;
+    ;; rf2-dokz adds a FOURTH condition, and folds the three above into the same
+    ;; `and` so the short-circuit order is unchanged: the install base must be
+    ;; obtainable. `install-base-after-replacing-occupant!` runs LAST — after the
+    ;; validator verdict, so a rejected spawn never disturbs an occupant — and it
+    ;; tears a LIVE occupant of a supplied `:fixed-actor-id` down through the
+    ;; ORDINARY destroy path before returning the POST-teardown value the install
+    ;; must be built on. It returns nil when the occupant's authored `:exit` cost
+    ;; us the frame or the exact owner, which suppresses the spawned traces and
+    ;; the install together. On every other spawn it returns `rt-after-alloc`
+    ;; unchanged, so this reads exactly as it did before.
+    ;;
+    ;; The teardown sits AHEAD of the `:rf.machine.spawn/spawned` trace on
+    ;; purpose: the occupant's `:rf.machine/destroyed` is therefore observed
+    ;; BEFORE the replacement's spawned traces, and a tool pairing lifecycle
+    ;; events never sees one address spawned twice with no destroy between.
+    (when-let [rt-install (and (not rejected?) old-rt (continue?)
+                               (install-base-after-replacing-occupant!
+                                 frame-id args spawned-id prepared rt-after-alloc continue?))]
       (rf.trace/emit! :rf.machine :rf.machine.spawn/spawned
                    {:frame      frame-id
                     ;; `:machine-id` is the spec-time registered TYPE (xor
@@ -1032,7 +1133,7 @@
       ;; that. `continue?` is threaded into `install-spawn!` so the write is
       ;; rechecked against the exact incarnation immediately before it lands.
       (when (continue?)
-        (let [installed (install-spawn! frame-id rt-after-alloc spec'' spawned-id initial-snap
+        (let [installed (install-spawn! frame-id rt-install spec'' spawned-id initial-snap
                                         {:parent-id   parent-id
                                          :invoke-id   invoke-id
                                          :track?      track?

--- a/implementation/machines/test/re_frame/fixed_actor_id_addressing_test.clj
+++ b/implementation/machines/test/re_frame/fixed_actor_id_addressing_test.clj
@@ -18,18 +18,22 @@
        then dispatches to that address and destroys it explicitly. There is NO
        second spawn-result channel.
 
-    3. **Occupied-fixed-address reuse is CHARACTERISED, not guaranteed.**
-       `spawn-all-address-collisions` is a WITHIN-BATCH guard; the ordinary
-       `spawn-fx*` path installs at a supplied fixed address with no general
-       occupied-address rejection. The test below records what the runtime
-       actually does today rather than asserting a guarantee the code does not
-       make."
+    3. **Spawning onto an OCCUPIED fixed address destroys the occupant
+       CLEANLY first (rf2-dokz).** `spawn-all-address-collisions` is a
+       WITHIN-BATCH guard and stays one; the ordinary `spawn-fx*` path still
+       has no occupied-address rejection and still takes the supplied address
+       verbatim — but it now runs a LIVE occupant through the ORDINARY destroy
+       path (`:reason :explicit`, join preparation included) before installing
+       the replacement from the post-teardown `runtime-db`. Independent CHILD
+       lifetimes are NOT reaped. The tests below are the CONTRACT, replacing
+       the characterisation that preceded them."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines]
             [re-frame.machines.reply :as rf.machines.reply]
             [re-frame.machines.test-support :as rf.machines.test-support]
-            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (use-fixtures :each
   (rf.machines.test-support/make-reset-runtime-fixture
@@ -161,32 +165,293 @@
     (is (some? (snapshot :fai.w/two)) "the newer worker is untouched")))
 
 ;; ---------------------------------------------------------------------------
-;; (3) Occupied-fixed-address reuse — CHARACTERISATION, not a guarantee
+;; (3) Spawning onto an OCCUPIED fixed address — the CONTRACT (rf2-dokz)
 ;; ---------------------------------------------------------------------------
+;;
+;; These replace a CHARACTERISATION suite. Its predecessor recorded that a
+;; second spawn at a live fixed address "REPLACES the occupant's snapshot in
+;; place" and said in as many words that this was "what the runtime actually
+;; does today rather than asserting a guarantee the code does not make". What it
+;; was protecting is worth keeping and is kept below: that the ordinary spawn
+;; path takes the supplied address VERBATIM (no `<type>#<n>` sidelining, no
+;; second name registry) and does NOT reject an occupied one, so nobody
+;; "restores parity" by adding a registry or an error.
+;;
+;; What it did NOT say — because the code did not do it — is what happened to
+;; the OCCUPANT. Liveness IS snapshot presence (Spec 005 §Liveness is derived
+;; from runtime-db), so the one unguarded `assoc-in` was simultaneously a birth
+;; and an unannounced death: the occupant's authored `:exit` never ran and none
+;; of the three framework-managed resource kinds released. rf2-dokz ruled that a
+;; replacement runs the occupant through the ORDINARY destroy path first. These
+;; tests pin THAT, and each of them goes RED against the old behaviour.
 
-(deftest spawning-onto-an-occupied-fixed-address-replaces-the-occupant
-  (testing "rf2-kuky.70 Target 4 — CHARACTERISATION of current behaviour, NOT a
-            contract this bead widens. `spawn-all-address-collisions` is a
-            WITHIN-BATCH guard (pinned separately); the ORDINARY spawn path has
-            no general occupied-address rejection, so a second spawn at a LIVE
-            fixed address REPLACES the occupant's snapshot in place. The
-            address stays the one name; the earlier incarnation is gone."
-    (rf/reg-machine :fai/occupant
+(defn- capture-traces [id]
+  (let [a (atom [])]
+    (rf.trace.tooling/register-listener! id (fn [ev] (swap! a conj ev)))
+    a))
+
+(defn- operations [traces]
+  (mapv :operation @traces))
+
+(deftest spawning-onto-an-occupied-fixed-address-destroys-the-occupant-then-installs
+  (testing "rf2-dokz — a spawn arriving at a LIVE :fixed-actor-id runs the
+            occupant through the ordinary destroy path (:reason :explicit) and
+            only then installs the replacement: the occupant's authored :exit
+            runs exactly once, its :rf.machine/destroyed is observed BEFORE the
+            replacement's spawned traces, the address carries a FRESH snapshot,
+            and a later dispatch reaches the replacement"
+    (let [exits  (atom 0)
+          traces (capture-traces ::occupied-contract)]
+      (try
+        (rf/reg-machine :fai/occupant
+          {:initial :running
+           :data    {}
+           :actions {:mark (fn [{d :data ev :event}] {:data (assoc d :tag (second ev))})}
+           :states  {:running {:exit (fn [_] (swap! exits inc) {})
+                               :on   {:mark {:action :mark}}}}})
+        (rf/reg-event :fai/install
+          (fn [_ [_ payload]]
+            {:fx [[:rf.machine/spawn {:machine-id     :fai/occupant
+                                      :fixed-actor-id :fai/slot
+                                      :data           {:payload payload}}]]}))
+
+        (rf/dispatch-sync [:fai/install :first])
+        (rf/dispatch-sync [:fai/slot [:mark :first-tag]])
+        (is (= :first (:payload (:data (snapshot :fai/slot))))
+            "precondition: the address is OCCUPIED by the first incarnation")
+        (is (= :first-tag (:tag (:data (snapshot :fai/slot))))
+            "precondition: the occupant has state of its own to lose")
+        (is (zero? @exits)
+            "precondition: the occupant is LIVE — its :exit has not run")
+        (reset! traces [])
+
+        ;; The replacement.
+        (rf/dispatch-sync [:fai/install :second])
+
+        ;; (a) THE LEAK THIS BEAD IS ABOUT. Under the old silent overwrite this
+        ;; counter stayed at 0: the author's own teardown never ran, which also
+        ;; voids the escape hatch Spec 005 designates for every resource the
+        ;; framework cannot manage (sockets, clearInterval, workers, SDK
+        ;; subscriptions).
+        (is (= 1 @exits)
+            "the occupant's authored :exit ran EXACTLY once — not zero (silently
+             overwritten) and not twice (destroyed twice)")
+
+        ;; (b) The address carries a FRESH snapshot, not a patched old one.
+        (is (= :second (:payload (:data (snapshot :fai/slot))))
+            "the replacement is installed at the same address")
+        (is (nil? (:tag (:data (snapshot :fai/slot))))
+            "the snapshot is FRESH — the occupant's own :data did not survive")
+
+        ;; (c) Retained from the characterisation: the supplied address is used
+        ;; VERBATIM and an occupied one is not rejected. Both still hold, and
+        ;; both are the reason nobody should re-add a name registry.
+        (is (nil? (snapshot :fai/occupant#1))
+            "no sidelined copy of either incarnation under an allocated <type>#<n> id")
+
+        ;; (d) The lifecycle pairing contract: destroyed BEFORE spawned, so a
+        ;; tool pairing lifecycle events never sees one address spawned twice
+        ;; with no destroy between. Under the old behaviour there was no
+        ;; :rf.machine/destroyed here at all.
+        (let [ops (filterv #{:rf.machine/destroyed
+                             :rf.machine.spawn/spawned
+                             :rf.machine.lifecycle/spawned}
+                           (operations traces))]
+          (is (some #{:rf.machine/destroyed} ops)
+              "the replaced occupant emitted :rf.machine/destroyed")
+          (is (some #{:rf.machine.spawn/spawned} ops)
+              "the replacement emitted its spawned trace")
+          (is (= :rf.machine/destroyed (first ops))
+              "DESTROYED is observed BEFORE the replacement's spawned traces"))
+
+        ;; (e) The replacement owns the address.
+        (rf/dispatch-sync [:fai/slot [:mark :second-tag]])
+        (is (= :second-tag (:tag (:data (snapshot :fai/slot))))
+            "an ordinary dispatch to the address reaches the REPLACEMENT")
+        (is (= 1 @exits)
+            "and nothing re-ran the destroyed occupant's :exit")
+        (finally (rf.trace.tooling/unregister-listener! ::occupied-contract))))))
+
+(deftest replacing-an-occupant-cancels-its-armed-after-timer
+  (testing "rf2-dokz — the occupant's armed :after is cancelled by the
+            replacement's teardown. The successor is a type with NO :after, so
+            the cancellation cannot be the leading :on-supersede cancel that
+            arming at the same key would produce: any timer cancellation in the
+            window belongs to the destroy"
+    (let [traces (capture-traces ::occupied-timer)]
+      (try
+        (rf/reg-machine :fai/timed
+          {:initial :waiting
+           :data    {}
+           :states  {:waiting   {:after {60000 :timed-out}}
+                     :timed-out {}}})
+        (rf/reg-machine :fai/untimed
+          {:initial :running
+           :data    {}
+           :states  {:running {}}})
+        (rf/reg-event :fai/install-timed
+          (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :fai/timed
+                                              :fixed-actor-id :fai/tslot}]]}))
+        (rf/reg-event :fai/install-untimed
+          (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :fai/untimed
+                                              :fixed-actor-id :fai/tslot}]]}))
+
+        (rf/dispatch-sync [:fai/install-timed])
+        (is (= :waiting (:state (snapshot :fai/tslot)))
+            "precondition: the occupant is live in its :after-bearing state")
+        (is (some #{:rf.machine.timer/scheduled} (operations traces))
+            "precondition: the occupant ARMED its 60s :after")
+        (reset! traces [])
+
+        (rf/dispatch-sync [:fai/install-untimed])
+
+        (is (some #{:rf.machine.timer/cancelled} (operations traces))
+            "the occupant's armed :after was CANCELLED by the replacement's
+             teardown — under the silent overwrite the entry was retained with
+             no cancellation, host clock still armed")
+        (is (= :running (:state (snapshot :fai/tslot)))
+            "sanity: the address really does carry the timer-less successor, so
+             the cancellation above cannot be an :on-supersede re-arm")
+        (finally (rf.trace.tooling/unregister-listener! ::occupied-timer))))))
+
+(deftest a-rejected-incoming-spawn-leaves-the-occupant-intact
+  (testing "rf2-dokz — the incoming spawn is resolved and VALIDATED before the
+            occupant is disturbed, so a spawn that will be rejected destroys
+            nothing. Replacement is not a licence to tear down on the way to
+            failing"
+    (let [exits (atom 0)]
+      (rf/reg-machine :fai/holder
+        {:initial :running
+         :data    {}
+         :states  {:running {:exit (fn [_] (swap! exits inc) {})}}})
+      (rf/reg-event :fai/hold
+        (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :fai/holder
+                                            :fixed-actor-id :fai/held
+                                            :data           {:payload :original}}]]}))
+      ;; An UNREGISTERED :machine-id — the child-local fail-closed gate rejects
+      ;; it before any install work runs.
+      (rf/reg-event :fai/bad-hold
+        (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :fai/never-registered
+                                            :fixed-actor-id :fai/held}]]}))
+
+      (rf/dispatch-sync [:fai/hold])
+      (is (= :original (:payload (:data (snapshot :fai/held))))
+          "precondition: the address is occupied")
+
+      (rf/dispatch-sync [:fai/bad-hold])
+      (is (= :original (:payload (:data (snapshot :fai/held))))
+          "the rejected spawn left the occupant's snapshot untouched")
+      (is (zero? @exits)
+          "and did NOT run the occupant's :exit — nothing was destroyed"))))
+
+(deftest the-occupants-teardown-writes-survive-the-replacements-install
+  (testing "rf2-dokz — the install is rebuilt from the POST-teardown runtime-db.
+            install-spawn!'s install-fn DISCARDS the swap's argument and returns
+            a pre-captured value, so an install built on the pre-teardown base
+            would RESTORE everything the teardown removed. Proved on a SECOND
+            actor the occupant's :exit destroys: if the install reverted the
+            teardown, that actor's snapshot would come back"
+    (rf/reg-machine :fai/sidekick
+      {:initial :running :data {} :states {:running {}}})
+    (rf/reg-machine :fai/boss2
       {:initial :running
        :data    {}
-       :states  {:running {}}})
-    (rf/reg-event :fai/install
-      (fn [_ [_ payload]]
-        {:fx [[:rf.machine/spawn {:machine-id     :fai/occupant
-                                  :fixed-actor-id :fai/slot
-                                  :data           {:payload payload}}]]}))
-    (rf/dispatch-sync [:fai/install :first])
-    (is (= :first (:payload (:data (snapshot :fai/slot))))
-        "precondition: the address is OCCUPIED by the first incarnation")
+       :states  {:running {:exit (fn [_]
+                                   {:fx [[:rf.machine/destroy :fai/sidekick]]})}}})
+    (rf/reg-event :fai/install-boss
+      (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :fai/boss2
+                                          :fixed-actor-id :fai/boss-slot}]]}))
 
-    (rf/dispatch-sync [:fai/install :second])
-    (is (= :second (:payload (:data (snapshot :fai/slot))))
-        "the second spawn REPLACED the live occupant at the same address —
-         no occupied-address rejection fires on the ordinary spawn path")
-    (is (nil? (snapshot :fai/occupant#1))
-        "no sidelined copy of the first incarnation survives under an allocated id")))
+    ;; Bring the sidekick to life (a singleton machine wakes on first dispatch).
+    (rf/dispatch-sync [:fai/sidekick [:rf.machine/noop]])
+    (is (some? (snapshot :fai/sidekick)) "precondition: the sidekick is live")
+    (rf/dispatch-sync [:fai/install-boss])
+    (is (some? (snapshot :fai/boss-slot)) "precondition: the address is occupied")
+    (is (some? (snapshot :fai/sidekick)) "precondition: the sidekick is still live")
+
+    (rf/dispatch-sync [:fai/install-boss])
+
+    (is (some? (snapshot :fai/boss-slot))
+        "the replacement installed at the address")
+    (is (nil? (snapshot :fai/sidekick))
+        "the occupant's :exit destroyed the sidekick and the REPLACEMENT'S
+         INSTALL DID NOT BRING IT BACK — the install base was rebuilt from the
+         post-teardown runtime-db")))
+
+(deftest replacing-an-occupant-does-not-reap-its-children
+  (testing "rf2-dokz — the CHILD-LIFETIME CONTROL. Ordinary destroy tears down
+            the PARENT ONLY (Spec 005 'Teardown is explicit in v1'), and this
+            change must not have introduced a descendant cascade under cover of
+            fixing the occupant leak. The occupant's declaratively-spawned child
+            survives its replacement, exactly as it survives an explicit destroy"
+    (rf/reg-machine :fai/kid
+      {:initial :running :data {} :states {:running {}}})
+    (rf/reg-machine :fai/breeder
+      {:initial :running
+       :data    {}
+       :states  {:running {:spawn {:machine-id     :fai/kid
+                                   :fixed-actor-id :fai/kid-addr}}}})
+    (rf/reg-event :fai/install-breeder
+      (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :fai/breeder
+                                          :fixed-actor-id :fai/breeder-slot}]]}))
+
+    (rf/dispatch-sync [:fai/install-breeder])
+    (is (some? (snapshot :fai/breeder-slot)) "precondition: the occupant is live")
+    (is (some? (snapshot :fai/kid-addr))
+        "precondition: the occupant spawned a child at its own fixed address")
+
+    (rf/dispatch-sync [:fai/install-breeder])
+
+    (is (some? (snapshot :fai/breeder-slot))
+        "the occupant was replaced")
+    (is (some? (snapshot :fai/kid-addr))
+        "the occupant's CHILD SURVIVES — no implicit ownership cascade was
+         introduced; the author's :exit is still where children are torn down")))
+
+(deftest replacing-a-join-child-retains-its-cancellation-facts
+  (testing "rf2-dokz — a replaced :spawn-all join child goes through
+            prepare-join-child-teardown! under the EXISTING :reason :explicit,
+            so its attempt is durably closed and its :rf.machine/destroyed
+            carries the cancelled reply facts. A bespoke :reason would have
+            skipped both gates silently"
+    (let [traces (capture-traces ::occupied-join)]
+      (try
+        (rf/reg-machine :fai/jchild
+          {:initial :running :data {} :states {:running {}}})
+        (rf/reg-machine :fai/jparent
+          {:initial :idle
+           :data    {}
+           :states  {:idle    {:on {:go :working}}
+                     :working {:spawn-all {:children        [{:id         :only
+                                                              :machine-id :fai/jchild
+                                                              :fixed-actor-id :fai/joined}]
+                                           :join            :all
+                                           :on-all-complete [:all-done]}
+                               :on        {:all-done :done}}
+                     :done    {}}})
+        (rf/reg-event :fai/take-the-address
+          (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :fai/jchild
+                                              :fixed-actor-id :fai/joined}]]}))
+
+        (rf/dispatch-sync [:fai/jparent [:go]])
+        (is (some? (snapshot :fai/joined))
+            "precondition: the join child is live at its fixed address")
+        (reset! traces [])
+
+        (rf/dispatch-sync [:fai/take-the-address])
+
+        (let [destroyed (->> @traces
+                             (filter #(= :rf.machine/destroyed (:operation %)))
+                             first)]
+          (is (some? destroyed)
+              "the replaced join child emitted :rf.machine/destroyed")
+          (let [tags (:tags destroyed)]
+            (is (= :explicit (:reason tags))
+                "the reason is the EXISTING :explicit — the keyword both the
+                 join-child cancellation gate and the cancelled-reply gate test
+                 for; a new enum member would skip both without erroring")
+            (is (true? (:rf.reply/cancelled? tags))
+                "the cancelled reply facts rode the destroyed trace")
+            (is (= :cancelled (:rf.reply/status tags))
+                "the attempt was closed the reply-envelope way")))
+        (finally (rf.trace.tooling/unregister-listener! ::occupied-join))))))

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -2632,7 +2632,7 @@ There is no `:timeout-ms` slot on `:spawn` / `:spawn-all` (`:rf.error/spawn-time
 
 If machines are event handlers and actors are machines, then **a spawned actor is addressable as an event handler whose id is the actor's address** — but, per [§Liveness is derived from runtime-db](#liveness-is-derived-from-runtime-db), that handler is NOT a per-instance registrar entry. It is *resolved on demand* from the actor's snapshot. The mailbox / addressing semantics fall out of `dispatch` — no new primitive.
 
-> **Teardown is explicit in v1.** Every spawned actor ends its life at a named `[:rf.machine/destroy <actor-id>]` site — there is no implicit ownership cascade. Auto-cleanup via an opt-in `:owned-by` relation is a v1.1+ direction; per [§Resolved decisions §Auto-cleanup of orphaned actors](#auto-cleanup-of-orphaned-actors--explicit-rfmachinedestroy-for-v1-resolved). The one composed-with cascade is the `:rf.http/managed`-abort cascade per [§Cancellation cascade — in-flight `:rf.http/managed` aborts](#cancellation-cascade--in-flight-rfhttpmanaged-aborts), which fires off the explicit `:rf.machine/destroy`.
+> **Teardown is explicit in v1.** Every spawned actor ends its life at a named `[:rf.machine/destroy <actor-id>]` site — there is no implicit ownership cascade. Auto-cleanup via an opt-in `:owned-by` relation is a v1.1+ direction; per [§Resolved decisions §Auto-cleanup of orphaned actors](#auto-cleanup-of-orphaned-actors--explicit-rfmachinedestroy-for-v1-resolved). The one composed-with cascade is the `:rf.http/managed`-abort cascade per [§Cancellation cascade — in-flight `:rf.http/managed` aborts](#cancellation-cascade--in-flight-rfhttpmanaged-aborts), which fires off the explicit `:rf.machine/destroy`. **One narrow qualification:** a `:rf.machine/spawn` arriving at a `:fixed-actor-id` that a LIVE actor occupies destroys that occupant through the ordinary destroy path before installing the replacement (per [§Spec-spec keys](#spec-spec-keys)). That is still an explicit teardown at a named address — the author named it by spawning there — and it reaps NOTHING beyond the occupant itself: the occupant's own spawned children survive it exactly as they survive an explicit `[:rf.machine/destroy <actor-id>]`.
 
 <a id="liveness-is-derived-from-app-db"></a>
 
@@ -2990,6 +2990,44 @@ literal address are rejected (`:rf.error/machine-spawn-all-duplicate-id`). XStat
 actor system THROWS on a duplicate `systemId`; re-frame2 keeps no separate
 registry to collide with — the id is the only name, so nobody should re-add one
 to "restore parity".
+
+**Spawning onto an OCCUPIED fixed address destroys the occupant CLEANLY first.**
+A `:rf.machine/spawn` that arrives at a `:fixed-actor-id` a LIVE actor still
+occupies runs that occupant through the ORDINARY destroy path — the same one
+`[:rf.machine/destroy <actor-id>]` takes, under `:reason :explicit` — and only
+then installs the replacement, built on the POST-teardown `runtime-db`. So the
+occupant's `:exit` action runs, and the three framework-managed resource kinds
+release exactly as [§What auto-cancels on
+destroy](#what-auto-cancels-on-destroy--exactly-three-framework-managed-resource-kinds-divergence-from-xstate)
+promises: in-flight `:rf.http/managed` requests abort, armed `:after` timers
+cancel, and `[:machine <actor-id>]` resource owners release. The lifecycle
+pairing holds too — the occupant's `:rf.machine/destroyed` is emitted BEFORE the
+replacement's `:rf.machine.spawn/spawned`, so a tool pairing lifecycle events
+never sees one address spawned twice with no destroy between.
+
+Replacement stays **one verb at one address**. There is no `:replace?` opt-in
+key, no occupied-address error and no warning: an author who names an address
+they have already named has asked for the actor at that address to become the
+new one, and honouring that request means the old one is finished with. Two
+limits of the rule are deliberate:
+
+- **The occupant's own descendants are NOT reaped.** They are ordinary actors
+  at their own addresses and outlive their spawner exactly as they outlive an
+  explicit `[:rf.machine/destroy <actor-id>]` — per the *Teardown is explicit in
+  v1* rule under [§Spawning — dynamic actors](#spawning--dynamic-actors). The
+  occupant's `:exit` is where an author tears down what it owns.
+- **The runtime does not distinguish a deliberate re-spawn from an accidental
+  collision.** Only author intent separates "restart the singleton" from two
+  unrelated spawn sites resolving to one address, and re-frame2 keeps no second
+  registry to consult. What it guarantees is that neither case LEAKS.
+
+Two neighbouring cases are unchanged. Ordinary re-entry — leaving the
+`:spawn`-bearing state, whose exit cascade destroys the child, then re-entering
+at an EMPTY address — installs a fresh incarnation with no occupant to tear
+down. And two children of one `:spawn-all` batch resolving to one literal
+address are still rejected outright with
+`:rf.error/machine-spawn-all-duplicate-id` rather than replaced: within a single
+batch there is no "previous occupant", only a malformed invoke.
 
 > **Wall-clock timeouts: use the parent state's `:after` slot.** There is **no** `:timeout-ms` slot on `:spawn` / `:spawn-all` for "the whole spawned actor must terminate within N ms (spanning retries)." Use the canonical `:after` primitive on the parent state — `:after` is one mechanism, not two. Per [§Whichever fires first wins](#whichever-fires-first-wins), an `:after` firing on the parent state exits the state and the standard exit cascade destroys the in-flight `:spawn`d child. The migration recipe is mechanical: lift the `:timeout-ms` value into the `:spawn`-bearing state's `:after` map, with a transition that exits the state to a "timeout" target. See [MIGRATION §M-44](../migration/from-re-frame-v1/README.md#m-44-timeout-ms-removed-from-spawn--spawn-all--use-parent-states-after).
 


### PR DESCRIPTION
Implements the rf2-dokz ruling: a `:rf.machine/spawn` arriving at a `:fixed-actor-id` that a LIVE actor occupies now runs that occupant through the ORDINARY destroy path before installing the replacement.

## The defect

The install was one unguarded `assoc-in` at the snapshot path. Because Spec 005 makes a spawned actor's liveness IDENTICAL to the presence of its snapshot and nothing else, that single write was simultaneously the newcomer's BIRTH and the occupant's unannounced DEATH — one write, two lifecycle events, one of them silent. None of `teardown-live-actor!`'s nine ordered steps ran, so all three of Spec 005 §What auto-cancels on destroy's named guarantees were void (in-flight `:rf.http/managed` requests not aborted, armed `:after` timers left on the host clock, `[:machine <actor-id>]` resource owners not released), the `:rf.machine/destroyed` trace never fired (a broken pairing contract for any tool watching lifecycle events), and the author's `:exit` cascade — which Spec 005 designates as the SUBSTITUTE for every resource the framework cannot manage — never ran either.

The within-batch `:rf.error/machine-spawn-all-duplicate-id` guard cannot see this: it is structurally a comparison of one `:spawn-all` invoke's children against each other, so a plain `:spawn`, a hand-emitted spawn fx, or two `:spawn` declarations in two regions never reach it.

## The fix

- **`destroy/destroy-occupant-for-replacement!`** probes liveness and, when the address is occupied, delegates to `destroy-machine-fx`'s KEYWORD branch — the same call `[:rf.machine/destroy <actor-id>]` itself makes. Delegating rather than reaching for the private `teardown-live-actor!` is deliberate: it gets `prepare-join-child-teardown!`'s join preparation and the fresh `effect-fence` for free, and it cannot drift from the ordinary path because it IS the ordinary path. The reason is the EXISTING `:explicit`, never a new enum member — `prepare-join-child-teardown!`'s `cancel-current?` gate and `traces/emit-destroyed!`'s `cancelled?` gate both test for exactly that keyword, so a bespoke reason would skip both silently and leave a replaced join child's attempt uncancelled with its reply facts unemitted.
- **`spawn/install-base-after-replacing-occupant!`** runs LAST in the cascade gate's `and`, so the incoming spawn is resolved and its `[:schemas :data]` validator has already run: a spawn that will be rejected disturbs nothing. It then rebuilds the install base from the live POST-teardown `runtime-db`. This is the trap the fix exists to avoid — `install-spawn!`'s `install-fn` DISCARDS the swap's `_rt` argument and returns a value captured before it, so handing in the pre-teardown base would have RESTORED every slot the teardown removed. It returns nil when the occupant's authored `:exit` (application code, synchronous, able to dispatch) costs us the frame or the exact owner; note the existing `continue?` is a FRAME fence, so it is rechecked here explicitly rather than assumed to cover same-address actor churn.
- The teardown sits ahead of the spawned traces, so `:rf.machine/destroyed` is observed BEFORE `:rf.machine.spawn/spawned`.
- Scoped to a SUPPLIED `:fixed-actor-id`. A generated `<type>#<n>` address colliding with a live actor is the separately-filed reseeded-`:rf/spawn-counter` defect (rf2-1sip) and is deliberately untouched.

Per the ruling's out-of-scope list, all decided rather than deferred: no `:rf.error/machine-spawn-occupied-address`, no warning trace of any kind, no `:replace?` opt-in key, no new `:reason` enum member, no second name registry, and **no descendant reaping** — the occupant's own children survive it exactly as they survive an explicit destroy.

## Spec

`spec/005-StateMachines.md` §Spec-spec keys gains the rule beside `:fixed-actor-id`, next to the existing "NEW INCARNATION" paragraph, and the "Teardown is explicit in v1" note is qualified with this one narrow case. Both state explicitly that independent CHILD lifetimes are not reaped, and that ordinary re-entry at an empty address and the within-batch rejection are unchanged.

## Tests

The characterisation test `spawning-onto-an-occupied-fixed-address-replaces-the-occupant` — whose own docstring said it recorded "what the runtime actually does today rather than asserting a guarantee the code does not make" — becomes a CONTRACT suite. The two claims it was genuinely protecting are kept: the supplied address is used VERBATIM (no `<type>#<n>` sidelining) and an occupied one is NOT rejected. Six tests now stand where one did:

- `…destroys-the-occupant-then-installs` — `:exit` runs exactly once, fresh snapshot at the address, destroyed-before-spawned ordering, a later dispatch reaches the replacement.
- `replacing-an-occupant-cancels-its-armed-after-timer` — the successor is a type with NO `:after`, so the cancellation cannot be the leading `:on-supersede` cancel that re-arming at the same key would produce.
- `a-rejected-incoming-spawn-leaves-the-occupant-intact`.
- `the-occupants-teardown-writes-survive-the-replacements-install` — proved on a second actor the occupant's `:exit` destroys: if the install had reverted the teardown, that actor's snapshot would come back.
- `replacing-an-occupant-does-not-reap-its-children` — the CHILD-LIFETIME CONTROL.
- `replacing-a-join-child-retains-its-cancellation-facts`.

### Sabotage proof

The old silent-replace behaviour was planted back on the committed tree (plant match count read as 1 BEFORE the run, so it was a real plant, not a no-op). The focused suite went **RED: exit 1, 10 failures across 4 of the 6 new tests**, naming the `:exit`-ran-once, timer-cancelled, destroyed-before-spawned, teardown-writes-survive and join-cancellation assertions. The two tests that stayed green under the plant are the ones that SHOULD — `a-rejected-incoming-spawn…` and `…does-not-reap-its-children` are controls that must hold under both behaviours, and would red only if the fix had erred in the opposite direction. The plant was then reverted and the restore verified by `git hash-object` against the committed blob rather than by a diff.

The gates print no root, so that red is also the proof the runs read this branch: those tests exist only here, and a run that had wandered elsewhere would have come back green.

## Xray

Xray spec unchanged because the change emits NO new trace id and no new `:reason`. `machine-invoke-trace-operations` in `tools/xray/.../managed_fx_helpers.cljc` already carries `:rf.machine/destroyed`, `:rf.machine.lifecycle/spawned` and `:rf.machine.timer/cancelled`; the ordered destroyed/spawned pair gives the tool its visibility with nothing to add.

## Quality gates

| gate | captured exit |
|---|---|
| `implementation/machines` `clojure -M:test` — 1212 tests, 4397 assertions, 0 failures | **0** |
| `implementation/core` `clojure -M:test` — 2301 tests, 11878 assertions, 0 failures | **0** |
| focused `re-frame.fixed-actor-id-addressing-test` — 9 tests, 50 assertions | **0** |
| the same focused suite with the OLD behaviour planted back — 10 failures | **1** (sabotage; the deliverable) |
| `python scripts/check_test_lane_bijection.py` — 1596 files, 45 lanes, every file selected | **0** |
| `python scripts/check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` (the bare `mkdocs` script exits 127 here) | **0** |
| ratchets over the touched paths — `check_retired_spellings`, `check_require_alias_dialect`, `check_ambient_durable_reads`, `check_keyword_catalogue_drift`, `check_retired_composition_vocab`, `check_architecture_census`, `check_allocation_non_claim`, `check_runtime_subsystem_grading`, `check_jvm_lane_rosters`, `check_readme_inventories` | **0** each |
| `check_require_alias_dialect` with a bare-leaf alias planted on the new require — the control proving that batch of zeros is live | **1**, naming the file, the line and the correct alias |

Every exit code above was captured on the runner's own command line and read from its own `.exit` file, never through a pipe.

**Two limits stated rather than papered over.** Neither link gate looks inside a fenced code block, and nothing grades prose for truth — so the new `spec/005` paragraphs were hand-checked against the code, clause by clause: the delegation really is `destroy-machine-fx`'s keyword branch; the install base really is re-read post-teardown (and the sabotage run proves that read is load-bearing); `:reason :explicit` is the only reason value the diff introduces; no `rf.error/`, warning emit or `:replace?` key appears in any added line (checked with a two-directions control that reads 1 when a synthetic offender is spliced through the same pipeline). The HTTP-abort and resource-release halves of the auto-cancel guarantee are covered transitively — they are unconditional steps of the same `teardown-live-actor!` pipeline the new tests prove now runs, and the existing destroy suites pin them — rather than by a new test here.

**One case is contract-covered but not test-covered:** frame loss during the occupant's `:exit`. The helper returns nil on both a destroyed frame and a lost exact owner, which suppresses the spawned traces and the install together, but driving a frame destroy from inside an `:exit` needs lifecycle machinery this suite's fixture does not carry.

Local green is not CI: this ran two JVM artefact suites plus the document and ratchet checks, not the CLJS lanes, the linters or the browser tiers. CI grades the matrix.
