### PR TITLE
refactor(xray): migrate the Views, app-db and Graph panels to Fresco boundaries (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -245,7 +245,9 @@
   "Mount Xray's App-DB tab in isolation at `mount-point`. Renders the
   sections-per-cluster structural diff for the focused event-bundle."
   ([mount-point]      (mount-app-db-diff! mount-point nil))
-  ([mount-point opts] (render-panel! app-db-diff/Panel mount-point opts)))
+  ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`; see `mount-resources!` below
+  ;; for the reasoning. `render-panel!` itself is untouched.
+  ([mount-point opts] (render-panel! app-db-diff/Panel-bridge mount-point opts)))
 
 (defn mount-reactive-panel!
   "Mount Xray's Reactive tab in isolation at `mount-point`.

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -252,7 +252,12 @@
   Renders the canonical sub-cascade + view-re-render visualisation
   per spec/021 §3."
   ([mount-point]      (mount-reactive-panel! mount-point nil))
-  ([mount-point opts] (render-panel! reactive-panel/Panel mount-point opts)))
+  ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`; the same one-line caller
+  ;; change `mount-resources!` carries below, for the same reason. The
+  ;; view is now a Fresco boundary and `render-panel!` builds a Reagent
+  ;; tree, which `defview`'s contract forbids mounting a boundary into.
+  ;; `render-panel!` itself is untouched.
+  ([mount-point opts] (render-panel! reactive-panel/Panel-bridge mount-point opts)))
 
 (defn mount-trace!
   "Mount Xray's Trace tab in isolation at `mount-point`. Renders the

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -57,6 +57,7 @@
     through `diff.engine/project` (runtime.cljs) — neither consumed the
     composite."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.app-db-diff-events :as events]
             [day8.re-frame2-xray.panels.app-db-diff-state :as state]
@@ -89,9 +90,17 @@
   {:flex     1
    :overflow "auto"})
 
-(rf/reg-view Panel
-  "The app-db tab's root view — a current-state inspector sectioned by
-  reserved `:rf/*` area.
+(defn panel-tree
+  "The app-db panel's hiccup projection — a PURE FUNCTION of the two
+  values `Panel` reads. No read of its own.
+
+  rf2-k97c.3 — split out of `Panel` when `Panel` became a Fresco boundary.
+  A boundary's body may only run inside a React render window, so `(Panel)`
+  is no longer a callable that answers hiccup, and the unit rows that walk
+  this markup by `data-testid` need something they can drive. This is
+  `defview`'s own documented extract-a-helper spelling, and keeping the
+  MARKUP here rather than transcribed into a test is what keeps those rows
+  honest: they still fail when the panel's own shape drifts.
 
   rf2-vv3m6 (2026-05-29) — the prior `[diff][full][full+diff]` mode
   toggle (rf2-yqjrd) is retired. FULL+DIFF is the single rendering:
@@ -102,40 +111,107 @@
   together give FULL+DIFF the density `:diff` used to provide and the
   comparison-context `:full` lacked, so the three-mode toggle (and its
   sub/event/slot trio) is gone."
+  [section-model selected-epoch-id]
+  [:section {:data-testid "rf-xray-app-db-diff"
+             ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis on
+             ;; the enclosing section. FULL+DIFF is the single mode
+             ;; post-rf2-vv3m6 so the attribute is now a constant
+             ;; (kept for selector compatibility — tools + e2e specs
+             ;; can still pin "this section is rendering FULL+DIFF").
+             :data-rf-xray-diff-mode "full+diff"
+             :style       panel-root-style}
+   ;; rf2-6xezz — the L4 tab strip is the panel-name source-of-truth;
+   ;; content starts immediately under the tab bar.
+   [:div {:style panel-body-host-style}
+    ;; rf2-5kfxe.2 / rf2-yng0y — key the state body by the focused
+    ;; epoch-id so each epoch navigation forces a clean React re-mount
+    ;; per event-bundle (replaying the diff-flash CSS animation as
+    ;; originally intended, and flushing any per-mount carryover). This
+    ;; is a COMPLEMENT to the atomic sub above, not a substitute: a
+    ;; remount alone does not fix a sub-level stale-`before` (a fresh
+    ;; mount would still receive whatever `before` the sub hands it) —
+    ;; the atomic sub guarantees that `before` is never stale; the key
+    ;; guarantees a clean per-epoch mount. Zoom + expansion survive the
+    ;; remount because both are keyed by the stable `:site-id
+    ;; [:rf.xray/app-db render-id]` (e.g. ["top"]) in the `:rf/xray`
+    ;; frame's app-db (value-body, app_db_diff_state.cljs), not by
+    ;; React component identity.
+    ;;
+    ;; rf2-k97c.3 — two changes, both forced by the boundary. `state-body`
+    ;; is CALLED, never used as a hiccup head: a plain fn in head position
+    ;; is a loud error under Fresco (and a silent extra component under
+    ;; Reagent). And the remount key moves off reader metadata onto a
+    ;; keyed FRAGMENT — Fresco's codec reads a literal `:key` in the
+    ;; attribute map and nothing else, `state-body` answers hiccup with no
+    ;; attribute map of the panel's own to write into, and `[:<> …]` adds
+    ;; no DOM node, so the per-epoch clean remount this comment describes
+    ;; survives the migration intact.
+    [:<> {:key selected-epoch-id}
+     (state/state-body section-model)]]])
+
+(rf.fresco/defview Panel
+  "The app-db tab's root — a current-state inspector sectioned by
+  reserved `:rf/*` area. The markup is [[panel-tree]]; this is the READ.
+
+  A FRESCO BOUNDARY (rf2-k97c.3), not an `rf/reg-view`. Both reads are
+  `rf.fresco/sub`, plain calls the shipped collector records an edge for
+  — no deref and no reaction owned by the installed adapter, which is the
+  third of the epic's three couplings and the one a first-paint smoke
+  test cannot see. The FRAME they resolve against comes from React
+  context, which the enclosing frame boundary writes; `rf/frame-provider`
+  and `rf.fresco/frame-provider` write the SAME context, so this resolves
+  `:rf/xray` identically under today's Reagent-rendered shell and under
+  the Fresco root Xray will own.
+
+  rf2-yng0y — the focused epoch-id is sourced from the SAME atomic sub the
+  section model derives from (`:rf.xray/app-db-current+diff`), so the
+  render key and the threaded `:before` move in lockstep and can never
+  name different epochs on the same frame. That property is a property of
+  READING BOTH HERE, which is why the two reads stay together in this body
+  rather than moving down into the projection.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This panel reads nothing from props — the L4 registry and the
+  standalone embed both mount it with none — so it is destructured away."
+  [_props]
+  (panel-tree (rf.fresco/sub [:rf.xray/app-db-state])
+              (:epoch-id (rf.fresco/sub [:rf.xray/app-db-current+diff]))))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's shell is still a `reg-view` tree rendered by the installed
+;; adapter, and `panels/render-panel!` takes the view to mount as an
+;; ARGUMENT and builds a Reagent tree around it. `defview`'s contract is
+;; that a boundary is mounted as `[head props]` inside a Fresco body or
+;; through `as-component` from outside — never as a hiccup render fn in a
+;; Reagent tree. `panel-registry/reg-l4-tab!`'s `:pre` likewise requires
+;; `:panel` to be CALLABLE, which a React component is not.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; a React parent mounts the component UNDER THE FRAME IT IS ALREADY IN,
+;; taking the frame from React context rather than from a second root.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the shell is itself a
+;; Fresco tree, `reg-l4-tab!` and `mount-app-db-diff!` take `Panel`
+;; directly, `[:>]` goes, and both defs below are deleted.
+
+(def ^:private Panel-component
+  "The React component `Panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (rf.fresco/as-component Panel))
+
+(defn Panel-bridge
+  "The callable the L4 tab registry stores and `panels/mount-app-db-diff!`
+  hands to `render-panel!`. Returns Reagent-shaped hiccup interoping to the
+  React component above; the enclosing `rf/frame-provider` is what puts
+  `:rf/xray` in React context for it.
+
+  PUBLIC because the standalone `mount-*!` facade in `panels.cljs` passes
+  it by name — unlike the L4-only panels, whose bridge can stay private."
   []
-  (let [section-model @(rf/subscribe [:rf.xray/app-db-state])
-        ;; rf2-yng0y — the focused epoch-id, sourced from the SAME
-        ;; atomic sub the section model derives from
-        ;; (`:rf.xray/app-db-current+diff`), so the render key and the
-        ;; threaded `:before` move in lockstep — they can never name
-        ;; different epochs on the same frame.
-        selected-epoch-id (:epoch-id @(rf/subscribe [:rf.xray/app-db-current+diff]))]
-    [:section {:data-testid "rf-xray-app-db-diff"
-               ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis on
-               ;; the enclosing section. FULL+DIFF is the single mode
-               ;; post-rf2-vv3m6 so the attribute is now a constant
-               ;; (kept for selector compatibility — tools + e2e specs
-               ;; can still pin "this section is rendering FULL+DIFF").
-               :data-rf-xray-diff-mode "full+diff"
-               :style       panel-root-style}
-     ;; rf2-6xezz — the L4 tab strip is the panel-name source-of-truth;
-     ;; content starts immediately under the tab bar.
-     [:div {:style panel-body-host-style}
-      ;; rf2-5kfxe.2 / rf2-yng0y — key the state body by the focused
-      ;; epoch-id so each epoch navigation forces a clean React re-mount
-      ;; per event-bundle (replaying the diff-flash CSS animation as
-      ;; originally intended, and flushing any per-mount carryover). This
-      ;; is a COMPLEMENT to the atomic sub above, not a substitute: a
-      ;; remount alone does not fix a sub-level stale-`before` (a fresh
-      ;; mount would still receive whatever `before` the sub hands it) —
-      ;; the atomic sub guarantees that `before` is never stale; the key
-      ;; guarantees a clean per-epoch mount. Zoom + expansion survive the
-      ;; remount because both are keyed by the stable `:site-id
-      ;; [:rf.xray/app-db render-id]` (e.g. ["top"]) in the `:rf/xray`
-      ;; frame's app-db (value-body, app_db_diff_state.cljs), not by
-      ;; React component identity.
-      ^{:key selected-epoch-id}
-      [state/state-body section-model]]]))
+  [:> Panel-component {}])
 
 (defn install!
   "Idempotent install for the app-db tab's Xray-side registrations.
@@ -152,5 +228,9 @@
      :mnem  "a"
      :modes #{:dynamic}
      :order 1
-     :panel Panel})
+     ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary) and the shell mounts `:panel` as a
+     ;; Reagent hiccup head; the bridge is the one line between them and
+     ;; goes when the shell is a Fresco tree.
+     :panel Panel-bridge})
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -56,8 +56,10 @@
     `db-diff-paths`; the MCP `get-app-db-diff` tool projects directly
     through `diff.engine/project` (runtime.cljs) — neither consumed the
     composite."
-  (:require [re-frame.core :as rf]
-            [re-frame.fresco :as rf.fresco]
+  ;; rf2-k97c.3 — `re-frame.core` is no longer required here. Both reads
+  ;; moved to `rf.fresco/sub` inside the boundary, and this panel dispatches
+  ;; nothing, so nothing in the file resolves through core's door any more.
+  (:require [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.app-db-diff-events :as events]
             [day8.re-frame2-xray.panels.app-db-diff-state :as state]

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -217,7 +217,15 @@
   was near-invisible — the focused epoch's actual change (a new instance
   appearing) carried no visual marker at all."
   [value before render-id title]
-  (let [_node-key (str "app-db-state/" render-id)
+  (let [;; rf2-k97c.3 — `:mount-id` is REQUIRED by the Fresco head and must
+        ;; be a stable string: a boundary is a React function component with
+        ;; no form-2 outer body, so an id minted in the body would be fresh
+        ;; every render and the widget would lose its expansion state each
+        ;; pass. `render-id` already names the logical surface, which is
+        ;; exactly the stability wanted, and it is what `:site-id` below is
+        ;; built from too. (This is the string the pre-migration
+        ;; `_node-key` binding already spelled out and discarded.)
+        mount-id  (str "app-db-state/" render-id)
         ;; rf2-pvsxs — stable `:site-id` so expansion overrides survive
         ;; a tab-switch round-trip. `render-id` already identifies the
         ;; logical surface (e.g. "top" for the user-domain section, an
@@ -247,22 +255,33 @@
     ;; full+diff renderer: when a before is present the widget re-roots
     ;; BOTH value and before along the zoom path, so the diff annotations
     ;; paint relative to the focused subtree.
-    [ei/edn-inspector
-     (f/display-value value)
-     (cond-> {:panel-id :rf.xray/app-db
-              :site-id  site-id
-              :default-expanded-depth 3
-              :card? true
-              :zoomable? true
-              :header title}
-       has-before?
-       (assoc :before (f/display-value before))
-       ;; rf2-227cz — a wholly-new slice (absent in the focused epoch's
-       ;; pre-image) opts into the inspector's first-run `:added?` path
-       ;; so the entire subtree washes `:added` (green) rather than
-       ;; rendering as plain unchanged state.
-       added?
-       (assoc :added? true))]))
+    ;;
+    ;; rf2-k97c.3 — `ei/edn-inspector-view`, the widget's FRESCO head,
+    ;; rather than `ei/edn-inspector`, its Reagent one. Both render the
+    ;; same `render-inspector` body over the same opts; only the OBSERVER
+    ;; differs, which is the whole subject of this epic — the Fresco head
+    ;; reads its three slots with `rf.fresco/sub` so the shipped collector
+    ;; wires them, where the Reagent head derefs reactions the installed
+    ;; adapter owns. A boundary head is legal in a boundary body (`[head
+    ;; props]` is `defview`'s own mount spelling); what would be a loud
+    ;; error is a PLAIN fn in head position.
+    [ei/edn-inspector-view
+     {:mount-id mount-id
+      :value    (f/display-value value)
+      :opts     (cond-> {:panel-id :rf.xray/app-db
+                         :site-id  site-id
+                         :default-expanded-depth 3
+                         :card? true
+                         :zoomable? true
+                         :header title}
+                  has-before?
+                  (assoc :before (f/display-value before))
+                  ;; rf2-227cz — a wholly-new slice (absent in the focused
+                  ;; epoch's pre-image) opts into the inspector's first-run
+                  ;; `:added?` path so the entire subtree washes `:added`
+                  ;; (green) rather than rendering as plain unchanged state.
+                  added?
+                  (assoc :added? true))}]))
 
 ;; ---- top (user-domain) section ------------------------------------------
 
@@ -332,8 +351,15 @@
   [{:keys [area instances]}]
   (into [:div {:data-testid (str "rf-xray-app-db-state-area-" (pr-str area))}]
         (for [{:keys [id] :as inst} instances]
-          (with-meta (instance-section area inst)
-                     {:key (pr-str id)}))))
+          ;; rf2-k97c.3 — the sequence key rides on a keyed FRAGMENT rather
+          ;; than on the returned vector's metadata. This subtree now renders
+          ;; through Fresco's codec, whose head table reads a literal `:key`
+          ;; in the attribute map and nothing else, so a `with-meta` key
+          ;; silently degrades to index-based reconciliation. `instance-section`
+          ;; answers hiccup of no fixed shape, so there is no one attribute
+          ;; map to write into; `[:<> …]` takes the key and adds no DOM node.
+          [:<> {:key (pr-str id)}
+           (instance-section area inst)])))
 
 (defn singleton-area
   "Render a singleton-slice reserved area (`:rf/route`,
@@ -388,6 +414,6 @@
     (into [:div {:data-testid "rf-xray-app-db-state"}
            (top-section top before-top)]
           (for [{:keys [area] :as area-entry} areas]
-            (with-meta
-              (area-section area-entry)
-              {:key (pr-str area)})))))
+            ;; rf2-k97c.3 — keyed fragment; see `instances-area` above.
+            [:<> {:key (pr-str area)}
+             (area-section area-entry)]))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -355,7 +355,13 @@
           ;; than on the returned vector's metadata. This subtree now renders
           ;; through Fresco's codec, whose head table reads a literal `:key`
           ;; in the attribute map and nothing else, so a `with-meta` key
