### PR TITLE
fix(gate): carry reader-top-level context so a live #?@ in a do keeps its publics

### DIFF
--- a/scripts/_test_fixtures/check_thrown_error_messages/wheresym/negative_where_syms.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/wheresym/negative_where_syms.cljc
@@ -191,3 +191,35 @@
     :rf.error/ok-twentytwo
     'rf.fixture/conditional-defined-public
     "`#?(:clj (defn conditional-defined-public ...))` interns the var"))
+
+;; ---- LIVE SPLICING CONDITIONALS: the false-RED direction (audit #9515) ----
+;;
+;; `(do #?@(:clj [(defn ...)]))` is legal Clojure and interns its var, but the
+;; composed-prefix repair consumed `#?@` wherever it met one — including
+;; inside a `do` body, which `_public_names_defined_by` walks by re-entering
+;; the same walker. All three doors below went dead in the oracle, so these
+;; three correct calls reddened.
+;;
+;; PINNED AS OBSERVED, and here that matters more than anywhere else in this
+;; file: these are the sites a FALSE RED fires on, so the regression they
+;; guard is the gate REPORTING them. A findings assertion alone cannot
+;; separate "resolves" from "never seen", and the third one resolves only
+;; because the oracle is feature-agnostic — a `:cljs`-only door.
+
+(defn splice-in-do-var-resolves []
+  (rf.error/throw-error!
+    :rf.error/ok-twentythree
+    'rf.fixture/splice-in-do-public
+    "`(do #?@(:clj [(defn splice-in-do-public ...)]))` interns the var"))
+
+(defn splice-in-conditional-do-var-resolves []
+  (rf.error/throw-error!
+    :rf.error/ok-twentyfour
+    'rf.fixture/splice-in-conditional-do-public
+    "a splice inside a `do` inside a reader-conditional interns it too"))
+
+(defn splice-cljs-only-var-resolves []
+  (rf.error/throw-error!
+    :rf.error/ok-twentyfive
+    'rf.fixture/splice-cljs-only-public
+    "a :cljs-ONLY door: live under ClojureScript, invisible to a JVM oracle"))

--- a/scripts/_test_fixtures/check_thrown_error_messages/wheresym/positive_where_syms.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/wheresym/positive_where_syms.cljc
@@ -286,3 +286,17 @@
     :rf.error/ghost-twentysix
     'rf.fixture/ghost-stacked-second
     "the SECOND form, which look-back cannot reach in principle"))
+
+;; ---- (8) A DISCARDED `do` AROUND A LIVE-LOOKING SPLICE -------------------
+;;
+;; Audit #9515. The three live splicing twins in the negative fixture resolve
+;; and are pinned OBSERVED there; this is the half that must FIRE. Its oracle
+;; form is byte-identical to the first of those three but for the leading
+;; `#_`, so the discard is the only thing making it inert — a repair that
+;; descends into every `#?@` it meets greens this line.
+
+(defn ghost-in-a-discarded-splicing-do []
+  (rf.error/throw-error!
+    :rf.error/ghost-twentyseven
+    'rf.fixture/ghost-splice-discarded
+    "`#_` swallows the whole `do`, splice and all"))

--- a/scripts/_test_fixtures/check_thrown_error_messages/wheresym/re_frame/fixture.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/wheresym/re_frame/fixture.cljc
@@ -157,3 +157,42 @@
 
 #?(:clj  (defn conditional-defined-public [] nil)
    :cljs (defn conditional-defined-public [] nil))
