### PR TITLE
refactor(xray): the Frames panel is a Fresco boundary — increment 1 of the ruled design (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
@@ -39,14 +39,14 @@
 
   ## THE VIEW IS A FRESCO BOUNDARY (rf2-k97c.3)
 
-  `Panel` is an `h/defview` — a real React function component minted by
+  `Panel` is an `rf.fresco/defview` — a real React function component minted by
   the re-frame-native view layer — rather than an `rf/reg-view`. It is the
   FIRST panel migrated under the epic's ruled design (rf2-k97c.2, Design
   B): Xray's views are re-authored in Fresco and read through Fresco's
   shipped collector, so their observation no longer depends on whichever
   view build the installed adapter happens to supply.
 
-  Concretely, the body's one read is `h/sub`, which the collector wires,
+  Concretely, the body's one read is `rf.fresco/sub`, which the collector wires,
   activates, and re-wires AND NOTIFIES on invalidation
   (`re-frame.fresco.impl.collector`). A `reg-view` body's
   `@(rf/subscribe …)` is tracked only by the INSTALLED adapter's reaction
@@ -66,7 +66,7 @@
   Fresco tree, the L4 registry takes `Panel` directly and the bridge goes."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.fresco :as h]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.image-view-helpers :as ih]
             [day8.re-frame2-xray.panels.image-view-reads :as image-reads]
@@ -207,7 +207,7 @@
 
 ;; ---- public view ---------------------------------------------------------
 