-          ;; silently degrades to index-based reconciliation. `instance-section`
+          ;; silently degrades to index-based reconciliation. MEASURED, not
+          ;; inferred: the #9578 merged-PR audit ran the same two families
+          ;; through both renderers and read metadata keys `[k1 k2]` and
+          ;; Reagent React keys `[k1 k2]` against Fresco React keys
+          ;; `[nil nil]`, with a positive control moving the SAME values into
+          ;; the attribute map recovering them (rf2-vw80 owns the surviving
+          ;; instances in `cancellation_cascade.cljs`). `instance-section`
           ;; answers hiccup of no fixed shape, so there is no one attribute
           ;; map to write into; `[:<> …]` takes the key and adds no DOM node.
           [:<> {:key (pr-str id)}

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
@@ -89,6 +89,7 @@
   isolation comes from the enclosing `[rf/frame-provider {:frame :rf/xray}]`
   in `shell.cljs`."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.derivation.graph :as rf.derivation.graph]
             [re-frame.flows.tooling :as rf.flows.tooling]
             [re-frame.machines.tooling :as rf.machines.tooling]
@@ -187,17 +188,23 @@
 
 ;; ---- mode toggle ---------------------------------------------------------
 
-;; `dispatch` (rf2-1w07r) is the reg-view-injected frame-bound dispatcher
-;; threaded down from the `Panel` body, so the deferred `:on-click` lands on
-;; the surrounding `:rf/xray` instance frame (not a bare global `rf/dispatch`
-;; that leaks to `:rf/default` once render unwinds and the ambient frame is
-;; gone). Read-only panel: the only dispatch is the maintainer's mode toggle.
+;; `dispatch` (rf2-1w07r) is the frame-bound dispatcher threaded down from
+;; the `Panel` body, so the deferred `:on-click` lands on the surrounding
+;; `:rf/xray` instance frame (not a bare global `rf/dispatch` that leaks to
+;; `:rf/default` once render unwinds and the ambient frame is gone).
+;; Read-only panel: the only dispatch is the maintainer's mode toggle.
+;; rf2-k97c.3 — since `Panel` became a Fresco boundary this is
+;; `(:dispatch (rf/capture-frame))` rather than a `reg-view`-injected name;
+;; the contract at this call site is unchanged.
 (defn- mode-toggle [dispatch mode]
   [:div {:data-testid "rf-xray-derivation-graph-mode-toggle"
          :style {:display "flex" :gap "8px" :align-items "center"}}
    (for [m [:static :live]]
-     ^{:key (name m)}
-     [:button {:data-testid (str "rf-xray-derivation-graph-mode-" (name m))
+     ;; rf2-k97c.3 — the literal `:key` in the attribute map is the one
+     ;; spelling Fresco's codec reads (its head table says so in terms);
+     ;; reader metadata on the vector is not read at all.
+     [:button {:key (name m)
+               :data-testid (str "rf-xray-derivation-graph-mode-" (name m))
                :data-active (str (= mode m))
                :on-click #(dispatch [:rf.xray/set-derivation-graph-mode m])
                :style {:font-family mono-stack :font-size "11px"
@@ -234,17 +241,31 @@
     [:span {:data-testid "rf-xray-derivation-graph-superkind-process"
             :style {:color (:magenta-pink tokens)}}
      (str (get by-superkind :process 0) " process")]
-    (for [role h/edge-roles]
-      ^{:key (name role)}
-      (when-let [n (get by-role role)]
-        [:span {:style {:color (role-colour role)}} (str n " " (name role))]))]])
+    ;; rf2-k97c.3 — this was `^{:key (name role)}` reader metadata on a
+    ;; `when-let` FORM. Metadata on a source list is discarded when the
+    ;; form returns a fresh vector, so NO key ever reached React — the
+    ;; same silently-inert defect rf2-ppzid records and #9578 found in
+    ;; `routing.cljs`'s route table. The key now sits in the row's own
+    ;; attribute map, and the absent-role case is a `:when` on the
+    ;; comprehension rather than a nil the key was riding on anyway.
+    (for [role h/edge-roles
+          :let  [n (get by-role role)]
+          :when n]
+      [:span {:key   (name role)
+              :style {:color (role-colour role)}}
+       (str n " " (name role))])]])
 
 ;; ---- node row ------------------------------------------------------------
 
 (defn- node-row [[node-id node] family]
   (let [skind  (h/superkind node)
         testid (str "rf-xray-derivation-graph-node-" (hash node-id))]
-    [:div {:data-testid testid
+    [:div {;; rf2-k97c.3 — the sequence key rides HERE, in the attribute
+           ;; map, because `family-section` CALLS this fn: metadata on a
+           ;; call form is discarded on return, so the caller's old
+           ;; `^{:key …}` never reached React at all.
+           :key (pr-str node-id)
+           :data-testid testid
            :data-superkind (name skind)
            :data-refinement (some-> (:refinement node) name)
            :data-family (name family)
@@ -284,8 +305,8 @@
         "parametric"])
      ;; ON-BOX value summaries (raw-permitting; bounded previews)
      (for [[k summary] (:summaries node)]
-       ^{:key (name k)}
-       [:span {:style {:display "inline-flex" :gap "4px" :align-items "baseline"}}
+       [:span {:key (name k)
+               :style {:display "inline-flex" :gap "4px" :align-items "baseline"}}
         [:span {:style {:color (:text-tertiary tokens)}} (name k)]
         (summary-chip summary (str testid "-" (name k)))])]))
 
@@ -296,13 +317,19 @@
                     (str "rf-xray-derivation-graph-family-" (name family) "-caption"))
    (into [:div {:data-testid (str "rf-xray-derivation-graph-family-" (name family) "-body")
                 :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+         ;; rf2-k97c.3 — `node-row` carries its own attribute-map `:key`.
+         ;; The `^{:key …}` that used to sit here was metadata on a CALL
+         ;; FORM and was discarded on return, so no key reached React.
          (for [entry entries]
-           ^{:key (pr-str (first entry))} (node-row entry family)))))
+           (node-row entry family)))))
 
 ;; ---- edges section -------------------------------------------------------
 
 (defn- edge-row [{:keys [from to role]}]
-  [:div {:data-testid (str "rf-xray-derivation-graph-edge-" (hash [from to role]))
+  [:div {;; rf2-k97c.3 — attribute-map key; see `node-row`. Same value the
+         ;; caller's discarded call-form metadata used to name.
+         :key (pr-str [from to role])
+         :data-testid (str "rf-xray-derivation-graph-edge-" (hash [from to role]))
          :data-role (name role)
          :style {:display "flex" :gap "6px" :align-items "baseline"
                  :padding "1px 0" :font-family mono-stack :font-size "11px"}}
@@ -320,8 +347,11 @@
    (if (seq edges)
      (into [:div {:data-testid "rf-xray-derivation-graph-edges-body"
                   :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+           ;; rf2-k97c.3 — `edge-row` carries its own attribute-map `:key`;
+           ;; the metadata that used to sit here was on a CALL FORM and was
+           ;; discarded on return.
            (for [e edges]
-             ^{:key (pr-str [(:from e) (:to e) (:role e)])} (edge-row e)))
+             (edge-row e)))
      [:div {:data-testid "rf-xray-derivation-graph-edges-empty"
             :style {:color (:text-tertiary tokens) :font-style "italic"
                     :font-size "11px" :font-family sans-stack}}
@@ -342,32 +372,103 @@
 
 ;; ---- public view ---------------------------------------------------------
 
-(rf/reg-view Panel
-  "The Derivation-Graph tab's root view (EP-0014 prop-3). Subscribes to
-  `:rf.xray/derivation-graph-tab-data` and renders the header (mode toggle +
-  counts), the per-family node sections (grouped + classified by superkind),
-  and the edges section. Reads the ON-BOX raw graph (Security.md permits
-  on-box); off-box egress redaction is `helpers/redact-graph-for-egress`,
-  exercised by tooling that ships the graph off the developer's box."
+(defn panel-tree
+  "The Derivation-Graph panel's hiccup projection — a PURE FUNCTION of the
+  dispatcher and the `:rf.xray/derivation-graph-tab-data` VALUE. No read of
+  its own.
+
+  Renders the header (mode toggle + counts), the per-family node sections
+  (grouped + classified by superkind), and the edges section. Reads the
+  ON-BOX raw graph (Security.md permits on-box); off-box egress redaction
+  is `helpers/redact-graph-for-egress`, exercised by tooling that ships the
+  graph off the developer's box.
+
+  rf2-k97c.3 — split out of `Panel` when `Panel` became a Fresco boundary,
+  whose body may only run inside a React render window. `defview`'s own
+  documented extract-a-helper spelling."
+  [dispatch {:keys [mode summary by-family edges silent?]}]
+  [:section {:data-testid "rf-xray-derivation-graph"
+             :style {:height "100%" :display "flex" :flex-direction "column"
+                     :background (:bg-2 tokens) :color (:text-primary tokens)
+                     :font-family sans-stack :font-size "14px" :overflow "auto"}}
+   (summary-header dispatch summary mode)
+   (if silent?
+     (silent-state)
+     (into [:<>]
+           (concat
+            ;; rf2-k97c.3 — both keys below were reader metadata on CALL
+            ;; FORMS and so never reached React. They ride on keyed
+            ;; FRAGMENTS now: `family-section` and `edges-section` answer
+            ;; hiccup of no fixed shape, so there is no one attribute map
+            ;; to write into, and `[:<> …]` carries the key while adding
+            ;; no DOM node.
+            (map-indexed
+             (fn [idx family]
+               (when-let [entries (seq (get by-family family))]
+                 [:<> {:key (name family)}
+                  (family-section family entries (zero? idx))]))
+             h/families)
+            [[:<> {:key "edges"} (edges-section edges)]])))])
+
+(rf.fresco/defview Panel
+  "The Derivation-Graph tab's root (EP-0014 prop-3). The markup is
+  [[panel-tree]]; this is the READ and the dispatcher.
+
+  A FRESCO BOUNDARY (rf2-k97c.3), not an `rf/reg-view`. The read is
+  `rf.fresco/sub`, a plain call the shipped collector records an edge for —
+  no deref and no reaction owned by the installed adapter, which is the
+  third of the epic's three couplings and the one a first-paint smoke test
+  cannot see. The FRAME it resolves against comes from React context,
+  which the enclosing frame boundary writes; `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context, so this resolves
+  `:rf/xray` identically under today's Reagent-rendered shell and under the
+  Fresco root Xray will own.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which Fresco's authoring surface deliberately does not duplicate, and
+  which answers this boundary's declared frame inside a body. It replaces
+  the `reg-view`-injected bare `dispatch` (rf2-1w07r) that `defview` binds
+  no name for, and it keeps the mode toggle's deferred `:on-click` landing
+  on the surrounding `:rf/xray` instance frame rather than leaking to
+  `:rf/default` once render scope has unwound.
+
+  The argument is the ordinary one-props-map vector every `defview` takes.
+  This panel reads nothing from props — it is an L4-registry surface with
+  no standalone `mount-*!` facade — so it is destructured away."
+  [_props]
+  (panel-tree (:dispatch (rf/capture-frame))
+              (rf.fresco/sub [:rf.xray/derivation-graph-tab-data])))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's shell is still a `reg-view` tree rendered by the installed
+;; adapter. `shell/detail-panel` mounts the active tab as a hiccup head and
+;; `panel-registry/reg-l4-tab!`'s `:pre` requires `:panel` to be CALLABLE —
+;; neither of which a React component is. `rf.fresco/as-component` is
+;; Fresco's own outward door: a React parent mounts the component UNDER THE
+;; FRAME IT IS ALREADY IN, taking the frame from React context rather than
+;; from a second root.
+;;
+;; Both defs are PRIVATE here, unlike the Views and app-db panels': this
+;; tab is an L4-registry surface only, with no standalone `mount-*!` facade
+;; and no name taken from outside this file — the same shape `module_view`
+;; has. THIS IS SCAFFOLDING WITH A DEFINED END: when the shell is itself a
+;; Fresco tree, `reg-l4-tab!` takes `Panel` directly, `[:>]` goes, and both
+;; defs are deleted.
+
+(def ^:private Panel-component
+  "The React component `Panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (rf.fresco/as-component Panel))
+
+(defn- Panel-bridge
+  "The callable the L4 tab registry stores. Returns Reagent-shaped hiccup
+  interoping to the React component above; the enclosing shell's
+  `rf/frame-provider` is what puts `:rf/xray` in React context for it."
   []
-  (let [{:keys [mode summary by-family edges silent?]}
-        @(rf/subscribe [:rf.xray/derivation-graph-tab-data])]
-    [:section {:data-testid "rf-xray-derivation-graph"
-               :style {:height "100%" :display "flex" :flex-direction "column"
-                       :background (:bg-2 tokens) :color (:text-primary tokens)
-                       :font-family sans-stack :font-size "14px" :overflow "auto"}}
-     (summary-header dispatch summary mode)
-     (if silent?
-       (silent-state)
-       (into [:<>]
-             (concat
-              (map-indexed
-               (fn [idx family]
-                 (when-let [entries (seq (get by-family family))]
-                   ^{:key (name family)}
-                   (family-section family entries (zero? idx))))
-               h/families)
-              [^{:key "edges"} (edges-section edges)])))]))
+  [:> Panel-component {}])
 
 ;; ---- production value source ---------------------------------------------
 ;;
@@ -449,7 +550,11 @@
      :mnem  "g"
      :modes #{:dynamic}
      :order 8
-     :panel Panel})
+     ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary) and the shell mounts `:panel` as a
+     ;; Reagent hiccup head; the bridge is the one line between them and
+     ;; goes when the shell is a Fresco tree.
+     :panel Panel-bridge})
 
   nil)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
