### PR TITLE
fix(uix): the recipe test asserts uix.dom is retired, not pinned (rf2-v37n)

### DIFF
--- a/implementation/adapters/uix/test/re_frame/adapter/uix_consumer_deps_recipe_test.clj
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_consumer_deps_recipe_test.clj
@@ -19,6 +19,16 @@
    the generator template. Drop `com.pitch/uix.dom` from any of those and this
    goes red naming the file.
 
+   The generator template is the VERSION SOURCE, not a fourth recipe, and it
+   alone does not name `uix.dom` (rf2-j908): the app it emits mounts through
+   `rf.adapter.uix/client-root` + `render!`, so the Root is minted by the
+   shared React spine and the DOM half is not a day-one dependency. That
+   absence is asserted here positively rather than merely dropped, because a
+   deleted assertion asserts nothing; `retired-coords` in the template suite
+   is the sibling half, which refuses the coordinate's return anywhere in the
+   emitted `deps.edn`. The three examples mint their own Root and so still
+   require `uix.dom` — which is why the recipe pages must still name it.
+
    What this does NOT do is resolve a real classpath. A genuine clean-consumer
    compile would need its own fixture project, its own Maven resolution and its
    own build step — a new CI lane, which this bead is not worth. The invariant
@@ -154,13 +164,23 @@
         owners     (->> example-sources
                         (mapcat #(required-uix-namespaces (slurp-at root %)))
                         set)]
