### PR TITLE
feat(beads): reconcile the memory population at checkpoint (rf2-cve7)

### DIFF
--- a/scripts/beads-checkpoint.ps1
+++ b/scripts/beads-checkpoint.ps1
@@ -41,6 +41,23 @@
 #   `status` before it is allowed to overwrite anything. See Get-GitOnlyFacts.
 #   EQUAL COUNTS ARE NOT EQUALITY.
 #
+# THE THIRD BLIND SPOT (rf2-cve7): BOTH GUARDS ABOVE ONLY SEE ISSUES.
+#
+#   The floor counts rows, which the issue rows dominate, and the divergence
+#   guard reads `"_type":"issue"` and skips everything else. So the memory rows
+#   - the `bd remember` store - are unguarded by construction.
+#
+#   OBSERVED, not hypothetical: on 2026-09-08, 210 memory keys vanished from
+#   the live store (1167 -> 957) and nothing said a word. `bd stats` reports
+#   ISSUES ONLY and read a healthy 1099 straight through it; the export was
+#   90.8% of HEAD's rows, over the floor. Two substantive memories went with the
+#   retention cull that took the other 204, including a standing operator
+#   preference, and both had to be recovered by hand from an older checkpoint.
+#
+#   Get-MemoryFacts now reconciles the two populations against HEAD by KEY SET.
+#   Unlike the two guards above it WARNS AND DOES NOT REFUSE - see the call site
+#   for why that constraint is deliberate.
+#
 # The commit carries the rows that changed and nothing else: `bd export` does
 # not fix the order of the memory rows, so the file is written in minimal-diff
 # order first (rf2-51uz1.1, Write-MinimalDiffOrder below).
@@ -353,6 +370,114 @@ function Get-GitOnlyFacts {
     }
 }
 
+# Get-MemoryFacts - the memory-reconciliation body when the fresh export
+# accounts for FEWER `bd remember` keys than HEAD, or when either file carries
+# rows that are neither an issue nor a memory. Empty when both populations
+# reconcile, which is every ordinary checkpoint. Identical contract to
+# memory_facts in the .sh sibling, down to the wording of the lines it returns.
+#
+# THE FAULT THIS EXISTS TO STOP (rf2-cve7). On 2026-09-08, 210 memory keys
+# vanished from the live store (1167 -> 957) and NO INSTRUMENT SAID A WORD.
+# `bd stats` read a healthy `Total Issues: 1099` straight through it, because it
+# reports ISSUES ONLY, and every guard above inherited the same blind spot:
+#
+#   * the row-count floor is dominated by issue rows, so a memory-only deletion
+#     slides under it. Measured on the real event: 2073 rows against HEAD's
+#     2283 is 90.8% - over the 90% floor, so it waves the export through.
+#   * Get-GitOnlyFacts reads `"_type":"issue"` rows and skips every other line,
+#     so memories are outside its remit by construction.
+#
+# WHY THIS IS NOT THE "SUM TO THE ROW COUNT" CHECK THE BEAD ASKED FOR, and the
+# distinction is the whole point rather than a quibble. Counting the two
+# populations and checking they sum to the file's row count is an INTERNAL
+# WELL-FORMEDNESS identity: it holds trivially whenever every row is one of the
+# two known types, so it is SILENT ON BOTH SIDES of the event it was proposed to
+# catch - 1116 + 1167 == 2283 before, 1116 + 957 == 2073 after. A population
+# that shrinks is only visible against a BASELINE, and HEAD's committed export
+# is exactly that baseline, already in hand for the guards above. So the sum is
+# kept (it catches a row of an unknown `_type`) and the LOSS DETECTOR is the
+# key-set comparison.
+#
+# KEY SETS, NOT COUNTS. A cull that deletes 210 keys and adds 210 leaves the
+# count flat while losing 210 memories, so the count is the same kind of floor
+# the row count already was. The key set has no such hole.
+function Get-MemoryFacts {
+    param([string]$Export, [string]$HeadCopy)
+
+    $cap = 10
+    $report = New-Object 'System.Collections.Generic.List[string]'
+
+    $xkey = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+    $xrows = 0; $xiss = 0; $xmem = 0; $xoth = 0; $xbad = 0
+
+    foreach ($raw in [System.IO.File]::ReadLines($Export)) {
+        $line = $raw -replace "`r$", ''
+        $xrows++
+        if ($line.IndexOf('"_type":"issue"', [System.StringComparison]::Ordinal) -ge 0) { $xiss++; continue }
+        if ($line.IndexOf('"_type":"memory"', [System.StringComparison]::Ordinal) -ge 0) {
+            $xmem++
+            $k = Get-JsonValue -Line $line -Key 'key'
+            if ($k -eq '') { $xbad++; continue }
+            [void]$xkey.Add($k)
+            continue
+        }
+        $xoth++
+    }
+
+    $hrows = 0; $hiss = 0; $hmem = 0; $hoth = 0; $hbad = 0
+    $ngone = 0
+    $lost = New-Object 'System.Collections.Generic.List[string]'
+    if (Test-Path -LiteralPath $HeadCopy) {
+        foreach ($raw in [System.IO.File]::ReadLines($HeadCopy)) {
+            $line = $raw -replace "`r$", ''
+            $hrows++
+            if ($line.IndexOf('"_type":"issue"', [System.StringComparison]::Ordinal) -ge 0) { $hiss++; continue }
+            if ($line.IndexOf('"_type":"memory"', [System.StringComparison]::Ordinal) -ge 0) {
+                $hmem++
+                $k = Get-JsonValue -Line $line -Key 'key'
+                if ($k -eq '') { $hbad++; continue }
+                if (-not $xkey.Contains($k)) {
+                    $ngone++
+                    if ($ngone -le $cap) { $lost.Add($k) }
+                }
+                continue
+            }
+            $hoth++
+        }
+    }
+
+    if ($ngone -eq 0 -and $xoth -eq 0 -and $hoth -eq 0 -and $xbad -eq 0 -and $hbad -eq 0) {
+        return @()
+    }
+
+    $report.Add("  export  $xrows rows = $xiss issues + $xmem memories")
+    $report.Add("  HEAD    $hrows rows = $hiss issues + $hmem memories")
+    if ($ngone -gt 0) {
+        $report.Add('')
+        $report.Add("  $ngone memory key(s) at HEAD are ABSENT from the fresh export:")
+        foreach ($k in $lost) { $report.Add("      $k") }
+        if ($ngone -gt $cap) { $report.Add("      ... and $($ngone - $cap) more") }
+    }
+    if ($xoth -gt 0) {
+        $report.Add('')
+        $report.Add("  $xoth row(s) in the fresh export are neither an issue nor a memory,")
+        $report.Add('  so the two populations do NOT sum to the export row count.')
+    }
+    if ($hoth -gt 0) {
+        $report.Add('')
+        $report.Add("  $hoth row(s) at HEAD are neither an issue nor a memory.")
+    }
+    if ($xbad -gt 0) {
+        $report.Add('')
+        $report.Add("  UNREADABLE  $xbad memory rows in the fresh export carry no readable key")
+    }
+    if ($hbad -gt 0) {
+        $report.Add('')
+        $report.Add("  UNREADABLE  $hbad memory rows at HEAD carry no readable key")
+    }
+    return $report.ToArray()
+}
+
 # ---------------------------------------------------------------------------
 # The tracker database is the MAYOR checkout's to commit (rf2-ia8o7). The
 # primary worktree is the first entry of `git worktree list --porcelain`; the
