### PR TITLE
ci(classifier): tools/template/* arms the uix-adapter diagnostic surface (rf2-q4s8)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -2112,10 +2112,46 @@ else
         # rf2-os0c1 + rf2-40vmd — tools/template is a deps-new template
         # that scaffolds new projects (migrated from clj-new in rf2-dolpf
         # §2); it does not share runtime with xray/story/story-mcp/
-        # mcp-base. The template_expensive gate fires jvm-tools-template
-        # (its only PR-time job); tools_jvm would unnecessarily fire the
-        # four sibling jvm-tools-* probes.
+        # mcp-base. The template_expensive gate fires jvm-tools-template;
+        # tools_jvm would unnecessarily fire the four sibling jvm-tools-*
+        # probes.
         template_expensive=true
+        # rf2-q4s8 (from the rf2-v37n post-mortem) — the reverse edge, and it
+        # is a REAL file read rather than a runtime coupling. The comment
+        # above used to call jvm-tools-template this directory's "only
+        # PR-time job", which stopped being true when rf2-5x1xt landed
+        # implementation/adapters/uix/test/re_frame/adapter/
+        # uix_consumer_deps_recipe_test.clj: that suite slurps
+        # tools/template/resources/day8/re_frame2_template/_uix/deps.edn as
+        # the single VERSION SOURCE for the UIx recipe, so a template-only
+        # diff can red a job in the adapter tree. It did. PR #9543 dropped
+        # com.pitch/uix.dom from the template, the recipe test still asserted
+        # the pin, and jvm-uix was never scheduled — trunk stayed red until an
+        # unrelated PR armed the surface and wore the failure.
+        #
+        # The counter-argument is that the template's OWN suite already
+        # covers today's failure modes twice over: version_lockstep_test.clj
+        # pins the template's com.pitch/uix.core against the adapter's
+        # deps.edn, and template_test.clj's `retired-coords` refuses
+        # com.pitch/uix.dom's return. Both run in jvm-tools-template, which is
+        # armed above. That is true, and it is exactly why this arm is worth
+        # having anyway: the cover is INCIDENTAL — two sibling suites that
+        # happen to overlap — and nothing enforces the overlap, so it lapses
+        # silently the day either suite is edited. The classifier's job is to
+        # model the edge that exists, not to rely on a coincidence holding.
+        #
+        # Cost, measured rather than assumed (run 34319107860, all jobs live):
+        # the four adapter_diagnostic jobs are short probes — jvm-uix 21s,
+        # jvm-reagent 14s, jvm-reagent-slim 22s, jvm-adapters-test-react 20s —
+        # and they run in PARALLEL behind jvm-tools-template's 5m38s, which
+        # every template change already pays for. So this adds ~77s of runner
+        # time and no wall-clock at all. Three of those four probes cannot
+        # reach a template file, which by the tools_jvm reasoning above would
+        # argue for a narrow per-job output instead (cf. test_react_jvm,
+        # tools_jvm_machines_viz); at 20s a probe that precision is not worth
+        # a new output plus a test.yml `if:` edit, and it was ruled out of
+        # scope under rf2-q4s8.
+        adapter_diagnostic=true
         ;;
       tools/story/*|tools/xray/*)
         # rf2-os0c1 + rf2-k9ekz + rf2-t5slp + rf2-f79t8 — Story / Xray

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2100,6 +2100,59 @@ test('tools/template change still arms template_expensive (regression) (rf2-jdj1
   assert.equal(result.template_expensive, 'true');
 });
 
+// ---------------------------------------------------------------------------
+// rf2-q4s8 (from the rf2-v37n post-mortem) — the template -> adapter reverse
+// edge. `uix_consumer_deps_recipe_test.clj` lives in the UIx ADAPTER tree but
+// slurps a file out of the TEMPLATE tree as its version source, so a
+// template-only diff can red a job the classifier was not scheduling. PR #9543
+// dropped com.pitch/uix.dom from the template, the recipe test still asserted
+// the pin, jvm-uix read SKIPPED, and trunk stayed red until an unrelated PR
+// armed the surface and wore the failure.
+//
+// Three assertions, and the third is what keeps the other two honest: an arm
+// pinned by path alone would survive the recipe test being rewritten to stop
+// reading the template at all, leaving a fan-out nothing justifies.
+
+const UIX_RECIPE_TEST_REL =
+  'implementation/adapters/uix/test/re_frame/adapter/uix_consumer_deps_recipe_test.clj';
+
+test('tools/template arms adapter_diagnostic, which is what schedules jvm-uix (rf2-q4s8)', () => {
+  for (const file of [
+    'tools/template/resources/day8/re_frame2_template/_uix/deps.edn',
+    'tools/template/src/day8/re_frame2_template/hooks.clj',
+  ]) {
+    assert.equal(
+      classify(file).adapter_diagnostic,
+      'true',
+      `${file} must arm adapter_diagnostic: jvm-uix runs ${UIX_RECIPE_TEST_REL}, which reads the template's _uix/deps.edn as its version source`,
+    );
+  }
+});
+
+test('jvm-uix is gated on adapter_diagnostic, so the template arm reaches it (rf2-q4s8)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'jvm-uix');
+  assert.match(block, /needs: detect_changed_surfaces/);
+  assert.match(
+    block,
+    /if: needs\.detect_changed_surfaces\.outputs\.adapter_diagnostic == 'true'/,
+    'jvm-uix must ride adapter_diagnostic — the arm added under rf2-q4s8 schedules nothing otherwise',
+  );
+});
+
+test('the UIx recipe test still reads a tools/template path that arms adapter_diagnostic (rf2-q4s8)', () => {
+  const source = fs.readFileSync(path.join(REPO_ROOT, UIX_RECIPE_TEST_REL), 'utf8');
+  const m = source.match(/"(tools\/template\/[^"]+)"/);
+  assert.ok(
+    m,
+    `${UIX_RECIPE_TEST_REL} no longer reads any tools/template path. If that cross-tree read is genuinely gone, the tools/template -> adapter_diagnostic arm in report-changed-surfaces.sh has lost its justification and should be retired rather than left firing three unrelated adapter probes.`,
+  );
+  assert.equal(
+    classify(m[1]).adapter_diagnostic,
+    'true',
+    `${UIX_RECIPE_TEST_REL} reads ${m[1]}, so that path must arm adapter_diagnostic`,
+  );
+});
+
 test('Core change still arms template_expensive (regression) (rf2-jdj17.1)', () => {
   const result = classify('implementation/core/src/re_frame/core.cljc');
   assert.equal(result.template_expensive, 'true');


### PR DESCRIPTION
Closes rf2-q4s8. From the rf2-v37n post-mortem.

## The gap, verified at source

`implementation/adapters/uix/test/re_frame/adapter/uix_consumer_deps_recipe_test.clj`
lives in the UIx **adapter** tree but slurps
`tools/template/resources/day8/re_frame2_template/_uix/deps.edn` as the single
version source for the UIx dependency recipe. The classifier did not model that
cross-tree read, and the coupling ran one way only:

* `implementation/adapters/*` arms `template_expensive` — an adapter change does
  schedule the template suite.
* `tools/template/*` armed `template_expensive` **alone** — it did not arm
  `adapter_diagnostic`, which is what `test.yml` gates `jvm-uix` on.

So a template-only diff could not schedule the one job that runs the test reading
its own file. PR #9543 dropped `com.pitch/uix.dom` from the template while the
recipe test still asserted the pin; `jvm-uix` read SKIPPED, trunk went red, and the
failure surfaced only when the unrelated PR #9550 armed the surface and wore it.

Measured with the classifier itself, exercised in both directions so a "not armed"
reading could not be an artefact:

| input | `adapter_diagnostic` | `template_expensive` | surfaces armed |
|---|---|---|---|
| `implementation/adapters/uix/deps.edn` (positive control) | `true` | `true` | 12 of 29 |
| `tools/template/.../_uix/deps.edn` (target, before this PR) | `false` | `true` | 1 of 29 |
| `origin/main...HEAD` (revision passed where paths are expected) | `false` | `false` | 0 of 29 |

The third row reproduces the documented failure mode in which this script reports
every surface unaffected; it is included so the second row is visibly not that.

## Why add the edge, given the template suite already covers this

Honestly stated, because it is the strongest argument against: the template's own
suite covers today's failure modes twice over. `version_lockstep_test.clj` pins the
template's `com.pitch/uix.core` against `implementation/adapters/uix/deps.edn`, and
`template_test.clj`'s `retired-coords` refuses `com.pitch/uix.dom`'s return. Both run
in `jvm-tools-template`, which `template_expensive` already arms — so every
template-only change that can red the recipe test today is already caught on the
same PR.

That cover is **incidental rather than structural**. It is two sibling suites that
happen to overlap; nothing enforces the overlap, and it lapses silently the day
either suite is edited. A classifier's job is to model the edge that exists, not to
rely on a coincidence continuing to hold. One residual is already outside the
overlap: `version_lockstep_test` reaches the template through `run-template!`, while
the recipe test hardcodes the resource path — so a template resource-layout refactor
breaks the recipe test and leaves the template suite green.

## Cost, measured rather than asserted

From run `34319107860`, where all four `adapter_diagnostic` jobs ran:

| job | duration |
|---|---|
| `jvm-uix` | 21s |
| `jvm-reagent` | 14s |
| `jvm-reagent-slim` | 22s |
| `jvm-adapters-test-react` | 20s |
| `jvm-tools-template` (already armed on every template change) | 5m 38s |

The four probes run in parallel behind a job an order of magnitude longer that every
template PR already pays for. The edge therefore adds ~77s of runner time and **no
wall-clock at all**. `tools/template` was touched by 27 commits in the last 30 days,
so this is roughly 35 runner-minutes a month against a recurrence of a red-trunk
incident that cost a post-mortem and two PRs.

Three of the four probes cannot reach a template file, which by the `tools_jvm`
reasoning already in that case would argue for a narrow per-job output instead (cf.
`test_react_jvm`, `tools_jvm_machines_viz`). At 20s a probe that precision is not
worth a new output plus a `test.yml` `if:` edit, and it was ruled out of scope.

## Scope

One edge, one line of behaviour change. No new gate, no new job, no merge clause —
clause 2's passed-OR-skipped is correct and untouched; the repair belongs in the
classifier and is here. `.github/scripts/report-changed-surfaces.sh` and
`implementation/scripts/_changed-surfaces.test.cjs` are one holding and move in
**one commit**.

The third new assertion reads the recipe test's own source and fails if it stops
reading a `tools/template` path, so the arm cannot outlive its justification.

Also corrected: the case comment called `jvm-tools-template` this directory's "only
PR-time job", which stopped being true when rf2-5x1xt landed the recipe test.

## Unrelated stale comment, deliberately not touched

`jvm-uix`'s own comment in `test.yml` still says the UIx artefact "has no
JVM-runnable tests of its own". The recipe test is one, and it runs there. Not fixed
here: `.github/workflows/**` was fenced to another live worker on this tick.

## Quality gates

All exit codes captured in the same shell as the runner, never through a pipe.

| gate | result | captured exit |
|---|---|---|
| `node --test scripts/_changed-surfaces.test.cjs` (baseline, pre-change) | 366 passed | `0` |
| `node --test scripts/_changed-surfaces.test.cjs` (post-change) | 369 passed | `0` |
| `node --test scripts/_changed-surfaces.test.cjs` (**final, post-rebase**) | **369 passed** | **`0`** |
| `check_gate_scheduling.py` | pass | `0` |
| `check_fast_pr_gap.py` | pass | `0` |
| `check_ci_reproduce_commands.py` | pass | `0` |
| `check_adapter_disposition.py` | pass | `0` |
| `check_jvm_lane_rosters.py` | pass | `0` |
| `check_require_alias_dialect.py` | pass | `0` |
| `check_runtime_subsystem_grading.py` | pass | `0` |
| `check_workflow_job_timeouts.py` | pass | `0` |
| `check_workflow_yaml.py` | pass | `0` |
| `check-no-hardcoded-paths.sh` | pass | `0` |
| `check-ai-tracking-ratchet.sh` | pass | `0` |
| `check-beads-pr-boundary.sh` | pass | `0` |
| `check-commit-attribution.sh` | pass | `0` |

Test count moves 366 -> 369: three new assertions, no existing row changed. No
pre-existing assertion pinned `adapter_diagnostic` false for a template path, so the
edge contradicts nothing.

### Sabotage run

The mirror gate prints no root, so its bite was proved by a planted fault rather than
inferred. Line 2154 `adapter_diagnostic=true` -> `=false` in the `tools/template/*`
case — the exact line this PR adds. Match count read **before** the run: the file's
count of that spelling went 4 -> 3, and the classifier then reported
`adapter_diagnostic=false` for the target path, which is positive evidence the
runtime observed the plant rather than a cached compile.

Sabotaged run: **exit 1**, `changed-surfaces tests: 2 failed`, naming both new
assertions by their rf2-q4s8 titles. That fault existed only in this worktree, so a
run that had wandered into another checkout would have come back green.

Restored with `git checkout HEAD --`, verified by git **blob** hash rather than by
reading a diff: `12d95dbc390de026c6faeb58263b349641cb6d1e` before the plant and
identical after the restore, with the spelling count back to 4 and the tree clean.

Re-run after rebasing onto `2828369eae` — the pre-rebase green was evidence about a
tree that no longer existed. Diffed against the merge base for silent reverts: the
only deletions are three comment lines reflowed on purpose.

No AI-attribution trailers, in the commit or in this body, per `CLAUDE.md`.
