### PR TITLE
fix(gate): consume reader prefixes and their form as a unit in the where-sym oracle (rf2-z5lv)

### DIFF
--- a/scripts/_test_fixtures/check_thrown_error_messages/wheresym/negative_where_syms.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/wheresym/negative_where_syms.cljc
@@ -177,3 +177,17 @@
 (defn commas-as-sole-separator-in-the-slot-resolves []
   (throw (ex-info "hand-built payload [:rf.error/ok-twentyone]"
                   {:rf.error/id :rf.error/ok-twentyone,:where,'rf.fixture/known-public,:reason "commas alone around the slot"})))
+
+;; ---- a LIVE reader-conditional, the twin of the discarded one ------------
+;;
+;; The oracle fixture writes `#_#?(:clj (defn ghost-discarded-conditional ...))`
+;; and `#?(:clj (defn conditional-defined-public ...))` with the same body, so
+;; the PAIR isolates the prefix as the only cause of inertness. This half is
+;; pinned as OBSERVED at its line: green here is also what a detector that has
+;; gone blind to the whole site looks like.
+
+(defn conditional-defined-var-resolves []
+  (rf.error/throw-error!
+    :rf.error/ok-twentytwo
+    'rf.fixture/conditional-defined-public
+    "`#?(:clj (defn conditional-defined-public ...))` interns the var"))

--- a/scripts/_test_fixtures/check_thrown_error_messages/wheresym/positive_where_syms.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/wheresym/positive_where_syms.cljc
@@ -235,3 +235,54 @@
 (defn ghost-commas-as-sole-separator-in-the-slot []
   (throw (ex-info "hand-built payload [:rf.error/ghost-twenty]"
                   {:rf.error/id :rf.error/ghost-twenty,:where,'rf.fixture/ghost-comma-six,:reason "commas alone between the slot's key and its value"})))
+
+;; ---- (7) COMPOSED READER PREFIXES ----------------------------------------
+;;
+;; Audit #9511's residual. Each name below is defined in the oracle fixture
+;; behind a COMPOSED reader prefix and NOWHERE ELSE, so a walker that decides
+;; inertness from the single character before the `(` greens every one of them:
+;; `#_#?(...)` and `'#?(...)` reach that `(` after a `?`, and a stacked
+;; `#_#_ a b` has no prefix behind `b` at all.
+;;
+;; THE PREFIX IS THE ONLY THING DOING THE WORK in every one — strip it and the
+;; oracle form defines its var for real. Its live twin
+;; `rf.fixture/conditional-defined-public` sits in the negative fixture with a
+;; byte-identical body, pinned as OBSERVED; the PAIR is the assertion, because
+;; a resolving site is green when seen and green again when it has vanished.
+
+(defn ghost-in-a-discarded-conditional []
+  (rf.error/throw-error!
+    :rf.error/ghost-twentyone
+    'rf.fixture/ghost-discarded-conditional
+    "`#_` applied to `#?` discards the conditional, arms and all"))
+
+(defn ghost-in-a-quoted-conditional []
+  (rf.error/throw-error!
+    :rf.error/ghost-twentytwo
+    'rf.fixture/ghost-quoted-conditional
+    "a quoted reader-conditional is data once the reader has resolved it"))
+
+(defn ghost-in-a-syntax-quoted-conditional []
+  (rf.error/throw-error!
+    :rf.error/ghost-twentythree
+    'rf.fixture/ghost-syntax-quoted-conditional
+    "syntax-quote over a conditional is data too"))
+
+(defn ghost-in-a-discarded-splice []
+  (rf.error/throw-error!
+    :rf.error/ghost-twentyfour
+    'rf.fixture/ghost-discarded-splice
+    "`#_#?@(...)` is discarded whole, and top-level splicing interns nothing
+     in any case"))
+
+(defn ghost-first-of-a-stacked-discard []
+  (rf.error/throw-error!
+    :rf.error/ghost-twentyfive
+    'rf.fixture/ghost-stacked-first
+    "the FIRST form a stacked `#_#_` discards, which look-back already saw"))
+
+(defn ghost-second-of-a-stacked-discard []
+  (rf.error/throw-error!
+    :rf.error/ghost-twentysix
+    'rf.fixture/ghost-stacked-second
+    "the SECOND form, which look-back cannot reach in principle"))

--- a/scripts/_test_fixtures/check_thrown_error_messages/wheresym/re_frame/fixture.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/wheresym/re_frame/fixture.cljc
@@ -114,3 +114,46 @@
 (do
   (defn do-defined-public [] nil)
   #_(defn ghost-discarded-inside-do [] nil))
+
+;; ---- COMPOSED READER PREFIXES: THE PREFIX IS THE ONLY THING DOING THE WORK -
+;;
+;; Audit #9511's residual on the repair above. `_reader_inert_at` decided
+;; inertness from the ONE character before the `(`, so `#_#?(...)` and
+;; `'#?(...)` reached that `(` after a `?` and were walked as LIVE, and a
+;; STACKED `#_#_ a b` skipped only the first form though the reader discards
+;; both. Reader-conditionals are why that matters more than the shapes it
+;; replaced: `#?` is ordinary `.cljc` and this tree is full of it.
+;;
+;; EVERY SHAPE HERE IS ADVERSARIAL AGAINST THE PREDICATE THAT READS IT. Strip
+;; the prefix and each form defines its var for real, so nothing BUT the prefix
+;; can be making it inert — `conditional-defined-public` below is that live
+;; twin, body for body. A fixture whose inertness has a second cause proves
+;; nothing about the predicate, which is exactly how every comma fixture came
+;; back green under a sabotage plant that reverted `_is_clj_ws`.
+
+#_#?(:clj  (defn ghost-discarded-conditional [] nil)
+     :cljs (defn ghost-discarded-conditional [] nil))
+
+'#?(:clj  (defn ghost-quoted-conditional [] nil)
+    :cljs (defn ghost-quoted-conditional [] nil))
+
+`#?(:clj (defn ghost-syntax-quoted-conditional [] nil))
+
+#_#?@(:clj [(defn ghost-discarded-splice [] nil)])
+
+;; A STACKED DISCARD NEUTRALISES BOTH FORMS. The first was already unreachable
+;; by look-back; the SECOND is the residual — nothing stands between it and the
+;; form the first discard consumed, so there is no prefix behind it to see.
+
+#_#_ (def ghost-stacked-first 1)
+     (defn ghost-stacked-second [] nil)
+
+;; ---- LIVE reader-conditional: the discriminating twin ---------------------
+;;
+;; Identical, body for body, to the discarded conditional above. It must stay
+;; PUBLIC: widening the inert set until it swallows this is the failure the
+;; `do` control guards against one shape along, and a `#?(:cljs (def
+;; frame-root ...))` export is how the real facade ships.
+
+#?(:clj  (defn conditional-defined-public [] nil)
+   :cljs (defn conditional-defined-public [] nil))

--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -1161,49 +1161,156 @@ _NS_FORM_RE = re.compile(
 )
 
 
-def _reader_inert_at(masked: str, open_idx: int) -> bool:
-    """Is the form opening at `open_idx` neutralised by a READER PREFIX?
+# THE PREFIX AND ITS FORM ARE ONE UNIT. A first repair (PR #9511) decided
+# inertness by looking back ONE character from the `(`, and audit #9511
+# reproduced three shapes it cannot see, each of which interns nothing and each
+# of which turned a dead door green:
+#
+#   * `#_#?(:clj (defn ghost …))` — the character before the `(` is `?`, so the
+#     discard is never reached and the conditional's arms are walked as live;
+#   * `'#?(:clj (defn ghost …))` — the same, through a quote;
+#   * `#_#_ (def ignored 1) (defn ghost …)` — a STACKED discard, which look-back
+#     cannot reach in principle: the second discard's target sits AFTER a form
+#     the walker has already stepped past, so there is no prefix behind it.
+#
+# Reader-conditionals are the reason this matters more than the shapes it
+# replaces: `#?` is ordinary `.cljc` and this tree is full of it.
+#
+# The fix is to read forward the way the READER does. `#_` does not decorate
+# the next balanced list — it consumes the next DATUM, whatever that datum is
+# spelled as, and a discard met while reading that datum is itself consumed
+# first, which is exactly why `#_#_ a b` neutralises BOTH. `_datum_end` is that
+# rule and nothing more; it answers `#_#?`, `'#?`, `` `#? ``, `#_#?@`, `#_'`
+# and any further stacking with the same six lines.
+#
+# Reader prefixes that DECORATE the datum after them, longest-first so `#?@` is
+# never read as `#?`. `#_` is deliberately absent: a discard consumes its datum
+# rather than decorating it, and that difference is the stacked-discard case.
+_READER_PREFIXES: tuple[str, ...] = ("#?@", "#?", "#'", "~@", "'", "`", "~", "@")
 
-    THE SAME FALSE-GREEN AS `comment`, REACHED THROUGH THE READER RATHER THAN
-    THROUGH A HEAD SYMBOL. `#_(defn ghost …)` is discarded and `'(defn ghost
-    …)` / `` `(defn ghost …) `` are data, so none of the three defines
-    anything — but each is a balanced `( … )` form, and a walk that only looks
-    at what is INSIDE the parens sees `defn` and calls `ghost` public.
 
-    THIS IS THE DANGEROUS DIRECTION AND THE MANIFEST CONTROL CANNOT REACH IT:
-    `oracle_problems` is a SUBSET test, so it detects public names the parser
-    has stopped seeing, never fictitious ones it has started inventing.
+def _string_end(text: str, open_idx: int) -> int:
+    """The index just past the string literal opening at `open_idx`."""
+    n = len(text)
+    i = open_idx + 1
+    while i < n:
+        if text[i] == "\\":
+            i += 2
+            continue
+        if text[i] == '"':
+            return i + 1
+        i += 1
+    return n
 
-    Look-BACK rather than a forward prefix stack, because the caller has
-    already walked to this `(` at depth 0 — so the characters behind it are
-    top-level text and nothing else. `\\'` is the CHARACTER quote, not a quote
-    prefix, which is the same reader trap that once swallowed half a file.
+
+def _at_datum_start(text: str, i: int) -> bool:
+    """Is `i` the START of a datum rather than a character inside a token?
+
+    `'` is BOTH the quote prefix and a legal symbol constituent (`foo'`), and
+    `\\'` is the character literal — the reader trap that once swallowed half a
+    file. Either read as a prefix would swallow the form after it, so a quote
+    counts only where a datum could actually begin.
     """
-    j = open_idx - 1
-    while j >= 0 and _is_clj_ws(masked[j]):
-        j -= 1
-    if j < 0:
-        return False
-    if masked[j] in "'`":
-        return not (j > 0 and masked[j - 1] == "\\")
-    return masked[j] == "_" and j > 0 and masked[j - 1] == "#"
+    return i == 0 or _is_clj_ws(text[i - 1]) or text[i - 1] in "()[]{}"
+
+
+def _skip_reader_discards(text: str, i: int) -> int:
+    """Advance past reader whitespace and every complete `#_ <datum>` at `i`.
+
+    STACKED DISCARDS FALL OUT OF THE RECURSION: reading the datum a `#_`
+    discards goes through `_datum_end`, which skips a nested discard on its way
+    to a datum — so `#_#_ a b` consumes `a` while reading the inner discard's
+    target and then `b` as the outer one's, and neither reaches the caller.
+    """
+    n = len(text)
+    while True:
+        while i < n and _is_clj_ws(text[i]):
+            i += 1
+        if not text.startswith("#_", i):
+            return i
+        i = _datum_end(text, i + 2)
+
+
+def _datum_end(text: str, i: int) -> int:
+    """The index just past the next complete DATUM at or after `i`.
+
+    A miniature reader, not a full one — it answers only "where does this datum
+    end", which is all a walk deciding what to DESCEND INTO needs. It is
+    string-aware through `_balanced_extent` and `_string_end`, prefix-aware
+    through `_READER_PREFIXES`, and discard-aware through
+    `_skip_reader_discards`.
+    """
+    n = len(text)
+    i = _skip_reader_discards(text, i)
+    if i >= n:
+        return n
+    for prefix in _READER_PREFIXES:
+        if text.startswith(prefix, i):
+            return _datum_end(text, i + len(prefix))
+    c = text[i]
+    if c == "^":
+        # Metadata is read, then the datum it decorates.
+        return _datum_end(text, _datum_end(text, i + 1))
+    if c == "#":
+        if i + 1 < n and (text[i + 1].isalpha() or text[i + 1] == ":"):
+            # A tagged literal — `#js {…}`, `#inst "…"` — is tag then datum.
+            return _datum_end(text, _datum_end(text, i + 1))
+        # `#(`, `#{`, `#"…"`: dispatch on whatever follows.
+        return _datum_end(text, i + 1)
+    if c in "([{":
+        end = _balanced_extent(text, i)
+        return n if end is None else end
+    if c == '"':
+        return _string_end(text, i)
+    j = i
+    while j < n and not _is_clj_ws(text[j]) and text[j] not in '()[]{}"':
+        j += 1
+    return j if j > i else i + 1
 
 
 def _top_level_forms(masked: str) -> Iterable[str]:
     """Every balanced top-level `( … )` form in comment-masked text, MINUS the
-    ones a reader prefix makes inert (see `_reader_inert_at`)."""
+    ones the READER neutralises — see the prefix note above.
+
+    DELIBERATELY NOT A FULL READER. Anything that is not a top-level `(`, a
+    discard run or a quote is stepped over one character at a time, exactly as
+    before, because this walker also serves `do` bodies and reader-conditional
+    ARMS (`_public_names_defined_by`), where the leading `:clj` / `:cljs`
+    keyword has to be walked past rather than parsed.
+    """
     i = 0
     n = len(masked)
     while i < n:
-        if masked[i] == "(":
+        # Reader whitespace and `#_ <datum>` runs — stacked ones included —
+        # vanish here, whatever the discarded datum turns out to be.
+        after_noise = _skip_reader_discards(masked, i)
+        if after_noise != i:
+            i = after_noise
+            continue
+        c = masked[i]
+        if c in "'`" and _at_datum_start(masked, i):
+            # Quoted and syntax-quoted data define nothing, however the datum
+            # is spelled: `'(defn …)`, `'#?(:clj (defn …))`, `` `#?(…) ``.
+            i = _datum_end(masked, i)
+            continue
+        if masked.startswith("#?@", i):
+            # Splicing is a reader ERROR at the top level, so it interns
+            # nothing; consume it rather than descending into its arms. Inside
+            # a collection it is legal, and that path is unchanged — the arms
+            # are reached through the enclosing form.
+            i = _datum_end(masked, i)
+            continue
+        if c == "(":
             end = _balanced_extent(masked, i)
             if end is None:
                 return
-            if not _reader_inert_at(masked, i):
-                yield masked[i:end]
+            # `#?(…)` reaches here with the `#?` stepped over, which is what
+            # keeps a LIVE reader-conditional's arms descendable: the façade
+            # ships `rf/frame-root` as `#?(:cljs (def frame-root …))`.
+            yield masked[i:end]
             i = end
-        else:
-            i += 1
+            continue
+        i += 1
 
 
 def _public_names_defined_by(form: str) -> list[str]:
@@ -2729,16 +2836,24 @@ def _run_where_sym_self_tests(verbose: bool = False) -> int:
     # transparent.
     #
     # THE ABSENCES ARE HALF THE ASSERTION, and this is the only place that can
-    # make them: three privacy spellings, a `defmethod`, and the four inactive
-    # forms (`comment`, `#_`, `'`, `` ` ``) plus the discard nested in the live
-    # `do`. The manifest control cannot stand in for it — `oracle_problems` is
-    # a SUBSET test, so it catches public names the parser has stopped seeing
-    # and is blind to fictitious ones it has started inventing, which is
-    # exactly the direction `comment` failed in.
+    # make them: three privacy spellings, a `defmethod`, the four inactive
+    # forms (`comment`, `#_`, `'`, `` ` ``), the discard nested in the live
+    # `do`, and — audit #9511's residual — the six names behind a COMPOSED
+    # reader prefix (`#_#?`, `'#?`, `` `#? ``, `#_#?@` and both halves of a
+    # stacked `#_#_`). The manifest control cannot stand in for it —
+    # `oracle_problems` is a SUBSET test, so it catches public names the parser
+    # has stopped seeing and is blind to fictitious ones it has started
+    # inventing, which is exactly the direction `comment` failed in.
+    #
+    # `conditional-defined-public` is the twin that keeps the repair honest in
+    # the other direction: the oracle fixture writes it as a LIVE `#?(…)` with
+    # a body identical to the discarded one, so an inert-set widened until it
+    # swallows reader-conditionals costs this name and the exact set says so.
     expected_publics = {
         "known-var", "known-public", "known-macro", "known-multi",
         "no-doc-public", "cljs-only-public", "clj-only-public",
         "Panel", "imported-fn", "do-defined-public",
+        "conditional-defined-public",
     }
     got_publics = index.publics_of("re-frame.fixture")
     if got_publics != expected_publics:
@@ -2811,6 +2926,24 @@ def _run_where_sym_self_tests(verbose: bool = False) -> int:
             # blind spot, which is the failure this gate's audit was about.
             (233, "where-sym-unresolvable", "rf.fixture/ghost-comma-five"),
             (236, "where-sym-unresolvable", "rf.fixture/ghost-comma-six"),
+            # (7) COMPOSED READER PREFIXES — audit #9511's residual. The first
+            # repair read the ONE character before the `(`, which is `?` for
+            # both `#_#?(…)` and `'#?(…)`; the stacked `#_#_ a b` it could not
+            # reach at all, because nothing stands behind the second form but
+            # the one the first discard consumed. Each name is defined in the
+            # oracle fixture behind its prefix and NOWHERE ELSE, and stripping
+            # that prefix makes the form define its var for real — so the
+            # prefix is the only thing under test here.
+            (254, "where-sym-unresolvable",
+             "rf.fixture/ghost-discarded-conditional"),
+            (260, "where-sym-unresolvable",
+             "rf.fixture/ghost-quoted-conditional"),
+            (266, "where-sym-unresolvable",
+             "rf.fixture/ghost-syntax-quoted-conditional"),
+            (272, "where-sym-unresolvable",
+             "rf.fixture/ghost-discarded-splice"),
+            (279, "where-sym-unresolvable", "rf.fixture/ghost-stacked-first"),
+            (285, "where-sym-unresolvable", "rf.fixture/ghost-stacked-second"),
         )),
         (_WHERE_SYM_NEGATIVE, ()),
     ]
@@ -2840,7 +2973,7 @@ def _run_where_sym_self_tests(verbose: bool = False) -> int:
     neg_path = _WHERE_SYM_FIXTURE_ROOT / _WHERE_SYM_NEGATIVE
     neg_text = neg_path.read_text(encoding="utf-8", errors="replace")
     neg_observed = _scan_where_syms(neg_path, neg_text, neg_text.splitlines())
-    if len(neg_observed) < 21:
+    if len(neg_observed) < 22:
         fail(
             f"the negative fixture observed only {len(neg_observed)} where-sym(s). "
             "A green there is only evidence while the sites are still being SEEN "
@@ -2865,6 +2998,10 @@ def _run_where_sym_self_tests(verbose: bool = False) -> int:
         # proved the pair above could not reach.
         (175, "builder", "rf.fixture/known-public"),
         (178, "where-slot", "rf.fixture/known-public"),
+        # a LIVE reader-conditional, body-for-body the twin of the oracle
+        # fixture's discarded one. Green here alone would also be what a
+        # detector blind to the whole site looks like, so it is pinned SEEN.
+        (190, "builder", "rf.fixture/conditional-defined-public"),
     )
     got_observations = {(w.line, w.source, w.symbol) for w in neg_observed}
     for pin in required_observations:

--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -1176,6 +1176,12 @@ _NS_FORM_RE = re.compile(
 # Reader-conditionals are the reason this matters more than the shapes it
 # replaces: `#?` is ordinary `.cljc` and this tree is full of it.
 #
+# AND THE MANIFEST CONTROL CANNOT REACH ANY OF IT. `oracle_problems` is a
+# SUBSET test, so it detects public names the parser has STOPPED seeing, never
+# fictitious ones it has STARTED inventing. What guards this direction is the
+# exact-set assertion in `_run_where_sym_self_tests`, over an oracle fixture
+# that defines each of these names behind its prefix and nowhere else.
+#
 # The fix is to read forward the way the READER does. `#_` does not decorate
 # the next balanced list — it consumes the next DATUM, whatever that datum is
 # spelled as, and a discard met while reading that datum is itself consumed


### PR DESCRIPTION
Audit #9511's P2 residual on rf2-z5lv, reopened on trunk within the hour of the parent fix merging. **Third round on this gate.** Bounded detector/oracle repair only — no baseline change, no convention ruling, no audit of the 82 existing unresolved sites (the module-naming question stays rf2-uewm).

## The residual

`_reader_inert_at` decided inertness from the **one character before a top-level `(`**, after skipping whitespace. That is `?` for both `#_#?(…)` and `'#?(…)`, so the discard and the quote were never seen and `_public_names_defined_by` descended into the conditional's arms as live. A stacked `#_#_ a b` was unreachable by look-back **in principle**: nothing stands behind the second form but the one the first discard consumed, so it skipped only the first while the Clojure reader discards both.

Reader-conditionals are why this matters more than the shapes it replaces: `#?` is ordinary `.cljc` and this tree is full of it. All of these intern **no** var, so each was a dead door the gate blessed. `oracle_problems` cannot catch any of it — it is a SUBSET test, blind to *extra* fictitious publics by construction.

Reproduced through the **default CLI** on an isolated git-tracked control repo (non-empty manifest subset, `:min-where-syms 1`, two always-present calls, one naming a var that exists and one naming the var under test):

| case | reader interns the ghost? | before | after |
|---|---|---|---|
| missing definition (control) | no | **1** | 1 |
| live `(do (defn ghost …))` (control) | yes | **0** | 0 |
| live `#?(:clj … :cljs …)` | yes | **0** | 0 |
| `#_(defn ghost …)` — #9511's repair | no | **1** | 1 |
| `'(defn ghost …)` — #9511's repair | no | **1** | 1 |
| `#_#?(:clj (defn ghost …))` | no | **0 — FALSE GREEN** | 1 |
| `'#?(:clj (defn ghost …))` | no | **0 — FALSE GREEN** | 1 |
| `#_#_ (def ignored 1) (defn ghost …)` | no | **0 — FALSE GREEN** | 1 |
| syntax-quoted conditional *(found here)* | no | **0 — FALSE GREEN** | 1 |
| `#_#?@(:clj [(defn ghost …)])` *(found here)* | no | **0 — FALSE GREEN** | 1 |

10/10 correct after. Two independent oracles agree on every row: a JVM `load-file` + `ns-publics` probe (the known var present in all ten cases, the ghost present only in the two live ones) and a `:cljs`-feature reader probe, because a JVM-only oracle reports a `:cljs`-only door as dead.

## The repair — the prefix and its form are ONE unit

`_reader_inert_at` is gone. In its place a forward scan that reads the way the reader does:

- `_datum_end` — "where does this datum end", prefix-aware (the reader-macro prefixes, plus metadata, dispatch forms and tagged literals), string-aware, collection-aware;
- `_skip_reader_discards` — consumes a discard and its datum. **Stacked discards fall out of the recursion**: reading the datum a discard neutralises goes through `_datum_end`, which skips a nested discard on its way to a datum, so `#_#_ a b` consumes `a` as the inner target and `b` as the outer one's;
- `_at_datum_start` — a quote counts only where a datum could begin, which keeps `foo'` a symbol and preserves the character-literal guard #9511 documented.

Every composed spelling — a discard or a quote over a conditional, a syntax-quote over one, a discard over a splicing conditional, a discard over a quote, and any further stacking — is the same six lines. A **live** `#?(…)` still has its arms descended, which is how the facade's platform-specific exports ship. A top-level splicing conditional is consumed rather than descended, because splicing there is a reader error and interns nothing.

Deliberately **not** a full reader: anything that is not a top-level `(`, a discard run or a quote is still stepped over one character at a time, because this walker also serves `do` bodies and reader-conditional arms where a leading platform keyword has to be walked past rather than parsed.

## The #9511 fixes are preserved, and that is PROVEN rather than asserted

A passing self-test says the fixtures agree with the code; it does not say a fix is still load-bearing. Each was planted back out and the self-test re-run — every restore verified by **blob hash** against the committed object, never by the restore command's exit code:

| plant | self-test | what it lost |
|---|---|---|
| `_is_clj_ws` back to Python whitespace | **1** | findings at 233, 236; observations at 175, 178 |
| `_CLJ_WS` back to a comma-free class | **1** | findings at 182, 194; observation at 146 |
| map-tail closer-at-depth-0 removed | **1** | finding at 217; observation at 164 |
| `comment` back in `_TRANSPARENT_DEF_WRAPPERS` | **1** | finding at 139 |

The corrected manifest-subset comment is untouched everywhere #9511 put it, and **restated at the new walker** — #9511 had one copy in `_reader_inert_at`'s docstring, and that function is gone, so the warning moved to the code that now owns the dangerous direction.

## Fixtures — line numbers, not counts

The `:min-where-syms` floor of 173 cannot detect a single lost call against 193 observed, so a total-count guard is no substitute.

- **Oracle fixture**: six ghost names behind composed prefixes, plus `conditional-defined-public` as a **live** conditional written body-for-body identical to the discarded one. The exact public set goes 10 → 11 and now also asserts six absences.
- **Positive fixture**: six new findings pinned `(line, kind, symbol)` — 254, 260, 266, 272, 279, 285. Both halves of the stacked discard are pinned; the first was already caught by look-back, the second is the residual.
- **Negative fixture**: the live twin pinned as **OBSERVED** at `(190, builder, rf.fixture/conditional-defined-public)`, and the observation floor raised 21 → 22 — because a resolving site is green when seen and green again when it has vanished.

**Every new oracle form is adversarial against the predicate that reads it.** Strip the prefix and each defines its var for real, so nothing *but* the prefix is under test. That is the direct lesson of #9511's green sabotage plant, where every comma fixture wrote its comma beside whitespace and the splitter's own notion was never exercised.

## Sabotage proof — six directions

Each plant match-counted at exactly 1 before the run; each restore verified by blob hash against `HEAD`.

| plant | self-test | findings lost / gained | CLI flipped |
|---|---|---|---|
| the conditional prefixes dropped from the prefix roster | **1** | lost 254, 260, 266, 272 | four composed cases 1 → 0 |
| quote handling disabled at top level | **1** | lost 151, 157, 260, 266 | three quoted cases 1 → 0 |
| the discard loop reduced to a single pass | **1** | lost 285 | stacked discard 1 → 0; simple discard **stays 1** |
| the inert set widened onto live conditionals | **1** | **gained** false findings at 53, 59, 190 | live conditional 0 → **1** |

The third plant leaves the simple discard red, which is what says it is surgical to *stacking* — #9511's shipped repair is untouched. The fourth is the green direction: widening the inert set until it swallows a live conditional is caught by the exact set (all three conditional-defined names reported "NOT SEEN as public") and by the pinned observation at 190. The live `do` control stayed green under all four plants.

## Quality gates

| gate | exit | note |
|---|---|---|
| `python scripts/check_thrown_error_messages.py --self-test --verbose` | **0** | 27/27; log **4833 bytes**, so the green is visibly not the zero-byte one this gate is known for |
| `python scripts/check_thrown_error_messages.py --verbose` | **0** | **333 files / 193 where-syms (191 qualified) / 82 unresolved / 37 baselined**, floor 173 — byte-identical to the pristine gate's output on this tree |
| all **80** `check_*.py` invocations CI runs, extracted from the 11 workflow files | **0** | **80/80** |
| JVM `load-file` + `ns-publics` oracle, 10 cases | **0** | the ghost is interned only by the live `do` and the live conditional |
| `:cljs`-feature reader oracle, 11 cases | **0** | same verdict under the other runtime |
| JVM + `:cljs` oracle over the **fixture's own bytes** | **0** | 2 live names interned, 11 dead names absent |
| whole-tree derived-public-set delta, pristine vs repaired parser | **0** | **0 files moved** across 2936 tracked Clojure sources, 32150 publics identical |

Exit codes captured on the runner's own command line, never through a pipe. Both cheap gates re-run on the final rebased base.

`scripts/where-sym-baseline.edn` is **unchanged** — no baseline delta, no site re-adjudicated.

**Gates that do NOT cover this path, verified at source rather than taken on trust:** `check_doc_slugs.py`'s `DEFAULT_ROOTS` are `docs`, `spec`, `skills` and `migration` plus `tools/*/spec` — `scripts/` is not among them; `check_readme_links.py` excludes `_test_fixtures` by name; `mkdocs.yml`'s `docs_dir` is `docs` and the hook stages only `spec/` and `migration/`. There is **no Python linter or formatter in this repo** — no tracked config and no workflow mention of ruff, flake8, black, mypy, pylint, isort or pyright, with clj-kondo as a live control that fires in 2 workflow files. clj-kondo's lint roster (implementation, examples, testbeds, the tool trees) and Splint's (implementation, tools, examples, testbeds) both exclude `scripts/`, so the new `.cljc` fixtures are unlinted too. Nothing here is a coverage hole to fill; the gate's own self-test is the gate for this surface.

Refs: rf2-z5lv
