### PR TITLE
fix(machines): a registered TYPE is not a live occupant at a fixed address (rf2-dokz residual)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -165,6 +165,32 @@
            (and (some #(= actor-id %) (rf.machines.spawn-order/frame-order frame-id))
                 (snapshot-present? (rf.frame/frame-runtime-db-value frame-id) actor-id)))))
 
+(def ^:private ^:dynamic *definition-preserved-at*
+  "The ONE actor-id whose `:event` registrar entry step (8) of
+  `teardown-live-actor!` must NOT clear, or nil (the value everywhere except
+  inside `destroy-occupant-for-replacement!`'s delegated teardown).
+
+  WHY IT EXISTS. A machine TYPE is an `:event` registration carrying
+  `:rf/machine? true` (Spec 005 §Querying machines) — a DEFINITION shared by
+  every actor of that type, never an actor. When a `:fixed-actor-id` equals its
+  own registered `:machine-id`, the address the replacement installs at and the
+  key the definition is registered under are the SAME keyword, so step (8) —
+  which exists to clear a stale or externally installed PER-INSTANCE entry —
+  would delete the definition the replacement is about to resolve through, and
+  every sibling actor of that type with it.
+
+  WHY DYNAMIC. `destroy-occupant-for-replacement!` delegates to
+  `destroy-machine-fx` on purpose (it IS the ordinary destroy path, so it cannot
+  drift from it), and that fn's map grammar is a CLOSED discriminated union
+  (rf2-3phait) an option key would widen. The binding's extent is ONE teardown of
+  ONE address, and step (8) compares the id, so an `:exit` callback that destroys
+  a DIFFERENT actor within that extent still clears its entry exactly as before.
+
+  NOT a licence to preserve on the ordinary destroy path: `[:rf.machine/destroy
+  <id>]` against a singleton machine still clears that machine's registration,
+  which is the long-standing behaviour of destroying a singleton."
+  nil)
+
 (defn- teardown-live-actor!
   "The shared ordered teardown pipeline for a LIVE actor (the caller has
   already confirmed liveness). Both destroy entry-points — the per-actor
@@ -282,7 +308,13 @@
       ;; ownership here rather than reusing (6)'s precheck, so A's teardown
       ;; never clears B's just-registered handler (the ordinary-destroy
       ;; terminal-fence law, Spec 005 §Destroy is silent-idempotent).
