### PR TITLE
feat(fresco): Fragment refs through the codec (rf2-26hs); the browser() composition refuted (rf2-4sys)

### DIFF
--- a/docs/core/fresco/18-ssr-and-hydration.md
+++ b/docs/core/fresco/18-ssr-and-hydration.md
@@ -240,6 +240,38 @@ cannot be part of the fixed fallback contract.
 
 Use a same-footprint skeleton to reduce layout shift.
 
+### One browser-only leaf inside a server-rendered region
+
+The two policies compose, and the composition is the answer when a region is
+server-safe **except** for one leaf. There is no third policy to reach for:
+declare the region Render and the leaf Client-only, and only the leaf stands
+down.
+
+```clojure
+(h/defhost product-panel ProductPanel
+  {:server :render})
+
+(h/defhost viewport-badge ViewportBadge
+  {:server   :client-only
+   :fallback [:span {:class "badge badge--pending"} "Measures in the browser"]})
+
+[product-panel {}
+ [:p "Server-rendered copy."]
+ [viewport-badge {}]
+ [:p "More server-rendered copy."]]
+```
+
+The response carries the panel, both paragraphs and the badge's fallback; the
+badge's own component never runs on the server. The leaf is an ordinary
+Client-only crossing, so everything above applies to it unchanged — it
+hydrates against the fallback it emitted, and the live component mounts after
+adoption.
+
+Nesting does not narrow what stands down. A Client-only crossing replaces
+itself **and its children**, so moving the region's server-safe content
+*inside* the leaf would delete that content from the response. Keep the leaf
+as small as the browser dependency actually is.
+
 ## Render-safe hosts
 
 Declare `{:server :render}` when a component is deterministic and safe to run

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -1163,7 +1163,18 @@
 (defn- fragment-element
   "Emit `:<>` — React.Fragment.
   `[:<> & children]` or `[:<> {:key k} & children]`. Props map (if
-  present) is JS-converted; only `:key` is meaningful on Fragments."
+  present) is JS-converted.
+
+  React accepts `key`, `ref` and `children` on a Fragment and nothing
+  else. `:ref` therefore already crosses here and needs no arm of its
+  own: the whole map goes through `convert-prop-value`'s `map?` branch,
+  which camelCases the key to `ref` via `cached-prop-name` and answers a
+  function value from the `fn?` arm BY IDENTITY — which is the part that
+  matters, because React detaches and reattaches on a changed ref
+  identity. An object ref falls to the `:else` arm and is likewise
+  untouched. React answers either with a `FragmentInstance` rather than a
+  DOM node. This docstring previously said only `:key` was meaningful
+  here; that was true before React 19.3 and is no longer."
   [argv]
   (let [slot-value  (nth argv 1 nil)
         has-props?  (props-slot? slot-value)

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -529,6 +529,31 @@
       (is (= (.-Fragment react) (.-type el)))
       (is (= "k" (.-key el))))))
 
