### PR TITLE
fix(gate): rule (g) grades the restored bench run corpus as source (rf2-20h4)

### DIFF
--- a/scripts/check_retired_spellings.py
+++ b/scripts/check_retired_spellings.py
@@ -363,6 +363,23 @@ reason, which is exactly what the mechanism is for — not in a hole cut through
 the tree that needs them most. That case arrived (rf2-d1nr.2) and is on the
 roster: three entries, four constructs, two files, and no prose.
 
+AND THE LINE THAT SEPARATES THAT FROM THE ONE HOLE UNDER `bench/`, because the
+paragraph above rules against a hole and `PRODUCT_EXCLUDE_PATHS` now carries
+one (rf2-20h4). The distinction is SOURCE against RESTORED ARCHIVE, and it is
+not a softening of the rule. What the paragraph anticipated is tracked bench
+SOURCE that must NAME the archive — the recovery command's pre-rename path, the
+translation table's left column, the assertion that reads an archived record's
+raw bytes. That is three entries in two files, it stays exempted per line and
+per construct, and the whole bench source tree stays scanned. What arrived
+beside it is the archive ITSELF: `data_archive.cjs --restore` writes 237 whole
+files of pre-rename bytes into a gitignored tree, and 41,106 lines of them are
+not a construct anything can name. An exemption is a PATH plus a LINE CONSTRUCT
+matched exactly, so exempting them means 237 path entries — which is the
+inclusion roster this rule refuses, arrived at from the other end. The bytes
+cannot move either: the corpus is the measured evidence and `data_archive.cjs`
+says it is never rewritten. So the archive is subtracted where the source that
+names it is exempted, and the two mechanisms stay for the two different things.
+
 WHERE A SHAPE IS TOO AMBIGUOUS TO LINT WITHOUT NOISE (documented, not shipped)
 
 EP-0007 §Enforcement says "where shapes allow"; two shapes are deliberately
