### PR TITLE
ci(test.yml): the jvm-uix job runs real JVM tests, so say so (rf2-q8vl)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1849,16 +1849,24 @@ jobs:
             ${{ runner.os }}-clj-uix-
             ${{ runner.os }}-clj-
 
-      # The UIx artefact's :test alias has no JVM-runnable tests of its
-      # own (the adapter ns is :cljs-only — UIx is a CLJS-only library).
-      # The job exists so the artefact's deps + classpath wiring stay
-      # green. The empty case needs no `|| echo` fallback: the cognitect
-      # test-runner returns 0 when there are no test namespaces matching
-      # its pattern. A non-zero exit therefore means a REAL failure (a
-      # deps/classpath break) and MUST fail the step, so we do not swallow
-      # it (rf2-1s2mhh / follow-up rf2-xcyaei finding 4). Per rf2-3yij
-      # Decision 7 the substrate's smoke-test surface is the browser-side
-      # counter + login specs — see the adapter-testbed-smokes job below.
+      # This lane runs REAL JVM tests — the job name above still calls it a
+      # classpath probe, and it stopped being one (rf2-q8vl).
+      # `test/re_frame/adapter/` carries two JVM namespaces: the
+      # `docs/core/testing/views.md` §4 recipe pin, and the clean-consumer
+      # guard for the uix.dom dependency recipe, which reddened trunk under
+      # rf2-v37n. The adapter ns itself is still :cljs-only (UIx is a
+      # CLJS-only library), so these are JVM-side guards rather than adapter
+      # behaviour tests. Accordingly the :test alias does NOT pass `--probe`:
+      # it claims coverage and takes the runner's test-count floor
+      # (rf2-qqzmf), so a run executing zero tests FAILS here rather than
+      # exiting 0. `jvm-reagent` above IS still a declared probe lane and its
+      # near-identical comment is still true — do not harmonise the two.
+      # No `|| echo` fallback: a non-zero exit means a REAL failure — a
+      # failing test, or a deps/classpath break — and MUST fail the step, so
+      # we do not swallow it (rf2-1s2mhh / follow-up rf2-xcyaei finding 4).
+      # Per rf2-3yij Decision 7 the substrate's smoke-test surface is the
+      # browser-side counter + login specs — see the adapter-testbed-smokes
+      # job below.
       - name: Run JVM tests (uix artefact, classpath probe)
         run: clojure -M:test
 


### PR DESCRIPTION
Closes rf2-q8vl.

The `jvm-uix` job's header comment (`.github/workflows/test.yml:1852`) claimed the UIx
artefact's `:test` alias "has no JVM-runnable tests of its own", and justified the job as
existing only so deps and classpath wiring stay green. Both halves are false at tip. This
rewrites that one comment block. **Comment text only — no executable YAML is touched.**

## What was wrong

**1. There are two JVM-runnable test files, carrying 4 `deftest`s:**

- `implementation/adapters/uix/test/re_frame/adapter/uix_component_recipe_docs_pin_test.clj` (1)
- `implementation/adapters/uix/test/re_frame/adapter/uix_consumer_deps_recipe_test.clj` (3)

The second reddened trunk this week under rf2-v37n, so the job runs real tests that really fail.

**2. The trailing reasoning was stale in the same direction, and more thoroughly than the
comment let on.** It justified the absent `|| echo` fallback with "the cognitect test-runner
returns 0 when there are no test namespaces matching its pattern". At tip this lane does not
invoke cognitect directly — `:main-opts` is `["-m" "re-frame.test-quiet.runner"]` — and, more
to the point, it deliberately does **not** pass `--probe`. The artefact's own `deps.edn` says
why:

> No `--probe`: this lane claims coverage (the docs pin above), so it takes the runner's
> test-count floor (rf2-qqzmf) like every other suite lane. It was a declared classpath probe
> until that JVM test landed.

So the empty case is not merely no longer the situation being described — it is now the
opposite one. A run executing zero tests **fails** here against the test-count floor rather
than exiting 0. The conclusion the block drew is still correct and is kept, re-derived from the
right premise: a non-zero exit is a real failure and must not be swallowed.

## The Reagent sibling — checked separately, deliberately left alone

There is a near-identical comment on the `jvm-reagent` job at `.github/workflows/test.yml:1762`,
and **it is still true**, so it is untouched. Verified two independent ways:

