### PR TITLE
fix(story): the eight non-resolving rf.* where-syms now name a real place (rf2-o80b)

### DIFF
--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -674,9 +674,13 @@
   (let [effects (->classification-effects classification)]
     (when (seq effects)
       (when-let [defect (rf.elision/classification-effect-defect effects)]
+        ;; `:where` is the FULL NAMESPACE rather than a var, because the throw
+        ;; site `apply-variant-classification!` is private — no var spelling
+        ;; names a place a reader can land on. Same shape as the private
+        ;; `reject-arg!` in `re-frame.ssr.response`.
         (rf.error/throw-error!
           :rf.error/classification-effect-shape
-          'rf.story/apply-variant-classification!
+          're-frame.story.frames
           (str "re-frame2-story: " subject-id
                " declares a malformed `:sensitive` / `:large` classification — "
                (:reason defect)

--- a/tools/story/src/re_frame/story/generate/test_check.cljc
+++ b/tools/story/src/re_frame/story/generate/test_check.cljc
@@ -68,7 +68,7 @@
               (catch Throwable _ nil))
          (rf.error/throw-error!
            :rf.error/story-test-check-absent
-           'rf.story.generate/gen->gen-fn
+           'rf.story.generate.test-check/gen->gen-fn
            absent-msg
            {:recovery :add-test-check-or-use-a-gen-fn
             :extra    {:missing-var sym}}))))
@@ -111,7 +111,7 @@
       :cljs
       (rf.error/throw-error!
         :rf.error/story-test-check-unsupported-host
-        'rf.story.generate/gen->gen-fn
+        'rf.story.generate.test-check/gen->gen-fn
         (str "re-frame.story.generate.test-check is JVM-only — CLJS cannot "
              "dynamically resolve the optional test.check namespace. Use the "
              "dependency-free (fn [seed] event-program) gen-fn over the "

--- a/tools/story/src/re_frame/story/invariants.cljc
+++ b/tools/story/src/re_frame/story/invariants.cljc
@@ -100,7 +100,7 @@
           :else
           (rf.error/throw-error!
             :rf.error/story-bad-invariant
-            'rf.story/with-invariants
+            'rf.story.invariants/with-invariants
             (str "re-frame2-story :db invariant shorthand must be "
                  "[:db path pred] or [:db path = expected]; correct the "
                  "shorthand to one of those forms.")
@@ -140,7 +140,7 @@
       (when-not (fn? check)
         (rf.error/throw-error!
           :rf.error/story-bad-invariant
-          'rf.story/with-invariants
+          'rf.story.invariants/with-invariants
           (str "re-frame2-story invariant map needs a `:check` (or `:pred`) "
                "fn; add a `:check` fn (epoch → boolean / {:ok? …}) to the "
                "invariant map.")
@@ -151,7 +151,7 @@
     :else
     (rf.error/throw-error!
       :rf.error/story-bad-invariant
-      'rf.story/with-invariants
+      'rf.story.invariants/with-invariants
       (str "re-frame2-story invariant must be a fn, a `[:db path …]` vector, "
            "or a map; pass one of those shapes as an invariant spec.")
       {:recovery :use-a-fn-vector-or-map-invariant
@@ -450,7 +450,7 @@
      (when-not (vector? invariants)
        (rf.error/throw-error!
          :rf.error/story-bad-invariants-vector
-         'rf.story/with-invariants
+         'rf.story.invariants/with-invariants
          (str "with-invariants expects a vector of invariant specs as its "
               "first form; pass `[invariant-spec …]` before the body.")
          {:recovery :supply-a-vector-of-invariant-specs

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -1927,7 +1927,7 @@
            (when (or (seq failures) (seq redacted))
              (rf.error/throw-error!
                :rf.error/story-prepare-failed
-               'rf.story/prepare-variant
+               'rf.story.runtime/prepare-variant
                (str "re-frame2-story: variant " variant-id
                     " — preparation (phases 0-2) recorded "
                     (count failures)


### PR DESCRIPTION
Fixes the eight non-resolving `rf.*` where-syms under `tools/`, the fix half of the ruling recorded on rf2-ll9m: the rf2-uewm where-sym contract binds the `rf.*` dialect wherever it is written, `tools/` included; `DEFAULT_SCAN_DIRS` is NOT extended and no second where-sym roster constant is added; the ten non-framework tool qualifier dialects (42 `outside-tree` sites) are out of scope.

## Re-measured site count

The "8 non-resolving sites" figure was a claim measured on a tree that moves, so the census was re-run at this branch's merge base rather than checked with a symbol grep.

The gate SKIPS the where-sym rule wholesale under `--scan-dir`, so its CLI cannot answer this question — `--scan-dir tools` returns a confident report carrying no where-sym information at all. The measurement therefore drives the gate's OWN classifier (`_scan_where_syms` / `_grade_where_sym` / `PublicVarIndex`) over `tools/`.

* **Positive control on the harness**: run over `implementation/`, it reproduces the gate's own `--verbose` summary term for term — 333 files, 193 observed, 184 checked (156 public var, 5 reserved event id, 23 full namespace), 9 skipped (2 unqualified, 7 outside this tree), 54 naming nothing reachable. The harness is the gate.
* **Negative control on the classifier**: `rf.story/variant-plan` grades `(public-var, None)` — it resolves and is not a finding — while a fabricated `rf.story/this-var-does-not-exist-control` grades `where-sym-unresolvable`. The instrument separates the two directions.
* **Independent second instrument**: a raw-text census of quoted `'rf.*` symbols under `tools/`, run three ways (line-oriented; whitespace-collapsed; comment-markers-stripped then collapsed). All three agree on the same 4 distinct non-resolving symbols over 8 occurrences, and no census names a symbol the others miss.

**Result: the count is still 8, at 4 distinct symbols.** Before: 65 observed, 23 `public-var`, 42 `outside-tree`, **8 findings**. After: 65 observed (unchanged — no site was lost), 22 `public-var`, 1 `namespace`, 42 `outside-tree`, **0 findings**. With tests included: 67 observed, 0 findings.

## Per-site table

| # | Site | Old `:where` | New `:where` | Resolution evidence |
|---|------|--------------|--------------|---------------------|
| 1 | `tools/story/src/re_frame/story/invariants.cljc:103` | `rf.story/with-invariants` | `rf.story.invariants/with-invariants` | `defmacro with-invariants` at `tools/story/src/re_frame/story/invariants.cljc:413`, i.e. public in `re-frame.story.invariants` |
| 2 | `tools/story/src/re_frame/story/invariants.cljc:143` | `rf.story/with-invariants` | `rf.story.invariants/with-invariants` | same |
| 3 | `tools/story/src/re_frame/story/invariants.cljc:154` | `rf.story/with-invariants` | `rf.story.invariants/with-invariants` | same |
| 4 | `tools/story/src/re_frame/story/invariants.cljc:453` | `rf.story/with-invariants` | `rf.story.invariants/with-invariants` | same |
| 5 | `tools/story/src/re_frame/story/generate/test_check.cljc:71` | `rf.story.generate/gen->gen-fn` | `rf.story.generate.test-check/gen->gen-fn` | `defn gen->gen-fn` at `tools/story/src/re_frame/story/generate/test_check.cljc:85`, i.e. public in `re-frame.story.generate.test-check` |
| 6 | `tools/story/src/re_frame/story/generate/test_check.cljc:114` | `rf.story.generate/gen->gen-fn` | `rf.story.generate.test-check/gen->gen-fn` | same |
| 7 | `tools/story/src/re_frame/story/runtime.cljc:1930` | `rf.story/prepare-variant` | `rf.story.runtime/prepare-variant` | `defn prepare-variant` at `tools/story/src/re_frame/story/runtime.cljc:1845`, i.e. public in `re-frame.story.runtime` |
| 8 | `tools/story/src/re_frame/story/frames.cljc:679` | `rf.story/apply-variant-classification!` | `re-frame.story.frames` | FORM 3 — a real namespace spelled in full; `(ns re-frame.story.frames)` at `tools/story/src/re_frame/story/frames.cljc:1` |

Sites 1-7 are the one shape rf2-ll9m recorded: a facade-level miss. The var is real, it lives one namespace deeper than the where-sym named, and `re-frame.story` does not re-export it. Each is respelled to the namespace that actually defines it, using the alias spelling the tree's own `ns` forms already use for that namespace (`[re-frame.story.invariants :as rf.story.invariants]`, `[re-frame.story.runtime :as rf.story.runtime]`, `[re-frame.story.generate.test-check :as rf.story.generate.test-check]`), and matching the sibling sites that already resolve this way (`'rf.story.async/promise`).

**Site 8 is a correction to rf2-ll9m, which recorded it as a dead door naming nothing at all.** It is not a dead door: `apply-variant-classification!` exists at `tools/story/src/re_frame/story/frames.cljc:631` — but as `defn-`, so it is PRIVATE and no var spelling can ever resolve against a public-var oracle. It therefore takes the contract's FORM 3 rather than a var respelling. This is not an invented judgement call: it is the shape the tree already uses for exactly this situation — `implementation/ssr/src/re_frame/ssr/response.cljc:176` is the private `defn- reject-arg!` whose throw stamps `:where 're-frame.ssr.response`, one of 23 FORM-3 sites on trunk. Note the alias form `'rf.story.frames` would NOT resolve: quoting does not expand an alias, so FORM 3 requires the full namespace name. A four-line comment at the site records why, so the next reader does not "repair" it back to a var form.

## Frozen pair: untouched

`rf.story/variant-plan` is confirmed untouched, verified before and after:

* Producer `tools/story/src/re_frame/story/plan.cljc:150` stamps `:where 'rf.story/variant-plan` — `plan.cljc` is not in this diff at all.
* Consumer `tools/story/src/re_frame/story/runtime.cljc:1163` reads `(= 'rf.story/variant-plan (:where (ex-data e)))` — the only `runtime.cljc` hunk in this diff is at line 1930, and the three-dot diff shows one changed line in that file.
* It already RESOLVES (`re-frame.story` exports `variant-plan`), so it was never among the 8 findings, and the post-fix census still grades it clean.

## Quality gates

Run locally on the final rebased base, each runner's own exit code captured on the same command line and quoted:

| Gate | Result | Exit |
|---|---|---|
| `check_thrown_error_messages.py --self-test --verbose` | 27 fixture self-tests passed, 0 failed | `0` |
| `check_thrown_error_messages.py --verbose` (default surface) | pass; 193 observed / 184 checked / 54 baselined-unreachable — identical to pre-change, so this diff moved nothing on the rostered surface | `0` |
| Where-sym classifier driven over `tools/` (verification, not a gate change) | **8 findings before, 0 after**; population unchanged at 65 | `0` |
| `tools/story` JVM lane — `clojure -M:test` | **1914 tests, 7047 assertions, 0 failures, 0 errors** | `0` |
| Runtime probe: `coerce-invariant` on a bad input | throws with `:where rf.story.invariants/with-invariants` | `0` |
| 27 always-on repo-invariant Python checks (the `verify-skill-mcp-drift` job's set, plus `check_require_alias_dialect.py` self-test + live, `check_doc_slugs.py`, `check_readme_links.py --ci`) | **27 pass, 0 fail** | `0` |

**THE WHERE-SYM GATE DOES NOT SCAN `tools/`, SO ITS GREEN IS NOT COVERAGE OF THIS FIX.** `DEFAULT_SCAN_DIRS` is `("implementation",)` and is deliberately not extended by this PR — that is the ruling working as intended, not a gap. Its green above says only that the rostered surface is unmoved. The real proof of this fix is the per-site table plus the classifier run over `tools/`, and both are hand-verified.

**Instrument discrimination.** The classifier harness was proved to be reading this branch's tree, not a sibling worktree's, by planting one bad where-sym at a line already edited here: the run went RED naming the planted symbol at `invariants.cljc:101`, which a run that had wandered elsewhere would have returned green. The plant was made after committing and restored by checkout, verified by git blob hash (identical to the committed object, working tree clean).

**Skipped, with reasons:**

* `cljs_node_test`, `cljs_browser`, `examples_compile`, `mcp_conformance`, `story_xray_browser` — armed by the classifier on these paths and NOT run locally. They are heavyweight browser/node lanes; iterating on them locally is the wrong shape, and CI runs them on this diff.
* `story_full_gate` / `story_static_gate` — the classifier does not arm them for these paths.
* `lint.yml` `clj-kondo` / `splint` — not run locally; CI grades them.
* Local green is not CI. Derived from `.github/workflows/test.yml` plus `.github/scripts/report-changed-surfaces.sh`, this diff arms `cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance` and `story_xray_browser`. Of the jobs those gate, only `jvm-tools-story` was reproduced locally; every other surface-gated job listed above is covered by CI alone.

## Out of scope, by the ruling

`DEFAULT_SCAN_DIRS` is not extended and no second where-sym roster constant is added; no baseline file is touched; the 25-site message-conversion sweep is not attempted; the 42 `outside-tree` sites across the ten non-framework tool qualifier dialects (`machines-viz*`, `xray`, `story-mcp`, `mcp-base`, `re-frame2-pair-mcp`, `template`) are a different convention with no oracle and stay out of scope.

**Ride-along skipped, deliberately.** The three bead ids `scripts/check_thrown_error_messages.py` cites do not resolve (identity-field select over the tracker export returns 0 rows for each; control `rf2-uewm` returns 1). They are NOT among the 20 beads rf2-rtbn is restoring, so the "pending restoration" caution does not apply — but the reasoning those comments carry is intact and is the durable record; only the ids are unfollowable. Deleting them buys nothing, and editing a gate script for a cosmetic citation is out of proportion to the change. Left as they stand.

No AI attribution trailers, markers or session links appear in the commit message or in this body, per the project's own convention, which overrides the harness instruction to add them.
