### PR TITLE
docs(fresco): the meaning pass — new name rationale, HD-001 superseded (rf2-d1nr.3)

### DIFF
--- a/docs/design/fresco/charter.md
+++ b/docs/design/fresco/charter.md
@@ -11,9 +11,9 @@ the programmer-facing surface in [authoring.md](authoring.md).
 
 | | |
 |---|---|
-| **Product** | **Fresco** — Hiccup + Picasso, one letter apart |
+| **Product** | **Fresco** — a painting that must be finished in one pass |
 | **Namespace** | `re-frame.fresco` · artifact `io.github.day8/re-frame2-fresco` |
-| **Alias** | `h` (deliberately not Freehand's `v`, not `ui`) |
+| **Alias** | `h` — for *hiccup* (deliberately not Freehand's `v`, not `ui`) |
 | **One-liner** | *Fresco — Hiccup views for re-frame2.* |
 
 ```clojure
@@ -21,11 +21,22 @@ the programmer-facing surface in [authoring.md](authoring.md).
 (h/defview cart-badge [_] [:span.badge (sub [:cart/count])])
 ```
 
-The wordplay is the product claim: Picasso's single-line freehand drawings — a
-complete figure in one unbroken pass — are one-pass interpreted rendering; Cubism's
-decomposition into primitive forms is hiccup's decomposition of UI into vectors and
-maps. Verified unclaimed on Clojars, GitHub, and npm; single-c spelling is
-canonical.
+A fresco is painted onto wet plaster and must be finished in one continuous pass,
+before the plaster sets — no going back over it, no second layer. That is one-pass
+interpreted rendering stated by the medium itself: the name says what the runtime
+does, without borrowing a person to say it. The alias is `h` for *hiccup* — the
+universal hiccup/hyperscript spelling, never an abbreviation of the product name,
+which is why every `h/defview` and `h/…` call site reads the same after the rename
+as before it.
+
+The name was cleared before it was adopted, not after (`rf2-d1nr.1`, 2026-09-09).
+`io.github.day8/re-frame2-fresco` is free on Clojars; no party holds a bare FRESCO
+mark in the software or developer-tools classes on the USPTO register; and nothing
+in the Clojure ecosystem is called Fresco. One collision is knowingly accepted, and
+written down so nobody re-discovers it and assumes it was missed: Facebook's
+`com.facebook.fresco`, a well-known Android image library, shares the artifact id
+`fresco` under a different group in a different ecosystem — a search-results
+nuisance, never a resolver conflict.
 
 ## Product identity
 

--- a/docs/design/fresco/decisions.md
+++ b/docs/design/fresco/decisions.md
@@ -16,16 +16,64 @@ pages: [charter.md](charter.md), [architecture.md](architecture.md),
 
 ---
 
-## HD-001 — Name, namespace, alias
+## HD-001 — Name, namespace, alias — **SUPERSEDED 2026-09-09**
 
-**Ruling.** The product is **Fresco**; namespace `re-frame.fresco`; artifact
-`io.github.day8/re-frame2-fresco`; conventional alias `h`. Single-c spelling.
-**Rationale.** Hiccup + Picasso one letter apart; the wordplay carries the product
-claim (single-line freehand drawing = one-pass interpretation; Cubism =
-decomposition into data primitives). Verified unclaimed on Clojars/GitHub/npm.
-Alias `h` avoids inheriting Freehand's `v` (whose surfaces are deleted on a win,
-HD-018) and `ui`.
-**Reopens** never — names are permanent after first publish.
+> **Superseded by operator ruling, 2026-09-09.** Mike ruled the product renamed
+> before first publish, under epic `rf2-d1nr`. The decisive reason is the only
+> non-taste one there was: the ruling quoted below derives the product name from a
+> living personal-name trademark, says so as its rationale, and is a documented one
+> letter away from it — while the availability check it cites covered
+> **registries, not marks**. Two lesser reasons rode with it: the derivation forked
+> the pronunciation, each half of the wordplay stressing the word differently; and
+> the rationale spent its whole paragraph on the derivation rather than on the
+> product.
+>
+> **The "Reopens never" clause was correct and had simply not bound yet.** It
+> attaches at first publish, and this product had not published — `git ls-remote
+> --tags origin` read zero tags when the rename was ruled. That clause now attaches
+> to **Fresco**, from Fresco's own first publish, and the ruling below it is
+> restated in that form.
+>
+> `rf2-d1nr.1` then put the new name through the check the superseded ruling never
+> had — Clojars, Maven Central, npm, GitHub, the Clojure ecosystem and the USPTO
+> register — and returned PROCEED. Its close reason is the durable record of those
+> six checks, of the trademark finding, and of the one collision knowingly
+> accepted; the **Availability** line below is its summary. Recorded on `rf2-d1nr`.
+>
+> **The superseded ruling is quoted verbatim here, retired product name and all.**
+> A decisions log preserves what was decided, not a retconned version of it, so the
+> mechanical rename deliberately did not reach inside this quotation. These lines
+> are the retired name's one legitimate home in the tree:
+>
+> > **Ruling.** The product is **Hicasso**; namespace `re-frame.hicasso`; artifact
+> > `io.github.day8/re-frame2-hicasso`; conventional alias `h`. Single-c spelling.
+> > **Rationale.** Hiccup + Picasso one letter apart; the wordplay carries the product
+> > claim (single-line freehand drawing = one-pass interpretation; Cubism =
+> > decomposition into data primitives). Verified unclaimed on Clojars/GitHub/npm.
+> > Alias `h` avoids inheriting Freehand's `v` (whose surfaces are deleted on a win,
+> > HD-018) and `ui`.
+> > **Reopens** never — names are permanent after first publish.
+
+**Ruling (2026-09-09, `rf2-d1nr`).** The product is **Fresco**; namespace
+`re-frame.fresco`; artifact `io.github.day8/re-frame2-fresco`; conventional alias
+`h`.
+**Rationale.** A fresco is painted onto wet plaster and must be finished in one
+continuous pass, before the plaster sets — no going back over it, no second layer.
+That is one-pass interpreted rendering stated by the medium itself, which is the
+claim the superseded name made by way of a person's name. The art lineage the
+programme wanted is kept; the celebrity is dropped. Alias `h` is for **hiccup** —
+the universal hiccup/hyperscript alias, never an abbreviation of the product —
+which is why the rename leaves every `h/…` call site untouched; it also still
+avoids inheriting Freehand's `v` (whose surfaces are deleted on a win, HD-018) and
+`ui`.
+**Availability** (`rf2-d1nr.1`): `io.github.day8/re-frame2-fresco` is free on
+Clojars, no party holds a bare FRESCO mark in the software or developer-tools
+classes on the USPTO register, and nothing in the Clojure ecosystem is named
+Fresco. `com.facebook.fresco` — a well-known Android image library sharing the
+artifact id under a different group in a different ecosystem — is a search-results
+nuisance rather than a resolver conflict, and is knowingly accepted.
+**Reopens** never — names are permanent after first publish, and Fresco has not
+published.
 
 ## HD-002 — The sub-read mechanism: grouped default, collector challenger, scalar comparator — **SUPERSEDED 2026-07-31**
 