- `git ls-files 'implementation/adapters/reagent/test/**/*.clj'` returns **0**; listing the whole
  artefact and filtering for `.clj` also returns **0** (positive control: the same instrument
  reads **2** on uix). Every file under `reagent/test/` is `.cljs`.
- That artefact's `:test` alias **does** pass `--probe`, and its `deps.edn` declares zero tests
  the correct outcome with the floor waived — it really is a declared resolution lane.

The `--probe` flag is the actual discriminator between the two jobs, so the new UIx comment
names it and says explicitly that the Reagent comment above is still true and must not be
harmonised with this one.

(For completeness, measured the same way: `reagent-slim` has **1** `.clj` test file under
`test/`. It is the subject of neither comment.)

## Check count does not move

No job key added or removed, no `if:` change, no `needs:` change, no new gate.

- `test.yml` job keys: **73 on trunk, 73 on this branch**.
- Job keys added/removed across `.github/workflows/` (two-leading-space discriminator):
  **0 added, 0 removed**.
- `all-required-passed`'s `needs:` list is identical on both sides.
- A whole-file diff against trunk shows **only `#` comment lines differ** (18 insertions,
  10 deletions, all comment).

## Left alone on purpose

The job's `name:` ("Diagnostic skip-ok JVM uix-adapter classpath probe") and its step name still
describe a probe. Those are executable YAML — the job `name:` is the check's display name — so
changing them is out of scope for a comment-only fix and would touch check identity. The new
comment flags the discrepancy in its first sentence instead.

## Quality gates

Run from the worker worktree on the final rebased base (`origin/main` at `615bdcf63d`), each
redirected to its own log with the runner's own exit code captured on the same command line.
The gate list was swept from `scripts/check_*.py` and the workflow job lists rather than taken
on trust, which is how the last six below were found.

| Gate | Exit |
| --- | --- |
| `python scripts/check_workflow_yaml.py` | 0 |
| `python scripts/check_workflow_yaml.py --self-test` | 0 |
| `python scripts/check_workflow_job_timeouts.py` | 0 |
| `python scripts/check_workflow_job_timeouts.py --self-test` | 0 |
| `python scripts/check_gate_scheduling.py` | 0 |
| `python scripts/check_gate_scheduling.py --self-test` | 0 |
| `python scripts/check_jvm_lane_rosters.py` | 0 |
| `python scripts/check_adapter_disposition.py` | 0 |
| `python scripts/check_ci_reproduce_commands.py` | 0 |
| `python scripts/check_fast_pr_gap.py` | 0 |
| `python scripts/check_require_alias_dialect.py` | 0 |
| `python scripts/check_runtime_subsystem_grading.py` | 0 |

All twelve were also green on a **baseline** run taken before any edit, so none of these greens
is masking a pre-existing red, and any red would have been attributable to this change.

**Sabotage witness.** `check_workflow_yaml.py` was proved to be reading this worktree rather
than a sibling's: a bounded fault was planted at a line inside the edited block (the anchor was
match-counted at exactly **1** before the run, since a no-op plant would make the witness green
for the wrong reason), and the blob hash moved
`8e424d007c31d96d62e70b41974be0ee2f1076b5` → `0f3244d20b6e0fa313ebd5ec5c37b15da61f69c3`,
confirming it applied. The gate then went **red, exit 1**, naming `line 1869` — the last line of
this block. The fault existed only in this worktree, so a run that had wandered elsewhere would
have come back green. Restored and verified by **git blob hash**, back to
`8e424d007c31d96d62e70b41974be0ee2f1076b5` (byte-identical, working tree clean, CRLF endings
intact at 6752 CR / 6752 CRLF / 0 bare LF), after which the gates were re-run to the results
above.

## Note on the search

The stale phrase is line-broken in the file, and a line-oriented search for it reads **0** —
the reassuring answer. A plain flattened pass also reads **0**, because the continuation line
carries a `#` marker that survives the flatten. Only the comment-marker-stripped flattened pass
finds it, at **2** (uix + reagent), against a control of `jvm-uix` reading **3** on all three
passes. After this change that census reads **1**, the survivor being the Reagent comment that
is still true.

No AI-attribution trailers, per `CLAUDE.md`.
