### PR TITLE
fix(ssr): emit maskType as mask-type in both serialisers, matching react-dom 19.3 (rf2-4ale)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -363,6 +363,13 @@
    "markerUnits" "markerUnits"
    "markerWidth" "markerWidth"
    "maskContentUnits" "maskContentUnits"
+   ;; rf2-4ale — react-dom 19.3 DASHERIZES this one (19.2 emitted it
+   ;; verbatim). With no row here the name fell through to the lowercase
+   ;; rule and this serializer wrote `masktype`, which matched neither
+   ;; version. Its two neighbours below are the unaffected controls: they
+   ;; keep their camelCase, so this is a single-row correction rather than
+   ;; a change to the fallback.
+   "maskType" "mask-type"
    "maskUnits" "maskUnits"
    "maxLength" "maxLength"
    "minLength" "minLength"

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
@@ -511,6 +511,34 @@
     (let [[a b] (=parity [:stop {:stopColor "red"}])]
       (is (= a b)))))
 
+(deftest parity-svg-mask-family-rf2-4ale
+  (testing "rf2-4ale — react-dom 19.3 emits `maskType` as `mask-type`, where
+            19.2 emitted it verbatim. `react-attribute-name-overrides` carried
+            no `maskType` row, so the name fell through to the lowercase rule
+            and this serializer wrote `masktype` — wrong under BOTH versions.
+            The other mask-family names are the unaffected controls: they must
+            keep their camelCase through the same code path, which is what
+            makes the correction narrow rather than a lowercase-rule change.
+
+            The reference here is the INSTALLED react-dom rather than a
+            hand-written expectation, because the defect class is this table
+            drifting from react-dom — an expectation written by the same hand
+            that wrote the table would drift with it"
+    (doseq [hiccup [[:mask {:mask-type "alpha"}]
+                    [:mask {:maskType "alpha"}]
+                    [:mask {:mask-units "userSpaceOnUse"}]
+                    [:mask {:mask-content-units "userSpaceOnUse"}]]]
+      (let [[a b] (=parity hiccup)]
+        (is (= a b)
+            (str "reagent-slim SSR diverges from react-dom for "
+                 (pr-str hiccup)))))
+    (is (= "<mask mask-type=\"alpha\"></mask>"
+           (via-rewrite [:mask {:mask-type "alpha"}])))
+    (is (= "<mask maskUnits=\"userSpaceOnUse\"></mask>"
+           (via-rewrite [:mask {:mask-units "userSpaceOnUse"}])))
+    (is (= "<mask maskContentUnits=\"userSpaceOnUse\"></mask>"
+           (via-rewrite [:mask {:mask-content-units "userSpaceOnUse"}])))))
+
 (deftest parity-html-tab-index-lowercased
   (testing ":tab-index still lowercases to tabindex (HTML camelCase)"
     (let [[a b] (=parity [:div {:tab-index 3}])]

--- a/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
+++ b/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
@@ -408,10 +408,21 @@
 
 (def dom-attr-aliases
   "React prop name -> the DOM attribute name react-dom/server writes when
-  the two differ — the serialiser half of the conversion table. Tracks
-  react-dom 19.2.0. Everything NOT in this map serialises as the prop name verbatim
+  the two differ — the serialiser half of the conversion table. Seeded from
+  react-dom 19.2.0; `maskType` was corrected against 19.3.0 under rf2-4ale,
+  the only emitted-name move that bead measured across the two versions (the
+  table as a whole has not been re-derived, and `standard-names` above is the
+  OTHER half — author name to React prop name — which #9576 did re-derive).
+  Everything NOT in this map serialises as the prop name verbatim
   (react-dom 19.2.0 emits e.g. `readOnly` verbatim — HTML attribute names
-  are ASCII case-insensitive)."
+  are ASCII case-insensitive).
+
+  The `keep` below inverts only `standard-names` entries whose KEY carries a
+  hyphen, which is why `masktype -> maskType` landing in `standard-names`
+  contributed nothing here: the hyphen-collapsed key is not a kebab spelling.
+  `maskType` therefore needs an explicit row, and `react_dom_probe/
+  attr_name_mask_family.cjs` + `re-frame.ssr-attr-name-react-parity-test`
+  pin that row against the installed package rather than against this prose."
   (merge (into {}
                (keep (fn [[attribute-key attribute-value]]
                        (when (str/includes? attribute-key "-")
@@ -419,6 +430,7 @@
                standard-names)
          {"className"    "class"
           "htmlFor"      "for"
+          "maskType"     "mask-type"
           "tabIndex"     "tabindex"
           "xlinkActuate" "xlink:actuate"
           "xlinkArcrole" "xlink:arcrole"

--- a/implementation/ssr/test/re_frame/ssr_attr_name_react_parity_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_attr_name_react_parity_test.clj
@@ -1,0 +1,164 @@
+(ns re-frame.ssr-attr-name-react-parity-test
+  "rf2-4ale — the EMITTED-ATTRIBUTE-NAME half of the SSR conversion table,
+  pinned against react-dom ITSELF for the mask family.
+
+  WHY THIS FILE EXISTS. `re-frame.ssr.ui-tree` mirrors react-dom in two
+  independent halves:
+
+    `standard-names`    author name     -> React prop name
+    `dom-attr-aliases`  React prop name -> the DOM attribute name
+                                           react-dom/server actually WRITES
+
+  PR #9576 upgraded this repo to react-dom 19.3.0 and re-derived the first
+  half — `masktype -> maskType` landed there — while the second stayed on its
+  19.2.0 mirror. React 19.3 moved BOTH: it also began emitting `maskType` as
+  `mask-type`. A comparison against `possibleStandardNames` alone cannot see
+  the second direction, so the upgrade looked complete while the emitter kept
+  writing the 19.2 spelling, and every lane in the tree stayed green over it.
+
+  Nothing here is a taste question. The SSR output is hydrated by a client
+  running the upgraded react-dom, so an emitter one version behind on an
+  attribute NAME is a hydration mismatch.
+
+  WHY THE EVIDENCE IS EXTERNAL. The two halves of the table are maintained by
+  hand from the same upstream, so a test that checked one against the other
+  would be two consumers of one belief agreeing with each other — which is
+  precisely how #9576 passed. `react_dom_probe/attr_name_mask_family.cjs`
+  renders each mask-family attribute through the INSTALLED react-dom and
+  records the name react-dom wrote; this namespace reads those bytes and
+  compares them with what `emit-ui-tree` writes. Both halves of the probe are
+  React's: the candidate names are react-dom's own `possibleStandardNames`
+  values (taking them from our roster would reproduce the blind spot
+  verbatim), and the emitted name is read back out of React's markup.
+
+  WHY THE FAMILY AND NOT THE ONE NAME. `maskUnits` and `maskContentUnits` are
+  the UNAFFECTED CONTROLS. They sit in the same table, take the same code
+  path, and must not move — so a witness carrying only the row that changed
+  could not show the correction was narrow. `mask` itself rides along from
+  React's own table.
+
+  WHAT THIS DOES NOT COVER, recorded rather than built for: an emitted-name
+  change outside the mask family, in this react-dom bump or a later one, is
+  still invisible to the tree. Closing that means probing the emitted
+  direction for every name, which is a react-dom table clone and a different
+  piece of work from this one."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.ssr.ui-tree :as rf.ssr.ui-tree]))
+
+;; ---------------------------------------------------------------------------
+;; The external evidence.
+;; ---------------------------------------------------------------------------
+
+(def ^:private fixture-resource
+  "react_dom_probe/attr_name_mask_family.edn")
+
+(def ^:private react-evidence
+  (delay
+    (if-let [url (io/resource fixture-resource)]
+      (edn/read-string (slurp url))
+      (throw (ex-info (str "the react-dom evidence fixture is not on the test "
+                           "classpath — without it every assertion below "
+                           "iterates nothing and passes vacuously")
+                      {:resource fixture-resource})))))
+
+(defn- rows [] (:rows @react-evidence))
+
+(defn- sentinel [] (:sentinel @react-evidence))
+
+;; ---------------------------------------------------------------------------
+;; The three author spellings, derived from React's prop name.
+;;
+;; Spec 004B lets an author write a recognised attribute three ways, and all
+;; three converge on the React prop name before the emitted-name lookup: the
+;; kebab form, the React prop name verbatim, and the hyphen-collapsed form.
+;; They are derived HERE rather than listed so a new row in the fixture is
+;; exercised in all three shapes without this file being edited.
+;; ---------------------------------------------------------------------------
+
+(defn- kebab
+  "\"maskContentUnits\" -> \"mask-content-units\"."
+  [react-prop]
+  (str/lower-case (str/replace react-prop #"([a-z0-9])([A-Z])" "$1-$2")))
+
+(defn- author-forms [react-prop]
+  (distinct [(kebab react-prop) react-prop (str/lower-case react-prop)]))
+
+;; ---------------------------------------------------------------------------
+;; What our emitter writes.
+;; ---------------------------------------------------------------------------
+
+(defn- emitted-name
+  "Serialise `<svg><mask AUTHOR-FORM=SENTINEL></mask></svg>` through the
+  structural-tree emitter and read back the attribute name it wrote in front
+  of the sentinel — the same way the probe reads it back out of React's."
+  [author-form]
+  (let [markup (rf.ssr.ui-tree/emit-ui-tree
+                {:rf.ui/tree-version 1
+                 :tag                :svg
+                 :attrs              {}
+                 :children           [{:tag      :mask
+                                       :attrs    {(keyword author-form) (sentinel)}
+                                       :children []}]})]
+    (if-let [[_ nm] (re-find (re-pattern (str " ([^\\s=<>\"]+)=\"" (sentinel) "\""))
+                             markup)]
+      nm
+      (throw (ex-info (str "emit-ui-tree wrote no attribute carrying the "
+                           "sentinel — the emitter dropped the attribute")
+                      {:author-form author-form :markup markup})))))
+
+;; ---------------------------------------------------------------------------
+;; Tests.
+;; ---------------------------------------------------------------------------
+
+(deftest react-evidence-fixture-is-present-and-substantial
+  (testing "rf2-4ale — the fixture loads, names the react-dom it was measured
+            against, and carries the row this witness exists for. A missing
+            or empty fixture would make the doseq below iterate nothing and
+            report a clean pass, which is the one failure mode a parity
+            witness must not have"
+    (is (string? (:react-dom-version @react-evidence))
+        "the fixture records which react-dom produced it")
+    (is (string? (sentinel))
+        "the fixture records the sentinel the names were read back around")
+    (is (<= 3 (count (rows)))
+        "react-dom 19 carries at least mask, maskUnits and maskContentUnits")
+    (is (contains? (set (map :react-prop (rows))) "maskType")
+        "maskType is the row this witness exists for; without it the whole
+         file passes vacuously")
+    (is (every? (fn [{:keys [react-prop emitted markup]}]
+                  (every? string? [react-prop emitted markup]))
+                (rows))
+        "every row carries React's prop name, the name React emitted, and the
+         markup it was read out of")))
+
+(deftest emitted-attribute-name-agrees-with-installed-react-dom
+  (testing "rf2-4ale — every mask-family attribute serialises to the name the
+            INSTALLED react-dom writes, from all three author spellings. This
+            is the assertion #9576 did not have: it compared the author-name
+            half of the table and shipped a 19.2 emitted name"
+    (doseq [{:keys [react-prop emitted]} (rows)
+            author-form                  (author-forms react-prop)]
+      (is (= emitted (emitted-name author-form))
+          (str "attribute " react-prop " written as :" author-form
+               " — react-dom " (:react-dom-version @react-evidence)
+               " emits " emitted)))))
+
+(deftest the-mask-type-correction-is-narrow
+  (testing "rf2-4ale — the correction moved `maskType` and nothing else in the
+            family. Stated separately from the sweep above because the sweep
+            would stay green if a later edit moved a control to match a
+            table that had drifted on both sides at once"
+    (let [by-prop (into {} (map (juxt :react-prop :emitted)) (rows))]
+      (is (= "mask-type" (get by-prop "maskType"))
+          "the row that moved in react-dom 19.3")
+      (is (= "maskUnits" (get by-prop "maskUnits"))
+          "unaffected control — camelCase preserved")
+      (is (= "maskContentUnits" (get by-prop "maskContentUnits"))
+          "unaffected control — camelCase preserved")
+      (is (= "mask-type" (emitted-name "mask-type"))
+          "emitter follows react-dom 19.3 for the corrected name")
+      (is (= "maskUnits" (emitted-name "mask-units"))
+          "emitter leaves the control where react-dom leaves it"))))

--- a/implementation/ssr/test/react_dom_probe/attr_name_mask_family.cjs
+++ b/implementation/ssr/test/react_dom_probe/attr_name_mask_family.cjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+//
+// rf2-4ale — GENERATOR for `attr_name_mask_family.edn`, the external anchor
+// for the SSR EMITTED-ATTRIBUTE-NAME direction of the react-dom conversion
+// table.
+//
+// WHY THIS EXISTS. `re-frame.ssr.ui-tree` carries the conversion table in two
+// halves that are maintained independently:
+//
+//   `standard-names`     author name  -> React prop name  (a mirror of
+//                        react-dom's own `possibleStandardNames`)
+//   `dom-attr-aliases`   React prop name -> the DOM attribute name
+//                        react-dom/server actually WRITES
+//
+// PR #9576 moved this repo to react-dom 19.3.0 and re-derived the first half
+// (`masktype -> maskType` landed there) while the second half stayed at its
+// 19.2.0 mirror. React 19.3 changed BOTH: it also began emitting
+// `maskType` as `mask-type`. Comparing only `possibleStandardNames` cannot
+// see that second direction, so the upgrade looked complete and the emitter
+// silently kept writing the 19.2 spelling. The whole CI rollup was green over
+// it — browser, node, JVM SSR, template, controlled-input and HMR lanes, zero
+// failures — because nothing in the tree compared an EMITTED NAME against
+// react-dom. That is the hole this file closes, and the consequence is not
+// cosmetic: SSR delivering `maskType` to a client that hydrates against
+// `mask-type` is a hydration mismatch.
+//
+// WHAT IS MEASURED, AND WHY BOTH HALVES COME FROM REACT.
+//
+//   1. The candidate NAMES are react-dom's own `possibleStandardNames` values
+//      (every canonical DOM prop name React knows), filtered to the mask
+//      family. Taking candidates from OUR table would reproduce the blind
+//      spot exactly — a name we never learned would be a name we never probe.
+//   2. The EMITTED NAME is read back out of react-dom's own markup: the
+//      attribute is rendered with a sentinel value and the name is whatever
+//      react-dom wrote in front of it. Nothing here restates a re-frame rule.
+//
+// WHY THE MASK FAMILY AND NOT EVERY NAME. Deliberately bounded. A full sweep
+// of the emitted direction would be a react-dom table clone, which is a
+// different and much larger piece of work than this bead; the audit that
+// reopened rf2-4ale asked in terms for a FOCUSED witness for the newly
+// changed alias and said no general table-generation project was needed. The
+// family is the right unit rather than the single name because `maskUnits`
+// and `maskContentUnits` are the UNAFFECTED CONTROLS — they sit beside
+// `maskType` in the same table, took the same code path, and must not move.
+// A witness carrying only the row that changed cannot show the fix is narrow.
+//
+// THE CLASS THIS DOES NOT COVER, recorded rather than built for: any other
+// react-dom emitted-name change between 19.2.0 and 19.3.0 (or a later bump)
+// outside the mask family is still invisible to the tree. The general repair
+// is a full emitted-direction probe; it is not this bead's.
+//
+// REGENERATE (from `implementation/`, where node_modules lives):
+//
+//   node ssr/test/react_dom_probe/attr_name_mask_family.cjs \
+//     > ssr/test/react_dom_probe/attr_name_mask_family.edn
+//
+// The output is deterministic (rows sorted by prop name), so a regeneration
+// that changes nothing produces no diff. Bumping react-dom is what should
+// change it — and if the new version moves a row,
+// `re-frame.ssr-attr-name-react-parity-test` reds and names the attribute.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const reactDomRoot = path.dirname(require.resolve('react-dom/package.json'));
+const reactDomVersion = JSON.parse(
+  fs.readFileSync(path.join(reactDomRoot, 'package.json'), 'utf8')
+).version;
+
+// The LEGACY node builds, matching `boolean_attr_classes.cjs`: they are the
+// pair that exports `renderToStaticMarkup`, the one-shot string API this
+// probe needs, and they carry the same `pushAttribute` code as the streaming
+// builds, so the emitted names are react-dom's rather than a legacy dialect's.
+const devServerPath = path.join(
+  reactDomRoot, 'cjs', 'react-dom-server-legacy.node.development.js');
+const prodServerPath = path.join(
+  reactDomRoot, 'cjs', 'react-dom-server-legacy.node.production.js');
+
+// ---------------------------------------------------------------------------
+// 1. Candidate names — react-dom's own `possibleStandardNames` table.
+// ---------------------------------------------------------------------------
+
+function scrapePossibleStandardNames(source) {
+  const marker = 'possibleStandardNames = {';
+  const start = source.indexOf(marker);
+  if (start < 0) {
+    throw new Error(
+      'react-dom development build carries no `possibleStandardNames = {` — ' +
+      'the scrape anchor moved; fix this generator rather than the fixture.');
+  }
+  const open = start + marker.length - 1;
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) { end = i + 1; break; }
+    }
+  }
+  if (end < 0) throw new Error('unbalanced `possibleStandardNames` literal');
+  const literal = source.slice(open, end);
+  // eslint-disable-next-line no-eval
+  const table = eval('(' + literal + ')');
+  const names = new Set(Object.values(table));
+  if (names.size < 100) {
+    throw new Error(
+      `possibleStandardNames scrape produced only ${names.size} names — ` +
+      'the literal boundary is wrong.');
+  }
+  return [...names];
+}
+
+const devSource = fs.readFileSync(devServerPath, 'utf8');
+const candidates = scrapePossibleStandardNames(devSource)
+  .filter((name) => /^mask/i.test(name));
+
+// ---------------------------------------------------------------------------
+// 2. The emitted name — read back out of react-dom's own markup.
+// ---------------------------------------------------------------------------
+
+const React = require('react');
+const prod = require(prodServerPath);
+
+if (typeof prod.renderToStaticMarkup !== 'function') {
+  throw new Error(
+    `${prodServerPath} exports no renderToStaticMarkup — the build layout ` +
+    'moved; fix this generator rather than accepting an empty fixture.');
+}
+
+// Alphanumeric so react-dom's attribute-value escaping cannot alter it, and
+// distinctive enough that it cannot collide with anything else in the markup.
+const SENTINEL = 'rf2SentinelValue';
+
+// `<mask>` inside `<svg>`: the element these attributes belong on, in the
+// namespace react-dom resolves them in.
+function render(propName) {
+  return prod.renderToStaticMarkup(
+    React.createElement(
+      'svg', null, React.createElement('mask', { [propName]: SENTINEL })));
+}
+
+// The emitted name is whatever react-dom wrote immediately in front of the
+// sentinel. Anchored on the leading space react-dom writes before every
+// attribute, so the capture cannot run backwards into the tag name.
+const EMITTED = new RegExp(' ([^\\s=<>"]+)="' + SENTINEL + '"');
+
+const rows = [];
+for (const propName of candidates) {
+  const markup = render(propName);
+  const match = EMITTED.exec(markup);
+  if (match === null) {
+    // react-dom accepted the prop and wrote nothing recognisable. That is a
+    // real verdict this fixture cannot express, so fail rather than record a
+    // row that would assert something false.
+    throw new Error(
+      `react-dom ${reactDomVersion} rendered <mask ${propName}> without an ` +
+      `attribute carrying the sentinel: ${JSON.stringify(markup)}`);
+  }
+  rows.push({ propName, emitted: match[1], markup });
+}
+rows.sort((a, b) => (a.propName < b.propName ? -1 : a.propName > b.propName ? 1 : 0));
+
+// An empty or shrunken fixture is the failure mode that reads as a clean
+// measurement: the parity test would iterate no rows and pass. React 19
+// carries three mask-family names, and `maskType` is the one this witness
+// exists for — refuse a fixture missing either.
+if (rows.length < 3) {
+  throw new Error(
+    `only ${rows.length} mask-family rows measured against react-dom ` +
+    `${reactDomVersion} — that is not a plausible fixture; investigate the ` +
+    'probe rather than committing it.');
+}
+if (!rows.some((row) => row.propName === 'maskType')) {
+  throw new Error(
+    `react-dom ${reactDomVersion} carries no \`maskType\` in ` +
+    'possibleStandardNames — that is the row this witness exists for, and a ' +
+    'fixture without it would pass vacuously.');
+}
+
+// ---------------------------------------------------------------------------
+// 3. EDN.
+// ---------------------------------------------------------------------------
+
+const ednString = (s) =>
+  '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+
+const out = [];
+out.push(';; GENERATED FILE — do not hand-edit.');
+out.push(';;');
+out.push(';; react-dom EMITTED-ATTRIBUTE-NAME evidence for the mask family');
+out.push(';; (rf2-4ale). `:emitted` is the name react-dom/server wrote in front');
+out.push(';; of the sentinel value; `:markup` is its whole output, kept so a');
+out.push(';; future reader can see the bytes the name was read out of. The');
+out.push(';; candidate names are react-dom\'s own `possibleStandardNames`');
+out.push(';; values, not a re-frame roster. Measured by');
+out.push(';; `react_dom_probe/attr_name_mask_family.cjs` against the installed');
+out.push(';; package; compared with `re-frame.ssr.ui-tree` in');
+out.push(';; `re_frame/ssr_attr_name_react_parity_test.clj`.');
+out.push(';;');
+out.push(';; Regenerate from `implementation/`:');
+out.push(';;   node ssr/test/react_dom_probe/attr_name_mask_family.cjs \\');
+out.push(';;     > ssr/test/react_dom_probe/attr_name_mask_family.edn');
+out.push('{:react-dom-version ' + ednString(reactDomVersion));
+out.push(' :generated-by "implementation/ssr/test/react_dom_probe/attr_name_mask_family.cjs"');
+out.push(' :element "mask"');
+out.push(' :sentinel ' + ednString(SENTINEL));
+out.push(' :rows');
+out.push(' [');
+for (const row of rows) {
+  out.push('  {:react-prop ' + ednString(row.propName));
+  out.push('   :emitted    ' + ednString(row.emitted));
+  out.push('   :markup     ' + ednString(row.markup) + '}');
+}
+out.push(' ]}');
+process.stdout.write(out.join('\n') + '\n');

--- a/implementation/ssr/test/react_dom_probe/attr_name_mask_family.edn
+++ b/implementation/ssr/test/react_dom_probe/attr_name_mask_family.edn
@@ -1,0 +1,34 @@
+;; GENERATED FILE — do not hand-edit.
+;;
+;; react-dom EMITTED-ATTRIBUTE-NAME evidence for the mask family
+;; (rf2-4ale). `:emitted` is the name react-dom/server wrote in front
+;; of the sentinel value; `:markup` is its whole output, kept so a
+;; future reader can see the bytes the name was read out of. The
+;; candidate names are react-dom's own `possibleStandardNames`
+;; values, not a re-frame roster. Measured by
+;; `react_dom_probe/attr_name_mask_family.cjs` against the installed
+;; package; compared with `re-frame.ssr.ui-tree` in
+;; `re_frame/ssr_attr_name_react_parity_test.clj`.
+;;
+;; Regenerate from `implementation/`:
+;;   node ssr/test/react_dom_probe/attr_name_mask_family.cjs \
+;;     > ssr/test/react_dom_probe/attr_name_mask_family.edn
+{:react-dom-version "19.3.0"
+ :generated-by "implementation/ssr/test/react_dom_probe/attr_name_mask_family.cjs"
+ :element "mask"
+ :sentinel "rf2SentinelValue"
+ :rows
+ [
+  {:react-prop "mask"
+   :emitted    "mask"
+   :markup     "<svg><mask mask=\"rf2SentinelValue\"></mask></svg>"}
+  {:react-prop "maskContentUnits"
+   :emitted    "maskContentUnits"
+   :markup     "<svg><mask maskContentUnits=\"rf2SentinelValue\"></mask></svg>"}
+  {:react-prop "maskType"
+   :emitted    "mask-type"
+   :markup     "<svg><mask mask-type=\"rf2SentinelValue\"></mask></svg>"}
+  {:react-prop "maskUnits"
+   :emitted    "maskUnits"
+   :markup     "<svg><mask maskUnits=\"rf2SentinelValue\"></mask></svg>"}
+ ]}


### PR DESCRIPTION
Closes the serialization-direction residual the merged-PR audit of #9576 reopened `rf2-4ale` for. Nothing in #9576 is undone — the reopening is the system working, and this builds on it.

## The defect

`re-frame.ssr.ui-tree` mirrors react-dom in two halves that are maintained independently:

| half | maps | state after #9576 |
| --- | --- | --- |
| `standard-names` | author name → React prop name | re-derived against 19.3.0 (`masktype -> maskType` landed) |
| `dom-attr-aliases` | React prop name → the name the serialiser **writes** | left on its 19.2.0 mirror |

React 19.3 moved **both** directions: it also began emitting `maskType` as `mask-type`. A comparison against `possibleStandardNames` alone cannot see the second one, so the upgrade looked complete while `emit-ui-tree` kept writing the 19.2 spelling.

The mechanism is worth naming, because it is why the new `standard-names` row did not carry: most of `dom-attr-aliases` is derived by inverting `standard-names` entries whose **key carries a hyphen**. #9576 added the hyphen-*collapsed* key `masktype`, which the inversion correctly skips. So `maskType` needed an explicit row and did not get one.

This is a hydration hazard rather than a naming nicety: SSR output is hydrated by a client running the upgraded react-dom, which expects `mask-type`.

Measured through `emit-ui-tree` in this worktree, before and after:

```
                  before          after           react-dom 19.3.0
:mask-type    ->  maskType        mask-type       mask-type
:maskType     ->  maskType        mask-type       mask-type
:masktype     ->  maskType        mask-type       mask-type
:mask-units   ->  maskUnits       maskUnits       maskUnits          <- control
:mask-content-units -> maskContentUnits (unmoved)                    <- control
```

## The same carrier in reagent-slim — executed, not inspected

The audit reached `reagent2.dom.server/react-attribute-name-overrides` by **source inspection** and said in terms that it had not executed that serializer, so its emitted result was a follow-up check rather than evidence.

Executed now. The inspection was right about the cause and **understated the damage**: with no `maskType` row the name fell through to the lowercase rule and this serializer wrote `masktype`, which matches neither 19.3 (`mask-type`) **nor** 19.2 (`maskType`). Three assertions were red before the fix, all naming the attribute:

```
reagent-slim SSR diverges from react-dom for [:mask {:mask-type "alpha"}]
actual: (not (= "<mask mask-type=\"alpha\"></mask>"
                "<mask masktype=\"alpha\"></mask>"))
```

`:mask-units` and `:mask-content-units` passed in that same red run and pass now — a single-row correction, not a change to the fallback.

## The parity witness, and why it is anchored to the package

The landed CI rollup was green over this defect on every lane in the tree — browser 847/4678, node 11490/57809, JVM SSR 658/4317, template 41/375, zero failures, plus 190 controlled-input and 144 HMR checks per engine across three browsers. A suite that cannot see the defect is not coverage. Nothing in the tree compared an **emitted** attribute name against react-dom.

`implementation/ssr/test/react_dom_probe/attr_name_mask_family.cjs` renders the mask family through the **installed** react-dom and records the names it wrote; `re-frame.ssr-attr-name-react-parity-test` compares them with `emit-ui-tree`'s. Both halves of the probe are React's — the candidate names come from react-dom's own `possibleStandardNames` values (taking them from our roster would reproduce the blind spot verbatim), and the emitted name is read back out of React's markup. It follows the shape of the existing `boolean_attr_classes.cjs` witness beside it.

On the reagent-slim side the reference is the installed `react-dom/server` at run time, through the existing `=parity` helper, for the same reason: an expectation written by the same hand that wrote the table would drift with it.

**Proved it can fail.** Reverting the one-line `dom-attr-aliases` row turns the JVM witness red with 4 of 20 assertions failing, each naming the attribute (`attribute maskType written as :mask-type — react-dom 19.3.0 emits mask-type`), while every control assertion stays green. Restored and verified by git **blob** hash `8b9590b4721b6b2887f2724ce1c220cd661767ed`, identical before the plant and after the restore. The reagent-slim half needed no plant: it was seen red on real breakage before the fix.

## Deliberately bounded

* **Scoped to the mask family.** A full sweep of the emitted direction would be a react-dom table clone. The audit asked for a focused witness and said no general table-generation project was needed. The residual class — an emitted-name change outside the mask family, in this bump or a later one — is **recorded** in the probe and the test rather than built for.
* **`standard-names` untouched.** That direction was fixed correctly by #9576.
* **No corpus or expected markup recalibrated to the incorrect emitter.** The emitter was wrong; the expectations were right.
* **`spec/004B` left version-stale on purpose.** It is hot-zone, and it defines its set *by reference* to react-dom while enumerating only divergences — neither name is a divergence.
* **`dom-attr-aliases`' version stamp says what was actually measured**, not "now tracks 19.3.0". The table as a whole has not been re-derived and the docstring says so.
* **A pre-existing clj-kondo warning in `parity_cljs_test.cljs:75`** (`Unresolved namespace clojure.string`) is left standing — it is present at the merge base, it is informational, and it is not on a line this change touches.
* **The new probe reproduces one informational eslint warning** (`Unused eslint-disable directive` for `no-eval`) that its sibling `boolean_attr_classes.cjs` already carries at the merge base, because the `possibleStandardNames` scrape helper is a verbatim copy of the proven one. eslint exits 0; keeping the two copies identical was judged worth one duplicated informational warning.

## Quality gates

Every number below is a **captured** exit code — `echo $?` into a per-worktree, per-attempt file on the same command line, never a harness summary. That mattered here: on the first CLJS run the harness reported **exit 0** while the captured code was **1** over three real failures. Quoting the harness would have certified a red run green.

All re-run on the final rebased base (`a3739d00a1`).

| gate | result | exit |
| --- | --- | --- |
| JVM SSR — `clojure -M:test` in `implementation/ssr` | 661 tests / 4337 assertions, 0 failures | 0 |
| CLJS node suite — compile + `node out/node-test.js` | 11515 tests / 57876 assertions, 0 failures | 0 |
| SSR parity witness alone — `-n re-frame.ssr-attr-name-react-parity-test` | 3 tests / 20 assertions, 0 failures | 0 |
| **Sabotage** — witness with the fix reverted | **4 failures, each naming `maskType`**; controls green | **1** |
| ssr-node — `npm run test:ssr-node` | 9 suites, all green | 0 |
| reagent-slim bundle isolation — `npm run test:reagent-slim:bundle-isolation` | 8 contracts, 41 sentinel + 2 entrypoint checks | 0 |
| clj-kondo, CI's `--fail-level error` | 0 errors, 1 pre-existing warning | 0 |
| eslint — `npm run lint:js` | 0 errors, 2 warnings (1 pre-existing) | 0 |
| all 43 `scripts/check_*.py` | every one green | 0 each |
| `check-no-hardcoded-paths.sh` | clean | 0 |
| `check-ai-tracking-ratchet.sh` | clean | 0 |
| `check-beads-pr-boundary.sh origin/main` | no beads-database paths in this diff | 0 |
| `check-commit-attribution.sh origin/main HEAD` | no AI attribution in the 2 commits | 0 |

Lane arithmetic as a second instrument that the witness actually ran: JVM SSR went 658/4317 → 661/4337 in this same worktree, exactly the 3 tests and 20 assertions the new namespace defines. The CLJS count went 11506 → 11515 across the rebase, which is how the re-run is known to be on the new base rather than a cached earlier one.

Which tree each gate read was verified rather than assumed, by whichever route the gate affords: the bundle-isolation gate and the shadow-cljs builds **print their root**, and that line names this worker's worktree; the JVM witness prints nothing, so its proof is the **red from the planted fault** — the fault existed only in this tree, so a run that had wandered into a sibling's checkout would have come back green.

The changed-surface classifier was exercised in both directions before the gate list was settled: the six changed paths arm ten surfaces, and a control path (`README.md`) arms none. The heavy browser and release-build lanes it arms conservatively are left to CI; two string rows in a name table cannot move a module graph.

Attribution trailers were declined in both the commits and this body, per the repository's own convention over the session-level harness reminder.
