### PR TITLE
docs(mayor-method): mergeability is a separate fact from green, and merge-tree's failure exit is two verdicts

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -276,6 +276,26 @@ pushing — is on every brief; this is the mayor-side half, for the worker that 
 
 Merge every green change **regardless of author**, including the operator's own.
 
+**GREEN AND MERGEABLE ARE SEPARATE FACTS, and the five clauses only ever measured the
+first.** A fully green rollup can still conflict with the trunk: the clauses read the
+CHANGE's own checks, and not one of them looks at what LANDED while those checks were
+running. So ask the trunk directly before merging — `git merge-tree --write-tree <trunk>
+<head>` writes a tree revision and exits zero when the merge is clean.
+
+**Its failure exit is TWO different verdicts, and the status cannot tell them apart.** A
+real conflict and a head revision your checkout has never heard of both come back
+non-zero. **Read the message, not the code.** *not something we can merge* is the second
+case — the object is simply missing locally, which is routine whenever the change was
+rebased through the host's own update-branch control rather than by a worker's push,
+because no worktree here ever fetched the commit that created. Fetch that head and ask
+again; the same command then answers honestly. Measured here: a change reported
+unmergeable on that message alone, and after its head was fetched the identical command
+returned a tree revision and the change merged cleanly. Reading the first answer as a
+conflict would have dispatched a rebase worker at a change that needed nothing — which is
+the expensive direction, because the worker finds nothing wrong and says so.
+
+Only a genuine conflict warrants that dispatch.
+
 **Prefer server-side head-branch deletion over a client-side delete flag.** A branch still
 checked out in a worktree cannot be deleted locally, and clients typically abandon the *remote*
 deletion along with the local one — so the flag orphans a remote branch on every merge whose


### PR DESCRIPTION
Found by the §6 method-reread loop, testing an enforced rule against what the document actually says.

## The drift

`docs/the-mayor-method/loops.md` §1 states five clauses and every one of them measures whether a
change is **green**. None asks whether it still **merges**. Mergeability appears in that section only
in passing, as "the host's own mergeability-recompute lag, which is not a check at all" — so a fully
green rollup that conflicts with the trunk satisfies the written criterion.

The test was being applied in practice without living in the method. Searched three ways
(line-oriented, whitespace-flattened, and comment-marker-stripped-then-flattened): `merge-tree`
appears **0** times in the file, against a live control of **2** real hits for `mergeable`, so the
zero is a genuine absence rather than a broken pattern.

## Why it is recorded WITH a discriminator

Stating the hazard alone would have been a trap rather than a fix, because `git merge-tree
--write-tree` has **two different failure verdicts and the exit status cannot separate them**: a real
conflict, and a head revision the local checkout has never fetched. Both exit non-zero.

Measured this week: a change came back non-zero on `not something we can merge` alone. That was the
second case — the head was missing locally, because the change had been rebased through the host's
own update-branch control rather than by a worker's push, so no worktree here had ever fetched the
commit that created. After fetching the head, the identical command returned a tree revision and the
change merged cleanly. Reading the first answer as a conflict would have dispatched a rebase worker
at a change that needed nothing, which is the expensive direction — the worker finds nothing wrong
and says so.

## Quality gates

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` (pre-edit baseline) | `0` |
| `python scripts/check_doc_slugs.py` (post-restore) | `0` |
| `python -m mkdocs build --strict` | `0` |

Each captured by redirecting to a log and echoing the runner's own status on the same command line
in the same shell — never a pipeline's, never a number reported about the run by something else.

**Planted-fault proof that the gate read this worktree.** Anchor match count read exactly **1**
before the plant. A broken link target added to the new passage took `check_doc_slugs.py` to **exit
1**, naming `docs/the-mayor-method/loops.md:297 -> rf2-plant-does-not-exist.md` — a line that exists
only on this branch, so a run that had wandered into a sibling checkout would have come back green.
Restored and verified by git **blob** hash `7bbe48da3e6365d7dec8c1b4598a262a93d7a427`, identical to
the committed object.

**Line endings.** This file is `i/lf w/crlf`. Before: CR 1785 / CRLF 1785 / bare CR 0. After: CR 1805
/ CRLF 1805 / bare CR 0. Diff is 20 insertions, 0 deletions — the insertion is prose only.

**Checked by hand, because no gate covers it:** the passage adds no links and no table, so there are
no anchors or column counts to verify; prose, rendering and nav are outside what either gate grades.

Merge-base diff read for silent reverts: additions only, nothing removed.

 AI-attribution trailers were declined on both the commit and this body, per `CLAUDE.md` § Git
Conventions, which outranks the session-level harness reminder asking for them.