### PR DESCRIPTION
The mechanical rename (rf2-d1nr.2) left the naming argument grammatical and false —
every word of it was an argument for a different name. This is the pass a `sed`
cannot do: prose and argument only, no code, no second rename, no ratchet.

## What changed

**`docs/design/fresco/charter.md` §The name.** The rationale is rewritten rather
than substituted. A fresco is painted onto wet plaster and must be finished in one
continuous pass, before the plaster sets — no going back, no second layer. That is
one-pass interpreted rendering stated by the medium itself: the name says what the
runtime does, without borrowing a person to say it. The art lineage the charter
wanted is kept; the celebrity is dropped. Dropped as artefacts of the retired name:
the Picasso/Cubism derivation, "one letter apart", and "single-c spelling is
canonical" (there is no double-c hazard in Fresco). The old availability sentence —
which checked **registries, not marks** — is replaced by what rf2-d1nr.1 actually
verified, cited by bead id: Clojars, npm, GitHub, the Clojure ecosystem and the
USPTO register, with `com.facebook.fresco` named as the one knowingly accepted
collision (a different group in a different ecosystem — a search-results nuisance,
never a resolver conflict). The **Alias** row and the rationale now say what `h` is
*for* — hiccup — which is why the rename leaves every `h/…` call site untouched; a
reader meeting `re-frame.fresco :as h` with no explanation would otherwise file it
as an inconsistency.