+(deftest as-element-fragment-with-ref
+  (testing "React accepts `key`, `ref` and `children` on a Fragment, and this
+            path converts the WHOLE props map — so a fragment ref crosses here
+            with no arm of its own. Measured rather than read off the
+            conversion rules, because the identity is the part that matters:
+            React detaches and reattaches on a changed ref identity, so a
+            wrapper allocated per render would re-run the author's callback,
+            and its cleanup, on every commit."
+    (let [f      (fn [_instance] nil)
+          ^js el (template/as-element [:<> {:ref f} [:div "a"]])]
+      (is (= (.-Fragment react) (.-type el)))
+      (is (identical? f (-> el .-props .-ref))
+          "the author's own function, not a wrapper")))
+  (testing "an object ref crosses untouched too — it takes the `:else` arm
+            rather than any of the converting ones"
+    (let [r      (react/createRef)
+          ^js el (template/as-element [:<> {:ref r} [:div "a"]])]
+      (is (identical? r (-> el .-props .-ref)))))
+  (testing "and a key and a ref from one map land in their two different
+            places: the key on the element, the ref in the props"
+    (let [f      (fn [_instance] nil)
+          ^js el (template/as-element [:<> {:key "k" :ref f} [:div "a"]])]
+      (is (= "k" (.-key el)))
+      (is (identical? f (-> el .-props .-ref))))))
+
 (deftest as-element-interop-react-component
   (testing "[:> Comp {:foo \"bar\"} child] → React.createElement on Comp"
     (let [Comp (fn FakeComp [_props] nil)

--- a/implementation/fresco/src/re_frame/fresco/impl/codec.cljs
+++ b/implementation/fresco/src/re_frame/fresco/impl/codec.cljs
@@ -13,7 +13,7 @@
   | Native tag | attr map, each key emitted under one canonical slot, the tag's `#id.class` shorthand folded onto the emitted object | trailing forms; a seq realized once and spliced; `nil`/`false` render nothing, `true` is an error | literal `:key` in the attr map |
   | Boundary (a marked `defview` head) | one props map crossing as a CLJS value, every lazy seq in it forced and an unforced `delay` refused (`realize-deep`) | trailing forms as `(:children props)`, a realized vector | literal `:key`, taken off before the body sees props |
   | Host (a `defhost` head), or `[:> Component …]` | attr map converted shallowly (`host-entry`): declared `:callbacks` contracts applied, declared `:slots` lowered to elements, `:ref` untouched, the class slot coerced and composed, the rest inferred by position | trailing forms lowered to elements in the writing boundary's render window, handed on as React children | literal `:key` |
-  | Fragment `[:<> …]` | optional attr map | trailing forms | on the fragment |
+  | Fragment `[:<> …]` | optional attr map, read for the two slots React accepts there and no others: `:ref` crosses untouched onto the fragment, where React answers it with a `FragmentInstance` over the run of children | trailing forms | on the fragment |
 
   A React element is a legal child anywhere; a plain function in head
   position is a loud error. Five keys are never emitted as attributes:
@@ -1641,11 +1641,47 @@
     (when-some [k (:key props)] (unchecked-set carrier "key" k))
     (make-element raw-gate carrier argv (if has-props? 3 2))))
 
-(defn- fragment-element [argv]
+(defn- fragment-ref-entry
+  "`fragment-element`'s reducing function over a fragment's attr map: the
+  value at whichever key lands on the `ref` slot, `reduced` so a map that
+  carries one stops there and one that does not costs a `canonical-slot`
+  per key and no allocation. A named var so the walk allocates no
+  closure, like `convert-entry` and `host-entry`.
+
+  The SLOT and never the spelling, because `ref` is an ATTRIBUTE and this
+  codec asks `canonical-slot` about every rule concerning one — so
+  `{\"ref\" f}` and `{:x/ref f}` land where `:ref` does, exactly as
+  `structural-slot?` already reads them. `:key`, read literally by the
+  caller, is the exact-keyword exception this namespace's docstring
+  names: it is a trigger rather than an attribute."
+  [found k v]
+  (if (identical? ref-slot (canonical-slot k)) (reduced v) found))
+
+(defn- fragment-element
+  "`[:<> …]` as a `React.Fragment` element. React accepts exactly `key`,
+  `ref` and `children` on a fragment — its own words, in its
+  `validateFragmentProps` warning — so those two slots are the whole of
+  what this reads off the optional attr map, and anything else written
+  there is dropped as it always was.
+
+  `:ref` crosses UNTOUCHED: the identity the author wrote, the same
+  crossing `convert-entry` and `host-entry` give HD-016's node handle.
+  That is the contract rather than an optimisation — React detaches and
+  reattaches whenever a ref's identity changes, so a handle this codec
+  re-wrapped per render would re-run a callback ref, and its cleanup, on
+  every commit. What React hands back is a `FragmentInstance` rather than
+  a DOM node: a fragment has no element of its own, so the handle
+  addresses the run of children it holds.
+
+  Before React 19.3 a fragment took no ref at all and this dropped one
+  silently."
+  [argv]
   (let [has-props? (props-map? argv 1)
         props      (if has-props? (nth argv 1) nil)
         js-props   #js {}]
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
+    (when-some [r (reduce-kv fragment-ref-entry nil props)]
+      (unchecked-set js-props ref-slot r))
     (make-element (.-Fragment react) js-props argv (if has-props? 2 1))))
 
 (defn- fragment-head?

--- a/implementation/fresco/test/re_frame/fresco/codec_cljs_test.cljs
+++ b/implementation/fresco/test/re_frame/fresco/codec_cljs_test.cljs
@@ -348,6 +348,56 @@
   (testing "a keyed fragment carries its key"
     (is (= "k" (el-key (rf.fresco.impl.codec/as-element [:<> {:key "k"} [:li "a"]]))))))
 
+(deftest a-fragment-forwards-its-ref-to-react-by-identity
+  (testing "React reads a fragment's ref off `element.props.ref` — its own
+            `coerceRef` does, and its `validateFragmentProps` names `key`,
+            `ref` and `children` as the whole of what a fragment accepts. So
+            the handle has to be IN THE PROPS, and it has to be the author's
+            own object: React detaches and reattaches on a changed ref
+            identity, so a handle rewrapped per render would re-run a
+            callback ref and its cleanup on every commit."
+    (let [f (fn [_instance] nil)
+          e (rf.fresco.impl.codec/as-element [:<> {:ref f} [:li "a"]])]
+      (is (identical? (.-Fragment react) (el-type e)))
+      (is (identical? f (prop e "ref")))))
+  (testing "an object ref crosses the same way — the codec claims nothing
+            about the slot's value-space here either"
+    (let [r (react/createRef)
+          e (rf.fresco.impl.codec/as-element [:<> {:ref r} [:li "a"]])]
+      (is (identical? r (prop e "ref")))))
+  (testing "and by the SLOT rather than the spelling, exactly as a tag's ref
+            is read — `ref` is an attribute, and every rule about one is
+            asked of `canonical-slot`"
+    (let [f (fn [_instance] nil)]
+      (doseq [k ["ref" 'ref :x/ref]]
+        (is (identical? f (prop (rf.fresco.impl.codec/as-element [:<> {k f} [:li "a"]]) "ref"))
+            (str "ref, spelled " (pr-str k)))))))
+
+(deftest a-fragment-emits-the-two-slots-react-accepts-there-and-nothing-else
+  (testing "no attr map, and no ref: children alone. A ref slot standing
+            empty on every fragment on the page would be a prop React has to
+            read and reject"
+    (is (= ["children"] (prop-names (rf.fresco.impl.codec/as-element [:<> [:li "a"]])))))
+  (testing "a fragment written with a key emits no `key` PROP — the key
+            addresses the element, and React strips it in `createElement`"
+    (let [e (rf.fresco.impl.codec/as-element [:<> {:key "k"} [:li "a"]])]
+      (is (= ["children"] (prop-names e)))
+      (is (= "k" (el-key e)))))
+  (testing "a ref and a key together: the key on the element, the ref in the
+            props, both from one attr map"
+    (let [f (fn [_instance] nil)
+          e (rf.fresco.impl.codec/as-element [:<> {:key "k" :ref f} [:li "a"]])]
+      (is (= "k" (el-key e)))
+      (is (= ["children" "ref"] (prop-names e)))
+      (is (identical? f (prop e "ref")))))
+  (testing "and an attribute React would refuse on a fragment is dropped
+            before React sees it, exactly as it always was — this bead
+            forwards the ref, it does not open the fragment to attributes"
+    (let [e (rf.fresco.impl.codec/as-element [:<> {:class "x" :on-click [:evt]} [:li "a"]])]
+      (is (= ["children"] (prop-names e)))))
+  (testing "a nil ref sets no slot, the same `when-some` reading `:key` gets"
+    (is (= ["children"] (prop-names (rf.fresco.impl.codec/as-element [:<> {:ref nil} [:li "a"]]))))))
+
 ;; ---------------------------------------------------------------------------
 ;; Boundaries — the HD-016 head rules
 ;; ---------------------------------------------------------------------------

--- a/implementation/fresco/test/re_frame/fresco/fragment_ref_dom_cljs_test.cljs
+++ b/implementation/fresco/test/re_frame/fresco/fragment_ref_dom_cljs_test.cljs
@@ -1,0 +1,410 @@
+(ns re-frame.fresco.fragment-ref-dom-cljs-test
+  "A REF ON A FRAGMENT — `[:<> {:ref f} …]`, mounted.
+
+  [[re-frame.fresco.codec-cljs-test]] pins what the codec BUILDS: the
+  handle reaches `element.props.ref` by identity, and the fragment emits
+  no other slot. This file pins what React then DOES with it, which is
+  the half a codec test cannot see, and it is the half the feature is
+  for.
+
+  Five claims, each one a caller can get wrong:
+
+  1. **The handle is a `FragmentInstance`, not a DOM node.** A fragment
+     has no element of its own, so there is nothing for React to hand
+     back but an object addressing the run of children — and the whole
+     reason to want one is that the alternative is a wrapper `<div>`
+     that changes the layout. Both ref shapes are measured, because
+     React reaches them by different arms: a callback ref is CALLED with
+     the instance, an object ref has its `.current` assigned.
+
+  2. **The fragment still contributes no element.** Asserted as the
+     parent's child list, before and after, because that is the claim in
+     the form a caller cares about: the flex row does not gain a box.
+     A ref that silently made the codec wrap its children would satisfy
+     every other row here.
+
+  3. **Identity is the contract, not an optimisation** — and this is the
+     row the codec's `:ref`-crosses-untouched rule exists for. React
+     detaches and reattaches whenever a ref's identity changes, so the
+     two directions are measured together: the SAME function across a
+     re-render attaches once and its cleanup does not run, and a
+     DIFFERENT function runs the old cleanup and attaches the new
+     handle. A codec that re-wrapped the author's ref per render would
+     pass row 1 and fail this one — the second half is what would go
+     red, on every commit, in a shape that reads as a React bug.
+
+  4. **The handle addresses whatever the fragment currently holds.**
+     Children are conditional in real markup, so the instance is
+     measured across a change to the run: `focusLast` follows the new
+     last child rather than the one that was there at attach.
+
+  5. **Neither arm of the SSR seam is disturbed.** The server bytes
+     carry no artefact of the ref — no attribute, no wrapper — because
+     refs are a client-commit concern and `renderToString` has no commit;
+     and hydrating those same bytes attaches the handle without React
+     recovering from anything.
+
+  6. **An Activity hide DETACHES the handle and a reveal reattaches it.**
+     Measured rather than assumed, and it comes out the opposite way to
+     the intuition that a hidden Activity merely stops painting: React
+     treats a fragment ref as a layout-tier attachment like a host ref,
+     so the author's CLEANUP RUNS on a hide. Anything registered through
+     the handle is torn down there and set up again on reveal, which is
+     the fact a caller has to build against.
+
+  ## What is deliberately NOT claimed here
+
+  The Activity row says nothing about WHEN the reveal's work lands: the
+  stale-window figure this package carries is preserved at one animation
+  frame and was not re-measured under the current React (rf2-4ale), and
+  a row that timed a reveal would be re-deriving it by accident.
+
+  ## The mutation witnesses
+
+  Drop the `:ref` copy from `codec/fragment-element` and rows 1, 3, 4 and
+  the hydration half of 5 go red on a handle that never arrives. Copy it
+  under the literal key instead of the canonical slot and the
+  spelling row in [[re-frame.fresco.codec-cljs-test]] goes red while
+  every row here stays green — which is why that claim is pinned there
+  and not restated here. Re-wrap the author's function per render and
+  [[a-stable-ref-attaches-once-and-a-changed-one-runs-the-old-cleanup]]
+  goes red on the attach count.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM. The server-bytes row needs no DOM and runs under
+  `:node-test` too."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.fresco.checkpoint-support :as rf.fresco.checkpoint-support]
+            [re-frame.fresco.impl.mount :as rf.fresco.impl.mount]
+            [re-frame.fresco.roots-frames-support :as rf.fresco.roots-frames-support]
+            [re-frame.test-support :as rf.test-support]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            ["react-dom/server" :as react-dom-server]))
+
+(def ^:private frame-id ::fragment-ref)
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- skip! [why]
+  (is true (str "a fragment-ref claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (rf.fresco.checkpoint-support/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  frame-id)
+
+(defn- tags
+  "The parent's child ELEMENTS, lowercased — the shape a fragment must not
+  change. Read off `.-children` rather than `.-childNodes` so a text node
+  cannot stand in for the wrapper this row is looking for."
+  [node]
+  (mapv #(.toLowerCase (.-tagName %)) (array-seq (.-children node))))
+
+(defn- owner [container] (.querySelector container ".owner"))
+
+;; ---------------------------------------------------------------------------
+;; The page
+;; ---------------------------------------------------------------------------
+
+(rf.fresco/defview ref-page
+  "Two siblings the fragment must not come between, and a run of children
+  it holds. `:handle-ref` and `:last?` arrive as props so a row can
+  re-render with a different ref, or a different run, through the same
+  handle — which is what rows 3 and 4 are."
+  [{:keys [handle-ref last?]}]
+  [:div.owner
+   [:span.before "before"]
+   [:<> {:ref handle-ref}
+    [:button.first {:type "button"} "first"]
+    (when last? [:button.last {:type "button"} "last"])]
+   [:span.after "after"]])
+
+;; ---------------------------------------------------------------------------
+;; 1 + 2 — what the handle IS, and what the DOM is not
+;; ---------------------------------------------------------------------------
+
+(deftest a-fragment-ref-answers-with-a-fragment-instance-and-adds-no-element
+  (if-not (rf.fresco.impl.mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [!seen (atom [])
+            f     (fn [instance] (swap! !seen conj instance) js/undefined)
+            h     (rf.fresco.impl.mount/root!
+                    (rf.fresco.impl.mount/fresh-container!) frame-id
+                    [ref-page {:handle-ref f :last? true}])]
+        (try
+          (testing "the callback ran once, during the commit `root!` flushed,
+                    and what it was handed is React's FragmentInstance — an
+                    object carrying the fragment's own API, and specifically
+                    NOT a DOM node, because the fragment has no element"
+            (is (= 1 (count @!seen)))
+            (let [instance (first @!seen)]
+              (is (some? instance))
+              (is (not (instance? js/Element instance))
+                  "a DOM node here would mean the codec had wrapped the children")
+              (is (fn? (.-focus instance)) "focus, the FragmentInstance API")
+              (is (fn? (.-focusLast instance)))
+              (is (fn? (.-getClientRects instance)) "and its measurement half")))
+          (testing "and the DOM is exactly the shape it would have been with no
+                    ref at all: the fragment's children are the owner's own
+                    children, in order, between the two siblings"
+            (is (= ["span" "button" "button" "span"] (tags (owner (:container h))))))
+          (finally (rf.fresco.impl.mount/release! h)))))))
+
+(deftest an-object-ref-is-assigned-the-same-instance
+  (if-not (rf.fresco.impl.mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [r (react/createRef)
+            h (rf.fresco.impl.mount/root!
+                (rf.fresco.impl.mount/fresh-container!) frame-id
+                [ref-page {:handle-ref r :last? true}])]
+        (try
+          (testing "React reaches an object ref by a different arm than a
+                    callback — it assigns `.current` rather than calling —
+                    so the shape is measured rather than assumed to follow"
+            (is (some? (.-current r)))
+            (is (fn? (.-focus (.-current r)))))
+          (testing "and it is released at unmount, so the handle cannot outlive
+                    the tree it addresses"
+            (rf.fresco.impl.mount/unmount! h)
+            (rf.fresco.impl.mount/settle!)
+            (is (nil? (.-current r))))
+          (finally (rf.fresco.impl.mount/release! h)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — identity, in both directions
+;; ---------------------------------------------------------------------------
+
+(deftest a-stable-ref-attaches-once-and-a-changed-one-runs-the-old-cleanup
+  (if-not (rf.fresco.impl.mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [!a       (atom 0)
+            !cleanup (atom 0)
+            !b       (atom 0)
+            f        (fn [_instance] (swap! !a inc) (fn [] (swap! !cleanup inc)))
+            g        (fn [_instance] (swap! !b inc) js/undefined)
+            h        (rf.fresco.impl.mount/root!
+                       (rf.fresco.impl.mount/fresh-container!) frame-id
+                       [ref-page {:handle-ref f :last? true}])]
+        (try
+          (is (= 1 @!a) "attached once at mount")
+          (is (= 0 @!cleanup))
+          (testing "A RE-RENDER WITH THE SAME FUNCTION IS NOT A REATTACH. This
+                    is the claim `:ref` crosses the codec untouched FOR: React
+                    compares the ref by identity, so a handle this codec
+                    rewrapped per render would detach and reattach here — and
+                    would run the author's cleanup — on every single commit"
+            (rf.fresco.impl.mount/render! h [ref-page {:handle-ref f :last? false}])
+            (rf.fresco.impl.mount/settle!)
+            (is (= 1 @!a) "still one attach")
+            (is (= 0 @!cleanup) "and the cleanup has not run"))
+          (testing "and the same mechanism the other way round, so the row above
+                    is a measurement rather than a tautology: a DIFFERENT
+                    function does run the old cleanup and does attach the new
+                    handle"
+            (rf.fresco.impl.mount/render! h [ref-page {:handle-ref g :last? false}])
+            (rf.fresco.impl.mount/settle!)
+            (is (= 1 @!cleanup) "the first ref's cleanup ran")
+            (is (= 1 @!b) "and the second attached"))
+          (finally (rf.fresco.impl.mount/release! h)))))))
+
+(deftest the-cleanup-a-callback-ref-returns-runs-at-unmount
+  (if-not (rf.fresco.impl.mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [!cleanup (atom 0)
+            f        (fn [_instance] (fn [] (swap! !cleanup inc)))
+            h        (rf.fresco.impl.mount/root!
+                       (rf.fresco.impl.mount/fresh-container!) frame-id
+                       [ref-page {:handle-ref f :last? true}])]
+        (try
+          (is (= 0 @!cleanup))
+          (rf.fresco.impl.mount/unmount! h)
+          (rf.fresco.impl.mount/settle!)
+          (is (= 1 @!cleanup)
+              "a fragment ref's cleanup is the ordinary React 19 one — the
+               function the callback returned, run once when the fragment goes")
+          (finally (rf.fresco.impl.mount/release! h)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the run of children is not frozen at attach
+;; ---------------------------------------------------------------------------
+
+(deftest the-handle-follows-the-children-the-fragment-currently-holds
+  (if-not (rf.fresco.impl.mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [!seen (atom nil)
+            f     (fn [instance] (reset! !seen instance) js/undefined)
+            h     (rf.fresco.impl.mount/root!
+                    (rf.fresco.impl.mount/fresh-container!) frame-id
+                    [ref-page {:handle-ref f :last? true}])]
+        (try
+          (let [instance @!seen
+                c        (:container h)]
+            (testing "focus and measurement reach the children through the
+                      handle — the two the FragmentInstance API exists for"
+              (.focus instance)
+              (is (= "first" (.-textContent js/document.activeElement))
+                  "focus lands on the first focusable child")
+              (.focusLast instance)
+              (is (= "last" (.-textContent js/document.activeElement)))
+              (is (pos? (.-length (.getClientRects instance)))
+                  "and the fragment measures as the rects of what it holds"))
+            (testing "then the last child goes away. The ref did not change, so
+                      React did not reattach — and the SAME instance now
+                      addresses the shorter run, which is the property that
+                      makes a fragment ref usable on conditional markup at all"
+              (rf.fresco.impl.mount/render! h [ref-page {:handle-ref f :last? false}])
+              (rf.fresco.impl.mount/settle!)
+              (is (= ["span" "button" "span"] (tags (owner c)))
+                  "the conditional child is out of the DOM")
+              (.focusLast instance)
+              (is (= "first" (.-textContent js/document.activeElement))
+                  "and the handle's last child is the one that is left")))
+          (finally (rf.fresco.impl.mount/release! h)))))))
+
+;; ---------------------------------------------------------------------------
+;; Activity — a hide is not a detach
+;; ---------------------------------------------------------------------------
+
+(def ^:private !set-mode (atom nil))
+
+(defn- activity-host
+  "Owns the Activity mode, published from a passive effect so a row cannot
+  drive the tree before React has mounted it. The page underneath is the
+  ordinary Fresco one, reached through `root-element` — the fragment ref
+  under test is the page's own."
+  [^js props]
+  (let [[mode set-mode] (react/useState "visible")]
+    (react/useEffect (fn [] (reset! !set-mode set-mode) js/undefined)
+                     #js [set-mode])
+    (react/createElement
+      (.-Activity react) #js {:mode mode}
+      (rf.fresco.impl.codec/root-element
+        frame-id [ref-page {:handle-ref (.-handleRef props) :last? true}]))))
+
+(unchecked-set activity-host "displayName" "frd/activity-host")
+
+(deftest an-activity-hide-detaches-a-fragment-ref-and-a-reveal-reattaches-it
+  (if-not (rf.fresco.impl.mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (reset! !set-mode nil)
+      (let [!a        (atom 0)
+            !cleanup  (atom 0)
+            f         (fn [_instance] (swap! !a inc) (fn [] (swap! !cleanup inc)))
+            container (rf.fresco.impl.mount/fresh-container!)
+            root      (react-dom-client/createRoot container)]
+        (try
+          (react-dom/flushSync
+            (fn []
+              (.render root (rf.fresco.impl.mount/provider
+                              frame-id
+                              (react/createElement activity-host #js {:handleRef f})))))
+          (rf.fresco.impl.mount/settle!)
+          (is (= 1 @!a) "attached on the visible mount")
+          (is (= 0 @!cleanup))
+          (is (some? @!set-mode) "the host published its setter")
+          (testing "A HIDE DETACHES IT, and this is the row most likely to be
+                    assumed the other way. React treats a fragment ref as a
+                    layout-tier attachment like a host ref — its
+                    `disappearLayoutEffects` detaches the Fragment fiber's ref
+                    alongside the host ones — so the author's CLEANUP RUNS on a
+                    hide, not only on an unmount. Anything registered through
+                    the handle (an observer, a listener) is torn down here and
+                    has to survive being set up again"
+            (react-dom/flushSync (fn [] (@!set-mode "hidden")))
+            (rf.fresco.impl.mount/settle!)
+            (is (= 1 @!cleanup) "the cleanup ran on the hide")
+            (is (= 1 @!a) "and nothing reattached while hidden"))
+          (testing "and a REVEAL reattaches, symmetrically — a fresh handle for
+                    the run of children as it stands on reveal"
+            (react-dom/flushSync (fn [] (@!set-mode "visible")))
+            (rf.fresco.impl.mount/settle!)
+            (is (= 2 @!a) "attached a second time")
+            (is (= 1 @!cleanup) "and the reveal ran no further cleanup"))
+          (testing "WHAT THIS ROW DOES NOT CLAIM: when the reveal's work lands.
+                    The stale-window figure this package carries is preserved
+                    at one animation frame and was not re-measured under the
+                    current React (rf2-4ale), and a row that timed a reveal
+                    would be re-deriving it by accident"
+            (is true "stated, not measured"))
+          (finally (.unmount root)))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — the SSR seam
+;; ---------------------------------------------------------------------------
+
+(deftest the-server-bytes-carry-no-artefact-of-a-fragment-ref
+  (testing "a ref is a client-commit concern and `renderToString` has no
+            commit, so the markup is byte-identical to the same page with no
+            ref at all — no attribute, and above all no wrapper element. This
+            row needs no DOM and runs on the node lane too"
+    (let [f      (fn [_instance] nil)
+          render (fn [hiccup]
+                   (react-dom-server/renderToString
+                     (rf.fresco.impl.mount/provider
+                       frame-id (rf.fresco.impl.codec/root-element frame-id hiccup))))
+          with   (render [ref-page {:handle-ref f :last? true}])
+          without (render [ref-page {:handle-ref nil :last? true}])]
+      (is (= without with)
+          "the ref changed nothing in the response")
+      (is (not (re-find #"(?i)\bref=" with))
+          "and nothing named ref reached the bytes"))))
+
+(deftest hydrating-those-bytes-attaches-the-handle-without-a-recovery
+  (async done
+    (if-not (rf.fresco.impl.mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [!seen (atom [])
+              f     (fn [instance] (swap! !seen conj instance) js/undefined)
+              page  [ref-page {:handle-ref f :last? true}]
+              html  (react-dom-server/renderToString
+                      (rf.fresco.impl.mount/provider
+                        frame-id (rf.fresco.impl.codec/root-element frame-id page)))
+              container (rf.fresco.roots-frames-support/stamp-server-nodes!
+                          (rf.fresco.roots-frames-support/server-dom! html))
+              {:keys [seen stop!]} (rf.fresco.roots-frames-support/watch-mismatches!)
+              h     (rf.fresco.impl.mount/hydrate-root! container frame-id page)]
+          (js/setTimeout
+            (fn []
+              (stop!)
+              (try
+                (is (= 1 (count @!seen))
+                    "the handle arrived on the hydration commit, once")
+                (is (some? (first @!seen)))
+                (is (fn? (.-focus (first @!seen))))
+                (is (= [] @seen)
+                    "and React recovered from nothing — a fragment ref is
+                     invisible to the markup, so it cannot be a mismatch")
+                (is (rf.fresco.roots-frames-support/every-server-node?
+                      container ".owner button")
+                    "the server's own nodes were adopted rather than replaced")
+                (finally
+                  (rf.fresco.impl.mount/release! h)
+                  (rf.fresco.impl.collector/reset-runtime!)
+                  (done))))
+            200))))))


### PR DESCRIPTION
Two beads, one surface: `implementation/fresco/src/re_frame/fresco/impl/codec.cljs`.

- **rf2-26hs** — forward `:ref` through fragment lowering. Implemented.
- **rf2-4sys** — an experiment comparing `use(browser())` against the adoption window. **The premise does not hold**; the comparison is recorded on the bead and the docs paragraph landed on the mechanism that actually works.

---

## rf2-26hs — Fragment refs

`codec/fragment-element` copied only `:key` into `React.Fragment` props, so `[:<> {:ref f} …]` dropped the handle before React ever saw it. The obstacle was ours, not React's — as rf2-4ale predicted.

**The upstream half nobody had checked.** React 19.3.0 support was verified in the installed `react-dom` rather than taken from release notes: `createElement` leaves `ref` in props; `coerceRef` reads `element.props.ref`; `updateElement` calls it on the `REACT_FRAGMENT_TYPE` arm; `commitAttachRef` case 7 mints a `FragmentInstance`. No feature flag — `enableFragmentRefs` appears 0 times in either build, and `FragmentInstance` appears 72 times in development and 58 in **production**. React's own `validateFragmentProps` states the roster: *"React.Fragment can only have `key`, `ref`, and `children` props."*

**The ref is read by canonical slot, not by the literal key.** That is this namespace's own stated law rather than a preference: its docstring says every rule about an *attribute* is asked of `canonical-slot`, and names `:key` and the revision key as the only two exact-keyword exceptions, because they are triggers. So `{"ref" f}` and `{:x/ref f}` land where `:ref` does. The value crosses untouched — the contract, not an optimisation, since React detaches and reattaches on a changed ref identity.

**No refusal arm was added, and that is a fence rather than taste.** The bead offered "refuse a non-`:key` fragment attr" as the alternative. A new refusal needs a new `:rf.error/fresco-*` id, and those are rostered in `spec/009-Instrumentation.md` — hot-zone for this dispatch. So it is not the smallest correct change; it is one that cannot be completed inside the fence. Other fragment attrs are dropped exactly as before.

**reagent-slim needed no code change.** Checked separately, as the bead insisted. Its fragment path converts the whole props map, so a ref already crosses by identity in both shapes. Only its docstring was stale; corrected, with three assertions added so the claim is pinned rather than re-derived. UIx remains unverified for the same reason as before — fragment lowering there belongs to the uix library, not to us.

**One finding that came out opposite to the intuition:** an **Activity hide DETACHES a fragment ref**, and a reveal reattaches it. Read at source (`disappearLayoutEffects` `case 7: safelyDetachRef`, and the symmetric `reappearLayoutEffects` `case 7: safelyAttachRef`), then measured: attach 1 → hide → cleanup 1 → reveal → attach 2. So the author's cleanup runs on a hide, not only on unmount. I had assumed the opposite and had written the row that way before checking.

Deliberately **not** claimed: anything about *when* a reveal's work lands. Per rf2-4ale that stale-window figure is preserved-and-unremeasured at one animation frame, and timing a reveal would re-derive it by accident.

## rf2-4sys — the experiment, and its refutation

The bead asked whether `use(browser())` under a local Suspense boundary gives Fresco a finer-grained third SSR policy by composition.

**It already has one.** A `:server :render` host may contain a `:server :client-only` leaf; only the leaf stands down. Measured on the Node arm:

```
<section class="shell"><h2>server-safe shell</h2><p class="sibling-before">…</p><span class="leaf-pending">measures in the browser</span><p class="sibling-after">…</p></section>
```

Shell rendered with children, leaf's `js/window`-reading body never ran, siblings intact, and **no Suspense machinery in the bytes at all**. The `browser()` recipe reaches the same shape but adds `<!--$!-->`, an error `<template>` and `data-dgst`, and the client **discards** that boundary and re-renders it rather than adopting it — trading adoption and `:rf.ssr/host-adopted` for a subtree rebuild.

**And the decisive one: `onBrowserBailout` cannot reach this package at all.** `renderToString` is the only server API Fresco uses (`server.cljs:402`, `:530`). It is exported from react-dom's **legacy** server build, and `renderToStringImpl` reads exactly one caller option — `identifierPrefix` — with every other slot hardcoded. The modern build wires `onBrowserBailout` only into the streaming/prerender family. Measured both ways: a supplied `onBrowserBailout` fired **0** times, in dev and in production. Separately, Fresco's "recovered-error stream" is re-frame's own `error-emit` registry, not a React channel, so even a delivered bailout would not land there.

So no recipe is adopted and no plumbing added — both were conditional on it holding. What landed instead is a short subsection documenting the composition that does work.

**One thing the recipe does not do wrong**, recorded so nobody re-derives it: it raises no unintended recoverable error. React stamps a browser bailout with the empty digest, and `REACT_RECOVERABLE_DIGEST` **is** the empty string, so the client skips `queueHydrationError` by design. The only real blemish is dev-only: the `<template>` carries `data-msg` and a `data-cstck` component stack with absolute source paths, both gone under a production build.

## Filed, not fixed

**rf2-3357** (P1) — the pure-CLJS SSR emitter dumps a fragment's attribute map into the markup as escaped EDN. `re-frame.ssr.emit`'s `:<>` branch splices `(rest el)` with no props-map skip, so `[:<> {:key "k"} [:div "x"]]` emits `{:key &quot;k&quot;}<div>x</div>`. Pre-existing, bites `:key` today — and a keyed fragment inside a `for` is the canonical idiom — and it is exactly the failure the sibling `:>` branch's own comment says it refuses to commit. Out of this dispatch's write surface, and the `:key` case dominates the `:ref` one, so it is its own bead rather than a passenger.

## Line-number claims checked at source

All bead citations were accurate: `codec.cljs:1644-1649` (`fragment-element`), `codec.cljs:578-600` (the `useSyncExternalStore` triple), `server.cljs:402` / `:530` (`renderToString`), `server.cljs:135-145` (`render-options`), `18-ssr-and-hydration.md:217-236`, and reagent-slim `template.cljs:1164-1179`. None had moved.

## Quality gates

Every number below is **my own captured exit code**, taken unpiped on one command line, never the harness's report of the same run — rf2-4ale found the harness reporting exit 0 twice over real failures.

Re-run on the **final rebased base** (`a3739d00a1`). Both suites' counts rose across the rebase (node 11511 → 11525, browser 859 → 873), which is itself the proof the re-run was on the new base rather than a cached earlier one.

| Gate | Exit | Result |
| --- | --- | --- |
| `test:cljs` (node, compile + run) | 0 | 11525 tests / 57897 assertions, 0 failures |
| `test:browser` (headless Chromium) | 0 | 873 tests / 4817 assertions, 0 failures |
| `check_guide_samples.py` (+ `--self-test`) | 0 | self-test fires; 75 verbs at 426 sites across 29 pages |
| `check_doc_slugs.py` | 0 | |
| `check_readme_links.py --ci` | 0 | |
| `mkdocs build --strict` | 0 | |
| `check-beads-pr-boundary.sh` | 0 | no beads-database paths in the diff |
| `check-commit-attribution.sh` | 0 | no AI attribution in either commit |
| `check_require_alias_dialect.py` | 0 | |
| `check_test_lane_bijection.py` | 0 | |
| `check_retired_spellings.py` | 0 | |
| `check_retired_composition_vocab.py` | 0 | |
| `check_architecture_census.py` | 0 | |
| `check_keyword_catalogue_drift.py` | 0 | |
| `check_thrown_error_messages.py` | 0 | |
| `check_readme_inventories.py` | 0 | |
| `check_fast_pr_gap.py` | 0 | |
| `check_gate_scheduling.py` | 0 | |
| `check-no-hardcoded-paths.sh` | 0 | |
| `check-ai-tracking-ratchet.sh` | 0 | |

**Sabotage control — it bites.** A planted sentinel in the new DOM witness's sibling-shape assertion turned the browser gate **red (captured exit 1)**, naming `PLANTED-FAULT-frescoref-a`, with `actual` reading `["span" "button" "button" "span"]`. That is also the positive evidence that the row ran in a real browser against this worktree: the plant exists only here, so a run that had wandered into a sibling checkout would have come back green. Restored and verified by git **blob** hash — `2c614bd0f7eb4cafaec878b2084d135109f820b0` before and after, zero residue. The guide-samples gate's own `--self-test` likewise reports the rule firing.

**Isolation.** A real per-worktree `node_modules` was installed from the lockfile — **no junction to the mayor's tree**, which rf2-4ale records as still holding react 19.2.0 and which would have silently built this against the wrong version. Counted with `find -mindepth 1 -maxdepth 1` rather than bare `ls`: 103 immediate entries, 27 executables in `.bin`.

AI attribution was declined in both commits and in this body, per `CLAUDE.md` over the harness reminder.
