### PR TITLE
fix(xray): key the inspector's per-mount store by frame, not by the logical mount-id (rf2-d2aj)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -225,6 +225,17 @@
         ;; exactly the stability wanted, and it is what `:site-id` below is
         ;; built from too. (This is the string the pre-migration
         ;; `_node-key` binding already spelled out and discarded.)
+        ;;
+        ;; rf2-d2aj — and a LOGICAL name is all it is. This string is not
+        ;; unique to a mounted panel: the gallery renders twelve variants at
+        ;; once and each embedded panel is another, so several live mounts
+        ;; present `app-db-state/top` together. The widget is what keeps the
+        ;; two identities apart — it qualifies this name by the frame the
+        ;; mount renders under to key its per-mount store — so DO NOT make
+        ;; this string unique per render to fix a lifecycle collision: it
+        ;; would take `:site-id` with it and lose expansion and zoom on
+        ;; every pass, which is the trade the widget's split exists to
+        ;; avoid.
         mount-id  (str "app-db-state/" render-id)
         ;; rf2-pvsxs — stable `:site-id` so expansion overrides survive
         ;; a tab-switch round-trip. `render-id` already identifies the

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -62,9 +62,17 @@
 
   A mount owns three pieces of mutable state — its ResizeObserver, the
   width debounce, and the Editscript projection cache. They live in one
-  module-level store keyed by `mount-id`, and are released together when
-  React calls the container `:ref` with `nil`. `mount-state-count` reads
-  the store, so teardown is assertable rather than assumed.
+  module-level store keyed by the mount's LIFECYCLE KEY, and are released
+  together when React calls the container `:ref` with `nil`.
+  `mount-state-count` reads the store, so teardown is assertable rather
+  than assumed.
+
+  THE LIFECYCLE KEY IS NOT THE MOUNT-ID (rf2-d2aj). `mount-id` is a
+  LOGICAL name — the surface, deliberately stable, keying the width slot
+  and the testids — while the lifecycle key names ONE LIVE MOUNT of it and
+  is the mount-id qualified by the frame the mount renders under. Two
+  panels under two `frame-provider`s legitimately render the same stable
+  mount-id; keyed on that alone they shared one entry and one observer.
 
   `opts` keys:
 
@@ -3034,8 +3042,36 @@
   (str (random-uuid)))
 
 ;; =========================================================================
-;; per-mount runtime state — ONE store, keyed by mount-id (rf2-k97c.3)
+;; per-mount runtime state — ONE store, keyed by LIFECYCLE KEY (rf2-k97c.3,
+;; re-keyed rf2-d2aj)
 ;; =========================================================================
+;;
+;; TWO IDENTITIES, AND KEEPING THEM APART IS THE WHOLE OF THIS SECTION.
+;;
+;;   `mount-id`      — the caller's LOGICAL name for the surface. It keys
+;;                     the width slot, the popup id and the container
+;;                     testid, and it is deliberately stable: a panel that
+;;                     leaves and returns to the same surface wants the
+;;                     same one back.
+;;   `lifecycle-key` — the identity of one LIVE MOUNT, and the key of this
+;;                     store. It is the mount-id qualified by the frame the
+;;                     mount renders under.
+;;
+;; The store is MODULE-GLOBAL while every piece of state it holds is
+;; FRAME-RELATIVE: the observer's dispatcher is bound to one frame, and the
+;; width it writes lands in THAT frame's app-db. A global store keyed by a
+;; frame-relative name is the entrenched singleton this widget refuses
+;; everywhere else (see `zoom-trigger-attrs` on why the zoom write must not
+;; name `:rf/xray` literally), and rf2-d2aj is what it costs: two panels in
+;; two frames sharing one stable mount-id got ONE entry and ONE observer
+;; between them, the second panel never measured, and detaching the second
+;; released the FIRST — disconnecting its observer and clearing its frame's
+;; width. Qualifying the key by the frame makes the store's key exactly as
+;; specific as the state under it.
+;;
+;; Nothing else moves. `:site-id` still keys expansion and zoom, `mount-id`
+;; still keys the width slot and every testid, and the two heads' public
+;; shapes are untouched — the collision was in this store's key alone.
 ;;
 ;; The widget carries three pieces of per-mount MUTABLE state: the
 ;; ResizeObserver instance, the last width it dispatched (a debounce), and
@@ -3052,9 +3088,9 @@
 ;; standing it back up on a loop.
 ;;
 ;; So the state moves OUT of the closure and into this module-level store,
-;; keyed by the mount-id. That makes the lifetime EXPLICIT rather than
+;; keyed by the lifecycle key. That makes the lifetime EXPLICIT rather than
 ;; implicit, which is the whole point: the entry is minted on first sight
-;; of a mount-id and RELEASED when React calls the ref with `nil`. One
+;; of a lifecycle key and RELEASED when React calls the ref with `nil`. One
 ;; store serves both heads, so the Reagent head loses its closure atoms
 ;; too and the two heads share one lifecycle rather than each having their
 ;; own.
@@ -3066,6 +3102,19 @@
 
 (defonce ^:private mount-state
   (atom {}))
