### PR TITLE
docs(pilots): flip the two counted-pilot briefs to the published artefact (rf2-pug6)

### DIFF
--- a/docs/design/hicasso/product/pilots/brief-linearlite.md
+++ b/docs/design/hicasso/product/pilots/brief-linearlite.md
@@ -2,9 +2,9 @@
 
 Copy the block below into `<pilot-root>/BRIEF.md`. Everything inside it is written *to the pilot agent* and is the only thing that agent is given, alongside the blank friction log and the workspace itself.
 
-The brief is deliberately free of in-tree references: no bead ids, no spec sections, no repository paths except the ones the published documentation itself tells a reader to use, and one added since: `docs/core/hicasso/` inside the checkout, which is where the published documentation is kept until a site exists (`rf2-lpfz`). Naming it is what makes the pilot's only reference reachable at all. That is not tidiness. A brief that leaks in-tree knowledge does not bend a rule, it invalidates the evidence the pilot exists to produce, and the leak is invisible in the output.
+The brief is deliberately free of in-tree references: no bead ids, no spec sections, no repository paths except the ones the published documentation itself tells a reader to use. `rf2-lpfz` had to add one — `docs/core/hicasso/` inside the checkout — because the published documentation had nowhere else to live, and naming it was what made the pilot's only reference reachable at all. **That exception is retired under `rf2-pug6`: the documentation site is published, so the brief gives the pilot a URL and the checkout goes back to being a build input with no reading exception at all.** That is not tidiness. A brief that leaks in-tree knowledge does not bend a rule, it invalidates the evidence the pilot exists to produce, and the leak is invisible in the output.
 
-Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the sentence naming the test command, under `rf2-xkhul`; the address of the published documentation in the read rules, under `rf2-lpfz`; the paragraph naming the page check, under `rf2-ek1a`. Assemble the workspace first, per [`workspace.md`](workspace.md).
+Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the sentence naming the test command, under `rf2-xkhul`; the address of the published documentation in the read rules, under `rf2-lpfz`, and its flip from the checkout to the published site — with the public Xray manual admitted and outcome 7 moved onto released versions — under `rf2-pug6`; the paragraph naming the page check, under `rf2-ek1a`. Assemble the workspace first, per [`workspace.md`](workspace.md).
 
 **Why this pilot is shaped differently from [Pilot 1](brief-realworld.md), and it matters that it is.** Pilot 1 translates two screens that already exist, which measures whether the documentation supports *porting*. This one ports one screen and grows a second that does not exist yet, which measures whether the documentation supports *authoring* — reaching for a form you have never written, from the guide alone. Those are different failure modes and the two pilots are chosen to cover both, so the card detail is a shipped screen rather than a stretch goal and must not be softened into one when the brief is handed over.
 
@@ -50,8 +50,8 @@ your time on it and log it heavily.
 
 ## The rule
 
-**Everything you need is in the published Hicasso documentation. You may not
-use anything else to learn how Hicasso works.**
+**Everything you need is in the published documentation. You may not use
+anything else to learn how Hicasso works.**
 
 This is the whole point of the exercise, so it is worth being exact about it.
 The question being asked is not "can this be built" — of course it can. The
@@ -63,12 +63,13 @@ produce. Only you can tell us.
 
 **You may read:**
 
-- The published Hicasso documentation, in full. It is your reference for
-  everything: what to type, what things are called, why something broke, how
-  to test, how to build for production. It has not been put on a website yet,
-  so your copy of it is the one inside the checkout beside your project, at
-  `re-frame2/docs/core/hicasso/`. Those pages are the documentation; reading
-  them is not reading the checkout.
+- The published documentation site, in full, at
+  <https://day8.github.io/re-frame2/>. It is your reference for everything:
+  what to type, what things are called, why something broke, how to test, how
+  to build for production. If the site publishes a page, you may read it. The
+  Hicasso guide is the part you will live in, and the Xray manual beside it is
+  documentation on the same footing — outcome 5 sends you there, so read it as
+  freely as the guide.
 - Everything in `app/`. That is your codebase. Its README explains what the
   application does and which patterns it is built from — read it freely.
 - Ordinary error output: compiler messages, stack traces, browser console.
