### PR TITLE
fix(ssr): React's content channels are not DOM attributes (rf2-dgyi)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -546,6 +546,77 @@
 (def ^:private structural-slot-names
   #{"key" "ref"})
 
+;; rf2-dgyi — REACT'S TWO CONTENT CHANNELS. A SEPARATE ROSTER FROM THE
+;; STRUCTURAL SLOTS ABOVE, DELIBERATELY. `key` and `ref` are IDENTITY —
+;; reconciliation identity and an instance handle, neither of which has
+;; anything to render. `children` and `dangerouslySetInnerHTML` are the
+;; two channels React takes an element's CONTENT from, so they fail the
+;; same way on the wire and for a different reason, and folding them into
+;; one roster entry for tidiness would lose that reason. React consumes
+;; all four before the host sees them; only these two were ever about
+;; what the element CONTAINS.
+;;
+;; Measured on all four surfaces before this entry existed:
+;;
+;;   [:div {:children "v"}]        => <div children="v"></div>
+;;   [:div {:dangerouslySetInnerHTML {:__html "<b>x</b>"}}]
+;;                                 => <div dangerouslySetInnerHTML="{:__html
+;;                                    &quot;<b>x</b>&quot;}"></div>
+;;   {:meta [{:children "v" :name "a"}]}  => <meta children="v" name="a">
+;;
+;; WHY DROPPING LOSES NOTHING, WHICH IS THE WHOLE ARGUMENT AND IS A
+;; MEASUREMENT RATHER THAN A JUDGEMENT. The obvious objection is that
+;; `dangerouslySetInnerHTML` is CONTENT, so dropping it silently discards
+;; something the author asked to render — a worse failure than a stray
+;; attribute, and a new server-stricter-than-client divergence. It is not,
+;; because this emitter renders NO content for either prop TODAY: both
+;; land in the ATTRIBUTE stream, and the raw-HTML one arrives there as the
+;; escaped EDN PRINT of the `{:__html …}` map, which no browser renders as
+;; anything. The content divergence is therefore PRE-EXISTING and is not
+;; created here. Dropping strictly REDUCES the disagreement with the
+;; client — it removes the attribute half and leaves the content half
+;; exactly where it already was.
+;;
+;; WHAT THE CLIENT DOES, established rather than assumed. The client
+;; adapters pass both straight through to React: `reagent2.impl.template`
+;; drops only the three prototype-pollution names, so both reach
+;; `createElement`, and React then renders `props.children` as the
+;; element's children and `dangerouslySetInnerHTML.__html` as its raw
+;; body — painting NEITHER as an attribute. react-dom's own output for
+;; the raw-HTML case is pinned in-repo against the real serialiser by
+;; `reagent2.dom.parity-cljs-test/parity-dangerously-set-inner-html`, and
+;; the peer hiccup serialiser `reagent2.dom.server` already strips both
+;; from its attribute stream for exactly this reason (`emit-attribute`).
+;;
+;; SO HONOURING THEM, RATHER THAN DROPPING, IS THE REAL REPAIR — AND IT IS
+;; NOT AN ATTRIBUTE-PATH CHANGE, WHICH IS WHY IT IS NOT DONE HERE. It
+;; belongs to the CHILDREN path (`emit/emit-element`, `streaming/
+;; walk-dom-tag`), needs React's precedence rule (variadic children beat
+;; `props.children`), and is undefined on three of this roster's four
+;; surfaces: `<meta>` / `<link>` are void and take no children at all, and
+;; the Ring host shell's `:html-attrs` / `:body-attrs` are attribute bags
+;; with no children slot. For the raw-HTML channel it would additionally
+;; mint a SECOND trusted-markup spelling, which 004B refuses in terms
+;; ("`v/html` is the one visible trusted-markup spelling"). Filed rather
+;; than absorbed; see this entry's bead.
+;;
+;; NOT A THROW, THOUGH 004B SAYS "REFUSED" FOR THE TREE-SPACE GRAMMAR.
+;; That refusal is a compile/walk-time gate in a grammar that HAS a
+;; trusted-markup node; this fn's contract is narrower and says so above —
+;; it recognises "exactly the props that are *safe to silently drop*",
+;; and malformed input is `validate-attr-name!`'s job. A throw here would
+;; also take the Ring host shell down on a config typo in an attribute
+;; bag, and would diverge from react-dom/server harder than either drop
+;; or honour: react-dom throws for neither.
+;;
+;; MATCHED CASE-SENSITIVELY, for the same reason as the structural slots:
+;; React extracts both by exact JS property name, so `:Children` and the
+;; all-lowercase `:dangerouslysetinnerhtml` really do reach the host as
+;; ordinary unknown props that the client paints — stripping those would
+;; be this same divergence pointed the other way.
+(def ^:private content-channel-names
+  #{"children" "dangerouslySetInnerHTML"})
+
 (defn strip-prop?
   "True when the attribute `[k v]` MUST be dropped at SSR static-markup
   emission:
@@ -571,6 +642,18 @@
       React before the host sees them and neither serialised by
       react-dom/server. Matched case-sensitively; see
       `structural-slot-names`.
+    - React's two CONTENT CHANNELS, `:children` and
+      `:dangerouslySetInnerHTML` (rf2-dgyi) — the two slots React takes
+      an element's CONTENT from, likewise consumed before the host sees
+      them and likewise serialised by react-dom/server as neither. A
+      SEPARATE roster from the structural slots because the reason
+      differs: those are identity, these are content, and this emitter
+      renders no content for either today — the raw-HTML one reached the
+      wire as the escaped EDN print of its `{:__html …}` map. Dropping
+      therefore removes a stray attribute without discarding anything
+      that was being rendered; HONOURING them is a children-path change
+      and is deliberately not done here. Matched case-sensitively; see
+      `content-channel-names`, which carries the full argument.
 
   Mirrors react-dom/server behaviour. Recognised here are exactly the
   props that are *safe to silently drop*; malformed keys (breakout chars)
@@ -594,7 +677,8 @@
         (fn? v)
         (contains? reserved-prop-keys (str/lower-case nm))
         (contains? jsx-source-prop-names nm)
-        (contains? structural-slot-names nm))))
+        (contains? structural-slot-names nm)
+        (contains? content-channel-names nm))))
 
 ;; ---- boolean attribute-value classes (rf2-r9kf) ---------------------------
 ;;

