### PR TITLE
fix(ssr): fragment props map on the streaming path, and React's structural slots as DOM attributes (rf2-n2y3, rf2-gw87)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -517,6 +517,35 @@
 (def ^:private jsx-source-prop-names
   #{"_jsxFileName" "_jsxLineNumber" "_jsxColumnNumber"})
 
+;; rf2-gw87 — REACT'S TWO STRUCTURAL SLOTS. `key` and `ref` are read off a
+;; props map by React itself (the JSX transform / `createElement`) and are
+;; never handed to the host as DOM attributes: `key` is reconciliation
+;; identity and `ref` is an instance handle, and neither has an HTML wire
+;; representation. This emitter passed both straight through, so
+;; `[:div {:key "k"}]` served `<div key="k">` and a string `[:div {:ref "R"}]`
+;; served `<div ref="R">` — measured live before this fix.
+;;
+;; A function-valued `:ref` was already dropped by the `fn?` arm below, which
+;; is what kept this narrow: the REACHABLE case is `:key`, and `:key` on a
+;; native tag is ordinary application markup rather than a curiosity — the
+;; same `[:div {:key i}]`-inside-a-`for` idiom that produced rf2-3357's
+;; fragment defect one slot over.
+;;
+;; WHY DROPPING IS RIGHT RATHER THAN MERELY TIDY. The client paints no such
+;; attribute, so emitting one server-side is precisely a hydration
+;; divergence — the emitter's whole contract here is agreeing with
+;; react-dom/server, and react-dom/server emits neither. A custom element
+;; genuinely wanting a `key` attribute cannot get one out of React either,
+;; so refusing it costs nothing that was reachable on the client.
+;;
+;; MATCHED CASE-SENSITIVELY, unlike the event-handler and prototype-pollution
+;; rosters above. React extracts these two slots by exact JS property name,
+;; so `:Key` really does reach the host as an ordinary unknown prop; matching
+;; loosely here would make the SERVER strip a name the client paints, which
+;; is the divergence this entry exists to remove, pointed the other way.
+(def ^:private structural-slot-names
+  #{"key" "ref"})
+
 (defn strip-prop?
   "True when the attribute `[k v]` MUST be dropped at SSR static-markup
   emission:
@@ -537,17 +566,35 @@
       shims (the framework itself does not emit them; see Spec 006
       §Historical: JSX source-coord props). They have no HTML wire
       representation and would fail the HTML5 attribute-name grammar.
+    - React's two STRUCTURAL SLOTS, `:key` and `:ref` (rf2-gw87) —
+      reconciliation identity and an instance handle, both consumed by
+      React before the host sees them and neither serialised by
+      react-dom/server. Matched case-sensitively; see
+      `structural-slot-names`.
 
   Mirrors react-dom/server behaviour. Recognised here are exactly the
   props that are *safe to silently drop*; malformed keys (breakout chars)
   are NOT this fn's concern — they surface at the `validate-attr-name!`
-  grammar gate (rf2-vl8ir)."
+  grammar gate (rf2-vl8ir).
+
+  ONE ROSTER, READ BY EVERY SSR SURFACE THAT EMITS AN ATTRIBUTE. This fn
+  is called only from `attr-string` below, and `attr-string` is what the
+  hiccup body emitter (`emit/emit-element`), the streaming shell walker
+  (`streaming/walk-dom-tag`, via the `emit/attr-string` re-export), the
+  head emitter (`head.emit`'s `<meta>` / `<link>` / `<script>`) and the
+  Ring host shell (`ring.shell`'s `<html>` / `<body>`) all serialise
+  through. That is the whole reason rf2-gw87 was fixed HERE rather than
+  as a `dissoc` local to one emitter: a second stripping roster is a
+  drift surface, and a local fix would have left the streaming path
+  divergent from the non-streaming one — the class of split that
+  produced rf2-n2y3 next door."
   [[k v]]
   (let [nm (name k)]
     (or (event-handler-name? nm)
         (fn? v)
         (contains? reserved-prop-keys (str/lower-case nm))
-        (contains? jsx-source-prop-names nm))))
+        (contains? jsx-source-prop-names nm)
+        (contains? structural-slot-names nm))))
 
 ;; ---- boolean attribute-value classes (rf2-r9kf) ---------------------------
 ;;

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -479,8 +479,43 @@
     (let [head (first element)]
       (cond
         ;; Fragment — splice children, recurse.
+        ;;
+        ;; rf2-n2y3 — A FRAGMENT MAY CARRY A PROPS MAP AT SLOT 1, AND IT IS
+        ;; NOT A CHILD. This arm was a plain `(rest element)`, so the map
+        ;; itself was walked as a child, fell through to the scalar arm's
+        ;; `emit/emit-element` → `escape-html`, and put its EDN in the
+        ;; streamed shell bytes (`[:<> {:key "k"} [:div "x"]]` →
+        ;; `{:key &quot;k&quot;}<div>x</div>`). `[:<> {:key i} …]` inside a
+        ;; `for` is the canonical fragment idiom, so this is ordinary
+        ;; application markup, and the garbage is a guaranteed hydration
+        ;; mismatch against a client render that emits none of it.
+        ;;
+        ;; The IDENTICAL defect was fixed in the non-streaming emitter by
+        ;; rf2-3357; until this arm matched it the two paths DIVERGED on the
+        ;; same input. The slot test is the same one — `(map? (second …))` —
+        ;; which is also what `walk-dom-tag` above already uses to split a
+        ;; DOM tag's attrs from its children, and the same rule as the
+        ;; React-side codec's `props-map?`.
+        ;;
+        ;; NO ROOT-ATTRS ANALOGUE ON THIS PATH. On the non-streaming side the
+        ;; worse half of the bug was that the map became the first child and
+        ;; displaced the rf2-lxwse `data-rf-render-hash` marker. This walker
+        ;; threads no attrs at all — `walk-shell` / `walk-children` /
+        ;; `walk-dom-tag` take only `[element continuation-accumulator]`, and
+        ;; `render-shell` takes only `[root-hiccup]` — so here the defect was
+        ;; the visible garbage and nothing hid behind it. (The `render-hash`
+        ;; this namespace does carry is a `build-streaming-payload` argument
+        ;; that rides the `__rf_payload` JSON, not a root attr.)
+        ;;
+        ;; WHAT HAPPENS TO THE ATTRIBUTES: dropped, silently, `:key`
+        ;; included — the rf2-3357 ruling, which owns the argument. A
+        ;; fragment is not an element, so no attribute on one has a wire
+        ;; representation, and every sibling emitter here already drops.
         (= :<> head)
-        (walk-children (rest element) continuation-accumulator)
+        (walk-children (if (map? (second element))
+                         (drop 2 element)
+                         (rest element))
+                       continuation-accumulator)
 
         ;; Reagent-native interop head `:>` — cannot be rendered on the
         ;; JVM (no React). rf2-ee38b.10 — mirror the non-streaming

--- a/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
@@ -11,9 +11,15 @@
       round-trip (rf2-1uex4 — HTML attribute names are case-insensitive,
       so the canonical lowercase + arbitrary `on`-prefix casings were the
       live XSS hole the camelCase/kebab-only regex missed).
-    - function-valued prop values, and
+    - function-valued prop values,
     - reserved prototype-pollution keys (`__proto__` / `constructor` /
-      `prototype`),
+      `prototype`), and
+    - React's two STRUCTURAL SLOTS, `:key` and `:ref` (rf2-gw87) —
+      reconciliation identity and an instance handle, consumed by React
+      before the host sees them and serialised by react-dom/server as
+      neither. Unlike the handler and prototype rosters this one matches
+      CASE-SENSITIVELY, because React extracts the two slots by exact JS
+      property name,
 
   matching react-dom/server behaviour. The filter is the per-attribute
   prop-name position in the locked emitter composition order, so it runs
@@ -25,7 +31,9 @@
   the head emitter, and the streaming emitter)."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
+            [re-frame.ssr.head.emit :as rf.ssr.head.emit]
             [re-frame.ssr.html-helpers :as rf.ssr.html-helpers]
+            [re-frame.ssr.streaming :as rf.ssr.streaming]
             [re-frame.ssr.emit :as rf.ssr.emit]))
 
 (deftest attr-string-strips-event-handler-props
@@ -112,6 +120,117 @@
     (testing "the match is case-insensitive on the normalised name"
       (is (= " id=\"x\""
              (rf.ssr.html-helpers/attr-string {(keyword "Constructor") "polluted" :id "x"}))))))
