### PR TITLE
fix(machines): the generated-address reject must name an escape the shape can use

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -937,12 +937,29 @@
   without breaking the deterministic `<type>#<n>` sequencing
   `machine-transition`'s purity contract rests on, and it must not destroy the
   occupant, which Spec 005's *Teardown is explicit in v1* rule reserves to the
-  author. The `reason` therefore names the author-side escapes: a distinct
-  `:id-prefix` (rf2-r9ey made that key load-bearing on the declarative path,
-  where it had been accepted, documented and then ignored — it is the
-  NAMESPACING escape, and the one that fits the two-parents-one-TYPE shape this
-  reject fires on), a distinct `:fixed-actor-id`, or destroying the occupant
-  before spawning over it."
+  author. The `reason` therefore names the author-side escapes, and it names
+  them PER SHAPE, because the three collision shapes do not share a recovery and
+  one of them has neither of the obvious two (rf2-1sip, measured):
+
+    * DISTINCT parent TYPES minting one child type — a distinct `:id-prefix`
+      separates them. rf2-r9ey made that key load-bearing on the declarative
+      path, where it had been accepted, documented and then ignored.
+    * A parent colliding with its OWN live orphan — destroy the orphan first,
+      or name a distinct `:fixed-actor-id`.
+    * TWO LIVE INSTANCES OF ONE PARENT TYPE — NEITHER key can separate them.
+      Both are static literals read off the ONE spec the two instances share,
+      so `:id-prefix` re-mints the same address for both, and a shared
+      `:fixed-actor-id` is worse than useless: it sends the second instance
+      down the occupied-fixed-address path, where it REPLACES the first
+      instance's live child. This shape spawns its child by emitting
+      `[:rf.machine/spawn ...]` from an action instead — the hand-emitted
+      allocator's counter is the FRAME-wide slot at
+      `[:rf.runtime/machines :spawn-counter <id-prefix>]`
+      (`allocate-actor-id-in-runtime-db` above), so siblings get `#1` and `#2`.
+
+  Naming an escape that the shape in front of the author cannot use is worse
+  than naming none: the `:fixed-actor-id` advice, followed on the third shape,
+  destroys a live actor."
   [frame-id args spawned-id]
   (let [machine-id (:machine-id args)
         parent-id  (:rf/parent-id args)
@@ -956,10 +973,20 @@
                           "<type>#<n> counter is per-spawning-snapshot while the "
                           "address space is per-frame, so a respawned parent, or "
                           "a second parent spawning the same machine TYPE, can "
-                          "re-mint an address that is still held. Give this spawn "
-                          "a distinct :id-prefix so its addresses are namespaced "
-                          "apart, or a distinct :fixed-actor-id, or destroy the "
-                          "occupant explicitly before spawning over it."))]
+                          "re-mint an address that is still held. The recovery "
+                          "depends on which of those shapes this is. Two DISTINCT "
+                          "parent types minting one child type: give each spawn a "
+                          "distinct :id-prefix. A parent colliding with its OWN "
+                          "live orphan: destroy the orphan first, or give the "
+                          "spawn a distinct :fixed-actor-id. But TWO LIVE "
+                          "INSTANCES OF ONE PARENT TYPE cannot be separated by "
+                          "either key — both are static literals on the one spec "
+                          "the instances share, and a shared :fixed-actor-id "
+                          "makes the second instance REPLACE the first's child — "
+                          "so spawn the child by emitting [:rf.machine/spawn "
+                          "{:machine-id " machine-id "}] from an action instead, "
+                          "which allocates on the frame-wide counter and cannot "
+                          "collide."))]
     (rf.trace/emit-error! :rf.error/machine-spawn-all-duplicate-id
                        {:machine-id machine-id
                         :failing-id spawned-id

--- a/implementation/machines/test/re_frame/generated_address_collision_test.clj
+++ b/implementation/machines/test/re_frame/generated_address_collision_test.clj
@@ -313,10 +313,11 @@
 ;; (5) The reject's own shape.
 ;; ---------------------------------------------------------------------------
 
-(deftest the-reject-carries-structural-context-only-and-names-both-escapes
+(deftest the-reject-carries-structural-context-only-and-names-a-per-shape-escape
   (testing "rf2-1sip — the diagnostic is structural-only (Spec 009 privacy: the
             spawn args / :data may hold application PII) and its human reason
-            names the two author-side escapes, since :recovery is :no-recovery"
+            names the author-side escape PER SHAPE, since :recovery is
+            :no-recovery and the three shapes do not share one"
     (reg-child! :gac8/child)
     (rf/reg-machine :gac8/parent
       {:initial :idle
@@ -346,9 +347,117 @@
           "the reason names the distinct-address escape")
       (is (re-find #"destroy" (:reason ev))
           "and the destroy-the-occupant-first escape")
+      (is (re-find #":id-prefix" (:reason ev))
+          "and the namespacing escape")
+      ;; rf2-1sip: the three shapes do NOT share a recovery, and the reason
+      ;; must say which is which — see `two-instances-of-one-parent-type-*`
+      ;; below, where BOTH static keys fail and the fixed one destroys an actor.
+      (is (re-find #"TWO LIVE INSTANCES OF ONE PARENT TYPE" (:reason ev))
+          "and it calls out the shape for which NEITHER static key works")
+      (is (re-find #"\[:rf\.machine/spawn" (:reason ev))
+          "naming the hand-emitted escape that shape actually has")
       (is (not (re-find #"hunter2" (:reason ev)))
           "and it never echoes the spawn :data")
       (is (nil? (:data ev)) "no :data rides the record")
       (is (nil? (:args ev)) "nor the raw spawn args")
       (is (not (re-find #"hunter2" (pr-str raw)))
           "and no slot of the WHOLE emitted event smuggles the payload through"))))
+
+;; ---------------------------------------------------------------------------
+;; (4) rf2-1sip — WHICH ESCAPE THE REJECT MAY HONESTLY NAME.
+;;
+;; The reject's `:recovery` is `:no-recovery`, so its human `reason` is the
+;; author's only guidance. These pin that the guidance is SHAPE-SPECIFIC: for
+;; two live instances of ONE parent type neither static key works, and the
+;; `:fixed-actor-id` half — named unconditionally before this — DESTROYS a live
+;; actor when followed. The escape that shape does have is the hand-emitted
+;; spawn, whose counter is the FRAME-wide runtime-db slot rather than the
+;; spawning snapshot's.
+;; ---------------------------------------------------------------------------
+
+(defn- hire!
+  "Register an event that spawns `parent-type` at an explicit address, so a test
+  can stand up N live INSTANCES of one parent TYPE."
+  [ev-id parent-type]
+  (rf/reg-event ev-id
+    (fn [_ [_ addr]] {:fx [[:rf.machine/spawn {:machine-id     parent-type
+                                               :fixed-actor-id addr}]]})))
+
+(deftest two-instances-of-one-parent-type-are-NOT-separated-by-id-prefix
+  (testing "rf2-1sip — `:id-prefix` is a static literal on the ONE spec both
+            instances share, so both mint the SAME <prefix>#1 and the second is
+            refused. The namespacing escape cannot reach this shape."
+    (reg-child! :gac9/child)
+    (rf/reg-machine :gac9/parent
+      {:initial :idle
+       :states  {:idle    {:on {:go :working}}
+                 :working {:spawn {:machine-id :gac9/child
+                                   :id-prefix  :gac9/worker}}}})
+    (hire! :gac9/hire :gac9/parent)
+    (rf/dispatch-sync [:gac9/hire :gac9/a])
+    (rf/dispatch-sync [:gac9/hire :gac9/b])
+    (rf/dispatch-sync [:gac9/a [:go]])
+    (is (some? (snapshot :gac9/worker#1)) "A's child took the id-prefix address")
+    (rf/dispatch-sync [:gac9/worker#1 [:mark :FROM-A]])
+
+    (rf.machines.test-support/reset-captured!)
+    (rf/dispatch-sync [:gac9/b [:go]])
+    (is (= 1 (count (rejects)))
+        "B is refused even though the author supplied the documented :id-prefix")
+    (is (= :gac9/worker#1 (:failing-id (first (rejects)))))
+    (is (nil? (snapshot :gac9/worker#2))
+        "and B gets no child at all — the prefix did not advance the counter")
+    (is (= :FROM-A (:mark (machine-data :gac9/worker#1)))
+        "A's child is untouched")))
+
+(deftest a-shared-fixed-actor-id-makes-the-second-instance-DESTROY-the-firsts-child
+  (testing "rf2-1sip — the `:fixed-actor-id` escape is also static, so both
+            instances name ONE address. That routes the second spawn down the
+            occupied-fixed-address path (rf2-dokz), which REPLACES. Following
+            this advice on this shape costs a live actor — which is why the
+            reason must not offer it here."
+    (reg-child! :gac10/child)
+    (rf/reg-machine :gac10/parent
+      {:initial :idle
+       :states  {:idle    {:on {:go :working}}
+                 :working {:spawn {:machine-id     :gac10/child
+                                   :fixed-actor-id :gac10/thechild}}}})
+    (hire! :gac10/hire :gac10/parent)
+    (rf/dispatch-sync [:gac10/hire :gac10/a])
+    (rf/dispatch-sync [:gac10/hire :gac10/b])
+    (rf/dispatch-sync [:gac10/a [:go]])
+    (rf/dispatch-sync [:gac10/thechild [:mark :FROM-A]])
+    (is (= :FROM-A (:mark (machine-data :gac10/thechild))))
+
+    (rf.machines.test-support/reset-captured!)
+    (rf/dispatch-sync [:gac10/b [:go]])
+    (is (empty? (rejects))
+        "no generated-address reject — a FIXED address is a named request")
+    (is (= :none (:mark (machine-data :gac10/thechild)))
+        "and A's child is GONE, replaced by B's fresh incarnation")))
+
+(deftest sibling-instances-CAN-each-own-a-child-via-the-hand-emitted-spawn
+  (testing "rf2-1sip — the escape this shape DOES have. A hand-emitted
+            `[:rf.machine/spawn ...]` allocates from the FRAME-wide counter at
+            `[:rf.runtime/machines :spawn-counter <id-prefix>]` rather than the
+            spawning snapshot's, so two instances of one parent TYPE receive
+            #1 and #2 and never collide. This is the control that shows the
+            frame-wide allocator already exists and already behaves correctly."
+    (reg-child! :gac11/child)
+    (rf/reg-machine :gac11/parent
+      {:initial :idle
+       :actions {:hire (fn [_] {:fx [[:rf.machine/spawn {:machine-id :gac11/child}]]})}
+       :states  {:idle    {:on {:go :working}}
+                 :working {:entry :hire}}})
+    (hire! :gac11/hire :gac11/parent)
+    (rf/dispatch-sync [:gac11/hire :gac11/a])
+    (rf/dispatch-sync [:gac11/hire :gac11/b])
+    (rf/dispatch-sync [:gac11/a [:go]])
+    (rf/dispatch-sync [:gac11/b [:go]])
+    (is (empty? (rejects)) "no collision anywhere")
+    (is (and (some? (snapshot :gac11/child#1)) (some? (snapshot :gac11/child#2)))
+        "each sibling instance owns its own child")
+    (rf/dispatch-sync [:gac11/child#1 [:mark :FROM-A]])
+    (is (= :FROM-A (:mark (machine-data :gac11/child#1))))
+    (is (= :none (:mark (machine-data :gac11/child#2)))
+        "and they are genuinely distinct actors, not one address twice")))

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -3069,8 +3069,19 @@ address and the spawning parent. That is the existing category rather than a new
 one — it already means "two distinct spawns resolve to one actor address and one
 would silently overwrite the other", including the fixed-versus-generated shape —
 and `:recovery` is `:no-recovery`: the runtime may not pick a different address
-without breaking the deterministic `<type>#<n>` sequencing, so the author gives
-the spawn a distinct `:fixed-actor-id` or destroys the occupant first. One case
+without breaking the deterministic `<type>#<n>` sequencing. **Which author-side
+recovery exists depends on the shape, and one shape has neither obvious one.**
+Two DISTINCT parent types minting the same child type are separated by giving
+each a distinct `:id-prefix`; a parent colliding with its own live orphan
+destroys that orphan first, or names a distinct `:fixed-actor-id`. But **two live
+instances of ONE parent type share ONE spec**, so neither key can separate them:
+both are static literals read off that one shared spec, and pointing both
+instances at a single fixed address makes the second REPLACE the first's child
+under the occupied-`:fixed-actor-id` rule above. That shape spawns its child by
+emitting `[:rf.machine/spawn {:machine-id <child>}]` from an action instead — the
+hand-emitted allocator's counter is the frame-wide one described under
+[§Spawn-id allocator — counter location](#spawn-id-allocator--counter-location),
+so sibling instances receive `#1` and `#2` and cannot collide. One case
 is deliberately outside the guard: an **admitted `:spawn-all` child** is never
 rejected here, because the invoke-level preflight is that child's sole verdict
 (a second per-child reject would strand a live join naming a child that never


### PR DESCRIPTION
Closes the design question on rf2-1sip by taking option 3 — **accept the generated-address collision for v1 and document it** — and by repairing the one thing that made acceptance untenable: the documentation was wrong.

## The defect this fixes

A spawn onto an occupied GENERATED `<type>#<n>` address is rejected fail-closed with `:recovery :no-recovery`, so the human `reason` string is the author's **only** guidance. It named three escapes unconditionally: a distinct `:id-prefix`, a distinct `:fixed-actor-id`, or destroying the occupant. Measured against the runtime, **none of the three is available for the shape the reject most often fires on, and one of them destroys a live actor.**

Two live *instances* of one parent *type* share **one** spec, and both keys are static literals read off it:

| shape | `:id-prefix` | `:fixed-actor-id` | destroy occupant |
|---|---|---|---|
| two DISTINCT parent types, one child type | works | works | n/a |
| parent vs. its OWN live orphan | no | works | works |
| **two INSTANCES of ONE parent type** | **no — re-mints the same `#1`** | **no — second REPLACES the first's child** | **means killing a sibling's child** |

The escape that third shape *does* have went unmentioned: a hand-emitted `[:rf.machine/spawn ...]` allocates from the frame-wide counter at `[:rf.runtime/machines :spawn-counter <id-prefix>]` rather than the spawning snapshot's, so sibling instances receive `#1` and `#2` and cannot collide.

## What changed

* `reject-generated-address-collision!`'s `reason` now gives the recovery **per shape**, and names the hand-emitted escape for the shape with no static-key escape. Its docstring's claim that `:id-prefix` "fits the two-parents-one-TYPE shape this reject fires on" was measured false for the two-instances reading and is corrected in place.
* The `spec/005` *Spawning onto an occupied GENERATED address is REJECTED* paragraph carries the same three-way recovery.
* Three tests pin the measurements so the advice cannot silently regress: `:id-prefix` failing to separate instances, the shared fixed address destroying the first child, and the hand-emitted path succeeding where both static keys fail. The existing escapes test was renamed off "names-both-escapes" and extended.

**No allocator change, no new error id, no new option key, no warning trace, no Spec 009 catalogue row, no tombstone, no second registry, no public API change.** `parallel.cljc` is untouched — the counter still seeds `{}` fresh.

Re-homing the declarative counter so the collision never arises at all (option (e)) is **declined for v1, not deferred by silence**: it reverses the RESOLVED decision at `005:4614`, which chose the in-snapshot home precisely so `machine-transition` is pure in its spawn-id sequencing; the harm it would prevent is no longer data loss (the reject already fail-closes it); and the shape is expressible today via the hand-emitted path. The reasoning and the trigger to revisit are recorded on rf2-1sip.

## Quality gates

Every exit code below was captured with the runner's own `$?` on the same command line as the redirect, never read from a pipeline or a harness report.

| gate | before | after | exit |
|---|---|---|---|
| `implementation/machines` `clojure -M:test` | 1244 tests / 4569 assertions | **1247 tests / 4584 assertions**, 0 failures / 0 errors | **0** |
| `python -m mkdocs build --strict` | — | built, `spec/` auto-staged by `mkdocs_hooks.py` | **0** |
| `scripts/check_doc_slugs.py` | — | silent pass | **0** |

Assertion count rose by 15 across 3 added tests; nothing fell.

**Sabotage witness (machines gate).** Planted at a line already being edited — one word of the new `reason` string, anchor match count read as `1` before the run. Result: **exit 1, exactly 1 failure, identical 1247 tests / 4584 assertions**, so the red discriminates rather than crashing the lane. The failure quoted the planted text, which existed only in this worktree — that is the evidence the gate read the right tree. Restore verified by git **blob** hash, identical before and after.

**The silent gate was proven live rather than trusted.** `check_doc_slugs.py` prints nothing on success, so a planted broken anchor was used as its witness: exit 1 naming the file, line and anchor; restored and blob-hash verified.

Refs: rf2-1sip

### Ratchets covering the changed paths

The gates below were located by asking which checks grade `implementation/machines/**` and `spec/005-StateMachines.md`, rather than by relying on the gates this change "looks like". All were run locally from this worktree; **every one exited 0.**

`check_view_lifetime_residue.py` · `check_require_alias_dialect.py` · `check_retired_spellings.py` · `check_retired_image_keys.py` · `check_thrown_error_messages.py` · `check_keyword_catalogue_drift.py` · `check_test_lane_bijection.py` · `check_jvm_lane_rosters.py` · `check_retired_composition_vocab.py` · `check_inject_cofx_residue.py` · `check_runtime_subsystem_grading.py` · `check_skill_re_frame2_drift.py --ci` · `check_skill_implementor_partition_drift.py --ci` · `check-no-hardcoded-paths.sh`

Two are worth calling out because this change could plausibly have tripped them and did not: `check_keyword_catalogue_drift.py` (the reject reuses the existing `:rf.error/machine-spawn-all-duplicate-id`, so no Spec 009 row is owed) and `check_test_lane_bijection.py` (the three added tests land in the existing `generated_address_collision_test.clj`, already on the machines `:test` lane).

`check-no-hardcoded-paths.sh` was also proven live rather than trusted on its silence: an absolute worktree path planted in the test file drove it to **exit 1** with the remediation text, and the restore was verified by git blob hash before the gate was re-run to **exit 0**.

### Verified by hand, because no gate covers it

Heading anchors and prose in the `spec/005` edit were checked by hand. The one new link, `[§Spawn-id allocator — counter location](#spawn-id-allocator--counter-location)`, targets an existing `###` heading in the same file and resolves under both the MkDocs `_N` and GitHub `-N` slug rules; the edit adds no table, so there are no column counts to reconcile.

No AI-attribution trailers appear in the commit or in this body, per the repository's git conventions.