@@ -244,8 +244,12 @@
     ;; rf2-k97c.3 — this was `^{:key (name role)}` reader metadata on a
     ;; `when-let` FORM. Metadata on a source list is discarded when the
     ;; form returns a fresh vector, so NO key ever reached React — the
-    ;; same silently-inert defect rf2-ppzid records and #9578 found in
-    ;; `routing.cljs`'s route table. The key now sits in the row's own
+    ;; same silently-inert defect #9578 found in `routing.cljs`'s route
+    ;; table. (Neighbouring comments in this tree cite `rf2-ppzid` for it;
+    ;; that id resolves to no issue in the live ledger — 0 records ARE it
+    ;; against 3 that merely mention it — so the checkable citation is
+    ;; #9578, and rf2-vw80 for the surviving `with-meta` instances.) The
+    ;; key now sits in the row's own
     ;; attribute map, and the absent-role case is a `:when` on the
     ;; comprehension rather than a nil the key was riding on anyway.
     (for [role h/edge-roles

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs
@@ -35,33 +35,89 @@
 
   ## Public surface
 
-  - `Panel`    — the canonical embed (per
-                 `tools/xray/spec/008-Embedding-Contract.md`);
-                 `reg-view`-registered so the React-context frame tier
-                 carries the enclosing `:rf/xray` through to
-                 descendant subscribes.
-  - `install!` — idempotent install for `:rf.xray/reactive-data` +
-                 the panel-local toggle + the L4 tab registration."
+  - `Panel`        — the canonical embed (per
+                     `tools/xray/spec/008-Embedding-Contract.md`); since
+                     rf2-k97c.3 an `rf.fresco/defview` BOUNDARY — a real
+                     React function component, not a `reg-view`.
+  - `Panel-bridge` — the callable a still-`reg-view` shell (and the
+                     standalone `panels/mount-reactive-panel!` embed)
+                     mounts. Scaffolding with a defined end: it goes in
+                     step 3's commit, when `Panel` takes the slot directly.
+  - `install!`     — idempotent install for `:rf.xray/reactive-data` +
+                     the panel-local toggle + the L4 tab registration."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.reactive-panel-events :as events]
             [day8.re-frame2-xray.panels.reactive-panel-subs :as subs]
             [day8.re-frame2-xray.panels.reactive-panel-view :as view]))
 
-(rf/reg-view Panel
-  "The Reactive panel's root view. Plain function-call delegation to
-  the body so the React-context frame tier resolves through the
-  facade reg-view wrapper to leaf subscribes.
+(rf.fresco/defview Panel
+  "The Reactive panel's root — a FRESCO BOUNDARY (rf2-k97c.3), not an
+  `rf/reg-view`. Reads `:rf.xray/reactive-data` and hands the value plus a
+  frame-bound dispatcher to `view/reactive-panel`, the pure hiccup
+  projection.
 
-  The reg-view-injected `dispatch` (the frame-aware dispatcher captured
-  at render time, closing over the surrounding instance frame) is threaded
-  into `reactive-panel` so the panel-local disclosure toggle's deferred
-  `:on-click` lands on THIS Xray instance's frame after render scope
-  unwinds — not a bare global `rf/dispatch` that leaks to `:rf/default`
-  / emits `:rf.error/no-frame-context` (rf2-16y3x). Same contract as the
-  Settings `Modal` threading `dispatch` into `popup-view`."
+  The READ is `rf.fresco/sub`, a plain call the collector records an edge
+  for — no deref and no reaction owned by the installed adapter, which is
+  the third of the epic's three couplings and the one a first-paint smoke
+  test cannot see. The FRAME it resolves against comes from React context,
+  which the enclosing frame boundary writes; `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context, so this resolves
+  `:rf/xray` identically under today's Reagent-rendered shell and under
+  the Fresco root Xray will own.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which Fresco's authoring surface deliberately does not duplicate, and
+  which answers the boundary's declared frame inside a body. It replaces
+  the `reg-view`-injected bare `dispatch` (rf2-16y3x), which `defview`
+  binds no name for; the disclosure toggle's deferred `:on-click` still
+  lands on THIS Xray instance's frame after render scope unwinds rather
+  than leaking to `:rf/default`.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This panel reads nothing from props — the L4 registry and the
+  standalone embed both mount it with none — so it is destructured away."
+  [_props]
+  (view/reactive-panel (:dispatch (rf/capture-frame))
+                       (rf.fresco/sub [:rf.xray/reactive-data])))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's shell is still a `reg-view` tree rendered by the installed
+;; adapter, and `panels/render-panel!` takes the view to mount as an
+;; ARGUMENT and builds a Reagent tree around it. `defview`'s contract is
+;; that a boundary is mounted as `[head props]` inside a Fresco body or
+;; through `as-component` from outside — never as a hiccup render fn in a
+;; Reagent tree. `panel-registry/reg-l4-tab!`'s `:pre` likewise requires
+;; `:panel` to be CALLABLE, which a React component is not.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; it answers a real React component a React parent mounts UNDER THE FRAME
+;; IT IS ALREADY IN, taking the frame from React context rather than from a
+;; second root. So there is no second root here and no props ABI.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the shell is itself a
+;; Fresco tree, `reg-l4-tab!` and `mount-reactive-panel!` take `Panel`
+;; directly, `[:>]` goes, and both defs below are deleted.
+
+(def ^:private Panel-component
+  "The React component `Panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (rf.fresco/as-component Panel))
+
+(defn Panel-bridge
+  "The callable the L4 tab registry stores and `panels/mount-reactive-panel!`
+  hands to `render-panel!`. Returns Reagent-shaped hiccup interoping to the
+  React component above; the enclosing `rf/frame-provider` is what puts
+  `:rf/xray` in React context for it.
+
+  PUBLIC because the standalone `mount-*!` facade in `panels.cljs` passes
+  it by name — unlike the L4-only panels, whose bridge can stay private."
   []
-  (view/reactive-panel dispatch))
+  [:> Panel-component {}])
 
 (defn install!
   "Idempotent install for the Reactive panel's Xray-side
@@ -84,5 +140,9 @@
      :mnem  "v"
      :modes #{:dynamic}
      :order 2
-     :panel Panel})
+     ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary) and the shell mounts `:panel` as a
+     ;; Reagent hiccup head; the bridge is the one line between them and
+     ;; goes when the shell is a Fresco tree.
+     :panel Panel-bridge})
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -292,8 +292,13 @@
   "Render one event-bundle edge. Changed → solid accent line + arrowhead
   (propagates). Unchanged → dashed dim line, NO arrowhead (cut)."
   [{:keys [from-id to-id x1 y1 x2 y2 changed? kind]} i]
-  ^{:key (str "edge-" kind "-" i)}
-  [:line (cond-> {:data-testid (str "rf-xray-reactive-edge-" (name kind))
+  ;; rf2-k97c.3 — the React key is a LITERAL `:key` in the attribute map,
+  ;; not reader metadata on the returned vector. Fresco's codec reads the
+  ;; attr-map slot only (`codec.cljs` head table: "literal `:key` in the
+  ;; attr map"), so a metadata key silently degrades to index-based
+  ;; reconciliation once this subtree renders inside a boundary.
+  [:line (cond-> {:key (str "edge-" kind "-" i)
+                  :data-testid (str "rf-xray-reactive-edge-" (name kind))
                   :data-edge-changed (str (boolean changed?))
                   :data-edge-from (str from-id)
                   :data-edge-to (str to-id)
@@ -324,7 +329,12 @@
   Clicking the node jumps to the sub's registration source."
   [{:keys [id slug label changed? shared-count coord x y w h kind]}]
   (let [click (when coord (fn [e] (open-source! coord e)))]
-    [:g (cond-> {:data-testid (str "rf-xray-reactive-node-" (name kind) "-" slug)
+    [:g (cond-> {;; rf2-k97c.3 — the sequence key rides in the attribute
+                 ;; map. `flow-graph` CALLS this fn (a plain fn in hiccup
+                 ;; head position is a loud error under Fresco), and a
+                 ;; call form discards reader metadata on return anyway.
+                 :key slug
+                 :data-testid (str "rf-xray-reactive-node-" (name kind) "-" slug)
                  :data-node-changed (str (boolean changed?))
                  :data-node-id (str id)}
           click (assoc :on-click click
@@ -376,7 +386,9 @@
                     :else        "← props")
         timing    (elapsed-label elapsed-ms)
         meta-line (->> [cause timing] (remove nil?) (string/join " · "))]
-    [:g {:data-testid (str "rf-xray-reactive-view-node-" slug)
+    [:g {;; rf2-k97c.3 — attribute-map key; see `sub-node`.
+         :key slug
+         :data-testid (str "rf-xray-reactive-view-node-" slug)
          :data-node-id (str id)
          :data-rf-xray-view-id (str id)
          :on-mouse-enter (fn [_e] (apply-highlight! id))
@@ -431,12 +443,16 @@
         (into [:g {:data-testid "rf-xray-reactive-edges"}]
               (map-indexed (fn [i e] (edge e i)) (:edges g)))
         (appdb-node (:appdb g))
+        ;; rf2-k97c.3 — `sub-node` / `view-node` are CALLED, never used as
+        ;; a hiccup head: a plain fn in head position is a loud error in a
+        ;; Fresco body and a silent extra component under Reagent. Each
+        ;; carries its own attribute-map `:key`.
         (into [:g {:data-testid "rf-xray-reactive-l1-nodes"}]
-              (map (fn [n] ^{:key (:slug n)} [sub-node n]) (-> g :nodes :l1)))
+              (map sub-node (-> g :nodes :l1)))
         (into [:g {:data-testid "rf-xray-reactive-l2-nodes"}]
-              (map (fn [n] ^{:key (:slug n)} [sub-node n]) (-> g :nodes :l2)))
+              (map sub-node (-> g :nodes :l2)))
         (into [:g {:data-testid "rf-xray-reactive-view-nodes"}]
-              (map (fn [n] ^{:key (:slug n)} [view-node n]) (-> g :nodes :view)))]])))
+              (map view-node (-> g :nodes :view)))]])))
 
 ;; ---- hoisted row-level styles (rf2-gjiog · audit F9) -------------------
 ;;
@@ -492,8 +508,13 @@
 (defn- list-row
   "One teardown-list row: a small tinted swatch + identifier + a muted
   trailing tag, matching the Figma `divide-y` list rows."
-  [{:keys [testid swatch-token primary tag]}]
-  [:div {:data-testid testid
+  [{:keys [testid swatch-token primary tag row-key]}]
+  [:div {;; rf2-k97c.3 — `row-key` is the caller's React key, carried in
+         ;; the attribute map because this fn is CALLED from a `for`
+         ;; rather than used as a hiccup head. nil when the caller has
+         ;; no sequence to key, which the codec treats as absent.
+         :key row-key
+         :data-testid testid
          :style list-row-style}
    [:span {:style (assoc list-row-swatch-style-base
                          :background (with-alpha swatch-token 20))}]
@@ -513,12 +534,12 @@
              (for [{:keys [view-id]} rows
                    :let [meta (when view-id (rf/handler-meta {:source :store :kind :view :id view-id}))
                          nm   (view-display-name view-id meta)]]
-               ^{:key (str view-id)}
-               [list-row {:testid (str "rf-xray-reactive-unmounted-row-"
+               (list-row {:row-key (str view-id)
+                          :testid (str "rf-xray-reactive-unmounted-row-"
                                        (id-slug view-id))
                           :swatch-token :error
                           :primary nm
-                          :tag "unmounted"}]))
+                          :tag "unmounted"})))
        [:div {:data-testid "rf-xray-reactive-unmounted-empty"
               :style empty-placeholder-style}
         "(no views unmounted)"])]))
@@ -533,12 +554,12 @@
        (into [:div {:data-testid "rf-xray-reactive-destroyed-list"
                     :style list-card-style}]
              (for [{:keys [sub-id]} rows]
-               ^{:key (str sub-id)}
-               [list-row {:testid (str "rf-xray-reactive-destroyed-row-"
+               (list-row {:row-key (str sub-id)
+                          :testid (str "rf-xray-reactive-destroyed-row-"
                                        (id-slug sub-id))
                           :swatch-token :dim
                           :primary (format-id sub-id)
-                          :tag "no readers remaining"}]))
+                          :tag "no readers remaining"})))
        [:div {:data-testid "rf-xray-reactive-destroyed-empty"
               :style empty-placeholder-style}
         "(no subscriptions destroyed)"])
