### PR TITLE
ci(bench): compile the hicasso bench lane nightly (rf2-a7ds)

### DIFF
--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -792,6 +792,95 @@ jobs:
           RF2_KSBUR_STRESS_ITERS: ${{ matrix.artefact == 'routing' && '500' || '' }}
         run: clojure -M:slow-test
 
+  # rf2-a7ds — THE ONLY THING IN CI THAT COMPILES THE HICASSO BENCH LANE.
+  # NIGHTLY, AND NIGHTLY ONLY: ruling rf2-6c12m.1 deliberately keeps `bench/*`
+  # off every per-PR lane, and a nightly is not a PR gate. Nothing here may be
+  # promoted to `test.yml`, whose `pull_request` trigger is unfiltered.
+  #
+  # WHAT WAS UNCOVERED, AND WHY THE OBVIOUS INSTRUMENT COULD NOT SEE IT.
+  # `bench/hicasso/` is its own shadow-cljs project rather than a roster entry:
+  # `implementation/scripts/check-examples-compile.cjs` derives its build ids
+  # from `implementation/shadow-cljs.edn`, which carries none of the bench ones
+  # (ask it — `node implementation/scripts/check-examples-compile.cjs --list`).
+  # `bench/` Clojure files DO arm `lint.yml`'s require-alias-dialect step, but
+  # clj-kondo runs with no classpath and therefore cannot resolve vars at all —
+  # run over the pre-fix tree it named the deleted `re-frame.hicasso/mount!`
+  # ZERO times. An undeclared var is caught by a COMPILER or by nothing, so
+  # five bench arms called a deleted public name from the day it was deleted
+  # until somebody happened to look (fixed in 5c024a0eb3). This job is the
+  # instrument of the right kind.
+  #
+  # NO `npm ci` IN `bench/hicasso/`, AND THAT IS THE DESIGN RATHER THAN A
+  # SHORTCUT — so do not "fix" the absent `bench/hicasso/package-lock.json` by
+  # adding one. The lane has no `node_modules` of its own and needs none:
+  # `lane_build.cjs` spawns shadow-cljs's JS entry point out of the
+  # implementation install, and `shadow-cljs.edn` points npm resolution at that
+  # same tree through `:js-options :node-modules-dir`. Its `package.json`
+  # exists only to declare the shadow-cljs pin — 3.4.10, the identical version
+  # `implementation/package.json` pins — so the CLI does not warn. One install,
+  # one lockfile, one pin.
+  hicasso-bench-compile:
+    name: Hicasso bench lane compiles (nightly only - rf2-6c12m.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      # shadow-cljs resolves this project's `:dependencies` itself (there is no
+      # `:deps true` and no `deps.edn` beside it), so the JVM is required and
+      # the Clojure CLI is not.
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-expensive-hicasso-bench-${{ hashFiles('bench/hicasso/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-expensive-hicasso-bench-
+            ${{ runner.os }}-cljs-
+
+      - name: Install the implementation node tree (the bench lane borrows it)
+        working-directory: implementation
+        run: npm ci
+
+      # The entry list is DERIVED by walking `src/`, never listed — so a bench
+      # arm added tomorrow is covered by this job without editing it. The gate
+      # refuses a collapsed derivation (floor 40) and refuses an unparsable
+      # shadow summary, so it cannot pass vacuously.
+      - name: Compile every lane namespace (:hicasso-bench, warnings-fatal)
+        working-directory: bench/hicasso
+        run: node src/re_frame/bench/hicasso/compile_gate.cjs
+
+      # The step above compiles that same source under the BROWSER id; this is
+      # the `:node-script` target with `:infer-externs false`, which is the one
+      # claim the browser id cannot make. Driven through `lane_build.cjs`
+      # rather than shadow's CLI deliberately: SHADOW-CLJS EXITS 0 ON WARNINGS,
+      # and that module is the lane's only warnings-fatal judge. No
+      # `--config-merge` is needed — `shadow-cljs.edn` already declares this
+      # build's `:main` and `:output-to` so that a bare compile builds the SSR
+      # entry rather than nothing.
+      - name: Compile the node lane (:hicasso-bench-node, warnings-fatal)
+        working-directory: bench/hicasso
+        # A literal block, because the inline object below carries `: ` pairs
+        # that a plain YAML scalar cannot hold (measured: it parses as a
+        # mapping and `check_workflow_yaml.py` refuses the file).
+        run: |
+          node -e "require('./src/re_frame/bench/hicasso/lane_build.cjs').shadowBuild({project: process.cwd(), mode: 'compile', buildId: 'hicasso-bench-node', tag: 'hicasso-bench-node'})"
+
   # THE GATE-SCHEDULING AUDIT USED TO LIVE HERE, AND NO LONGER DOES (rf2-k78o2).
   # It asserts that every `test:*` / `bench:*` / `build:*` command in
   # implementation/package.json is either reachable from a workflow or carries a
@@ -840,6 +929,11 @@ jobs:
       - mcp-live
       - mcp-live-windows
       - jvm-slow-tests
+      # rf2-a7ds. The alerter reads the whole run's jobs from the API, so this
+      # entry is about ORDERING rather than visibility: without it the
+      # signature can be derived while the bench compile is still running, and
+      # a red lane would be absent from the night's tracking issue.
+      - hicasso-bench-compile
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Closes the remaining clause of **rf2-a7ds**: nothing in CI has ever compiled `bench/hicasso/`, so a bench arm can reference a deleted public name indefinitely and the breakage is only found when somebody tries to run a benchmark. Five arms did exactly that until `5c024a0eb3`.

One job, one workflow file, 94 added lines, nothing removed.

## Why nightly only, and why that honours rf2-6c12m.1

Ruling rf2-6c12m.1 deliberately moved this lane out of `implementation/hicasso/test` and off **every per-PR lane**, because its suites exercise *local copies* of the runtime and so cannot catch a regression in the shipped one. That ruling is about **PR gates**. A nightly is not a PR gate, which is precisely why this shape was chosen over the cheaper-looking alternative of adding the bench build ids to `implementation/shadow-cljs.edn` so `check-examples-compile.cjs` picks them up — that roster runs on every PR and would contradict the ruling.

The job lives in `expensive-tests.yml` and nowhere else. `test.yml` is untouched: its `pull_request` trigger is deliberately unfiltered, so a job key added there is a real new per-PR check every time.

## Why the obvious instrument could not see this

`bench/` Clojure files **do** arm `lint.yml`'s require-alias-dialect step, so "bench reaches no gate" is too broad. But clj-kondo runs with no classpath and therefore cannot resolve vars at all — run over the pre-fix tree it named the deleted `re-frame.hicasso/mount!` **zero** times. An undeclared var is caught by a compiler or by nothing. Re-measured on this base:

| claim | measured |
|---|---|
| `bench` mentions in `.github/workflows/*.yml` | 16, on **0** non-comment lines |
| `compile_gate` mentions in `.github/workflows/` | 0 |
| bench build ids in `check-examples-compile.cjs --list` | 0 of 58 |

Anyone re-running the bead's original `grep -rn bench .github/workflows/*.yml` gets 16 and must not read it as coverage.

## The lockfile decision: neither `npm ci` nor `npm install` — no install at all

`bench/hicasso/` has no `package-lock.json`, which frames a choice between committing one (`npm ci`) and installing non-reproducibly (`npm install`). **Both are wrong here, and the tree says so in its own words.** The lane has **no `node_modules` of its own by design**:

- `package.json` describes itself as *"No install needed - it reuses implementation/node_modules"*;
- `shadow-cljs.edn` states *"No `node_modules` of its own... the CLI is spawned from the implementation install by `lane_build.cjs`, and `:node-modules-dir` points npm resolution at the same place"*;
- `lane_build.cjs` resolves `implementation/node_modules/shadow-cljs/cli/runner.js` directly.

Its one dependency is a `devDependencies` pin of `shadow-cljs` at **3.4.10** — the identical version `implementation/package.json` pins — declared *only* so the CLI does not warn about a version mismatch.

So the job runs `npm ci` in `implementation/` (against the lockfile that already exists and is already cached by every other job here) and installs nothing in `bench/hicasso/`. This adds no file to a tree CI has never built, keeps one lockfile rather than two, and cannot drift from the implementation install because it *is* the implementation install. A comment at the job says so, so the next reader does not "fix" the absent lockfile by adding one.

## What the job compiles

Two steps, both warnings-fatal through the lane's own `lane_build.cjs` door rather than shadow's CLI — **shadow-cljs exits 0 on warnings**, so its CLI is not a judge:

- **`:hicasso-bench`** via `compile_gate.cjs`, whose entry list is *derived* by walking `src/`. A bench arm added tomorrow is covered without editing this workflow. The gate refuses a collapsed derivation (floor 40) and refuses an unparsable shadow summary, so it cannot pass vacuously.
- **`:hicasso-bench-node`** — the same source under `:node-script` with `:infer-externs false`, the one claim the browser id cannot make. Nothing else compiles it: `bake_bytes.test.cjs` says outright that the bake "costs a shadow-cljs compile and cannot run in a unit gate".

Added to `nightly-result`'s `needs:` for ordering. The alerter reads the whole run's jobs from the API, so this is not about visibility — without it a signature can be derived while the bench compile is still running, and a red lane would be missing from the night's tracking issue.

No Clojure CLI step: `bench/hicasso/shadow-cljs.edn` carries `:dependencies` with no `:deps true` and no `deps.edn` beside it, so shadow-cljs resolves its own classpath and needs only the JVM. Verified locally — the run left no `.cpcache`.

## Quality gates

Run locally in the worker worktree; every exit code below was captured to a `.exit` file in the same shell as the run, never read from a pipeline.

| gate | exit | note |
|---|---|---|
| `node src/re_frame/bench/hicasso/compile_gate.cjs` | **0** | 155 namespaces, 465 files, 464 compiled, **0 warnings**, 18.88s |
| `:hicasso-bench-node` compile via `lane_build.cjs` | **0** | 193 files, 192 compiled, **0 warnings**, 10.32s |
| `python scripts/check_workflow_yaml.py` | **0** | 11 files; **caught a real defect first** — see below |
| `python scripts/check_workflow_job_timeouts.py --verbose` | **0** | `expensive-tests.yml: 7/7 jobs capped` (was 6/6) |
| `python scripts/check_gate_scheduling.py` | **0** | |
| `python scripts/check_fast_pr_gap.py` | **0** | |
| `python scripts/check_jvm_lane_rosters.py` | **0** | |
| `python scripts/check_ci_reproduce_commands.py` | **0** | |
| `sh scripts/check-commit-attribution.sh origin/main` | **0** | commits arm |
| `sh scripts/check-commit-attribution.sh --pr-body` | **0** | body arm, this text on stdin |

**9 pass, 0 fail.** One earlier red, fixed: `check_workflow_yaml.py` exited **1** on `expensive-tests.yml: line 878, column 98: mapping values are not allowed here` — the `node -e "...{project: process.cwd(), mode: 'compile'...}"` step was written as a plain YAML scalar, and the `: ` pairs inside the inline object made it parse as a mapping. Rewritten as a literal block; the gate then passed. GitHub would have refused the whole workflow.

Gates deliberately **not** run: `check_doc_slugs.py` and `mkdocs build --strict` do not reach `.github/**` at all (outside `docs_dir`, and never staged into it), so nominating either would have bought a green that inspected nothing. No CLJS or JVM artefact suite is touched by this diff.

### Sabotage proof — the job would have caught the historical defect

A workflow job that has never been exercised is not evidence, so the sweep was run against the real defect. Committed first, so the restore came from a known object.

1. Planted `rf.hicasso/render!` → `rf.hicasso/mount!` at `amp_merge_clock_app.cljs:699`, reproducing the exact form that survived undetected. **Match count read before the run: 1** — a plant that matches zero lines is not a plant.
2. `compile_gate.cjs` exited **1**, naming the file at `:699:8` and `Use of undeclared Var re-frame.hicasso/mount!`. Note shadow-cljs itself reported `Build completed. (465 files, 464 compiled, 1 warnings)` and would have exited **0** — `lane_build.cjs` is what refused it.
3. Restored, and verified by **blob hash** against the committed object rather than by the restore command's exit code: `7e171df2bc30da397f69bff4e664788c413d8a05` on both sides, CRLF line endings back (the planting `sed` had normalised them — which a diff would have shown as clean while changing every line), 0 remaining occurrences, working tree clean.

The red is also the worktree discrimination: the fault existed only in this branch's checkout, and both compiles printed their `shadow-cljs.edn` path, so a run that had wandered into a sibling tree would have come back green.

### Verified by hand

The diff is one workflow file, so nothing automated grades its prose or its table columns. Checked by hand: the four action `uses:` pins are copied verbatim from sibling jobs in this same file (same SHAs, same version comments); the job carries `timeout-minutes` (and the ratchet confirms it); and the new `needs:` entry names a job key that exists.

**One thing worth knowing before merge, not a request:** `post-merge-workflow-sanity.yml` fires on any push to `main` touching `.github/workflows/*.yml` and `workflow_dispatch`es the changed cron-only workflow — which is `expensive-tests.yml`. So merging this will produce a **natural** dispatch run of the nightly within minutes. That is the canary working as designed. No dispatch was triggered by hand from this branch, deliberately (rf2-amh0 is waiting on an uncontaminated natural dispatch-run witness).
