### PR TITLE
docs(machines): transition.cljc's :tags gloss said EVOLVING; the cross-region view is FROZEN

### DIFF
--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -306,9 +306,15 @@
 ;;   :tags       — the MACHINE-WIDE active-configuration tag union across
 ;;                 EVERY region (the coarse `stateIn` substitute; a sibling
 ;;                 region advertises a state-tag and any region's guard
-;;                 reads `(contains? (:tags ctx) :some/tag)`). It reflects
-;;                 the EVOLVING macrostep snapshot — a sibling region that
-;;                 transitioned earlier in the same macrostep is visible.
+;;                 reads `(contains? (:tags ctx) :some/tag)`). Like
+;;                 `:all-state` below, it reflects the FROZEN pre-broadcast
+;;                 snapshot at the start of the selection round — computed
+;;                 ONCE by `reduce-regions` and threaded unchanged, NOT
+;;                 rebuilt from the evolving states. A sibling region that
+;;                 transitions in the SAME round is NOT visible; its result
+;;                 lands on the next parent round, which is what makes
+;;                 enabled-set selection declaration-order-independent
+;;                 (Spec 005 §Cross-region coordination).
 ;;   :all-state  — the full region-name → active-state map (the PRECISE
 ;;                 `stateIn` equivalent; `(= :valid (:form (:all-state ctx)))`
 ;;                 reads a sibling region's discrete state value directly).


### PR DESCRIPTION
Comment-only. One file, one comment block, no behaviour change and none wanted.

## The defect

`implementation/machines/src/re_frame/machines/transition.cljc:310` described the
region guard/action ctx key `:tags` as reflecting

> the EVOLVING macrostep snapshot — a sibling region that transitioned earlier in
> the same macrostep is visible.

The behaviour is the opposite. `parallel/reduce-regions` computes
`frozen-all-state` / `frozen-tags` **once** from the pre-broadcast `state-map`
(`parallel.cljc:611`, `:907`, `:947`) and threads them **unchanged** into every
region's step ctx (`:726`, `:918`, `:957`). A sibling that transitions in the same
selection round is therefore *not* visible to a co-selected region; its result
lands on the next parent round.

The docstring was the only wrong artefact. Three sites already state it correctly,
and they are the model for the new wording — all three re-measured at this base:

| site | text |
|---|---|
| `parallel.cljc:580` | `;; FROZEN pre-broadcast cross-region snapshot.` … "computed ONCE here … NOT rebuilt per region from the evolving `new-states`" |
| `parallel.cljc:702` | "Both resolve against the FROZEN pre-broadcast snapshot (`state-map` → `frozen-all-state` / `frozen-tags`, computed ONCE above), NOT the evolving `new-states`" |
| `spec/005-StateMachines.md:1792` (§Cross-region coordination — tags as `stateIn`, heading at `:1781`) | "Both keys reflect the **frozen snapshot at the start of the current selection round** … so enabled-set selection is declaration-order-independent" |

The code is correct and is untouched. The frozen SELECT pass is what delivers
Spec 005's guarantee that region declaration order governs APPLY ordering only,
never selection — that guarantee was read at source before editing and it says
exactly that, so the fix is the comment and not the code.

## The neighbouring `:all-state` gloss is NOT wrong

It reads "the full region-name → active-state map (the PRECISE `stateIn`
equivalent; `(= :valid (:form (:all-state ctx)))` reads a sibling region's
discrete state value directly)". It makes **no freshness claim at all**, so it
does not carry the same error, and it is left alone. The corrected `:tags`
sentence names `:all-state` so that the freeze reads as a property of both
cross-region keys — which is how `spec/005:1792` states it ("Both keys reflect
the frozen snapshot…") — without editing the `:all-state` bullet.

The second `EVOLVING` in the artefact, `parallel.cljc:819`, was read and is
correct: it describes the FIFO `:raise` re-broadcast, where each re-broadcast
runs a fresh `reduce-regions` that recomputes a fresh frozen view
(`parallel.cljc:715-718`). Different thing, left alone.

## Quality gates

| gate | exit | result |
|---|---|---|
| `implementation/machines` `clojure -M:test` | **0** | **1207 tests / 4367 assertions, 0 failures, 0 errors** |
| `scripts/check_require_alias_dialect.py` | **0** | pass (repo-wide `git ls-files '*.clj' '*.cljs' '*.cljc'`; `implementation/machines` floor 0) |
| `scripts/check_retired_spellings.py` | **0** | pass |
| `scripts/check_thrown_error_messages.py` | **0** | pass |
| `scripts/check_keyword_catalogue_drift.py` | **0** | pass |
| `scripts/check_retired_image_keys.py` | **0** | pass |
| `scripts/check_fast_pr_gap.py --brief` | **0** | report only — names 100 required checks this spine does not decide |

Every exit code was captured on the runner's own command line and echoed, never
read through a pipe. The suite was run detached with per-worktree, per-attempt
log/exit artefact names; its verdict is the captured exit file, not a harness
report. All gates were re-run on the final rebased base except the JVM suite,
which is left to CI per the standing "do not re-run a heavy gate after a rebase"
rule — the file's blob hash is byte-identical to the tree the green run graded,
and the three commits the rebase took on touch no `implementation/machines` path.

### Sabotage proof — a comment-only diff makes every gate green by default

Planted a real fault on the surface: line 54's libspec
`[re-frame.machines.grammar :as rf.machines.grammar]` rewritten to the bare-leaf
`:as grammar`, which the require-alias dialect reserves for application
namespaces. **The plant's match count was read before any gate ran: 1** (a plant
matching zero lines is not a plant), and the working blob hash moved
`b52e53d5bb…` → `3db3796c04…`, so the source really changed.

