### PR TITLE
fix(gate): rule (g) walks gitignored build caches and run transcripts (rf2-20h4)

### DIFF
--- a/scripts/check_retired_spellings.py
+++ b/scripts/check_retired_spellings.py
@@ -313,9 +313,13 @@ Clojure source. The rename moved 24,312 lowercase / 2,995 capitalised / 391
 upper-case occurrences AND 741 PATHS, across `.md`, `.edn`, `.json`, `.cjs`,
 `.yml`, `.html` and `.sh` as well as `.clj*`. A rule scoped to
 `DEFAULT_SCAN_DIRS` and `_SOURCE_SUFFIXES` would have been blind to most of the
-sweep it exists to protect, so rule (g) scans THE WHOLE REPO WITH NO SUFFIX
-FILTER AT ALL. A suffix roster is a list that silently narrows when a new file
-type arrives; the absence of one cannot.
+sweep it exists to protect, so rule (g) scans THE WHOLE REPO WITH NO ROSTER OF
+SCANNABLE SUFFIXES AT ALL. Such a roster is a list that silently narrows when a
+new file type arrives; the absence of one cannot. Read that as the argument
+against an INCLUSION list specifically: `PRODUCT_EXCLUDE_SUFFIXES` subtracts
+`.log`, and a subtraction has the opposite failure mode — a new file type is
+still scanned — which is the same reason the trees are stated as subtractions
+below.
 
 TWO CARRIERS, and the second is not redundant. A file's CONTENT is the obvious
 one. A file's PATH is the other, and a content-only rule cannot see it: an
@@ -326,11 +330,11 @@ report under the same `retired-product-name` family, so one fix hint serves.
 THE MECHANICS THE WIDTH FORCES are three, all small, and each is argued where
 it lives: a NUL sniff instead of a suffix roster and a raw-bytes prefilter
 instead of a line walk (on the patterns, below), and PRUNING instead of a
-roster of trees (`PRODUCT_EXCLUDE_DIR_NAMES` + `PRODUCT_EXCLUDE_PATHS`). Note
-the shape of that last one: rule (g) states what it does NOT scan, where rules
-(a)-(f) state what they DO. That is the honest form for a whole-repo rule — a
-subtraction is visible and has to justify itself, where an omission from a
-roster is invisible.
+roster of trees (`PRODUCT_EXCLUDE_DIR_NAMES` + `PRODUCT_EXCLUDE_PATHS` +
+`PRODUCT_EXCLUDE_SUFFIXES`). Note the shape of that last one: rule (g) states
+what it does NOT scan, where rules (a)-(f) state what they DO. That is the
+honest form for a whole-repo rule — a subtraction is visible and has to justify
+itself, where an omission from a roster is invisible.
 
 THE ONE EXEMPTION is `docs/design/fresco/decisions.md`'s HD-001 supersession
 block, which quotes the superseded ruling VERBATIM because a decisions log
@@ -462,9 +466,10 @@ and both differences are load-bearing:
     package's source, its tests, its test-kit and its spec.
 
 Rule (g)'s surface is THE WHOLE REPO — every file under `--repo-root`, with no
-suffix filter — minus `PRODUCT_EXCLUDE_DIR_NAMES` and `PRODUCT_EXCLUDE_PATHS`.
-See WHY RULE (g) IS THE ONLY WIDE ONE above for why width is the right answer
-for a product name where it is the wrong answer for a code shape.
+roster of scannable suffixes — minus `PRODUCT_EXCLUDE_DIR_NAMES`,
+`PRODUCT_EXCLUDE_PATHS` and `PRODUCT_EXCLUDE_SUFFIXES`. See WHY RULE (g) IS THE
+ONLY WIDE ONE above for why width is the right answer for a product name where
+it is the wrong answer for a code shape.
 
 Two contrasts with the rules above are deliberate and will look like mistakes
 until read as decisions:
