### PR TITLE
docs(method): the branch sweep's ownership zero cannot see a live worker (rf2-2yp5)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1535,6 +1535,19 @@ export, which carries descriptions, notes and close reasons, rather than its tit
 asymmetry from the `-`/`+` rule above governs here too: mistaking a record for residue destroys it,
 while mistaking residue for a record costs a branch nobody was using.
 
+**Every defence above finds a record that EXISTS; the case with no record yet is a LIVE worker's
+branch.** A dispatch in flight has not written its branch name into any item, so it returns zero from
+the full export at all statuses — the strongest form prescribed here — and zero is precisely the
+answer that authorises deleting it. Measured here across five pushed worker branches: two were named
+by owner records, one of them by a spike whose own text says *do not delete*, while the other three
+read zero and every one was a live dispatch — including the branch this paragraph was written on. The
+two non-zero answers are the positive control, so the instrument is working correctly and still
+answering a different question than the sweep is asking. **So subtract the live set before reading any
+zero as an orphan**: the branches `git worktree list` reports, and the dispatch ledger rows whose
+worker has not reported. Both are in hand at that moment, and this is *The stranded sweep*'s rule
+asked on branches rather than on items. The criterion does not move — only the reading — but here the
+wrong reading acts against live work rather than costing a search.
+
 **Key destructive operations on identity, never on a name.** Branch names repeat across sessions and
 prefix-match each other. A search for `head:feature-x` also returns the change for `feature-x2`, and
 may rank the sibling *first*, so a loop reading the top row reads one branch's state as another's.


### PR DESCRIPTION
One paragraph added to `docs/the-mayor-method/loops.md` section 5, beside the existing ownership
paragraphs. No code, no other edits.

## The gap

Section 5's ownership check already prescribes, correctly, that you ask the tracker who owns a branch;
that you ask with **closed items included**; that you widen to **all statuses** rather than to closed
alone; that you search the **full export** because a retention lives in a close reason; and that you key
destructive operations on **identity, never a name**.

Every one of those defences is about finding a record that EXISTS. The missing case is the one with no
record yet: a **live worker's branch**. A dispatch in flight has not written its branch name into any
item, so it returns zero from the full export at all statuses — the strongest form the section
prescribes — and zero is precisely the answer that authorises deleting it.

The paragraph names that third case and the subtraction that resolves it: the worktrees `git worktree
list` reports, and the dispatch ledger rows whose worker has not reported. Both are enumerations the
hygiene loop already has in hand at that moment, so this is new *reading*, not new machinery.

**The deletion criterion is unchanged.** Deleting only on `git cherry` `-` already prevents the
destructive outcome; this is about the mayor's reading, the same distinction the section already draws
for `+`.

## Measurement, re-derived

Re-derived from `git branch -r`, `git worktree list`, the dispatch ledger, and the beads export —
selecting on each record's own `title`/`description`/`notes`/`close_reason` rather than a bare id grep.

Five pushed worker branches. Owner records naming each:

| branch | records | live? | reading |
| --- | --- | --- | --- |
| `worker/receipts-hic081` | 11 | no | retained, ruled (`rf2-xcqk` carries the standing KEEP) |
| `worker/ratchet-a` | 3 | **yes** | all 3 closed 2026-09-03/04 — a *prior* occupant of a reused name |
| `worker/xspike-a` | 1 | no | `rf2-k97c.1`, a spike whose own text says *do not delete* |
| `worker/xrayimpl-a` | **0** | **yes** | live on `rf2-k97c.3` (`in_progress`) |
| `worker/frescoarch-a` | **0** | **yes** | live on `rf2-d1nr.2` |
| `worker/branchsweep-a` | **0** | **yes** | this PR's own branch |

Three branches read zero and every one was a live dispatch. The two genuine non-zero answers are the
positive control, so the zero is a real absence rather than a broken instrument — which is what makes it
dangerous: the instrument works correctly and still answers a different question than the sweep asks.

Two notes where my measurement differs from the filing:

* The bead recorded three surviving remote branches; there are now **five**, and the two that appeared
  since (`frescoarch-a`, `branchsweep-a`) both read zero while live — strengthening the finding rather
  than weakening it.
* The bead says `rf2-xcqk` names `receipts-hic081` 7 times; I measure **10**. Immaterial to the claim,
  and the count is not carried into the prose.
* `ratchet-a` is the one live branch reading non-zero, and it does so for the *wrong* reason — its three
  records belong to a dispatch that closed on 2026-09-03. Its live occupant has written nothing either.
  That corroborates the existing name-reuse paragraph and is left to it.

