### PR TITLE
fix(bench/fresco): route the pass-position CLI's dataset ingress through the archive boundary (rf2-d1nr.2)

### DIFF
--- a/bench/fresco/src/re_frame/bench/fresco/alloc_pass_position.cjs
+++ b/bench/fresco/src/re_frame/bench/fresco/alloc_pass_position.cjs
@@ -1907,8 +1907,15 @@ if (require.main === module) {
     console.error('usage: alloc_pass_position.cjs [--declared <pre-registration.json>] <dataset.json>... | --self-test');
     process.exit(2);
   }
+  // THE DATASET INGRESS GOES THROUGH THE ARCHIVE BOUNDARY (rf2-d1nr.2). These
+  // are run records, and the ones this report was published from are archived
+  // in the pre-rename vocabulary — a raw parse reads 27 of the record's 55
+  // certified cells, drops the native arm entirely, and prints a plausible
+  // number over what is left. `readRecord` is the identity on a record a driver
+  // wrote today, so this is the right door for BOTH. The declaration read above
+  // is not a corpus record and stays as it is.
   const rows = files.map((f, i) => {
-    const j = JSON.parse(fs.readFileSync(f, 'utf8'));
+    const j = archive.readRecord(f);
     return { label: String(i + 1), row: j.alloc, box: j.box };
   });
   const { lines, refused } = report(rows, declared);

--- a/bench/fresco/src/re_frame/bench/fresco/data_archive.test.cjs
+++ b/bench/fresco/src/re_frame/bench/fresco/data_archive.test.cjs
@@ -122,6 +122,71 @@ corpusTest('the archived alloc-0gjqi record reads its FULL published population'
   );
 });
 