+
+;; ---- SPLICING READER-CONDITIONALS: THE POSITION IS THE WHOLE RULE ---------
+;;
+;; Audit #9515's residual on the repair above, and it points the OTHER WAY.
+;; `#?@` means opposite things in the two places it can stand: at file top
+;; level there is no collection to splice into, so it is a reader ERROR and
+;; interns nothing; inside a collection it is ordinary legal Clojure. The
+;; composed-prefix repair consumed it in BOTH, so the legal splice below was
+;; discarded as though it were the illegal one and `splice-in-do-public` went
+;; MISSING from the derived set — a FALSE RED, where a where-sym naming a var
+;; that genuinely exists reds a correct PR. Every other case in this file
+;; tests green-should-be-red, which is exactly why none of them saw it.
+;;
+;; THE ENCLOSING COLLECTION IS THE ONLY THING MAKING THESE LEGAL, which is the
+;; adversarial property the composed-prefix cases have one direction along:
+;; strip the `do` from the first and what is left is a top-level `#?@` that
+;; interns nothing. So a repair that loses the top-level/inside-a-collection
+;; distinction cannot satisfy this file and the positive one at the same time.
+;;
+;; BOTH RUNTIMES WERE ASKED, AND THEY DISAGREE ON ONE ROW ON PURPOSE. JVM
+;; `load-file` + `ns-publics` interns the first two; a `:cljs`-feature reader
+;; oracle interns all three, and it is the ONLY one that sees
+;; `splice-cljs-only-public`. A JVM-only oracle would call that door dead —
+;; the same false red one runtime along, and the reason the derived set here
+;; is deliberately feature-agnostic.
+
+(do #?@(:clj  [(defn splice-in-do-public [] :live)]
+        :cljs [(defn splice-in-do-public [] :live)]))
+
+#?(:clj  (do #?@(:clj  [(defn splice-in-conditional-do-public [] :live)]))
+   :cljs (do #?@(:cljs [(defn splice-in-conditional-do-public [] :live)])))
+
+(do #?@(:cljs [(defn splice-cljs-only-public [] :live)]))
+
+;; The DISCARDED twin, body for body — `#_` neutralises the whole `do`, splice
+;; and all, so this name must stay absent however far the splice repair goes.
+
+#_(do #?@(:clj  [(defn ghost-splice-discarded [] nil)]
+          :cljs [(defn ghost-splice-discarded [] nil)]))

--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -1274,7 +1274,9 @@ def _datum_end(text: str, i: int) -> int:
     return j if j > i else i + 1
 
 
-def _top_level_forms(masked: str) -> Iterable[str]:
+def _top_level_forms(
+    masked: str, *, at_reader_top_level: bool = True
+) -> Iterable[str]:
     """Every balanced top-level `( … )` form in comment-masked text, MINUS the
     ones the READER neutralises — see the prefix note above.
 
@@ -1283,6 +1285,12 @@ def _top_level_forms(masked: str) -> Iterable[str]:
     before, because this walker also serves `do` bodies and reader-conditional
     ARMS (`_public_names_defined_by`), where the leading `:clj` / `:cljs`
     keyword has to be walked past rather than parsed.
+
+    `at_reader_top_level` IS THE ONE THING THOSE TWO USES DO NOT SHARE, and it
+    governs exactly one construct: `#?@`. It is a reader error at file top
+    level and legal inside a collection, so the same text means different
+    things depending on which caller is walking it. Callers walking the inside
+    of a form pass False.
     """
     i = 0
     n = len(masked)
@@ -1299,11 +1307,26 @@ def _top_level_forms(masked: str) -> Iterable[str]:
             # is spelled: `'(defn …)`, `'#?(:clj (defn …))`, `` `#?(…) ``.
             i = _datum_end(masked, i)
             continue