Against the live export all three counts rise by exactly one, because `rf2-2yp5` — the bead being
implemented — names all three branches in its own description. That is the sweep's own filing, which the
section already warns about; subtracting it reproduces the numbers above exactly.

## The overshoot test

Section 6 warns that a correction tends to overshoot into the inverse of the claim it replaces. Ran it.

**What would I expect to see that is different if the new claim were false?** A live worker's branch
would return a NON-zero owner record. Three did not, across three independent live dispatches, against
two non-zero controls in the same sweep. So the observation supports the claim positively rather than
merely refuting its opposite. The answer came out **stronger** than the filing, not weaker, so the
paragraph was not weakened.

The paragraph also deliberately does *not* invert into "a tracker zero means nothing" — the two non-zero
readings are stated as the working control, and the criterion is left untouched.

## Sibling search

Checked whether any other passage in `docs/the-mayor-method/` reads a tracker zero as evidence of
absence without naming the live case. **Clean — no sibling found.** The live case is already named
everywhere else it arises:

* §2 *Routing a finding onto a live worker's file*
* §3 — the ready list "omits held items, blocked items and items a live worker already holds"
* §4 *The stranded sweep* — "a worker holds items that still read *open*", so it starts from the
  worktrees rather than the tracker
* §5's own name-reuse paragraph — "deletes a live worker's branch on its sibling's verdict"

Two near-misses inspected and rejected as siblings: §3's commit-message sweep (a zero there is a
too-narrow search *field*, and a mid-flight worker has correctly merged nothing), and §3's fence-marker
scan (a zero from a short phrase roster). Neither has a liveness gap.

*The stranded sweep* is the structural precedent — the same lesson asked on branches rather than on
items — so the new paragraph cross-references it in the section's existing style (italics, matching the
cross-reference already at the top of *Branches*) instead of restating it.

## Quality gates

`docs/the-mayor-method/` sits under `docs/`, so `scripts/check_doc_slugs.py` is the gate for link targets
and heading anchors. Exit codes captured to files on the same command line as the run, never through a
pipe, and quoted from those files.

| run | exit |
| --- | --- |
| `python scripts/check_doc_slugs.py --self-test` | **0** |
| `python scripts/check_doc_slugs.py` (working form, post-edit) | **0** |
| `python scripts/check_doc_slugs.py` (sabotaged) | **1** |
| `python scripts/check_doc_slugs.py` (after restore) | **0** |

**Sabotage evidence.** The gate prints nothing on success, so it was proved to have teeth. A broken
anchor was planted at a line in the new paragraph. The plant genuinely changed the file — blob
`2313182e…` → `f89bdca1…` — so it was not a silent no-op. The gate then failed correctly:

```
1 broken anchor link(s) found:

  BROKEN ANCHOR: docs\the-mayor-method\loops.md:1547 -> #the-stranded-sweep-SABOTAGE
      (target: docs\the-mayor-method\loops.md)
```

**Restore verified by blob hash, not by reading a diff**: after restoring, `git hash-object` returns
`2313182ea0314d6971b8b14e0c4631d8484f784a`, byte-identical to the pre-sabotage state, and the gate
returns to exit 0.

**Fences in this tree.** Checked what the gate actually does rather than trusting either half of the
general rule: `docs/the-mayor-method` is in `FENCED_DOC_LINK_TREES` (with `docs/design/fresco`), so in
this tree a markdown doc link inside a fence **is** reported. The stricter rule applies here.

**`mkdocs build --strict` deliberately not nominated.** It does not validate heading anchors at all
(MkDocs grades them INFO; `--strict` promotes WARNING but not INFO — `mkdocs.yml` documents this at the
`validation:` block), so `check_doc_slugs.py` is the only anchor gate. This tree is *not* in
`exclude_docs`, so the strict build does cover it for link resolution — but the change adds no link and
no heading, so it would have validated nothing new here.

**Verified by hand**, since nothing gates prose or rendering: the change adds **no** heading (so no
anchor is created, renamed or invalidated), **no** table, and **no** markdown link. The one emphasis
construct, `*The stranded sweep*'s`, closes emphasis before the possessive. The diff is a pure insertion
— 13 added, 0 removed — and line endings stayed consistent CRLF (1818 CRs across 1818 lines), so nothing
was reclassified.

Bead `rf2-2yp5` left **open** for close after merge.