@@ -615,6 +740,115 @@ if ($SelfTest) {
     Assert-True ($code -ne 0) 'T6 -PrePull warns when clearing .beads would discard state'
     Assert-True ((Get-ChildErr) -match 'AHEAD of HEAD') 'T6 and says so in those words'
 
+    # -----------------------------------------------------------------------
+    # T7-T9: THE MEMORY RECONCILIATION (rf2-cve7).
+    #
+    # T1-T4 grade the ISSUE rows. Nothing above grades the memories: the row
+    # floor is dominated by issue rows and Get-GitOnlyFacts reads issue rows
+    # only, so a memory-only deletion is invisible to both - which is how 210
+    # keys vanished on 2026-09-08 with `bd stats` reporting a healthy issue
+    # count throughout.
+    #
+    # The fixture models that arithmetic rather than just the symptom: 20 issues
+    # and 10 memories at HEAD (30 rows) against an export that has lost 2
+    # memories (28 rows). 28*10 = 280 is NOT less than 30*9 = 270, so the floor
+    # is silent here exactly as it was on the real event.
+    #
+    # AND IT MUST NOT REFUSE. This is the one shared tool the mayor runs several
+    # times an hour; a false positive that aborted it would halt the dispatch
+    # loop. T7 asserts both halves - it warns, AND it commits - and T9 is the
+    # no-false-positive case, which matters more than either.
+    # -----------------------------------------------------------------------
+    # Concatenation rather than the -f operator: these rows are JSON, so every
+    # one carries literal braces and -f reads them as format placeholders
+    # ("Error formatting a string"). -SelfTest caught that too.
+    $memHead = @()
+    for ($i = 1; $i -le 20; $i++) {
+        $n = $i.ToString('00')
+        $memHead += '{"_type":"issue","id":"rf2-m' + $n + '","status":"open","updated_at":"2026-09-01T00:00:00Z"}'
+    }
+    for ($i = 1; $i -le 10; $i++) {
+        $n = $i.ToString('00')
+        $memHead += '{"_type":"memory","key":"mem-key-' + $n + '","value":"body ' + $i + '"}'
+    }
+    Write-Rows -Path (Join-Path $repo '.beads/issues.jsonl') -Rows $memHead
+    & git -C $repo add -- '.beads/issues.jsonl' | Out-Null
+    & git -C $repo commit -q -m 'seed: 20 issues and 10 memories' | Out-Null
+
+    # The same database one retention cull later: two memories dropped, every
+    # issue row untouched.
+    $memCulled = $memHead | Where-Object {
+        $_ -notmatch '"key":"mem-key-03"' -and $_ -notmatch '"key":"mem-key-07"'
+    }
+    Assert-True ($memCulled.Count -eq 28 -and $memHead.Count -eq 30) `
+                'T7 the fixture slides under the row floor (28/30 rows), as the real event did' `
+                "got $($memCulled.Count)/$($memHead.Count)"
+
+    Write-Rows -Path $dbPath -Rows $memCulled
+    $before = Get-HeadSha
+    $code = Invoke-Child @()
+    $err  = Get-ChildErr
+    Assert-True ($code -eq 0) 'T7 a memory-only deletion does NOT refuse the checkpoint' "exit $code"
+    Assert-True ((Get-HeadSha) -ne $before) 'T7 and it still commits'
+    Assert-True ($err -match 'MEMORY RECONCILIATION FAILED') `
+                'T7 a memory-only deletion WARNS rather than passing in silence'
+    Assert-True ($err -match 'mem-key-03' -and $err -match 'mem-key-07') `
+                'T7 and it NAMES the lost keys'
+    Assert-True (-not ($err -match 'mem-key-05')) 'T7 and names no key that was not lost'
+    Assert-True ($err -match 'export  28 rows = 20 issues \+ 8 memories' -and
+                 $err -match 'HEAD    30 rows = 20 issues \+ 10 memories') `
+                'T7 and reports both populations on both sides, separately counted'
+    Assert-True ($err -match 'WARNING, NOT A REFUSAL') `
+                'T7 and says the checkpoint continues, so the operator can tell what happened'
+
+    # T8 - a row of an unknown `_type` is reported. This is the "two populations
+    # sum to the row count" half of the bead. It cannot detect the deletion
+    # above - the identity holds trivially whenever every row is one of the two
+    # known types - but it catches a row that is neither.
+    Write-Rows -Path $dbPath -Rows ($memHead + @('{"_type":"sprint","id":"s1"}'))
+    $before = Get-HeadSha
+    $code = Invoke-Child @()
+    $err  = Get-ChildErr
+    Assert-True ($code -eq 0) 'T8 an unknown _type row does not refuse the checkpoint' "exit $code"
+    Assert-True ($err -match 'neither an issue nor a memory') `
+                'T8 a row that is neither an issue nor a memory is reported'
+    Assert-True ((Get-HeadSha) -ne $before) 'T8 and it still commits'
+
+    # T9 - THE NO-FALSE-POSITIVE CASE. Ordinary forward motion - an issue
+    # closes, a memory is ADDED, the rest are shuffled the way `bd export`
+    # shuffles them on every invocation - must commit without a murmur.
+    #
+    # HEAD IS RE-SEEDED FIRST: T8's checkpoint COMMITTED its unknown-`_type`
+    # row, so HEAD would carry it into this case and the guard would truthfully
+    # report it - a red that looks like a false positive and is not one. A
+    # no-false-positive case has to start from a clean baseline.
+    Write-Rows -Path (Join-Path $repo '.beads/issues.jsonl') -Rows $memHead
+    & git -C $repo add -- '.beads/issues.jsonl' | Out-Null
+    & git -C $repo commit -q -m 'seed: back to 20 issues and 10 memories' | Out-Null
+
+    $forwardMem = @()
+    for ($i = 1; $i -le 20; $i++) {
+        $n  = $i.ToString('00')
+        $st = if ($i -eq 4) { 'closed' } else { 'open' }
+        $up = if ($i -eq 4) { '2026-09-02T00:00:00Z' } else { '2026-09-01T00:00:00Z' }
+        $forwardMem += '{"_type":"issue","id":"rf2-m' + $n + '","status":"' + $st + '","updated_at":"' + $up + '"}'
+    }
+    for ($i = 10; $i -ge 1; $i--) {
+        $n = $i.ToString('00')
+        $forwardMem += '{"_type":"memory","key":"mem-key-' + $n + '","value":"body ' + $i + '"}'
+    }
+    $forwardMem += '{"_type":"memory","key":"mem-key-11","value":"a new lesson"}'
+    Write-Rows -Path $dbPath -Rows $forwardMem
+    $before = Get-HeadSha
+    $code = Invoke-Child @()
+    $err  = Get-ChildErr
+    Assert-True ($code -eq 0) 'T9 ordinary forward motion still checkpoints' "exit $code : $err"
+    Assert-True ((Get-HeadSha) -ne $before) 'T9 and it commits'
+    Assert-True (-not ($err -match 'MEMORY RECONCILIATION')) `
+                'T9 the reconciliation does NOT cry wolf on a close, a new memory and a reorder' $err
+    Assert-True ((Get-HeadTracker) -match '"key":"mem-key-11"') `
+                'T9 and the new memory reached the commit'
+
     Remove-Item -LiteralPath $box -Recurse -Force -ErrorAction SilentlyContinue
     if ($script:failures -gt 0) {
         Write-Output ''
@@ -762,6 +996,55 @@ try {
         $lines.Add('')
         [Console]::Error.WriteLine(($lines -join "`n"))
         exit 1
+    }
+
+    # MEMORY RECONCILIATION (rf2-cve7). Every guard above is blind to the
+    # memory rows: the floor is diluted by the issue rows and the divergence
+    # guard reads only `"_type":"issue"`. This one counts the two populations
+    # separately and names the keys HEAD holds that the export does not.
+    #
+    # IT WARNS. IT DOES NOT REFUSE, and that is a deliberate design constraint
+    # rather than an unfinished one. This is the single shared tool the mayor
+    # runs several times an hour, and a false positive that aborted it would
+    # halt the whole dispatch loop - which is precisely why the reconciliation
+    # sat unbuilt as "a ruling and not a dispatch" while 210 keys went missing
+    # in silence. A warning delivers the entire value of the guard (the event
+    # becomes one loud block instead of nothing at all) with that risk removed.
+    # There is deliberately no strict mode, no override flag and no config key.
+    #
+    # It also runs AFTER the divergence guard on purpose, so it speaks only
+    # when the checkpoint is genuinely about to commit and can say so truly.
+    # @(...) is load-bearing under Set-StrictMode: PowerShell unrolls an empty
+    # or single-element array return, so a bare assignment yields $null on the
+    # ordinary no-warning path and `.Count` then throws. Caught by -SelfTest T2
+    # and T3, which is what that arm is for.
+    $memFacts = @(Get-MemoryFacts -Export $tmpExport -HeadCopy $tmpHead)
+    if ($memFacts.Count -gt 0) {
+        $lines = New-Object 'System.Collections.Generic.List[string]'
+        $lines.Add('')
+        $lines.Add('beads-checkpoint: ***** MEMORY RECONCILIATION FAILED (rf2-cve7) *****')
+        $lines.Add('  The tracker''s `bd remember` rows do not reconcile against HEAD.')
+        $lines.Add('')
+        foreach ($r in $memFacts) { $lines.Add($r) }
+        $lines.Add('')
+        $lines.Add('  `bd stats` reports ISSUES ONLY, and the row-count floor above is dominated')
+        $lines.Add('  by issue rows, so a memory-only deletion passes both in silence. That is')
+        $lines.Add('  exactly how 210 keys disappeared on 2026-09-08 with nothing on screen.')
+        $lines.Add('')
+        $lines.Add('  THIS IS A WARNING, NOT A REFUSAL - the checkpoint continues and commits')
+        $lines.Add('  the export. The database is the source of truth, and this may well be a')
+        $lines.Add('  deliberate `bd forget` or a retention cull. If it is NOT, the rows are not')
+        $lines.Add('  lost: HEAD still carries every one of them, and so does any earlier')
+        $lines.Add('  checkpoint commit.')
+        $lines.Add('')
+        $lines.Add("      git show HEAD:$tracker |")
+        $lines.Add('        jq -r --arg k "<key>" ''select(._type=="memory" and .key==$k)|.value''')
+        $lines.Add('')
+        $lines.Add('  Select on `.key`. A bare grep for the key matches rows that merely MENTION')
+        $lines.Add('  it - bead prose naming a deleted key has already been mistaken for the')
+        $lines.Add('  memory itself (rf2-cve7, CLAUDE.md instrument item (f)).')
+        $lines.Add('')
+        [Console]::Error.WriteLine(($lines -join "`n"))
     }
 
     # The export is trustworthy - it is now the working tracker. From here on