-        if masked.startswith("#?@", i):
-            # Splicing is a reader ERROR at the top level, so it interns
-            # nothing; consume it rather than descending into its arms. Inside
-            # a collection it is legal, and that path is unchanged — the arms
-            # are reached through the enclosing form.
+        if at_reader_top_level and masked.startswith("#?@", i):
+            # SPLICING IS POSITIONAL, AND THE TWO POSITIONS ARE OPPOSITE.
+            # At TRUE file top level `#?@` is a reader ERROR — there is no
+            # collection to splice into — so it interns nothing and is
+            # consumed here. INSIDE a collection it is ordinary legal Clojure,
+            # and this walker also serves `do` bodies and reader-conditional
+            # arms, both of which ARE inside one. Those two callers pass
+            # `at_reader_top_level=False`, so `(do #?@(:clj [(defn foo …)]))`
+            # is descended and contributes `foo`.
+            #
+            # THE FIRST VERSION OF THIS BRANCH CONSUMED IT UNCONDITIONALLY
+            # (rf2-z5lv, audit #9515) and the comment claimed the collection
+            # path was "unchanged — the arms are reached through the enclosing
+            # form". It is not: `_public_names_defined_by` re-enters THIS
+            # function for a `do` body, so a legal splice was discarded as
+            # though it were an illegal file-top-level one and a real public
+            # var went missing from the oracle. That is a FALSE RED — a
+            # where-sym naming a var that genuinely exists reds a correct PR —
+            # and it is the opposite direction from every other case this
+            # walker guards, which is why the fixtures did not see it.
             i = _datum_end(masked, i)
             continue
         if c == "(":
@@ -1330,11 +1353,15 @@ def _public_names_defined_by(form: str) -> list[str]:
     # only argument is returned WITH it and matches no symbol pattern. That
     # is not hypothetical: it is what hid every `(import-fn …)` re-export.
     body = form[m.end():-1]
+    # BOTH RECURSIONS BELOW ARE INSIDE A COLLECTION, so both switch the walker
+    # out of reader-top-level mode: a reader-conditional's `(:clj … :cljs …)`
+    # arm list and a `(do …)` body are each a list the reader is part-way
+    # through, which is exactly where `#?@` is legal (see `_top_level_forms`).
     if _PLATFORM_KEYWORD_RE.match(raw_head):