-      (when (and db-swapped? (not (owner-gone?)))
+      ;; rf2-dokz residual — EXCEPT at the one address a replacement is
+      ;; preserving the machine DEFINITION at (see `*definition-preserved-at*`):
+      ;; there the entry is a shared TYPE rather than this actor's own, and
+      ;; clearing it would strand the replacement and every sibling actor of
+      ;; that type.
+      (when (and db-swapped? (not (owner-gone?))
+                 (not= actor-id *definition-preserved-at*))
         (rf.registrar/unregister! :event actor-id))
       ;; (9) release the actor's resource owners once it is gone, so
       ;; a `[:machine actor-id]`-owned resource does not outlive the actor and
@@ -761,6 +793,30 @@
 
 ;; ---- occupied-address replacement (rf2-dokz) -------------------------------
 
+(defn- occupant-actor-live?
+  "Is `actor-id` OCCUPIED by a live spawned ACTOR, for the purpose of deciding
+  replacement? True iff the frame's LIVE `runtime-db` carries a snapshot there.
+
+  DELIBERATELY NOT `actor-live?`, and that difference is the whole of this
+  predicate. `actor-live?` is the shared silent-idempotent DESTROY probe
+  (rf2-s2bsmw), and it also counts a bare registrar entry because
+  `[:rf.machine/destroy <id>]` must still recognise and clear a stale or
+  externally installed one. That disjunct answers \"is there anything here to
+  clean up?\" — the right question for destroy and the WRONG one here, where the
+  question is \"is a live ACTOR occupying this address?\". A registered but
+  never-spawned machine TYPE has an `:event` entry and no actor at all, so
+  `actor-live?` reported the type's own name occupied and the FIRST spawn at a
+  `:fixed-actor-id` equal to its `:machine-id` tore the freshly registered
+  definition down. Spec 005 §Liveness is derived from runtime-db makes a spawned
+  actor's liveness identical to its snapshot's presence and nothing else, which
+  is exactly this predicate.
+
+  `actor-live?`'s spawn-order clause is not needed here either: it covers the
+  drain-time stale `old-db` window, and this predicate's only caller reads the
+  frame's LIVE `runtime-db`, which by definition has no such window."
+  [frame-id actor-id]
+  (snapshot-present? (rf.frame/frame-runtime-db-value frame-id) actor-id))
+
 (defn destroy-occupant-for-replacement!
   "Tear a LIVE occupant of `actor-id` down through the ORDINARY destroy path so
   a `:rf.machine/spawn` arriving at an OCCUPIED `:fixed-actor-id` REPLACES it
@@ -791,15 +847,33 @@
   would SKIP both and leave a replaced join child's attempt uncancelled with its
   reply facts unemitted.
 
+  OCCUPANCY IS `occupant-actor-live?`, NEVER `actor-live?`. Only a live spawned
+  ACTOR is an occupant; an uninstantiated registered TYPE or plain event handler
+  sitting at the same keyword is not — see that predicate for why the shared
+  destroy probe cannot answer this question.
+
+  AND THE DEFINITION SURVIVES. When the address IS a registered machine's own
+  registration key, the teardown's registrar cleanup would delete that shared
+  DEFINITION — stranding the replacement, whose snapshot resolves its handler
+  back through exactly that key, and every sibling actor of the type with it.
+  Binding `*definition-preserved-at*` for the teardown's extent keeps it, and
+  keeps it WITHOUT re-registering afterwards: a re-registration would fire the
+  hot-reload hooks and a `:rf.registry/handler-cleared` +
+  `:rf.registry/handler-registered` pair for a definition that never changed, and
+  would open a fresh callback-bearing boundary between the teardown and the
+  install.
+
   Returns `true` when the address was occupied and the teardown ran, `false`
   when it was EMPTY. False is the overwhelmingly common answer — ordinary
   re-entry at a `:fixed-actor-id` arrives after the exit cascade has already
-  destroyed the previous incarnation — and one `actor-live?` read is its whole
-  cost. A `true` tells the caller its pre-teardown `runtime-db` snapshot is
-  STALE and the install must be rebuilt from the post-teardown value."
+  destroyed the previous incarnation — and one snapshot read is its whole cost.
+  A `true` tells the caller its pre-teardown `runtime-db` snapshot is STALE and
+  the install must be rebuilt from the post-teardown value."
   [frame-id actor-id]
   (boolean
-    (when (and actor-id
-               (actor-live? frame-id actor-id (rf.frame/frame-runtime-db-value frame-id)))
-      (destroy-machine-fx {:frame frame-id} actor-id)
+    (when (and actor-id (occupant-actor-live? frame-id actor-id))
+      (binding [*definition-preserved-at*
+                (when (rf.machines.lifecycle-fx.resolver/spec-from-registry actor-id)
+                  actor-id)]
+        (destroy-machine-fx {:frame frame-id} actor-id))
       true)))

--- a/implementation/machines/test/re_frame/fixed_actor_id_addressing_test.clj
+++ b/implementation/machines/test/re_frame/fixed_actor_id_addressing_test.clj
@@ -455,3 +455,136 @@
             (is (= :cancelled (:rf.reply/status tags))
                 "the attempt was closed the reply-envelope way")))
         (finally (rf.trace.tooling/unregister-listener! ::occupied-join))))))
