### PR TITLE
fix(machines): honour :id-prefix on the declarative :spawn path (rf2-r9ey)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -932,8 +932,12 @@
   without breaking the deterministic `<type>#<n>` sequencing
   `machine-transition`'s purity contract rests on, and it must not destroy the
   occupant, which Spec 005's *Teardown is explicit in v1* rule reserves to the
-  author. The `reason` therefore names both author-side escapes: a distinct
-  `:fixed-actor-id`, or destroying the occupant before spawning over it."
+  author. The `reason` therefore names the author-side escapes: a distinct
+  `:id-prefix` (rf2-r9ey made that key load-bearing on the declarative path,
+  where it had been accepted, documented and then ignored — it is the
+  NAMESPACING escape, and the one that fits the two-parents-one-TYPE shape this
+  reject fires on), a distinct `:fixed-actor-id`, or destroying the occupant
+  before spawning over it."
   [frame-id args spawned-id]
   (let [machine-id (:machine-id args)
         parent-id  (:rf/parent-id args)
@@ -948,8 +952,9 @@
                           "address space is per-frame, so a respawned parent, or "
                           "a second parent spawning the same machine TYPE, can "
                           "re-mint an address that is still held. Give this spawn "
-                          "a distinct :fixed-actor-id, or destroy the occupant "
-                          "explicitly before spawning over it."))]
+                          "a distinct :id-prefix so its addresses are namespaced "
+                          "apart, or a distinct :fixed-actor-id, or destroy the "
+                          "occupant explicitly before spawning over it."))]
     (rf.trace/emit-error! :rf.error/machine-spawn-all-duplicate-id
                        {:machine-id machine-id
                         :failing-id spawned-id

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -14,7 +14,7 @@
   `:rf.machine/spawn` allocator's id sequencing) depends ONLY on the
   arguments. There is no module-level mutable state and no `app-db` read
   — the declarative-`:spawn` spawn-id allocator lives
-  INSIDE the snapshot under `:rf/spawn-counter` (a per-machine-id integer
+  INSIDE the snapshot under `:rf/spawn-counter` (a per-id-prefix integer
   map), so identical triples produce identical Results and the reducer
   threads the bumped counter through the returned snapshot. That is the
   determinism the conformance corpus, the SSR pure-fn surface, and
@@ -542,8 +542,11 @@
 ;; Per Spec 005 §Declarative :spawn (sugar over spawn): on
 ;; entry to a :spawn-bearing state the runtime emits a :rf.machine/spawn
 ;; fx and assigns the spawned actor a deterministic id of the form
-;; `<machine-id>#<n>`. The counter lives inside the snapshot under the
-;; reserved key `:rf/spawn-counter` — a per-machine-id integer map. This
+;; `<id-prefix>#<n>` — the spawn-spec's own `:id-prefix` when it carries
+;; one, else its `:machine-id`. The counter lives inside the snapshot
+;; under the reserved key `:rf/spawn-counter` — a per-id-prefix integer
+;; map, keyed by the SAME prefix the address is minted from, per Spec 005
+;; §Spawn-id allocator — counter location. This
 ;; makes `apply-transition-once` an honest pure function: identical
 ;; (machine snapshot event) triples produce identical [next-snapshot
 ;; effects] pairs including spawn-id sequencing. Each spawn bumps
@@ -558,22 +561,22 @@
 ;; key — the reducer uses `(fnil inc 0)` so absent slots default to 0.
 
 (defn- format-spawn-id
-  "Format a spawned actor id of the form `<machine-id>#<n>` preserving
-  any namespace on the machine-id."
-  [machine-id n]
-  (keyword (namespace machine-id)
-           (str (name machine-id) "#" n)))
+  "Format a spawned actor id of the form `<id-prefix>#<n>` preserving
+  any namespace on the id-prefix."
+  [id-prefix n]
+  (keyword (namespace id-prefix)
+           (str (name id-prefix) "#" n)))
 
 (defn- allocate-spawned-id
-  "Pure allocator. Given a snapshot and the spawned actor's machine-id,
+  "Pure allocator. Given a snapshot and the spawned actor's id-prefix,
   return `[snap' spawned-id]` where snap' carries the bumped counter at
-  `[:rf/spawn-counter <machine-id>]` and spawned-id is
-  `<machine-id>#<bumped-n>`. The counter lives in-snapshot
+  `[:rf/spawn-counter <id-prefix>]` and spawned-id is
+  `<id-prefix>#<bumped-n>`. The counter lives in-snapshot
   so machine-transition is deterministic from its arguments."
-  [snap machine-id]
-  (let [snap' (update-in snap [:rf/spawn-counter machine-id] (fnil inc 0))
-        n     (get-in snap' [:rf/spawn-counter machine-id])]
-    [snap' (format-spawn-id machine-id n)]))
+  [snap id-prefix]
+  (let [snap' (update-in snap [:rf/spawn-counter id-prefix] (fnil inc 0))
+        n     (get-in snap' [:rf/spawn-counter id-prefix])]
+    [snap' (format-spawn-id id-prefix n)]))
 
 (defn- bind-spawned-id-into-parent-data
   "Bind a declaratively-`:spawn`'d actor's assigned id into
@@ -2353,9 +2356,34 @@
 ;; The mode-specific spawn-args wiring is the only delta — a small
 ;; `args-builder` closure per mode.
 
+(defn- spawn-id-prefix
+  "The base the generated `<prefix>#<n>` address is minted from, and the key
+  the in-snapshot `:rf/spawn-counter` sequences it under: `spawn-spec`'s own
+  `:id-prefix` when it carries one, else its `:machine-id` (the registered
+  machine TYPE).
+
+  Per Spec 005 §Spawn-spec keys, `:id-prefix` is `optional; defaults to
+  :machine-id`, and §Spawn-id allocator — counter location keys the
+  declarative counter at `[:rf/spawn-counter <id-prefix>]`. rf2-r9ey: the
+  declarative allocator previously read `:machine-id` unconditionally, so an
+  author who supplied the documented `:id-prefix` was silently ignored — the
+  key was accepted by the spawn-args validator, documented in three places,
+  and had no effect at all. That mattered beyond tidiness once rf2-1sip
+  shipped option (f) alone: a generated address held by a live actor now
+  fails closed, and `:id-prefix` is the author's only namespacing escape from
+  the collision it refuses.
+
+  PREFIX AND COUNTER KEY MOVE TOGETHER, deliberately. Sequencing under one key
+  while minting from another would re-mint `<prefix>#1` for every distinct
+  prefix sharing a `:machine-id`, which is the collision the escape exists to
+  avoid."
+  [spawn-spec]
+  (or (:id-prefix spawn-spec) (:machine-id spawn-spec)))
+
 (defn- allocate-one
-  "Allocate one spawned-id from `spawn-spec`'s `:machine-id` (the registered
-  machine TYPE) against `snap`'s in-snapshot counter. When
+  "Allocate one spawned-id from `spawn-spec`'s `spawn-id-prefix` (its
+  `:id-prefix`, else the registered machine TYPE) against `snap`'s
+  in-snapshot counter. When
   `spawn-spec` carries an explicit `:fixed-actor-id` literal (the explicit
   actor-address input — per-state singleton) the counter is NOT
   bumped and that fixed address is used verbatim. Returns
@@ -2363,7 +2391,7 @@
   [snap spawn-spec]
   (if-let [explicit (:fixed-actor-id spawn-spec)]
     [snap explicit]
-    (allocate-spawned-id snap (:machine-id spawn-spec))))
+    (allocate-spawned-id snap (spawn-id-prefix spawn-spec))))
 
 (defn- spawn-one
   "Single-spawn primitive shared by `:spawn` and `:spawn-all` per-child.
@@ -2405,7 +2433,7 @@
         [s-alloc id] (allocate-one s spawn-spec)
         args-builder (fn [spec' spawned-id]
                        (-> spec'
-                           (assoc :id-prefix     (:machine-id spec'))
+                           (assoc :id-prefix     (spawn-id-prefix spec'))
                            (assoc :rf/spawned-id spawned-id)
                            (assoc :rf/parent-id  parent-id)
                            (assoc :rf/invoke-id  invoke-id)))
@@ -2474,7 +2502,7 @@
                   (fn [child' spawned-id]
                     (-> child'
                         (dissoc :id)
-                        (assoc :id-prefix              (:machine-id child'))
+                        (assoc :id-prefix              (spawn-id-prefix child'))
                         (assoc :rf/spawned-id           spawned-id)
                         (assoc :rf/parent-id            parent-id)
                         (assoc :rf/spawn-all-id        invoke-id)

--- a/implementation/machines/test/re_frame/spawn_id_prefix_test.clj
+++ b/implementation/machines/test/re_frame/spawn_id_prefix_test.clj
@@ -1,0 +1,300 @@
+(ns re-frame.spawn-id-prefix-test
+  "rf2-r9ey — a declarative `:spawn` / `:spawn-all` allocates its generated
+  address from the spawn-spec's `:id-prefix` when one is supplied, and from its
+  `:machine-id` when one is not.
+
+  THE DEFECT THIS PINS. `:id-prefix` was ACCEPTED by the spawn-args validator
+  (`lifecycle-fx.validation`'s spawn-spec key set), DOCUMENTED by Spec 005 in
+  three places (§Spawn-spec keys and §Spec-spec keys both gloss it as
+  `optional; defaults to :machine-id`, and §Spawn-id allocator — counter
+  location keys the declarative counter at `[:rf/spawn-counter <id-prefix>]`),
+  and then IGNORED: `transition/allocate-one` read `:machine-id`
+  unconditionally, and the two args-builders that assemble the
+  `:rf.machine/spawn` fx overwrote the author's `:id-prefix` with the child's
+  `:machine-id` on the way out. So a spawn-spec asking for `:id-prefix :pc/mine`
+  got `:pc/child#1` under counter key `:pc/child`, with nothing raised anywhere.
+  That is the worst shape a knob can have — it fails in the REASSURING
+  direction at authoring time and is diagnosable only by reading the allocator.
+
+  WHY IT IS LOAD-BEARING RATHER THAN COSMETIC. rf2-1sip shipped option (f)
+  ALONE: a generated `<type>#<n>` address already held by a live actor is now
+  REJECTED fail-closed with `:rf.error/machine-spawn-all-duplicate-id`
+  (`generated_address_collision_test`). The declarative counter lives in the
+  SPAWNING PARENT'S SNAPSHOT while the address space is FRAME-GLOBAL, so two
+  parents spawning the same child TYPE both mint `<type>#1` and the second is
+  refused. `:id-prefix` is the only namespacing escape an author has from that
+  refusal — which is exactly what (5) below exercises. Option (e) (re-homing
+  the counter so `<type>#<n>` is frame-unique) is NOT attempted here and
+  remains unruled; nothing in this file seeds or advances `:rf/spawn-counter`
+  across incarnations, and `machine-transition` stays pure.
+
+  BOTH DIRECTIONS ARE PINNED, and the second is the one that matters. (2) is
+  the CONTROL: a spawn WITHOUT `:id-prefix` must still allocate under
+  `:machine-id`, exactly as before. Without it, an allocator that simply read
+  the prefix key unconditionally — a silent rename rather than a repair — would
+  pass (1) and every other test here.
+
+  Spec contract: [Spec 005 §Spawn-spec keys], [Spec 005 §Spec-spec keys],
+  [Spec 005 §Spawn-id allocator — counter location],
+  [Spec 005 §Spawn id format — `<id-prefix>#<n>` keyword]."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
+
+(use-fixtures :each
+  (rf.machines.test-support/make-reset-runtime-fixture
+    {:adapter rf.substrate.plain-atom/adapter})
+  rf.machines.test-support/trace-capture-fixture)
+
+(def ^:private snapshot rf.machines.test-support/snapshot)
+(def ^:private runtime-db rf.machines.test-support/runtime-db)
+
+(defn- spawned-id-for
+  "The address the runtime recorded for `parent-id`'s spawn at `invoke-id`, read
+  from the runtime-owned registry rather than guessed from the id format."
+  [parent-id invoke-id]
+  (get-in (runtime-db) [:rf.runtime/machines :spawned parent-id invoke-id]))
+
+(defn- spawn-counter
+  "`parent-id`'s in-snapshot `:rf/spawn-counter` map — the per-prefix sequence
+  the allocator bumps. Asserting on the KEY, not merely on the minted address,
+  is what stops a fix that spelled the address from one key while sequencing it
+  under another."
+  [parent-id]
+  (:rf/spawn-counter (snapshot parent-id)))
+
+(defn- reg-leaf!
+  "A do-nothing child machine, used only as a spawnable TYPE."
+  [id]
+  (rf/reg-machine id {:initial :running :data {} :states {:running {}}}))
+
+;; ---------------------------------------------------------------------------
+;; (1) THE DEFECT: a supplied `:id-prefix` decides the address AND the counter.
+;; ---------------------------------------------------------------------------
+
+(deftest supplied-id-prefix-decides-the-generated-address
+  (testing "rf2-r9ey — a declarative :spawn carrying :id-prefix allocates
+            <id-prefix>#<n>, sequenced under the SUPPLIED prefix. Before this
+            bead it allocated <machine-id>#<n> under the machine-id and the
+            supplied prefix had no effect at all."
+    (reg-leaf! :idp/child)
+    (rf/reg-machine :idp/parent
+      {:initial :idle
+       :data    {}
+       :states  {:idle    {:on {:go :working}}
+                 :working {:spawn {:machine-id :idp/child
+                                   :id-prefix  :idp/mine}}}})
+    (rf/dispatch-sync [:idp/parent [:go]])
+
+    (is (= :idp/mine#1 (spawned-id-for :idp/parent [:working]))
+        "the registry records the address minted from the SUPPLIED prefix")
+    (is (some? (snapshot :idp/mine#1))
+        "and a live actor installed there")
+    (is (nil? (snapshot :idp/child#1))
+        "nothing installed at the machine-id-derived address — the supplied
+         prefix REPLACED it rather than sitting alongside it")
+
+    (testing "the counter is keyed by the same prefix the address was minted from"
+      (is (= {:idp/mine 1} (spawn-counter :idp/parent))
+          "one entry, under the supplied prefix — not under :idp/child, and not
+           a second bookkeeping entry beside it"))))
+
+;; ---------------------------------------------------------------------------
+;; (2) THE CONTROL: no `:id-prefix` still allocates under `:machine-id`.
+;; ---------------------------------------------------------------------------
+
+(deftest absent-id-prefix-still-allocates-under-the-machine-id
+
+  (testing "rf2-r9ey CONTROL — a :spawn with NO :id-prefix is unchanged: it
+            allocates <machine-id>#<n> under counter key <machine-id>. This is
+            the assertion that distinguishes a repair from a silent rename; an
+            allocator that always read :id-prefix would pass every other test
+            in this file and fail here with a nil-derived address."
+    (reg-leaf! :idp2/child)
+    (rf/reg-machine :idp2/parent
+      {:initial :idle
+       :data    {}
+       :states  {:idle    {:on {:go :working}}
+                 :working {:spawn {:machine-id :idp2/child}}}})
+    (rf/dispatch-sync [:idp2/parent [:go]])
+
+    (is (= :idp2/child#1 (spawned-id-for :idp2/parent [:working]))
+        "the address is still derived from :machine-id")
+    (is (some? (snapshot :idp2/child#1))
+        "and the actor installed there")
+    (is (= {:idp2/child 1} (spawn-counter :idp2/parent))
+        "and the counter is still keyed by :machine-id")))
+
+;; ---------------------------------------------------------------------------
+;; (3) Two prefixes over ONE machine TYPE sequence INDEPENDENTLY.
+;; ---------------------------------------------------------------------------
+
+(deftest distinct-prefixes-over-one-type-sequence-independently
+
+  (testing "rf2-r9ey — the counter is per-PREFIX, so two :spawn nodes of the
+            SAME machine type under DIFFERENT prefixes each start at #1 rather
+            than sharing one 1,2 sequence. This is the fact that makes
+            :id-prefix a namespacing escape rather than a relabelling: had the
+            fix minted from the prefix while sequencing under the machine-id,
+            the second address would read <prefix-b>#2 and this test would say
+            so."
+    (reg-leaf! :idp3/child)
+    (rf/reg-machine :idp3/parent
+      {:initial :idle
+       :data    {}
+       :states  {:idle  {:on {:go :outer}}
+                 :outer {:spawn   {:machine-id :idp3/child :id-prefix :idp3/left}
+                         :initial :inner
+                         :states  {:inner {:spawn {:machine-id :idp3/child
+                                                   :id-prefix  :idp3/right}}}}}})
+    (rf/dispatch-sync [:idp3/parent [:go]])
+
+    (is (= :idp3/left#1 (spawned-id-for :idp3/parent [:outer]))
+        "the outer spawn's own prefix starts at 1")
+    (is (= :idp3/right#1 (spawned-id-for :idp3/parent [:outer :inner]))
+        "and so does the inner spawn's — NOT #2, which is what a shared
+         machine-id-keyed counter would have produced")
+    (is (= {:idp3/left 1 :idp3/right 1} (spawn-counter :idp3/parent))
+        "two independent per-prefix sequences in one parent snapshot")
+
+    (testing "and the same prefix twice DOES share one sequence"
+      (reg-leaf! :idp3b/child)
+      (rf/reg-machine :idp3b/parent
+        {:initial :idle
+         :data    {}
+         :states  {:idle  {:on {:go :outer}}
+                   :outer {:spawn   {:machine-id :idp3b/child :id-prefix :idp3b/pool}
+                           :initial :inner
+                           :states  {:inner {:spawn {:machine-id :idp3b/child
+                                                     :id-prefix  :idp3b/pool}}}}}})
+      (rf/dispatch-sync [:idp3b/parent [:go]])
+      (is (= :idp3b/pool#1 (spawned-id-for :idp3b/parent [:outer])))
+      (is (= :idp3b/pool#2 (spawned-id-for :idp3b/parent [:outer :inner]))
+          "one prefix, one monotonic sequence — the shallowest-first cascade
+           order is unchanged")
+      (is (= {:idp3b/pool 2} (spawn-counter :idp3b/parent))))))
+
+;; ---------------------------------------------------------------------------
+;; (4) `:spawn-all` honours each child's own `:id-prefix`.
+;; ---------------------------------------------------------------------------
+
+(deftest spawn-all-children-honour-their-own-id-prefix
+
+  (testing "rf2-r9ey — Spec 005 §Spawn-and-join via :spawn-all says each child
+            invoke-spec accepts the same keys as a single :spawn, :id-prefix
+            among them. The per-child allocator and the per-child args-builder
+            were the second and third sites reading :machine-id, so both are
+            exercised here: one child overrides its prefix, its sibling does
+            not, and the join records the addresses the registry reports."
+    (reg-leaf! :idp4/child)
+    (rf/reg-machine :idp4/parent
+      {:initial :idle
+       :data    {}
+       :states  {:idle      {:on {:fan-out :hydrating}}
+                 :hydrating {:spawn-all
+                             {:children        [{:id :a :machine-id :idp4/child
+                                                 :id-prefix :idp4/alpha}
+                                                {:id :b :machine-id :idp4/child}]
+                              :join            :all
+                              :on-all-complete [:idp4/done]}
+                             :on {:idp4/done :ready}}
+                 :ready     {}}})
+    (rf/dispatch-sync [:idp4/parent [:fan-out]])
+
+    (let [jstate (get-in (runtime-db)
+                         [:rf.runtime/machines :spawned :idp4/parent [:hydrating]])]
+      (is (= :idp4/alpha#1 (get-in jstate [:children :a]))
+          "the child that supplied a prefix installed under it")
+      (is (= :idp4/child#1 (get-in jstate [:children :b]))
+          "its sibling, with no prefix, is unchanged — the control inside the
+           :spawn-all case")
+      (is (some? (snapshot :idp4/alpha#1)) "prefixed child is live")
+      (is (some? (snapshot :idp4/child#1)) "unprefixed sibling is live"))
+
+    (is (= {:idp4/alpha 1 :idp4/child 1} (spawn-counter :idp4/parent))
+        "two per-prefix sequences, one per distinct prefix in the batch")))
+
+;; ---------------------------------------------------------------------------
+;; (5) THE POINT OF THE REPAIR: `:id-prefix` is the escape from rf2-1sip (f).
+;; ---------------------------------------------------------------------------
+
+(deftest distinct-prefixes-let-two-parents-spawn-one-type-without-colliding
+
+  (testing "rf2-r9ey + rf2-1sip (f) — two live parents spawning the SAME child
+            TYPE both mint <type>#1, and since rf2-1sip the second is REFUSED
+            fail-closed. Giving each parent its own :id-prefix separates the
+            addresses, so both children install and NO
+            :rf.error/machine-spawn-all-duplicate-id fires. This is why the
+            knob had to work rather than merely be documented.
+
+            Option (e) — re-homing the counter so <type>#<n> is frame-unique —
+            is deliberately NOT exercised: nothing here seeds or advances
+            :rf/spawn-counter across incarnations."
+    (reg-leaf! :idp5/child)
+    (rf/reg-machine :idp5/parent-a
+      {:initial :idle
+       :data    {}
+       :states  {:idle    {:on {:go :working}}
+                 :working {:spawn {:machine-id :idp5/child :id-prefix :idp5/from-a}}}})
+    (rf/reg-machine :idp5/parent-b
+      {:initial :idle
+       :data    {}
+       :states  {:idle    {:on {:go :working}}
+                 :working {:spawn {:machine-id :idp5/child :id-prefix :idp5/from-b}}}})
+
+    (rf/dispatch-sync [:idp5/parent-a [:go]])
+    (rf/dispatch-sync [:idp5/parent-b [:go]])
+
+    (is (some? (snapshot :idp5/from-a#1)) "parent A's child installed")
+    (is (some? (snapshot :idp5/from-b#1))
+        "and so did parent B's — the collision rf2-1sip (f) refuses never
+         arose, because the two addresses differ")
+    (is (empty? (rf.machines.test-support/events-of
+                  :rf.error/machine-spawn-all-duplicate-id))
+        "no duplicate-id rejection fired")))
+
+;; ---------------------------------------------------------------------------
+;; (6) The emitted spawn args / trace report the EFFECTIVE prefix.
+;; ---------------------------------------------------------------------------
+
+(deftest the-spawned-trace-reports-the-effective-id-prefix
+
+  (testing "rf2-r9ey — the two args-builders in `transition` stamp :id-prefix
+            onto the outgoing :rf.machine/spawn args, and that value reaches
+            the :rf.machine.spawn/spawned trace. They previously overwrote a
+            supplied prefix with the child's :machine-id, so a tool reading the
+            trace was told a prefix the address did not come from. Both the
+            supplied and the defaulted case are asserted."
+    (reg-leaf! :idp6/child)
+    (rf/reg-machine :idp6/prefixed
+      {:initial :idle
+       :data    {}
+       :states  {:idle    {:on {:go :working}}
+                 :working {:spawn {:machine-id :idp6/child :id-prefix :idp6/mine}}}})
+    (rf/reg-machine :idp6/plain
+      {:initial :idle
+       :data    {}
+       :states  {:idle    {:on {:go :working}}
+                 :working {:spawn {:machine-id :idp6/child}}}})
+
+    (rf/dispatch-sync [:idp6/prefixed [:go]])
+    (let [tags (mapv :tags (rf.machines.test-support/events-of
+                             :rf.machine.spawn/spawned))]
+      (is (= [:idp6/mine] (mapv :id-prefix tags))
+          "the trace names the SUPPLIED prefix")
+      (is (= [:idp6/child] (mapv :machine-id tags))
+          "and still names the registered TYPE separately — the two are
+           distinct facts and the repair must not conflate them")
+      (is (= [:idp6/mine#1] (mapv :spawned-id tags))
+          "and the address agrees with the prefix it reports"))
+
+    (rf.machines.test-support/reset-captured!)
+    (rf/dispatch-sync [:idp6/plain [:go]])
+    (let [tags (mapv :tags (rf.machines.test-support/events-of
+                             :rf.machine.spawn/spawned))]
+      (is (= [:idp6/child] (mapv :id-prefix tags))
+          "CONTROL — with no supplied prefix the trace still reports the
+           machine-id-derived default, exactly as before")
+      (is (= [:idp6/child#1] (mapv :spawned-id tags))))))


### PR DESCRIPTION
Closes the remaining half of **rf2-r9ey**. (Its other finding — `spec/005` naming the wrong default for `:id-prefix` — landed in #9519; nothing here touches `spec/`.)

## The defect

`:id-prefix` was **accepted, documented, and then ignored** on the declarative `:spawn` / `:spawn-all` path. A spawn-spec written as

```clojure
{:spawn {:machine-id :pc/child :id-prefix :pc/mine}}
```

allocated `:pc/child#1` under counter key `:pc/child`. The supplied prefix had no effect at all, and nothing raised anywhere:

- `lifecycle_fx/validation.cljc:1501` carries `:id-prefix` in the accepted spawn-spec key set, so registration is clean.
- `spec/005-StateMachines.md` documents it three times — §Spawn-spec keys and §Spec-spec keys both gloss it `optional; defaults to :machine-id`, and §Spawn-id allocator — counter location keys the declarative counter at `[:rf/spawn-counter <id-prefix>]`.
- `transition/allocate-one` read `(:machine-id spawn-spec)` unconditionally.
- The two args-builders that assemble the outgoing `:rf.machine/spawn` fx (`handle-spawn-decl`, `handle-spawn-all-decl`) then overwrote a supplied `:id-prefix` with the child's `:machine-id`, so even the `:rf.machine.spawn/spawned` trace reported a prefix the address had not come from.

That is the worst shape a knob can have: it fails in the reassuring direction at authoring time and is diagnosable only by reading the allocator.

## Why it is load-bearing rather than cosmetic

rf2-1sip shipped **option (f) alone** (#9534): a generated `<type>#<n>` address already held by a live actor is now rejected fail-closed with `:rf.error/machine-spawn-all-duplicate-id`. The declarative counter lives in the *spawning parent's snapshot* while the address space is *frame-global*, so two parents spawning the same child TYPE both mint `<type>#1` and the second is refused. `:id-prefix` is the author's only **namespacing** escape from that refusal — which is exactly why the bead says it "becomes load-bearing and must work".

**Option (e) was not touched.** Nothing here seeds or advances `:rf/spawn-counter` across incarnations, no generated id is incarnation-stamped, and `machine-transition`'s purity contract is unchanged. `parallel.cljc` still seeds `:rf/spawn-counter {}` fresh and `machine_transition_purity_test` is untouched. That remains Mike's ruling.

## The change

The declarative allocator now mints from — and sequences the in-snapshot counter under — one shared helper:

```clojure
(defn- spawn-id-prefix [spawn-spec]
  (or (:id-prefix spawn-spec) (:machine-id spawn-spec)))
```

used at all three sites (`allocate-one` and both args-builders). **Prefix and counter key move together on purpose**: sequencing under one key while minting from another would re-mint `<prefix>#1` for every distinct prefix sharing a `:machine-id`, which is the collision the escape exists to avoid.

**No spec text moves, and that is the finding rather than an omission.** `spec/005` already specifies exactly this — §Spawn-id allocator — counter location keys the declarative counter at `[:rf/spawn-counter <id-prefix>]`, and §Spawn-spec keys already glosses the default as `:machine-id`. The code was out of line with the spec, not the other way round, so the hot-zone file is untouched.

One diagnostic follow-on: `reject-generated-address-collision!`'s `reason` named only `:fixed-actor-id` and destroying the occupant, because when it was written `:id-prefix` did nothing. It now names `:id-prefix` first — it is the escape that fits the two-parents-one-TYPE shape that reject fires on. Text only; category, `:recovery` and structural tags unchanged, and no test pins the string.

## Tests — both directions, and the control is the point

New `implementation/machines/test/re_frame/spawn_id_prefix_test.clj` (6 deftests, 26 assertions):

1. a supplied `:id-prefix` decides the address **and** the counter key (`{:idp/mine 1}`, nothing at `:idp/child#1`);
2. **CONTROL** — a `:spawn` with no `:id-prefix` still allocates `<machine-id>#<n>` under counter key `<machine-id>`. This is what distinguishes a repair from a silent rename: an allocator that simply read the prefix key unconditionally would pass every other test here and fail this one;
3. two prefixes over one machine TYPE sequence independently (`#1` each, not `#1`/`#2`), and the same prefix twice still shares one monotonic sequence;
4. `:spawn-all` honours each child's own `:id-prefix`, with an unprefixed sibling in the same batch as the in-case control;
5. the point of the repair — two parents spawning one TYPE under distinct prefixes both install and **no** `:rf.error/machine-spawn-all-duplicate-id` fires;
6. the `:rf.machine.spawn/spawned` trace reports the effective prefix, with the defaulted case as its control.

Failing-first was demonstrated against the pre-fix allocator (`git checkout HEAD~1 -- transition.cljc`): **21 failures across 5 of the 6 tests, exit 1** — and (2), the control, passed in that run, which is what a control must do. Case (5) failed there with the real rejection payload (`:failing-id :idp5/child#1, :parent-id :idp5/parent-b`), confirming the rf2-1sip interaction is genuine and not hypothetical.

## Quality gates

Every exit code below was captured on the runner's own command line and read from a per-worktree, per-attempt `.exit` file — never from a pipeline.

| gate | result |
|---|---|
| `implementation/machines` `clojure -M:test` | **exit 0** — 1231 tests, 4494 assertions, 0 failures, 0 errors |
| `implementation/core` `clojure -M:test` | **exit 0** — 2305 tests, 11923 assertions, 0 failures, 0 errors |
| `generated_address_collision_test` (rf2-1sip's suite, run explicitly) | **exit 0** — 8 tests, 47 assertions, 0 failures, 0 errors |
| new `spawn_id_prefix_test` focused | **exit 0** — 6 tests, 26 assertions, 0 failures, 0 errors |
| failing-first, pre-fix allocator | **exit 1** — 21 failures over 26 assertions, control passing |
| `scripts/check_test_lane_bijection.py` | **exit 0** — 1600 test-defining files, 45 lanes, every file selected |
| `scripts/check_jvm_lane_rosters.py` | **exit 0** |
| `scripts/check_retired_spellings.py` | **exit 0** |
| `scripts/check_thrown_error_messages.py` | **exit 0** — graded because this PR edits an error `reason` string |
| `scripts/check_require_alias_dialect.py` | **exit 0** — graded because this PR adds a namespace |
| `scripts/check_keyword_catalogue_drift.py` | **exit 0** |
| `scripts/check_architecture_census.py` | **exit 0** |

**The collision suite's numbers did not move**, and it could not have: it contains zero occurrences of `:id-prefix`, so every address it mints is still `<machine-id>#<n>`. Its 8/47 is stated explicitly because this PR changes how those addresses are minted in general.

**Doc gates deliberately skipped, with reason.** `python scripts/check_doc_slugs.py` and `python -m mkdocs build --strict` were nominated for a `spec/005` edit that this PR turned out not to need — the diff touches zero markdown, so running them would buy a green that inspected nothing changed here.

**Sabotage.** A fault was planted at `spawn_id_prefix_test.clj:123` — the control assertion — after the fix was committed. Match count read **1** before the run; the suite went **exit 1** naming `spawn_id_prefix_test.clj:123` and the planted token; restored with `git checkout HEAD --` and verified by **blob hash** `6b8fd0c94e` against the committed object, with zero residue of the plant. The failing-first restore of `transition.cljc` was verified the same way, blob hash `995cbe54e6`.

**Local green is not CI.** `python scripts/check_fast_pr_gap.py --brief` reports **100** required checks this box does not decide; CI owns all of them. Nothing here was re-run after a rebase, because no rebase was needed: the only upstream commits since the merge base `d3e5845193` are two tracker checkpoints, and `git log d3e5845193..origin/main -- <the three files>` is empty.

Diff against the merge base is 3 files, `9/4 + 48/20 + 300/0` — no `.beads` path, no `spec/` path, and nothing a sibling landed is reverted.

## Reported separately, not fixed here

Three hot-zone files outside this dispatch state the *hand-emitted* spawn counter as keyed by `<machine-id>`, where `spawn.cljc`'s `machine-id-for-alloc` has always used `(or (:id-prefix args) (:machine-id args))`. `spec/005:2826` already says `<id-prefix>` and is right. Pre-existing, untouched here: `spec/Conventions.md:616`, `spec/Conventions.md:641`, `spec/Conventions.md:1048`, `spec/Spec-Schemas.md:2934`.