@@ -631,8 +652,8 @@
                       :style       list-card-style}]
                (for [{:keys [query-v] :as row} rows
                      :let [ident (unchanged-row-identity row)]]
-                 ^{:key (str ident)}
-                 [:div {:data-testid (str "rf-xray-reactive-unchanged-row-"
+                 [:div {:key (str ident)
+                        :data-testid (str "rf-xray-reactive-unchanged-row-"
                                           (concrete-query-selector ident))
                         :data-query-v (str query-v)
                         :style       unchanged-row-style}
@@ -699,42 +720,50 @@
 ;; ---- panel root --------------------------------------------------------
 
 (defn reactive-panel
-  "Plain Reagent fn — invoked from `reactive-panel/Panel` (the public
-  facade reg-view) via a function call so the React-context frame tier
-  resolves to `:rf/xray` inside the leaf's subscribes.
+  "The panel's hiccup projection — a PURE FUNCTION of the dispatcher and
+  the `:rf.xray/reactive-data` VALUE. No read of its own.
 
   Renders the left → right REACTIVE FLOW graph (rf2-ad7zx.6) followed by
   the UNMOUNTED VIEWS + DESTROYED SUBSCRIPTIONS sections and the closing
   legend.
 
-  `dispatch` (rf2-16y3x) is the frame-aware dispatcher the facade `Panel`
-  reg-view injects and threads down — the panel-local unchanged-subs
-  disclosure toggle's deferred `:on-click` calls it (never a bare global
-  `rf/dispatch`) so the click lands on the surrounding instance frame after
-  render scope unwinds. The 0-arity is a test convenience (plain-fn mounts
-  that never click the toggle); production always threads a real dispatcher."
-  ([] (reactive-panel nil))
-  ([dispatch]
-   (let [data @(rf/subscribe [:rf.xray/reactive-data])]
-    [:section {:data-testid "rf-xray-reactive"
-               :style {:height "100%"
-                       :display "flex"
-                       :flex-direction "column"
-                       :background (:bg-2 tokens)
-                       :color (:text-primary tokens)
-                       :font-family sans-stack
-                       :font-size "14px"}}
-     [:div {:style {:flex 1 :overflow "auto"}}
-      (if (not (:has-event-bundle? data))
-        [:div {:data-testid "rf-xray-reactive-pipeline-empty"
-               :style {:padding "16px"}}
-         (empty-state data)]
-        [:div {:data-testid "rf-xray-reactive-pipeline"
-               :style {:padding "16px"}}
-         [:section {:data-testid "rf-xray-reactive-flow-section"}
-          (section-label "flow" "Reactive Flow" {:title-case? true})
-          (flow-graph data)]
-         (unchanged-subs-section dispatch data)
-         (unmounted-views-section data)
-         (destroyed-subs-section data)
-         (legend)])]])))
+  rf2-k97c.3 — the read moved UP into `reactive-panel/Panel`, which is now
+  an `rf.fresco/defview` boundary reading `:rf.xray/reactive-data` with
+  `rf.fresco/sub`. Two things forced the split and neither is stylistic.
+  A boundary's body may only run inside a React render window, so `(Panel)`
+  is no longer a callable that answers hiccup; and `intent/with-frame` —
+  which the collector wraps every body in — binds core's REFUSAL tier, so
+  an ambient `@(rf/subscribe …)` left down here would not resolve
+  elsewhere, it would refuse. This is `defview`'s own documented
+  extract-a-helper spelling, and it keeps every hiccup-walking unit row
+  drivable: the row supplies the value the boundary would have read.
+
+  `dispatch` (rf2-16y3x) is the frame-aware dispatcher — `(:dispatch
+  (rf/capture-frame))` inside the boundary — threaded down so the
+  panel-local unchanged-subs disclosure toggle's deferred `:on-click`
+  lands on the surrounding instance frame after render scope unwinds,
+  never on a bare global `rf/dispatch` that would leak to `:rf/default`.
+  nil is legal for a mount that never clicks the toggle."
+  [dispatch data]
+  [:section {:data-testid "rf-xray-reactive"
+             :style {:height "100%"
+                     :display "flex"
+                     :flex-direction "column"
+                     :background (:bg-2 tokens)
+                     :color (:text-primary tokens)
+                     :font-family sans-stack
+                     :font-size "14px"}}
+   [:div {:style {:flex 1 :overflow "auto"}}
+    (if (not (:has-event-bundle? data))
+      [:div {:data-testid "rf-xray-reactive-pipeline-empty"
+             :style {:padding "16px"}}
+       (empty-state data)]
+      [:div {:data-testid "rf-xray-reactive-pipeline"
+             :style {:padding "16px"}}
+       [:section {:data-testid "rf-xray-reactive-flow-section"}
+        (section-label "flow" "Reactive Flow" {:title-case? true})
+        (flow-graph data)]
+       (unchanged-subs-section dispatch data)
+       (unmounted-views-section data)
+       (destroyed-subs-section data)
+       (legend)])]])

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -52,8 +52,7 @@
             [day8.re-frame2-xray.egress :as egress]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.panels.app-db-diff :as app-db-diff]
-            [day8.re-frame2-xray.panels.app-db-diff-state :as state]))
+            [day8.re-frame2-xray.panels.app-db-diff :as app-db-diff]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
@@ -63,6 +62,26 @@
   ;; which already includes the trace-collector ring reset the old init
   ;; called a SECOND, redundant time.
   (xray-test-support/make-xray-runtime-fixture))
+
+;; ---- the panel under test ------------------------------------------------
+
+(defn- panel-tree
+  "The app-db panel's hiccup, driven the way the rows below need it.
+
+  rf2-k97c.3 — `app-db-diff/Panel` is now an `rf.fresco/defview` boundary,
+  a real React function component whose body may only run inside a React
+  render window, so it is no longer callable. This helper REPRODUCES THE
+  BOUNDARY EXACTLY — the same two reads, in the same order, with the same
+  query vectors, and the same keyed-fragment wrapper around
+  `state-body` — so every row keeps asserting on the hiccup it did before.
+
+  Only the READS are reproduced here; the MARKUP stays in the panel, as
+  `app-db-diff/panel-tree`, so these rows still fail when the panel's own
+  shape drifts."
+  []
+  (app-db-diff/panel-tree
+    @(rf/subscribe [:rf.xray/app-db-state])
+    (:epoch-id @(rf/subscribe [:rf.xray/app-db-current+diff]))))
 
 ;; ---- fixture data --------------------------------------------------------
 
@@ -141,46 +160,26 @@
 
 ;; ---- hiccup walker (mirrors event_detail_cljs_test.cljs) ----------------
 