-        return [n for f in _top_level_forms(form[1:-1])
+        return [n for f in _top_level_forms(form[1:-1], at_reader_top_level=False)
                 for n in _public_names_defined_by(f)]
     if head in _TRANSPARENT_DEF_WRAPPERS:
-        return [n for f in _top_level_forms(body)
+        return [n for f in _top_level_forms(body, at_reader_top_level=False)
                 for n in _public_names_defined_by(f)]
     if head == "import-fn":
         # `(import-fn <ns>/<name>)` interns `<name>` in THIS namespace.
@@ -2855,11 +2882,20 @@ def _run_where_sym_self_tests(verbose: bool = False) -> int:
     # the other direction: the oracle fixture writes it as a LIVE `#?(…)` with
     # a body identical to the discarded one, so an inert-set widened until it
     # swallows reader-conditionals costs this name and the exact set says so.
+    #
+    # The three `splice-…-public` names are audit #9515's residual and they
+    # are the only entries here that guard the FALSE-RED direction: each is
+    # defined by a LIVE `#?@` inside a collection, which the composed-prefix
+    # repair consumed as though it were an illegal top-level splice. A name
+    # MISSING from this set is the failure they pin, where every other entry
+    # pins a fictitious one being present.
     expected_publics = {
         "known-var", "known-public", "known-macro", "known-multi",
         "no-doc-public", "cljs-only-public", "clj-only-public",
         "Panel", "imported-fn", "do-defined-public",
         "conditional-defined-public",
+        "splice-in-do-public", "splice-in-conditional-do-public",
+        "splice-cljs-only-public",
     }
     got_publics = index.publics_of("re-frame.fixture")
     if got_publics != expected_publics:
@@ -2884,6 +2920,55 @@ def _run_where_sym_self_tests(verbose: bool = False) -> int:
     # never opened — here it would silently green every where-sym naming it.
     if index.publics_of("re-frame.nosuch") is not None:
         fail("an undefined namespace must answer None, not an empty public set")
+
+    # ---- `#?@` IS POSITIONAL, AND NO FIXTURE FILE CAN HOLD BOTH POSITIONS --
+    #
+    # A file-top-level `#?@` is a reader ERROR, so a fixture carrying one is
+    # unreadable by the very reader that corroborates the exact set above —
+    # the whole file interns nothing, `known-var` included. The two positions
+    # therefore cannot share a file, and the top-level half is asserted here
+    # over source text instead. The inside-a-collection half is asserted BOTH
+    # ways: here, and by the three `splice-…-public` names above.
+    #
+    # THESE ARE ADVERSARIAL AGAINST THE REPAIR ITSELF, which is what the file
+    # fixtures cannot be. Delete the `at_reader_top_level` flag and descend
+    # into every `#?@`, and every fixture file still passes — the live twins
+    # resolve, and the discarded twin stays inert because `#_` neutralises it
+    # regardless. Only the FIRST row below goes red.
+    position_cases: list[tuple[str, str, set[str]]] = [
+        ("a file-top-level splice interns nothing: there is no collection to "
+         "splice into, so the reader errors",
+         "#?@(:clj [(defn spliced [] nil)] :cljs [(defn spliced [] nil)])",
+         set()),
+        ("a splice inside a `do` body is ordinary legal Clojure",
+         "(do #?@(:clj [(defn spliced [] nil)] :cljs [(defn spliced [] nil)]))",
+         {"spliced"}),
+        ("... and inside a `do` inside a reader conditional, where the walker "
+         "re-enters itself twice",
+         "#?(:clj (do #?@(:clj [(defn spliced [] nil)])))",
+         {"spliced"}),
+        ("a DISCARDED `do` takes the splice with it",
+         "#_(do #?@(:clj [(defn spliced [] nil)]))",
+         set()),
+    ]
+    position_failures = 0
+    for why, source, expected in position_cases:
+        got = {n for f in _top_level_forms(source)
+               for n in _public_names_defined_by(f)}
+        if got != expected:
+            position_failures += 1
+            fail(
+                f"`#?@` position — {why}\n"
+                f"      source   {source}\n"
+                f"      expected {sorted(expected)}\n"
+                f"      got      {sorted(got)}"
+            )
+    if verbose and not position_failures:
+        sys.stderr.write(
+            f"where-sym self-test PASS: all {len(position_cases)} `#?@` "
+            "position case(s) — inert at file top level, live inside a "
+            "collection\n"
+        )
 
     # ---- the two fixture files, pinned by (line, kind, symbol) --------------
     cases: list[tuple[str, tuple[tuple[int, str, str], ...]]] = [
@@ -2950,6 +3035,12 @@ def _run_where_sym_self_tests(verbose: bool = False) -> int:
              "rf.fixture/ghost-discarded-splice"),
             (279, "where-sym-unresolvable", "rf.fixture/ghost-stacked-first"),
             (285, "where-sym-unresolvable", "rf.fixture/ghost-stacked-second"),
+            # (8) a DISCARDED `do` around a live-looking splice — audit
+            # #9515. Its three LIVE twins resolve in the negative fixture and
+            # are pinned OBSERVED there; this is the half that must FIRE, and
+            # the pair is what separates "the splice repair is positional"
+            # from "the walker descends into every `#?@` it meets".
+            (299, "where-sym-unresolvable", "rf.fixture/ghost-splice-discarded"),
         )),
         (_WHERE_SYM_NEGATIVE, ()),
     ]
@@ -2979,7 +3070,7 @@ def _run_where_sym_self_tests(verbose: bool = False) -> int:
     neg_path = _WHERE_SYM_FIXTURE_ROOT / _WHERE_SYM_NEGATIVE
     neg_text = neg_path.read_text(encoding="utf-8", errors="replace")
     neg_observed = _scan_where_syms(neg_path, neg_text, neg_text.splitlines())
