### PR TITLE
docs(claude): give the project stance a tracked home

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,20 @@
 
 This file provides instructions and context for AI coding agents working on this project.
 
+## Project stance
+
+> Posture is that we are pre-alpha and focused on elegance, power and a masterpiece.
+> But we are not over-engineering or gold plating. Also, we trust the programmer.
+> We're trying to facilitate high productivity for them (and the AI they use) via a
+> library with excellent ergonomics and low friction. We don't need to litigate every
+> last fine detail and drown in the minutiae.
+
+**That quoted block is the stance, and it is pasted VERBATIM into every dispatch preamble — never summarised, never trimmed to fit.** The reason is in its shape: the lenses say what good looks like, and everything after them says when to STOP. A paraphrase keeps the memorable half and drops the restraining one, and what survives does not read as incomplete — it reads as a stance that wants MORE of everything, which is precisely the failure the second half exists to prevent. Two clauses do the most work and are the first to be lost: *trust the programmer* rejects a nagging diagnostic, and *don't litigate the minutiae* lets an item die with its reasoning recorded instead of consuming a worker.
+
+**This file is the stance's home, and that is deliberate rather than incidental.** [`docs/the-mayor-method/dispatch-prompt-template.md`](docs/the-mayor-method/dispatch-prompt-template.md) does NOT carry it and must not: that page is the reusable, OS-neutral method, and it says in terms that the stance is project-specific, that it is "PASTED rather than pulled", that it "lives in its own file", and — the sentence that matters here — **"Do not send the worker to a file that does not carry a stance."** So do not go looking for it there, and do not add it there.
+
+**It is written down HERE because it was measured to have no tracked home at all (2026-09-09).** The full text appeared in exactly ZERO git-tracked files as a stance block — the only hit anywhere was inside `.beads/issues.jsonl`, i.e. quoted in bead prose, against a live control of 70 tracked files carrying `hot-zone`. Its one working copy was `ai/dispatch-blocks.md`, which is **gitignored** (`/ai/`), and whose own header names `dispatch-prompt-template.md` as the source it was regenerated from — a file that, by the design above, does not contain the stance. So the standing regeneration procedure would have silently dropped the one block the method says must never be lost or paraphrased, and the staleness test everybody runs (blocks-file header sha against the template's last commit) cannot see it, because it can only ever validate the three blocks that DO come from the template. Regenerate the other three from the template; take the stance from here.
+
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker
 


### PR DESCRIPTION
## What

Adds the project stance to `CLAUDE.md` as a single quoted block, above the tool-generated `BEADS INTEGRATION` marker. One file, 14 insertions, 0 deletions.

## Why

The stance is pasted verbatim into every dispatch preamble and is the one block the method says must never be lost or paraphrased. Measured 2026-09-09, it existed in **zero git-tracked files** as a stance block — the only hit anywhere was inside `.beads/issues.jsonl`, quoted in bead prose, against a live control of **70** tracked files carrying `hot-zone`.

Its only working copy was `ai/dispatch-blocks.md`, which is **gitignored** (`/ai/`), and whose own header names `docs/the-mayor-method/dispatch-prompt-template.md` as the source it was regenerated from — a file that deliberately does **not** carry the stance and says so at its lines 19-22 ("PASTED rather than pulled", "lives in its own file", "Do not send the worker to a file that does not carry a stance").

Two consequences, both closed by this change:

- A regeneration of the blocks file from its stated source would have silently dropped the stance.
- The staleness test everybody runs — blocks-file header sha against the template's last commit — can only ever validate the **three** blocks that do come from the template. It reads EQUAL while saying nothing about the fourth.

## What is deliberately NOT changed

`dispatch-prompt-template.md` is untouched. It is the reusable, OS-neutral method and already rules that the stance is project-specific; adding it there would contradict the passage this change relies on. `CLAUDE.md` is the repository's agent-instructions file, which is where that same passage sends project-specifics.

## Verification

- Stance text is **byte-identical** to the `ai/dispatch-blocks.md` copy (5 lines, `diff` clean).
- CRLF preserved: 142 -> 156 CRLF, **0 bare LF**, `git diff --numstat` = `14 0` (a CR-stripping rewrite would have shown 156 changed lines). Inserted at the byte level; no `sed -i`.
- `BEADS INTEGRATION` begin marker still present exactly once, and the block was inserted **above** it so no regeneration overwrites it.

## Gates

Repo-root markdown is **outside** `check_doc_slugs.py`'s roots and outside `mkdocs`' `docs_dir`, so the gate here is `check_readme_links.py --ci`. Nominated by path, not by job name.

| gate | exit |
|---|---|
| `check_readme_links.py --ci` | 0 |
| `check_doc_slugs.py` | 0 (run only to show the split; vacuous for this path) |
| `check-no-hardcoded-paths.sh` | 0 |
| `check-commit-attribution.sh` (commits) | 0 |

**Sabotage, because the gate is silent on success (0-byte log):** the added link target was repointed to a nonexistent file, match-counted at **1** before the run. `check_readme_links.py --ci` went to **exit 1**, naming the target and `CLAUDE.md`. Restored and verified by blob hash — `git hash-object` = `3eea73a8c479c56e799d9c657ed4273f3a4f6d4e` = the committed blob; residue 0; gate back to 0. (`git ls-files --eol` reads `i/lf w/crlf`, so the filtered `hash-object` is the right instrument here.)