--- a/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
@@ -19,7 +19,16 @@
       before the host sees them and serialised by react-dom/server as
       neither. Unlike the handler and prototype rosters this one matches
       CASE-SENSITIVELY, because React extracts the two slots by exact JS
-      property name,
+      property name, and
+    - React's two CONTENT CHANNELS, `:children` and
+      `:dangerouslySetInnerHTML` (rf2-dgyi) — the slots React takes an
+      element's CONTENT from, likewise consumed before the host sees them
+      and likewise serialised as neither, likewise case-sensitive. A
+      SEPARATE roster from the structural slots: those are identity,
+      these are content. Dropping them discards nothing that was being
+      rendered, because this emitter rendered no content for either — the
+      raw-HTML one reached the wire as the escaped EDN print of its
+      `{:__html …}` map,
 
   matching react-dom/server behaviour. The filter is the per-attribute
   prop-name position in the locked emitter composition order, so it runs
@@ -231,6 +240,135 @@
               at `attr-string`, which is the fn `ring.shell` calls"
       (is (= " lang=\"en\"" (rf.ssr.html-helpers/attr-string {:key "k" :lang "en"})))
       (is (= " class=\"c\"" (rf.ssr.html-helpers/attr-string {:ref "R" :class "c"}))))))
+
+(deftest attr-string-drops-reacts-content-channels
+  (testing "rf2-dgyi — `:children` and `:dangerouslySetInnerHTML` are the two
+            slots React takes an element's CONTENT from. Both were reaching
+            the wire as DOM attributes. Measured before the fix:
+            `{:children \"v\"}` emitted ` children=\"v\"`, and the raw-HTML
+            channel emitted the escaped EDN PRINT of its map —
+            ` dangerouslySetInnerHTML=\"{:__html &quot;<b>x</b>&quot;}\"` —
+            which is the measurement that settles the design question. This
+            emitter rendered NO content for either prop, so dropping them
+            discards nothing that was being rendered; it removes the
+            attribute half of a divergence and leaves the content half
+            exactly where it already was."
+    (testing ":children is dropped"
+      (is (= " id=\"x\"" (rf.ssr.html-helpers/attr-string {:children "v" :id "x"})))
+      (is (= "" (rf.ssr.html-helpers/attr-string {:children "v"}))
+          "a props map that is ONLY :children yields the empty string, not a
+           stray leading space")
+      (is (= "" (rf.ssr.html-helpers/attr-string {:children ["a" "b"]}))
+          "a VECTOR of children — the shape a hiccup caller's children slot
+           actually holds — dropped too, rather than printed as EDN"))
+
+    (testing ":dangerouslySetInnerHTML is dropped, in the `{:__html …}` shape
+              React defines and in any other"
+      (is (= " id=\"x\""
+             (rf.ssr.html-helpers/attr-string
+               {:dangerouslySetInnerHTML {:__html "<b>x</b>"} :id "x"})))
+      (is (= "" (rf.ssr.html-helpers/attr-string
+                  {:dangerouslySetInnerHTML {:__html "<b>x</b>"}})))
+      (is (not (str/includes?
+                 (rf.ssr.html-helpers/attr-string
+                   {:dangerouslySetInnerHTML {:__html "<b>x</b>"} :id "x"})
+                 ":__html"))
+          "the raw EDN map text must never reach the wire — the defect was
+           not merely a stray attribute NAME but a printed map as its VALUE"))
+
+    (testing "REAL children still render — dropping the prop does not touch
+              the children slot, which is also React's own precedence rule
+              (variadic children beat `props.children`)"
+      (is (= "<div>real</div>"
+             (rf.ssr.emit/render-to-string [:div {:children "v"} "real"] {}))))
+
+    (testing "the match is CASE-SENSITIVE, like the structural slots and for
+              the same reason: React extracts both channels by exact JS
+              property name, so these reach the host as ordinary unknown
+              props that the CLIENT paints — stripping them here would be the
+              same server/client divergence pointed the other way"
+      (is (str/includes? (rf.ssr.html-helpers/attr-string {:Children "v"})
+                         "Children=\"v\""))
+      (is (str/includes? (rf.ssr.html-helpers/attr-string
+                           {:dangerouslysetinnerhtml "v"})
+                         "dangerouslysetinnerhtml=\"v\"")
+          "the all-lowercase spelling is NOT React's reserved prop"))
+
+    (testing "the filter does not over-reach onto names that merely contain
+              or start with the two words"
+      (doseq [[k expected] {:data-children  "data-children=\"v\""
+                            :aria-children  "aria-children=\"v\""
+                            :childrenish    "childrenish=\"v\""}]
+        (is (str/includes? (rf.ssr.html-helpers/attr-string {k "v"}) expected)
+            (str k " is an ordinary attribute and must round-trip"))))))
+
+(deftest content-channels-drop-on-every-emitter-that-shares-the-roster
+  (testing "rf2-dgyi — the same four-surface obligation rf2-gw87 carried: the
+            argument for editing shared `strip-prop?` rather than
+            `dissoc`-ing in one emitter is that `attr-string` is the single
+            per-attribute emission point every SSR surface goes through, so a
+            change demonstrating only one has not shown the thing that
+            justified its own location."
+    (testing "the hiccup BODY emitter (emit/render-to-string)"
+      (is (= "<div></div>" (rf.ssr.emit/render-to-string [:div {:children "v"}] {})))
+      (is (= "<div></div>"
+             (rf.ssr.emit/render-to-string
+               [:div {:dangerouslySetInnerHTML {:__html "<b>x</b>"}}] {})))
+      (is (= "<div id=\"a\">x</div>"
+             (rf.ssr.emit/render-to-string [:div {:children "c" :id "a"} "x"] {}))
+          "the surviving attributes and the real children are untouched"))
+
+    (testing "the STREAMING shell walker (streaming/render-shell), which
+              reaches this roster through the `emit/attr-string` re-export"
+      (is (= "<div></div>"
+             (:shell-html (rf.ssr.streaming/render-shell [:div {:children "v"}]))))
+      (is (= "<div></div>"
+             (:shell-html (rf.ssr.streaming/render-shell
+                            [:div {:dangerouslySetInnerHTML {:__html "<b>x</b>"}}])))))
+
+    (testing "body and streaming emitters agree byte-for-byte, which is the
+              property the shared roster exists to guarantee"
+      (doseq [tree [[:div {:children "v"}]
+                    [:div {:dangerouslySetInnerHTML {:__html "<b>x</b>"}}]
+                    [:div {:children "v" :id "a"} "x"]
+                    [:main [:div {:children "v"} "x"]]]]
+        (is (= (rf.ssr.emit/render-to-string tree {})
+               (:shell-html (rf.ssr.streaming/render-shell tree)))
+            (str "emitters disagree on " (pr-str tree)))))
+
+    (testing "the HEAD emitter — a DELIBERATE consequence, pinned rather than
+              discovered later. `strip-prop?` is shared, so widening it
+              changes head output too. Measured BEFORE this change:
+              `{:meta [{:children \"v\" :name \"a\"}]}` emitted
+              `<meta children=\"v\" name=\"a\">`, and `<link>` / `<script>`
+              the same. That is the SAME defect in the same direction —
+              react-dom/server emits no `children` attribute on a `<meta>`
+              either — and on a VOID element `<meta>`/`<link>` the prop could
+              not be honoured as children even in principle, which is part of
+              why dropping rather than honouring is right here."
+      (is (= "<meta name=\"a\">"
+             (rf.ssr.head.emit/head-model->html
+               {:meta [{:children "v" :name "a"}]})))
+      (is (= "<meta name=\"a\">"
+             (rf.ssr.head.emit/head-model->html
+               {:meta [{:dangerouslySetInnerHTML {:__html "<b>x</b>"} :name "a"}]})))
+      (is (= "<link rel=\"stylesheet\" href=\"/a.css\">"
+             (rf.ssr.head.emit/head-model->html
+               {:link [{:children "v" :rel "stylesheet" :href "/a.css"}]})))
+      (is (= "<script src=\"/a.js\"></script>"
+             (rf.ssr.head.emit/head-model->html
+               {:script [{:children "v" :src "/a.js"}]}))))
+
+    (testing "the `:html-attrs` / `:body-attrs` bags the Ring host shell
+              stamps onto `<html>` / `<body>` read the same roster — pinned
+              at `attr-string`, which is the fn `ring.shell` calls. (The
+              shell itself lives in the ssr-ring artefact and is exercised by
+              that suite; this row pins the shared function it calls.)"
+      (is (= " lang=\"en\""
+             (rf.ssr.html-helpers/attr-string {:children "v" :lang "en"})))
+      (is (= " class=\"c\""
+             (rf.ssr.html-helpers/attr-string
+               {:dangerouslySetInnerHTML {:__html "<b>x</b>"} :class "c"}))))))
 
 (deftest attr-string-normal-attrs-still-emit
   (testing "the filter does not over-reach — ordinary attrs round-trip"

--- a/implementation/ssr/test/re_frame/ssr_boolean_attr_react_parity_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_boolean_attr_react_parity_test.clj
@@ -412,17 +412,113 @@
   [attribute markup]
   (react-writes? attribute markup "=\""))
 
+;; rf2-dgyi — RESERVED PROPS THAT REACHED THIS CORPUS BY AN ARTEFACT OF THE
+;; PROBE'S INCLUSION TEST, AND FOR WHICH THE MARKUP MODEL BELOW DOES NOT HOLD.
+;;
+;; `boolean_attr_classes.cjs` admits a name when `createElement('div', {name:
+;; true})` neither throws nor warns "Received `true` for a non-boolean
+;; attribute". `dangerouslySetInnerHTML` THROWS, so the probe's own comment
+;; records it as excluded. `children` does neither — it is a perfectly legal
+;; React prop — so it was admitted, and its six rows faithfully record what
+;; react-dom does with it. What they record is that it is NOT AN ATTRIBUTE:
+;;
+;;   :true-markup "<div></div>"        :string-markup       "<div>yes</div>"
+;;   :false-markup "<div></div>"       :empty-string-markup "<div></div>"
+;;   :zero-markup "<div>0</div>"       :string-zero-markup  "<div>0</div>"
+;;
+;; React consumes `children` before the host sees it and renders it as the
+;; element's CONTENT, emitting no `children=` attribute for any of the six
+;; values. So the generic arm below — "every other class keeps the value",
+;; i.e. stringifies it into an attribute — is a MODEL that this one name
+;; falsifies, and it was falsifying it silently: before `children` joined the
+;; SSR strip roster the emitter wrote `<div children="0"></div>`, the model
+;; expected `<div children="0"></div>`, the row said `<div>0</div>`, and the
+;; test was GREEN. The failure message printed react-dom's real markup all
+;; along; nothing compared against it. That is the shape this file's own
+;; docstring exists to rule out — a check that agrees with the thing it
+;; checks — reached through the EXPECTATION function rather than through the
+;; classifier.
+;;
+;; So the expectation for these names is read off the evidence rather than
+;; modelled, and `reserved-prop-row-carries-no-attribute` below asserts the
+;; premise against the fixture instead of trusting this comment.
+;;
+;; THE RESIDUAL IS REAL AND IS NOT PAPERED OVER HERE. For `""`/`true`/`false`
+;; react-dom renders `<div></div>` and so does this emitter — exactly right.
+;; For `"yes"`/`0`/`"0"` react-dom renders the value as CONTENT and this
+;; emitter renders nothing, because honouring a content channel is a
+;; children-path change rather than an attribute-path one (see
+;; `html-helpers/content-channel-names`). That gap is filed on rf2-dgyi, and
+;; `reserved-prop-content-residual-is-known` below PINS it, so it is a
+;; recorded divergence with a test that goes red the day somebody closes it
+;; rather than an omission a later reader has to rediscover.
+(def ^:private reserved-props
+  #{"children"})
+
 (defn- expected-hiccup-markup-for-value
   "The `<div>` markup the hiccup emitters must produce for a NON-boolean
   `value`. For the presence class the expectation is react-dom's OWN verdict
   on the same value — read off the row rather than restated — re-spelled in
-  this grammar's bare presence form. Every other class keeps the value."
+  this grammar's bare presence form. For a RESERVED prop (rf2-dgyi) react-dom
+  writes no attribute at any value and this emitter strips the prop, so the
+  expectation is the bare element. Every other class keeps the value."
   [klass attribute {:keys [field serialised]} row]
-  (if (= :presence klass)
+  (cond
+    (contains? reserved-props attribute)
+    "<div></div>"
+
+    (= :presence klass)
     (if (react-emits? attribute (get row field))
       (str "<div " attribute "></div>")
       "<div></div>")
+
+    :else
     (str "<div " attribute "=\"" serialised "\"></div>")))
+
+(deftest reserved-prop-row-carries-no-attribute
+  (testing "rf2-dgyi — the premise of the `reserved-props` exception, taken
+            from the FIXTURE rather than asserted in a comment: react-dom
+            writes no `children=` attribute at ANY of the six probe values.
+            If a future react-dom ever did, this exception would be wrong and
+            this row is what says so"
+    (doseq [attribute reserved-props
+            row       (rows)
+            :when     (= attribute (:attribute row))
+            field     [:true-markup :false-markup :string-markup
+                       :empty-string-markup :zero-markup :string-zero-markup]]
+      (is (not (react-emits? attribute (get row field)))
+          (str "react-dom wrote a " attribute "= attribute in " field ": "
+               (pr-str (get row field)))))
+
+    (testing "and the exception is not vacuous — the name really is in the
+              corpus, so a probe that stopped emitting the row would fail
+              here rather than silently exercising nothing"
+      (doseq [attribute reserved-props]
+        (is (some #(= attribute (:attribute %)) (rows))
+            (str attribute " is absent from the react-dom evidence"))))))
+
+(deftest reserved-prop-content-residual-is-known
+  (testing "rf2-dgyi — the KNOWN, FILED gap. react-dom renders a reserved
+            content prop's value as the element's CONTENT; this emitter drops
+            the prop and renders nothing, because honouring it is a
+            children-path change (`emit/emit-element`, `streaming/
+            walk-dom-tag`) rather than an attribute-path one, and is
+            undefined on the void `<meta>`/`<link>` and the host shell's
+            attribute bags. Pinned so the divergence is a recorded decision
+            with a red the day it is closed, not an omission to rediscover"
+    (doseq [row   (rows)
+            :when (contains? reserved-props (:attribute row))
+            probe non-boolean-probe-values]
+      (let [react-markup (get row (:field probe))
+            ours         (rf.ssr.emit/render-to-string
+                           [:div {(keyword (:attribute row)) (:value probe)}] {})]
+        (is (= "<div></div>" ours)
+            "this emitter renders the bare element for every value")
+        (when (not= "<div></div>" react-markup)
+          (is (not= react-markup ours)
+              (str "react-dom renders " (pr-str react-markup)
+                   " as CONTENT — if this now matches, the residual has been
+                    closed and this pin should be retired with the bead")))))))
 
 (deftest render-to-string-follows-react-for-every-non-boolean-probe-value
   (testing "rf2-u82a — the PUBLIC hiccup render path over the whole evidence


### PR DESCRIPTION
Closes rf2-dgyi (P3). Follows rf2-gw87 (#9593) in the same file; that one landed as `98f99ad2e1`, this branch's base.

## The defect

`:children` and `:dangerouslySetInnerHTML` are the two slots React takes an element's **content** from. React consumes both before the host sees them, and react-dom/server serialises neither. This emitter passed both through as DOM attributes. Measured on the JVM in this worktree, at the base commit:

```
[:div {:children "v"}]
  =>  <div children="v"></div>
[:div {:dangerouslySetInnerHTML {:__html "<b>x</b>"}}]
  =>  <div dangerouslySetInnerHTML="{:__html &quot;<b>x</b>&quot;}"></div>
```

The raw-HTML channel is the sharper half: it reached the wire as the escaped **EDN print of its map**. Not an injection — the quotes are escaped, so the value stays inside its attribute — but not content by any reading either.

## The judgement, which is the substance of this bead

The bead held these back from rf2-gw87 deliberately, because `:dangerouslySetInnerHTML` is a **content channel** rather than an identity slot. They get their own roster (`content-channel-names`) beside `structural-slot-names`, sharing the mechanism but not the policy line.

**Why dropping is right, and this is a measurement rather than a judgement.** The objection to dropping is that it silently discards content the author asked to render — a worse failure than a stray attribute, and a new server-stricter-than-client divergence. Measured, it is not: **this emitter renders no content for either prop today**, because both land in the attribute stream. The content divergence is *pre-existing*. Dropping removes the attribute half and leaves the content half exactly where it already was, so it strictly reduces the disagreement with the client.

**What the client does, established rather than assumed.** `reagent2.impl.template` drops only the three prototype-pollution names, so both props reach `createElement`; React then renders `props.children` as children and `dangerouslySetInnerHTML.__html` as the raw body, painting **neither** as an attribute. The peer hiccup serialiser `reagent2.dom.server` already strips both from its attribute stream and honours the raw-HTML one as content (`emit-attribute`, `emit-dom-element`), and `parity-dangerously-set-inner-html` pins that against real react-dom.

**Honouring, not dropping, is the real repair — and is deliberately not done here.** It is a children-path change (`emit/emit-element`, `streaming/walk-dom-tag`), needs React's precedence rule (variadic children beat `props.children`), and is **undefined on three of the four surfaces**: `<meta>`/`<link>` are void and take no children, and the host shell's `:html-attrs`/`:body-attrs` are attribute bags with no children slot. For the raw-HTML channel it would additionally mint a second trusted-markup spelling, which 004B refuses in terms. Reported rather than built, per the bead's own boundary.

**Not a throw**, though 004B says "refused" for the tree-space grammar: that is a compile/walk-time gate in a grammar that *has* a trusted-markup node, whereas this fn's contract is "exactly the props that are safe to silently drop". A throw here would also take the Ring host shell down on a config typo in an attribute bag, and would diverge from react-dom harder than either drop or honour, since react-dom throws for neither.

## Second finding: a parity test was green against evidence that refutes it

`react_dom_probe/boolean_attr_classes.edn` already carries a `children` row measured from react-dom itself:

```
:true-markup "<div></div>"   :string-markup       "<div>yes</div>"
:false-markup "<div></div>"  :empty-string-markup "<div></div>"
:zero-markup "<div>0</div>"  :string-zero-markup  "<div>0</div>"
```

No attribute at any of six values. The parity test never compared against it: `expected-hiccup-markup-for-value` reads react-dom's markup only for the `:presence` class and **models** every other class as "stringify into an attribute". So it expected `<div children="0"></div>`, the emitter produced `<div children="0"></div>`, the row said `<div>0</div>`, and the test was **green while its own failure message printed the refuting evidence**. That is the shape that file's docstring exists to rule out — a check agreeing with the thing it checks — reached through the expectation function instead of the classifier.

Repaired: the expectation now reads the evidence for reserved props, `reserved-prop-row-carries-no-attribute` asserts the premise against the fixture rather than trusting a comment (and asserts the row is present, so it cannot pass vacuously), and `reserved-prop-content-residual-is-known` **pins the residual** so it goes red the day somebody closes it.

`children` is in that corpus by an artefact of the probe's inclusion test — `boolean_attr_classes.cjs` admits a name when `createElement('div', {name: true})` neither throws nor warns. `dangerouslySetInnerHTML` **throws**, which is why the probe's own comment records it as excluded and why it has no row.

## Four surfaces, established before the roster widened

The whole argument for editing shared `strip-prop?` is that it reaches all four, so each was measured **before** the change, in this worktree:

| surface | before | after |
|---|---|---|
| hiccup body emitter (`emit/render-to-string`) | `<div children="v"></div>` | `<div></div>` |
| streaming walker (`streaming/render-shell`) | `<div children="v"></div>` | `<div></div>` |
| head emitter (`head.emit/head-model->html`) | `<meta children="v" name="a">` | `<meta name="a">` |
| Ring host shell (`ring.shell/document-prefix`) | reads the same roster | `<html lang="en">`, `<body class="c">` |

`<link>` and `<script>` carried it too (`<link children="v" rel="stylesheet" …>`, `<script children="v" src="/a.js">`), and the raw-HTML channel carried its EDN print on every one of them.

**The head-emitter change is a deliberate consequence, pinned as a recorded decision** rather than left for a later reader — the same call rf2-gw87 made one slot over, and reinforced here by `<meta>`/`<link>` being void, so the prop could not be honoured as children on them even in principle. The Ring shell was measured through the real `document-prefix`, not only at `attr-string`.

Negative controls, all still round-tripping: `:Children`, `:dangerouslysetinnerhtml` (all-lowercase — not React's reserved prop, so the client paints it), `:data-children`, `:aria-children`, `:childrenish`.

## The residual, stated plainly

For `""`/`true`/`false` react-dom renders `<div></div>` and so does this emitter — exactly right, where **none** of the six values was right before. For `"yes"`/`0`/`"0"` react-dom renders the value as content and this emitter renders nothing. That gap is pre-existing, is not widened here, and is pinned by a test.

## Quality gates

All run in this worktree, on the final rebased base (`bba62bc905`). Each number is the runner's own exit code, captured unpiped on the same command line as the redirect.

| Gate | Command | Exit | Result |
|---|---|---|---|
| JVM SSR suite | `clojure -M:test` in `implementation/ssr` | **0** | 672 tests, 4454 assertions, 0 failures, 0 errors |
| JVM ssr-ring suite | `clojure -M:test` in `implementation/ssr-ring` | **0** | 240 tests, 1211 assertions, 0 failures, 0 errors |
| JVM security suite | `clojure -M:test` in `implementation/security` | **0** | 92 tests, 725 assertions, 0 failures, 0 errors |
| `test:ssr-node` | `node ssr-node/test/run.cjs` | **0** | 9 suites, all green |
| clj-kondo | `--fail-level error` over the three touched files | **0** | errors: 0, warnings: 0 |
| Splint | `-M:splint --fail-on-errors ../implementation/ssr` | **0** | 104 files; 162 style warnings, all pre-existing |

Gates were **derived**, not guessed, on rf2-gw87's basis: `implementation/{ssr,ssr-ring,fresco}` require `html-helpers` in src and `implementation/security` does in test. Fresco's use is `.cljs` with no JVM lane, so **that side is CI's — this branch claims no coverage of it**.

The three Splint warnings naming `html_helpers.cljc` are at lines I did not touch (`apply-str` at an accumulator, two `identical-branches` in `boolean-attr-class`); both were confirmed present at the base commit. None name the two test files.

**Ratchets.** 21 checks covering these paths were run individually; every one exited 0: retired spellings, retired composition vocab, retired image keys, keyword catalogue drift, JVM lane rosters, test lane bijection, thrown error messages, require alias dialect, ambient durable reads, CI reproduce commands, fast-PR gap, gate scheduling, egress walker residue, inject-cofx residue, view-lifetime residue, failure-corpus residue, allocation non-claim, conformance fixture EDN, README inventories, no-hardcoded-paths, ai-tracking ratchet.

### Sabotage

Committed first, then planted, then restored, then hash-verified — in that order, so the restore could not silently discard uncommitted work.

- Blob hash of `html_helpers.cljc` at the commit: `15999b5be16337b8987daa6f4d40c17ead46fcb0`.
- Plant anchor read **1** match before the run (single-line anchor; the roster set emptied to `#{}`).
- Planted blob hash `fc2a1b2e9566d186e61bd25888bb638549b0303d` — differs, so the plant genuinely applied rather than no-opping.
- Result: **exit 1, 30 failures across 5 deftests**, naming the emitted attribute verbatim — `children="v"`, `children="0"`, `children="yes"`, `children=""`, `children="c"`, `children="[&quot;a&quot; &quot;b&quot;]"` — with `dangerouslySetInnerHTML=` on 13 lines and **7 head-emitter rows red** (`<meta children=`, `<link children=`, `<script children=`), which demonstrates the shared roster reaching multiple surfaces live rather than arguing for it.
- The red spans my new rows **and** the two pre-existing react-dom parity deftests, so the corpus repair is exercised too.
- Restored blob hash `15999b5be16337b8987daa6f4d40c17ead46fcb0` — matches the committed object; working tree clean.
- Full suite re-run after restore: exit 0, 672/4454.

The plant exists only in this worktree, so the red is what discriminates the run from one that had wandered into a sibling checkout.

## Out of scope, reported not absorbed

- **Honouring either channel as content** — the residual above. Children-path work, undefined on three of the four surfaces, and a second trusted-markup spelling for the raw-HTML one.
- **Spec 011 §XSS at output boundaries** enumerates this filter's roster (`on*`, fn-valued, prototype-pollution) and names neither the structural slots nor these content channels. rf2-gw87 did not update it either, so the roster's record has lived in the fn's docstring for both. Flagged as a doc-drift follow-up; not touched here, matching the immediately preceding sibling's register.
- `spec/004B` states the tree-space rule and is hot-zone; read, not edited.

Worker fence honoured: this branch touches `html_helpers.cljc` and `implementation/ssr/test/**` only — not `emit.cljc`, not `streaming.cljc`, no hot-zone file, and no tracker-database path.

AI attribution was declined in both the commit message and this body, per CLAUDE.md.