-    if len(neg_observed) < 22:
+    if len(neg_observed) < 25:
         fail(
             f"the negative fixture observed only {len(neg_observed)} where-sym(s). "
             "A green there is only evidence while the sites are still being SEEN "
@@ -3008,6 +3099,18 @@ def _run_where_sym_self_tests(verbose: bool = False) -> int:
         # fixture's discarded one. Green here alone would also be what a
         # detector blind to the whole site looks like, so it is pinned SEEN.
         (190, "builder", "rf.fixture/conditional-defined-public"),
+        # THE THREE LIVE SPLICING TWINS — audit #9515, and the direction is
+        # reversed here. Everywhere else in this tuple an OBSERVED pin guards
+        # a site going UNSEEN; these three guard the gate REPORTING them,
+        # because each names a var a live `#?@` really does intern and the
+        # composed-prefix repair had stopped seeing. Green here alone would
+        # equally be what a detector blind to the whole site looks like, so
+        # they are pinned SEEN, and their discarded twin fires in the
+        # positive fixture. The third resolves ONLY because the oracle is
+        # feature-agnostic: it is a `:cljs`-only door, dead to a JVM oracle.
+        (210, "builder", "rf.fixture/splice-in-do-public"),
+        (216, "builder", "rf.fixture/splice-in-conditional-do-public"),
+        (222, "builder", "rf.fixture/splice-cljs-only-public"),
     )
     got_observations = {(w.line, w.source, w.symbol) for w in neg_observed}
     for pin in required_observations:


### PR DESCRIPTION
Round four on `check_thrown_error_messages.py`'s where-sym oracle, and the
first one pointing the other way. Rounds 1-3 all closed FALSE GREENS — a dead
door the gate blessed. Audit #9515 found a FALSE RED the round-three repair
introduced: a real public var goes missing from the oracle, so a where-sym
naming it reds a PR that is correct.

## The defect

`_top_level_forms` consumed `#?@` unconditionally, under a comment asserting
the invariant it breaks: *"Inside a collection it is legal, and that path is
unchanged — the arms are reached through the enclosing form."* It is not
unchanged. `_public_names_defined_by` **re-enters the same walker** for a
`do` body, so the recursive call had no memory that it was now inside a
collection and ate the legal splice.

```clojure
(do #?@(:clj [(defn ghost [] nil)] :cljs [(defn ghost [] nil)]))
```

Clojure interns `ghost`. The landed gate did not see it.

## The repair

Splicing is **positional**, and the two positions are opposite:

| position | meaning | walker |
|---|---|---|
| file top level | reader ERROR — no collection to splice into | consume, contributes nothing |
| inside a collection | ordinary legal Clojure | descend into the arms |

`_top_level_forms` now takes `at_reader_top_level`, True for the file walk.
Both recursive entries pass False, because both are unambiguously inside a
list the reader is part-way through: a `(do …)` body, and a reader
conditional's own `(:clj … :cljs …)` arm list. Three lines of behaviour; the
rest is the comment that was wrong.

No baseline change, no scanning-scope widening, no site re-adjudicated.

## Reproduction and both runtime oracles

Through the DEFAULT CLI on an isolated git-tracked control repo (non-empty
manifest subset, `:min-where-syms 1`, two unchanged `known`/`ghost` calls, so
the observed population is never zero and `known` resolves on every run):

| shape | pre-#9515 | landed | this PR | JVM interns | CLJS interns |
|---|---|---|---|---|---|
| `(do #?@(:clj […] :cljs […]))` | 0 | **1** | 0 | yes | yes |
| `#?(:clj (do #?@(:clj […])) …)` | 0 | **1** | 0 | yes | yes |
| `(do (do #?@(…)))` | 0 | **1** | 0 | yes | yes |
| `(do #?@(:cljs […]))` | 0 | **1** | 0 | no | **yes** |
| `#?@(…)` at file top level | 0 | 1 | 1 | no | no |
| `#_(do #?@(…))` | 1 | 1 | 1 | no | no |
| `(do #_#?@(…))` | 0 | 1 | 1 | no | no |
| `(do '#?@(…))` | 0 | 1 | 1 | no | no |
| live `do`, live `#?` (controls) | 0 | 0 | 0 | yes | yes |
| missing definition (control) | 1 | 1 | 1 | no | no |

