### PR TITLE
fix(beads): the memory warning's recovery command names an immutable commit (rf2-cve7)

### DIFF
--- a/scripts/beads-checkpoint.ps1
+++ b/scripts/beads-checkpoint.ps1
@@ -592,6 +592,30 @@ if ($SelfTest) {
     function Get-HeadTracker { return (& git -C $repo show 'HEAD:.beads/issues.jsonl') -join "`n" }
     function Get-HeadSha { return (& git -C $repo rev-parse HEAD).Trim() }
 
+    # The memory `value` a given commit carries for a key, or '' when that commit
+    # carries no such row. This is the emitted recovery lookup expressed without
+    # jq, which Windows does not ship: the claim under test is that the printed
+    # REFERENCE still resolves, not that jq is installed. `${Ref}:` needs the
+    # braces - a bare `$Ref:` parses as a scope qualifier. The try/catch is
+    # load-bearing under $ErrorActionPreference = 'Stop': pwsh 7.4+ turns a
+    # native command's non-zero exit into a terminating error, and asking an
+    # unresolvable ref is a case these tests deliberately exercise.
+    function Get-MemoryValueAt {
+        param([string]$Ref, [string]$Key)
+        if (-not $Ref) { return '' }
+        try { $rows = @(& git -C $repo show "${Ref}:.beads/issues.jsonl" 2>$null) }
+        catch { return '' }
+        if ($LASTEXITCODE -ne 0) { return '' }
+        foreach ($r in $rows) {
+            if ($r -match '"_type":"memory"' -and
+                $r -match ('"key":"' + [regex]::Escape($Key) + '"') -and
+                $r -match '"value":"([^"]*)"') {
+                return $Matches[1]
+            }
+        }
+        return ''
+    }
+
     function Assert-True {
         param([bool]$Cond, [string]$What, [string]$Detail = '')
         if ($Cond) { Write-Output "  PASS  $What" }
@@ -801,6 +825,46 @@ if ($SelfTest) {
     Assert-True ($err -match 'WARNING, NOT A REFUSAL') `
                 'T7 and says the checkpoint continues, so the operator can tell what happened'
 
+    # T7, second half: THE PRINTED RECOVERY COMMAND MUST ACTUALLY RECOVER
+    # (rf2-cve7, merged-PR audit of #9520).
+    #
+    # The warning above is correct and fires correctly. Its recovery instruction
+    # was not: it printed `git show HEAD:.beads/issues.jsonl`, and the checkpoint
+    # COMMITS the export a few lines after printing it. By the time an operator
+    # reads the message and pastes the command, `HEAD` IS the commit that removed
+    # the rows, so the lookup exits 0 and prints NOTHING - the worst available
+    # failure shape for a recovery instruction, because success and total failure
+    # are the same exit code and the same empty output.
+    #
+    # These assertions therefore run the emitted lookup AFTER the checkpoint has
+    # committed, with the HEAD-form control beside them reproducing the defect in
+    # the same repo in the same breath.
+    $recRefs = @([regex]::Matches($err, '(?m)^\s*git show (\S+?):') |
+                 ForEach-Object { $_.Groups[1].Value })
+    $recRef = if ($recRefs.Count -gt 0) { $recRefs[0] } else { '' }
+    Assert-True ($recRefs.Count -eq 1) `
+                'T7 the warning carries exactly one recovery lookup' "found $($recRefs.Count)"
+    Assert-True ($recRef -eq $before) `
+                'T7 and it names the immutable pre-checkpoint commit, not the moving HEAD' `
+                "printed '$recRef', pre-checkpoint commit '$before'"
+
+    $lookupRef = if ($recRef) { $recRef } else { 'HEAD' }
+    Assert-True ((Get-MemoryValueAt -Ref $lookupRef -Key 'mem-key-03') -eq 'body 3') `
+                'T7 and running it AFTER the checkpoint committed recovers the deleted value'
+    # The control, and it is the whole reason the assertion above means anything:
+    # the reference the script USED to print returns nothing at this exact point.
+    Assert-True ((Get-MemoryValueAt -Ref 'HEAD' -Key 'mem-key-03') -eq '') `
+                'T7 while the same lookup against HEAD recovers nothing - the defect this pins'
+
+    # And later commits must not invalidate it. A commit oid is content-addressed
+    # so this holds by construction - but "by construction" is what the HEAD form
+    # looked like too, so it is asserted rather than assumed.
+    Write-Rows -Path (Join-Path $repo 'later.txt') -Rows @('a later commit, unrelated to the tracker')
+    & git -C $repo add -- 'later.txt' | Out-Null
+    & git -C $repo commit -q -m 'a later commit lands on top of the checkpoint' | Out-Null
+    Assert-True ((Get-MemoryValueAt -Ref $lookupRef -Key 'mem-key-03') -eq 'body 3') `
+                'T7 and a further commit on top does not invalidate the printed reference'
+
     # T8 - a row of an unknown `_type` is reported. This is the "two populations
     # sum to the row count" half of the bead. It cannot detect the deletion
     # above - the identity holds trivially whenever every row is one of the two
@@ -929,6 +993,29 @@ try {
     }
 
     Write-HeadCopy -Path $tmpHead
+    # The commit $tmpHead was read from - captured HERE, beside the copy it
+    # names, because the memory warning below prints it as a RECOVERY REFERENCE
+    # and this script COMMITS the fresh export a hundred lines later (rf2-cve7,
+    # merged-PR audit of #9520). Printing `HEAD` there is worse than useless: by
+    # the time an operator reads the warning and pastes the command, `HEAD` IS
+    # the checkpoint that just removed those rows, so the lookup exits 0 and
+    # prints nothing - succeeding, and recovering nothing.
+    #
+    # A full commit oid is content-addressed and immutable, so it keeps naming
+    # this exact tree after the checkpoint commits and after any number of later
+    # commits land on top; `HEAD` is a symbolic ref re-resolved at read time and
+    # does not. Empty on an unborn branch (a first-ever checkpoint), where there
+    # is no baseline to recover from and the recovery paragraph is skipped.
+    # --quiet keeps git silent on an unborn branch, and the try/catch is
+    # load-bearing rather than defensive: $ErrorActionPreference is 'Stop' here,
+    # and pwsh 7.4+ turns a native command's non-zero exit into a terminating
+    # error, so the unborn-branch case would abort the whole checkpoint.
+    $baselineCommit = ''
+    try {
+        $probe = (& git rev-parse --verify --quiet HEAD 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $probe) { $baselineCommit = ([string]$probe).Trim() }
+    } catch { $baselineCommit = '' }
+
     $exportRows = Get-RowCount -Path $tmpExport
     $headRows   = Get-RowCount -Path $tmpHead
 
@@ -1034,11 +1121,27 @@ try {
         $lines.Add('  THIS IS A WARNING, NOT A REFUSAL - the checkpoint continues and commits')
         $lines.Add('  the export. The database is the source of truth, and this may well be a')
         $lines.Add('  deliberate `bd forget` or a retention cull. If it is NOT, the rows are not')
-        $lines.Add('  lost: HEAD still carries every one of them, and so does any earlier')
-        $lines.Add('  checkpoint commit.')
-        $lines.Add('')
-        $lines.Add("      git show HEAD:$tracker |")
-        $lines.Add('        jq -r --arg k "<key>" ''select(._type=="memory" and .key==$k)|.value''')
+        if ($baselineCommit) {
+            $lines.Add('  lost. The commit this export was compared against still carries every')
+            $lines.Add('  one of them, and this is the lookup:')
+            $lines.Add('')
+            $lines.Add("      git show ${baselineCommit}:$tracker |")
+            $lines.Add('        jq -r --arg k "<key>" ''select(._type=="memory" and .key==$k)|.value''')
+            $lines.Add('')
+            $lines.Add('  THAT COMMIT IS SPELLED OUT RATHER THAN `HEAD` ON PURPOSE. This checkpoint')
+            $lines.Add('  commits the export a moment from now, so by the time you read this `HEAD`')
+            $lines.Add('  is the commit that REMOVED the rows: the same lookup against it would exit')
+            $lines.Add('  0 and print nothing - succeeding, and recovering nothing. A full commit oid')
+            $lines.Add('  is immutable, so it stays valid after this commit and every later one.')
+            $lines.Add('')
+            $lines.Add('  Older checkpoints are NOT a general fallback - one made before a key was')
+            $lines.Add('  created does not carry it. To find the commit where any single key changed:')
+            $lines.Add('')
+            $lines.Add("      git log -S'""key"":""<key>""' -- $tracker")
+        } else {
+            $lines.Add('  lost - but this is a first-ever checkpoint with no commit behind it, so')
+            $lines.Add('  there is no baseline to recover from. The database is the only copy.')
+        }
         $lines.Add('')
         $lines.Add('  Select on `.key`. A bare grep for the key matches rows that merely MENTION')
         $lines.Add('  it - bead prose naming a deleted key has already been mistaken for the')

--- a/scripts/beads-checkpoint.sh
+++ b/scripts/beads-checkpoint.sh
@@ -493,6 +493,21 @@ bd export --include-memories > "$TMP_EXPORT" 2>/dev/null \
 TMP_HEAD=$(mktemp "${TMPDIR:-/tmp}/rf2-bdchk-head-XXXXXX")
 head_copy "$TMP_HEAD"
 
+# The commit TMP_HEAD was read from — captured HERE, beside the copy it names,
+# because the memory warning below prints it as a RECOVERY REFERENCE and this
+# script COMMITS the fresh export a hundred lines later (rf2-cve7, merged-PR
+# audit of #9520). Printing `HEAD` there is worse than useless: by the time an
+# operator reads the warning and pastes the command, `HEAD` IS the checkpoint
+# that just removed those rows, so the lookup exits 0 and prints nothing —
+# succeeding, and recovering nothing.
+#
+# A full commit oid is content-addressed and immutable, so it keeps naming this
+# exact tree after the checkpoint commits and after any number of later commits
+# land on top; `HEAD` is a symbolic ref re-resolved at read time and does not.
+# Empty on an unborn branch (a first-ever checkpoint), where there is no
+# baseline to recover from and the recovery paragraph is skipped.
+BASELINE_COMMIT=$(git rev-parse --verify HEAD 2>/dev/null || printf '')
+
 export_rows=$(rows "$TMP_EXPORT")
 head_rows=$(rows "$TMP_HEAD")
 
@@ -578,10 +593,23 @@ if [ -n "$MEMORY_FACTS" ]; then
   printf '\n  THIS IS A WARNING, NOT A REFUSAL — the checkpoint continues and commits\n' >&2
   printf '  the export. The database is the source of truth, and this may well be a\n' >&2
   printf '  deliberate `bd forget` or a retention cull. If it is NOT, the rows are not\n' >&2
-  printf '  lost: HEAD still carries every one of them, and so does any earlier\n' >&2
-  printf '  checkpoint commit.\n' >&2
-  printf '\n      git show HEAD:%s \\\n' "$TRACKER" >&2
-  printf '        | jq -r --arg k "<key>" '"'"'select(._type=="memory" and .key==$k)|.value'"'"'\n' >&2
+  if [ -n "$BASELINE_COMMIT" ]; then
+    printf '  lost. The commit this export was compared against still carries every\n' >&2
+    printf '  one of them, and this is the lookup:\n' >&2
+    printf '\n      git show %s:%s \\\n' "$BASELINE_COMMIT" "$TRACKER" >&2
+    printf '        | jq -r --arg k "<key>" '"'"'select(._type=="memory" and .key==$k)|.value'"'"'\n' >&2
+    printf '\n  THAT COMMIT IS SPELLED OUT RATHER THAN `HEAD` ON PURPOSE. This checkpoint\n' >&2
+    printf '  commits the export a moment from now, so by the time you read this `HEAD`\n' >&2
+    printf '  is the commit that REMOVED the rows: the same lookup against it would exit\n' >&2
+    printf '  0 and print nothing — succeeding, and recovering nothing. A full commit oid\n' >&2
+    printf '  is immutable, so it stays valid after this commit and every later one.\n' >&2
+    printf '\n  Older checkpoints are NOT a general fallback — one made before a key was\n' >&2
+    printf '  created does not carry it. To find the commit where any single key changed:\n' >&2
+    printf '\n      git log -S'"'"'"key":"<key>"'"'"' -- %s\n' "$TRACKER" >&2
+  else
+    printf '  lost — but this is a first-ever checkpoint with no commit behind it, so\n' >&2
+    printf '  there is no baseline to recover from. The database is the only copy.\n' >&2
+  fi
   printf '\n  Select on `.key`. A bare grep for the key matches rows that merely MENTION\n' >&2
   printf '  it — bead prose naming a deleted key has already been mistaken for the\n' >&2
   printf '  memory itself (rf2-cve7, CLAUDE.md instrument item (f)).\n\n' >&2

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -1782,6 +1782,12 @@ esac
 # went missing. 8m therefore asserts BOTH halves — it warns, AND it commits.
 # 8p is the no-false-positive case, and it matters more than the rest: a warning
 # that fires on ordinary forward motion is one the loop learns to scroll past.
+#
+# AND THE WARNING'S RECOVERY COMMAND MUST RECOVER. 8m's second half runs the
+# emitted lookup AFTER the checkpoint has committed, because that is the only
+# moment that grades what the operator experiences — and the first version of
+# this warning failed exactly there, printing a `HEAD` reference that the
+# checkpoint's own commit invalidated a few lines later.
 # ----------------------------------------------------------------------------
 {
   awk 'BEGIN{for(i=1;i<=20;i++) printf "{\"_type\":\"issue\",\"id\":\"rf2-m%02d\",\"status\":\"open\",\"updated_at\":\"2026-09-01T00:00:00Z\"}\n", i}'
@@ -1850,6 +1856,84 @@ case "$out" in
   *) fail "(8m) the memory reconciliation REFUSED the checkpoint ($out); it must only warn"
      cat "$CERR" >&2 ;;
 esac
+
+# 8m, second half: THE PRINTED RECOVERY COMMAND MUST ACTUALLY RECOVER (rf2-cve7,
+# merged-PR audit of #9520).
+#
+# The warning above is correct and fires correctly. Its recovery instruction was
+# not: it printed `git show HEAD:.beads/issues.jsonl`, and the checkpoint COMMITS
+# the export a few lines after printing it. By the time an operator reads the
+# message and pastes the command, `HEAD` IS the commit that removed the rows, so
+# the lookup exits 0 and prints NOTHING — the worst available failure shape for a
+# recovery instruction, because success and total failure are the same exit code
+# and the same empty output.
+#
+# So the assertions below run the emitted command AFTER the checkpoint has
+# committed, which is the only moment that grades what the operator experiences.
+# The HEAD-form control beside them is what makes the pass mean something: it
+# reproduces the defect in the same repo, in the same breath, so a printed
+# reference that recovers cannot be credited to the deletion never having
+# happened.
+mem_value_at() {
+  # $1 = commit-ish, $2 = key. jq where it exists — that is literally the
+  # emitted pipeline — and a fixed-shape row read where it does not, since the
+  # claim under test is that the REFERENCE still resolves, not that jq is
+  # installed. Both arms return the memory's `value` and nothing else.
+  if command -v jq >/dev/null 2>&1; then
+    git -C "$CREPO" show "$1:.beads/issues.jsonl" 2>/dev/null \
+      | jq -r --arg k "$2" 'select(._type=="memory" and .key==$k)|.value'
+  else
+    git -C "$CREPO" show "$1:.beads/issues.jsonl" 2>/dev/null \
+      | sed -n 's/^{"_type":"memory","key":"'"$2"'","value":"\([^"]*\)"}$/\1/p'
+  fi
+}
+
+rec_lines=$(grep -c '^ *git show ' "$CERR" || :)
+rec_ref=$(sed -n 's/^ *git show \([^:]*\):.*/\1/p' "$CERR" | sed -n '1p')
+if [ "$rec_lines" != "1" ]; then
+  fail "(8m) expected exactly one recovery lookup in the warning, found $rec_lines"
+  cat "$CERR" >&2
+elif [ -z "$rec_ref" ] || [ "$rec_ref" = "HEAD" ]; then
+  fail "(8m) the recovery lookup names '$rec_ref', a MOVING reference; the checkpoint commits below it"
+  cat "$CERR" >&2
+elif [ "$rec_ref" != "$before" ]; then
+  fail "(8m) the recovery lookup names $rec_ref, not the pre-checkpoint commit $before"
+  cat "$CERR" >&2
+else
+  pass "(8m) the recovery lookup names the immutable pre-checkpoint commit, not \`HEAD\`"
+fi
+
+recovered=$(mem_value_at "${rec_ref:-HEAD}" mem-key-03)
+if [ "$recovered" = "body 3" ]; then
+  pass "(8m) and running it AFTER the checkpoint committed recovers the deleted value"
+else
+  fail "(8m) the emitted recovery lookup returned '$recovered', not the deleted value 'body 3'"
+fi
+
+# The control, and it is the whole reason the assertion above is meaningful:
+# the command the script USED to print returns nothing at this exact point.
+head_recovered=$(mem_value_at HEAD mem-key-03)
+if [ -z "$head_recovered" ]; then
+  pass "(8m) while the same lookup against \`HEAD\` recovers nothing — the defect this pins"
+else
+  fail "(8m) the HEAD-form control returned '$head_recovered'; the fixture no longer models the defect"
+fi
+
+# And later commits must not invalidate it. A commit oid is content-addressed,
+# so this holds by construction — but "by construction" is what the HEAD form
+# looked like too, so it is asserted rather than assumed.
+(
+  cd "$CREPO"
+  printf 'a later commit, unrelated to the tracker\n' > later.txt
+  git add -- later.txt
+  git commit -q -m 'a later commit lands on top of the checkpoint'
+) >/dev/null 2>&1
+recovered_later=$(mem_value_at "${rec_ref:-HEAD}" mem-key-03)
+if [ "$recovered_later" = "body 3" ]; then
+  pass "(8m) and a further commit on top does not invalidate the printed reference"
+else
+  fail "(8m) after one more commit the printed reference returned '$recovered_later', not 'body 3'"
+fi
 
 # 8o: A ROW OF AN UNKNOWN `_type` IS REPORTED. This is the "two populations sum
 # to the row count" half of the bead. It cannot detect the deletion above — the


### PR DESCRIPTION
## What

PR #9520 added a memory-reconciliation warning to the checkpoint. The warning is correct and fires correctly. **Its printed recovery instruction does not work**, and this completes it.

It printed

    git show HEAD:.beads/issues.jsonl | jq -r --arg k "<key>" 'select(._type=="memory" and .key==$k)|.value'

and asserted that `HEAD`, and any earlier checkpoint, still carried the deleted rows. Both halves are wrong by the time an operator can act on them.

1. **The checkpoint COMMITS the fresh export a hundred lines after printing that message.** By the time a human reads it and pastes the command, `HEAD` *is* the checkpoint that just removed those rows. The lookup exits 0 and prints nothing — it succeeds and recovers nothing, which is the worst available failure shape for a recovery instruction: success and total failure share an exit code and an empty stdout.
2. **"any earlier checkpoint commit" is too broad.** A checkpoint predating a key's creation does not carry it.

## The change

Both scripts now capture the commit their HEAD copy was read from — beside the `head_copy` / `Write-HeadCopy` call that reads it, so the captured oid and the compared bytes cannot drift apart — and print that full 40-character oid in place of `HEAD`. A commit oid is content-addressed, so it keeps naming the same tree after this checkpoint commits and after any number of later commits land on top; `HEAD` is a symbolic ref re-resolved at read time and does not.

The over-broad sentence is replaced by the `git log -S'"key":"<key>"' -- .beads/issues.jsonl` pickaxe — the route that actually found the two recoverable keys on 2026-09-08.

The unborn-branch case (a first-ever checkpoint, no commit behind it) prints an honest "there is no baseline to recover from" instead of a broken reference. In the `.ps1` the probe is wrapped in try/catch because `$ErrorActionPreference` is `Stop` and pwsh 7.4+ turns a native command's non-zero exit into a terminating error.

**The warn-only, continue-and-commit policy is UNCHANGED and deliberate.** A refusal here could halt the mayor loop, which is why it was built that way. This is not a strict mode, not a new subsystem, not a change to retention policy. Nothing else about the guard moves.

## Coverage

`8m` in `scripts/git-hooks/test-pre-commit.sh` and `T7` in the `.ps1` `-SelfTest` now, **after the checkpoint has committed** — the only moment that grades what the operator experiences:

- assert the printed reference equals the captured pre-checkpoint commit and is not `HEAD`;
- run the emitted lookup and assert it returns the deleted value `body 3`;
- run the same lookup against `HEAD` and assert it recovers **nothing** — the control that reproduces the defect in the same repo in the same breath, so a passing recovery cannot be credited to the deletion never having happened;
- land one further unrelated commit on top and assert the printed reference still resolves.

## Quality gates

| gate | captured exit | result |
|---|---|---|
| `sh scripts/git-hooks/test-pre-commit.sh` | 0 | **135 passed / 0 failed** |
| `powershell -File scripts/beads-checkpoint.ps1 -SelfTest` | 0 | all cases passed |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 | pass |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 | pass |

135 reconciles against trunk's 131: four new assertions in `8m`. The shell harness is the real CI gate here — `test.yml`'s `beads-pr-boundary` job, step *Self-test the beads + mayor commit guards*, whose layer 8 drives `beads-checkpoint.sh` against a stub `bd`.

**No automated gate covers the `.ps1`** — layer 8 is POSIX sh and cannot run it — so its `-SelfTest` is the only proof for that arm and was run by hand, exit 0, with the five new T7 assertions passing.

`check_doc_slugs.py` and `mkdocs` are deliberately **not** nominated: `scripts/` is outside the roots of both.

Not re-run after the rebase: the only thing it brought in was a `.beads/issues.jsonl` checkpoint, which cannot reach this diff.

## Sabotage proof

Planted the exact landed defect — the printed reference reverted to `HEAD` — at `scripts/beads-checkpoint.sh:599`. Match count **1**; blob `a4cb7512124ce3917721211919649e012c9b8c9c` -> `d954acac26fabb920b6bd5fd0d188fc5a0982aac`, so the plant was not a silent no-op. (A first `perl -i -pe` attempt *was* a silent no-op — same blob, exit 0 — and the hash is what caught it.)

Gate went **RED at captured exit 1, 132 passed / 3 failed**, all three naming the case:

    FAIL  (8m) the recovery lookup names 'HEAD', a MOVING reference; the checkpoint commits below it
    FAIL  (8m) the emitted recovery lookup returned '', not the deleted value 'body 3'
    FAIL  (8m) after one more commit the printed reference returned '', not 'body 3'

Note the empty string in the second and third: that is the defect's signature — the lookup succeeded and recovered nothing.

Restored with `git checkout HEAD --` and verified by `git hash-object` against the committed blob: `a4cb7512124ce3917721211919649e012c9b8c9c` on both sides, identical, tree clean.

## Independent reproduction

Against isolated scratch repos with a stub `bd` (the real tracker database was never written): baseline 20 issues + 10 memories, export drops two keys at 28/30 rows — under the 10% refusal floor. Pre-fix, the printed `HEAD` lookup after the checkpoint exits 0 with 0 bytes; post-fix, the printed sha returns `body 3`, and still does after a further commit lands.

Closes nothing — rf2-cve7 stays open for the operator to dispose.
