### PR TITLE
docs(method): five findings from one saturated session

### DIFF
--- a/docs/the-mayor-method/README.md
+++ b/docs/the-mayor-method/README.md
@@ -117,6 +117,11 @@ maintainer has. Two audits were lost that way here, and a mayor re-ran an entire
 stay local. The conclusion gets promoted into whatever tracked record already
 owns the surface.
 
+A file there whose header says it was regenerated from somewhere else reads as
+wholly disposable, and usually isn't: hand-added material accretes below the
+generated part, under a header that is still true. Check which parts actually
+regenerate before discarding one.
+
 That invisibility runs both ways, and the second direction bites at dispatch
 time. A worker in its own isolated checkout cannot see the tree at all, so a
 brief that cites a file there by a path relative to the worker's own checkout

--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -208,6 +208,13 @@ sentence, a worker handed a task that should not exist will invent one that does
 
 **The work**, with a control that proves it.
 
+But a report is not uniformly measured, and its credibility does not partition the
+way its sentences do. It mixes what the worker checked in its own tree with what it
+inferred about someone else's — a sibling's branch, another dispatch's needs, what a
+file will look like after a change it cannot see. Only the first half was checked.
+Relaying the second as fact is how a brief acquires an error the mayor did not make
+and cannot trace.
+
 The best refusal seen here came with measurement rather than argument. An item claimed a
 CI timeout was too tight; the worker sampled 183 runs of that step — median 13 seconds
 against a 300-second cap — found the real cause was a slow mirror, closed the item, and

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -41,6 +41,11 @@ the pipeline moving. What you must never do is *block* on CI: no watch commands,
 no polling loops that occupy the session. One-shot queries, merge what passes now,
 re-check the rest on the next signal.
 
+**And the same holds for any long LOCAL operation** — a bulk cleanup, a dependency install, a
+batch of tracker queries. The operator cannot distinguish a session busy on one from a session
+that has stalled, and will read a long silence as the latter. Run it detached and stay
+answerable.
+
 ---
 
 ## 1. Merge
@@ -1630,6 +1635,13 @@ Watch specifically for:
   discriminator **is worse than no remedy at all** — that judgement applies to its own prose, and
   this loop is the only place that checks whether it does.
 
+**Read a loop's page when you are about to do that loop's work, whatever this loop's cadence says.**
+The cadence is decoupled from need: a destructive or unfamiliar step performed hours before its page
+comes round is a step taken without it, and the reread that follows finds nothing wrong because the
+damage is already done. One branch sweep here re-derived, at length, a test its own page states
+outright. That is not an argument for re-reading everything — it is the reason this loop is a drift
+check rather than the only time a page gets opened.
+
 Report one or two lines unless you find real drift. If you find drift, fix the document or the command
 file — do not just note it.
 
@@ -1793,6 +1805,13 @@ words each time, and give the writer one full pass of this loop. If nothing has 
 restoring the original close reason — the flip cleared it — and recording the reopen's emptiness alongside.
 Measured against the twelve above: two such flips in one session, distinguishable from the legitimate
 reopens around them only by the absence of any recorded residual.
+
+**And a wiped closure makes any brief that CITES it unsatisfiable.** A worker sent to read closure text
+the reopen deleted finds an empty field, and reads the absence as its own failure rather than the
+tracker's. Restore the text or cite where it was preserved, **before** dispatching. Having verified the
+preservation yourself is no protection: the verification and the brief are separate acts, and one mayor
+here confirmed a closure had been preserved into notes and an hour later still pointed a worker at the
+erased field.
 
 **Checkpoint tracker state on the heartbeat.** Many trackers auto-stage but never commit, so a long
 session's state strands locally. Commit and push it each cycle.


### PR DESCRIPTION
Retrospective on one long mayor session running six concurrent workers. Five findings, each one paragraph into an existing section. Nothing restructured, nothing removed, +31 lines total.

Everything here is generic: no OS-specific, project-specific or operator-specific detail. Each addition records a failure that happened, not a rule that could be derived.

## What was added, and what it cost

**`README.md` — the `ai` tree.** A file whose header says it was regenerated from somewhere else reads as wholly disposable, and usually isn't: hand-added material accretes below the generated part, under a header that stays true. Met live — a 1071-line local blocks file, half regenerable from the template, half unique mayor notes found in no tracked file (five distinctive phrases, zero hits each, against a control returning 76).

**`bootstrap.md` — what a worker is for.** The section rightly raises trust in worker reports ("the only part of the system that reads the real tree"), and does not mark the boundary. A report mixes what the worker *measured* in its own tree with what it *inferred* about someone else's, and only the first half was checked. One worker's inference about a sibling's branch was relayed as fact into a live dispatch; the sibling's branch turned out not to touch the file at all.

**`loops.md` — merge on most signals.** The existing rule forbids blocking on CI. It generalises: the operator cannot distinguish a session busy on a long *local* operation from one that has stalled. Raised twice by the operator in this session, both times against local work rather than polling.

**`loops.md` — method reread.** Read a loop's page when about to do that loop's work, whatever the cadence says. A branch sweep here re-derived at length a test the branch page states outright, because the sweep happened hours before that page came round. Framed so it does not contradict the section's own "not by re-reading" thesis.

**`loops.md` — tracker mechanics.** Where a reopen wipes the closure text, a brief that cites it is unsatisfiable: the worker finds an empty field and reads the absence as its own failure. The sharp half is that verifying the preservation yourself is no protection — the verification and the brief are separate acts. Happened exactly that way here, an hour apart, and cost a worker a recovery from tracker history.

## Considered and rejected

Three candidates were dropped as already covered, on reading rather than memory:

- **Patch-equivalence vs ancestry for branch deletion** — `loops.md` § Branches already carries it in full, including the `-`/`+` asymmetry. I rediscovered it the hard way, which is what the method-reread addition above is about.
- **Store contention under a saturated fleet** — already stated, including one-query-per-command.
- **Over-deference on held items** — already in three places.

Two more were dropped as derivable: naming the instrument in a receipt token, and not quoting a harness's exit code.

## Quality gates

Captured by me, unpiped, on this branch:

| gate | exit |
|---|---|
| `check_doc_slugs.py` | 0 |
| `python -m mkdocs build --strict` | 0 |
| `check_readme_links.py --ci` | 0 |
| `check-commit-attribution.sh origin/main HEAD` | 0 |
| `check-beads-pr-boundary.sh origin/main HEAD` | 0 |

`docs/the-mayor-method/` is not in `mkdocs.yml`'s `exclude_docs`, so the strict build covers these pages.

**Gate provenance proved, not assumed.** A planted broken anchor took `check_doc_slugs.py` to exit 1 naming `loops.md:1839` — a line that exists only in this worktree. Restored and verified by git blob hash `7beb7c8964…`, identical before the plant and after the restore.

**One process note against myself:** the first sabotage pass was run before committing, so the `git checkout --` that restored the plant also silently reverted all three `loops.md` edits. Caught by a blob-hash mismatch on the very check meant to prove the restore. Redone, committed first, then re-sabotaged against the committed state — where the same hash matched.

No AI attribution in the commit or this body, per the project's own convention.