--- a/scripts/beads-checkpoint.sh
+++ b/scripts/beads-checkpoint.sh
@@ -41,6 +41,23 @@
 #   `status` before it is allowed to overwrite anything — see `git_only_facts`.
 #   EQUAL COUNTS ARE NOT EQUALITY.
 #
+# THE THIRD BLIND SPOT (rf2-cve7): BOTH GUARDS ABOVE ONLY SEE ISSUES.
+#
+#   The floor counts rows, which the issue rows dominate, and the divergence
+#   guard reads `"_type":"issue"` and skips everything else. So the memory rows
+#   — the `bd remember` store — are unguarded by construction.
+#
+#   OBSERVED, not hypothetical: on 2026-09-08, 210 memory keys vanished from
+#   the live store (1167 -> 957) and nothing said a word. `bd stats` reports
+#   ISSUES ONLY and read a healthy 1099 straight through it; the export was
+#   90.8% of HEAD's rows, over the floor. Two substantive memories went with the
+#   retention cull that took the other 204, including a standing operator
+#   preference, and both had to be recovered by hand from an older checkpoint.
+#
+#   `memory_facts` now reconciles the two populations against HEAD by KEY SET.
+#   Unlike the two guards above it WARNS AND DOES NOT REFUSE — see the call site
+#   for why that constraint is deliberate.
+#
 # USAGE
 #
 #   sh scripts/beads-checkpoint.sh [-m MESSAGE]