+corpusTest('and the REPORT ITSELF reads it — the boundary is on the path the CLI takes', () => {
+  // THE CHECK ABOVE WAS HOLLOW AND THIS IS WHY THIS ONE EXISTS (the merged-PR
+  // audit of #9571). It proves `readRecord` by CALLING `readRecord`, so it went
+  // green over a `main` that never touched the boundary: the published report
+  // parsed its dataset arguments raw and printed n=[1,4,4,4,2,4], PASS TERM
+  // +0.89% and null arm n=8 over 27 of the 55 cells, exit 0, no remark. A test
+  // that exercises a path the CLI does not take says nothing about the CLI. So
+  // this one SPAWNS the CLI exactly as `bench/fresco/README.md` documents it and
+  // reads the population out of what it printed — a future raw read anywhere on
+  // that path goes red HERE, whatever shape it is written in.
+  const cp = require('node:child_process');
+  const record = path.join(archive.DATA, 'alloc-0gjqi', 'paired-run1.json');
+  const r = cp.spawnSync(
+    process.execPath,
+    [path.join(__dirname, 'alloc_pass_position.cjs'), record],
+    { encoding: 'utf8' }
+  );
+  assert.strictEqual(r.status, 0, `the report must run over the archived record: ${r.stderr}`);
+
+  // Its tables, read as tables: the `;;   a | b | ...` rows under a heading,
+  // less the column line that leads them. Scanned forward to the first such row
+  // rather than taken at a fixed offset, because a heading is prose and runs to
+  // as many lines as it needs. Parsed rather than matched verbatim, so that a
+  // reworded heading or a re-rounded median cannot fail a POPULATION check.
+  const printed = r.stdout.split(/\r?\n/);
+  const isRow = (l) => /^;; {3}.+ \| /.test(l);
+  const table = (heading) => {
+    const at = printed.findIndex((l) => l.startsWith(heading));
+    assert.ok(at >= 0, `the report must print "${heading}" — got:\n${r.stdout}`);
+    let from = at + 1;
+    while (from < printed.length && !isRow(printed[from])) from += 1;
+    const rows = [];
+    for (const l of printed.slice(from)) {
+      if (!isRow(l)) break;
+      rows.push(l.slice(5).split(' | '));
+    }
+    assert.ok(rows.length > 1, `"${heading}" printed no rows under its column line`);
+    return rows.slice(1);
+  };
+
+  assert.deepStrictEqual(
+    table(';; THE ROUND BLOCKS').map((c) => Number(c[4])),
+    [3, 8, 7, 8, 4, 7],
+    'the per-round n the studio pages publish; [1,4,4,4,2,4] is the raw-read population'
+  );
+  assert.strictEqual(
+    Number(table(';; THE NULL ARM')[0][1]),
+    18,
+    'the null arm licenses reading the rest, and a raw read halves it to 8'
+  );
+  assert.ok(r.stdout.includes('PASS TERM +0.68%'), 'the published term');
+  assert.ok(!r.stdout.includes('PASS TERM +0.89%'), 'and not the one the smaller population produces');
+
+  // AND THE CONTROL IN THE OTHER DIRECTION, without which this passes over
+  // bytes that never needed a boundary: the same record parsed RAW must still
+  // read the SMALLER population. That is what makes the figures above evidence
+  // that the translation ran, rather than evidence that the corpus was rewritten.
+  const pass = require('./alloc_pass_position.cjs');
+  assert.deepStrictEqual(
+    pass.blocks(JSON.parse(fs.readFileSync(record, 'utf8')).alloc, 'raw').map((b) => b.n),
+    [1, 4, 4, 4, 2, 4],
+    'a raw parse of the archived record must still lose the native arm'
+  );
+});
+
 corpusTest('the archived corpus really is in the OLD vocabulary — so the translation is doing work', () => {
   // The control for the check above: without this, a corpus that had somehow
   // been rewritten in the current vocabulary would pass it while proving


### PR DESCRIPTION
Fixes the one archive-reader residual the merged-PR audit of #9571 found in this owner (rf2-d1nr.2, reopened by that audit — the reopening is the system working, not a revert).

## The defect, reproduced at source before acting

PR #9571 repaired the archive boundary and routed 21 corpus reads through `archive.readRecord`. It missed the one path the published report actually takes: `alloc_pass_position.cjs`'s `main` parsed its dataset arguments with a bare `JSON.parse(fs.readFileSync(...))`. A record in the archived pre-rename vocabulary therefore lost its native arm on the way in — not an error, a smaller population and a different median, exit 0 either way.

Measured on the archived sentinel (`alloc-0gjqi/paired-run1.json`, blob `33ba5f67b7df92b17cd0fc372a86cc3621ac9773`, restored from `7b492b98cb`), same bytes both times, one line changed between the two runs:

| | per-round n | PASS TERM | null arm n | exit |
|---|---|---|---|---|
| landed CLI (raw read) | `[1,4,4,4,2,4]` | +0.89% | 8 | 0 |
| this branch | `[3,8,7,8,4,7]` | +0.68% | 18 | 0 |

The second row is the published population: 55 certified cells, `lad/fresco` 28 / `lad/reagent` 14 / `lad/uix` 13. The first is 27 of them with the native arm gone.

### What this is NOT

**No corpus rewrite, no rename of any archived record, no recalibration of any published population.** The archived bytes were always right and the reader was reading past them. All 237 restored files were verified against their archived Git blob hashes (237/237 match, 0 mismatched) both before and after the change. The figures above are a *corrected reading of unchanged evidence*, not a new measurement — the studio pages' numbers are the ones this branch now reproduces, and the landed CLI was the outlier.

## The hollow gate, and the test that closes it

All six archive checks passed over the broken CLI, because the corpus-backed one proves `readRecord` **by calling `readRecord`** and then hands the result to `roundCells`/`blocks`. It exercises a path the CLI does not take, so it says nothing about the CLI.

The new check **spawns the CLI** exactly as `bench/fresco/README.md` documents it and reads the population out of what it printed. Nothing in the assertion depends on how the read is spelled, so a future raw read anywhere on that path goes red here whatever shape it takes. Its tables are parsed rather than matched verbatim, so a reworded heading or a re-rounded median cannot fail a *population* check.

It carries a control in the other direction as well — the same record parsed RAW must still read the smaller `[1,4,4,4,2,4]` — without which the check would pass over bytes that never needed a boundary.

**Proved by sabotage rather than asserted.** Reverting the one-line fix turns the new check red naming `[1,4,4,4,2,4]` while the pre-existing check stays green — the hollow gate demonstrated live. Restored and verified by git blob hash `6c418796c9ea62f98788e4cfb93c68589dc4f7d5` either side of the plant, with `git status` clean.

## The class was wider than the audit's one site, and most of it was already right

The audit named one line. Bounded repair bounds the *change*, not the *search*: the class was censused across `bench/` three ways — line-oriented, whitespace-flattened, and comment-markers-stripped-then-flattened — all three agreeing at **15 sites in 6 files**, so nothing is hiding across a line break. Every hit was read.

**Changed — 1 site.** `alloc_pass_position.cjs:1911`, the dataset ingress. It reads legacy corpus records.

**Left standing — 14 sites**, on this discriminator: *does this read a legacy pre-rename corpus record whose vocabulary the reader translates, or a declaration, a fixture, or a file this run just wrote?*

| site(s) | what it reads | why it stays raw |
|---|---|---|
| `alloc_pass_position.cjs` x6 (1329, 1580, 1624, 1649, 1708, 1715) | `fixtures/alloc-legorder/{pre-registration,phase3-re-adjudication}.json` | committed declarations on main, current vocabulary |
| `alloc_pass_position.cjs:1903` | the `--declared` argument | a declaration, not a corpus record — see the measurement below |
| `alloc_level_witness.test.cjs:178` | `fixtures/alloc-77gz8/run01-a4a1537cb71.json` | committed fixture; retired name 0, current name 1 |
| `jsfb_compare_exit_path.test.cjs` x3 (118, 132, 285) | `oursJson(...)` output in TMP | a file this run just wrote |
| `z3vlz_run.cjs:257` | `main.js.map` | a shadow-cljs source map, not a record |
| `p0_run.cjs:329` | the box session marker | machine state this driver writes; the file's own header says it is deliberately not in the repository |
| `data_archive.cjs:166` | the boundary itself | it *is* the reader — making it call itself is the mirror hazard |
| `data_archive.test.cjs:131` | the archived record, raw | load-bearing: the control proving the corpus really is in the old vocabulary |

The `--declared` case is the one that could have gone either way, since the archive *does* carry an `alloc-legorder/pre-registration.json`. Measured rather than assumed: the archived declaration is **byte-identical to the committed fixture** (both blob `ba755a74d66bda250ea474f788a55606ac383ed6`) and carries **zero** occurrences of the retired name in any of its three case forms. It is vocabulary-blind, translation over it is the identity, and it stays raw per the audit's own instruction to keep declaration and fixture reads scoped as they are.

## Quality gates

Every exit code below was captured by redirecting to a log and echoing the runner's own status on one command line in one shell, and re-run on the final base after the rebase onto `2fcb7f1598`.

| gate | exit | result |
|---|---|---|
| `data_archive.test.cjs` (corpus restored) | 0 | 7/7 |
| `data_archive.test.cjs` (corpus absent) | 0 | 4/4, 3 corpus-backed skipped |
| `alloc_pass_position.cjs --self-test` | 0 | all blocks reproduce |
| `clock_exit_path.test.cjs` | 0 | 390 passed |
| `alloc_level_witness.test.cjs` | 0 | 14/14 |
| `jsfb_compare_exit_path.test.cjs` | 0 | 46 passed |
| `p0_ladder_structural.test.cjs` | 0 | 100 passed |
| `ssr/bake_bytes.test.cjs` | 0 | 13 passed |
| `eslint` over both changed files | 0 | no findings |
| `check_retired_spellings.py --verbose` | 0 | no retired spellings |
| `check_retired_spellings.py --self-test` | 0 | 102/102 |
| `check_readme_links.py --ci` | 0 | |
| `check_gate_scheduling.py` | 0 | 34 commands, 30 scheduled, 4 declared |
| `check_fast_pr_gap.py` | 0 | gap map clean |
| `check-commit-attribution.sh` | 0 | both commits and this body |
| `check-beads-pr-boundary.sh` | 0 | no tracker-database paths |
| `check-ai-tracking-ratchet.sh` | 0 | nothing tracked under `ai/` |
| 237 restored files vs archived blob hashes | 0 | 237/237 match |

**Both silent gates were proved to have read this branch by a planted fault, since neither prints a root.** ESLint: a `no-undef` planted at a line being edited went red naming the identifier at both sites, restored and verified by blob hash `6c1d90c83bb421a46a80213f035a33aadca737ee`. `data_archive.test.cjs`: the reverted fix above.

Two things worth recording about running these here:

* **The retired-spellings gate goes red on a checkout with the corpus restored** — roughly 41k findings inside the git-ignored `data/` tree, the filesystem walk grading historical archived bytes as current source. That is a separate reopened residual owned elsewhere and is **not** this change. It was run with the corpus moved right out of the tree (renaming it in place is not enough — the ignore is keyed on the path), then moved back and re-verified at 237 files with the sentinel matching.
* **The surface classifier reports every surface `false` for a `bench/`-only diff**, and CI's nightly `fresco-bench-compile` runs the compile gate rather than the lane's `npm run check`. So the bench suites above are the substantive coverage for this change and the captured local exit codes are the evidence for it. That is pre-existing and untouched here.

No AI-attribution trailers in either commit or in this body — CLAUDE.md outranks the harness instruction that asks for them. The branch carries no `.beads` path; both commits stage explicit paths.

The bead is left OPEN for the mayor. It has already been closed once and reopened by audit, and a premature close would destroy that record.

### CI

Rollup at head `cc9e5b791c5b23f329c6d97aad0755a6e4d38ba2`: **87 checks, 19 success, 68 skipped, 0 failure, 0 non-terminal**; all four workflow runs completed success.

The first attempt was red on `JVM repo-wide source walks` with a `java.lang.StackOverflowError` inside a regex in `re-frame.no-rf-default-floor-lint-test`, which took the `All required checks passed` aggregator down with it. That test walks `implementation/**/src/` and `tools/**/src/` and nothing else, so a `bench/`-only diff has no path to it; the same job was green on trunk and on both sibling PRs in flight. Re-run of the failed jobs alone, no code change, and it passed — a flake, recorded here rather than left as an unexplained red in the history.
