### PR TITLE
test(conformance): grade the hydrated :after timer, not just its trace row

### DIFF
--- a/implementation/core/test/re_frame/conformance_runner.cljc
+++ b/implementation/core/test/re_frame/conformance_runner.cljc
@@ -18,6 +18,7 @@
     - handler-body / sub / cofx / fx / route / view / machine / flow /
       classification-effect / app-schema realisation
     - the `:fixture/calls` execution (`run-call`)
+    - the `:fixture/clock` controlled host clock (`run-clock-steps!`)
     - all `:fixture/expect` matchers (app-db, runtime-db, subs, traces,
       effects-routed, error-emit-records, epoch-records, absent-paths,
       SSR public-error)
@@ -68,6 +69,11 @@
     [re-frame.subs :as rf.subs]
     [re-frame.conformance :as rf.conformance]
     [re-frame.identity :as rf.identity]
+    ;; rf2-bmqv — `:fixture/clock` replaces the Spec 005 §Clock-abstraction
+    ;; primitives (`schedule-after!` / `cancel-scheduled!`) with a recording
+    ;; realisation, and collapses the router's `next-tick` drain while a
+    ;; captured host callback runs.
+    [re-frame.interop :as rf.interop]
     [re-frame.path :as rf.path]
     [re-frame.projection :as rf.projection]
     [re-frame.http.privacy-headers :as rf.http.privacy-headers]
@@ -1339,6 +1345,195 @@
 
 ;; ---- fixture execution ----------------------------------------------------
 
