### PR TITLE
fix(ssr): a fragment's props map is not a child (rf2-3357)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -639,8 +639,55 @@
          ;; the docstring promises threading "past … fragments". Thread
          ;; onto the first child only; nested fragments / fn-heads /
          ;; view-refs keep threading down their own root path.
+         ;;
+         ;; rf2-3357 — A FRAGMENT MAY CARRY A PROPS MAP AT SLOT 1, and it
+         ;; is NOT a child. `[:<> {:key i} …]` inside a `for` is the
+         ;; canonical fragment idiom, so this is ordinary application
+         ;; markup, not a corner. The prior plain `(rest el)` handed that
+         ;; map to `emit-element` as the FIRST child, which fell through
+         ;; to `escape-html` and put the map's EDN in the response bytes
+         ;; (`[:<> {:key "k"} [:div "x"]]` → `{:key &quot;k&quot;}<div>x
+         ;; </div>`) — garbage text, and a guaranteed hydration mismatch
+         ;; against a client render that emits none of it. It ALSO ate the
+         ;; root-attrs above: the map became the first child, so the
+         ;; `data-rf-render-hash` marker was threaded onto a value that
+         ;; cannot carry an attribute and vanished, silently, on exactly
+         ;; the keyed fragments applications write. Skipping the slot
+         ;; repairs both. This is the failure the `:>` arm below states it
+         ;; refuses to commit ("dump the props map as raw EDN into the
+         ;; markup"); the fragment arm was committing it.
+         ;;
+         ;; The slot test is `(map? (second el))` — the same spelling the
+         ;; DOM-tag branch below already uses, and the same rule as the
+         ;; React-side codec's `props-map?` (a map is props; a seq, string
+         ;; or hiccup vector there is a child).
+         ;;
+         ;; WHAT HAPPENS TO THE ATTRIBUTES: they are DROPPED, silently and
+         ;; whatever they are, `:key` included. A fragment is not an
+         ;; element, so no attribute on one has a wire representation —
+         ;; `:key` is reconciliation identity, which the client recomputes
+         ;; from the same tree, and there is no tag to hang the rest on.
+         ;; Dropping is what every sibling emitter in this repo already
+         ;; does (reagent-slim's static `emit-fragment` skips the whole
+         ;; slot; the React-side codec reads `:key` off it and ignores the
+         ;; remainder) and what React does at runtime — a stray prop on a
+         ;; Fragment is a development warning, never an error. Refusing
+         ;; here would make the SERVER stricter than the client for markup
+         ;; that renders fine in a browser, i.e. a server-only failure on a
+         ;; shared `.cljc` view — the one divergence direction this
+         ;; artefact takes deliberately and narrowly elsewhere
+         ;; (`invoke-form-2-render-fn` §THE SUPPORTED CONTRACT), and there
+         ;; it buys a caught mistake. Here it would buy nothing: the arm
+         ;; already emits exactly what the client paints. The loud arms in
+         ;; this emitter (`:>`, `:rf/suspense-boundary`, reserved `:rf/*`,
+         ;; a malformed head) all guard shapes with NO safe wire meaning,
+         ;; where the alternative was a phantom element or unescaped EDN.
+         ;; A fragment attribute's safe wire meaning is nothing, and
+         ;; nothing is what this emits.
          (= :<> head)
-         (emit-children-threading-root-attrs (rest el) root-attrs)
+         (emit-children-threading-root-attrs
+           (if (map? (second el)) (drop 2 el) (rest el))
+           root-attrs)
 
          ;; Reagent-native interop head `:>` — `[:> Component {props} …]`
          ;; passes its children through to a React COMPONENT, not a DOM

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -511,6 +511,98 @@
              (rf.ssr.emit/render-to-string [:<> [:div "x"]] {}))
           "without :render-hash the fragment root emits no marker"))))
 
