### PR TITLE
feat(machines): reject a spawn onto an occupied GENERATED actor address (rf2-1sip, option (f))

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -793,9 +793,10 @@
 
 ;; ---- occupied-address replacement (rf2-dokz) -------------------------------
 
-(defn- occupant-actor-live?
+(defn occupant-actor-live?
   "Is `actor-id` OCCUPIED by a live spawned ACTOR, for the purpose of deciding
-  replacement? True iff the frame's LIVE `runtime-db` carries a snapshot there.
+  what a spawn arriving there means? True iff the frame's LIVE `runtime-db`
+  carries a snapshot there.
 
   DELIBERATELY NOT `actor-live?`, and that difference is the whole of this
   predicate. `actor-live?` is the shared silent-idempotent DESTROY probe
@@ -812,8 +813,17 @@
   is exactly this predicate.
 
   `actor-live?`'s spawn-order clause is not needed here either: it covers the
-  drain-time stale `old-db` window, and this predicate's only caller reads the
-  frame's LIVE `runtime-db`, which by definition has no such window."
+  drain-time stale `old-db` window, and both callers read the frame's LIVE
+  `runtime-db`, which by definition has no such window.
+
+  TWO CALLERS, ONE PROBE, OPPOSITE VERDICTS (rf2-1sip). Occupancy at a SUPPLIED
+  `:fixed-actor-id` means REPLACE — `destroy-occupant-for-replacement!` below.
+  Occupancy at a GENERATED `<type>#<n>` address means REJECT: nobody named that
+  address, so nobody asked for a replacement, and the runtime allocated it only
+  because its counter did not know the occupant existed. That is
+  `lifecycle-fx.spawn/generated-address-collision?`. The predicate is shared
+  deliberately — the two paths must never disagree about what \"occupied\"
+  means — and it is PUBLIC for that second caller alone."
   [frame-id actor-id]
   (snapshot-present? (rf.frame/frame-runtime-db-value frame-id) actor-id))
 

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -853,6 +853,113 @@
       :else
       (spawn-fx* frame-id args))))
 