@@ -316,6 +333,112 @@ git_only_facts() {
   ' "$1" "$2"
 }
 
+# memory_facts EXPORT HEAD_COPY — print the memory-reconciliation body when the
+# fresh export accounts for FEWER `bd remember` keys than HEAD, or when either
+# file carries rows that are neither an issue nor a memory. Prints NOTHING when
+# both populations reconcile, which is every ordinary checkpoint.
+#
+# THE FAULT THIS EXISTS TO STOP (rf2-cve7). On 2026-09-08, 210 memory keys
+# vanished from the live store (1167 -> 957) and NO INSTRUMENT SAID A WORD.
+# `bd stats` read a healthy `Total Issues: 1099` straight through it, because it
+# reports ISSUES ONLY, and every guard above inherited the same blind spot:
+#
+#   * the row-count floor is dominated by issue rows, so a memory-only deletion
+#     slides under it. Measured on the real event: 2073 rows against HEAD's
+#     2283 is 90.8% — over the 90% floor, so it waves the export through.
+#   * `git_only_facts` reads `"_type":"issue"` rows and skips every other line,
+#     so memories are outside its remit by construction.
+#
+# WHY THIS IS NOT THE "SUM TO THE ROW COUNT" CHECK THE BEAD ASKED FOR, and the
+# distinction is the whole point rather than a quibble. Counting the two
+# populations and checking they sum to the file's row count is an INTERNAL
+# WELL-FORMEDNESS identity: it holds trivially whenever every row is one of the
+# two known types, so it is SILENT ON BOTH SIDES of the event it was proposed to
+# catch — 1116 + 1167 == 2283 before, 1116 + 957 == 2073 after. A population
+# that shrinks is only visible against a BASELINE, and HEAD's committed export
+# is exactly that baseline, already in hand for the guards above. So the sum is
+# kept (it catches a row of an unknown `_type`, which is cheap to notice and
+# would otherwise be invisible) and the LOSS DETECTOR is the key-set comparison.
+#
+# KEY SETS, NOT COUNTS. A cull that deletes 210 keys and adds 210 leaves the
+# count flat while losing 210 memories, so the count is the same kind of floor
+# the row count already was. The key set has no such hole.
+#
+# THE KEY IS READ FROM THE `key` FIELD, never grepped for. `bd export` writes a
+# memory row as exactly `_type`, `key`, `value`, so the FIRST `"key":"` is the
+# row's own; a later one inside `value` is JSON-escaped (`\"key\":\"`) and
+# cannot match. This is the same identity-field discipline `git_only_facts`
+# documents for `"id":"` — and the bead recorded the cost of ignoring it: a
+# `git grep -F` for a deleted key "found" it in a commit that does not carry the
+# memory at all, because it matched the BEAD'S OWN PROSE naming the key.
+#
+# (FNR == NR is sound here for the same reason it is in `git_only_facts`: the
+# caller has already refused a zero-row export, so file 1 is never empty.)
+memory_facts() {
+  awk -v cap=10 '
+    function jval(line, key,   pfx, re) {
+      pfx = "\"" key "\":\""
+      re  = pfx "[^\"]*\""
+      if (match(line, re)) {
+        return substr(line, RSTART + length(pfx), RLENGTH - length(pfx) - 1)
+      }
+      return ""
+    }
+    { sub(/\r$/, "") }
+    # First file: the fresh export.
+    FNR == NR {
+      xrows++
+      if (index($0, "\"_type\":\"issue\"")  > 0) { xiss++; next }
+      if (index($0, "\"_type\":\"memory\"") > 0) {
+        xmem++
+        k = jval($0, "key")
+        if (k == "") { xbad++; next }
+        xkey[k] = 1
+        next
+      }
+      xoth++
+      next
+    }
+    # Second file: HEAD.
+    {
+      hrows++
+      if (index($0, "\"_type\":\"issue\"")  > 0) { hiss++; next }
+      if (index($0, "\"_type\":\"memory\"") > 0) {
+        hmem++
+        k = jval($0, "key")
+        if (k == "") { hbad++; next }
+        if (!(k in xkey)) { if (++ngone <= cap) lost[ngone] = k }
+        next
+      }
+      hoth++
+    }
+    END {
+      if (ngone == 0 && xoth == 0 && hoth == 0 && xbad == 0 && hbad == 0) { exit 0 }
+      printf "  export  %d rows = %d issues + %d memories\n", xrows, xiss, xmem
+      printf "  HEAD    %d rows = %d issues + %d memories\n", hrows, hiss, hmem
+      if (ngone > 0) {
+        printf "\n  %d memory key(s) at HEAD are ABSENT from the fresh export:\n", ngone
+        n = (ngone < cap ? ngone : cap)
+        for (i = 1; i <= n; i++) { printf "      %s\n", lost[i] }
+        if (ngone > cap) { printf "      ... and %d more\n", ngone - cap }
+      }
+      if (xoth > 0) {
+        printf "\n  %d row(s) in the fresh export are neither an issue nor a memory,\n", xoth
+        printf "  so the two populations do NOT sum to the export row count.\n"
+      }
+      if (hoth > 0) {
+        printf "\n  %d row(s) at HEAD are neither an issue nor a memory.\n", hoth
+      }
+      if (xbad > 0) {
+        printf "\n  UNREADABLE  %d memory rows in the fresh export carry no readable key\n", xbad
+      }
+      if (hbad > 0) {
+        printf "\n  UNREADABLE  %d memory rows at HEAD carry no readable key\n", hbad
+      }
+    }
+  ' "$1" "$2"
+}
+
 # ---------------------------------------------------------------------------
 # --pre-pull: would clearing `.beads` throw tracker state away?
 # ---------------------------------------------------------------------------