The fourth row is why one runtime is not enough: `(do #?@(:cljs […]))` is a
`:cljs`-ONLY door that a JVM `ns-publics` oracle calls dead. The oracle is
deliberately feature-agnostic — this tree ships `#?(:cljs (def frame-root …))`
exports the same way.

Corroborated by `load-file` + `ns-publics` on the JVM and by a
`clojure.tools.reader` oracle under `:features #{:cljs}`, both over the same
bytes. They agree on every row.

## Fixtures

The audit's specification, met case for case:

* **Oracle fixture** gains three LIVE splicing publics
  (`splice-in-do-public`, `splice-in-conditional-do-public`,
  `splice-cljs-only-public`) and a DISCARDED twin (`ghost-splice-discarded`)
  written body-for-body identical but for the `#_`. Exact public set 11 → 14.
* **Negative fixture** pins all three as **OBSERVED** at `(210, builder, …)`,
  `(216, builder, …)`, `(222, builder, …)`. This is where most of the work
  went, and the direction is reversed from every other pin in that tuple:
  elsewhere an OBSERVED pin guards a site going unseen, here it guards the
  gate *reporting* it. Observation floor 22 → 25.
* **Positive fixture** pins the discarded twin as a finding at line 299.
* **A four-row position table** asserts the top-level-versus-inside question
  over source text. A file carrying a top-level `#?@` is unreadable by the
  very reader that corroborates the exact set — the whole file interns
  nothing — so the two positions cannot share a fixture file.

**The position table is the case adversarial against the repair itself.**
Delete the flag and descend into every `#?@`, and every fixture FILE still
passes: the live twins resolve, and the discarded twin stays inert because
`#_` neutralises it regardless. Only the first row of that table goes red —
measured, below.

Line numbers are pinned, never counts. `:min-where-syms 173` against 193
observed cannot detect a single lost call.

## Whole-tree oracle delta

The decisive control for a false-RED fix, because the repair ADDS publics.
Derived public set computed with the pristine parser and with this one across
**2936 tracked Clojure sources**:

* Before adding fixtures: **0 files moved, 32162 publics identical.**
* After: **1 file moved — the oracle fixture — +3 publics, 0 removed**, and
  those three are exactly the shapes intended.

The instrument was run against something it should find before that zero was
believed: on the synthetic control repos it reports `ghost` added for
`(do #?@ …)` and `(do #?@(:cljs …))` and nothing added for the top-level and
discarded shapes.

Trunk carries 162 `#?@` occurrences, every one inside an `ns` `:require`,
which the def-walker never descends. So the live scan is unmoved — this is a
hazard armed for the next author who writes a platform-conditional definition
block, not one firing today.

## Sabotage, in both directions

Every plant match-counted at exactly 1 before the run; every restore verified
against the committed blob `755c68cffc92aef3901f3b75849e99021c2d9e32`; the
CLI arm run against the PLANTED copy, not a clean one.

**1 — the false red must be gone.** Reverting the fix
(`at_reader_top_level and …` → unconditional) turns the three live-splice CLI
cases 0 → 1 naming `ghost`, drops all three publics from the exact set, and
GAINS findings at negative-fixture lines 210/216/222 — the OBSERVED pins
catching the regression as a finding where there should be none.

**2 — the invalid cases must stay inert.** Widening the other way (always
descend) turns the file-top-level CLI case 1 → 0, blessing a fictitious
public, and the position table's first row goes red naming it. The two
discarded shapes stay at 1 under BOTH plants, which is the discrimination:
`#_` neutralises regardless, so only the top-level row separates them.