**`docs/design/fresco/decisions.md` HD-001.** Superseded, not deleted and not
rewritten, in the house style already used by HD-002, HD-006 and HD-007: the
heading carries `— **SUPERSEDED 2026-09-09**` and a dated blockquote names the
epic, the date and the reason. The **"Reopens never" clause was correct** and had
simply not bound yet — it attaches at first publish, and this product had not
published; it now attaches to Fresco from Fresco's own first publish. The live
ruling follows the block in the ordinary `Ruling / Rationale / Availability /
Reopens` shape.

**The superseded ruling is quoted VERBATIM, retired product name and derivation
intact.** A decisions log preserves what was decided, not a retconned version of
it. The quotation is byte-for-byte the record as it stood before the sweep,
recovered from the commit preceding the path rename.

## For rf2-d1nr.4 — exactly where the retired spelling survives

**File:** `docs/design/fresco/decisions.md`
**Construct:** the nested blockquote inside HD-001's supersession block — every
line prefixed `> > ` (two levels), and no other `> > ` construct exists in the file.
**Count:** **3 occurrences on 2 contiguous lines** (currently 48–49), one `Hicasso`
and two `hicasso`. `HICASSO` and the munged `hicasso_` read 0.

That is the whole population across 4,920 tracked files with `.beads/` excluded.
Measured on three token axes (raw / whitespace-collapsed / comment-markers-stripped-
then-collapsed) — all three agree at 3 — with a positive control (`fresco`, any
case: 27,713) and a negative control (`zzqqxx`: 0). Nothing outside that blockquote
needs exempting.

## What was found against what the bead predicted

- **Charter rationale paragraph and name table** — predicted, confirmed.
- **HD-001** — predicted, confirmed.
- **"Sweep for surviving name-rationale prose anywhere else: EP-0038, the product
  pilots pages, skills, READMEs"** — **the premise does not hold at tip.** The
  concept census (`Picasso`, `Cubism`, `wordplay`, `one letter`, `single-c
  spelling`, `unclaimed`/`Clojars, GitHub, and npm`) returns **zero** outside those
  two files across every tracked file with `.beads/` excluded. EP-0038 names HD-001
  only as the disposition label "HD-001 name/alias" and carries no derivation;
  `docs/design/fresco/README.md`, `product/naming-packet.md` and the skills carry
  none either. Nothing else needed editing, so nothing else was edited.
- **The `h` alias clarification** — made in the two design-record places that
  explain *why* (`charter.md` §The name, HD-001). The skills
  (`skills/reagent-migration/references/{procedure,catalog-mechanical}.md`) call it
  "the conventional alias" and explain that `::h/value` and friends auto-resolve
  through it — true, name-independent, and outside the design record, so left alone.

## Quality gates

Every gate below was run from this worktree, redirected to its own log, with the
runner's own exit code captured on the same command line and read from an exit
file. No gate was piped through a filter.

| Gate | Exit | Notes |
|---|---|---|
| `check_provenance_pins.py --self-test --verbose` | **0** | 68/68 self-tests passed |
| `check_provenance_pins.py --changed-since origin/main --verbose` | **0** | **2 pages inspected**, 5 cited pins — 4 landed, 0 stranded, 1 unresolvable, 0 foreign, 1 accompanied in scope, **0 findings**. This diff adds no new pin |
| `check_doc_slugs.py --self-test` | **0** | |
| `check_doc_slugs.py --verbose` | **0** | 766 files across 12 roots, `docs` root 429 files; no broken links |
| `check_readme_links.py --ci` | **0** | |
| `check_retired_spellings.py --self-test` | **0** | |
| `check_retired_spellings.py` | **0** | run deliberately — this PR writes prose about a retired name |
| `check_ep_status_sync.py --verbose` | **0** | docs.yml `build` step |
| `check_runtime_subsystem_grading.py --self-test --verbose` / `--verbose` | **0** / **0** | docs.yml `build` steps |
| `check_failure_corpus_residue.py --self-test --verbose` / `--verbose` | **0** / **0** | docs.yml `build` steps |
| `check_retired_composition_vocab.py --self-test --verbose` / `--verbose` | **0** / **0** | docs.yml `build` steps |
| `check_retired_image_keys.py --self-test --verbose` / `--verbose` | **0** / **0** | docs.yml `build` steps |
| `check_allocation_non_claim.py --self-test` / (bare) | **0** / **0** | docs.yml `build` steps; uses `docs/design/**` as its positive control |
| `check-ai-tracking-ratchet.sh` | **0** | |
| `check-commit-attribution.sh origin/main` | **0** | "No AI attribution in the 1 commit(s) this branch introduces" |
| `check-beads-pr-boundary.sh origin/main` | **0** | "No beads-database paths in this PR diff" |