-(defn- structural-component?
-  "True when `node` is one of the App-DB Panel's OWN pure-hiccup
-  structural fn-components — currently just `state/state-body`, the
-  per-epoch keyed body wrapper the Panel mounts (rf2-yng0y). These
-  realize to plain section `:div`s carrying the `data-testid` hooks the
-  assertions below pin. Leaf widgets like the `edn-inspector` (which
-  produce render-context-bound wrapper fns that are not ISeqable) are
-  deliberately NOT structural — they stay un-expanded so the walker
-  treats them as leaves, exactly as the pre-rf2-yng0y shallow walker
-  did when `state-body` was called inline."
-  [node]
-  (and (vector? node) (= state/state-body (first node))))
-
-(defn- expand-fn-component [node]
-  (if (and (vector? node) (fn? (first node)))
-    (apply (first node) (rest node))
-    node))
-
 (defn- hiccup-seq
-  "Walk a (possibly component-wrapped) hiccup tree, expanding the
-  Panel's own structural fn-components (see `structural-component?`) AS
-  the walk descends so their nested section testids are realized.
+  "Walk the panel's hiccup tree. Plain descent — nothing is CALLED.
 
-  rf2-yng0y — the App-DB Panel now wraps its body as a KEYED component
-  `^{:key epoch-id} [state/state-body model]` (to force a clean per-epoch
-  React remount). The pre-rf2-yng0y walker expanded one component deep at
-  each leaf, which sufficed when `state-body` was called inline; the new
-  wrapper hides the section testids one level down. Expanding the
-  structural wrapper during descent restores full visibility while
-  leaving the leaf widgets (edn-inspector) un-expanded, as before."
+  rf2-yng0y wrapped the body as a keyed COMPONENT
+  `^{:key epoch-id} [app-db-diff-state/state-body model]`, which hid the section
+  testids one level down, so this walker used to expand structural
+  fn-components as it descended.
+
+  rf2-k97c.3 removed the need and, more importantly, made the expansion
+  UNSAFE. `state-body` is now CALLED by the panel (a plain fn in hiccup
+  head position is a loud error under Fresco), so its sections are already
+  realized in the tree and the pre-rf2-yng0y shallow walk suffices again.
+  And the one remaining fn-headed vector is `[ei/edn-inspector-view …]`,
+  a FRESCO BOUNDARY — a React function component whose body may only run
+  inside a React render window. Applying it here would run `rf.fresco/sub`
+  outside the collector, which is not a leaf-expansion at all. So the
+  widget stays a leaf, which is what the old walker's `structural?` test
+  was reaching for in the first place."
   [tree]
-  (let [descend (fn [node]
-                  (seq (if (structural-component? node)
-                         (expand-fn-component node)
-                         node)))
-        seed    (if (structural-component? tree)
-                  (expand-fn-component tree)
-                  tree)]
-    (->> (tree-seq (some-fn vector? seq?) descend seed)
-         (map expand-fn-component))))
+  (tree-seq (some-fn vector? seq?) seq tree))
 
 (defn- find-by-testid [tree testid]
   (some (fn [node]
@@ -534,7 +533,7 @@
     (registry/register-xray-handlers!)
     (rf/make-frame {:id :rf/xray})
     (rf/with-frame :rf/xray
-      (let [tree (app-db-diff/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-app-db-diff"))
             "panel root present")
         (is (some? (find-by-testid tree "rf-xray-app-db-state"))
@@ -564,7 +563,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default]))
     (rf/with-frame :rf/xray
-      (let [tree (app-db-diff/Panel)]
+      (let [tree (panel-tree)]
         ;; machines fan out one section per id (title = machine id).
         (is (some? (find-by-testid
                      tree "rf-xray-app-db-state-instance-:rf/machines-:auth"))
@@ -590,7 +589,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default]))
     (rf/with-frame :rf/xray
-      (let [tree (app-db-diff/Panel)]
+      (let [tree (panel-tree)]
         (doseq [area [:rf/machines :rf/spawned :rf/route
                       :rf/pending-navigation :rf/elision]]
           (is (nil? (find-by-testid
@@ -649,7 +648,7 @@
     (rf/replace-frame-state! :checkout-frame {:rf.db/app {:checkout {:step :payment}}})
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-frame :checkout-frame])
-      (let [tree (app-db-diff/Panel)
+      (let [tree (panel-tree)
             top  (find-by-testid tree "rf-xray-app-db-state-top")]
         (is (some? top) "TOP section present")
         (is (= :checkout-frame @(rf/subscribe [:rf.xray/observed-frame]))

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -304,18 +304,28 @@
 ;; threaded through when the pre-image differs, omitted when not.
 
 (defn- find-edn-inspector-mounts
-  "Walk the hiccup tree and collect every `[ei/edn-inspector value opts]`
-  mount. Returns a vec of `{:value :opts}` maps so tests can assert
-  against the threaded opts (in particular `:before`)."
+  "Walk the hiccup tree and collect every edn-inspector-widget mount.
+  Returns a vec of `{:value :opts}` maps so tests can assert against the
+  threaded opts (in particular `:before`).
+
+  rf2-k97c.3 — the mount is now `[ei/edn-inspector-view {:mount-id …
+  :value … :opts …}]`, the widget's FRESCO head, where it used to be
+  `[ei/edn-inspector value opts]`, its Reagent one. Both render the same
+  body over the same opts; the head takes ONE props map, as every
+  `defview` boundary does, so the value and opts are read out of it
+  rather than off positions 1 and 2. The head is still detected by being
+  a function — a Fresco boundary is a real React function component —
+  and is never CALLED here: its body may only run inside a React render
+  window."
   [tree]
   (let [out (atom [])]
     (letfn [(walk [n]
               (cond
                 (vector? n)
-                (do (when (and (fn? (first n)))
-                      (let [a (when (>= (count n) 2) (nth n 1))
-                            b (when (>= (count n) 3) (nth n 2))]
-                        (swap! out conj {:value a :opts b})))
+                (do (when (fn? (first n))
+                      (let [props (when (>= (count n) 2) (nth n 1))]
+                        (swap! out conj {:value (:value props)
+                                         :opts  (:opts props)})))
                     (doseq [c (rest n)] (walk c)))
                 (seq? n) (doseq [c n] (walk c))))]
       (walk tree))

--- a/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_view_cljs_test.cljs
@@ -1,0 +1,259 @@
+(ns day8.re-frame2-xray.panels.derivation-graph-view-cljs-test
+  "View rows for the Derivation-Graph panel (EP-0014 prop-3), added under
+  rf2-k97c.3 when the panel became a Fresco boundary.
+
+  ## Why this file did not exist before, and why it does now
+
+  The panel had NO view coverage at all — `derivation_graph_consumer_cljs_test`
+  exercises the sub graph and `derivation_graph_helpers_cljs_test` the pure
+  projection algebra, but nothing walked the rendered markup. That gap is
+  exactly why the panel accumulated FIVE React keys written as `^{:key …}`
+  reader metadata on CALL FORMS, where the metadata is discarded on return
+  and no key ever reaches React. The same defect `rf2-ppzid` records and
+  #9578 found in `routing.cljs`'s route table; the mayor's 2026-09-10 ruling
+  made sweeping it part of every remaining panel dispatch.
+
+  A LOST KEY DOES NOT FAIL, IT DEGRADES — into index-based reconciliation,
+  which paints identically and corrupts identity only once a list changes
+  shape. So it is invisible to any row that only asks what the markup looks
+  like. `every-sequence-row-carries-a-react-key` below asks the one question
+  that sees it.
+
+  ## What drives the markup
+
+  `panel-tree` — the pure projection `Panel` calls. `Panel` itself is an
+  `rf.fresco/defview` boundary, a real React function component whose body
+  may only run inside a React render window, so it is not callable here.
+  The value handed to `panel-tree` is built by the SAME expression the
+  panel's own `:rf.xray/derivation-graph-tab-data` sub uses, so a drift in
+  that projection surfaces here rather than being papered over by a
+  hand-written fixture of the composite's output."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.panels.derivation-graph :as derivation-graph]
+            [day8.re-frame2-xray.panels.derivation-graph-helpers :as h]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
+
+;; ---- fixture -------------------------------------------------------------
+
+(def ^:private fixture-graph
+  "A small graph carrying at least TWO nodes in one family, TWO edges, and a
+  node with TWO value summaries — two of each, because a one-element
+  sequence cannot distinguish a real key from a missing one."
+  {:mode  :static
+   :nodes {[:sub :cart/total] {:kind      :derivation
+                               :rf/family :subs
+                               :storage   :memo
+                               :summaries {:last-value {:type :map :size 2 :preview "{…}"}
+                                           :inputs     {:type :vector :size 1 :preview "[…]"}}}
+           [:sub :cart/state] {:kind :derivation :rf/family :subs}
+           [:machine :auth]   {:kind :process :rf/family :machines}}
+   :edges [{:from [:sub :cart/state] :to [:sub :cart/total] :role :input}
+           {:from [:machine :auth]   :to [:sub :cart/state] :role :selector}]})
+
+(defn- tab-data
+  "The `:rf.xray/derivation-graph-tab-data` projection, spelled exactly as
+  `derivation-graph/install!` spells it."
+  [graph]
+  (let [summarized (h/summarize-graph graph)]
+    {:mode      (:mode graph)
+     :silent?   (h/empty-graph? graph)
+     :summary   (h/graph-summary graph)
+     :by-family (h/group-by-family summarized)
+     :edges     (:edges graph)}))
+
+(defn- render
+  ([]           (render (tab-data fixture-graph)))
+  ([data]       (render data (fn [_ev] nil)))
+  ([data disp]  (derivation-graph/panel-tree disp data)))
+
+;; ---- hiccup walking ------------------------------------------------------
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- props-of [node]
+  (let [p (second node)] (if (map? p) p {})))
+
+(defn- nodes-with-testid-prefix [tree prefix]
+  (filter #(and (vector? %)
+                (some-> (:data-testid (props-of %)) (.startsWith prefix)))
+          (hiccup-seq tree)))
+
+;; A testid PREFIX is not a row selector: `rf-xray-derivation-graph-node-`
+;; also matches each row's `-superkind` / `-id` / `-refinement` spans, and
+;; `-mode-` also matches the toggle container and the mode badge. Each row
+;; kind therefore selects on the attribute that only the row itself carries.
+
+(defn- node-rows [tree]
+  (filter #(contains? (props-of %) :data-superkind)
+          (nodes-with-testid-prefix tree "rf-xray-derivation-graph-node-")))
+
+(defn- edge-rows [tree]
+  (filter #(contains? (props-of %) :data-role)
+          (nodes-with-testid-prefix tree "rf-xray-derivation-graph-edge-")))
+
+(defn- mode-buttons [tree]
+  (filter #(= :button (first %))
+          (nodes-with-testid-prefix tree "rf-xray-derivation-graph-mode-")))
+
+(defn- keyed-fragments
+  "Fragments carrying a props map. The OUTER `(into [:<>] …)` wrapper has
+  none and needs none — it is not an element of a sequence."
+  [tree]
+  (filter #(and (vector? %) (= :<> (first %)) (map? (second %)))
+          (hiccup-seq tree)))
+
+(defn- keys-of [nodes]
+  (mapv #(:key (props-of %)) nodes))
+
+;; ---- (1) the markup renders ----------------------------------------------
+
+(deftest panel-tree-renders-header-families-and-edges
+  (testing "the projection renders the header count strip, one section per
+            populated family, and the edges section"
+    (let [tree (render)]
+      (is (seq (nodes-with-testid-prefix tree "rf-xray-derivation-graph-header"))
+          "header section renders")
+      (is (seq (nodes-with-testid-prefix tree "rf-xray-derivation-graph-counts"))
+          "count strip renders")
+      (is (seq (nodes-with-testid-prefix tree "rf-xray-derivation-graph-family-subs"))
+          "the subs family section renders")
+      (is (seq (nodes-with-testid-prefix tree "rf-xray-derivation-graph-family-machines"))
+          "the machines family section renders")
+      (is (seq (nodes-with-testid-prefix tree "rf-xray-derivation-graph-edges"))
+          "the edges section renders")
+      (is (empty? (nodes-with-testid-prefix tree "rf-xray-derivation-graph-silent"))
+          "a populated graph does not render the silent state"))))
+
+(deftest empty-graph-renders-the-silent-state
+  (testing "a graph with no nodes renders the silent state and no family
+            sections — the honest no-registrations story"
+    (let [tree (render (tab-data {:mode :static :nodes {} :edges []}))]
+      (is (seq (nodes-with-testid-prefix tree "rf-xray-derivation-graph-silent"))
+          "silent state renders")
+      (is (empty? (nodes-with-testid-prefix tree "rf-xray-derivation-graph-family-"))
+          "no family section renders"))))
+
+;; ---- (2) THE KEY ROW -----------------------------------------------------
+;;
+;; This is the row the ns docstring exists for. Read `keys-of` as "what
+;; React actually receives": Fresco's codec head table says the literal
+;; `:key` in the ATTRIBUTE MAP is the one spelling that reaches React, so a
+;; key written as reader metadata — on a vector literal, and far worse on a
+;; CALL FORM, where it is discarded outright — is simply absent here.
+
+(deftest every-sequence-row-carries-a-react-key
+  (testing "rf2-k97c.3 — every row the panel emits from a sequence carries a
+            LITERAL `:key` in its attribute map, distinct within its list.
+
+            Before this bead five of these keys were `^{:key …}` reader
+            metadata on CALL FORMS (`(node-row …)`, `(edge-row …)`,
+            `(family-section …)`, `(edges-section …)` and a `when-let` in
+            the role strip). Metadata on a source list is discarded when the
+            form returns a fresh vector, so none of them reached React at
+            all — silently, with the panel painting correctly throughout."
+    (let [tree      (render)
+          node-rows (node-rows tree)
+          edge-rows (edge-rows tree)
+          buttons   (mode-buttons tree)
+          frags     (keyed-fragments tree)]
+
+      ;; Preconditions — a vacuous pass is the failure mode here, so the
+      ;; counts are asserted before the keys are.
+      (is (= 3 (count node-rows)) "the fixture's three nodes each render a row")
+      (is (= 2 (count edge-rows)) "the fixture's two edges each render a row")
+      (is (= 2 (count buttons))   "both mode buttons render")
+      (is (<= 3 (count frags))    "two family fragments plus the edges fragment")
+
+      (is (every? some? (keys-of node-rows))
+          "every node row carries an attribute-map :key")
+      (is (= (count node-rows) (count (distinct (keys-of node-rows))))
+          "node-row keys are distinct")
+
+      (is (every? some? (keys-of edge-rows))
+          "every edge row carries an attribute-map :key")
+      (is (= (count edge-rows) (count (distinct (keys-of edge-rows))))
+          "edge-row keys are distinct — the two fixture edges differ only in
+           their endpoints and role, which is what the key is built from")
+
+      (is (every? some? (keys-of buttons))
+          "every mode-toggle button carries an attribute-map :key")
+
+      (is (every? some? (keys-of frags))
+          "every keyed fragment carries an attribute-map :key"))))
+
+(deftest role-chips-and-value-summaries-carry-react-keys
+  (testing "rf2-k97c.3 — the two remaining sequence positions. The role
+            chip strip's key was metadata on a `when-let` form and so was
+            discarded; the summary chip's was metadata on a vector literal,
+            which Reagent reads and Fresco's codec does not."
+    (let [tree     (render)
+          counts   (first (nodes-with-testid-prefix tree "rf-xray-derivation-graph-counts"))
+          chips    (->> (hiccup-seq counts)
+                        (filter #(and (vector? %) (= :span (first %))
+                                      (some? (:key (props-of %))))))
+          summaries (->> (hiccup-seq tree)
+                         (filter #(and (vector? %) (= :span (first %))
+                                       (contains? (props-of %) :key)
+                                       (= "inline-flex" (:display (:style (props-of %)))))))]
+      (is (some? counts) "the count strip renders")
+      ;; The fixture's two edges carry roles :input and :selector, so two
+      ;; role chips must render, each keyed.
+      (is (= 2 (count chips))
+          "both role chips render and both carry an attribute-map :key")
+      (is (= 2 (count summaries))
+          "both of the fixture node's value summaries render keyed"))))
+
+;; ---- (3) the dispatcher contract ----------------------------------------
+
+(deftest mode-toggle-dispatches-through-the-supplied-dispatcher
+  (testing "rf2-k97c.3 — the mode toggle calls the dispatcher THREADED IN,
+            never a bare global `rf/dispatch`.
+
+            `Panel` takes that dispatcher from `(:dispatch (rf/capture-frame))`
+            now that it is a Fresco boundary and `defview` binds no
+            `reg-view`-injected name inside a body. The property this row
+            pins is the one rf2-1w07r cared about and is unchanged by the
+            migration: the deferred click lands on the frame the panel
+            rendered under, not on whatever ambient frame survives after
+            render scope unwinds."
+    (let [seen (atom [])
+          tree (render (tab-data fixture-graph) #(swap! seen conj %))
+          live (first (nodes-with-testid-prefix tree "rf-xray-derivation-graph-mode-live"))
+          on-click (:on-click (props-of live))]
+      (is (some? live) "the :live mode button renders")
+      (is (fn? on-click) "it carries an :on-click handler")
+      (on-click nil)
+      (is (= [[:rf.xray/set-derivation-graph-mode :live]] @seen)
+          "the handler called the supplied dispatcher with the mode event"))))
+
+;; ---- (4) the boundary / bridge contract ---------------------------------
+
+(deftest l4-tab-registers-the-bridge-not-the-boundary
+  (testing "rf2-k97c.3 — `install!` registers the `as-component` BRIDGE, not
+            `Panel` itself.
+
+            `reg-l4-tab!`'s `:pre` requires `:panel` to be CALLABLE and the
+            shell mounts it as a Reagent hiccup head; a Fresco boundary is a
+            React component and `defview`'s contract forbids mounting one
+            that way. The bridge is scaffolding with a defined end — it is
+            deleted in step 3, when the shell is itself a Fresco tree and
+            `reg-l4-tab!` takes `Panel` directly."
+    (derivation-graph/install!)
+    (let [tab   (panel-registry/tab-by-id :dynamic :derivation-graph)
+          panel (:panel tab)]
+      (is (some? tab) "the Graph tab is registered")
+      (is (fn? panel) "its :panel is callable, as reg-l4-tab! requires")
+      (is (not= derivation-graph/Panel panel)
+          "and it is NOT the boundary itself")
+      (let [mounted (panel)]
+        (is (vector? mounted) "the bridge answers hiccup")
+        (is (= :> (first mounted))
+            "an interop mount — Fresco's outward `as-component` door, which
+             takes the frame from the React context the enclosing
+             `rf/frame-provider` already wrote")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_view_cljs_test.cljs
@@ -9,9 +9,17 @@
   projection algebra, but nothing walked the rendered markup. That gap is
   exactly why the panel accumulated FIVE React keys written as `^{:key …}`
   reader metadata on CALL FORMS, where the metadata is discarded on return
-  and no key ever reaches React. The same defect `rf2-ppzid` records and
-  #9578 found in `routing.cljs`'s route table; the mayor's 2026-09-10 ruling
-  made sweeping it part of every remaining panel dispatch.
+  and no key ever reaches React. The same defect #9578 found in
+  `routing.cljs`'s route table; the mayor's 2026-09-10 ruling made sweeping
+  it part of every remaining panel dispatch.
+
+  (Several comments in this tree cite `rf2-ppzid` as the record for this
+  defect. Checked at source: that id resolves to NO issue in the live
+  ledger — an identity-field scan of the export finds 0 records that ARE it
+  against 3 that merely MENTION it, and `bd show` refuses it. The #9578
+  merged-PR audit reached the same conclusion independently. So the
+  checkable citations are #9578 and rf2-vw80; the dead id is left where it
+  already sits in seven unrelated files rather than swept from them here.)
 
   A LOST KEY DOES NOT FAIL, IT DEGRADES — into index-based reconciliation,
   which paints identically and corrupts identity only once a list changes

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs
@@ -3,11 +3,22 @@
   disclosure controls (rf2-16y3x).
 
   Sibling in shape to `settings/popup_dispatch_routing_cljs_test.cljs`:
-  it mounts the REAL facade `reg-view` (not the plain `reactive-panel`
-  fn), plucks a deferred `:on-click` off the rendered hiccup, and invokes
-  it OUTSIDE any `with-frame` binding — reproducing the browser reality
-  that a React click fires AFTER render commits and the ambient frame
-  scope has unwound.
+  it plucks a deferred `:on-click` off the rendered hiccup and invokes it
+  OUTSIDE any `with-frame` binding — reproducing the browser reality that
+  a React click fires AFTER render commits and the ambient frame scope has
+  unwound.
+
+  rf2-k97c.3 — the facade's `Panel` is now an `rf.fresco/defview` BOUNDARY,
+  a real React function component whose body may only run inside a React
+  render window, so `reactive-panel/Panel` is no longer callable from the node
+  lane. `render-panel` below REPRODUCES THE BOUNDARY EXACTLY instead — the
+  same `(:dispatch (rf/capture-frame))` dispatcher and the same one
+  `:rf.xray/reactive-data` read, both under the same `with-frame` — and
+  hands them to the pure projection. The subject of these rows is
+  unchanged and is if anything sharper: the dispatcher whose frame-binding
+  they defend is now `capture-frame`'s rather than `reg-view`'s injected
+  name, and `capture-frame` is precisely the door documented for a
+  dispatch that fires long after the render extent has unwound.
 
   ## The two bugs these mounted tests defend against
 
@@ -17,9 +28,11 @@
      resolution falls through to `:rf/default` (or emits
      `:rf.error/no-frame-context`), so the click never flipped Xray's
      `:reactive/show-unchanged?` and the disclosure stayed collapsed.
-     The fix threads the facade `reg-view`-injected frame-aware
-     `dispatch` down through `reactive-panel` → `unchanged-subs-section`,
-     so the deferred click lands on the surrounding instance frame.
+     The fix threads a frame-aware `dispatch` down through
+     `reactive-panel` → `unchanged-subs-section`, so the deferred click
+     lands on the surrounding instance frame. Since rf2-k97c.3 that
+     dispatcher is `(:dispatch (rf/capture-frame))`, taken inside the
+     boundary, rather than the name `reg-view` used to inject.
 
   2. **Settings pin had no UI.** The `:general :show-unchanged-subs?`
      pin (spec/021 §3.4) lost its control on 2026-05-27 while the slot
@@ -27,14 +40,14 @@
 
   The earlier registry tests dispatched inside a manually-bound
   `:rf/xray` frame, which MASKED the click failure (they proved plumbing,
-  not the deferred-click path). These tests render the actual `Panel` and
-  fire its real deferred handler frameless, so the leak reproduces."
+  not the deferred-click path). These tests drive the real boundary's own dispatcher and read, then
+  fire the real deferred handler frameless, so the leak reproduces."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
             [re-frame.test-helpers :as rf.test-helpers]
             [re-frame.test-support :as rf.test-support]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.panels.reactive-panel :as facade]
+            [day8.re-frame2-xray.panels.reactive-panel-view :as view]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; A test-only event that writes the `:epoch-history` db slot the REAL
@@ -86,8 +99,15 @@
        [{:epoch-id     :ep-1
          :trace-events [(skip-ev :user/name) (skip-ev :cart/total)]}]])))
 
-(defn- render-panel [frame-id]
-  (rf/with-frame frame-id (facade/Panel)))
+(defn- render-panel
+  "The boundary `reactive-panel/Panel` reproduced for the node lane — same
+  dispatcher door, same single read, same frame — handed to the pure
+  projection. See the ns docstring's rf2-k97c.3 paragraph for why this is
+  not `reactive-panel/Panel` any more."
+  [frame-id]
+  (rf/with-frame frame-id
+    (view/reactive-panel (:dispatch (rf/capture-frame))
+                         @(rf/subscribe [:rf.xray/reactive-data]))))
 
 (defn- toggle-on-click [tree]
   (:on-click (second (rf.test-helpers/find-by-testid tree "rf-xray-reactive-unchanged-toggle"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
@@ -36,6 +36,21 @@
   (mapv #(:data-testid (rf.test-helpers/attrs %))
         (rf.test-helpers/find-by-testid-prefix tree "rf-xray-reactive-unchanged-row-")))
 
+(defn- panel-tree
+  "The hiccup these rows walk, driven through the pure projection.
+
+  rf2-k97c.3 — `facade/Panel` is now an `rf.fresco/defview` boundary, a
+  real React function component whose body may only run inside a React
+  render window, so it is no longer callable and neither is the old
+  0-arity `view/reactive-panel`. This helper REPRODUCES THE BOUNDARY'S
+  READ EXACTLY — the one `:rf.xray/reactive-data` query the boundary
+  issues — and hands the value to the projection, so every row below
+  asserts on the same hiccup it asserted on before. The dispatcher is nil:
+  no row here clicks the disclosure toggle (that is
+  `reactive_panel_disclosure_dispatch_routing_cljs_test`'s subject)."
+  []
+  (view/reactive-panel nil @(rf/subscribe [:rf.xray/reactive-data])))
+
 (use-fixtures :each
   (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
 
@@ -43,7 +58,7 @@
   (testing "the panel root surfaces `rf-xray-reactive` data-testid"
     (facade/install!)
     (rf/make-frame {:id :rf/xray})
-    (let [tree (view/reactive-panel)]
+    (let [tree (panel-tree)]
       (is (has-testid? tree "rf-xray-reactive")
           "the root :section data-testid is present"))))
 
@@ -51,7 +66,7 @@
   (testing "Empty-state copy renders when no cascade is focused"
     (facade/install!)
     (rf/make-frame {:id :rf/xray})
-    (let [tree (view/reactive-panel)]
+    (let [tree (panel-tree)]
       (is (has-testid? tree "rf-xray-reactive-empty")
           "empty-state surfaces when no cascade exists"))))
 
@@ -60,7 +75,7 @@
             tab strip is the panel-name source-of-truth."
     (facade/install!)
     (rf/make-frame {:id :rf/xray})
-    (let [tree (view/reactive-panel)
+    (let [tree (panel-tree)
           icon (rf.test-helpers/find-by-testid tree "rf-xray-reactive-panel-icon")]
       (is (nil? icon) "panel-icon span is gone (lived in the deleted h1)"))))
 
@@ -97,7 +112,7 @@
        :view-rows [{:view-id :cart/Summary :action :rerender
                     :reason {:kind :reactive :subs [:cart/total]}
                     :triggered-by :cart/total :elapsed-ms 1.5}]})
-    (let [tree (view/reactive-panel)]
+    (let [tree (panel-tree)]
       (is (has-testid? tree "rf-xray-reactive-flow-svg") "the SVG canvas renders")
       (is (has-testid? tree "rf-xray-reactive-appdb-node") "app-db source node renders")
       (is (has-testid? tree "rf-xray-reactive-node-l1-_cart_state") "Level-1 node renders")
@@ -115,7 +130,7 @@
     (seed-reactive-data!
       {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-1-subs [] :level-2-subs [] :view-rows []})
-    (let [tree (view/reactive-panel)]
+    (let [tree (panel-tree)]
       (is (= "Reactive Flow" (text-of tree "rf-xray-reactive-section-flow-label"))
           "graph section heading is `Reactive Flow`"))))
 
@@ -130,7 +145,7 @@
       {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
        :unmounted-views [] :destroyed-subs []})
-    (let [tree (view/reactive-panel)
+    (let [tree (panel-tree)
           flow (rf.test-helpers/find-by-testid tree "rf-xray-reactive-section-flow-label")
           unmnt (rf.test-helpers/find-by-testid tree
                                    "rf-xray-reactive-section-unmounted-label")]
@@ -154,7 +169,7 @@
        :counts {}
        :level-1-subs [{:sub-id :cart/state :changed? true}]
        :level-2-subs [] :view-rows []})
-    (let [tree (view/reactive-panel)
+    (let [tree (panel-tree)
           card (rf.test-helpers/find-by-testid tree "rf-xray-reactive-graph-card")
           border (get-in card [1 :style :border])]
       (is (some? card) "the graph card renders")
@@ -172,7 +187,7 @@
       {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-2-subs [] :view-rows []
        :level-1-subs [{:sub-id :cart/state :changed? true}]})
-    (let [tree (view/reactive-panel)
+    (let [tree (panel-tree)
           node (rf.test-helpers/find-by-testid tree "rf-xray-reactive-node-l1-_cart_state")]
       (is (some? node) "changed node renders")
       (is (= "true" (get-in node [1 :data-node-changed]))
@@ -189,7 +204,7 @@
       {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-2-subs [] :view-rows []
        :level-1-subs [{:sub-id :cart/title :changed? false}]})
-    (let [tree (view/reactive-panel)
+    (let [tree (panel-tree)
           node (rf.test-helpers/find-by-testid tree "rf-xray-reactive-node-l1-_cart_title")]
       (is (= "false" (get-in node [1 :data-node-changed]))
           "unchanged node tagged data-node-changed=false"))))
@@ -205,7 +220,7 @@
        :view-rows [{:view-id :cart/Summary :action :rerender
                     :reason {:kind :reactive :subs [:cart/total]}
                     :triggered-by :cart/total :elapsed-ms 2.0}]})
-    (let [tree (view/reactive-panel)
+    (let [tree (panel-tree)
           meta (text-of tree "rf-xray-reactive-view-meta-_cart_Summary")]
       (is (some? meta) "view-node meta label renders")
       (is (re-find #"rerendered" meta) "labelled (rerendered)")
@@ -224,7 +239,7 @@
        :counts {} :level-1-subs [] :level-2-subs []
        :view-rows [{:view-id :cart/Badge :action :rerender
                     :reason {:kind :structural} :elapsed-ms 0.5}]})
-    (let [tree (view/reactive-panel)
+    (let [tree (panel-tree)
           meta (text-of tree "rf-xray-reactive-view-meta-_cart_Badge")]
       (is (some? meta) "view-node meta label renders")
       (is (re-find #"rerendered" meta) "labelled (rerendered)")
@@ -242,7 +257,7 @@
        :counts {} :level-1-subs [] :level-2-subs []
        :view-rows [{:view-id :cart/Fresh :action :mount
                     :reason {:kind :structural}}]})
-    (let [tree (view/reactive-panel)
+    (let [tree (panel-tree)
           meta (text-of tree "rf-xray-reactive-view-meta-_cart_Fresh")]
       (is (re-find #"mounted" meta) "labelled (mounted)")
       (is (not (re-find #"← " meta))
@@ -260,7 +275,7 @@
                        :readers [:app/Header :app/Sidebar]}]
        :view-rows [{:view-id :app/Header :action :rerender :reason {:kind :structural}}
                    {:view-id :app/Sidebar :action :rerender :reason {:kind :structural}}]})
-    (let [tree (view/reactive-panel)]
+    (let [tree (panel-tree)]
       (is (= "×2" (text-of tree "rf-xray-reactive-shared-_app_session"))
           "shared sub carries a ×2 annotation")
       (is (has-testid? tree "rf-xray-reactive-view-node-_app_Header") "fans out to Header")
@@ -276,7 +291,7 @@
        :counts {} :level-1-subs [] :level-2-subs []
        :view-rows [{:view-id :cart/Summary :action :rerender
                     :reason {:kind :structural}}]})
-    (let [tree (view/reactive-panel)
+    (let [tree (panel-tree)
           node (rf.test-helpers/find-by-testid tree "rf-xray-reactive-view-node-_cart_Summary")]
       (is (some? node) "the view node renders")
       (is (fn? (rf.test-helpers/extract-handler node :on-mouse-enter))
@@ -292,7 +307,7 @@
     (seed-reactive-data!
       {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-1-subs [] :level-2-subs [] :view-rows []})
-    (let [tree (view/reactive-panel)]
+    (let [tree (panel-tree)]
       (is (has-testid? tree "rf-xray-reactive-graph-empty")
           "sparse cascade shows the graph empty placeholder")
       (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-reactive-flow-svg"))
@@ -309,7 +324,7 @@
       {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
        :unmounted-views [{:view-id :app/Modal} {:view-id :app/Tooltip}]})
-    (let [tree (view/reactive-panel)]
+    (let [tree (panel-tree)]
       (is (= "Unmounted Views"
              (text-of tree "rf-xray-reactive-section-unmounted-label"))
           "section heading renders")
@@ -327,7 +342,7 @@
       {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
        :unmounted-views []})
-    (let [tree (view/reactive-panel)]
+    (let [tree (panel-tree)]
       (is (has-testid? tree "rf-xray-reactive-unmounted-empty")
           "empty placeholder renders when nothing unmounted"))))
 
@@ -340,7 +355,7 @@
       {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
        :destroyed-subs [{:sub-id :app/modal-state}]})
-    (let [tree (view/reactive-panel)]
+    (let [tree (panel-tree)]
       (is (= "Destroyed Subscriptions"
              (text-of tree "rf-xray-reactive-section-destroyed-label"))
           "section heading renders")
@@ -361,7 +376,7 @@
     (seed-reactive-data!
       {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-1-subs [] :level-2-subs [] :view-rows []})
-    (let [tree (view/reactive-panel)
+    (let [tree (panel-tree)
           legend-text (text-of tree "rf-xray-reactive-legend")]
       (is (some? legend-text) "legend renders")
       (is (re-find #"changed \(propagates" legend-text) "changed swatch labelled")
@@ -387,7 +402,7 @@
                        :reason :input-value-equal :input-paths-unchanged []}
                       {:sub-id :item/derived :query-v [:item/derived 2]
                        :reason :input-value-equal :input-paths-unchanged []}]})
-    (let [tree    (view/reactive-panel)
+    (let [tree    (panel-tree)
           testids (unchanged-row-testids tree)
           id-for  (fn [stem]
                     (some #(when (str/starts-with?
@@ -427,7 +442,7 @@
                        :reason :input-value-equal :input-paths-unchanged []}
                       {:sub-id :item/derived :query-v [:item/derived :a/b]
                        :reason :input-value-equal :input-paths-unchanged []}]})
-    (let [tree    (view/reactive-panel)
+    (let [tree    (panel-tree)
           testids (unchanged-row-testids tree)]
       (is (= 2 (count testids)) "both colliding parameterizations render a row")
       (is (= 2 (count (distinct testids)))
@@ -459,7 +474,7 @@
                        :reason :input-value-equal :input-paths-unchanged []}
                       {:sub-id :item/derived :query-v [:item/derived "!!"]
                        :reason :input-value-equal :input-paths-unchanged []}]})
-    (let [tree    (view/reactive-panel)
+    (let [tree    (panel-tree)
           testids (unchanged-row-testids tree)]
       (is (= 2 (count testids)) "both hash-colliding parameterizations render a row")
       (is (= 2 (count (distinct testids)))
@@ -491,7 +506,7 @@
                        :reason :input-value-equal :input-paths-unchanged []}
                       {:sub-id :cfg/derived :query-v [:cfg/derived {:a 1 :b 3}]
                        :reason :input-value-equal :input-paths-unchanged []}]})
-    (let [tree    (view/reactive-panel)
+    (let [tree    (panel-tree)
           testids (unchanged-row-testids tree)]
       (is (= 3 (count testids)) "all three seeded rows render")
       (is (= 2 (count (distinct testids)))
@@ -531,7 +546,7 @@
                        :reason :input-value-equal :input-paths-unchanged []}
                       {:sub-id :cfg/derived :query-v [:cfg/derived {:x 1}]
                        :reason :input-value-equal :input-paths-unchanged []}]})
-    (let [tree    (view/reactive-panel)
+    (let [tree    (panel-tree)
           testids (unchanged-row-testids tree)]
       (is (= 3 (count testids)) "all three seeded rows render")
       (is (= 3 (count (distinct testids)))
@@ -567,7 +582,7 @@
                       {:sub-id  :cfg/derived
                        :query-v [:cfg/derived (assoc (->RecA 1) :b 2 :c 4)]
                        :reason :input-value-equal :input-paths-unchanged []}]})
-    (let [tree    (view/reactive-panel)
+    (let [tree    (panel-tree)
           testids (unchanged-row-testids tree)]
       (is (= 3 (count testids)) "all three seeded rows render")
       (is (= 2 (count (distinct testids)))
@@ -596,7 +611,7 @@
                       {:sub-id  :cfg/derived
                        :query-v [:cfg/derived {:k {:x 1}}]
                        :reason :input-value-equal :input-paths-unchanged []}]})
-    (let [tree    (view/reactive-panel)
+    (let [tree    (panel-tree)
           testids (unchanged-row-testids tree)]
       (is (= 3 (count testids)) "all three seeded rows render")
       (is (= 3 (count (distinct testids)))
@@ -619,7 +634,7 @@
        :show-unchanged? true
        :subs-skipped [{:sub-id :user/name :query-v [:user/name]
                        :reason :input-value-equal :input-paths-unchanged []}]})
-    (let [tree    (view/reactive-panel)
+    (let [tree    (panel-tree)
           testids (unchanged-row-testids tree)
           id      (first testids)
           row     (text-of tree id)]

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -127,10 +127,16 @@
       (is (frame-provider-wrap? (captured-tree capture) app-db-diff/Panel)))))
 
 (deftest mount-reactive-panel-wraps-in-frame-provider
+  ;; rf2-k97c.3 — the expected view is `Panel-bridge`. `Panel` is now a
+  ;; Fresco boundary (a React function component) and `render-panel!`
+  ;; builds a REAGENT tree, so the bridge is what the mount fn hands it.
+  ;; The shape this row pins — frame-provider :rf/xray wrapping the view
+  ;; — is unchanged, which is the point: the bridge takes its frame from
+  ;; the same React context the provider writes.
   (let [[capture _ render-stub] (make-render-stub)]
     (with-redefs [rf.substrate.adapter/render render-stub]
       (panels/mount-reactive-panel! :mount-point)
-      (is (frame-provider-wrap? (captured-tree capture) reactive-panel/Panel)))))
+      (is (frame-provider-wrap? (captured-tree capture) reactive-panel/Panel-bridge)))))
 
 (deftest mount-trace-wraps-in-frame-provider
   (let [[capture _ render-stub] (make-render-stub)]

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -121,10 +121,11 @@
             ":rf/xray frame is registered as a side-effect of mount")))))
 
 (deftest mount-app-db-diff-wraps-in-frame-provider
+  ;; rf2-k97c.3 — `Panel-bridge`; see `mount-reactive-panel-…` below.
   (let [[capture _ render-stub] (make-render-stub)]
     (with-redefs [rf.substrate.adapter/render render-stub]
       (panels/mount-app-db-diff! :mount-point)
-      (is (frame-provider-wrap? (captured-tree capture) app-db-diff/Panel)))))
+      (is (frame-provider-wrap? (captured-tree capture) app-db-diff/Panel-bridge)))))
 
 (deftest mount-reactive-panel-wraps-in-frame-provider
   ;; rf2-k97c.3 — the expected view is `Panel-bridge`. `Panel` is now a

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -915,8 +915,14 @@
   `:epoch` tab supersedes the retired `:event` tab post rf2-5gl5r
   (Epoch panel is the canonical 'what happened in this epoch' surface)."
   {:epoch           epoch-panel/Panel
-   :app-db          app-db-diff/Panel
-   :views           reactive-panel/Panel
+   ;; rf2-k97c.3 — the app-db and Views panels' roots are now Fresco
+   ;; boundaries (React function components); `reg-l4-tab!` stores the
+   ;; `as-component` BRIDGE, which is what `detail-panel` mounts as a
+   ;; hiccup head. The routing entry stays `Panel` because that slice
+   ;; kept the natural name ON the bridge (the divergence the mayor
+   ;; ruled on 2026-09-10; step 3 converges both onto this spelling).
+   :app-db          app-db-diff/Panel-bridge
+   :views           reactive-panel/Panel-bridge
    :trace           trace/Panel
    :machines        machine-inspector/Panel
    :routing         routing/Panel})

--- a/tools/xray/testbeds/panel_gallery/panel_views.cljs
+++ b/tools/xray/testbeds/panel_gallery/panel_views.cljs
@@ -128,7 +128,13 @@
   [_args]
   [:div {:style       card-style
          :data-testid "panel-gallery-reactive-card"}
-   [reactive-panel/Panel]])
+   ;; rf2-k97c.3 — `Panel-bridge`. This gallery cell is a Reagent tree, and
+   ;; `reactive-panel/Panel` is now a Fresco boundary (a React function
+   ;; component), which `defview`'s contract forbids mounting as a Reagent
+   ;; hiccup head. The bridge is Fresco's `as-component` door and takes the
+   ;; frame from React context, which the variant `frame-provider` above
+   ;; already wrote — so the variant isolation this ns documents is intact.
+   [reactive-panel/Panel-bridge]])
 
 (defn- trace-tab-panel
   "Embedded mount of the Trace tab body — the trace panel."

--- a/tools/xray/testbeds/panel_gallery/panel_views.cljs
+++ b/tools/xray/testbeds/panel_gallery/panel_views.cljs
@@ -109,7 +109,8 @@
   [_args]
   [:div {:style       card-style
          :data-testid "panel-gallery-app-db-card"}
-   [app-db-diff/Panel]])
+   ;; rf2-k97c.3 — `Panel-bridge`; see the Reactive cell below for why.
+   [app-db-diff/Panel-bridge]])
 
 (defn- epoch-tab-panel
   "Embedded mount of the Epoch panel — `panels.epoch.view/Panel` via the


### PR DESCRIPTION
Step 2 of the Design B migration (rf2-k97c.3), increment 5. Four panels were
briefed; **three migrated, one is a finding**.

| panel | boundary spelling | why |
|---|---|---|
| `reactive_panel.cljs` (Views) | #9581 — boundary keeps `Panel`, **public** `Panel-bridge` | nothing fenced names it; `mount-reactive-panel!` passes the bridge |
| `app_db_diff.cljs` (app-db) | #9581 — boundary keeps `Panel`, **public** `Panel-bridge` | same; `mount-app-db-diff!` passes the bridge |
| `derivation_graph.cljs` (Graph) | #9581 — boundary keeps `Panel`, **private** bridge | L4-registry surface only, no `mount-*!` facade, no name taken from outside the file — the `module_view` shape |
| `machine_canvas.cljs` | **NOT MIGRATED — see below** | its fix needs four files outside the four, and it has zero reads |

No panel needed #9578's inverted spelling. The mayor's 2026-09-10 ruling makes
#9581's the default and #9578's available only where a FENCED file mounts by
name; no fenced file names any of these three, so the default held everywhere.
`render-panel!`, `shell.cljs`, `mount.cljs`, the denylist and the
edn_inspector / edn_widget views are untouched.

## A briefed premise that does not hold: `derivation_graph` is not mounted by name

The brief has it "mounted from `shell.cljs` (mounted BY NAME — see the spelling
ruling)". Measured at my base: `shell.cljs` names `derivation-graph/Panel` only
in a **docstring** (line 98). `shell/detail-panel` is registry-driven — its
literal case-switch was removed under rf2-2moh1 — and the only other references
in the tree are `registry/install!` and `test_support/install-test-overrides!`.
So the panel is L4-only, exactly like `module_view`, and its bridge is private.
Nothing was forced.

## `machine_canvas` — the odd one, and it is a STOP, not a migration

Its public var is **`Chart`**, not `Panel`, and it has no `mount-*!` facade and
no L4 tab. It is a **shared widget**, not a panel. Four source files mount it
BY NAME as a Reagent hiccup head:

  * `panels/machines/topology_view.cljs:281`
  * `panels/machine_inspector.cljs:399`
  * `static/machines/sim.cljs:715`
  * `static/machines/topology.cljs:115`

plus five test files that pin `(= machine-canvas/Chart (first node))` on the
hiccup, i.e. VAR IDENTITY, not markup.

Two independent reasons not to migrate it inside this slice's fence:

1. **Its own body mounts two things a Fresco body cannot take.**
   `[mv-chart/MachineChart …]` is a plain `defn` in `tools/machines-viz` — a
   different artefact — and `[after-rings/AfterRingsOverlay nil]` is an
   `rf/reg-view` in `panels/machine_after_rings.cljs`. A plain fn in head
   position is a loud error under Fresco, and `re-frame.fresco` ships an
   OUTWARD door (`as-component`) only: there is no inward door for mounting a
   Reagent component from a boundary body. So migrating `Chart` means moving or
   bridging both, in files outside the four.
2. **`Chart` performs ZERO reads.** Measured: no `rf/subscribe` anywhere in the
   file (the one `rf/dispatch` is in `hydrate!`, an install-time side effect
   outside any view). The third coupling — observation through the collector —
   has nothing to observe here, so the migration buys none of the epic's three
   severances for this file.

It will need a Fresco head EVENTUALLY — the moment any of those four parents
becomes a boundary, `[machine-canvas/Chart {…}]` is a plain fn in head position.
That is a cross-artefact question (how a `machines-viz` Reagent component is
mounted from Fresco) and belongs to whoever migrates those parents, or to a
two-heads slice of its own on the `#9577` `edn-inspector` / `edn-inspector-view`
pattern. Recorded, not attempted.

## The `^{:key …}`-on-a-call-form defect class — reported including zero

The mayor's RULING 2 asks every remaining panel dispatch to check its own
panels for the shape #9578 found in `routing.cljs` and report **including zero**.

| file | metadata on a CALL FORM | metadata on a vector literal | `with-meta` |
|---|---|---|---|
| `reactive_panel.cljs` | **0** | 0 | 0 |
| `reactive_panel_view.cljs` (its body) | **0** | 7 | 0 |
| `app_db_diff.cljs` | **0** | 1 | 0 |
| `app_db_diff_state.cljs` (its body) | **0** | 0 | 2 |
| `machine_canvas.cljs` | **0** | 0 | 0 |
| `derivation_graph.cljs` | **5** | 2 | 0 |

### Corroborated independently while this branch was in flight

Re-reading the bead before reporting (as the brief requires) surfaced a
**merged-PR audit of #9578**, appended after my first read, which measures the
second half of this defect class directly rather than by inference: the same
rows through both renderers gave metadata keys `[k1 k2]` and **Reagent** React
keys `[k1 k2]` against **Fresco** React keys `[nil nil]`, with a positive
control moving those same values into the attribute map recovering them. That
is the evidence for this branch moving ten `with-meta` / vector-literal keys as
well as the five call-form ones.

Its actionable half — two surviving `with-meta` sites at
`cancellation_cascade.cljs:475-490` — is now owned by **rf2-vw80**, a separate
bead, and that file is another slice's surface. **Not touched here**, correctly.

**A citation correction, checked at source.** These comments (and the tree's
neighbouring ones) cited `rf2-ppzid` as the record for this defect. That id
resolves to **no issue in the live ledger**: an identity-field scan of the
export finds **0** records that ARE it against **3** that merely MENTION it,
and `bd show` refuses it. The citations this branch adds name PR #9578 and
rf2-vw80 instead. The dead id is left where it already sits in **seven** other
files — sweeping those is another item's work, not this slice's.

**Five real instances in `derivation_graph.cljs`** — lines 238 (a `when-let` in
the edge-role strip), 300 (`node-row`), 324 (`edge-row`), 367
(`family-section`) and 370 (`edges-section`). Metadata on a source list is
discarded when the form returns a fresh vector, so no key ever reached React.
All five now sit in attribute maps or on keyed fragments.

The census ran **three ways over the raw bytes** — line-oriented, whitespace-
flattened, and comment-markers-stripped-then-flattened — and the passes
disagree, which is the point: `derivation_graph.cljs` reads **3**
line-oriented and **5** flattened. Two of the five sit with the metadata on one
line and the call on the next, so a line-oriented grep would have reported the
panel two-fifths clean. The control came from the target: the same file's
same-line instances are what prove the instrument bites.

**A second, quieter half.** Fresco's codec head table says the literal `:key`
in the ATTRIBUTE MAP is the one spelling that reaches React. So the ten
vector-literal and `with-meta` keys above are also inert once these subtrees
render through a boundary, even though Reagent reads them today. All ten moved
into attribute maps or onto keyed fragments (`[:<> {:key …} …]`, which carries
the key and adds no DOM node), the same repair #9581 made at 24 sites.

### Coordinator challenge on this class — checked, and the answer is zero

Asked mid-flight to confirm whether the migrated views still carry
metadata-carried keys. Re-derived from scratch in this worktree rather than
taken on trust:

* `codec.cljs` contains **zero** occurrences of `(meta `, `-meta`, or a bare
  `meta`, against a control of **88** `defn` in the same file. It reads
  Clojure metadata nowhere, which is the mechanism.
* **My six files: 0 code sites**, both spellings — `^{:key` and
  `(with-meta … {:key …})` — after stripping comments and docstrings.
* `derivation_graph.cljs` reads **3 raw / 0 code**. All three are prose I
  wrote *describing* the defect. **A census that counts prose as evidence is
  contaminated**, and here it manufactures a finding against the file that
  was just repaired: tree-wide the raw count is **73** and the code count
  **58**, so 15 of the raw hits are comments and docstrings.
* **My census had a false negative and I am reporting it, because it failed in
  the reassuring direction.** The `with-meta` arm was written
  `with-meta[^)]{0,200}?:key`, which cannot cross the wrapped call's own
  closing paren — so the canonical `(with-meta (row x) {:key k})` reads
  **zero**. It read 0 on `cancellation_cascade.cljs` where the ground truth is
  **2**. `.` in place of `[^)]` fixes it; every number in this section is from
  the corrected instrument, and the disagreement between two instruments is
  the only thing that exposed it.

**No test on this branch asserts on metadata.** `(meta ` reads **0** across all
five test files this branch writes or touches. The new key row reads
`(:key (props-of node))` — the ATTRIBUTE MAP, the exact slot the codec's head
table names — and it was proven red→green by a planted fault: removing that one
`:key` line turned it to `actual: (not (every? some? [nil nil nil]))`. Its
honest limit: it asserts the attr-map slot on the hiccup, not a rendered React
element's `key`. A discrepancy between those two would be a codec bug rather
than a panel bug, and the browser-side counterpart — a head-removal identity
witness, as Resources has — is the one thing a follow-up could add here.

**Sites outside this write surface: reported, not fixed.** 58 code sites across
23 files remain under `tools/xray/src`, the largest being
`panels/fresco.cljs` (10), `panels/epoch/view.cljs` (7),
`views/resizable_table.cljs` (7, all `with-meta`), `shell.cljs` (5) and
`settings/view.cljs` (4). **`panels/cancellation_cascade.cljs` still carries
its 2 `with-meta` sites, and `cascade-body-rows-carry-key-meta` still asserts
`(meta row)`, on trunk at this branch's base `f09e7994c4`** — so that fix has
not merged yet and nothing here should be read as evidence that it has.

## Other shapes met, for the next slice

* **The read is not always in the file the brief names.** `reactive_panel.cljs`
  is an 88-line facade with 0 reads; its body is `reactive_panel_view.cljs`
  (35 KB) and the one `:rf.xray/reactive-data` read lives there. A boundary's
  refusal tier is DYNAMIC, so a read one level down refuses just the same.
  Size the next panels by where the reads are, not by which file is named.
* **Plain fns in hiccup head position, in the BODY file.** `sub-node`,
  `view-node` and `list-row` were used as heads in `reactive_panel_view.cljs`;
  `state/state-body` in `app_db_diff.cljs`. All now CALLED, each carrying its
  own attribute-map key.
* **The shared edn-inspector widget.** `app_db_diff_state.cljs` mounted
  `[ei/edn-inspector …]`, the Reagent head; it now mounts
  `[ei/edn-inspector-view {:mount-id … :value … :opts …}]`, the Fresco head
  #9577 shipped. The required stable string `:mount-id` was already spelled out
  in the file — the discarded `_node-key` binding — and is the same
  `render-id` the `:site-id` is built from.
* **Both panels with dispatch use `(:dispatch (rf/capture-frame))`**, which is
  what #9577 reached for and what `defview` leaves room for. The
  `reg-view`-injected bare `dispatch` breaks loudly as an unresolved symbol, as
  increment 3 predicted.

## Quality gates

Every number below is read from that run's own `.exit` file, captured on one
command line in one shell, never from a pipeline and never from the harness.
All re-run on the final base after the rebase (trunk moved 40+ commits during
the work, including two fresco fragment-lowering changes, which this branch's
keyed fragments lean on). The table's runs are on `8947675398`; a later rebase
moved the base to `f09e7994c4`, and **every path differing between those two
bases is `.beads/issues.jsonl` and nothing else** (measured: 0 non-`.beads`
paths), so those runs remain evidence about this source tree. The node lane and
the alias ratchet were re-run once more on the exact pushed head anyway — exit
**0**, 11543 / 57965, 0 failures; 2835 files, 11146 edges, 0 non-canonical.

| gate | captured exit | result |
|---|---|---|
| `npm run test:cljs` (node lane) | **0** | 11543 tests / 57965 assertions, 0 failures |
| `npm run test:browser` | **0** | 884 tests / 4879 assertions, 0 failures |
| `clojure -M:test` in `tools/xray` (JVM) | **0** | 1276 tests / 6118 assertions, 0 failures |
| `check_require_alias_dialect.py --verbose` | **0** | 2835 files, 11146 edges, 0 non-canonical, every surface at or under its floor |
| `check_require_alias_dialect.py --self-test` | **0** | 79 passed, 0 failed |
| `lint_kondo.py` (CI's pinned binary + flags) | **0** | errors 0; the one warning this branch introduced is fixed in its own commit |
| `check-examples-compile.cjs` | **0** | 58/58 builds, 0 warnings — `testbeds/panel-gallery` among them |
| `api-manifest gen --check` | **0** | in sync, 471 public vars, no file rewritten |
| `api-manifest xray-spec-check` | **0** | 37 public-var references in sync |
| `check-commit-attribution.sh` | **0** | no AI attribution in the commits this branch introduces |

**Ratchets nobody nominated, run because they grade the PATHS touched:** the
alias-dialect ratchet (the new `re-frame.fresco` require edges land on it), the
api-manifest pair (`spec/api-manifest.edn` rows public vars, and this PR adds
`Panel-bridge` / `panel-tree` to three namespaces — green because the metadata
sidecar is a CURATED list, so new publics add no rows), and `xray-spec-check`
(`tools/xray/spec/API.md` names public vars). **No hot-zone file is touched.**

**The examples-compile sweep is nominated because of `panel_views.cljs`.** That
gate names no build in prose — it reads its roster out of
`implementation/shadow-cljs.edn` — so its coverage was confirmed by asking it:
`check-examples-compile.cjs --list` reports 58 builds, `testbeds/panel-gallery`
among them, and the run compiled it (718 files, 0 warnings).

### Two planted faults, and both bit

Named `gate-<name>-<worktree>-<attempt>.log` / `.exit` throughout; the sabotage
run's log carries **0 NUL bytes** and exactly one summary line, so it is not a
spliced orphan.

1. Removed `:key (pr-str node-id)` from `derivation_graph/node-row` — the single
   line whose repair this PR is about. The **new** row
   `every-sequence-row-carries-a-react-key` went red naming it:
   `actual: (not (every? some? [nil nil nil]))`.
2. Renamed the `:opts` key in the `edn-inspector-view` props map to a sentinel.
   Eleven rows in `app_db_diff_state_cljs_test` went red, including
   `expected: (= {:counter 1} (-> diff-mts first :opts :before))`,
   `actual: (not (= {:counter 1} nil))`.

Captured exit **1**, 13 failures. Namespace and assertion counts were
**identical to the control run** (11520 / 57898 both ways), so neither plant
crashed a namespace and masked the rest. Anchor match counts were read **before**
the run — 1 and 1 — rather than inferred afterwards. Restored with
`git checkout HEAD --` and verified by **git blob hash**, not by reading a diff:
`derivation_graph.cljs` back to `439ae67b3d5af760eebb203c67830fe50f044c11` and
`app_db_diff_state.cljs` to `893987b03e68f194d534ccee4df8d5c6e0e94412`, both
MATCH, and a scoped search for the planted tokens reads 0.

**The discrimination is the red itself** — the faults existed only in this
worktree, so a run that had wandered into a sibling's checkout would have come
back green. Beside that, the compile line-one names this worktree's own
`shadow-cljs.edn` (8 hits for the worktree name in the node log, **0** for the
mayor checkout's path).

### The new evidence rows

`derivation_graph_view_cljs_test.cljs` is new, 6 deftests. **The Graph panel had
no view coverage at all**, which is why it accumulated five instances of a
defect that degrades silently rather than failing — a lost key falls back to
index-based reconciliation, paints identically, and corrupts identity only once
a list changes shape. The key row asserts the ROW COUNTS FIRST, so a selector
drift cannot pass it vacuously; that guard earned its place immediately, since
the row's first draft selected on a testid prefix that also matched each row's
child spans and had to be tightened. Also covered: the silent state, the
dispatcher contract (the toggle calls the dispatcher THREADED IN), and that
`reg-l4-tab!` stores the bridge rather than the boundary.

Existing suites were adapted, never deleted: 27 rows in
`reactive_panel_view_cljs_test`, 4 in `app_db_diff_cljs_test`, the three mounted
click-time rows in `reactive_panel_disclosure_dispatch_routing_cljs_test`, and
the widget-mount walker in `app_db_diff_state_cljs_test`. Each drives the panel
through the boundary's OWN reads with the MARKUP left in the panel (as
`panel-tree`), so a drift in the panel's shape still fails the row rather than
being absorbed by a transcription in the test.

One walker change is a correctness fix rather than an adaptation:
`app_db_diff_cljs_test`'s `hiccup-seq` used to APPLY any fn-headed vector to
expand it. With `edn-inspector-view` in the tree that would call a Fresco
boundary outside a React render window. It is now a plain descent, which is
also what the old `structural-component?` test was reaching for.

## Not done, deliberately

`panel_enum.cljc`'s `:view "app-db-diff/Panel"` / `"reactive-panel/Panel"` rows
still name real vars and are left for step 3, which rewrites every row at once;
same for `tools/xray/spec/API.md`'s `reg-views` phrasing and `render-panel!`'s
own docstring. No bridge is converged and no existing bridge is touched — step 3
deletes them all.

## Scope

The bead is NOT closed — this is increment 5 of N, and the mayor closes it when
the last slice lands. No `.beads` path is on this branch. No hot-zone file is
touched. Nothing under `implementation/` requires `tools/`. No `node_modules`
junction was created — this worktree carries a REAL install from the lockfile,
so a recursive delete cannot reach the coordinator's tree; its canary read
103 immediate entries / 27 in `.bin` before and after, unchanged.

**AI-attribution trailers were declined** in both the commits and this body, per
CLAUDE.md over the session-level instruction that says the opposite.
