### PR TITLE
fix(machines): the manual-spawn escape is unique only within its own stream

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -955,11 +955,22 @@
       `[:rf.machine/spawn ...]` from an action instead — the hand-emitted
       allocator's counter is the FRAME-wide slot at
       `[:rf.runtime/machines :spawn-counter <id-prefix>]`
-      (`allocate-actor-id-in-runtime-db` above), so siblings get `#1` and `#2`.
+      (`allocate-actor-id-in-runtime-db` above), so siblings get `#1` and `#2`
+      — WITHIN THAT ALLOCATION STREAM, which is not the same thing as an
+      unconditional escape from this reject. The two counters are SEPARATE:
+      the frame-wide one is not advanced by declarative spawns and does not
+      skip an occupied address, so where a declarative child already holds
+      `<child>#1` the BARE hand-emitted form re-mints exactly that address and
+      is refused again — on every retry, since a rejected allocation is not
+      committed either (rf2-1sip, merged-PR audit of #9563, measured). The
+      recovery therefore carries its OWN `:id-prefix`, naming an address
+      namespace no declarative spawn allocates into, so the frame-wide counter
+      starts from an empty one.
 
   Naming an escape that the shape in front of the author cannot use is worse
   than naming none: the `:fixed-actor-id` advice, followed on the third shape,
-  destroys a live actor."
+  destroys a live actor — and an escape that works only from an EMPTY address
+  namespace must say so, or the author retries it forever."
   [frame-id args spawned-id]
   (let [machine-id (:machine-id args)
         parent-id  (:rf/parent-id args)
@@ -984,9 +995,16 @@
                           "the instances share, and a shared :fixed-actor-id "
                           "makes the second instance REPLACE the first's child — "
                           "so spawn the child by emitting [:rf.machine/spawn "
-                          "{:machine-id " machine-id "}] from an action instead, "
-                          "which allocates on the frame-wide counter and cannot "
-                          "collide."))]
+                          "{:machine-id " machine-id " :id-prefix "
+                          "<unused-prefix>}] from an action instead, which "
+                          "allocates on the frame-wide counter. That counter is "
+                          "a SEPARATE stream, not a higher one: it sequences its "
+                          "own spawns #1, #2, ... but declarative spawns do not "
+                          "advance it and it does not skip an occupied address, "
+                          "so the BARE form re-mints " spawned-id " and is "
+                          "refused again on every retry. Name an :id-prefix no "
+                          "declarative spawn uses, so the hand-emitted spawn "
+                          "allocates into an EMPTY address namespace."))]
     (rf.trace/emit-error! :rf.error/machine-spawn-all-duplicate-id
                        {:machine-id machine-id
                         :failing-id spawned-id

--- a/implementation/machines/test/re_frame/generated_address_collision_test.clj
+++ b/implementation/machines/test/re_frame/generated_address_collision_test.clj
@@ -356,6 +356,17 @@
           "and it calls out the shape for which NEITHER static key works")
       (is (re-find #"\[:rf\.machine/spawn" (:reason ev))
           "naming the hand-emitted escape that shape actually has")
+      ;; rf2-1sip (merged-PR audit of #9563): that escape is unique only WITHIN
+      ;; the hand-emitted allocation stream. See
+      ;; `a-BARE-hand-emitted-spawn-does-NOT-escape-an-OCCUPIED-generated-address`
+      ;; below, where the bare form is refused at this very address on every
+      ;; retry, and the `:id-prefix` form succeeds.
+      (is (re-find #":id-prefix <unused-prefix>" (:reason ev))
+          "and it spells that escape WITH its own :id-prefix, which is the form
+           that works from an occupied allocation namespace")
+      (is (re-find #"does not skip an occupied address" (:reason ev))
+          "and it qualifies the promise rather than offering the bare form as an
+           unconditional escape")
       (is (not (re-find #"hunter2" (:reason ev)))
           "and it never echoes the spawn :data")
       (is (nil? (:data ev)) "no :data rides the record")
@@ -461,3 +472,93 @@
     (is (= :FROM-A (:mark (machine-data :gac11/child#1))))
     (is (= :none (:mark (machine-data :gac11/child#2)))
         "and they are genuinely distinct actors, not one address twice")))
+
+;; ---------------------------------------------------------------------------
+;; (5) rf2-1sip — THE HAND-EMITTED ESCAPE IS UNIQUE ONLY WITHIN ITS OWN STREAM.
+;;
+;; The control directly above is the ALL-MANUAL shape: neither instance ever
+;; spawned declaratively, so the frame-wide counter owns the whole
+;; `<prefix>#<n>` namespace and hands out `#1` and `#2`. The two tests below pin
+;; the shape an author actually MEETS — the reject fires because a DECLARATIVE
+;; child is already installed, and the hand-emitted spawn is reached for as the
+;; recovery FROM that reject, in the same live frame.
+;;
+;; The two counters are SEPARATE (Spec 005 §Spawn-id allocator — counter
+;; location): the frame-wide slot is not advanced by declarative spawns, and
+;; `allocate-actor-id-in-runtime-db` does not skip occupied addresses. So a BARE
+;; hand-emitted spawn re-mints `<child>#1` — the very address the reject named —
+;; and is refused again, on every retry, because the rejected allocation is not
+;; committed either. The usable escape is a distinct `:id-prefix` ON THE
+;; HAND-EMITTED SPAWN, which allocates in an EMPTY namespace; that is what the
+;; reject's `reason` and Spec 005 must say.
+;; ---------------------------------------------------------------------------
+
+(deftest a-BARE-hand-emitted-spawn-does-NOT-escape-an-OCCUPIED-generated-address
+  (testing "rf2-1sip — the frame-wide counter is a SEPARATE stream, not a
+            higher one: a declarative sibling already holding <child>#1 leaves it
+            at zero, and it does not skip occupied addresses, so the bare
+            hand-emitted recovery is refused at the SAME address the reject
+            named — on every retry, since the rejected allocation is not
+            committed"
+    (reg-child! :gac12/child)
+    (rf/reg-machine :gac12/parent
+      {:initial :idle
+       :actions {:hire (fn [_] {:fx [[:rf.machine/spawn {:machine-id :gac12/child}]]})}
+       :states  {:idle    {:on {:go :working}}
+                 :working {:spawn {:machine-id :gac12/child}
+                           :on    {:manual {:action :hire}}}}})
+    (hire! :gac12/hire :gac12/parent)
+    (rf/dispatch-sync [:gac12/hire :gac12/a])
+    (rf/dispatch-sync [:gac12/hire :gac12/b])
+    (rf/dispatch-sync [:gac12/a [:go]])
+    (is (some? (snapshot :gac12/child#1)) "A's declarative child holds #1")
+    (rf/dispatch-sync [:gac12/child#1 [:mark :FROM-A]])
+
+    (rf.machines.test-support/reset-captured!)
+    (rf/dispatch-sync [:gac12/b [:go]])
+    (is (= [:gac12/child#1] (mapv :failing-id (rejects)))
+        "B's declarative spawn is refused, as the earlier shape tests pin")
+
+    ;; B now follows the reject's advice, twice.
+    (rf/dispatch-sync [:gac12/b [:manual]])
+    (rf/dispatch-sync [:gac12/b [:manual]])
+    (is (= [:gac12/child#1 :gac12/child#1 :gac12/child#1]
+           (mapv :failing-id (rejects)))
+        "both hand-emitted attempts are refused at the SAME address — the
+         frame-wide counter began at zero and does not skip an occupant")
+    (is (nil? (snapshot :gac12/child#2))
+        "no #2 is ever installed: the rejected allocation is not committed, so
+         a retry repeats the address rather than advancing past it")
+    (is (= :FROM-A (:mark (machine-data :gac12/child#1)))
+        "and the occupant is untouched throughout — the reject is fail-closed")))
+
+(deftest a-DISTINCT-id-prefix-on-the-hand-emitted-spawn-IS-the-usable-escape
+  (testing "rf2-1sip — the recovery that works in the live frame. The
+            hand-emitted spawn carries its own `:id-prefix`, so it allocates in
+            an EMPTY namespace on the frame-wide counter: the instance gets
+            <prefix>#1 and <prefix>#2, and the declarative occupant survives"
+    (reg-child! :gac13/child)
+    (rf/reg-machine :gac13/parent
+      {:initial :idle
+       :actions {:hire (fn [_] {:fx [[:rf.machine/spawn {:machine-id :gac13/child
+                                                         :id-prefix  :gac13/manual}]]})}
+       :states  {:idle    {:on {:go :working}}
+                 :working {:spawn {:machine-id :gac13/child}
+                           :on    {:manual {:action :hire}}}}})
+    (hire! :gac13/hire :gac13/parent)
+    (rf/dispatch-sync [:gac13/hire :gac13/a])
+    (rf/dispatch-sync [:gac13/hire :gac13/b])
+    (rf/dispatch-sync [:gac13/a [:go]])
+    (rf/dispatch-sync [:gac13/child#1 [:mark :FROM-A]])
+    (rf/dispatch-sync [:gac13/b [:go]])
+
+    (rf.machines.test-support/reset-captured!)
+    (rf/dispatch-sync [:gac13/b [:manual]])
+    (rf/dispatch-sync [:gac13/b [:manual]])
+    (is (empty? (rejects))
+        "the distinct prefix names an EMPTY allocation namespace, so neither
+         hand-emitted spawn collides")
+    (is (and (some? (snapshot :gac13/manual#1)) (some? (snapshot :gac13/manual#2)))
+        "and the frame-wide counter sequences them #1 and #2 under that prefix")
+    (is (= :FROM-A (:mark (machine-data :gac13/child#1)))
+        "the declarative occupant is preserved — the escape costs no live actor")))

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -3078,10 +3078,19 @@ instances of ONE parent type share ONE spec**, so neither key can separate them:
 both are static literals read off that one shared spec, and pointing both
 instances at a single fixed address makes the second REPLACE the first's child
 under the occupied-`:fixed-actor-id` rule above. That shape spawns its child by
-emitting `[:rf.machine/spawn {:machine-id <child>}]` from an action instead — the
-hand-emitted allocator's counter is the frame-wide one described under
+emitting `[:rf.machine/spawn {:machine-id <child> :id-prefix <unused-prefix>}]`
+from an action instead — the hand-emitted allocator's counter is the frame-wide
+one described under
 [§Spawn-id allocator — counter location](#spawn-id-allocator--counter-location),
-so sibling instances receive `#1` and `#2` and cannot collide. One case
+so sibling instances receive `#1` and `#2`. **That uniqueness holds WITHIN the
+hand-emitted allocation stream; it is not an unconditional escape from the
+reject.** The two counters are separate, so the frame-wide one is not advanced by
+declarative spawns and does not skip an occupied address: where a declarative
+child already holds `<child>#1`, a BARE hand-emitted spawn re-mints that same
+address and is rejected again — on every retry, because a rejected allocation is
+not committed. The `:id-prefix` is what makes the recovery usable in the live
+frame; it names an address namespace no declarative spawn allocates into, so the
+frame-wide counter starts from an empty one. One case
 is deliberately outside the guard: an **admitted `:spawn-all` child** is never
 rejected here, because the invoke-level preflight is that child's sole verdict
 (a second per-child reject would strand a live join naming a child that never


### PR DESCRIPTION
PR #9563 gave the *two live instances of one parent TYPE* collision shape the
recovery it lacked: emit `[:rf.machine/spawn ...]` by hand, whose counter is the
frame-wide slot rather than the spawning snapshot's, "so siblings get `#1` and
`#2` and cannot collide". The merged-PR audit of that PR measured the promise
against the runtime and it does not hold unconditionally — and it fails exactly
where the author reads it, standing in front of the reject in the live frame.

The two counters are **separate streams, not one stream at two heights**. The
frame-wide slot is not advanced by declarative spawns, and
`allocate-actor-id-in-runtime-db` does not skip an occupied address. So where a
declarative sibling already holds `<child>#1` — which is the situation the reject
fires in — the recommended **bare** hand-emitted spawn re-mints exactly that
address and is refused again. On every retry, because a rejected allocation is
never committed, so the counter does not advance past the occupant either.

## Reproduction (re-derived, not quoted)

One parent TYPE instantiated at two addresses. A declaratively spawns
`child#1`; B's declarative spawn is rejected; B then emits the recommended bare
manual spawn from an action, twice. Both attempts reject at `child#1`, no
`child#2` is installed, and A's child keeps its `:mark` — the reject stays
fail-closed throughout, which is why this is a **wording** defect and not a leak.

Positive control, same setup with a distinct unused `:id-prefix` on the
hand-emitted spawn: `manual#1` and `manual#2` install with no rejects, and the
declarative occupant survives. The pre-existing all-manual-siblings control
(`sibling-instances-CAN-each-own-a-child-via-the-hand-emitted-spawn`) still
passes and stays the control for the empty-namespace case.

## What changed

* `spawn.cljc` — the reject's human `reason` now qualifies the guarantee as
  uniqueness *within that manual allocation stream*, states that declarative
  spawns do not advance it and that it does not skip an occupied address, names
  the failing address as the one the bare form would re-mint, and spells the
  escape **with its own `:id-prefix`**, which is the form that works. The
  docstring records the same qualification and its measurement.
* `spec/005-StateMachines.md` — the same qualification in the generated-address
  paragraph, confined to that paragraph (serial-lane file).
* Two tests beside the existing controls: the occupied-declarative-child case
  (bare hand-emitted spawn refused at the same address on both retries, no `#2`,
  occupant intact) and the distinct-`:id-prefix` escape. The reject-shape test
  gains two assertions pinning the qualification and the `:id-prefix` spelling.

## What is deliberately NOT changed

No allocator change, no new option key, no registry, no warning, no public API
addition, no broad defensive layer. The occupant, explicit-teardown semantics,
the existing error id `:rf.error/machine-spawn-all-duplicate-id`, the pure
in-snapshot declarative allocator (recorded v1 decision) and the recorded
decision against rf2-1sip option (e) are all untouched. The separate Spec 009
residual and the admitted `:spawn-all` exception are out of scope.

## Quality gates

| gate | result |
|---|---|
| `clojure -M:test -n re-frame.generated-address-collision-test` (from `implementation/machines/`) | **13 tests / 72 assertions / 0 failures / 0 errors**, captured exit `0` (baseline before the change on the same namespace: 11 / 62 / 0 / 0, exit `0`) |
| `clojure -M:test` — full machines JVM artefact lane | **1249 tests / 4594 assertions / 0 failures / 0 errors**, captured exit `0` |
| Gate-reads-my-tree discrimination | a single-line planted fault in the new test (`nil?` → `some?`) turned the namespace run **red**, captured exit `1`, 1 failure; restored and verified by git blob hash against the committed object, then green again |
| `python -m mkdocs build --strict` (repo root; stages `spec/` via `mkdocs_hooks.py`) | captured exit `0` |
| `python scripts/check_doc_slugs.py` | exit `0` |
| `python scripts/check_readme_links.py --ci` | exit `0` |
| `clj-kondo --fail-level error` on both changed Clojure files | `errors: 0, warnings: 0`, exit `0` |
| Ratchet / residue checks run tree-wide | all exit `0`: `check_retired_spellings`, `check_thrown_error_messages`, `check_keyword_catalogue_drift`, `check_architecture_census`, `check_allocation_non_claim`, `check_ambient_durable_reads`, `check_egress_walker_residue`, `check_retired_composition_vocab`, `check_retired_image_keys`, `check_runtime_subsystem_grading`, `check_failure_corpus_residue`, `check_view_lifetime_residue`, `check_inject_cofx_residue`, `check_conformance_fixture_edn`, `check_require_alias_dialect`, `check_test_lane_bijection`, `check_skill_re_frame2_drift`, `check-no-hardcoded-paths.sh`, `check-ai-tracking-ratchet.sh` |

**Local green is not CI.** `.github/scripts/report-changed-surfaces.sh` classifies
this diff as arming `implementation_jvm`, `cljs_node_test`, `cljs_browser`,
`cljs_prod`, `examples_compile`, `bundle_isolation`, `tools_jvm_machines_viz`,
`tools_cljs_machines_viz`, `skills_structural` and `playground`. Of those, the
local run above covers only the JVM machines artefact and the documentation
gates. **Skipped locally, and left to CI:** every CLJS lane (node, browser,
release/prod, examples-compile, bundle-isolation) and both `machines-viz` lanes —
they need `node_modules`, and this diff changes only docstring and human-message
string text inside a `.cljc` plus a `.clj`-only test, so nothing there can move
except by compilation, which CI compiles. The `clj-kondo` run used a locally
installed binary rather than CI's pinned `2026.04.15`.

Refs: rf2-1sip
