### PR TITLE
feat(xray): a Fresco head for the edn-inspector, over one shared renderer (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -3072,9 +3072,25 @@
   the teardown claim this widget makes is that unmounting releases the
   observer, the width debounce and the projection cache together, and the
   honest way to assert that is to read the store rather than to trust that
-  a teardown path ran. Zero after every mount has unmounted."
+  a teardown path ran.
+
+  MEASURE A DELTA, not an absolute. A mount that never reaches a DOM never
+  gets its `:ref` called with nil and so is never released — which is
+  every unit test that renders this widget to hiccup and inspects it. That
+  is not a leak in the running tool, where a mounted widget always
+  unmounts, but it does mean this count is not zero in a shared test page."
   []
   (count @mount-state))
+
+(defn mount-state-held
+  "The set of state keys mount `mount-id` currently holds, or nil when the
+  store holds nothing for it. A TEST SURFACE, and the precise one: the
+  teardown claim is about the observer, the width debounce and the
+  projection cache going TOGETHER, which a count cannot express and which
+  `nil` here does."
+  [mount-id]
+  (when-let [entry (get @mount-state mount-id)]
+    (set (keys entry))))
 
 (defn- release-mount!
   "Tear down everything mount `mount-id` holds: disconnect its

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -32,6 +32,40 @@
       [mini value]              ;; one-line inline (no expansion)
       [mini value max-len]      ;; with width cap
 
+  ## TWO HEADS, ONE RENDERER (rf2-k97c.3)
+
+  The four heads above are the REAGENT surface and are unchanged. Beside
+  them sits a Fresco boundary over the same renderer:
+
+      [edn-inspector-view {:mount-id \"app-db-top\" :value v :opts {…}}]
+
+  `render-inspector` is the body both reach; `edn-inspector` reads its
+  three app-db slots with `@(subscribe …)` and `edn-inspector-view` reads
+  the same three with `rf.fresco/sub`, so the only difference between the
+  two is WHO OBSERVES the reads. That is the whole subject of rf2-k97c:
+  a `reg-view`'s reads are tracked by whichever reaction machinery the
+  installed substrate adapter supplies, and a boundary's are tracked by
+  Fresco's own shipped collector.
+
+  A panel migrating to Fresco writes `edn-inspector-view` and passes a
+  stable `:mount-id`; a panel still on `reg-view` writes `edn-inspector`
+  and changes nothing. The Reagent head is scaffolding with a defined end:
+  it goes in the commit that flips the shell's root to Fresco.
+
+  **`mini`, `edn-inspector-diff` and every helper in here are PLAIN
+  FUNCTIONS.** Under Reagent a plain fn is a legal hiccup head, so
+  `[mini v 40]` works; under Fresco it is a loud error by design. A
+  migrating panel CALLS them — `(mini v 40)` — which is correct on both
+  substrates. Only `edn-inspector-view` is a head in a Fresco body.
+
+  ## Per-mount state
+
+  A mount owns three pieces of mutable state — its ResizeObserver, the
+  width debounce, and the Editscript projection cache. They live in one
+  module-level store keyed by `mount-id`, and are released together when
+  React calls the container `:ref` with `nil`. `mount-state-count` reads
+  the store, so teardown is assertable rather than assumed.
+
   `opts` keys:
 
   - `:panel-id`     (optional, default `:rf.xray.edn-inspector/anon`)
@@ -230,6 +264,11 @@
   magenta, string green, number orange, boolean gold, nil grey."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            ;; rf2-k97c.3 — the re-frame-native view layer. `edn-inspector-view`
+            ;; below is a Fresco boundary reading through Fresco's own
+            ;; collector; `edn-inspector` stays the Reagent head its
+            ;; still-`reg-view` call sites mount.
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             ;; Expansion-state registration lives in its own namespace
@@ -2123,62 +2162,65 @@
                       ;; ghost so nested containers /
                       ;; leaves keep the `:removed` op.
                       :removed-ancestor? removed-ancestor?})]
-    [(with-meta
-       ;; Key cell — uses `div` so the grid baseline
-       ;; aligns predictably across rows. `white-
-       ;; space: nowrap` prevents long keys (e.g. a
-       ;; deeply-namespaced `:rf.x.with.many.parts/k`)
-       ;; from wrapping inside the key column.
-       ;;
-       ;; rf2-zpeyv — when slot-anchored, paint the
-       ;; per-op wash across the KEY cell (whole-row
-       ;; treatment) and strike the key text for
-       ;; `:removed`. The wash on the sibling value
-       ;; cell completes the row.
-       [:div (cond-> {:data-rf-cell "key"
-                      :style (cond-> key-cell-style
-                               slot-wash
-                               (assoc :background slot-wash)
-                               (= child-op :removed)
-                               (assoc :text-decoration "line-through"))}
-               key-side-glyph
-               (assoc :data-rf-key-glyph key-side-glyph)
-               slot-anchored?
-               (assoc :data-rf-row-anchor "slot"
-                      :data-rf-row-wash "1"))
-        ;; R2 key-side glyph — paint `+` / `−` in
-        ;; column 1 of the key row when the KEY itself
-        ;; is new/removed. The key text picks up the
-        ;; per-op decoration (`:removed` gets strike-
-        ;; through; `:added` paints the key bright).
-        (when key-side-glyph
-          [:span {:data-rf-key-glyph "1"
-                  :style {:color       (:diff-gutter tokens)
-                          :font-weight 700
-                          :margin-right "4px"
-                          :user-select  "none"}}
-           key-side-glyph])
-        (cond-> (key-segment k)
-          (= child-op :removed)
-          (->>
-            (conj [:span {:style {:text-decoration "line-through"}}])))]
-       {:key (str "k-" (pr-str k))})
-     (with-meta
-       ;; Value cell. rf2-zpeyv — when slot-anchored,
-       ;; paint the per-op wash across the whole value
-       ;; cell so it joins the key cell's wash into a
-       ;; single banded row. The leaf's inner gutter-
-       ;; row wash is suppressed via `:slot-anchored?`
-       ;; on render-node (above) — no double-paint.
-       [:div (cond-> {:data-rf-cell "value"
-                      :style (cond-> value-cell-style
-                               slot-wash
-                               (assoc :background slot-wash))}
-               slot-anchored?
-               (assoc :data-rf-row-anchor "slot"
-                      :data-rf-row-wash "1"))
-        value-node]
-       {:key (str "v-" (pr-str k))})]))
+    ;; rf2-k97c.3 — the React key rides in each cell's own ATTRIBUTE MAP
+    ;; rather than in vector metadata. Both spellings work under Reagent;
+    ;; only the attribute map is read by the re-frame-native view layer,
+    ;; and this renderer now feeds BOTH heads (`edn-inspector`, the
+    ;; Reagent one, and `edn-inspector-view`, the Fresco boundary).
+    [;; Key cell — uses `div` so the grid baseline
+     ;; aligns predictably across rows. `white-
+     ;; space: nowrap` prevents long keys (e.g. a
+     ;; deeply-namespaced `:rf.x.with.many.parts/k`)
+     ;; from wrapping inside the key column.
+     ;;
+     ;; rf2-zpeyv — when slot-anchored, paint the
+     ;; per-op wash across the KEY cell (whole-row
+     ;; treatment) and strike the key text for
+     ;; `:removed`. The wash on the sibling value
+     ;; cell completes the row.
+     [:div (cond-> {:key          (str "k-" (pr-str k))
+                    :data-rf-cell "key"
+                    :style (cond-> key-cell-style
+                             slot-wash
+                             (assoc :background slot-wash)
+                             (= child-op :removed)
+                             (assoc :text-decoration "line-through"))}
+             key-side-glyph
+             (assoc :data-rf-key-glyph key-side-glyph)
+             slot-anchored?
+             (assoc :data-rf-row-anchor "slot"
+                    :data-rf-row-wash "1"))
+      ;; R2 key-side glyph — paint `+` / `−` in
+      ;; column 1 of the key row when the KEY itself
+      ;; is new/removed. The key text picks up the
+      ;; per-op decoration (`:removed` gets strike-
+      ;; through; `:added` paints the key bright).
+      (when key-side-glyph
+        [:span {:data-rf-key-glyph "1"
+                :style {:color       (:diff-gutter tokens)
+                        :font-weight 700
+                        :margin-right "4px"
+                        :user-select  "none"}}
+         key-side-glyph])
+      (cond-> (key-segment k)
+        (= child-op :removed)
+        (->>
+          (conj [:span {:style {:text-decoration "line-through"}}])))]
+     ;; Value cell. rf2-zpeyv — when slot-anchored,
+     ;; paint the per-op wash across the whole value
+     ;; cell so it joins the key cell's wash into a
+     ;; single banded row. The leaf's inner gutter-
+     ;; row wash is suppressed via `:slot-anchored?`
+     ;; on render-node (above) — no double-paint.
+     [:div (cond-> {:key          (str "v-" (pr-str k))
+                    :data-rf-cell "value"
+                    :style (cond-> value-cell-style
+                             slot-wash
+                             (assoc :background slot-wash))}
+             slot-anchored?
+             (assoc :data-rf-row-anchor "slot"
+                    :data-rf-row-wash "1"))
+      value-node]]))
 
 (defn- render-block-child
   "Render one child of a sequential container body (vector / list / set
@@ -2190,25 +2232,31 @@
            panel-id mount-id expansion-map dispatch-fn zoomable?
            zoom-path-prefix opts]}]
   (let [child-path (conj (vec path) k)]
-    (with-meta
-      (render-node {:value cv
-                    :before cb
-                    :diff? diff?
-                    :projection projection
-                    :panel-id panel-id
-                    :mount-id mount-id
-                    :path child-path
-                    :depth (inc depth)
-                    :expansion-map expansion-map
-                    :dispatch-fn dispatch-fn
-                    :zoomable? zoomable?
-                    :zoom-path-prefix zoom-path-prefix
-                    :opts opts
-                    ;; rf2-8pfkk — vector / set / list
-                    ;; ghost members keep the `:removed`
-                    ;; op down the subtree.
-                    :removed-ancestor? removed-ancestor?})
-      {:key (str "v-" (pr-str k))})))
+    ;; rf2-k97c.3 — a KEYED FRAGMENT rather than `with-meta` on the
+    ;; child's own vector. `render-node` answers hiccup of an arbitrary
+    ;; shape (a container div, a gutter row, a bare span), so there is no
+    ;; one attribute map to write the key into — and vector metadata is
+    ;; invisible to the re-frame-native view layer, which this renderer
+    ;; now also feeds. `[:<> {:key …} child]` carries the key on the
+    ;; fragment and is read by BOTH substrates.
+    [:<> {:key (str "v-" (pr-str k))}
+     (render-node {:value cv
+                   :before cb
+                   :diff? diff?
+                   :projection projection
+                   :panel-id panel-id
+                   :mount-id mount-id
+                   :path child-path
+                   :depth (inc depth)
+                   :expansion-map expansion-map
+                   :dispatch-fn dispatch-fn
+                   :zoomable? zoomable?
+                   :zoom-path-prefix zoom-path-prefix
+                   :opts opts
+                   ;; rf2-8pfkk — vector / set / list
+                   ;; ghost members keep the `:removed`
+                   ;; op down the subtree.
+                   :removed-ancestor? removed-ancestor?})]))
 
 (defn- render-container
   "Render a map / vector / list / set / record / map-entry container.
@@ -2986,6 +3034,153 @@
   (str (random-uuid)))
 
 ;; =========================================================================