+
+(deftest attr-string-drops-reacts-structural-slots
+  (testing "rf2-gw87 — `:key` and `:ref` are React's two STRUCTURAL SLOTS.
+            React reads them off the props map itself and hands the host
+            neither, so react-dom/server serialises neither. This emitter
+            passed both straight through. Measured before the fix:
+            `[:div {:key \"k\"}]` served `<div key=\"k\">` and a string
+            `[:div {:ref \"R\"}]` served `<div ref=\"R\">`."
+    (testing ":key is dropped"
+      (is (= " id=\"x\"" (rf.ssr.html-helpers/attr-string {:key "k" :id "x"})))
+      (is (= " id=\"x\"" (rf.ssr.html-helpers/attr-string {:key 1 :id "x"}))
+          "a numeric :key — the `for`-loop spelling — drops too")
+      (is (= "" (rf.ssr.html-helpers/attr-string {:key "k"}))
+          "a props map that is ONLY a :key yields the empty string, not a
+           stray leading space"))
+
+    (testing ":ref is dropped whatever its value"
+      (is (= " id=\"x\"" (rf.ssr.html-helpers/attr-string {:ref "R" :id "x"}))
+          "a STRING ref — illegal in React, and the arm that was reachable
+           past the fn? filter")
+      (is (= " id=\"x\"" (rf.ssr.html-helpers/attr-string {:ref (fn [_]) :id "x"}))
+          "a function-valued ref was already dropped by the fn? arm and
+           still is"))
+
+    (testing "the match is CASE-SENSITIVE, unlike the handler and
+              prototype-pollution rosters. React extracts these two slots
+              by exact JS property name, so `:Key` reaches the host as an
+              ordinary unknown prop and the client paints it — stripping it
+              here would be the same server/client divergence pointed the
+              other way."
+      (is (str/includes? (rf.ssr.html-helpers/attr-string {:Key "k"}) "Key=\"k\""))
+      (is (str/includes? (rf.ssr.html-helpers/attr-string {:REF "r"}) "REF=\"r\"")))
+
+    (testing "the filter does not over-reach onto names that merely start
+              with or contain the two words"
+      (doseq [[k expected] {:keygen        "keygen=\"v\""
+                            :data-key      "data-key=\"v\""
+                            :aria-keyshortcuts "aria-keyshortcuts=\"v\""
+                            :referrerpolicy "referrerpolicy=\"v\""
+                            :data-ref      "data-ref=\"v\""}]
+        (is (str/includes? (rf.ssr.html-helpers/attr-string {k "v"}) expected)
+            (str k " is an ordinary attribute and must round-trip"))))))
+
+(deftest structural-slots-drop-on-every-emitter-that-shares-the-roster
+  (testing "rf2-gw87 — the whole argument for fixing `strip-prop?` rather
+            than `dissoc`-ing in one emitter is that `attr-string` is the
+            single per-attribute emission point every SSR surface goes
+            through. A change that only demonstrated the body emitter would
+            not have shown the thing that justified its own location, so
+            each surface is exercised here."
+    (testing "the hiccup BODY emitter (emit/render-to-string)"
+      (is (= "<div></div>" (rf.ssr.emit/render-to-string [:div {:key "k"}] {})))
+      (is (= "<div></div>" (rf.ssr.emit/render-to-string [:div {:ref "R"}] {})))
+      (is (= "<div id=\"a\">x</div>"
+             (rf.ssr.emit/render-to-string [:div {:key 1 :id "a"} "x"] {}))
+          "the surviving attributes are untouched")
+      (is (= "<li>1</li><li>2</li>"
+             (rf.ssr.emit/render-to-string
+               (into [:<>] (for [i [1 2]] [:li {:key i} i])) {}))
+          "the canonical keyed-list idiom — the reachable case — is clean"))
+
+    (testing "the STREAMING shell walker (streaming/render-shell), which
+              reaches this roster through the `emit/attr-string` re-export"
+      (is (= "<div></div>"
+             (:shell-html (rf.ssr.streaming/render-shell [:div {:key "k"}]))))
+      (is (= "<div></div>"
+             (:shell-html (rf.ssr.streaming/render-shell [:div {:ref "R"}]))))
+      (is (= "<main><div>x</div></main>"
+             (:shell-html
+               (rf.ssr.streaming/render-shell [:main [:div {:key "k"} "x"]])))
+          "nested under a DOM tag, where walk-dom-tag does the merging"))
+
+    (testing "streaming and non-streaming agree, which is the property the
+              shared roster exists to guarantee"
+      (doseq [tree [[:div {:key "k"}]
+                    [:div {:ref "R"}]
+                    [:div {:key 1 :id "a"} "x"]
+                    [:main [:div {:key "k"} "x"]]
+                    [:ul (for [i [1 2]] [:li {:key i} i])]]]
+        (is (= (rf.ssr.emit/render-to-string tree {})
+               (:shell-html (rf.ssr.streaming/render-shell tree)))
+            (str "emitters disagree on " (pr-str tree)))))
+
+    (testing "the HEAD emitter, and this one is a DELIBERATE consequence
+              rather than a side effect. `strip-prop?` is shared, so
+              widening it changes head output too — measured before the
+              change, `{:meta [{:key \"m1\" :name \"a\"}]}` emitted
+              `<meta key=\"m1\" name=\"a\">`. That is the SAME defect in the
+              same direction: react-dom/server would emit no `key` on a
+              `<meta>` either, and a head model built from a keyed component
+              list is exactly where a stray `:key` comes from. Pinned so the
+              shared-roster consequence is a recorded decision rather than
+              something a future reader discovers."
+      (is (= "<meta name=\"a\" content=\"b\">"
+             (rf.ssr.head.emit/head-model->html
+               {:meta [{:key "m1" :name "a" :content "b"}]})))
+      (is (= "<link rel=\"stylesheet\" href=\"/a.css\">"
+             (rf.ssr.head.emit/head-model->html
+               {:link [{:key "l1" :rel "stylesheet" :href "/a.css"}]})))
+      (is (= "<script src=\"/a.js\"></script>"
+             (rf.ssr.head.emit/head-model->html
+               {:script [{:key "s1" :src "/a.js"}]})))
+      (is (= "<head><title>T</title><meta charset=\"utf-8\"></head>"
+             (rf.ssr.head.emit/head-model->html
+               {:title "T" :meta [{:key 1 :charset "utf-8"}]} {:wrap? true}))))
+
+    (testing "the `:html-attrs` / `:body-attrs` bags the Ring host shell
+              stamps onto `<html>` / `<body>` read the same roster — pinned
+              at `attr-string`, which is the fn `ring.shell` calls"
+      (is (= " lang=\"en\"" (rf.ssr.html-helpers/attr-string {:key "k" :lang "en"})))
+      (is (= " class=\"c\"" (rf.ssr.html-helpers/attr-string {:ref "R" :class "c"}))))))
 
 (deftest attr-string-normal-attrs-still-emit
   (testing "the filter does not over-reach — ordinary attrs round-trip"

--- a/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
@@ -45,6 +45,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
             [re-frame.interop :as rf.interop]
+            [re-frame.ssr.emit :as rf.ssr.emit]
             [re-frame.ssr.streaming :as rf.ssr.streaming]
             [re-frame.ssr.test-fixture :as rf.ssr.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
@@ -328,6 +329,130 @@
           "fragment sibling below the boundary emitted")
       (is (str/includes? shell-html "fragment loading")
           "the buried boundary's fallback materialised inline"))))
+
+(deftest fragment-props-map-is-not-a-child-in-the-streaming-walker
+  (testing "rf2-n2y3 — a `:<>` fragment's PROPS MAP at slot 1 is not a
+            child, on the STREAMING path too. The walker's arm was a plain
+            `(rest element)`, so the map itself was walked as a child, fell
+            through to `emit/emit-element` → `escape-html`, and put its EDN
+            in the streamed shell bytes. `[:<> {:key i} …]` inside a `for`
+            is the canonical fragment idiom, so this was reachable from
+            ordinary application markup. rf2-3357 fixed the IDENTICAL
+            defect in the non-streaming emitter; until this arm matched it
+            the two paths disagreed on the same input."
+    (testing "the three rows rf2-3357 measured now agree on this path"
+      ;; Measured on the streaming walker BEFORE the fix, for the record:
+      ;;   [:<> {:key "k"} [:div "x"]] => "{:key &quot;k&quot;}<div>x</div>"
+      ;;   [:<> {}         [:div "x"]] => "{}<div>x</div>"
+      ;;   [:<>            [:div "x"]] => "<div>x</div>"
+      ;; Only the third was right; all three are the same markup now.
+      (is (= "<div>x</div>"
+             (:shell-html (rf.ssr.streaming/render-shell [:<> {:key "k"} [:div "x"]])))
+          "a keyed fragment streams its children and nothing else")
+      (is (= "<div>x</div>"
+             (:shell-html (rf.ssr.streaming/render-shell [:<> {} [:div "x"]])))
+          "an EMPTY props map is still a props map, not a child")
+      (is (= "<div>x</div>"
+             (:shell-html (rf.ssr.streaming/render-shell [:<> [:div "x"]])))
+          "the no-props spelling is unchanged"))
+    (testing "no EDN of the props map survives anywhere in the shell bytes"
+      (let [html (:shell-html
+                   (rf.ssr.streaming/render-shell
+                     [:<> {:key "k" :data-x "v"} [:p "body"]]))]
+        (is (= "<p>body</p>" html) (str "got: " html))
+        (is (not (str/includes? html ":key")) "no keyword EDN on the wire")
+        (is (not (str/includes? html "&quot;")) "no escaped EDN string on the wire")))
+    (testing "a fragment that is ONLY a props map streams nothing"
+      (is (= "" (:shell-html (rf.ssr.streaming/render-shell [:<> {:key "k"}]))))
+      (is (= "" (:shell-html (rf.ssr.streaming/render-shell [:<>])))))
+    (testing "rf2-3357's ruling holds here — a NON-`:key` fragment attribute
+              is DROPPED, silently, not refused. A fragment is not an
+              element, so no attribute on one has a wire representation."
+      (is (= "<div>x</div>"
+             (:shell-html
+               (rf.ssr.streaming/render-shell
+                 [:<> {:class "nope" :id "nope" :onClick "alert(1)"} [:div "x"]])))
+          "non-:key fragment attrs stream nothing and throw nothing"))
+    (testing "ONLY a map at slot 1 is skipped — a string / vector / seq
+              there is a genuine first child"
+      (is (= "text<div></div>"
+             (:shell-html (rf.ssr.streaming/render-shell [:<> "text" [:div]])))
+          "a string at slot 1 is a child")
+      (is (= "<span>a</span><div>b</div>"
+             (:shell-html (rf.ssr.streaming/render-shell [:<> [:span "a"] [:div "b"]])))
+          "a hiccup vector at slot 1 is a child")
+      (is (= "<div>a</div><div>b</div>"
+             (:shell-html
+               (rf.ssr.streaming/render-shell [:<> (list [:div "a"]) [:div "b"]])))
+          "a seq at slot 1 is a child, not props"))))
+
+(deftest streaming-and-non-streaming-fragments-agree-byte-for-byte
+  (testing "rf2-n2y3 — the pin that stops these two arms drifting apart
+            again. rf2-3357 fixed `emit.cljc`'s `:<>` arm and this walker's
+            was left behind, so for two hours the SAME hiccup rendered one
+            way through `render-to-string` and another through
+            `render-shell`. A boundary-free tree contains nothing the
+            streaming walker is FOR, so its shell HTML must equal what the
+            non-streaming emitter produces, byte for byte."
+    (doseq [tree [[:<> {:key "k"} [:div "x"]]
+                  [:<> {} [:div "x"]]
+                  [:<> [:div "x"]]
+                  [:<> {:key "k"}]
+                  [:<>]
+                  [:<> "text" [:div]]
+                  [:<> {:key "k" :data-x "v"} [:p "body"]]
+                  [:<> {:class "nope" :onClick "alert(1)"} [:div "x"]]
+                  [:<> {:key "outer"} [:<> {:key "inner"} [:div "y"]]]
+                  [:main [:<> {:key "k"} [:span "a"] [:span "b"]]]
+                  (into [:<>] (for [i [1 2]] [:<> {:key i} [:li i]]))]]
+      (is (= (rf.ssr.emit/render-to-string tree {})
+             (:shell-html (rf.ssr.streaming/render-shell tree)))
+          (str "streaming and non-streaming disagree on " (pr-str tree))))))
+
+(deftest fragment-props-map-does-not-displace-a-suspense-boundary
+  (testing "rf2-n2y3 — the STREAMING-SPECIFIC analogue of rf2-3357's worse
+            half. There, the props map becoming the first child displaced
+            the value that was supposed to receive the root-attrs, and the
+            `data-rf-render-hash` marker vanished. This walker threads no
+            attrs at all — `walk-shell` / `walk-children` / `walk-dom-tag`
+            take only `[element continuation-accumulator]` and
+            `render-shell` only `[root-hiccup]` — so there is no marker to
+            lose. What it DOES carry through the children is the
+            continuation accumulator, so the shape worth pinning here is
+            that a props-carrying fragment still reaches its boundaries and
+            drains them."
+    (testing "a boundary inside a KEYED fragment is still registered, and the
+              shell carries no props EDN in front of its placeholder"
+      (let [{:keys [shell-html continuations]}
+            (rf.ssr.streaming/render-shell
+              [:<> {:key "k"}
+               [:h1 "header"]
+               [:rf/suspense-boundary {:id :inside/frag :fallback [:p "loading"]}
+                [:p "body"]]])]
+        (is (= 1 (count continuations))
+            "the walker skipped the props slot and still reached the boundary")
+        (is (= :inside/frag (-> continuations first :id)))
+        (is (str/starts-with? shell-html "<h1>header</h1>")
+            (str "the shell opens with the first real child; got: " shell-html))
+        ;; The boundary id is deliberately free of the substring `:key` —
+        ;; a first spelling of this test used `:keyed/frag` and the probe
+        ;; matched the id stamped on the fallback `<template>` rather than
+        ;; any props EDN, which is a false positive in the direction that
+        ;; looks like a caught bug.
+        (is (not (str/includes? shell-html ":key"))
+            "no props EDN in front of the fallback placeholder")))
+    (testing "a keyed fragment as a continuation SUBTREE drains clean — the
+              drain re-enters the same arm through `render-continuation`"
+      (let [{:keys [continuations]}
+            (rf.ssr.streaming/render-shell
+              [:div
+               [:rf/suspense-boundary {:id :frag/subtree :fallback [:p "loading"]}
+                [:<> {:key "k"} [:div "resolved"]]]])
+            fid    (make-server-frame)
+            result (rf.ssr.streaming/render-continuation fid (first continuations))]
+        (is (not (:failed? result)))
+        (is (= "<div>resolved</div>" (:html result))
+            (str "the drained chunk carries no props EDN; got: " (:html result)))))))
 
 (deftest triple-duplicate-id-keeps-only-last-of-three
   (testing "rf2-u91hb: three boundaries with the same :id — dedup keeps


### PR DESCRIPTION
Two beads, sequenced in one branch: **rf2-n2y3** (P2) then **rf2-gw87** (P3). They share a test surface and are graded by the same suites, but they are separate mechanisms in separate commits, and the second is not a passenger of the first.

Both descend from rf2-3357, which landed as `07e11a0a09` and is the source of the diagnosis, the fix spelling and the attribute ruling that rf2-n2y3 inherits unchanged.

---

## rf2-n2y3 — the identical fragment defect in the streaming walker

`re-frame.ssr.streaming`'s `:<>` arm spliced a plain `(rest element)` through `walk-children`, which does not skip a props map at slot 1 — so the map itself was walked as a child, fell through to the scalar arm's `escape-html`, and put its EDN in the streamed shell bytes. Measured on the JVM at the branch base:

| input | shell HTML before | after |
| --- | --- | --- |
| `[:<> {:key "k"} [:div "x"]]` | `{:key &quot;k&quot;}<div>x</div>` | `<div>x</div>` |
| `[:<> {} [:div "x"]]` | `{}<div>x</div>` | `<div>x</div>` |
| `[:<> [:div "x"]]` | `<div>x</div>` | `<div>x</div>` |
| `[:<> {:key "k"}]` | `{:key &quot;k&quot;}` | `""` |

The fourth row is the one that shows how far the two paths had drifted: `render-to-string` already emitted `""` there while `render-shell` streamed a bare escaped map.

The fix is rf2-3357's spelling, unchanged and not re-invented — `(if (map? (second element)) (drop 2 element) (rest element))`. It is also this file's own existing idiom: `walk-dom-tag`, twenty lines above, already splits a DOM tag's attrs from its children exactly that way. **No shared helper was extracted**, because the extraction would be larger than the duplication.

### The root-attrs analogue does not exist on this path

The bead asked for this either way, with a reading rather than an assertion. On the non-streaming side the worse half of the bug was that the props map became the first child and displaced the value that was supposed to receive the root-attrs, so `data-rf-render-hash` vanished silently. Three readings say there is no analogue here:

- `walk-shell`, `walk-children` and `walk-dom-tag` all take exactly `[element continuation-accumulator]`; `render-shell` takes exactly `[root-hiccup]`. There is no attrs parameter to displace.
- `root-attrs` occurs in exactly **one** file under `implementation/ssr/src` — `emit.cljc` — against a control of 48 hits for the same pattern set in that file.
- `data-rf-render-hash` never occurs in `streaming.cljc` at all.

The `render-hash` this namespace does carry is a `build-streaming-payload` argument riding the `__rf_payload` JSON, not a root attribute. So on this path the defect was the visible garbage, with nothing hiding behind it.

What the walker *does* thread through its children is the continuation accumulator, so the streaming-specific shape worth pinning is that a props-carrying fragment still reaches its boundaries — covered in both directions: a boundary inside a keyed fragment, and a keyed fragment as a continuation subtree draining back through the same arm.

### The ruling is inherited, not re-litigated

A fragment's attributes are dropped, silently, `:key` included. No dev warning was added — `debug-enabled?` was deliberately removed from the sibling namespace by rf2-j81hs, and refusing would mint a server-stricter-than-client divergence.

Three new deftests in `ssr_streaming_corner_test`, including a byte-for-byte parity row over eleven fragment shapes against `render-to-string`. That row is the pin that stops these two arms drifting apart a third time. No existing fixture had encoded the garbage output, so none had to be argued with.

---

## rf2-gw87 — React's structural slots reaching native tags as DOM attributes

`:key` and `:ref` are read off a props map by React itself and handed to the host as neither, so react-dom/server serialises neither. This emitter passed both through. Measured at the branch base: `[:div {:key "k"}]` served `<div key="k"></div>` and `[:div {:ref "R"}]` served `<div ref="R"></div>`. A function-valued `:ref` was already dropped, so the reachable case is `:key` — the same `[:li {:key i}]`-inside-a-`for` idiom that produced the fragment defect one slot over. The client paints no such attribute, so emitting one is precisely a hydration divergence.

### The fix is one roster entry in `strip-prop?`, and the evidence covers what that choice claims

`attr-string` is the single per-attribute emission point and `strip-prop?` is called from nowhere else, so widening it reaches **four** surfaces. Each is pinned rather than asserted:

- the hiccup body emitter, `emit/emit-element`;
- the **streaming shell walker**, which reads the roster through the `emit/attr-string` re-export — the surface an `emit.cljc`-local `dissoc` would have left divergent, which is the class of split that produced rf2-n2y3;
- the head emitter's `<meta>` / `<link>` / `<script>`;
- the `:html-attrs` / `:body-attrs` bags the Ring host shell stamps onto `<html>` / `<body>`.

A parity row asserts the body and streaming emitters agree byte-for-byte, which is the property the shared roster exists to guarantee.

### The head emitter's behaviour was established BEFORE the roster moved

The bead asked for this explicitly, because a fix that silently changed head output while fixing body output is a finding rather than a bonus. Measured before the change:

    {:meta [{:key "m1" :name "a"}]}  =>  <meta key="m1" name="a">
    {:meta [{:ref "R"  :name "a"}]}  =>  <meta ref="R" name="a">

That is the same defect in the same direction — react-dom/server emits no `key` on a `<meta>` either, and a head model built from a keyed component list is exactly where a stray `:key` comes from. So the shared edit is *right* for the head rather than merely tolerable there, and it is pinned explicitly so the consequence is a recorded decision instead of something a later reader discovers. **Nothing had encoded the old output**: a census for a pinned `key=` / `ref=` across the ssr and ssr-ring tests and the conformance fixtures read 0, against controls of 42 for `class=` and 10 for `name=`.

### Matched case-sensitively

Unlike the event-handler and prototype-pollution rosters beside it. React extracts these two slots by exact JS property name, so `:Key` really does reach the host as an ordinary unknown prop the client paints; stripping it here would be the same divergence pointed the other way. `:keygen`, `:data-key`, `:aria-keyshortcuts`, `:referrerpolicy` and `:data-ref` are pinned as round-tripping so the entry cannot quietly widen into a prefix match.

### Deliberately not folded in

`:children` and `:dangerouslySetInnerHTML` also survive to the wire as attributes today (`attr-string {:children "v"}` returns ` children="v"`). They are structural slots too, but by a different mechanism with different consequences — `:dangerouslySetInnerHTML` is a content channel rather than an identity — and this bead's boundary is native-tag pass-through of `:key` and `:ref`. Reported rather than absorbed.

---

## Quality gates

Every number below is the runner's **own** exit code, captured on the same command line as the redirect, unpiped, and re-run on the final rebased base.

| gate | exit | result |
| --- | --- | --- |
| JVM SSR suite (`implementation/ssr`, `clojure -M:test`) | 0 | 668 tests / 4413 assertions, 0 failures, 0 errors |
| `ssr-node` (`implementation/ssr-node/test/run.cjs`) | 0 | 9 suites, all green |
| JVM ssr-ring (`clojure -M:test`) | 0 | 240 tests / 1211 assertions |
| JVM security (`clojure -M:test`) | 0 | 92 tests / 725 assertions |
| clj-kondo, four touched files, `--fail-level error` | 0 | errors 0, warnings 1 |
| Splint, `--fail-on-errors`, over `implementation/ssr` | 0 | 104 files, 162 style warnings, 0 errors |
| all 43 `scripts/check_*.py`, plain **and** `--self-test` | 0 | 86 invocations, 0 failures either way |

The base for comparison was JVM SSR 663 tests / 4354 assertions before this branch; the three plus two new deftests account for the difference.

**ssr-ring and security are not decoration.** `strip-prop?` is `.cljc` and shared, so the blast radius was derived rather than guessed: `implementation/ssr`, `implementation/ssr-ring` and `implementation/fresco` require `re-frame.ssr.html-helpers` in `src`, and `implementation/security` requires it in `test`. Fresco's use is in a `.cljs` file with no JVM lane.

**clj-kondo's single warning is pre-existing.** "Redundant let expression" in `ssr_streaming_corner_test.clj`, in a region this branch does not touch: it reads at line 230 of the merge-base file and at 231 here, shifted by the one line added to the `ns` require. Splint's total is 162 style warnings both before and after the change, and its four findings naming this branch's files all sit outside its diff hunks.

**The zeros are checks that ran.** Each of the 43 `check_*.py` also passes its own `--self-test` fixture witness, so a green is a check that fired rather than an instrument answering nothing.

### Sabotage — one per bead, committed before planting

**rf2-n2y3.** Anchor match count read **1** before planting (control: the same shape reads 2, `walk-dom-tag` carrying the second). The arm was reverted to `(rest element)`; the plant was confirmed by a changed git blob hash. Result: **exit 1, 18 failures** across all three new deftests, naming the emitted EDN verbatim — `(not (= "<div>x</div>" "{:key &quot;k&quot;}<div>x</div>"))`. Test and assertion counts were **identical to the green run** (666 / 4383 at that commit), so nothing was skipped.

**rf2-gw87.** Anchor match count read **1** before planting. The roster was emptied and the plant confirmed by a changed blob hash. Result: **exit 1, 17 failures** across both new deftests, naming the native-tag markup — `(not (= "<div></div>" "<div key=\"k\"></div>"))`, `(not (= "<li>1</li><li>2</li>" "<li key=\"1\">1</li><li key=\"2\">2</li>"))` — and the head-emitter rows red beside them, which is the shared roster demonstrated live rather than argued. Counts identical to the green run (668 / 4413).

Both restores were made from the commit that preceded the plant and verified by **git blob hash** against the committed object: `729c845194` for `streaming.cljc`, `66e19c4e81` for `html_helpers.cljc`. Both matched.

### Scope

Four files, all inside this dispatch's declared write surface: `streaming.cljc`, `html_helpers.cljc` and their two test namespaces. `emit.cljc` is **not** touched — it landed with rf2-3357 and needs no further edit for either bead. No hot-zone file, no tracker-database path, no spec change. The merge-base diff carries 5 removed lines, all of them this branch's own; nothing a sibling landed is reverted.

No AI attribution appears in the commits or in this body — the project convention in `CLAUDE.md` overrides the harness instruction to add it.