- `scripts/check_require_alias_dialect.py` → **exit 1**, naming
  `implementation/machines/src/re_frame/machines/transition.cljc:54`,
  surface `implementation/machines`, floor 0.
- `implementation/machines` `clojure -M:test` → **exit 1**,
  `Syntax error (ClassNotFoundException) compiling at
  (re_frame/machines/transition.cljc:676:3) — rf.machines.grammar`, and **0 tests
  ran** against the control's 1207 / 4367.

Both reds discriminate this worktree: the fault existed only here, so a run that
had wandered into a sibling checkout would have come back green.

Restore verified **by git blob hash**, not by the restore command's exit code:
working `b52e53d5bb486da78a2d75e4b85e536fba8f7923` == committed
`b52e53d5bb486da78a2d75e4b85e536fba8f7923`. The alias ratchet was re-run after
the restore and returned to exit 0.

### CRLF

`transition.cljc` is a CRLF file (`core.autocrlf=true`, no `.gitattributes` pin
for this path). Measured at byte level, not with `file` or `grep -c $'\r'`:
before the edit 4286 CRLF / 0 bare LF; after 4292 CRLF / 0 bare LF; after the
plant-and-restore cycle and again after the rebase, 251424 bytes / 4292 CRLF /
0 bare LF. The edit was anchored on `\r\n`-terminated lines and its pre-edit
match count was read as exactly 1 before it was applied, so it cannot have
silently no-opped. Line endings are unchanged.

### Gates that do NOT cover this path, and why

- `scripts/check_doc_slugs.py` — its roots are `docs/`, `spec/`, `skills/`,
  `migration/` and `tools/*/spec`. `implementation/**` is outside them; it exits
  0 on this path having inspected nothing.
- `mkdocs build --strict` — `docs_dir` is `docs`, and `mkdocs_hooks.py` stages
  only `spec/` and `migration/` into it. `implementation/**` was never a
  candidate, and the hooks file classes it as "CLJS source; not docs".
- `scripts/check_readme_links.py --ci` — READMEs and tracked non-README markdown
  beside source. This diff touches no markdown.
- `scripts/check_retired_composition_vocab.py` — `DEFAULT_SCAN_DIRS` is
  `docs/core`, `docs/api`, `docs/EP`, `spec`, `skills`; it does not reach
  `implementation/`.

**Nothing in this repository grades the PROSE of a source comment.** The gates
above prove the file still parses, still compiles, still passes its suite and
still satisfies every ratchet over its path — none of them can say the new
sentence is *true*. Its correctness was therefore verified **by hand** against
the three corroborating sites tabulated above, each re-read at source at this
base, plus the mechanism itself (`frozen-tags` computed once at `parallel.cljc:611`,
`:907`, `:947`; threaded unchanged at `:726`, `:918`, `:957`).

rf2-mix8
