### PR TITLE
refactor(xray): the Routes and cancellation-cascade views are Fresco boundaries (rf2-k97c.3, step-2 slice)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade.cljs
@@ -39,8 +39,67 @@
 
   Same contract as every other Xray panel — no Reagent / UIx /
   references. Frame isolation comes from the enclosing
-  `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`."
+  `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`.
+
+  ## THE TWO VIEWS ARE FRESCO BOUNDARIES (rf2-k97c.3)
+
+  [[SidePanelView]] and [[PopoverView]] are `rf.fresco/defview`s — real
+  React function components minted by the re-frame-native view layer —
+  rather than `rf/reg-view`s, following `panels/module_view.cljs`,
+  increment 1's merged template, under the epic's ruled design
+  (rf2-k97c.2, Design B).
+
+  ### The reads
+
+  Every read is `rf.fresco/sub`, which the collector wires, activates,
+  and re-wires AND NOTIFIES on invalidation. Mandatory rather than
+  stylistic: `re-frame.fresco.impl.intent/with-frame` binds core's
+  refusal tier for the extent of a body, so a left-behind ambient
+  `@(rf/subscribe …)` REFUSES rather than quietly reading elsewhere.
+
+  The reads stay CONDITIONAL, which is why the popover's dormant cost
+  is unchanged. `rf.fresco/sub` records its edge WHERE THE READ HAPPENS,
+  so a branch not taken contributes no edge — a closed popover still
+  costs one subscription and a gate, exactly as it did.
+
+  ### The dispatches — and the ONE that had to move
+
+  The row handlers are unchanged and deliberately so. `rf.fresco/defview`
+  passes a PLAIN FUNCTION at an `on-*` prop through untouched, reaching
+  React by identity; and the rf2-nesy9 render-time capture these rows
+  already do is exactly right, because `with-frame`'s refusal deletes the
+  ambient FIND and not the CARRYING — an explicit `{:frame <id>}` still
+  answers — while `rf/current-frame-id` answers the declared frame,
+  reading and dispatching nothing.
+
+  What DID have to move is `reg-view`'s LEXICALLY INJECTED bare
+  `dispatch`, which the popover used. A `defview` binds no name inside
+  its body, so an injected name is simply unresolved — a loud compile
+  error rather than a silent misfire. It is now `rf/dispatch` carrying
+  the same captured frame every row already carries.
+
+  ### The bridges own the PUBLIC names, and that inverts the template
+
+  `module_view` is an L4-only tab whose own `install!` is the sole thing
+  naming it, so there the boundary kept the name and the bridge was
+  private. These two are named from OUTSIDE: `shell.cljs` mounts
+  `[cancellation-cascade/Popover]` as a hiccup head, and `panels.cljs`'s
+  `render-panel!` chokepoint takes both vars — files this bead may not
+  edit (they are step 3). So the mechanism is the template's and the
+  assignment is inverted: [[SidePanel]] and [[Popover]] stay the public
+  callables those sites already hold and are now the
+  `rf.fresco/as-component` bridges, with the boundaries private behind
+  them. Same one door, same defined end.
+
+  ### The markup stays a pure projection
+
+  [[render-cascade]] takes the `expanded?` flag as an ARGUMENT rather
+  than reading it, so the whole waterfall remains a value → hiccup
+  function drivable from the node lane with no React commit. Same split
+  `cancellation_cascade_helpers.cljc` already makes for the data
+  algebra, one layer up."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.panels.cancellation-cascade-events :as events]
             [day8.re-frame2-xray.panels.cancellation-cascade-helpers :as h]
             [day8.re-frame2-xray.panels.cancellation-cascade-subs :as subs]
@@ -385,11 +444,12 @@
 
 (defn- body
   "Render the waterfall body — decision + teardown rows + abort rows.
-  Reads `:rf.xray/cancellation-cascade-expanded?` to decide whether
-  the abort list is collapsed."
-  [cascade]
+  `expanded?` is the `:rf.xray/cancellation-cascade-expanded?` VALUE,
+  passed in rather than read here (rf2-k97c.3): the read moved up into
+  the boundary so this whole projection stays value → hiccup and runs
+  outside a React commit."
+  [cascade expanded?]
   (let [{:keys [parent-decision child-teardowns effect-aborts]} cascade
-        expanded? @(rf/subscribe [:rf.xray/cancellation-cascade-expanded?])
         collapse? (h/should-collapse? cascade)
         visible-aborts (cond
                          (not collapse?) effect-aborts
@@ -449,11 +509,18 @@
 (defn render-cascade
   "Render the cascade as a self-contained block. `cascade` is the
   helpers/extract-cascade record; `close-fn` is optional (popover
-  mount passes a close handler; side-panel mount passes nil).
+  mount passes a close handler; side-panel mount passes nil);
+  `expanded?` is the `:rf.xray/cancellation-cascade-expanded?` VALUE.
 
   Always renders SOMETHING — the empty-state branches still render
-  so the mount point can place this unconditionally."
-  [cascade close-fn]
+  so the mount point can place this unconditionally.
+
+  rf2-k97c.3 — `expanded?` became an ARGUMENT when the views became
+  Fresco boundaries. It used to be read inside [[body]], which made
+  this whole projection reactive and callable only under a substrate
+  render; taking it as a value keeps the waterfall a pure function that
+  the node-lane view rows can drive directly."
+  [cascade close-fn expanded?]
   [:section {:data-testid    "rf-xray-cancellation-cascade"
              :data-empty-kind (when (:empty-kind cascade)
                                 (name (:empty-kind cascade)))
@@ -461,21 +528,30 @@
    (header cascade close-fn)
    (if (:empty-kind cascade)
      (empty-state cascade)
-     (body cascade))])
+     (body cascade expanded?))])
 
-(rf/reg-view SidePanel
-  "Machines-tab side-panel mount. Reads
-  `:rf.xray/cancellation-cascade-for-focused-machine` and renders
-  only when the cascade is non-empty (i.e. the focused machine had a
-  destroy in the trace window). Closed-state cost is one subscribe
-  + a when-gate."
-  []
-  (let [cascade @(rf/subscribe [:rf.xray/cancellation-cascade-for-focused-machine])]
+(rf.fresco/defview ^:private SidePanelView
+  "Machines-tab side-panel mount — a FRESCO BOUNDARY (rf2-k97c.3), not
+  an `rf/reg-view`. Reads
+  `:rf.xray/cancellation-cascade-for-focused-machine` and renders only
+  when the cascade is non-empty (i.e. the focused machine had a destroy
+  in the trace window).
+
+  DORMANT COST IS UNCHANGED — still one subscription and a gate. The
+  `expanded?` read sits INSIDE the `when-not`, and `rf.fresco/sub`
+  records its edge where the read happens, so the branch not taken
+  contributes no edge.
+
+  PRIVATE; [[SidePanel]] in front of it is the public name — see the ns
+  docstring's section on the inverted bridge."
+  [_props]
+  (let [cascade (rf.fresco/sub [:rf.xray/cancellation-cascade-for-focused-machine])]
     ;; The bead's contract: mount in the side-rail WHEN a destroy
     ;; lands. Empty `:no-trigger` cascades render nothing so the
     ;; mount stays dormant most of the time.
     (when-not (= :no-trigger (:empty-kind cascade))
-      (render-cascade cascade nil))))
+      (render-cascade cascade nil
+                      (rf.fresco/sub [:rf.xray/cancellation-cascade-expanded?])))))
 
 ;; ---- popover (overlay) ---------------------------------------------------
 ;;
@@ -514,7 +590,13 @@
 
 (defn- handle-popover-keydown
   "Build the popover Esc-closes keydown handler, closing over the
-  captured frame-aware `dispatch` (rf2-nesy9)."
+  captured frame-aware `dispatch` (rf2-nesy9).
+
+  The argument is a PARAMETER and always was — it never depended on
+  `reg-view`'s lexical injection, which is why this fn survived the
+  Fresco migration untouched. [[popover-tree]] now hands it a
+  `rf/dispatch` closed over the frame captured at render time; the
+  contract is identical."
   [dispatch]
   (fn [^js e]
     (when (= "Escape" (.-key e))
@@ -522,45 +604,140 @@
       (.stopPropagation e)
       (dispatch [:rf.xray/cancellation-cascade-close]))))
 