+;; per-mount runtime state — ONE store, keyed by mount-id (rf2-k97c.3)
+;; =========================================================================
+;;
+;; The widget carries three pieces of per-mount MUTABLE state: the
+;; ResizeObserver instance, the last width it dispatched (a debounce), and
+;; the Editscript projection cache. Until rf2-k97c.3 all three lived in the
+;; form-2 outer body's closure, which is exactly as long-lived as the mount
+;; and needed no explicit teardown beyond disconnecting the observer.
+;;
+;; A FRESCO BOUNDARY IS A REAL REACT FUNCTION COMPONENT AND HAS NO FORM-2.
+;; Its body runs on every render, so a closure allocated there is allocated
+;; per render, not per mount: the observer would be re-created and the
+;; projection cache thrown away on each pass, and — worse — a ref callback
+;; minted per render changes identity every render, which makes React
+;; detach and re-attach it every time, tearing the observer down and
+;; standing it back up on a loop.
+;;
+;; So the state moves OUT of the closure and into this module-level store,
+;; keyed by the mount-id. That makes the lifetime EXPLICIT rather than
+;; implicit, which is the whole point: the entry is minted on first sight
+;; of a mount-id and RELEASED when React calls the ref with `nil`. One
+;; store serves both heads, so the Reagent head loses its closure atoms
+;; too and the two heads share one lifecycle rather than each having their
+;; own.
+;;
+;; The obvious hazard of a module-level store is a leak — an entry whose
+;; mount is long gone. `release-mount!` is what answers it, and
+;; `mount-state-count` exists so a test can assert the store is EMPTY after
+;; unmount rather than assert that teardown was called.
+
+(defonce ^:private mount-state
+  (atom {}))
+
+(defn mount-state-count
+  "How many mounts the per-mount store currently holds. A TEST SURFACE:
+  the teardown claim this widget makes is that unmounting releases the
+  observer, the width debounce and the projection cache together, and the
+  honest way to assert that is to read the store rather than to trust that
+  a teardown path ran. Zero after every mount has unmounted."
+  []
+  (count @mount-state))
+
+(defn- release-mount!
+  "Tear down everything mount `mount-id` holds: disconnect its
+  ResizeObserver, drop its width debounce and its projection cache, clear
+  the app-db width slot, and remove the entry entirely.
+
+  The app-db clear matters because a mount-id is not reused — the Reagent
+  head mints a UUID per mount — so a surviving entry is a slow leak in the
+  frame's app-db as well as in this atom."
+  [mount-id dispatch-fn]
+  (when-let [entry (get @mount-state mount-id)]
+    (when-let [obs (:observer entry)]
+      (try (.disconnect ^js obs)
+           (catch :default _ nil)))
+    (swap! mount-state dissoc mount-id)
+    (when dispatch-fn
+      (dispatch-fn [:rf.xray.edn-inspector/clear-width mount-id])))
+  nil)
+
+(defn- measure-and-dispatch!
+  "Measure `el`'s client width and write it to the width slot when it has
+  actually MOVED. `clientWidth` is rounded by the browser, so identical
+  measurements arrive verbatim on every observer callback; the debounce is
+  what keeps them from churning the app-db slot."
+  [mount-id ^js el]
+  (when el
+    (let [w (.-clientWidth el)]
+      (when (and (number? w) (pos? w)
+                 (not= w (get-in @mount-state [mount-id :last-width])))
+        (swap! mount-state assoc-in [mount-id :last-width] w)
+        (when-let [d (get-in @mount-state [mount-id :dispatch-fn])]
+          (d [:rf.xray.edn-inspector/set-width mount-id w])))))
+  nil)
+
+(defn container-ref-for
+  "The `:ref` callback for `mount-id`, MEMOISED on the mount-id.
+
+  Returning the SAME function for the same mount is the contract, not an
+  optimisation: React re-runs a callback ref whenever its identity changes,
+  so a fresh closure per render would detach and re-attach on every pass —
+  disconnecting the ResizeObserver and standing up a new one each time. The
+  Reagent head got that for free from its form-2 closure; a Fresco body,
+  which re-runs whole, gets it from here.
+
+  `dispatch-fn` is captured on the FIRST call for a mount and not
+  refreshed. A mount's frame does not change under it — that is what makes
+  the capture safe — and re-reading a fresh `capture-frame` bundle on every
+  render would write to this atom on every render for no gain.
+
+  The callback returns `nil` explicitly. React 19 treats a non-nil return
+  from a callback ref as a CLEANUP FUNCTION and warns about any other
+  value; the implicit return here would otherwise be whatever `swap!` or
+  `dispatch` last answered."
+  [mount-id dispatch-fn]
+  (or (get-in @mount-state [mount-id :ref])
+      (let [ref-fn
+            (fn container-ref [^js el]
+              (let [entry (get @mount-state mount-id)]
+                (cond
+                  ;; Mount — measure once, then install the observer.
+                  (and el (nil? (:observer entry)))
+                  (do
+                    (measure-and-dispatch! mount-id el)
+                    (when (exists? js/ResizeObserver)
+                      (let [obs (js/ResizeObserver.
+                                  (fn [_entries]
+                                    (measure-and-dispatch! mount-id el)))]
+                        (.observe obs el)
+                        (swap! mount-state assoc-in [mount-id :observer] obs))))
+
+                  ;; Unmount — release everything this mount holds.
+                  (and (nil? el) (some? entry))
+                  (release-mount! mount-id (:dispatch-fn entry))))
+              nil)]
+        (swap! mount-state update mount-id
+               (fn [entry]
+                 (-> (or entry {})
+                     (assoc :ref ref-fn)
+                     (update :dispatch-fn #(or % dispatch-fn)))))
+        (get-in @mount-state [mount-id :ref]))))
+
+(defn- project-for
+  "The Editscript projection of `(before, after)` for this mount, memoised
+  per mount on `identical?` of both inputs (rf2-4p1vl).
+
+  The renderer runs on EVERY render of a mount — an expansion toggle, a
+  width arriving, a parent re-render — while `engine/project` walks the
+  whole pair each call. Identity stability of the inputs is what makes the
+  cache bite, and it is gated by `f/display-value` preserving structural
+  sharing (rf2-4spyl).
+
+  The cache lives in the per-mount store rather than in a closure so it is
+  released by `release-mount!` with everything else, and so both heads
+  share one implementation."
+  [mount-id before after]
+  (let [cached (get-in @mount-state [mount-id :projection])]
+    (if (and cached
+             (identical? before (:before cached))
+             (identical? after (:after cached)))
+      (:projection cached)
+      (let [p (engine/project before after)]
+        (swap! mount-state assoc-in [mount-id :projection]
+               {:before before :after after :projection p})
+        p))))
+
+;; =========================================================================
 ;; popup affordance — opt-in "open in popup" control (rf2-l4625)
 ;; =========================================================================
 ;;
@@ -3313,146 +3508,47 @@
     ;; / title — the glyph swap is visual only.
     "↗"]))
 
-(rf/reg-view edn-inspector
-  "First-class edn-inspector widget — single source of truth for
-  browse + diff + mini.
+(defn render-inspector
+  "THE RENDERER — pure, and the single body both heads share.
 
-  Pass `[edn-inspector value]` or `[edn-inspector value opts]`. The
-  `opts` map carries `:panel-id`, `:default-expanded-depth`,
-  `:max-inline-width`, `:max-depth`, `:before` — see the ns
-  docstring for the full key inventory.
+  Answers the widget's hiccup for one mount. Everything ambient in the
+  old form-2 component is now a NAMED ARGUMENT: the subscription values,
+  the frame-aware dispatcher, the per-mount id and the `:ref` callback all
+  arrive in the map rather than being read or allocated in here. That is
+  what lets one body serve two substrates — `edn-inspector`, the Reagent
+  head, reads its three slots with `@(subscribe …)`; `edn-inspector-view`,
+  the Fresco boundary, reads the same three with `rf.fresco/sub` — without
+  either spelling leaking into the 400 lines below.
 
-  - Browse mode (default): no `:before` opt; the widget renders
-    `value` with expand/collapse + sticky operator overrides.
-  - Diff mode: pass `:before` in `opts` (or use the
-    `edn-inspector-diff` 3-arg convenience). The widget renders
-    `value` as the AFTER side with gutter glyphs +
-    `← was <prior>` annotations, force-expands the
-    ancestor chain over any changed descendant, and dims `:same`
-    rows.
+  Keys:
 
-  Form-2 component: the outer body allocates a stable `mount-id`
-  in closure; the inner fn subscribes to the expansion slot,
-  threads the snapshot through the recursive renderer, and returns
-  hiccup.
-
-  Per D4=a (rf2-sndui) the public API does NOT take a `:render-id` —
-  mount-id is generated internally. Two simultaneous mounts get
-  independent expansion state via the auto-id.
-
-  Per-call-site isolation is the key correctness property here: two
-  `[edn-inspector value]` mounts in the same panel must NOT share
-  expansion state. The form-2 closure delivers that — the outer body
-  runs once per mount.
-
-  ## rf2-y59tb — `reg-view`-registered so dispatch / subscribe inherit
-  the surrounding frame
-
-  Before this fix `edn-inspector` was a plain `defn`. Plain Reagent fns
-  do not consult the `frame-provider` React context, so when the
-  widget mounted under `:rf/xray` (App-DB panel) toggle dispatches and
-  expansion-slot subscribes routed to `:rf/default` instead — the
-  click landed in the wrong frame's app-db and the rendering sub
-  never saw it. Same root cause as `ribbon-theme-toggle` (rf2-uu3lp).
-
-  The `reg-view` registration makes the component
-  `:contextType frame-context`-aware: dispatch / subscribe both
-  resolve to whatever frame the enclosing `frame-provider` puts in
-  scope. The lexical `dispatch` injected by the macro is threaded
-  through `render-node` opts so callbacks deep in the recursion
-  carry the same frame.
-
-  Call sites continue to read `[ei/edn-inspector value opts]` — the
-  macro defs the `edn-inspector` Var to the registered render fn, so
-  the public API is unchanged. Call sites that omit `opts`
-  (`[ei/edn-inspector value]`) flow the same way; Reagent passes the
-  positional args from the hiccup vector to both the outer and inner
-  fn, and the inner fn tolerates `opts=nil` via the destructure's
-  `:or` defaults."
-  [_value & _opts]
-  (let [mount-id    (gen-mount-id)
-        ;; Capture the frame-aware dispatcher lexically. The closure
-        ;; binds to the surrounding frame the outer body runs under;
-        ;; every callback the inner renderer creates (toggle handlers,
-        ;; recursive render-node descents) threads this closure so the
-        ;; dispatch carries the right frame even when fired long after
-        ;; render unwinds.
-        dispatch-fn dispatch
-        ;; rf2-kbdk8 — width measurement state captured in the form-2
-        ;; closure so the ResizeObserver + ref callback persist across
-        ;; re-renders. `observer` holds the per-mount ResizeObserver
-        ;; instance (or nil before/after the lifecycle); `last-width`
-        ;; debounces redundant dispatches by remembering the last
-        ;; measurement we wrote — `clientWidth` returns fractional
-        ;; pixels rounded by the browser, so identical measurements
-        ;; arrive verbatim and should not churn the app-db slot.
-        observer    (atom nil)
-        last-width  (atom nil)
-        ;; rf2-4p1vl — per-mount projection cache. The Editscript-backed
-        ;; `engine/project` walks the full `(before, after)` pair every
-        ;; call; the inner render fn runs on EVERY render of the mount
-        ;; (expansion toggle, ResizeObserver widths update, parent re-
-        ;; render). Without this cache the diff render path re-walks the
-        ;; same byte-identical inputs N times per epoch (the redundant
-        ;; per-render Editscript walk an efficiency audit flagged).
-        ;;
-        ;; Atom holds `{:before <ref> :after <ref> :projection <map>}` or
-        ;; nil. Cache hit when both refs match the previous call by
-        ;; `identical?`; otherwise recompute and store. The cache is
-        ;; closure-scoped so it lives exactly as long as the mount —
-        ;; unmount frees the closure, no leak.
-        ;;
-        ;; Identity stability of the inputs is gated by
-        ;; `f/display-value` preserving structural sharing (rf2-4spyl).
-        projection-cache (atom nil)
-        memoised-project
-        (fn [before after]
-          (let [cached @projection-cache]
-            (if (and cached
-                     (identical? before (:before cached))
-                     (identical? after  (:after  cached)))
-              (:projection cached)
-              (let [p (engine/project before after)]
-                (reset! projection-cache
-                        {:before before :after after :projection p})
-                p))))
-        measure-and-dispatch
-        (fn [^js el]
-          (when el
-            (let [w (.-clientWidth el)]
-              (when (and (number? w) (pos? w) (not= @last-width w))
-                (reset! last-width w)
-                (dispatch-fn
-                  [:rf.xray.edn-inspector/set-width mount-id w])))))
-        container-ref
-        (fn [^js el]
-          (cond
-            ;; Mount — measure once, install the observer.
-            (and el (nil? @observer))
-            (do
-              (measure-and-dispatch el)
-              (when (exists? js/ResizeObserver)
-                (let [obs (js/ResizeObserver.
-                            (fn [_entries]
-                              (measure-and-dispatch el)))]
-                  (.observe obs el)
-                  (reset! observer obs))))
-
-            ;; Unmount — tear down observer, clear the slot. The slot
-            ;; clear matters because the same mount-id may not recur
-            ;; (each fresh mount allocates a UUID); leaving stale entries
-            ;; in app-db is a slow leak.
-            (and (nil? el) @observer)
-            (do
-              (try (.disconnect ^js @observer)
-                   (catch :default _ nil))
-              (reset! observer nil)
-              (reset! last-width nil)
-              (dispatch-fn
-                [:rf.xray.edn-inspector/clear-width mount-id]))))]
-    (fn render-edn-inspector
-      [value & rest-args]
-      (let [opts          (first rest-args)
+  - `:value` / `:opts`   — the public positional API, as a map. `opts` is
+                           destructured here exactly as it always was, so
+                           every documented key keeps its meaning and its
+                           default.
+  - `:mount-id`          — the per-mount identity string. Keys the width
+                           slot, the popup id and the container testid,
+                           and is the expansion key's second component
+                           when no `:site-id` is supplied.
+  - `:dispatch-fn`       — the frame-aware dispatcher. Threaded down
+                           through `render-node` so a toggle fired long
+                           after this render unwound still lands on the
+                           frame the widget was mounted under.
+  - `:container-ref`     — the `:ref` callback driving width measurement.
+                           Supplied rather than made here: React re-runs a
+                           callback ref whose identity moved, so it has to
+                           be stable across renders (`container-ref-for`).
+  - `:expansion-map`     — the expansion slot's value.
+  - `:zoom-map`          — the zoom slot's value, or nil for a mount that
+                           is not `:zoomable?`. Read CONDITIONALLY by both
+                           heads: an unconditional read would put every
+                           mount on the zoom slot's invalidation list, and
+                           the epoch panel alone mounts this widget dozens
+                           of times.
+  - `:widths`            — the measured-width slot's value."
+  [{:keys [value opts mount-id dispatch-fn container-ref
+           expansion-map zoom-map widths]}]
+      (let [
             {:keys [panel-id site-id default-expanded-depth max-inline-width
                     max-depth popup-affordance? card? header zoomable?
                     added?]
@@ -3520,7 +3616,7 @@
             ;; `subscribe` is the lexical frame-aware closure
             ;; injected by `reg-view` — reads the expansion-slot
             ;; from the surrounding frame's app-db (e.g. `:rf/xray`).
-            expansion-map @(subscribe [expansion-slot])
+            ;; `expansion-map`, `zoom-map` and `widths` are ARGUMENTS.
             ;; rf2-h71e0 — zoom slot read alongside expansion. Nil/empty
             ;; for unzoomed mounts; non-empty vec for mounts with an
             ;; active zoom. The slot is per-frame (same `:rf/xray`
@@ -3540,7 +3636,7 @@
             ;; `resolve-zoom-into`. (The earlier rf2-h71e0 design
             ;; suppressed zoom whenever a `before` was present; that
             ;; conflict is resolved by re-rooting both halves together.)
-            zoom-map      (when zoomable? @(subscribe [zoom-slot]))
+            ;; Each head reads them in its own substrate's spelling.
             zoom-path     (resolve-zoom-path zoom-map panel-id
                                              (or site-id mount-id))
             zoom-active?  (and zoomable? (seq zoom-path))
@@ -3565,7 +3661,7 @@
             ;; fired yet); subsequent renders see the width and the
             ;; width-aware heuristic kicks in. ResizeObserver keeps the
             ;; slot live across panel resizes.
-            widths        @(subscribe [widths-slot])
+            ;; See this fn's docstring for why the zoom read is conditional.
             available-width-px (get widths mount-id)
             container-id  (str "rf-xray-edn-inspector-"
                                (name panel-id) "-" mount-id)
@@ -3587,9 +3683,10 @@
             ;; return `:same` for everything. Pure data — same value
             ;; key composability as `expansion-map`.
             ;;
-            ;; rf2-4p1vl — the projection is computed via the per-mount
-            ;; `memoised-project` closure (captured in the form-2 outer
-            ;; body). Byte-identical `(displayed-before, displayed-
+            ;; rf2-4p1vl — the projection is computed via `project-for`,
+            ;; the per-mount memo in the module-level store (rf2-k97c.3
+            ;; moved it out of the form-2 closure so both heads share
+            ;; one cache and one release path). Byte-identical `(displayed-before, displayed-
             ;; value)` pairs across renders short-circuit to the cached
             ;; result; only changed inputs trigger a fresh Editscript
             ;; walk. Mirrors the sub-cache layer that fronts the
@@ -3598,7 +3695,7 @@
             ;; inputs reuse the cached Editscript result rather than
             ;; recomputing the A* edit-script on every render.
             projection    (when diff?
-                            (memoised-project displayed-before displayed-value))
+                            (project-for mount-id displayed-before displayed-value))
             body-content  (render-node
                             {:value displayed-value
                              :before (if diff? displayed-before ::missing)
@@ -3728,9 +3825,11 @@
                  :data-rf-available-width-px (when available-width-px
                                                (str available-width-px))
                  ;; rf2-kbdk8 — `:ref` callback drives the measurement.
-                 ;; Captured once in the form-2 closure; React calls
-                 ;; the same fn on mount + unmount so the observer's
-                 ;; lifecycle mirrors the widget's DOM lifecycle.
+                 ;; Memoised per mount by `container-ref-for`, so React
+                 ;; sees ONE identity for the life of the mount and calls
+                 ;; it on mount + unmount only — the observer's lifecycle
+                 ;; mirrors the widget's DOM lifecycle rather than its
+                 ;; render count.
                  :ref             container-ref
                  :on-key-down     on-keydown
                  :tab-index       (when zoom-active? -1)
@@ -3765,7 +3864,208 @@
            ;; active. nil when not zoomed so the un-zoomed render is
            ;; unchanged.
            breadcrumbs
-           body-content])))))
+           body-content])))
+
+;; =========================================================================
+;; THE TWO HEADS (rf2-k97c.3)
+;; =========================================================================
+;;
+;; One renderer, two heads, because the tree has two kinds of parent in it
+;; at once and will have until the shell itself is a Fresco tree.
+;;
+;; `edn-inspector` is the REAGENT head and its public hiccup shape is
+;; unchanged: every `[ei/edn-inspector value opts]` call site in the tree
+;; keeps working, keeps its testids, and keeps the per-call-site expansion
+;; isolation the form-2 closure used to deliver. It is SCAFFOLDING with a
+;; defined end — it goes in the commit that flips the shell's root, which
+;; is the same commit that deletes every `*-bridge` (see the bead's step 3).
+;;
+;; `edn-inspector-view` is the FRESCO BOUNDARY: a real React function
+;; component whose reads go through Fresco's own collector rather than
+;; through whichever reaction machinery the installed substrate adapter
+;; happens to supply. It is the head a MIGRATED panel writes, and it is the
+;; reason this increment unblocks the panels rather than merely preparing
+;; for them — a panel that shows a value cannot become a Fresco tree until
+;; this widget has a Fresco head, because a plain function in head position
+;; is a loud error there by design.
+;;
+;; WHY NOT ONE HEAD PLUS AN `as-component` BRIDGE, which is the shape the
+;; first migrated panel used: because THE VALUE CANNOT CROSS. Fresco's own
+;; `as-component` contract says the outward decode is shallow and that
+;; "names round-trip across a crossing; values do not" — a Reagent parent's
+;; `[:>]` runs `convert-prop-value` first, which turns a CLJS map into a
+;; camelCased JS object. `module_view`'s bridge crosses an EMPTY props map,
+;; which is why it is sound there. This widget's entire payload is an
+;; arbitrary CLJS value, so a props crossing would hand the renderer a
+;; mangled one. Two heads over one renderer is the shape that has no such
+;; seam: nothing is converted, because nothing crosses.
+
+(rf/reg-view edn-inspector
+  "First-class edn-inspector widget — single source of truth for
+  browse + diff + mini. THE REAGENT HEAD.
+
+  Pass `[edn-inspector value]` or `[edn-inspector value opts]`. The
+  `opts` map carries `:panel-id`, `:default-expanded-depth`,
+  `:max-inline-width`, `:max-depth`, `:before` — see the ns
+  docstring for the full key inventory.
+
+  - Browse mode (default): no `:before` opt; the widget renders
+    `value` with expand/collapse + sticky operator overrides.
+  - Diff mode: pass `:before` in `opts` (or use the
+    `edn-inspector-diff` 3-arg convenience). The widget renders
+    `value` as the AFTER side with gutter glyphs +
+    `← was <prior>` annotations, force-expands the
+    ancestor chain over any changed descendant, and dims `:same`
+    rows.
+
+  Form-2 component: the outer body allocates a stable `mount-id` and
+  captures the frame-aware dispatcher once; the inner fn reads the
+  three slots and hands everything to `render-inspector`, which owns
+  the rendering. Per D4=a (rf2-sndui) the public API does NOT take a
+  `:render-id` — mount-id is generated internally, so two simultaneous
+  mounts get independent expansion state.
+
+  Per-call-site isolation is the key correctness property here: two
+  `[edn-inspector value]` mounts in the same panel must NOT share
+  expansion state. The form-2 closure delivers that — the outer body
+  runs once per mount.
+
+  ## rf2-y59tb — `reg-view`-registered so dispatch / subscribe inherit
+  the surrounding frame
+
+  Before this fix `edn-inspector` was a plain `defn`. Plain Reagent fns
+  do not consult the `frame-provider` React context, so when the
+  widget mounted under `:rf/xray` (App-DB panel) toggle dispatches and
+  expansion-slot subscribes routed to `:rf/default` instead — the
+  click landed in the wrong frame's app-db and the rendering sub
+  never saw it. Same root cause as `ribbon-theme-toggle` (rf2-uu3lp).
+
+  ## rf2-k97c.3 — the three closure atoms moved out
+
+  The ResizeObserver, the width debounce and the projection cache used
+  to live in this closure. They now live in the module-level per-mount
+  store, keyed by this mount's id and released when React calls the
+  `:ref` with nil. Nothing about this head's behaviour moved with them —
+  the store is keyed per mount exactly as the closure was scoped per
+  mount — but the lifetime is now EXPLICIT, which is what let the
+  Fresco head, whose body has no closure to hold them, share the same
+  renderer."
+  [_value & _opts]
+  (let [mount-id    (gen-mount-id)
+        ;; Capture the frame-aware dispatcher lexically. The closure
+        ;; binds to the surrounding frame the outer body runs under;
+        ;; every callback the renderer creates (toggle handlers,
+        ;; recursive render-node descents, the observer) threads this
+        ;; closure so the dispatch carries the right frame even when
+        ;; fired long after render unwinds.
+        dispatch-fn dispatch]
+    (fn render-edn-inspector
+      [value & rest-args]
+      (let [opts      (first rest-args)
+            zoomable? (boolean (:zoomable? opts))]
+        (render-inspector
+          {:value         value
+           :opts          opts
+           :mount-id      mount-id
+           :dispatch-fn   dispatch-fn
+           :container-ref (container-ref-for mount-id dispatch-fn)
+           ;; `subscribe` is the lexical frame-aware closure injected by
+           ;; `reg-view` — reads from the surrounding frame's app-db.
+           :expansion-map @(subscribe [expansion-slot])
+           :zoom-map      (when zoomable? @(subscribe [zoom-slot]))
+           :widths        @(subscribe [widths-slot])})))))
+
+(rf.fresco/defview edn-inspector-view
+  "First-class edn-inspector widget — THE FRESCO BOUNDARY.
+
+      [edn-inspector-view {:mount-id \"app-db-top\"
+                           :value    v
+                           :opts     {:panel-id :rf.xray/app-db …}}]
+
+  A real React function component, so its reads go through Fresco's
+  shipped collector: the collector wires each `rf.fresco/sub`, activates
+  it, re-wires it as the body's branches change and notifies on
+  invalidation. A `reg-view` body's `@(rf/subscribe …)` is tracked only
+  by the INSTALLED adapter's reaction machinery, which is the coupling
+  this epic exists to sever.
+
+  ## `:mount-id` IS REQUIRED, and that is the honest shape
+
+  A form-2 component allocates its per-mount identity once, in an outer
+  body that runs on mount. A React function component has no such body:
+  everything here runs on EVERY render, so `(gen-mount-id)` written in
+  this body would mint a fresh id per render and the widget would lose
+  its expansion state on every pass.
+
+  `rf.fresco/reg-state` is the runtime's own answer to per-instance
+  state, and reading it settles the question rather than leaving it open:
+  it CONSUMES an instance key, it does not mint one. So the identity has
+  to come from the caller. That is not a workaround — a React component's
+  identity is its caller's to name, and every real call site in this tree
+  already passes a stable `:site-id` for the neighbouring reason (surviving
+  a panel leave-and-return).
+
+  `:mount-id` is a string and keys the width slot, the popup id and the
+  container testid. `:site-id`, in `opts`, keeps its own separate meaning
+  — the expansion key's second component — and is unchanged.
+
+  ## Reads, and why the zoom read is conditional
+
+  Three slots, each `rf.fresco/sub`. The zoom slot is read ONLY for a
+  `:zoomable?` mount: the collector records an edge where the read
+  happens, so an unconditional read would put every mount on the zoom
+  slot's invalidation list, and the epoch panel alone mounts this widget
+  dozens of times.
+
+  ## The dispatcher, and why it is captured rather than lowered
+
+  `(rf/capture-frame)` answers the frame api for the frame THIS boundary
+  renders under — core's own door, which Fresco's authoring surface
+  deliberately does not duplicate, and which answers the boundary's
+  declared frame inside a body. Its `:dispatch` is the right shape here
+  because most of this widget's dispatches do not originate at an `on-*`
+  prop at all: they fire from a ResizeObserver callback and from
+  handlers threaded many levels down the recursive renderer, long after
+  the render extent has unwound. That is the case `capture-frame`
+  documents itself for."
+  [{:keys [mount-id value opts]}]
+  (when-not (string? mount-id)
+    (throw (ex-info
+             (str "edn-inspector-view needs a stable string :mount-id; it was "
+                  (pr-str mount-id) ". A Fresco boundary is a React function "
+                  "component and has no form-2 outer body to allocate one in, "
+                  "so minting an id here would mint a fresh one on every "
+                  "render and the widget would lose its expansion state each "
+                  "pass. Name the mount at the call site — a panel id plus the "
+                  "slot's role is usually the whole of it.")
+             {:mount-id mount-id})))
+  (let [zoomable?   (boolean (:zoomable? opts))
+        dispatch-fn (:dispatch (rf/capture-frame))]
+    (render-inspector
+      {:value         value
+       :opts          opts
+       :mount-id      mount-id
+       :dispatch-fn   dispatch-fn
+       :container-ref (container-ref-for mount-id dispatch-fn)
+       :expansion-map (rf.fresco/sub [expansion-slot])
+       :zoom-map      (when zoomable? (rf.fresco/sub [zoom-slot]))
+       :widths        (rf.fresco/sub [widths-slot])})))
+
+(def edn-inspector-component
+  "The React component `edn-inspector-view` presents as, for a parent
+  that is not a Fresco tree.
+
+  Declared once at top level, as `rf.fresco/as-component`'s contract
+  requires — deriving one per render mints a fresh element type and
+  remounts the subtree.
+
+  READ THE CROSSING NOTE ABOVE BEFORE REACHING FOR THIS. A Reagent
+  parent's `[:>]` converts props before they arrive, so the inspected
+  VALUE cannot cross this way; `edn-inspector`, the Reagent head, is what
+  a Reagent parent mounts. This exists for a non-Reagent React parent —
+  UIx, or plain JavaScript — that holds the value on its own side and can
+  hand it over without a Reagent conversion in between."
+  (rf.fresco/as-component edn-inspector-view))
 
 (defn edn-inspector-diff
   "Diff convenience — `[edn-inspector-diff before after]` or

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget.cljs
@@ -22,10 +22,25 @@
 
       (inspect v)               ;; canonical L4 detail-panel renderer
       (inspect v node-key)      ;; with a stable per-mount qualifier
+      (inspect-view v node-key) ;; the same, for a Fresco-authored panel
       (inspect-inline v)        ;; compact one-liner (hover / list cells)
 
       (code-block {:source \"(reg-event :foo …)\"
                    :lang   :clojure})
+
+  ## Two heads, one renderer (rf2-k97c.3)
+
+  `inspect` emits the Reagent head; `inspect-view` emits the Fresco
+  boundary. Same value, same opts, same renderer underneath — only the
+  observer differs. A panel re-authored in the re-frame-native view layer
+  reaches for `inspect-view`; a panel still on `reg-view` keeps `inspect`
+  and changes nothing.
+
+  Everything else here — `inspect-inline`, `code-block`, the tokenizer —
+  is a PLAIN FUNCTION returning pure hiccup, so a migrated panel CALLS it
+  (`(code-block {…})`) rather than putting it in head position, where
+  Fresco refuses a plain fn by design. That is a call-site rule for the
+  migrating panel, not a change here.
 
   ## Posture
 
@@ -75,6 +90,15 @@
 ;; sentinel-routing branches. Call sites may also call `ei/edn-inspector`
 ;; directly.
 
+(defn inspect-opts
+  "The opts map `inspect` and `inspect-view` both hand the widget. Named
+  once so the two heads cannot drift apart on the thing that decides what
+  the operator sees — the panel-id that keys expansion state, and the
+  expand ceiling."
+  [node-key]
+  {:panel-id (keyword (str "rf.xray.inspect/" node-key))
+   :default-expanded-depth 3})
+
 (defn inspect
   "Sentinel-aware current-state rendering for one value — the canonical
   L4 detail-panel renderer. Routes through the first-class
@@ -89,9 +113,34 @@
   mode on `ei/edn-inspector`)."
   ([v] (inspect v "root"))
   ([v node-key]
-   [ei/edn-inspector v
-    {:panel-id (keyword (str "rf.xray.inspect/" node-key))
-     :default-expanded-depth 3}]))
+   [ei/edn-inspector v (inspect-opts node-key)]))
+
+(defn inspect-view
+  "`inspect`, for a panel that has been re-authored in the re-frame-native
+  view layer (rf2-k97c.3).
+
+  Same value, same opts, same renderer — the ONLY difference is the head.
+  `inspect` emits `[ei/edn-inspector …]`, which is a Reagent component;
+  this emits `[ei/edn-inspector-view …]`, which is a Fresco boundary
+  reading through Fresco's own collector. A plain function in head
+  position is a loud error in a Fresco body by design, so a migrated panel
+  cannot keep calling `inspect`, and giving each migrating panel its own
+  hand-rolled head would put the facade's one-renderer-many-call-sites
+  property back where it was before this namespace existed.
+
+  `node-key` does double duty here: it is the panel-id qualifier, as it is
+  for `inspect`, AND the boundary's required `:mount-id`. A Fresco
+  boundary is a React function component with no form-2 outer body, so it
+  cannot mint its own per-mount identity — see `ei/edn-inspector-view`.
+  That makes `node-key` load-bearing rather than decorative: two mounts
+  sharing one `node-key` now share a width slot and a projection cache as
+  well as a panel-id, so give each mount its own."
+  ([v] (inspect-view v "root"))
+  ([v node-key]
+   [ei/edn-inspector-view
+    {:mount-id (str "rf-xray-inspect-" node-key)
+     :value    v
+     :opts     (inspect-opts node-key)}]))
 
 (defn inspect-inline
   "Compact one-line current-state rendering for hover tooltips / list
@@ -370,13 +419,19 @@
                      :box-sizing  "border-box"
                      :overflow-x  "auto"
                      :white-space "pre"}}
+       ;; rf2-k97c.3 — the React key rides in each span's own ATTRIBUTE
+       ;; MAP rather than in vector metadata. Both spellings work under
+       ;; Reagent; only the attribute map is read by the re-frame-native
+       ;; view layer, and this block is pure hiccup that a migrated panel
+       ;; will render inside a Fresco boundary. The whitespace branch
+       ;; gains an attribute map it did not have, which is the whole of
+       ;; the change to it.
        (into [:code]
              (for [[idx [t literal]] (map-indexed vector tokens-seq)]
-               (with-meta
-                 (if (= t :whitespace)
-                   [:span literal]
-                   [:span {:style {:color (get tokens
-                                               (highlight-clojure-token t)
-                                               (:text-primary tokens))}}
-                    literal])
-                 {:key idx})))])))
+               (if (= t :whitespace)
+                 [:span {:key idx} literal]
+                 [:span {:key   idx
+                         :style {:color (get tokens
+                                             (highlight-clojure-token t)
+                                             (:text-primary tokens))}}
+                  literal])))])))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,472 @@
+(ns day8.re-frame2-xray.views.edn-inspector-fresco-boundary-dom-cljs-test
+  "THE SHARED VALUE WIDGET, AS A FRESCO BOUNDARY, read off a real React
+  commit (rf2-k97c.3).
+
+  `edn-inspector-view` is the head a migrated panel writes. It is a real
+  React function component whose three app-db reads go through Fresco's
+  own shipped collector, rather than an `rf/reg-view` whose reads are
+  tracked by whichever reaction machinery the installed substrate adapter
+  supplies. This file is the behavioural evidence for that head.
+
+  ## The mount is the SHAPE STEP 2 WILL USE, not a contrivance
+
+  A migrated panel is a Fresco boundary that the still-`reg-view` shell
+  mounts through `as-component` with an EMPTY props map, and the widget
+  sits INSIDE that panel's body as an ordinary Fresco head. [[HostPanel]]
+  is exactly that, in miniature: the value lives on the Fresco side and
+  reaches the widget as an ordinary Clojure argument.
+
+  That shape is load-bearing rather than incidental. Fresco's
+  `as-component` contract says the outward decode is shallow and that
+  \"names round-trip across a crossing; values do not\" — a Reagent
+  parent's `[:>]` runs `convert-prop-value` first, which turns a CLJS map
+  into a camelCased JS object. So the inspected VALUE cannot cross a
+  Reagent boundary crossing, and a test that handed it across one would be
+  testing a shape no call site can use. What crosses here is an empty
+  props map, which is what `module_view`'s bridge crosses too.
+
+  ## Which claim each row answers
+
+    W1  first display, and the read lands in the frame the tree NAMED
+    W2  it updates on a real dependency change — with a deaf control
+    W3  the boundary's render is not application view evidence
+    W4  teardown releases BOTH the subscription reference AND the
+        per-mount store entry (the ResizeObserver, the width debounce and
+        the projection cache)
+
+  W4 is the row this widget needed and `module_view` did not. That panel
+  holds no per-mount mutable state; this one holds three pieces of it, and
+  they used to live in a form-2 closure that was collected with the mount.
+  A Fresco boundary has no such closure, so they moved to a module-level
+  store with an EXPLICIT release — which is precisely the change that
+  passes its happy path and leaks on unmount.
+
+  ## Instrument notes inherited from the first migrated panel
+
+  Two facts each made a live panel read as dead there, and both apply
+  here. A Fresco boundary is NOT in Reagent's render queue, so the
+  adapter's `:flush-render!` slot commits nothing of its update — mount is
+  committed with React's own `flushSync` and everything after it is a
+  bounded poll. And the collector releases a cell ONE MACROTASK after its
+  last reader unmounts (`impl/collector`'s `cell-reapers`, so that a keyed
+  reorder within one turn reuses the reaction), so W4 polls rather than
+  reading once."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco :as rf.fresco]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. W1 reads it as
+  the negative half of the frame-targeting claim and W3 mounts inside it,
+  so the evidence claim cannot be carried by `:rf/xray`'s trace gate."
+  ::app)
+
+(def ^:private panel-id
+  "The consuming panel's id, which is the expansion key's first component."
+  ::panel)
+
+(def ^:private mount-id
+  "The boundary's REQUIRED `:mount-id`. A Fresco boundary has no form-2
+  outer body to mint one in, so the caller names it — see
+  `ei/edn-inspector-view`. Named once here because four rows key off it:
+  it is the store key, the width-slot key and half the expansion key."
+  "edn-inspector-boundary-test")
+
+(def ^:private expansion-q
+  "The widget's expansion read. The sub-cache is keyed by the query vector
+  itself, so this value IS the cache key the ref-count rows read."
+  [ei/expansion-slot])
+
+(def ^:private subject-value
+  "One nested container, because the row W2 drives is a TOGGLE: `:a` has to
+  be a container for it to have an expanded state at all."
+  {:a {:b 1 :c 2}})
+
+(def ^:private inspector-opts
+  {:panel-id panel-id
+   ;; Deep enough that `:a` renders EXPANDED at first paint, so W2's
+   ;; toggle has somewhere to move to.
+   :default-expanded-depth 8})
+
+;; ---- the host panel: the shape step 2 will use ----------------------------
+
+(rf.fresco/defview HostPanel
+  "A migrated panel, in miniature. Holds the value on the Fresco side and
+  renders the widget as an ordinary Fresco head — no props crossing, so
+  the value arrives as the Clojure value it is."
+  [_props]
+  [:div {:data-testid "rf-xray-host-panel"}
+   [ei/edn-inspector-view
+    {:mount-id mount-id
+     :value    subject-value
+     :opts     inspector-opts}]])
+
+(def ^:private HostPanel-component
+  "Declared once at top level, as `as-component`'s contract requires:
+  deriving one per render mints a fresh element type and remounts the
+  subtree."
+  (rf.fresco/as-component HostPanel))
+
+;; ---- a probe the deaf control and the frame-targeting control need --------
+
+(rf/reg-event ::bump
+  (fn [{:keys [db]} [_ n]] {:db (assoc db ::n n)}))
+
+(rf/reg-sub ::n (fn [db _] (::n db)))
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W3, and nothing else. An ordinary `reg-view`
+  rendered by the installed adapter in the same root, the same frame and
+  the same commit as the subject — so the only variable between them is
+  which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-probe-reg-view"} (str @(rf/subscribe [::n]))])
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     ;; `:async? true` because W2 and W4 are `async` rows, and `cljs.test`
+     ;; refuses a FUNCTION fixture in any namespace carrying one.
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into — and
+  no `js/ResizeObserver` either, which W4's precondition depends on."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for W2's CONTROL: an absence asserted immediately after an event is a
+  race; asserted after this, it is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- mount-host!
+  "Mount the host panel the way the shell mounts a migrated one: the
+  `as-component` bridge as a Reagent hiccup head inside a
+  `frame-provider` scoping `frame`. Committed synchronously — React 19's
+  `root.render` is otherwise async and the first assertion would read an
+  empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [:> HostPanel-component {}]])))
+    {:container container :root root}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads and where React detaches the
+  container `:ref` — have RUN by the time the next line reads. A bare
+  `.unmount` merely schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- container-node
+  "The widget's own root element, addressed by the testid the renderer
+  composes from panel-id and mount-id."
+  [container]
+  (q container (str "[data-testid=\"rf-xray-edn-inspector-"
+                    (name panel-id) "-" mount-id "\"]")))
+
+(defn- a-expanded
+  "The `data-rf-expanded` flag on the `[:a]` container node — \"1\", \"0\",
+  or nil when the node is not on screen."
+  [container]
+  (some-> (q container (str "[data-testid=\"rf-xray-edn-inspector-"
+                            (name panel-id) "-" mount-id "-:a\"]"))
+          (.getAttribute "data-rf-expanded")))
+
+(defn- cache-of [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+;; ===========================================================================
+;; W1 — first display, and the read lands in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-widget-paints-and-its-read-lands-in-the-named-frame
+  (testing "rf2-k97c.3 — the boundary commits real DOM, and its
+            `rf.fresco/sub` on the expansion slot resolves against the frame
+            the enclosing `frame-provider` named rather than the ambient
+            one. Epic criteria 1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim is measured with an instrument demonstrably
+            ;; able to see an entry in that frame's cache.
+            _probe (rf/subscribe [::n] {:frame app-frame})
+            {:keys [container root]} (mount-host! :rf/xray)]
+        (try
+          (is (some? (q container "[data-testid=\"rf-xray-host-panel\"]"))
+              "the host panel committed real DOM through the as-component bridge")
+          (is (some? (container-node container))
+              "and the widget rendered its own container, so the boundary's
+               body ran rather than short-circuiting")
+          (is (= "1" (a-expanded container))
+              "the nested container painted EXPANDED, which is what W2's
+               toggle has to move")
+
+          ;; ---- criterion 4: the read is where the tree said it would be ---
+          (is (pos? (ref-count-of :rf/xray expansion-q))
+              (str "the widget's expansion read holds a reference in "
+                   ":rf/xray's sub-cache — the frame the frame-provider "
+                   "named. Cache keys: " (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame expansion-q))
+              "and NOT in the application frame's — a boundary that took the
+               ambient scope instead of reading React context would put it here")
+          (is (pos? (ref-count-of app-frame [::n]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence rather than a broken reader")
+          (finally
+            (rf/unsubscribe [::n] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-widget-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — a toggle written into the expansion slot reaches the
+            committed DOM, and a write the widget does NOT read does not.
+            Epic criterion 2, with the control that makes the update mean
+            liveness rather than a commit that had simply not happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-host! :rf/xray)]
+          (is (= "1" (a-expanded container))
+              "PRECONDITION: the node starts expanded, so the toggle below has
+               somewhere to move to")
+
+          ;; ---- the deaf control: a write the widget does not read ---------
+          ;; Same frame, same app-db, a key the expansion sub does not
+          ;; project. The sub recomputes to an unchanged value, so nothing
+          ;; the boundary reads was invalidated and it must not re-render.
+          (rf/dispatch-sync [::bump 1] {:frame :rf/xray})
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (= "1" (a-expanded container))
+                      "CONTROL: given a full settling window, an app-db write
+                       the widget does not read leaves the committed DOM
+                       exactly where it was. A widget that re-rendered here
+                       would make the phase below pass for a reason that is
+                       not liveness")
+
+                  ;; ---- the real change ---------------------------------
+                  (rf/dispatch-sync
+                    [:rf.xray.edn-inspector/toggle-node panel-id mount-id [:a] true]
+                    {:frame :rf/xray})
+                  (rf.test-support/poll-until
+                    #(= "0" (a-expanded container))
+                    {:label "the toggle reached the committed DOM"})))
+              (.then
+                (fn [_]
+                  (is (= "0" (a-expanded container))
+                      "the boundary re-rendered on a real change to the slot it
+                       reads through Fresco's collector — NOT through the
+                       installed adapter's reaction machinery")
+                  (is (some? (container-node container))
+                      "and the widget is still the SAME mount rather than a
+                       remount, which would not be liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — the tool's own render is not application view evidence
+;; ===========================================================================
+
+(deftest w3-the-boundarys-render-emits-no-view-trace
+  (testing "rf2-k97c.3 / rf2-tqlmq — rendering the widget contributes NOTHING
+            to the substrate's view-trace stream, even mounted INSIDE an
+            application frame. Epic criterion 5, structural rather than the
+            `:rf/xray` frame gate: a Fresco boundary is not a substrate view
+            render, so there is no event to gate. The control is an ordinary
+            `reg-view` in the same root, frame and commit."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_        (setup!)
+            traces   (atom [])
+            view-op? #(and (keyword? (:operation %))
+                           (= "rf.view" (namespace (:operation %))))]
+        (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+        (try
+          (let [{:keys [container root]} (mount-host! app-frame)
+                subject-views (filterv view-op? @traces)]
+            (try
+              (is (some? (container-node container))
+                  "precondition: the widget really did render in this commit —
+                   an empty container would make the zero below vacuous")
+              (is (zero? (count subject-views))
+                  (str "the widget's render put NO :rf.view/* op in the trace "
+                       "stream while rendering inside an application frame. "
+                       "Ops seen: " (pr-str (mapv :operation subject-views))))
+              (finally (teardown! root container))))
+
+          (reset! traces [])
+          (let [container (.createElement js/document "div")
+                root      (rdc/create-root container)]
+            (.appendChild (.-body js/document) container)
+            (try
+              (react-dom/flushSync
+                (fn []
+                  (rdc/render root [rf/frame-provider {:frame app-frame}
+                                    [ProbeRegView]])))
+              (let [control-views (filterv view-op? @traces)]
+                (is (some? (q container "[data-testid=\"rf-xray-probe-reg-view\"]"))
+                    "precondition: the control really did render")
+                (is (pos? (count control-views))
+                    (str "CONTROL FIRES: an ordinary reg-view rendered the same "
+                         "way DOES emit a :rf.view/* op, so the subject's zero "
+                         "is a property of the boundary and not of a dead "
+                         "instrument. Ops seen: "
+                         (pr-str (mapv :operation control-views)))))
+              (finally (teardown! root container))))
+          (finally
+            (rf/unregister-listener! :trace ::collect)))))))
+
+;; ===========================================================================
+;; W4 — teardown releases the read AND the per-mount store
+;; ===========================================================================
+
+(defn- released? []
+  (zero? (ref-count-of :rf/xray expansion-q)))
+
+(deftest w4-unmount-releases-the-read-and-the-per-mount-store
+  (testing "rf2-k97c.3 — unmounting releases the subscription reference
+            completely AND drops everything the per-mount store held for this
+            mount; remounting returns to the same reference count rather than
+            a higher one. Epic criterion 6.
+
+            THE STORE HALF IS THE ADVERSARIAL ONE, and it is why this row is
+            longer than the panel template's. The widget's ResizeObserver, its
+            width debounce and its Editscript projection cache used to live in
+            a form-2 closure that was collected with the mount. A Fresco
+            boundary has no such closure, so they live in a module-level map
+            with an explicit release keyed on React calling the container
+            `:ref` with nil. A port that got the rendering right and the
+            release wrong would pass every other row in this file: the DOM
+            would be correct, the subscription would be released by the
+            collector, and the observer would go on observing a detached node
+            for the life of the page.
+
+            THE RELEASE OF THE READ IS ASYNCHRONOUS BY DESIGN, so that half
+            polls: `impl/collector`'s `cell-reapers` gives a cell whose last
+            reader unmounts one macrotask of grace. The STORE half is
+            synchronous — React detaches refs inside the `flushSync` above —
+            so it is asserted directly."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (is (nil? (ei/mount-state-held mount-id))
+                    "PRECONDITION: the store holds nothing for this mount id
+                     before it mounts")
+                (let [{:keys [container root]} (mount-host! :rf/xray)
+                      mounted (ref-count-of :rf/xray expansion-q)
+                      held    (ei/mount-state-held mount-id)]
+                  (is (pos? mounted)
+                      "the mount took a subscription reference — otherwise the
+                       release below is vacuous")
+                  (is (contains? held :ref)
+                      "the store holds the mount's memoised container ref")
+                  (is (contains? held :observer)
+                      (str "and its ResizeObserver, which is the piece with a "
+                           "real resource behind it. This assertion is the "
+                           "reason W4 lives in the BROWSER lane: js/ResizeObserver "
+                           "does not exist under Node, so the observer branch "
+                           "is never taken there and a release row written for "
+                           "the node lane would be releasing nothing. Held: "
+                           (pr-str held)))
+                  (teardown! root container)
+
+                  ;; ---- the store half: synchronous, asserted directly -----
+                  (is (nil? (ei/mount-state-held mount-id))
+                      (str "unmount released the WHOLE entry — observer, width "
+                           "debounce and projection cache together — rather "
+                           "than emptying part of it. Held after unmount: "
+                           (pr-str (ei/mount-state-held mount-id))))
+
+                  ;; ---- the read half: polled, per the collector's grace ---
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released the read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released the read COMPLETELY, "
+                                   "within the collector's grace macrotask. "
+                                   "Cache: " (pr-str (keys (cache-of :rf/xray)))))
+                          (let [{c2 :container r2 :root} (mount-host! :rf/xray)
+                                remounted (ref-count-of :rf/xray expansion-q)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" mounted ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (is (contains? (ei/mount-state-held mount-id) :ref)
+                                "and the remount minted a FRESH store entry,
+                                 proving the first one really went rather than
+                                 being reused")
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_]
+                     (is (released?)
+                         "and the second unmount releases the read too")
+                     (is (nil? (ei/mount-state-held mount-id))
+                         "and the store too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_fresco_boundary_dom_cljs_test.cljs
@@ -88,8 +88,24 @@
 
 (def ^:private subject-value
   "One nested container, because the row W2 drives is a TOGGLE: `:a` has to
-  be a container for it to have an expanded state at all."
-  {:a {:b 1 :c 2}})
+  be a container for it to have an expanded state at all.
+
+  AND IT IS DELIBERATELY TOO WIDE TO INLINE. The first draft used
+  `{:a {:b 1 :c 2}}` and W2's deaf control failed against a DOM reading
+  `{:a {:b 1, :c 2}}` — the whole value on one line, with no `[:a]`
+  container node in it at all. Nothing was broken: the widget's
+  width-aware heuristic had simply done its job. A mount renders
+  depth-driven on its FIRST pass, because no measurement has arrived yet;
+  the container `:ref` then measures, the width reaches the slot, and the
+  next render inlines anything whose `pr-str` fits the measured column.
+  A small value therefore CHANGES SHAPE between the mount and the first
+  settle, which is fatal to a control asserting that nothing moved.
+
+  This value's `:a` runs to several hundred characters, so it cannot fit
+  any plausible column and renders as a container at every width."
+  {:a (into {} (for [i (range 12)]
+                 [(keyword (str "key-" i))
+                  (str "a deliberately long value string number " i)]))})
 
 (def ^:private inspector-opts
   {:panel-id panel-id
@@ -280,12 +296,46 @@
               "PRECONDITION: the node starts expanded, so the toggle below has
                somewhere to move to")
 
-          ;; ---- the deaf control: a write the widget does not read ---------
-          ;; Same frame, same app-db, a key the expansion sub does not
-          ;; project. The sub recomputes to an unchanged value, so nothing
-          ;; the boundary reads was invalidated and it must not re-render.
-          (rf/dispatch-sync [::bump 1] {:frame :rf/xray})
+          ;; ---- settle BEFORE taking the baseline --------------------------
+          ;; A mount's first render is depth-driven, because no width
+          ;; measurement has arrived yet; the container `:ref` measures, the
+          ;; width reaches the slot, and the widget renders again. So the DOM
+          ;; legitimately moves once between the mount and the first idle
+          ;; moment, and a control that straddled that would be asserting
+          ;; against a shape the widget had already left. Settle first, then
+          ;; everything after it is attributable to the dispatches below.
           (-> (settle)
+              (.then
+                (fn [_]
+                  ;; The width having ARRIVED is itself evidence, and worth
+                  ;; banking rather than merely waiting for: the ResizeObserver
+                  ;; is one of the three pieces of per-mount state that moved
+                  ;; out of the form-2 closure for this migration, and this is
+                  ;; the whole loop working through the boundary — observer
+                  ;; fires, `capture-frame`'s dispatcher writes the slot, the
+                  ;; boundary's `rf.fresco/sub` sees it, React commits.
+                  ;; Read the frame's app-db directly rather than taking an
+                  ;; imperative subscription: `unsubscribe`'s own docstring
+                  ;; says an imperative subscriber must not lean on the view
+                  ;; lifecycle to dispose it, and a stray reference here would
+                  ;; be one more thing for W4's counts to have to explain.
+                  (is (pos? (or (get-in (rf/app-db-value :rf/xray)
+                                        [ei/widths-slot mount-id])
+                                0))
+                      "the mount measured itself and the width reached the slot
+                       — the ResizeObserver survived the move out of the form-2
+                       closure and dispatches into the boundary's own frame")
+                  (is (= "1" (a-expanded container))
+                      "and the node is still expanded once the measurement has
+                       landed — this value is too wide to inline at any column")
+
+                  ;; ---- the deaf control: a write the widget does not read --
+                  ;; Same frame, same app-db, a key the expansion sub does not
+                  ;; project. The sub recomputes to an unchanged value, so
+                  ;; nothing the boundary reads was invalidated and it must not
+                  ;; re-render.
+                  (rf/dispatch-sync [::bump 1] {:frame :rf/xray})
+                  (settle)))
               (.then
                 (fn [_]
                   (is (= "1" (a-expanded container))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_mount_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_mount_state_cljs_test.cljs
@@ -1,0 +1,177 @@
+(ns day8.re-frame2-xray.views.edn-inspector-mount-state-cljs-test
+  "THE PER-MOUNT STORE — the three pieces of state that used to live in the
+  form-2 closure (rf2-k97c.3).
+
+  `edn-inspector` was a form-2 component, so its ResizeObserver, its width
+  debounce and its Editscript projection cache lived in an outer body that
+  ran once per mount and was collected with it. `edn-inspector-view` is a
+  Fresco boundary — a real React function component — and has no such
+  body: everything in it runs on every render. So the three moved into one
+  module-level store keyed by mount-id, with an EXPLICIT release.
+
+  Moving state out of a closure and into a module-level map is exactly the
+  change that passes its happy path and leaks on unmount, so the rows here
+  are written against the two ways it goes wrong rather than against the
+  way it goes right:
+
+    R1  the `:ref` callback is MEMOISED per mount — the adversarial case,
+        because a fresh closure per render would be invisible to any
+        rendering assertion and would make React tear the observer down
+        and stand it up again on every pass.
+    R2  a different mount gets a DIFFERENT ref, so the memo is keyed and
+        not a singleton.
+    R3  release drops the WHOLE entry, and the count returns to where it
+        started — the aggregate leak claim.
+    R4  release is per-mount: a sibling mount is untouched by it. The
+        negative half of R3, and the one a `(reset! store {})` teardown
+        would fail.
+    R5  the projection cache is held under the same key and goes with the
+        rest, so a diff mount releases its Editscript result too. A cache
+        that survives its mount is the leak that costs REAL memory.
+    R6  releasing a mount that holds nothing is a no-op that dispatches
+        nothing — the negative case, and the one that fires if React
+        calls a ref with nil twice, which it is entitled to do.
+
+  ## No DOM here, deliberately
+
+  `js/ResizeObserver` does not exist under Node, so the observer branch of
+  the ref callback is skipped and the rows below are about the STORE's
+  lifecycle rather than the observer's. The observer's own lifecycle is
+  read off a real React commit in
+  `edn_inspector_fresco_boundary_dom_cljs_test`, which is the browser
+  lane. Splitting them this way is not a compromise: the store is where
+  the release actually happens, and it is assertable here in milliseconds
+  against a browser lane's seconds."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
+
+(defn- unmount!
+  "What React does at unmount: call the container ref with nil."
+  [ref-fn]
+  (ref-fn nil))
+
+(deftest r1-the-ref-callback-is-memoised-per-mount
+  (testing "rf2-k97c.3 — two asks for the same mount's ref answer the
+            IDENTICAL function.
+
+            This is the row that matters most and the one nothing else
+            can catch. A Fresco body runs whole on every render, so a ref
+            callback built in it would be a new closure each pass; React
+            re-runs a callback ref whose identity moved, detaching the old
+            one with nil and attaching the new one — which, for this
+            widget, means disconnecting the ResizeObserver and building
+            another one on every single render. Nothing about the
+            rendered output would look wrong."
+    (let [mid  "r1-mount"
+          ref1 (ei/container-ref-for mid identity)
+          ref2 (ei/container-ref-for mid identity)]
+      (is (identical? ref1 ref2)
+          "same mount-id ⇒ identical ref fn, so React sees one identity for the mount")
+      ;; The control: the memo is real rather than an accident of two
+      ;; calls in one tick. Ask again after the store has been written to.
+      (is (identical? ref1 (ei/container-ref-for mid identity))
+          "still identical on a third ask")
+      (unmount! ref1))))
+
+(deftest r2-a-different-mount-gets-a-different-ref
+  (testing "rf2-k97c.3 — the memo is KEYED. Two mounts must not share a
+            ref, or they would share an observer and a width slot."
+    (let [ref-a (ei/container-ref-for "r2-a" identity)
+          ref-b (ei/container-ref-for "r2-b" identity)]
+      (is (not (identical? ref-a ref-b))
+          "distinct mount-ids ⇒ distinct ref fns")
+      (unmount! ref-a)
+      (unmount! ref-b))))
+
+(deftest r3-release-drops-the-whole-entry
+  (testing "rf2-k97c.3 — calling the ref with nil, which is what React
+            does at unmount, releases everything the mount held and the
+            store returns to the size it was."
+    (let [before (ei/mount-state-count)
+          mid    "r3-mount"
+          ref-fn (ei/container-ref-for mid identity)]
+      (is (= (inc before) (ei/mount-state-count))
+          "the mount is in the store while it is mounted")
+      (is (contains? (ei/mount-state-held mid) :ref)
+          "and it holds its ref")
+      (unmount! ref-fn)
+      (is (nil? (ei/mount-state-held mid))
+          "after unmount the entry is GONE, not merely emptied")
+      (is (= before (ei/mount-state-count))
+          "and the store is back to the size it was")
+      ;; The discriminating half: a store that had merely been emptied of
+      ;; observers would still answer the SAME ref here.
+      (let [ref-again (ei/container-ref-for mid identity)]
+        (is (not (identical? ref-fn ref-again))
+            "a remount mints a fresh ref, proving the entry really went")
+        (unmount! ref-again)))))
+
+(deftest r4-release-is-per-mount
+  (testing "rf2-k97c.3 — releasing one mount leaves its siblings standing.
+            The negative half of R3: a teardown that reset the whole store
+            would pass R3 and fail here, and this widget is mounted dozens
+            of times on one page (the epoch panel alone)."
+    (let [keeper (ei/container-ref-for "r4-keeper" identity)
+          goer   (ei/container-ref-for "r4-goer" identity)]
+      (unmount! goer)
+      (is (nil? (ei/mount-state-held "r4-goer"))
+          "the released mount is gone")
+      (is (contains? (ei/mount-state-held "r4-keeper") :ref)
+          "the sibling is untouched")
+      (is (identical? keeper (ei/container-ref-for "r4-keeper" identity))
+          "and still answers its own ref")
+      (unmount! keeper))))
+
+(deftest r5-the-projection-cache-lives-and-dies-with-the-mount
+  (testing "rf2-k97c.3 — a diff render stores its Editscript projection
+            under the mount's key, and unmount takes it with everything
+            else. This is the piece with real bytes behind it: the
+            projection of a large app-db diff is not small, and one that
+            outlives its mount is a leak that grows with every epoch the
+            operator steps through."
+    (let [before (ei/mount-state-count)
+          mid    "r5-mount"
+          ref-fn (ei/container-ref-for mid identity)]
+      ;; A diff render — `:before` is what puts the widget in diff mode
+      ;; and so what makes it compute a projection at all.
+      (ei/render-inspector
+        {:value         {:a 1 :b 2}
+         :opts          {:panel-id :r5 :before {:a 1}}
+         :mount-id      mid
+         :dispatch-fn   identity
+         :container-ref ref-fn
+         :expansion-map {}
+         :zoom-map      nil
+         :widths        {}})
+      (is (contains? (ei/mount-state-held mid) :projection)
+          "the diff render left its projection in the store")
+      (unmount! ref-fn)
+      (is (nil? (ei/mount-state-held mid))
+          "unmount released the projection with the rest of the entry")
+      (is (= before (ei/mount-state-count))
+          "and the store is back where it started"))))
+
+(deftest r6-releasing-nothing-is-a-no-op
+  (testing "rf2-k97c.3 — a ref called with nil for a mount the store does
+            not hold does nothing and dispatches nothing.
+
+            React is entitled to detach a ref it has already detached, and
+            a hot reload can leave a ref fn alive over a store that has
+            been rebuilt. Neither should reach the dispatcher: a stray
+            `:clear-width` would be a write into a frame's app-db on
+            behalf of a mount that no longer exists."
+    (let [dispatched (atom [])
+          mid        "r6-mount"
+          ref-fn     (ei/container-ref-for mid #(swap! dispatched conj %))]
+      (unmount! ref-fn)
+      (is (= 1 (count @dispatched))
+          "the real release cleared the width slot exactly once")
+      (is (= :rf.xray.edn-inspector/clear-width (first (first @dispatched)))
+          "and it was the clear-width event")
+      (reset! dispatched [])
+      (unmount! ref-fn)
+      (unmount! ref-fn)
+      (is (= [] @dispatched)
+          "two further detaches of an already-released mount dispatch NOTHING")
+      (is (nil? (ei/mount-state-held mid))
+          "and the store is still empty for it"))))


### PR DESCRIPTION
Increment 2 of N on rf2-k97c.3. The bead stays open: this pass does step 1 of its
"WHAT THE NEXT WORKER DOES, IN ORDER" list and nothing else.

## What this is

The shared value widget every remaining Xray panel reaches now has a re-frame-native
head beside its Reagent one. That is what unblocks step 2: a plain function in head
position is a loud error in a Fresco body by design, so until now no panel that shows
a value could be migrated at all.

`render-inspector` is the pure body both heads share. Everything the form-2 component
read or allocated ambiently is now a named argument -- the three subscription values,
the frame-aware dispatcher, the per-mount id and the container ref -- so `edn-inspector`
reads its slots with `@(subscribe ...)` and `edn-inspector-view` reads the same three
with `rf.fresco/sub`, without either spelling reaching the 400 lines underneath. Only
the observer differs, which is the whole subject of the epic.

## Two heads, not an `as-component` bridge -- and that is a premise that did not hold

The bead's step 1 says the widget's head use sites "each take an `as-component` bridge
until its own panel migrates". They cannot. **The inspected value cannot cross a Reagent
props crossing.** Fresco's own `as-component` contract says the outward decode is shallow
and that "names round-trip across a crossing; values do not" -- a Reagent parent's `[:>]`
runs `convert-prop-value` first, which turns a CLJS map into a camelCased JS object.
`module_view`'s bridge is sound because it crosses an EMPTY props map; this widget's
entire payload is an arbitrary CLJS value.

So the shape is two heads over one renderer, which has no such seam: nothing is
converted, because nothing crosses. The Reagent head keeps its exact public hiccup shape,
so every existing call site and every hiccup-walking panel test is untouched. It is
scaffolding with the same defined end as every `*-bridge`: it goes in the commit that
flips the shell's root.

## The three closure atoms

A Fresco boundary is a real React function component and has no form-2, so a closure
allocated in its body is allocated per render: the ResizeObserver would be rebuilt and
the projection cache discarded every pass, and -- the invisible one -- a ref callback
minted per render changes identity every render, which makes React detach and re-attach
it in a loop. The three now live in one module-level store keyed by mount-id, released
together when React calls the ref with nil.

`:mount-id` is required on the Fresco head. Reading `rf.fresco/reg-state` settled why
rather than leaving it open: it CONSUMES an instance key, it does not mint one. A React
component's identity is its caller's to name.

## The real head use-site set, measured

The bead names two files. Measured at this tip over `tools/`, `implementation/`,
`examples/` and `testbeds/`, three passes (line-oriented, whitespace-flattened, and
comment-markers-stripped-then-flattened), with a positive and a negative control:

| file | head mounts |
|---|---|
| `panels/epoch/view.cljs` | 34 |
| `panels/app_db_diff_state.cljs` | 1 |
| `panels/machine_canvas.cljs` | 1 |
| `panels/trace.cljs` | 1 |
| `views/edn_inspector_popup.cljs` | 1 |
| `views/edn_widget.cljs` | 1 |
| `testbeds/panel_gallery/panel_views.cljs` | 1 |

Six source files plus one testbed, not two. Hits in `registry.cljs` and `shell.cljs` are
prose in comments and are not mounts. Two of the six are the widget's own neighbours
(`edn_inspector_popup`, `edn_widget`) rather than panels. Nothing here is migrated by
this PR -- the list is what step 2 is actually sized against.

## Scope fences held

No panel migrated. `shell.cljs`, `static/shell.cljs`, `mount.cljs`, every `*-bridge` and
`panels.cljs`'s `render-panel!` untouched. The element-shaped-adapter denylist untouched
(rf2-k97c.4). Nothing under `implementation/` requires anything under `tools/`. No
`.beads` path on this branch.

## Quality gates

Every number below is read from that run's own `.exit` file, never from a pipeline and
never from a harness report. All of them were re-run on the FINAL base after the rebase
onto `79673116b8`; the pre-rebase greens are not what is quoted.

| gate | exit | result |
|---|---|---|
| `python scripts/check_require_alias_dialect.py --verbose` | 0 | 2828 files, 11103 re-frame require edges, 0 non-canonical, every surface at or under its floor |
| `python scripts/check_require_alias_dialect.py --self-test` | 0 | 79 passed, 0 failed |
| every `scripts/check_*.py` (43 of them) | 0 | all clean |
| `npm run test:cljs` (split: compile, then run) | 0 / 0 | 1927 files compiled with 0 warnings; **11500 tests / 57835 assertions, 0 failures, 0 errors** |
| `npm run test:browser` (split: compile, then run) | 0 / 0 | 1036 files, 5 warnings (all pre-existing, in `implementation/fresco/test/.../login_server_crossing_ssr_dom_cljs_test.cljs`, none in a file this PR touches); **851 tests / 4704 assertions, 0 failures, 0 errors** |
| `clojure -M:test` in `tools/xray` (`tools_jvm`) | 0 | 1276 tests / 6118 assertions, 0 failures |

Against increment 1's figures: node 11490 -> **11500** tests, 57807 -> **57835** assertions;
browser 847 -> **851** tests, 4678 -> **4704** assertions. The +10 node tests are exactly
the 6 store rows plus the 4 browser rows, which load under Node and report their skip.
`tools_jvm` is unchanged at 1276/6118, which is right -- this change is entirely `.cljs`.

The classifier arms `cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`,
`mcp_conformance` and `story_xray_browser` for this diff. Four were run locally. Two were
not, with reasons: `examples_compile` reads its roster out of `shadow-cljs.edn`, which is
untouched and gains no build id; `mcp_conformance` has no new sub, event or fx and no
MCP-visible surface moved. `story_xray_browser` needs the Story browser lane.

### Three independent witnesses that these gates read THIS worktree

Not one of them is a naming convention, which is what the method says actually catches a
cross-worktree read.

1. **The alias gate's own counts moved with the edits** -- 11096 -> 11097 when the new
   `re-frame.fresco` require landed, 11097 -> 11103 when the two test files were staged.
   That also caught a real mistake: an early `git checkout --` reverted the require along
   with a clumsy edit, and the unchanged 11096 is the only thing that said so.
2. **A planted fault went red naming the plant.** `check_retired_spellings.py` exits 0
   across this tree; with the retired product name planted in one comment of
   `edn_widget.cljs` it exits **1**, naming that file, that line and that text. The plant
   existed in no other checkout, so the 43-gate all-clear is a real all-clear rather than
   a broken instrument. Restored and verified by git blob hash
   (`4d0cebb9d79217a42f85fc3cc047a81bd35d5d89` before and after), then re-run green.
3. **W2 was RED on its first browser run and went green on a real fix**, not a retry --
   see its own commit. Every compile also printed this worktree's own `shadow-cljs.edn`
   path on its first line.

### One harness disagreement, recorded

The first browser run's captured `.exit` file read **1** (2 failures) while the harness
reported that same run as "exit code 0". The captured number is the one quoted here and
the one acted on.
