### PR TITLE
ci(nightly): run bench members 2..22 in fresco-bench-compile (rf2-u297)

### DIFF
--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -915,22 +915,26 @@ jobs:
       # github.com). This checkout is depth-1, so the commit is absent
       # altogether and `data_archive.test.cjs`'s FIRST check — history-backed,
       # deliberately not corpus-backed, so that it runs in the state every clone
-      # is in — fails with `fatal: Not a valid object name`, taking the file to
-      # 1 of 4 with exit 1. The full oid is therefore spelled HERE, once, and
-      # this is the only place in the tree it is spelled: which commit is the
-      # readers' business and `ARCHIVE_SHA` stays its single source of truth,
-      # while a fetchable spelling of it is a shallow CLONE's business and
-      # belongs to CI. The prefix test below is what stops the two drifting
-      # apart in silence.
+      # is in — fails with `fatal: Not a valid object name`, leaving the file at
+      # 3/4 and exit 1 (measured in a real depth-1 clone of this repo). The full
+      # oid is therefore spelled HERE, once, and this is the only place in the
+      # tree it is spelled: WHICH commit is the readers' business and
+      # `ARCHIVE_SHA` stays its single source of truth, while a FETCHABLE
+      # spelling of it is a shallow CLONE's business and belongs to CI. The
+      # prefix test below is what stops the two drifting apart in silence.
       #
       # AND THE CORPUS IS RESTORED, which is the point of the step rather than a
-      # bonus: the 237-file restore costs ~0.5s and takes `data_archive.test.cjs`
-      # from 4/4 plus 3 SKIPPED to 7/7, and those three are precisely the
-      # corpus-backed checks named above. `data/` is git-ignored and the restore
-      # writes the working tree only. A failed fetch REDS this step rather than
-      # falling back to the corpus-free path: a silent fallback would disarm the
-      # checks this exists to arm and report green, which is the failure mode
-      # rf2-u297 was filed against.
+      # bonus. It costs ~0.5s for 237 files, and it is NOT only about
+      # `data_archive.test.cjs` going from 4/4 plus 3 SKIPPED to 7/7: measured
+      # both ways in that same depth-1 clone, EIGHT members print more with the
+      # corpus than without, and `alloc_null_floor`'s self-test does not run at
+      # all without it — 777 checks corpus-free against 995 with, summing each
+      # member's own printed summary. A corpus-free run therefore exits 0 over
+      # a lane whose corpus-backed checks announced themselves SKIPPED, which is
+      # the present-but-not-executed failure this whole step exists to end. So a
+      # failed fetch REDS this step rather than falling back: `data/` is
+      # git-ignored, the restore writes the working tree only, and a silent
+      # fallback would disarm exactly what rf2-u297 was filed to arm.
       - name: Run bench members 2..22 of `npm run check` (nothing else in CI does)
         working-directory: bench/fresco
         run: |

--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -881,6 +881,87 @@ jobs:
         run: |
           node -e "require('./src/re_frame/bench/fresco/lane_build.cjs').shadowBuild({project: process.cwd(), mode: 'compile', buildId: 'fresco-bench-node', tag: 'fresco-bench-node'})"
 