-(rf/reg-view Popover
-  "Overlay popover mount. Reads
-  `:rf.xray/cancellation-cascade-popover-open?` and short-circuits to
-  nil when closed (one subscribe + when-gate). When open, reads
-  `:rf.xray/cancellation-cascade-for-focused-event` and renders the
-  cascade body inside the dialog."
+(defn popover-tree
+  "The OPEN popover's markup, as a pure function of the values it is
+  handed — `:cascade`, `:positioning` and `:expanded?`. The open/closed
+  gate is the CALLER's, so this never answers nil.
+
+  rf2-k97c.3 — split out of the view when the view became a Fresco
+  boundary, so the dialog stays drivable from the node lane without a
+  React commit.
+
+  THE DISPATCHES ARE FRAME-CARRYING, captured here at render time
+  (rf2-nesy9), which is what makes them correct under BOTH substrates.
+  `rf/current-frame-id` answers the declared frame inside a Fresco
+  body — it neither reads nor dispatches, so the boundary's refusal
+  tier does not touch it — and an explicitly carried `{:frame <id>}`
+  still answers, because that tier deletes the ambient FIND and not the
+  carrying. This is what replaced `reg-view`'s lexically injected bare
+  `dispatch`, which a `defview` body does not bind."
+  [{:keys [cascade positioning expanded?]}]
+  (let [frame     (rf/current-frame-id)
+        dispatch* (fn [ev] (rf/dispatch ev {:frame frame}))
+        close     (fn [_] (dispatch* [:rf.xray/cancellation-cascade-close]))]
+    ;; rf2-7oxvd — shared backdrop + dialog scaffold. This popover keeps
+    ;; its own `backdrop-style` / `dialog-style`, the backdrop -1 /
+    ;; dialog 0 tab-index split, and its `:label` accessible name (no
+    ;; visible title id — unlike the labelled-by modals). `modal-chrome`
+    ;; owns the positioning attribute, the click-outside dismiss,
+    ;; `a11y/dialog-attrs` + the `a11y/dialog-ref` focus trap. It is
+    ;; CALLED, never used as a hiccup head, so Fresco's "a plain fn in
+    ;; head position is a loud error" rule never meets it; and the
+    ;; `:ref` it installs crosses Fresco's codec untouched.
+    ;;
+    ;; Both the backdrop and the dialog get the BUILT keydown handler
+    ;; `(handle-popover-keydown dispatch*)` (rf2-op8c7). The dialog
+    ;; previously received the bare 1-arity builder, so React called the
+    ;; builder with the keydown event and discarded the handler fn it
+    ;; returned — making the dialog-level Esc a no-op. With the focus
+    ;; trap keeping focus inside the dialog, a dialog-focused Esc never
+    ;; reached the backdrop's handler, so Esc-on-dialog did not close.
+    (modal-chrome/modal-chrome
+      {:positioning          positioning
+       :backdrop-style       (backdrop-style positioning)
+       :dialog-style         (dialog-style)
+       :on-dismiss           #(dispatch* [:rf.xray/cancellation-cascade-close])
+       :label                "Cancellation cascade"
+       :backdrop-testid      "rf-xray-cancellation-cascade-popover-backdrop"
+       :dialog-testid        "rf-xray-cancellation-cascade-popover-dialog"
+       :on-backdrop-key-down (handle-popover-keydown dispatch*)
+       :on-dialog-key-down   (handle-popover-keydown dispatch*)
+       :backdrop-tab-index   -1
+       :dialog-tab-index     0}
+      (render-cascade cascade close expanded?))))
+
+(rf.fresco/defview ^:private PopoverView
+  "Overlay popover mount — a FRESCO BOUNDARY (rf2-k97c.3), not an
+  `rf/reg-view`. Reads `:rf.xray/cancellation-cascade-popover-open?`
+  and short-circuits to nil when closed. When open, reads the focused
+  event's cascade, the modal positioning and the expand flag, and hands
+  them to [[popover-tree]].
+
+  CLOSED-STATE COST IS UNCHANGED — one subscription and a gate. The
+  other three reads sit inside the `when`, and `rf.fresco/sub` records
+  its edge where the read happens, so a branch not taken contributes no
+  edge. That is Fresco's documented behaviour rather than an accident,
+  and it is why the short-circuit survived the migration intact.
+
+  PRIVATE; [[Popover]] in front of it is the public name — see the ns
+  docstring's section on the inverted bridge."
+  [_props]
+  (when (rf.fresco/sub [:rf.xray/cancellation-cascade-popover-open?])
+    (popover-tree
+      {:cascade     (rf.fresco/sub [:rf.xray/cancellation-cascade-for-focused-event])
+       :positioning (rf.fresco/sub [:rf.xray/modal-positioning])
+       :expanded?   (rf.fresco/sub [:rf.xray/cancellation-cascade-expanded?])})))
+
+;; ---- the migration bridges (rf2-k97c.3) ----------------------------------
+;;
+;; Xray's shell is still a `reg-view` tree rendered by the installed
+;; adapter. `shell.cljs` mounts `[cancellation-cascade/Popover]` as a
+;; hiccup head, and `panels.cljs`'s `render-panel!` takes both vars and
+;; mounts them the same way — neither of which a React component is, and
+;; both of those files belong to step 3 rather than to this bead.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly
+;; this: it answers a real React component for a boundary, which a React
+;; parent (UIx, Reagent or plain JavaScript) mounts UNDER THE FRAME IT IS
+;; ALREADY IN, taking the frame from React context rather than from a
+;; second root. So there is no second root here, no adapter-kind branch,
+;; and no props ABI.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the shell is itself a
+;; Fresco tree, the two `*View` boundaries take these names directly,
+;; `[:>]` goes, and the four defs below are deleted.
+
+(def ^:private SidePanel-component
+  "The React component [[SidePanelView]] presents as, for a non-Fresco
+  parent. Declared once at top level beside the view, as
+  `rf.fresco/as-component`'s contract requires — deriving it per render
+  would mint a new component type every time and remount the panel."
+  (rf.fresco/as-component SidePanelView))
+
+(def ^:private Popover-component
+  "The React component [[PopoverView]] presents as, for a non-Fresco
+  parent. Declared once at top level, for the same reason as
+  [[SidePanel-component]]."
+  (rf.fresco/as-component PopoverView))
+
+(defn SidePanel
+  "The cancellation-cascade side panel's public callable — what
+  `panels.cljs`'s `render-panel!` chokepoint and its
+  `mount-cancellation-cascade-side-panel!` facade already hold.
+
+  Since rf2-k97c.3 it is the migration bridge rather than the view:
+  Reagent-shaped hiccup interoping to the React component
+  [[SidePanelView]] presents as. The enclosing `rf/frame-provider` is
+  what puts the frame in React context for it.
+
+  Callers wanting the MARKUP as data — the node-lane view rows — build
+  it from [[render-cascade]] with the composite's value instead; this
+  returns an interop vector, not a tree to walk."
   []
-  (when @(rf/subscribe [:rf.xray/cancellation-cascade-popover-open?])
-    (let [cascade     @(rf/subscribe [:rf.xray/cancellation-cascade-for-focused-event])
-          positioning @(rf/subscribe [:rf.xray/modal-positioning])
-          close       (fn [_]
-                        (dispatch [:rf.xray/cancellation-cascade-close]))]
-      ;; rf2-7oxvd — shared backdrop + dialog scaffold. This popover keeps
-      ;; its own `backdrop-style` / `dialog-style`, the backdrop -1 /
-      ;; dialog 0 tab-index split, and its `:label` accessible name (no
-      ;; visible title id — unlike the labelled-by modals). `modal-chrome`
-      ;; owns the positioning attribute, the click-outside dismiss,
-      ;; `a11y/dialog-attrs` + the `a11y/dialog-ref` focus trap.
-      ;;
-      ;; Both the backdrop and the dialog get the BUILT keydown handler
-      ;; `(handle-popover-keydown dispatch)` (rf2-op8c7). The dialog
-      ;; previously received the bare 1-arity builder, so React called the
-      ;; builder with the keydown event and discarded the handler fn it
-      ;; returned — making the dialog-level Esc a no-op. With the focus
-      ;; trap keeping focus inside the dialog, a dialog-focused Esc never
-      ;; reached the backdrop's handler, so Esc-on-dialog did not close.
-      (modal-chrome/modal-chrome
-        {:positioning          positioning
-         :backdrop-style       (backdrop-style positioning)
-         :dialog-style         (dialog-style)
-         :on-dismiss           #(dispatch [:rf.xray/cancellation-cascade-close])
-         :label                "Cancellation cascade"
-         :backdrop-testid      "rf-xray-cancellation-cascade-popover-backdrop"
-         :dialog-testid        "rf-xray-cancellation-cascade-popover-dialog"
-         :on-backdrop-key-down (handle-popover-keydown dispatch)
-         :on-dialog-key-down   (handle-popover-keydown dispatch)
-         :backdrop-tab-index   -1
-         :dialog-tab-index     0}
-        (render-cascade cascade close)))))
+  [:> SidePanel-component {}])
+
+(defn Popover
+  "The cancellation-cascade popover's public callable — what
+  `shell.cljs` mounts as a hiccup head and what `panels.cljs`'s
+  `mount-cancellation-cascade-popover!` facade holds.
+
+  Since rf2-k97c.3 it is the migration bridge rather than the view; see
+  [[SidePanel]], which says the same thing at more length. The
+  open/closed gate is inside [[PopoverView]], so this is always mounted
+  and renders nothing while the popover is closed — the same shape a
+  mounted `reg-view` returning nil had."
+  []
+  [:> Popover-component {}])
 
 ;; ---- registration entry --------------------------------------------------
 
@@ -568,9 +745,11 @@
   "Idempotent install for the visualiser's sub/event registrations.
   Called from `registry.cljs`'s `register-xray-handlers!` fan-out.
 
-  The view-side `reg-view`s above are picked up at ns-load (the
-  `reg-view` macro registers eagerly); this `install!` only registers
-  the subs + events under the orchestrator's idempotency sentinel."
+  The two view boundaries above are minted at ns-load (rf2-k97c.3 —
+  `rf.fresco/defview` mints its React component at definition, as
+  `rf/reg-view` registered eagerly before it); this `install!` only
+  registers the subs + events under the orchestrator's idempotency
+  sentinel."
   []
   (subs/install!)
   (events/install!)

--- a/tools/xray/src/day8/re_frame2_xray/panels/routing.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/routing.cljs
@@ -72,13 +72,53 @@
   no Reagent / UIx references. Frame isolation comes from the
   enclosing `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`.
 
+  ## THE VIEW IS A FRESCO BOUNDARY (rf2-k97c.3)
+
+  [[PanelView]] is an `rf.fresco/defview` — a real React function
+  component minted by the re-frame-native view layer — rather than an
+  `rf/reg-view`. It follows `panels/module_view.cljs`, increment 1's
+  merged template, under the epic's ruled design (rf2-k97c.2, Design
+  B): Xray's views are re-authored in Fresco and read through Fresco's
+  shipped collector, so their observation no longer depends on
+  whichever view build the installed adapter happens to supply.
+
+  The one read is `rf.fresco/sub`, which the collector wires,
+  activates, and re-wires AND NOTIFIES on invalidation
+  (`re-frame.fresco.impl.collector`). It is not a matter of taste: for
+  the extent of a boundary's body `re-frame.fresco.impl.intent/with-frame`
+  binds core's refusal tier, so an ambient `@(rf/subscribe …)` REFUSES
+  rather than silently reading the wrong frame.
+
+  ## WHERE THIS DEPARTS FROM THE TEMPLATE, AND WHY — THE BRIDGE OWNS THE
+  ## PUBLIC NAME
+
+  In `module_view.cljs` the boundary keeps the name `Panel` and the
+  bridge is a private `Panel-bridge`, because that panel is L4-only:
+  its own `install!` is the sole thing that names it. This panel is one
+  of the seven standalone-mountable ones, so the name `routing/Panel`
+  is read from five places this bead may not edit or would rather not
+  move — `panels.cljs`'s `render-panel!` chokepoint, the panel-gallery
+  testbed, two shell/mount test suites, and `spec/api-manifest.edn`
+  plus its curated metadata sidecar, which are hot-zone files.
+
+  So the assignment is inverted rather than the mechanism: [[Panel]]
+  stays the public callable every one of those sites already holds, and
+  it is the `rf.fresco/as-component` bridge; the boundary is the private
+  [[PanelView]] behind it. Same one door (`as-component`), same defined
+  end — when the shell is itself a Fresco tree the bridge collapses and
+  `PanelView` takes the name.
+
   ## Helpers
 
   Pure-data projection (`project-topology`, `epoch-routing-activity`,
   `project-topology-data`, plus the lens helpers) lives in
   `routing_helpers.cljc` so the algebra runs under the JVM unit-test
-  target."
+  target. The hiccup projection is [[panel-tree]], a plain fn over the
+  composite's VALUE — so the panel's markup stays drivable from the
+  node lane without a React commit, which is what the pre-migration
+  `(routing/Panel)` call gave those tests."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.routing-helpers :as h]
             [day8.re-frame2-xray.theme.tokens
@@ -303,14 +343,28 @@
   marker); other rows are quiet. Nested routes indent by depth and
   their parent rows carry a `▾` disclosure chevron (leaves get an
   aligned spacer). The FROM/TO overlay glyph paints to the right of
