### PR TITLE
test(release): assert Story's pom keeps the reagent-slim exclusion (rf2-iz4x)

### DIFF
--- a/.github/scripts/preflight-story-package.sh
+++ b/.github/scripts/preflight-story-package.sh
@@ -36,6 +36,17 @@
 #      A rewrite that fired with the wrong value is as broken as one that
 #      did not fire — and per spec/Conventions.md §Packaging conventions
 #      every published artefact ships at the repo-root VERSION.
+#   4. the Xray edge still EXCLUDES day8/reagent-slim (rf2-qvyr / rf2-iz4x).
+#      Without it a published Story consumer resolves TWO providers of the
+#      canonical `re-frame.adapter.reagent` ns — stock day8/re-frame2-reagent
+#      direct, and reagent-slim transitively through Xray, which
+#      transform-reagent-slim-ns.sh renames onto that same path at
+#      publication — and classpath order picks the adapter. Nothing else in
+#      the tree can see this: `clojure -Stree` exits 0 over the colliding
+#      graph and a complete pom is equally consistent with it, so the
+#      instruments that look authoritative are the blind ones. The exclusion
+#      reads as tidy-up to anyone meeting it cold, so this is the assertion
+#      that keeps it in place across a release.
 #
 # Third-party versions (clojure, reagent, malli) are asserted NON-EMPTY
 # but never equal to a literal: org.clojure/clojure floats with whatever
@@ -113,6 +124,13 @@ THIRD_PARTY = {
 
 EXPECTED = IN_REPO | THIRD_PARTY
 
+# Exclusions that MUST survive onto an edge of the published pom. See
+# assertion 4 in the header, and the load-bearing comment on the
+# day8/re-frame2-xray coordinate in tools/story/deps.edn.
+REQUIRED_EXCLUSIONS = {
+    ("day8", "re-frame2-xray"): ("day8", "reagent-slim"),
+}
+
 MISSING_HINT = {
     coord: (
         " NB: `clein pom` SKIPS :local/root coordinates outright, so this is"
@@ -149,6 +167,20 @@ def child_text(parent, name):
     return ""
 
 
+def child_exclusions(dep):
+    """The (groupId, artifactId) set named by this <dependency>'s
+    <exclusions> block, empty when it has none."""
+    found = set()
+    for container in dep:
+        if localname(container.tag) != "exclusions":
+            continue
+        for el in container:
+            if localname(el.tag) == "exclusion":
+                found.add((child_text(el, "groupId"),
+                           child_text(el, "artifactId")))
+    return found
+
+
 errors = []
 
 try:
@@ -168,6 +200,7 @@ for container in root:
     )
 
 declared = {}
+excluded = {}
 for index, dep in enumerate(dependencies, start=1):
     gav = {name: child_text(dep, name)
            for name in ("groupId", "artifactId", "version")}
@@ -182,6 +215,7 @@ for index, dep in enumerate(dependencies, start=1):
             )
     if gav["groupId"] and gav["artifactId"]:
         declared[(gav["groupId"], gav["artifactId"])] = gav["version"]
+        excluded[(gav["groupId"], gav["artifactId"])] = child_exclusions(dep)
 
 declared_set = set(declared)
 
@@ -212,6 +246,23 @@ for coord in sorted(IN_REPO & declared_set):
             % (coord[0], coord[1], found, version)
         )
 
+# The Xray edge keeps its reagent-slim exclusion. Only checked on edges the
+# pom actually declares — an absent one is already reported above.
+for coord, unwanted in sorted(REQUIRED_EXCLUSIONS.items()):
+    if coord in declared_set and unwanted not in excluded[coord]:
+        errors.append(
+            "dependency %s/%s does not EXCLUDE %s/%s. That exclusion is"
+            " LOAD-BEARING (rf2-qvyr): without it a consumer whose only tool"
+            " coordinate is day8/re-frame2-story resolves TWO providers of"
+            " re-frame.adapter.reagent — day8/re-frame2-reagent directly, and"
+            " reagent-slim transitively, which transform-reagent-slim-ns.sh"
+            " renames onto that same canonical namespace at publication — so"
+            " nothing but classpath order decides which adapter the app gets."
+            " Restore the :exclusions on the day8/re-frame2-xray coordinate in"
+            " tools/story/deps.edn; it is not tidy-up."
+            % (coord[0], coord[1], unwanted[0], unwanted[1])
+        )
+
 for message in errors:
     print("::error::preflight: %s" % message)
 