+      # rf2-u297 — AND THE 21 NON-COMPILE MEMBERS, WHICH NOTHING ELSE IN CI RUNS.
+      #
+      # Ruled YES by rf2-50fe, narrowly, and for THIS job only: it already pays
+      # for checkout, JDK, Node, `npm ci` and a 30-minute budget, so the whole
+      # marginal cost is the ~35s below. rf2-6c12m.1's ground is untouched —
+      # `bench/*` arms NOTHING on any per-PR lane, this changes no classifier and
+      # no registry, and nothing here may be promoted to `test.yml`. The bench
+      # suites exercise LOCAL COPIES of the runtime, so a per-PR run could not
+      # catch a regression in the shipped one; that is why cheapness was never
+      # the rebuttal, and it is still not.
+      #
+      # WHAT WAS UNCOVERED. `npm run check` is a 22-command chain and CI ran
+      # member 1. `test:scripts` globs `implementation/`-relative paths and so
+      # reaches exactly one of the other 21 (`lane_cache_wiring.test.cjs`);
+      # ESLint lints the files and cannot see a failing assertion. So PR #9580's
+      # corpus-backed boundary check — added to stop a future raw read silently
+      # dropping the native arm from a published population — was a gate nothing
+      # executed.
+      #
+      # MEMBER 1 IS DROPPED, THE OTHER 21 ARE NOT LISTED, so a member added to
+      # `check` tomorrow is covered without editing this job — the same
+      # derive-don't-enumerate rule the compile step above states. Two floors
+      # keep the derivation honest, because a collapsed split would run nothing
+      # and exit 0: the chain must still carry at least its 22 members, and
+      # member 1 must still BE the compile gate, since it is dropped by POSITION
+      # and a reorder would otherwise skip a real member in silence.
+      #
+      # THE ARCHIVE COMMIT IS FETCHED BY ITS FULL 40-CHARACTER OID, which is the
+      # one thing a naive version of this step gets wrong. `data_archive.cjs`
+      # pins the corpus commit as a 10-CHARACTER ABBREVIATION: fine in a full
+      # clone, and not a fetchable ref (`git fetch` exits 128 against
+      # github.com). This checkout is depth-1, so the commit is absent
+      # altogether and `data_archive.test.cjs`'s FIRST check — history-backed,
+      # deliberately not corpus-backed, so that it runs in the state every clone
+      # is in — fails with `fatal: Not a valid object name`, taking the file to
+      # 1 of 4 with exit 1. The full oid is therefore spelled HERE, once, and
+      # this is the only place in the tree it is spelled: which commit is the
+      # readers' business and `ARCHIVE_SHA` stays its single source of truth,
+      # while a fetchable spelling of it is a shallow CLONE's business and
+      # belongs to CI. The prefix test below is what stops the two drifting
+      # apart in silence.
+      #
+      # AND THE CORPUS IS RESTORED, which is the point of the step rather than a
+      # bonus: the 237-file restore costs ~0.5s and takes `data_archive.test.cjs`
+      # from 4/4 plus 3 SKIPPED to 7/7, and those three are precisely the
+      # corpus-backed checks named above. `data/` is git-ignored and the restore
+      # writes the working tree only. A failed fetch REDS this step rather than
+      # falling back to the corpus-free path: a silent fallback would disarm the
+      # checks this exists to arm and report green, which is the failure mode
+      # rf2-u297 was filed against.
+      - name: Run bench members 2..22 of `npm run check` (nothing else in CI does)
+        working-directory: bench/fresco
+        run: |
+          set -euo pipefail
+
+          oid=7b492b98cbee0a5a1e6f2ef157698c033d798d56
+          pin=$(node -p "require('./src/re_frame/bench/fresco/data_archive.cjs').ARCHIVE_SHA")
+          case "$oid" in
+            "$pin"*) ;;
+            *) echo "::error::the corpus pin moved to $pin; re-resolve the full oid with 'git rev-parse $pin' in a full clone and update this step"; exit 1 ;;
+          esac
+          git fetch --depth=1 origin "$oid"
+          node src/re_frame/bench/fresco/data_archive.cjs --restore
+
+          node -e '
+            const { execSync } = require("node:child_process");
+            const chain = require("./package.json").scripts.check.split("&&").map((c) => c.trim()).filter(Boolean);
+            if (chain.length < 22) {
+              throw new Error("the check chain collapsed to " + chain.length + " members; member 1 is dropped by position, so re-read it before lowering this floor");
+            }
+            if (!chain[0].includes("compile_gate.cjs")) {
+              throw new Error("member 1 is no longer the compile gate, so dropping it would drop a real member: " + chain[0]);
+            }
+            for (const [i, cmd] of chain.slice(1).entries()) {
+              console.log("::group::member " + (i + 2) + " of " + chain.length + ": " + cmd);
+              execSync(cmd, { stdio: "inherit" });
+              console.log("::endgroup::");
+            }
+            console.log(";; " + (chain.length - 1) + " members ran");
+          '
+
   # THE GATE-SCHEDULING AUDIT USED TO LIVE HERE, AND NO LONGER DOES (rf2-k78o2).
   # It asserts that every `test:*` / `bench:*` / `build:*` command in
   # implementation/package.json is either reachable from a workflow or carries a