@@ -425,6 +548,44 @@ if [ -n "$FACTS" ]; then
   exit 1
 fi
 rm -f "$REMEDY"
+
+# MEMORY RECONCILIATION (rf2-cve7). Every guard above is blind to the memory
+# rows: the floor is diluted by the issue rows and the divergence guard reads
+# only `"_type":"issue"`. This one counts the two populations separately and
+# names the keys HEAD holds that the export does not.
+#
+# IT WARNS. IT DOES NOT REFUSE, and that is a deliberate design constraint
+# rather than an unfinished one. This is the single shared tool the mayor runs
+# several times an hour, and a false positive that aborted it would halt the
+# whole dispatch loop — which is precisely why the reconciliation sat unbuilt as
+# "a ruling and not a dispatch" while 210 keys went missing in silence. A
+# warning delivers the entire value of the guard (the event becomes one loud
+# block instead of nothing at all) with that risk removed. There is deliberately
+# no --strict mode, no override flag and no config key: the whole deliverable is
+# one unmissable warning, and a knob would be machinery guarding a warning.
+#
+# It also runs AFTER the divergence guard on purpose, so it speaks only when the
+# checkpoint is genuinely about to commit and can say so truthfully.
+MEMORY_FACTS=$(memory_facts "$TMP_EXPORT" "$TMP_HEAD")
+if [ -n "$MEMORY_FACTS" ]; then
+  printf '\n' >&2
+  printf 'beads-checkpoint: ***** MEMORY RECONCILIATION FAILED (rf2-cve7) *****\n' >&2
+  printf '  The tracker'"'"'s `bd remember` rows do not reconcile against HEAD.\n\n' >&2
+  printf '%s\n' "$MEMORY_FACTS" >&2
+  printf '\n  `bd stats` reports ISSUES ONLY, and the row-count floor above is dominated\n' >&2
+  printf '  by issue rows, so a memory-only deletion passes both in silence. That is\n' >&2
+  printf '  exactly how 210 keys disappeared on 2026-09-08 with nothing on screen.\n' >&2
+  printf '\n  THIS IS A WARNING, NOT A REFUSAL — the checkpoint continues and commits\n' >&2
+  printf '  the export. The database is the source of truth, and this may well be a\n' >&2
+  printf '  deliberate `bd forget` or a retention cull. If it is NOT, the rows are not\n' >&2
+  printf '  lost: HEAD still carries every one of them, and so does any earlier\n' >&2
+  printf '  checkpoint commit.\n' >&2
+  printf '\n      git show HEAD:%s \\\n' "$TRACKER" >&2
+  printf '        | jq -r --arg k "<key>" '"'"'select(._type=="memory" and .key==$k)|.value'"'"'\n' >&2
+  printf '\n  Select on `.key`. A bare grep for the key matches rows that merely MENTION\n' >&2
+  printf '  it — bead prose naming a deleted key has already been mistaken for the\n' >&2
+  printf '  memory itself (rf2-cve7, CLAUDE.md instrument item (f)).\n\n' >&2
+fi
 
 # The export is trustworthy — it is now the working tracker. From here on the
 # working file cannot be a stale revert, whatever it was a moment ago.

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -60,7 +60,10 @@
 #      against a stub `bd`: a close that lives only in the database survives the
 #      pre-pull checkout, a broken export commits nothing, and a memory reorder
 #      is not a commit — nor does one ride along with a real change
-#      (rf2-51uz1.1), while the >1/10 shrink guard still refuses.
+#      (rf2-51uz1.1), while the >1/10 shrink guard still refuses. 8m-8p add the
+#      memory reconciliation (rf2-cve7): a memory-only deletion is invisible to
+#      every guard above it, so it now WARNS — loudly, by key, and without
+#      refusing the checkpoint.
 #
 #   9. The TRUNCATION FLOOR in the hook (rf2-or8te) — layer 8's guard repeated
 #      where no committer can route around it. Layer 8 proves the checkpoint
@@ -1262,6 +1265,13 @@ rm -rf "$RBOX"
 # so the stub models that contract and 8a asserts the committed tracker still
 # carries its memories — a checkpoint that loses --include-memories fails here
 # before it can silently drop every memory on main.
