### PR TITLE
fix(beads): the checkpoint's two memory detectors get two messages (rf2-q88t)

### DIFF
--- a/scripts/beads-checkpoint.ps1
+++ b/scripts/beads-checkpoint.ps1
@@ -56,7 +56,10 @@
 #
 #   Get-MemoryFacts now reconciles the two populations against HEAD by KEY SET.
 #   Unlike the two guards above it WARNS AND DOES NOT REFUSE - see the call site
-#   for why that constraint is deliberate.
+#   for why that constraint is deliberate. It has two arms and they get two
+#   headlines (rf2-q88t): the loss banner when a KEY has gone, and a short note
+#   when only the row-count SUM is off, which is a well-formedness artefact and
+#   not a deletion.
 #
 # The commit carries the rows that changed and nothing else: `bd export` does
 # not fix the order of the memory rows, so the file is written in minimal-diff
@@ -424,8 +427,30 @@ function Get-GitOnlyFacts {
 # KEY SETS, NOT COUNTS. A cull that deletes 210 keys and adds 210 leaves the
 # count flat while losing 210 memories, so the count is the same kind of floor
 # the row count already was. The key set has no such hole.
+#
+# WHICH ARM FIRED IS AN OUT-PARAMETER, SO THE CALLER CAN HEAD THE TWO
+# DIFFERENTLY (rf2-q88t). The split above is a real one, and for one release
+# both answers came out under ONE message - the loss banner. So an ordinary
+# checkpoint whose export carried a TRAILING BLANK LINE printed `MEMORY
+# RECONCILIATION FAILED`, the 210-key incident and four paragraphs of deletion
+# recovery, over a key set that had already reconciled 1063 against 1063 and
+# named no missing key at all. Measured 2026-09-10 in the mayor checkout. A
+# guard that cries wolf on a formatting artefact is worth less than one that
+# stays quiet, and this one is guarding a real incident.
+#
+#   $KeySetShort $true   a memory KEY at HEAD is missing from the export: a
+#                        real loss, whatever the sum says
+#   $KeySetShort $false  the report exists only because the two populations do
+#                        not account for every row: WELL-FORMEDNESS, and NOT a
+#                        deletion
+#
+# It is set on BOTH return paths, so a caller reads it unconditionally. No new
+# detector and no new state stand behind it: both answers were already computed
+# a few lines apart, and only the message was single. The .sh sibling spells the
+# same distinction as an exit status (2 loss, 1 well-formedness); the two are
+# kept in step BY HAND.
 function Get-MemoryFacts {
-    param([string]$Export, [string]$HeadCopy)
+    param([string]$Export, [string]$HeadCopy, [ref]$KeySetShort)
 
     $cap = 10
     $report = New-Object 'System.Collections.Generic.List[string]'
@@ -468,6 +493,9 @@ function Get-MemoryFacts {
             $hoth++
         }
     }
+
+    # Set before either return, so the caller never reads a stale value.
+    if ($null -ne $KeySetShort) { $KeySetShort.Value = ($ngone -gt 0) }
 
     if ($ngone -eq 0 -and $xoth -eq 0 -and $hoth -eq 0 -and $xbad -eq 0 -and $hbad -eq 0) {
         return @()
@@ -1044,10 +1072,18 @@ if ($SelfTest) {
     & git -C $repo add -- '.beads/issues.jsonl' | Out-Null
     & git -C $repo commit -q -m 'restore: the tracker as it stood before the race arm' | Out-Null
 
-    # T8 - a row of an unknown `_type` is reported. This is the "two populations
-    # sum to the row count" half of the bead. It cannot detect the deletion
-    # above - the identity holds trivially whenever every row is one of the two
-    # known types - but it catches a row that is neither.
+    # T8 - a row of an unknown `_type` is reported, AND IT IS NOT REPORTED AS A
+    # DELETION (rf2-q88t). This is the "two populations sum to the row count"
+    # half of the bead. It cannot detect the deletion above - the identity holds
+    # trivially whenever every row is one of the two known types - but it
+    # catches a row that is neither.
+    #
+    # THE NEGATIVE ASSERTIONS ARE THE ONES THAT MATTER, and they are the whole
+    # of rf2-q88t: for one release this arm printed T7's banner, so a checkpoint
+    # whose export carried a trailing blank line announced MEMORY RECONCILIATION
+    # FAILED, the 210-key incident and four paragraphs of key recovery over a
+    # key set that had reconciled exactly. The key set is the loss detector, it
+    # runs on this path too, and here it found nothing.
     Write-Rows -Path $dbPath -Rows ($memHead + @('{"_type":"sprint","id":"s1"}'))
     $before = Get-HeadSha
     $code = Invoke-Child @()
@@ -1056,6 +1092,59 @@ if ($SelfTest) {
     Assert-True ($err -match 'neither an issue nor a memory') `
                 'T8 a row that is neither an issue nor a memory is reported'
     Assert-True ((Get-HeadSha) -ne $before) 'T8 and it still commits'
+    Assert-True (-not ($err -match 'MEMORY RECONCILIATION FAILED')) `
+                'T8 and it does NOT wear the loss banner, because no key is missing' $err
+    Assert-True ($err -match 'NOT a memory deletion') `
+                'T8 and the headline says so in the first line the operator reads' $err
+    Assert-True (-not ($err -match 'git log -S')) `
+                'T8 and the deletion-recovery paragraphs stay out of it' $err
+    Assert-True ($err -match 'USUALLY A BLANK LINE') `
+                'T8 and it names the usual cause and the two-second check instead' $err
+
+    # T8b - THE OBSERVED INCIDENT ITSELF (rf2-q88t). The unclassifiable row that
+    # actually fired in the mayor checkout on 2026-09-10 was a TRAILING BLANK
+    # LINE, not a row of an invented `_type`. Same arm, same verdict, and this
+    # is the fixture that reproduces the reported symptom exactly.
+    Write-Rows -Path (Join-Path $repo '.beads/issues.jsonl') -Rows $memHead
+    & git -C $repo add -- '.beads/issues.jsonl' | Out-Null
+    & git -C $repo commit -q -m 'seed: back to 20 issues and 10 memories' | Out-Null
+    Write-Rows -Path $dbPath -Rows ($memHead + @(''))
+    $before = Get-HeadSha
+    $code = Invoke-Child @()
+    $err  = Get-ChildErr
+    $trackerText = [System.IO.File]::ReadAllText((Join-Path $repo '.beads/issues.jsonl')).Replace("`r", '')
+    Assert-True ($code -eq 0) 'T8b a trailing blank line does not refuse the checkpoint' "exit $code"
+    Assert-True ((Get-HeadSha) -ne $before) 'T8b and it still commits'
+    Assert-True (-not ($err -match 'MEMORY RECONCILIATION FAILED')) `
+                'T8b a BLANK LINE is not announced as a memory deletion' $err
+    Assert-True (($err -match 'NOT a memory deletion') -and ($err -match 'USUALLY A BLANK LINE')) `
+                'T8b and the note names a cause the operator can act on' $err
+    # The discriminator the old message had in hand and did not use: EQUAL
+    # memory populations rule out a memory deletion outright.
+    Assert-True (($err -match 'export  31 rows = 20 issues \+ 10 memories') -and
+                 ($err -match 'HEAD    30 rows = 20 issues \+ 10 memories')) `
+                'T8b and the two memory counts are EQUAL, which is why it is not a loss' $err
+    Assert-True ($trackerText.EndsWith("`n`n")) `
+                'T8b the blank line does ride into this commit, exactly as the note says'
+
+    # T8c - the note's other claim, graded rather than asserted: the NEXT
+    # checkpoint drops it. HEAD now carries the blank line and the fresh export
+    # does not, so Write-MinimalDiffOrder - which takes its rows from the
+    # EXPORT - must leave it behind. The export also adds a memory, so this
+    # checkpoint is a real change and T9's re-seed below still has something to
+    # commit.
+    Write-Rows -Path $dbPath -Rows ($memHead +
+        @('{"_type":"memory","key":"mem-key-12","value":"another lesson"}'))
+    $before = Get-HeadSha
+    $code = Invoke-Child @()
+    $err  = Get-ChildErr
+    $trackerText = [System.IO.File]::ReadAllText((Join-Path $repo '.beads/issues.jsonl')).Replace("`r", '')
+    Assert-True ($code -eq 0) 'T8c the follow-up checkpoint runs clean' "exit $code"
+    Assert-True ((Get-HeadSha) -ne $before) 'T8c and it commits'
+    Assert-True (-not $trackerText.EndsWith("`n`n")) `
+                'T8c and the blank line is GONE - benign and self-healing, as the note promises'
+    Assert-True (-not ($err -match 'MEMORY RECONCILIATION FAILED')) `
+                'T8c and a blank line sitting at HEAD is not a deletion either' $err
 
     # T9 - THE NO-FALSE-POSITIVE CASE. Ordinary forward motion - an issue
     # closes, a memory is ADDED, the rest are shuffled the way `bd export`
@@ -1301,8 +1390,17 @@ try {
     # or single-element array return, so a bare assignment yields $null on the
     # ordinary no-warning path and `.Count` then throws. Caught by -SelfTest T2
     # and T3, which is what that arm is for.
-    $memFacts = @(Get-MemoryFacts -Export $tmpExport -HeadCopy $tmpHead)
-    if ($memFacts.Count -gt 0) {
+    #
+    # TWO ARMS, TWO HEADLINES (rf2-q88t). Get-MemoryFacts reports which of its
+    # two detectors fired, and the loss narrative below - the 210-key incident,
+    # the spelled-out recovery oid, the `git log -S` hunt - is correct for a
+    # LOSS and for nothing else. A short, differently-headed note carries the
+    # other case, so `MEMORY RECONCILIATION FAILED` stays a string that means
+    # what it says. Graded by -SelfTest T7 (loss) and T8 (well-formedness).
+    $keySetShort = $false
+    $memFacts = @(Get-MemoryFacts -Export $tmpExport -HeadCopy $tmpHead `
+                                  -KeySetShort ([ref]$keySetShort))
+    if ($memFacts.Count -gt 0 -and $keySetShort) {
         $lines = New-Object 'System.Collections.Generic.List[string]'
         $lines.Add('')
         $lines.Add('beads-checkpoint: ***** MEMORY RECONCILIATION FAILED (rf2-cve7) *****')
@@ -1342,6 +1440,38 @@ try {
         $lines.Add('  Select on `.key`. A bare grep for the key matches rows that merely MENTION')
         $lines.Add('  it - bead prose naming a deleted key has already been mistaken for the')
         $lines.Add('  memory itself (rf2-cve7, CLAUDE.md instrument item (f)).')
+        $lines.Add('')
+        [Console]::Error.WriteLine(($lines -join "`n"))
+    }
+    elseif ($memFacts.Count -gt 0) {
+        # WELL-FORMEDNESS ONLY (rf2-q88t). The key set reconciled, so nothing is
+        # missing and none of the recovery narrative above applies. Say what
+        # fired, give the two-second check, and get out of the operator's way.
+        $lines = New-Object 'System.Collections.Generic.List[string]'
+        $lines.Add('')
+        $lines.Add('beads-checkpoint: unaccounted rows in the export - NOT a memory deletion.')
+        $lines.Add('  The loss detector is the KEY-SET comparison against HEAD, it ran, and it')
+        $lines.Add('  found nothing missing: every `bd remember` key HEAD carries is present in')
+        $lines.Add('  the fresh export. What fired is the other arm - the two populations do not')
+        $lines.Add('  account for every row of the file (rf2-cve7, rf2-q88t).')
+        $lines.Add('')
+        foreach ($r in $memFacts) { $lines.Add($r) }
+        $lines.Add('')
+        $lines.Add('  A row that is neither an issue nor a memory is USUALLY A BLANK LINE. The')
+        $lines.Add('  count above names the side that carries it - the tracker this checkpoint')
+        $lines.Add('  is about to commit, or HEAD''s copy of it (`git show HEAD:' + $tracker + '`)')
+        $lines.Add('  - and either check settles it in seconds:')
+        $lines.Add('')
+        $lines.Add('      grep -n -v ''^{'' ' + $tracker)
+        $lines.Add('      tail -c 3 ' + $tracker + ' | od -c')
+        $lines.Add('')
+        $lines.Add('  The first names the offending rows; the second shows a trailing blank line')
+        $lines.Add('  as a doubled newline at the end of the file.')
+        $lines.Add('')
+        $lines.Add('  A blank line is BENIGN and does not accumulate: Write-MinimalDiffOrder')
+        $lines.Add('  takes its rows from the fresh export, so one that is absent there is not')
+        $lines.Add('  carried over from HEAD. At worst it rides in one commit and the next')
+        $lines.Add('  checkpoint drops it. Nothing is refused, and nothing needs recovering.')
         $lines.Add('')
         [Console]::Error.WriteLine(($lines -join "`n"))
     }

--- a/scripts/beads-checkpoint.sh
+++ b/scripts/beads-checkpoint.sh
@@ -56,7 +56,10 @@
 #
 #   `memory_facts` now reconciles the two populations against HEAD by KEY SET.
 #   Unlike the two guards above it WARNS AND DOES NOT REFUSE — see the call site
-#   for why that constraint is deliberate.
+#   for why that constraint is deliberate. It has two arms and they get two
+#   headlines (rf2-q88t): the loss banner when a KEY has gone, and a short note
+#   when only the row-count SUM is off, which is a well-formedness artefact and
+#   not a deletion.
 #
 # USAGE
 #
@@ -385,6 +388,26 @@ git_only_facts() {
 #
 # (FNR == NR is sound here for the same reason it is in `git_only_facts`: the
 # caller has already refused a zero-row export, so file 1 is never empty.)
+#
+# THE EXIT STATUS SAYS WHICH ARM FIRED, SO THE CALLER CAN HEAD THE TWO
+# DIFFERENTLY (rf2-q88t). The split above is a real one — the sum is
+# well-formedness, the key set is loss — and for one release both answers came
+# out under ONE message, the loss banner. So an ordinary checkpoint whose export
+# carried a TRAILING BLANK LINE printed `MEMORY RECONCILIATION FAILED`, the
+# 210-key incident and four paragraphs of deletion recovery, over a key set that
+# had already reconciled 1063 against 1063 and named no missing key at all.
+# Measured 2026-09-10 in the mayor checkout. A guard that cries wolf on a
+# formatting artefact is worth less than one that stays quiet, and this one is
+# guarding a real incident, so the split now reaches the OUTPUT:
+#
+#   0  both populations reconcile — nothing is printed, which is every
+#      ordinary checkpoint
+#   1  the SUM is short and the KEY SET is intact — well-formedness only, and
+#      NOT a deletion
+#   2  the KEY SET is short — a real loss, whatever the sum says
+#
+# No new detector and no new state stand behind that: both answers were already
+# computed a few lines apart, and only the message was single.
 memory_facts() {
   awk -v cap=10 '
     function jval(line, key,   pfx, re) {
@@ -446,6 +469,10 @@ memory_facts() {
       if (hbad > 0) {
         printf "\n  UNREADABLE  %d memory rows at HEAD carry no readable key\n", hbad
       }
+      # 2 when the LOSS detector fired, 1 when only the well-formedness sum did.
+      # Spelled as an if rather than a ternary so every awk takes it.
+      if (ngone > 0) { exit 2 }
+      exit 1
     }
   ' "$1" "$2"
 }
@@ -609,8 +636,22 @@ rm -f "$REMEDY"
 #
 # It also runs AFTER the divergence guard on purpose, so it speaks only when the
 # checkpoint is genuinely about to commit and can say so truthfully.
-MEMORY_FACTS=$(memory_facts "$TMP_EXPORT" "$TMP_HEAD")
-if [ -n "$MEMORY_FACTS" ]; then
+#
+# TWO ARMS, TWO HEADLINES (rf2-q88t). `memory_facts` reports which of its two
+# detectors fired, and the loss narrative below — the 210-key incident, the
+# spelled-out recovery oid, the `git log -S` hunt — is correct for a LOSS and
+# for nothing else. A short, differently-headed note carries the other case, so
+# `MEMORY RECONCILIATION FAILED` stays a string that means what it says.
+#
+# `|| MEMORY_VERDICT=$?` rather than a bare capture: `set -e` is on, and a
+# non-zero command substitution in a bare assignment would abort the checkpoint
+# on the very warning it is trying to print.
+MEMORY_VERDICT=0
+MEMORY_FACTS=$(memory_facts "$TMP_EXPORT" "$TMP_HEAD") || MEMORY_VERDICT=$?
+# The body has to be non-empty for either headline. GNU awk also exits 2 on a
+# fatal error, which is the loss code, so an awk that died stays silent exactly
+# as it does today rather than printing a loss banner with no facts under it.
+if [ -n "$MEMORY_FACTS" ] && [ "$MEMORY_VERDICT" -eq 2 ]; then
   printf '\n' >&2
   printf 'beads-checkpoint: ***** MEMORY RECONCILIATION FAILED (rf2-cve7) *****\n' >&2
   printf '  The tracker'"'"'s `bd remember` rows do not reconcile against HEAD.\n\n' >&2
@@ -641,6 +682,29 @@ if [ -n "$MEMORY_FACTS" ]; then
   printf '\n  Select on `.key`. A bare grep for the key matches rows that merely MENTION\n' >&2
   printf '  it — bead prose naming a deleted key has already been mistaken for the\n' >&2
   printf '  memory itself (rf2-cve7, CLAUDE.md instrument item (f)).\n\n' >&2
+elif [ -n "$MEMORY_FACTS" ]; then
+  # WELL-FORMEDNESS ONLY (rf2-q88t). The key set reconciled, so nothing is
+  # missing and none of the recovery narrative above applies. Say what fired,
+  # give the two-second check, and get out of the operator's way.
+  printf '\n' >&2
+  printf 'beads-checkpoint: unaccounted rows in the export — NOT a memory deletion.\n' >&2
+  printf '  The loss detector is the KEY-SET comparison against HEAD, it ran, and it\n' >&2
+  printf '  found nothing missing: every `bd remember` key HEAD carries is present in\n' >&2
+  printf '  the fresh export. What fired is the other arm — the two populations do not\n' >&2
+  printf '  account for every row of the file (rf2-cve7, rf2-q88t).\n\n' >&2
+  printf '%s\n' "$MEMORY_FACTS" >&2
+  printf '\n  A row that is neither an issue nor a memory is USUALLY A BLANK LINE. The\n' >&2
+  printf '  count above names the side that carries it — the tracker this checkpoint is\n' >&2
+  printf '  about to commit, or HEAD'"'"'s copy of it (`git show HEAD:%s`) —\n' "$TRACKER" >&2
+  printf '  and either check settles it in seconds:\n' >&2
+  printf '\n      grep -n -v '"'"'^{'"'"' %s\n' "$TRACKER" >&2
+  printf '      tail -c 3 %s | od -c\n' "$TRACKER" >&2
+  printf '\n  The first names the offending rows; the second shows a trailing blank line\n' >&2
+  printf '  as a doubled newline at the end of the file.\n' >&2
+  printf '\n  A blank line is BENIGN and does not accumulate: `minimal_diff_rewrite` takes\n' >&2
+  printf '  its rows from the fresh export, so one that is absent there is not carried\n' >&2
+  printf '  over from HEAD. At worst it rides in one commit and the next checkpoint\n' >&2
+  printf '  drops it. Nothing is refused, and nothing needs recovering.\n\n' >&2
 fi
 
 # The export is trustworthy — it is now the working tracker. From here on the


### PR DESCRIPTION
## What this fixes

`memory_facts` has run **two** detectors since rf2-cve7, and its own header comment
says which is which:

> So the sum is kept (it catches a row of an unknown `_type`, which is cheap to notice
> and would otherwise be invisible) and the LOSS DETECTOR is the key-set comparison.

Both are computed a few lines apart. Both answers came out under **one** message, and
that message is written for loss.

So an ordinary checkpoint whose export carried a **trailing blank line** printed
`***** MEMORY RECONCILIATION FAILED *****`, named the 2026-09-08 incident in which 210
memory keys vanished, and spent four paragraphs on recovering deleted keys from git
history — over a key set that had already reconciled and named no missing key at all.
The message's own second and third lines said so:

```
export  2278 rows = 1214 issues + 1063 memories
HEAD    2277 rows = 1214 issues + 1063 memories
```

Equal memory counts rule out a memory deletion outright. The one row it could not
classify was an empty line.

## The change

The split now reaches the output, along the split the function already made:

| what fired | what prints |
| --- | --- |
| key set short (a real loss) | today's message, **unchanged** |
| sum short, key set intact | a short, differently-headed note |
| both short | the loss message wins, and it already carries the sum line inside it |

No new detector, no new state, no refusal. `memory_facts` reports which arm fired as
its exit status (2 loss, 1 well-formedness, 0 silent); the `.ps1` twin spells the same
distinction as a `[ref]` out-parameter. The captured status needs `|| MEMORY_VERDICT=$?`
rather than a bare capture because `set -e` is on and a bare assignment would abort the
checkpoint on the very warning it is printing.

The new note says the key set reconciles so this is **not** a deletion, names a blank
line as the usual cause, gives two checks against the tracker, and says it is benign
and does not accumulate. `MEMORY RECONCILIATION FAILED` is the string an operator greps
for, remembers, and eventually learns to skip — it now means what it says.

### The `.ps1` twin

`scripts/beads-checkpoint.ps1` **does** carry this guard, with the same message shape,
so it carries the same split. The two are kept in step by hand. Its `-SelfTest` suite
grades the new behaviour: T8 gained the negative assertions, and new **T8b/T8c**
reproduce the reported incident itself — a trailing blank line — and grade the note's
own two claims.

## Quality gates

Neither script is run by CI. Measured rather than assumed: `beads-checkpoint` appears in
**zero** files under `.github/` (grep exit 1, against a control of `remove-worker-worktree`
at exit 0), `portability.yml` shellchecks three scripts by name and neither of these is
among them, and `shellcheck` is not installed on this machine. The script's own header
says the same thing in terms: *"This is an operator helper, not a gate: nothing in CI
runs it."* So the evidence below is behavioural and hand-built.

| gate | exit | result |
| --- | --- | --- |
| `beads-checkpoint.ps1 -SelfTest` (before this change) | 0 | 55 PASS / 0 FAIL |
| `beads-checkpoint.ps1 -SelfTest` (after, on the final rebased base) | 0 | **69 PASS / 0 FAIL** |
| `sh -n scripts/beads-checkpoint.sh` | 0 | parses |
| `scripts/check-no-hardcoded-paths.sh` | 0 | no hardcoded personal paths |
| `scripts/check-ai-tracking-ratchet.sh` | 0 | nothing under `ai/` tracked |
| `scripts/check_retired_spellings.py` | 0 | clean |

Every exit code above is the runner's own, captured unpiped on the same command line.
All were re-run on the final base after the rebase onto `8999e651a8`.

### Four quadrants, driven end to end

A harness ran the whole `.sh` inside a throwaway git repo with a stub `bd`, so the real
tracker was never touched and no `.beads` path was written outside the sandbox. Each
quadrant was compared against the **pre-change** script run through the identical
harness (git's CRLF warnings and the per-run recovery oid normalised away):

| quadrant | vs pre-change | headline |
| --- | --- | --- |
| clean export, clean HEAD | **byte-identical** | nothing printed at all |
| trailing blank line, keys intact | differs | the new note, **not** the loss banner |
| export missing two memory keys | **byte-identical** | the loss banner |
| both at once | **byte-identical** | the loss banner, carrying the sum line |

The two identical loss quadrants are the regression evidence: the deletion-recovery
paragraphs come out byte-for-byte as they do today, including the spelled-out recovery
oid, which the harness re-ran and confirmed still resolves.

A fifth case grades the note's self-heal claim rather than asserting it: with HEAD
carrying the blank line and the fresh export clean, the committed tracker came back 31
rows and **0** blank. That case also surfaced a wording defect on the first pass — when
the unclassified row sits at HEAD rather than in the export, the note pointed the
operator at the wrong file — which is fixed.

### Sabotage

Both instruments were shown to bite, from a committed tree, with the restore verified
by blob hash against the committed object rather than by reading a diff:

* Reverting the `.ps1` headline selection to the single-message form: `-SelfTest` exit
  **1**, **7 FAIL**, and every one of them is a new negative assertion. Total case count
  unchanged at 69 (62 + 7), so the plant stopped nothing from running.
* Reverting the `.sh` condition the same way: all **five** quadrants became identical to
  the pre-change baseline, i.e. the blank-line case wore the loss banner again.
* `check_retired_spellings.py` is silent on success, so it was exercised against an input
  it should flag — a retired product name planted in `scripts/beads-checkpoint.sh` — and
  returned exit 1 naming the file and line. Its zero on this change is a real pass.

## Scope

Deliberately not done, per the item:

* No defensive blank-line stripping anywhere in the export path. Different change,
  different risk, and the observed blank line self-healed.
* No refusal added. This stays a warning, for the reason the call site already gives.
* The deletion-recovery paragraphs are untouched beyond being gated on the key set
  actually being short.
* `minimal_diff_rewrite`, `same_content`, `git_only_facts` and the truncation floor are
  untouched.

The item's account of the **cause** — a `bd export` racing the out-of-repo merged-PR
audit harness's memory write — is inference and was not reproduced. It is not written
into the message. The message names a blank line as a possibility and gives the check,
which is all it needs to do. Nothing cheaper or deterministic turned up while reading.

No AI attribution trailers in the commit or in this body: CLAUDE.md forbids them and
outranks the session-level reminder that asks for them.