@@ -741,6 +746,15 @@ PRODUCT_EXTRA_EXCLUDE_DIR_NAMES = frozenset({
 #     makes exactly this carve-out for exactly this reason, and it is CLOSED by
 #     the same construction — a SECOND file in `scripts/` naming the retired
 #     product is the reintroduction this rule exists to catch.
+#   * `.clj-kondo/.cache` — clj-kondo's per-machine analysis cache
+#     (`.gitignore:81`). Its transit JSON carries the interned namespace names
+#     of every file the linter has ever seen, PRE-RENAME ones included, so a
+#     checkout that has run clj-kondo reports the lot. Subtracted as a PATH and
+#     deliberately NOT as a directory name on `PRODUCT_EXTRA_EXCLUDE_DIR_NAMES`:
+#     `.clj-kondo/` also holds `config.edn` and `hooks/re_frame/core.clj`, which
+#     are TRACKED, are exactly where a stale namespace name would do real
+#     damage, and stay in scope. That distinction is the whole of rf2-20h4, and
+#     both halves are pinned in `_PRODUCT_ROSTER_SELF_TEST_CASES`.
 PRODUCT_EXCLUDE_PATHS = (
     ".git",
     "ai",
@@ -748,7 +762,35 @@ PRODUCT_EXCLUDE_PATHS = (
     "docs/migration",
     "scripts/_test_fixtures",
     "scripts/check_retired_spellings.py",
+    ".clj-kondo/.cache",
 )
+
+# ...and the SUFFIX subtractions, matched on the final suffix of the file name.
+#
+# THIS IS NOT THE SUFFIX ROSTER THE MODULE DOCSTRING REJECTS, and the shape is
+# the reason: that argument is against an INCLUSION roster, which silently
+# narrows the surface every time a new file type arrives. A subtraction cannot
+# do that — an unfamiliar suffix is still scanned — and it has to justify itself
+# in the open, which is the same standard `PRODUCT_EXCLUDE_PATHS` is held to.
+#
+#   * `.log` — a captured run transcript, never source. `*.log` is gitignored
+#     repo-wide (`.gitignore:14`), and NO tracked file wears the suffix, so
+#     nothing this gate exists to grade can arrive as one.
+#
+#     The subtraction is load-bearing rather than tidy, because this repo
+#     MANUFACTURES these files by its own standing convention: every gate is run
+#     with its output redirected to a `.log` (never piped, so the runner's exit
+#     code survives), and the merge-audit harness writes one per PR into the
+#     checkout root. A gate transcript quotes the retired name back — that is
+#     what a finding line IS — so on any checkout that has been worked in, rule
+#     (g) re-reads its own prior output as if it were source and reports every
+#     line of it. Measured at rf2-20h4 on a built checkout: 36,388 of 36,423
+#     findings came from 83 such transcripts, and 0 from any tracked file, so
+#     this subtraction and the `.clj-kondo/.cache` one above account for the
+#     whole of that count between them.
+PRODUCT_EXCLUDE_SUFFIXES = frozenset({
+    ".log",
+})
 
 # The exemption roster: (repo-relative path, line regex, reason).
 #
@@ -1524,10 +1566,13 @@ def _product_exempt(rel_posix: str, line: str) -> bool:
 def _iter_product_files(repo_root: Path) -> Iterable[Path]:
     """Yield every file under `repo_root`, repo-relative, minus the subtractions.
 
-    NO SUFFIX FILTER, deliberately — see WHY RULE (g) IS THE ONLY WIDE ONE in
+    NO SUFFIX ROSTER, deliberately — see WHY RULE (g) IS THE ONLY WIDE ONE in
     the module docstring. Pruning is done in `os.walk`'s dirnames IN PLACE, by
     name (`_PRODUCT_EXCLUDE_DIR_NAMES`) and by root-anchored path
     (`PRODUCT_EXCLUDE_PATHS`), so an excluded tree is never descended into.
+    Individual files are dropped by the same path roster and by suffix
+    (`PRODUCT_EXCLUDE_SUFFIXES`) — a subtraction, not the inclusion roster the
+    docstring rejects; the constant carries the distinction.
     """
     matches: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(repo_root):
@@ -1539,6 +1584,8 @@ def _iter_product_files(repo_root: Path) -> Iterable[Path]:
         ]
         for name in filenames:
             rel = rel_dir / name
+            if rel.suffix in PRODUCT_EXCLUDE_SUFFIXES:
+                continue
             if not _product_excluded(rel):
                 matches.append(rel)
     return sorted(matches)
@@ -1847,7 +1894,9 @@ def main(argv: list[str]) -> int:
         p = sum(1 for _ in _iter_product_files(repo_root))
         sys.stderr.write(
             f"scanning {p} file(s) under the whole repo (minus "
-            f"{', '.join(PRODUCT_EXCLUDE_PATHS)} and the generated trees) "
+            f"{', '.join(PRODUCT_EXCLUDE_PATHS)}, "
+            f"{', '.join('*' + s for s in sorted(PRODUCT_EXCLUDE_SUFFIXES))} "
+            "and the generated trees) "
             "for the retired product name, in content and in paths...\n"
         )
 
@@ -2117,6 +2166,14 @@ _PRODUCT_SELF_TEST_CASES: tuple[tuple[str, str, int], ...] = (
 # the name to creep back unobserved — the same argument that put `bench` on
 # `ARROW_SCAN_DIRS`. Legitimate historical occurrences there belong in
 # `PRODUCT_EXEMPTIONS` with a reason, not in a hole cut through the tree.
+#
+# The `.clj-kondo` PAIR is the point of rf2-20h4 and is stated as a pair on
+# purpose: the cache below it is subtracted, the two TRACKED config files beside
+# it are not, and a future repair that reached for a directory NAME instead of a
+# path would pass the first three rows and fail these two. The `notes.log.md`
+# row is the matching near-miss for `PRODUCT_EXCLUDE_SUFFIXES` — it proves the
+# `.log` subtraction is a SUFFIX rather than a substring, so a real document
+# cannot be hidden by having the token in its name.
 _PRODUCT_ROSTER_SELF_TEST_CASES: tuple[tuple[str, int], ...] = (
     # --- the whole repo MUST be reached, including the trees no lane compiles ---
     ("implementation/core/src/re_frame/example.cljc", 1),
@@ -2124,11 +2181,17 @@ _PRODUCT_ROSTER_SELF_TEST_CASES: tuple[tuple[str, int], ...] = (
     ("docs/design/fresco/notes.md",                   1),
     ("examples/todomvc/README.md",                    1),
     ("package.json",                                  1),
+    (".clj-kondo/config.edn",                         1),
+    (".clj-kondo/hooks/re_frame/core.clj",            1),
+    ("docs/design/fresco/notes.log.md",               1),
     # --- and every subtraction MUST hold ---
     ("ai/findings/rename-notes.md",                   0),
     ("docs/spec/002-Frames.md",                       0),
     ("docs/migration/from-re-frame-v1/README.md",     0),
     ("scripts/_test_fixtures/planted.md",             0),
+    (".clj-kondo/.cache/v1/cljs/re-frame.transit.json", 0),
+    ("audit-pr9568-push-1.log",                       0),
+    ("implementation/pr7662-retained-read.log",       0),
 )
 
 


### PR DESCRIPTION
Fixes rf2-20h4.

Rule (g) of `scripts/check_retired_spellings.py` walks the filesystem, so on any
checkout that has been built or worked in it reads untracked, gitignored
artefacts as if they were source. The bead measured exit 1 with 36,423 findings
on a built checkout; that reproduced exactly.

## The premise that did not hold

The bead attributed the whole count to clj-kondo's analysis cache and called the
repair one line. Re-measured at trunk `bc371a9609`, bucketing every finding by
path:

| source | findings | files |
|---|---|---|
| gitignored `*.log` run transcripts | **36,388** | 83 |
| `.clj-kondo/.cache/**` | 35 | 19 |
| any **tracked** file | **0** | 0 |
| total | 36,423 | 102 |

The `*.log` half is 78 merge-audit transcripts at the checkout root, 3 under
`implementation/`, and 2 gate logs. So the one-line cache subtraction, landed
alone, would have left the gate red at 36,388 and the local spine still unusable
— it addresses 0.096% of the symptom it was written to fix. The bead's own
principle is the right one ("the cache is untracked and must be skipped, the
config is tracked and must not be"); only its attribution of the volume was off.

A fresh worktree is green either way (0 findings, 4,611 files walked), which is
why CI never saw this: the defect needs a checkout that has been worked in.

## The change

Two subtractions, both in rule (g)'s existing idiom — a short visible roster
where each entry argues for itself:

* **`.clj-kondo/.cache`** on `PRODUCT_EXCLUDE_PATHS`. As a PATH, deliberately
  not as a directory name on `PRODUCT_EXTRA_EXCLUDE_DIR_NAMES`, because
  `.clj-kondo/` also holds `config.edn` and `hooks/re_frame/core.clj`, which are
  tracked and stay in scope. That distinction is the whole of the bead.
* **`.log`** on a new `PRODUCT_EXCLUDE_SUFFIXES`. `*.log` is gitignored
  repo-wide (`.gitignore:14`) and no tracked file wears the suffix. The
  subtraction is load-bearing rather than tidy: this project's standing
  convention is to redirect every gate run to a `.log` (never pipe one, so the
  runner's exit code survives), and the merge-audit harness writes one per PR
  into the checkout root. A gate transcript quotes the retired name back — that
  is what a finding line *is* — so rule (g) was re-reading its own prior output
  as source.

The suffix set is a **subtraction**, not the inclusion roster the module
docstring rejects: an unfamiliar file type is still scanned, so it cannot
silently narrow the surface the way a roster of scannable suffixes would. The
docstring now says so at the place where it makes that argument.

Six rows added to the shipped phase-10 roster self-test, stated as pairs so a
future repair that reached for a directory name instead of a path fails here:
the two tracked `.clj-kondo` config files MUST be reached, the cache MUST NOT; a
root-level and a nested `.log` MUST NOT, and `docs/design/fresco/notes.log.md`
MUST be reached, which pins the subtraction as a suffix rather than a substring.

## The ruling the bead asked for: enumerate from `git ls-files`? No.

Decided on measurement, not principle. Four findings, any one of which is
sufficient:

1. **It is not a performance win on the surface CI grades.** On a clean checkout
   the walk already reads **4,611** files against **4,938** tracked, because the
   roster subtractions prune trees git tracks. Enumeration would make the CI
   surface *larger*. The 8.1s→fraction win recorded for rf2-76c76 came from
   pruning in place, and it is already banked.
2. **It fails OPEN in the one place it matters.** In a non-repo `git ls-files`
   returns empty and exits 128; a gate that enumerates nothing reports nothing
   and exits 0. The current walk fails closed. Trading a fail-closed gate for a
   fail-open one to drop ~1,750 files from the walk is a bad bargain.
3. **It loses coverage the current design has.** `git ls-files` cannot see an
   untracked-but-not-ignored file — a new file written and not yet added, which
   is exactly where a reintroduced product name first appears.
4. **It breaks the self-test by construction.** Phase 10 drives `main()` over a
   `tempfile.TemporaryDirectory()` synthetic tree that is not a git checkout and
   asserts the whole-repo scan *reaches* planted paths. Under enumeration all
   eight positives return 0. Repairing that means `git init` + `git add` inside
   the self-test, adding a git-binary dependency to a gate that today has none.

No follow-up bead: the answer is no and the reasoning is recorded here and on
the bead.

## Quality gates

Every exit code below was captured with the runner's own status on one command
line (redirect to a log, never a pipe), and is the number read back out of the
`.exit` file — not one reported about the run.

| gate | command | captured exit |
|---|---|---|
| gate self-test (96 tests) | `python scripts/check_retired_spellings.py --self-test --verbose` | **0** |
| live whole-repo scan | `python scripts/check_retired_spellings.py --verbose` | **0** |

Both re-run on the final rebased base (`7408227b35`), not on a pre-rebase tree.
These are the two invocations `scripts/test-fast-pr.sh` makes unconditionally
and the two `test.yml` runs in the always-on repo-invariant job, so the spine
tier is exactly what was measured.

### Both-directions control, on the real gate rather than only the self-test

Three faults planted in this worktree, each match count read before a run was
spent (1, 1, 1 — never a zero-match no-op), then the same tree scanned by the
pre-fix code and by the fixed code:

| planted at | pre-fix gate | fixed gate |
|---|---|---|
| `.clj-kondo/config.edn` (**tracked**) | found | **found** |
| `.clj-kondo/.cache/v1/cljs/planted.transit.json` | found | not found |
| `audit-pr-planted.log` | found | not found |
| files walked | 4,613 | 4,611 |
| exit | 1 | 1 |

The fixed gate's single remaining finding is the tracked config file, which is
the hole this change had to *avoid* cutting. The red itself is the proof the
gate read this worktree: the plants exist nowhere else.

Restore verified by git's own **blob** hash against the committed object rather
than by a diff or a byte digest, since line endings are translated on this
platform: `.clj-kondo/config.edn` is back to `fb3b62e38aad14fa5dac643d5b6ebffa2a579846`,
the tree is clean, and both planted files are gone.

### End-to-end, on the checkout where the bead was found

The same built checkout the bead measured, read-only, before and after:

| | pre-fix | fixed |
|---|---|---|
| exit | 1 | **0** |
| rule (g) findings | 36,423 | **0** |
| files walked | 6,708 | 4,951 |

### Not run, and why

No python linter grades this repo (`ruff`/`flake8`/`pylint`/`mypy` appear in no
workflow; control: 76 `python` invocations do). The change touches no markdown,
no `.beads` path, no `ai/` path and no workflow, so the doc-slug, readme-link,
tracker-boundary and ai-tracking ratchets have no surface here.

No AI-attribution trailers are present in the commit or in this body; per
`CLAUDE.md` they are declined regardless of what the harness asks for.