-  the path when the focused epoch navigated to/from this route."
+  the path when the focused epoch navigated to/from this route.
+
+  The row owns its own React `:key`, in its ATTRIBUTE map. The caller
+  used to attach it as `^{:key …}` reader metadata on the CALL FORM
+  `(route-table-row entry)` — metadata on a source list, which the call
+  discards when it returns a fresh vector, so no key ever reached React
+  (the same defect `cancellation_cascade.cljs` records under rf2-ppzid
+  and works around with `with-meta`). Putting it in the attribute map
+  is the one spelling BOTH substrates read: Reagent's `get-react-key`
+  and Fresco's codec head table. A portability fix rather than a Fresco
+  accommodation. `route-id` is unique across a topology by
+  construction — the topology is projected from a `{<route-id> <meta>}`
+  map — and a nil id degrades to the same `\"\"` the old expression
+  produced."
   [{:keys [row depth has-children? cycle-root?]}]
   (let [{:keys [route-id path doc marker]} row
         current?  (= marker :here)
         glyph     (marker-glyph marker)
         testid    (str "rf-xray-routing-table-row-"
                        (when route-id (name route-id)))]
-    [:div {:data-testid   testid
+    [:div {:key           (str route-id)
+           :data-testid   testid
            :data-route-id (when route-id (str route-id))
            :data-marker   (when marker (name marker))
            :data-current  (when current? "true")
@@ -378,7 +432,12 @@
 (defn- route-table-section
   "§3 — the full registered route graph as a tree (always visible per
   the topology-plus-overlay contract). Empty topology vector ⇒ the
-  surrounding panel renders the silent state instead."
+  surrounding panel renders the silent state instead.
+
+  `route-table-row` is CALLED here, never used as a hiccup head: a
+  plain fn in head position is a loud error under Fresco and a silent
+  extra component under Reagent, and neither is wanted. The React key
+  rides in the row's own attribute map — see its docstring."
   [topology]
   (section
     {:first? false :testid "rf-xray-routing-table"}
@@ -387,10 +446,7 @@
            :style       {:display        "flex"
                          :flex-direction "column"
                          :gap            "2px"}}
-     (into [:<>]
-           (for [entry topology]
-             ^{:key (str (-> entry :row :route-id))}
-             (route-table-row entry)))]))
+     (into [:<>] (map route-table-row topology))]))
 
 ;; ---- empty (no routes registered) ---------------------------------------
 
@@ -418,10 +474,10 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view Panel
-  "The Routing tab's root view — three stacked sections per spec/021 §7.2
-  (reconciled to RoutesPanel). Subscribes to
-  `:rf.xray/routing-tab-data` and renders, top → bottom:
+(defn panel-tree
+  "The Routing tab's markup, as a pure function of the
+  `:rf.xray/routing-tab-data` composite's VALUE — three stacked
+  sections per spec/021 §7.2 (reconciled to RoutesPanel), top → bottom:
 
     1. CURRENT ROUTE          — active id + params + matched path.
     2. NAVIGATION THIS EPOCH  — FROM ──► TO + params + outcome
@@ -436,31 +492,108 @@
   identity). This matches the Figma `RoutesPanel`, which opens
   directly on the CURRENT ROUTE section with no header chrome.
 