+;; ---- `:fixture/clock` — a controlled host clock (rf2-bmqv) ----------------
+;;
+;; Spec 005 §Clock abstraction names ONE host seam for delayed work:
+;; `re-frame.interop/schedule-after!` and `cancel-scheduled!`. A fixture that
+;; declares `:fixture/clock` runs its dispatches with that seam replaced by a
+;; RECORDING realisation, so the harness can observe how many timers the host
+;; armed and still holds, and can fire one on demand instead of waiting out
+;; wall time.
+;;
+;; Everything the steps grade is host-observable AT THE SPEC'S OWN CLOCK
+;; BOUNDARY — no port-internal timer table is read, so a port that arms
+;; through a different internal seam conforms so long as it arms through the
+;; clock primitive Spec 005 names.
+;;
+;; LIVE, not merely ARMED. An arm records a handle; a `cancel-scheduled!` of
+;; that handle marks it dead. `:assert-timers :live` therefore counts what the
+;; host is still HOLDING, which is what "arms exactly one timer per active
+;; declaration" means — a host that arms and then cancels holds none.
+;;
+;; The affordance is general: any fixture whose contract is about delayed host
+;; work may declare it. It is engaged ONLY for a fixture carrying the key, so
+;; every other fixture keeps the real host clock.
+
+(defn- new-clock
+  "Fresh recording-clock state. `:timers` is arm-ordered; each entry is
+  `{:id n :delay ms :thunk f :cancelled? bool}`."
+  []
+  (atom {:next-id 0 :timers []}))
+
+(defn- clock-arm-fn
+  "The recording `schedule-after!`. Records the arm and returns an opaque
+  handle `clock-cancel-fn` recognises."
+  [clock]
+  (fn [thunk delay-ms]
+    (let [state (swap! clock (fn [c]
+                               (-> c
+                                   (update :next-id inc)
+                                   (update :timers conj
+                                           {:id         (:next-id c)
+                                            :delay      delay-ms
+                                            :thunk      thunk
+                                            :cancelled? false}))))]
+      [::clock-handle (:id (peek (:timers state)))])))
+
+(defn- clock-cancel-fn
+  "The recording `cancel-scheduled!`. Marks the named arm dead. A handle this
+  clock did not issue is ignored, exactly as the real host primitives ignore
+  a handle of the wrong kind."
+  [clock]
+  (fn [handle]
+    (when (and (vector? handle) (= ::clock-handle (first handle)))
+      (let [id (second handle)]
+        (swap! clock update :timers
+               (fn [ts]
+                 (mapv #(if (= id (:id %)) (assoc % :cancelled? true) %) ts)))))
+    nil))
+
+(defn- clock-live-timers
+  "The timers the host armed and has NOT cancelled, in arm order."
+  [clock]
+  (into [] (remove :cancelled?) (:timers @clock)))
+
+(defn- run-clock-step!
+  "Execute ONE `:fixture/clock` step. Returns a failure string, or nil on
+  success. Three steps, each orthogonal:
+
+    `{:step :assert-timers :live N :delays [ms …]}`
+        the host holds exactly N live host-clock timers, armed for exactly
+        those delays in arm order. Either key may be omitted.
+
+    `{:step :assert-runtime-db :expect {…} :frame <id>}`
+        a MID-RUN runtime-db assertion (submap, like `:final-runtime-db`), so
+        a fixture can pin the state before a timer expires as well as after.
+        `:frame` defaults to `:rf/default`.
+
+    `{:step :fire :index i}`
+        invoke the i-th LIVE timer's host callback. The callback dispatches
+        through the ASYNC router, whose drain is scheduled on `next-tick`;
+        collapsing that to an inline call is the established seam for
+        observing an async drain deterministically on both hosts."
+  [step clock]
+  (case (:step step)
+    :assert-timers
+    (let [all    (:timers @clock)
+          live   (clock-live-timers clock)
+          want-n (:live step)
+          want-d (:delays step)]
+      (cond
+        (and want-n (not= want-n (count live)))
+        (str ":assert-timers expected " want-n " live host-clock timer(s); the host holds "
+             (count live) " (armed " (count all) ", cancelled "
+             (count (filter :cancelled? all)) ")")
+
+        (and want-d (not= (vec want-d) (mapv :delay live)))
+        (str ":assert-timers expected live delays " (pr-str (vec want-d))
+             "; the host holds " (pr-str (mapv :delay live)))))
+
+    :assert-runtime-db
+    (let [frame-id (:frame step :rf/default)
+          expected (:expect step)
+          actual   (:rf.db/runtime (rf/frame-state-value frame-id))]
+      (when-not (rf.conformance/submap? expected actual)
+        (str ":assert-runtime-db on frame " frame-id " expected " (pr-str expected)
+             " to be a submap of " (pr-str actual))))
+
+    :fire
+    (let [idx  (:index step 0)
+          live (clock-live-timers clock)]
+      (if-let [timer (get live idx)]
+        (do (with-redefs [rf.interop/next-tick (fn [f] (f) nil)]
+              ((:thunk timer)))
+            nil)
+        (str ":fire index " idx " but the host holds only " (count live)
+             " live host-clock timer(s)")))
+
+    (str "unknown :fixture/clock step " (pr-str (:step step)))))
+
+(defn- run-clock-steps!
+  "Run the fixture's `:fixture/clock` steps in order, stopping at the first
+  failure. Throws so `run-fixture`'s catch reports it as a fixture failure,
+  matching how `:fixture/calls` failures surface."
+  [steps clock]
+  (when-let [failure (some #(run-clock-step! % clock) steps)]
+    (throw (ex-info (str "clock step failed: " failure) {:clock-failure failure}))))
+
+(defn- dispatch-fixture-event!
+  "Execute ONE `:fixture/dispatches` entry. Extracted from `run-fixture` so the
+  dispatch phase can be run inside the `:fixture/clock` redefs (rf2-bmqv)
+  without duplicating it. Must run inside the fixture's established frame
+  scope."
+  [ev sub-registry dispatch-error-failures]
+  (cond
+    (map? ev)
+    (cond
+      ;; Harness teardown `{:destroy-frame <frame-id>}`.
+      (contains? ev :destroy-frame)
+      (rf/destroy-frame! (:destroy-frame ev))
+
+      ;; Harness re-registration `{:reg-sub <sub-id> :body <body>}`
+      ;; (Cross-Spec Interaction §18, rf2-qei5a). The realised sub's
+      ;; :kind MUST drive the registration form.
+      (contains? ev :reg-sub)
+      (let [sub-id (:reg-sub ev)
+            steps  (:body ev)
+            {:keys [kind inputs body]} (rf.conformance/realise-sub steps)
+            sub-meta (get sub-registry sub-id {})]
+        (case kind
+          :layer-1 (if (seq sub-meta)
+                     (rf.subs/reg-sub sub-id sub-meta body)
+                     (rf.subs/reg-sub sub-id body))
+          :runtime-db (if (seq sub-meta)
+                        (rf.subs/reg-runtime-sub sub-id sub-meta body)
+                        (rf.subs/reg-runtime-sub sub-id body))
+          :layer-2 (rf.subs/reg-sub
+                     sub-id (assoc sub-meta :inputs (vec inputs)) body)))
+
+      ;; EP-0017 (rf2-d8mvke.3): a dispatch asserting a boundary /
+      ;; context-assembly THROW. The throw escapes `dispatch-sync`, so
+      ;; catch it here and compare the ex-data `:rf.error/id`.
+      (contains? ev :expect-error)
+      (let [{event :event want :expect-error} ev
+            opts (dissoc ev :event :expect-error)
+            got  (try (rf/dispatch-sync event opts) ::no-throw
+                      (catch #?(:clj Throwable :cljs :default) e
+                        (or (:rf.error/id (ex-data e)) e)))]
+        (cond
+          (= got ::no-throw)
+          (swap! dispatch-error-failures conj
+                 (str "dispatch " (pr-str event) " expected to throw "
+                      want " but did not throw"))
+          (not= got want)
+          (swap! dispatch-error-failures conj
+                 (str "dispatch " (pr-str event) " expected error " want
+                      " but got " (if (keyword? got)
+                                    got
+                                    (str "a non-rf.error/id throw: "
+                                         (some-> got ex-message)))))))
+
+      :else
+      (let [{event :event :as opts} ev]
+        (rf/dispatch-sync event (dissoc opts :event))))
+
+    ;; :rf/hydrate dispatches with :source :ssr-hydration (Spec 011).
+    (and (vector? ev) (= :rf/hydrate (first ev)))
+    (rf/dispatch-sync ev {:source :ssr-hydration})
+
+    :else
+    (rf/dispatch-sync ev)))
+
 (defn run-fixture
   "Realise, dispatch, and grade one fixture against `:fixture/expect`. `host`
   supplies the genuinely host-specific seams (`:reset-runtime!`,
@@ -1399,66 +1594,26 @@
           dispatches   (or (:fixture/dispatches fixture) [])
           sub-registry (get-in fixture [:fixture/registry :sub] {})
           ;; EP-0017 (rf2-d8mvke.3): per-dispatch `:expect-error` assertions.
-          dispatch-error-failures (atom [])]
-      (rf/with-frame scope-frame
-        (doseq [ev dispatches]
-          (cond
-            (map? ev)
-            (cond
-              ;; Harness teardown `{:destroy-frame <frame-id>}`.
-              (contains? ev :destroy-frame)
-              (rf/destroy-frame! (:destroy-frame ev))
-
-              ;; Harness re-registration `{:reg-sub <sub-id> :body <body>}`
-              ;; (Cross-Spec Interaction §18, rf2-qei5a). The realised sub's
-              ;; :kind MUST drive the registration form.
-              (contains? ev :reg-sub)
-              (let [sub-id (:reg-sub ev)
-                    steps  (:body ev)
-                    {:keys [kind inputs body]} (rf.conformance/realise-sub steps)
-                    sub-meta (get sub-registry sub-id {})]
-                (case kind
-                  :layer-1 (if (seq sub-meta)
-                             (rf.subs/reg-sub sub-id sub-meta body)
-                             (rf.subs/reg-sub sub-id body))
-                  :runtime-db (if (seq sub-meta)
-                                (rf.subs/reg-runtime-sub sub-id sub-meta body)
-                                (rf.subs/reg-runtime-sub sub-id body))
-                  :layer-2 (rf.subs/reg-sub
-                             sub-id (assoc sub-meta :inputs (vec inputs)) body)))
-
-              ;; EP-0017 (rf2-d8mvke.3): a dispatch asserting a boundary /
-              ;; context-assembly THROW. The throw escapes `dispatch-sync`, so
-              ;; catch it here and compare the ex-data `:rf.error/id`.
-              (contains? ev :expect-error)
-              (let [{event :event want :expect-error} ev
-                    opts (dissoc ev :event :expect-error)
-                    got  (try (rf/dispatch-sync event opts) ::no-throw
-                              (catch #?(:clj Throwable :cljs :default) e
-                                (or (:rf.error/id (ex-data e)) e)))]
-                (cond
-                  (= got ::no-throw)
-                  (swap! dispatch-error-failures conj
-                         (str "dispatch " (pr-str event) " expected to throw "
-                              want " but did not throw"))
-                  (not= got want)
-                  (swap! dispatch-error-failures conj
-                         (str "dispatch " (pr-str event) " expected error " want
-                              " but got " (if (keyword? got)
-                                            got
-                                            (str "a non-rf.error/id throw: "
-                                                 (some-> got ex-message)))))))
-
-              :else
-              (let [{event :event :as opts} ev]
-                (rf/dispatch-sync event (dissoc opts :event))))
-
-            ;; :rf/hydrate dispatches with :source :ssr-hydration (Spec 011).
-            (and (vector? ev) (= :rf/hydrate (first ev)))
-            (rf/dispatch-sync ev {:source :ssr-hydration})
-
-            :else
-            (rf/dispatch-sync ev))))
+          dispatch-error-failures (atom [])
+          ;; rf2-bmqv — `:fixture/clock`. Present ⇒ the dispatch phase runs
+          ;; with the Spec 005 clock primitives recording rather than really
+          ;; scheduling, and the declared steps run immediately after it,
+          ;; still inside those redefs (a fired callback releases its own
+          ;; handle through `cancel-scheduled!`).
+          clock-steps  (:fixture/clock fixture)
+          clock        (when clock-steps (new-clock))
+          run-dispatches!
+          (fn []
+            (rf/with-frame scope-frame
+              (doseq [ev dispatches]
+                (dispatch-fixture-event! ev sub-registry dispatch-error-failures))))]
+      (if clock
+        (with-redefs [rf.interop/schedule-after!   (clock-arm-fn clock)
+                      rf.interop/cancel-scheduled! (clock-cancel-fn clock)]
+          (run-dispatches!)
+          (rf/with-frame scope-frame
+            (run-clock-steps! clock-steps clock)))
+        (run-dispatches!))
       ;; :fixture/render-after-hydrate — simulate the client-side first render
       ;; so `verify-hydration!` can compare hashes.
       (when-let [render-spec (:fixture/render-after-hydrate fixture)]

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -55,6 +55,7 @@ Every top-level key the corpus uses. A harness that meets a key it does not impl
 | `:fixture/dynamic-host-only?` | gating | `true` marks a fixture asserting a **runtime** validation trace that a statically-typed host claiming schemas through its type system cannot produce — the malformed value never compiles. Such a host filters these out *before* the capability-subset check and records the reason; that is a documented static-host path, not claim-set drift. |
 | `:fixture/dispatches` | Mode A | The event vectors to dispatch, in order. |
 | `:fixture/calls` | Mode B | Direct invocations of pure primitives, each carrying its own expectation. See [§Mode B](#mode-b--pure--direct-call). |
+| `:fixture/clock` | Mode A | Runs the dispatches against a **controlled** realisation of the Spec 005 §Clock-abstraction primitives (`schedule-after!` / `cancel-scheduled!`), then executes the declared steps against it. See [§The `:fixture/clock` controlled host clock](#the-fixtureclock-controlled-host-clock). |
 | `:fixture/expect` | Mode A | The single post-drain expectation block. |
 | `:fixture/compute-subs` | expectation | Sub query-vectors the harness invokes against the post-dispatch state, so a sub that *throws* is observed as a sub failure rather than as an absent value. |
 | `:fixture/render-after-hydrate` | expectation | Simulates the client's first render after `:rf/hydrate` so hydration-mismatch detection can be exercised: `:simulated-client-render-hash` and optional `:first-diff-path` are compared against the server hash carried in the hydrate payload. |
@@ -90,6 +91,34 @@ The classic shape: a starting state (frame configuration plus initial `app-db`),
 ```
 
 The expectation keys inside `:fixture/expect` are partial-match by convention: `:trace-emissions` matches each trace event by its specified keys (absent keys ignored), `:final-app-db` is a submap compare (every declared key must match; extra actual keys are tolerated), `:effects-routed` matches the routed-fx pairs in declaration order. Because `:final-app-db`'s submap match tolerates extras, a negative companion key `:final-app-db-absent` — a vector of `get-in`-shaped paths that must be ABSENT from the final app-db (the tip key not present; a present-with-`nil` leaf counts as present) — pins contracts the positive submap cannot, for example declared-only coeffect delivery (a port that over-delivers undeclared coeffects still passes the positive check but fails the absent-path check). See [§Fixture lifecycle](#fixture-lifecycle) for the full comparison contract.
+
+### The `:fixture/clock` controlled host clock
+
+Some contracts are about **delayed host work** — a machine `:after` timer, an SSR hydration re-arm — and a post-drain expectation block cannot reach them. A trace assertion says a row was emitted; it cannot say the timer behind that row still exists (`:trace-emissions` is an order-preserving **subset** match, so a later cancellation is tolerated), and it cannot say the timer is wired to anything, because a row is not a callback. Waiting out wall time is not an option for a corpus.
+
+`:fixture/clock` closes that gap at the seam Spec 005 §Clock abstraction already names — `re-frame.interop/schedule-after!` and `cancel-scheduled!`. A fixture carrying the key runs its `:fixture/dispatches` with those two primitives replaced by a **recording** realisation, then executes the declared steps against it, before `:fixture/calls` and before `:fixture/expect` is graded. A fixture without the key is untouched and keeps the real host clock.
+
+Everything the steps observe is host-observable at that clock boundary; no port-internal timer table is read. A port that arms through some other internal mechanism conforms so long as it arms through the clock primitive the spec names.
+
+The value is a vector of step maps, executed in order, stopping at the first failure:
+
+| Step | Keys | What it asserts / does |
+|---|---|---|
+| `:assert-timers` | `:live`, `:delays` | The host holds exactly `:live` timers it armed and has **not** cancelled, armed for exactly `:delays` (in arm order). Either key may be omitted. |
+| `:assert-runtime-db` | `:expect`, `:frame` | A **mid-run** runtime-db assertion, submap-compared like `:final-runtime-db`, so a fixture can pin the state *before* a timer expires as well as after. `:frame` defaults to `:rf/default`. |
+| `:fire` | `:index` | Invoke the `:index`-th **live** timer's own host callback (default `0`). Whatever that callback does — typically dispatching a synthetic elapsed event — then settles, and the rest of the fixture grades the result. |
+
+`:live` is deliberately *live* rather than *armed*: an arm records a handle, and a `cancel-scheduled!` of that handle marks it dead, so "arms exactly one timer per active declaration" is graded as *still holding one*. A host that arms and immediately cancels holds none and fails, even though its `/scheduled` trace row is identical to a conforming host's. A host that arms nothing holds none either, so a fixture using this step cannot pass vacuously.
+
+```clojure
+:fixture/clock
+[{:step :assert-timers :live 1 :delays [5000]}
+ {:step   :assert-runtime-db
+  :expect {:rf.runtime/machines {:snapshots {:auth/probe {:state :waiting}}}}}
+ {:step :fire :index 0}]
+```
+
+`cross-spec-machine-after-hydration-rearm.edn` is the worked example.
 
 ### Mode B — pure / direct-call
 
@@ -413,10 +442,11 @@ Each fixture defines an invariant the implementation upholds. The harness:
 1. Bootstraps the registrar — for each kind in `:fixture/registry`, register every id with the supplied metadata.
 2. Realises handler bodies — for each `:fixture/handlers` entry, interpret the DSL ops into a host-native closure and bind it to the id under the kind.
 3. Creates the frame — apply `:fixture/frame-config` via `make-frame` (or the host equivalent); this fires the frame's `:initial-events` seeded into it.
-4. Runs `:fixture/dispatches` — one event vector per call, each via `dispatch-sync`. Each settles to fixed point before the next.
-5. Runs `:fixture/calls` (if present) — direct invocations of pure primitives (`machine-transition`, `reg-machine`, `make-frame`, `match-url`, `route-url`, `render-to-string`, `round-trip`, `assert-rank-greater`, and the data-classification projector ops). Each call carries its own expectation; mismatches surface as fixture-level failures.
-6. Captures observables (Mode A) — final `app-db`, sub values (per `:fixture/expect :sub-values`), trace events emitted, effects routed.
-7. Compares (Mode A) — partial-match per assertion. `:trace-emissions` partial-matches each trace event by its specified keys; absent keys are ignored. `:final-app-db` is a submap compare (declared keys must match; extra actual keys tolerated); `:final-app-db-absent` (a vector of `get-in`-shaped paths) asserts each path's tip key is ABSENT. `:effects-routed` matches the routed-fx pairs in declaration order. A dispatch carrying `:expect-error` asserts that dispatch threw the named `:rf.error/id`.
+4. Runs `:fixture/dispatches` — one event vector per call, each via `dispatch-sync`. Each settles to fixed point before the next. Where `:fixture/clock` is present, this step runs against the controlled clock described in [§The `:fixture/clock` controlled host clock](#the-fixtureclock-controlled-host-clock).
+5. Runs `:fixture/clock` steps (if present) — still inside the controlled clock, so a fired callback releases its own handle through it.
+6. Runs `:fixture/calls` (if present) — direct invocations of pure primitives (`machine-transition`, `reg-machine`, `make-frame`, `match-url`, `route-url`, `render-to-string`, `round-trip`, `assert-rank-greater`, and the data-classification projector ops). Each call carries its own expectation; mismatches surface as fixture-level failures.
+7. Captures observables (Mode A) — final `app-db`, sub values (per `:fixture/expect :sub-values`), trace events emitted, effects routed.
+8. Compares (Mode A) — partial-match per assertion. `:trace-emissions` partial-matches each trace event by its specified keys; absent keys are ignored. `:final-app-db` is a submap compare (declared keys must match; extra actual keys tolerated); `:final-app-db-absent` (a vector of `get-in`-shaped paths) asserts each path's tip key is ABSENT. `:effects-routed` matches the routed-fx pairs in declaration order. A dispatch carrying `:expect-error` asserts that dispatch threw the named `:rf.error/id`.
 
 For Mode B fixtures, comparison happens inline at each call; there is no top-level `:fixture/expect` to evaluate after drain.
 
@@ -432,7 +462,8 @@ Each fixture is a single file of <200 lines including registrations and expectat
    b. Realise handler bodies via the DSL interpreter.
    c. If `:fixture/dispatches` is present (Mode A):
       - Create a frame per `:fixture/frame-config`.
-      - Run each dispatch.
+      - Run each dispatch — against the controlled clock where `:fixture/clock` is present.
+      - Run the `:fixture/clock` steps, if any, still inside that clock.
       - After drain, capture: final `app-db`, sub values, emitted trace events, effects routed.
       - Compare actuals against `:fixture/expect`.
    d. If `:fixture/calls` is present (Mode B):

--- a/spec/conformance/fixtures/cross-spec-machine-after-hydration-rearm.edn
+++ b/spec/conformance/fixtures/cross-spec-machine-after-hydration-rearm.edn
@@ -33,7 +33,8 @@
 ;; WHICH HOST SEAM PERFORMS THE ARM IS UNSPECIFIED, and this fixture does not
 ;; pin one. It dispatches `:rf/hydrate` with a server-produced payload and
 ;; grades only what 011 makes normative: the emitted schedule's delay and
-;; epoch, the snapshot the client is left holding, and the absence of a
+;; epoch, the host-clock timers the client is left HOLDING, the snapshot it
+;; is left holding before and after that timer expires, and the absence of a
 ;; replayed entry. A port whose hydration arms through some other seam
 ;; conforms so long as those observables match.
 ;;
@@ -44,19 +45,50 @@
 ;; `:data` records `:entries 1` -- the server ran `:waiting`'s entry action
 ;; exactly once, on the way in.
 ;;
+;; THE CLOCK PHASE IS THE LOAD-BEARING HALF, and it is here because a
+;; SUBSET-matched `/scheduled` trace alone is not the contract (rf2-bmqv, the
+;; merged-PR audit of the fixture's first form). A trace assertion says a row
+;; was emitted; it cannot say the timer behind that row still EXISTS, because
+;; an order-preserving subset match tolerates a later cancellation, and it
+;; cannot say the timer is wired to anything, because a row is not a
+;; callback. `:fixture/clock` closes both by driving the Spec 005
+;; §Clock-abstraction primitives themselves:
+;;
+;;   * `:assert-timers :live 1 :delays [5000]` -- the client HOLDS exactly
+;;     one host-clock timer, armed for the full delay. A host that armed and
+;;     then cancelled holds zero and fails here, even though its
+;;     `/scheduled` row is identical. A host that armed nothing at all --
+;;     the empty-`:fx` shape described under `:platform :client` below --
+;;     also holds zero, so no assertion in this fixture can pass vacuously.
+;;   * `:assert-runtime-db` BEFORE the fire -- the retained epoch, the
+;;     un-replayed entry count and the un-moved state, observed while the
+;;     timer is still pending. This is where "nothing transitions before the
+;;     interval elapses" is graded.
+;;   * `:fire` -- the client's OWN captured host callback is invoked. What
+;;     follows is the hydrated actor's real transition, so `:final-runtime-db`
+;;     and the `/fired` + `/transition` rows below grade THAT timer's expiry
+;;     rather than a manufactured one.
+;;
 ;; WHAT EACH ASSERTION DISCRIMINATES:
-;;   * `:delay 5000` on the `/scheduled` trace -- a host that computed a
-;;     remainder (from `:rf/ssr-rendered-at`, a header, or a client clock
-;;     read) would arm something smaller, and a host that treated a past-due
-;;     timer as fire-immediately would arm 0 or fire at once.
+;;   * `:delay 5000` on the `/scheduled` trace, and `:delays [5000]` on the
+;;     live timer -- a host that computed a remainder (from
+;;     `:rf/ssr-rendered-at`, a header, or a client clock read) would arm
+;;     something smaller, and a host that treated a past-due timer as
+;;     fire-immediately would arm 0 or fire at once.
 ;;   * `:epoch 1` on that trace, and `:rf/after-epoch {[:waiting] 1}` in the
-;;     final snapshot -- a host that treated hydration as a state ENTRY would
-;;     bump to 2, stranding the very snapshot it just restored.
-;;   * `:entries 1` in the final snapshot -- a host that re-fired the entry
+;;     pre-expiry snapshot -- a host that treated hydration as a state ENTRY
+;;     would bump to 2, stranding the very snapshot it just restored.
+;;   * `:entries 1` in both snapshots -- a host that re-fired the entry
 ;;     cascade to start scheduling would read 2.
-;;   * `:state :waiting` -- nothing transitions before the interval elapses.
-;;   * the Mode B call -- the retained epoch is the OPERATIVE one: an elapsed
-;;     event carrying it drives the declared transition to `:timeout`.
+;;   * `:state :waiting` pre-expiry -- nothing transitions before the
+;;     interval elapses.
+;;   * `:live 1` -- exactly one timer per active declaration, and it is still
+;;     there. Cardinality, not merely emission.
+;;   * `:state :timeout` and `:rf/after-epoch {[:waiting] 2}` in
+;;     `:final-runtime-db`, with `/fired :fired? true` and the
+;;     `:rf.machine/transition` row -- the retained epoch is the OPERATIVE
+;;     one: the hydrated timer's own callback drives the declared
+;;     transition, and exiting `:waiting` bumps its per-path epoch.
 ;;
 ;; NOT EXERCISED HERE, deliberately. Epoch restore is the mirror image and
 ;; stays cancel-only (005 §Epoch-based stale detection, `:reason
@@ -69,7 +101,7 @@
 {:fixture/id           :cross-spec/machine-after-hydration-rearm
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:fsm/flat :fsm/delayed-after :ssr/hydration :core/event-handler :core/trace}
- :fixture/doc          "The CLIENT half of the SSR :after hydration handoff. From a server-produced payload carrying an :after-bearing snapshot, hydration arms exactly ONE timer per ACTIVE declaration, for the FULL client-resolved delay measured from the client arm; the hydrated epoch is RETAINED, not bumped; no :entry / :action / :raise / :spawn / :always is replayed; nothing transitions before the interval elapses, and the retained epoch is the one an elapsed event must carry to drive the declared transition."
+ :fixture/doc          "The CLIENT half of the SSR :after hydration handoff. From a server-produced payload carrying an :after-bearing snapshot, hydration arms exactly ONE LIVE host-clock timer per ACTIVE declaration, for the FULL client-resolved delay measured from the client arm; the hydrated epoch is RETAINED, not bumped; no :entry / :action / :raise / :spawn / :always is replayed; nothing transitions before the interval elapses; and firing that timer's own host callback drives the declared transition."
 
  :fixture/registry
  {:machine-action
@@ -105,7 +137,9 @@
  ;; the reason the sibling server-half fixture sees no timer. A port
  ;; whose harness leaves the platform unresolved will observe an empty
  ;; `:fx` and no `/scheduled` row; that is a harness fact, not a
- ;; conformance failure.
+ ;; conformance failure -- and it is now a LOUD one, because the clock
+ ;; phase below reads zero live timers and fails rather than passing
+ ;; vacuously.
  :fixture/frame-config {:initial-events [] :platform :client}
 
  :fixture/dispatches
@@ -120,18 +154,45 @@
                                             :rf/after-epoch {[:waiting] 1}}}}}}
                 :rf/render-hash "h1"}]]
 
+ ;; The controlled host clock. Runs after `:fixture/dispatches`, with the
+ ;; Spec 005 §Clock-abstraction primitives (`schedule-after!` /
+ ;; `cancel-scheduled!`) recording rather than really scheduling, so the
+ ;; steps below observe and drive the timers the HOST armed.
+ :fixture/clock
+ [;; ONE live timer, at the full declared delay. Live, not merely armed:
+  ;; a cancellation of the just-armed handle reads zero here.
+  {:step :assert-timers :live 1 :delays [5000]}
+
+  ;; The hydrated snapshot BEFORE that timer expires -- left EXACTLY as the
+  ;; server settled it: same state, same epoch, same entry count. Hydration
+  ;; writes no snapshot, and nothing transitions early.
+  {:step   :assert-runtime-db
+   :expect {:rf.runtime/machines
+            {:snapshots
+             {:auth/probe
+              {:state :waiting
+               :data  {:entries        1
+                       :rf/after-epoch {[:waiting] 1}}}}}}}
+
+  ;; Expire it -- by invoking the client's own captured host callback, not by
+  ;; manufacturing an elapsed event. Everything in `:fixture/expect` about
+  ;; `:timeout` is downstream of THIS.
+  {:step :fire :index 0}]
+
  :fixture/expect
  {:final-app-db {:page :dashboard}
 
-  ;; The hydrated snapshot is left EXACTLY as the server settled it: same
-  ;; state, same epoch, same entry count. Hydration writes no snapshot.
+  ;; AFTER the hydrated timer fired: the declared transition ran, exiting
+  ;; `:waiting` bumped its per-path epoch to 2, and `:entries` is STILL 1 --
+  ;; the re-arm reconstructed host work, it did not replay history, and the
+  ;; `:timeout` state declares no entry of its own.
   :final-runtime-db
   {:rf.runtime/machines
    {:snapshots
     {:auth/probe
-     {:state :waiting
+     {:state :timeout
       :data  {:entries        1
-              :rf/after-epoch {[:waiting] 1}}}}}}
+              :rf/after-epoch {[:waiting] 2}}}}}}
 
   ;; The load-bearing trace contract. The hydrate event runs with
   ;; :source :ssr-hydration (Spec 011 §The :rf/hydrate event), and the
