### PR TITLE
fix(beads): read the checkpoint baseline through one resolved snapshot

### DIFF
--- a/scripts/beads-checkpoint.ps1
+++ b/scripts/beads-checkpoint.ps1
@@ -145,11 +145,34 @@ function Get-RowCount {
     return $n
 }
 
-# Write HEAD's copy of the tracker to $Path; an empty file if the tracker does
-# not exist at HEAD (a first-ever checkpoint).
+# Resolve git ONCE, to a full path, for the same reason `bd` is resolved that
+# way below: CreateProcess's own PATH search appends only .exe, so a `git.cmd`
+# ahead of git.exe would be found by PowerShell's `& git` and NOT by
+# Process.Start. The baseline capture and the comparison copy are ONE snapshot
+# (see the checkpoint path below) and they run through those two different
+# launchers, so they must resolve to the same binary. `-CommandType Application`
+# skips a `git` function or alias from an operator profile, which has no
+# `.Source` to hand Process.Start. Falls back to the bare name, i.e. to today's
+# behaviour, if resolution finds nothing.
+$gitExe = 'git'
+$gitCmd = @(Get-Command git -CommandType Application -ErrorAction SilentlyContinue)
+if ($gitCmd.Count -gt 0 -and $gitCmd[0].Source) { $gitExe = $gitCmd[0].Source }
+
+# Write $Ref's copy of the tracker to $Path (default HEAD); an empty file if the
+# tracker does not exist there (a first-ever checkpoint, or an unborn branch).
+#
+# THE REF PARAMETER IS THE FIX (rf2-cve7, merged-PR audit of #9524), not an
+# ergonomic flourish. The caller prints a commit oid as a RECOVERY REFERENCE,
+# and a helper that re-resolves `HEAD` for itself makes that oid a SEPARATE READ
+# of a moving branch: a commit landing in the shared checkout between the two
+# reads leaves the guard comparing commit A's bytes while printing commit B's
+# oid, and B never carried the values the operator is told to recover. Adjacent
+# calls are not one snapshot - the drift reproduces deterministically with a
+# single commit in the gap. Pass the resolved oid and the two cannot disagree.
+# `${Ref}:` needs the braces: a bare `$Ref:` parses as a scope qualifier.
 function Write-HeadCopy {
-    param([string]$Path)
-    $code = Invoke-RawToFile -Exe 'git' -Arguments @('show', "HEAD:$tracker") -OutFile $Path
+    param([string]$Path, [string]$Ref = 'HEAD')
+    $code = Invoke-RawToFile -Exe $gitExe -Arguments @('show', "${Ref}:$tracker") -OutFile $Path
     if ($code -ne 0) {
         [System.IO.File]::WriteAllText($Path, '', (New-Object System.Text.UTF8Encoding $false))
     }
@@ -865,6 +888,162 @@ if ($SelfTest) {
     Assert-True ((Get-MemoryValueAt -Ref $lookupRef -Key 'mem-key-03') -eq 'body 3') `
                 'T7 and a further commit on top does not invalidate the printed reference'
 
+    # -----------------------------------------------------------------------
+    # T7, third arm: A CONCURRENT COMMIT BETWEEN THE CAPTURE AND THE COPY
+    # (rf2-cve7, merged-PR audit of #9524).
+    #
+    # The arm above proves the printed reference is IMMUTABLE. It cannot prove
+    # it is the RIGHT object, because in a quiet repo every reading of `HEAD`
+    # returns the same oid, so a script that reads it twice looks identical to
+    # one that reads it once. The first fix did read it twice - Write-HeadCopy
+    # ran its own `git show HEAD:`, and the rev-parse below it was a SECOND
+    # read - and its comment asserted that adjacency made them one snapshot. It
+    # does not. This is the mayor's SHARED checkout: a second checkpoint or an
+    # ordinary commit lands in that gap, and then the guard compares commit A's
+    # bytes while printing commit B's oid. B never carried the values the
+    # message tells the operator to recover, so the printed lookup exits 0 and
+    # prints nothing - the same reassuring failure #9520 removed, one step on.
+    #
+    # THE SEAM. A `git.cmd` ahead of the real git on the CHILD's PATH, firing
+    # once, immediately after the checkpoint's first read of the tracker at
+    # HEAD - whichever of the two reads that turns out to be. Keying it on "the
+    # first of the pair" is what lets ONE fixture grade BOTH shapes. The script
+    # under test is NOT modified; a permanent case that patched its own subject
+    # would drift away from it.
+    #
+    # THE SHIM REACHES BOTH READS ONLY BECAUSE THE SCRIPT RESOLVES git ONCE.
+    # `& git` is PowerShell's resolution and finds a .cmd; Process.Start's PATH
+    # search appends only .exe and would not. Write-HeadCopy therefore launches
+    # the resolved $gitExe, exactly as the bd call does and for the same
+    # documented reason - which is also what stops the two reads resolving to
+    # two different binaries in the field.
+    #
+    # THE FIXTURE, which is the audit's own:
+    #   A  the baseline commit          30 rows = 20 issues + 10 memories
+    #   B  the concurrent commit        28 rows, mem-key-03 and mem-key-07 culled
+    #   E  this checkpoint's export     29 rows, B's rows plus a new mem-key-11
+    # E is B plus a row rather than B exactly, so this checkpoint has something
+    # to commit on top of B - `git commit` on an empty diff fails, and the case
+    # would then red for the wrong reason. Against A, E is still missing 03 and
+    # 07, so the warning fires with the same two keys the arms above use.
+    #
+    # WHAT EACH SHAPE PRODUCES:
+    #   fixed      oid A, bytes A  -> warns, prints A, and A recovers `body 3`
+    #   two reads  oid B, bytes A  -> warns, prints B, and B recovers NOTHING
+    #   reversed   oid A, bytes B  -> E matches B on memories, so no warning
+    # The negative control is B specifically, not merely `HEAD`: the question is
+    # not "did it print something immutable" but "did it print the object whose
+    # bytes it actually compared".
+    # -----------------------------------------------------------------------
+    $raceHeadBefore = @(Get-HeadTracker -split "`n")
+    $realGitCmd = @(Get-Command git -CommandType Application -ErrorAction SilentlyContinue)
+    $realGit = if ($realGitCmd.Count -gt 0) { $realGitCmd[0].Source } else { 'git' }
+    $seamBin = Join-Path $box 'seam-bin'
+    New-Item -ItemType Directory -Force -Path $seamBin | Out-Null
+    $armFile = Join-Path $box 'seam-armed'
+    $raceLedger = Join-Path $box 'race-concurrent.jsonl'
+    # CRLF, and written whole: cmd.exe mis-parses a parenthesised block in an
+    # LF-only batch file, and this shim is nothing but such a block.
+    $seamLines = @(
+        '@echo off',
+        'setlocal EnableDelayedExpansion',
+        'set "RF2ARGS=%*"',
+        'set "RF2FIRE="',
+        'echo(!RF2ARGS!| findstr /C:"rev-parse --verify" >nul 2>&1 && set "RF2FIRE=1"',
+        'echo(!RF2ARGS!| findstr /C:":.beads/issues.jsonl" >nul 2>&1 && set "RF2FIRE=1"',
+        ('if defined RF2FIRE if exist "' + $armFile + '" ('),
+        ('  "' + $realGit + '" %*'),
+        '  set RF2ST=!ERRORLEVEL!',
+        ('  del "' + $armFile + '" >nul 2>&1'),
+        ('  copy /y "' + $raceLedger + '" "' + (Join-Path $repo '.beads\issues.jsonl') + '" >nul 2>&1'),
+        ('  "' + $realGit + '" -C "' + $repo + '" add -- .beads/issues.jsonl >nul 2>&1'),
+        ('  "' + $realGit + '" -C "' + $repo + '" commit -q -m "a concurrent checkpoint lands between the two reads" >nul 2>&1'),
+        '  exit /b !RF2ST!',
+        ')',
+        ('"' + $realGit + '" %*'),
+        'exit /b %ERRORLEVEL%'
+    )
+    [System.IO.File]::WriteAllText((Join-Path $seamBin 'git.cmd'),
+                                   (($seamLines -join "`r`n") + "`r`n"),
+                                   (New-Object System.Text.UTF8Encoding $false))
+
+    # A: the baseline this checkpoint will compare against and must name.
+    Write-Rows -Path (Join-Path $repo '.beads/issues.jsonl') -Rows $memHead
+    & git -C $repo add -- '.beads/issues.jsonl' | Out-Null
+    & git -C $repo commit -q -m 'seed: 20 issues and 10 memories, ahead of the race' | Out-Null
+    $raceA = Get-HeadSha
+
+    # B: what the racing process commits. E: what this checkpoint exports.
+    Write-Rows -Path $raceLedger -Rows $memCulled
+    Write-Rows -Path $dbPath -Rows ($memCulled +
+        @('{"_type":"memory","key":"mem-key-11","value":"a new lesson"}'))
+
+    [System.IO.File]::WriteAllText($armFile, '', (New-Object System.Text.UTF8Encoding $false))
+    $savedPath = $env:PATH
+    $env:PATH = "$seamBin;$env:PATH"
+    try { $code = Invoke-Child @() } finally { $env:PATH = $savedPath }
+    $err = Get-ChildErr
+    $seamFired = -not (Test-Path -LiteralPath $armFile)
+    Remove-Item -LiteralPath $armFile -Force -ErrorAction SilentlyContinue
+
+    # The seam has to have fired, or every assertion below passes vacuously.
+    $raceB = ''
+    $raceBSubject = ''
+    try {
+        $probe = (& git -C $repo rev-parse 'HEAD~1' 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $probe) { $raceB = ([string]$probe).Trim() }
+    } catch { $raceB = '' }
+    if ($raceB) {
+        try { $raceBSubject = ([string](& git -C $repo log -1 --format=%s $raceB)).Trim() }
+        catch { $raceBSubject = '' }
+    }
+    Assert-True ($seamFired -and $raceB -and $raceB -ne $raceA -and
+                 $raceBSubject -eq 'a concurrent checkpoint lands between the two reads') `
+                'T7 the seam landed a concurrent commit between the capture and the copy' `
+                "fired=$seamFired raceA=$raceA raceB=$raceB subject='$raceBSubject'"
+
+    Assert-True ($code -eq 0) 'T7 the racing checkpoint still warns-and-commits' "exit $code : $err"
+    Assert-True (($err -match 'MEMORY RECONCILIATION FAILED') -and
+                 ($err -match 'mem-key-03') -and ($err -match 'mem-key-07')) `
+                'T7 a concurrent commit does not stop the warning naming the lost keys' $err
+
+    $raceRefs = @([regex]::Matches($err, '(?m)^\s*git show (\S+?):') |
+                  ForEach-Object { $_.Groups[1].Value })
+    $raceRef = if ($raceRefs.Count -gt 0) { $raceRefs[0] } else { '' }
+    Assert-True ($raceRef -eq $raceA) `
+                'T7 and it prints the commit it COMPARED against, not the one that raced it' `
+                "printed '$raceRef', compared baseline '$raceA', racer '$raceB'"
+
+    # The populations the warning reports for HEAD must be the populations at
+    # the commit it printed. This grades the pairing itself rather than the oid:
+    # bytes from one snapshot described under another's name IS the drift.
+    if ($raceRef) {
+        $refRows = @()
+        try { $refRows = @(& git -C $repo show "${raceRef}:.beads/issues.jsonl" 2>$null) }
+        catch { $refRows = @() }
+        $refIss = @($refRows | Where-Object { $_ -match '"_type":"issue"' }).Count
+        $refMem = @($refRows | Where-Object { $_ -match '"_type":"memory"' }).Count
+        $want = "HEAD    $($refRows.Count) rows = $refIss issues + $refMem memories"
+        Assert-True ($err -match [regex]::Escape($want)) `
+                    "T7 and the populations it reports are the ones at that very commit ($($refRows.Count) rows)" `
+                    "expected '$want'"
+    }
+
+    Assert-True ((Get-MemoryValueAt -Ref (&{ if ($raceRef) { $raceRef } else { 'HEAD' } }) -Key 'mem-key-03') -eq 'body 3') `
+                'T7 and the emitted lookup still recovers the deleted value through the race'
+
+    # THE NEGATIVE CONTROL, and it is the racer rather than `HEAD`: this is the
+    # oid the two-reads shape printed, and it recovers nothing.
+    Assert-True (((Get-MemoryValueAt -Ref $raceB -Key 'mem-key-03') -eq '') -and
+                 ((Get-MemoryValueAt -Ref 'HEAD' -Key 'mem-key-03') -eq '')) `
+                'T7 while the racing commit - the oid the two-reads shape printed - recovers nothing'
+
+    # Put HEAD's tracker back exactly as T8 and T9 found it, so this arm is an
+    # addition to the group rather than a change of their inputs.
+    Write-Rows -Path (Join-Path $repo '.beads/issues.jsonl') -Rows $raceHeadBefore
+    & git -C $repo add -- '.beads/issues.jsonl' | Out-Null
+    & git -C $repo commit -q -m 'restore: the tracker as it stood before the race arm' | Out-Null
+
     # T8 - a row of an unknown `_type` is reported. This is the "two populations
     # sum to the row count" half of the bead. It cannot detect the deletion
     # above - the identity holds trivially whenever every row is one of the two
@@ -992,29 +1171,46 @@ try {
         Die "bd export failed (exit $code); leaving $tracker untouched."
     }
 
-    Write-HeadCopy -Path $tmpHead
-    # The commit $tmpHead was read from - captured HERE, beside the copy it
-    # names, because the memory warning below prints it as a RECOVERY REFERENCE
-    # and this script COMMITS the fresh export a hundred lines later (rf2-cve7,
-    # merged-PR audit of #9520). Printing `HEAD` there is worse than useless: by
-    # the time an operator reads the warning and pastes the command, `HEAD` IS
-    # the checkpoint that just removed those rows, so the lookup exits 0 and
-    # prints nothing - succeeding, and recovering nothing.
+    # THE BASELINE SNAPSHOT. Resolved ONCE, and resolved FIRST - every read of
+    # the tracker-at-HEAD below goes through this one oid, so the bytes this
+    # checkpoint compares against and the oid it prints are the same object by
+    # construction.
     #
-    # A full commit oid is content-addressed and immutable, so it keeps naming
-    # this exact tree after the checkpoint commits and after any number of later
-    # commits land on top; `HEAD` is a symbolic ref re-resolved at read time and
-    # does not. Empty on an unborn branch (a first-ever checkpoint), where there
-    # is no baseline to recover from and the recovery paragraph is skipped.
-    # --quiet keeps git silent on an unborn branch, and the try/catch is
-    # load-bearing rather than defensive: $ErrorActionPreference is 'Stop' here,
-    # and pwsh 7.4+ turns a native command's non-zero exit into a terminating
-    # error, so the unborn-branch case would abort the whole checkpoint.
+    # WHY IT IS PRINTED AT ALL (rf2-cve7, merged-PR audit of #9520). The memory
+    # warning below prints it as a RECOVERY REFERENCE, and this script COMMITS
+    # the fresh export a hundred lines later. Printing `HEAD` there is worse
+    # than useless: by the time an operator reads the warning and pastes the
+    # command, `HEAD` IS the checkpoint that just removed those rows, so the
+    # lookup exits 0 and prints nothing - succeeding, and recovering nothing. A
+    # full commit oid is content-addressed and immutable, so it keeps naming
+    # this exact tree after the checkpoint commits and after every later one.
+    #
+    # WHY IT IS RESOLVED BEFORE THE COPY, AND PASSED IN (rf2-cve7, merged-PR
+    # audit of #9524). The first version of this captured the oid immediately
+    # AFTER Write-HeadCopy, on the reasoning that adjacent statements cannot
+    # drift. They can: those were two separate reads of a moving branch, and
+    # this is the mayor's SHARED checkout, where a second checkpoint or an
+    # ordinary commit can land in the gap. When one does, the guard compares
+    # commit A's bytes and prints commit B's oid - and B never contained the
+    # values the message tells the operator to recover. Moving this up while
+    # leaving Write-HeadCopy to resolve `HEAD` for itself would REVERSE that
+    # race, not close it; both reads have to come from this one oid.
+    #
+    # Empty on an unborn branch (a first-ever checkpoint), where there is no
+    # baseline to recover from and the recovery paragraph is skipped; the copy
+    # then falls back to `HEAD`, which fails the same way and yields the same
+    # empty comparison file. --quiet keeps git silent there, and the try/catch
+    # is load-bearing rather than defensive: $ErrorActionPreference is 'Stop'
+    # here, and pwsh 7.4+ turns a native command's non-zero exit into a
+    # terminating error, so the unborn-branch case would abort the checkpoint.
     $baselineCommit = ''
     try {
-        $probe = (& git rev-parse --verify --quiet HEAD 2>$null)
+        $probe = (& $gitExe rev-parse --verify --quiet HEAD 2>$null)
         if ($LASTEXITCODE -eq 0 -and $probe) { $baselineCommit = ([string]$probe).Trim() }
     } catch { $baselineCommit = '' }
+
+    $baselineRef = if ($baselineCommit) { $baselineCommit } else { 'HEAD' }
+    Write-HeadCopy -Path $tmpHead -Ref $baselineRef
 
     $exportRows = Get-RowCount -Path $tmpExport
     $headRows   = Get-RowCount -Path $tmpHead

--- a/scripts/beads-checkpoint.sh
+++ b/scripts/beads-checkpoint.sh
@@ -158,10 +158,21 @@ rows() {
   awk 'END{print NR}' "$1"
 }
 
-# head_copy PATH — write HEAD's copy of the tracker to PATH. Empty file if the
-# path does not exist at HEAD (a first-ever checkpoint).
+# head_copy PATH [REF] — write REF's copy of the tracker to PATH; REF defaults
+# to HEAD. Empty file if the path does not exist there (a first-ever checkpoint,
+# or an unborn branch).
+#
+# THE REF ARGUMENT IS THE FIX (rf2-cve7, merged-PR audit of #9524), not an
+# ergonomic flourish. The caller below prints a commit oid as a RECOVERY
+# REFERENCE, and a helper that re-resolves `HEAD` for itself makes that oid a
+# SEPARATE READ of a moving branch: a commit landing in the shared checkout
+# between the two reads leaves the guard comparing commit A's bytes while
+# printing commit B's oid, and B never carried the values the operator is told
+# to recover. Adjacent calls are not one snapshot — the drift reproduces
+# deterministically with a single commit in the gap. Pass the resolved oid and
+# the two cannot disagree.
 head_copy() {
-  git show "HEAD:$TRACKER" > "$1" 2>/dev/null || : > "$1"
+  git show "${2:-HEAD}:$TRACKER" > "$1" 2>/dev/null || : > "$1"
 }
 
 # minimal_diff_rewrite EXPORT HEAD_COPY OUT — write EXPORT's rows to OUT, but
@@ -490,23 +501,40 @@ TMP_EXPORT=$(mktemp "${TMPDIR:-/tmp}/rf2-bdchk-export-XXXXXX")
 bd export --include-memories > "$TMP_EXPORT" 2>/dev/null \
   || die "bd export failed; leaving $TRACKER untouched."
 
-TMP_HEAD=$(mktemp "${TMPDIR:-/tmp}/rf2-bdchk-head-XXXXXX")
-head_copy "$TMP_HEAD"
-
-# The commit TMP_HEAD was read from — captured HERE, beside the copy it names,
-# because the memory warning below prints it as a RECOVERY REFERENCE and this
-# script COMMITS the fresh export a hundred lines later (rf2-cve7, merged-PR
-# audit of #9520). Printing `HEAD` there is worse than useless: by the time an
-# operator reads the warning and pastes the command, `HEAD` IS the checkpoint
-# that just removed those rows, so the lookup exits 0 and prints nothing —
-# succeeding, and recovering nothing.
+# THE BASELINE SNAPSHOT. Resolved ONCE, and resolved FIRST — every read of the
+# tracker-at-HEAD below goes through this one oid, so the bytes this checkpoint
+# compares against and the oid it prints are the same object by construction.
 #
-# A full commit oid is content-addressed and immutable, so it keeps naming this
-# exact tree after the checkpoint commits and after any number of later commits
-# land on top; `HEAD` is a symbolic ref re-resolved at read time and does not.
+# WHY IT IS PRINTED AT ALL (rf2-cve7, merged-PR audit of #9520). The memory
+# warning below prints it as a RECOVERY REFERENCE, and this script COMMITS the
+# fresh export a hundred lines later. Printing `HEAD` there is worse than
+# useless: by the time an operator reads the warning and pastes the command,
+# `HEAD` IS the checkpoint that just removed those rows, so the lookup exits 0
+# and prints nothing — succeeding, and recovering nothing. A full commit oid is
+# content-addressed and immutable, so it keeps naming this exact tree after the
+# checkpoint commits and after any number of later commits land on top.
+#
+# WHY IT IS RESOLVED BEFORE THE COPY, AND PASSED IN (rf2-cve7, merged-PR audit
+# of #9524). The first version of this captured the oid immediately AFTER
+# `head_copy "$TMP_HEAD"`, on the reasoning that adjacent statements cannot
+# drift. They can: those were two separate reads of a moving branch, and this is
+# the mayor's SHARED checkout, where a second checkpoint or an ordinary commit
+# can land in the gap. When one does, the guard compares commit A's bytes and
+# prints commit B's oid — and B never contained the values the message tells the
+# operator to recover, so the printed lookup exits 0 and prints nothing. That is
+# the same reassuring failure the #9520 fix set out to remove, reached one step
+# further along. Moving the `rev-parse` up while leaving `head_copy` reading
+# `HEAD` for itself would REVERSE that race, not close it — both reads have to
+# come from this one oid, which is why it is an argument and not a comment.
+#
 # Empty on an unborn branch (a first-ever checkpoint), where there is no
-# baseline to recover from and the recovery paragraph is skipped.
+# baseline to recover from and the recovery paragraph is skipped; `head_copy`
+# then falls back to `HEAD`, which fails the same way and yields the same empty
+# comparison file.
 BASELINE_COMMIT=$(git rev-parse --verify HEAD 2>/dev/null || printf '')
+
+TMP_HEAD=$(mktemp "${TMPDIR:-/tmp}/rf2-bdchk-head-XXXXXX")
+head_copy "$TMP_HEAD" "${BASELINE_COMMIT:-HEAD}"
 
 export_rows=$(rows "$TMP_EXPORT")
 head_rows=$(rows "$TMP_HEAD")

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -1935,6 +1935,184 @@ else
   fail "(8m) after one more commit the printed reference returned '$recovered_later', not 'body 3'"
 fi
 
+# ----------------------------------------------------------------------------
+# 8m, third arm: A CONCURRENT COMMIT BETWEEN THE CAPTURE AND THE COPY
+# (rf2-cve7, merged-PR audit of #9524).
+#
+# The arm above proves the printed reference is IMMUTABLE. It cannot prove it is
+# the RIGHT object, because in a quiet repo every reading of `HEAD` returns the
+# same oid, so a script that reads it twice looks identical to one that reads it
+# once. The first fix did read it twice — `head_copy` ran its own
+# `git show HEAD:`, and the `rev-parse` fifteen lines later was a SECOND read —
+# and its comment asserted that adjacency made them one snapshot. It does not.
+# This is the mayor's SHARED checkout: a second checkpoint or an ordinary commit
+# lands in that gap, and then the guard compares commit A's bytes while printing
+# commit B's oid. B never carried the values the message tells the operator to
+# recover, so the printed lookup exits 0 and prints nothing — the SAME
+# reassuring failure the #9520 fix removed, one step further along.
+#
+# THE SEAM. A `git` shim ahead of the real one on the child's PATH, firing ONCE,
+# immediately after the checkpoint's FIRST read of the tracker at HEAD —
+# whichever of the two reads that turns out to be. Keying it on "the first of the
+# pair" is what lets ONE fixture grade BOTH shapes: the fixed script resolves the
+# oid first and copies through it, the defective one copied the bytes first and
+# resolved after, and the concurrent commit lands between the pair either way.
+# The script under test is NOT modified — a permanent case that patched its own
+# subject would drift away from it.
+#
+# THE FIXTURE, which is the audit's own:
+#   A  the baseline commit          30 rows = 20 issues + 10 memories
+#   B  the concurrent commit        28 rows, mem-key-03 and mem-key-07 culled
+#   E  this checkpoint's export     29 rows, B's rows plus a new mem-key-11
+# E is B plus a row rather than B exactly, so this checkpoint has something to
+# commit on top of B — `git commit` on an empty diff fails, and the case would
+# then red for the wrong reason. Against A, E is still missing 03 and 07, so the
+# warning fires with the same two keys the arms above use.
+#
+# WHAT EACH SHAPE PRODUCES, and why the assertions are the ones below:
+#   fixed      oid A, bytes A  → warns, prints A, and A recovers `body 3`
+#   two reads  oid B, bytes A  → warns, prints B, and B recovers NOTHING
+#   reversed   oid A, bytes B  → E matches B exactly on memories, so it does not
+#                                warn at all, and the acceptance above reds
+# The negative control is therefore B specifically, not merely `HEAD`: the
+# question is not "did it print something immutable" but "did it print the
+# object whose bytes it actually compared".
+# ----------------------------------------------------------------------------
+race_head_before=$(git -C "$CREPO" show HEAD:.beads/issues.jsonl 2>/dev/null || true)
+
+REAL_GIT=$(command -v git)
+CSEAM="$CBOX/seam-bin"
+mkdir -p "$CSEAM"
+cat > "$CSEAM/git" <<EOF
+#!/usr/bin/env sh
+# Layer-8 race seam. Forwards every call to the real git untouched, and once —
+# while \$CBOX/seam-armed exists — lands an ordinary concurrent commit right
+# after the first read of the tracker at HEAD. Nothing is written to stdout, so
+# the forwarded \`git show\` still delivers the tracker bytes to its redirect.
+case "\$*" in
+  'rev-parse --verify HEAD'|'show '*':.beads/issues.jsonl')
+    if [ -f "$CBOX/seam-armed" ]; then
+      "$REAL_GIT" "\$@"
+      st=\$?
+      rm -f "$CBOX/seam-armed"
+      cp -f "$CBOX/race-concurrent.jsonl" "$CREPO/.beads/issues.jsonl"
+      "$REAL_GIT" -C "$CREPO" add -- .beads/issues.jsonl >/dev/null 2>&1
+      "$REAL_GIT" -C "$CREPO" commit -q -m 'a concurrent checkpoint lands between the two reads' >/dev/null 2>&1
+      exit \$st
+    fi ;;
+esac
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$CSEAM/git"
+
+run_checkpoint_seamed() {
+  d="$1"; shift
+  ( cd "$d" && PATH="$CSEAM:$CBIN:$PATH" sh scripts/beads-checkpoint.sh "$@" \
+      >"$COUT" 2>"$CERR" ) && echo "EXIT=0" || echo "EXIT=$?"
+}
+
+# A: the baseline this checkpoint will compare against and must name.
+(
+  cd "$CREPO"
+  cp -f "$CBOX/head-mem.jsonl" .beads/issues.jsonl
+  git add -- .beads/issues.jsonl
+  git commit -q -m 'seed: 20 issues and 10 memories, ahead of the race'
+) >/dev/null 2>&1
+race_a=$(git -C "$CREPO" rev-parse HEAD)
+
+# B: what the racing process commits. E: what this checkpoint exports.
+cp -f "$CBOX/db-mem-culled.jsonl" "$CBOX/race-concurrent.jsonl"
+{
+  cat "$CBOX/db-mem-culled.jsonl"
+  printf '{"_type":"memory","key":"mem-key-11","value":"a new lesson"}\n'
+} > "$CBOX/db-race.jsonl"
+cp -f "$CBOX/db-race.jsonl" "$CBOX/db.jsonl"
+
+: > "$CBOX/seam-armed"
+out=$(run_checkpoint_seamed "$CREPO")
+# `if`, not `[ ... ] && x`: under `set -e` an AND-list whose test fails takes the
+# whole script down, and the test failing here is the PASSING case.
+seam_fired=1
+if [ -f "$CBOX/seam-armed" ]; then seam_fired=0; fi
+rm -f "$CBOX/seam-armed"
+
+# The seam has to have fired, or every assertion below passes vacuously — this
+# is the control that stops the case grading a quiet repo.
+race_b=$(git -C "$CREPO" rev-parse HEAD~1 2>/dev/null || true)
+race_b_subject=$(git -C "$CREPO" log -1 --format=%s "${race_b:-HEAD}" 2>/dev/null || true)
+if [ "$seam_fired" = "1" ] && [ -n "$race_b" ] && [ "$race_b" != "$race_a" ] \
+   && [ "$race_b_subject" = "a concurrent checkpoint lands between the two reads" ]; then
+  pass "(8m) the seam landed a concurrent commit between the capture and the copy"
+else
+  fail "(8m) the race seam did not fire; every assertion below would pass vacuously"
+  printf 'seam_fired=%s race_a=%s race_b=%s subject=%s\n' \
+    "$seam_fired" "$race_a" "$race_b" "$race_b_subject" >&2
+fi
+
+case "$out" in
+  EXIT=0)
+    if grep -q 'MEMORY RECONCILIATION FAILED' "$CERR" \
+       && grep -q 'mem-key-03' "$CERR" && grep -q 'mem-key-07' "$CERR"; then
+      pass "(8m) a concurrent commit does not stop the warning naming the lost keys"
+    else
+      fail "(8m) with a commit racing the capture the warning was lost or renamed no keys"
+      cat "$CERR" >&2
+    fi ;;
+  *) fail "(8m) the racing checkpoint exited $out; it must still warn-and-commit"
+     cat "$CERR" >&2 ;;
+esac
+
+race_ref=$(sed -n 's/^ *git show \([^:]*\):.*/\1/p' "$CERR" | sed -n '1p')
+if [ "$race_ref" = "$race_a" ]; then
+  pass "(8m) and it prints the commit it COMPARED against, not the one that raced it"
+else
+  fail "(8m) the printed reference is '$race_ref'; the compared baseline was $race_a (the racer was $race_b)"
+  cat "$CERR" >&2
+fi
+
+# The populations the warning reports for HEAD must be the populations at the
+# commit it printed. This grades the pairing itself rather than the oid: bytes
+# from one snapshot described under another's name is precisely the drift.
+if [ -n "$race_ref" ]; then
+  ref_body=$(git -C "$CREPO" show "$race_ref:.beads/issues.jsonl" 2>/dev/null || true)
+  ref_rows=$(printf '%s\n' "$ref_body" | awk 'END{print NR}')
+  ref_iss=$(printf '%s\n' "$ref_body" | grep -c '"_type":"issue"' || :)
+  ref_mem=$(printf '%s\n' "$ref_body" | grep -c '"_type":"memory"' || :)
+  if grep -q "HEAD    $ref_rows rows = $ref_iss issues + $ref_mem memories" "$CERR"; then
+    pass "(8m) and the populations it reports are the ones at that very commit ($ref_rows rows)"
+  else
+    fail "(8m) the reported HEAD populations do not match the printed commit $race_ref"
+    cat "$CERR" >&2
+  fi
+fi
+
+race_recovered=$(mem_value_at "${race_ref:-HEAD}" mem-key-03)
+if [ "$race_recovered" = "body 3" ]; then
+  pass "(8m) and the emitted lookup still recovers the deleted value through the race"
+else
+  fail "(8m) the emitted lookup returned '$race_recovered' after the race, not 'body 3'"
+fi
+
+# THE NEGATIVE CONTROL, and it is the racer rather than `HEAD`: this is the oid
+# the two-reads shape printed, and it recovers nothing. A pass above that also
+# passed here would mean the fixture had stopped modelling the defect.
+race_b_recovered=$(mem_value_at "${race_b:-HEAD}" mem-key-03)
+race_head_recovered=$(mem_value_at HEAD mem-key-03)
+if [ -z "$race_b_recovered" ] && [ -z "$race_head_recovered" ]; then
+  pass "(8m) while the racing commit — the oid the two-reads shape printed — recovers nothing"
+else
+  fail "(8m) the controls recovered '$race_b_recovered' / '$race_head_recovered'; the fixture no longer models the defect"
+fi
+
+# Put HEAD's tracker back exactly as 8o and 8p found it, so this arm is an
+# addition to the group rather than a change of their inputs.
+(
+  cd "$CREPO"
+  printf '%s\n' "$race_head_before" > .beads/issues.jsonl
+  git add -- .beads/issues.jsonl
+  git commit -q -m 'restore: the tracker as it stood before the race arm'
+) >/dev/null 2>&1
+
 # 8o: A ROW OF AN UNKNOWN `_type` IS REPORTED. This is the "two populations sum
 # to the row count" half of the bead. It cannot detect the deletion above — the
 # identity holds trivially whenever every row is one of the two known types, so


### PR DESCRIPTION
Closes the audit residual from #9524 (rf2-cve7).

## The race

#9524 made the memory-loss warning print an immutable commit oid instead of `HEAD`, which closed the #9520 defect where the checkpoint's own commit invalidated the printed lookup a moment after printing it. It left a TOCTOU race behind it, and the close reason asserted the opposite.

`head_copy` ran its own `git show HEAD:$TRACKER`. The `rev-parse --verify HEAD` fifteen lines below it was a **second read of the same moving branch**. The comment beside it reasoned that capturing the oid "immediately after the head copy" meant the two could not drift apart. Adjacency is not identity: this is the mayor's shared checkout, where a second checkpoint or an ordinary commit lands in that gap. When one does, the guard compares commit A's bytes while printing commit B's oid — and B never carried the values the message tells the operator to recover, so the printed lookup exits 0 and prints nothing. That is the same reassuring failure #9520 set out to remove, reached one step further along.

The `.ps1` had the identical shape: `Write-HeadCopy` reading `HEAD`, `$baselineCommit` resolved after it.

## The fix

Resolve the baseline **once**, and **first**, and pass it to the helper's `git show`, so the bytes compared and the oid printed are one object by construction. `head_copy` / `Write-HeadCopy` take a ref (defaulting to `HEAD`), and the caller hands them the oid it has already resolved.

Moving `rev-parse` up alone would have **reversed** the race rather than closing it — the copy would then read the racer's bytes while the message named the older oid — which is why the ref is a parameter and not a comment. Both directions are pinned by the new tests.

Unchanged on purpose: the warning-only policy (no memory-triggered refusal path; the guard must never halt the mayor loop), the first-checkpoint / unborn-branch case that prints an honest "no baseline to recover from", `--pre-pull`, and the row floor, divergence and reconciliation guards themselves.

The `.ps1` now also resolves `git` once, to a full path, exactly as it already resolves `bd` and for the reason that file already documents: PowerShell's `& git` finds a `.cmd`, while `Process.Start`'s PATH search appends only `.exe`. The two halves of the snapshot pair run through those two different launchers, so they have to resolve to the same binary.

## Tests — a controlled HEAD advance between the capture and the copy

`8m` (layer 8, `scripts/git-hooks/test-pre-commit.sh`) and `T7` (`beads-checkpoint.ps1 -SelfTest`) each gain a race arm. The existing assertions are untouched; this is an extension.

The seam is a `git` shim ahead of the real one **on the child's PATH only** — the script under test is not modified, so the case cannot drift away from its subject. It fires once, immediately after the checkpoint's **first** read of the tracker at HEAD, whichever of the two reads that turns out to be. Keying it on "the first of the pair" is what lets one fixture grade both shapes.

Fixture (the audit's own): baseline `A` = 30 rows (20 issues + 10 memories); the racing commit `B` = 28 rows with `mem-key-03` and `mem-key-07` culled; this checkpoint's export = `B`'s rows plus a new `mem-key-11`, so the checkpoint still has something to commit on top of `B` and, against `A`, is still missing the same two keys.

Asserted: the seam really fired (a vacuous-pass control); the run still warns and still commits; the printed oid is the compared baseline and **not** the racer; the populations the warning reports for HEAD are the populations at the oid it printed; the emitted lookup still recovers `body 3` after the checkpoint has committed; and the racer's oid — the one the two-reads shape printed — recovers nothing.

## Quality gates

| gate | captured exit | result |
|---|---|---|
| `sh scripts/git-hooks/test-pre-commit.sh` | 0 | 141 passed, 0 failed (135 on base; +6) |
| `powershell -File scripts/beads-checkpoint.ps1 -SelfTest` | 0 | all cases passed (T7 +7) |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 | pass |
| `sh scripts/check-ai-tracking-ratchet.sh` | 0 | pass |
| `python scripts/check_view_lifetime_residue.py --verbose` | 0 | pass |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 | no beads-database paths in the diff |
| `sh scripts/check-commit-attribution.sh origin/main` | 0 | clean over the 1 commit this branch introduces |
| `sh scripts/check-commit-attribution.sh --pr-body` | 0 | clean over this body |

Every number above is the exit code captured beside the run's own log, not a harness summary.

`check_doc_slugs.py` and `mkdocs build --strict` are **not** nominated and do not cover this diff: `scripts/` is outside both their roots. `shellcheck` is not nominated either — `portability.yml` states in terms that its shellcheck step covers `.github/scripts/` only, and that scripts under `scripts/` are not yet shellcheck-clean.

**No automated gate covers `scripts/beads-checkpoint.ps1`** — layer 8 is POSIX sh, and `test.yml`'s `beads-pr-boundary` job drives only the shell harness. Its `-SelfTest` is the only proof for that arm and was run by hand, twice clean and twice red under plants.

## Sabotage

Each plant: match count read as exactly 1 before the run, blob hash recorded either side, restore verified against the committed object by `git hash-object`, gate re-run green. The plants were made **after** committing, so the restore is a `git checkout HEAD --` against a known object.

| plant | arm | captured exit | what went red |
|---|---|---|---|
| the race itself — restore the two-reads-of-HEAD shape | `.sh` | 1 | 138/3. Named the drift exactly: printed reference is the racer's oid, compared baseline is `A`, reported HEAD populations do not match the printed commit, emitted lookup returned an empty string rather than `body 3` |
| the same, on the PowerShell arm | `.ps1` | 1 | 3 FAILED, same three signatures |
| the wrong fix the audit names — `rev-parse` moved up, copy still reading `HEAD` | `.sh` | 1 | 137/3. Different signature: the reversed race makes the export match the racer's memories exactly, so the warning is **lost entirely** and no reference is printed at all |
| the same reversed fix | `.ps1` | 1 | 3 FAILED, same signature |

Blob hashes for the `.sh`: clean `4b02fcfcf2`, two-reads plant `5ee655c24b`, reversed plant `14914d8252`, restored `4b02fcfcf2` (byte-identical to clean). Blob hashes for the `.ps1`: clean `f7b7cea2af`, two-reads plant `03a104977c`, reversed plant `f24f3288b8`, restored `f7b7cea2af`. Those are blob hashes, not commit ids.

The PowerShell two-reads plant is also the positive evidence that the shim reached **both** git reads on that arm: in that shape the seam can only fire on the `git show`, and the "seam landed a concurrent commit" assertion passed. That is what the single git resolution buys.

## Found and deliberately not fixed

- **`--pre-pull` still re-resolves `HEAD` for its own comparison copy.** Left alone deliberately: it prints no oid, so there is no pairing to keep consistent, and its question really is "is the working file ahead of HEAD *now*".
- **The `.ps1`'s other `git` call sites** (`rev-parse --show-toplevel`, `worktree list`, the final `add`/`commit`) still go through PowerShell's own resolution. They are not part of the snapshot pair; converting them would be churn without a defect behind it.
- **No automated gate covers the `.ps1`**, as above. Pre-existing, unchanged by this PR, and not a new finding.
- **`scripts/*.sh` is outside the shellcheck roster.** `portability.yml` records this as a known separate cleanup with named codes; not touched here.
