### PR TITLE
docs(beads): make PRIME.md carry the sanctioned GC command, not just the hazard

### DIFF
--- a/.beads/PRIME.md
+++ b/.beads/PRIME.md
@@ -61,8 +61,14 @@ wrong answer.
   repo root and read it back. `bd recall bd-write-from-wrong-cwd-silently-discarded`
 - **`bd export` silently drops every memory without `--include-memories`.**
   `bd recall bd-export-drops-memories-without-flag`
-- **`bd gc`'s decay phase deletes closed beads**, whose close reasons are normative records
-  here, and reclaims no space anyway. `bd recall bd-gc-decay-silently-deletes-closed-beads`
+- **Routine bead decay is OFF, permanently** — it deletes closed beads, whose close reasons
+  are normative records here, and reclaims no space anyway. The ONLY sanctioned invocation:
+
+  ```
+  bd gc --skip-decay --force      # NEVER pass --older-than; routine decay is OFF (rf2-nj0c)
+  ```
+
+  `bd recall bd-gc-decay-silently-deletes-closed-beads`
 - **A 502 from `gh pr merge` can mean the merge SUCCEEDED and only its response was lost** —
   wait a tick, don't retry. `bd recall 502-on-merge-means-it-may-have-happened`
 


### PR DESCRIPTION
Implements rf2-nj0c. Routine bead decay is OFF, permanently. One line, one file.

## What changed

`.beads/PRIME.md`, the third of the "Four hazards `CLAUDE.md` does not carry" bullets. Before, it stated a hazard:

> **`bd gc`'s decay phase deletes closed beads**, whose close reasons are normative records here, and reclaims no space anyway. `bd recall bd-gc-decay-silently-deletes-closed-beads`

After, it states the rule and hands over the command to copy, keeping the `bd recall` pointer beneath it:

> **Routine bead decay is OFF, permanently** — it deletes closed beads, whose close reasons are normative records here, and reclaims no space anyway. The ONLY sanctioned invocation:
>
>     bd gc --skip-decay --force      # NEVER pass --older-than; routine decay is OFF (rf2-nj0c)
>
> `bd recall bd-gc-decay-silently-deletes-closed-beads`

## Why this file, and why a command rather than a warning

The rule already existed twice as memories (`bd-gc-verbs-decay-is-prune-and-restore-does-not-cover-compact`, `bd-gc-decay-silently-deletes-closed-beads`) and a GC run decayed anyway on 2026-09-08 — memories are not injected into a session. `CLAUDE.md` gained a ban only as a subordinate clause inside a bullet about a different trap. `.beads/PRIME.md` named the hazard but not the command.

An operator types a command line; a hazard note does not change what gets typed. Copy-pasteable beats admonitory, and `.beads/PRIME.md` is the one in-repo file `bd prime` emits at SessionStart and PreCompact, so it reaches every session's opening context.

Deliberately not done here, per the ruling on the bead: no fourth prose ban in `CLAUDE.md`, no wrapper/hook/workflow around `bd gc`, no recovery of the 20 decayed beads (its own bead, and it runs only after the operator-side prompt change lands).

## Verification

The change is only worth anything if it reaches a session, so that is what was measured rather than the file alone:

- `bd prime` run from this branch's checkout is **byte-identical** to the edited `.beads/PRIME.md` (`cmp` exit 0, 4015 bytes), and the new command line appears exactly once in what it emits.
- Discriminating control: `bd prime` run from an unedited checkout still emits the old 3844 bytes with zero matches for the new command — so `bd prime` genuinely reads the working file under test, and the identity above is not a coincidence.
- Working-tree CRLF endings preserved (76 CR / 76 LF / 76 CRLF before and after).

Gates, each exit code captured from the runner itself rather than through a pipe, and all re-run after the rebase onto `433c9383ac`:

| Gate | Exit |
| --- | --- |
| `scripts/check-beads-pr-boundary.sh origin/main` | 0 — "No beads-database paths in this PR diff" |
| `scripts/check-commit-attribution.sh origin/main` | 0 |
| `scripts/check-no-hardcoded-paths.sh` | 0 |
| `scripts/check-ai-tracking-ratchet.sh` | 0 |
| `scripts/check_readme_links.py --ci` | 0 — but see below |

`.beads/PRIME.md` is explicitly allow-listed in the boundary classifier (`scripts/git-hooks/lib/check-beads-boundary.sh`), so that green is a real classification of this path rather than an absence of it. The diff carries `.beads/PRIME.md` and no other `.beads` path.

## A finding: `.beads/PRIME.md` has no link gate at all

Worth recording because it is easy to nominate the wrong gate for this path. `check_readme_links.py` returns green on `.beads/**` because it cannot see it: `.beads` is a member of that script's `EXCLUDE_DIR_NAMES`, so `_is_excluded` refuses the path from all three of its rosters. `check_doc_slugs.py` never reaches it either — its roots are `docs`, `spec`, `skills`, `migration` and `tools/*/spec`. And `mkdocs build --strict` has `docs_dir: docs` with only `spec/` and `migration/` staged in.

Measured rather than read off the source, in both directions with one fault shape:

- The same broken link planted in a line of `.beads/PRIME.md` edited by this PR: `check_readme_links.py --ci` exit **0**, silent.
- The identical broken link planted in `implementation/SECURITY.md`, a file the gate does cover: exit **1**, naming the planted target.

Both plants were reverted and verified by git blob hash against the committed object, and the tree was confirmed clean before the push.

This change adds no links or anchors, so nothing here is at risk from the hole. Naming it so the next author does not read a green from that gate as coverage; closing it is not this bead's work.