**3 — every earlier fix proven still live, not asserted.** This gate's
standing hazard is a repair undoing its predecessor, and it has now had
three predecessors:

| plant | lost |
|---|---|
| `_is_clj_ws` → Python whitespace | findings 233/236, observations 175/178 |
| `_CLJ_WS` → `[\s]` | findings 182/194, observation 146 |
| map-tail closer-at-depth-0 removed | finding 217, observation 164 |
| `comment` back in the transparent wrappers | finding 139, gains public `ghost-in-comment` |
| composed prefixes dropped from the roster | findings 254/260/266/272, gains 4 fictitious publics |
| discard loop reduced to a single pass | finding 285, gains `ghost-stacked-second` |

Each red at self-test rc=1. The fifth earlier fix — the corrected
manifest-subset comment — is prose and carries no plant; it is verified
present at the walker that owns the dangerous direction.

## Quality gates

Exit codes captured on the runner's own command line, never through a pipe.

| gate | exit | note |
|---|---|---|
| `check_thrown_error_messages.py --self-test --verbose` | 0 | 27/27; log **4946 bytes** (was 4833) — not the zero-byte green this gate is known for |
| `check_thrown_error_messages.py --verbose` | 0 | 333 files, 193 where-syms (191 qualified), 82 unresolved, 37 baselined, floor 173 — unmoved, as the delta predicted |
| all `check_*.py` invocations CI runs, extracted from 11 workflows | 0 | **79/79 standalone at exit 0.** The 80th is `check_ci_reproduce_commands.py --emit "$id"`, which takes a CI step id; run with two real ids it exits 0 both times, and its `--check --verbose` guard step is in the 79 |
| `check-beads-pr-boundary.sh` | 0 | no beads-database paths; checked with a control that fires |
| `check-commit-attribution.sh` (commits arm) | 0 | |
| whole-tree oracle delta, 2936 sources | 0 | see above |
| JVM `load-file` + `ns-publics` oracle | 0 | |
| `:cljs`-feature reader oracle | 0 | |

Deliberately not run: `scripts/test-fast-pr.sh`. Per the gate-nomination
policy it is a spine, not a mirror, and it tiers itself on the changed-surface
classifier; the one thing in it whose subject is this diff is
`check_thrown_error_messages.py`, run directly above.

**Coverage stated plainly and verified at source, not quoted.** No
documentation gate reaches `scripts/**`: `check_doc_slugs.py`'s
`DEFAULT_ROOTS` are `docs`, `spec`, `skills`, `migration` (plus
`tools/*/spec`) and carry no `scripts`; `check_readme_links.py` excludes
`_test_fixtures` at its line 222; `mkdocs.yml`'s `docs_dir` is `docs` and the
hook stages only `spec/` and `migration/`. **There is no Python linter or
formatter in this repo** — no tracked config and no workflow mention of
ruff/flake8/black/mypy/pylint/isort/pyright, both greps exiting 1 with
clj-kondo as a live control that fires. clj-kondo's `--lint` roster
(`implementation`, `examples`, `testbeds`, six `tools/*`) and Splint's
(`../implementation ../tools ../examples ../testbeds`) both omit `scripts/`,
so the new `.cljc` fixtures are **unlinted**; their syntax is instead graded
by four readers over their own bytes.

## One divergence recorded rather than litigated

`#?@` standing directly inside a top-level `#?`'s own arm list is the one
shape the two readers disagree about: Clojure's `LispReader` accepts it and
interns, `clojure.tools.reader` refuses it as *cond-splice not in list*. The
walker sides with the runtime that actually loads `.cljc` on the JVM and
descends. A file carrying that shape fails to compile under one of the two
runtimes either way, so the gate's answer about it cannot matter. Same
divergence already exists on the round-three `#_#?@` fixture line and is
unchanged by this PR.

rf2-z5lv