@@ -761,6 +778,40 @@ PRODUCT_EXTRA_EXCLUDE_DIR_NAMES = frozenset({
 #     are TRACKED, are exactly where a stale namespace name would do real
 #     damage, and stay in scope. That distinction is the whole of rf2-20h4, and
 #     both halves are pinned in `_PRODUCT_ROSTER_SELF_TEST_CASES`.
+#   * `bench/fresco/src/re_frame/bench/fresco/data` — the Fresco run corpus,
+#     restored on demand and never on main (`bench/fresco/.gitignore:7`;
+#     `git ls-files` reads 0 under it). It is the THIRD carrier of the same
+#     defect as the two above, and the one that makes it a workflow problem
+#     rather than a housekeeping one: `data_archive.cjs --restore` is the
+#     project's own ADVERTISED command, quoted in `bench/fresco/README.md`, and
+#     it writes 237 files that are byte-identical to blobs archived BEFORE the
+#     rename. So every record names the product as it was named when the run
+#     was taken, and the walk grades those historical bytes as current source.
+#     Measured at rf2-20h4 on a restored corpus: exit 1 with 41,106 findings,
+#     EVERY one inside this tree and 0 from any tracked file. Since
+#     `scripts/test-fast-pr.sh` runs this gate unconditionally, following the
+#     documented restore made the local pre-checkin spine unusable.
+#
+#     THE BYTES CANNOT BE THE THING THAT CHANGES. The corpus is the measured
+#     evidence the Fresco verdicts were taken from, `data_archive.cjs` says in
+#     terms that it "is never rewritten", and the reader translates the
+#     archived vocabulary on the way IN rather than on disk (rf2-d1nr.2). A
+#     record renamed to please this gate is a record that no longer matches its
+#     archived blob hash, so the only correct move is to stop reading it as
+#     source — the same conclusion as the two subtractions above, reached from
+#     immutability instead of from regeneration.
+#
+#     Subtracted as a PATH and deliberately NOT as a directory name `data` on
+#     `PRODUCT_EXTRA_EXCLUDE_DIR_NAMES`, for the reason the `.clj-kondo` bullet
+#     gives: a NAME is repo-wide, so it would silently hide any future tracked
+#     `data/` tree anywhere in the repo, which is precisely the narrowing this
+#     roster's whole shape exists to refuse. The path form leaves the live
+#     readers beside the hole in scope — `data_archive.cjs` and
+#     `data_archive.test.cjs` share its final component and are NOT under it
+#     (`_product_excluded` matches whole path segments, never a substring) — as
+#     it does the tracked `fixtures/` sibling, `bench/fresco/README.md` and
+#     `bench/fresco/package.json`. Both halves are pinned as pairs in
+#     `_PRODUCT_ROSTER_SELF_TEST_CASES`.
 PRODUCT_EXCLUDE_PATHS = (
     ".git",
     "ai",
@@ -769,6 +820,7 @@ PRODUCT_EXCLUDE_PATHS = (
     "scripts/_test_fixtures",
     "scripts/check_retired_spellings.py",
     ".clj-kondo/.cache",
+    "bench/fresco/src/re_frame/bench/fresco/data",
 )
 
 # ...and the SUFFIX subtractions, matched on the final suffix of the file name.
@@ -2238,6 +2290,38 @@ _PRODUCT_SELF_TEST_CASES: tuple[tuple[str, str, int], ...] = (
 # row is the matching near-miss for `PRODUCT_EXCLUDE_SUFFIXES` — it proves the
 # `.log` subtraction is a SUFFIX rather than a substring, so a real document
 # cannot be hidden by having the token in its name.
+#
+# THE RUN-CORPUS ROWS pin a hole whose edge four different wrong repairs would
+# each put somewhere else, so there is one row per wrong repair. Three of them
+# are stated as pairs sharing a path shape, and each pair was RUN in both
+# directions against the wrong repair it names, not merely reasoned about:
+#
+#   * `data_archive.cjs` against a record under `data/` — the near-miss for a
+#     SUBSTRING or bare-prefix match. The reader's name begins with the
+#     subtracted path's final component, so a repair that dropped
+#     `_product_excluded`'s segment boundary would silently blind the gate to
+#     the very file that carries `ARCHIVE_PATH`.
+#   * `fixtures/alloc-legorder/pre-registration.json` against
+#     `data/alloc-legorder/pre-registration.json` — the sharpest pair, because
+#     the two share every path segment but the tree they hang off. Both files
+#     really exist: the tracked one is a fixture a self-test reads in its own
+#     right, the other is the archived record it was taken from. This is what a
+#     repair reaching for `alloc-legorder`, or for any record-directory name,
+#     fails.
+#   * `bench/fresco/README.md` against a `README.md` inside the corpus — the
+#     near-miss for a SUFFIX or file-name match, and the one the audit of
+#     PR #9571 actually planted in: a retired-name line added to the tracked
+#     README raised the live count by exactly one and named that line.
+#   * `implementation/core/src/re_frame/data/registry.cljc` — the one row with
+#     no partner, and the one that costs the most to get right. A repair that
+#     put `data` on `PRODUCT_EXTRA_EXCLUDE_DIR_NAMES` instead of the path here
+#     passes ALL SIX rows above (measured: the three subtracted rows go green
+#     under it, because in the synthetic tree the only `data/` directory is the
+#     corpus one), so without this row the name/path distinction — which is the
+#     whole of the `.clj-kondo` precedent — would be pinned by nothing. No
+#     tracked file sits under any directory named `data` today; that is what
+#     makes the wrong repair invisible now and expensive later, so the row is
+#     representative rather than real, exactly as the eight rows above it are.
 _PRODUCT_ROSTER_SELF_TEST_CASES: tuple[tuple[str, int], ...] = (
     # --- the whole repo MUST be reached, including the trees no lane compiles ---
     ("implementation/core/src/re_frame/example.cljc", 1),
@@ -2248,6 +2332,11 @@ _PRODUCT_ROSTER_SELF_TEST_CASES: tuple[tuple[str, int], ...] = (
     (".clj-kondo/config.edn",                         1),
     (".clj-kondo/hooks/re_frame/core.clj",            1),
     ("docs/design/fresco/notes.log.md",               1),
+    ("bench/fresco/README.md",                        1),
+    ("bench/fresco/src/re_frame/bench/fresco/data_archive.cjs", 1),
+    ("bench/fresco/src/re_frame/bench/fresco/fixtures/alloc-legorder/"
+     "pre-registration.json",                         1),
+    ("implementation/core/src/re_frame/data/registry.cljc", 1),
     # --- and every subtraction MUST hold ---
     ("ai/findings/rename-notes.md",                   0),
     ("docs/spec/002-Frames.md",                       0),
@@ -2256,6 +2345,12 @@ _PRODUCT_ROSTER_SELF_TEST_CASES: tuple[tuple[str, int], ...] = (
     (".clj-kondo/.cache/v1/cljs/re-frame.transit.json", 0),
     ("audit-pr9568-push-1.log",                       0),
     ("implementation/pr7662-retained-read.log",       0),
+    ("bench/fresco/src/re_frame/bench/fresco/data/"
+     "workcount-n1b9h/run5-a4a1537cb71.json",         0),
+    ("bench/fresco/src/re_frame/bench/fresco/data/"
+     "alloc-legorder/pre-registration.json",          0),
+    ("bench/fresco/src/re_frame/bench/fresco/data/"
+     "alloc-legorder/README.md",                      0),
 )
 
 


### PR DESCRIPTION
Closes rf2-20h4 (reopened by the merged-PR audit of #9571, which found a third carrier of the defect PR #9575 fixed).

## The defect

Rule (g) of `scripts/check_retired_spellings.py` walks the **filesystem**, so it reads gitignored artefacts as source. PR #9575 subtracted two carriers of that: `.clj-kondo/.cache` and `*.log`. This is the third, and it is the one that is the project's own **advertised workflow** rather than an incidental artefact.

`bench/fresco/README.md` tells a reader to run:

```
node bench/fresco/src/re_frame/bench/fresco/data_archive.cjs --restore
```

That writes 237 files, byte-identical to blobs archived **before** the rename, into a tree `bench/fresco/.gitignore:7` ignores and `git ls-files` reads 0 under. The walk then grades those historical bytes as current source.

`scripts/test-fast-pr.sh` runs this gate unconditionally, so following the documented restore made the local pre-checkin spine unusable with a five-figure count that has nothing to do with anybody's diff. A CI clone has no corpus, so CI cannot see it — the same inverted shape as the original bead.

## Why the bytes are not what changes

The corpus is the measured evidence the Fresco verdicts were taken from. `data_archive.cjs` says in terms that it "is never rewritten", and the reader translates the archived vocabulary on the way **in** rather than on disk (rf2-d1nr.2). A record renamed to please this gate no longer matches its archived blob hash. So the only correct move is to stop reading it as source — the same conclusion as the two subtractions above it, reached from immutability instead of from regeneration.

## The change

One entry on `PRODUCT_EXCLUDE_PATHS`: `bench/fresco/src/re_frame/bench/fresco/data`. A **path**, deliberately not a directory name `data`, which would be repo-wide and would hide any future tracked `data/` tree.

Everything beside the hole stays in scope. `data_archive.cjs` and `data_archive.test.cjs` share the subtracted path's final component but are not under it, because `_product_excluded` matches whole path segments; so do the tracked `fixtures/` sibling, `bench/fresco/README.md` and `bench/fresco/package.json`.

Seven rows added to the phase-10 roster self-test (102 -> 109), one per wrong repair, three of them stated as pairs sharing a path shape. The fourth reached row — a `data/` directory elsewhere in the tree — is the only thing that fails a repair reaching for the directory NAME; that wrong repair passes all six other rows, measured, so without it the name/path distinction would be pinned by nothing.

One docstring paragraph, because the change would otherwise contradict the rule directly above it. `WHY `bench/` IS IN SCOPE` argues against cutting a hole under `bench/` and says archived records belong in `PRODUCT_EXEMPTIONS`; it now gains the line that separates the two cases. Tracked bench **source** that must NAME the archive (the recovery command's pre-rename path, the translation table's left column, the assertion over an archived record's raw bytes) stays exempted per line and per construct, and the whole bench source tree stays scanned. The restored **archive itself** is subtracted, because an exemption is a path plus a line construct matched exactly, so exempting 237 whole files of pre-rename bytes means 237 path entries — the inclusion roster this rule refuses, reached from the other end.

## Measurements

Reproduced the audit's numbers before fixing, then re-measured after. Three states of the same worktree:

| state | exit | findings | files walked |
| --- | --- | --- | --- |
| clean tree, before fix | 0 | 0 | 4,613 |
| corpus restored, before fix | 1 | 41,106 | 4,850 |
| corpus restored, after fix | 0 | 0 | 4,613 |
| corpus moved aside, after fix | 0 | 0 | 4,613 |

All 41,106 findings bucketed to a single prefix: `bench/fresco/src/re_frame/bench/fresco/data`. None from any tracked file. The post-fix walk over the restored corpus reaches exactly the same 4,613 files as the clean tree, so the subtraction removes the 237 corpus files and nothing else.

The audit's both-directions control, reproduced: one retired-name line planted in the **tracked** `bench/fresco/README.md` took the count to **41,107** and the gate named `bench\fresco\README.md:138` with the planted line; restoring the README returned it to **41,106**. Restore verified by git blob hash against the committed object (`26f730424c3a608cedbb812915b3a902a697179e`), not by a diff.

## Both-directions control on the new self-test rows

Each new row was run against the wrong repair it names, not merely reasoned about. Both sabotages restored and verified by git blob hash against the committed object (`ec3cde5143c7a349e973ac3a3ce0ebee593a3799`); each plant's match count was read as 1 before a run was spent — the first attempt read **0** and was corrected, because the working file is CRLF and an anchor ending `,\n` matches nothing here.

* **Remove the subtraction** — self-test exit 1, exactly the three corpus rows fail, no others.
* **Replace it with the directory name `data`** — self-test exit 1, and the only row that fails is `implementation/core/src/re_frame/data/registry.cljc`. All three corpus rows go green under it, which is precisely why that row exists.

## What was left standing

* The recorded decision **against** enumerating from `git ls-files` is untouched. The audit says this finding does not reopen it, and nothing here depends on it.
* No bench reader is touched. The production CLI's remaining ingress residual belongs to rf2-d1nr.2; the audit states the two are not duplicates — this is the scanner's surface, that is the reader's ingress.
* No archived record renamed, no corpus deleted, no floor raised, no exclusion widened beyond the one archived-data path.

## Quality gates

Every exit code below was captured with the runner redirected to a log and its own status echoed on the same command line — never piped — and re-run on the final rebased base (`2fcb7f1598`), not on a pre-rebase tree. The gate refuses by design, so its verdict is the findings it printed rather than its status.

| gate | exit |
| --- | --- |
| `python scripts/check_retired_spellings.py --self-test --verbose` | 0 (109 self-tests) |
| `python scripts/check_retired_spellings.py --verbose` | 0 (0 findings, corpus restored) |
| `sh scripts/check-commit-attribution.sh origin/main` | 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | 0 |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 |
| `python scripts/check_gate_scheduling.py` | 0 |
| `python scripts/check_fast_pr_gap.py` | 0 |

The surface classifier arms no surface for this diff, so the graded set is the always-on jobs.

Branch carries one commit and one file; no `.beads` path is staged. No AI-attribution trailers in the commit or in this body — CLAUDE.md outranks the harness reminder that asks for them, and they were declined deliberately.