-    (testing "the template pins both UIx coordinates"
-      (is (some? core-ver) (str template-deps-path " has no com.pitch/uix.core."))
-      (is (some? dom-ver)  (str template-deps-path " has no com.pitch/uix.dom.")))
-    (testing "at the same version — the pair moves in lockstep"
-      (is (= core-ver dom-ver)
-          (str template-deps-path " pins uix.core at " core-ver
-               " and uix.dom at " dom-ver ".")))
+    (testing "the template pins uix.core — the one version source"
+      (is (some? core-ver) (str template-deps-path " has no com.pitch/uix.core.")))
+    (testing "and deliberately does NOT pin uix.dom (rf2-j908)"
+      ;; The absence half, asserted rather than assumed. The emitted app
+      ;; mounts through the adapter's `client-root` / `render!`, so uix.dom
+      ;; is not on its classpath and there is no second version to keep in
+      ;; lockstep. Restoring the pin would re-teach the superseded
+      ;; `uix-dom/create-root` boot, so this must go red if it comes back.
+      (is (nil? dom-ver)
+          (str template-deps-path " pins com.pitch/uix.dom at "
+               (pr-str dom-ver) ". rf2-j908 retired that coordinate from the "
+               "scaffold: the emitted app mounts through "
+               "`rf.adapter.uix/client-root` + `render!`, so the React Root "
+               "is minted by the shared spine and uix.dom is not a day-one "
+               "dependency. If the pin was restored deliberately, this guard "
+               "and `retired-coords` in the template suite both need "
+               "revisiting rather than relaxing.")))
     (doseq [rel recipe-pages]
       (testing rel
         (let [found (recipe-coordinates (slurp-at root rel))]


### PR DESCRIPTION
Trunk was red for `Diagnostic skip-ok JVM uix-adapter classpath probe`.
`published-recipes-name-both-uix-coordinates-in-lockstep` required the
generator template to pin `com.pitch/uix.dom`, and to hold it at the same
version as `uix.core`:

```
expected: (some? dom-ver)       actual: (not (some? nil))
expected: (= core-ver dom-ver)  actual: (not (= "1.4.4" nil))
```

**The test was the stale artefact, not the template.** Verified at source rather
than taken on report: `_uix/deps.edn` pins `com.pitch/uix.core {:mvn/version
"1.4.4"}` and no `uix.dom`, and rf2-j908 (PR #9543, commit `606414f7b2`)
dropped that coordinate deliberately — the emitted app mounts through
`rf.adapter.uix/client-root` + `render!`, so the React Root is minted by the
shared React spine and the DOM half is not a day-one dependency. That same PR
added `com.pitch/uix.dom` to `retired-coords` in the template suite, precisely
because `view-lib-coords` is a PRESENCE check and deleting a row asserts
nothing.

## What changed

One file: `implementation/adapters/uix/test/re_frame/adapter/uix_consumer_deps_recipe_test.clj`.

The two template assertions now read the ruled shape — `uix.core` pinned as the
one version source, `uix.dom` ABSENT. The absence is asserted **positively**
rather than deleted, for the same reason `retired-coords` exists: a deleted
assertion asserts nothing. Its failure message names rf2-j908 and points at
`retired-coords` as the sibling half, so a future reader who restores the pin is
told to revisit both guards rather than relax either.

The recipe-page assertions below are untouched and still demand
`com.pitch/uix.dom` at the template's version. That is not an oversight: the
three examples mint their own React Root and genuinely require `uix.dom`, so a
consumer copying one of them still needs the coordinate. The template is the
version source, not a fourth recipe — which is what the new docstring paragraph
records.

## Assertion count moves 34 -> 33, and the arithmetic is exact

Three assertions were replaced by two: `(some? core-ver)` survives,
`(some? dom-ver)` becomes `(nil? dom-ver)`, and `(= core-ver dom-ver)` is
**deleted with no replacement** — a lockstep check between two coordinates
cannot survive the second coordinate's removal, and asserting it against `nil`
is not a check but a contradiction. Test count is unchanged at 4. The sabotage
run below is the positive evidence that the namespace still executes rather
than being skipped.

## Not done here, deliberately

* **The template is NOT touched.** Restoring `uix.dom` would revert a ruled
  migration and re-teach the superseded `uix-dom/create-root` boot.
* **`_uix/deps.edn`'s comment is NOT stale, so it is left alone.** The brief for
  this fix expected a leftover line explaining what `uix.dom` is for. It is not
  there: `606414f7b2` rewrote that comment as part of the migration and
  `bca094d97b` trimmed it for the leaf byte ceiling. It now reads "`uix.core` is
  direct: the views author with `$` and `defui`. `uix.dom` is NOT — the
  adapter's `client-root` / `render!` own the React Root", which is exactly the
  post-migration truth. Editing it would also have armed `template_expensive`
  for no gain.
* **The classifier is NOT widened and no gate is added.** Recorded only: #9543's
  diff armed `template_expensive` alone, so this probe read SKIPPED on the PR
  that broke it, and it surfaced on an unrelated PR whose diff armed the
  uix-adapter surface. The merge criterion accepts passed-OR-SKIPPED, so a
  diagnostic the classifier did not schedule is admitted. That is structural
  rather than any author's error, and whether `tools/template/*` should arm the
  uix-adapter probe is a separate question worth its own bead.

## Quality gates

All exit codes below are the runner's own status, captured with the redirect and
the echo on one command line, and quoted from that capture rather than from any
harness report.

| Gate | Exit | Result |
| --- | --- | --- |
| `clojure -M:test` in `implementation/adapters/uix` — BEFORE | `1` | Ran 4 tests containing 34 assertions. **2 failures**, 0 errors |
| `clojure -M:test` in `implementation/adapters/uix` — AFTER | `0` | Ran 4 tests containing 33 assertions. **0 failures**, 0 errors |
| `clojure -M:test` — AFTER, re-run on the final rebased base | `0` | Ran 4 tests containing 33 assertions. **0 failures**, 0 errors |
| `clj-kondo --lint <the changed file> --fail-level error` | `0` | errors: 0, warnings: 0 |
| `python scripts/check_retired_spellings.py` | `0` | clean |
| `python scripts/check_retired_spellings.py --self-test` | `0` | instrument control — exercises its fixtures in both directions |

The before/after counts are quoted because a green run that skipped the
namespace is not the same as a green run that executed it.

### Sabotage control

The nominated gate is plantable, so it was proved to read this branch's tree
rather than another checkout's. The rewritten assertion was changed to
`(is (= "RF2-V37N-PLANTED-FAULT" dom-ver) ...)` — a token that exists nowhere
else in the repository. Anchor match count was read as `1` **before** the run,
so the plant cannot have silently no-opped.

Result: **exit 1**, `Ran 4 tests containing 33 assertions. 1 failures, 0 errors`,
naming

```
expected: (= "RF2-V37N-PLANTED-FAULT" dom-ver)
  actual: (not (= "RF2-V37N-PLANTED-FAULT" nil))
```

That red is the discrimination: the fault existed only in this branch's
worktree, so a run that had wandered into a sibling checkout would have come
back green. It also settles the 33-assertion question — the namespace demonstrably
executed.

Restored and verified by git **blob** hash
`872cdf7fd8cfd0ff935b446fdad440d9f4ef8896` (identical before the plant and after
the restore), with zero residue of the planted token and a clean worktree. The
hash is used rather than a diff read because an unapplied patch and an
unmodified file produce the same diff.

### Rebase

Rebased onto `5f274a4851` after the first green. That commit touches
`.beads/issues.jsonl` only, but the gate was re-run on the final base anyway,
since a pre-rebase green is evidence about a tree that no longer exists. The
branch diff against its merge base is one file, +27/-7, and reverts nothing a
sibling landed.

Closes rf2-v37n.


### Ratchets covering `implementation/adapters/uix/**`

Found by sweeping the workflow job lists and the surface classifier rather than
by nominating from memory, then run locally. Each was run twice — once as its
own `--self-test`, which is the control that proves the instrument bites, and
once for real.

| Ratchet | `--self-test` | Real run |
| --- | --- | --- |
| `scripts/check_require_alias_dialect.py` | `0` | `0` |
| `scripts/check_test_lane_bijection.py` | `0` | `0` |
| `scripts/check_jvm_lane_rosters.py` | `0` | `0` |
| `scripts/check_retired_spellings.py` | `0` | `0` |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | — | `0` — "No beads-database paths in this PR diff." |
| `sh scripts/check-commit-attribution.sh origin/main` | — | `0` — "No AI attribution in the 1 commit(s) this branch introduces" |

The one that needed real thought is
`re-frame.observation-render-law-drift-test` in `jvm-repo-source-walks`: it is a
zero-tolerance vocabulary scan whose census is `git ls-files`, it grades `.clj`,
and — unlike most such gates — it does **not** strip docstrings or comments. This
PR adds prose about `render!` and a shared React spine, which is exactly the
shape it polices. Checked with its own two patterns and a control string that
the same expression **does** match: 0 hits here, and the file contains no
occurrence of `epoch` at all, so neither arm can fire. It passes in CI.

No byte ceiling or line-count ratchet covers this artefact; the neighbouring
byte-pin test (`uix_component_recipe_docs_pin_test.clj`) targets a different
file.

### CI rollup

Settled at **67 pass / 20 skipping / 0 failures / 0 pending** on head oid
`265e85af39f77590c4c6a3618abeaa8a8ee2a1a1` (full 40 characters, from
`gh pr view --json headRefOid`, not extended by hand). The job this PR exists to
repair — **`Diagnostic skip-ok JVM uix-adapter classpath probe`** — is green.