### PR DESCRIPTION
Executes the ruling rf2-50fe made: **YES, narrowly, to one nightly addition**, and no to a per-PR surface. One file, one job, one added step. No classifier change, no mirror-test change, no registry change — `bench/*` still arms nothing on any per-PR lane, and rf2-6c12m.1's ground is untouched.

## What was uncovered

`bench/fresco`'s `npm run check` is a 22-command chain and CI ran member 1. `test:scripts` globs `implementation/`-relative paths and reaches exactly one of the other 21 (`lane_cache_wiring.test.cjs`); ESLint lints the files and cannot see a failing assertion. So PR #9580's corpus-backed boundary check — added to stop a future raw read silently dropping the native arm from a published population — was a gate nothing executed.

The step lands on `fresco-bench-compile`, which already pays for checkout, JDK, Node, `npm ci` and a 30-minute budget, so the marginal cost is ~35s.

## The three constraints, each measured in a real depth-1 clone

A throwaway `git clone --depth=1` of this repo was used as the CI simulator, and the step's `run:` block was extracted from this YAML by the parser and executed verbatim rather than retyped.

**1. Members 2..22, not `check` wholesale.** Member 1 duplicates the compile the job already runs. It is dropped by POSITION rather than the other 21 being enumerated, so a member added tomorrow is covered without editing the job — the same derive-don't-enumerate rule the compile step above it states. Two floors keep that honest, because a collapsed split would run nothing and exit 0: the chain must still carry its 22 members, and member 1 must still *be* the compile gate.

**2. The archive commit is fetched by its FULL 40-character oid.** Measured, all three:

| what | exit | |
|---|---|---|
| `data_archive.test.cjs` in a depth-1 clone, no fetch | **1** | `fatal: Not a valid object name 7b492b98cb`, leaving 3/4 |
| `git fetch --depth=1 origin 7b492b98cb` (the 10-char pin) | **128** | `couldn't find remote ref` — an abbreviation is not a fetchable ref |
| `git fetch --depth=1 origin 7b492b98cb...d56` (full oid) | **0** | ~9s against github.com |

**Where the full oid lives, and why:** in this step, spelled once, and this is the only place in the tree it is spelled. WHICH commit the corpus sits at is the readers' business and `ARCHIVE_SHA` in `data_archive.cjs` stays its single source of truth; a FETCHABLE spelling of that same commit is a shallow CLONE's business, and the only shallow clone in this project is CI's. Putting a second 40-character pin beside the first would duplicate the readers' constant for a reason the readers do not have. The step therefore reads `ARCHIVE_SHA` back out of `data_archive.cjs` and refuses to run unless the oid is its prefix, so the two cannot drift apart in silence — and once the object is fetched, the 10-character abbreviation resolves normally (measured: `git ls-tree` by the abbreviation returns all 237 entries).

**3. The corpus: restored.** The bead put this as 3 extra checks in `data_archive.test.cjs`. It is much more than that. Measured both ways in the same clone:

| | corpus-free | with corpus |
|---|---|---|
| members exit 0 | 21/21 | 21/21 |
| checks (each member's own printed summary, summed) | **777** | **995** |
| `data_archive.test.cjs` | 4/4 + 3 skipped | 7/7 |
| `alloc_level_witness.test.cjs` | 4 | 14 |
| `alloc_cluster_carrier` self-test | 50 | 115 |
| `alloc_mode_rate_session` self-test | 17 | 42 |
| `ladder_band` self-test | 15 | 29 |
| `alloc_null_floor` self-test | **not run at all** | 86 |
| `clock_exit_path.test.cjs` | 375 | 390 |
| `alloc_pass_position`, `alloc_window_ceiling` | checks skipped | run |

Eight members print more with the corpus, and one does not run at all without it. A corpus-free run exits 0 over a lane that announced its corpus-backed checks SKIPPED — which is the present-but-not-executed failure this step exists to end, arriving one level down. At ~10s for the fetch and ~0.5s for the 237-file restore, on a 30-minute budget, refusing that would be arming the cheap half of the gate and calling it done. A failed fetch reds the step rather than falling back to the corpus-free path, for the same reason.

## Verified by effect, not by a green job

A step that is present but skipped is the failure mode here. Read off the parsed YAML rather than assumed: the workflow's `on:` is `schedule` + `workflow_dispatch` with no filters, `fresco-bench-compile` carries **no job-level `if:`**, and the new step carries **no step-level `if:`** and no `continue-on-error` — the only job-level `if:` in this file belongs to the nightly-failure reporter. It is the job's last step, so it runs whenever the steps before it succeed.

Beyond reading the chain, the step was run twice: verbatim from this YAML in the depth-1 clone (exit 0, `;; 21 members ran`, 37s wall including the fetch), and by dispatching this workflow on this branch — [run 34424644573](https://github.com/day8/re-frame2/actions/runs/34424644573), where `Fresco bench lane compiles` came back **success** and the new step is **step 9, `conclusion: success`**, not `skipped`. From that run's own log:

* the checkout really was shallow — `fetch --no-tags --prune --no-recurse-submodules --depth=1`;
* `* branch 7b492b98cbee0a5a1e6f2ef157698c033d798d56 -> FETCH_HEAD`, so the full-oid fetch works against github.com from a runner;
* `restored 237 files into /home/runner/work/re-frame2/re-frame2/bench/fresco/src/re_frame/bench/fresco/data`;
* `;; 21 members ran`, **zero** `SKIPPED` lines, and **995 checks** across 17 summary lines — identical, line for line, to the local depth-1 measurement;
* 33 seconds wall for the whole step, fetch and restore included (01:15:45 → 01:16:18).

Note for whoever restores the corpus by hand afterwards: no `npm install` is needed for members 2..22 — they ran in a clone with no `node_modules` anywhere.

## Quality gates

Captured unpiped in this worktree, one command line per run, exit code echoed and quoted:

| gate | exit |
|---|---|
| `scripts/check_workflow_yaml.py --self-test --verbose` | 0 (PASS, 5 cases) |
| `scripts/check_workflow_yaml.py` | 0 (11 files) |
| `scripts/check_workflow_job_timeouts.py` | 0 (118 jobs across 11 files) |
| `scripts/check_gate_scheduling.py` | 0 (34 gate commands, 30 scheduled, 4 declared) |
| `scripts/check_fast_pr_gap.py --check` | 0 (79 required jobs across 3 workflows) |
| `scripts/check_retired_spellings.py` | 0 |
| `scripts/check_require_alias_dialect.py` | 0 |
| `scripts/check_ci_reproduce_commands.py` | 0 (47 checker steps in sync) |
| bench members 2..22, with corpus, depth-1 clone | 0 (21/21, 995 checks) |
| bench members 2..22, corpus-free, depth-1 clone | 0 (21/21, 777 checks) |

Both silent-on-pass gates were exercised against a planted fault at a line in the step itself, so the red is discriminating — the fault existed in no other checkout:

* `check_retired_spellings.py`: the retired product name planted in one comment line took it to **exit 1**, naming that file and line.
* `check_workflow_yaml.py`: a colon-space planted in the step's `name:` plain scalar took it to **exit 1** at that line — the exact failure mode the neighbouring step's comment documents.

Both restored and verified by git blob hash `de4bc95f9ce2e6c48e7a35bf8910b5566b006510` against the committed object, not by reading a diff.

## Reported, not edited

Two precision defects, both outside this bead:

1. **The registry `why` text names two PR-time readers for `bench` and there are four** (the other two are ESLint and require-alias-dialect). Carried forward from rf2-50fe. Correcting it is a one-toucher hot-zone edit in `implementation/scripts/_changed-surfaces.test.cjs`; not touched here.
2. **The bead's check counts (133 corpus-free / 223 with corpus) do not reproduce under any counting rule I could find.** Summing every member's own printed summary gives 777 / 995. The direction and the conclusion are unchanged and the corpus case is stronger than recorded, so this is a note rather than a finding.

No AI attribution trailers appear in the commits or in this description, per `CLAUDE.md`.
