### PR TITLE
docs(spec): strike the alpha-tag delete clauses on HTTP :accept and :abort-signal (rf2-kuky.deferrals)

### DIFF
--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -319,7 +319,7 @@ The 10-second **connect** timeout is configured separately at the shared JDK Htt
 
 ## `:accept` — domain-failure normalisation
 
-**Parked 2026-09-08 (api-review wave 3, rf2-kuky.13):** zero shipped consumers at that date — the corpus's `:accept` slots are never-filled passthroughs. Kept because the written discriminator holds: an `:after` interceptor is not presently equivalent, since `dispatch-reply!` selects the branch destination BEFORE the response-side chain transforms the payload, so an `:after` returning `{:status :error …}` would send an error-shaped payload to the SUCCESS target. **Un-park** (promote to a taught option with a worked example) when a named consumer needs a 2xx domain failure to select the failure PIPELINE rather than a branch inside the success handler. **Delete under a spec change** if no such consumer appears by the alpha tag.
+**Parked 2026-09-08 (api-review wave 3, rf2-kuky.13):** zero shipped consumers at that date — the corpus's `:accept` slots are never-filled passthroughs. Kept because the written discriminator holds: an `:after` interceptor is not presently equivalent, since `dispatch-reply!` selects the branch destination BEFORE the response-side chain transforms the payload, so an `:after` returning `{:status :error …}` would send an error-shaped payload to the SUCCESS target. **Un-park** (promote to a taught option with a worked example) when a named consumer needs a 2xx domain failure to select the failure PIPELINE rather than a branch inside the success handler. **No deadline.** Absence of call sites is evidence against a *convenience*, not against a capability whose discriminator is written down. Until a consumer of that shape appears, `:accept` stays exactly as it is — shipped, specified here, untaught, and secondary to the ordinary request map.
 
 After decoding, the user's `:accept` fn classifies the decoded value:
 
@@ -691,7 +691,7 @@ There is deliberately **no** cross-frame cancellation through this effect. A fra
 
 ### `:abort-signal` (external)
 
-**Parked 2026-09-08 (api-review wave 3, rf2-kuky.13):** zero shipped consumers at that date — the corpus's `:abort-signal` slots are never-filled passthroughs. Kept because the written discriminator holds: a controller shared with non-re-frame operations is FOREIGN lifecycle ownership, which frame- and actor-destroy cancellation cannot express. **Un-park** (promote to a taught option with a worked example) when a named consumer holds a foreign `AbortController` shared with non-re-frame work. **Delete under a spec change** if no such consumer appears by the alpha tag.
+**Parked 2026-09-08 (api-review wave 3, rf2-kuky.13):** zero shipped consumers at that date — the corpus's `:abort-signal` slots are never-filled passthroughs. Kept because the written discriminator holds: a controller shared with non-re-frame operations is FOREIGN lifecycle ownership, which frame- and actor-destroy cancellation cannot express. **Un-park** (promote to a taught option with a worked example) when a named consumer holds a foreign `AbortController` shared with non-re-frame work. **No deadline.** Absence of call sites is evidence against a *convenience*, not against a capability whose discriminator is written down. Until a consumer of that shape appears, `:abort-signal` stays exactly as it is — shipped, specified here, untaught, and secondary to the framework-owned cancellation paths (`:request-id` supersede/managed-abort, frame destroy, actor destroy).
 
 Pass an `AbortController.signal` directly:
 


### PR DESCRIPTION
`spec/014-HTTPRequests.md` carried two shipped, documented, zero-consumer public HTTP options — `:accept` (domain-failure normalisation) and `:abort-signal` (external cancellation) — each ending its park paragraph with a written self-delete promise keyed to the alpha tag:

> Delete under a spec change if no such consumer appears by the alpha tag.

Nothing would have fired them. Ruled at the `rf2-kuky` epic closeout: **RETAIN BOTH, and STRIKE THE DEADLINE**, replacing it with the demand-trigger form the other wave-3 parks carry (flows `:inputs` in `spec/013-Flows.md`, route-derived scope in `spec/016-Resources.md`) — a named trigger plus an explicit "until then", and no deadline.

Time-sensitive: this had to land before `rf2-kmqx3` cuts `v0.0.1.alpha`, because shipping into alpha carrying a promise nobody intends to honour is the worse outcome.

## What changed

Prose only — one file, two paragraphs, two lines. In each, the delete-clause sentence is replaced with:

> **No deadline.** Absence of call sites is evidence against a *convenience*, not against a capability whose discriminator is written down. Until a consumer of that shape appears, `<key>` stays exactly as it is — shipped, specified here, untaught, and secondary to …

…closing on the ordinary request map for `:accept`, and on the framework-owned cancellation paths (`:request-id` supersede/managed-abort, frame destroy, actor destroy) for `:abort-signal`.

Deliberately unchanged in both paragraphs: the `Parked 2026-09-08 (api-review wave 3, rf2-kuky.13)` provenance, the discriminator sentence, and the `Un-park` sentence.