+#
+# WHETHER ANY OF THEM WENT MISSING is the fourth (rf2-cve7). 8a proves the
+# memories ride; nothing proved they were all still there. The row floor is
+# dominated by issue rows and the divergence guard reads issue rows only, so a
+# memory-only deletion is invisible to both — 210 keys went that way on
+# 2026-09-08 with `bd stats` reporting a healthy issue count throughout. 8m-8p
+# pin the reconciliation, and 8p pins that it stays quiet the rest of the time.
 # ----------------------------------------------------------------------------
 
 printf '\n[8] checkpoint helper: export from the database, never the working file\n'
@@ -1745,6 +1755,167 @@ case "$out" in
     else
       pass "(8l) a same-timestamp status conflict is refused, and no import is offered"
     fi ;;
+esac
+
+# ----------------------------------------------------------------------------
+# 8m-8p: THE MEMORY POPULATION IS RECONCILED, AND THE GUARD WARNS (rf2-cve7).
+#
+# Every guard above is blind to the `bd remember` rows. 8i's floor counts ROWS,
+# which the issue rows dominate, so a memory-only deletion is diluted under it;
+# 8j-8l read `"_type":"issue"` and skip every other line by construction.
+#
+# OBSERVED: on 2026-09-08, 210 memory keys vanished from the live store
+# (1167 -> 957) and NOTHING said a word. `bd stats` reports ISSUES ONLY and read
+# a healthy 1099 straight through the event, and the export was 90.8% of HEAD's
+# rows — comfortably over the floor 8i pins.
+#
+# THE FIXTURE MODELS THAT ARITHMETIC RATHER THAN JUST THE SYMPTOM: 20 issues and
+# 10 memories at HEAD (30 rows), against an export that has lost 2 memories
+# (28 rows). 28*10 = 280 is NOT less than 30*9 = 270, so 8i's floor is silent
+# here — the deletion slides under it exactly as the real one did. If a future
+# change ever made the floor catch this, 8m would still pass for the WRONG
+# reason, so 8n pins the floor's silence separately.
+#
+# AND THE GUARD MUST NOT REFUSE. This is the one shared tool the mayor runs
+# several times an hour; a false positive that aborted it would halt the whole
+# dispatch loop, which is why the reconciliation went unbuilt while the keys
+# went missing. 8m therefore asserts BOTH halves — it warns, AND it commits.
+# 8p is the no-false-positive case, and it matters more than the rest: a warning
+# that fires on ordinary forward motion is one the loop learns to scroll past.
+# ----------------------------------------------------------------------------
+{
+  awk 'BEGIN{for(i=1;i<=20;i++) printf "{\"_type\":\"issue\",\"id\":\"rf2-m%02d\",\"status\":\"open\",\"updated_at\":\"2026-09-01T00:00:00Z\"}\n", i}'
+  awk 'BEGIN{for(i=1;i<=10;i++) printf "{\"_type\":\"memory\",\"key\":\"mem-key-%02d\",\"value\":\"body %d\"}\n", i, i}'
+} > "$CBOX/head-mem.jsonl"
+
+# The same database one retention cull later: both cursor-ish memories dropped,
+# every issue row untouched.
+grep -v '"key":"mem-key-03"' "$CBOX/head-mem.jsonl" \
+  | grep -v '"key":"mem-key-07"' > "$CBOX/db-mem-culled.jsonl"
+
+(
+  cd "$CREPO"
+  cp -f "$CBOX/head-mem.jsonl" .beads/issues.jsonl
+  git add -- .beads/issues.jsonl
+  git commit -q -m 'seed: 20 issues and 10 memories'
+) >/dev/null 2>&1
+
+# 8n: THE FLOOR IS GENUINELY SILENT HERE. Asserted before 8m so that a pass
+# there cannot be credited to the wrong guard. This is the negative control for
+# the whole group: it establishes the hole is open.
+export_rows=$(awk 'END{print NR}' "$CBOX/db-mem-culled.jsonl")
+head_rows=$(awk 'END{print NR}' "$CBOX/head-mem.jsonl")
+if [ "$export_rows" = "28" ] && [ "$head_rows" = "30" ] \
+   && [ $((export_rows * 10)) -ge $((head_rows * 9)) ]; then
+  pass "(8n) the fixture slides under the row floor ($export_rows/$head_rows rows), as the real event did"
+else
+  fail "(8n) the fixture does NOT model the event: $export_rows/$head_rows rows would trip the floor"
+fi
+
+# 8m: THE ACCEPTANCE. A memory-only deletion must produce a loud, NAMED warning
+# and must still checkpoint. Both halves are load-bearing.
+cp -f "$CBOX/db-mem-culled.jsonl" "$CBOX/db.jsonl"
+before=$(git -C "$CREPO" rev-parse HEAD)
+out=$(run_checkpoint "$CREPO")
+after=$(git -C "$CREPO" rev-parse HEAD)
+case "$out" in
+  EXIT=0)
+    if [ "$before" = "$after" ]; then
+      fail "(8m) the memory-loss warning became a refusal: nothing was committed"
+      cat "$CERR" >&2
+    elif ! grep -q 'MEMORY RECONCILIATION FAILED' "$CERR"; then
+      fail "(8m) a 2-of-10 memory deletion was checkpointed in SILENCE — the rf2-cve7 hole is open"
+      cat "$CERR" >&2
+    elif ! grep -q 'mem-key-03' "$CERR" || ! grep -q 'mem-key-07' "$CERR"; then
+      fail "(8m) warned, but did not NAME the lost keys; a count sends the operator diffing by hand"
+      cat "$CERR" >&2
+    elif grep -q 'mem-key-05' "$CERR"; then
+      fail "(8m) named a key that was never lost"
+      cat "$CERR" >&2
+    elif ! grep -q 'WARNING, NOT A REFUSAL' "$CERR"; then
+      fail "(8m) warned without saying the checkpoint continues; the operator cannot tell what happened"
+      cat "$CERR" >&2
+    else
+      pass "(8m) a memory-only deletion WARNS, names the lost keys, and still checkpoints"
+    fi
+    # And the counts must be reported, not merely the names: the operator's
+    # first question is how big the loss is.
+    if grep -q 'export  28 rows = 20 issues + 8 memories' "$CERR" \
+       && grep -q 'HEAD    30 rows = 20 issues + 10 memories' "$CERR"; then
+      pass "(8m) and it reports both populations on both sides, separately counted"
+    else
+      fail "(8m) the warning did not report the two populations against HEAD"
+      cat "$CERR" >&2
+    fi ;;
+  *) fail "(8m) the memory reconciliation REFUSED the checkpoint ($out); it must only warn"
+     cat "$CERR" >&2 ;;
+esac
+
+# 8o: A ROW OF AN UNKNOWN `_type` IS REPORTED. This is the "two populations sum
+# to the row count" half of the bead. It cannot detect the deletion above — the
+# identity holds trivially whenever every row is one of the two known types, so
+# it is silent on both sides of a cull — but it does catch a row that is neither,
+# which nothing else here would notice.
+{
+  cat "$CBOX/head-mem.jsonl"
+  printf '{"_type":"sprint","id":"s1"}\n'
+} > "$CBOX/db.jsonl"
+before=$(git -C "$CREPO" rev-parse HEAD)
+out=$(run_checkpoint "$CREPO")
+after=$(git -C "$CREPO" rev-parse HEAD)
+case "$out" in
+  EXIT=0)
+    if ! grep -q 'neither an issue nor a memory' "$CERR"; then
+      fail "(8o) a row of an unknown _type was not reported; the populations do not sum"
+      cat "$CERR" >&2
+    elif [ "$before" = "$after" ]; then
+      fail "(8o) the unknown-type report became a refusal"
+    else
+      pass "(8o) a row that is neither an issue nor a memory is reported, and still commits"
+    fi ;;
+  *) fail "(8o) an unknown _type row REFUSED the checkpoint ($out); it must only warn"
+     cat "$CERR" >&2 ;;
+esac
+
+# 8p: THE NO-FALSE-POSITIVE CASE, and it is the one that decides whether this
+# guard survives contact with the dispatch loop. Ordinary forward motion — an
+# issue closes, a memory is ADDED, the rest are shuffled the way `bd export`
+# shuffles them on every invocation — must commit without a murmur.
+#
+# HEAD IS RE-SEEDED FIRST, and the reason is worth keeping: 8o's checkpoint
+# COMMITTED its unknown-`_type` row, so HEAD carried it into this case and the
+# guard truthfully reported it — a red that looked like a false positive and was
+# not one. A no-false-positive case has to start from a clean baseline or it
+# grades the previous case's leftovers.
+(
+  cd "$CREPO"
+  cp -f "$CBOX/head-mem.jsonl" .beads/issues.jsonl
+  git add -- .beads/issues.jsonl
+  git commit -q -m 'seed: back to 20 issues and 10 memories, no stray row types'
+) >/dev/null 2>&1
+{
+  awk 'BEGIN{for(i=1;i<=20;i++){s=(i==4?"closed":"open"); u=(i==4?"2026-09-02T00:00:00Z":"2026-09-01T00:00:00Z"); printf "{\"_type\":\"issue\",\"id\":\"rf2-m%02d\",\"status\":\"%s\",\"updated_at\":\"%s\"}\n", i, s, u}}'
+  awk 'BEGIN{for(i=10;i>=1;i--) printf "{\"_type\":\"memory\",\"key\":\"mem-key-%02d\",\"value\":\"body %d\"}\n", i, i}'
+  printf '{"_type":"memory","key":"mem-key-11","value":"a new lesson"}\n'
+} > "$CBOX/db.jsonl"
+git -C "$CREPO" checkout -q HEAD -- .beads
+before=$(git -C "$CREPO" rev-parse HEAD)
+out=$(run_checkpoint "$CREPO")
+after=$(git -C "$CREPO" rev-parse HEAD)
+case "$out" in
+  EXIT=0)
+    if [ "$before" = "$after" ]; then
+      fail "(8p) ordinary forward motion produced no commit"
+      cat "$COUT" >&2
+    elif grep -q 'MEMORY RECONCILIATION' "$CERR"; then
+      fail "(8p) the reconciliation CRIED WOLF on a close plus a new memory plus a reorder"
+      cat "$CERR" >&2
+    elif ! git -C "$CREPO" show HEAD:.beads/issues.jsonl | grep -q '"key":"mem-key-11"'; then
+      fail "(8p) the new memory did not reach the commit"
+    else
+      pass "(8p) a close, a NEW memory and a full memory reorder warn about nothing"
+    fi ;;
+  *) fail "(8p) ordinary forward motion was refused ($out)"; cat "$CERR" >&2 ;;
 esac
 
 rm -rf "$CBOX"