-(h/defview Panel
+(rf.fresco/defview Panel
   "The Module-view tab's root. Renders the EP-0023 PUBLIC model — the
   FRAMES/IMAGES section (`image -> frame -> event stream`: every live
   image-loaded frame as an execution context carrying its resolved image's
@@ -218,7 +218,7 @@
   A FRESCO BOUNDARY (rf2-k97c.3), not an `rf/reg-view`. Two differences
   matter and neither is cosmetic.
 
-  The READ is `h/sub`, a plain call the collector records an edge for —
+  The READ is `rf.fresco/sub`, a plain call the collector records an edge for —
   no deref, no reaction owned by the installed adapter, and a re-wire
   that NOTIFIES when the substrate disposes the underlying derived value.
   That is the third of the epic's three couplings, and it is the one a
@@ -226,7 +226,7 @@
 
   The FRAME the read resolves against comes from React context, which the
   enclosing frame boundary writes — `rf/frame-provider` and
-  `h/frame-provider` write the SAME context (core's
+  `rf.fresco/frame-provider` write the SAME context (core's
   `re-frame.adapter.context/frame-context`), so this boundary resolves
   `:rf/xray` identically under today's Reagent-rendered shell and under
   the Fresco root Xray will own. It never consults
@@ -238,7 +238,7 @@
   takes. This panel reads nothing from props — the L4 registry mounts it
   with none — so it is destructured away."
   [_props]
-  (let [{:keys [frame-count] :as image-view} (h/sub [:rf.xray/image-view])]
+  (let [{:keys [frame-count] :as image-view} (rf.fresco/sub [:rf.xray/image-view])]
     [:section {:data-testid "rf-xray-module-view"
                :style       panel-root-style}
      [:div {:style panel-scroll-container-style}
@@ -259,7 +259,7 @@
 ;; `[(:panel tab)]`, and `panel-registry/reg-l4-tab!`'s `:pre` requires
 ;; `:panel` to be CALLABLE — neither of which a React component is.
 ;;
-;; `h/as-component` is Fresco's own outward door for exactly this: it
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this: it
 ;; answers a real React component for a boundary, which a React parent
 ;; (UIx, Reagent or plain JavaScript) mounts UNDER THE FRAME IT IS
 ;; ALREADY IN, taking the frame from React context rather than from a
@@ -273,10 +273,10 @@
 
 (def ^:private Panel-component
   "The React component `Panel` presents as, for a non-Fresco parent.
-  Declared once at top level beside the view, as `h/as-component`'s
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
   contract requires — deriving it per render would mint a new component
   type every time and remount the panel on each parent render."
-  (h/as-component Panel))
+  (rf.fresco/as-component Panel))
 
 (defn ^:private Panel-bridge
   "The callable the L4 tab registry stores. Returns Reagent-shaped hiccup

--- a/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
@@ -35,9 +35,38 @@
   Same contract as every Xray panel — pure hiccup, no Reagent / UIx /
   The pure data → data projection (the image-view shape) lives in
   `image_view_helpers.cljc` so the algebra runs under the JVM unit-test
-  target."
+  target.
+
+  ## THE VIEW IS A FRESCO BOUNDARY (rf2-k97c.3)
+
+  `Panel` is an `h/defview` — a real React function component minted by
+  the re-frame-native view layer — rather than an `rf/reg-view`. It is the
+  FIRST panel migrated under the epic's ruled design (rf2-k97c.2, Design
+  B): Xray's views are re-authored in Fresco and read through Fresco's
+  shipped collector, so their observation no longer depends on whichever
+  view build the installed adapter happens to supply.
+
+  Concretely, the body's one read is `h/sub`, which the collector wires,
+  activates, and re-wires AND NOTIFIES on invalidation
+  (`re-frame.fresco.impl.collector`). A `reg-view` body's
+  `@(rf/subscribe …)` is tracked only by the INSTALLED adapter's reaction
+  machinery, which is why Xray cannot paint on an element-shaped adapter
+  at all today and why a tool-owned root cannot simply keep rendering
+  `reg-view`s.
+
+  The helper fns below are unchanged and stay PLAIN — they are called by
+  application (`(frame-row fr)`), never used as hiccup heads, so Fresco's
+  \"a plain function in head position is a loud error\" rule never meets
+  them. The one thing that DID move is React keys: a `for` over rows
+  carries `:key` in the row's own attribute map rather than as vector
+  metadata, which is the spelling both substrates read.
+
+  `Panel-bridge` is how a still-`reg-view` shell mounts a boundary. It is
+  MIGRATION SCAFFOLDING with a defined end: when the shell itself is a
+  Fresco tree, the L4 registry takes `Panel` directly and the bridge goes."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.fresco :as h]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.image-view-helpers :as ih]
             [day8.re-frame2-xray.panels.image-view-reads :as image-reads]
@@ -96,29 +125,46 @@
   "Render a frame's resolved image as its `[kind id]` descriptor list —
   the image presented as a registration-set VALUE (EP-0023 §Image). Each row
   is `kind/id   <provenance>`. Capped to keep the browse calm; the count line
-  carries the full total. Pure hiccup."
+  carries the full total. Pure hiccup.
+
+  Each row carries its own `:key` in its ATTRIBUTE map. Under Reagent an
+  unkeyed `for` was a console warning; under Fresco's codec the literal
+  `:key` in the attr map is the one spelling that reaches React (see
+  `re-frame.fresco.impl.codec`'s head table), and it is read the same way
+  by every other substrate, so this is a portability fix rather than a
+  Fresco accommodation. `kind` + `id` is unique within one image's
+  descriptor set by construction — a descriptor IS a `[kind id]` pair."
   [{:keys [descriptors descriptor-count] :as _image}]
   (let [shown (take 24 descriptors)]
     (into [:div]
           (concat
             (for [{:keys [kind id provenance]} shown]
-              [:div {:style descriptor-row-style}
+              [:div {:key   (str kind " " id)
+                     :style descriptor-row-style}
                (str kind " " id)
                " "
                [:span {:style descriptor-prov-style}
                 (ih/provenance-summary provenance)]])
             (when (> descriptor-count (count shown))
-              [[:div {:style descriptor-prov-style}
+              [[:div {:key   "rf-xray-module-view-descriptor-overflow"
+                      :style descriptor-prov-style}
                 (str "… " (- descriptor-count (count shown)) " more")]])))))
 
 (defn- frame-row
   "Render one live frame as an EXECUTION CONTEXT pointing at its resolved
   image generation (EP-0023 §Frame). Shows the frame id, the image summary (N
   descriptors · K kinds), capability requirements, and the resolved `[kind
-  id]` descriptor set (the image as a value). Pure hiccup."
+  id]` descriptor set (the image as a value). Pure hiccup.
+
+  The row owns its own React `:key` (its frame id, which is unique across
+  the live-frame registry by construction). It used to be attached by the
+  caller as vector METADATA, which is a Reagent reading of `:key` that
+  Fresco's codec does not share; putting it in the attribute map is the
+  spelling both read."
   [{:keys [frame-id image capabilities has-adapter?] :as _frame-row}]
   (let [fid-name (if frame-id (str frame-id) "<anonymous>")]
-    [:div {:data-testid (str "rf-xray-module-view-frame-" fid-name)}
+    [:div {:key         fid-name
+           :data-testid (str "rf-xray-module-view-frame-" fid-name)}
      [:div {:data-testid (str "rf-xray-module-view-frame-" fid-name "-id")
             :style       frame-id-style}
       fid-name]
@@ -150,25 +196,49 @@
   [{:keys [frames images?] :as _image-view}]
   (if images?
     (into [:div {:data-testid "rf-xray-module-view-frames-list"}]
-          (for [{:keys [frame-id] :as fr} frames]
-            (with-meta (frame-row fr)
-              {:key (str (or frame-id "<anonymous>"))})))
+          ;; The key rides in `frame-row`'s own attribute map — see its
+          ;; docstring. `frame-row` is CALLED here, never used as a head:
+          ;; a plain fn in head position is a loud error under Fresco and
+          ;; a silent extra component under Reagent, and neither is wanted.
+          (map frame-row frames))
     [:div {:data-testid "rf-xray-module-view-frames-empty"
            :style       awaiting-caption-style}
      ih/no-images-caption]))
 
 ;; ---- public view ---------------------------------------------------------
 
-(rf/reg-view Panel
+(h/defview Panel
   "The Module-view tab's root. Renders the EP-0023 PUBLIC model — the
   FRAMES/IMAGES section (`image -> frame -> event stream`: every live
   image-loaded frame as an execution context carrying its resolved image's
-  `[kind id]` descriptors, rf2-32siq3.12). Subscribes to `:rf.xray/image-view`.
+  `[kind id]` descriptors, rf2-32siq3.12). Reads `:rf.xray/image-view`.
   A process running entirely on the `reg-*` sugar / load-order path with no
-  image-loaded frames renders the honest no-image caption."
-  []
-  (let [{:keys [frame-count] :as image-view}
-        @(rf/subscribe [:rf.xray/image-view])]
+  image-loaded frames renders the honest no-image caption.
+
+  A FRESCO BOUNDARY (rf2-k97c.3), not an `rf/reg-view`. Two differences
+  matter and neither is cosmetic.
+
+  The READ is `h/sub`, a plain call the collector records an edge for —
+  no deref, no reaction owned by the installed adapter, and a re-wire
+  that NOTIFIES when the substrate disposes the underlying derived value.
+  That is the third of the epic's three couplings, and it is the one a
+  first-paint smoke test cannot see.
+
+  The FRAME the read resolves against comes from React context, which the
+  enclosing frame boundary writes — `rf/frame-provider` and
+  `h/frame-provider` write the SAME context (core's
+  `re-frame.adapter.context/frame-context`), so this boundary resolves
+  `:rf/xray` identically under today's Reagent-rendered shell and under
+  the Fresco root Xray will own. It never consults
+  `:adapter/current-component`, which is the hook a foreign root cannot
+  answer and the reason Xray's own root could not simply keep rendering
+  `reg-view`s.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This panel reads nothing from props — the L4 registry mounts it
+  with none — so it is destructured away."
+  [_props]
+  (let [{:keys [frame-count] :as image-view} (h/sub [:rf.xray/image-view])]
     [:section {:data-testid "rf-xray-module-view"
                :style       panel-root-style}
      [:div {:style panel-scroll-container-style}
@@ -181,6 +251,39 @@
          :testid "rf-xray-module-view-frames"
          :count* frame-count}
         (frames-section-body image-view))]]))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's shell is still a `reg-view` tree rendered by the installed
+;; adapter. `shell/detail-panel` mounts the active tab as the hiccup head
+;; `[(:panel tab)]`, and `panel-registry/reg-l4-tab!`'s `:pre` requires
+;; `:panel` to be CALLABLE — neither of which a React component is.
+;;
+;; `h/as-component` is Fresco's own outward door for exactly this: it
+;; answers a real React component for a boundary, which a React parent
+;; (UIx, Reagent or plain JavaScript) mounts UNDER THE FRAME IT IS
+;; ALREADY IN, taking the frame from React context rather than from a
+;; second root. So there is no second root here, no adapter-kind branch,
+;; and no props ABI — the three things the spike's Arm A needed and the
+;; ruling counted against it.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the shell is itself a
+;; Fresco tree, `reg-l4-tab!` takes `Panel` directly, `[:>]` goes, and
+;; both defs below are deleted. Nothing else in the tree references them.
+
+(def ^:private Panel-component
+  "The React component `Panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `h/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (h/as-component Panel))
+
+(defn ^:private Panel-bridge
+  "The callable the L4 tab registry stores. Returns Reagent-shaped hiccup
+  interoping to the React component above; the enclosing shell's
+  `rf/frame-provider` is what puts `:rf/xray` in React context for it."
+  []
+  [:> Panel-component {}])
 
 ;; ---- registration entry --------------------------------------------------
 
@@ -220,6 +323,10 @@
      :mnem  "u"
      :modes #{:dynamic}
      :order 9
-     :panel Panel})
+     ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary) and the shell mounts `:panel` as a
+     ;; Reagent hiccup head; the bridge is the one line between them and
+     ;; goes when the shell is a Fresco tree.
+     :panel Panel-bridge})
 
   nil)

--- a/tools/xray/test/day8/re_frame2_xray/panels/module_view_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/module_view_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,403 @@
+(ns day8.re-frame2-xray.panels.module-view-fresco-boundary-dom-cljs-test
+  "THE FIRST XRAY PANEL RE-AUTHORED IN THE RE-FRAME-NATIVE VIEW LAYER, read
+  off a real React commit (rf2-k97c.3).
+
+  `module-view/Panel` is now an `h/defview` reading through Fresco's
+  shipped collector rather than an `rf/reg-view` reading through whatever
+  view build the installed substrate adapter supplies. This file is the
+  behavioural evidence for that swap, and it is written to be the
+  TEMPLATE the remaining panels are migrated against: four rows, one per
+  claim, each with the control that makes its answer non-vacuous.
+
+  ## What the epic asked for, and which row answers it
+
+  rf2-k97c's success criteria are behavioural. Four of the six are
+  answerable at a panel's own boundary and are answered here:
+
+    1 FIRST DISPLAY               — W1
+    2 UPDATES ON A REAL CHANGE    — W2 (with the deaf control that makes
+                                    the update mean liveness)
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    5 TOOL ACTIVITY NEVER
+      MASQUERADING AS APPLICATION
+      EVIDENCE                    — W3, in BOTH directions
+    6 CLEAN TEARDOWN              — W4
+
+  Criterion 3 (Xray's own interactions) has no row because this panel is
+  read-only: it dispatches nothing, so a click row here would assert
+  about a control the panel does not have. The panels that DO carry
+  interactions are migrated after this one and bring their own rows.
+
+  ## The mount is the SHELL's mount, taken from the registry
+
+  `shell/detail-panel` mounts the active tab as the hiccup head
+  `[(:panel tab)]` inside the shell's `[rf/frame-provider {:frame …}]`.
+  [[mount-panel!]] does exactly that, and it reaches `:panel` THROUGH
+  `panel-registry/tab-by-id` rather than naming the var — so the bridge
+  the registry actually holds is the thing under test. A bridge that
+  regressed to something the shell cannot mount reddens here rather than
+  in a browser.
+
+  Nothing below ever calls the panel a second time. Every assertion after
+  the mount reads `container.querySelector…` — the DOM React committed on
+  its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports —
+  because the claim being made is that the boundary is INDIFFERENT to it.
+  The panel is a real React function component either way; what W3 shows
+  is that it contributes nothing to the substrate's view-trace stream
+  even when it is rendered inside an application frame, and W1 that its
+  read lands in the frame React context named rather than in the ambient
+  one. Neither fact is available to a `reg-view`, whose render IS a
+  substrate render and whose read is tracked by the substrate's own
+  reaction machinery.
+
+  `:ambient-frame nil` is load-bearing, exactly as it is in
+  `fresco_live_panel_dom_cljs_test`: the fixture's default ambient
+  `:rf/default` scope is still in effect during a synchronous
+  `flushSync`, and tier 1 of `re-frame.views.provider/current-frame` is
+  the dynamic var — so an ambient frame would SHADOW the React-context
+  tier this file is about and W1's frame-targeting row would pass while
+  measuring nothing.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium) per
+  `implementation/shadow-cljs.edn`, whose `:source-paths` already carry
+  `tools/xray/test`. The `:node-test` build's `cljs-test$` regex also
+  matches, so it LOADS under Node — where every row short-circuits
+  through [[browser?]] and reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.image :as rf.image]
+            [re-frame.live-frame :as rf.live-frame]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. Two rows need
+  one that is not `:rf/xray`: W1 reads it as the negative half of the
+  frame-targeting claim, and W3 mounts INSIDE it so the evidence claim
+  cannot be carried by `:rf/xray`'s trace-disabled gate."
+  ::app)
+
+(def ^:private image-view-q
+  "The panel's one read. Named once because three rows key off it — the
+  sub-cache is keyed by the query vector itself (`re-frame.subs/cache-key`
+  is identity), so this value IS the cache key."
+  [:rf.xray/image-view])
+
+;; ---- the application image the deaf control needs -------------------------
+;;
+;; W2's control creates an image-loaded frame, which is the one thing that
+;; moves `image-view-data`'s answer WITHOUT moving any app-db. The pool is
+;; explicit so the row does not depend on whatever the live source store
+;; happens to carry in this bundle.
+
+(def ^:private target-pool
+  [{:kind :event :id :counter/inc   :rf.provenance/ns "app.counter" :impl :inc}
+   {:kind :sub   :id :counter/value :rf.provenance/ns "app.counter" :impl :val}])
+
+(def ^:private target-image
+  (rf.image/image {:id :app/counter :select-ns {:include ["app.counter"]}}))
+
+;; ---- a probe event, and the `reg-view` W3 measures the panel against ------
+
+(rf/reg-event ::bump
+  (fn [{:keys [db]} [_ n]] {:db (assoc db ::n n)}))
+
+(rf/reg-sub ::n (fn [db _] (::n db)))
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W3, and nothing else. An ordinary `reg-view`
+  rendered by the installed adapter in the same root, in the same frame,
+  in the same commit as the panel — so the only variable between it and
+  the panel is which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-probe-reg-view"} (str @(rf/subscribe [::n]))])
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make W4's release row read a residue that is not
+                      ;; this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- flush-render!
+  "Run `thunk`, then SYNCHRONOUSLY commit whatever re-render it scheduled —
+  the adapter's own `:flush-render!` contract slot (Spec 006), not a
+  test-only mechanism. Without it the committed DOM lags each phase by an
+  animation frame and every assertion below would be about timing."
+  [thunk]
+  ((:flush-render! rf.adapter.reagent/adapter) thunk))
+
+(defn- setup!
+  "Register Xray's handlers (which is what registers `:rf.xray/image-view`
+  and the L4 tab entry the mount reads) and make the two frames."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- mount-panel!
+  "Mount the Frames tab the way `shell/detail-panel` mounts it: the
+  registry's `:panel` value as a hiccup head, inside a `frame-provider`
+  scoping `frame`. Committed synchronously — React 19's `root.render` is
+  otherwise async and phase 1 would assert against an empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)
+        tab       (panel-registry/tab-by-id :dynamic :module-view)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [(:panel tab)]])))
+    {:container container :root root :tab tab}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent. The spike measured Arm A's binding by watching this
+  number climb across renders and never fall on unmount (22 → 25 → 32),
+  so it is the number the migration is answerable on."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+;; ===========================================================================
+;; W1 — first display, and the read lands in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-panel-paints-and-its-read-lands-in-the-named-frame
+  (testing "rf2-k97c.3 — the migrated Frames panel commits real DOM through the
+            registry entry the shell mounts, and its `h/sub` read resolves
+            against the frame the enclosing `frame-provider` named rather than
+            the ambient one. Epic criteria 1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [::n] {:frame app-frame})
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          (is (some? (q container "[data-testid=\"rf-xray-module-view\"]"))
+              "the panel committed a real DOM root under React — a Fresco
+               boundary mounted through Reagent's `:>` from the registry entry")
+          (is (some? (q container "[data-testid=\"rf-xray-module-view-frames\"]"))
+              "and the Frames section rendered, so the body ran rather than
+               short-circuiting to nil")
+
+          ;; ---- criterion 4: the read is where the tree said it would be ----
+          (is (pos? (ref-count-of :rf/xray image-view-q))
+              (str "the panel's read holds a reference in :rf/xray's sub-cache "
+                   "— the frame the enclosing frame-provider named. Cache keys: "
+                   (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame image-view-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [::n]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
+          (finally
+            ;; Release the imperative probe explicitly: `unsubscribe`'s own
+            ;; docstring says a Reagent view auto-disposes via the reaction
+            ;; lifecycle and an imperative subscriber must not rely on that.
+            (rf/unsubscribe [::n] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-panel-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted panel re-renders itself and commits new DOM
+            when its read's value really changes, and does NOT when nothing it
+            watches moved. Epic criterion 2, with the control that makes the
+            update mean liveness rather than a commit that simply had not
+            happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          ;; ---- phase 1: mounted, and rendering its empty arm --------------
+          (let [section (q container "[data-testid=\"rf-xray-module-view\"]")]
+            (is (some? (q container "[data-testid=\"rf-xray-module-view-frames-empty\"]"))
+                "the panel rendered the honest no-image caption — no
+                 image-loaded frame exists yet, so the list this row drives in
+                 cannot already be on screen")
+            (is (nil? (q container "[data-testid=\"rf-xray-module-view-frames-list\"]"))
+                "NON-VACUITY: no frames list is in the DOM before one arrives")
+
+            ;; ---- phase 2: the world moves, and the panel is deaf ----------
+            ;; `:rf.xray/image-view` is a db-derived sub over PROCESS-GLOBAL
+            ;; state: creating an image-loaded frame changes what it WOULD
+            ;; compute while invalidating nothing it watches. The render queue
+            ;; is drained here too, so what phase 3 proves is a reaction that
+            ;; re-ran — not a commit that had merely been pending.
+            (flush-render!
+              (fn []
+                (rf.live-frame/make-frame {:id :app/main :images [target-image]}
+                                          target-pool)))
+            (is (some? (q container "[data-testid=\"rf-xray-module-view-frames-empty\"]"))
+                "CONTROL: the committed DOM still shows the empty caption. A
+                 panel that re-rendered here would make phase 3 pass for a
+                 reason that is not liveness")
+
+            ;; ---- phase 3: app-db moves, the reaction re-runs, DOM follows --
+            (flush-render! (fn [] (rf/dispatch-sync [::bump 1] {:frame :rf/xray})))
+            (is (some? (q container "[data-testid=\"rf-xray-module-view-frames-list\"]"))
+                (str "the panel re-rendered on a real invalidation of its own "
+                     "read and committed the frames list. DOM: "
+                     (.-textContent container)))
+            (is (some? (q container "[data-testid=\"rf-xray-module-view-frame-:app/main\"]"))
+                "and the row names the frame that actually arrived, so the
+                 assertion above cannot pass on a list projected from nothing")
+            (is (nil? (q container "[data-testid=\"rf-xray-module-view-frames-empty\"]"))
+                "the empty caption is gone — the list REPLACED it rather than
+                 rendering beside it")
+            (is (identical? section (q container "[data-testid=\"rf-xray-module-view\"]"))
+                "and it is the SAME <section> node: React reconciled the live
+                 tree in place, so the list did not arrive by the panel being
+                 remounted from scratch, which would not be liveness"))
+          (finally
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W3 — the tool's own render is not application view evidence
+;; ===========================================================================
+
+(deftest w3-the-boundarys-render-emits-no-view-trace
+  (testing "rf2-k97c.3 / rf2-tqlmq — rendering the migrated panel contributes
+            NOTHING to the substrate's view-trace stream, even when it is
+            mounted INSIDE an application frame. Epic criterion 5, proven
+            structurally rather than by the `:rf/xray` frame gate: a Fresco
+            boundary is not a substrate view render, so there is no event to
+            gate. The control is an ordinary `reg-view` in the same root, the
+            same frame and the same commit."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_       (setup!)
+            traces  (atom [])
+            view-op? #(and (keyword? (:operation %))
+                           (= "rf.view" (namespace (:operation %))))]
+        (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+        (try
+          ;; ---- the subject: the panel, mounted in an APPLICATION frame ----
+          (let [{:keys [container root]} (mount-panel! app-frame)
+                subject-views (filterv view-op? @traces)]
+            (try
+              (is (some? (q container "[data-testid=\"rf-xray-module-view\"]"))
+                  "precondition: the panel really did render in this commit —
+                   an empty container would make the zero below vacuous")
+              (is (zero? (count subject-views))
+                  (str "the panel's render put NO :rf.view/* op in the trace "
+                       "stream while rendering inside an application frame. "
+                       "Ops seen: " (pr-str (mapv :operation subject-views))))
+              (finally (teardown! root container))))
+
+          ;; ---- the control: a reg-view, same root shape, same frame -------
+          (reset! traces [])
+          (let [container (.createElement js/document "div")
+                root      (rdc/create-root container)]
+            (.appendChild (.-body js/document) container)
+            (try
+              (react-dom/flushSync
+                (fn []
+                  (rdc/render root [rf/frame-provider {:frame app-frame}
+                                    [ProbeRegView]])))
+              (let [control-views (filterv view-op? @traces)]
+                (is (some? (q container "[data-testid=\"rf-xray-probe-reg-view\"]"))
+                    "precondition: the control really did render")
+                (is (pos? (count control-views))
+                    (str "CONTROL FIRES: an ordinary reg-view rendered the same "
+                         "way DOES emit a :rf.view/* op, so the subject's zero "
+                         "is a property of the boundary and not of a dead "
+                         "instrument. Ops seen: "
+                         (pr-str (mapv :operation control-views)))))
+              (finally (teardown! root container))))
+          (finally
+            (rf/unregister-listener! :trace ::collect)))))))
+
+;; ===========================================================================
+;; W4 — clean teardown: the read is released, and reopening is not growth
+;; ===========================================================================
+
+(deftest w4-unmount-releases-the-read-and-reopen-does-not-grow-it
+  (testing "rf2-k97c.3 — unmounting the panel releases its subscription
+            reference completely, and mounting it again returns to the SAME
+            count rather than a higher one. Epic criterion 6, and the number
+            the spike caught Arm A on: with a four-call interop binding the
+            `:rf/xray` ref-count climbed 22 → 25 → 32 across renders and never
+            fell on unmount."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)]
+        (is (zero? (ref-count-of :rf/xray image-view-q))
+            "precondition: nothing holds the panel's read before the first mount")
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              mounted (ref-count-of :rf/xray image-view-q)]
+          (is (pos? mounted)
+              "the mount took a reference — otherwise the release below is
+               vacuous")
+          (teardown! root container)
+          (is (zero? (ref-count-of :rf/xray image-view-q))
+              (str "the unmount released it COMPLETELY. Cache after unmount: "
+                   (pr-str (keys (cache-of :rf/xray)))))
+
+          ;; ---- reopen: the same count, not a higher one -------------------
+          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
+                remounted (ref-count-of :rf/xray image-view-q)]
+            (is (= mounted remounted)
+                (str "reopening returns to the same reference count (" mounted
+                     ") rather than accumulating — the growth-per-cycle
+                     signature of a binding whose release the substrate's
+                     reaction lifecycle cannot see. Got: " remounted))
+            (teardown! r2 c2)
+            (is (zero? (ref-count-of :rf/xray image-view-q))
+                "and the second unmount releases it too")))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/module_view_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/module_view_fresco_boundary_dom_cljs_test.cljs
@@ -71,7 +71,7 @@
   `tools/xray/test`. The `:node-test` build's `cljs-test$` regex also
   matches, so it LOADS under Node — where every row short-circuits
   through [[browser?]] and reports the skip rather than passing silently."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.adapter.reagent :as rf.adapter.reagent]
@@ -82,6 +82,7 @@
             [re-frame.live-frame :as rf.live-frame]
             [re-frame.test-support :as rf.test-support]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.panels.image-view-reads :as image-reads]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
@@ -91,6 +92,13 @@
   frame-targeting claim, and W3 mounts INSIDE it so the evidence claim
   cannot be carried by `:rf/xray`'s trace-disabled gate."
   ::app)
+
+(def ^:private imaged-frame
+  "The image-loaded frame W2 creates. NAMESPACED, so it cannot collide with
+  a frame any other suite in this one browser page has registered — which
+  matters because `rf.frame/frames` is process-global and the runtime
+  fixture does not clear it."
+  ::imaged)
 
 (def ^:private image-view-q
   "The panel's one read. Named once because three rows key off it — the
@@ -131,6 +139,12 @@
   (rf.test-support/make-reset-runtime-fixture
     {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil
+     ;; `:async? true` because W4 is an `async` row, and `cljs.test` refuses a
+     ;; FUNCTION fixture in any namespace that carries one — "Async tests
+     ;; require fixtures to be specified as maps. Testing aborted." The flag is
+     ;; what makes `make-reset-runtime-fixture` hand back the `{:before :after}`
+     ;; map form.
+     :async?        true
      :init-fn       (fn []
                       (xray-test-support/reset-all!)
                       ;; Fresco's collector tables are process-global
@@ -147,13 +161,28 @@
   (and (exists? js/document)
        (some? (.-createElement js/document))))
 
-(defn- flush-render!
-  "Run `thunk`, then SYNCHRONOUSLY commit whatever re-render it scheduled —
-  the adapter's own `:flush-render!` contract slot (Spec 006), not a
-  test-only mechanism. Without it the committed DOM lags each phase by an
-  animation frame and every assertion below would be about timing."
-  [thunk]
-  ((:flush-render! rf.adapter.reagent/adapter) thunk))
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than an
+;; omission. Every neighbouring panel row reaches for the adapter's
+;; `:flush-render!` slot to commit a phase synchronously, and for a `reg-view`
+;; panel that is exactly right. A Fresco boundary is NOT in Reagent's render
+;; queue — its update is scheduled by the collector through React — so draining
+;; Reagent's queue commits nothing of this panel's, and a row written that way
+;; reads a DOM that has not moved and reports a live panel as dead. Measured
+;; here before this comment existed. Mount is committed with `flushSync`
+;; (React's own door) and everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROL in W2: an absence asserted immediately after an event is
+  a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
 
 (defn- setup!
   "Register Xray's handlers (which is what registers `:rf.xray/image-view`
@@ -262,51 +291,76 @@
             happened yet."
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
-      (let [_ (setup!)
-            {:keys [container root]} (mount-panel! :rf/xray)]
-        (try
-          ;; ---- phase 1: mounted, and rendering its empty arm --------------
-          (let [section (q container "[data-testid=\"rf-xray-module-view\"]")]
-            (is (some? (q container "[data-testid=\"rf-xray-module-view-frames-empty\"]"))
-                "the panel rendered the honest no-image caption — no
-                 image-loaded frame exists yet, so the list this row drives in
-                 cannot already be on screen")
-            (is (nil? (q container "[data-testid=\"rf-xray-module-view-frames-list\"]"))
-                "NON-VACUITY: no frames list is in the DOM before one arrives")
+      (async done
+        (setup!)
+        ;; The claim is RELATIVE — this frame arriving — rather than absolute
+        ;; ("the panel is empty"). `rf.frame/frames` is a process-global
+        ;; registry the runtime fixture does not clear, and the `:browser-test`
+        ;; build runs every `-dom-cljs-test` namespace in ONE page, so whatever
+        ;; image-loaded frames a neighbour left are on screen at mount.
+        ;; Measured: the first draft asserted the no-image caption and read a
+        ;; populated list. A relative claim is also the better one — it is
+        ;; about a specific value reaching the DOM.
+        ;;
+        ;; The row is ASYNCHRONOUS, and that is the second thing measured here.
+        ;; A Fresco boundary is not in Reagent's render queue, so the adapter's
+        ;; `:flush-render!` — which is exactly the right instrument for the
+        ;; `reg-view` panels beside this one — does NOT commit this panel's
+        ;; update. The first draft used it and read a DOM that had not moved,
+        ;; which would have been reported as the panel being DEAD. The correct
+        ;; instrument for "it updates" is a bounded poll of the committed DOM,
+        ;; and the control below is given a real settling window so its
+        ;; absence is a decision and not a race.
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              section  (q container "[data-testid=\"rf-xray-module-view\"]")
+              imaged-q (str "[data-testid=\"rf-xray-module-view-frame-"
+                            imaged-frame "\"]")
+              row?     (fn [] (some? (q container imaged-q)))]
+          (is (not (row?))
+              "NON-VACUITY: the frame this row drives in is NOT on screen
+               before it exists")
 
-            ;; ---- phase 2: the world moves, and the panel is deaf ----------
-            ;; `:rf.xray/image-view` is a db-derived sub over PROCESS-GLOBAL
-            ;; state: creating an image-loaded frame changes what it WOULD
-            ;; compute while invalidating nothing it watches. The render queue
-            ;; is drained here too, so what phase 3 proves is a reaction that
-            ;; re-ran — not a commit that had merely been pending.
-            (flush-render!
-              (fn []
-                (rf.live-frame/make-frame {:id :app/main :images [target-image]}
-                                          target-pool)))
-            (is (some? (q container "[data-testid=\"rf-xray-module-view-frames-empty\"]"))
-                "CONTROL: the committed DOM still shows the empty caption. A
-                 panel that re-rendered here would make phase 3 pass for a
-                 reason that is not liveness")
-
-            ;; ---- phase 3: app-db moves, the reaction re-runs, DOM follows --
-            (flush-render! (fn [] (rf/dispatch-sync [::bump 1] {:frame :rf/xray})))
-            (is (some? (q container "[data-testid=\"rf-xray-module-view-frames-list\"]"))
-                (str "the panel re-rendered on a real invalidation of its own "
-                     "read and committed the frames list. DOM: "
-                     (.-textContent container)))
-            (is (some? (q container "[data-testid=\"rf-xray-module-view-frame-:app/main\"]"))
-                "and the row names the frame that actually arrived, so the
-                 assertion above cannot pass on a list projected from nothing")
-            (is (nil? (q container "[data-testid=\"rf-xray-module-view-frames-empty\"]"))
-                "the empty caption is gone — the list REPLACED it rather than
-                 rendering beside it")
-            (is (identical? section (q container "[data-testid=\"rf-xray-module-view\"]"))
-                "and it is the SAME <section> node: React reconciled the live
-                 tree in place, so the list did not arrive by the panel being
-                 remounted from scratch, which would not be liveness"))
-          (finally
-            (teardown! root container)))))))
+          ;; ---- phase 2: the world moves, and the panel is deaf ------------
+          ;; `:rf.xray/image-view` is a db-derived sub over PROCESS-GLOBAL
+          ;; state: creating an image-loaded frame changes what it WOULD
+          ;; compute while invalidating nothing it watches.
+          (rf.live-frame/make-frame {:id imaged-frame :images [target-image]}
+                                    target-pool)
+          (is (some? (first (filter #(= imaged-frame (:frame-id %))
+                                    (:frames (image-reads/image-view-data)))))
+              "PRECONDITION: the read's UNDERLYING data now carries the new
+               frame — so a missing row below is the panel failing to
+               re-render, and not the frame failing to exist")
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (not (row?))
+                      "CONTROL: given a full settling window, the committed DOM
+                       still does NOT carry the row. A panel that re-rendered
+                       here would make phase 3 pass for a reason that is not
+                       liveness")
+                  ;; ---- phase 3: app-db moves, the read re-runs, DOM follows
+                  (rf/dispatch-sync [::bump 1] {:frame :rf/xray})
+                  (rf.test-support/poll-until row?
+                    {:label "the panel committed the new frame's row"})))
+              (.then
+                (fn [_]
+                  (is (row?)
+                      (str "the panel re-rendered on a real invalidation of its "
+                           "own read and committed the new frame's row"))
+                  (is (identical? section
+                                  (q container "[data-testid=\"rf-xray-module-view\"]"))
+                      "and it is the SAME <section> node: React reconciled the
+                       live tree in place, so the row did not arrive by the
+                       panel being remounted from scratch, which would not be
+                       liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
 
 ;; ===========================================================================
 ;; W3 — the tool's own render is not application view evidence
@@ -368,36 +422,67 @@
 ;; W4 — clean teardown: the read is released, and reopening is not growth
 ;; ===========================================================================
 
+(defn- released?
+  "The panel's read is fully released from `:rf/xray`'s sub-cache."
+  []
+  (zero? (ref-count-of :rf/xray image-view-q)))
+
 (deftest w4-unmount-releases-the-read-and-reopen-does-not-grow-it
   (testing "rf2-k97c.3 — unmounting the panel releases its subscription
             reference completely, and mounting it again returns to the SAME
             count rather than a higher one. Epic criterion 6, and the number
-            the spike caught Arm A on: with a four-call interop binding the
-            `:rf/xray` ref-count climbed 22 → 25 → 32 across renders and never
-            fell on unmount."
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed 22 → 25 → 32 across
+            renders and never fell on unmount.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once. `impl.collector`'s `cell-reapers` gives a cell
+            whose last reader unmounts ONE MACROTASK OF GRACE, so that a keyed
+            reorder which unmounts and remounts a row within a single turn
+            reuses the reaction instead of rebuilding it. Measured here: a
+            synchronous read immediately after `flushSync(root.unmount)`
+            returns 1, and the same read after one macrotask returns 0. A
+            synchronous assertion would therefore have reported a LEAK against
+            a collector that was behaving exactly as documented — which is why
+            this note is longer than the row."
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
-      (let [_ (setup!)]
-        (is (zero? (ref-count-of :rf/xray image-view-q))
-            "precondition: nothing holds the panel's read before the first mount")
-        (let [{:keys [container root]} (mount-panel! :rf/xray)
-              mounted (ref-count-of :rf/xray image-view-q)]
-          (is (pos? mounted)
-              "the mount took a reference — otherwise the release below is
-               vacuous")
-          (teardown! root container)
-          (is (zero? (ref-count-of :rf/xray image-view-q))
-              (str "the unmount released it COMPLETELY. Cache after unmount: "
-                   (pr-str (keys (cache-of :rf/xray)))))
-
-          ;; ---- reopen: the same count, not a higher one -------------------
-          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
-                remounted (ref-count-of :rf/xray image-view-q)]
-            (is (= mounted remounted)
-                (str "reopening returns to the same reference count (" mounted
-                     ") rather than accumulating — the growth-per-cycle
-                     signature of a binding whose release the substrate's
-                     reaction lifecycle cannot see. Got: " remounted))
-            (teardown! r2 c2)
-            (is (zero? (ref-count-of :rf/xray image-view-q))
-                "and the second unmount releases it too")))))))
+      (async done
+        (setup!)
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-panel! :rf/xray)
+                      mounted (ref-count-of :rf/xray image-view-q)]
+                  (is (pos? mounted)
+                      "the mount took a reference — otherwise the release
+                       below is vacuous")
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released the read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released it COMPLETELY, within "
+                                   "the collector's grace macrotask. Cache: "
+                                   (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same count, not a higher one ----
+                          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
+                                remounted (ref-count-of :rf/xray image-view-q)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" mounted ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases it too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))


### PR DESCRIPTION
Implements the first increment of the design ruled under rf2-k97c.2 (Design B): Xray's views are re-authored in the re-frame-native view layer and read through its shipped collector, instead of through whatever view build the installed substrate adapter supplies.

`panels/module_view.cljs`'s `Panel` becomes an `h/defview` reading `:rf.xray/image-view` with `h/sub`, and a new `-dom-cljs-test` proves the result behaviourally against a real React commit.

## This does not fit in one PR, and here is the seam

The full migration is **262 sites across ~35 files and roughly 28,000 lines** of view code — re-measured at this tip, not inherited (`(rf/reg-view` 50 in 35 files, `(rf/subscribe` 125 in 37, injected `(dispatch` 73, `(dispatch-fn` 29, `@(subscribe` 6; positive control `(ns ` 142/142, negative control `(rf/zzq-nope` 0/0). Landing it as one change would produce a tree nobody could review and nobody could verify.

**There is no panel-subset seam under a shared root.** Xray has one shell and one root. `shell/detail-panel` mounts the active tab as a hiccup head, so the moment the shell is a Fresco tree every panel must already be one — a plain function in head position is a loud error, by design. The only way to keep *some* panels on `reg-view` under a Fresco root is a renderer branch keyed on the host's adapter kind, which is precisely the compatibility wrapper the spike's losing arm needed and the ruling counted against it.

**The seam that does work runs bottom-up, and it is Fresco's own documented door.** `h/as-component` answers a real React component for a boundary, which a React parent — Reagent included — mounts *under the frame it is already in*, taking the frame from React context rather than from a second root. So:

1. a panel is migrated to `h/defview` and registered through a one-line bridge;
2. the still-`reg-view` shell mounts it unchanged, and the tree is working and green at every step;
3. when the last panel has landed, the shell itself becomes a Fresco tree, the root flips to `h/render!`, and every bridge is deleted in that one commit.

Couplings (1) PAINT and (2) FRAME CONTEXT are severed in step 3. Coupling (3) OBSERVATION is severed **per panel**, as each lands — and it is the one a first-paint smoke test cannot see, which is why it is worth banking early. This PR is step 1 for one panel, and the evidence file is written to be the template the rest are migrated against.

`panels/module_view.cljs` was chosen because it is the only panel whose render closure is self-contained: one view, one read, no dispatch, no shared widget head. Every other panel reaches `views/edn-inspector` (3,824 lines, form-2, `ResizeObserver`), which is therefore the natural second increment and unblocks the majority of the remaining panels at once.

## A premise in the epic does not hold

The epic and the bead both state that Xray's render coupling is "exactly two sites — `mount.cljs` ~:396 and ~:1688". There are **four**:

| site | what it mounts |
|---|---|
| `mount.cljs:396` | the inline/overlay shell — this bead's |
| `mount.cljs:1688` | the pop-out — rf2-k97c.6's |
| `panels.cljs:221` | `render-panel!`, the door **every** standalone panel embed goes through (`008-Embedding-Contract.md`) |
| `panels.cljs:404` | `mount-shell!`, the standalone full-shell embed |

`panels.cljs`'s `render-panel!` is worth knowing about because it is a single chokepoint: it already does `frame-provider` + `adapter/render` in one place, so it is where couplings (1) and (2) are severed for the whole embedding contract in one edit, once the panels it names are migrated. Whoever picks up .6 and .7 should have this in hand.

## Two measured facts about instrumenting a boundary

Recorded because both made a live panel read as a dead one, and both will meet the next migrator.

**A Fresco boundary is not in Reagent's render queue.** The adapter's `:flush-render!` slot is exactly right for a `reg-view` panel and commits nothing of a boundary's update, so a row written that way reads a DOM that has not moved. Mount goes through React's own `flushSync`; everything after it is a bounded poll of the committed DOM, with the control given a full settling window so its absence is a decision rather than a race.

**The collector releases a cell one macrotask after its last reader unmounts** — deliberately, so a keyed reorder within a single turn reuses the reaction. A synchronous read straight after `flushSync(root.unmount)` returns 1; the same read one macrotask later returns 0. Asserting synchronously reports a leak against a collector behaving exactly as documented.

## What the evidence file pins

Four rows, each with the control that makes its answer non-vacuous, all reaching `:panel` **through the L4 registry** rather than naming the var — so what is under test is the thing the shell actually mounts.

- **W1 — first display, and the read lands in the frame the tree named.** Read off the frame's own sub-cache rather than off the DOM, with a live entry in the *other* frame proving the reader is not simply blind.
- **W2 — it updates on a real dependency change**, with a deaf control: an image-loaded frame arriving moves what the read *would* compute while invalidating nothing it watches, so the panel must not move; the app-db dispatch that follows is what proves liveness. Node identity is asserted, so the row cannot have arrived by a remount.
- **W3 — the boundary's render puts nothing in the substrate's view-trace stream**, even when mounted *inside an application frame* — proven structurally rather than by the `:rf/xray` trace gate — against a `reg-view` control in the same root, same frame, same commit, which fires.
- **W4 — unmount releases the subscription reference completely, and reopening returns to the same count.** That is the number the spike caught the rejected design on: its ref-count climbed across renders and never fell on unmount.

The rf2-k97c.5 evidence pin still holds and is not made vacuous: it walks the tree `mount-shell-into!` hands the substrate, and neither `mount.cljs` nor `shell.cljs` is touched here, so its `shell-view` head and its positional wrap index are exactly where it left them.

## Scope

Left deliberately to the beads that own them: the element-shaped-adapter denylist stays (rf2-k97c.4), the pop-out stays on the adapter's render (rf2-k97c.6), and no minimum-host-contract documentation is written (rf2-k97c.7). Nothing under `implementation/` requires anything under `tools/`; the core is unchanged and unaware of Xray.

## Quality gates

Surfaces the classifier arms for this diff (`report-changed-surfaces.sh`): `cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance`, `story_xray_browser`.

| gate | exit | result |
|---|---|---|
| `npm run test:cljs` (node-test compile + run) | **0** | 11490 tests / 57807 assertions — **0 failures, 0 errors** |
| `npm run test:browser` (browser-test compile + run) | **0** | 847 tests / 4678 assertions — **0 failures, 0 errors** |
| `clojure -M:test` in `tools/xray` (`tools_jvm`) | **0** | 1276 tests / 6118 assertions — **0 failures, 0 errors** |
| `npm run test:xray-feature-gate:smoke` (`story_xray_browser` proxy) | **0** | 5 scenarios over 3 surfaces, **0 failures**, 10 matrix rows |

Each gate was run with its exit code captured to its own file and quoted from there, never from a pipeline. Each compile named this worktree's own `implementation/shadow-cljs.edn` on its first line, so no run read a sibling's tree.

**The new rows are not vacuous, and the record of that is this branch's own history.** W2 and W4 were RED on their first browser run and went green only after two real defects in the instruments were fixed (the two facts above); W1 and W3 each carry an in-row control that fires. The browser lane went 8 failures → 1 → 0 across three runs.

Not run locally, with reasons:

- **`examples_compile`** — the sweep reads its roster out of `implementation/shadow-cljs.edn`, which is untouched; this diff adds and changes no build id. CI runs it.
- **`mcp_conformance`** — the diff registers no new sub, event or fx and changes no MCP-visible surface; the panel's `:rf.xray/image-view` registration is unchanged. CI runs it.
- **`story_xray_browser`** — needs the Story browser lane; `test:xray-feature-gate:smoke` is the closest local proxy and is green above. CI runs it.

Local green is not CI. The band is 87 checks; the four gates above are a subset of them, and the three surfaces listed as not-run-locally are the omissions this PR is asking CI to decide.

Two unrelated routing rows (`recipes.async-nav-guard`, `routing-conduct`) failed on the first browser run with `poll-until` timeouts on the real Back button and passed on both subsequent runs, on an unchanged tree — flaky in this environment, not caused by this diff, which touches no routing namespace.


### Follow-up: the require-alias dialect ratchet (second pass)

The first pass left `lint / Require-alias dialect ratchet` red — one violation against a floor of 0 — and `lint / Lint required` red downstream of it. `spec/Conventions.md` §Require-alias dialect reserves the bare leaf form for APPLICATION namespaces: `re-frame.core` takes the bare root `rf`, every other `re-frame.<tail>` takes the full dotted `rf.<tail>`. The panel had `[re-frame.fresco :as h]`; every other `re-frame.fresco` require in the tree already spells it `rf.fresco`, the four Fresco tests next door included.

Ten sites moved, all inside `panels/module_view.cljs`: the `:as` form, three call sites (`defview`, `sub`, `as-component`) and six docstring/comment references that name an alias-qualified var. The three `ih/` hits — `image-view-helpers` — are a different alias and are deliberately left standing, which is why this was not a blind substitution; there are no `::h/` auto-resolved keywords and no `:h/` literal keywords in the file, so no keyword moved. An alias is a compile-time name, so behaviour is unchanged.

| gate | exit | result |
|---|---|---|
| `python scripts/check_require_alias_dialect.py --verbose` (before) | **1** | `tools: 1 violation(s), floor 0` — `module_view.cljs:69` |
| `python scripts/check_require_alias_dialect.py --verbose` (after) | **0** | 2826 files, 11096 re-frame require edges, **0 non-canonical**, every surface at or under its floor |
| `python scripts/check_require_alias_dialect.py --self-test` | **0** | 79 passed, 0 failed |
| `npm run test:cljs` (node-test compile + run) | **0** | 11490 tests / 57807 assertions — **0 failures, 0 errors** |
| `npm run test:browser` (browser-test compile + run) | **0** | 847 tests / 4678 assertions — **0 failures, 0 errors** |

The floor in `scripts/require-alias-baseline.edn` was **not** touched: a ratchet is repaired by changing your own lines, never by raising its recorded count. Both re-run lanes reproduce the first pass's counts exactly, so the rename is inert to behaviour as claimed. Exit codes are read from each run's own `.exit` file, never from a pipeline; each compile named this worktree's own `implementation/shadow-cljs.edn` on its first line, and the gate's own first run went RED naming a line that exists only on this branch, which is the evidence it read this tree.