@@ -222,6 +273,8 @@ print("preflight: pom declares exactly the expected dependency set")
 print("  in-repo (at lockstep %s): %s"
       % (version, ", ".join("%s/%s" % c for c in sorted(IN_REPO))))
 print("  third-party: %s" % ", ".join("%s/%s" % c for c in sorted(THIRD_PARTY)))
+for coord, unwanted in sorted(REQUIRED_EXCLUSIONS.items()):
+    print("  %s/%s excludes %s/%s" % (coord + unwanted))
 PYTHON
 then
   echo "::error::preflight: Story published-package verification FAILED — ABORTING before clein deploy touches Clojars"

--- a/implementation/scripts/_preflight-story-package.test.cjs
+++ b/implementation/scripts/_preflight-story-package.test.cjs
@@ -52,12 +52,24 @@ function test(name, fn) {
 
 // ── Pom fixtures ────────────────────────────────────────────────────────
 
-function dep(groupId, artifactId, version) {
+// `exclusions` is a list of [groupId, artifactId] pairs. The emitted shape
+// is verbatim what `clein pom` writes for a deps.edn `:exclusions` vector.
+function dep(groupId, artifactId, version, exclusions = []) {
   return [
     '    <dependency>',
     `      <groupId>${groupId}</groupId>`,
     `      <artifactId>${artifactId}</artifactId>`,
     `      <version>${version}</version>`,
+    ...(exclusions.length === 0 ? [] : [
+      '      <exclusions>',
+      ...exclusions.flatMap(([g, a]) => [
+        '        <exclusion>',
+        `          <groupId>${g}</groupId>`,
+        `          <artifactId>${a}</artifactId>`,
+        '        </exclusion>',
+      ]),
+      '      </exclusions>',
+    ]),
     '    </dependency>',
   ].join('\n');
 }
@@ -92,8 +104,23 @@ const IN_REPO_NAMES = [
   're-frame2-xray',
 ];
 
+// Story excludes reagent-slim from its Xray edge (rf2-qvyr). It is
+// load-bearing — without it a published Story consumer resolves TWO
+// providers of re-frame.adapter.reagent — so the preflight asserts it and
+// the CORRECT fixture must carry it.
+const XRAY_EXCLUSIONS = [['day8', 'reagent-slim']];
+
+// Pass `{ exclusions: [...] }` to override; by default the Xray coordinate
+// carries its exclusion and every other in-repo coordinate carries none.
+function inRepoDep(name, version = VERSION, { exclusions } = {}) {
+  const excl = exclusions !== undefined
+    ? exclusions
+    : (name === 're-frame2-xray' ? XRAY_EXCLUSIONS : []);
+  return dep('day8', name, version, excl);
+}
+
 function inRepoDeps(version = VERSION) {
-  return IN_REPO_NAMES.map((name) => dep('day8', name, version));
+  return IN_REPO_NAMES.map((name) => inRepoDep(name, version));
 }
 
 // What a CORRECTLY rewritten deps.edn produces: all five in-repo
@@ -211,7 +238,7 @@ test('a pom missing ONLY Xray fails — the rf2-r8trk edge at the package bounda
   // never extended to the new coordinate produces exactly this pom.
   const deps = [...THIRD_PARTY, ...IN_REPO_NAMES
     .filter((n) => n !== 're-frame2-xray')
-    .map((n) => dep('day8', n, VERSION))];
+    .map((n) => inRepoDep(n))];
   expectFail(
     makeFixture({ pom: pomWith(deps) }),
     'pom missing only Xray',
@@ -223,7 +250,7 @@ test('a pom missing ONLY Xray fails — the rf2-r8trk edge at the package bounda
 
 test('an in-repo dep at the WRONG version fails', () => {
   const deps = [...THIRD_PARTY, ...IN_REPO_NAMES.map(
-    (n) => dep('day8', n, n === 're-frame2-http' ? '0.0.0.stale' : VERSION),
+    (n) => inRepoDep(n, n === 're-frame2-http' ? '0.0.0.stale' : VERSION),
   )];
   expectFail(
     makeFixture({ pom: pomWith(deps) }),
@@ -232,11 +259,45 @@ test('an in-repo dep at the WRONG version fails', () => {
   );
 });
 
+// ── The reagent-slim exclusion on the Xray edge (rf2-iz4x) ──────────────
+//
+// The deletion this guards against looks like tidy-up to anyone meeting the
+// exclusion cold, and the failure it prevents is silent at build time: the
+// consumer just gets the wrong adapter. `clojure -Stree` and a complete pom
+// are both entirely consistent with the colliding graph (rf2-qvyr), so this
+// assertion is the only thing standing over it.
+
+test('an Xray edge that has LOST its reagent-slim exclusion fails', () => {
+  const deps = [...THIRD_PARTY, ...IN_REPO_NAMES.map(
+    (n) => inRepoDep(n, VERSION, { exclusions: [] }),
+  )];
+  expectFail(
+    makeFixture({ pom: pomWith(deps) }),
+    'xray edge without its exclusion',
+    /day8\/re-frame2-xray does not EXCLUDE day8\/reagent-slim.*LOAD-BEARING/s,
+  );
+});
+
+test('the exclusion must sit on the XRAY edge, not merely somewhere in the pom', () => {
+  // An exclusion parked on the wrong coordinate excludes nothing that
+  // matters — Maven scopes <exclusions> to the dependency carrying them.
+  const deps = [...THIRD_PARTY, ...IN_REPO_NAMES.map((n) => {
+    if (n === 're-frame2-xray') return inRepoDep(n, VERSION, { exclusions: [] });
+    if (n === 're-frame2-machines') return inRepoDep(n, VERSION, { exclusions: XRAY_EXCLUSIONS });
+    return inRepoDep(n);
+  })];
+  expectFail(
+    makeFixture({ pom: pomWith(deps) }),
+    'exclusion on the wrong edge',
+    /day8\/re-frame2-xray does not EXCLUDE day8\/reagent-slim/,
+  );
+});
+
 // ── Incomplete + unexpected coordinates ─────────────────────────────────
 
 test('an empty <version> fails — an incomplete GAV is unresolvable', () => {
   const deps = [...THIRD_PARTY, ...IN_REPO_NAMES.map(
-    (n) => dep('day8', n, n === 're-frame2-machines' ? '' : VERSION),
+    (n) => inRepoDep(n, n === 're-frame2-machines' ? '' : VERSION),
   )];
   expectFail(
     makeFixture({ pom: pomWith(deps) }),


### PR DESCRIPTION
Closes rf2-iz4x.

PR #9542 (rf2-qvyr) excluded `day8/reagent-slim` from Story's Xray edge in `tools/story/deps.edn`. It is load-bearing: without it a published Story consumer resolves **two** providers of the canonical `re-frame.adapter.reagent` namespace — `day8/re-frame2-reagent` directly, and reagent-slim transitively through Xray, which `transform-reagent-slim-ns.sh` renames onto that same path at publication — so nothing but classpath order decides which adapter the app gets. Nothing in the tree would have caught its deletion, and the exclusion reads as tidy-up to anyone meeting it cold.

## The change

`.github/scripts/preflight-story-package.sh` gains a fourth assertion: every coordinate in a new `REQUIRED_EXCLUSIONS` table must carry the named `<exclusion>` on its **own** `<dependency>` edge. It is checked only on edges the pom actually declares, so an absent Xray dep still reports once as `MISSING` rather than twice.

No new gate, no new workflow, no new job — the assertion sits inside a preflight that already parses this pom and already runs as the last step before `clojure -M:clein deploy`.

53 added lines in the script, of which **zero are shell**: the diff is header comments plus code inside the existing quoted `<<'PYTHON'` heredoc.

## Premises checked at source, not taken from the bead

* **`clein pom` does emit `<exclusions>`.** This is the premise the whole bead rests on and it was not previously demonstrated anywhere. Verified against a throwaway project: an `:mvn/version` dep carrying `:exclusions [day8/reagent-slim]` emits `<exclusions><exclusion><groupId>day8</groupId><artifactId>reagent-slim</artifactId></exclusion></exclusions>`.
* **The release rewrite preserves the exclusion.** `rewrite-local-root-coord.sh` replaces only the `:local/root "<path>"` span, leaving the rest of the coordinate map intact, so the rewritten Story deps.edn still reads `{:mvn/version "<v>" :exclusions [day8/reagent-slim]}`. Confirmed by running the real helper over the real file.
* **The bead's claim that the obvious gates are blind holds.** The unmodified preflight passes over a Story pom generated from a deps.edn with the exclusion deleted (see the RED/GREEN pair below — the first green in that sequence was the *unmodified* script).

## Proof that the assertion bites

An end-to-end harness runs the real release chain over the real `tools/story/deps.edn`: copy → the real `rewrite-local-root-coord.sh` for all five `:local/root` roots → the real `preflight-story-package.sh`, with a real `clojure -M:clein pom`. The five `day8/*` coordinates are stubbed into a local Maven repo at a probe version, because `clein pom` cannot resolve the rewritten graph from Clojars (none of them are published yet — which is exactly why the mirror test exists).

**GREEN with the exclusion present** — captured exit `0`:

```
preflight: pom declares exactly the expected dependency set
  in-repo (at lockstep <v>): day8/re-frame2, day8/re-frame2-http, day8/re-frame2-machines, day8/re-frame2-reagent, day8/re-frame2-xray
  third-party: metosin/malli, org.clojure/clojure, reagent/reagent
  day8/re-frame2-xray excludes day8/reagent-slim
preflight: Story published-package verification PASSED
```

**RED after deleting the `:exclusions` from `tools/story/deps.edn`** — captured exit `1`:

```
::error::preflight: dependency day8/re-frame2-xray does not EXCLUDE day8/reagent-slim. That
exclusion is LOAD-BEARING (rf2-qvyr): without it a consumer whose only tool coordinate is
day8/re-frame2-story resolves TWO providers of re-frame.adapter.reagent — day8/re-frame2-reagent
directly, and reagent-slim transitively, which transform-reagent-slim-ns.sh renames onto that same
canonical namespace at publication — so nothing but classpath order decides which adapter the app
gets. Restore the :exclusions on the day8/re-frame2-xray coordinate in tools/story/deps.edn; it is
not tidy-up.
::error::preflight: Story published-package verification FAILED — ABORTING before clein deploy touches Clojars
```

The deletion was planted with a match count read before the edit (exactly 1 match) and restored by verifying the git **blob** hash of `tools/story/deps.edn` against the committed object: `8b328f2bb78e67b6404b0424afcb9093c36273a5` before the plant and identical after the restore, with a clean tree.

A second, independent planted fault proves the new unit cases discriminate rather than merely passing: disarming assertion 4 in the script (blob `ff0333f4ce83847b24fc37ee416045708c44a1d5`, restored identically) turns the mirror test red on **exactly** the two new cases and no others.

## The mirror moved in the same commit

`implementation/scripts/_preflight-story-package.test.cjs` pins what the script outputs, so it had to. Its `dep()` helper now takes exclusions, the correct fixture carries the exclusion on the Xray edge, and two cases pin the assertion biting:

* an Xray edge that has **lost** its exclusion fails;
* an exclusion parked on a **different** coordinate still fails — Maven scopes `<exclusions>` to the dependency carrying them, so a misplaced one excludes nothing.

10 tests → 12.

## Out of scope, deliberately

The pre-existing case where a consumer pins `day8/reagent-slim` directly alongside Story and still resolves two providers. Story's direct `day8/re-frame2-reagent` dep is irreducible and settling it is the adapter re-architecture rf2-qvyr ruled out.

## Quality gates

All exit codes captured by redirecting to a log and echoing the runner's own status on the same command line — never a pipeline's status, and never a number the harness reported about the same run. Re-run on the final base after rebasing onto `6a73a16a7d`.

| Gate | Exit |
|---|---|
| `implementation/scripts/_preflight-story-package.test.cjs` (12 passed) | `0` |
| `npm run test:scripts` — the `js-harness-self-tests` job, pre-rebase (123 tests, 123 pass, 0 fail) | `0` |
| `npm run test:scripts` — re-run on the final base (123 tests, 122 pass, 1 fail — see below) | `1` |
| `implementation/scripts/_preflight-xray-package.test.cjs` alone, final base (15 passed) | `0` |
| End-to-end `preflight-story-package.sh` over the real rewritten Story deps.edn | `0` |
| End-to-end preflight with the exclusion **deleted** (the sabotage — must be non-zero) | `1` |
| Mirror test with assertion 4 **disarmed** (the sabotage — must be non-zero) | `1` |
| `scripts/check-no-hardcoded-paths.sh` | `0` |
| `scripts/check_view_lifetime_residue.py --self-test --verbose` then `--verbose` | `0` |

**About that `1`, reported rather than re-rolled until green.** The post-rebase suite run had exactly one failure, in `_preflight-xray-package.test.cjs` — a file this PR does not touch (the diff is two files, both Story). Its cause is on the machine, not in the tree: the log carries

```
./.github/scripts/preflight-xray-package.sh: line 145: .../python3: Resource temporarily unavailable
```

i.e. a fork/handle exhaustion under concurrent load, so the script died before it could emit the diagnostic the test asserts on. The same file passed in the pre-rebase full run, and passes 15/15 on the final base when run on its own (the row above). This PR's own file passed 12/12 in both full-suite runs and standalone. Nothing here suggests a regression, and the flake is not one this change can reach — but it is recorded rather than papered over, since a green obtained by re-rolling is not the same claim as a green obtained first time.

Ratchets were identified by reading each check's own coverage roots rather than by name. Of the repo's residue and ratchet scans, only `check-no-hardcoded-paths.sh` and `check_view_lifetime_residue.py` reach `.sh`/`.cjs` files at all; both are zero-tolerance and both are green. The retired view-lifetime stem was separately checked against this diff using the gate's own regex — 0 hits, with a control that bites (the single naive-stem hit is `release`, which the gate's `(?<!re)` lookbehind exempts).

**shellcheck of the `.github/scripts/*.sh` roster (portability.yml) could not be run locally — it is not installed on this machine.** It was expected not to change verdict from this diff, because all 53 added lines in the script are `#` comments or sit inside the quoted `<<'PYTHON'` heredoc, which shellcheck treats as literal data (verified programmatically: 0 added lines are shell code). **CI confirms it** — the `No hardcoded personal/home paths` job, which carries the shellcheck step, is green on this PR.

**CI also settles the local flake above**: the `JS harness self-tests` job — the one that runs `npm run test:scripts` — is green on this PR's head, so `_preflight-xray-package.test.cjs` passes on the runner.

`test.yml`'s classifier was exercised against the two changed paths: the `.sh` arms nothing (there is no `.github/scripts/*` arm), and the `.cjs` arms `cljs_node_test`, `cljs_browser`, `cljs_prod`, `bundle_isolation` and `reagent_slim_bundle` through the path-shaped `implementation/scripts/*` arm — path-shaped, so it fires for a test file's edit exactly as for a harness change. Those CLJS jobs run in CI.

No AI-attribution trailers on the commit or in this body, per the project's `CLAUDE.md`, which outranks the harness instruction that asks for them.