### PR DESCRIPTION
Closes the one residual clause on rf2-cve7: whether `scripts/beads-checkpoint.sh` gains an issues-plus-memories reconciliation.

## The hole

Every guard in the checkpoint is blind to a `bd remember` row.

- The **row-count floor** (>1/10 shrink) is dominated by issue rows, so a memory-only deletion is diluted under it.
- The **rf2-rjqtj divergence guard** reads `"_type":"issue"` and skips every other line by construction.

On 2026-09-08 that cost 210 memory keys (1167 -> 957) with nothing on screen. `bd stats` reports ISSUES ONLY and read a healthy `Total Issues: 1099` straight through the event, and the export was **90.8%** of HEAD's rows — comfortably over the 90% floor. Two substantive memories went with the retention cull that took the other 204, including a standing operator preference, and both had to be recovered by hand from an older checkpoint commit.

## What landed

`memory_facts` (POSIX) and `Get-MemoryFacts` (PowerShell) count the two populations separately against HEAD and name the keys HEAD holds that the fresh export does not.

**It warns; it does not refuse.** This is the one shared tool the mayor runs several times an hour, and a false positive that aborted it would halt the whole dispatch loop — which is precisely why this reconciliation sat unbuilt as "a ruling and not a dispatch" while the keys went missing. A warning delivers the entire value with that risk removed: the event becomes one loud block instead of silence. There is deliberately no strict mode, no override flag and no config key.

