### PR TITLE
feat(xray): re-author the Resources panel as a Fresco boundary (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -283,7 +283,20 @@
   lifecycle timeline, the invalidation graph, the cache-growth view, and
   the scope audit + lints. Read-only — observing pins no resource."
   ([mount-point]      (mount-resources! mount-point nil))
-  ([mount-point opts] (render-panel! resources/Panel mount-point opts)))
+  ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. The Resources panel's view
+  ;; is now a Fresco boundary (a real React function component), and
+  ;; `re-frame.fresco/defview`'s own contract is that a boundary is
+  ;; mounted as `[head props]` inside a Fresco body or through
+  ;; `as-component` from outside, NEVER as a hiccup render fn in a
+  ;; Reagent tree — which is what `render-panel!` builds. The bridge is
+  ;; Fresco's `as-component` door and is deleted with every other
+  ;; `*-bridge` when the shell itself becomes a Fresco tree.
+  ;;
+  ;; `render-panel!` ITSELF is deliberately untouched: it is the single
+  ;; chokepoint where the frame-provider and adapter/render couplings are
+  ;; severed for the whole embedding contract, and that is one edit in
+  ;; the final commit rather than N edits now.
+  ([mount-point opts] (render-panel! resources/Panel-bridge mount-point opts)))
 
 (defn mount-event-spine!
   "Mount Xray's L2 event spine in isolation at `mount-point`.

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -50,9 +50,45 @@
   Same contract as every Xray panel — the view is pure hiccup, no
   Reagent/UIx references. Frame isolation comes from the enclosing
   `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`. Projection
-  algebra lives in `resources_helpers.cljc` (JVM-portable)."
+  algebra lives in `resources_helpers.cljc` (JVM-portable).
+
+  ## THE VIEW IS A FRESCO BOUNDARY (rf2-k97c.3)
+
+  [[Panel]] is an `rf.fresco/defview` — a real React function component
+  minted by the re-frame-native view layer — rather than an
+  `rf/reg-view`. It follows the merged template
+  `panels/module_view.cljs`, which is increment 1 of the epic's ruled
+  design (rf2-k97c.2, Design B): Xray's views are re-authored in Fresco
+  and read through Fresco's shipped collector, so their observation no
+  longer depends on whichever view build the installed adapter happens
+  to supply. That is why Xray cannot paint on an element-shaped adapter
+  today, and why a tool-owned root cannot simply keep rendering
+  `reg-view`s.
+
+  Concretely, the ONE read below is `rf.fresco/sub`, which the collector
+  wires, activates, re-wires and NOTIFIES on invalidation
+  (`re-frame.fresco.impl.collector`) — where a `reg-view` body's
+  `@(rf/subscribe …)` is tracked only by the INSTALLED adapter's
+  reaction machinery.
+
+  ## ONE boundary, at 1,433 lines
+
+  Boundary count tracks READS and head-position use, not file size. This
+  panel has exactly ONE read and every section helper below is CALLED by
+  application rather than used as a hiccup head, so the whole file is one
+  boundary and its interior is substrate-agnostic hiccup. See [[Panel]]
+  and [[panel-tree]] for the split, which is `defview`'s own documented
+  extract-a-helper spelling.
+
+  ## The migration bridge
+
+  [[Panel-bridge]] is how a still-`reg-view` shell — and the standalone
+  `panels/mount-resources!` embed — mounts a boundary. It is MIGRATION
+  SCAFFOLDING with a defined end: when the shell is itself a Fresco tree,
+  the L4 registry takes [[Panel]] directly and the bridge goes."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.resources-helpers :as h]
             [day8.re-frame2-xray.panels.local-render :as local-render]
@@ -1039,56 +1075,152 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view Panel
-  "The Resources tab's root view (Spec 016 §Xray and AI tooling).
-  Subscribes to `:rf.xray/resources-tab-data` and renders the sections
-  top → bottom: static registry, named scope resolvers (EP-0016 D3), live
-  instances, work ledger, route/resource graph, lifecycle timeline,
-  invalidation graph, scope resolution timeline (EP-0016 D3), mutation
-  continuations + scoped invalidation (EP-0016 D1/D2), optimistic mutations
-  (EP-0019 — the apply→reconcile/rollback lifecycle), cache growth, scope
-  audit + lints. When the host has no resources registered AND no live
-  instances, renders the silent-by-default caption."
+(defn panel-tree
+  "The Resources tab's WHOLE body, as a pure function of the one value
+  [[Panel]] reads — the `:rf.xray/resources-tab-data` composite. Renders
+  the sections top → bottom: static registry, named scope resolvers
+  (EP-0016 D3), live instances, work ledger, route/resource graph,
+  lifecycle timeline, invalidation graph, scope resolution timeline
+  (EP-0016 D3), mutation continuations + scoped invalidation (EP-0016
+  D1/D2), optimistic mutations (EP-0019 — the apply→reconcile/rollback
+  lifecycle), cache growth, scope audit + lints. When the host has no
+  resources registered AND no live instances, renders the
+  silent-by-default caption.
+
+  SPLIT OUT OF [[Panel]] BY rf2-k97c.3, and the split is `defview`'s own
+  documented extract-a-helper spelling (`re-frame.fresco/defview`
+  §\"The fn this expands to is ANONYMOUS\"), not an invention. Two things
+  turn on it:
+
+  * A boundary's body may only run inside a React render window, so
+    `(Panel)` is no longer a callable that answers hiccup. The panel's
+    section-rendering algebra is nonetheless ordinary data → data and is
+    worth testing in the fast node lane rather than behind a real React
+    commit. `resources_cljs_test` drives THIS fn with the value it takes
+    from the sub directly; the boundary's own behaviour — first paint,
+    liveness, frame targeting, evidence isolation and teardown — is
+    `resources_fresco_boundary_dom_cljs_test`'s subject.
+  * It keeps the read on ONE line inside the boundary, where it is easy
+    to see that the panel takes exactly one and that nothing below it
+    reads the substrate at all.
+
+  PURE: every helper it calls is a plain fn of its argument."
+  [{:keys [silent? registry scope-resolvers instances work route-graph
+           live-work stale-races stale-tally
+           timeline invalidations scope-resolutions mutation-invalidations
+           continuations optimistic-mutations optimistic-force-clobbers
+           cache-growth audit]}]
+  [:section {:data-testid "rf-xray-resources"
+             :style {:height         "100%"
+                     :display        "flex"
+                     :flex-direction "column"
+                     :background     (:bg-2 tokens)
+                     :color          (:text-primary tokens)
+                     :font-family    sans-stack
+                     :font-size      "14px"
+                     :overflow       "auto"}}
+   (if silent?
+     (silent-state)
+     [:<>
+      (registry-section registry)
+      (scope-resolvers-section scope-resolvers)
+      (instances-section instances)
+      (work-ledger-section work)
+      ;; EP-0011 uniform reply-envelope reads — "what is still running?"
+      ;; (live work + active-effects tally) and the cross-family stale-races
+      ;; view. Silent-by-default: each renders nothing when its data is
+      ;; empty (quiet baseline for a settled app).
+      (live-work-section {:live-work live-work :stale-tally stale-tally})
+      (stale-races-section stale-races)
+      (route-graph-section route-graph)
+      (timeline-section timeline)
+      (invalidation-section invalidations)
+      (scope-resolution-section scope-resolutions)
+      (continuations-section {:continuations continuations
+                              :mutation-invalidations mutation-invalidations})
+      (optimistic-mutations-section
+        {:optimistic-mutations optimistic-mutations
+         :optimistic-force-clobbers optimistic-force-clobbers})
+      (cache-growth-section cache-growth)
+      (audit-section audit)])])
+
+;; ---- the boundary --------------------------------------------------------
+
+(rf.fresco/defview Panel
+  "The Resources tab's root (Spec 016 §Xray and AI tooling) — the ONE
+  read, and [[panel-tree]] for everything below it.
+
+  A FRESCO BOUNDARY (rf2-k97c.3), not an `rf/reg-view`. Two differences
+  matter and neither is cosmetic.
+
+  The READ is `rf.fresco/sub`, a plain call the collector records an
+  edge for — no deref, no reaction owned by the installed adapter, and a
+  re-wire that NOTIFIES when the substrate disposes the underlying
+  derived value. That is the third of the epic's three couplings, and it
+  is the one a first-paint smoke test cannot see.
+
+  The FRAME the read resolves against comes from React context, which
+  the enclosing frame boundary writes — `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context (core's
+  `re-frame.adapter.context/frame-context`) — so this boundary resolves
+  `:rf/xray` identically under today's Reagent-rendered shell and under
+  the Fresco root Xray will own. It never consults
+  `:adapter/current-component`, which is the hook a foreign root cannot
+  answer.
+
+  ONE read and ONE boundary, at 1,433 lines. Boundary count tracks reads
+  and head-position use, not file size: every section helper is CALLED,
+  never used as a hiccup head, so Fresco's \"a plain function in head
+  position is a loud error\" rule never meets one and there is nothing
+  in the interior that wants a boundary of its own.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This panel reads nothing from props — neither the L4 registry
+  nor the standalone embed passes any — so it is destructured away."
+  [_props]
+  (panel-tree (rf.fresco/sub [:rf.xray/resources-tab-data])))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's shell is still a `reg-view` tree rendered by the installed
+;; adapter. `shell/detail-panel` mounts the active tab as the hiccup head
+;; `[(:panel tab)]`, and `panel-registry/reg-l4-tab!`'s `:pre` requires
+;; `:panel` to be CALLABLE — neither of which a React component is.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly
+;; this: it answers a real React component for a boundary, which a React
+;; parent (UIx, Reagent or plain JavaScript) mounts UNDER THE FRAME IT IS
+;; ALREADY IN, taking the frame from React context rather than from a
+;; second root. So there is no second root here, no adapter-kind branch,
+;; and no props ABI.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the shell is itself a
+;; Fresco tree, `reg-l4-tab!` takes `Panel` directly, `[:>]` goes, and
+;; both defs below are deleted.
+
+(def ^:private Panel-component
+  "The React component `Panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (rf.fresco/as-component Panel))
+
+(defn Panel-bridge
+  "The callable a Reagent parent mounts this panel through. Returns
+  Reagent-shaped hiccup interoping to the React component above; the
+  enclosing `rf/frame-provider` is what puts the frame in React context
+  for it.
+
+  PUBLIC, where the merged `module_view.cljs` template's equivalent is
+  private, and the difference is a real one rather than a slip. That
+  panel is L4-only — a `reg-l4-tab!` surface with no standalone facade —
+  so its bridge has exactly one consumer, in its own namespace. This
+  panel is ALSO in `panel_enum` with a `mount-resources!` facade, and
+  `panels/render-panel!` takes the view to mount as an ARGUMENT, so the
+  embedding contract needs a name it can pass. Every panel carrying a
+  `mount-*!` facade will want the same."
   []
-  (let [{:keys [silent? registry scope-resolvers instances work route-graph
-                live-work stale-races stale-tally
-                timeline invalidations scope-resolutions mutation-invalidations
-                continuations optimistic-mutations optimistic-force-clobbers
-                cache-growth audit]}
-        @(rf/subscribe [:rf.xray/resources-tab-data])]
-    [:section {:data-testid "rf-xray-resources"
-               :style {:height         "100%"
-                       :display        "flex"
-                       :flex-direction "column"
-                       :background     (:bg-2 tokens)
-                       :color          (:text-primary tokens)
-                       :font-family    sans-stack
-                       :font-size      "14px"
-                       :overflow       "auto"}}
-     (if silent?
-       (silent-state)
-       [:<>
-        (registry-section registry)
-        (scope-resolvers-section scope-resolvers)
-        (instances-section instances)
-        (work-ledger-section work)
-        ;; EP-0011 uniform reply-envelope reads — "what is still running?"
-        ;; (live work + active-effects tally) and the cross-family stale-races
-        ;; view. Silent-by-default: each renders nothing when its data is
-        ;; empty (quiet baseline for a settled app).
-        (live-work-section {:live-work live-work :stale-tally stale-tally})
-        (stale-races-section stale-races)
-        (route-graph-section route-graph)
-        (timeline-section timeline)
-        (invalidation-section invalidations)
-        (scope-resolution-section scope-resolutions)
-        (continuations-section {:continuations continuations
-                                :mutation-invalidations mutation-invalidations})
-        (optimistic-mutations-section
-          {:optimistic-mutations optimistic-mutations
-           :optimistic-force-clobbers optimistic-force-clobbers})
-        (cache-growth-section cache-growth)
-        (audit-section audit)])]))
+  [:> Panel-component {}])
 
 ;; ---- production value sources --------------------------------------------
 ;;
@@ -1352,7 +1484,11 @@
      :mnem  "s"
      :modes #{:dynamic}
      :order 7
-     :panel Panel})
+     ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary) and the shell mounts `:panel` as a
+     ;; Reagent hiccup head; the bridge is the one line between them and
+     ;; goes when the shell is a Fresco tree.
+     :panel Panel-bridge})
 
   nil)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -137,7 +137,8 @@
   (let [rid (:resource-id row)
         testid (str "rf-xray-resources-registry-row-"
                     (when rid (-> rid str (subs 1))))]
-    [:div {:data-testid testid
+    [:div {:key   (str rid)
+           :data-testid testid
            :data-resource-id (str rid)
            :style {:display       "flex"
                    :align-items   "baseline"
@@ -178,8 +179,7 @@
     (if (seq rows)
       (into [:div {:data-testid "rf-xray-resources-registry-body"
                    :style {:display "flex" :flex-direction "column" :gap "2px"}}]
-            (for [row rows]
-              ^{:key (str (:resource-id row))} (registry-row-view row)))
+            (map registry-row-view rows))
       (empty-caption "No resources registered in the host app."
                      "rf-xray-resources-registry-empty"))))
 
@@ -197,7 +197,8 @@
   (let [sid (:scope-id row)
         testid (str "rf-xray-resources-scope-resolver-row-"
                     (when sid (-> sid str (subs 1))))]
-    [:div {:data-testid testid
+    [:div {:key   (str sid)
+           :data-testid testid
            :data-scope-id (str sid)
            :style {:display "flex" :align-items "baseline" :gap "10px"
                    :flex-wrap "wrap" :padding "3px 0"
@@ -226,8 +227,7 @@
     (if (seq rows)
       (into [:div {:data-testid "rf-xray-resources-scope-resolvers-body"
                    :style {:display "flex" :flex-direction "column" :gap "2px"}}]
-            (for [row rows]
-              ^{:key (str (:scope-id row))} (scope-resolver-row-view row)))
+            (map scope-resolver-row-view rows))
       (empty-caption "No named resource-scope resolvers registered."
                      "rf-xray-resources-scope-resolvers-empty"))))
 
@@ -237,7 +237,8 @@
   (let [testid (str "rf-xray-resources-instance-row-"
                     (when (:resource-id row) (-> row :resource-id str (subs 1)))
                     "-g" (:generation row))]
-    [:div {:data-testid testid
+    [:div {:key   (str (:scoped-key row))
+           :data-testid testid
            :style {:display       "flex"
                    :align-items   "baseline"
                    :gap           "10px"
@@ -301,8 +302,8 @@
            (into [:<>]
                  (map-indexed
                    (fn [i p]
-                     ^{:key i}
-                     [:span {:style {:display "flex" :gap "2px"
+                     [:span {:key   i
+                             :style {:display "flex" :gap "2px"
                                      :align-items "baseline"}}
                       [:span {:style {:color (:text-tertiary tokens)}}
                        (str "p" i)]
@@ -320,8 +321,7 @@
     (if (seq rows)
       (into [:div {:data-testid "rf-xray-resources-instances-body"
                    :style {:display "flex" :flex-direction "column" :gap "2px"}}]
-            (for [row rows]
-              ^{:key (str (:scoped-key row))} (instance-row-view row)))
+            (map instance-row-view rows))
       (empty-caption "No live resource instances in this frame."
                      "rf-xray-resources-instances-empty"))))
 
@@ -330,7 +330,8 @@
 (defn- work-row-view [row]
   (let [testid (str "rf-xray-resources-work-row-"
                     (hash (:work-id row)))]
-    [:div {:data-testid testid
+    [:div {:key   (str (:work-id row))
+           :data-testid testid
            :data-terminal (str (:terminal? row))
            :style {:display     "flex"
                    :align-items "baseline"
@@ -380,8 +381,7 @@
     (if (seq rows)
       (into [:div {:data-testid "rf-xray-resources-work-body"
                    :style {:display "flex" :flex-direction "column" :gap "2px"}}]
-            (for [row rows]
-              ^{:key (str (:work-id row))} (work-row-view row)))
+            (map work-row-view rows))
       (empty-caption "No in-flight or recent resource work in this frame."
                      "rf-xray-resources-work-empty"))))
 
@@ -397,7 +397,8 @@
 
 (defn- live-work-row-view [row]
   (let [testid (str "rf-xray-resources-live-work-row-" (hash (:work-id row)))]
-    [:div {:data-testid testid
+    [:div {:key   (str (:work-id row))
+           :data-testid testid
            :data-work-kind (str (some-> (:work-kind row) name))
            :style {:display     "flex"
                    :align-items "baseline"
@@ -439,8 +440,7 @@
        (if (seq live-work)
          (into [:div {:data-testid "rf-xray-resources-live-work-body"
                       :style {:display "flex" :flex-direction "column" :gap "2px"}}]
-               (for [row live-work]
-                 ^{:key (str (:work-id row))} (live-work-row-view row)))
+               (map live-work-row-view live-work))
          (empty-caption "No live managed-async work in this frame."
                         "rf-xray-resources-live-work-empty"))
        ;; the active-effects tally headline — live count per family.
@@ -451,8 +451,8 @@
                               :font-size "11px" :color (:text-tertiary tokens)}}
                 [:span {:style {:font-weight 600}} "suppressed: "]]
                (for [[kind n] (sort-by (comp str key) stale-tally)]
-                 ^{:key (str kind)}
-                 [:span {:data-testid (str "rf-xray-resources-stale-tally-"
+                 [:span {:key         (str kind)
+                         :data-testid (str "rf-xray-resources-stale-tally-"
                                            (some-> kind name))
                          :style {:color (:warning tokens)}}
                   (str (some-> kind name) " " n)])))])))
@@ -469,7 +469,8 @@
 
 (defn- stale-race-row-view [arc]
   (let [testid (str "rf-xray-resources-stale-race-row-" (hash (:work-id arc)))]
-    [:div {:data-testid testid
+    [:div {:key   (str (:work-id arc))
+           :data-testid testid
            :data-work-kind (str (some-> (:work-kind arc) name))
            :style {:display     "flex"
                    :align-items "baseline"
@@ -501,8 +502,7 @@
         (section-caption "Stale races" "rf-xray-resources-stale-races-caption")
         (into [:div {:data-testid "rf-xray-resources-stale-races-body"
                      :style {:display "flex" :flex-direction "column" :gap "2px"}}]
-              (for [arc suppressed]
-                ^{:key (str (:work-id arc))} (stale-race-row-view arc)))))))
+              (map stale-race-row-view suppressed))))))
 
 ;; ---- §4 ROUTE / RESOURCE GRAPH -----------------------------------------
 
@@ -518,7 +518,8 @@
 (defn- route-graph-row-view [node]
   (let [testid (str "rf-xray-resources-route-row-"
                     (when (:route-id node) (-> node :route-id str (subs 1))))]
-    [:div {:data-testid testid
+    [:div {:key   (str (:route-id node))
+           :data-testid testid
            :style {:display "flex" :flex-direction "column" :gap "2px"
                    :padding "4px 0"}}
      [:div {:style {:display "flex" :gap "10px" :align-items "baseline"
@@ -544,8 +545,8 @@
                           :padding-left "12px" :font-family mono-stack
                           :font-size "11px"}}]
            (for [res (:resources node)]
-             ^{:key (str (:resource res) (:local-id res))}
-             [:span {:style {:color (if (:blocking? res)
+             [:span {:key   (str (:resource res) (:local-id res))
+                     :style {:color (if (:blocking? res)
                                      (:warning tokens)
                                      (:text-tertiary tokens))}}
               (str (:resource res))
@@ -568,15 +569,15 @@
     (if (seq nodes)
       (into [:div {:data-testid "rf-xray-resources-route-graph-body"
                    :style {:display "flex" :flex-direction "column" :gap "4px"}}]
-            (for [node nodes]
-              ^{:key (str (:route-id node))} (route-graph-row-view node)))
+            (map route-graph-row-view nodes))
       (empty-caption "No routes declare :resources."
                      "rf-xray-resources-route-graph-empty"))))
 
 ;; ---- §5 LIFECYCLE TIMELINE ---------------------------------------------
 
 (defn- timeline-row-view [row]
-  [:div {:data-testid (str "rf-xray-resources-timeline-row-" (:id row))
+  [:div {:key         (str (:id row))
+         :data-testid (str "rf-xray-resources-timeline-row-" (:id row))
          :data-op     (str (:operation row))
          :style {:display "flex" :gap "8px" :align-items "baseline"
                  :padding "2px 0" :font-family mono-stack :font-size "11px"}}
@@ -633,15 +634,15 @@
     (if (seq rows)
       (into [:div {:data-testid "rf-xray-resources-timeline-body"
                    :style {:display "flex" :flex-direction "column" :gap "1px"}}]
-            (for [row rows]
-              ^{:key (str (:id row))} (timeline-row-view row)))
+            (map timeline-row-view rows))
       (empty-caption "No resource lifecycle events in this epoch."
                      "rf-xray-resources-timeline-empty"))))
 
 ;; ---- §6 INVALIDATION GRAPH ----------------------------------------------
 
 (defn- invalidation-row-view [row]
-  [:div {:data-testid (str "rf-xray-resources-invalidation-row-" (:id row))
+  [:div {:key         (str (:id row))
+         :data-testid (str "rf-xray-resources-invalidation-row-" (:id row))
          :style {:display "flex" :gap "8px" :align-items "baseline"
                  :padding "2px 0" :font-family mono-stack :font-size "11px"}}
    [:span {:style {:color (:orange tokens) :font-weight 600}} "invalidate"]
@@ -662,8 +663,7 @@
     (if (seq rows)
       (into [:div {:data-testid "rf-xray-resources-invalidation-body"
                    :style {:display "flex" :flex-direction "column" :gap "1px"}}]
-            (for [row rows]
-              ^{:key (str (:id row))} (invalidation-row-view row)))
+            (map invalidation-row-view rows))
       (empty-caption "No invalidations in this epoch."
                      "rf-xray-resources-invalidation-empty"))))
 
@@ -675,7 +675,8 @@
 ;; never an implicit global). Per Spec 016 §Named resource-scope resolvers.
 
 (defn- scope-resolution-row-view [row]
-  [:div {:data-testid (str "rf-xray-resources-scope-resolution-row-" (:id row))
+  [:div {:key         (str (:id row))
+         :data-testid (str "rf-xray-resources-scope-resolution-row-" (:id row))
          :data-resolved-nil (str (:resolved-nil? row))
          :style {:display "flex" :gap "8px" :align-items "baseline"
                  :padding "2px 0" :font-family mono-stack :font-size "11px"}}
@@ -704,8 +705,7 @@
     (if (seq rows)
       (into [:div {:data-testid "rf-xray-resources-scope-resolution-body"
                    :style {:display "flex" :flex-direction "column" :gap "1px"}}]
-            (for [row rows]
-              ^{:key (str (:id row))} (scope-resolution-row-view row)))
+            (map scope-resolution-row-view rows))
       (empty-caption "No named-scope resolutions in this epoch."
                      "rf-xray-resources-scope-resolution-empty"))))
 
@@ -719,7 +719,8 @@
 ;; completion continuations / §Trace evidence for invalidation).
 
 (defn- descriptor-chip [d]
-  [:span {:style {:color (:text-tertiary tokens)}}
+  [:span {:key   (str (get-in d [:scope :preview]) (:tags d))
+          :style {:color (:text-tertiary tokens)}}
    "["
    (if (:cross-scope? d)
      [:span {:style {:color (:warning tokens)}} "cross-scope"]
@@ -736,7 +737,8 @@
    "]"])
 
 (defn- mutation-invalidation-row-view [row]
-  [:div {:data-testid (str "rf-xray-resources-mutation-invalidation-row-" (:id row))
+  [:div {:key         (str (:id row))
+         :data-testid (str "rf-xray-resources-mutation-invalidation-row-" (:id row))
          :data-mutation (str (:mutation row))
          :style {:display "flex" :gap "8px" :align-items "baseline" :flex-wrap "wrap"
                  :padding "2px 0" :font-family mono-stack :font-size "11px"}}
@@ -746,8 +748,7 @@
    [:span {:style {:color (:text-tertiary tokens)}}
     (str (:descriptor-count row) " descriptors")]
    (into [:span {:style {:display "flex" :gap "6px" :flex-wrap "wrap"}}]
-         (for [d (:dispatched row)]
-           ^{:key (str (get-in d [:scope :preview]) (:tags d))} (descriptor-chip d)))
+         (map descriptor-chip (:dispatched row)))
    (when (seq (:unresolved row))
      [:span {:data-testid (str "rf-xray-resources-mutation-invalidation-unresolved-" (:id row))
              :style {:color (:warning tokens)}}
@@ -768,7 +769,8 @@
     mode-accent))
 
 (defn- continuation-row-view [row]
-  [:div {:data-testid (str "rf-xray-resources-continuation-row-" (:id row))
+  [:div {:key         (str (:id row))
+         :data-testid (str "rf-xray-resources-continuation-row-" (:id row))
          :data-mutation (str (:mutation row))
          :data-status (str (some-> (:status row) name))
          :style {:display "flex" :gap "8px" :align-items "baseline" :flex-wrap "wrap"
@@ -790,16 +792,14 @@
      (if (seq mutation-invalidations)
        (into [:div {:data-testid "rf-xray-resources-mutation-invalidation-body"
                     :style {:display "flex" :flex-direction "column" :gap "1px"}}]
-             (for [row mutation-invalidations]
-               ^{:key (str (:id row))} (mutation-invalidation-row-view row)))
+             (map mutation-invalidation-row-view mutation-invalidations))
        (empty-caption "No scoped mutation invalidations in this epoch."
                       "rf-xray-resources-mutation-invalidation-empty"))
      ;; the call-site :reply-to continuation dispatch (workflow)
      (if (seq continuations)
        (into [:div {:data-testid "rf-xray-resources-continuations-body"
                     :style {:display "flex" :flex-direction "column" :gap "1px"}}]
-             (for [row continuations]
-               ^{:key (str (:id row))} (continuation-row-view row)))
+             (map continuation-row-view continuations))
        (empty-caption "No :reply-to continuations dispatched in this epoch."
                       "rf-xray-resources-continuations-empty"))]))
 
@@ -837,7 +837,8 @@
 
 (defn- optimistic-mutation-row-view [row]
   (let [testid (str "rf-xray-resources-optimistic-row-" (:id row))]
-    [:div {:data-testid testid
+    [:div {:key   (str (:id row))
+           :data-testid testid
            :data-mutation (str (:mutation row))
            :data-outcome (str (some-> (:outcome row) name))
            :style {:display "flex" :flex-direction "column" :gap "2px"
@@ -864,9 +865,17 @@
        (into [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px"
                             :padding-left "12px"}}
               [:span {:style {:color (:text-tertiary tokens)}} "affected"]]
+             ;; `summary-chip` is a SHARED helper called from a dozen
+             ;; positions and it owns no key of its own — the identity is
+             ;; the affected KEY, which the chip never sees. So the key
+             ;; rides on a fragment wrapping the call: `[:<> …]` takes an
+             ;; optional attr map and carries `:key` on the fragment
+             ;; itself (`re-frame.fresco.impl.codec`'s head table), which
+             ;; adds no DOM node and leaves the shared helper's signature
+             ;; alone. Every other row in this file keys its own root.
              (for [k (:affected-keys row)]
-               ^{:key (str (:resource-id k) (get-in k [:params :preview]))}
-               (summary-chip (:scope k) nil))))
+               [:<> {:key (str (:resource-id k) (get-in k [:params :preview]))}
+                (summary-chip (:scope k) nil)])))
      ;; ON RECONCILE — the committed keys (authoritative write owned them)
      (when (= :reconciled (:outcome row))
        [:div {:data-testid (str testid "-committed")
@@ -895,9 +904,9 @@
         ;; per-key restored-vs-conflict disposition (the truthful evidence)
         (into [:div {:style {:display "flex" :flex-direction "column" :gap "1px"}}]
               (for [d (:dispositions row)]
-                ^{:key (str (get-in d [:resource/key :resource-id])
-                            (get-in d [:resource/key :params :preview]))}
-                [:span {:style {:color (if (:conflict d)
+                [:span {:key   (str (get-in d [:resource/key :resource-id])
+                                    (get-in d [:resource/key :params :preview]))
+                        :style {:color (if (:conflict d)
                                          (:warning tokens)
                                          (:text-tertiary tokens))}}
                  (str (get-in d [:resource/key :resource-id]))
@@ -906,7 +915,8 @@
                    (str " · conflict (" (some-> (:on-conflict d) name) ")"))]))])]))
 
 (defn- optimistic-force-clobber-row-view [row]
-  [:div {:data-testid (str "rf-xray-resources-optimistic-clobber-row-" (:id row))
+  [:div {:key         (str (:id row))
+         :data-testid (str "rf-xray-resources-optimistic-clobber-row-" (:id row))
          :data-mutation (str (:mutation row))
          :style {:display "flex" :gap "8px" :align-items "baseline" :flex-wrap "wrap"
                  :padding "2px 0" :font-family mono-stack :font-size "11px"
@@ -929,16 +939,14 @@
      (if (seq optimistic-mutations)
        (into [:div {:data-testid "rf-xray-resources-optimistic-body"
                     :style {:display "flex" :flex-direction "column" :gap "3px"}}]
-             (for [row optimistic-mutations]
-               ^{:key (str (:id row))} (optimistic-mutation-row-view row)))
+             (map optimistic-mutation-row-view optimistic-mutations))
        (empty-caption "No optimistic mutations in this epoch."
                       "rf-xray-resources-optimistic-empty"))
      ;; the loud :force-over-a-concurrent-write clobber warnings
      (when (seq optimistic-force-clobbers)
        (into [:div {:data-testid "rf-xray-resources-optimistic-clobber-body"
                     :style {:display "flex" :flex-direction "column" :gap "1px"}}]
-             (for [row optimistic-force-clobbers]
-               ^{:key (str (:id row))} (optimistic-force-clobber-row-view row))))]))
+             (map optimistic-force-clobber-row-view optimistic-force-clobbers)))]))
 
 ;; ---- §7 CACHE GROWTH ----------------------------------------------------
 
@@ -955,8 +963,8 @@
       (:live-work growth) " live work"]
      (into [:div {:style {:display "flex" :flex-direction "column" :gap "1px"}}]
            (for [r (:by-resource growth)]
-             ^{:key (str (:resource-id r))}
-             [:div {:style {:display "flex" :gap "8px"}}
+             [:div {:key   (str (:resource-id r))
+                    :style {:display "flex" :gap "8px"}}
               [:span {:style {:color mode-accent :min-width "10rem"}}
                (str (:resource-id r))]
               [:span {:style {:color (:text-tertiary tokens)}}
@@ -987,16 +995,16 @@
        (into [:div {:data-testid "rf-xray-resources-audit-suspicious"
                     :style {:display "flex" :flex-direction "column" :gap "1px"}}]
              (for [w suspicious]
-               ^{:key (str (:resource-id w))}
-               [:div {:style {:color (:warning tokens)}}
+               [:div {:key   (str (:resource-id w))
+                      :style {:color (:warning tokens)}}
                 "⚠ " (str (:resource-id w)) " — " (:hint w)])))
      ;; scope-mismatch lint
      (when (seq mismatches)
        (into [:div {:data-testid "rf-xray-resources-audit-mismatch"
                     :style {:display "flex" :flex-direction "column" :gap "1px"}}]
              (for [m mismatches]
-               ^{:key (str (:resource-id m) (get-in m [:sub-scope :preview]))}
-               [:div {:style {:color (:error tokens)}}
+               [:div {:key   (str (:resource-id m) (get-in m [:sub-scope :preview]))
+                      :style {:color (:error tokens)}}
                 "scope mismatch on " (str (:resource-id m))
                 " — sub scope " (get-in m [:sub-scope :preview])
                 " ≠ entry scope " (get-in m [:entry-scope :preview])])))
@@ -1005,8 +1013,8 @@
        (into [:div {:data-testid "rf-xray-resources-audit-orphan"
                     :style {:display "flex" :flex-direction "column" :gap "1px"}}]
              (for [o orphans]
-               ^{:key (str (:owner o))}
-               [:div {:style {:color (:warning tokens)}}
+               [:div {:key   (str (:owner o))
+                      :style {:color (:warning tokens)}}
                 "orphaned owner " (pr-str (:owner o))
                 " pins " (str (:resource-id o))])))]))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -75,6 +75,31 @@
   (xray-test-support/install-test-overrides!)
   (rf/make-frame {:id :rf/xray}))
 
+(defn- panel-tree
+  "The panel's hiccup tree, for the section rows below.
+
+  THIS USED TO BE A DIRECT CALL TO THE PANEL VAR. rf2-k97c.3 made `Panel` an
+  `rf.fresco/defview` — a real React function component whose body may
+  only run inside a React render window — so it is no longer a callable
+  that answers hiccup, and every row here walks hiccup.
+
+  The panel's body was split out as `resources/panel-tree`, a pure fn of
+  the one value the boundary reads. That is `re-frame.fresco/defview`'s
+  own documented extract-a-helper spelling, and it keeps the division of
+  labour honest: the section-rendering algebra is data → data and belongs
+  in this fast node-lane suite, while the boundary's OWN behaviour —
+  first paint, liveness on a real invalidation, frame targeting, evidence
+  isolation and teardown release — is
+  `resources_fresco_boundary_dom_cljs_test`'s subject, read off a real
+  React commit.
+
+  The read is spelled `@(rf/subscribe …)` rather than `rf.fresco/sub`
+  deliberately: outside a render window there is no collector edge to
+  record, and what these rows want is the sub's VALUE. That the boundary
+  reads the same query through the collector is the DOM suite's W1."
+  []
+  (resources/panel-tree @(rf/subscribe [:rf.xray/resources-tab-data])))
+
 ;; ---- fixtures: registry + entries + ledger ------------------------------
 
 (def session-scope [:rf.scope/session {:user-id "u-42"}])
@@ -225,7 +250,7 @@
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-overrides!)
-      (let [tree (resources/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-resources")) "panel root")
         (is (some? (find-by-testid tree "rf-xray-resources-registry")) "registry section")
         (is (some? (find-by-testid tree "rf-xray-resources-instances")) "instances section")
@@ -299,7 +324,7 @@
                          scope-resolver-regs]
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray/sync-trace-buffer ep0016-buffer] {:frame :rf/xray})
-      (let [tree (resources/Panel)]
+      (let [tree (panel-tree)]
         ;; D3 — the named-scope-resolver registry row (id + declared inputs)
         (is (some? (find-by-testid tree "rf-xray-resources-scope-resolver-row-realworld/session"))
             "named scope-resolver row rendered")
@@ -364,7 +389,7 @@
     (rf/with-frame :rf/xray
       (seed-overrides!)
       (rf/dispatch-sync [:rf.xray/sync-trace-buffer ep0011-buffer] {:frame :rf/xray})
-      (let [tree (resources/Panel)]
+      (let [tree (panel-tree)]
         ;; "what is still running?" section + the live resource row, joined
         ;; to its latest trace phase (issued via :rf.resource/work-started).
         (is (some? (find-by-testid tree "rf-xray-resources-live-work-caption"))
@@ -396,7 +421,7 @@
       (rf/dispatch-sync [:rf.xray/set-resource-work-ledger-override-for-test {}]
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray/sync-trace-buffer []] {:frame :rf/xray})
-      (let [tree (resources/Panel)]
+      (let [tree (panel-tree)]
         (is (nil? (find-by-testid tree "rf-xray-resources-live-work-caption"))
             "no live-work section when nothing is running / suppressed")
         (is (nil? (find-by-testid tree "rf-xray-resources-stale-races-caption"))
@@ -457,7 +482,7 @@
     (rf/with-frame :rf/xray
       (seed-overrides!)
       (rf/dispatch-sync [:rf.xray/sync-trace-buffer ep0019-buffer] {:frame :rf/xray})
-      (let [tree (resources/Panel)]
+      (let [tree (panel-tree)]
         ;; the section renders
         (is (some? (find-by-testid tree "rf-xray-resources-optimistic"))
             "optimistic-mutations section rendered")
@@ -488,7 +513,7 @@
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-overrides!)
-      (let [tree   (resources/Panel)
+      (let [tree   (panel-tree)
             status (find-by-testid tree "rf-xray-resources-instance-row-article/by-slug-g4-status")]
         (is (some? status))
         (is (re-find #"loaded" (node-text status)) "status reads loaded")))))
@@ -521,7 +546,7 @@
     (rf/with-frame :rf/xray
       (seed-overrides!)
       (seed-live-route!)
-      (let [tree (resources/Panel)
+      (let [tree (panel-tree)
             row  (find-by-testid tree "rf-xray-resources-route-row-route/article")]
         (is (some? row) "the route row renders")
         (is (some? (find-by-testid tree "rf-xray-resources-route-row-route/article-current"))
@@ -545,7 +570,7 @@
     (rf/with-frame :rf/xray
       (seed-overrides! (stale-live-entries))
       (seed-live-route!)
-      (let [tree (resources/Panel)
+      (let [tree (panel-tree)
             row  (find-by-testid tree "rf-xray-resources-route-row-route/article")]
         (is (some? row) "the route row renders")
         (is (re-find #"stale" (node-text row))
@@ -573,7 +598,7 @@
                            :data :rf/redacted :generation 1
                            :active-owners #{}}}]
                         {:frame :rf/xray})
-      (let [tree (resources/Panel)
+      (let [tree (panel-tree)
             data (find-by-testid tree "rf-xray-resources-instance-row-article/by-slug-g1-data")
             scope (find-by-testid tree "rf-xray-resources-instance-row-article/by-slug-g1-scope")]
         (is (some? data))
@@ -685,7 +710,7 @@
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray/set-resource-entries-override-for-test {}]
                         {:frame :rf/xray})
-      (let [tree (resources/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-resources")) "panel root present")
         (is (some? (find-by-testid tree "rf-xray-resources-silent")) "silent caption")
         (is (nil? (find-by-testid tree "rf-xray-resources-registry"))

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,614 @@
+(ns day8.re-frame2-xray.panels.resources-fresco-boundary-dom-cljs-test
+  "THE RESOURCES TAB RE-AUTHORED IN THE RE-FRAME-NATIVE VIEW LAYER, read off
+  a real React commit (rf2-k97c.3, step 2).
+
+  `resources/Panel` is now an `rf.fresco/defview` reading through Fresco's
+  shipped collector rather than an `rf/reg-view` reading through whatever
+  view build the installed substrate adapter supplies. This file is the
+  behavioural evidence for that swap. Its first four rows are the merged
+  `module_view_fresco_boundary_dom_cljs_test` template, claim for claim;
+  the fifth is this panel's own and is described below.
+
+  ## What the epic asked for, and which row answers it
+
+    1 FIRST DISPLAY               — W1
+    2 UPDATES ON A REAL CHANGE    — W2 (with the deaf control that makes
+                                    the update mean liveness)
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    5 TOOL ACTIVITY NEVER
+      MASQUERADING AS APPLICATION
+      EVIDENCE                    — W3, in BOTH directions
+    6 CLEAN TEARDOWN              — W4
+
+  Criterion 3 (Xray's own interactions) has no row: this panel is
+  READ-ONLY by contract (Spec 016 §Active owners and causes — opening it
+  pins nothing, and it registers no `:rf.resource/*` event), so a click
+  row would assert about a control the panel does not have. The
+  `resources_cljs_test` suite already pins the read-only claim
+  structurally, against the registrar.
+
+  ## W5 IS THIS PANEL'S OWN ROW, AND IT IS THE ADVERSARIAL ONE
+
+  The template's four rows all mount ONE subtree and watch it live or
+  die. They cannot see the change this migration actually made to the
+  panel's interior: all 24 of its `for`-row React keys moved out of
+  vector METADATA and into each row's own ATTRIBUTE MAP, because
+  metadata is a Reagent reading of `:key` that Fresco's codec does not
+  share (`re-frame.fresco.impl.codec`'s head table). Nothing else in the
+  tree tests that, and a lost key does not fail — it DEGRADES, silently,
+  into index-based reconciliation, which renders correctly on first
+  paint and corrupts row identity only once a list changes shape.
+
+  W5 changes a list's shape and reads identity. It removes the FIRST of
+  two sorted registry rows and asserts the SURVIVOR'S DOM node is the
+  same node it was. Under real keys React deletes the first fiber and
+  moves the second; under index keys it keeps fiber 0 and rewrites its
+  content, so the survivor would arrive in the node that used to be the
+  removed row's. Both spellings paint; only one preserves identity.
+
+  ## The mount is the SHELL's mount, taken from the registry
+
+  `shell/detail-panel` mounts the active tab as the hiccup head
+  `[(:panel tab)]` inside the shell's `[rf/frame-provider {:frame …}]`.
+  [[mount-panel!]] does exactly that, and it reaches `:panel` THROUGH
+  `panel-registry/tab-by-id` rather than naming the var — so the bridge
+  the registry actually holds is the thing under test.
+
+  Nothing below ever calls the panel a second time. Every assertion after
+  the mount reads `container.querySelector…` — the DOM React committed on
+  its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports —
+  because the claim being made is that the boundary is INDIFFERENT to it.
+  `:ambient-frame nil` is load-bearing exactly as it is in the template:
+  the fixture's default ambient `:rf/default` scope would otherwise
+  SHADOW the React-context tier W1 is about, and the frame-targeting row
+  would pass while measuring nothing.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium) per
+  `implementation/shadow-cljs.edn`, whose `:source-paths` already carry
+  `tools/xray/test`. The `:node-test` build's `cljs-test$` regex also
+  matches, so it LOADS under Node — where every row short-circuits
+  through [[browser?]] and reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. Two rows need
+  one that is not `:rf/xray`: W1 reads it as the negative half of the
+  frame-targeting claim, and W3 mounts INSIDE it so the evidence claim
+  cannot be carried by `:rf/xray`'s trace-disabled gate."
+  ::app)
+
+(def ^:private tab-data-q
+  "The panel's ONE read. Named once because four rows key off it — the
+  sub-cache is keyed by the query vector itself (`re-frame.subs/cache-key`
+  is identity), so this value IS the cache key."
+  [:rf.xray/resources-tab-data])
+
+;; ---- fixtures --------------------------------------------------------------
+;;
+;; Shaped after `resources_cljs_test`'s, trimmed to what these rows read. The
+;; panel is fed through the `install-test-overrides!` seam rather than through
+;; a live resources artefact, which Xray deliberately does not require.
+
+(defn- resource-reg
+  "One `:rf/resource` registry entry, minimal but complete enough for
+  `resources-helpers/registry-row` to project a row from it."
+  [rid]
+  {rid {:doc "probe resource"
+        :rf/resource {:doc            "probe resource"
+                      :params-schema  [:map [:slug :string]]
+                      :scope          :rf.scope/global
+                      :transport      :rf.http/managed
+                      :stale-after-ms 60000
+                      :gc-after-ms    300000
+                      :tags           (fn [_ _] #{})
+                      :request        (fn [_ _] {})}}})
+
+(def ^:private two-resources
+  "Two registry entries. `project-registry` sorts by `(str :resource-id)`,
+  so `:aaa/one` renders FIRST and `:zzz/two` second — which is what makes
+  W5's removal a removal from the HEAD of the list, the only position at
+  which keyed and index-based reconciliation disagree."
+  (merge (resource-reg :aaa/one) (resource-reg :zzz/two)))
+
+(def ^:private one-resource
+  "W5's second state: the head row gone, the survivor untouched."
+  (resource-reg :zzz/two))
+
+(def ^:private deaf-route
+  "W2's DEAF CONTROL, and its deafness is structural rather than lucky.
+  `:rf.xray/resources-tab-data` reads the route registry INSIDE its own
+  handler body — `(rf/registrations {:source :store :kind :route})` — and
+  that read is NOT one of its declared `:inputs`. So registering a route
+  moves what the composite WOULD compute while invalidating nothing it
+  watches, which is precisely the shape W2 needs.
+
+  Registration goes through the registrar directly because the routing
+  artefact's `reg-route` macro is not on the Xray test classpath —
+  the same route `resources_cljs_test/seed-live-route!` takes."
+  :route/deaf)
+
+(def ^:private probe-trace-op
+  "One well-formed trace op, for W2's phase 3. `:rf.xray/trace-buffer` IS
+  a declared input of the composite, so syncing a non-empty buffer over
+  an empty one is a REAL invalidation — where the deaf control above is
+  not one."
+  {:id        7001
+   :op-type   :rf.event
+   :operation :rf.resource/scope-resolved
+   :tags      {:resource-id   :probe/session
+               :kind          :resource-scope
+               :inputs        [:username]
+               :input-values  {:username "probe"}
+               :whole-db?     false
+               :scope         [:rf.scope/session {:username "probe"}]
+               :resolved-nil? false}})
+
+;; ---- a probe event, and the `reg-view` W3 measures the panel against ------
+
+(rf/reg-event ::bump
+  (fn [{:keys [db]} [_ n]] {:db (assoc db ::n n)}))
+
+(rf/reg-sub ::n (fn [db _] (::n db)))
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W3, and nothing else. An ordinary `reg-view`
+  rendered by the installed adapter in the same root, in the same frame,
+  in the same commit as the panel — so the only variable between it and
+  the panel is which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-resources-probe-reg-view"} (str @(rf/subscribe [::n]))])
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     ;; `:async? true` because W2, W4 and W5 are `async` rows, and
+     ;; `cljs.test` refuses a FUNCTION fixture in any namespace that
+     ;; carries one — "Async tests require fixtures to be specified as
+     ;; maps. Testing aborted."
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make W4's release row read a residue that is not
+                      ;; this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than an
+;; omission — the template records it and it cost that worker a red row. A
+;; Fresco boundary is NOT in Reagent's render queue: its update is scheduled by
+;; the collector through React, so draining Reagent's queue commits nothing of
+;; this panel's and a row written that way reads a DOM that has not moved and
+;; reports a LIVE panel as dead. Mount is committed with `flushSync` (React's
+;; own door) and everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROL in W2: an absence asserted immediately after a change is
+  a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup!
+  "Register Xray's handlers (which is what registers
+  `:rf.xray/resources-tab-data` and the L4 tab entry the mount reads),
+  open the test-override seam, and make the two frames."
+  []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- seed-registry!
+  "Put `regs` in front of the panel through the test-override seam. A
+  dispatch, so it IS a real invalidation of the composite."
+  [regs]
+  (rf/dispatch-sync [:rf.xray/set-registered-resources-override-for-test regs]
+                    {:frame :rf/xray}))
+
+(defn- mount-panel!
+  "Mount the Resources tab the way `shell/detail-panel` mounts it: the
+  registry's `:panel` value as a hiccup head, inside a `frame-provider`
+  scoping `frame`. Committed synchronously — React 19's `root.render` is
+  otherwise async and phase 1 would assert against an empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)
+        tab       (panel-registry/tab-by-id :dynamic :resources)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [(:panel tab)]])))
+    {:container container :root root :tab tab}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- testid-sel [testid] (str "[data-testid=\"" testid "\"]"))
+
+(defn- registry-row-sel
+  "The DOM selector for one static-registry row. `registry-row-view`
+  builds its testid by dropping the resource-id's leading colon."
+  [rid]
+  (testid-sel (str "rf-xray-resources-registry-row-" (subs (str rid) 1))))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent. The spike measured the rejected design's binding by
+  watching this number climb across renders and never fall on unmount
+  (22 → 25 → 32), so it is the number the migration is answerable on."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+;; ===========================================================================
+;; W1 — first display, and the read lands in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-panel-paints-and-its-read-lands-in-the-named-frame
+  (testing "rf2-k97c.3 — the migrated Resources panel commits real DOM through
+            the registry entry the shell mounts, and its `rf.fresco/sub` read
+            resolves against the frame the enclosing `frame-provider` named
+            rather than the ambient one. Epic criteria 1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            _ (seed-registry! two-resources)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [::n] {:frame app-frame})
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          (is (some? (q container (testid-sel "rf-xray-resources")))
+              "the panel committed a real DOM root under React — a Fresco
+               boundary mounted through Reagent's `:>` from the registry entry")
+          (is (some? (q container (testid-sel "rf-xray-resources-registry")))
+              "and the static-registry section rendered, so the body ran
+               rather than short-circuiting to the silent caption")
+          (is (some? (q container (registry-row-sel :aaa/one)))
+              "with a real row from the seeded registry — the read reached
+               the panel rather than the panel painting an empty shell")
+
+          ;; ---- criterion 4: the read is where the tree said it would be ----
+          (is (pos? (ref-count-of :rf/xray tab-data-q))
+              (str "the panel's read holds a reference in :rf/xray's sub-cache "
+                   "— the frame the enclosing frame-provider named. Cache keys: "
+                   (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame tab-data-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [::n]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
+          (finally
+            ;; Release the imperative probe explicitly: `unsubscribe`'s own
+            ;; docstring says a Reagent view auto-disposes via the reaction
+            ;; lifecycle and an imperative subscriber must not rely on that.
+            (rf/unsubscribe [::n] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-panel-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted panel re-renders itself and commits new DOM
+            when its read's value really changes, and does NOT when nothing it
+            watches moved. Epic criterion 2, with the control that makes the
+            update mean liveness rather than a commit that simply had not
+            happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed-registry! two-resources)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              section (q container (testid-sel "rf-xray-resources"))
+              route-q (testid-sel (str "rf-xray-resources-route-row-"
+                                       (subs (str deaf-route) 1)))
+              row?    (fn [] (some? (q container route-q)))]
+          (is (not (row?))
+              "NON-VACUITY: the route this row drives in is NOT on screen
+               before it is registered")
+
+          ;; ---- phase 2: the world moves, and the panel is deaf ------------
+          ;; The composite reads the ROUTE registry inside its own handler
+          ;; body rather than through a declared input, so registering a
+          ;; route changes what it WOULD compute while invalidating nothing.
+          (rf.registrar/register! :route deaf-route
+                                  {:path      "/deaf"
+                                   :resources [{:resource :aaa/one :blocking? true}]})
+          (is (contains? (rf/with-frame :rf/xray
+                           (rf/registrations {:source :store :kind :route}))
+                         deaf-route)
+              "PRECONDITION: the read's UNDERLYING data now carries the route
+               — so a missing row below is the panel failing to re-render,
+               and not the route failing to exist")
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (not (row?))
+                      "CONTROL: given a full settling window, the committed DOM
+                       still does NOT carry the row. A panel that re-rendered
+                       here would make phase 3 pass for a reason that is not
+                       liveness")
+                  ;; ---- phase 3: a declared input moves, the read re-runs ---
+                  (rf/dispatch-sync [:rf.xray/sync-trace-buffer [probe-trace-op]]
+                                    {:frame :rf/xray})
+                  (rf.test-support/poll-until row?
+                    {:label "the panel committed the new route's row"})))
+              (.then
+                (fn [_]
+                  (is (row?)
+                      (str "the panel re-rendered on a real invalidation of its "
+                           "own read and committed the new route's row"))
+                  (is (identical? section
+                                  (q container (testid-sel "rf-xray-resources")))
+                      "and it is the SAME <section> node: React reconciled the
+                       live tree in place, so the row did not arrive by the
+                       panel being remounted from scratch, which would not be
+                       liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — the tool's own render is not application view evidence
+;; ===========================================================================
+
+(deftest w3-the-boundarys-render-emits-no-view-trace
+  (testing "rf2-k97c.3 / rf2-tqlmq — rendering the migrated panel contributes
+            NOTHING to the substrate's view-trace stream, even when it is
+            mounted INSIDE an application frame. Epic criterion 5, proven
+            structurally rather than by the `:rf/xray` frame gate: a Fresco
+            boundary is not a substrate view render, so there is no event to
+            gate. The control is an ordinary `reg-view` in the same root, the
+            same frame and the same commit."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_        (setup!)
+            _        (seed-registry! two-resources)
+            traces   (atom [])
+            view-op? #(and (keyword? (:operation %))
+                           (= "rf.view" (namespace (:operation %))))]
+        (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+        (try
+          ;; ---- the subject: the panel, mounted in an APPLICATION frame ----
+          (let [{:keys [container root]} (mount-panel! app-frame)
+                subject-views (filterv view-op? @traces)]
+            (try
+              (is (some? (q container (testid-sel "rf-xray-resources")))
+                  "precondition: the panel really did render in this commit —
+                   an empty container would make the zero below vacuous")
+              (is (zero? (count subject-views))
+                  (str "the panel's render put NO :rf.view/* op in the trace "
+                       "stream while rendering inside an application frame. "
+                       "Ops seen: " (pr-str (mapv :operation subject-views))))
+              (finally (teardown! root container))))
+
+          ;; ---- the control: a reg-view, same root shape, same frame -------
+          (reset! traces [])
+          (let [container (.createElement js/document "div")
+                root      (rdc/create-root container)]
+            (.appendChild (.-body js/document) container)
+            (try
+              (react-dom/flushSync
+                (fn []
+                  (rdc/render root [rf/frame-provider {:frame app-frame}
+                                    [ProbeRegView]])))
+              (let [control-views (filterv view-op? @traces)]
+                (is (some? (q container
+                              (testid-sel "rf-xray-resources-probe-reg-view")))
+                    "precondition: the control really did render")
+                (is (pos? (count control-views))
+                    (str "CONTROL FIRES: an ordinary reg-view rendered the same "
+                         "way DOES emit a :rf.view/* op, so the subject's zero "
+                         "is a property of the boundary and not of a dead "
+                         "instrument. Ops seen: "
+                         (pr-str (mapv :operation control-views)))))
+              (finally (teardown! root container))))
+          (finally
+            (rf/unregister-listener! :trace ::collect)))))))
+
+;; ===========================================================================
+;; W4 — clean teardown: the read is released, and reopening is not growth
+;; ===========================================================================
+
+(defn- released?
+  "The panel's read is fully released from `:rf/xray`'s sub-cache."
+  []
+  (zero? (ref-count-of :rf/xray tab-data-q)))
+
+(deftest w4-unmount-releases-the-read-and-reopen-does-not-grow-it
+  (testing "rf2-k97c.3 — unmounting the panel releases its subscription
+            reference completely, and mounting it again returns to the SAME
+            count rather than a higher one. Epic criterion 6, and the number
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed 22 → 25 → 32 across
+            renders and never fell on unmount.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once. `impl.collector`'s `cell-reapers` gives a cell
+            whose last reader unmounts ONE MACROTASK OF GRACE, so that a keyed
+            reorder which unmounts and remounts a row within a single turn
+            reuses the reaction instead of rebuilding it. A synchronous read
+            straight after `flushSync(root.unmount)` returns 1 and the same
+            read one macrotask later returns 0, so a synchronous assertion
+            would report a LEAK against a collector behaving exactly as
+            documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed-registry! two-resources)
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-panel! :rf/xray)
+                      mounted (ref-count-of :rf/xray tab-data-q)]
+                  (is (pos? mounted)
+                      "the mount took a reference — otherwise the release
+                       below is vacuous")
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released the read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released it COMPLETELY, within "
+                                   "the collector's grace macrotask. Cache: "
+                                   (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same count, not a higher one ----
+                          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
+                                remounted (ref-count-of :rf/xray tab-data-q)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" mounted ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases it too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
+
+;; ===========================================================================
+;; W5 — ADVERSARIAL: the rows are really KEYED, not index-reconciled
+;; ===========================================================================
+
+(deftest w5-row-keys-survive-a-removal-from-the-head-of-the-list
+  (testing "rf2-k97c.3 — removing the FIRST of two sorted registry rows leaves
+            the survivor in the SAME DOM node. This is the row that can see the
+            interior change this migration made: all 24 of the panel's `for`-row
+            keys moved from vector METADATA into each row's own attribute map,
+            because Fresco's codec reads only the literal `:key` in the attr map
+            (`re-frame.fresco.impl.codec`'s head table) where Reagent also read
+            the metadata form.
+
+            A LOST KEY DOES NOT FAIL, IT DEGRADES — into index-based
+            reconciliation, which paints identically and corrupts identity only
+            once a list changes shape. So the discriminator is node identity
+            across a change of shape, and the change is made at the HEAD of the
+            list because that is the only position where the two spellings
+            disagree: keyed, React deletes fiber 0 and MOVES fiber 1; indexed,
+            it keeps fiber 0 and rewrites its content, delivering the survivor
+            in the node that used to be the removed row's."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed-registry! two-resources)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              head-sel     (registry-row-sel :aaa/one)
+              survivor-sel (registry-row-sel :zzz/two)
+              head-before  (q container head-sel)
+              surv-before  (q container survivor-sel)]
+          (is (some? head-before)  "PRECONDITION: the head row painted")
+          (is (some? surv-before)  "PRECONDITION: the survivor row painted")
+          (is (not (identical? head-before surv-before))
+              "PRECONDITION: they are two distinct DOM nodes, so the identity
+               assertion below can distinguish them at all")
+          ;; Count on `data-resource-id`, which ONLY the row root carries —
+          ;; a `data-testid^=` prefix match would also catch each row's own
+          ;; `-id` / `-scope` / `-routes` child spans and read 6 for 2 rows.
+          (is (= 2 (.-length (.querySelectorAll container "[data-resource-id]")))
+              "PRECONDITION: exactly two rows, so the removal below really is a
+               change of the list's SHAPE and not merely of its content")
+          ;; `project-registry` sorts by `(str :resource-id)`, so `:aaa/one`
+          ;; is DOM-first; assert that rather than trusting it, because the
+          ;; whole discriminator rests on which row is removed.
+          (is (pos? (bit-and (.compareDocumentPosition head-before surv-before)
+                             (.-DOCUMENT_POSITION_FOLLOWING js/Node)))
+              "PRECONDITION: the row being removed really is the one that comes
+               FIRST — a removal from the TAIL would leave the survivor's node
+               untouched under index keys too, and the row would be vacuous")
+
+          ;; ---- the change of shape -----------------------------------------
+          (seed-registry! one-resource)
+          (-> (rf.test-support/poll-until
+                (fn [] (nil? (q container head-sel)))
+                {:label "the head row left the committed DOM"})
+              (.then
+                (fn [_]
+                  (let [surv-after (q container survivor-sel)]
+                    (is (nil? (q container head-sel))
+                        "the removed resource's row is gone from the DOM")
+                    (is (some? surv-after)
+                        "and the survivor is still on screen")
+                    (is (identical? surv-before surv-after)
+                        "THE CLAIM: the survivor is the SAME DOM node it was.
+                         React matched it by KEY and moved its fiber. Under
+                         index-based reconciliation it would have arrived in
+                         the node that used to hold the removed row, and this
+                         assertion is the only thing in the suite that can
+                         tell those two apart."))))
+              (.catch (fn [e]
+                        (is false (str "W5 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))


### PR DESCRIPTION
Step 2 of the ruled Design B migration (rf2-k97c.3), one panel: **Resources**
(1,433 lines — the largest of the remaining set). Increment 1 migrated
`panels/module_view.cljs` and merged; this follows it as the template, claim
for claim, and invents no second pattern.

`Panel` is now an `rf.fresco/defview` reading `:rf.xray/resources-tab-data`
through `rf.fresco/sub` — an edge Fresco's collector wires, activates, re-wires
and *notifies* on invalidation — rather than an `rf/reg-view` whose
`@(rf/subscribe …)` is tracked only by whichever reaction machinery the
installed adapter happens to supply. That is the epic's third coupling
(observation), severed for this panel. Couplings 1 and 2 stay for the final
root-flip commit.

**The bead is NOT finished by this PR.** It is one panel of a dozen, and step 3
— `shell.cljs`, `mount.cljs`, `render-panel!`, the bridge deletions — is
untouched and stays one-toucher by construction.

## The one design question the brief asked to be answered out loud

**One boundary, and the answer is not close.** Boundary count tracks *reads* and
*head-position use*, not file size. This panel has exactly ONE read, and all 37
section helpers are CALLED by application — never used as a hiccup head — so
Fresco's "a plain function in head position is a loud error" rule never meets
one. The 1,433 lines are almost entirely substrate-agnostic projection helpers.
Nothing in the interior asked for a boundary of its own, and nothing about the
size changed the shape of the migration.

That finding binds the remaining panels: **size is not the axis**. The axes are
read count, head-position use, form-2, and per-mount closure state.

## Two shapes the merged template does not cover

Both follow from this panel having a standalone embed where `module_view` is
L4-only, so both will recur on every remaining panel with a `mount-*!` facade
(seven of the ten Dynamic tabs, per `panel_enum`).

**1. `Panel-bridge` is PUBLIC here where the template's is private.**
`panels/render-panel!` takes the view to mount as an ARGUMENT, so the embedding
contract needs a name it can pass. `mount-resources!` now passes the bridge — a
one-line call-site change in `panels.cljs`.

`render-panel!` ITSELF is deliberately untouched, and that is the fence holding
rather than an oversight: it is the single chokepoint where the frame-provider
and `adapter/render` couplings are severed for the whole embedding contract, and
that is one edit in the final commit rather than N edits now. Changing which var
a caller hands it is not changing it.

Leaving the call site alone was considered and rejected: `re-frame.fresco/defview`'s
own contract is that a boundary is mounted as `[head props]` inside a Fresco
body or through `as-component` from outside, **never as a hiccup render fn in a
Reagent tree** — which is exactly what `render-panel!` builds. Not changing the
line would have shipped a broken `mount-resources!`, against a design whose
stated property is that the tree works and is green at every step.

**2. The body is split into `panel-tree`**, a pure fn of the value the boundary
reads, with the `defview` reduced to the read plus a call. That is
`re-frame.fresco/defview`'s own documented extract-a-helper spelling, not an
invention, and it is what keeps a 694-line node-lane suite alive: a boundary's
body may only run inside a React render window, so `(Panel)` is no longer a
callable that answers hiccup, and ten rows of `resources_cljs_test` walked
exactly that hiccup. They now drive `panel-tree` with the sub's value. The
division of labour is honest — projection algebra in the fast node lane, the
boundary's own behaviour in a real React commit.

## The interior change, and the row that can see it

All 24 of the panel's `for`-row React keys moved out of vector METADATA and into
each row's own attribute map. `re-frame.fresco.impl.codec`'s head table is
explicit that the literal `:key` in the attr map is the one spelling that reaches
React; every substrate reads it, so this is a portability fix rather than a
Fresco accommodation. It landed as its own commit ahead of the boundary so that
commit carries no mechanical churn.

**A lost key does not fail — it DEGRADES** into index-based reconciliation, which
paints identically and corrupts row identity only once a list changes shape.
Nothing in the template's four rows can see that, so **W5** was written for it:
it removes the FIRST of two sorted registry rows and asserts the survivor is the
SAME DOM node. The head position is asserted rather than assumed
(`compareDocumentPosition`), because a removal from the TAIL leaves the survivor
untouched under either spelling and would make the row vacuous.

One site the template does not cover: the affected-keys chips call the SHARED
`summary-chip`, which owns no key and never sees the affected key the identity
comes from. Rather than widen a helper called from a dozen positions, the key
rides on a fragment wrapping the call — `[:<> {:key …} …]`, which the codec's
head table carries on the fragment and which adds no DOM node.

## What was measured against the brief's premises

Every premise checked at source, and all held:

- **ZERO** `reagent/create-class` / `:reagent-render` (form-2) — confirmed.
- **ZERO** references to `views/edn_inspector` or `views/edn_widget` — confirmed,
  so no collision with increment 2.
- **ZERO** dispatch sites in the view. The five `dispatch` hits in the file are
  prose in comments plus one `(:dispatched row)` keyword lookup.
- **ZERO** helpers used as a hiccup head — every one is called. This is the fact
  that made a single boundary correct.
- The alias `h` was **not available** in this namespace in any case: it is
  `resources-helpers`. `rf.fresco` is both the Conventions-canonical dialect and
  the only spelling that would have compiled.

## Quality gates

Every number below is read from that run's own `.exit` file, written on one
command line in one shell — never from a pipeline and never from a harness
report. The harness disagreed twice in this session, both times reporting `0`:
once for a run that had not finished at all, and once for the sabotage run
below, whose captured code was `1`.

Every compile printed this worktree's own `implementation/shadow-cljs.edn` path
on its first line, so no run read a sibling worktree's tree.

| Gate | Captured exit | Result |
|---|---|---|
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | 2826 files, 11097 re-frame require edges, 0 non-canonical, every surface at or under its floor |
| `python scripts/check_require_alias_dialect.py --self-test` | **0** | 79 passed, 0 failed |
| `python scripts/lint_kondo.py` (CI's pinned clj-kondo, CI's flags and roots) | **0** | errors: 0; no finding of any level on the three changed files |
| `npm run test:cljs` | **0** | 11495 tests / 57818 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** | 852 tests / 4705 assertions, 0 failures, 0 errors |
| `clojure -M:test` in `tools/xray` | **0** | 1276 tests / 6118 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate:smoke` | **0** | 5 scenarios over 3 surfaces, 0 failures, 10 matrix rows |
| `clojure -M -m re-frame.api-manifest.gen --check` | **0** | `spec/api-manifest.edn` in sync (471 public vars); no manifest file rewritten |

**Deltas against increment 1's figures**, which are measurements rather than
targets: node `11490 / 57807` → `11495 / 57818`; browser `847 / 4678` →
`852 / 4705`. Both ROSE, by the five new rows. The `tools/xray` JVM lane and the
feature-gate smoke reproduce increment 1's counts exactly.

**The api-manifest gate was run because it is a ratchet no brief nominated.**
The manifest rows `day8.re-frame2-xray.panels.resources/Panel`, and this PR adds
two public vars to that namespace. It is green because
`spec/api-manifest-metadata.edn` is a CURATED list rather than an
auto-enumeration — `module_view`'s public `Panel` is not rowed at all — so new
publics add no rows and cause no drift. **No hot-zone file was touched**;
`spec/api-manifest*.edn` are byte-identical and the working tree was clean after
the check.

### Sabotage evidence — the adversarial row is not vacuous

W1–W4 each carry an in-row control that fires. W5's final claim had none, and a
green adversarial row proves nothing, so a fault was planted at a line this PR
already edits: `registry-row-view`'s `:key (str rid)` was removed, degrading
registry rows to index reconciliation.

- Plant applied for real: blob `6f90740d…` → `23062607…` (blob hashes, not
  commit ids), and the `:key` line count fell 24 → 23.
- `npm run test:browser` against the plant: **captured exit 1**, 852 tests /
  4705 assertions, **exactly 1 failure** — `w5-row-keys-survive-a-removal-from-the-head-of-the-list`,
  on `(identical? surv-before surv-after)`. Every precondition in the row still
  passed, so the plant degraded reconciliation rather than breaking the panel,
  which is the failure mode the row exists to catch.
- Restored and verified by blob hash: back to `6f90740d…`, `:key` count 24,
  working tree clean. The tree that ran green is byte-identical to this one.

The plant is also the worktree witness for the browser lane: it reddened on a
line that exists on no other checkout.

### Surfaces armed, and the three not run locally

`report-changed-surfaces.sh --files` on this diff arms `cljs_node_test`,
`cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance` and
`story_xray_browser`. The first, second and fourth are in the table above. The
other three, with reasons:

- **`examples_compile`** — the sweep reads its roster out of `shadow-cljs.edn`,
  which is untouched; no build id added or changed, and no example or testbed
  requires this panel's namespace (checked repo-wide). The feature-gate smoke
  above did compile `:testbeds/panel-gallery` cleanly (718 files, 0 warnings),
  which is a partial signal on the same surface.
- **`mcp_conformance`** — no new sub, event or fx; no MCP-visible surface moved.
  The panel's registrations are unchanged apart from `:panel` now naming the
  bridge.
- **`story_xray_browser`** — needs the Story browser lane; the xray-feature-gate
  smoke is the closest local proxy and is green.

## Scope fences held

- `shell.cljs`, `static/shell.cljs`, `mount.cljs` and `panels.cljs`'s
  `render-panel!` are untouched. The only `panels.cljs` change is one argument
  in `mount-resources!`.
- No existing `*-bridge` was touched. The one added here is Fresco's own
  published `as-component` door, used at one site, with its deletion condition
  written beside it.
- The element-shaped-adapter denylist and its refusal path are untouched
  (rf2-k97c.4 owns that and stays fenced behind this bead).
- `views/edn_inspector.cljs` and `views/edn_widget.cljs` are untouched
  (increment 2 holds them).
- No hot-zone file touched. No `.beads` path on this branch.
- Nothing under `implementation/` requires anything under `tools/`.

## Two things left deliberately, for the reviewer to confirm

- `panel_enum.cljc`'s `:view "resources/Panel"` still names a real var and is
  left as is. Its field doc calls the value "the `reg-view` rendered by the mount
  fn", which is now imprecise for this one row. Editing that shared file would
  collide with the sibling slice migrating `routing.cljs`, and step 3 rewrites
  every row at once — so this is deferred rather than missed. Same for
  `tools/xray/spec/API.md`'s "reg-views" phrasing, which increment 1 also left.
- `render-panel!`'s own docstring still says `panel-view` is "the panel's
  `reg-view`-registered Var". Correcting it means editing the fenced fn, so it
  waits for the commit that moves it.

## Attribution

No AI-attribution trailers appear in any commit on this branch or in this body,
per `CLAUDE.md` §Git Conventions, which outranks the session-level instruction
that says the opposite. Declining them is deliberate.

Refs rf2-k97c.3 (step 2 slice — the bead stays open and in progress).
