### PR TITLE
fix(story): exclude reagent-slim from Story's Xray edge (rf2-qvyr)

### DIFF
--- a/.github/scripts/verify-version-lockstep.sh
+++ b/.github/scripts/verify-version-lockstep.sh
@@ -929,12 +929,26 @@ for tool in "${TOOLS[@]}"; do
   # tools/story/deps.edn pads its dep map with column-aligned whitespace
   # (`day8/re-frame2          {:local/root …}`) so we collapse all
   # runs of whitespace to a single space before matching.
+  #
+  # rf2-qvyr — the file-text match drops the inventory entry's CLOSING BRACE
+  # and matches the `<lib> {:local/root "<path>"` prefix instead. A coordinate
+  # map may legitimately carry keys BESIDE :local/root — Story's Xray edge
+  # carries `:exclusions [day8/reagent-slim]` to keep a second provider of
+  # `re-frame.adapter.reagent` out of the published Story graph — and with the
+  # brace included this check demanded that :local/root be the map's ONLY key,
+  # which is a constraint it never meant to impose and never stated. The
+  # closing brace contributed nothing to the property the entry asserts: the
+  # lib↔path PAIRING is pinned just as exactly by the prefix, which is also
+  # what the release rewrite step itself keys off. The converse pass below is
+  # unaffected — local_root_coords() derives the normalised
+  # `<lib> {:local/root "<path>"}` form regardless of any extra keys, so the
+  # inventory stays in that form and keeps matching it exactly.
   normalised="$(tr -s '[:space:]' ' ' < "${deps_file}")"
   tool_expected=""
   while IFS='|' read -r entry_tool entry_local_root; do
     [[ -z "${entry_tool}" ]] && continue
     [[ "${entry_tool}" == "${tool}" ]] || continue
-    if ! grep -qF "${entry_local_root}" <<< "${normalised}"; then
+    if ! grep -qF "${entry_local_root%\}}" <<< "${normalised}"; then
       echo "::error file=${rel_label}::expected '${entry_local_root}' (lockstep contract; the release workflow rewrites this to :mvn/version at deploy time)"
       errors=$((errors + 1))
     fi

--- a/tools/story/deps.edn
+++ b/tools/story/deps.edn
@@ -64,7 +64,37 @@
          ;; neither reaches a production bundle, so bundle-isolation is
          ;; unaffected (that gate forbids `implementation/` → `tools/`,
          ;; not `tools/story` → `tools/xray`).