## Why it is a KEY-SET comparison and not the "sum to the row count" check

The bead proposed counting the two populations and checking they sum to the export's row count. **That identity cannot detect the event it was proposed for.** It holds trivially whenever every row is one of the two known types, so it is silent on *both* sides of the cull:

| | issues | memories | rows | sum check |
|---|---|---|---|---|
| before | 1116 | 1167 | 2283 | 2283 == 2283, silent |
| after | 1116 | 957 | 2073 | 2073 == 2073, silent |

A shrinking population is only visible against a **baseline**, and HEAD's committed export is already that baseline — in hand, because the guards above it already read HEAD. So the sum is kept as a secondary check (it catches a row of an unknown `_type`, which nothing else here would notice) and the loss detector is the key set. Key sets rather than counts, because a cull that drops 210 keys and adds 210 leaves a count flat while losing 210 memories.

The key is read from the `key` field, never grepped for — the same identity-field discipline `git_only_facts` documents for `"id":"`. The bead records the cost of ignoring it: a `git grep -F` for a deleted key "found" it in a commit that does not carry the memory at all, because it matched the bead's own prose naming the key.

## Tests

`scripts/git-hooks/test-pre-commit.sh` layer 8 gains **8m-8p**; `scripts/beads-checkpoint.ps1` gains **-SelfTest T7-T9**.

The fixture models the event's arithmetic rather than just its symptom: 20 issues + 10 memories at HEAD (30 rows) against an export that lost 2 memories (28 rows). `28*10 = 280` is not less than `30*9 = 270`, so the existing floor is silent here exactly as it was on the real event — **8n pins that silence separately**, so a pass on 8m can never be credited to the wrong guard.

- **8m / T7** — a memory-only deletion warns, names the lost keys, reports both populations on both sides, and **still commits**.
- **8n** — the fixture genuinely slides under the row floor.
- **8o / T8** — a row of an unknown `_type` is reported (the sum half), and still commits.
- **8p / T9** — the no-false-positive case, which matters more than the rest: a close plus a **new** memory plus a full memory reorder warns about nothing. A warning that fires on ordinary forward motion is one the loop learns to scroll past.

Also verified at full scale against a synthetic fixture reproducing the bead's own numbers — 1116 issues + 1167 memories at HEAD, 210 memory keys culled — where the guard reports `export 2073 rows = 1116 issues + 957 memories` against `HEAD 2283 rows = 1116 issues + 1167 memories`, lists 10 keys with `... and 200 more`, and exits **0** having committed.

One finding worth recording: a memory cull larger than 10% of *total* rows is already caught by the existing floor, as a refusal. The 210-key event slid under precisely because 210/2283 = 9.2%. This guard covers the band below that floor.

## Quality gates

All exit codes captured from the runner on one command line, never read through a pipe. Run on the final rebased base (`9386286714`).

| gate | exit | result |
|---|---|---|
| `sh scripts/git-hooks/test-pre-commit.sh` | **0** | 131 passed, 0 failed |
| `powershell -File scripts/beads-checkpoint.ps1 -SelfTest` | **0** | all cases passed |
| `sh scripts/check-commit-attribution.sh origin/main` | **0** | no AI attribution in the 1 commit introduced |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** | no beads-database paths in the diff |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** | no hardcoded personal/home paths |

`test-pre-commit.sh` is the CI gate for this diff — `.github/workflows/test.yml` job `beads-pr-boundary` (check name *PR guards (no tracker database, no AI attribution)*), step *Self-test the beads + mayor commit guards*. Its layer 8 drives `scripts/beads-checkpoint.sh` directly against a stub `bd`, so the new cases run on every PR.

**Not nominated, with reasons:** `check_doc_slugs.py` (its roots are `docs/`, `spec/`, `skills/`, `migration/`, `tools/*/spec` — `scripts/` is outside all of them) and `mkdocs build --strict` (`docs_dir` is `docs`, and `scripts/` is never staged into it). Both would have returned a green that inspected nothing in this diff.

**No automated gate covers `scripts/beads-checkpoint.ps1`** — layer 8 is POSIX sh and cannot run it, which is why that file carries its own `-SelfTest` arm. It was run by hand on the final base (exit 0) and is reported above.

### Sabotage proof

Both directions, on the gate that grades this diff.

1. Baseline blob hash of `scripts/beads-checkpoint.sh`: `0d2db8aba90b25e9a168ac0461863f950d3c2ada`, equal to the committed blob.
2. Planted a single-line fault in `memory_facts`, making the key-loss detector blind. **Match count 1** before the run; the working blob hash moved to `6f419eff3c557eb7c2ca5e3845b9fc025cfba0af`, proving the plant applied rather than silently no-opping.
3. Gate went **RED, captured exit 1**, 129 passed / 2 failed, naming what was broken: `FAIL (8m) a 2-of-10 memory deletion was checkpointed in SILENCE — the rf2-cve7 hole is open`.
4. Restored with `git checkout HEAD --`; verified **by blob hash**, not by diff or exit code: working `0d2db8aba90b25e9a168ac0461863f950d3c2ada` == committed, byte-exact.
5. Gate green again, **captured exit 0**, 131 passed / 0 failed.

Note that 8p stayed green under the plant — correct, since a blind guard does not cry wolf. It is 8m that discriminates.

The 8p case earned its place during development: it went red on first run because 8o's checkpoint had committed its unknown-`_type` row into HEAD, so the guard truthfully reported it. That was a sequencing defect in the test, not a false positive in the guard, and 8p/T9 now re-seed a clean baseline with a comment saying why.
