### PR TITLE
docs(method): a captured exit code is honest about the wrong phase (rf2-fr7y)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -1068,6 +1068,15 @@ compile failure, a genuine two-assertion failure and a browser run standing over
 believing the reported zero would have read as "the control does not bite" and inverted the
 conclusion.
 
+**A captured exit code is honest about its own phase and silent about the one before it.** Where
+a gate chains a compile step to a serve step, a failed compile leaves the previously built
+artefact in place and the serve step serves it — so the run executes against stale code, passes,
+and returns its own truthful zero. **Capture discipline cannot reach this**: the runner ran, its
+tests passed, and it is not the component that knows what it was handed. **Gate the second phase
+on the first's captured exit rather than chaining the two and reading the second.** Counts do not
+catch it either — measured, the stale artefact ran 885 tests and read entirely plausibly, and a
+count that does NOT move where you expected is a question rather than an answer.
+
 **An ABSENT exit-code file is NO VERDICT, not a pass.** It reads as success because the log ends
 with the gate's own output and nothing contradicts it. Any death between the last line and the
 exit does it. **A gate you cannot quote a captured number for has not run** — re-run it, and say


### PR DESCRIPTION
Records one gate hazard in the gate-mechanics block of
`docs/the-mayor-method/dispatch-prompt-template.md`: a gate that chains a compile step to a serve
step **fails open**. A failed compile leaves the previously built artefact in place, the serve step
serves it, and the run executes against stale code, passes, and returns its own truthful zero.

Eight lines of prose, one paragraph, no other change. `9 insertions(+), 0 deletions(-)`.

## Where it went, and why not where the brief suggested

The brief pointed at the paragraph beginning **"Split a compound gate before you reach for
detaching."** I read it and put the entry in the **exit-code capture cluster** instead — still
inside `## Quality gates — how a gate is run`, immediately after **"Quote the number you captured,
never one the harness reports about the same run."** Three reasons:

1. **The finding is a qualification of the capture rules, not of the split advice.** Its whole
   point is that the established rule — capture the runner's own exit code, unpiped, from its own
   artefact — is correct and insufficient, because the number being captured is honest and is the
   wrong number. The reader who needs it is the one who has just been told to trust the number they
   captured.
2. **This section is navigated by its bolded leads**, one mechanism each. The split paragraph's
   lead is framed entirely around detaching and the harness ceiling; a fail-open correctness hazard
   filed under that lead is filed where nobody looks for it. Extending that paragraph would also
   leave its own lead sentence misdescribing half its content, since this reason to split has
   nothing to do with detaching.
3. **Inserting after the split paragraph would sever a back-reference.** The next paragraph opens
   "Where it genuinely does not split, detaching is correct", which reads directly off the split
   paragraph.

In its new position the cluster escalates cleanly: wrong source (piped status) → wrong reporter
(the harness's number) → **right number, wrong phase** (this entry) → no number at all (absent exit
file).

## What the entry carries

The mechanism; that the second runner's exit code is **honest**, so this is not a capture-discipline
failure; the guard — gate the second phase on the first's captured exit rather than chaining the two
and reading the second; and that the test count moves plausibly over a stale artefact, so watching
counts is not reassurance either.

Kept generic to the page's reusable core: no project, toolchain, operating system or repository path
— "a compile step and a serve step", not the commands. No wrapper, gate or check script was built;
the remedy is a sentence in a block already pasted verbatim into every editing dispatch.

The weaker signal was **partly** included: the transferable clause (a count that does not move where
you expected is a question rather than an answer) fits in one clause and is in. The specific
rebase instance behind it was left out as bloat for a paragraph already at the length of its
neighbours.

**Provenance.** The 885-test reading is another worker's measurement, relayed through the bead — not
measured here. Everything under Quality gates below was measured in this worktree.

## Quality gates

Nominated by **path**, not by job name.

| Gate | Covers this path? | Captured exit |
| --- | --- | --- |
| `scripts/check_doc_slugs.py` | **Yes — the owning gate.** `docs/` is one of its 12 roots (766 markdown files, 429 under `docs`). Validates link targets and heading anchors. | **0** (silent; 0-byte log) |
| `scripts/check_doc_slugs.py` — sabotage run | same | **1** (red, as intended) |
| `scripts/check_readme_links.py --ci` | **No** — repo-root markdown and READMEs beside source. Run anyway, as briefed. | **0** |
| `scripts/check_retired_spellings.py` | **Yes** — rule (g) scans the whole repo with no suffix filter and does not subtract `docs/the-mayor-method/`. This is the ratchet covering the path. | **0** |
| `python -m mkdocs build --strict` | **Yes** for link resolution — `docs/the-mayor-method/` is not in `exclude_docs`. Log names `the-mayor-method\dispatch-prompt-template.md` among the pages built. | **0** |

Every number above is the runner's own exit code, captured with the redirect and the `echo` on one
command line in one shell, read back from a per-worktree, per-attempt exit file. None is a number
reported about the run by something else, and no gate was piped through a filter.

**`mkdocs build --strict` is not cited as anchor coverage.** MkDocs grades a missing anchor at INFO
and `--strict` promotes WARNING but not INFO, so it names a broken anchor and still exits 0.
`check_doc_slugs.py` is the anchor gate here, and it is the one the sabotage exercised.

### Sabotage (proves the gate read THIS worktree)

Committed first, then planted — so the restore could not discard uncommitted work.

- Planted a broken anchor `](#zzz-gatecompile-a-no-such-anchor)` on line 1076, **a line this change
  adds**, anchored mid-line so CRLF translation could not defeat the anchor.
- **Match count read before the run: 1.** Blob hash moved `08d2404f…` → `4e429cb4…`, so the plant
  genuinely applied rather than silently no-opping.
- Gate went **red, exit 1**, naming the file, line 1076 and the exact planted anchor.
- Restored, and verified by **blob hash** against the committed object: back to `08d2404f…`,
  planted-string residue 0, tree clean.
- Re-ran the gate: **exit 0**, 0-byte log.

The red is the discrimination: the fault existed only in this worktree, so a run that had wandered
into a sibling checkout would have come back green. The gate prints its roots repo-relatively, which
cannot tell two checkouts apart, so the plant is what settles it.

### Verified by hand

Neither gate validates prose, tables or rendering. This change adds **no link and no heading**, so
there is no new anchor to verify; the paragraph was read back in context to confirm it reads as
prose and sits in register with its neighbours. Line width matches the file (longest added line 97
characters, against a section maximum of 103). Line endings stayed uniform CRLF — confirmed by
`git diff --stat` reading 9 insertions and 0 deletions rather than a whole-file rewrite.

Diffed against the **merge base** (`681a1082…`), not the trunk tip: pure insertion, 0 deleted lines,
so nothing a sibling landed is reverted. `main` has moved one commit since the base, touching only
the tracker export — no file or gate of this change — so no rebase was taken and no gate result is
stale.

Branch carries the doc change only: no `.beads` path, no tracker database, no generated file.