-  When the host has no routes registered the panel renders the
-  silent-by-default caption (no sections)."
+  When the host has no routes registered this renders the
+  silent-by-default caption (no sections).
+
+  SEPARATED FROM THE BOUNDARY DELIBERATELY (rf2-k97c.3). The read moved
+  into [[PanelView]], leaving this a value → hiccup projection with no
+  reactive surface of its own — the same split
+  `routing_helpers.cljc` already makes for the data algebra, one layer
+  up. It takes NO reads, so it is drivable from the node lane by handing
+  it a composite value, which is what `(routing/Panel)` used to give
+  those tests before the panel became a React component."
+  [{:keys [silent? topology activity from-id to-id navigated? current]
+    :as _data}]
+  [:section {:data-testid "rf-xray-routing"
+             :style       {:height         "100%"
+                           :display        "flex"
+                           :flex-direction "column"
+                           :background     (:bg-2 tokens)
+                           :color          (:text-primary tokens)
+                           :font-family    sans-stack
+                           :font-size      "14px"
+                           :overflow       "auto"}}
+   (if silent?
+     (silent-state)
+     [:<>
+      (current-route-section {:current current})
+      (navigation-section {:activity   activity
+                           :from-id    from-id
+                           :to-id      to-id
+                           :navigated? navigated?
+                           :current    current})
+      (route-table-section topology)])])
+
+(rf.fresco/defview ^:private PanelView
+  "The Routing tab's root — a FRESCO BOUNDARY (rf2-k97c.3), not an
+  `rf/reg-view`. Reads `:rf.xray/routing-tab-data` and hands the value
+  to [[panel-tree]].
+
+  The READ is `rf.fresco/sub`, a plain call the collector records an
+  edge for — no deref, no reaction owned by the installed adapter, and a
+  re-wire that NOTIFIES when the substrate disposes the underlying
+  derived value. That is the third of the epic's three couplings, and it
+  is the one a first-paint smoke test cannot see.
+
+  The FRAME the read resolves against comes from React context, which
+  the enclosing frame boundary writes — `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context (core's
+  `re-frame.adapter.context/frame-context`) — so this boundary resolves
+  `:rf/xray` identically under today's Reagent-rendered shell and under
+  the Fresco root Xray will own. It never consults
+  `:adapter/current-component`, the hook a foreign root cannot answer.
+
+  PRIVATE, and [[Panel]] in front of it is the public name — see the ns
+  docstring's section on the inverted bridge. The argument is the
+  ordinary one-props-map vector every `defview` takes; this panel reads
+  nothing from props, so it is destructured away."
+  [_props]
+  (panel-tree (rf.fresco/sub [:rf.xray/routing-tab-data])))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's shell, `panels.cljs`'s `render-panel!` and the panel-gallery
+;; testbed are all still `reg-view` trees rendered by the installed
+;; adapter, and each mounts this panel as the hiccup head `[routing/Panel]`
+;; — which a React component is not.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly
+;; this: it answers a real React component for a boundary, which a React
+;; parent (UIx, Reagent or plain JavaScript) mounts UNDER THE FRAME IT IS
+;; ALREADY IN, taking the frame from React context rather than from a
+;; second root. So there is no second root here, no adapter-kind branch,
+;; and no props ABI — the three things the spike's Arm A needed and the
+;; ruling counted against it.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the shell is itself a
+;; Fresco tree, `PanelView` takes the name `Panel` directly, `[:>]` goes,
+;; and both defs below are deleted.
+
+(def ^:private Panel-component
+  "The React component [[PanelView]] presents as, for a non-Fresco
+  parent. Declared once at top level beside the view, as
+  `rf.fresco/as-component`'s contract requires — deriving it per render
+  would mint a new component type every time and remount the panel on
+  each parent render."
+  (rf.fresco/as-component PanelView))
+
+(defn Panel
+  "The Routing tab's public callable — the one every existing mount site
+  already holds: `panels.cljs`'s `render-panel!` chokepoint (and its
+  `mount-routing!` facade), `shell/detail-panel`'s tab case, the
+  panel-gallery testbed, and the `reg-l4-tab!` entry below.
+
+  Since rf2-k97c.3 it is the migration bridge rather than the view:
+  Reagent-shaped hiccup interoping to the React component
+  [[PanelView]] presents as. The enclosing `rf/frame-provider` is what
+  puts `:rf/xray` in React context for it — this returns no provider of
+  its own and needs none.
+
+  Callers wanting the MARKUP as data — the node-lane view tests — call
+  [[panel-tree]] with the composite's value instead; this returns an
+  interop vector, not a tree to walk."
   []
-  (let [{:keys [silent? topology activity from-id to-id navigated? current]
-         :as _data}
-        @(rf/subscribe [:rf.xray/routing-tab-data])]
-    [:section {:data-testid "rf-xray-routing"
-               :style       {:height         "100%"
-                             :display        "flex"
-                             :flex-direction "column"
-                             :background     (:bg-2 tokens)
-                             :color          (:text-primary tokens)
-                             :font-family    sans-stack
-                             :font-size      "14px"
-                             :overflow       "auto"}}
-     (if silent?
-       (silent-state)
-       [:<>
-        (current-route-section {:current current})
-        (navigation-section {:activity   activity
-                             :from-id    from-id
-                             :to-id      to-id
-                             :navigated? navigated?
-                             :current    current})
-        (route-table-section topology)])]))
+  [:> Panel-component {}])
 
 ;; ---- production value sources --------------------------------------------
 ;;
@@ -569,6 +702,10 @@
      :mnem  "r"
      :modes #{:dynamic}
      :order 6
+     ;; rf2-k97c.3 — still `Panel`, and deliberately so: the registry
+     ;; requires `:panel` to be CALLABLE and the shell mounts it as a
+     ;; Reagent hiccup head, which is what the bridge now is. The
+     ;; boundary behind it is the private `PanelView`.
      :panel Panel})
 
   nil)

--- a/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
@@ -162,6 +162,23 @@
 ;; macro defs the symbol; invoking it directly under `with-frame`
 ;; resolves subscribes against `:rf/xray` the same way the shell
 ;; mount does.
+;;
+;; EXCEPT the cancellation-cascade popover, which since rf2-k97c.3 is a
+;; FRESCO BOUNDARY behind an `as-component` bridge: the var answers an
+;; interop vector, not a tree to walk. The helper below reproduces the
+;; boundary's own gate and reads exactly - same gate, same query vectors -
+;; so both rows below assert on the same hiccup they did before.
+
+(defn- cancellation-cascade-popover-tree
+  "The cancellation-cascade popover's markup for the current state:
+  nil while closed, the dialog otherwise. Mirrors
+  `cancellation-cascade/PopoverView`'s gate and reads."
+  []
+  (when @(rf/subscribe [:rf.xray/cancellation-cascade-popover-open?])
+    (cancellation-cascade/popover-tree
+      {:cascade     @(rf/subscribe [:rf.xray/cancellation-cascade-for-focused-event])
+       :positioning @(rf/subscribe [:rf.xray/modal-positioning])
+       :expanded?   @(rf/subscribe [:rf.xray/cancellation-cascade-expanded?])})))
 
 (deftest cancellation-cascade-popover-carries-dialog-contract
   (testing "rf2-7389r — the cancellation-cascade popover (audit
@@ -171,7 +188,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/cancellation-cascade-open
                          {:dispatch-id :test-dispatch-id}]))
-    (let [tree (rf/with-frame :rf/xray (cancellation-cascade/Popover))]
+    (let [tree (rf/with-frame :rf/xray (cancellation-cascade-popover-tree))]
       (is (some? tree) "Popover renders when open")
       (when tree
         (assert-dialog-contract!
@@ -235,7 +252,7 @@
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/cancellation-cascade-open
                        {:dispatch-id :test-dispatch-id}]))
-  (let [tree (rf/with-frame :rf/xray (cancellation-cascade/Popover))]
+  (let [tree (rf/with-frame :rf/xray (cancellation-cascade-popover-tree))]
     (is (some? tree) "Popover renders when open")
     (when tree
       (assert-dialog-focus-ref!

--- a/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
@@ -69,6 +69,45 @@
                          (.startsWith prefix))))
           (hiccup-seq tree)))
 
+;; ---- the two views, as trees (rf2-k97c.3) --------------------------------
+;;
+;; `cc/SidePanel` and `cc/Popover` are now `rf.fresco/as-component`
+;; bridges and answer an interop vector, not a tree to walk. The markup
+;; is `cc/render-cascade` / `cc/popover-tree`, pure fns of the values the
+;; boundary reads.
+;;
+;; The two helpers below reproduce each boundary's gate and reads
+;; EXACTLY — same gate, same order, same query vectors — so every row in
+;; this file asserts on the same hiccup it did before, and a boundary
+;; that stopped reading one of these subs would diverge from its own
+;; test helper rather than silently agreeing with it.
+;;
+;; These are deliberately the AMBIENT `rf/subscribe`, because these rows
+;; run under `rf/with-frame :rf/xray` in the node lane with no React
+;; commit at all. What each boundary's own read resolves to — the frame
+;; React context names, not the ambient one — is the subject of
+;; `cancellation_cascade_fresco_boundary_dom_cljs_test`, which mounts
+;; for real.
+
+(defn- side-panel-tree
+  "What calling the SidePanel var directly returned before the
+  migration: nil while dormant, the cascade block otherwise."
+  []
+  (let [cascade @(rf/subscribe [:rf.xray/cancellation-cascade-for-focused-machine])]
+    (when-not (= :no-trigger (:empty-kind cascade))
+      (cc/render-cascade
+        cascade nil @(rf/subscribe [:rf.xray/cancellation-cascade-expanded?])))))
+
+(defn- popover-tree
+  "What calling the Popover var directly returned before the migration:
+  nil while closed, the dialog otherwise."
+  []
+  (when @(rf/subscribe [:rf.xray/cancellation-cascade-popover-open?])
+    (cc/popover-tree
+      {:cascade     @(rf/subscribe [:rf.xray/cancellation-cascade-for-focused-event])
+       :positioning @(rf/subscribe [:rf.xray/modal-positioning])
+       :expanded?   @(rf/subscribe [:rf.xray/cancellation-cascade-expanded?])})))
+
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
   (rf/make-frame {:id :rf/xray}))
@@ -123,7 +162,7 @@
             nil (mount stays dormant)"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
-      (let [out (cc/SidePanel)]
+      (let [out (side-panel-tree)]
         (is (nil? out)
             "no rendered hiccup when no cancellation cascade is present")))))
 
@@ -131,7 +170,7 @@
   (testing "Popover short-circuits to nil when the open? slot is false"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
-      (is (nil? (cc/Popover))))))
+      (is (nil? (popover-tree))))))
 
 (deftest popover-renders-empty-state-when-open-with-no-cascade
   (testing "Popover renders the no-trigger empty state when open but
@@ -139,7 +178,7 @@
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/cancellation-cascade-open nil])
-      (let [tree (cc/Popover)]
+      (let [tree (popover-tree)]
         (is (some? (find-by-testid tree "rf-xray-cancellation-cascade-popover-dialog")))
         (is (some? (find-by-testid tree "rf-xray-cancellation-cascade-empty-no-trigger")))))))
 
@@ -153,7 +192,7 @@
       (seed-trace! cancel-cascade-buffer)
       ;; Pick the machine that had the destroy
       (rf/dispatch-sync [:rf.xray/select-machine-id :user-session])
-      (let [tree (cc/SidePanel)]
+      (let [tree (side-panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-cancellation-cascade"))
             "section root rendered")
         (is (some? (find-by-testid tree "rf-xray-cancellation-cascade-decision-row"))
@@ -184,7 +223,7 @@
       (seed-trace! cancel-cascade-buffer)
       (rf/dispatch-sync [:rf.xray/cancellation-cascade-open
                          {:kind :dispatch-id :id 7}])
-      (let [tree (cc/Popover)]
+      (let [tree (popover-tree)]
         (is (some? (find-by-testid tree "rf-xray-cancellation-cascade-popover-dialog")))
         (is (some? (find-by-testid tree "rf-xray-cancellation-cascade-decision-row")))
         (is (= 2 (count (find-all-by-testid-prefix
@@ -297,7 +336,7 @@
         (seed-trace! (concat [decision destroy] many-aborts))
         (rf/dispatch-sync [:rf.xray/cancellation-cascade-open
                            {:kind :dispatch-id :id 9}])
-        (let [tree (cc/Popover)]
+        (let [tree (popover-tree)]
           (is (some? (find-by-testid tree "rf-xray-cancellation-cascade-expander"))
               "expander present when collapsed-by-default kicks in")
           (let [shown-when-collapsed
@@ -331,7 +370,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/cancellation-cascade-open nil]))
     (rf/with-frame :rf/xray
-      (let [tree     (cc/Popover)
+      (let [tree     (popover-tree)
             backdrop (find-by-testid tree "rf-xray-cancellation-cascade-popover-backdrop")
             style    (:style (second backdrop))]
         (is (some? backdrop))
@@ -349,7 +388,7 @@
       (rf/dispatch-sync [:rf.xray/cancellation-cascade-open nil])
       (rf/dispatch-sync [:rf.xray/set-modal-positioning :absolute]))
     (rf/with-frame :rf/xray
-      (let [tree     (cc/Popover)
+      (let [tree     (popover-tree)
             backdrop (find-by-testid tree "rf-xray-cancellation-cascade-popover-backdrop")
             style    (:style (second backdrop))]
         (is (some? backdrop))
@@ -390,7 +429,7 @@
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/cancellation-cascade-open nil])
-      (let [tree     (cc/Popover)
+      (let [tree     (popover-tree)
             dialog   (find-by-testid tree "rf-xray-cancellation-cascade-popover-dialog")
             on-key   (:on-key-down (second dialog))
             captured (atom nil)]
@@ -407,7 +446,7 @@
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/cancellation-cascade-open nil])
-      (let [tree     (cc/Popover)
+      (let [tree     (popover-tree)
             dialog   (find-by-testid tree "rf-xray-cancellation-cascade-popover-dialog")
             on-key   (:on-key-down (second dialog))
             captured (atom nil)]
@@ -464,7 +503,7 @@
       (seed-trace! cancel-cascade-buffer)
       (rf/dispatch-sync [:rf.xray/cancellation-cascade-open
                          {:kind :dispatch-id :id 7}])
-      (let [tree         (cc/Popover)
+      (let [tree         (popover-tree)
             teardowns    (raw-find-by-testid tree "rf-xray-cancellation-cascade-teardowns")
             aborts       (raw-find-by-testid tree "rf-xray-cancellation-cascade-aborts")
             keyed-children (fn [container]

--- a/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,576 @@
+(ns day8.re-frame2-xray.panels.cancellation-cascade-fresco-boundary-dom-cljs-test
+  "THE CANCELLATION-CASCADE POPOVER RE-AUTHORED IN THE RE-FRAME-NATIVE
+  VIEW LAYER, read off a real React commit (rf2-k97c.3, step 2).
+
+  `cancellation-cascade/PopoverView` is now an `rf.fresco/defview`
+  reading through Fresco's shipped collector rather than an
+  `rf/reg-view` reading through whatever view build the installed
+  substrate adapter supplies. This file is the behavioural evidence for
+  that swap, following the merged template
+  (`module_view_fresco_boundary_dom_cljs_test`).
+
+  ## What the epic asked for, and which row answers it
+
+  This panel is the first migrated one that DISPATCHES, so unlike the
+  template it can answer criterion 3 — and W5 is the whole reason this
+  file is worth more than a copy of the template:
+
+    1 FIRST DISPLAY               — W1
+    2 UPDATES ON A REAL CHANGE    — W2 (with the deaf control that makes
+                                    the update mean liveness)
+    3 XRAY'S OWN INTERACTIONS     — W5, a real browser click on a real
+                                    button, with the cross-frame control
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    5 TOOL ACTIVITY NEVER
+      MASQUERADING AS APPLICATION
+      EVIDENCE                    — W3, in BOTH directions
+    6 CLEAN TEARDOWN              — W4
+
+  ## Why W5 matters beyond this panel
+
+  The template panel dispatches nothing, so increment 1 left open the
+  question of how a dispatch behaves inside a boundary. The answer was
+  read out of Fresco's own shipped code before a line moved:
+  `re-frame.fresco.impl.intent/with-frame` — which
+  `collector/run-once` wraps every body in — binds core's refusal tier,
+  so an AMBIENT dispatch refuses, while an explicitly carried
+  `{:frame <id>}` still answers, because that tier deletes the ambient
+  FIND and not the carrying; and `rf/current-frame-id` answers the
+  declared frame, because it neither reads nor dispatches. Plus
+  `defview`'s own contract that a PLAIN FUNCTION at an `on-*` prop is
+  passed through untouched.
+
+  W5 is that reasoning put in front of a browser. It clicks the real
+  expander button and asserts the event landed in the frame the tree
+  NAMED and nowhere else. If the reasoning above were wrong, the
+  handler would either refuse at the click or write into the wrong
+  frame, and one of W5's two halves would say so.
+
+  ## The mount is the SHELL's mount
+
+  `shell.cljs` mounts this popover as the hiccup head
+  `[cancellation-cascade/Popover]` at the shell root, inside the
+  shell's `[rf/frame-provider {:frame :rf/xray}]`. [[mount-popover!]]
+  does exactly that — same head, same wrapper — so the bridge the shell
+  actually holds is the thing under test.
+
+  Nothing below ever calls the view a second time. Every assertion
+  after the mount reads `container.querySelector…` — the DOM React
+  committed on its own.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium). The `:node-test` build's
+  `cljs-test$` regex also matches, so it LOADS under Node — where every
+  row short-circuits through [[browser?]] and reports the skip rather
+  than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panels.cancellation-cascade :as cc]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. Three rows
+  need one that is not `:rf/xray`: W1 reads it as the negative half of
+  the frame-targeting claim, W3 mounts INSIDE it, and W5 asserts the
+  click's event did NOT land in it."
+  ::app)
+
+(def ^:private open?-q
+  "The popover's GATE read — the one subscription a closed popover
+  costs. Named once because three rows key off it; the sub-cache is
+  keyed by the query vector itself (`re-frame.subs/cache-key` is
+  identity), so this value IS the cache key."
+  [:rf.xray/cancellation-cascade-popover-open?])
+
+(def ^:private expanded?-q
+  [:rf.xray/cancellation-cascade-expanded?])
+
+(def ^:private focus-dispatch-id 7)
+
+(defn- abort-event
+  [n]
+  {:id        (+ 10 n)
+   :operation :rf.http/aborted-on-actor-destroy
+   :op-type   :rf.http
+   :severity  :info
+   :time      (+ 1020 n)
+   :tags      {:request-id           (keyword (str "r" n))
+               :url                  (str "/api/x" n)
+               :actor-id             :user-session
+               :rf.trace/dispatch-id focus-dispatch-id
+               :frame                :rf/default}})
+
+(def ^:private cascade-buffer
+  "One decision + one cancellation-anchor + TWELVE aborts. Twelve
+  rather than two because W5 clicks the collapse expander, which only
+  renders once the abort list is over the collapse threshold — a
+  fixture with two aborts would give W5 no control to press."
+  (into [{:id 1 :operation :rf.event/dispatched :op-type :rf.event
+          :time 1000
+          :tags {:rf.event/v           [:auth/logout]
+                 :rf.trace/dispatch-id focus-dispatch-id
+                 :frame                :rf/default}}
+         {:id 2 :operation :rf.machine/destroyed :op-type :rf.machine
+          :time 1010
+          :tags {:machine-id           :user-session
+                 :reason               :explicit
+                 :rf.trace/dispatch-id focus-dispatch-id
+                 :frame                :rf/default}}]
+        (map abort-event (range 1 13))))
+
+;; ---- a probe event, and the `reg-view` W3 measures the panel against ------
+
+(rf/reg-event ::bump
+  (fn [{:keys [db]} [_ n]] {:db (assoc db ::n n)}))
+
+(rf/reg-sub ::n (fn [db _] (::n db)))
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W3, and nothing else. An ordinary
+  `reg-view` rendered by the installed adapter in the same root, in the
+  same frame, in the same commit as the popover — so the only variable
+  between it and the popover is which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-probe-reg-view"} (str @(rf/subscribe [::n]))])
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     ;; `:async? true` because W2, W4 and W5 are `async` rows, and
+     ;; `cljs.test` refuses a FUNCTION fixture in any namespace that
+     ;; carries one.
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing
+                      ;; about; a neighbour's boundary left in the entry
+                      ;; cache would make W4's release row read a
+                      ;; residue that is not this popover's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than
+;; an omission — a Fresco boundary is NOT in Reagent's render queue, so
+;; draining that queue commits nothing of this popover's update and a row
+;; written that way reads a DOM that has not moved and reports a live view
+;; as dead. Mount is committed with `flushSync`; everything after it is a
+;; bounded poll of the committed DOM.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It
+  exists for the CONTROL in W2: an absence asserted immediately after a
+  write is a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup!
+  "Register Xray's handlers and make the two frames."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- seed-cascade!
+  "Put a real cancellation cascade in Xray's trace buffer and focus it."
+  []
+  (rf/dispatch-sync [:rf.xray/sync-trace-buffer cascade-buffer]
+                    {:frame :rf/xray})
+  (rf/dispatch-sync [:rf.xray/cancellation-cascade-open
+                     {:kind :dispatch-id :id focus-dispatch-id}]
+                    {:frame :rf/xray}))
+
+(defn- mount-popover!
+  "Mount the popover the way `shell.cljs` mounts it: the var as a hiccup
+  head at the root of a `frame-provider` scoping `frame`. Committed
+  synchronously — React 19's `root.render` is otherwise async and phase
+  1 would assert against an empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [cc/Popover]])))
+    {:container container :root root}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads the sub-cache."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+(defn- aborts-shown
+  "How many abort rows the committed body says it is showing. The panel
+  stamps this on its own root as `data-aborts-shown`, so the number is
+  read off the DOM rather than counted from a query."
+  [container]
+  (some-> (q container "[data-testid=\"rf-xray-cancellation-cascade-body\"]")
+          (.getAttribute "data-aborts-shown")
+          js/parseInt))
+
+;; ===========================================================================
+;; W1 — first display, and the read lands in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-popover-paints-and-its-reads-land-in-the-named-frame
+  (testing "rf2-k97c.3 — the migrated cancellation-cascade popover commits
+            real DOM through the head `shell.cljs` mounts, and its
+            `rf.fresco/sub` reads resolve against the frame the enclosing
+            `frame-provider` named rather than the ambient one. Epic
+            criteria 1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            _ (seed-cascade!)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [::n] {:frame app-frame})
+            {:keys [container root]} (mount-popover! :rf/xray)]
+        (try
+          (is (some? (q container "[data-testid=\"rf-xray-cancellation-cascade-popover-dialog\"]"))
+              "the dialog committed a real DOM root under React — a Fresco
+               boundary mounted through Reagent's `:>` from the shell's head")
+          (is (some? (q container "[data-testid=\"rf-xray-cancellation-cascade-decision-row\"]"))
+              "and the waterfall's decision row rendered, so the body ran
+               against a real cascade rather than an empty state")
+
+          ;; ---- criterion 4: the reads are where the tree said ----
+          (is (pos? (ref-count-of :rf/xray open?-q))
+              (str "the popover's GATE read holds a reference in :rf/xray's "
+                   "sub-cache — the frame the enclosing frame-provider named. "
+                   "Cache keys: " (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame open?-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [::n]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
+          (finally
+            (rf/unsubscribe [::n] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-popover-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted popover re-renders itself and commits
+            new DOM when a read's value really changes, and does NOT when
+            nothing it watches moved. Epic criterion 2, with the control
+            that makes the update mean liveness rather than a commit that
+            simply had not happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed-cascade!)
+        (let [{:keys [container root]} (mount-popover! :rf/xray)
+              dialog?  (fn [] (some? (q container "[data-testid=\"rf-xray-cancellation-cascade-popover-dialog\"]")))
+              gone?    (fn [] (not (dialog?)))]
+          (is (dialog?)
+              "PRECONDITION: the dialog is on screen, so its disappearance
+               below is a real transition and not a panel that never
+               rendered")
+
+          ;; ---- phase 2: the world moves, and the popover is deaf ---------
+          ;; A real app-db write into the SAME frame the popover reads,
+          ;; under a key none of its four subscriptions computes over. Every
+          ;; db-derived sub recomputes and answers the value it answered
+          ;; before, so nothing the boundary watches is invalidated. A
+          ;; binding that repainted on db MOVEMENT rather than on VALUE
+          ;; CHANGE fires here.
+          (rf/dispatch-sync [::bump 1] {:frame :rf/xray})
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (dialog?)
+                      "CONTROL: given a full settling window, the deaf write
+                       moved nothing — the dialog is still exactly where it
+                       was. A popover that re-rendered its way out of
+                       existence here would make phase 3 pass for a reason
+                       that is not liveness")
+                  ;; ---- phase 3: the gate flips, DOM follows --------------
+                  (rf/dispatch-sync [:rf.xray/cancellation-cascade-close]
+                                    {:frame :rf/xray})
+                  (is (false? @(rf/subscribe open?-q {:frame :rf/xray}))
+                      "PRECONDITION: the underlying gate value really did
+                       flip — so a dialog still on screen below is the
+                       popover failing to re-render, not the event failing
+                       to land")
+                  (rf.test-support/poll-until gone?
+                    {:label "the popover committed its own disappearance"})))
+              (.then
+                (fn [_]
+                  (is (gone?)
+                      "the popover re-rendered on a real invalidation of its
+                       gate read and committed the closed state")
+                  ;; ---- phase 4: and it comes back, so the close was not
+                  ;; a one-way teardown of the boundary itself -------------
+                  (rf/dispatch-sync [:rf.xray/cancellation-cascade-open
+                                     {:kind :dispatch-id :id focus-dispatch-id}]
+                                    {:frame :rf/xray})
+                  (rf.test-support/poll-until dialog?
+                    {:label "the popover re-opened"})))
+              (.then
+                (fn [_]
+                  (is (dialog?)
+                      "and re-opening commits the dialog again — the gate is
+                       live in both directions, not a latch")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — the tool's own render is not application view evidence
+;; ===========================================================================
+
+(deftest w3-the-boundarys-render-emits-no-view-trace
+  (testing "rf2-k97c.3 / rf2-tqlmq — rendering the migrated popover
+            contributes NOTHING to the substrate's view-trace stream, even
+            when it is mounted INSIDE an application frame. Epic criterion
+            5, proven structurally rather than by the `:rf/xray` frame gate:
+            a Fresco boundary is not a substrate view render, so there is no
+            event to gate. The control is an ordinary `reg-view` in the same
+            root, the same frame and the same commit."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_       (setup!)
+            traces  (atom [])
+            view-op? #(and (keyword? (:operation %))
+                           (= "rf.view" (namespace (:operation %))))]
+        ;; The popover's gate lives in the frame it is MOUNTED in, so seed
+        ;; the application frame here rather than `:rf/xray` — otherwise
+        ;; the subject renders nil and its zero is vacuous, which is exactly
+        ;; what the precondition below refuses to let happen quietly.
+        (rf/dispatch-sync [:rf.xray/sync-trace-buffer cascade-buffer]
+                          {:frame app-frame})
+        (rf/dispatch-sync [:rf.xray/cancellation-cascade-open
+                           {:kind :dispatch-id :id focus-dispatch-id}]
+                          {:frame app-frame})
+        (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+        (try
+          ;; ---- the subject: the popover, mounted in an APPLICATION frame --
+          (let [{:keys [container root]} (mount-popover! app-frame)
+                subject-views (filterv view-op? @traces)]
+            (try
+              (is (some? (q container "[data-testid=\"rf-xray-cancellation-cascade-popover-dialog\"]"))
+                  "precondition: the popover really did render in this commit
+                   — an empty container would make the zero below vacuous")
+              (is (zero? (count subject-views))
+                  (str "the popover's render put NO :rf.view/* op in the trace "
+                       "stream while rendering inside an application frame. "
+                       "Ops seen: " (pr-str (mapv :operation subject-views))))
+              (finally (teardown! root container))))
+
+          ;; ---- the control: a reg-view, same root shape, same frame -------
+          (reset! traces [])
+          (let [container (.createElement js/document "div")
+                root      (rdc/create-root container)]
+            (.appendChild (.-body js/document) container)
+            (try
+              (react-dom/flushSync
+                (fn []
+                  (rdc/render root [rf/frame-provider {:frame app-frame}
+                                    [ProbeRegView]])))
+              (let [control-views (filterv view-op? @traces)]
+                (is (some? (q container "[data-testid=\"rf-xray-probe-reg-view\"]"))
+                    "precondition: the control really did render")
+                (is (pos? (count control-views))
+                    (str "CONTROL FIRES: an ordinary reg-view rendered the same "
+                         "way DOES emit a :rf.view/* op, so the subject's zero "
+                         "is a property of the boundary and not of a dead "
+                         "instrument. Ops seen: "
+                         (pr-str (mapv :operation control-views)))))
+              (finally (teardown! root container))))
+          (finally
+            (rf/unregister-listener! :trace ::collect)))))))
+
+;; ===========================================================================
+;; W4 — clean teardown: the reads are released, and reopening is not growth
+;; ===========================================================================
+
+(defn- released?
+  "The popover's gate read is fully released from `:rf/xray`'s sub-cache."
+  []
+  (zero? (ref-count-of :rf/xray open?-q)))
+
+(deftest w4-unmount-releases-the-reads-and-reopen-does-not-grow-them
+  (testing "rf2-k97c.3 — unmounting the popover releases its subscription
+            references completely, and mounting it again returns to the SAME
+            count rather than a higher one. Epic criterion 6, and the number
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed 22 → 25 → 32 across
+            renders and never fell on unmount.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once. `impl.collector`'s `cell-reapers` gives a cell
+            whose last reader unmounts ONE MACROTASK OF GRACE, so that a keyed
+            reorder which unmounts and remounts a row within a single turn
+            reuses the reaction instead of rebuilding it. A synchronous
+            assertion would therefore report a LEAK against a collector
+            behaving exactly as documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed-cascade!)
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-popover! :rf/xray)
+                      gate    (ref-count-of :rf/xray open?-q)
+                      body    (ref-count-of :rf/xray expanded?-q)]
+                  (is (pos? gate)
+                      "the mount took a reference on the gate read —
+                       otherwise the release below is vacuous")
+                  (is (pos? body)
+                      "AND on a read made INSIDE the open branch, so this row
+                       is about the conditional reads too and not only the
+                       gate")
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released the reads"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released the gate COMPLETELY, "
+                                   "within the collector's grace macrotask. "
+                                   "Cache: " (pr-str (keys (cache-of :rf/xray)))))
+                          (is (zero? (ref-count-of :rf/xray expanded?-q))
+                              "and the conditional read too — a branch-taken
+                               edge is released on the same lifecycle as the
+                               gate, not leaked because it was conditional")
+                          ;; ---- reopen: the same count, not a higher one ----
+                          (let [{c2 :container r2 :root} (mount-popover! :rf/xray)
+                                remounted (ref-count-of :rf/xray open?-q)]
+                            (is (= gate remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" gate ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases it too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
+
+;; ===========================================================================
+;; W5 — CRITERION 3: a real click inside the boundary dispatches, and it
+;;      dispatches into the frame the tree NAMED
+;; ===========================================================================
+;;
+;; This is the row the template could not carry, and it is the reason this
+;; file exists rather than a second copy of module_view's. See the ns
+;; docstring for the contract it is putting in front of a browser.
+
+(deftest w5-a-click-inside-the-boundary-dispatches-into-the-named-frame
+  (testing "rf2-k97c.3 — clicking the collapse expander inside the migrated
+            popover dispatches `:rf.xray/cancellation-cascade-toggle-expand`,
+            the DOM follows, and the event lands in the frame the enclosing
+            `frame-provider` NAMED rather than in the ambient one or in a
+            neighbouring application frame. Epic criterion 3."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed-cascade!)
+        (let [{:keys [container root]} (mount-popover! :rf/xray)
+              toggle (q container "[data-testid=\"rf-xray-cancellation-cascade-expand-toggle\"]")
+              before (aborts-shown container)]
+          (is (some? toggle)
+              "PRECONDITION: the collapse expander rendered — the fixture
+               carries more aborts than the collapse threshold, so there is
+               a real control to press")
+          (is (= 5 before)
+              (str "PRECONDITION: the body opens COLLAPSED, showing the "
+                   "default five of twelve abort rows. Got: " before))
+          (is (false? @(rf/subscribe expanded?-q {:frame :rf/xray}))
+              "PRECONDITION: and the expand flag is off in :rf/xray")
+          (is (false? @(rf/subscribe expanded?-q {:frame app-frame}))
+              "PRECONDITION: and off in the application frame, so the
+               cross-frame control below starts from a real zero")
+
+          ;; ---- the act: a REAL browser click on a REAL button -------------
+          (when toggle (.click toggle))
+
+          (-> (rf.test-support/poll-until
+                #(= 12 (aborts-shown container))
+                {:label "the popover committed the expanded abort list"})
+              (.then
+                (fn [_]
+                  (is (= 12 (aborts-shown container))
+                      "the click reached the handler, the dispatch landed, the
+                       read was invalidated and the boundary committed the
+                       expanded list — the whole round trip through a Fresco
+                       boundary, in a browser")
+                  (is (true? @(rf/subscribe expanded?-q {:frame :rf/xray}))
+                      "and the flag flipped in :rf/xray — the frame the
+                       enclosing frame-provider named")
+                  (is (false? @(rf/subscribe expanded?-q {:frame app-frame}))
+                      "CROSS-FRAME CONTROL: and NOT in the application frame.
+                       A handler that had lost its captured frame and fallen
+                       back to an ambient or default one would write here")))
+              (.catch (fn [e]
+                        (is false (str "W5 never settled: " (.-message e)
+                                       " — aborts-shown: "
+                                       (pr-str (aborts-shown container))))
+                        nil))
+              (.then (fn [_]
+                       (rf/unsubscribe expanded?-q {:frame :rf/xray})
+                       (rf/unsubscribe expanded?-q {:frame app-frame})
+                       (teardown! root container)
+                       (done)))))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
@@ -100,6 +100,25 @@
        (filter string?)
        (apply str)))
 
+(defn- panel-tree
+  "The panel's markup for the CURRENT state of `:rf.xray/routing-tab-data`
+  — what calling the panel var directly returned before rf2-k97c.3 made
+  the panel a Fresco boundary.
+
+  `routing/Panel` is now the `as-component` bridge and answers an
+  interop vector, not a tree to walk; the markup is
+  `routing/panel-tree`, a pure fn of the composite's VALUE. So the read
+  the panel used to make inside its own body is made here, one line
+  above it, and every row below asserts on exactly the hiccup it did.
+
+  This is deliberately still the AMBIENT `rf/subscribe`, because these
+  rows run under `rf/with-frame :rf/xray` in the node lane with no
+  React commit at all. What the panel's own read now resolves to — the
+  frame React context names, not the ambient one — is the subject of
+  `routing_fresco_boundary_dom_cljs_test`, which mounts for real."
+  []
+  (routing/panel-tree @(rf/subscribe [:rf.xray/routing-tab-data])))
+
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
   (xray-test-support/install-test-overrides!)
@@ -194,7 +213,7 @@
       (rf/dispatch-sync [:rf.xray/set-current-route-slice-override-for-test
                          {:route-id :route/cart :params {} :query {}}]
                         {:frame :rf/xray})
-      (let [tree (routing/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-routing"))
             "panel root present")
         ;; spec/021 §14.1 (rf2-6xezz) — every L4 panel scrubs its
@@ -245,7 +264,7 @@
       (rf/dispatch-sync [:rf.xray/set-current-route-slice-override-for-test
                          {:route-id :route/cart :params {:id 42} :path "/cart"}]
                         {:frame :rf/xray})
-      (let [tree (routing/Panel)
+      (let [tree (panel-tree)
             id   (find-by-testid tree "rf-xray-routing-current-id")
             params (find-by-testid tree "rf-xray-routing-current-params")
             path (find-by-testid tree "rf-xray-routing-current-path")]
@@ -262,7 +281,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test {}]
                         {:frame :rf/xray})
-      (let [tree (routing/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-routing"))
             "panel root present")
         (is (nil? (find-by-testid tree "rf-xray-routing-header"))
@@ -287,7 +306,7 @@
       (rf/dispatch-sync [:rf.xray/set-current-route-slice-override-for-test
                          {:route-id :route/cart :params {} :query {}}]
                         {:frame :rf/xray})
-      (let [tree (routing/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-routing-current"))
             "CURRENT ROUTE renders")
         (is (some? (find-by-testid tree "rf-xray-routing-table"))
@@ -322,7 +341,7 @@
         (rf/dispatch-sync [:rf.xray/sync-trace-buffer buffer]
                           {:frame :rf/xray})
         (rf/dispatch-sync [:rf.xray/focus-event 99 nil] {:frame :rf/xray}))
-      (let [tree (routing/Panel)]
+      (let [tree (panel-tree)]
         ;; ROUTE TABLE still renders.
         (is (some? (find-by-testid tree "rf-xray-routing-table")))
         ;; :to overlay glyph present on the destination table row.
@@ -369,7 +388,7 @@
         (rf/dispatch-sync [:rf.xray/sync-trace-buffer buffer]
                           {:frame :rf/xray})
         (rf/dispatch-sync [:rf.xray/focus-event 99 nil] {:frame :rf/xray}))
-      (let [tree (routing/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-routing-table-marker-from"))
             ":from overlay glyph rendered on origin route in the table")
         (is (some? (find-by-testid tree "rf-xray-routing-table-marker-to"))

--- a/tools/xray/test/day8/re_frame2_xray/panels/routing_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/routing_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,504 @@
+(ns day8.re-frame2-xray.panels.routing-fresco-boundary-dom-cljs-test
+  "THE ROUTES PANEL RE-AUTHORED IN THE RE-FRAME-NATIVE VIEW LAYER, read
+  off a real React commit (rf2-k97c.3, step 2).
+
+  `routing/PanelView` is now an `rf.fresco/defview` reading through
+  Fresco's shipped collector rather than an `rf/reg-view` reading
+  through whatever view build the installed substrate adapter supplies.
+  This file is the behavioural evidence for that swap, and it is the
+  merged template
+  (`module_view_fresco_boundary_dom_cljs_test`) applied to the second
+  panel: four rows, one per claim, each with the control that makes its
+  answer non-vacuous.
+
+  ## What the epic asked for, and which row answers it
+
+  rf2-k97c's success criteria are behavioural. Four of the six are
+  answerable at a panel's own boundary and are answered here:
+
+    1 FIRST DISPLAY               — W1
+    2 UPDATES ON A REAL CHANGE    — W2 (with the deaf control that makes
+                                    the update mean liveness)
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    5 TOOL ACTIVITY NEVER
+      MASQUERADING AS APPLICATION
+      EVIDENCE                    — W3, in BOTH directions
+    6 CLEAN TEARDOWN              — W4
+
+  Criterion 3 (Xray's own interactions) has no row because this panel
+  is read-only: the Routes panel dispatches nothing — measured, zero
+  dispatch sites — so a click row here would assert about a control the
+  panel does not have. Its sibling in this slice, the
+  cancellation-cascade family, is where the interaction rows live.
+
+  ## The mount is the SHELL's mount, taken from the registry
+
+  `shell/detail-panel` mounts the active tab as the hiccup head
+  `[(:panel tab)]` inside the shell's `[rf/frame-provider {:frame …}]`.
+  [[mount-panel!]] does exactly that, and it reaches `:panel` THROUGH
+  `panel-registry/tab-by-id` rather than naming the var — so the bridge
+  the registry actually holds is the thing under test. A bridge that
+  regressed to something the shell cannot mount reddens here rather
+  than in a browser.
+
+  Nothing below ever calls the panel a second time. Every assertion
+  after the mount reads `container.querySelector…` — the DOM React
+  committed on its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports —
+  because the claim being made is that the boundary is INDIFFERENT to
+  it. The panel is a real React function component either way; what W3
+  shows is that it contributes nothing to the substrate's view-trace
+  stream even when it is rendered inside an application frame, and W1
+  that its read lands in the frame React context named rather than in
+  the ambient one.
+
+  `:ambient-frame nil` is load-bearing, exactly as it is in the
+  template: the fixture's default ambient `:rf/default` scope is still
+  in effect during a synchronous `flushSync`, and tier 1 of
+  `re-frame.views.provider/current-frame` is the dynamic var — so an
+  ambient frame would SHADOW the React-context tier this file is about
+  and W1's frame-targeting row would pass while measuring nothing.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium) per
+  `implementation/shadow-cljs.edn`, whose `:source-paths` already carry
+  `tools/xray/test`. The `:node-test` build's `cljs-test$` regex also
+  matches, so it LOADS under Node — where every row short-circuits
+  through [[browser?]] and reports the skip rather than passing
+  silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. Two rows
+  need one that is not `:rf/xray`: W1 reads it as the negative half of
+  the frame-targeting claim, and W3 mounts INSIDE it so the evidence
+  claim cannot be carried by `:rf/xray`'s trace-disabled gate."
+  ::app)
+
+(def ^:private routing-q
+  "The panel's one read. Named once because three rows key off it — the
+  sub-cache is keyed by the query vector itself
+  (`re-frame.subs/cache-key` is identity), so this value IS the cache
+  key."
+  [:rf.xray/routing-tab-data])
+
+(def ^:private base-routes
+  "The route table the panel opens on. Two routes so the table is
+  non-empty at mount and W2's claim can be RELATIVE — a third route
+  arriving — rather than absolute."
+  {:route/cart     {:path "/cart"     :doc "cart"}
+   :route/checkout {:path "/checkout" :doc "checkout"}})
+
+(def ^:private late-route
+  "The route W2 makes arrive. Its row is the DOM movement the liveness
+  claim is about."
+  :route/receipt)
+
+(def ^:private late-routes
+  (assoc base-routes late-route {:path "/receipt" :doc "receipt"}))
+
+;; ---- a probe event, and the `reg-view` W3 measures the panel against ------
+
+(rf/reg-event ::bump
+  (fn [{:keys [db]} [_ n]] {:db (assoc db ::n n)}))
+
+(rf/reg-sub ::n (fn [db _] (::n db)))
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W3, and nothing else. An ordinary
+  `reg-view` rendered by the installed adapter in the same root, in the
+  same frame, in the same commit as the panel — so the only variable
+  between it and the panel is which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-probe-reg-view"} (str @(rf/subscribe [::n]))])
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     ;; `:async? true` because W2 and W4 are `async` rows, and
+     ;; `cljs.test` refuses a FUNCTION fixture in any namespace that
+     ;; carries one — "Async tests require fixtures to be specified as
+     ;; maps. Testing aborted." The flag is what makes
+     ;; `make-reset-runtime-fixture` hand back the `{:before :after}`
+     ;; map form.
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing
+                      ;; about; a neighbour's boundary left in the entry
+                      ;; cache would make W4's release row read a
+                      ;; residue that is not this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than
+;; an omission — the template records it and it is reproduced here because
+;; it is the first thing anyone migrating a panel reaches for. Every
+;; neighbouring panel row uses the adapter's `:flush-render!` slot to commit
+;; a phase synchronously, and for a `reg-view` panel that is exactly right.
+;; A Fresco boundary is NOT in Reagent's render queue — its update is
+;; scheduled by the collector through React — so draining Reagent's queue
+;; commits nothing of this panel's, and a row written that way reads a DOM
+;; that has not moved and reports a live panel as dead. Mount is committed
+;; with `flushSync` (React's own door) and everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It
+  exists for the CONTROL in W2: an absence asserted immediately after a
+  write is a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup!
+  "Register Xray's handlers (which is what registers
+  `:rf.xray/routing-tab-data` and the L4 tab entry the mount reads),
+  open the test-only override seam the route table is driven through,
+  and make the two frames."
+  []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- set-routes!
+  "Drive the panel's route table through the panel's own test-override
+  seam (`install-test-overrides!`, rf2-e8330v). A real app-db write into
+  `:rf/xray`, so it invalidates `:rf.xray/registered-routes-override` and
+  the composite above it — which is what makes W2's phase 3 a REAL
+  dependency change rather than a poke at the view."
+  [routes]
+  (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test routes]
+                    {:frame :rf/xray}))
+
+(defn- mount-panel!
+  "Mount the Routes tab the way `shell/detail-panel` mounts it: the
+  registry's `:panel` value as a hiccup head, inside a `frame-provider`
+  scoping `frame`. Committed synchronously — React 19's `root.render` is
+  otherwise async and phase 1 would assert against an empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)
+        tab       (panel-registry/tab-by-id :dynamic :routing)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [(:panel tab)]])))
+    {:container container :root root :tab tab}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent. The spike measured the rejected design's binding by
+  watching this number climb across renders and never fall on unmount
+  (22 → 25 → 32), so it is the number the migration is answerable on."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+;; ===========================================================================
+;; W1 — first display, and the read lands in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-panel-paints-and-its-read-lands-in-the-named-frame
+  (testing "rf2-k97c.3 — the migrated Routes panel commits real DOM through
+            the registry entry the shell mounts, and its `rf.fresco/sub`
+            read resolves against the frame the enclosing `frame-provider`
+            named rather than the ambient one. Epic criteria 1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            _ (set-routes! base-routes)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [::n] {:frame app-frame})
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          (is (some? (q container "[data-testid=\"rf-xray-routing\"]"))
+              "the panel committed a real DOM root under React — a Fresco
+               boundary mounted through Reagent's `:>` from the registry entry")
+          (is (some? (q container "[data-testid=\"rf-xray-routing-table\"]"))
+              "and the ROUTE TABLE section rendered, so the body ran rather
+               than short-circuiting to the silent state")
+          (is (some? (q container "[data-testid=\"rf-xray-routing-table-row-cart\"]"))
+              "and a real route row is on screen, so the read reached the
+               override seam's data and not an empty topology")
+
+          ;; ---- criterion 4: the read is where the tree said it would be ----
+          (is (pos? (ref-count-of :rf/xray routing-q))
+              (str "the panel's read holds a reference in :rf/xray's sub-cache "
+                   "— the frame the enclosing frame-provider named. Cache keys: "
+                   (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame routing-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [::n]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
+          (finally
+            ;; Release the imperative probe explicitly: `unsubscribe`'s own
+            ;; docstring says a Reagent view auto-disposes via the reaction
+            ;; lifecycle and an imperative subscriber must not rely on that.
+            (rf/unsubscribe [::n] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-panel-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted panel re-renders itself and commits new
+            DOM when its read's value really changes, and does NOT when
+            nothing it watches moved. Epic criterion 2, with the control that
+            makes the update mean liveness rather than a commit that simply
+            had not happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (set-routes! base-routes)
+        ;; The claim is RELATIVE — this route arriving — rather than absolute
+        ;; ("the table is empty"). The `:browser-test` build runs every
+        ;; `-dom-cljs-test` namespace in ONE page over process-global
+        ;; registries, so an absolute claim about what is on screen at mount
+        ;; is a claim about whatever the neighbours left.
+        ;;
+        ;; The row is ASYNCHRONOUS, and that is the second thing measured
+        ;; here. A Fresco boundary is not in Reagent's render queue, so the
+        ;; adapter's `:flush-render!` — exactly the right instrument for the
+        ;; `reg-view` panels beside this one — does NOT commit this panel's
+        ;; update. The correct instrument for "it updates" is a bounded poll
+        ;; of the committed DOM, and the control below is given a real
+        ;; settling window so its absence is a decision and not a race.
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              section  (q container "[data-testid=\"rf-xray-routing\"]")
+              late-q   (str "[data-testid=\"rf-xray-routing-table-row-"
+                            (name late-route) "\"]")
+              row?     (fn [] (some? (q container late-q)))]
+          (is (some? section)
+              "PRECONDITION: the panel is on screen, so the absence below is
+               an absence in a rendered table and not an unrendered panel")
+          (is (not (row?))
+              "NON-VACUITY: the route this row drives in is NOT on screen
+               before it is registered")
+
+          ;; ---- phase 2: the world moves, and the panel is deaf ------------
+          ;; A real app-db write into the SAME frame the panel reads, under a
+          ;; key no input of `:rf.xray/routing-tab-data` computes over. Every
+          ;; db-derived sub in that composite recomputes and answers the value
+          ;; it answered before, so nothing the boundary watches is
+          ;; invalidated. A binding that repainted on db MOVEMENT rather than
+          ;; on VALUE CHANGE — which is the failure mode a hand-rolled interop
+          ;; binding has — fires here.
+          (rf/dispatch-sync [::bump 1] {:frame :rf/xray})
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (not (row?))
+                      "CONTROL: given a full settling window, the committed
+                       DOM still does NOT carry the row. A panel that
+                       re-rendered its way to a new table here would make
+                       phase 3 pass for a reason that is not liveness")
+                  (is (identical? section
+                                  (q container "[data-testid=\"rf-xray-routing\"]"))
+                      "and the panel was not remounted by the deaf write
+                       either — same <section> node")
+                  ;; ---- phase 3: a real invalidation, DOM follows ----------
+                  (set-routes! late-routes)
+                  (is (contains? (set (keys late-routes)) late-route)
+                      "PRECONDITION: the read's UNDERLYING data now carries the
+                       new route — so a missing row below is the panel failing
+                       to re-render, and not the route failing to exist")
+                  (rf.test-support/poll-until row?
+                    {:label "the panel committed the new route's row"})))
+              (.then
+                (fn [_]
+                  (is (row?)
+                      (str "the panel re-rendered on a real invalidation of "
+                           "its own read and committed the new route's row"))
+                  (is (identical? section
+                                  (q container "[data-testid=\"rf-xray-routing\"]"))
+                      "and it is the SAME <section> node: React reconciled the
+                       live tree in place, so the row did not arrive by the
+                       panel being remounted from scratch, which would not be
+                       liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — the tool's own render is not application view evidence
+;; ===========================================================================
+
+(deftest w3-the-boundarys-render-emits-no-view-trace
+  (testing "rf2-k97c.3 / rf2-tqlmq — rendering the migrated panel contributes
+            NOTHING to the substrate's view-trace stream, even when it is
+            mounted INSIDE an application frame. Epic criterion 5, proven
+            structurally rather than by the `:rf/xray` frame gate: a Fresco
+            boundary is not a substrate view render, so there is no event to
+            gate. The control is an ordinary `reg-view` in the same root, the
+            same frame and the same commit."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_       (setup!)
+            _       (set-routes! base-routes)
+            traces  (atom [])
+            view-op? #(and (keyword? (:operation %))
+                           (= "rf.view" (namespace (:operation %))))]
+        (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+        (try
+          ;; ---- the subject: the panel, mounted in an APPLICATION frame ----
+          (let [{:keys [container root]} (mount-panel! app-frame)
+                subject-views (filterv view-op? @traces)]
+            (try
+              (is (some? (q container "[data-testid=\"rf-xray-routing\"]"))
+                  "precondition: the panel really did render in this commit —
+                   an empty container would make the zero below vacuous")
+              (is (zero? (count subject-views))
+                  (str "the panel's render put NO :rf.view/* op in the trace "
+                       "stream while rendering inside an application frame. "
+                       "Ops seen: " (pr-str (mapv :operation subject-views))))
+              (finally (teardown! root container))))
+
+          ;; ---- the control: a reg-view, same root shape, same frame -------
+          (reset! traces [])
+          (let [container (.createElement js/document "div")
+                root      (rdc/create-root container)]
+            (.appendChild (.-body js/document) container)
+            (try
+              (react-dom/flushSync
+                (fn []
+                  (rdc/render root [rf/frame-provider {:frame app-frame}
+                                    [ProbeRegView]])))
+              (let [control-views (filterv view-op? @traces)]
+                (is (some? (q container "[data-testid=\"rf-xray-probe-reg-view\"]"))
+                    "precondition: the control really did render")
+                (is (pos? (count control-views))
+                    (str "CONTROL FIRES: an ordinary reg-view rendered the same "
+                         "way DOES emit a :rf.view/* op, so the subject's zero "
+                         "is a property of the boundary and not of a dead "
+                         "instrument. Ops seen: "
+                         (pr-str (mapv :operation control-views)))))
+              (finally (teardown! root container))))
+          (finally
+            (rf/unregister-listener! :trace ::collect)))))))
+
+;; ===========================================================================
+;; W4 — clean teardown: the read is released, and reopening is not growth
+;; ===========================================================================
+
+(defn- released?
+  "The panel's read is fully released from `:rf/xray`'s sub-cache."
+  []
+  (zero? (ref-count-of :rf/xray routing-q)))
+
+(deftest w4-unmount-releases-the-read-and-reopen-does-not-grow-it
+  (testing "rf2-k97c.3 — unmounting the panel releases its subscription
+            reference completely, and mounting it again returns to the SAME
+            count rather than a higher one. Epic criterion 6, and the number
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed 22 → 25 → 32 across
+            renders and never fell on unmount.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once. `impl.collector`'s `cell-reapers` gives a cell
+            whose last reader unmounts ONE MACROTASK OF GRACE, so that a keyed
+            reorder which unmounts and remounts a row within a single turn
+            reuses the reaction instead of rebuilding it. A synchronous
+            assertion would therefore report a LEAK against a collector
+            behaving exactly as documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (set-routes! base-routes)
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-panel! :rf/xray)
+                      mounted (ref-count-of :rf/xray routing-q)]
+                  (is (pos? mounted)
+                      "the mount took a reference — otherwise the release
+                       below is vacuous")
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released the read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released it COMPLETELY, within "
+                                   "the collector's grace macrotask. Cache: "
+                                   (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same count, not a higher one ----
+                          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
+                                remounted (ref-count-of :rf/xray routing-q)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" mounted ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases it too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))


### PR DESCRIPTION
Step-2 slice of rf2-k97c.3 (Xray Design B migration): the **cancellation-cascade family + Routes** panel cluster — three views across two files. The bead is NOT finished by this PR and must not be closed: several workers are cutting disjoint slices concurrently, and step 3 (the shell/root flip) is still ahead.

Follows the merged increment-1 template, `tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs`, and does not invent a second migration pattern.

## What landed

- **`panels/routing.cljs`** — `PanelView` is an `rf.fresco/defview` reading `:rf.xray/routing-tab-data` through `rf.fresco/sub`.
- **`panels/cancellation_cascade.cljs`** — `SidePanelView` and `PopoverView` likewise, over four subscriptions.

That severs the epic's third coupling — OBSERVATION — for all three views.

`cancellation_cascade_events.cljs` and `cancellation_cascade_subs.cljs` are in this slice's file set and are **untouched, deliberately**: measured, they contain no views at all — they are pure `reg-sub` / `reg-event` installers, so there is nothing in either to migrate.

## The shape the template does not cover — settled at source, not guessed

The template panel has no dispatch. This slice's cascade panel has five dispatch sites, so the contract had to be established before the first line moved. It was, in Fresco's own shipped code.

`re-frame.fresco.impl.intent/with-frame` — which `collector/run-once` wraps every body in — is normative here and says three things:

1. It **binds core's refusal tier**, so an ambient `@(rf/subscribe …)` or `(rf/dispatch …)` **refuses** for the extent of a body. Migrating a body's reads is therefore mandatory, not stylistic: a left-behind ambient read does not quietly resolve elsewhere, it refuses.
2. *"The refusal deletes the ambient FIND, not the carrying"* — an explicitly carried `{:frame <id>}` **still answers**.
3. The pure doors `rf/current-frame-id` and zero-arity `rf/capture-frame` **answer the declared frame**, because neither reads nor dispatches. `re-frame.fresco`'s own namespace docstring says the same from the other side: *"The frame doors are core's … this door duplicates neither."*

And `rf.fresco/defview`'s docstring adds that **a plain function at an `on-*` prop is passed through untouched**, reaching React by identity.

**Consequence, and it is the good news:** the rf2-nesy9 render-time frame capture these rows already do — `(let [frame (rf/current-frame-id)] … :on-click (fn [_] (rf/dispatch ev {:frame frame})))` — is exactly right under a boundary and carries over **unchanged**. No new idiom, no intent-vector rewrite.

**The one dispatch shape that does break** is `reg-view`'s lexically injected bare `dispatch`, which the popover used — the class the ruling counted at 109 sites. A `defview` *"binds NO name inside your body"*, so an injected name is simply unresolved: a loud compile error rather than a silent misfire. It is now `rf/dispatch` carrying the same captured frame the rows carry.

This binds every remaining panel and is recorded on the bead.

## Where this departs from the template, and why

The template keeps the name `Panel` on the boundary and makes the bridge a private `Panel-bridge`. That works because `module_view` is an L4-only tab whose own `install!` is the sole thing naming it — measured: its `Panel` appears nowhere else in the tree.

**These three are named from outside**, and one of those places is fenced:

- `shell.cljs:2770` mounts `[cancellation-cascade/Popover]` as a hiccup head — step 3, not this bead's to edit.
- `panels.cljs`'s `render-panel!` chokepoint takes all three vars.
- `routing/Panel` is additionally read by the panel-gallery testbed, two shell/mount test suites, and `spec/api-manifest.edn` plus its curated metadata sidecar — hot-zone files.

So the **mechanism is the template's and the name assignment is inverted**: the public names stay the callables every existing site already holds and become the `rf.fresco/as-component` bridges; the boundaries sit behind them as private `*View`s. One door, same defined end — when the shell becomes a Fresco tree the bridges collapse and the boundaries take the names. **No fenced file is touched and no hot-zone file moves.**

## The conditional reads survive intact

`rf.fresco/sub` *"records the edge where the read happens, so a branch not taken contributes no edge"*. So the popover's short-circuit is preserved exactly: a closed popover still costs **one** subscription and a gate, as its docstring always promised. That is Fresco's documented behaviour rather than an accident, and W4 asserts the conditional read is released on the same lifecycle as the gate.

## The markup stays a pure projection

`routing/panel-tree`, `cascade/render-cascade` (now taking `expanded?` as an argument rather than reading it) and `cascade/popover-tree` are plain value → hiccup functions. Same split `routing_helpers.cljc` and `cancellation_cascade_helpers.cljc` already make one layer up for the data algebra, and it is what keeps the node-lane view rows drivable without a React commit.

## One portability fix found on the way past

The route table's React key was `^{:key …}` reader metadata on the **call form** `(route-table-row entry)`. Metadata on a source list is discarded when the call returns a fresh vector, so **no key ever reached React** — the same defect `cancellation_cascade.cljs` records under rf2-ppzid and works around with `with-meta`. It now rides in the row's own attribute map, the one spelling both Reagent's `get-react-key` and Fresco's codec read.

## Tests

The existing node-lane view rows — six in `routing_cljs_test`, thirteen in `cancellation_cascade_cljs_test`, two in `modals_aria_cljs_test` — drive the pure projections through helpers that reproduce each boundary's gate and reads **exactly** (same gate, same order, same query vectors), so every one asserts on the hiccup it did before, and a boundary that stopped reading one of these subs would diverge from its own test helper rather than silently agreeing with it.

Two new `*_fresco_boundary_dom_cljs_test` namespaces carry the template's rows against a real React commit. Routing's four reach `:panel` **through** `panel-registry/tab-by-id` rather than naming the var; the cascade's five mount the way `shell.cljs` does.

- **W1** first display, plus the read landing in the frame the tree NAMED — off the frame's own sub-cache, with a live probe in the OTHER frame proving the reader is not blind.
- **W2** liveness with a **deaf control** — an app-db write into the panel's own frame under a key none of its subscriptions computes over, given a full settling window, must move nothing. Node identity asserted, so nothing arrives by remount.
- **W3** the boundary emitting NOTHING into the substrate's view-trace stream while mounted **inside an application frame**, against a `reg-view` control in the same root, frame and commit that DOES fire.
- **W4** unmount releasing the references completely (polled — `cell-reapers` grants one macrotask of grace) and reopening returning to the SAME count.
- **W5, cascade only, and the reason this file is worth more than a copy of the template** — epic **criterion 3**, which the template could not answer because `module_view` dispatches nothing. It clicks the real collapse expander in a real browser and asserts the whole round trip (handler reached → dispatch landed → read invalidated → boundary committed the expanded list), then asserts the event landed in the frame the tree NAMED and **not** in a neighbouring application frame. That is the contract above put in front of a browser.

## Quality gates

Every number is read from that run's own `.exit` file, never from a pipeline and never from a harness report. Both compiles printed this branch's own worktree `implementation/shadow-cljs.edn` on their first line.

| Gate | Exit | Result |
|---|---|---|
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | 2831 files, 11122 re-frame require edges, 0 non-canonical, every surface at or under its floor (`tools` floor 0, **not** touched) |
| `python scripts/check_require_alias_dialect.py --self-test` | **0** | 79 passed, 0 failed |
| `npm run test:cljs` | **0** | 11514 tests / 57867 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** | 865 tests / 4779 assertions, 0 failures, 0 errors |

Increment 1 measured 11490 / 57807 and 847 / 4678 on an earlier trunk. Both lanes RISE, which is this PR's nine new rows plus the sibling's five and what else landed on trunk in between. No drop anywhere.

### Three sabotage runs — every green was made to bite

**Alias ratchet.** The Fresco require was planted as the bare leaf alias — the exact violation increment 1 tripped. Exit **1**, naming `panels/routing.cljs:121`, a line that exists on no other checkout: the gate demonstrably read *this* branch's tree, so no separate worktree witness was needed.

**Browser lane, routing.** The boundary's read was replaced with a frozen literal. Exit **1**, `4 failures, 0 errors`, and exactly the predicted four — W1's route-row assertion, W1's `:rf/xray` ref-count assertion, W2's liveness poll, and W4's "the mount took a reference" precondition. W3 correctly stayed green, since a boundary emits no view-trace op whatever it reads.

**Browser lane, cascade — the one that matters most.** The expander's carried frame was planted as the wrong frame. Exit **1**, `1 failures, 0 errors`, and it was **W5 alone**. So W5's cross-frame claim is load-bearing rather than decorative: the frame the handler carries is the frame the event lands in, and the row can tell.

All three restores verified by **git blob hash**, identical before and after, rather than by reading a diff.

### Rebase note, and a SPELLING DIVERGENCE the mayor should rule on

Rebased onto `e15e1b430a`, which carries PR #9581 — the Resources panel, the sibling slice of this same bead. **All four gates were then re-run on that final base**, and the numbers in the table above are those runs.

The rebase was **clean, with no conflict**, and that refutes the warning I was sent: this branch touches no line of `panels.cljs`. The reason is a real design difference between the two slices, and it is worth a ruling rather than a silent divergence.

| | Resources (#9581) | This PR |
|---|---|---|
| boundary | `Panel` | private `PanelView` / `SidePanelView` / `PopoverView` |
| bridge | public `Panel-bridge` | `Panel` / `SidePanel` / `Popover` — the existing public names |
| caller | `mount-resources!` changed to pass `Panel-bridge` | unchanged |

Same mechanism (`rf.fresco/as-component`), opposite name assignment.

**The sibling's spelling is not available to this slice, and the blocker is a fence rather than a preference.** `shell.cljs:2770` mounts `[cancellation-cascade/Popover]` as a hiccup head, naming the var directly. `shell.cljs` is step 3 and explicitly out of scope. Under the sibling's spelling that line would have to pass `Popover-bridge` — a fenced edit — or the shell would mount a React component as a Reagent render fn, which `defview`'s contract forbids outright. So the popover must keep its public name on the bridge, and the other two follow it so this slice does not carry two spellings of its own.

Reconciling the two is mechanical whenever the mayor wants it, and cheapest at step 3, where every bridge is deleted anyway and each boundary takes its final name in one commit.

### Not run locally, with reasons

`examples_compile` (no build id added or changed; the sweep reads its roster out of `shadow-cljs.edn`, untouched), `mcp_conformance` (no new sub/event/fx and no MCP-visible surface moved), `story_xray_browser` (needs the Story browser lane).

## Scope fences held

The element-shaped-adapter denylist and its refusal path are untouched (rf2-k97c.4). `shell.cljs`, `static/shell.cljs`, `mount.cljs`, `panels.cljs`'s `render-panel!`, every `*-bridge`, and `views/edn_inspector.cljs` / `views/edn_widget.cljs` are untouched — that is step 3 and increment 2. No hot-zone file is touched, `spec/api-manifest*.edn` included. Nothing under `implementation/` requires anything under `tools/`. The branch carries no tracker-database path — its whole diff is seven files under `tools/xray`.

Premise check, reported because it did not hold: the brief called this "four independent panel files". Two of the four carry no view surface at all. Both were left untouched.

No AI-attribution trailers were added to any commit or to this description, per the project's CLAUDE.md over the session-level instruction that says the opposite.