+;; ---- generated-address collision (rf2-1sip) --------------------------------
+
+(defn- generated-address-collision?
+  "rf2-1sip — is this spawn's GENERATED `<type>#<n>` address already occupied by
+  a LIVE actor? True only when every clause below holds; the answer is `false`
+  on every ordinary spawn and costs one `runtime-db` read.
+
+  WHY A GENERATED COLLISION IS A DIFFERENT ANIMAL FROM AN OCCUPIED
+  `:fixed-actor-id`. rf2-dokz ruled that a spawn arriving at a fixed address a
+  live actor occupies REPLACES it cleanly and raises nothing: the author named
+  that address, and naming an address twice is a request for the actor there to
+  become the new one. NOBODY NAMES A GENERATED ADDRESS. `<type>#<n>` is minted
+  by a counter, and the counter can hand out a live actor's address because the
+  two allocators do not share a home — the declarative reducer's counter lives
+  IN THE SPAWNING PARENT'S SNAPSHOT (`:rf/spawn-counter`,
+  `transition/allocate-spawned-id`) while the address space it allocates into is
+  FRAME-GLOBAL. So a parent destroyed and respawned at the same address begins
+  counting from zero beside its own still-live orphans, and two parents spawning
+  the same child TYPE both mint `#1`. There is no author intent to honour, so
+  the replacement reading is unavailable and the write is pure data loss: the
+  occupant is not detached but GONE, with no `:rf.machine/destroyed`, no
+  `:exit`, and a `:rf.machine.spawn/spawned` naming an address already spawned.
+
+  CLAUSES, and each is load-bearing.
+
+  - A SUPPLIED `:fixed-actor-id` is excluded — that is rf2-dokz's replacement
+    path, ruled and delivered, and it is checked on `args` rather than on the
+    id's SPELLING because a fixed literal may itself end in `#<digits>`
+    (`join-child-record-from-state`'s `:work-generation` makes the same
+    distinction for the same reason).
+  - A PREPARED `:spawn-all` child is excluded. rf2-v4oqd's invariant is that an
+    ADMITTED child ALWAYS installs — the authoritative preflight is the sole
+    verdict, and a second per-child reject here would strand a live join naming
+    a child that never appears, which is the dead-join class rf2-ek435 closed.
+    The WITHIN-BATCH aliasing case is already rejected atomically by that
+    preflight (`spawn-all-address-collisions`); a prepared child colliding with
+    a live actor OUTSIDE its batch is left alone and belongs to the counter
+    re-homing, not here.
+  - A nil `spawned-id` is excluded: the cascade gate already refuses that spawn.
+
+  Occupancy is `lifecycle-fx.destroy/occupant-actor-live?` — the SAME probe the
+  replacement path consults, deliberately shared so the two can never disagree
+  about what occupied means. It is snapshot presence and nothing else (Spec 005
+  §Liveness is derived from runtime-db), so a registered-but-never-spawned TYPE
+  sitting at the keyword is not an occupant."
+  [frame-id args prepared spawned-id]
+  (boolean
+    (and (some? spawned-id)
+         (nil? prepared)
+         (not (contains? args :fixed-actor-id))
+         (rf.machines.lifecycle-fx.destroy/occupant-actor-live? frame-id spawned-id))))
+
+(defn- reject-generated-address-collision!
+  "rf2-1sip — REJECT a spawn whose GENERATED address is already held by a live
+  actor, and emit `:rf.error/machine-spawn-all-duplicate-id`. Returns nil, so
+  the caller's cascade gate suppresses the whole spawn — no snapshot, no
+  spawn-order entry, no `:rf.machine.spawn/spawned`, no `:start` dispatch —
+  exactly as the schema-reject and unregistered-TYPE paths do.
+
+  THE EXISTING CATEGORY, NOT A NEW ONE. `:rf.error/machine-spawn-all-duplicate-id`
+  is already the name for \"two distinct spawns resolve to one actor address and
+  one would silently overwrite the other\" (Spec 005 §Errors; its runtime
+  surfacing is `reject-address-collision!`, which names a fixed id colliding
+  with a generated `<type>#n` among the shapes it refuses). This is the same
+  failure with the batch boundary removed: the occupant is a live actor rather
+  than a sibling in the same invoke. A distinct id would give one failure two
+  names.
+
+  DIAGNOSTIC channel (Spec 009), matching `reject-address-collision!`: the
+  fail-closed reject itself runs in production — the spawn does not install
+  either way — while the observability trace rides the dev-only surface DCE'd
+  under `goog.DEBUG=false`. STRUCTURAL context ONLY: the machine TYPE, the
+  occupied address, the spawning parent and invoke path. Never the spawn `args`
+  / `:data`, which may hold application PII.
+
+  `:recovery` is `:no-recovery` — the runtime cannot pick a different address
+  without breaking the deterministic `<type>#<n>` sequencing
+  `machine-transition`'s purity contract rests on, and it must not destroy the
+  occupant, which Spec 005's *Teardown is explicit in v1* rule reserves to the
+  author. The `reason` therefore names both author-side escapes: a distinct
+  `:fixed-actor-id`, or destroying the occupant before spawning over it."
+  [frame-id args spawned-id]
+  (let [machine-id (:machine-id args)
+        parent-id  (:rf/parent-id args)
+        reason     (rf.error/human-message
+                     :rf.error/machine-spawn-all-duplicate-id
+                     (str "Cannot spawn machine " machine-id " at the generated "
+                          "actor address " spawned-id ": a LIVE actor already "
+                          "occupies it, and installing there would destroy that "
+                          "actor with no :exit, no teardown and no trace — so the "
+                          "spawn is rejected fail-closed. The generated "
+                          "<type>#<n> counter is per-spawning-snapshot while the "
+                          "address space is per-frame, so a respawned parent, or "
+                          "a second parent spawning the same machine TYPE, can "
+                          "re-mint an address that is still held. Give this spawn "
+                          "a distinct :fixed-actor-id, or destroy the occupant "
+                          "explicitly before spawning over it."))]
+    (rf.trace/emit-error! :rf.error/machine-spawn-all-duplicate-id
+                       {:machine-id machine-id
+                        :failing-id spawned-id
+                        :parent-id  parent-id
+                        :invoke-id  (:rf/invoke-id args)
+                        :frame      frame-id
+                        :recovery   :no-recovery
+                        :reason     reason})
+    nil))
+
 (defn- install-base-after-replacing-occupant!
   "rf2-dokz — the occupied-`:fixed-actor-id` step. Returns the `runtime-db`
   value `install-spawn!` must build its install on, or nil when the install must
@@ -871,9 +978,12 @@
   EXISTING `:reason :explicit` (see
   `lifecycle-fx.destroy/destroy-occupant-for-replacement!` for why it delegates
   and why the reason may not be a new enum member). Scoped to a SUPPLIED
-  `:fixed-actor-id`: a generated `<type>#<n>` address that collides with a live
-  actor is the separate reseeded-`:rf/spawn-counter` defect (rf2-1sip), not this
-  one, and is deliberately left alone.
+  `:fixed-actor-id`, and that scope is now the OTHER half of a two-way split
+  rather than an omission: a generated `<type>#<n>` address that collides with a
+  live actor is REJECTED instead (rf2-1sip —
+  `generated-address-collision?` / `reject-generated-address-collision!` above),
+  because nobody named that address so there is no replacement request to
+  honour. The caller picks exactly one of the two.
 
   (3) THE INSTALL BASE IS REBUILT FROM THE POST-TEARDOWN VALUE. This is the trap
   the fix exists to avoid: `install-spawn!`'s `install-fn` DISCARDS the swap's
@@ -1093,9 +1203,26 @@
     ;; purpose: the occupant's `:rf.machine/destroyed` is therefore observed
     ;; BEFORE the replacement's spawned traces, and a tool pairing lifecycle
     ;; events never sees one address spawned twice with no destroy between.
+    ;;
+    ;; rf2-1sip SPLITS that fourth condition in two on the SAME occupancy
+    ;; question, because occupancy means opposite things at the two kinds of
+    ;; address. At a SUPPLIED `:fixed-actor-id` it means REPLACE (rf2-dokz,
+    ;; above). At a GENERATED `<type>#<n>` it means REJECT: the counter is
+    ;; per-snapshot while the address space is per-frame, so a respawned parent
+    ;; — or a second parent of the same child TYPE — re-mints an address a live
+    ;; actor still holds, and installing there is the unannounced death rf2-dokz
+    ;; removed from the fixed path, reached with no author involvement at all.
+    ;; The reject returns nil and so suppresses the traces and the install
+    ;; together, exactly as an unobtainable install base does. It sits INSIDE
+    ;; the same `and`, after the validator verdict, so a schema-rejected spawn
+    ;; still reports only its own diagnostic.
     (when-let [rt-install (and (not rejected?) old-rt (continue?)
-                               (install-base-after-replacing-occupant!
-                                 frame-id args spawned-id prepared rt-after-alloc continue?))]
+                               (if (generated-address-collision?
+                                     frame-id args prepared spawned-id)
+                                 (reject-generated-address-collision!
+                                   frame-id args spawned-id)
+                                 (install-base-after-replacing-occupant!
+                                   frame-id args spawned-id prepared rt-after-alloc continue?)))]
       (rf.trace/emit! :rf.machine :rf.machine.spawn/spawned
                    {:frame      frame-id
                     ;; `:machine-id` is the spec-time registered TYPE (xor

--- a/implementation/machines/test/re_frame/generated_address_collision_test.clj
+++ b/implementation/machines/test/re_frame/generated_address_collision_test.clj
@@ -1,0 +1,354 @@
+(ns re-frame.generated-address-collision-test
+  "A spawn whose GENERATED `<type>#<n>` address is already held by a LIVE actor
+  is REJECTED fail-closed with `:rf.error/machine-spawn-all-duplicate-id`
+  (rf2-1sip, option (f)).
+
+  WHY THE ADDRESS CAN COLLIDE AT ALL. The declarative allocator's counter lives
+  INSIDE THE SPAWNING PARENT'S SNAPSHOT (`:rf/spawn-counter`,
+  `transition/allocate-spawned-id` — that in-snapshot home is what makes
+  `machine-transition` pure in its spawn-id sequencing) while the address space
+  it allocates into is FRAME-GLOBAL. The two disagree in the ordinary
+  multi-actor shapes:
+
+    - a parent DESTROYED and RESPAWNED at the same address begins counting from
+      zero beside its own still-live orphans, so its first new child re-mints
+      `<type>#1`; and
+    - two parents spawning the same child TYPE each mint `<type>#1`, with no
+      destroy or re-incarnation anywhere in sight.
+
+  BEFORE THIS BEAD both installed straight over the live occupant through an
+  unguarded `assoc-in`. Because a spawned actor's liveness IS its snapshot's
+  presence (Spec 005 §Liveness is derived from runtime-db), that one write was
+  simultaneously a birth and an unannounced death: no `:exit`, no teardown, no
+  `:rf.machine/destroyed`, and two `:rf.machine.spawn/spawned` traces naming one
+  address with no destroy between them. The actor was GONE, not detached.
+
+  WHY REJECT RATHER THAN REPLACE — the distinction this suite exists to pin.
+  rf2-dokz ruled that a spawn arriving at an occupied `:fixed-actor-id` REPLACES
+  the occupant cleanly and raises nothing, because the AUTHOR NAMED that
+  address and naming it twice is a request. Nobody names a generated address, so
+  that reading is unavailable here: there is no request to honour, and Spec 005's
+  *Teardown is explicit in v1* rule reserves destroying the occupant to the
+  author. Rejecting is what is left, and it uses the EXISTING category rather
+  than a new one — `:rf.error/machine-spawn-all-duplicate-id` already names
+  \"two distinct spawns resolve to one actor address and one would silently
+  overwrite the other\", including the fixed-versus-generated shape.
+
+  NOT ATTEMPTED HERE, deliberately: re-homing the counter so `<type>#<n>` is
+  frame-unique (rf2-1sip option (e)) — that moves `machine-transition`'s
+  purity contract and is a separate ruling. This suite pins the loud failure,
+  not the absence of the collision.
+
+  Both directions are pinned, because an error-only suite is half a suite:
+  every reject test asserts the OCCUPANT SURVIVED INTACT, and the controls
+  assert that ordinary generated spawning, re-entry re-allocation, and
+  `:spawn-all` batches are unchanged."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
+
+(use-fixtures :each
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
+
+(def ^:private snapshot rf.machines.test-support/snapshot)
+(def ^:private machine-data rf.machines.test-support/machine-data)
+
+(defn- rejects
+  "The captured collision rejects, each reduced to its `:tags` map (a trace
+  event carries its structural context there, not at the root)."
+  []
+  (mapv :tags (rf.machines.test-support/events-of
+                :rf.error/machine-spawn-all-duplicate-id)))
+
+(defn- spawned-ids
+  "Every actor address announced by a `:rf.machine.spawn/spawned` trace so far,
+  oldest first. The invariant a colliding install used to break is that no
+  address appears here twice with no `:rf.machine/destroyed` between."
+  []
+  (mapv (comp :spawned-id :tags)
+        (rf.machines.test-support/events-of :rf.machine.spawn/spawned)))
+
+;; ---------------------------------------------------------------------------
+;; Shared fixtures under test.
+;; ---------------------------------------------------------------------------
+
+(defn- reg-child!
+  "A child machine that records a mark in its own `:data`, so a surviving
+  occupant can be told apart from a replacement that overwrote it."
+  [id]
+  (rf/reg-machine id
+    {:initial :running
+     :data    {:mark :none}
+     :actions {:mark (fn [{d :data ev :event}] {:data (assoc d :mark (second ev))})}
+     :states  {:running {:on {:mark {:action :mark}}}}}))
+
+(defn- reg-parent!
+  "A parent whose `:working` state declaratively spawns `child-id` at a
+  GENERATED address (no `:fixed-actor-id`), and which can leave and re-enter
+  that state."
+  [id child-id]
+  (rf/reg-machine id
+    {:initial :idle
+     :states  {:idle    {:on {:go :working}}
+               :working {:spawn {:machine-id child-id}
+                         :on    {:back :idle}}}}))
+
+;; ---------------------------------------------------------------------------
+;; (1) The filed defect: a respawned parent re-mints its live orphan's address.
+;; ---------------------------------------------------------------------------
+
+(deftest a-respawned-parent-is-refused-its-live-orphans-generated-address
+  (testing "rf2-1sip — a parent destroyed and respawned at the SAME address
+            starts its :rf/spawn-counter fresh, so its first new child would
+            allocate <type>#1 over the still-live orphan the previous
+            incarnation left. That install is now REJECTED: the orphan keeps its
+            snapshot and its :data verbatim, no second spawned trace names the
+            address, and one :rf.error/machine-spawn-all-duplicate-id fires."
+    (reg-child! :gac/child)
+    (reg-parent! :gac/parent :gac/child)
+    (rf/reg-event :gac/hire
+      (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :gac/parent
+                                          :fixed-actor-id :gac/p}]]}))
+    (rf/reg-event :gac/fire
+      (fn [_ _] {:fx [[:rf.machine/destroy :gac/p]]}))
+
+    ;; First incarnation of the parent spawns a child at the generated address.
+    (rf/dispatch-sync [:gac/hire])
+    (rf/dispatch-sync [:gac/p [:go]])
+    (is (some? (snapshot :gac/child#1))
+        "the first incarnation's child installed at the generated address")
+    (rf/dispatch-sync [:gac/child#1 [:mark :FIRST]])
+    (is (= :FIRST (:mark (machine-data :gac/child#1)))
+        "and it is addressable — the mark distinguishes it from any successor")
+
+    ;; An IMPERATIVE destroy of the parent tears down the parent ONLY: the
+    ;; child is an independent actor at its own address and outlives its
+    ;; spawner (Spec 005 §Teardown is explicit in v1). That orphan is the
+    ;; occupant the respawned parent will collide with.
+    (rf/dispatch-sync [:gac/fire])
+    (is (nil? (snapshot :gac/p)) "the parent was destroyed")
+    (is (some? (snapshot :gac/child#1))
+        "its child survives as an orphan — teardown is explicit in v1")
+
+    (rf.machines.test-support/reset-captured!)
+
+    ;; A new incarnation at the SAME address, with a FRESH counter.
+    (rf/dispatch-sync [:gac/hire])
+    (is (= {} (:rf/spawn-counter (snapshot :gac/p)))
+        "the new incarnation's spawn-counter is seeded fresh — this is the
+         defect's cause, and pinning it keeps the test honest about what it
+         reproduces")
+    (rf/dispatch-sync [:gac/p [:go]])
+
+    (testing "the collision is REFUSED"
+      (is (= 1 (count (rejects)))
+          "exactly one :rf.error/machine-spawn-all-duplicate-id, not zero and
+           not one per retry")
+      (is (= :gac/child#1 (:failing-id (first (rejects))))
+          "the reject names the occupied address")
+      (is (= :gac/child (:machine-id (first (rejects))))
+          "and the machine TYPE that could not be spawned")
+      (is (= :gac/p (:parent-id (first (rejects))))
+          "and the spawning parent"))
+
+    (testing "the occupant SURVIVED — the half of this that is not the error"
+      (is (some? (snapshot :gac/child#1))
+          "the orphan still has a snapshot")
+      (is (= :FIRST (:mark (machine-data :gac/child#1)))
+          "and it is the SAME actor: its :data was never overwritten")
+      (is (= [] (filterv #(= :gac/child#1 %) (spawned-ids)))
+          "no :rf.machine.spawn/spawned announced the address a second time")
+      (is (nil? (snapshot :gac/child#2))
+          "and the runtime did not silently side-line the spawn to a fresh
+           address either — the reject is fail-closed, not a re-allocation"))))
+
+;; ---------------------------------------------------------------------------
+;; (2) The same collision with no re-incarnation at all: two live parents.
+;; ---------------------------------------------------------------------------
+
+(deftest a-second-parent-is-refused-the-address-its-sibling-already-holds
+  (testing "rf2-1sip — the counter is per-snapshot and the address space is
+            per-frame, so two parents of one type at DISTINCT addresses both
+            mint <type>#1 with no destroy and no re-incarnation anywhere. The
+            second is refused and the first parent's child is untouched."
+    (reg-child! :gac2/child)
+    (reg-parent! :gac2/parent :gac2/child)
+    (rf/reg-event :gac2/hire
+      (fn [_ [_ addr]] {:fx [[:rf.machine/spawn {:machine-id     :gac2/parent
+                                                 :fixed-actor-id addr}]]}))
+
+    (rf/dispatch-sync [:gac2/hire :gac2/a])
+    (rf/dispatch-sync [:gac2/hire :gac2/b])
+    (is (and (some? (snapshot :gac2/a)) (some? (snapshot :gac2/b)))
+        "two live parents at two distinct addresses — the ordinary multi-actor
+         shape, nothing exotic")
+
+    (rf/dispatch-sync [:gac2/a [:go]])
+    (is (some? (snapshot :gac2/child#1)) "parent A's child installed")
+    (rf/dispatch-sync [:gac2/child#1 [:mark :FROM-A]])
+
+    (rf.machines.test-support/reset-captured!)
+    (rf/dispatch-sync [:gac2/b [:go]])
+
+    (is (= 1 (count (rejects)))
+        "parent B's spawn is refused rather than collapsing onto A's child")
+    (is (= :gac2/child#1 (:failing-id (first (rejects)))))
+    (is (= :gac2/b (:parent-id (first (rejects))))
+        "the reject names B, the parent whose spawn was refused")
+    (is (= :FROM-A (:mark (machine-data :gac2/child#1)))
+        "A's child is the SAME actor it was — this is the silent data loss the
+         reject replaces")
+    (is (= :gac2/child#1 (get-in (machine-data :gac2/a) [:rf/spawned [:working]]))
+        "and A still records that address as the child it spawned")))
+
+;; ---------------------------------------------------------------------------
+;; (3) Controls — ordinary generated spawning is UNCHANGED.
+;; ---------------------------------------------------------------------------
+
+(deftest an-uncontended-generated-spawn-installs-exactly-as-before
+  (testing "rf2-1sip — the guard costs one runtime-db read and changes nothing
+            when the generated address is free: the child installs, the spawned
+            trace fires once, and no reject is emitted"
+    (reg-child! :gac3/child)
+    (reg-parent! :gac3/parent :gac3/child)
+    (rf/dispatch-sync [:gac3/parent [:go]])
+    (is (some? (snapshot :gac3/child#1)) "the child installed normally")
+    (is (= [:gac3/child#1] (spawned-ids)) "one spawned trace, naming it")
+    (is (empty? (rejects)) "and no collision reject")))
+
+(deftest re-entry-re-allocates-and-never-collides
+  (testing "rf2-1sip — leaving a :spawn-bearing state destroys the child through
+            the exit cascade AND the parent's counter advances, so re-entry
+            allocates <type>#2 at an empty address. Both defences hold and the
+            guard never fires."
+    (reg-child! :gac4/child)
+    (reg-parent! :gac4/parent :gac4/child)
+    (rf/dispatch-sync [:gac4/parent [:go]])
+    (is (some? (snapshot :gac4/child#1)))
+    (rf/dispatch-sync [:gac4/parent [:back]])
+    (is (nil? (snapshot :gac4/child#1))
+        "the exit cascade destroyed the child — unlike an imperative parent
+         destroy, which does not")
+    (rf/dispatch-sync [:gac4/parent [:go]])
+    (is (some? (snapshot :gac4/child#2))
+        "re-entry allocated the NEXT address, not a re-mint of #1")
+    (is (nil? (snapshot :gac4/child#1)))
+    (is (empty? (rejects)) "no reject on the ordinary re-entry path")))
+
+(deftest an-occupied-fixed-address-still-REPLACES-rather-than-rejecting
+  (testing "rf2-1sip does NOT reopen rf2-dokz: an address the AUTHOR NAMED is
+            still replaced cleanly, with no error, because naming it twice is a
+            request. Only the generated case rejects."
+    (reg-child! :gac5/child)
+    (rf/reg-event :gac5/hire
+      (fn [_ _] {:fx [[:rf.machine/spawn {:machine-id     :gac5/child
+                                          :fixed-actor-id :gac5/pinned}]]}))
+    (rf/dispatch-sync [:gac5/hire])
+    (rf/dispatch-sync [:gac5/pinned [:mark :FIRST]])
+    (is (= :FIRST (:mark (machine-data :gac5/pinned))))
+
+    (rf/dispatch-sync [:gac5/hire])
+    (is (some? (snapshot :gac5/pinned)) "the replacement installed")
+    (is (= :none (:mark (machine-data :gac5/pinned)))
+        "and it IS the replacement — a fresh incarnation at the named address")
+    (is (empty? (rejects))
+        "no reject: rf2-dokz's ruling is untouched by rf2-1sip's guard")))
+
+;; ---------------------------------------------------------------------------
+;; (4) `:spawn-all` — the within-batch guard and the admitted-child invariant.
+;; ---------------------------------------------------------------------------
+
+(deftest an-intra-spawn-all-duplicate-still-rejects-the-whole-invoke
+  (testing "rf2-qlzh9's within-batch resolved-address guard is structurally
+            elsewhere (the invoke preflight) and is UNCHANGED: two children
+            sharing one :fixed-actor-id still reject the whole invoke before
+            anything installs"
+    (reg-child! :gac6/child)
+    (rf/reg-machine :gac6/parent
+      {:initial :idle
+       :states  {:idle    {:on {:go :forking}}
+                 :forking {:spawn-all {:children        [{:id :x :machine-id :gac6/child
+                                                          :fixed-actor-id :gac6/one}
+                                                         {:id :y :machine-id :gac6/child
+                                                          :fixed-actor-id :gac6/one}]
+                                       :join            :all
+                                       :on-all-complete [:all/done]}
+                           :on {:all/done :ready}}
+                 :ready   {}}})
+    (rf/dispatch-sync [:gac6/parent [:go]])
+    (is (= 1 (count (rejects)))
+        "one deterministic reject for the aliased invoke")
+    (is (= [[:gac6/one [:x :y]]] (:collisions (first (rejects))))
+        "and it is the PREFLIGHT's reject — it carries the :collisions vector,
+         which the generated-address reject does not")
+    (is (nil? (snapshot :gac6/one))
+        "nothing installed: the invoke was rejected atomically")))
+
+(deftest an-admitted-spawn-all-child-still-always-installs
+  (testing "rf2-v4oqd — the authoritative preflight is the SOLE verdict for a
+            :spawn-all child, so the generated-address guard deliberately
+            excludes prepared children: a second per-child reject would strand
+            a live join naming a child that never appears. A batch of two
+            children of one type allocates #1 and #2 and both install."
+    (reg-child! :gac7/child)
+    (rf/reg-machine :gac7/parent
+      {:initial :idle
+       :states  {:idle    {:on {:go :forking}}
+                 :forking {:spawn-all {:children        [{:id :x :machine-id :gac7/child}
+                                                         {:id :y :machine-id :gac7/child}]
+                                       :join            :all
+                                       :on-all-complete [:all/done]}
+                           :on {:all/done :ready}}
+                 :ready   {}}})
+    (rf/dispatch-sync [:gac7/parent [:go]])
+    (is (some? (snapshot :gac7/child#1)) "the first child installed")
+    (is (some? (snapshot :gac7/child#2)) "and the second, at the NEXT address")
+    (is (empty? (rejects)) "no reject — the batch's addresses are distinct")))
+
+;; ---------------------------------------------------------------------------
+;; (5) The reject's own shape.
+;; ---------------------------------------------------------------------------
+
+(deftest the-reject-carries-structural-context-only-and-names-both-escapes
+  (testing "rf2-1sip — the diagnostic is structural-only (Spec 009 privacy: the
+            spawn args / :data may hold application PII) and its human reason
+            names the two author-side escapes, since :recovery is :no-recovery"
+    (reg-child! :gac8/child)
+    (rf/reg-machine :gac8/parent
+      {:initial :idle
+       :states  {:idle    {:on {:go :working}}
+                 :working {:spawn {:machine-id :gac8/child
+                                   :data       {:secret "hunter2"}}}}})
+    (rf/reg-event :gac8/hire
+      (fn [_ [_ addr]] {:fx [[:rf.machine/spawn {:machine-id     :gac8/parent
+                                                 :fixed-actor-id addr}]]}))
+    (rf/dispatch-sync [:gac8/hire :gac8/a])
+    (rf/dispatch-sync [:gac8/hire :gac8/b])
+    (rf/dispatch-sync [:gac8/a [:go]])
+    (rf.machines.test-support/reset-captured!)
+    (rf/dispatch-sync [:gac8/b [:go]])
+
+    (let [ev  (first (rejects))
+          raw (first (rf.machines.test-support/events-of
+                       :rf.error/machine-spawn-all-duplicate-id))]
+      (is (some? ev) "the reject fired")
+      ;; Spec 009 §Core fields hoists `:recovery` onto the event root and
+      ;; drops it from `:tags`, so it is read off the raw event.
+      (is (= :no-recovery (:recovery raw))
+          "the runtime may neither re-allocate (that would break the
+           deterministic <type>#<n> sequencing) nor destroy the occupant")
+      (is (string? (:reason ev)))
+      (is (re-find #":fixed-actor-id" (:reason ev))
+          "the reason names the distinct-address escape")
+      (is (re-find #"destroy" (:reason ev))
+          "and the destroy-the-occupant-first escape")
+      (is (not (re-find #"hunter2" (:reason ev)))
+          "and it never echoes the spawn :data")
+      (is (nil? (:data ev)) "no :data rides the record")
+      (is (nil? (:args ev)) "nor the raw spawn args")
+      (is (not (re-find #"hunter2" (pr-str raw)))
+          "and no slot of the WHOLE emitted event smuggles the payload through"))))

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -3030,10 +3030,10 @@ and the machine's registration — which the replacement and every sibling actor
 of that type resolve through — **survives** that teardown.
 
 Replacement stays **one verb at one address**. There is no `:replace?` opt-in
-key, no occupied-address error and no warning: an author who names an address
-they have already named has asked for the actor at that address to become the
-new one, and honouring that request means the old one is finished with. Two
-limits of the rule are deliberate:
+key, no error at an occupied **fixed** address and no warning: an author who
+names an address they have already named has asked for the actor at that address
+to become the new one, and honouring that request means the old one is finished
+with. Two limits of the rule are deliberate:
 
 - **The occupant's own descendants are NOT reaped.** They are ordinary actors
   at their own addresses and outlive their spawner exactly as they outlive an
@@ -3045,10 +3045,35 @@ limits of the rule are deliberate:
   unrelated spawn sites resolving to one address, and re-frame2 keeps no second
   registry to consult. What it guarantees is that neither case LEAKS.
 
+**Spawning onto an occupied GENERATED address is REJECTED, not replaced.** The
+rule above turns entirely on the author having NAMED the address. Nobody names a
+generated one: `<type>#<n>` is minted by a counter, and that counter is
+[per-spawning-snapshot](#reserved-snapshot-internal-keys) while the address space
+it allocates into is per-frame. The two disagree in ordinary programs — a parent
+destroyed and respawned at the same address begins counting from zero beside its
+own still-live orphans, and two parents spawning the same child type each mint
+`#1` — so a generated address can arrive at a live actor with no author
+involvement anywhere. There is no request to honour, and *Teardown is explicit in
+v1* reserves destroying the occupant to the author, so the spawn is **rejected
+fail-closed**: it installs no snapshot, records no spawn-order entry, emits no
+`:rf.machine.spawn/spawned` and dispatches no `:start`, and one
+`:rf.error/machine-spawn-all-duplicate-id` names the machine type, the occupied
+address and the spawning parent. That is the existing category rather than a new
+one — it already means "two distinct spawns resolve to one actor address and one
+would silently overwrite the other", including the fixed-versus-generated shape —
+and `:recovery` is `:no-recovery`: the runtime may not pick a different address
+without breaking the deterministic `<type>#<n>` sequencing, so the author gives
+the spawn a distinct `:fixed-actor-id` or destroys the occupant first. One case
+is deliberately outside the guard: an **admitted `:spawn-all` child** is never
+rejected here, because the invoke-level preflight is that child's sole verdict
+(a second per-child reject would strand a live join naming a child that never
+appears); within-batch aliasing is already rejected atomically by that preflight.
+
 Two neighbouring cases are unchanged. Ordinary re-entry — leaving the
 `:spawn`-bearing state, whose exit cascade destroys the child, then re-entering
 at an EMPTY address — installs a fresh incarnation with no occupant to tear
-down. And two children of one `:spawn-all` batch resolving to one literal
+down, and the parent's counter has advanced, so neither defence is load-bearing
+alone. And two children of one `:spawn-all` batch resolving to one literal
 address are still rejected outright with
 `:rf.error/machine-spawn-all-duplicate-id` rather than replaced: within a single
 batch there is no "previous occupant", only a malformed invoke.
@@ -3916,7 +3941,7 @@ A common partial-success idiom is to declare `:after` for the phase-level timeou
 `:spawn-all` introduces three new registration-time error categories on top of the existing `:rf.error/machine-*`:
 
 - `:rf.error/machine-spawn-all-bad-shape` — a child invoke-spec is missing `:id` or both `:machine-id` and `:definition`; or `:spawn-all` is not a vector; or the join-event slots are missing per the required-iff rules above.
-- `:rf.error/machine-spawn-all-duplicate-id` — two `:spawn-all` children collide on an id. At **registration** two child invoke-specs share a logical `:id` keyword (each `:id` must be unique inside the same `:spawn-all` block). The **same category** also surfaces at **spawn time** for resolved actor-address aliasing — see the invoke-level admission preflight below.
+- `:rf.error/machine-spawn-all-duplicate-id` — two spawns collide on one actor address. At **registration** two child invoke-specs share a logical `:id` keyword (each `:id` must be unique inside the same `:spawn-all` block). The **same category** also surfaces at **spawn time**, twice: for resolved actor-address aliasing *within* one `:spawn-all` batch — see the invoke-level admission preflight below — and, outside `:spawn-all` entirely, for a **single `:spawn` whose GENERATED `<type>#<n>` address is already held by a live actor**, per [§Declarative `:spawn`](#declarative-spawn). All three are one failure: two distinct spawns resolving to one address, where one would silently overwrite the other.
 - `:rf.error/machine-spawn-all-with-spawn` — a state node declares both `:spawn` and `:spawn-all`; the combination is rejected.
 
 **Invoke-level child admission — the atomic fail-closed reject.** The `:rf.machine/spawn-all-init` fx fires **FIRST** in the entry `:fx` vector, before every per-child `:rf.machine/spawn` fx, and its **preflight is the authoritative decision for every fail-closed child-admission condition**. It preflights the *prepared per-child spawn args* — the exact payloads the per-child fxs will run, so it sees each child's materialised `:data` and allocated id, and therefore its real verdict. If **any** child fails admission, the whole invoke is **rejected atomically**: instead of a live child-bearing join state, the fx seeds a **childless reject sentinel** (`{:rf/spawn-all-rejected? true}`, no `:children`) at the join slot. Three conditions gate admission — an unregistered TYPE, a spawn-time schema rejection, and resolved actor-address aliasing (the first two are disjoint: an unregistered type resolves to no spec, so it can never also be a schema reject):


### PR DESCRIPTION
Closes rf2-1sip — **option (f) only**.

A spawn whose **generated** `<type>#<n>` address is already held by a **live actor** is now REJECTED fail-closed with the existing `:rf.error/machine-spawn-all-duplicate-id`, instead of being installed over the occupant through the unguarded `assoc-in` at the spawn install path.

**Option (e) is deliberately NOT attempted.** The bead's own recommendation is *"Take (e); land (f) first if the silence should stop this week."* (e) re-homes the declarative allocator's counter to the frame runtime-db slot, which moves the `machine-transition` purity contract the replay guarantee and `machine_transition_purity_test.clj` rest on, and requires re-siting `bind-spawned-id-into-parent-data`. Nothing here seeds `:rf/spawn-counter` from an outgoing incarnation, makes generated ids incarnation-stamped, or touches purity. This PR converts silent data loss into a named error and does no more than that.

## The ruling this embeds — please read before merging

rf2-dokz **REJECTED** an occupied-address error outright: *"REJECTED, decided not deferred: no `:rf.error/machine-spawn-occupied-address`; no warning trace of any kind"*. This PR raises an error at an occupied address, so it depends on that rejection **not** binding here.

**I read rf2-dokz at source and agree with rf2-1sip's characterisation of it.** Three independent citations, all from rf2-dokz's own text:

- Its **Scope** section: *"ONLY the ordinary spawn-fx path installing at a supplied `:fixed-actor-id` that is currently LIVE."*
- Its **RULING note** gives the reasoning, and both legs of that reasoning are about an address the author named: the warning was rejected because *"a warning whose recommended response is 'write the destroy yourself', for a cleanup the framework is perfectly capable of performing, is exactly the nag shape the house stance rejects"*, and `Principles.md` §No silent swallow was held not to reach the case because *"the supplied address IS honoured exactly as given"*.
- Its implementation note says so in terms: *"Scoped to a SUPPLIED `:fixed-actor-id`, so rf2-1sip's generated-address recursion is left exactly as filed."*

Neither leg survives the move to a generated address. The framework is **not** capable of performing the cleanup — `005` §Teardown is explicit in v1 rules out an implicit ownership cascade, so destroying the occupant is not on the table — and nothing was "supplied" to honour, because a counter minted the address. So the reject is not a nag: there is no author request being second-guessed.

**This is still Mike's read to make, and review is the cheap place to veto it.** If the rejection is meant to bind at every address regardless of who named it, the whole PR should be reverted rather than narrowed.

## Line numbers — what the bead claimed vs what is at tip

Every site was re-derived at `033663cba2`. The bead's own dossier note had already corrected most of these; the corrections all hold.

| bead's citation | actual at tip | note |
|---|---|---|
| `parallel.cljc:395-397` (counter seed) | `parallel.cljc:397` | as the dossier corrected |
| `spawn.cljc:542` (install `assoc-in`) | `spawn.cljc:557` | as the dossier corrected |
| `transition.cljc:2783` (`run-active-exit-cascade`) | unchanged | as the dossier said |
| `spec/005:3902` (the `:spawn-all` silent-overwrite write-up) | catalogue row `3919`, write-up `3926` | drifted; both read as the bead describes |
| `spawn_order.cljc:50-57` | docstring prose only | the dossier's correction confirmed; nothing here depends on it |

One dossier finding this PR can now confirm from the other side: the premise *"the orphan is reaped at frame destroy either way"* is indeed false under the OLD behaviour — the sabotage run below shows the occupant's `:data` overwritten and a second `:rf.machine.spawn/spawned` naming the same address, so there is nothing left to reap. Under the new behaviour the orphan is intact and is reaped normally.

## What changed

- **`lifecycle_fx/spawn.cljc`** — `generated-address-collision?` (a predicate) and `reject-generated-address-collision!` (the emitter), and a two-way branch on the existing rf2-dokz cascade condition. The branches are mutually exclusive by construction: occupancy at a supplied `:fixed-actor-id` means REPLACE (rf2-dokz), occupancy at a generated `<type>#<n>` means REJECT.
- **`lifecycle_fx/destroy.cljc`** — `occupant-actor-live?` made public for that second caller, with the reasoning recorded in its docstring. The probe is shared deliberately so the two paths can never disagree about what "occupied" means, and it stays *not* `actor-live?`, for exactly the reason rf2-dokz recorded.
- **`spec/005-StateMachines.md`** — the contract paragraph under §Declarative `:spawn`, plus the §Errors catalogue row updated to name the third surfacing of the category. `spec/005` is the only spec file touched.
- **`generated_address_collision_test.clj`** — 8 tests / 47 assertions, new file.

Three clauses gate the reject, and each is load-bearing:

- a **supplied `:fixed-actor-id` is excluded** — checked on `args`, never on the id's spelling, because a fixed literal may itself end in `#<digits>`;
- an **admitted `:spawn-all` child is excluded** — rf2-v4oqd's invariant is that an admitted child ALWAYS installs, and a second per-child reject would strand a live join naming a child that never appears (the dead-join class rf2-ek435 closed). Within-batch aliasing is already rejected atomically by the preflight;
- a nil `spawned-id` is excluded — the cascade gate already refuses that spawn.

## The blast-radius numbers: the REAL count is ZERO

The bead measured **559** literal `<type>#<n>` pins across 65 files and **100** direct `:rf/spawn-counter` reads across 23, and was explicit that those are upper bounds rather than predicted breakage. Measured rather than reasoned: `implementation/machines` is green at **1225 tests / 4468 assertions, 0 failures, 0 errors** with this change in, and `implementation/core` is green at **2305 / 11923**. Zero pre-existing tests broke. That is consistent with the bead's own reasoning — a literal `#1` pin only breaks if the test spawns twice against the same allocator, and one that did would have been reproducing the defect.

## Both directions are pinned

An error-only suite is half a suite, so every reject test also asserts the **occupant survived intact** (its `:data` mark unchanged, its snapshot present, no second `:rf.machine.spawn/spawned` for the address, and no side-lining to a fresh address), and five controls assert nothing else moved:

1. `a-respawned-parent-is-refused-its-live-orphans-generated-address` — the filed defect: destroy the parent, respawn at the same address, fresh counter, `#1` collides with the live orphan. Also pins that the new incarnation's `:rf/spawn-counter` really is `{}`, so the test is honest about what it reproduces.
2. `a-second-parent-is-refused-the-address-its-sibling-already-holds` — the bead's measured case (i): two parents at distinct addresses, no destroy, no re-incarnation anywhere.
3. `an-uncontended-generated-spawn-installs-exactly-as-before` — control.
4. `re-entry-re-allocates-and-never-collides` — control; both defences (the exit cascade destroying the child, and the counter advancing) hold.
5. `an-occupied-fixed-address-still-REPLACES-rather-than-rejecting` — control: rf2-dokz's ruling is untouched.
6. `an-intra-spawn-all-duplicate-still-rejects-the-whole-invoke` — control: the within-batch preflight guard still fires, still carries its `:collisions` vector, still installs nothing.
7. `an-admitted-spawn-all-child-still-always-installs` — control for the prepared-child exclusion.
8. `the-reject-carries-structural-context-only-and-names-both-escapes` — `:recovery :no-recovery`, the reason names both author-side escapes, and no slot of the emitted event carries the spawn `:data`.

## Known gaps, stated rather than reasoned past

- **`spec/009-Instrumentation.md`'s error-catalogue row for this category is now one surfacing short.** It documents two surfacings; there are three. `spec/009` is hot-zone and this dispatch was scoped to `spec/005` exclusively, so it was not touched. This is owed follow-up, not an oversight.
- **A prepared `:spawn-all` child colliding with a live actor OUTSIDE its batch is still a silent overwrite**, by the deliberate exclusion above. That case belongs to option (e), which makes `<type>#<n>` frame-unique and so removes the collision rather than reporting it.
- **JVM only.** The new suite is a `.clj`; CLJS is graded by CI.
- A rejected spawn still leaves the parent's `[:data :rf/spawned <invoke-id>]` binding pointing at the address it could not install at, because `bind-spawned-id-into-parent-data` runs in the pure reducer. That is pre-existing and identical on the schema-reject and unregistered-TYPE paths; it is not changed here.

## Quality gates

Every exit code below was read from a `.exit` file written on the same command line as the redirect — never from a pipeline, never from the harness.

| gate | result |
|---|---|
| `implementation/machines` `clojure -M:test` | **exit 0** — 1225 tests / 4468 assertions / **0 failures / 0 errors** |
| `implementation/core` `clojure -M:test` | **exit 0** — 2305 tests / 11923 assertions / **0 failures / 0 errors** |
| focused `-n re-frame.generated-address-collision-test` | **exit 0** — 8 tests / 47 assertions / 0 failures / 0 errors |
| `python scripts/check_doc_slugs.py` | **exit 0** |
| `python -m mkdocs build --strict` | **exit 0** (`spec/` auto-staged by `mkdocs_hooks.py`) |
| 16 ratchets over the touched paths | **all exit 0** |

The ratchets run: `check_test_lane_bijection` (which reported 1599 test-defining files, 45 lanes, every file selected — so it saw the new file rather than skipping it), `check_jvm_lane_rosters`, `check_require_alias_dialect`, `check_retired_spellings`, `check_keyword_catalogue_drift`, `check_thrown_error_messages`, `check_retired_composition_vocab`, `check_ambient_durable_reads`, `check_allocation_non_claim`, `check_architecture_census`, `check_egress_walker_residue`, `check_failure_corpus_residue`, `check_view_lifetime_residue`, `check_inject_cofx_residue`, `check_retired_image_keys`, `check_runtime_subsystem_grading`.

Not run locally and left to CI: the CLJS lanes, clj-kondo / Splint (a locally-installed linter of a different version than the workflow pin proves nothing in either direction), and every other required check. CI grades the matrix; the local run answered "did I break something obvious?" once.

### Sabotage proof

The fix was committed **before** the plant, so the restore came from a known object.

- **Plant**, one line, in the predicate under test: `(nil? prepared)` became `(some? prepared)` in `generated-address-collision?`. That makes the guard unreachable for a single `:spawn`, reinstating the pre-change silent overwrite exactly.
- **Match count read BEFORE the run: 1.** The two-token anchor `and (some? spawned-id)` was rejected first because it matched 2 lines.
- **Result: exit 1** — 13 failures / 3 errors, naming `generated_address_collision_test.clj` at lines 148, 151, 153, 155, 161, 163, 197, 199, 200, 202, 338, 341 and 344. The failures include the occupant-survival half, not merely the error half: `:gac/child#1`'s `:mark` was no longer `:FIRST`, and `:gac/child#1` appeared in the spawned-trace stream a second time with no destroy between.
- **The five controls stayed GREEN under the plant**, which is the discrimination that matters: they must hold under both behaviours, and they did.
- **Restore verified by BLOB HASH**, never by the restore command's exit code: the working file hashes to the blob `5f9dbd0ef9218ae6a0eed5e4b4f8472e1f2bf55b`, equal to `git rev-parse HEAD:<path>`. `git status` clean afterwards.

Diffed against the merge base (three-dot, `033663cba2...HEAD`) before pushing and read for reverts: four files, nothing undone. Trunk moved to `02c7127fae` while this was in flight, touching only `.beads/`, `spec/009` and docs — none of this PR's paths.