## Why retain — both discriminators verified at source at this tip

- **`:accept`** — `dispatch-reply!` (`implementation/http/src/re_frame/http/transport.cljc`, defined at :177) selects the branch destination at :219's `(case kind …)` **before** `run-after-then-dispatch!` runs the response-side chain, so an `:after` returning `{:status :error …}` would send an error-shaped payload to the SUCCESS target. An `:after` interceptor cannot do `:accept`'s job. The domain-failure workflow is witnessed by the 200/quota test at `implementation/http/test/re_frame/http_managed_test.clj:2118`, which serves `{"ok":false,"reason":"quota"}` on a 200.
- **`:abort-signal`** — external cancellation is a *request*-lifecycle source that must follow the request across phases, including sleeping retry backoff (`implementation/http/src/re_frame/http/transport_cljs.cljc:288`; `implementation/http/test/re_frame/http_cljs_test.cljs:1328`). A controller shared with non-re-frame work is FOREIGN lifecycle ownership, which frame- and actor-destroy cancellation cannot express.

The zero-consumer premise was re-checked at this tip and still holds: the `examples/real-apps/realworld_http/http.cljs` `:accept` and `:abort-signal` slots are destructured passthroughs (:129 → :155/:156) that no caller ever fills, and no `AbortController` is constructed anywhere under `examples/`, `docs/`, `skills/` or `testbeds/`. The un-park trigger has not fired.

## Non-goals honoured

No code, no tests, no `spec/API.md`, no `spec/api-manifest*.edn` sidecars, no manifest regeneration, no public name moves. No invented consumer and no worked example — promoting either key to a taught option is the un-park act, and its trigger has not fired.

## Quality gates

All run from the worktree root on the final rebased base, each exit code captured in the same shell as the run (never through a pipe):

| Gate | Command | Captured exit |
|---|---|---|
| Doc slugs / anchors | `python scripts/check_doc_slugs.py` | **0** |
| MkDocs strict build | `python -m mkdocs build --strict` | **0** |
| Ratchet sweep — all 43 `scripts/check_*.py` | loop, exit code per script | **0 non-zero of 43** |
| Portability — hardcoded paths | `sh scripts/check-no-hardcoded-paths.sh` | **0** |
| Portability — `ai/` tracking ratchet | `sh scripts/check-ai-tracking-ratchet.sh` | **0** |
| Portability — view-lifetime residue (whole tracked tree) | `python scripts/check_view_lifetime_residue.py` | **0** |
| Beads PR boundary | `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** |
| Commit attribution | `sh scripts/check-commit-attribution.sh origin/main` | **0** |
| Whole-tree prose drift ratchet (JVM) | `clojure -M:test -n re-frame.observation-render-law-drift-test` (from `implementation/core`) | **0** — 5 tests, 21 assertions, 0 failures, 0 errors |

The ratchet sweep covers every spec-facing vocabulary gate — `check_retired_composition_vocab`, `check_retired_image_keys`, `check_inject_cofx_residue`, `check_retired_spellings` and `check_view_lifetime_residue` all read `spec/`, and all are zero-tolerance forbidden-token scans rather than counted floors, so added prose can only fail one by containing a forbidden token. None does.

Note: the bare `mkdocs` console script is not on PATH in this environment (exit **127**, which reads as a failed build rather than a missing tool); `python -m mkdocs` (1.6.1) is the form that answers.

### Gate provenance — each gate proven to read this tree

Neither nominated gate prints an absolute root, so each was proven by a planted fault at a line this PR already edits:

- A broken link **and** a broken anchor planted at line 322 turned `check_doc_slugs.py` **red (exit 1)**, naming both faults at `spec/014-HTTPRequests.md:322`.
- A broken relative link planted at line 694 turned `python -m mkdocs build --strict` **red (exit 1)**, naming the file and the unresolvable target.

Both faults exist only in this worktree, so the red is the discrimination. Both were removed and the restore verified by git **blob** hash returning to `6b320c6b21` — the same object the commit carries, confirming the plant left no residue. The strict build's staged copy of the page was also confirmed to carry this PR's edit, i.e. the build's runtime observed the changed source rather than a stale compile.

## By-hand verification

Neither link gate validates prose, and neither looks inside a fenced code block, so these were checked by hand:

- **Anchors** — no heading was added, removed or reworded. The `^#{1,6} ` heading inventory of the file is identical to trunk's (empty `diff`), so no anchor any other page links to was disturbed.
- **Links** — the added prose contains no markdown links at all: `](` count across the added lines is **0**, against **177** elsewhere in the same file, so the probe bites rather than returning a vacuous zero.
- **Tables** — no table row touched (`^[+-]\|` count in the diff is **0**), so no column-count concern.
- Both edited paragraphs are prose, not fenced samples — confirmed by the planted-fault runs above, which the gates did see.

Closes rf2-kuky.deferrals.