@@ -142,7 +203,11 @@
   ;;
   ;; :delay 5000 is the FULL declared delay and :epoch 1 is the payload's
   ;; own epoch. A remainder rule would show a smaller delay; an
-  ;; entry-replay would show epoch 2 and a :rf.machine/transition row.
+  ;; entry-replay would show epoch 2 and an early :rf.machine/transition row.
+  ;;
+  ;; The /fired row closes that pair at the SAME (actor-id, state, epoch),
+  ;; which is what makes the transition below attributable to the hydrated
+  ;; timer rather than to anything else the run did.
   :trace-emissions
   [{:operation :rf.event/run-start
     :source    :ssr-hydration
@@ -152,12 +217,40 @@
                 :state        :waiting
                 :delay        5000
                 :epoch        1
-                :delay-source :literal}}]}
+                :delay-source :literal}}
+   {:operation :rf.machine.timer/fired
+    :tags      {:actor-id :auth/probe
+                :state    :waiting
+                :delay    5000
+                :epoch    1
+                :fired?   true}}
+   ;; The runtime transition row carries `:before` / `:after` SNAPSHOTS and the
+   ;; inner `:event` (the pure `machine-transition` primitive's row, asserted
+   ;; in the Mode B companion below, carries `:from` / `:to` instead). The
+   ;; `:event` tag is what ties this transition to the hydrated timer: it is
+   ;; the synthetic elapsed event that timer's own callback dispatched,
+   ;; carrying the delay-key, the RETAINED epoch and the declaring path.
+   ;;
+   ;; The two snapshots are given WHOLE because a trace tag is matched by
+   ;; equality, not submap-wise (`check-trace-emissions` recurses one level,
+   ;; into `:tags`, and no further). Whole is what we want here anyway: it
+   ;; pins the un-replayed entry count on BOTH sides of the one transition
+   ;; the hydrated timer caused.
+   {:operation :rf.machine/transition
+    :tags      {:actor-id :auth/probe
+                :event    [:rf.machine.timer/after-elapsed 5000 1 [:waiting]]
+                :before   {:state :waiting
+                           :data  {:entries 1 :rf/after-epoch {[:waiting] 1}}}
+                :after    {:state :timeout
+                           :data  {:entries 1 :rf/after-epoch {[:waiting] 2}}}}}]}
 