@@ -77,22 +78,23 @@ produce. Only you can tell us.
 **You may not read:**
 
 - The `re-frame2/` checkout sitting beside your project, for anything other
-  than the documentation named above and the two mechanical uses below. Not
-  its source, not its internal design notes, not its other example
-  applications, not its history.
+  than the two mechanical uses below. Not its source, not its internal design
+  notes, not its other example applications, not its history — and not its
+  copy of the documentation either, because the site is the documentation and
+  is where you read it.
 - Any file your app's README links to outside `app/`. The README is yours; the
   things it points at are not.
 - Any source file named in a stack trace. Knowing that a complaint came from
   some internal file is diagnosis and is fine. Opening that file is research
   and is not.
 
-**The `re-frame2/` checkout is a build input, not a reference work.** The
-documentation above is the one exception, and only because it has nowhere else
-to live yet. Two further uses of it are expected and correct, because the
-published documentation itself tells you to make them: your `deps.edn` resolves
-the library from it, and the migration tool the documentation opens with is run
-from a path inside it. Both are the documented setup. Neither is licence to
-browse.
+**The `re-frame2/` checkout is a build input, not a reference work.** There is
+no reading exception: the documentation is on the site, so nothing in the
+checkout is a reference for how Hicasso works. Two uses of it are expected and
+correct, because the published documentation itself tells you to make them:
+your `deps.edn` resolves the library from it, and the migration tool the
+documentation opens with is run from a path inside it. Both are the documented
+setup. Neither is licence to browse.
 
 There is no trick here and you are not being tested for compliance. If you
 read something you should not have, write it down in the log's attestation and
@@ -165,9 +167,12 @@ of you, and you should not go looking for more.
    accidents, and this outcome is about the instrument.
 6. **A production build succeeds and the built page runs.** Both halves. A
    bundle that compiles and does not boot is the interesting failure.
-7. **Move the version pin and upgrade across it.** Your setup pins the library
-   to one commit; record it, then move it to a later one at the end and record
-   what the move cost. A rename that surfaces as a compile error at your own
+7. **Upgrade across a released version.** Record the released version your
+   project depends on, then move it to a later released version at the end and
+   record what the move cost. Both versions go in the log. Moving a checkout to
+   a different commit is not this outcome and does not stand in for it — a git
+   pin is not a version, and a row built from one reads as upgrade evidence
+   without being any. A rename that surfaces as a compile error at your own
    call site is the documented behaviour, not a bug — say so if you meet one.
 
 For each, record the verdict and the evidence in Part 1 of the log. Quote

--- a/docs/design/hicasso/product/pilots/brief-realworld.md
+++ b/docs/design/hicasso/product/pilots/brief-realworld.md
@@ -2,9 +2,9 @@
 
 Copy the block below into `<pilot-root>/BRIEF.md`. Everything inside it is written *to the pilot agent* and is the only thing that agent is given, alongside the blank friction log and the workspace itself.
 
-The brief is deliberately free of in-tree references: no bead ids, no spec sections, no repository paths except the ones the published documentation itself tells a reader to use, and one added since: `docs/core/hicasso/` inside the checkout, which is where the published documentation is kept until a site exists (`rf2-lpfz`). Naming it is what makes the pilot's only reference reachable at all. That is not tidiness. A brief that leaks in-tree knowledge does not bend a rule, it invalidates the evidence the pilot exists to produce, and the leak is invisible in the output.
+The brief is deliberately free of in-tree references: no bead ids, no spec sections, no repository paths except the ones the published documentation itself tells a reader to use. `rf2-lpfz` had to add one — `docs/core/hicasso/` inside the checkout — because the published documentation had nowhere else to live, and naming it was what made the pilot's only reference reachable at all. **That exception is retired under `rf2-pug6`: the documentation site is published, so the brief gives the pilot a URL and the checkout goes back to being a build input with no reading exception at all.** That is not tidiness. A brief that leaks in-tree knowledge does not bend a rule, it invalidates the evidence the pilot exists to produce, and the leak is invisible in the output.
 
-Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the sentence naming the test command, under `rf2-xkhul`; the address of the published documentation in the read rules, under `rf2-lpfz`; the paragraph naming the page check, under `rf2-ek1a`. Assemble the workspace first, per [`workspace.md`](workspace.md).
+Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the sentence naming the test command, under `rf2-xkhul`; the address of the published documentation in the read rules, under `rf2-lpfz`, and its flip from the checkout to the published site — with the public Xray manual admitted and outcome 7 moved onto released versions — under `rf2-pug6`; the paragraph naming the page check, under `rf2-ek1a`. Assemble the workspace first, per [`workspace.md`](workspace.md).
 
 ---
 
@@ -34,8 +34,8 @@ Your two screens are **the feed** and **the article editor**.
 
 ## The rule
 
-**Everything you need is in the published Hicasso documentation. You may not
-use anything else to learn how Hicasso works.**
+**Everything you need is in the published documentation. You may not use
+anything else to learn how Hicasso works.**
 
 This is the whole point of the exercise, so it is worth being exact about it.
 The question being asked is not "can this application be migrated" — of course
@@ -47,12 +47,13 @@ afterwards from the code you produce. Only you can tell us.
 
 **You may read:**
 
-- The published Hicasso documentation, in full. It is your reference for
-  everything: what to type, what things are called, why something broke, how
-  to test, how to build for production. It has not been put on a website yet,
-  so your copy of it is the one inside the checkout beside your project, at
-  `re-frame2/docs/core/hicasso/`. Those pages are the documentation; reading
-  them is not reading the checkout.
+- The published documentation site, in full, at
+  <https://day8.github.io/re-frame2/>. It is your reference for everything:
+  what to type, what things are called, why something broke, how to test, how
+  to build for production. If the site publishes a page, you may read it. The
+  Hicasso guide is the part you will live in, and the Xray manual beside it is
+  documentation on the same footing — outcome 5 sends you there, so read it as
+  freely as the guide.
 - Everything in `app/`. That is your codebase. Its README explains what the
   application does and which patterns it is built from — read it freely.
 - Ordinary error output: compiler messages, stack traces, browser console.
@@ -61,22 +62,23 @@ afterwards from the code you produce. Only you can tell us.
 **You may not read:**
 
 - The `re-frame2/` checkout sitting beside your project, for anything other
-  than the documentation named above and the two mechanical uses below. Not
-  its source, not its internal design notes, not its other example
-  applications, not its history.
+  than the two mechanical uses below. Not its source, not its internal design
+  notes, not its other example applications, not its history — and not its
+  copy of the documentation either, because the site is the documentation and
+  is where you read it.
 - Any file your app's README links to outside `app/`. The README is yours; the
   things it points at are not.
 - Any source file named in a stack trace. Knowing that a complaint came from
   some internal file is diagnosis and is fine. Opening that file is research
   and is not.
 
-**The `re-frame2/` checkout is a build input, not a reference work.** The
-documentation above is the one exception, and only because it has nowhere else
-to live yet. Two further uses of it are expected and correct, because the
-published documentation itself tells you to make them: your `deps.edn` resolves
-the library from it, and the migration tool the documentation opens with is run
-from a path inside it. Both are the documented setup. Neither is licence to
-browse.
+**The `re-frame2/` checkout is a build input, not a reference work.** There is
+no reading exception: the documentation is on the site, so nothing in the
+checkout is a reference for how Hicasso works. Two uses of it are expected and
+correct, because the published documentation itself tells you to make them:
+your `deps.edn` resolves the library from it, and the migration tool the
+documentation opens with is run from a path inside it. Both are the documented
+setup. Neither is licence to browse.
 
 There is no trick here and you are not being tested for compliance. If you
 read something you should not have, write it down in the log's attestation and
