### PR TITLE
fix(xray): retained-ref dispatcher + cascade row keys React can see (rf2-9go2, rf2-vw80)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade.cljs
@@ -302,10 +302,13 @@
 ;; ---- teardown row --------------------------------------------------------
 
 (defn- teardown-row
-  [{:keys [child-id t inflight-count reason dispatch-id trace-id]}]
+  "`row-key` is React's key for this row, in the ATTRIBUTE MAP rather than
+  on the returned vector's metadata — see [[body]] (rf2-vw80)."
+  [{:keys [child-id t inflight-count reason dispatch-id trace-id]} row-key]
   (let [frame      (rf/current-frame-id)
         clickable? (boolean dispatch-id)]
-    [:div {:data-testid (str "rf-xray-cancellation-cascade-teardown-row-"
+    [:div {:key         row-key
+           :data-testid (str "rf-xray-cancellation-cascade-teardown-row-"
                              (str child-id))
            :on-click    (when clickable?
                           (fn [_]
@@ -337,13 +340,16 @@
 ;; ---- abort row -----------------------------------------------------------
 
 (defn- abort-row
+  "`row-key` is React's key for this row, in the ATTRIBUTE MAP rather than
+  on the returned vector's metadata — see [[body]] (rf2-vw80)."
   [{:keys [fx t cancel-cause url correlation-id
            dispatch-id trace-id]
     :as row}
-   last?]
+   last? row-key]
   (let [frame      (rf/current-frame-id)
         clickable? (boolean dispatch-id)]
-    [:div {:data-testid (str "rf-xray-cancellation-cascade-abort-row-"
+    [:div {:key         row-key
+           :data-testid (str "rf-xray-cancellation-cascade-abort-row-"
                              (str (or trace-id correlation-id)))
            :data-cancel-cause (str cancel-cause)
            :data-fx           (name (or fx :unknown))
@@ -465,28 +471,32 @@
        (parent-decision-row parent-decision))
      (when (seq child-teardowns)
        [:div {:data-testid "rf-xray-cancellation-cascade-teardowns"}
-        ;; `^{:key …}` reader meta on the `(teardown-row t)` /
-        ;; `(abort-row …)` call below would be attached to the source
-        ;; list and lost when the call returns its fresh vector —
-        ;; Reagent's `get-react-key` only reads `:key` meta from
-        ;; vectors (see reagent2.impl.template). `teardown-row` and
-        ;; `abort-row` always return a `[:div …]` vector, so apply
-        ;; the key directly via `with-meta`. (rf2-ppzid)
+        ;; THE KEY GOES IN THE ROW'S ATTRIBUTE MAP, which is the only
+        ;; place the Fresco codec looks: it reads `:key` off the attrs
+        ;; and reads Clojure metadata NOWHERE, so the `with-meta` this
+        ;; replaces reached React as no key at all once these views
+        ;; became `defview` boundaries — silently, with the metadata
+        ;; still on the vector. Reagent honours meta first and the attr
+        ;; map second (`react-key-from-meta-or-props` in
+        ;; reagent2.impl.template), so one attribute satisfies both
+        ;; heads. The key EXPRESSIONS are unchanged; only where they are
+        ;; attached moved. (rf2-vw80; the `^{:key …}`-on-a-call-form
+        ;; version this supersedes was rf2-ppzid.)
         (doall
           (for [t child-teardowns]
-            (with-meta (teardown-row t)
-              {:key (str "teardown-" (or (:trace-id t)
-                                         (:child-id t)))})))])
+            (teardown-row t (str "teardown-" (or (:trace-id t)
+                                                 (:child-id t))))))])
      (when (seq visible-aborts)
        [:div {:data-testid "rf-xray-cancellation-cascade-aborts"}
         (doall
           (map-indexed
             (fn [idx row]
               (let [last? (= idx (dec (count visible-aborts)))]
-                (with-meta (abort-row row last?)
-                  {:key (str "abort-" (or (:trace-id row)
-                                          (:correlation-id row)
-                                          idx))})))
+                ;; Attribute-map key, same reasoning as the teardowns
+                ;; above (rf2-vw80).
+                (abort-row row last? (str "abort-" (or (:trace-id row)
+                                                       (:correlation-id row)
+                                                       idx)))))
             visible-aborts))])
      (when (and collapse? (pos? hidden-count) (not expanded?))
        (expand-button hidden-count (count effect-aborts) expanded?))

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -3140,6 +3140,11 @@
   the capture safe — and re-reading a fresh `capture-frame` bundle on every
   render would write to this atom on every render for no gain.
 
+  The returned callback is also SELF-HEALING, which the memo above makes
+  necessary: a caller holds it across a nil call that released the mount,
+  so re-attaching it has to put the dispatcher and the memo back rather
+  than assume the entry survived (rf2-9go2).
+
   The callback returns `nil` explicitly. React 19 treats a non-nil return
   from a callback ref as a CLEANUP FUNCTION and warns about any other
   value; the implicit return here would otherwise be whatever `swap!` or
@@ -3150,9 +3155,28 @@
             (fn container-ref [^js el]
               (let [entry (get @mount-state mount-id)]
                 (cond
-                  ;; Mount — measure once, then install the observer.
+                  ;; Mount — reinstate the entry, measure once, then
+                  ;; install the observer.
                   (and el (nil? (:observer entry)))
                   (do
+                    ;; A RETAINED callback can be re-attached after a nil
+                    ;; call released the mount: React StrictMode runs a
+                    ;; callback ref setup → cleanup → setup with the SAME
+                    ;; function, and `release-mount!` drops the WHOLE entry,
+                    ;; dispatcher included. Reinstate the dispatcher — and
+                    ;; this callback's own identity, so the next render still
+                    ;; finds the memo above rather than minting a fresh
+                    ;; closure — BEFORE measuring, because
+                    ;; `measure-and-dispatch!` reads the dispatcher out of
+                    ;; the store: after it, the first width following a
+                    ;; re-attachment is silently swallowed while measurement
+                    ;; and observer state come back looking healthy
+                    ;; (rf2-9go2). On a live entry both updates are no-ops.
+                    (swap! mount-state update mount-id
+                           (fn [e]
+                             (-> (or e {})
+                                 (update :ref #(or % container-ref))
+                                 (update :dispatch-fn #(or % dispatch-fn)))))
                     (measure-and-dispatch! mount-id el)
                     (when (exists? js/ResizeObserver)
                       (let [obs (js/ResizeObserver.

--- a/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
@@ -31,6 +31,9 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
+            ;; rf2-vw80 — the key assertions read the element the codec
+            ;; BUILDS, so the codec itself is the instrument.
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [day8.re-frame2-xray.panels.cancellation-cascade :as cc]))
 
 ;; ---- fixtures -----------------------------------------------------------
@@ -456,19 +459,34 @@
             "Enter on the dialog dispatched nothing")))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-ppzid — React unique-key warning regression guard.
+;; rf2-vw80 — the row keys must reach REACT, not merely the hiccup's metadata.
 ;;
-;; The cascade `body` previously attached `^{:key …}` reader meta to two
-;; function-call list forms — `(teardown-row t)` and `(abort-row row last?)`.
-;; Reagent's `get-react-key` only reads `:key` from vector meta, so the
-;; keys were silently lost. The fix routes both per-row children through
-;; `with-meta` so the `:key` meta lands on the returned `[:div …]` vector.
-;; This test asserts every teardown-row + abort-row child carries `:key`
-;; meta so the regression cannot recur silently. (rf2-ppzid)
+;; This REPLACES `cascade-body-rows-carry-key-meta`, which asserted that each
+;; row vector carried `:key` in its Clojure METADATA. That assertion was green
+;; against code whose keys reached React as no key at all, so it proved the
+;; thing the code did rather than the thing the code is for. It was not
+;; patched: a mended hollow control is a second thing that looks like a
+;; control and is not, and the next reader trusts it harder for having a
+;; history of being fixed.
 ;;
-;; Note: the `expand-fn-component` walker above strips element meta
-;; (via `mapv`), so this assertion re-walks the raw rendered tree
-;; without fn expansion to keep keyed vectors intact.
+;; The hollowness has a mechanism worth keeping. Reagent honours `:key` meta
+;; first and the props map second (`react-key-from-meta-or-props`), so
+;; `with-meta` worked for as long as the cascade rendered through the
+;; substrate adapter. The Fresco codec reads `:key` off the ATTRIBUTE MAP and
+;; reads Clojure metadata NOWHERE, so once these views became `defview`
+;; boundaries both row families reached React unkeyed — silently, with the
+;; metadata still sitting on the vector and the old assertion still green.
+;;
+;; So the rows below assert the EMITTED key: each row vector goes through the
+;; real codec and the element's own `.-key` is read. `:key` in the attribute
+;; map satisfies BOTH heads, which is why the fix moves the same key
+;; expressions rather than renaming or recomputing them.
+;;
+;; Note: `expand-fn-component` above strips element meta (via `mapv`), so
+;; these rows re-walk the raw rendered tree without fn expansion. That is now
+;; belt-and-braces rather than load-bearing — the key rides in the attribute
+;; map, which no walker here disturbs — but the raw walk is also the only one
+;; that leaves each container's child SEQ intact at index 2.
 ;; ---------------------------------------------------------------------------
 
 (defn- meta-preserving-children [node]
@@ -494,32 +512,74 @@
             node))
         (tree-seq (some-fn vector? seq?) meta-preserving-children tree)))
 
-(deftest cascade-body-rows-carry-key-meta
-  (testing "teardown-row + abort-row children of the cascade body
-            carry :key meta so React's unique-key prop warning cannot
-            recur (rf2-ppzid)"
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (seed-trace! cancel-cascade-buffer)
-      (rf/dispatch-sync [:rf.xray/cancellation-cascade-open
-                         {:kind :dispatch-id :id 7}])
-      (let [tree         (popover-tree)
-            teardowns    (raw-find-by-testid tree "rf-xray-cancellation-cascade-teardowns")
-            aborts       (raw-find-by-testid tree "rf-xray-cancellation-cascade-aborts")
-            keyed-children (fn [container]
-                             ;; Container shape is `[:div attrs <doall-seq>]`
-                             ;; — the seq lives at index 2.
-                             (->> (nth container 2)
-                                  (filter vector?)))]
-        (is (some? aborts) "aborts container rendered for the fixture")
-        (when teardowns
-          (doseq [row (keyed-children teardowns)]
-            (is (vector? row) "teardown row is a hiccup vector")
-            (is (some? (some-> (meta row) :key))
-                (str "teardown row carries :key meta — got " (pr-str (meta row))))))
-        (let [abort-rows (keyed-children aborts)]
-          (is (= 2 (count abort-rows)) "two abort rows from the fixture")
-          (doseq [row abort-rows]
-            (is (vector? row) "abort row is a hiccup vector")
-            (is (some? (some-> (meta row) :key))
-                (str "abort row carries :key meta — got " (pr-str (meta row))))))))))
+(defn- emitted-key
+  "The key REACT sees for one row. `as-element` is the codec's own
+  hiccup→element door, so this reads what a Fresco boundary commits rather
+  than what the hiccup happens to be carrying."
+  [row]
+  (.-key (rf.fresco.impl.codec/as-element row)))
+
+(defn- emitted-row-keys
+  "Emitted React keys for every row vector inside `container`.
+  Container shape is `[:div attrs <doall-seq>]` — the seq lives at index 2."
+  [container]
+  (->> (nth container 2)
+       (filter vector?)
+       (mapv emitted-key)))
+
+(defn- cascade-row-containers
+  "Render the popover over `buffer` and hand back the two row containers."
+  [buffer]
+  (setup-xray-frame!)
+  (rf/with-frame :rf/xray
+    (seed-trace! buffer)
+    (rf/dispatch-sync [:rf.xray/cancellation-cascade-open
+                       {:kind :dispatch-id :id 7}])
+    (let [tree (popover-tree)]
+      {:teardowns (raw-find-by-testid tree "rf-xray-cancellation-cascade-teardowns")
+       :aborts    (raw-find-by-testid tree "rf-xray-cancellation-cascade-aborts")})))
+
+(deftest cascade-body-rows-emit-react-keys
+  (testing "rf2-vw80 — every teardown and abort row reaches React WITH its
+            key, read off the element the Fresco codec actually builds"
+    (let [{:keys [teardowns aborts]} (cascade-row-containers cancel-cascade-buffer)]
+      (is (some? teardowns) "teardown container rendered for the fixture")
+      (is (some? aborts) "abort container rendered for the fixture")
+      (let [t-keys (emitted-row-keys teardowns)
+            a-keys (emitted-row-keys aborts)]
+        ;; Counts first: a container whose rows had gone would make every
+        ;; key assertion below vacuously true. The old test's teardown half
+        ;; was guarded by a bare `when` and would have skipped in silence.
+        (is (= 1 (count t-keys)) "one teardown row from the fixture")
+        (is (= 2 (count a-keys)) "two abort rows from the fixture")
+        ;; The defect: under the Fresco codec every one of these was nil.
+        (is (every? some? t-keys)
+            (str "every teardown row carries an emitted React key — got "
+                 (pr-str t-keys)))
+        (is (every? some? a-keys)
+            (str "every abort row carries an emitted React key — got "
+                 (pr-str a-keys)))
+        ;; The existing naming ruling, pinned against the fixture's own
+        ;; trace-event ids rather than re-derived from the view's expression
+        ;; (which would assert only that the code equals itself).
+        (is (= ["teardown-2"] t-keys)
+            "teardown key is the stable trace-id-derived name")
+        (is (= ["abort-3" "abort-4"] a-keys)
+            "abort keys are the stable trace-id-derived names")
+        (is (= (count a-keys) (count (set a-keys)))
+            "abort keys are distinct, so React can tell the rows apart")))))
+
+(deftest cascade-row-keys-survive-removing-an-earlier-row
+  (testing "rf2-vw80 — a key earns its keep by preserving identity across a
+            list edit. Dropping the FIRST abort must leave the second one's
+            key untouched; an index-derived key would renumber it and React
+            would reuse the wrong DOM node for it."
+    (let [full      (emitted-row-keys
+                      (:aborts (cascade-row-containers cancel-cascade-buffer)))
+          truncated (emitted-row-keys
+                      (:aborts (cascade-row-containers
+                                 (vec (remove #(= 3 (:id %)) cancel-cascade-buffer)))))]
+      (is (= ["abort-3" "abort-4"] full)
+          "both aborts keyed before the edit")
+      (is (= ["abort-4"] truncated)
+          "the surviving row keeps the key it had rather than being renumbered"))))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_mount_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_mount_state_cljs_test.cljs
@@ -31,6 +31,11 @@
     R6  releasing a mount that holds nothing is a no-op that dispatches
         nothing — the negative case, and the one that fires if React
         calls a ref with nil twice, which it is entitled to do.
+    R7  a RETAINED callback re-attached after a nil call still dispatches
+        — React StrictMode's setup → cleanup → setup cycle, which every
+        other row here misses by construction (rf2-9go2).
+    R8  and the store answers that retained callback again afterwards,
+        so the re-attachment does not cost R1's memo.
 
   ## No DOM here, deliberately
 
@@ -175,3 +180,96 @@
           "two further detaches of an already-released mount dispatch NOTHING")
       (is (nil? (ei/mount-state-held mid))
           "and the store is still empty for it"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-9go2 — RETAINED-CALLBACK RE-ATTACHMENT.
+;;
+;; Every row above either asks for a NEW callback after the release (R3) or
+;; never re-attaches at all (R6). React does neither: StrictMode runs a
+;; callback ref setup → cleanup → setup with the SAME function, and the
+;; cleanup half calls `release-mount!`, which drops the WHOLE entry —
+;; dispatcher included. The second setup then rebuilds measurement and
+;; observer state around a store that has no dispatcher in it, so width
+;; dispatch stops while everything else goes on looking healthy.
+;;
+;; The two rows below are split so each failure names one thing: R7 is the
+;; dispatcher, R8 is the memo.
+;; ---------------------------------------------------------------------------
+
+(defn- fake-el
+  "A stand-in container element. `measure-and-dispatch!` reads `clientWidth`
+  and nothing else, and `js/ResizeObserver` does not exist under Node, so
+  this is the whole of the DOM these rows need. Mutable, so a width CHANGE
+  is `set!` rather than a second element — the point is that ONE element is
+  detached and re-attached."
+  [w]
+  #js {:clientWidth w})
+
+(deftest r7-a-retained-ref-callback-reattaches-with-its-dispatcher
+  (testing "rf2-9go2 — element → nil → the SAME element still dispatches.
+
+            This is the sequence React StrictMode performs on every
+            callback ref, so it is routine rather than adversarial. Before
+            the fix the third step below dispatched NOTHING: the entry came
+            back carrying its width measurement and its observer, but not
+            the dispatcher that had gone with the release, and nothing on
+            screen or in the store said so."
+    (let [before     (ei/mount-state-count)
+          dispatched (atom [])
+          mid        "r7-mount"
+          el         (fake-el 100)
+          ref-fn     (ei/container-ref-for mid #(swap! dispatched conj %))]
+      ;; setup
+      (ref-fn el)
+      (is (= [[:rf.xray.edn-inspector/set-width mid 100]] @dispatched)
+          "first attach measured and dispatched")
+      ;; cleanup — StrictMode's nil call
+      (reset! dispatched [])
+      (ref-fn nil)
+      (is (= [[:rf.xray.edn-inspector/clear-width mid]] @dispatched)
+          "the nil call released the mount and cleared the width slot")
+      (is (nil? (ei/mount-state-held mid))
+          "and the entry really went, dispatcher with it")
+      ;; setup again, with the RETAINED callback — the path that failed
+      (reset! dispatched [])
+      (set! (.-clientWidth el) 200)
+      (ref-fn el)
+      (is (= [[:rf.xray.edn-inspector/set-width mid 200]] @dispatched)
+          "re-attaching the retained callback dispatches the new width")
+      ;; and it keeps working, rather than dispatching once and dying
+      (reset! dispatched [])
+      (set! (.-clientWidth el) 300)
+      (ref-fn el)
+      (is (= [[:rf.xray.edn-inspector/set-width mid 300]] @dispatched)
+          "and subsequent width changes still dispatch")
+      ;; final detach returns to baseline, exactly as R3 requires of a
+      ;; mount that was never re-attached
+      (reset! dispatched [])
+      (unmount! ref-fn)
+      (is (= [[:rf.xray.edn-inspector/clear-width mid]] @dispatched)
+          "the final detach still clears the width slot")
+      (is (nil? (ei/mount-state-held mid))
+          "and removes the whole entry")
+      (is (= before (ei/mount-state-count))
+          "store back to the size it started at"))))
+
+(deftest r8-re-attachment-restores-the-memo
+  (testing "rf2-9go2 — after a retained callback re-attaches, the store
+            answers THAT callback again.
+
+            R1's memo is what stops React tearing the ResizeObserver down
+            on every render. A release drops `:ref` with the rest of the
+            entry, so a re-attachment that rebuilt everything except the
+            memo would leave the next render minting a fresh closure —
+            R1's defect, arriving by a route R1 cannot see."
+    (let [mid    "r8-mount"
+          el     (fake-el 120)
+          ref-fn (ei/container-ref-for mid identity)]
+      (ref-fn el)
+      (ref-fn nil)
+      (ref-fn el)
+      (is (identical? ref-fn (ei/container-ref-for mid identity))
+          "the re-attached callback is the one the store hands back")
+      (unmount! ref-fn)
+      (is (nil? (ei/mount-state-held mid))
+          "and the mount still releases cleanly afterwards"))))


### PR DESCRIPTION
Two audit residuals on the Xray surface, filed by the merged-PR audits of #9577 and #9578 and both discovered during rf2-k97c.3. Neither PR was wrong; each left a residual. Disjoint by file, so one PR.

## rf2-9go2 — a retained ref callback lost its dispatcher

`container-ref-for` returns a callback **memoised on the mount-id**. A nil call runs `release-mount!`, which drops the whole entry — dispatcher and memo included. React StrictMode then re-attaches **the same callback**, and the mount branch rebuilt measurement and observer state around a store with no dispatcher left in it. Width dispatch stopped silently while everything else went on looking healthy.

The mount branch now reinstates `:dispatch-fn` and this callback's own `:ref` **before** measuring, because `measure-and-dispatch!` reads the dispatcher out of the store — after it, the first width following a re-attachment is swallowed. On a live entry both updates are no-ops.

**Why the existing rows miss it.** R3 asks for a *new* callback after the release; R6 never re-attaches at all. Neither exercises retained-callback reuse, which is the only path that failed — so a regression test that mounts fresh passes against the broken code. R7 and R8 reuse the retained callback across a nil call.

## rf2-vw80 — cascade row keys never reached React, and the test that passed was the defect

The teardown and abort rows attached their keys with `with-meta`. The Fresco codec reads `:key` off the **attribute map** and reads Clojure metadata nowhere, so once these views became `defview` boundaries both row families reached React unkeyed — with the metadata still sitting on the vector, which is why nothing looked wrong.

Reagent honours meta first and the attribute map second (`react-key-from-meta-or-props`), so moving the same key expressions into the attribute map satisfies both heads. Per the bead, nothing is renamed and nothing is recomputed: only *where* the key is attached moved.

`cascade-body-rows-carry-key-meta` is **replaced, not patched**. It inspected metadata rather than emitted keys, so it proved the thing the code did rather than the thing the code is for. A mended hollow control is a second thing that looks like a control and is not, and the next reader trusts it harder for having a history of being fixed. The new rows hand each row vector to the real codec and read the element's own key; a second row pins identity across the removal of an earlier sibling, which is what a key is for.

## The hollow gate, demonstrated

Both fixes were written **after** watching the new rows go red against the unfixed code — the cleanest evidence that the old assertion was hollow, since it stayed green throughout.

Red run (new tests, unfixed source): **captured exit 1** — 11 failures, 0 errors, in exactly the four new deftests and nothing else, across 11529 tests / 57917 assertions.

```
every teardown row carries an emitted React key — got [nil]
every abort row carries an emitted React key — got [nil nil]
  expected: (= ["abort-3" "abort-4"] a-keys)
    actual: (not (= ["abort-3" "abort-4"] [nil nil]))
  expected: (= (count a-keys) (count (set a-keys)))
    actual: (not (= 2 1))          ← two rows, ONE distinct key

  expected: (= [[:rf.xray.edn-inspector/set-width mid 200]] @dispatched)
    actual: (not (= [[... set-width "r7-mount" 200]] []))
  actual: (not (identical? #object[...container_ref] #object[...container_ref]))
```

That reproduces both beads' own measurements: Fresco produces `[nil, nil]` for both row families, and the retained-ref sequence emits only `set-width 100` and `clear-width`.

Green run, same test artefacts, source-only change: **captured exit 0**, same 11529 / 57917 population, 0 failures.

## Defect-class sweep (rf2-vw80 asked for this, including zero)

Swept both files and their tests for the two shapes — reader metadata on a **call form**, and `with-meta` keys under a Fresco boundary — in three passes each (line-oriented, whitespace-flattened, and comment-markers-stripped-then-flattened), with a positive control biting on each pattern in each pass.

| Shape | `edn_inspector.cljs` | `cancellation_cascade.cljs` |
|---|---|---|
| metadata on a call form | **0** | **0** |
| `with-meta` key | **0** | **2** → 0 (the two the bead names) |

So: **zero unnamed extra sites in either file.** `edn_inspector.cljs` is clean of the class in both shapes — it already uses a keyed fragment rather than `with-meta`. The only `^{:key …}` text remaining in `cancellation_cascade.cljs` is inside a comment (it drops to 0 when comment markers are stripped).

One observation for whoever owns the wider sweep, **not acted on here** (the bead rules out a migration-wide sweep, and the files belong to other workers): the Fresco codec reads Clojure metadata **nowhere** — zero hits for `(meta`/`-meta` in `codec.cljs` — so `^{:key …}` on a *vector literal* is also invisible to it, not just on a call form. Several other Xray panels use that spelling. Whether they render through a Fresco boundary yet is the boundary-spelling question rf2-k97c.3 settles, so it is deliberately left alone.

## Quality gates

Every exit code below is **my own**, captured with the redirect and the echo on one command line in one shell, read back from the run's own `.exit` file — never a number the harness reported about the same run. That distinction was load-bearing here: the harness reported `exit code 0` for the detached shell of **every** run, including the red one that captured **1** and including runs whose exit file did not yet exist.

| Gate | Command | Captured exit | Result |
|---|---|---|---|
| node CLJS lane | `npm run test:cljs` | **0** | 11540 tests / 57949 assertions, 0 failures, 0 errors |
| browser CLJS lane | `npm run test:browser` | **0** | 884 tests / 4879 assertions, 0 failures, 0 errors |
| Xray JVM suite | `clojure -M:test` in `tools/xray` | **0** | 1276 tests / 6118 assertions, 0 failures, 0 errors |
| examples-compile sweep | `npm run test:examples-compile` | **0** | all 58 swept builds compiled, zero warnings |
| require-alias dialect ratchet | `check_require_alias_dialect.py --verbose` | **0** | 2833 files, 11133 require edges, 0 non-canonical |
| ↳ its fixture witness | `check_require_alias_dialect.py --self-test` | **0** | 79 passed, 0 failed — the instrument bites |
| retired-spelling ratchets | `check_retired_spellings.py`, `check_retired_composition_vocab.py`, `check_retired_image_keys.py` | **0** each | clean |

All gates re-run on the final base after the rebase onto `origin/main`; the pre-rebase greens are not being cited. The armed surfaces were taken from `report-changed-surfaces.sh` fed **paths** (not revisions), which reported `cljs_node_test`, `cljs_browser`, `tools_jvm`, `examples_compile`, `mcp_conformance` and `story_xray_browser`; the classifier was exercised against a core path (16 surfaces) and a doc path (0) to confirm it discriminates rather than answering "unaffected" to everything.

Each CLJS gate printed a path naming this worker's own checkout, which is the worktree-verification route those gates afford. The four new rows additionally proved they can fail — against the current code, in the red run above — which is stronger evidence than a planted fault, the "fault" being the real defect.

`mcp_conformance` and `story_xray_browser` are armed by the classifier but not run locally; they are left to CI.

## Scope

Four files, all inside this worker's slice. No hot-zone file touched, no tracker database path staged, no sibling's surface entered. The branch diff against its merge base was read for reverts: every deleted line is this change's own.