- ;; Mode B tail (pure, run AFTER the dispatches): the RETAINED epoch is the
- ;; operative one. An elapsed event carrying epoch 1 -- the epoch the
- ;; re-armed timer was given above -- drives the declared transition; exiting
- ;; :waiting bumps its per-path epoch to 2 and releases the host handle.
+ ;; Mode B companion (pure, run AFTER the dispatches and the clock phase):
+ ;; the same transition, taken as a pure function of an explicit snapshot and
+ ;; event, so a port can check its transition kernel independently of its
+ ;; clock. It is a COMPANION, not the grading of the hydrated timer -- that
+ ;; is the `:fixture/clock` phase above, and this call cannot substitute for
+ ;; it because it supplies its own inputs rather than observing the ones
+ ;; hydration produced.
  :fixture/calls
  [{:call       :machine-transition
    :definition {:initial :idle


### PR DESCRIPTION
rf2-bmqv audit residual (merged-PR audit of #9517).

## The defect

`spec/conformance/fixtures/cross-spec-machine-after-hydration-rearm.edn` claimed in its header and its catalogue row to pin the CLIENT half of the SSR `:after` hydration handoff. It graded neither of the two things that matter, and it was a false green for its own acceptance criteria.

- `check-trace-emissions` is an order-preserving **subset** matcher (`implementation/core/src/re_frame/conformance.cljc:842` says so in terms). Asserting a `:rf.machine.timer/scheduled` row therefore does not exclude a later cancellation of that same timer — a host that arms and immediately cancels emits a byte-identical row.
- `:fixture/calls` are pure assertions run against the fixture's OWN declared inputs. The fixture's Mode B tail fed a hard-coded snapshot and event to `machine-transition`, disconnected from the timer `:rf/hydrate` actually armed.

So neither *exactly one live timer* nor *expiry of THAT timer* was graded. Measured below in both directions.

## The harness affordance: `:fixture/clock`

Kept minimal and general rather than special-cased to this fixture. A fixture carrying `:fixture/clock` runs its `:fixture/dispatches` with the **Spec 005 §Clock-abstraction primitives** — `re-frame.interop/schedule-after!` and `cancel-scheduled!` — replaced by a recording realisation, then runs its declared steps against it, before `:fixture/calls` and before `:fixture/expect` is graded. A fixture without the key is untouched and keeps the real host clock.

Three orthogonal steps:

| Step | Keys | What it does |
|---|---|---|
| `:assert-timers` | `:live`, `:delays` | The host holds exactly `:live` timers it armed and has not cancelled, at exactly `:delays` (arm order). |
| `:assert-runtime-db` | `:expect`, `:frame` | A mid-run runtime-db submap assertion, so a fixture can pin state *before* a timer expires as well as after. |
| `:fire` | `:index` | Invoke the i-th live timer's own host callback. |

Two shape decisions worth stating:

- **Observed at the clock boundary the spec already names**, not at a port-internal timer table. A port that arms through some other internal mechanism conforms so long as it arms through the primitive Spec 005 names. That is what makes this a conformance affordance rather than a reference-implementation probe.
- **LIVE, not merely ARMED.** An arm records a handle; a `cancel-scheduled!` of that handle marks it dead. "Arms exactly one timer per active declaration" is therefore graded as *still holding one*. This is what makes the cancel-after-arm mutation fail, and it also means a host that arms nothing holds zero — so no assertion in this fixture can pass under an empty effect list, which is the `:platform :client` trap the fixture already documents.

`run-fixture`'s per-event dispatch body is extracted to `dispatch-fixture-event!` so the dispatch phase can run inside the clock redefs without being duplicated. It is a pure move.

**No runtime behaviour changed.** This is a conformance COVERAGE residual; nothing under `implementation/*/src` is touched by this branch.

## What the fixture now grades

One live 5000ms timer; the un-moved snapshot with its RETAINED epoch and un-replayed entry count while that timer is still pending; then the client's own captured callback is fired, and `:final-runtime-db` plus the `/fired` and `:rf.machine/transition` rows grade the resulting hydrated actor transition. The `/transition` row's `:event` tag is the synthetic elapsed event that timer's callback dispatched, which is what attributes the transition to the hydrated timer rather than to anything else in the run.

The existing duration, epoch and no-entry-replay checks and the ruled spec text are preserved; the header's claims are now true rather than weakened. The Mode B tail stays, relabelled as an explicitly pure companion that cannot substitute for the clock phase.

## Mutation proof

Both mutations were run against BOTH the old fixture (from the parent commit) and the new one, so the false green is demonstrated rather than asserted. Each plant matched exactly 1 line; each restore was verified by `git hash-object` against the committed blob (these files are LF in the index, CRLF in the worktree, so the default filtered form is the one that matches — confirmed against an unmodified file first).

**cancel-after-arm** — `machines/hydrate.cljc`, the reconcile loop cancels the actor's timers immediately after `rearm-hydrated-after-timer!` returns.

| corpus run | exit |
|---|---|
| old fixture + mutation | **0** — the false green |
| new fixture + mutation | **1** — `clock step failed: :assert-timers expected 1 live host-clock timer(s); the host holds 0 (armed 1, cancelled 1)` |

**disconnected-callback** — `core/managed_timer.cljc`, `arm!` schedules `(fn [] nil)` in place of the caller's thunk.

| corpus run | exit |
|---|---|
| old fixture + mutation | **0** — the false green |
| new fixture + mutation | **1** — both the `/fired` and the `/transition` rows unseen |

Exactly one fixture failed in each red run; the other 239 stayed green, so the discrimination is this fixture's rather than collateral.

Restore blob hashes, each equal to the committed blob:
- `implementation/machines/src/re_frame/machines/hydrate.cljc` — `11d5abeb2d23148b01bce9eac610078fb4124a1d` (blob hash)
- `implementation/core/src/re_frame/managed_timer.cljc` — `4e765a51866ebc4c0fac8d44112a9b70030e647a` (blob hash)
- the fixture — `a683363c08c6c901f4002c92030f8f1db4d7ec18` (blob hash)

## Quality gates

Every exit code captured on the runner's own command line, never through a pipe.

| gate | exit |
|---|---|
| `implementation/core`, `clojure -M:test -n re-frame.conformance-test` (baseline, after both restorations) | 0 — 243 fixtures, 240 runnable, **240 passed**, 3 skipped |
| `implementation/machines`, `clojure -M:test` | 0 — 1217 tests, 4421 assertions |
| `python scripts/check_conformance_fixture_edn.py --ci` | 0 |
| `python scripts/check_doc_slugs.py` | 0 |
| `python -m mkdocs build --strict` | 0 (bare `mkdocs` is not on PATH on this box) |
| ratchets over the touched paths: `check_retired_spellings`, `check_retired_composition_vocab`, `check_require_alias_dialect`, `check_keyword_catalogue_drift`, `check_readme_inventories`, `check_architecture_census` | 0 each |

Fixture counts are unchanged at 243/240/240 — no fixture added or removed, so the count reconciles exactly against the figure recorded when the fixture landed.

**Left to CI:** the CLJS corpus leaf shares this runner, so `npm run test:cljs` grades the same fixture on the node build. It is not run locally per the gate-nomination policy. `with-redefs` over `rf.interop/schedule-after!` on the `:node-test` build is already established in-tree by `implementation/ssr/test/re_frame/ssr/machine_after_rearm_cljs_test.cljc`, which uses the identical seam.

## Hand-verified

`spec/conformance/README.md`: the new `:fixture/clock` section's anchor link resolves (the doc gate covers `spec/`, and it is green), the new table's three column counts match its header, and the renumbered fixture-lifecycle list (items 4–8) reads in order.
