### PR TITLE
fix(epoch): resolve the shared egress size axes once at the record boundary

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -1406,13 +1406,15 @@
   slot-by-slot, so an offset applied to each slot walk would be wrong.
 
   Read as a SELECTION, never as a floor (rf2-kuky.92): `select-keys` keeps
-  only the keys the caller ACTUALLY supplied, so a key the caller omitted
-  stays omitted and the profile's own floor stands. The previous form
-  spelled two of them `(boolean …)`, which forced them PRESENT AND FALSE
-  on every call and so overrode the floor — invisible under the five
-  fail-closed profiles, whose floor is false anyway, but it silently
-  defeated `:rf.egress/local-raw`, the one profile whose floor opts
-  sensitive and large back IN."
+  only the keys PRESENT on the opts it is handed, and it is handed opts the
+  record boundary has already floor-resolved (`resolve-shared-size-axes`), so
+  the three shared axes arrive carrying the profile's own answer. Re-resolving
+  them downstream is therefore idempotent — `project-egress` merges the same
+  floor under the same values. The previous form spelled two of them
+  `(boolean …)`, which forced them PRESENT AND FALSE on every call and so
+  overrode the floor — invisible under the five fail-closed profiles, whose
+  floor is false anyway, but it silently defeated `:rf.egress/local-raw`, the
+  one profile whose floor opts sensitive and large back IN."
   [:rf.size/include-sensitive?
    :rf.size/include-large?
    :rf.size/include-digests?
@@ -1429,10 +1431,12 @@
 
   The resolved profile is the FLOOR and the caller's explicit `:rf.size/*`
   booleans OVERLAY it (the override wins — see
-  `re-frame.projection/resolve-elision-opts`). Only the keys the caller
-  supplied are overlaid (`walker-overlay-keys`). ONE spelling for the two
-  shared axes: these were read here in the bare form, so the `:rf.size/*`
-  spelling every other door takes was silently dropped (rf2-kuky.6).
+  `re-frame.projection/resolve-elision-opts`). That composition happens ONCE,
+  at the record boundary (`resolve-shared-size-axes`); what reaches here is
+  its answer, and re-resolving it downstream is idempotent. ONE spelling for
+  the two shared axes: these were read here in the bare form, so the
+  `:rf.size/*` spelling every other door takes was silently dropped
+  (rf2-kuky.6).
 
   The frame is threaded rather than re-read from the record, so an
   explicit `:frame` override resolved at the door reaches the walk
@@ -1448,6 +1452,59 @@
   (assoc (select-keys opts walker-overlay-keys)
          :rf.egress/profile (resolve-egress-profile (:rf.egress/profile opts))
          :frame             frame-id))