@@ -139,9 +141,12 @@ of you, and you should not go looking for more.
    accidents, and this outcome is about the instrument.
 6. **A production build succeeds and the built page runs.** Both halves. A
    bundle that compiles and does not boot is the interesting failure.
-7. **Move the version pin and upgrade across it.** Your setup pins the library
-   to one commit; record it, then move it to a later one at the end and record
-   what the move cost. A rename that surfaces as a compile error at your own
+7. **Upgrade across a released version.** Record the released version your
+   project depends on, then move it to a later released version at the end and
+   record what the move cost. Both versions go in the log. Moving a checkout to
+   a different commit is not this outcome and does not stand in for it — a git
+   pin is not a version, and a row built from one reads as upgrade evidence
+   without being any. A rename that surfaces as a compile error at your own
    call site is the documented behaviour, not a bug — say so if you meet one.
 
 For each, record the verdict and the evidence in Part 1 of the log. Quote


### PR DESCRIPTION
Both counted-pilot briefs carried instructions that would have contaminated the run they exist to evidence. A counted pilot's whole value is that it used the **published** artefact; an instruction sending it into a source checkout invalidates the measurement, and the leak is invisible in the output. `rf2-hic-063` owns these files but is titled `[HELD GATE — nothing to pick up]`, so a dispatcher skips it and this pre-publication repair would have stayed invisible until a pilot ran on stale text.

Three repairs, prose only, applied symmetrically to `brief-realworld.md` and `brief-linearlite.md`.

### 1. The "no website" read fence

The read bullet told the pilot the documentation had not been published and to read the checkout copy at `docs/core/hicasso/` instead. **The site is live.** It now names the site URL, and the exception `rf2-lpfz` had to add is retired: the checkout goes back to being a build input with *no reading exception at all*. Its two mechanical uses — `:local/root` resolution and the migration reporter — are unchanged and remain documented setup, so nothing about how the workspace is assembled moves here.

### 2. Outcome 7 prescribed a commit move

`friction-log.md:50` already resolves this coherently: a git pin is not a version, and a simulated move "yields a row which reads as upgrade evidence without being any". The briefs were simply never flipped to match it. Outcome 7 now prescribes a released-version move and explicitly forecloses the commit-move stand-in. **This was verified against that line rather than re-decided.**

The operator's rehearsal variant in `workspace.md:181` replaces outcome 7 *positionally* ("replace outcome 7 in the definition of done with"), not by quoting its text, so it is unaffected by this rewording.

### 3. The read fence barred the public Xray manual

`docs/xray/` is published by the site and `workspace.md:44`/`:49` admits it by the same site-build rule ("anything under `docs/` that the published site builds is documentation and is readable"). The brief's fence did not, while outcome 5 requires the documented diagnostic path — so the fence blocked its own outcome. The fence now admits any page the site publishes and names the Xray manual explicitly.

This is **only the read-fence half** of outcome 5. `docs/core/hicasso/16-diagnostics.md` resolving Xray from a checkout is `rf2-i6ug`'s, and is untouched here.

### One consequential edit beyond the three

"The rule" heading read *"Everything you need is in the published **Hicasso** documentation"*. Left alone it re-bars Xray one section above the fence that admits it, so it was widened to "the published documentation". The following sentence ("You may not use anything else to learn how Hicasso works") is unchanged.

### Effect on a standing claim

`workspace.md:179` asserts the briefs "are correct as written for the counted run on a published artefact, where two pins genuinely exist". That was **false** before this change — the briefs prescribed a commit move — and is true after it. No edit to `workspace.md` was needed or made; it and `friction-log.md` were read, not edited.

## Quality gates