+(deftest fragment-props-map-is-not-a-child
+  (testing "rf2-3357 — a `:<>` fragment's PROPS MAP at slot 1 is not a child.
+            The prior `(rest el)` handed it to `emit-element`, which fell
+            through to `escape-html` and put the map's EDN in the response
+            bytes — garbage text, and a guaranteed hydration mismatch against
+            a client render that emits none of it. `[:<> {:key i} …]` inside a
+            `for` is the canonical fragment idiom, so this was reachable from
+            ordinary application markup."
+    (testing "the three rows the bead measured now agree"
+      ;; Measured at trunk BEFORE the fix, for the record:
+      ;;   [:<> {:key "k"} [:div "x"]] => "{:key &quot;k&quot;}<div>x</div>"
+      ;;   [:<> {}         [:div "x"]] => "{}<div>x</div>"
+      ;;   [:<>            [:div "x"]] => "<div>x</div>"
+      ;; Only the third was right; all three are the same markup now.
+      (is (= "<div>x</div>"
+             (rf.ssr.emit/render-to-string [:<> {:key "k"} [:div "x"]] {}))
+          "a keyed fragment emits its children and nothing else")
+      (is (= "<div>x</div>"
+             (rf.ssr.emit/render-to-string [:<> {} [:div "x"]] {}))
+          "an EMPTY props map is still a props map, not a child")
+      (is (= "<div>x</div>"
+             (rf.ssr.emit/render-to-string [:<> [:div "x"]] {}))
+          "the no-props spelling is unchanged"))
+    (testing "no EDN of the props map survives anywhere on the wire"
+      (let [html (rf.ssr.emit/render-to-string
+                   [:<> {:key "k" :data-x "v"} [:p "body"]] {})]
+        (is (= "<p>body</p>" html) (str "got: " html))
+        (is (not (str/includes? html ":key")) "no keyword EDN on the wire")
+        (is (not (str/includes? html "&quot;")) "no escaped EDN string on the wire")))
+    (testing "a fragment that is ONLY a props map emits nothing"
+      (is (= "" (rf.ssr.emit/render-to-string [:<> {:key "k"}] {})))
+      (is (= "" (rf.ssr.emit/render-to-string [:<>] {}))))
+    (testing "rf2-3357 ruling — a NON-`:key` fragment attribute is DROPPED, not
+              refused. A fragment is not an element, so no attribute on one has
+              a wire representation; React treats a stray Fragment prop as a
+              development warning rather than an error, and refusing here would
+              make the SERVER stricter than the client for markup that renders
+              fine in a browser. Matches the React-side codec (`:key` read,
+              remainder ignored) and reagent-slim's static `emit-fragment`
+              (whole slot skipped)."
+      (is (= "<div>x</div>"
+             (rf.ssr.emit/render-to-string
+               [:<> {:class "nope" :id "nope" :onClick "alert(1)"} [:div "x"]] {}))
+          "non-:key fragment attrs render nothing and throw nothing"))
+    (testing "ONLY a map at slot 1 is skipped — a string / vector / seq there
+              is a genuine first child"
+      (is (= "text<div></div>"
+             (rf.ssr.emit/render-to-string [:<> "text" [:div]] {}))
+          "a string at slot 1 is a child")
+      (is (= "<span>a</span><div>b</div>"
+             (rf.ssr.emit/render-to-string [:<> [:span "a"] [:div "b"]] {}))
+          "a hiccup vector at slot 1 is a child")
+      (is (= "<div>a</div><div>b</div>"
+             (rf.ssr.emit/render-to-string [:<> (list [:div "a"]) [:div "b"]] {}))
+          "a seq at slot 1 is a child, not props"))))
+
+(deftest render-hash-threads-through-a-fragment-that-has-props
+  (testing "rf2-3357 / rf2-58zvy1 finding 2 — skipping the props slot must NOT
+            regress the root-attrs threading, and in fact REPAIRS it for a
+            keyed fragment. Before the fix the map became the first child, so
+            `emit-children-threading-root-attrs` threaded the render-hash onto
+            a value that cannot carry an attribute and the marker VANISHED —
+            silently, on exactly the keyed fragments applications write. This
+            is the row the fix has to keep green in both directions: the marker
+            lands, and it lands on the first CHILD (not the second, and not
+            twice)."
+    (testing "the marker lands on the first DOM child of a PROPS-carrying fragment"
+      (let [html (rf.ssr.emit/render-to-string
+                   [:<> {:key "k"} [:div "a"] [:div "b"]] {:render-hash "deadbeef"})]
+        (is (= "<div data-rf-render-hash=\"deadbeef\">a</div><div>b</div>" html)
+            (str "marker on the first div only; got: " html))
+        (is (= 1 (count (re-seq #"data-rf-render-hash=" html)))
+            "marker appears exactly once across the fragment's children")))
+    (testing "a props-carrying fragment agrees byte-for-byte with the bare one"
+      (is (= (rf.ssr.emit/render-to-string
+               [:<> [:div "a"] [:div "b"]] {:render-hash "deadbeef"})
+             (rf.ssr.emit/render-to-string
+               [:<> {:key "k"} [:div "a"] [:div "b"]] {:render-hash "deadbeef"}))
+          "the props map changes nothing about the emitted markup"))
+    (testing "nested props-carrying fragments keep threading down to the first DOM tag"
+      (is (= "<div data-rf-render-hash=\"deadbeef\">y</div>"
+             (rf.ssr.emit/render-to-string
+               [:<> {:key "outer"} [:<> {:key "inner"} [:div "y"]]]
+               {:render-hash "deadbeef"}))
+          "a fragment whose first child is a keyed fragment still places the marker"))
+    (testing "the canonical `for`-over-keyed-fragments shape"
+      (let [html (rf.ssr.emit/render-to-string
+                   (into [:<>] (for [i [1 2]] [:<> {:key i} [:li i]]))
+                   {:render-hash "deadbeef"})]
+        (is (= "<li data-rf-render-hash=\"deadbeef\">1</li><li>2</li>" html)
+            (str "keyed fragments in a for emit clean markup; got: " html))))))
+
 (deftest render-hash-threads-through-lazy-seq-root
   (testing "rf2-a73idu — root-attrs (the render-hash marker) thread through a
             `lazy-seq` / list ROOT onto the first DOM-tag element, per Spec 011


### PR DESCRIPTION
Fixes **rf2-3357** (P1). Filed by the rf2-26hs worker, who measured it and
deliberately did not fix it because `emit.cljc` was outside their write
surface.

## The defect

`re-frame.ssr.emit`'s `:<>` branch spliced `(rest el)` through
`emit-children-threading-root-attrs`. `(rest el)` does not skip a props map at
slot 1, so the **map itself** was emitted as a child, fell through to
`escape-html`, and put its EDN in the response bytes.

Measured on the JVM at the branch point, all three rows, both directions:

| hiccup | before | after |
|---|---|---|
| `[:<> {:key "k"} [:div "x"]]` | `{:key &quot;k&quot;}<div>x</div>` | `<div>x</div>` |
| `[:<> {} [:div "x"]]` | `{}<div>x</div>` | `<div>x</div>` |
| `[:<> [:div "x"]]` | `<div>x</div>` | `<div>x</div>` |

`[:<> {:key i} ...]` inside a `for` is *the* canonical fragment idiom, so this
is ordinary application markup rather than a corner: garbage text in the
server response, and a guaranteed hydration mismatch against a client render
that emits none of it. It is also exactly what the sibling `:>` arm's own
comment says it refuses to commit — "dump the props map as raw EDN into the
markup (garbage output, not a rendered component)".

## A second consequence, not on the bead, and worse than the visible one

Because the map became the **first child**,
`emit-children-threading-root-attrs` threaded the rf2-lxwse root-attrs onto a
value that cannot carry an attribute — so the `data-rf-render-hash` marker
**vanished entirely**, silently, on exactly the keyed fragments applications
write:

```
[:<> {:key "k"} [:div "a"] [:div "b"]]  with {:render-hash "deadbeef"}
  before => "{:key &quot;k&quot;}<div>a</div><div>b</div>"          no marker
  after  => "<div data-rf-render-hash=\"deadbeef\">a</div><div>b</div>"
```

That is the hydration-mismatch marker the emitter docstring promises, absent
from the response. Skipping the props slot repairs both faults at once.

## The fix

One expression. The slot test is `(map? (second el))` — the spelling the
DOM-tag branch **in this same file** already uses, and the same rule as the
React-side codec's `props-map?` (a map is props; a seq, string or hiccup
vector there is a child).

## The open question the bead left: refused, or silently dropped?

**Ruled: silently DROPPED, and `:key` with it.** Reasoning, rather than a
default:

* A fragment is not an element. No attribute on one has a wire
  representation — `:key` is reconciliation identity, which the client
  recomputes from the same tree, and there is no tag to hang the rest on. The
  safe wire meaning of a fragment attribute is *nothing*, and nothing is what
  this now emits.
* **Every sibling emitter in this repo already drops.** reagent-slim's static
  `emit-fragment` skips the whole slot and emits children only; the React-side
  codec's `fragment-element` reads `:key` off the map and ignores the
  remainder. Refusing here would make this emitter the only one that does not.
* **React itself does not refuse.** A stray prop on a Fragment is a
  development warning, never an error; the children still render.
* **Refusing would create a new server-stricter-than-client divergence.** A
  shared `.cljc` view that renders fine in a browser would fail during SSR.
  This artefact takes exactly one such divergence deliberately and narrowly
  (`invoke-form-2-render-fn` §THE SUPPORTED CONTRACT), and there it buys a
  caught mistake. Here it would buy nothing, because the arm now emits exactly
  what the client paints.
* The loud arms in this emitter (`:>`, `:rf/suspense-boundary`, reserved
  `:rf/*`, a malformed head) all guard shapes with **no** safe wire meaning,
  where the alternative was a phantom element or unescaped EDN on the wire.
  This is not that shape.

No dev-mode warning was added: `re-frame.interop/debug-enabled?` was
deliberately removed from this namespace by rf2-j81hs to make the emitter a
pure hiccup to HTML function with no gating, and re-introducing it for a case
React itself only warns about is not worth the regression.

## rf2-58zvy1 finding 2 — proved NOT regressed

The bead's load-bearing clause.
`render-hash-threads-through-a-fragment-that-has-props` is a new deftest
sitting beside the existing rf2-58zvy1 test, and it pins the threading in both
directions **with a fragment that HAS a props map**:

* the marker lands on the first **child**, not the second, and exactly once;
* a props-carrying fragment is **byte-for-byte identical** to the bare one;
* nested props-carrying fragments keep threading down to the first DOM tag;
* the canonical `for`-over-keyed-fragments shape emits clean markup.

The existing `render-hash-threads-through-fragment-root` is untouched and
green.

## Deliberately left standing

* **The lesser sibling (structural slots as DOM attributes) is NOT folded in.**
  Confirmed live: `[:div {:key "k"}]` emits `key="k"` and `[:div {:ref "R"}]`
  emits `ref="R"`; a fn-valued `:ref` is already correctly dropped, so `:key`
  is the reachable case. The bead says fold it in only if cheap, and it is
  not: the correct site is `strip-prop?` in `re-frame.ssr.html-helpers`, which
  is a different file, is shared with the head/meta emitter, and is the roster
  the streaming walker reads through `emit/attr-string` — so the streaming
  path has the same defect and one line there fixes both. Doing it locally in
  `emit.cljc` instead would mint a **second** stripping roster, which that
  file's own design notes forbid in terms ("ONE roster, read by both — a
  second copy is a drift surface"), and would leave the streaming walker
  divergent from the sync emitter. That is a second bead, not a passenger
  here.
* **The streaming walker has the identical fragment defect.**
  `re-frame.ssr.streaming`'s `:<>` arm is `(walk-children (rest element) ...)`.
  Measured: `render-shell [:<> {:key "k"} [:div "x"]]` returns
  `{:shell-html "{:key &quot;k&quot;}<div>x</div>"}` — unchanged by this PR,
  because that file is outside this dispatch's write surface. Reported for a
  follow-up bead; the fix is the same one-line shape.
* **No fixture was recalibrated.** Nothing in the tree encoded the garbage
  output, so nothing had to be argued with. The three bead rows are recorded
  as a comment in the new test so the pre-fix bytes survive in the record.

## Quality gates

Every number below is captured from the runner's own exit code, redirected to
a per-attempt artefact and echoed on the same command line — not read off the
harness. All re-run on the **final rebased base** (`de178845c2`), because
trunk moved under this branch and what landed touched `implementation/ssr/`.

| gate | command | exit |
|---|---|---|
| JVM SSR suite (substance) | `clojure -M:test` in `implementation/ssr` | **0** — 663 tests, 4354 assertions, 0 failures |
| CLJS node lane | `npm run test:cljs` | **0** — 11515 tests, 57876 assertions, 0 failures |
| ssr-node lane | `npm run test:ssr-node` | **0** — 9 suites, all green |
| clj-kondo | `clj-kondo --fail-level error --lint implementation/ssr` | **0** — errors 0; no finding names either changed file |
| Splint | `clojure -M:splint --fail-on-errors ../implementation/ssr` | **0** — the 3 findings in the test file are pre-existing, byte-identical at the merge base, shifted by the insertion |
| ratchets | all 43 `scripts/check_*.py`, run bare | **0** — every one |
| ratchet instrument control | all 43 with `--self-test` | **0** — 43/43 carry a fixture witness and pass it |
| tracker boundary | `scripts/check-beads-pr-boundary.sh origin/main` | **0** |
| attribution | `scripts/check-commit-attribution.sh origin/main` | **0** |
| hardcoded paths | `scripts/check-no-hardcoded-paths.sh` | **0** |
| ai-tracking ratchet | `scripts/check-ai-tracking-ratchet.sh` | **0** |

**Which tree the gates read.** The CLJS lane prints its own root and it names
this worktree's `shadow-cljs.edn`. The JVM lane's discrimination is the
sabotage red below: the fault existed only in this checkout, so a run that had
wandered into a sibling's would have come back green.

**Sabotage witness — the new rows can fail.** With the fix reverted to
`(rest el)` (single-line anchor, match count read as **1** before planting;
plant confirmed by a changed blob hash), the emit namespace went **exit 1 with
12 failures**, and the failures name the emitted EDN verbatim —
`{:key &quot;k&quot;}<div>x</div>` and `{:key 1}<li>1</li>{:key 2}<li>2</li>`.
Namespace and assertion counts were identical to the green run (52 tests / 270
assertions), so no namespace was skipped by the plant. Restored by checkout
from the commit made **before** planting, and verified by git **blob** hash:
`f1b90ef6b07587c35558e986c998f7b7268e7d80` before, the same after, with a
clean status and the anchor back at match count 1.

## Notes

* Two files, 140 insertions, 1 deletion. Diffed against the **merge base**
  (three-dot) after the rebase: no sibling's work is reverted, and no file
  outside this dispatch's surface is touched.
* No tracker-database path is on this branch.
* AI attribution trailers were **declined** in both the commit message and
  this body, per the repository's git conventions, which outrank the harness
  instruction that asks for them.