+
+(def ^:private shared-size-axis-keys
+  "The `:rf.size/*` booleans a NAMED PROFILE resolves — the axes this door
+  shares with every other egress door, as opposed to the three epoch-only
+  opt-ins (`:include-fx-args?` / `:include-runtime-db?` /
+  `:include-event-args?`), which no profile speaks to and which stay
+  fail-closed until their own key says otherwise.
+
+  Named here so `resolve-shared-size-axes` is true to its name by
+  construction: a key outside this set cannot be floor-filled by a profile
+  however the projection layer's table changes."
+  [:rf.size/include-sensitive?
+   :rf.size/include-large?
+   :rf.size/include-digests?])
+
+(defn- resolve-shared-size-axes
+  "Resolve the SHARED `:rf.size/*` axes ONCE, at the record boundary: the
+  named profile's opt-set is the FLOOR, and only the keys the caller ACTUALLY
+  supplied overlay it (an explicit `false` therefore stays authoritative).
+  Returns `opts` with those three keys present and answered; every other key —
+  `:rf.egress/profile` included, since `egress-opts` still needs it — rides
+  through untouched.
+
+  WHY IT IS NEEDED HERE RATHER THAN LEFT TO THE WALKER (rf2-kuky.92, the
+  merged-PR audit of #9522). `project-egress` resolves the profile into the
+  elision-opts it hands its OWN arms, but its `:rf/epoch-record` arm forwards
+  the caller's ORIGINAL opts — correctly, because the epoch-only axes must
+  survive the trip and the walker's map is closed against them. So an epoch
+  record's slots divide into two populations:
+
+    - the TREE-SHAPED slots re-enter `project-egress` through `egress-opts`
+      and get the floor applied on the way back in;
+    - the WHOLE-OUTPUT slots — the `:sub-runs` row and its `:rf.sub/run`
+      trace twin, plus the four off-box `omit-*` seams — never re-enter it.
+      They read their axis off this opts map BY KEY PRESENCE.
+
+  Reading a floor-resolved axis by key presence on an UNRESOLVED map answers
+  `nil`, which is indistinguishable from an explicit `false`. Under the five
+  fail-closed profiles that is the right answer by accident; under
+  `:rf.egress/local-raw` — the ONE profile whose floor opts sensitive and
+  large back IN — it silently defeated the floor, so the same 25,000-character
+  value survived in `:db-after` and became a size marker in the two
+  subscription slots. Resolving once, here, is what makes the two populations
+  answer the same question the same way.
+
+  Resolving EARLY is also why this is idempotent: the tree-walker path
+  re-resolves the same floor under the same profile, so the second resolution
+  is a no-op rather than a second, differing policy."
+  [opts]
+  (let [floor (select-keys (rf.projection/profile-size-opts
+                             (resolve-egress-profile (:rf.egress/profile opts)))
+                           shared-size-axis-keys)]
+    (merge opts floor (select-keys opts shared-size-axis-keys))))
 
 (defn- project-payload-slot
   "Project one payload slot through `project-egress` under the egress
@@ -2163,36 +2220,48 @@
   resolved. Record bookkeeping slots (`:kind`, `:epoch-id`, `:frame`,
   `:committed-at`, `:event-id`, `:outcome`, `:halt-reason`,
   `:schema-digest`, the two `:rf.epoch/*` rollups) and every absent slot
-  pass through untouched; the raw ring is never mutated."
+  pass through untouched; the raw ring is never mutated.
+
+  THE SHARED SIZE AXES ARE RESOLVED HERE, ONCE, before any slot is projected
+  (`resolve-shared-size-axes`, rf2-kuky.92). Every slot below therefore reads
+  the SAME answer to \"does the named profile opt sensitive / large back in?\",
+  whether it reaches that answer through the tree-walker (which re-resolves
+  the same floor, idempotently) or reads it off this map by key presence. The
+  three epoch-only axes are deliberately NOT touched: no profile speaks to
+  them, and `:rf.egress/local-raw` is a statement about app-db sensitivity and
+  token budget, not about effect args or the runtime-db partition."
   [record frame-id opts]
-  (cond-> record
-    ;; Whole-frame slots project app-db and redact runtime-db
-    ;; unless the corresponding trusted-local opts lift them.
-    (contains? record :frame-state-before)
-    (update :frame-state-before project-frame-state-slot frame-id opts)
+  ;; ONE resolution of the shared size axes for the whole record — see the
+  ;; docstring above and `resolve-shared-size-axes`.
+  (let [opts (resolve-shared-size-axes opts)]
+    (cond-> record
+      ;; Whole-frame slots project app-db and redact runtime-db
+      ;; unless the corresponding trusted-local opts lift them.
+      (contains? record :frame-state-before)
+      (update :frame-state-before project-frame-state-slot frame-id opts)
 
-    (contains? record :frame-state-after)
-    (update :frame-state-after project-frame-state-slot frame-id opts)
+      (contains? record :frame-state-after)
+      (update :frame-state-after project-frame-state-slot frame-id opts)
 
-    (contains? record :db-before)
-    (update :db-before project-payload-slot frame-id opts)
+      (contains? record :db-before)
+      (update :db-before project-payload-slot frame-id opts)
 
-    (contains? record :db-after)
-    (update :db-after project-payload-slot frame-id opts)
+      (contains? record :db-after)
+      (update :db-after project-payload-slot frame-id opts)
 
-    ;; Trigger args are not app-db-rooted and fail closed.
-    (contains? record :trigger-event)
-    (update :trigger-event elide-trigger-event-slot opts)
+      ;; Trigger args are not app-db-rooted and fail closed.
+      (contains? record :trigger-event)
+      (update :trigger-event elide-trigger-event-slot opts)
 
-    (contains? record :trace-events)
-    (update :trace-events elide-trace-events-slot frame-id opts)
+      (contains? record :trace-events)
+      (update :trace-events elide-trace-events-slot frame-id opts)
 
-    (contains? record :sub-runs)
-    (update :sub-runs elide-sub-runs-slot opts)
+      (contains? record :sub-runs)
+      (update :sub-runs elide-sub-runs-slot opts)
 
-    ;; Effect args are not app-db-rooted and fail closed.
-    (contains? record :effects)
-    (update :effects elide-effects-slot opts)))
+      ;; Effect args are not app-db-rooted and fail closed.
+      (contains? record :effects)
+      (update :effects elide-effects-slot opts))))
 
 (defn project-record
   "The PER-KIND projector `re-frame.projection/project-egress` dispatches a

--- a/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
+++ b/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
@@ -1146,6 +1146,122 @@
           "an EXPLICIT false still overlays the floor and wins — overriding
            is what the caller's own key is for"))))
 
+(defn- large-everywhere-record!
+  "ONE cascade that populates all THREE record surfaces the shared
+  `:rf.size/include-large?` axis governs:
+
+    - `:db-after [:blob :payload]`  — a frame-declared `:large` app-db path,
+      reached by the TREE-WALKER path (`project-payload-slot` →
+      `project-egress` → `elide-wire-value`);
+    - the `:sub-runs` row's `:value`, and
+    - its `:rf.sub/run` trace-tag twin's `:rf.sub/value` — both reached by the
+      WHOLE-OUTPUT path (`elide-whole-output-large-slots`), which reads the
+      axis off the epoch opts directly rather than through the walker.
+
+  One record carrying all three is what makes the matrix below a statement
+  about POLICY RESOLUTION rather than about any one seam: a profile floor that
+  reaches only some of them is exactly the defect."
+  []
+  (fresh-frame!)
+  (rf/reg-sub :egress/big {:large? true} (fn [_ _] (big-string payload-size)))
+  (rf/reg-event :egress/upload-and-read
+    (fn [{:keys [db]} [_ payload]]
+      (rf/subscribe-once [:egress/big] {:frame frame-id})
+      {:db (assoc-in db [:blob :payload] payload)}))
+  (rf/dispatch-sync [:egress/upload-and-read (big-string payload-size)]
+                    {:frame frame-id})
+  (last-record))
+
+(defn- large-surfaces
+  "The three whole-record slots the shared large axis governs, keyed by the
+  seam that projects each. Read as a SET of three answers that must agree."
+  [record]
+  {:db-after  (get-in record [:db-after :blob :payload])
+   :sub-run   (->> (:sub-runs record)
+                   (filter #(= :egress/big (:sub-id %)))
+                   first
+                   :value)
+   :trace-tag (->> (:trace-events record)
+                   (filter #(= :rf.sub/run (:operation %)))
+                   (filter #(= :egress/big (get-in % [:tags :rf.sub/id])))
+                   first
+                   :tags
+                   :rf.sub/value)})
+
+(defn- all-raw?
+  [surfaces]
+  (every? #(and (string? %) (= payload-size (count %))) (vals surfaces)))
+
+(defn- all-elided?
+  [surfaces]
+  (every? rf.elision/marker? (vals surfaces)))
+
+(deftest local-raw-large-axis-reaches-every-whole-output-slot
+  (testing "rf2-kuky.92 (merged-PR audit of #9522) — the RESOLVED profile, not
+            the caller's raw opts map, is what every epoch-side reader of a
+            SHARED `:rf.size/*` axis must see.
+
+            `project-egress` resolves the named profile into `elision-opts`,
+            but its `:rf/epoch-record` arm forwards the ORIGINAL opts, and the
+            whole-output helpers read `:rf.size/include-large?` off them by key
+            presence. So under `:rf.egress/local-raw` — the ONE profile whose
+            floor opts large back IN — the tree-walker path honoured the floor
+            while the two whole-output subscription slots did not, and the same
+            25,000-character value survived in `:db-after` and became a size
+            marker in the `:sub-runs` row and its `:rf.sub/run` trace twin.
+
+            The old and new doors produced EQUAL outputs in all six cases, so
+            door-vs-door comparison could not see this; only a matrix over the
+            three surfaces can. Asserted as a MATRIX rather than per slot: the
+            claim is that the three agree, which is what a policy resolved once
+            at the record boundary buys."
+    (let [raw        (large-everywhere-record!)
+          projected  (fn [opts] (large-surfaces (rf/project-egress raw opts)))
+          raw-slots  (large-surfaces raw)]
+      ;; ---- fixture control: all three surfaces are actually populated ------
+      (is (= 3 (count raw-slots)) "fixture: three surfaces under test")
+      (is (all-raw? raw-slots)
+          "fixture control — the RAW ring record carries the full payload in
+           ALL THREE slots, so a green matrix below cannot come from an absent
+           `:sub-runs` row or an absent trace twin")
+
+      ;; ---- the shared large axis, four ways -------------------------------
+      (is (all-raw? (projected {:rf.egress/profile :rf.egress/local-raw}))
+          "OMITTED OVERRIDE — `local-raw`'s own floor opts large back in for
+           ALL THREE surfaces with no explicit key from the caller. This is the
+           arm the #9522 audit measured failing on two of the three.")
+      (is (all-raw? (projected {:rf.egress/profile      :rf.egress/local-raw
+                                :rf.size/include-large? true}))
+          "EXPLICIT TRUE — agreeing with the floor changes nothing")
+      (is (all-elided? (projected {:rf.egress/profile      :rf.egress/local-raw
+                                   :rf.size/include-large? false}))
+          "EXPLICIT FALSE stays authoritative — an explicit key still overlays
+           the floor and WINS, on all three surfaces. This is the arm a fix
+           that merely forced the floor present-and-true would break.")
+      (is (all-elided? (projected {:rf.egress/profile :rf.egress/off-box-tool}))
+          "OFF-BOX CONTROL — a fail-closed profile still elides all three, so
+           the assertions above cannot pass by the elision having stopped
+           happening at all")
+      (is (all-raw? (projected {:rf.egress/profile      :rf.egress/off-box-tool
+                                :rf.size/include-large? true}))
+          "and an explicit TRUE lifts all three under a fail-closed profile —
+           the override wins in both directions")
+
+      ;; ---- the epoch-only axes stay INDEPENDENT ---------------------------
+      (is (= :rf/redacted
+             (get-in (rf/project-egress
+                       raw {:rf.egress/profile :rf.egress/local-raw})
+                     [:frame-state-after :rf.db/runtime]))
+          "GUARD — resolving the SHARED axes must not lift the epoch-only
+           ones: `:include-runtime-db?` is a different keyspace with its own
+           fail-closed default, and `local-raw` is a statement about app-db
+           sensitivity and token budget, not about the runtime partition")
+
+      ;; ---- the source record is untouched ---------------------------------
+      (is (all-raw? (large-surfaces raw))
+          "the RAW ring record is unchanged by any projection above — egress
+           projects a copy; the on-box ring keeps the exact value"))))
+
 ;; ---- guards G1 and G2 ------------------------------------------------------
 
 (deftest guard-g1-absent-projector-yields-no-payload-at-all

--- a/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
@@ -481,6 +481,45 @@
       (is (= body (get-in ev [:tags :value]))
           "with :rf.size/include-sensitive? true the body is NOT omitted (lifted)"))))
 
+(deftest local-raw-profile-lifts-omission-without-an-explicit-key
+  (testing "rf2-kuky.92 — the docstring above, and every other `omit-off-box-*`
+            seam's, names `the local-raw boundary` as what lifts the omission.
+            Until this test, NOTHING asserted that: every arm reached the lift
+            through the EXPLICIT `:rf.size/include-sensitive? true` key, and
+            the PROFILE that resolves to it was never exercised on this seam.
+
+            It did not work. These seams read the axis off the epoch opts by
+            key presence, and `project-egress` forwards the caller's ORIGINAL
+            opts to its `:rf/epoch-record` arm — so under
+            `{:rf.egress/profile :rf.egress/local-raw}` and nothing else the
+            floor never arrived and the body stayed omitted, contradicting the
+            docstring. The shared axes are now resolved once at the record
+            boundary (`tool-pair/resolve-shared-size-axes`), which is the SAME
+            repair the whole-output `:large?` slots needed — one defect, two
+            axes.
+
+            The `:rf.size/include-large?` sibling of this claim is pinned as a
+            three-surface matrix in
+            `re-frame.epoch-egress-redaction-cljs-test`; this arm is the
+            sensitive half, on the seam whose docstrings assert it."
+    (rf/make-frame {:id :test/http})
+    (let [body   {:token http-body-secret :user-id 42}
+          record (http-record :test/http :rf.http/replied :value body :omit)
+          value  (fn [opts] (get-in (first (:trace-events (rf/project-egress record opts)))
+                                    [:tags :value]))]
+      (is (= :rf/redacted (value {:rf.egress/profile :rf.egress/off-box-observability}))
+          "CONTROL — a fail-closed profile still omits the body, so the
+           assertion below cannot pass by the omission having stopped")
+      (is (= body (value {:rf.egress/profile :rf.egress/local-raw}))
+          "the local-raw PROFILE lifts the omission with NO explicit
+           :rf.size/include-sensitive? key from the caller — the profile is the
+           floor, exactly as it already was for the app-db tree walk")
+      (is (= :rf/redacted (value {:rf.egress/profile          :rf.egress/local-raw
+                                  :rf.size/include-sensitive? false}))
+          "and an EXPLICIT false still overlays that floor and WINS")
+      (is (= body (get-in (first (:trace-events record)) [:tags :value]))
+          "the source record is untouched by any of the projections above"))))
+
 (deftest on-box-raw-body-preserved-on-ring
   (testing "rf2-t55hxg.6 — the ON-BOX ring record is NOT projected: the raw
             unschematized body rides verbatim on the ring (the local operator


### PR DESCRIPTION
Completes change 3 on rf2-kuky.92 — the merged-PR audit residual from #9522.

## The defect

`:rf.egress/local-raw` is the one profile whose floor opts sensitive and large back **in**. On an epoch record that floor reached the tree-walked slots and not the whole-output ones.

`project-egress` resolves a named profile into the elision-opts it hands its own arms, but its `:rf/epoch-record` arm forwards the caller's **original** opts. That is correct and must stay: the three epoch-only axes (`:include-fx-args?` / `:include-runtime-db?` / `:include-event-args?`) have to survive the trip, and the walker's map is closed against them. But it splits an epoch record's slots into two populations:

- **tree-shaped** slots re-enter `project-egress` through `egress-opts` and pick the floor up on the way back in;
- **whole-output** slots — the `:sub-runs` row, its `:rf.sub/run` trace twin, and the four off-box `omit-*` trace seams — read their axis off the forwarded opts **by key presence** and never re-enter it.

Reading a floor-resolved axis by key presence on an unresolved map answers `nil`, which is indistinguishable from an explicit `false`. Under the five fail-closed profiles that is the right answer by accident. Under `local-raw` it silently defeated the floor: the same 25,000-character value survived in `:db-after` and became a size marker in the `:sub-runs` row and the trace twin.

## The fix

`project-record-slots` now resolves the three shared `:rf.size/*` axes **once**, before any slot is projected (`resolve-shared-size-axes`):

- the named profile's opt-set is the floor;
- only caller-present keys overlay it, so an **explicit `false` stays authoritative**;
- the tree-walker path re-resolves the same floor under the same profile, so the second resolution is a no-op rather than a second, differing policy.

`walker-overlay-keys` is unchanged — the `select-keys` that structurally bars the three epoch-only axes from the closed walker map still does exactly that, and the deftest pinning it both ways (`an-epoch-only-axis-is-door-vocabulary-and-never-reaches-the-walker`) is untouched. Nothing in `implementation/core` changed: putting the resolution there would either strip the epoch-only axes or make core carry epoch policy knowledge.

## Widened beyond the audit's stated scope — the SENSITIVE axis had the same defect

The audit measured the large axis only, because its probe used a `:large?` row. The same unresolved map is read for `:rf.size/include-sensitive?` by four `omit-off-box-*` trace seams (`omit-off-box-http-bodies`, `omit-off-box-resource-scope-values`, `omit-off-box-resource-trace-keys`, `omit-off-box-fx-args-resource-keys`), and each one's docstring names **"the local-raw boundary"** as what lifts it. It did not. Every existing test in the tree reached that lift through the explicit `:rf.size/include-sensitive? true` key — none through the profile — so nothing pinned the claim the docstrings make, and nothing pinned the buggy behaviour either.

One resolution at the boundary repairs all five readers. Spec 015 already treats the two routes as equivalent (its four-case rule names "the explicit trusted-local opt-in (`:rf.egress/local-raw` / `:rf.size/include-sensitive? true`)" as one case), so **no spec change is needed** — the code now matches what the spec already said.

## Tests

`re-frame.epoch-egress-redaction-cljs-test/local-raw-large-axis-reaches-every-whole-output-slot` (dual-lane `.cljc`) builds ONE cascade carrying all three surfaces the shared large axis governs — a frame-declared `:large` app-db path, a `:large?` sub's `:sub-runs` row, and its `:rf.sub/run` trace twin — and asserts over the matrix:

| policy | expected |
|---|---|
| `local-raw`, override omitted | all three raw |
| `local-raw` + `:rf.size/include-large? true` | all three raw |
| `local-raw` + `:rf.size/include-large? false` | all three elided |
| `off-box-tool` defaults | all three elided |
| `off-box-tool` + `:rf.size/include-large? true` | all three raw |

Plus a fixture control that all three raw surfaces are populated (so a green matrix cannot come from an absent row or absent twin), a guard that `:frame-state-after` / `:rf.db/runtime` stays `:rf/redacted` under `local-raw` (the epoch-only axes stay independent), and a re-read proving the source record is untouched.

**The assertion is that the three surfaces AGREE**, not that each is individually right. Old and new entry points produced equal outputs in all six cases, which is exactly why stage 3a's door-vs-door acceptance test passed over this defect; only a matrix across the surfaces can see it.

`re-frame.epoch-egress-trace-events-test/local-raw-profile-lifts-omission-without-an-explicit-key` is the sensitive-axis arm, on the HTTP-body seam whose docstring asserts the claim: fail-closed control, the profile lifting with no explicit key, explicit `false` still winning, source record untouched.

## Quality gates

Every exit code below was captured per-command in one shell — never a pipeline's status.

| gate | exit | result |
|---|---|---|
| `epoch` focused test, failing-first (pre-fix) | **1** | RED — reproduced the defect independently: `:db-after` raw at 25000 chars, `:sub-run` and `:trace-tag` both size markers |
| `epoch` focused test (post-fix) | **0** | 1 test / 9 assertions |
| `epoch` sensitive-axis test | **0** | 1 test / 4 assertions |
| `implementation/epoch` full JVM suite (`clojure -M:test`) | **0** | 538 tests / 7290 assertions / 0 failures / 0 errors |
| `api-manifest gen --check` | **0** | in sync, 471 public vars — both new defs are `^:private`, no sidecar edit |
| `scripts/check-ai-tracking-ratchet.sh` | **0** | |
| `scripts/check-beads-pr-boundary.sh origin/main` | **0** | no beads-database paths in this PR diff |
| `scripts/check-no-hardcoded-paths.sh` | **0** | |
| `scripts/check-commit-attribution.sh origin/main` | **0** | |
| `python scripts/check_fast_pr_gap.py --brief` | **0** | a report, not a suite — run to learn what CI still owns |

**Skipped, with reasons.** `npm run test:cljs` (the node-test lane that runs the `.cljc` file's CLJS host): not run locally — it needs a `node_modules` junction and is a required CI check that grades this exact source; the JVM lane pins the identical `.cljc` namespace and the new test uses only host-neutral forms already exercised by its neighbours in the same file. `clj-kondo` / `splint`: CI pins clj-kondo 2026.04.15 and a differently-versioned local binary proves nothing in either direction. `scripts/test-fast-pr.sh`: not nominated — it tiers itself on the changed-surface classifier and would double-run the per-artefact suite above. `implementation/scripts/api-manifest`'s own `clojure -M:test`: no public name moved.

## Sabotage

The fix was committed first, so the restore is checkable against a known object.

- Needle `opts (resolve-shared-size-axes opts)` match-counted at **1** before planting — the call site; the identifier also appears in docstrings, which this needle excludes.
- Planted `(let [opts (identity opts)]` — the defect itself, reinstated. Blob hash moved `9801cab894...` to `5327824589...`, so the plant genuinely applied rather than silently no-opping.
- Both new deftests went **RED**, exit **1**, 2 tests / 13 assertions / 2 failures, naming:
  - `expected: (all-raw? (projected #:rf.egress{:profile :rf.egress/local-raw}))`
  - `expected: (= body (value #:rf.egress{:profile :rf.egress/local-raw}))`
- Restored with `git checkout HEAD --`; blob hash back to `9801cab894fa8d9debb4016417385eff2f073530`, byte-identical to the committed blob.
- Re-ran: exit **0**, 2 tests / 13 assertions / 0 failures.

The red is what discriminates: the plant existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green.

## Found and deliberately NOT fixed

- **The `:rf.size/include-*?` opt rename** is rf2-kuky.93's ruling. Not pre-empted; the qualified spellings are used as they stand.
- **`spec/`** carries no wrong claim to repair. Spec 015 already states the profile and the explicit key are equivalent routes to the trusted-local posture — the code was wrong, not the spec. Adding prose restating it would be redundant.
- **Line numbers cited in the bead's audit and notes are stale** (rf2-bv1p's retirement of `projected-record` moved everything below it). Every construct here was re-located by name rather than by the numbers given: `walker-overlay-keys`, `egress-opts`, `elide-whole-output-large-slots`, `elide-sub-runs-slot`, `elide-large-sub-trace-values`, `project-record-slots`, `project-record`. `projected-record` is confirmed gone from every `src/`; the surviving mentions are retirement bookkeeping.