-         day8/re-frame2-xray     {:local/root "../xray"}
+         ;;
+         ;; THE :exclusions IS LOAD-BEARING — do not drop it (rf2-qvyr).
+         ;; Xray declares `day8/reagent-slim` as its default transitive
+         ;; adapter (tools/xray/deps.edn, "Reagent Slim supplies the default
+         ;; transitive adapter"), and at PUBLICATION
+         ;; .github/scripts/transform-reagent-slim-ns.sh renames the slim
+         ;; adapter onto the CANONICAL `re-frame.adapter.reagent` ns — the
+         ;; very path `day8/re-frame2-reagent` (line 16 above) already ships.
+         ;; Without this exclusion a consumer whose only tool coordinate is
+         ;; `day8/re-frame2-story` resolves BOTH jars, both carrying
+         ;; `re_frame/adapter/reagent.cljs`, and nothing but classpath order
+         ;; decides which adapter the app gets. That is exactly the
+         ;; assumption release.yml states it relies on — "downstream apps
+         ;; depend on EXACTLY ONE of {day8/re-frame2-reagent,
+         ;; day8/reagent-slim} so the adapter ns is single-source per app".
+         ;; Resolution cannot see this: `clojure -P` / `-Stree` and a
+         ;; complete pom all go green on the colliding graph, because they
+         ;; prove the GAVs exist, not that they provide disjoint namespaces.
+         ;;
+         ;; THE STATED REPLACEMENT (this is a re-point, not a silent drop):
+         ;; Story supplies the substrate adapter for its embedded Xray
+         ;; itself, through the `day8/re-frame2-reagent` coordinate on line
+         ;; 16. Xray renders through `re-frame.substrate.adapter` and the
+         ;; adapter the HOST installs governs the runtime path, so Xray is
+         ;; fully served by Story's stock-Reagent adapter; Xray's src
+         ;; requires neither `reagent2.*` nor the adapter ns. Xray's own
+         ;; deps.edn is deliberately UNTOUCHED, so a standalone
+         ;; `day8/re-frame2-xray` consumer still gets reagent-slim by
+         ;; default — this narrows Story's edge only.
+         day8/re-frame2-xray     {:local/root "../xray"
+                                  :exclusions [day8/reagent-slim]}
 
          ;; Malli drives Story's three-level args / argtypes auto-derivation
          ;; from Spec 010 schemas (see IMPL-SPEC §4 + §5.2). Malli is


### PR DESCRIPTION
## The defect, reproduced against a packaged consumer

rf2-qvyr was filed source-derived and explicitly **not** reproduced at runtime. It now is.

The published Story graph provides **two** copies of the canonical namespace `re-frame.adapter.reagent`:

- `tools/story/deps.edn` declares `day8/re-frame2-reagent` directly, and
- pulls `day8/re-frame2-xray`, which declares `day8/reagent-slim` with no exclusion.

At publication `.github/scripts/transform-reagent-slim-ns.sh` renames the slim adapter onto the canonical path, so both jars ship `re_frame/adapter/reagent.cljs`.

**Reproduction.** Both adapter jars were built from the real transform script's output and installed into a local Maven repo modelling the published poms. A consumer whose only tool coordinate is `day8/re-frame2-story` resolves both, and they self-identify differently:

```
PROVIDERS_FOUND= 2
  provider[0] kind=:rf.adapter/reagent
  provider[1] kind=:rf.adapter/reagent-slim
```

The only non-manifest entry the two jars share is exactly `re_frame/adapter/reagent.cljs`.

**The winner flips on the consumer's own unrelated choices.** Ordering is by dependency depth, so plain Story gets stock Reagent (depth 1) — but a consumer that also pins `day8/reagent-slim` directly gets the *slim* adapter winning at the canonical ns, while Story's shell is built against stock `reagent.core`. Both graphs resolve green.

This is the condition `release.yml` states it relies on being false: "downstream apps depend on EXACTLY ONE of {day8/re-frame2-reagent, day8/reagent-slim} so the adapter ns is single-source per app."

## Why no gate caught it

Resolution cannot discriminate this. `clojure -Stree` exits 0 and prints a healthy tree over the colliding graph; a complete pom is equally consistent with it. Both prove the GAVs exist, not that they provide disjoint namespaces. The runtime `:kind` difference is the honest discriminator.

## The fix

`tools/story/deps.edn` excludes `day8/reagent-slim` from its Xray edge.

This is a re-point, not a silent drop. **Xray's `deps.edn` is deliberately untouched**, so a standalone `day8/re-frame2-xray` consumer still gets reagent-slim by default. Story supplies the substrate adapter for its embedded Xray itself, through the `day8/re-frame2-reagent` coordinate it already declares; Xray renders through `re-frame.substrate.adapter` and the host-installed adapter governs the runtime path. Xray's sources require neither `reagent2.*` nor the adapter ns — verified line-oriented and flattened/comment-stripped, with a control.

Verified end to end: the exclusion applies to `:local/root` too, so the in-tree graph now matches the published one (no tested-tree/published divergence); the release rewrite preserves it; and `clein pom` emits `<exclusions>`. The reproduced consumer then resolves exactly one provider.

## Second change, and why it was forced

`verify-version-lockstep.sh` checks its coordinate inventory two ways: a file-text substring match, and a converse pass comparing against `local_root_coords()`, which derives a **normalised** `<lib> {:local/root "<path>"}` form ignoring extra keys. With the closing brace in the substring, those two want different strings the moment a coordinate map carries a second key — so the gate structurally forbade **any** extra key on a tools `:local/root` coordinate. Measured: inventory unchanged reds the forward pass; inventory updated reds the converse.

The file-text match now drops the entry's closing brace and matches the `<lib> {:local/root "<path>"` prefix. The brace contributed nothing to the property the entry asserts — the lib-to-path pairing is pinned just as exactly by the prefix, which is also what the release rewrite step keys off. This is not a widening of a ratchet floor; it removes an over-specification the check never stated or intended.

## Gates

| Gate | Exit |
|---|---|
| `verify-version-lockstep.sh` (post-rebase) | 0 |
| `verify-version-lockstep.sh --self-test` (post-rebase) | 0 — 21/21 |
| `tools/story` `clojure -M:test` (post-rebase) | 0 — 1914 tests, 7047 assertions, 0 failures |
| `scripts/test-jvm-tools.sh` (all tool artefacts) | 0 |
| script unit tests (preflight-story-package, rewrite-local-root-coord, transform-reagent-slim-ns, changed-surfaces) | 0 — 395 assertions |

Sabotage check: with the lib-to-path pairing broken, the lockstep gate exits 1 and both directions fire; the file's blob hash restored identically afterwards. So the prefix match still bites.

`examples_compile` is armed by the classifier but **cannot observe this diff**: `implementation/shadow-cljs.edn` enumerates explicit `:source-paths` and never consumes `tools/story/deps.edn`. `mcp_conformance`'s only graph-sensitive gate is the story-mcp JVM suite, green above; its remaining gates need `implementation/` devDependencies not present in a fresh worktree and are protocol-level.

## Not fixed here, deliberately

A consumer that uses Story **and** pins `day8/reagent-slim` directly still resolves two providers, because Story's own direct `day8/re-frame2-reagent` dep is irreducible. That is a pre-existing structural fact about Story rather than something this change creates or worsens, and settling it would be the adapter re-architecture rf2-qvyr rules out. Flagged for a separate decision.