+
+(defn lifecycle-key
+  "Compose the per-mount store's key — the `mount-id` qualified by the id of
+  the frame the mount renders under (rf2-d2aj).
+
+  PURE, and public because a test that asserts on the store has to be able
+  to name an entry the way the widget named it.
+
+  `frame-id` may be nil, which is the honest answer for a caller whose
+  mount-id is already unique on its own — the Reagent head's is a UUID, so
+  it has nothing to qualify."
+  [frame-id mount-id]
+  [frame-id mount-id])
 
 (defn mount-state-count
   "How many mounts the per-mount store currently holds. A TEST SURFACE:
@@ -3083,50 +3132,75 @@
   (count @mount-state))
 
 (defn mount-state-held
-  "The set of state keys mount `mount-id` currently holds, or nil when the
-  store holds nothing for it. A TEST SURFACE, and the precise one: the
-  teardown claim is about the observer, the width debounce and the
+  "The set of state keys the mount under `lifecycle-key` currently holds, or
+  nil when the store holds nothing for it. A TEST SURFACE, and the precise
+  one: the teardown claim is about the observer, the width debounce and the
   projection cache going TOGETHER, which a count cannot express and which
-  `nil` here does."
-  [mount-id]
-  (when-let [entry (get @mount-state mount-id)]
+  `nil` here does.
+
+  The argument is a LIFECYCLE KEY, not a mount-id (rf2-d2aj) — compose one
+  with [[lifecycle-key]], or pass a bare id for a mount whose id is its own
+  lifecycle key."
+  [lifecycle-key]
+  (when-let [entry (get @mount-state lifecycle-key)]
     (set (keys entry))))
 
 (defn- release-mount!
-  "Tear down everything mount `mount-id` holds: disconnect its
-  ResizeObserver, drop its width debounce and its projection cache, clear
-  the app-db width slot, and remove the entry entirely.
+  "Tear down everything the mount under `lifecycle-key` holds: disconnect
+  its ResizeObserver, drop its width debounce and its projection cache,
+  clear the app-db width slot, and remove the entry entirely.
 
-  The app-db clear matters because a mount-id is not reused — the Reagent
-  head mints a UUID per mount — so a surviving entry is a slow leak in the
-  frame's app-db as well as in this atom."
-  [mount-id dispatch-fn]
-  (when-let [entry (get @mount-state mount-id)]
+  The app-db clear matters because a live mount is not reused — the Reagent
+  head mints a UUID per mount, and the Fresco head's key carries the frame
+  — so a surviving entry is a slow leak in the frame's app-db as well as in
+  this atom. The slot it clears is keyed by the LOGICAL `mount-id`, which
+  the entry carries, because that is the name the renderer reads a width
+  back under."
+  [lifecycle-key dispatch-fn]
+  (when-let [entry (get @mount-state lifecycle-key)]
     (when-let [obs (:observer entry)]
       (try (.disconnect ^js obs)
            (catch :default _ nil)))
-    (swap! mount-state dissoc mount-id)
+    (swap! mount-state dissoc lifecycle-key)
     (when dispatch-fn
-      (dispatch-fn [:rf.xray.edn-inspector/clear-width mount-id])))
+      (dispatch-fn [:rf.xray.edn-inspector/clear-width
+                    (or (:mount-id entry) lifecycle-key)])))
   nil)
 
 (defn- measure-and-dispatch!
   "Measure `el`'s client width and write it to the width slot when it has
   actually MOVED. `clientWidth` is rounded by the browser, so identical
   measurements arrive verbatim on every observer callback; the debounce is
-  what keeps them from churning the app-db slot."
-  [mount-id ^js el]
+  what keeps them from churning the app-db slot.
+
+  Both identities are arguments and neither can stand in for the other: the
+  debounce is per LIVE MOUNT (`lifecycle-key`) while the slot it writes is
+  keyed by the logical `mount-id` the renderer reads back under."
+  [lifecycle-key mount-id ^js el]
   (when el
     (let [w (.-clientWidth el)]
       (when (and (number? w) (pos? w)
-                 (not= w (get-in @mount-state [mount-id :last-width])))
-        (swap! mount-state assoc-in [mount-id :last-width] w)
-        (when-let [d (get-in @mount-state [mount-id :dispatch-fn])]
+                 (not= w (get-in @mount-state [lifecycle-key :last-width])))
+        (swap! mount-state assoc-in [lifecycle-key :last-width] w)
+        (when-let [d (get-in @mount-state [lifecycle-key :dispatch-fn])]
           (d [:rf.xray.edn-inspector/set-width mount-id w])))))
   nil)
 
 (defn container-ref-for
-  "The `:ref` callback for `mount-id`, MEMOISED on the mount-id.
+  "The `:ref` callback for one live mount, MEMOISED on its LIFECYCLE KEY.
+
+  Two arities, and the difference between them is the whole of rf2-d2aj:
+
+    [mount-id dispatch-fn]                 the id IS its own lifecycle key
+    [lifecycle-key mount-id dispatch-fn]   they are separate
+
+  MEMOISING ON A LOGICAL NAME IS WHAT COLLIDES. Two panels rendering the
+  same stable `mount-id` at the same time are two mounts and want two
+  refs; memoised on that name they get one function, so the second element
+  never installs an observer, never measures, and detaching it releases the
+  FIRST mount's entry. The 2-arity is therefore for a caller whose id is
+  unique per live mount by construction — the Reagent head's UUID — and
+  every other caller composes a key with [[lifecycle-key]].
 
   Returning the SAME function for the same mount is the contract, not an
   optimisation: React re-runs a callback ref whenever its identity changes,
@@ -3137,8 +3211,10 @@
 
   `dispatch-fn` is captured on the FIRST call for a mount and not
   refreshed. A mount's frame does not change under it — that is what makes
-  the capture safe — and re-reading a fresh `capture-frame` bundle on every
-  render would write to this atom on every render for no gain.
+  the capture safe, and with the frame now IN the key it is safe by
+  construction rather than by convention — and re-reading a fresh
+  `capture-frame` bundle on every render would write to this atom on every
+  render for no gain.
 
   The returned callback is also SELF-HEALING, which the memo above makes
   necessary: a caller holds it across a nil call that released the mount,
@@ -3149,11 +3225,13 @@
   from a callback ref as a CLEANUP FUNCTION and warns about any other
   value; the implicit return here would otherwise be whatever `swap!` or
   `dispatch` last answered."
-  [mount-id dispatch-fn]
-  (or (get-in @mount-state [mount-id :ref])
+  ([mount-id dispatch-fn]
+   (container-ref-for mount-id mount-id dispatch-fn))
+  ([lifecycle-key mount-id dispatch-fn]
+  (or (get-in @mount-state [lifecycle-key :ref])
       (let [ref-fn
             (fn container-ref [^js el]
-              (let [entry (get @mount-state mount-id)]
+              (let [entry (get @mount-state lifecycle-key)]
                 (cond
                   ;; Mount — reinstate the entry, measure once, then
                   ;; install the observer.
@@ -3172,29 +3250,33 @@
                     ;; re-attachment is silently swallowed while measurement
                     ;; and observer state come back looking healthy
                     ;; (rf2-9go2). On a live entry both updates are no-ops.
-                    (swap! mount-state update mount-id
+                    (swap! mount-state update lifecycle-key
                            (fn [e]
                              (-> (or e {})
+                                 (assoc :mount-id mount-id)
                                  (update :ref #(or % container-ref))
                                  (update :dispatch-fn #(or % dispatch-fn)))))
-                    (measure-and-dispatch! mount-id el)
+                    (measure-and-dispatch! lifecycle-key mount-id el)
                     (when (exists? js/ResizeObserver)
                       (let [obs (js/ResizeObserver.
                                   (fn [_entries]
-                                    (measure-and-dispatch! mount-id el)))]
+                                    (measure-and-dispatch! lifecycle-key
+                                                           mount-id el)))]
                         (.observe obs el)
-                        (swap! mount-state assoc-in [mount-id :observer] obs))))
+                        (swap! mount-state assoc-in
+                               [lifecycle-key :observer] obs))))
 
                   ;; Unmount — release everything this mount holds.
                   (and (nil? el) (some? entry))
-                  (release-mount! mount-id (:dispatch-fn entry))))
+                  (release-mount! lifecycle-key (:dispatch-fn entry))))
               nil)]
-        (swap! mount-state update mount-id
+        (swap! mount-state update lifecycle-key
                (fn [entry]
                  (-> (or entry {})
+                     (assoc :mount-id mount-id)
                      (assoc :ref ref-fn)
                      (update :dispatch-fn #(or % dispatch-fn)))))
-        (get-in @mount-state [mount-id :ref]))))
+        (get-in @mount-state [lifecycle-key :ref])))))
 
 (defn- project-for
   "The Editscript projection of `(before, after)` for this mount, memoised
@@ -3208,15 +3290,17 @@
 
   The cache lives in the per-mount store rather than in a closure so it is
   released by `release-mount!` with everything else, and so both heads
-  share one implementation."
-  [mount-id before after]
-  (let [cached (get-in @mount-state [mount-id :projection])]
+  share one implementation. Keyed by the LIFECYCLE KEY for the same reason
+  the rest of the entry is (rf2-d2aj): two live mounts of one logical
+  surface hold two different values and must not share a memo."
+  [lifecycle-key before after]
+  (let [cached (get-in @mount-state [lifecycle-key :projection])]
     (if (and cached
              (identical? before (:before cached))
              (identical? after (:after cached)))
       (:projection cached)
       (let [p (engine/project before after)]
-        (swap! mount-state assoc-in [mount-id :projection]
+        (swap! mount-state assoc-in [lifecycle-key :projection]
                {:before before :after after :projection p})
         p))))
 
@@ -3566,10 +3650,17 @@
                            destructured here exactly as it always was, so
                            every documented key keeps its meaning and its
                            default.
-  - `:mount-id`          — the per-mount identity string. Keys the width
-                           slot, the popup id and the container testid,
-                           and is the expansion key's second component
-                           when no `:site-id` is supplied.
+  - `:mount-id`          — the caller's LOGICAL name for the surface. Keys
+                           the width slot, the popup id and the container
+                           testid, and is the expansion key's second
+                           component when no `:site-id` is supplied.
+  - `:lifecycle-key`     — the identity of THIS LIVE MOUNT, which keys the
+                           per-mount store (rf2-d2aj). Optional; defaults
+                           to `:mount-id`, which is right only for a caller
+                           whose id is unique per live mount. The head
+                           passes the same key it built `:container-ref`
+                           with, so the projection memo and the observer
+                           live and die together.
   - `:dispatch-fn`       — the frame-aware dispatcher. Threaded down
                            through `render-node` so a toggle fired long
                            after this render unwound still lands on the
@@ -3586,9 +3677,9 @@
                            the epoch panel alone mounts this widget dozens
                            of times.
   - `:widths`            — the measured-width slot's value."
-  [{:keys [value opts mount-id dispatch-fn container-ref
+  [{:keys [value opts mount-id lifecycle-key dispatch-fn container-ref
            expansion-map zoom-map widths]}]
-      (let [
+      (let [lifecycle-key (or lifecycle-key mount-id)
             {:keys [panel-id site-id default-expanded-depth max-inline-width
                     max-depth popup-affordance? card? header zoomable?
                     added?]
@@ -3735,7 +3826,8 @@
             ;; inputs reuse the cached Editscript result rather than
             ;; recomputing the A* edit-script on every render.
             projection    (when diff?
-                            (project-for mount-id displayed-before displayed-value))
+                            (project-for lifecycle-key
+                                         displayed-before displayed-value))
             body-content  (render-node
                             {:value displayed-value
                              :before (if diff? displayed-before ::missing)
@@ -4007,6 +4099,12 @@
           {:value         value
            :opts          opts
            :mount-id      mount-id
+           ;; rf2-d2aj — this head's id IS its lifecycle key: the form-2
+           ;; outer body mints a fresh UUID per mount, so it is already
+           ;; unique across every concurrently live mount on the page and
+           ;; has nothing to qualify. The Fresco head, whose id is a
+           ;; caller-supplied logical name, is the one that must.
+           :lifecycle-key mount-id
            :dispatch-fn   dispatch-fn
            :container-ref (container-ref-for mount-id dispatch-fn)
            ;; `subscribe` is the lexical frame-aware closure injected by
@@ -4049,6 +4147,30 @@
   container testid. `:site-id`, in `opts`, keeps its own separate meaning
   — the expansion key's second component — and is unchanged.
 
+  ## A LOGICAL NAME IS NOT A LIVE-MOUNT IDENTITY (rf2-d2aj)
+
+  Because the id is the caller's and the caller wants it stable, two
+  panels on one page routinely present the SAME one — a gallery rendering
+  twelve variants of a panel, or two embedded panels each under its own
+  `frame-provider`. That is not a caller error; it is what a stable
+  logical name means. So this head qualifies it by the frame it renders
+  under and hands the result down as the `:lifecycle-key` — the key of the
+  per-mount store and of the `:ref` memo — leaving `:mount-id` to go on
+  naming the surface for the width slot, the popup and the testids.
+
+  The frame is the right qualifier and not an arbitrary one: everything in
+  that store is frame-relative already. The dispatcher it captures is bound
+  to one frame and the width it writes lands in that frame's app-db, so a
+  module-global store keyed by a frame-relative name was under-specified
+  by exactly one component.
+
+  What this does NOT reach is two panels in ONE frame presenting one
+  mount-id. A React function component has no per-instance storage a
+  Fresco body may use — hooks do not belong in a body, and
+  `rf.fresco/reg-state` consumes an instance key rather than minting one —
+  so nothing here can tell two structurally identical siblings apart. That
+  case is the caller's to name, which is what the refusal below asks for.
+
   ## Reads, and why the zoom read is conditional
 
   Three slots, each `rf.fresco/sub`. The zoom slot is read ONLY for a
@@ -4080,13 +4202,20 @@
                   "slot's role is usually the whole of it.")
              {:mount-id mount-id})))
   (let [zoomable?   (boolean (:zoomable? opts))
-        dispatch-fn (:dispatch (rf/capture-frame))]
+        ;; ONE capture, read twice. `:frame` is the id this boundary
+        ;; renders under and `:dispatch` is bound to it, so the lifecycle
+        ;; key and the dispatcher that writes under it can never name
+        ;; different frames (rf2-d2aj).
+        frame-api   (rf/capture-frame)
+        dispatch-fn (:dispatch frame-api)
+        lkey        (lifecycle-key (:frame frame-api) mount-id)]
     (render-inspector
       {:value         value
        :opts          opts
        :mount-id      mount-id
+       :lifecycle-key lkey
        :dispatch-fn   dispatch-fn
-       :container-ref (container-ref-for mount-id dispatch-fn)
+       :container-ref (container-ref-for lkey mount-id dispatch-fn)
        :expansion-map (rf.fresco/sub [expansion-slot])
        :zoom-map      (when zoomable? (rf.fresco/sub [zoom-slot]))
        :widths        (rf.fresco/sub [widths-slot])})))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_fresco_boundary_dom_cljs_test.cljs
@@ -33,6 +33,8 @@
     W4  teardown releases BOTH the subscription reference AND the
         per-mount store entry (the ResizeObserver, the width debounce and
         the projection cache)
+    W5  TWO panels mounted at once under one logical `:mount-id` are
+        independent, and one's unmount leaves the other whole (rf2-d2aj)
 
   W4 is the row this widget needed and `module_view` did not. That panel
   holds no per-mount mutable state; this one holds three pieces of it, and
@@ -77,8 +79,12 @@
 (def ^:private mount-id
   "The boundary's REQUIRED `:mount-id`. A Fresco boundary has no form-2
   outer body to mint one in, so the caller names it — see
-  `ei/edn-inspector-view`. Named once here because four rows key off it:
-  it is the store key, the width-slot key and half the expansion key."
+  `ei/edn-inspector-view`. Named once here because five rows key off it: it
+  is the width-slot key, the container testid and half the expansion key.
+
+  It is NOT the store key (rf2-d2aj). That is the LIFECYCLE KEY — this name
+  qualified by the frame the mount renders under — because this name is
+  logical and W5 mounts two panels that both present it."
   "edn-inspector-boundary-test")
 
 (def ^:private expansion-q
@@ -234,6 +240,26 @@
 
 (defn- ref-count-of [frame-id query-v]
   (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+(defn- held-in
+  "What the per-mount store holds for this widget's mount UNDER `frame-id`.
+
+  The store's key is the LIFECYCLE KEY — the logical `mount-id` qualified by
+  the frame the mount renders under (rf2-d2aj) — because everything the entry
+  holds is frame-relative: the dispatcher is bound to one frame and the width
+  it writes lands in that frame's app-db."
+  [frame-id]
+  (ei/mount-state-held (ei/lifecycle-key frame-id mount-id)))
+
+(defn- width-in
+  "The width this widget measured for itself in `frame-id`'s app-db, or nil.
+
+  Reads the LOGICAL id, which is what keys the slot and what the renderer
+  reads a width back under — deliberately not the lifecycle key, so this
+  probe is unaffected by how the store is keyed and stays a witness to the
+  measurement rather than to the fix."
+  [frame-id]
+  (get-in (rf/app-db-value frame-id) [ei/widths-slot mount-id]))
 
 ;; ===========================================================================
 ;; W1 — first display, and the read lands in the frame the tree named
@@ -460,12 +486,12 @@
               {:label "no reference held before the first mount"})
             (.then
               (fn [_]
-                (is (nil? (ei/mount-state-held mount-id))
+                (is (nil? (held-in :rf/xray))
                     "PRECONDITION: the store holds nothing for this mount id
                      before it mounts")
                 (let [{:keys [container root]} (mount-host! :rf/xray)
                       mounted (ref-count-of :rf/xray expansion-q)
-                      held    (ei/mount-state-held mount-id)]
+                      held    (held-in :rf/xray)]
                   (is (pos? mounted)
                       "the mount took a subscription reference — otherwise the
                        release below is vacuous")
@@ -482,11 +508,11 @@
                   (teardown! root container)
 
                   ;; ---- the store half: synchronous, asserted directly -----
-                  (is (nil? (ei/mount-state-held mount-id))
+                  (is (nil? (held-in :rf/xray))
                       (str "unmount released the WHOLE entry — observer, width "
                            "debounce and projection cache together — rather "
                            "than emptying part of it. Held after unmount: "
-                           (pr-str (ei/mount-state-held mount-id))))
+                           (pr-str (held-in :rf/xray))))
 
                   ;; ---- the read half: polled, per the collector's grace ---
                   (-> (rf.test-support/poll-until released?
@@ -506,7 +532,7 @@
                                      "open/close cycles is the signature of a "
                                      "release the substrate's own reaction "
                                      "lifecycle cannot see. Got: " remounted))
-                            (is (contains? (ei/mount-state-held mount-id) :ref)
+                            (is (contains? (held-in :rf/xray) :ref)
                                 "and the remount minted a FRESH store entry,
                                  proving the first one really went rather than
                                  being reused")
@@ -516,7 +542,160 @@
             (.then (fn [_]
                      (is (released?)
                          "and the second unmount releases the read too")
-                     (is (nil? (ei/mount-state-held mount-id))
+                     (is (nil? (held-in :rf/xray))
                          "and the store too")))
             (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
             (.then (fn [_] (done))))))))
+
+;; ===========================================================================
+;; W5 — TWO PANELS AT ONCE, one logical mount-id between them (rf2-d2aj)
+;; ===========================================================================
+;;
+;; Every row above mounts ONE panel, so none of them can see this and none of
+;; them is wrong: the widget's per-mount state was correct for a mount that
+;; had the page to itself. The case the tool actually presents is two of them
+;; standing at the same time under the same logical name — the panel gallery
+;; renders twelve variants of a panel side by side, each wrapped in its own
+;; `frame-provider`, and each embedded panel is another. A `:mount-id` is a
+;; LOGICAL surface name and is deliberately stable, so all of them say
+;; `app-db-state/top`.
+;;
+;; The widths are the load-bearing probe here and are read through the
+;; LOGICAL id, which no part of the repair touched: they witness that each
+;; panel MEASURED ITSELF INTO ITS OWN FRAME, which is the behaviour, rather
+;; than witnessing how the store happens to be keyed. Two deliberately
+;; different column widths, so "independent" is a distinguishable claim and
+;; not two panels agreeing by accident.
+
+(def ^:private slot-a-width-px
+  "The first panel's column. Wide, and unequal to the second — a row that
+  mounted both at one width could not tell one shared measurement from two
+  independent ones."
+  640)
+
+(def ^:private slot-b-width-px
+  "The second panel's column."
+  320)
+
+(defn- two-panel-tree
+  "Two host panels at two widths under two `frame-provider`s, or — when
+  `both?` is false — the first alone. Re-rendering the SAME root with the
+  second gone is what unmounting one panel of a live pair actually is, and is
+  what the last phase of W5 needs: a second root would prove nothing about a
+  sibling's survival."
+  [both?]
+  [:div {:data-testid "rf-xray-two-panel-host"}
+   [:div {:data-testid "rf-xray-slot-a"
+          :style       {:width (str slot-a-width-px "px")}}
+    [rf/frame-provider {:frame :rf/xray}
+     [:> HostPanel-component {}]]]
+   (when both?
+     [:div {:data-testid "rf-xray-slot-b"
+            :style       {:width (str slot-b-width-px "px")}}
+      [rf/frame-provider {:frame app-frame}
+       [:> HostPanel-component {}]]])])
+
+(defn- mount-two!
+  "Commit both panels in ONE synchronous render, the way a gallery commits
+  its variants."
+  []
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync (fn [] (rdc/render root (two-panel-tree true))))
+    {:container container :root root}))
+
+(defn- panel-count
+  "How many host panels are on screen.
+
+  COUNTED ON THE HOST PANEL, not on the widget's own container testid, and
+  the first draft of this row got that wrong in a way worth writing down:
+  `testid-for` composes the SAME string for the widget's outer container and
+  for its root render-node at path `[]`, so one mount answers that selector
+  TWICE. `container-node` above never noticed because `querySelector` takes
+  the first match — a count is the first instrument here that has to care."
+  [container]
+  (.-length (.querySelectorAll
+              container "[data-testid=\"rf-xray-host-panel\"]")))
+
+(deftest w5-two-simultaneous-panels-are-independent
+  (testing "rf2-d2aj — two panels rendering the same stable `:mount-id` at the
+            same time, each under its own frame, measure independently, hold
+            their own observers, and survive each other's unmount.
+
+            The regression this row exists for was invisible to every other
+            row in this file AND to a fully green CI: the panels both PAINT,
+            the DOM is correct, and the damage is that the second one never
+            measured and the first one's state went out with the second one's
+            unmount. Nothing on screen says so."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (let [before (ei/mount-state-count)
+              {:keys [container root]} (mount-two!)]
+          (is (= 2 (panel-count container))
+              "PRECONDITION: both panels committed real DOM — an assertion
+               about the second one's state is vacuous if it never rendered")
+          (-> (settle)
+              (.then
+                (fn [_]
+                  ;; ---- the store holds TWO live mounts, not one ----------
+                  (is (= (+ before 2) (ei/mount-state-count))
+                      (str "two panels on screen, two entries in the per-mount "
+                           "store. ONE entry here is the defect: the second "
+                           "panel's ref was memoised onto the first's identity, "
+                           "so it never installed an observer of its own. Held "
+                           (- (ei/mount-state-count) before) " for 2 mounts"))
+                  (is (contains? (held-in :rf/xray) :observer)
+                      "the first panel holds its own ResizeObserver")
+                  (is (contains? (held-in app-frame) :observer)
+                      (str "and so does the second, in ITS frame. Held there: "
+                           (pr-str (held-in app-frame))))
+
+                  ;; ---- each measured ITSELF, into ITS OWN frame ----------
+                  (is (= slot-a-width-px (width-in :rf/xray))
+                      (str "the first panel measured its own column into its "
+                           "own frame's width slot. Got: "
+                           (pr-str (width-in :rf/xray))))
+                  (is (= slot-b-width-px (width-in app-frame))
+                      (str "and the second measured ITS column into ITS frame. "
+                           "A nil here is the defect in its plainest form — "
+                           "the second panel is on screen and has no width, so "
+                           "its width-aware layout heuristic runs blind for the "
+                           "life of the page. Got: "
+                           (pr-str (width-in app-frame))))
+                  (is (not= (width-in :rf/xray) (width-in app-frame))
+                      "and the two widths are DIFFERENT, so 'independent' is a
+                       claim this row can distinguish rather than two panels
+                       agreeing by accident")
+
+                  ;; ---- unmount the second; the first must be untouched ---
+                  (react-dom/flushSync
+                    (fn [] (rdc/render root (two-panel-tree false))))
+                  (settle)))
+              (.then
+                (fn [_]
+                  (is (= 1 (panel-count container))
+                      "PRECONDITION: the second panel really did unmount")
+                  (is (nil? (held-in app-frame))
+                      "and released everything it held")
+                  (is (= (inc before) (ei/mount-state-count))
+                      "leaving exactly one live mount in the store")
+                  (is (contains? (held-in :rf/xray) :observer)
+                      (str "THE SURVIVOR IS WHOLE: the panel still on screen "
+                           "still holds its own observer. Sharing one entry "
+                           "disconnected it here — an observer torn down under "
+                           "a node still in the document, which no rendering "
+                           "assertion can see. Held: "
+                           (pr-str (held-in :rf/xray))))
+                  (is (= slot-a-width-px (width-in :rf/xray))
+                      (str "and its measured width survived its sibling's "
+                           "unmount rather than being cleared with it. Got: "
+                           (pr-str (width-in :rf/xray))))))
+              (.catch (fn [e]
+                        (is false (str "W5 never settled: " (.-message e)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_mount_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_mount_state_cljs_test.cljs
@@ -1,6 +1,6 @@
 (ns day8.re-frame2-xray.views.edn-inspector-mount-state-cljs-test
   "THE PER-MOUNT STORE — the three pieces of state that used to live in the
-  form-2 closure (rf2-k97c.3).
+  form-2 closure (rf2-k97c.3), and the key it is held under (rf2-d2aj).
 
   `edn-inspector` was a form-2 component, so its ResizeObserver, its width
   debounce and its Editscript projection cache lived in an outer body that
@@ -36,6 +36,10 @@
         other row here misses by construction (rf2-9go2).
     R8  and the store answers that retained callback again afterwards,
         so the re-attachment does not cost R1's memo.
+    R9  two live mounts of ONE logical surface — the case a stable
+        `:mount-id` makes routine and which every row above misses by
+        giving each mount an id of its own (rf2-d2aj). Positive half and
+        negative control, the control being the defect written out.
 
   ## No DOM here, deliberately
 
@@ -273,3 +277,110 @@
       (unmount! ref-fn)
       (is (nil? (ei/mount-state-held mid))
           "and the mount still releases cleanly afterwards"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-d2aj — TWO LIVE MOUNTS OF ONE LOGICAL SURFACE.
+;;
+;; Every row above hands each mount an id of its own, so none of them can see
+;; the case that actually reaches this store. A panel's `:mount-id` is a
+;; LOGICAL name and is deliberately stable — it keys the width slot and the
+;; testids, and a panel that leaves and returns wants the same one back — so
+;; several live mounts routinely present the SAME id at once: the gallery
+;; renders twelve variants of a panel side by side, and each embedded panel is
+;; another. R2 looks like the row that covers this and does not: it asks
+;; whether the memo is KEYED, which it always was, not whether the key names
+;; a live mount.
+;;
+;; R9 is that case, in both directions. The positive half is two mounts under
+;; two frames; the negative half is the same two keyed on the logical name
+;; alone, which is what the defect was — and it is written out rather than
+;; described because the symptom is not "the second mount is missing" but
+;; "the second mount's width is dispatched into the FIRST one's frame", which
+;; is the reading that makes a green browser lane look correct.
+;; ---------------------------------------------------------------------------
+
+(def ^:private shared-logical-id
+  "The App-db panel's real top-section mount-id — a logical surface name, the
+  same string from every panel that renders one."
+  "app-db-state/top")
+
+(deftest r9-two-live-mounts-of-one-logical-id-stay-independent
+  (testing "rf2-d2aj — two panels rendering the same stable `mount-id` under
+            two different frames get two refs, two entries and two
+            dispatchers, and releasing one leaves the other whole."
+    (let [before (ei/mount-state-count)
+          k-a    (ei/lifecycle-key :frame/a shared-logical-id)
+          k-b    (ei/lifecycle-key :frame/b shared-logical-id)
+          sink-a (atom [])
+          sink-b (atom [])
+          ref-a  (ei/container-ref-for k-a shared-logical-id
+                                       #(swap! sink-a conj %))
+          ref-b  (ei/container-ref-for k-b shared-logical-id
+                                       #(swap! sink-b conj %))
+          el-a   (fake-el 600)
+          el-b   (fake-el 300)]
+      (is (not (identical? ref-a ref-b))
+          "two live mounts of one logical surface get two ref callbacks —
+           sharing one is what leaves the second element unobserved")
+      (is (= (+ before 2) (ei/mount-state-count))
+          "and two entries, not one")
+
+      (ref-a el-a)
+      (ref-b el-b)
+      (is (= [[:rf.xray.edn-inspector/set-width shared-logical-id 600]] @sink-a)
+          "the first mount measured itself into its OWN frame's dispatcher")
+      (is (= [[:rf.xray.edn-inspector/set-width shared-logical-id 300]] @sink-b)
+          "and the second into its own, at its own width. The event payload
+           is the LOGICAL id in both, because the width slot is per-frame and
+           the frame is what separates them — the two identities doing two
+           jobs at once")
+
+      ;; ---- release one, and only one ---------------------------------
+      (reset! sink-a [])
+      (reset! sink-b [])
+      (unmount! ref-b)
+      (is (nil? (ei/mount-state-held k-b))
+          "the released mount is gone")
+      (is (contains? (ei/mount-state-held k-a) :ref)
+          "and the mount that is still on screen is untouched — releasing the
+           survivor is what the shared key did, and it disconnected an
+           observer of a node still in the document")
+      (is (= [[:rf.xray.edn-inspector/clear-width shared-logical-id]] @sink-b)
+          "the clear went to the leaving mount's own frame")
+      (is (= [] @sink-a)
+          "and NOTHING was written into the surviving mount's frame")
+
+      (unmount! ref-a)
+      (is (= before (ei/mount-state-count))
+          "both released, store back where it started")))
+
+  (testing "rf2-d2aj — THE NEGATIVE CONTROL, and it is the defect verbatim:
+            keyed on the logical name ALONE the same two mounts share one ref,
+            the second one's width is dispatched into the FIRST one's frame,
+            and detaching the second releases the first."
+    (let [before (ei/mount-state-count)
+          mid    "r9-control/top"
+          sink-a (atom [])
+          sink-b (atom [])
+          ref-a  (ei/container-ref-for mid #(swap! sink-a conj %))
+          ref-b  (ei/container-ref-for mid #(swap! sink-b conj %))]
+      (is (identical? ref-a ref-b)
+          "CONTROL BITES: one ref callback between two mounts")
+      (is (= (inc before) (ei/mount-state-count))
+          "and one entry between them")
+      (ref-a (fake-el 600))
+      (ref-b (fake-el 300))
+      (is (= [[:rf.xray.edn-inspector/set-width mid 600]
+              [:rf.xray.edn-inspector/set-width mid 300]]
+             @sink-a)
+          "BOTH widths landed in the first mount's frame — the second panel's
+           measurement overwrites the first's in an app-db it does not belong
+           to, which is a wrong number rather than a missing one")
+      (is (= [] @sink-b)
+          "and the second mount's own dispatcher was never called at all")
+      (unmount! ref-b)
+      (is (nil? (ei/mount-state-held mid))
+          "detaching the SECOND released the shared entry, so the first mount
+           — still on screen — has lost its state")
+      (is (= before (ei/mount-state-count))
+          "store back where it started"))))


### PR DESCRIPTION
Closes the instance-isolation defect rf2-d2aj records against PR #9590.

## The defect

`edn-inspector`'s per-mount store is a module-global `defonce` and was keyed by
`:mount-id`. `:mount-id` is a **logical** name — the App-db panel's top section
says `app-db-state/top` from every panel that renders one, deliberately, because
the same string is what `:site-id` is built from and what the width slot and the
testids read. So two panels standing at once shared one entry: the second never
installed a `ResizeObserver`, never measured, and detaching it released the
**first** panel's entry, disconnecting an observer of a node still in the
document and clearing that frame's width slot.

The panel gallery mounts twelve App-db variants at once, each under its own
`frame-provider`, and each embedded panel is another — so this is the tool's
ordinary shape rather than a corner.

## The repair, and what it deliberately does not move

**The two identities were already separate inside `render-inspector`, and stay
exactly as they were.** Expansion and zoom key off `(or site-id mount-id)`;
the width slot, the popup id, the container `data-testid` and the DOM id key off
`mount-id`. Nothing about either moves in this PR, so a fix that made the id
unique per mount — which would have taken `:site-id` with it and lost expansion
and zoom on every pass — was never the shape needed.

What was under-specified was the **store's own key**. A module-global map holding
frame-relative state — a dispatcher bound to one frame, a width that lands in
that frame's `app-db` — keyed by a name the caller keeps stable is the
entrenched singleton this widget refuses everywhere else (`zoom-trigger-attrs`
already carries the reasoning for why the zoom write must not name `:rf/xray`
literally). So the store, the `:ref` memo and the projection cache are now keyed
by a **lifecycle key**: the mount-id qualified by the frame the mount renders
under. The public shapes of both heads are untouched.

`edn-inspector`, the Reagent head, is unaffected: its form-2 outer body mints a
UUID per mount, already unique across every live mount, and `container-ref-for`
keeps a 2-arity for exactly that caller.

## What is NOT reached, and why

Two panels in **one frame** presenting one mount-id. A React function component
has no per-instance storage a Fresco body may use — hooks do not belong in a
body (`defview`'s own law, with `hook-budget-cljs-test` counting them at React's
dispatcher), and `rf.fresco/reg-state` **consumes** an instance key rather than
minting one — so nothing inside the widget can tell two structurally identical
siblings apart. That case is the caller's to name and would need a one-line
`:instance-id` prop on `app_db_diff/Panel`, which is outside this PR's write
surface. Two inspector mounts *within* one panel are already isolated: they
carry different `render-id`s, which R2 pins.

## Evidence

The existing rows could not have caught this and none of them is wrong: every
one mounts a single widget. R2 looks like the row that covers it and asks only
whether the memo is **keyed**, which it always was — not whether the key names a
live mount.

- **W5** (browser lane, `edn_inspector_fresco_boundary_dom_cljs_test`) mounts
  TWO panels in one commit under two frame providers at two different column
  widths (640 / 320) and asserts two store entries, two observers, two
  independent measured widths, and the survivor whole after the other unmounts.
- **R9** (node lane, `edn_inspector_mount_state_cljs_test`) is the same claim
  structurally, plus a **negative control** that writes the defect out: keyed on
  the logical name alone, the second mount's width is dispatched into the
  **first** mount's frame — a wrong number rather than a missing one.

### Proof the rows can fail

One planted line — `lifecycle-key` returning `[nil mount-id]`, dropping the
frame qualifier and restoring the collision with every symbol and key shape
intact — turns both lanes red:

- node lane: exit 1, **7 failures**, all in R9, the first reading
  *"two live mounts of one logical surface get two ref callbacks — sharing one
  is what leaves the second element unobserved"*.
- browser lane: exit 1, **3 failures**, all in W5, including
  *"and the second measured ITS column into ITS frame … Got: nil"* — the lost
  width — and `Held 1 for 2 mounts`.

The plant was restored with a blob-hash check against the committed object, and
the anchor's match count was read before the plant: the first anchor spanned a
line ending and matched **0**, which the count caught before a run was spent.

## An incidental finding, recorded in the helper rather than fixed

W5's first draft counted panels by the widget's container testid and read **4**
for 2 panels. `testid-for` composes the same string for the widget's outer
container and for its root render-node at path `[]`, so one mount answers that
selector twice. `container-node` never noticed because `querySelector` takes the
first match. Left alone — it is not this PR's surface — but named where the next
reader of a count will meet it.

## Sibling surfaces checked

`views/edn_widget.cljs`'s `inspect-view` has the same shape: `:mount-id` is
`(str "rf-xray-inspect-" node-key)` with `node-key` defaulting to `"root"`, so
the 1-arity is a constant. Its own docstring already warns that two mounts
sharing a `node-key` share a width slot. It has **zero call sites** in the tree
today, and the frame qualifier in this PR covers it across frames for free.
`views/edn_inspector_popup.cljs` is not the same shape: its mount-id is either
`(gen-mount-id)` in a form-2 outer body or a per-open id from the stack.

## Quality gates

Every number below is the runner's own exit code, captured unpiped on one
command line and read back from its own `.exit` artefact, on the final rebased
base (`origin/main` @ `0404b7d537`).

| Gate | Command | Exit | Result |
| --- | --- | --- | --- |
| CLJS node compile | `node scripts/compile-node-test.cjs node-test out/node-test.js` | 0 | 1933 files, 0 warnings |
| CLJS node suite | `node out/node-test.js` | 0 | **11550 tests / 57996 assertions, 0 failures, 0 errors** |
| Browser compile | `shadow-cljs compile browser-test` | 0 | 1041 files |
| Browser suite | `node scripts/serve-and-run-browser-tests.cjs` | 0 | **887 tests / 4908 assertions, 0 failures, 0 errors** |
| Xray JVM | `clojure -M:test` (in `tools/xray`) | 0 | **1276 tests / 6118 assertions, 0 failures, 0 errors** |
| clj-kondo | `clj-kondo --parallel --fail-level error --lint <the 4 files>` | 0 | 0 errors, 2 warnings |
| Splint | `clojure -M:splint --fail-on-errors <the 4 files>` | 0 | 10 style warnings, 0 errors |
| Ratchets | all 43 `scripts/check_*.py` | 0 | 43/43 green |
| Tracker boundary | `scripts/check-beads-pr-boundary.sh <base>` | 0 | no beads paths |
| AI-tracking ratchet | `scripts/check-ai-tracking-ratchet.sh` | 0 | — |
| Hardcoded paths | `scripts/check-no-hardcoded-paths.sh` | 0 | — |

Both shadow-cljs runs print `config: …/dbiso-a/implementation/shadow-cljs.edn`,
so each read this branch's tree and not a sibling's.

The two clj-kondo warnings (`unused binding kind`, `unused binding
max-inline-width`) are **pre-existing**: the same two, at the pre-shift line
numbers, on the base revision of the file. All ten Splint warnings are on lines
this PR does not touch. Local clj-kondo is v2025.10.23 against CI's v2026.04.15,
so the lint numbers are a local approximation and CI is the authority.

Examples-compile was not nominated: nothing here moves a file a testbed builds.