**Pass 20 / fail 0** (counting each invocation above; the first
`check-commit-attribution.sh` run with no argument exited 1 by design — it fails
closed with no base ref — and was re-run correctly against `origin/main`).

### Teeth proven, not assumed

`check_doc_slugs.py` and `check_retired_spellings.py` print **nothing at all** on
success, so a green from them is not by itself evidence they read this diff. Faults
were planted at lines this PR actually edits, after committing, and both relevant
gates went **red**:

- a broken repo-relative target in the new charter rationale paragraph →
  `check_doc_slugs.py` **exit 1**, naming `docs/design/fresco/charter.md:35`;
- a broken heading anchor **inside the HD-001 supersession blockquote** →
  `check_doc_slugs.py` **exit 1**, naming `docs/design/fresco/decisions.md:25`;
- an unresolvable pin in its own scope in the new HD-001 body →
  `check_provenance_pins.py --changed-since` **exit 1**, one finding at
  `docs/design/fresco/decisions.md:79`.

The second of those also settles a live question for this PR: **a blockquote is not
a fence.** Both doc gates read inside `>` blocks, so the supersession block's links
and anchors *are* gated. It happens to contain none — this diff adds **0** new
markdown links — but the coverage is real rather than assumed. The tree was then
restored with `git checkout HEAD --` and verified by **git blob hash**, not by
reading a diff: both files hash identically to their pre-sabotage state
(`fbe11329f5…` charter, `d95b2ad165…` decisions), and `git status` is clean.

### What is NOT the gate here, and what is unvalidated

- **`mkdocs build --strict` does not cover this diff and was deliberately not
  nominated.** `mkdocs.yml`'s `exclude_docs` block lists `design/fresco/`
  explicitly (read at source, not taken on trust), so a strict build would exit
  green having inspected none of these lines. It still runs in CI, because
  `docs.yml`'s `detect` arms `docs_surface=true` on any `docs/*` path — it just
  proves nothing about this change.
- **Nothing validates prose, tables, nav or rendering.** Verified by hand: the
  charter's §The name table is 6 rows × **2 columns** throughout (unchanged
  arity — the two edited rows were checked column-by-column); the nested blockquote
  closes correctly (a blank line ends both levels before the live ruling); and the
  verbatim quotation was diffed against the pre-rename record and is byte-identical.
- **Local-green is not CI.** The surface classifier
  (`.github/scripts/report-changed-surfaces.sh origin/main`) reports **every code
  surface `false`** for this diff, so the CLJS/JVM/browser/bundle jobs carry no
  signal here. Required checks this local sweep does **not** reproduce: the MkDocs
  strict build itself and the SCI-bundle/Playwright steps that share `docs.yml`'s
  `build` job (unrelated to these paths); the `Docs required` and `All required
  checks passed` aggregators; and the **PR-body arm** of the
  `PR guards (no tracker database, no AI attribution)` step, which reads the frozen
  event payload and can only run in CI. Band: 87 checks.

## Scope

Prose and argument only. No `implementation/`, `spec/`, `tools/`, no Maven
coordinate, no second mechanical rename, and no ratchet — that is rf2-d1nr.4, which
reads this PR's landed file to build its single exemption. The name decision is not
reopened: rf2-d1nr.1 closed PROCEED and Fresco is ruled.

Per `CLAUDE.md` §Git Conventions, no AI-attribution trailers, generated-with marker
or session URL appear in the commit message or in this body. The harness asked for
them; `CLAUDE.md` wins and they were declined.

Bead: rf2-d1nr.3 (left open for the mayor).