+
+;; ---------------------------------------------------------------------------
+;; (4) When the fixed address IS the machine type's own registration key
+;; ---------------------------------------------------------------------------
+;;
+;; A machine TYPE is an `:event` registration carrying `:rf/machine? true`
+;; (Spec 005 §Querying machines), so `{:machine-id :m/worker :fixed-actor-id
+;; :m/worker}` puts the actor's ADDRESS and the definition's REGISTRATION KEY on
+;; the same keyword. Nothing forbids that and nothing should: it is the obvious
+;; spelling for an app with one actor of a type.
+;;
+;; The two directions below are pinned separately because they fail for
+;; DIFFERENT reasons and a fix for either alone leaves the other broken.
+;;
+;;   (a) FIRST spawn — there is no actor at that address at all, only the
+;;       registered type. It must install untouched. It did not: the
+;;       replacement path's occupancy probe counted the TYPE's registrar entry
+;;       as a live occupant, so the very first spawn tore the freshly
+;;       registered definition down and installed an actor whose
+;;       `:rf/machine-type` no longer resolved.
+;;
+;;   (b) REPLACEMENT of a genuinely live actor there — the teardown must run
+;;       in full (this is rf2-dokz's whole point) while the shared DEFINITION
+;;       survives it, because the replacement resolves its own handler back
+;;       through exactly that key and so does every sibling actor of the type.
+
+(deftest first-spawn-at-an-address-equal-to-its-machine-type-is-not-a-replacement
+  (testing "rf2-dokz residual — direction (a). An uninstantiated registered TYPE
+            is NOT an occupant. The first spawn at a :fixed-actor-id equal to its
+            own :machine-id destroys nothing, keeps the definition registered,
+            and comes up FULLY BOOTSTRAPPED and addressable"
+    (let [exits  (atom 0)
+          traces (capture-traces ::selfnamed-first)]
+     (try
+      (rf/reg-machine :fai/selfnamed
+        {:initial :running
+         :data    {}
+         :actions {:touch (fn [{d :data}] {:data (assoc d :touched true)})}
+         :states  {:running {:exit (fn [_] (swap! exits inc) {})
+                             :on   {:touch {:action :touch}}}}})
+      (rf/reg-event :fai/install-selfnamed
+        (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :fai/selfnamed
+                                            :fixed-actor-id :fai/selfnamed}]]}))
+      (is (:rf/machine? (rf/handler-meta {:source :store :kind :event :id :fai/selfnamed}))
+          "precondition: the TYPE is registered at exactly the keyword the spawn
+           will use as its address")
+      (is (nil? (snapshot :fai/selfnamed))
+          "precondition: NO actor is live there — the registration is a definition,
+           not an occupant")
+
+      (rf/dispatch-sync [:fai/install-selfnamed])
+
+      (is (zero? @exits)
+          "nothing was destroyed — a registered-but-unspawned type is not a live
+           occupant, so no teardown ran")
+      (is (:rf/machine? (rf/handler-meta {:source :store :kind :event :id :fai/selfnamed}))
+          "the machine DEFINITION is still registered — the ordinary destroy
+           pipeline's registrar cleanup did not run over it")
+      (is (some? (snapshot :fai/selfnamed))
+          "the actor installed at its own type's name")
+      (is (nil? (:rf/bootstrap-pending? (snapshot :fai/selfnamed)))
+          "and it BOOTSTRAPPED — a stranded actor keeps :rf/bootstrap-pending?
+           because its :rf/machine-type no longer resolves to anything")
+
+      (is (not (some #{:rf.machine/destroyed} (operations traces)))
+          "and NO :rf.machine/destroyed was emitted — the phantom teardown of a
+           type that never had an actor is exactly what the occupancy probe must
+           not do; a tool pairing lifecycle events would otherwise see one
+           address destroyed before it was ever spawned")
+
+      (rf/dispatch-sync [:fai/selfnamed [:touch]])
+      (is (true? (:touched (:data (snapshot :fai/selfnamed))))
+          "an ordinary dispatch reaches it — the handler re-materialises from the
+           snapshot's :rf/machine-type, which still names a registered type")
+      (finally (rf.trace.tooling/unregister-listener! ::selfnamed-first))))))
+
+(deftest replacing-a-live-actor-at-its-machine-types-own-name-keeps-the-definition
+  (testing "rf2-dokz residual — direction (b). Once an actor IS live at that
+            address the ordinary replacement teardown runs in full (its authored
+            :exit fires exactly once), but the shared machine DEFINITION survives
+            it: the replacement resolves through that key, and so does a SIBLING
+            actor of the same type at another address"
+    (let [exits (atom 0)]
+      (rf/reg-machine :fai/selfnamed2
+        {:initial :running
+         :data    {}
+         :actions {:touch (fn [{d :data}] {:data (assoc d :touched true)})}
+         :states  {:running {:exit (fn [_] (swap! exits inc) {})
+                             :on   {:touch {:action :touch}}}}})
+      (rf/reg-event :fai/install-selfnamed2
+        (fn [_ [_ payload]]
+          {:fx [[:rf.machine/spawn {:machine-id     :fai/selfnamed2
+                                    :fixed-actor-id :fai/selfnamed2
+                                    :data           {:payload payload}}]]}))
+      (rf/reg-event :fai/install-sibling2
+        (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :fai/selfnamed2
+                                            :fixed-actor-id :fai/sibling2}]]}))
+
+      (rf/dispatch-sync [:fai/install-selfnamed2 :first])
+      (rf/dispatch-sync [:fai/install-sibling2])
+      (rf/dispatch-sync [:fai/selfnamed2 [:touch]])
+      (is (= :first (:payload (:data (snapshot :fai/selfnamed2))))
+          "precondition: a live actor OCCUPIES the type's own name")
+      (is (true? (:touched (:data (snapshot :fai/selfnamed2))))
+          "precondition: it is addressable")
+      (is (zero? @exits) "precondition: it is live — its :exit has not run")
+
+      (rf/dispatch-sync [:fai/install-selfnamed2 :second])
+
+      (is (= 1 @exits)
+          "THE TEARDOWN STILL RAN. The occupant's authored :exit fired exactly
+           once — narrowing the occupancy probe must not turn a genuine
+           replacement back into the silent overwrite rf2-dokz removed")
+      (is (:rf/machine? (rf/handler-meta {:source :store :kind :event :id :fai/selfnamed2}))
+          "and the shared machine DEFINITION SURVIVED that teardown — the
+           registrar entry at this address is a TYPE, not the occupant's own
+           per-instance entry")
+      (is (= :second (:payload (:data (snapshot :fai/selfnamed2))))
+          "the replacement installed at the address")
+      (is (nil? (:touched (:data (snapshot :fai/selfnamed2))))
+          "with FRESH :data — it is a new actor, not a patched old one")
+      (is (nil? (:rf/bootstrap-pending? (snapshot :fai/selfnamed2)))
+          "and it bootstrapped — its :rf/machine-type still resolves")
+
+      (rf/dispatch-sync [:fai/selfnamed2 [:touch]])
+      (is (true? (:touched (:data (snapshot :fai/selfnamed2))))
+          "an ordinary dispatch reaches the REPLACEMENT")
+
+      (rf/dispatch-sync [:fai/sibling2 [:touch]])
+      (is (true? (:touched (:data (snapshot :fai/sibling2))))
+          "and the SIBLING actor of the same type is untouched by the
+           replacement — deleting the shared registration would have taken its
+           definition too"))))


### PR DESCRIPTION
Residual on **rf2-dokz**, filed by the merged-PR audit of #9508. Leave the bead open.

## The regression

#9508's `destroy-occupant-for-replacement!` decided occupancy with `actor-live?` — the shared, silent-idempotent **destroy** probe. That probe deliberately counts a bare `:event` registrar entry, because `[:rf.machine/destroy <id>]` must still recognise and clear a stale or externally installed one. But a machine **type** is an `:event` registration carrying `:rf/machine? true` (Spec 005 §Querying machines), so a perfectly valid spawn

```clojure
[:rf.machine/spawn {:machine-id :probe/worker :fixed-actor-id :probe/worker}]
```

read the *type's own* registration as a live occupant and ran a full ordinary destroy over it on the **first** spawn. Teardown step (8) unregistered `:event :probe/worker`, and `install-spawn!` then stamped a `:rf/machine-type` that no longer resolved: the actor stayed `:rf/bootstrap-pending? true`, ordinary dispatch could not reach it, and every **sibling** actor of that type lost its definition too.

Reproduced at the audit's three cases, on this branch's base and with the pre-#9508 sources overlaid:

| case | type present after spawn | snapshot |
|---|---|---|
| distinct address `:probe/slot`, landed | yes | `:touched true` |
| **equal-name `:probe/worker`, landed** | **no** | **`:rf/bootstrap-pending? true`, no `:touched`** |
| equal-name `:probe/worker`, pre-PR `101d1c4664` | yes | `:touched true` |

## The fix — two changes, both scoped to the replacement path

**`occupant-actor-live?`** asks the replacement's own question — *is a live spawned ACTOR occupying this address* — which Spec 005 §Liveness is derived from runtime-db makes identical to snapshot presence and nothing else. **`actor-live?` itself is unchanged**, so rf2-s2bsmw's one-probe-per-destroy-shape ruling stands and every destroy path keeps its behaviour, including the stale/external-entry cleanup that the registrar disjunct exists for. Narrowing the shared probe would have removed that affordance from all four of its call sites to fix one; a separate, stricter predicate at the one site whose question differs is the smaller change and the more honest one.

**`*definition-preserved-at*`** keeps the teardown's registrar cleanup off the one address a replacement is preserving a machine **definition** at. The entry there is a shared TYPE, not the occupant's per-instance entry, and the replacement resolves its own handler back through exactly that key. Preventing the clear rather than re-registering afterwards keeps the hot-reload trace surface honest (no `:rf.registry/handler-cleared` + `handler-registered` pair for a definition that never changed) and opens no fresh callback-bearing boundary between the teardown and the install. Its extent is one teardown of one address and step (8) compares the id, so an `:exit` callback destroying a *different* actor inside that extent still clears its entry exactly as before.

Ordinary destroy is untouched: `[:rf.machine/destroy <id>]` against a singleton machine still clears that machine's registration, as it always has.

## Both directions pinned

`fixed_actor_id_addressing_test.clj` gains two tests, and they discriminate different halves:

- **first spawn at such an address is not a replacement** — nothing destroyed, no `:rf.machine/destroyed` trace, definition still registered, actor bootstrapped and addressable.
- **replacement of a genuinely live actor there keeps the definition** — the occupant's authored `:exit` still fires exactly once (the teardown really does run), while the definition, the replacement and a **sibling** actor of the same type all survive.

Nothing about rf2-dokz's ruling changes: one verb at one address, no reserved-address error, no warning, no registry, no opt-in flag. The `:exit`-hand-emits-a-spawn-at-its-own-address recursion #9508 flagged is deliberately still unguarded and remains a separate bead.

## Quality gates

Exit codes captured on the runner's own command line, never through a pipe.

| gate | exit | counts |
|---|---|---|
| `implementation/machines` `clojure -M:test` | **0** | 1214 tests / 4415 assertions, 0 failures, 0 errors (base: 1212 / 4397 — exactly +2 tests / +18 assertions) |
| `implementation/core` `clojure -M:test` | **0** | 2301 tests / 11878 assertions, 0 failures, 0 errors (identical to base) |
| focused `re-frame.fixed-actor-id-addressing-test` | **0** | 11 tests / 68 assertions (base: 9 / 50) |
| the six #9508 tests, run by name | **0** | 6 tests / 33 assertions |
| `check_require_alias_dialect.py --verbose` | **0** | 2821 files, 11069 edges, 0 non-canonical |
| 12 further ratchets over `implementation/**` | **0** | retired_spellings, ambient_durable_reads, thrown_error_messages, keyword_catalogue_drift, inject_cofx_residue, egress_walker_residue, test_lane_bijection, jvm_lane_rosters, allocation_non_claim, retired_composition_vocab, retired_image_keys, view_lifetime_residue |
| `check-no-hardcoded-paths.sh`, `check-ai-tracking-ratchet.sh` | **0** | |
| `check-beads-pr-boundary.sh origin/main` | **0** | no beads-database paths in this diff |
| `check-commit-attribution.sh origin/main` | **0** | |

**Sabotage proofs.** Every plant's match count read **1** before the run; every restore verified by `git hash-object` against the committed blob `b085d802d3` (destroy.cljc) and `6a0ba793ef` (the test file).

- Predicate widened back to `actor-live?` alone → **exit 1**, 1 failure, and it is exactly the phantom-`:rf.machine/destroyed` assertion. Isolates the occupancy half.
- Step-(8) guard removed alone → **exit 1**, 4 failures: definition gone, replacement stuck `:rf/bootstrap-pending?`, replacement unreachable, sibling actor unreachable. Isolates the preservation half.
- **Both reverted (the landed behaviour exactly)** → **exit 1**, 11 failures across both new tests, reproducing the audit's symptoms as assertions — `:rf/machine?` nil and `:rf/bootstrap-pending? true`. The nine pre-existing tests, including #9508's rejected-spawn and child-lifetime **controls**, stayed green under all three plants, as they must.
- Ratchet liveness: a bare-leaf `:as registrar` planted in `destroy.cljc`'s `:require` made `check_require_alias_dialect.py` exit **1** naming `destroy.cljc:68`. Restored, exit **0**.

**Not covered, stated plainly.** `check_doc_slugs.py`'s roots (`docs/`, `spec/`, `skills/`, `migration/`, `tools/*/spec`) and `mkdocs build --strict`'s `docs_dir` never reach `implementation/**`; neither was run and neither would have inspected anything in this diff. CI owns the rest — `python scripts/check_fast_pr_gap.py --brief` derives 100 required checks this local set does not decide.