| Gate | Invocation | Captured exit |
| --- | --- | --- |
| `scripts/check_doc_slugs.py` | `python scripts/check_doc_slugs.py` | **0** |
| `scripts/check_doc_slugs.py` (planted fault) | same, against a deliberately broken anchor | **1** — red, as intended |
| `scripts/check_provenance_pins.py` | `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** |
| `scripts/check_provenance_pins.py` | `--self-test` | **0** |
| `scripts/check_readme_links.py` | `python scripts/check_readme_links.py --ci` | **0** |
| `scripts/check_view_lifetime_residue.py` | `python scripts/check_view_lifetime_residue.py` | **0** |
| `scripts/check-no-hardcoded-paths.sh` | `sh scripts/check-no-hardcoded-paths.sh` | **0** |
| `scripts/check-commit-attribution.sh` | `sh scripts/check-commit-attribution.sh origin/main HEAD` | **0** |
| `scripts/check_retired_spellings.py` | `python scripts/check_retired_spellings.py` | **0** (ran; `docs/design` is outside its roster by design) |

Every number above was captured with the redirect and the `echo $?` on one command line in one shell, and re-run after rebasing onto the current `origin/main` — a pre-rebase green is evidence about a tree that no longer exists.

`python -m mkdocs build --strict` is **deliberately not nominated**: `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site build, so a green there would have inspected nothing changed here.

**Proof the slug gate read this worktree.** The gate prints no root, so the discrimination is the red from a planted fault: the `#what-governs-this-directory` anchor on `brief-realworld.md:7` was broken to `#deliberately-broken-anchor-pug6a`, and the gate failed exit **1** naming that file, that line and that anchor. The fault existed only in this worktree, so a run that had wandered elsewhere would have come back green. Restore was verified by git blob hash — back to blob `6d957c364163f1c33e7e0a0a893554732f5f6198`, with zero residual matches for the planted string — rather than by reading a diff, since "unchanged" and "not attempted" are the same diff.

`check_provenance_pins.py` reports its own scope, and it named exactly the two changed pages: `2 pages inspected, 0 cited pins … 0 findings`. Neither brief cites any hex token (controlled against `docs/design/hicasso/decisions.md`, which carries 2 forty-character tokens, so the scan was exercised against something it should find).

### Fence coverage, and what no gate checked

Most of this diff sits inside the fenced ```` ```markdown ```` block that is the copied-out `BRIEF.md`. The usual rule is that the link gates strip fences before reading a single link — **but this tree is one of the two exceptions.** `check_doc_slugs.py` carries `FENCED_DOC_LINK_TREES = ("docs/design/hicasso", "docs/the-mayor-method")`, so here a doc link inside a fence *is* reported, precisely because these fences are pasteable deliverables. Coverage is therefore better than the general rule would suggest, not worse.

What that gate treats as a doc destination is one ending `.md` or a bare `#fragment`. The one link this change adds inside the fence is an external site URL, so it is not a doc destination and is not graded as one — it was verified by probing it instead, below. The one repo-relative link in these files sits outside the fence on the authorization line, and that is the link the planted fault exercised.

**No gate inspects prose, tables or rendering** — link targets and anchors are the whole of what these gates check, and the substance of this change is instructions. So the wording was checked by hand: the bullet and numbered-list continuation indentation is preserved (2 spaces under bullets, 3 under the numbered outcomes), no tables were touched so no column counts are at risk, and the two briefs were diffed against each other to confirm the three repairs landed identically in both.

That URL was probed directly rather than taken on trust, with controls in both directions:

| URL | Status |
| --- | --- |
| `https://day8.github.io/re-frame2/` | 200 |
| `https://day8.github.io/re-frame2/core/hicasso/` | 200 |
| `https://day8.github.io/re-frame2/core/hicasso/00-installation/` | 200 |
| `https://day8.github.io/re-frame2/xray/` | 200 |
| `https://day8.github.io/re-frame2/xray/01-installation/` | 200 |
| `https://day8.github.io/re-frame2/this-page-does-not-exist-control/` | 404 (control) |
| `https://day8.github.io/re-frame2/design/hicasso/product/pilots/workspace/` | 404 (control) |

The first control shows the site returns real 404s rather than answering everything 200; the second shows `exclude_docs` genuinely excludes the design tree, which is the mechanism `workspace.md:49` relies on to decide what counts as documentation. A brief flipped toward a site that was down would be worse than the stale text it replaces, so this was re-probed rather than inherited from the tracker item.
